### PR TITLE
Add OMSimulator as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "OMShell"]
 	path = OMShell
 	url = ../OMShell.git
+[submodule "OMSimulator"]
+	path = OMSimulator
+	url = ../OMSimulator.git

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,6 +1,7 @@
 all: @ALL_TARGETS@ @OMLIBRARY_TARGET@
 
 .PRECIOUS: Makefile
+.PHONY: omsimulator
 
 omc:
 	$(MAKE) -C OMCompiler @OMC_TARGET@
@@ -12,6 +13,10 @@ omplot: omc
 	$(MAKE) -C OMPlot
 omedit: omc omplot
 	$(MAKE) -C OMEdit
+omsimulator:
+	$(MAKE) -C OMSimulator config-3rdParty
+	$(MAKE) -C OMSimulator config-OMSimulator OMBUILDDIR=@OMBUILDDIR@
+	$(MAKE) -C OMSimulator OMBUILDDIR=@OMBUILDDIR@
 omnotebook: omc omplot
 	$(MAKE) -C OMNotebook
 omoptim: omc omplot

--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -33,7 +33,7 @@ BUILDTYPE=Debug
 endif
 
 
-.PHONY: omc omc-diff omlibrary-core omplot omedit omnotebook omshell omoptim
+.PHONY: omc omc-diff omlibrary-core omplot omedit omsimulator omnotebook omshell omoptim
 
 all: omc omc-diff omlibrary-core
 
@@ -54,6 +54,11 @@ omplot: omc qtclientsDLLs
 
 omedit: omplot qtclientsDLLs
 	$(MAKE) -f $(defaultMakefileTarget) -C OMEdit OMBUILDDIR=$(OMBUILDDIR)
+
+omsimulator:
+	$(MAKE) -C OMSimulator config-3rdParty
+	$(MAKE) -C OMSimulator config-OMSimulator OMBUILDDIR=$(OMBUILDDIR)
+	$(MAKE) -C OMSimulator OMBUILDDIR=$(OMBUILDDIR)
 
 omnotebook: omc omplot qtclientsDLLs
 	$(MAKE) -f $(defaultMakefileTarget) -C OMNotebook/OMNotebook/OMNotebookGUI OMBUILDDIR=$(OMBUILDDIR)


### PR DESCRIPTION
### Purpose

This PR adds the OMSimulator to the OpenModelica super-project.

### Type of Change

- New feature (non-breaking change which adds functionality)

---

### Open Questions and Pre-Merge TODOs

- [x] Update makefiles
