### PR TITLE
ISSUE-5503: Focus set proper when changing the shape that we are drawing

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/MainWindow.cpp
@@ -2676,6 +2676,7 @@ void MainWindow::openAboutOMEdit()
 
 void MainWindow::toggleShapesButton()
 {
+  setFocus();
   QAction *clickedAction = qobject_cast<QAction*>(const_cast<QObject*>(sender()));
   QList<QAction*> shapeActions = mpShapesActionGroup->actions();
   foreach (QAction *shapeAction, shapeActions) {

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -2914,6 +2914,10 @@ void GraphicsView::focusOutEvent(QFocusEvent *event)
   if (QApplication::overrideCursor() && QApplication::overrideCursor()->shape() == Qt::CrossCursor) {
     QApplication::restoreOverrideCursor();
   }
+  /*If we get a focus out event while drawing. Stop drawing.*/
+  if (isCreatingShape()) {
+    finishDrawingGenericShape();
+  }
   QGraphicsView::focusOutEvent(event);
 }
 


### PR DESCRIPTION
Short solution for ticket 5503 

We will just finnish the drawing operation if the user decides to click around on other shapes while drawing