### PR TITLE
Do not link TLM with OMEdit

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/OMEdit.config.in
+++ b/OMEdit/OMEdit/OMEditGUI/OMEdit.config.in
@@ -6,7 +6,7 @@ QMAKE_LINK = @CXX@
 
 OPENMODELICAHOME = @OPENMODELICAHOME@
 
-LIBS += -L @OPENMODELICAHOME@/lib/@host_short@/omc -lOMPlot -lomqwt -lfmilib_shared -L../OMEditGUI/Debugger/Parser -lGDBMIParser -lomantlr3 @RPATH_QMAKE@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lomcgc -L@OMBUILDDIR@/lib/@host_short@/omc @LIBOSG@ -lomopcua -L@OMBUILDDIR@/lib -lOMSimulator -lomtlmsimulator @LIB_BOOST_REGEX@
+LIBS += -L @OPENMODELICAHOME@/lib/@host_short@/omc -lOMPlot -lomqwt -lfmilib_shared -L../OMEditGUI/Debugger/Parser -lGDBMIParser -lomantlr3 @RPATH_QMAKE@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lomcgc -L@OMBUILDDIR@/lib/@host_short@/omc @LIBOSG@ -lomopcua -L@OMBUILDDIR@/lib -lOMSimulator @LIB_BOOST_REGEX@
 INCLUDEPATH += @OPENMODELICAHOME@/include/omc/scripting-API @OPENMODELICAHOME@/include/omplot @OPENMODELICAHOME@/include/omplot/qwt @OPENMODELICAHOME@/include/@host_short@/omc/antlr3 @OPENMODELICAHOME@/include/omc/c ../../qjson-0.8.1/build/include @OPENMODELICAHOME@/include
 
 QMAKE_CXXFLAGS_RELEASE -= -O1

--- a/OMEdit/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -89,7 +89,7 @@ win32 {
     -L$$(OMBUILDDIR)/lib/omc -lomantlr3 -lOMPlot -lomqwt -lomopcua \
     -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib -lModelicaExternalC -lomcgc -lpthread -lshlwapi \
     -lws2_32 \
-    -L$$(OMBUILDDIR)/bin -lOMSimulator -lomtlmsimulator
+    -L$$(OMBUILDDIR)/bin -lOMSimulator
 
   INCLUDEPATH += $$(OMBUILDDIR)/include/omplot \
     $$(OMBUILDDIR)/include \


### PR DESCRIPTION
OMSimulator is a dynamic library and includes TLM if it was compiled
with TLM (which is false on MacOS).