### PR TITLE
set datarecon uncertain var unreplaceable

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -203,6 +203,15 @@ public function varUnreplaceable "author: lochel
   output Boolean outUnreplaceable = inVar.unreplaceable;
 end varUnreplaceable;
 
+public function setVarUnreplaceable "author: arun 
+  sets the unreplaceable attribute of a variable to be false or true"
+  input BackendDAE.Var inVar;
+  input Boolean value;
+  output BackendDAE.Var outVar = inVar;
+algorithm
+  outVar.unreplaceable:= value;
+end setVarUnreplaceable;
+
 public function varStartValueFail "author: Frenkel TUD
   Returns the DAE.StartValue of a variable if there is one.
   Otherwise fail"

--- a/OMCompiler/Compiler/BackEnd/Uncertainties.mo
+++ b/OMCompiler/Compiler/BackEnd/Uncertainties.mo
@@ -438,6 +438,8 @@ algorithm
         sets_inner_equations=createInnerEquations(tempsetS,var,setS,knowns,inputvarlist);
         //sets_inner_equations={BackendDAE.INNEREQUATION(eqn = 56, vars = {48}), BackendDAE.INNEREQUATION(eqn = 3, vars = {70}), BackendDAE.INNEREQUATION(eqn = 6, vars = {77}),BackendDAE.INNEREQUATION(eqn = 23, vars = {55}), BackendDAE.INNEREQUATION(eqn = 20, vars = {42}), BackendDAE.INNEREQUATION(eqn = 50, vars = {20})};
         (outDiffVars,outResidualVars,outOtherVars,outResidualEqns,outOtherEqns)=SymbolicJacobian.prepareTornStrongComponentData(allVars,allEqs,listReverse(knowns),setC,sets_inner_equations,shared.functionTree);
+        // set uncertain variables unreplaceable attributes to be true
+        outDiffVars=BackendVariable.listVar(List.map1(listReverse(BackendVariable.varList(outDiffVars)),BackendVariable.setVarUnreplaceable,true));
         // Dump the torn systems
         /*
         BackendDump.dumpVariables(outDiffVars,"Jacobian_knownVariables");


### PR DESCRIPTION
### Purpose
This is used to set the datareconciliation uncertain variables attribute unreplaceable to true, so that we can still use the backend preOptModules module "removeSimpleEquation"