### PR TITLE
Remove pedantic option.

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
@@ -569,10 +569,6 @@ void OptionsDialog::readSimulationSettings()
   if (mpSettings->contains("simulation/NLSanalyticJacobian")) {
     mpSimulationPage->getTranslationFlagsWidget()->getNLSanalyticJacobianCheckBox()->setChecked(mpSettings->value("simulation/NLSanalyticJacobian").toBool());
   }
-  // save pedantic mode
-  if (mpSettings->contains("simulation/pedantic")) {
-    mpSimulationPage->getTranslationFlagsWidget()->getPedanticCheckBox()->setChecked(mpSettings->value("simulation/pedantic").toBool());
-  }
   // save parmodauto
   if (mpSettings->contains("simulation/parmodauto")) {
     mpSimulationPage->getTranslationFlagsWidget()->getParmodautoCheckBox()->setChecked(mpSettings->value("simulation/parmodauto").toBool());
@@ -1192,8 +1188,6 @@ void OptionsDialog::saveSimulationSettings()
   mpSettings->setValue("simulation/evaluateAllParameters", mpSimulationPage->getTranslationFlagsWidget()->getEvaluateAllParametersCheckBox()->isChecked());
   // save NLS analytic jacobian
   mpSettings->setValue("simulation/NLSanalyticJacobian", mpSimulationPage->getTranslationFlagsWidget()->getNLSanalyticJacobianCheckBox()->isChecked());
-  // save pedantic mode
-  mpSettings->setValue("simulation/pedantic", mpSimulationPage->getTranslationFlagsWidget()->getPedanticCheckBox()->isChecked());
   // save parmodauto
   mpSettings->setValue("simulation/parmodauto", mpSimulationPage->getTranslationFlagsWidget()->getParmodautoCheckBox()->isChecked());
   // save new instantiation

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
@@ -707,7 +707,6 @@ void SimulationDialog::initializeFields(bool isReSimulate, SimulationOptions sim
       mpTranslationFlagsWidget->getInitializationCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getInitializationCheckBox()->isChecked());
       mpTranslationFlagsWidget->getEvaluateAllParametersCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getEvaluateAllParametersCheckBox()->isChecked());
       mpTranslationFlagsWidget->getNLSanalyticJacobianCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getNLSanalyticJacobianCheckBox()->isChecked());
-      mpTranslationFlagsWidget->getPedanticCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getPedanticCheckBox()->isChecked());
       mpTranslationFlagsWidget->getParmodautoCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getParmodautoCheckBox()->isChecked());
       mpTranslationFlagsWidget->getNewInstantiationCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getNewInstantiationCheckBox()->isChecked());
       mpTranslationFlagsWidget->getDataReconciliationCheckBox()->setChecked(pGlobalTranslationFlagsWidget->getDataReconciliationCheckBox()->isChecked());
@@ -749,8 +748,6 @@ void SimulationDialog::initializeFields(bool isReSimulate, SimulationOptions sim
                 mpTranslationFlagsWidget->getEvaluateAllParametersCheckBox()->setChecked(true);
               } else if (commandLineOptionValue.compare("NLSanalyticJacobian") == 0) {
                 mpTranslationFlagsWidget->getNLSanalyticJacobianCheckBox()->setChecked(true);
-              } else if (commandLineOptionValue.compare("pedantic") == 0) {
-                mpTranslationFlagsWidget->getPedanticCheckBox()->setChecked(true);
               } else if (commandLineOptionValue.compare("parmodauto") == 0) {
                 mpTranslationFlagsWidget->getParmodautoCheckBox()->setChecked(true);
               } else if (commandLineOptionValue.compare("newInst") == 0) {

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationOptions.h
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationOptions.h
@@ -75,7 +75,6 @@ public:
     setInitialization(true);
     setEvaluateAllParameters(false);
     setNLSanalyticJacobian(true);
-    setPedantic(false);
     setParmodauto(false);
     setNewInstantiation(false);
     setDataReconciliation(false);
@@ -172,8 +171,6 @@ public:
   bool getEvaluateAllParameters() const {return mEvaluateAllParameters;}
   void setNLSanalyticJacobian(bool nlsAnalyticJacobian) {mNLSanalyticJacobian = nlsAnalyticJacobian;}
   bool getNLSanalyticJacobian() const {return mNLSanalyticJacobian;}
-  void setPedantic(bool pedantic) {mPedantic = pedantic;}
-  bool getPedantic() const {return mPedantic;}
   void setParmodauto(bool parmodauto) {mParmodauto = parmodauto;}
   bool getParmodauto() const {return mParmodauto;}
   void setNewInstantiation(bool newInstantiation) {mNewInstantiation = newInstantiation;}
@@ -280,7 +277,6 @@ private:
   bool mInitialization;
   bool mEvaluateAllParameters;
   bool mNLSanalyticJacobian;
-  bool mPedantic;
   bool mParmodauto;
   bool mNewInstantiation;
   bool mDataReconciliation;

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/TranslationFlagsWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/TranslationFlagsWidget.cpp
@@ -75,7 +75,6 @@ TranslationFlagsWidget::TranslationFlagsWidget(QWidget *pParent)
   mpInitializationCheckBox = new QCheckBox(tr("Show additional information from the initialization process"));
   mpEvaluateAllParametersCheckBox = new QCheckBox(tr("Evaluate all parameters (faster simulation, cannot change them at runtime)"));
   mpNLSanalyticJacobianCheckBox = new QCheckBox(tr("Enable analytical jacobian for non-linear strong components"));
-  mpPedanticCheckBox = new QCheckBox(tr("Enable pedantic debug-mode, to get much more feedback"));
   mpParmodautoCheckBox = new QCheckBox(tr("Enable parallelization of independent systems of equations (Experimental)"));
   mpNewInstantiationCheckBox = new QCheckBox(tr("Enable experimental new instantiation phase"));
   mpDataReconciliationCheckBox = new QCheckBox(tr("Enable data reconciliation"));
@@ -99,7 +98,6 @@ TranslationFlagsWidget::TranslationFlagsWidget(QWidget *pParent)
   pMainLayout->addWidget(mpInitializationCheckBox, row++, 0, 1, 3);
   pMainLayout->addWidget(mpEvaluateAllParametersCheckBox, row++, 0, 1, 3);
   pMainLayout->addWidget(mpNLSanalyticJacobianCheckBox, row++, 0, 1, 3);
-  pMainLayout->addWidget(mpPedanticCheckBox, row++, 0, 1, 3);
   pMainLayout->addWidget(mpParmodautoCheckBox, row++, 0, 1, 3);
   pMainLayout->addWidget(mpNewInstantiationCheckBox, row++, 0, 1, 3);
   pMainLayout->addWidget(mpDataReconciliationCheckBox, row++, 0, 1, 3);
@@ -127,7 +125,6 @@ void TranslationFlagsWidget::applySimulationOptions(const SimulationOptions &sim
   mpInitializationCheckBox->setChecked(simulationOptions.getInitialization());
   mpEvaluateAllParametersCheckBox->setChecked(simulationOptions.getEvaluateAllParameters());
   mpNLSanalyticJacobianCheckBox->setChecked(simulationOptions.getNLSanalyticJacobian());
-  mpPedanticCheckBox->setChecked(simulationOptions.getPedantic());
   mpParmodautoCheckBox->setChecked(simulationOptions.getParmodauto());
   mpNewInstantiationCheckBox->setChecked(simulationOptions.getNewInstantiation());
   mpDataReconciliationCheckBox->setChecked(simulationOptions.getDataReconciliation());
@@ -146,7 +143,6 @@ void TranslationFlagsWidget::createSimulationOptions(SimulationOptions *pSimulat
   pSimulationOptions->setInitialization(mpInitializationCheckBox->isChecked());
   pSimulationOptions->setEvaluateAllParameters(mpEvaluateAllParametersCheckBox->isChecked());
   pSimulationOptions->setNLSanalyticJacobian(mpNLSanalyticJacobianCheckBox->isChecked());
-  pSimulationOptions->setPedantic(mpPedanticCheckBox->isChecked());
   pSimulationOptions->setParmodauto(mpParmodautoCheckBox->isChecked());
   pSimulationOptions->setNewInstantiation(mpNewInstantiationCheckBox->isChecked());
   pSimulationOptions->setDataReconciliation(mpDataReconciliationCheckBox->isChecked());
@@ -191,10 +187,6 @@ QString TranslationFlagsWidget::commandLineOptions()
   // NLS analytic jacobian
   if (mpNLSanalyticJacobianCheckBox->isChecked()) {
     debugFlags.append("NLSanalyticJacobian");
-  }
-  // pedantic mode
-  if (mpPedanticCheckBox->isChecked()) {
-    debugFlags.append("pedantic");
   }
   // parmodauto
   if (mpParmodautoCheckBox->isChecked()) {

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/TranslationFlagsWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/TranslationFlagsWidget.h
@@ -52,7 +52,6 @@ public:
   QCheckBox *getInitializationCheckBox() const {return mpInitializationCheckBox;}
   QCheckBox *getEvaluateAllParametersCheckBox() const {return mpEvaluateAllParametersCheckBox;}
   QCheckBox *getNLSanalyticJacobianCheckBox() const {return mpNLSanalyticJacobianCheckBox;}
-  QCheckBox *getPedanticCheckBox() const {return mpPedanticCheckBox;}
   QCheckBox *getParmodautoCheckBox() const {return mpParmodautoCheckBox;}
   QCheckBox *getNewInstantiationCheckBox() const {return mpNewInstantiationCheckBox;}
   QCheckBox *getDataReconciliationCheckBox() const {return mpDataReconciliationCheckBox;}
@@ -70,7 +69,6 @@ private:
   QCheckBox *mpInitializationCheckBox;
   QCheckBox *mpEvaluateAllParametersCheckBox;
   QCheckBox *mpNLSanalyticJacobianCheckBox;
-  QCheckBox *mpPedanticCheckBox;
   QCheckBox *mpParmodautoCheckBox;
   QCheckBox *mpNewInstantiationCheckBox;
   QCheckBox *mpDataReconciliationCheckBox;


### PR DESCRIPTION
- Remove the option to toggle the pedantic debug flag, since it's been
  removed from the compiler on account of being unused.