### PR TITLE
[NF] Avoid evaluating external functions.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -373,9 +373,13 @@ uniontype Call
       ty := getSpecialReturnType(func, args);
     end if;
 
-    // Functions that return a discrete type, e.g. Integer, should probably be
-    // treated as implicitly discrete if the arguments are continuous.
-    if Type.isDiscrete(ty) and var == Variability.CONTINUOUS then
+    if var == Variability.PARAMETER and Function.isExternal(func) then
+      // Mark external functions with parameter expressions as non-structural,
+      // to avoid them being marked as structural unnecessarily.
+      var := Variability.NON_STRUCTURAL_PARAMETER;
+    elseif Type.isDiscrete(ty) and var == Variability.CONTINUOUS then
+      // Functions that return a discrete type, e.g. Integer, should probably be
+      // treated as implicitly discrete if the arguments are continuous.
       var := Variability.IMPLICITLY_DISCRETE;
     end if;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -855,6 +855,10 @@ algorithm
              Binding.isCrefExp(binding) then
             attrs.variability := bind_var;
             c.attributes := attrs;
+          elseif bind_var == Variability.NON_STRUCTURAL_PARAMETER and
+                 comp_var == Variability.PARAMETER then
+            attrs.variability := bind_var;
+            c.attributes := attrs;
           end if;
         else
           if Binding.isBound(c.condition) then


### PR DESCRIPTION
- Mark external function calls as non-structural, to avoid expressions
  containing such calls from being marked as structural when its not
  strictly necessary.