### PR TITLE
[BE] fix bltdump

### DIFF
--- a/OMCompiler/Compiler/BackEnd/IndexReduction.mo
+++ b/OMCompiler/Compiler/BackEnd/IndexReduction.mo
@@ -1223,9 +1223,6 @@ algorithm
     end if;
   end if;
   eqns := BackendEquation.getEqnsFromEqSystem(inSystem);
-  if Flags.isSet(Flags.BLT_DUMP) then
-    BackendDump.dumpStateOrder(so);
-  end if;
   outArg := (so,arrayCreate(BackendEquation.getNumberOfEquations(eqns),{}),mapEqnIncRow,mapIncRowEqn,BackendEquation.getNumberOfEquations(eqns));
 end getStructurallySingularSystemHandlerArg;
 


### PR DESCRIPTION
 - removed dumping of stateorder in handler function to prevent
   failing during initialzation with NO_STATESELECTION
 - simulating with -d=bltdump should have always failed before