### PR TITLE
Use the macros for unicode to utf-8 and back conversions

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.h
+++ b/OMCompiler/Compiler/runtime/systemimpl.h
@@ -87,10 +87,6 @@ extern int SystemImpl__setCXXCompiler(const char *str);
 extern int SystemImpl__setLinker(const char *str);
 extern int SystemImpl__setCFlags(const char *str);
 extern int SystemImpl__setLDFlags(const char *str);
-#if defined(__MINGW32__) || defined(_MSC_VER)
-extern int SystemImpl__stringToUnicodeSize(const char* str);
-extern int SystemImpl__stringToUnicode(const char* str, wchar_t* unicode, int size);
-#endif
 extern char* SystemImpl__pwd(void);
 extern int SystemImpl__regularFileExists(const char* str);
 extern int SystemImpl__removeFile(const char* filename);

--- a/OMCompiler/Parser/parse.c
+++ b/OMCompiler/Parser/parse.c
@@ -45,6 +45,7 @@
 
 #include "errorext.h"
 #include "systemimpl.h"
+#include "omc_file.h"
 
 pthread_once_t parser_once_create_key = PTHREAD_ONCE_INIT;
 pthread_key_t modelicaParserKey;
@@ -434,16 +435,11 @@ static void* parseFile(const char* fileName, const char* infoName, int flags, co
    * So we pass an empty string instead :)
    */
 #if defined(__MINGW32__) || defined(_MSC_VER)
-  int unicodeFileNameLength = SystemImpl__stringToUnicodeSize(fileName);
-  wchar_t unicodeFileName[unicodeFileNameLength];
-  SystemImpl__stringToUnicode(fileName, unicodeFileName, unicodeFileNameLength);
-
   struct _stat st;
-  _wstat(unicodeFileName, &st);
 #else
   struct stat st;
-  stat(members.filename_C, &st);
 #endif
+  omc_stat(members.filename_C, &st);
   members.timestamp = mmc_mk_rcon((double)st.st_mtime);
   if (0 == st.st_size) return parseString("",members.filename_C,ModelicaParser_flags, langStd, runningTestsuite);
 

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -107,6 +107,7 @@ RUNTIMEUTIL_HEADERS = \
 ./util/modelica.h \
 ./util/modelica_string.h \
 ./util/omc_error.h \
+./util/omc_file.h \
 ./util/omc_mmap.h \
 ./util/omc_msvc.h \
 ./util/omc_spinlock.h \

--- a/OMCompiler/SimulationRuntime/c/Makefile.objs
+++ b/OMCompiler/SimulationRuntime/c/Makefile.objs
@@ -28,8 +28,8 @@ else
 UTIL_OBJS_NO_FMI=
 endif
 
-UTIL_OBJS_MINIMAL=base_array$(OBJ_EXT) boolean_array$(OBJ_EXT) omc_error$(OBJ_EXT) division$(OBJ_EXT) generic_array$(OBJ_EXT) index_spec$(OBJ_EXT) integer_array$(OBJ_EXT) list$(OBJ_EXT) modelica_string$(OBJ_EXT) real_array$(OBJ_EXT) ringbuffer$(OBJ_EXT) string_array$(OBJ_EXT) utility$(OBJ_EXT) varinfo$(OBJ_EXT) ModelicaUtilities$(OBJ_EXT) omc_msvc$(OBJ_EXT) simulation_options$(OBJ_EXT) rational$(OBJ_EXT) modelica_string_lit$(OBJ_EXT) omc_init$(OBJ_EXT) omc_mmap$(OBJ_EXT) $(UTIL_OBJS_NO_FMI)
-UTIL_HFILES_MINIMAL=base_array.h boolean_array.h division.h generic_array.h omc_error.h index_spec.h integer_array.h list.h modelica.h modelica_string.h read_write.h real_array.h ringbuffer.h rtclock.h string_array.h utility.h varinfo.h simulation_options.h omc_mmap.h modelica_string_lit.h omc_init.h
+UTIL_OBJS_MINIMAL=base_array$(OBJ_EXT) boolean_array$(OBJ_EXT) omc_error$(OBJ_EXT) omc_file$(OBJ_EXT) division$(OBJ_EXT) generic_array$(OBJ_EXT) index_spec$(OBJ_EXT) integer_array$(OBJ_EXT) list$(OBJ_EXT) modelica_string$(OBJ_EXT) real_array$(OBJ_EXT) ringbuffer$(OBJ_EXT) string_array$(OBJ_EXT) utility$(OBJ_EXT) varinfo$(OBJ_EXT) ModelicaUtilities$(OBJ_EXT) omc_msvc$(OBJ_EXT) simulation_options$(OBJ_EXT) rational$(OBJ_EXT) modelica_string_lit$(OBJ_EXT) omc_init$(OBJ_EXT) omc_mmap$(OBJ_EXT) $(UTIL_OBJS_NO_FMI)
+UTIL_HFILES_MINIMAL=base_array.h boolean_array.h division.h generic_array.h omc_error.h omc_file.h index_spec.h integer_array.h list.h modelica.h modelica_string.h read_write.h real_array.h ringbuffer.h rtclock.h string_array.h utility.h varinfo.h simulation_options.h omc_mmap.h modelica_string_lit.h omc_init.h
 
 ifeq ($(OMC_MINIMAL_RUNTIME),)
 UTIL_OBJS=$(UTIL_OBJS_MINIMAL) java_interface$(OBJ_EXT) libcsv$(OBJ_EXT) read_csv$(OBJ_EXT) OldModelicaTables$(OBJ_EXT) tinymt64$(OBJ_EXT) write_csv$(OBJ_EXT) rtclock$(OBJ_EXT)

--- a/OMCompiler/SimulationRuntime/c/gc/omc_gc.c
+++ b/OMCompiler/SimulationRuntime/c/gc/omc_gc.c
@@ -40,6 +40,7 @@
 #include "../omc_simulation_settings.h"
 #include "omc_gc.h"
 #include "../util/omc_error.h"
+#include "../util/omc_file.h"
 #include "../util/omc_init.h"
 
 static mmc_GC_state_type x_mmc_GC_state = {0};
@@ -67,7 +68,7 @@ static void print_words()
   pid_t pid = getpid();
   char str[50];
   sprintf(str, "omc-memory.%d.txt", pid);
-  FILE *fout = fopen(str, "w");
+  FILE *fout = omc_fopen(str, "w");
   HASH_ITER(hh, table, entry, tmp) {
     fprintf(fout, "%ld: %s\n", (long) entry->count, entry->pos);
   }

--- a/OMCompiler/SimulationRuntime/c/linearization/linearize.cpp
+++ b/OMCompiler/SimulationRuntime/c/linearization/linearize.cpp
@@ -29,6 +29,7 @@
  */
 
 #include "util/omc_error.h"
+#include "util/omc_file.h"
 #include "simulation_data.h"
 #include "openmodelica_func.h"
 #include "simulation/solver/external_input.h"
@@ -604,8 +605,7 @@ int linearize(DATA* data, threadData_t *threadData)
     }
 #endif
 
-
-    FILE *fout = fopen(filename.c_str(),"wb");
+    FILE *fout = omc_fopen(filename.c_str(),"wb");
     assertStreamPrint(threadData,0!=fout,"Cannot open File %s",filename.c_str());
     if(do_data_recovery > 0){
         fprintf(fout, data->callback->linear_model_datarecovery_frame(), strX.c_str(), strU.c_str(), strZ0.c_str(), strA.c_str(), strB.c_str(), strC.c_str(), strD.c_str(), strCz.c_str(), strDz.c_str());

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/DebugeOptimization.c
@@ -33,6 +33,7 @@
 
 #include "../OptimizerData.h"
 #include "../OptimizerLocalFunction.h"
+#include "../../util/omc_file.h"
 
 
 /*!
@@ -58,7 +59,7 @@ void debugeSteps(OptData * optData, modelica_real*vopt, modelica_real * lambda){
   double tmp;
 
   sprintf(buffer, "%s_%d.csv", optData->ipop.csvOstep,optData->dim.iter);
-  pFile = fopen(buffer, "wt");
+  pFile = omc_fopen(buffer, "wt");
 
   fprintf(pFile, "%s", "\"time\"");
   for(i = 0; i < nx; ++i){
@@ -127,7 +128,7 @@ void debugeJac(OptData * optData, Number* vopt){
 
   sJ = optData->s.JderCon;
   sprintf(buffer, "jac_ana_step_%i.csv", optData->iter_);
-  pFile = fopen(buffer, "wt");
+  pFile = omc_fopen(buffer, "wt");
 
   fprintf(pFile,"name;time;");
   for(j = 0; j < nx; ++j)
@@ -191,8 +192,8 @@ void debugeJac(OptData * optData, Number* vopt){
 
   optData->index = 1;
 #undef DF_STEP
- sprintf(buffer, "jac_num_step_%i.csv", optData->iter_);
-  pFile = fopen(buffer, "wt");
+  sprintf(buffer, "jac_num_step_%i.csv", optData->iter_);
+  pFile = omc_fopen(buffer, "wt");
 
   fprintf(pFile,"name;time;");
   for(j = 0; j < nx; ++j)
@@ -218,7 +219,7 @@ void debugeJac(OptData * optData, Number* vopt){
   optData2ModelData(optData, vopt, optData->index);
 
   if(optData->iter_ < 2){
-    pFile = fopen("omc_check_jac.py", "wt");
+    pFile = omc_fopen("omc_check_jac.py", "wt");
     fprintf(pFile,"\"\"\"\nautomatically generated code for analyse derivatives\n\n");
     fprintf(pFile,"  Input i:\n");
     for(j = 0; j < nx; ++j)

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/InitialGuess.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/InitialGuess.c
@@ -34,6 +34,8 @@
 #include "../OptimizerData.h"
 #include "../OptimizerLocalFunction.h"
 
+#include "../../util/omc_file.h"
+
 #include "simulation/solver/dassl.h"
 #include "simulation/options.h"
 #include "simulation/results/simulation_result.h"
@@ -62,8 +64,8 @@ inline void initial_guess_optimizer(OptData *optData, SOLVER_INFO* solverInfo){
   optData->ipop.csvOstep = (char*)(omc_flagValue[FLAG_CSV_OSTEP]);
   optData->ipop.debugeJ = (char*)omc_flagValue[FLAG_OPTDEBUGEJAC];
 
+  optData->pFile = omc_fopen("optimizeInput.csv", "wt");
 
-  optData->pFile = fopen("optimizeInput.csv", "wt");
   fprintf(optData->pFile, "%s ", "time");
   for(i=0; i < nu; ++i){
     sprintf(buffer, "%s", optData->dim.inputName[i]);

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
@@ -39,6 +39,7 @@
 #include "../../simulation/results/simulation_result.h"
 #include "../../simulation/options.h"
 #include "../../simulation/solver/model_help.h"
+#include "../../util/omc_file.h"
 
 static inline void pickUpDim(OptDataDim * dim, DATA* data, OptDataTime * time);
 static inline void pickUpTime(OptDataTime * time, OptDataDim * dim, DATA* data, const double preSimTime);
@@ -248,7 +249,7 @@ static int getNsi(char*filename, const int nsi, modelica_boolean * exTimeGrid){
   FILE * pFile = NULL;
 
   *exTimeGrid = 0;
-  pFile = fopen(filename,"r");
+  pFile = omc_fopen(filename,"r");
   if(pFile == NULL){
     warningStreamPrint(LOG_STDOUT, 0, "OMC can't find the file %s.", filename);
     fclose(pFile);
@@ -275,7 +276,7 @@ static inline void overwriteTimeGridFile(OptDataTime * time, char* filename, lon
   const int np1 = np - 1;
   double t;
   FILE * pFile = NULL;
-  pFile = fopen(filename,"r");
+  pFile = omc_fopen(filename,"r");
 
   fscanf(pFile, "%lf", &t);
   time->t0 = t;
@@ -923,7 +924,8 @@ static inline void pickUpStates(OptData* optData){
 
   if(cflags){
     FILE * pFile = NULL;
-    pFile = fopen(cflags,"r");
+    pFile = omc_fopen(cflags,"r");
+
     if(pFile == NULL){
       warningStreamPrint(LOG_STDOUT, 0, "OMC can't find the file %s.",cflags);
     }else{

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_csv.cpp
@@ -39,6 +39,7 @@
  */
 
 #include "util/omc_error.h"
+#include "util/omc_file.h"
 #include "simulation_result_csv.h"
 #include "util/rtclock.h"
 
@@ -117,7 +118,7 @@ void omc_csv_init(simulation_result *self, DATA *data, threadData_t *threadData)
   const MODEL_DATA *mData = data->modelData;
 
   const char* format = ",\"%s\"";
-  FILE *fout = fopen(self->filename, "w");
+  FILE *fout = omc_fopen(self->filename, "w");
 
   assertStreamPrint(threadData, 0!=fout, "Error, couldn't create output file: [%s] because of %s", self->filename, strerror(errno));
 

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_mat4.cpp
@@ -30,6 +30,7 @@
 
 #include "MatVer4.h"
 #include "util/omc_error.h"
+#include "util/omc_file.h"
 #include "util/rtclock.h"
 #include "simulation/options.h"
 #include "simulation_result_mat4.h"
@@ -78,7 +79,7 @@ void mat4_init4(simulation_result *self, DATA *data, threadData_t *threadData)
 
   matData->type = omc_flag[FLAG_SINGLE_PRECISION] ? MatVer4Type_SINGLE : MatVer4Type_DOUBLE;
 
-  matData->pFile = fopen(self->filename, "wb+");
+  matData->pFile = omc_fopen(self->filename, "wb+");
   if (!matData->pFile)
   {
     throwStreamPrint(threadData, "Cannot open file %s for writing", self->filename);

--- a/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_plt.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/simulation_result_plt.cpp
@@ -39,6 +39,7 @@
  */
 
 #include "util/omc_error.h"
+#include "util/omc_file.h"
 #include "simulation_result_plt.h"
 #include "util/rtclock.h"
 
@@ -246,7 +247,7 @@ void plt_free(simulation_result *self,DATA *data, threadData_t *threadData)
 
   rt_tick(SIM_TIMER_OUTPUT);
 
-  f = fopen(self->filename, "w");
+  f = omc_fopen(self->filename, "w");
   if(!f)
   {
     deallocResult(pltData);

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -42,6 +42,7 @@
 #include "simulation_runtime.h"
 #include "options.h"
 #include "../util/omc_error.h"
+#include "../util/omc_file.h"
 #include "../meta/meta_modelica.h"
 #include "../util/modelica_string.h"
 
@@ -456,7 +457,7 @@ void read_input_xml(MODEL_DATA* modelData,
     }
 
     /* open the file and fail on error. we open it read-write to be sure other processes can overwrite it */
-    file = fopen(filename, "r");
+    file = omc_fopen(filename, "r");
     if(!file) {
       throwStreamPrint(NULL, "simulation_input_xml.c: Error: can not read file %s as setup file to the generated simulation code.",filename);
     }

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -60,6 +60,7 @@
 #endif
 
 #include "util/omc_error.h"
+#include "util/omc_file.h"
 #include "simulation_data.h"
 #include "openmodelica_func.h"
 #include "meta/meta_modelica.h"
@@ -1014,26 +1015,39 @@ void communicateMsg(char id, unsigned int size, const char *data)
 
 int _main_SimulationRuntime(int argc, char**argv, DATA *data, threadData_t *threadData)
 {
-  int retVal = -1;
-  MMC_TRY_INTERNAL(globalJumpBuffer)
-    if (initRuntimeAndSimulation(argc, argv, data, threadData)) //initRuntimeAndSimulation returns 1 if an error occurs
-      return 1;
-
-    /* sighandler_t oldhandler = different type on all platforms... */
-#ifdef SIGUSR1
-    SimulationRuntime_printStatus_data = data; /* Global, but at least we get something back; doesn't matter which simulation run */
-    signal(SIGUSR1, SimulationRuntime_printStatus);
+#if defined(__MINGW32__) || defined(_MSC_VER)
+  /* Support for non-ASCII characters
+   * Read the unicode command line arguments and replace the normal arguments with it.
+   */
+  wchar_t** wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
+  for (int i = 0; i < argc; i++) {
+    WIDECHAR_TO_MULTIBYTE_LENGTH(wargv[i], len);
+    WIDECHAR_TO_MULTIBYTE_VAR(wargv[i], buf, len);
+    strcpy(argv[i], buf);
+    MULTIBYTE_OR_WIDECHAR_VAR_FREE(buf);
+  }
 #endif
 
-    retVal = startNonInteractiveSimulation(argc, argv, data, threadData);
+  int retVal = -1;
+  MMC_TRY_INTERNAL(globalJumpBuffer)
+  if (initRuntimeAndSimulation(argc, argv, data, threadData)) //initRuntimeAndSimulation returns 1 if an error occurs
+    return 1;
 
-    freeMixedSystems(data, threadData);        /* free mixed system data */
-    freeLinearSystems(data, threadData);       /* free linear system data */
-    freeNonlinearSystems(data, threadData);    /* free nonlinear system data */
+  /* sighandler_t oldhandler = different type on all platforms... */
+#ifdef SIGUSR1
+  SimulationRuntime_printStatus_data = data; /* Global, but at least we get something back; doesn't matter which simulation run */
+  signal(SIGUSR1, SimulationRuntime_printStatus);
+#endif
 
-    data->callback->callExternalObjectDestructors(data, threadData);
-    deInitializeDataStruc(data);
-    fflush(NULL);
+  retVal = startNonInteractiveSimulation(argc, argv, data, threadData);
+
+  freeMixedSystems(data, threadData);        /* free mixed system data */
+  freeLinearSystems(data, threadData);       /* free linear system data */
+  freeNonlinearSystems(data, threadData);    /* free nonlinear system data */
+
+  data->callback->callExternalObjectDestructors(data, threadData);
+  deInitializeDataStruc(data);
+  fflush(NULL);
   MMC_CATCH_INTERNAL(globalJumpBuffer)
 
 #ifndef NO_INTERACTIVE_DEPENDENCY

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
@@ -36,6 +36,7 @@
 #include "simulation_data.h"
 
 #include "util/omc_error.h"
+#include "util/omc_file.h"
 #include "gc/omc_gc.h"
 #include "util/read_csv.h"
 #include "util/libcsv.h"
@@ -62,11 +63,11 @@ int externalInputallocate(DATA* data)
     cflags = (char*)omc_flagValue[FLAG_INPUT_FILE];
     useLibCsvH = 0;
     if(cflags){
-      pFile = fopen(cflags,"r");
+      pFile = omc_fopen(cflags,"r");
       if(pFile == NULL)
         warningStreamPrint(LOG_STDOUT, 0, "OMC can't find the file %s.",cflags);
     }else{
-      pFile = fopen("externalInput.csv","r");
+      pFile = omc_fopen("externalInput.csv","r");
     }
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -34,6 +34,7 @@
 #include "initialization.h"
 
 #include "../../../util/omc_error.h"
+#include "../../../util/omc_file.h"
 #include "../../../openmodelica.h"
 #include "../../../openmodelica_func.h"
 #include "../../../simulation/options.h"
@@ -275,7 +276,7 @@ static int symbolic_initialization(DATA *data, threadData_t *threadData)
     {
       sprintf(buffer, "%s_equidistant_global_homotopy.csv", mData->modelFilePrefix);
       infoStreamPrint(LOG_INIT, 0, "The homotopy path will be exported to %s.", buffer);
-      pFile = fopen(buffer, "wt");
+      pFile = omc_fopen(buffer, "wt");
       fprintf(pFile, "\"sep=%s\"\n%s", sep, "\"lambda\"");
       for(i=0; i<mData->nVariablesReal; ++i)
         fprintf(pFile, "%s\"%s\"", sep, mData->realVarsData[i].info.name);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -45,6 +45,7 @@
 #include "../options.h"
 #include "../simulation_info_json.h"
 #include "../../util/omc_error.h"
+#include "../../util/omc_file.h"
 #include "../../util/varinfo.h"
 #include "model_help.h"
 #include "../../meta/meta_modelica.h"
@@ -1675,7 +1676,7 @@ static int homotopyAlgorithm(DATA_HOMOTOPY* solverData, double *x)
     {
       sprintf(buffer, "%s_nonlinsys%d_adaptive_%s_homotopy_%s.csv", solverData->data->modelData->modelFilePrefix, solverData->sysNumber, solverData->data->callback->useHomotopy == 2 ? "global" : "local", solverData->startDirection > 0 ? "pos" : "neg");
       infoStreamPrint(LOG_INIT, 0, "The homotopy path will be exported to %s.", buffer);
-      pFile = fopen(buffer, "wt");
+      pFile = omc_fopen(buffer, "wt");
       fprintf(pFile, "\"sep=%s\"\n%s", sep, "\"lambda\"");
       for(i=0; i<n; ++i)
         fprintf(pFile, "%s\"%s\"", sep, modelInfoGetEquation(&solverData->data->modelData->modelDataXml,solverData->eqSystemNumber).vars[i]);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -36,6 +36,7 @@
 
 #include "../../util/simulation_options.h"
 #include "../../util/omc_error.h"
+#include "../../util/omc_file.h"
 #include "nonlinearSystem.h"
 #include "nonlinearValuesList.h"
 #if !defined(OMC_MINIMAL_RUNTIME)
@@ -1076,7 +1077,7 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
     {
       sprintf(buffer, "%s_nonlinsys%d_equidistant_local_homotopy.csv", data->modelData->modelFilePrefix, sysNumber);
       infoStreamPrint(LOG_INIT, 0, "The homotopy path of system %d will be exported to %s.", sysNumber, buffer);
-      pFile = fopen(buffer, "wt");
+      pFile = omc_fopen(buffer, "wt");
       fprintf(pFile, "\"sep=%s\"\n%s", sep, "\"lambda\"");
       for(j=0; j<nonlinsys->size; ++j)
         fprintf(pFile, "%s\"%s\"", sep, modelInfoGetEquation(&data->modelData->modelDataXml, nonlinsys->equationIndex).vars[j]);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -42,6 +42,7 @@
 #include "dae_mode.h"
 
 #include "../../util/omc_error.h"
+#include "../../util/omc_file.h"
 #include "external_input.h"
 #include "../options.h"
 #include <math.h>
@@ -186,13 +187,13 @@ static void fmtInit(DATA* data, MEASURE_TIME* mt)
     char* filename = (char*) malloc((len+15) * sizeof(char));
     strncpy(filename,fullFileName,len);
     strncpy(&filename[len],"_prof.realdata",15);
-    mt->fmtReal = fopen(filename, "wb");
+    mt->fmtReal = omc_fopen(filename, "wb");
     if(!mt->fmtReal)
     {
       warningStreamPrint(LOG_STDOUT, 0, "Time measurements output file %s could not be opened: %s", filename, strerror(errno));
     }
     strncpy(&filename[len],"_prof.intdata",14);
-    mt->fmtInt = fopen(filename, "wb");
+    mt->fmtInt = omc_fopen(filename, "wb");
     if(!mt->fmtInt)
     {
       warningStreamPrint(LOG_STDOUT, 0, "Time measurements output file %s could not be opened: %s", filename, strerror(errno));

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -1,0 +1,94 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "omc_file.h"
+
+FILE* omc_fopen(const char *filename, const char *mode)
+{
+#if defined(__MINGW32__) || defined(_MSC_VER)
+  MULTIBYTE_TO_WIDECHAR_LENGTH(filename, unicodeFilenameLength);
+  MULTIBYTE_TO_WIDECHAR_VAR(filename, unicodeFilename, unicodeFilenameLength);
+
+  MULTIBYTE_TO_WIDECHAR_LENGTH(mode, unicodeModeLength);
+  MULTIBYTE_TO_WIDECHAR_VAR(mode, unicodeMode, unicodeModeLength);
+
+  FILE *f = _wfopen(unicodeFilename, unicodeMode);
+
+  MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodeFilename);
+  MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodeMode);
+#else /* unix */
+  FILE *f = fopen(filename, mode);
+#endif
+  return f;
+}
+
+#if defined(__MINGW32__) || defined(_MSC_VER)
+int omc_stat(const char *filename, struct _stat *statbuf)
+{
+  MULTIBYTE_TO_WIDECHAR_LENGTH(filename, unicodeFilenameLength);
+  MULTIBYTE_TO_WIDECHAR_VAR(filename, unicodeFilename, unicodeFilenameLength);
+
+  int res;
+  res = _wstat(unicodeFilename, statbuf);
+
+  MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodeFilename);
+
+  return res;
+}
+#else /* unix */
+int omc_stat(const char *filename, struct stat *statbuf)
+{
+  int res;
+  res = stat(filename, statbuf);
+  return res;
+}
+#endif
+
+int omc_unlink(const char *filename)
+{
+#if defined(__MINGW32__) || defined(_MSC_VER)
+  MULTIBYTE_TO_WIDECHAR_LENGTH(filename, unicodeFilenameLength);
+  MULTIBYTE_TO_WIDECHAR_VAR(filename, unicodeFilename, unicodeFilenameLength);
+  int result = _wunlink(unicodeFilename);
+  MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodeFilename);
+  return result;
+#else /* unix */
+  return unlink(filename);
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.h
@@ -1,0 +1,102 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef __OPENMODELICA_FILE_H
+#define __OPENMODELICA_FILE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#if defined(__MINGW32__) || defined(_MSC_VER)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#if defined(__MINGW32__) || defined(_MSC_VER)
+#ifndef MULTIBYTE_TO_WIDECHAR_LENGTH
+#define MULTIBYTE_TO_WIDECHAR_LENGTH(string, unicodeLength) int unicodeLength = MultiByteToWideChar(CP_UTF8, 0, string, -1, NULL, 0)
+#endif
+
+#ifndef WIDECHAR_TO_MULTIBYTE_LENGTH
+#define WIDECHAR_TO_MULTIBYTE_LENGTH(unicode, stringLength) int stringLength = WideCharToMultiByte(CP_UTF8, 0, unicode, -1, NULL, 0, NULL, NULL)
+#endif
+
+#if defined(_MSC_VER)
+
+#ifndef MULTIBYTE_TO_WIDECHAR_VAR
+#define MULTIBYTE_TO_WIDECHAR_VAR(string, unicodeString, unicodeLength) wchar_t *unicodeString = (wchar_t)malloc(unicodeLength*sizeof(wchar_t)); MultiByteToWideChar(CP_UTF8, 0, string, -1, unicodeString, unicodeLength)
+#endif
+
+#ifndef WIDECHAR_TO_MULTIBYTE_VAR
+#define WIDECHAR_TO_MULTIBYTE_VAR(unicode, string, stringLength) char *string = (char)malloc(stringLength*sizeof(char)); WideCharToMultiByte(CP_UTF8, 0, unicode, -1, string, stringLength, NULL, NULL)
+#endif
+
+#ifndef MULTIBYTE_OR_WIDECHAR_VAR_FREE
+#define MULTIBYTE_TO_WIDECHAR_VAR_FREE(unicodeString) if (unicodeString) { free(unicodeString); }
+#endif
+
+#else /* mingw */
+
+#ifndef MULTIBYTE_TO_WIDECHAR_VAR
+#define MULTIBYTE_TO_WIDECHAR_VAR(string, unicodeString, unicodeLength) wchar_t unicodeString[unicodeLength]; MultiByteToWideChar(CP_UTF8, 0, string, -1, unicodeString, unicodeLength)
+#endif
+
+#ifndef WIDECHAR_TO_MULTIBYTE_VAR
+#define WIDECHAR_TO_MULTIBYTE_VAR(unicode, string, stringLength) char string[stringLength]; WideCharToMultiByte(CP_UTF8, 0, unicode, -1, string, stringLength, NULL, NULL)
+#endif
+
+#ifndef MULTIBYTE_OR_WIDECHAR_VAR_FREE
+#define MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodeString)
+#endif
+
+#endif /* msvc */
+
+#endif /* mingw and msvc */
+
+FILE* omc_fopen(const char *filename, const char *mode);
+#if defined(__MINGW32__) || defined(_MSC_VER)
+int omc_stat(const char *filename, struct _stat *statbuf);
+#else
+int omc_stat(const char *filename, struct stat *statbuf);
+#endif
+int omc_unlink(const char *filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/OMCompiler/SimulationRuntime/c/util/omc_mmap.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_mmap.c
@@ -32,6 +32,7 @@
 
 #include "omc_mmap.h"
 #include "omc_error.h"
+#include "omc_file.h"
 #include <string.h>
 #include <errno.h>
 
@@ -102,7 +103,7 @@ void omc_mmap_close_write_unix(omc_mmap_write_unix map)
 
 static FILE* omc_mmap_common(const char *fileName, const char *mode, size_t *size, char **data)
 {
-  FILE *file = fopen(fileName, mode);
+  FILE *file = omc_fopen(fileName, mode);
   size_t fileSize;
   if (!file) {
     throwStreamPrint(NULL, "Failed to open file %s for reading: %s\n", fileName, strerror(errno));

--- a/OMCompiler/SimulationRuntime/c/util/read_csv.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_csv.c
@@ -34,9 +34,7 @@
 #include "read_csv.h"
 #include "read_matlab4.h"
 #include "libcsv.h"
-#if defined(__MINGW32__) || defined(_MSC_VER)
-#include <windows.h>
-#endif
+#include "omc_file.h"
 
 #if defined(__cplusplus)
 #include <sstream>
@@ -105,23 +103,7 @@ int read_csv_dataset_size(const char* filename)
   struct cell_row_count count = {0};
   size_t offset=0;
   unsigned char delim = CSV_COMMA;
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
-#if defined(_MSC_VER)
-  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
-#else /* mingw supports array definition with sizes from the stack */
-  wchar_t unicodeFilename[unicodeFilenameLength];
-#endif
-  MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
-
-  f = _wfopen(unicodeFilename, L"r");
-#if defined(_MSC_VER)
-  if (unicodeFilename) { free(unicodeFilename); }
-#endif
-
-#else
-  f = fopen(filename,"r");
-#endif
+  f = omc_fopen(filename,"r");
   if (f == NULL) {
     return -1;
   }
@@ -234,23 +216,7 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   char **res;
   struct csv_parser p;
   struct csv_body body = {0};
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
-#if defined(_MSC_VER)
-  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
-#else /* mingw supports array definition with sizes from the stack */
-  wchar_t unicodeFilename[unicodeFilenameLength];
-#endif
-  MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
-
-  FILE *fin = _wfopen(unicodeFilename, L"r");
-#if defined(_MSC_VER)
-  if (unicodeFilename) { free(unicodeFilename); }
-#endif
-
-#else
-  FILE *fin = fopen(filename, "r");
-#endif
+  FILE *fin = omc_fopen(filename, "r");
   size_t offset = 0;
   unsigned char delim = CSV_COMMA;
   if (!fin) {
@@ -298,24 +264,7 @@ struct csv_data* read_csv(const char *filename)
   struct csv_data *res;
   size_t offset = 0;
   unsigned char delim = CSV_COMMA;
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
-
-#if defined(_MSC_VER)
-  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
-#else /* mingw supports array definition with sizes from the stack */
-  wchar_t unicodeFilename[unicodeFilenameLength];
-#endif
-  MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
-
-  FILE *fin = _wfopen(unicodeFilename, L"r");
-#if defined(_MSC_VER)
-  if (unicodeFilename) { free(unicodeFilename); }
-#endif
-
-#else
-  FILE *fin = fopen(filename, "r");
-#endif
+  FILE *fin = omc_fopen(filename, "r");
   if (!fin) {
     return NULL;
   }

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -35,9 +35,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include "read_matlab4.h"
-#if defined(__MINGW32__) || defined(_MSC_VER)
-#include <windows.h>
-#endif
+#include "omc_file.h"
 
 extern const char *omc_mat_Aclass;
 
@@ -228,23 +226,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
   int i;
   char binTrans = 1;
   memset(reader, 0, sizeof(ModelicaMatReader));
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  int unicodeFilenameLength = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
-#if defined(_MSC_VER)
-  wchar_t *unicodeFilename = (wchar_t)malloc(unicodeFilenameLength*sizeof(wchar_t));
-#else /* mingw supports array definition with sizes from the stack */
-  wchar_t unicodeFilename[unicodeFilenameLength];
-#endif
-  MultiByteToWideChar(CP_UTF8, 0, filename, -1, unicodeFilename, unicodeFilenameLength);
-
-  reader->file = _wfopen(unicodeFilename, L"rb");
-#if defined(_MSC_VER)
-  if (unicodeFilename) { free(unicodeFilename); }
-#endif
-
-#else
-  reader->file = fopen(filename, "rb");
-#endif
+  reader->file = omc_fopen(filename, "rb");
   if(!reader->file) return strerror(errno);
   reader->fileName = strdup(filename);
   reader->readAll = 0;

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -2198,6 +2198,7 @@ void SetupDialog::applySetup()
   mpPlotWindow->getPlot()->replot();
 }
 
+#include "util/omc_file.c"
 #include "util/read_matlab4.c"
 #include "util/libcsv.c"
 #include "util/read_csv.c"

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
@@ -77,6 +77,7 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./util/base_array.c\" />
 //       <File name=\"./util/boolean_array.c\" />
 //       <File name=\"./util/omc_error.c\" />
+//       <File name=\"./util/omc_file.c\" />
 //       <File name=\"./util/division.c\" />
 //       <File name=\"./util/generic_array.c\" />
 //       <File name=\"./util/index_spec.c\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -68,6 +68,7 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./util/base_array.c\" />
 //       <File name=\"./util/boolean_array.c\" />
 //       <File name=\"./util/omc_error.c\" />
+//       <File name=\"./util/omc_file.c\" />
 //       <File name=\"./util/division.c\" />
 //       <File name=\"./util/generic_array.c\" />
 //       <File name=\"./util/index_spec.c\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
@@ -82,6 +82,7 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./util/base_array.c\" />
 //       <File name=\"./util/boolean_array.c\" />
 //       <File name=\"./util/omc_error.c\" />
+//       <File name=\"./util/omc_file.c\" />
 //       <File name=\"./util/division.c\" />
 //       <File name=\"./util/generic_array.c\" />
 //       <File name=\"./util/index_spec.c\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
@@ -79,6 +79,7 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./util/base_array.c\" />
 //       <File name=\"./util/boolean_array.c\" />
 //       <File name=\"./util/omc_error.c\" />
+//       <File name=\"./util/omc_file.c\" />
 //       <File name=\"./util/division.c\" />
 //       <File name=\"./util/generic_array.c\" />
 //       <File name=\"./util/index_spec.c\" />


### PR DESCRIPTION
Added a `omc_file.h/c` which contains the file system operations like fopen, stat etc. Use the functions declared in this file instead of directly calling them.