### PR TITLE
Use a mutex for nodes that share docker volumes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -537,7 +537,14 @@ void makeLibsAndCache(libs='core') {
   sh "find libraries"
   sh "ln -s '${env.LIBRARIES}/svn' '${env.LIBRARIES}/git' libraries/"
   generateTemplates()
-  sh "make -j${numLogicalCPU()} --output-sync omlibrary-${libs} ReferenceFiles"
+  def cmd = "make -j${numLogicalCPU()} --output-sync omlibrary-${libs} ReferenceFiles"
+  if (env.SHARED_LOCK) {
+    lock(env.SHARED_LOCK) {
+      sh cmd
+    }
+  } else {
+    sh cmd
+  }
 }
 
 void buildOMC(CC, CXX, extraFlags) {


### PR DESCRIPTION
This avoids problems when checking out git repositories that are
cached using docker volumes.