### PR TITLE
fix MSVC build

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/read_csv.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_csv.c
@@ -107,10 +107,18 @@ int read_csv_dataset_size(const char* filename)
   unsigned char delim = CSV_COMMA;
 #if defined(__MINGW32__) || defined(_MSC_VER)
   int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+#if defined(_MSC_VER)
+  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
+#else /* mingw supports array definition with sizes from the stack */
   wchar_t unicodeFilename[unicodeFilenameLength];
+#endif
   MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
 
   f = _wfopen(unicodeFilename, L"r");
+#if defined(_MSC_VER)
+  if (unicodeFilename) { free(unicodeFilename); }
+#endif
+
 #else
   f = fopen(filename,"r");
 #endif
@@ -228,10 +236,18 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   struct csv_body body = {0};
 #if defined(__MINGW32__) || defined(_MSC_VER)
   int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+#if defined(_MSC_VER)
+  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
+#else /* mingw supports array definition with sizes from the stack */
   wchar_t unicodeFilename[unicodeFilenameLength];
+#endif
   MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
 
   FILE *fin = _wfopen(unicodeFilename, L"r");
+#if defined(_MSC_VER)
+  if (unicodeFilename) { free(unicodeFilename); }
+#endif
+
 #else
   FILE *fin = fopen(filename, "r");
 #endif
@@ -284,10 +300,19 @@ struct csv_data* read_csv(const char *filename)
   unsigned char delim = CSV_COMMA;
 #if defined(__MINGW32__) || defined(_MSC_VER)
   int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+
+#if defined(_MSC_VER)
+  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
+#else /* mingw supports array definition with sizes from the stack */
   wchar_t unicodeFilename[unicodeFilenameLength];
+#endif
   MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
 
   FILE *fin = _wfopen(unicodeFilename, L"r");
+#if defined(_MSC_VER)
+  if (unicodeFilename) { free(unicodeFilename); }
+#endif
+
 #else
   FILE *fin = fopen(filename, "r");
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -231,10 +231,18 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
   memset(reader, 0, sizeof(ModelicaMatReader));
 #if defined(__MINGW32__) || defined(_MSC_VER)
   int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+#if defined(_MSC_VER)
+  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
+#else /* mingw supports array definition with sizes from the stack */
   wchar_t unicodeFilename[unicodeFilenameLength];
+#endif
   MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
 
   reader->file = _wfopen(unicodeFilename, L"rb");
+#if defined(_MSC_VER)
+  if (unicodeFilename) { free(unicodeFilename); }
+#endif
+
 #else
   reader->file = fopen(filename, "rb");
 #endif


### PR DESCRIPTION
- handle MSVC that doesn't know how to handle array declarations with sizes set by local variables on the stack