### PR TITLE
- more NF API changes

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Absyn.mo
+++ b/OMCompiler/Compiler/FrontEnd/Absyn.mo
@@ -67,6 +67,7 @@ encapsulated package Absyn
 
 protected import Dump;
 protected import System;
+protected import Flags;
 
 public
 type Ident = String "An identifier, for example a variable name" ;
@@ -5037,17 +5038,11 @@ algorithm
 
     case (NOMOD()) then true;
 
-    // DynamicSelect returns true!
-    case (EQMOD(exp=CALL(function_ = CREF_IDENT(name = "DynamicSelect")))) then true;
-
     // search inside, some(exp)
     case (EQMOD(exp=exp))
       equation
          (_, lst::{}) = traverseExpBidir(exp, onlyLiteralsInExpEnter, onlyLiteralsInExpExit, {}::{});
-         // if list is empty (no crefs were added)
          b = listEmpty(lst);
-         // debugging:
-         // print("Crefs in annotations: (" + stringDelimitList(List.map(lst, Dump.printExpStr), ", ") + ")\n");
       then
         b;
   end match;
@@ -5070,10 +5065,7 @@ algorithm
       list<Exp> lst;
       list<list<Exp>> rest;
       String name;
-
-    // first handle DynamicSelect (push a stack that we can pop and ignore later on)
-    case (CALL(function_ = CREF_IDENT(name = "DynamicSelect")), rest)
-      then (inExp, {}::rest);
+      FunctionArgs fargs;
 
     // first handle all graphic enumerations!
     // FillPattern.*, Smooth.*, TextAlignment.*, etc!
@@ -5092,6 +5084,7 @@ algorithm
 
     // crefs, add to list
     case (CREF(), lst::rest) then (inExp,(inExp::lst)::rest);
+
     // anything else, return the same!
     else (inExp,inLst);
 
@@ -5112,7 +5105,7 @@ algorithm
       list<list<Exp>> lst;
 
     // first handle DynamicSelect; pop the stack (ignore any crefs inside DynamicSelect)
-    case (CALL(function_ = CREF_IDENT(name = "DynamicSelect")), _::lst)
+    case (CALL(function_ = CREF_IDENT(name = "DynamicSelect")), lst)
       then (inExp, lst);
 
     // anything else, return the same!

--- a/OMCompiler/Compiler/FrontEnd/Constants.mo
+++ b/OMCompiler/Compiler/FrontEnd/Constants.mo
@@ -191,12 +191,12 @@ end CoordinateSystem;
 // i.e. a coordinate system with width 20 units and height 20 units.
 
 record Icon \"Representation of the icon layer\"
-  parameter CoordinateSystem coordinateSystem(extent = {{-100, -100}, {100, 100}});
+  CoordinateSystem coordinateSystem(extent = {{-100, -100}, {100, 100}});
   //GraphicItem[:] graphics;
 end Icon;
 
 record Diagram \"Representation of the diagram layer\"
-  parameter CoordinateSystem coordinateSystem(extent = {{-100, -100}, {100, 100}});
+  CoordinateSystem coordinateSystem(extent = {{-100, -100}, {100, 100}});
   //GraphicItem[:] graphics;
 end Diagram;
 
@@ -227,9 +227,9 @@ record Transformation
 end Transformation;
 
 record Placement
-  parameter Boolean visible = true;
-  parameter Transformation transformation \"Placement in the dagram layer\";
-  parameter Transformation iconTransformation \"Placement in the icon layer\";
+  Boolean visible = true;
+  Transformation transformation \"Placement in the dagram layer\";
+  Transformation iconTransformation \"Placement in the icon layer\";
 end Placement;
 
 record IconMap

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -1468,6 +1468,8 @@ protected
         then Expression.typeOf(Expression.unbox(listHead(args)));
       case Absyn.IDENT("subSample")
         then Expression.typeOf(Expression.unbox(listHead(args)));
+      case Absyn.IDENT("DynamicSelect")
+        then Expression.typeOf(Expression.unbox(listHead(args)));
       else
         algorithm
           Error.assertion(false, getInstanceName() + ": unhandled case for " +

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -1652,6 +1652,7 @@ algorithm
     case "realClock" then evalRealClock(args);
     case "booleanClock" then evalBooleanClock(args);
     case "solverClock" then evalSolverClock(args);
+    case "DynamicSelect" then evalBuiltinDynamicSelect(fn, args, target);
     else
       algorithm
         Error.addInternalError(getInstanceName() + ": unimplemented case for " +
@@ -3028,6 +3029,23 @@ algorithm
   Error.addInternalError(evalFunc + " got invalid arguments " +
     List.toString(args, Expression.toString, "", "(", ", ", ")", true), info);
 end printWrongArgsError;
+
+function evalBuiltinDynamicSelect
+  input Function fn;
+  input list<Expression> args;
+  input EvalTarget target;
+  output Expression result;
+protected
+  Expression s, d;
+algorithm
+  {s, d} := list(Expression.unbox(arg) for arg in args);
+  s := evalExp(s, target);
+  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT) then
+    result := Expression.CALL(Call.makeTypedCall(fn, {s, d}, Variability.CONTINUOUS, Expression.typeOf(s)));
+  else
+    result := s;
+  end if;
+end evalBuiltinDynamicSelect;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFCeval;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -35,6 +35,7 @@ protected
   import Absyn;
   import List;
   import System;
+  import Flags;
 
   import Builtin = NFBuiltin;
   import BuiltinCall = NFBuiltinCall;
@@ -861,6 +862,11 @@ public
       case (INTEGER(), Type.REAL())
         then REAL(intReal(exp.value));
 
+      // Boolean can be cast to Real (only if -d=nfAPI is on)
+      // as there are annotations having expressions such as Boolean x > 0.5
+      case (BOOLEAN(), Type.REAL()) guard Flags.isSet(Flags.NF_API)
+        then REAL(if exp.value then 1.0 else 0.0);
+
       // Real doesn't need to be cast to Real, since we convert e.g. array with
       // a mix of Integers and Reals to only Reals.
       case (REAL(), Type.REAL()) then exp;
@@ -1546,7 +1552,9 @@ public
 
       case UNBOX() then "UNBOX(" + toString(exp.exp) + ")";
       case BOX() then "BOX(" + toString(exp.exp) + ")";
-      case CAST() then "CAST(" + Type.toString(exp.ty) + ", " + toString(exp.exp) + ")";
+      case CAST()
+        then
+          if Flags.isSet(Flags.NF_API) then toString(exp.exp) else "CAST(" + Type.toString(exp.ty) + ", " + toString(exp.exp) + ")";
       case SUBSCRIPTED_EXP() then toString(exp.exp) + Subscript.toStringList(exp.subscripts);
       case TUPLE_ELEMENT() then toString(exp.tupleExp) + "[" + intString(exp.index) + "]";
       case RECORD_ELEMENT() then toString(exp.recordExp) + "[field: " + exp.fieldName + "]";

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -429,12 +429,14 @@ algorithm
 
   // If the component is an array component with a binding and at least discrete variability,
   // move the binding into an equation. This avoids having to scalarize the binding.
-  if Type.isArray(ty) and Binding.isBound(binding) and var >= Variability.DISCRETE then
-    name := ComponentRef.prefixCref(comp_node, ty, {}, prefix);
-    eq := Equation.ARRAY_EQUALITY(Expression.CREF(ty, name), Binding.getTypedExp(binding), ty,
-      ElementSource.createElementSource(info));
-    sections := Sections.prependEquation(eq, sections);
-    binding := NFBinding.EMPTY_BINDING;
+  if not Flags.isSet(Flags.NF_API) then
+    if Type.isArray(ty) and Binding.isBound(binding) and var >= Variability.DISCRETE then
+      name := ComponentRef.prefixCref(comp_node, ty, {}, prefix);
+      eq := Equation.ARRAY_EQUALITY(Expression.CREF(ty, name), Binding.getTypedExp(binding), ty,
+        ElementSource.createElementSource(info));
+      sections := Sections.prependEquation(eq, sections);
+      binding := NFBinding.EMPTY_BINDING;
+    end if;
   end if;
 
   name := ComponentRef.prefixScope(comp_node, ty, {}, prefix);

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -606,6 +606,16 @@ function size "Returns dimensions of an array"
 </html>"));
 end size;
 
+function DynamicSelect<T> "select static or dynamic expressions in the annotations"
+  input T static;
+  input T dynamic;
+  output T selected;
+  external "builtin";
+  annotation(__OpenModelica_UnboxArguments=true, __OpenModelica_Impure=true, Documentation(info="<html>
+  See <a href=\"modelica://ModelicaReference.Annotations.DynamicSelect\">DynamicSelect</a>
+</html>"));
+end DynamicSelect;
+
 function scalar<T,ScalarType> "Returns a one-element array as scalar"
   input T i;
   output ScalarType s;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -153,6 +153,14 @@ algorithm
           args := list(if Expression.hasArrayCall(arg) then arg else ExpandExp.expand(arg) for arg in args);
         end if;
 
+        // HACK, TODO, FIXME! handle DynamicSelect properly in OMEdit, then disable this stuff!
+        if Flags.isSet(Flags.NF_API) and not Flags.isSet(Flags.NF_API_DYNAMIC_SELECT) then
+          if stringEq("DynamicSelect", Absyn.pathString(Function.nameConsiderBuiltin(call.fn))) then
+            callExp := simplify(listHead(args));
+            return;
+          end if;
+        end if;
+
         args := list(simplify(arg) for arg in args);
         call.arguments := args;
         builtin := Function.isBuiltin(call.fn);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -51,6 +51,7 @@ import Debug;
 import DAEExpression = Expression;
 import Error;
 import ExpressionDump;
+import Flags;
 import List;
 import Types;
 import Operator = NFOperator;
@@ -85,7 +86,7 @@ import System;
 public
 type MatchKind = enumeration(
   EXACT "Exact match",
-  CAST  "Matched by casting, e.g. Integer to real",
+  CAST  "Matched by casting, e.g. Integer to Real",
   UNKNOWN_EXPECTED "The expected type was unknown",
   UNKNOWN_ACTUAL   "The actual type was unknown",
   GENERIC "Matched with a generic type e.g. function F<T> input T i; end F; F(1)",
@@ -2162,6 +2163,22 @@ algorithm
 
     case (Type.REAL(), Type.INTEGER())
       algorithm
+        exp2 := Expression.typeCast(exp2, type1);
+      then
+        (type1, MatchKind.CAST);
+
+    // Boolean can be cast to Real (only if -d=nfAPI is on)
+    // as there are annotations having expressions such as Boolean x > 0.5
+    case (Type.BOOLEAN(), Type.REAL()) guard Flags.isSet(Flags.NF_API)
+      algorithm
+        Error.addCompilerWarning("Allowing casting of boolean expression: " + Expression.toString(exp1) + " to Real.");
+        exp1 := Expression.typeCast(exp1, type2);
+      then
+        (type2, MatchKind.CAST);
+
+    case (Type.REAL(), Type.BOOLEAN()) guard Flags.isSet(Flags.NF_API)
+      algorithm
+        Error.addCompilerWarning("Allowing casting of boolean expression: " + Expression.toString(exp2) + " to Real.");
         exp2 := Expression.typeCast(exp2, type1);
       then
         (type1, MatchKind.CAST);

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -181,7 +181,7 @@ algorithm
 
           exp := NFInst.instExp(absynExp, inst_cls, info);
           (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
-          exp := NFCeval.evalExp(exp);
+          // exp := NFCeval.evalExp(exp);
           exp := SimplifyExp.simplify(exp);
           str := Expression.toString(exp);
         then
@@ -223,13 +223,17 @@ algorithm
           dae := frontEndBack(inst_anncls, annName);
           str := DAEUtil.getVariableBindingsStr(DAEUtil.daeElements(dae));
 
-          if stringEq(annName, "Icon") or stringEq(annName, "Diagram") then
-            {Absyn.MODIFICATION(modification = SOME(Absyn.CLASSMOD(eqMod = Absyn.EQMOD(exp = absynExp))))} := graphics_mod;
-            exp := NFInst.instExp(absynExp, inst_cls, info);
-            (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
-            exp := NFCeval.evalExp(exp);
-            exp := SimplifyExp.simplify(exp);
-            str := str + ", " + Expression.toString(exp);
+          if (stringEq(annName, "Icon") or stringEq(annName, "Diagram")) and not listEmpty(graphics_mod) then
+            try
+              {Absyn.MODIFICATION(modification = SOME(Absyn.CLASSMOD(eqMod = Absyn.EQMOD(exp = absynExp))))} := graphics_mod;
+              exp := NFInst.instExp(absynExp, inst_cls, info);
+              (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
+              // exp := NFCeval.evalExp(exp);
+              exp := SimplifyExp.simplify(exp);
+              str := str + ", " + Expression.toString(exp);
+            else
+              // just don't fail!
+            end try;
           end if;
         then
           str;
@@ -357,7 +361,7 @@ algorithm
 
           exp := NFInst.instExp(absynExp, inst_cls, info);
           (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
-          exp := NFCeval.evalExp(exp);
+          // exp := NFCeval.evalExp(exp);
           exp := SimplifyExp.simplify(exp);
           str := Expression.toString(exp);
         then
@@ -441,6 +445,23 @@ algorithm
   end for;
 
 end evaluateAnnotations_dispatch;
+
+public
+function mkFullyQual
+  input Absyn.Program absynProgram;
+  input Absyn.Path classPath;
+  input Absyn.Path pathToQualify;
+  output Absyn.Path qualPath;
+protected
+  InstNode top, inst_cls, cls;
+  SCode.Program program;
+  String name;
+algorithm
+  // run the front-end front
+  (program, name, top, inst_cls) := frontEndFront(absynProgram, classPath);
+  cls := Lookup.lookupClassName(pathToQualify, inst_cls, Absyn.dummyInfo, checkAccessViolations = false);
+  qualPath := InstNode.scopePath(cls, true);
+end mkFullyQual;
 
 protected
 function frontEndFront

--- a/OMCompiler/Compiler/Script/Refactor.mo
+++ b/OMCompiler/Compiler/Script/Refactor.mo
@@ -83,7 +83,7 @@ algorithm
       Absyn.ClassDef d;
       SourceInfo file_info;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case (Absyn.CLASS(
       name = n,
@@ -126,7 +126,7 @@ protected function refactorGraphAnnInClassDef "Helper function to refactorGraphA
   input Absyn.ClassDef inDef;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ClassDef outDef;
 algorithm
   outDef := matchcontinue (inDef,inProgram,classPath,inClassEnv)
@@ -140,7 +140,7 @@ algorithm
       list<Absyn.ElementArg> args,annList,resAnnList;
       Absyn.TypeSpec ts;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
       list<String> typeVars;
       list<Absyn.NamedArg> classAttrs;
 
@@ -167,7 +167,7 @@ protected function refactorGraphAnnInClassParts "Helper function to refactorGrap
   input list<Absyn.ClassPart> inParts;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph env;
+  input Interactive.GraphicEnvCache env;
   output list<Absyn.ClassPart> outParts;
 algorithm
   outParts := match (inParts,inProgram,classPath,env)
@@ -191,7 +191,7 @@ protected function refactorGraphAnnInClassPart"Helper function to refactorGraphA
   input Absyn.ClassPart inPart;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ClassPart outPart;
 
 algorithm
@@ -205,7 +205,7 @@ algorithm
       list<Absyn.EquationItem> eqContent,resultEqContent;
       list<Absyn.AlgorithmItem> algContent,resultAlgContent;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(Absyn.PUBLIC(contents = elContent),p,cPath,env)
       equation
@@ -254,7 +254,7 @@ protected function refactorGraphAnnInContentList"Helper function to refactorGrap
   input refactorGraphAnnInContent refactorGraphAnnInItem;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output list<contentType> outList;
   public
   replaceable type contentType subtypeof Any;
@@ -262,7 +262,7 @@ protected function refactorGraphAnnInContentList"Helper function to refactorGrap
     input contentType inItem;
     input Absyn.Program inProgram;
     input Absyn.Path classPath;
-    input FCore.Graph inClassEnv;
+    input Interactive.GraphicEnvCache inClassEnv;
     output contentType outItem;
   end refactorGraphAnnInContent;
 algorithm
@@ -272,7 +272,7 @@ algorithm
       list<contentType> restList,resList;
       contentType firstItem,resultItem;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
     case({},_,_,_,_) then {};
     case(firstItem :: restList,_,p,cPath,env)
       equation
@@ -288,7 +288,7 @@ protected function refactorGraphAnnInElItem"Helper function to refactorGraphAnnI
   input Absyn.ElementItem inItem;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ElementItem outItem;
 algorithm
   outItem := match (inItem,inProgram,classPath,inClassEnv)
@@ -297,7 +297,7 @@ algorithm
       Absyn.Element el,resultElement;
       list<Absyn.ElementArg> annList;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(Absyn.ELEMENTITEM(element = el) ,p,cPath,env)
       equation
@@ -312,7 +312,7 @@ protected function refactorGraphAnnInEqItem"Helper function to refactorGraphAnnI
   input Absyn.EquationItem inItem;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.EquationItem outItem;
 
 algorithm
@@ -341,7 +341,7 @@ protected function refactorGraphAnnInAlgItem"Helper function to refactorGraphAnn
   input Absyn.AlgorithmItem inItem;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.AlgorithmItem outItem;
 algorithm
   outItem := matchcontinue (inItem,inProgram,classPath,inClassEnv)
@@ -372,7 +372,7 @@ protected function refactorGraphAnnInElement"
   input Absyn.Element inElement;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.Element outElement;
 
 algorithm
@@ -389,7 +389,7 @@ algorithm
       SourceInfo i;
       Option<Absyn.ConstrainClass> cc;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(Absyn.ELEMENT(finalPrefix = f, redeclareKeywords = rdk,
       innerOuter = io, specification = es, info = i, constrainClass = cc),p,cPath,env)
@@ -413,7 +413,7 @@ protected function refactorConstrainClass "
   input Option<Absyn.ConstrainClass> inCC;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Option<Absyn.ConstrainClass> outCC;
 
 algorithm
@@ -425,7 +425,8 @@ algorithm
       Absyn.ElementSpec es,resultSpec;
       Option<Absyn.Comment> com;
       Absyn.Path cPath;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
+
     case(SOME(Absyn.CONSTRAINCLASS(elementSpec = es, comment = com)),p,cPath,env)
 
       equation
@@ -445,7 +446,7 @@ protected function refactorGraphAnnInElSpec"
   input Absyn.ElementSpec inSpec;
   input Absyn.Program inProgram;
   input Absyn.Path classPath;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ElementSpec outSpec;
 
 algorithm
@@ -462,7 +463,7 @@ algorithm
       list<Absyn.ComponentItem> restCompList,resCompList;
       Absyn.Class cl,cl1;
       Boolean r;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
       Option<Absyn.ArrayDim> z;
 
     case(Absyn.CLASSDEF(replaceable_ = r, class_ = cl),p,cPath,_)
@@ -500,7 +501,7 @@ protected function refactorGraphAnnInComponentItem"
   input Absyn.Path classPath;
   input Absyn.Path inPath;
   input Absyn.Program inProgram;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ComponentItem outCom;
 
 algorithm
@@ -516,7 +517,7 @@ algorithm
       list<Absyn.ElementArg> annList;
       Option<String> str;
       Option<Absyn.Comment> com;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(Absyn.COMPONENTITEM(component = comp, condition = con,
       comment = SOME(Absyn.COMMENT(annotation_ = SOME(Absyn.ANNOTATION(elementArgs = annList)), comment = str))),
@@ -544,7 +545,7 @@ protected function transformComponentAnnList "
   input Absyn.Path classPath;
   input Absyn.Path inPath;
   input Absyn.Program inProgram;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output list<Absyn.ElementArg> outArgs;
 
 algorithm
@@ -562,7 +563,7 @@ algorithm
       Absyn.Each e;
       Option<String> com;
       Option<Real> rot;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
       SourceInfo info;
 
 
@@ -611,7 +612,7 @@ protected function getRestrictionFromPath"
   input Absyn.Path classPath;
   input Absyn.Path inPath;
   input Absyn.Program inProgram;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.Restriction outRestriction;
 algorithm
   outRestriction := matchcontinue(classPath,inPath,inProgram, inClassEnv)
@@ -620,7 +621,7 @@ algorithm
       Absyn.Program p;
       Absyn.Path fullPath,path,cPath;
       Absyn.Restriction restriction;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(cPath,path,p, _) // try directly first
       equation
@@ -633,7 +634,7 @@ algorithm
 
     case(_,path,p, env) // if it fails try the hard way
       equation
-        (_,fullPath) = Inst.makeFullyQualified(FCore.emptyCache(),env,path);
+        (_,fullPath) = Interactive.mkFullyQual(env,path);
     //    debug_print("getRestrictionFromPath: LookingUp:", Absyn.pathString(fullPath));
         cdef = Interactive.getPathedClassInProgram(fullPath,p);
         restriction = getRestrictionInClass(cdef);
@@ -706,7 +707,7 @@ protected function getIconTransformation"
   input Absyn.Path classPath;
   input Absyn.Path inPath;
   input Absyn.Program inProg;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ElementArg iconTrans;
 
 algorithm
@@ -720,7 +721,7 @@ algorithm
       Absyn.Path path,cPath;
       Absyn.Program p;
       Absyn.Exp x1,x2,y1,y2;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(x1,y1,x2,y2,NONE(),cPath,path,p,env)
       equation
@@ -779,7 +780,7 @@ protected function getDiagramTransformation"
   input Absyn.Path classPath;
   input Absyn.Path inPath;
   input Absyn.Program inProg;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.ElementArg trans;
 
 algorithm
@@ -793,7 +794,7 @@ algorithm
       Absyn.Path path,cPath;
       Absyn.Program p;
       Absyn.Exp x1,x2,y1,y2;
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(x1,y1,x2,y2,NONE(),cPath,path,p, env)
 
@@ -964,7 +965,7 @@ protected function getCoordsInPath"Helper function to transformComponentAnnList.
   input Absyn.Path inPath;
   input Absyn.Program inProgram;
   input Context contextToGetCoordsFrom;
-  input FCore.Graph inClassEnv;
+  input Interactive.GraphicEnvCache inClassEnv;
   output Absyn.Exp posX1;
   output Absyn.Exp posY1;
   output Absyn.Exp posX2;
@@ -982,7 +983,7 @@ algorithm
       Context context;
 
 
-      FCore.Graph env;
+      Interactive.GraphicEnvCache env;
 
     case(cPath,path,p,context, _) // try directly first
       equation
@@ -997,7 +998,7 @@ algorithm
       equation
         //  p_1 = SCodeUtil.translateAbsyn2SCode(p);
         //  (_,env) = Inst.makeEnvFromProgram(FCore.emptyCache,p_1, Absyn.IDENT(""));
-        (_,fullPath) = Inst.makeFullyQualified(FCore.emptyCache(),env,path);
+        (_, fullPath) = Interactive.mkFullyQual(env, path);
         //  print("env:\n");print(FGraph.printGraphStr(env));
         //str = Absyn.pathString(cPath);
         //print("\npath = ");

--- a/OMCompiler/Compiler/Stubs/NFApi.mo
+++ b/OMCompiler/Compiler/Stubs/NFApi.mo
@@ -51,8 +51,15 @@ function evaluateAnnotations
   input Absyn.Path classPath;
   input list<Absyn.Element> inElements;
   output list<String> outStringLst = {};
-algorithm
 end evaluateAnnotations;
+
+public
+function mkFullyQual
+  input Absyn.Program absynProgram;
+  input Absyn.Path classPath;
+  input Absyn.Path pathToQualify;
+  output Absyn.Path qualPath = pathToQualify;
+end mkFullyQual;
 
   annotation(__OpenModelica_Interface="backend");
 end NFApi;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -536,11 +536,15 @@ constant DebugFlag NF_EXPAND_OPERATIONS = DEBUG_FLAG(180, "nfExpandOperations", 
   Util.gettext("Expand all unary/binary operations to scalar expressions in the new frontend."));
 constant DebugFlag NF_API = DEBUG_FLAG(181, "nfAPI", false,
   Util.gettext("Enables experimental new instantiation use in the OMC API."));
-constant DebugFlag FMI20_DEPENDENCIES = DEBUG_FLAG(182, "disableFMIDependency", false,
+constant DebugFlag NF_API_DYNAMIC_SELECT = DEBUG_FLAG(182, "nfAPIDynamicSelect", false,
+  Util.gettext("Show DynamicSelect(static, dynamic) in annotations. Default to false and will select the first (static) expression"));
+constant DebugFlag NF_API_NOISE = DEBUG_FLAG(183, "nfAPINoise", false,
+  Util.gettext("Enables error display for the experimental new instantiation use in the OMC API."));
+constant DebugFlag FMI20_DEPENDENCIES = DEBUG_FLAG(184, "disableFMIDependency", false,
   Util.gettext("Disables the dependency analysis and generation for FMI 2.0."));
-constant DebugFlag WARNING_MINMAX_ATTRIBUTES = DEBUG_FLAG(183, "warnMinMax", true,
+constant DebugFlag WARNING_MINMAX_ATTRIBUTES = DEBUG_FLAG(185, "warnMinMax", true,
   Util.gettext("Makes a warning assert from min/max variable attributes instead of error."));
-constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG(184, "nfExpandFuncArgs", false,
+constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG(186, "nfExpandFuncArgs", false,
   Util.gettext("Expand all function arguments in the new frontend."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
@@ -730,6 +734,8 @@ constant list<DebugFlag> allDebugFlags = {
   NF_EVAL_CONST_ARG_FUNCS,
   NF_EXPAND_OPERATIONS,
   NF_API,
+  NF_API_DYNAMIC_SELECT,
+  NF_API_NOISE,
   FMI20_DEPENDENCIES,
   WARNING_MINMAX_ATTRIBUTES,
   NF_EXPAND_FUNC_ARGS

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -76,6 +76,7 @@ getDefinitions.mos \
 StateMachine.mos \
 Ticket4674.mos \
 UsesAnnotation1.mos \
+Ticket5506.mos \
 
 
 # test that currently fail. Move up when fixed.

--- a/testsuite/openmodelica/interactive-API/Ticket5506.mos
+++ b/testsuite/openmodelica/interactive-API/Ticket5506.mos
@@ -1,0 +1,24 @@
+// name: Ticket5506.mos
+// keywords: test that -d=nfAPI works fine
+// status: correct
+// cflags: -d=nfAPI
+//
+// test for ticket:5506
+//
+
+
+loadString("
+model Test
+equation
+annotation(
+    Diagram(coordinateSystem(extent = {{-120, -80}, {120, 80}})),
+    version = \"\",uses);
+end Test;");
+
+getDiagramAnnotation(Test); getErrorString();
+
+// Result:
+// true
+// {-120.0,-80.0,120.0,80.0,true,0.1,2.0,2.0}
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/interactive_api_annotations.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_annotations.mos
@@ -9125,7 +9125,9 @@ getDocumentationAnnotation(Modelica.UsersGuide.Contact); getErrorString();
 // Evaluating: getIconAnnotation(Modelica.StateGraph.Examples.Utilities.Tank)
 // {-100.0,-100.0,100.0,100.0,true,0.1,1.0,1.0,{Text(true, {0.0, 0.0}, 0, {0, 0, 255}, {0, 0, 0}, LinePattern.Solid, FillPattern.None, 0.25, {{-122, -82}, {88, -42}}, "%name", 0, {-1, -1, -1}, "", {}, TextAlignment.Center), Rectangle(true, {0.0, 0.0}, 0, {0, 0, 0}, {255, 255, 255}, LinePattern.Solid, FillPattern.Solid, 0.5, BorderPattern.None, {{-60, 60}, {80, -40}}, 0), Rectangle(true, {0.0, 0.0}, 0, {0, 0, 0}, {191, 0, 95}, LinePattern.Solid, FillPattern.HorizontalCylinder, 0.5, BorderPattern.None, {{-60, -40}, {-60, -40}}, 0)}}
 // Evaluating: getErrorString()
-// ""
+// "[Modelica 3.1/StateGraph.mo:1516:7-1518:38:writable] Warning: Component inflow1 in env: Modelica.StateGraph.Examples.Utilities.Tank has the same name as its type Modelica.StateGraph.Examples.Utilities.inflow1.
+// 	This is forbidden by Modelica specification and may lead to lookup errors.
+// "
 // Evaluating: getDiagramAnnotation(Modelica.StateGraph.Examples.Utilities.Tank)
 // {-100.0,-100.0,100.0,100.0,true,0.1,1.0,1.0}
 // Evaluating: getErrorString()


### PR DESCRIPTION
more NF API changes
- expose DynamicSelect expressions in annotations
- avoid parameter in annotation records to force scalarization, use nfAPI flag to force it
- handle DynamicSelect typing and evaluation
- support conversion from Boolean to Real (not sure if is allowed by the Modelica Spec, but is used in annotations in MSL, i.e. Boolean > 0.5)
- fix for ticket:5506, add test: testsuite/openmodelica/interactive-API/Ticket5506
- fix for ticket:5502, return just the first expression in DynamicSelect for all API if -d=nfAPIDynamicSelect flag is not given
- update testsuite/openmodelica/interactive-API/interactive_api_annotations