### PR TITLE
Workaround for #5404 

### DIFF
--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -1626,6 +1626,12 @@ protected function CSE1
   output BackendDAE.Shared outShared = inShared;
   output Integer outIndex;
 algorithm
+  if BackendDAEUtil.isClockedSyst(inSystem) then
+    outSystem := inSystem;
+    outIndex := inIndex;
+    return;
+  end if;
+
   (outSystem, outIndex) := matchcontinue(inSystem)
     local
       BackendDAE.Variables orderedVars;
@@ -1923,6 +1929,12 @@ protected function commonSubExpression
   output BackendDAE.EqSystem sysOut;
   output BackendDAE.Shared sharedOut;
 algorithm
+  if BackendDAEUtil.isClockedSyst(sysIn) then
+    sysOut := sysIn;
+    sharedOut := sharedIn;
+    return;
+  end if;
+
   (sysOut, sharedOut) := matchcontinue(sysIn, sharedIn)
     local
     DAE.FunctionTree functionTree;

--- a/testsuite/simulation/modelica/synchronous/Bug5404.mos
+++ b/testsuite/simulation/modelica/synchronous/Bug5404.mos
@@ -1,0 +1,29 @@
+// name:     Bug5404
+// keywords: synchronous features
+// status: correct
+//
+
+loadString("
+model Bug5404
+  Real x, y;
+equation
+  when Clock(0.1) then
+    x + y = 0;
+    x - y = 0;
+  end when;
+end Bug5404;
+"); getErrorString();
+simulate(Bug5404); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Bug5404_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Bug5404', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/synchronous/Makefile
+++ b/testsuite/simulation/modelica/synchronous/Makefile
@@ -17,6 +17,7 @@ Modelica_Synchronous.Examples.Elementary.IntegerSignals.TimeBasedStep.mos \
 Modelica_Synchronous.Examples.SimpleControlledDrive.ClockedWithDiscreteTextbookController.mos \
 DID.mos \
 TestClockParameterEvaluation.mos \
+Bug5404.mos
 
 
 # test that currently fail. Move up when fixed.


### PR DESCRIPTION
Skip clocked equation systems in CommonSubExpression.mo.

Workaround for [#5404 ](https://trac.openmodelica.org/OpenModelica/ticket/5404)