### PR TITLE
[NF] Implement sum-reduction of operator records.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -670,6 +670,27 @@ uniontype Class
       else cmts;
     end match;
   end getDerivedComments;
+
+  function hasOperator
+    input String name;
+    input Class cls;
+    output Boolean hasOperator;
+  protected
+    InstNode op_node;
+    Class op_cls;
+  algorithm
+    if Restriction.isOperatorRecord(restriction(cls)) then
+      try
+        op_node := lookupElement(name, cls);
+        hasOperator := SCode.isOperator(InstNode.definition(op_node));
+      else
+        hasOperator := false;
+      end try;
+    else
+      hasOperator := false;
+    end if;
+  end hasOperator;
+
 end Class;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
@@ -166,6 +166,16 @@ public
     end match;
   end isOperatorRecord;
 
+  function isOperator
+    input Restriction res;
+    output Boolean isOperator;
+  algorithm
+    isOperator := match res
+      case OPERATOR() then true;
+      else false;
+    end match;
+  end isOperator;
+
   function isType
     input Restriction res;
     output Boolean isType;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -89,6 +89,7 @@ import StringUtil;
 import NFOCConnectionGraph;
 import System;
 import ErrorExt;
+import OperatorOverloading = NFOperatorOverloading;
 
 public
 uniontype TypingError
@@ -272,6 +273,7 @@ algorithm
     case CachedData.FUNCTION(funcs = fnl, typed = false)
       algorithm
         fnl := list(Function.typeFunction(fn) for fn in fnl);
+        fnl := list(OperatorOverloading.patchOperatorRecordConstructorBinding(fn) for fn in fnl);
         InstNode.setFuncCache(node, CachedData.FUNCTION(fnl, true, cache.specialBuiltin));
       then
         ();

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -842,6 +842,8 @@ public constant Message REDECLARE_ENUM_NON_SUBTYPE = MESSAGE(356, TRANSLATION(),
   Util.gettext("Redeclaration of enumeration ‘%s‘ is not a subtype of the redeclared element (use enumeration(:) for a generic replaceable enumeration)."));
 public constant Message CONDITIONAL_COMPONENT_INVALID_CONTEXT = MESSAGE(357, TRANSLATION(), WARNING(),
   Util.gettext("Conditional component ‘%s‘ is used in a non-connect context."));
+public constant Message OPERATOR_RECORD_MISSING_OPERATOR = MESSAGE(358, TRANSLATION(), ERROR(),
+  Util.gettext("Type ‘%s‘ of expression ‘%s‘ in ‘%s‘ does not implement the required operator ‘%s‘"));
 public constant Message INITIALIZATION_NOT_FULLY_SPECIFIED = MESSAGE(496, TRANSLATION(), WARNING(),
   Util.gettext("The initial conditions are not fully specified. %s."));
 public constant Message INITIALIZATION_OVER_SPECIFIED = MESSAGE(497, TRANSLATION(), WARNING(),

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1600,6 +1600,12 @@ algorithm
   end match;
 end swap;
 
+function replace<T>
+  input T replaced;
+  input T arg;
+  output T outArg = arg;
+end replace;
+
 public function realRangeSize
   "Calculates the size of a Real range given the start, step and stop values."
   input Real inStart;
@@ -1917,6 +1923,24 @@ function profilertock2
 algorithm
    t := System.realtimeTock(ClockIndexes.RT_PROFILER2);
 end profilertock2;
+
+function applyTuple31<T1, T2, T3>
+  input tuple<T1, T2, T3> inTuple;
+  input FuncT func;
+  output tuple<T1, T2, T3> outTuple;
+
+  partial function FuncT
+    input output T1 e;
+  end FuncT;
+protected
+  T1 t1, t1_new;
+  T2 t2;
+  T3 t3;
+algorithm
+  (t1, t2, t3) := inTuple;
+  t1_new := func(t1);
+  outTuple := if referenceEq(t1, t1_new) then inTuple else (t1_new, t2, t3);
+end applyTuple31;
 
 annotation(__OpenModelica_Interface="util");
 end Util;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -679,6 +679,7 @@ OperatorOverloadConstructorInvalidOutput1.mo \
 OperatorOverloadConstructorInvalidOutput2.mo \
 OperatorOverloadConstructorSimple.mo \
 OperatorOverloadError1.mo \
+OperatorOverloadSum1.mo \
 PackageConstant1.mo \
 ParameterBug.mos \
 PartialApplication1.mo \

--- a/testsuite/flattening/modelica/scodeinst/OperatorOverloadComplex.mo
+++ b/testsuite/flattening/modelica/scodeinst/OperatorOverloadComplex.mo
@@ -257,12 +257,6 @@ end OperatorOverloadComplex;
 //   c3 := Complex.'constructor'.fromReal((c1.re * c2.re + c1.im * c2.im) / (c2.re * c2.re + c2.im * c2.im), ((-c1.re * c2.im) + c1.im * c2.re) / (c2.re * c2.re + c2.im * c2.im));
 // end Complex.'/';
 //
-// function Complex.'0' "Inline before index reduction"
-//   output Complex c;
-// algorithm
-//   c := Complex.'constructor'.fromReal(0.0, 0.0);
-// end Complex.'0';
-//
 // function Complex.'==' "Test whether two complex numbers are identical"
 //   input Complex c1 "Complex number 1";
 //   input Complex c2 "Complex number 2";
@@ -371,7 +365,7 @@ end OperatorOverloadComplex;
 //   b2 = Complex.'=='(c4, Complex.'constructor'.fromReal(0.0, 0.0));
 //   c6 = Complex.'*'.multiply(c5, c4);
 //   c7 = Complex.'-'.subtract(Complex.'+'(Complex.'*'.multiply(Complex.'*'.multiply(Complex.'/'(c6, c5), Complex.'^'(c4, c3)), Complex.'constructor'.fromReal(1.0, 0.0)), c2), c1);
-//   c8 = Complex.'0'();
+//   c8 = Complex(0.0, 0.0);
 //   ca1 = Complex.'-'.negateArr(ca2);
 //   c1 = Complex.'*'.scalarProduct(ca2, ca3);
 //   c1 = Complex.'-'.subtract(Complex.'constructor'.fromReal(1.0, 0.0), c2);

--- a/testsuite/flattening/modelica/scodeinst/OperatorOverloadSum1.mo
+++ b/testsuite/flattening/modelica/scodeinst/OperatorOverloadSum1.mo
@@ -1,0 +1,84 @@
+// name: OperatorOverloadSum1
+// keywords: operator overload complex
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+operator record Complex "Complex number with overloaded operators"
+  Real re "Real part of complex number";
+  Real im "Imaginary part of complex number";
+
+  encapsulated operator 'constructor'  " Constructor"
+    function fromReal "Construct Complex from Real"
+      import Complex;
+      input Real re "Real part of complex number";
+      input Real im = 0.0 "Imaginary part of complex number";
+      output Complex result = Complex(re = re, im = im) "Complex number";
+    algorithm
+    end fromReal;
+  end 'constructor';
+
+  encapsulated operator function '+' "Add two complex numbers"
+    import Complex;
+    input Complex c1 "Complex number 1";
+    input Complex c2 "Complex number 2";
+    output Complex c3 "= c1 + c2";
+  algorithm
+    c3:=Complex(c1.re + c2.re, c1.im + c2.im);
+  end '+';
+
+  encapsulated operator function '0'
+    import Complex;
+    output Complex c;
+  algorithm
+    c := Complex(0,0);
+    annotation(Inline=true);
+  end '0';
+end Complex;
+
+model OperatorOverloadSum1
+  Complex c1[3] = {Complex(time), Complex(time), Complex(time)};
+  Complex c2;
+equation
+  c2 = sum(c1[i] for i in 1:size(c1, 1));
+end OperatorOverloadSum1;
+
+// Result:
+// function Complex "Automatically generated record constructor for Complex"
+//   input Real re;
+//   input Real im;
+//   output Complex res;
+// end Complex;
+//
+// function Complex.'+' "Add two complex numbers"
+//   input Complex c1 "Complex number 1";
+//   input Complex c2 "Complex number 2";
+//   output Complex c3 "= c1 + c2";
+// algorithm
+//   c3 := Complex.'constructor'.fromReal(c1.re + c2.re, c1.im + c2.im);
+// end Complex.'+';
+//
+// function Complex.'constructor'.fromReal "Construct Complex from Real"
+//   input Real re "Real part of complex number";
+//   input Real im = 0.0 "Imaginary part of complex number";
+//   output Complex result = Complex.'constructor'.fromReal(re, im) "Complex number";
+// algorithm
+// end Complex.'constructor'.fromReal;
+//
+// class OperatorOverloadSum1
+//   Real c1[1].re "Real part of complex number";
+//   Real c1[1].im "Imaginary part of complex number";
+//   Real c1[2].re "Real part of complex number";
+//   Real c1[2].im "Imaginary part of complex number";
+//   Real c1[3].re "Real part of complex number";
+//   Real c1[3].im "Imaginary part of complex number";
+//   Real c2.re "Real part of complex number";
+//   Real c2.im "Imaginary part of complex number";
+// equation
+//   c1[1] = Complex.'constructor'.fromReal(time, 0.0);
+//   c1[2] = Complex.'constructor'.fromReal(time, 0.0);
+//   c1[3] = Complex.'constructor'.fromReal(time, 0.0);
+//   c2 = sum(c1[i] for i in 1:3);
+// end OperatorOverloadSum1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeMax;
 
 // Result:
 // Error processing file: ReductionInvalidTypeMax.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo:10:3-10:36:writable] Error: Invalid expression ‘"test"‘ of type String in max reduction, expected scalar enumeration, Boolean, Integer or Real.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo:10:3-10:36:writable] Error: Invalid expression ‘"test"‘ of type String in max reduction, expected scalar enumeration, Boolean, Integer, or Real.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeMin;
 
 // Result:
 // Error processing file: ReductionInvalidTypeMin.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo:10:3-10:39:writable] Error: Invalid expression ‘{1, 2, 3}‘ of type Integer[3] in min reduction, expected scalar enumeration, Boolean, Integer or Real.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo:10:3-10:39:writable] Error: Invalid expression ‘{1, 2, 3}‘ of type Integer[3] in min reduction, expected scalar enumeration, Boolean, Integer, or Real.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeSum;
 
 // Result:
 // Error processing file: ReductionInvalidTypeSum.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo:10:3-10:36:writable] Error: Invalid expression ‘"test"‘ of type String in sum reduction, expected Integer or Real.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo:10:3-10:36:writable] Error: Invalid expression ‘"test"‘ of type String in sum reduction, expected Integer or Real, or operator record.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 ATotal.mos \
 InOutRecord.mos \
 TestComplexSum1.mos \
+TestComplexSum2.mos \
 Ticket5134.mos
 
 # test that currently fail. Move up when fixed. 

--- a/testsuite/simulation/modelica/records/TestComplexSum2.mos
+++ b/testsuite/simulation/modelica/records/TestComplexSum2.mos
@@ -1,0 +1,63 @@
+// name: TestComplexSum2
+// keywords: operator overload complex sum
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  operator record Complex
+    Real re;
+    Real im;
+
+    encapsulated operator 'constructor'
+      function fromReal
+        import Complex;
+        input Real re;
+        input Real im = 0.0;
+        output Complex result = Complex(re = re, im = im);
+      algorithm
+      end fromReal;
+    end 'constructor';
+
+    encapsulated operator function '+'
+      import Complex;
+      input Complex c1;
+      input Complex c2;
+      output Complex c3;
+    algorithm
+      c3:=Complex(c1.re + c2.re, c1.im + c2.im);
+    end '+';
+
+    encapsulated operator function '0'
+      import Complex;
+      output Complex c;
+    algorithm
+      c := Complex(0,0);
+      annotation(Inline=true);
+    end '0';
+  end Complex;
+
+  model TestComplexSum2
+    Complex c1[3] = {Complex(time), Complex(time), Complex(time)};
+    Complex c2;
+  equation
+    c2 = sum(c1[i] for i in 1:size(c1, 1));
+  end TestComplexSum2;
+");
+getErrorString();
+
+simulate(TestComplexSum2); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestComplexSum2_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestComplexSum2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
- Implemented support for sum-reductions of operator records that have
  the appropriate operators.
- Change constructor calls in bindings of outputs in operator record
  constructors into record expressions, to avoid infinite loops.