### PR TITLE
ticket:4475 write the simulation log to a file

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
@@ -625,6 +625,9 @@ void OptionsDialog::readSimulationSettings()
   if (mpSettings->contains("simulation/outputMode")) {
     mpSimulationPage->setOutputMode(mpSettings->value("simulation/outputMode").toString());
   }
+  if (mpSettings->contains("simulation/displayLimit")) {
+    mpSimulationPage->getDisplayLimitSpinBox()->setValue(mpSettings->value("simulation/displayLimit").toInt());
+  }
 }
 //! Reads the Messages section settings from omedit.ini
 void OptionsDialog::readMessagesSettings()
@@ -1206,6 +1209,7 @@ void OptionsDialog::saveSimulationSettings()
   mpSettings->setValue("simulation/deleteIntermediateCompilationFiles", mpSimulationPage->getDeleteIntermediateCompilationFilesCheckBox()->isChecked());
   mpSettings->setValue("simulation/deleteEntireSimulationDirectory", mpSimulationPage->getDeleteEntireSimulationDirectoryCheckBox()->isChecked());
   mpSettings->setValue("simulation/outputMode", mpSimulationPage->getOutputMode());
+  mpSettings->setValue("simulation/displayLimit", mpSimulationPage->getDisplayLimitSpinBox()->value());
 }
 
 /*!
@@ -3656,10 +3660,24 @@ SimulationPage::SimulationPage(OptionsDialog *pOptionsDialog)
   QHBoxLayout *pOutputRadioButtonsLayout = new QHBoxLayout;
   pOutputRadioButtonsLayout->addWidget(mpStructuredRadioButton);
   pOutputRadioButtonsLayout->addWidget(mpFormattedTextRadioButton);
+  // display limit
+  mpDisplayLimitLabel = new Label(tr("Display Limit:"));
+  mpDisplayLimitSpinBox = new QSpinBox;
+  mpDisplayLimitSpinBox->setSuffix(" KB");
+  mpDisplayLimitSpinBox->setRange(1, std::numeric_limits<int>::max());
+  mpDisplayLimitSpinBox->setSingleStep(100);
+  mpDisplayLimitSpinBox->setValue(500);
+  mpDisplayLimitMBLabel = new Label;
+  connect(mpDisplayLimitSpinBox, SIGNAL(valueChanged(int)), SLOT(displayLimitValueChanged(int)));
+  // calculate the display limit in MBs.
+  displayLimitValueChanged(mpDisplayLimitSpinBox->value());
   // set the layout of output view mode group
   QGridLayout *pOutputGroupGridLayout = new QGridLayout;
   pOutputGroupGridLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-  pOutputGroupGridLayout->addLayout(pOutputRadioButtonsLayout, 0, 0);
+  pOutputGroupGridLayout->addLayout(pOutputRadioButtonsLayout, 0, 0, 1, 3, Qt::AlignLeft);
+  pOutputGroupGridLayout->addWidget(mpDisplayLimitLabel, 1, 0);
+  pOutputGroupGridLayout->addWidget(mpDisplayLimitSpinBox, 1, 1);
+  pOutputGroupGridLayout->addWidget(mpDisplayLimitMBLabel, 1, 2);
   mpOutputGroupBox->setLayout(pOutputGroupGridLayout);
   // set the layout of simulation group
   QGridLayout *pSimulationLayout = new QGridLayout;
@@ -3723,6 +3741,18 @@ void SimulationPage::targetBuildChanged(int index)
     mpCompilerComboBox->setEnabled(false);
     mpCXXCompilerComboBox->setEnabled(false);
   }
+}
+
+/*!
+ * \brief SimulationPage::displayLimitValueChanged
+ * Slot activated when mpDisplayLimitSpinBox valueChanged SIGNAL is raised.
+ * Shows the display limit is MBs.
+ * 1 KB is 0,001 MB.
+ * \param value
+ */
+void SimulationPage::displayLimitValueChanged(int value)
+{
+  mpDisplayLimitMBLabel->setText(QString("(%1 MB)").arg(value*0.001));
 }
 
 //! @class MessagesPage

--- a/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.h
+++ b/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.h
@@ -619,6 +619,7 @@ public:
   QCheckBox* getDeleteEntireSimulationDirectoryCheckBox() {return mpDeleteEntireSimulationDirectoryCheckBox;}
   void setOutputMode(QString value);
   QString getOutputMode();
+  QSpinBox* getDisplayLimitSpinBox() {return mpDisplayLimitSpinBox;}
 private:
   OptionsDialog *mpOptionsDialog;
   QGroupBox *mpSimulationGroupBox;
@@ -642,8 +643,12 @@ private:
   QGroupBox *mpOutputGroupBox;
   QRadioButton *mpStructuredRadioButton;
   QRadioButton *mpFormattedTextRadioButton;
+  Label *mpDisplayLimitLabel;
+  QSpinBox *mpDisplayLimitSpinBox;
+  Label *mpDisplayLimitMBLabel;
 public slots:
   void targetBuildChanged(int index);
+  void displayLimitValueChanged(int value);
 };
 
 class MessagesPage : public QWidget

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationOutputHandler.h
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationOutputHandler.h
@@ -46,12 +46,13 @@ public:
   QString mText;
   int mLevel;
   QString mIndex;
+  QString mDeweyId;
   QList<SimulationMessage*> mChildren;
   SimulationMessage* mpParentSimulationMessage;
 public:
   SimulationMessage(SimulationMessage *pParentSimulationMessage = 0)
     : mpParentSimulationMessage(pParentSimulationMessage)
-  {mStream = ""; mType = StringHandler::Unknown; mText = ""; mIndex = "";}
+  {mStream = ""; mType = StringHandler::Unknown; mText = ""; mIndex = ""; mDeweyId="";}
   void setParent(SimulationMessage *pParentSimulationMessage) {mpParentSimulationMessage = pParentSimulationMessage;}
   SimulationMessage *parent() {return mpParentSimulationMessage;}
   SimulationMessage *child(int row) {return mChildren.value(row);}
@@ -81,14 +82,11 @@ public:
   int getDepth(const QModelIndex &index) const;
   void insertSimulationMessage(SimulationMessage *pSimulationMessage);
   void callLayoutChanged();
-  QModelIndexList selectedRows();
-  QModelIndex simulationMessageIndex(const SimulationMessage *pSimulationMessage) const;
 private:
   SimulationOutputWidget *mpSimulationOutputWidget;
   SimulationMessage* mpRootSimulationMessage;
   QModelIndexList mSelectedRowsList;
 
-  void selectedRowsHelper(SimulationMessage *pParentSimulationMessage);
   QModelIndex simulationMessageIndexHelper(const SimulationMessage *pSimulationMessage, const SimulationMessage *pParentSimulationMessage,
                                            const QModelIndex &parentIndex) const;
 };
@@ -98,12 +96,15 @@ class SimulationOutputHandler : private QXmlDefaultHandler
 private:
   SimulationOutputWidget *mpSimulationOutputWidget;
   int mLevel;
+  int mNumberOfBytes;
   SimulationMessage* mpSimulationMessage;
   QMap<int, SimulationMessage*> mSimulationMessagesLevelMap;
   SimulationMessageModel *mpSimulationMessageModel;
   QXmlSimpleReader mXmlSimpleReader;
   QXmlInputSource *mpXmlInputSource;
+  FILE *mpSimulationLogFile;
 
+  bool isMaximumDisplayLimitReached() const;
   bool startElement(const QString &namespaceURI, const QString &localName, const QString &qName, const QXmlAttributes &atts);
   bool endElement(const QString &namespaceURI, const QString &localName, const QString &qName);
   bool fatalError(const QXmlParseException &exception);
@@ -112,6 +113,8 @@ public:
   ~SimulationOutputHandler();
   SimulationMessageModel* getSimulationMessageModel() {return mpSimulationMessageModel;}
   void parseSimulationOutput(QString output);
+  void writeSimulationLog(const QString &text);
+  void simulationProcessFinished();
 };
 
 #endif // SIMULATIONOUTPUTHANDLER_H

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationOutputWidget.h
@@ -99,6 +99,7 @@ private:
   QProgressBar *mpProgressBar;
   QPushButton *mpCancelButton;
   QToolButton *mpOpenTransformationalDebuggerButton;
+  QPushButton *mpOpenOutputFileButton;
   QTabWidget *mpGeneratedFilesTabWidget;
   QList<QString> mGeneratedFilesList;
   QList<QString> mGeneratedAlgLoopFilesList;
@@ -126,6 +127,7 @@ public slots:
   void simulationProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
   void cancelCompilationOrSimulation();
   void openTransformationalDebugger();
+  void openSimulationLogFile();
   void openTransformationBrowser(QUrl url);
 protected:
   virtual void keyPressEvent(QKeyEvent *event);

--- a/OMEdit/OMEdit/OMEditGUI/Util/Utilities.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Utilities.cpp
@@ -242,17 +242,22 @@ void Label::setText(const QString &text)
 {
   mText = text;
   setToolTip(text);
-  QLabel::setText(text);
+  QLabel::setText(elidedText());
+}
+
+QString Label::elidedText() const
+{
+  if (mElideMode != Qt::ElideNone) {
+    return fontMetrics().elidedText(mText, mElideMode, size().width());
+  } else {
+    return mText;
+  }
 }
 
 void Label::resizeEvent(QResizeEvent *event)
 {
-  if (mElideMode != Qt::ElideNone) {
-    QFontMetrics fm(fontMetrics());
-    QString str = fm.elidedText(mText, mElideMode, event->size().width());
-    QLabel::setText(str);
-  }
   QLabel::resizeEvent(event);
+  QLabel::setText(elidedText());
 }
 
 FixedCheckBox::FixedCheckBox(QWidget *parent)

--- a/OMEdit/OMEdit/OMEditGUI/Util/Utilities.h
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Utilities.h
@@ -159,6 +159,8 @@ public:
 private:
   Qt::TextElideMode mElideMode;
   QString mText;
+
+  QString elidedText() const;
 protected:
   virtual void resizeEvent(QResizeEvent *event);
 };


### PR DESCRIPTION
Added a customizable display limit for the simulation log. Only display until the limit is reached and then show a link to the log file. Doesn't freeze the OMEdit window so user can cancel the simulation if needed.
Added a button in the simulation window to open the simulation log file.
Copy the plain text so it could be used in other tools.