### PR TITLE
[OMSimulator] Read OMSimulator output from tests on Windows

### DIFF
--- a/testsuite/omsimulator/DualMassOscillator_cs.mos
+++ b/testsuite/omsimulator/DualMassOscillator_cs.mos
@@ -1,6 +1,6 @@
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf DualMassOscillator_cs.lua DualMassOscillator.System1.fmu DualMassOscillator.System2.fmu DualMassOscillator_System1.log DualMassOscillator_System2.log temp-DualMassOscillator_cs/
+// teardown_command: rm -rf DualMassOscillator_cs.lua DualMassOscillator.System1.fmu DualMassOscillator.System2.fmu DualMassOscillator_System1.log DualMassOscillator_System2.log DualMassOscillator_cs_systemCall.log temp-DualMassOscillator_cs/
 
 loadFile("DualMassOscillator.mo"); getErrorString();
 
@@ -43,7 +43,8 @@ oms_terminate(\"DualMassOscillator\")
 oms_delete(\"DualMassOscillator\")
 "); getErrorString();
 
-system(getInstallationDirectoryPath() + "/bin/OMSimulator --ignoreInitialUnknowns=true DualMassOscillator_cs.lua");
+system(getInstallationDirectoryPath() + "/bin/OMSimulator --ignoreInitialUnknowns=true DualMassOscillator_cs.lua", "DualMassOscillator_cs_systemCall.log");
+readFile("DualMassOscillator_cs_systemCall.log");
 
 simulate(DualMassOscillator.CoupledSystem, stopTime=0.1, simflags="-override=system2.s2_start=2.5"); getErrorString();
 val(system1.s1, {0.0,0.1});
@@ -61,14 +62,15 @@ val(system2.s2, {0.0,0.1});
 // ""
 // true
 // ""
-// info:    No result file will be created
+// 0
+// "info:    No result file will be created
 // info:    Initialization
 // info:      system1.s1: 1.0
 // info:      system2.s2: 2.5
 // info:    Simulation
 // info:      system1.s1: 0.87154409411158
 // info:      system2.s2: 1.9937955391923
-// 0
+// "
 // record SimulationResult
 //     resultFile = "DualMassOscillator.CoupledSystem_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'DualMassOscillator.CoupledSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override=system2.s2_start=2.5'",

--- a/testsuite/omsimulator/DualMassOscillator_me.mos
+++ b/testsuite/omsimulator/DualMassOscillator_me.mos
@@ -1,6 +1,6 @@
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf DualMassOscillator_me.lua DualMassOscillator.System1.fmu DualMassOscillator.System2.fmu DualMassOscillator_System1.log DualMassOscillator_System2.log temp-DualMassOscillator_me/
+// teardown_command: rm -rf DualMassOscillator_me.lua DualMassOscillator.System1.fmu DualMassOscillator.System2.fmu DualMassOscillator_System1.log DualMassOscillator_System2.log DualMassOscillator_me_systemCall.log temp-DualMassOscillator_me/
 
 loadFile("DualMassOscillator.mo"); getErrorString();
 
@@ -43,7 +43,9 @@ oms_terminate(\"DualMassOscillator\")
 oms_delete(\"DualMassOscillator\")
 "); getErrorString();
 
-system(getInstallationDirectoryPath() + "/bin/OMSimulator --ignoreInitialUnknowns=true DualMassOscillator_me.lua");
+system(getInstallationDirectoryPath() + "/bin/OMSimulator --ignoreInitialUnknowns=true DualMassOscillator_me.lua", "DualMassOscillator_me_systemCall.log");
+readFile("DualMassOscillator_me_systemCall.log");
+
 
 simulate(DualMassOscillator.CoupledSystem, stopTime=0.1, simflags="-override=system2.s2_start=2.5"); getErrorString();
 val(system1.s1, {0.0,0.1});
@@ -61,7 +63,8 @@ val(system2.s2, {0.0,0.1});
 // ""
 // true
 // ""
-// info:    maximum step size for 'DualMassOscillator.root': 0.100000
+// 0
+// "info:    maximum step size for 'DualMassOscillator.root': 0.100000
 // info:    No result file will be created
 // info:    Initialization
 // info:      system1.s1: 1.0
@@ -72,7 +75,7 @@ val(system2.s2, {0.0,0.1});
 // info:    Final Statistics for 'DualMassOscillator.root':
 //          NumSteps = 1301 NumRhsEvals  = 1545 NumLinSolvSetups = 138
 //          NumNonlinSolvIters = 1544 NumNonlinSolvConvFails = 0 NumErrTestFails = 49
-// 0
+// "
 // record SimulationResult
 //     resultFile = "DualMassOscillator.CoupledSystem_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'DualMassOscillator.CoupledSystem', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override=system2.s2_start=2.5'",

--- a/testsuite/omsimulator/initialization.mos
+++ b/testsuite/omsimulator/initialization.mos
@@ -1,6 +1,6 @@
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf initialization.lua initialization.fmu initialization.log temp-initialization/
+// teardown_command: rm -rf initialization.lua initialization.fmu initialization.log initialization_systemCall.log temp-initialization/
 
 loadString("
 model initialization
@@ -46,7 +46,8 @@ oms_terminate(\"test\")
 oms_delete(\"test\")
 "); getErrorString();
 
-system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization.lua");
+system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization.lua", "initialization_systemCall.log");
+readFile("initialization_systemCall.log");
 
 // Result:
 // true
@@ -55,7 +56,8 @@ system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization.lua");
 // ""
 // true
 // ""
-// info:    maximum step size for 'test.root': 0.100000
+// 0
+// "info:    maximum step size for 'test.root': 0.100000
 // info:    No result file will be created
 // info:    Initialization
 // info:      A.x_start: 1.5
@@ -68,5 +70,5 @@ system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization.lua");
 // info:    Final Statistics for 'test.root':
 //          NumSteps = 37 NumRhsEvals  = 83 NumLinSolvSetups = 39
 //          NumNonlinSolvIters = 82 NumNonlinSolvConvFails = 0 NumErrTestFails = 18
-// 0
+// "
 // endResult

--- a/testsuite/omsimulator/initialization2.mos
+++ b/testsuite/omsimulator/initialization2.mos
@@ -1,6 +1,6 @@
 // keywords: fmu export import
 // status: correct
-// teardown_command: rm -rf initialization2.fmu initialization2.log initialization2.lua input.csv temp-initialization2/
+// teardown_command: rm -rf initialization2.fmu initialization2.log initialization2_systemCall.log initialization2.lua input.csv temp-initialization2/
 
 loadString("
 model initialization2
@@ -43,7 +43,8 @@ oms_terminate(\"test\")
 oms_delete(\"test\")
 "); getErrorString();
 
-system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization2.lua");
+system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization2.lua", "initialization2_systemCall.log");
+readFile("initialization2_systemCall.log");
 
 // Result:
 // true
@@ -54,7 +55,8 @@ system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization2.lua");
 // ""
 // true
 // ""
-// info:    maximum step size for 'test.root': 0.100000
+// 0
+// "info:    maximum step size for 'test.root': 0.100000
 // info:    No result file will be created
 // info:    Initialization
 // info:      A.y: 2.3
@@ -64,5 +66,5 @@ system(getInstallationDirectoryPath() + "/bin/OMSimulator initialization2.lua");
 // info:    Final Statistics for 'test.root':
 //          NumSteps = 0 NumRhsEvals  = 0 NumLinSolvSetups = 0
 //          NumNonlinSolvIters = 0 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
-// 0
+// "
 // endResult

--- a/testsuite/omsimulator/outputState.mos
+++ b/testsuite/omsimulator/outputState.mos
@@ -1,5 +1,5 @@
 // status: correct
-// teardown_command: rm -rf outputState.lua outputState.fmu outputState.log sink.fmu sink.log temp-outputState/
+// teardown_command: rm -rf outputState.lua outputState.fmu outputState.log sink.fmu sink.log outputState_systemCall.log temp-outputState/
 
 loadString("
 model outputState
@@ -45,7 +45,8 @@ oms_terminate(\"test\")
 oms_delete(\"test\")
 "); getErrorString();
 
-system(getInstallationDirectoryPath() + "/bin/OMSimulator outputState.lua");
+system(getInstallationDirectoryPath() + "/bin/OMSimulator outputState.lua", "outputState_systemCall.log");
+readFile("outputState_systemCall.log");
 
 // Result:
 // true
@@ -56,7 +57,8 @@ system(getInstallationDirectoryPath() + "/bin/OMSimulator outputState.lua");
 // ""
 // true
 // ""
-// info:    maximum step size for 'test.root': 0.100000
+// 0
+// "info:    maximum step size for 'test.root': 0.100000
 // info:    No result file will be created
 // info:    Initialization
 // info:      A.y: 1.5
@@ -67,5 +69,5 @@ system(getInstallationDirectoryPath() + "/bin/OMSimulator outputState.lua");
 // info:    Final Statistics for 'test.root':
 //          NumSteps = 12 NumRhsEvals  = 13 NumLinSolvSetups = 3
 //          NumNonlinSolvIters = 12 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
-// 0
+// "
 // endResult


### PR DESCRIPTION
`OpenModelica.Scripting.system` behaves differently on Linux and Windows. Now tests are using log files to pipe output to and read it with `OpenModelica.Scripting.readFile`.