### PR TITLE
Pass configure arguments to cpp-runtime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_SUBST(APP)
 
 AC_SUBST(OMC_TARGET)
 AC_ARG_WITH(cppruntime,  [  --with-cppruntime       (build the optional cppruntime simulation libraries)],[OMC_TARGET="$withval"],[OMC_TARGET="no"])
-AC_ARG_WITH(cppruntime-args,  [  --with-cppruntime-ags=[cpp-args]       (pass comma separated arguments to the cppruntime configuration - see the cpp runtime documentation for details)],[CPP_RUNTIME_ARGS="$withval"],[CPP_RUNTIME_ARGS=""])
+AC_ARG_WITH(cppruntime-args,  [  --with-cppruntime-args=[cpp-args]       (pass comma separated arguments to the cppruntime configuration - see the cpp runtime documentation for details)],[CPP_RUNTIME_ARGS="$withval"],[CPP_RUNTIME_ARGS=""])
 
 AC_MSG_CHECKING([if cppruntime is requested])
 if test "$OMC_TARGET" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ AC_SUBST(APP)
 
 AC_SUBST(OMC_TARGET)
 AC_ARG_WITH(cppruntime,  [  --with-cppruntime       (build the optional cppruntime simulation libraries)],[OMC_TARGET="$withval"],[OMC_TARGET="no"])
+AC_ARG_WITH(cppruntime-args,  [  --with-cppruntime-ags=[cpp-args]       (pass comma separated arguments to the cppruntime configuration - see the cpp runtime documentation for details)],[CPP_RUNTIME_ARGS="$withval"],[CPP_RUNTIME_ARGS=""])
 
 AC_MSG_CHECKING([if cppruntime is requested])
 if test "$OMC_TARGET" = "yes"; then


### PR DESCRIPTION
I have just added a autoconf line, that gives us the possibility to pass configure arguments through the superproject and through the OMCompiler-project to the cpp-runtime.