### PR TITLE
ISSUE-5507: Prevents OMEdit from crashing when parsing textAnnotations

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
@@ -159,7 +159,7 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
   FilledShape::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Text.
   QStringList list = StringHandler::getStrings(annotation);
-  if (list.size() < 12) {
+  if (list.size() < 15) {
     return;
   }
   // 9th item of the list contains the extent points


### PR DESCRIPTION
New indexing operations were added in 53f0fcbc8aa1ab13cd05be2c26c83ec0e2794ec3  however the function guard was not changed. Causing crashes in some cases. 

This will prevent OMEdit from crashing and resolves #5507. Still I think there is somewere else in OMEdit were I need to populate that list with more information

After some testing it seems that these lists are different so having a guard might not be good. See this PL as a request for comments. An alternative would be to not index things in the list which we do not have and remove the guard. The real solution I guess would be to rewrite the option dialog for text annotation so that it matches the changes introduced by  53f0fcbc8aa1ab13cd05be2c26c83ec0e2794ec3  