### PR TITLE
Add external TLM models to OMSimulator models

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Modeling/Commands.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/Commands.cpp
@@ -1841,12 +1841,13 @@ void AddSystemCommand::undo()
  * \param pGraphicsView
  * \param pParent
  */
-AddSubModelCommand::AddSubModelCommand(QString name, QString path, LibraryTreeItem *pLibraryTreeItem, QString annotation,
+AddSubModelCommand::AddSubModelCommand(QString name, QString path, QString startScript, LibraryTreeItem *pLibraryTreeItem, QString annotation,
                                        bool openingClass, GraphicsView *pGraphicsView, UndoCommand *pParent)
   : UndoCommand(pParent)
 {
   mName = name;
   mPath = path;
+  mStartScript = startScript;
   mpLibraryTreeItem = pLibraryTreeItem;
   mAnnotation = annotation;
   mOpeningClass = openingClass;
@@ -1864,9 +1865,17 @@ void AddSubModelCommand::redoInternal()
   QString nameStructure = QString("%1.%2").arg(pParentLibraryTreeItem->getNameStructure()).arg(mName);
   if (!mOpeningClass) {
     QFileInfo fileInfo(mPath);
-    if (!OMSProxy::instance()->addSubModel(nameStructure, fileInfo.absoluteFilePath())) {
-      setFailed(true);
-      return;
+    if(mStartScript.isEmpty()) {
+      if (!OMSProxy::instance()->addSubModel(nameStructure, fileInfo.absoluteFilePath())) {
+        setFailed(true);
+        return;
+      }
+    }
+    else {
+      if (!OMSProxy::instance()->addExternalTLMModel(nameStructure, mStartScript, fileInfo.absoluteFilePath())) {
+        setFailed(true);
+        return;
+      }
     }
     //mpGraphicsView->addSubModel(mName, mPath);
   }

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/Commands.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/Commands.h
@@ -430,13 +430,14 @@ private:
 class AddSubModelCommand : public UndoCommand
 {
 public:
-  AddSubModelCommand(QString name, QString path, LibraryTreeItem *pLibraryTreeItem, QString annotation, bool openingClass,
+  AddSubModelCommand(QString name, QString path, QString startScript, LibraryTreeItem *pLibraryTreeItem, QString annotation, bool openingClass,
                      GraphicsView *pGraphicsView, UndoCommand *pParent = 0);
   void redoInternal();
   void undo();
 private:
   QString mName;
   QString mPath;
+  QString mStartScript;
   LibraryTreeItem *mpLibraryTreeItem;
   QString mAnnotation;
   bool mOpeningClass;

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
@@ -86,6 +86,7 @@ LibraryTreeItem::LibraryTreeItem()
   setOMSBusConnector(0);
   setOMSTLMBusConnector(0);
   setFMUInfo(0);
+  setExternalTLMModelInfo(0);
   setSubModelPath("");
   setModelState(oms_modelState_virgin);
 }
@@ -132,6 +133,7 @@ LibraryTreeItem::LibraryTreeItem(LibraryType type, QString text, QString nameStr
   setOMSBusConnector(0);
   setOMSTLMBusConnector(0);
   setFMUInfo(0);
+  setExternalTLMModelInfo(0);
   setSubModelPath("");
   setModelState(oms_modelState_virgin);
 }
@@ -2769,6 +2771,11 @@ LibraryTreeItem* LibraryTreeModel::createOMSLibraryTreeItemImpl(QString name, QS
         pLibraryTreeItem->setFMUInfo(pFMUInfo);
         pLibraryTreeItem->setSubModelPath(QString(pFMUInfo->path));
       }
+    } else if (pLibraryTreeItem->isExternalTLMModelComponent()) {
+        const oms_external_tlm_model_info_t *pExternalTLMModelInfo;
+        if(OMSProxy::instance()->getExternalTLMModelInfo(pLibraryTreeItem->getNameStructure(), &pExternalTLMModelInfo)) {
+            pLibraryTreeItem->setExternalTLMModelInfo(pExternalTLMModelInfo);
+        }
     } else if (pLibraryTreeItem->isTableComponent()) {
       QString path;
       if (OMSProxy::instance()->getSubModelPath(pLibraryTreeItem->getNameStructure(), &path)) {

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.h
@@ -133,6 +133,7 @@ public:
   bool isSystemElement() const {return (mpOMSElement && (mpOMSElement->type == oms_element_system));}
   bool isComponentElement() const {return (mpOMSElement && (mpOMSElement->type == oms_element_component));}
   bool isFMUComponent() const {return (mpOMSElement && (mpOMSElement->type == oms_element_component) && (mComponentType == oms_component_fmu));}
+  bool isExternalTLMModelComponent() const {return (mpOMSElement && (mpOMSElement->type == oms_element_component) && (mComponentType == oms_component_external));}
   bool isTableComponent() const {return (mpOMSElement && (mpOMSElement->type == oms_element_component) && (mComponentType == oms_component_table));}
   void setSystemType(oms_system_enu_t type) {mSystemType = type;}
   oms_system_enu_t getSystemType() {return mSystemType;}
@@ -150,6 +151,8 @@ public:
   oms_tlmbusconnector_t* getOMSTLMBusConnector() const {return mpOMSTLMBusConnector;}
   void setFMUInfo(const oms_fmu_info_t *pFMUInfo) {mpFMUInfo = pFMUInfo;}
   const oms_fmu_info_t* getFMUInfo() const {return mpFMUInfo;}
+  void setExternalTLMModelInfo(const oms_external_tlm_model_info_t *pExternalTLMModelInfo) { mpExternalTLMModelInfo = pExternalTLMModelInfo;}
+  const oms_external_tlm_model_info_t* getExternalTLMModelInfo() const {return mpExternalTLMModelInfo;}
   void setSubModelPath(QString subModelPath) {mSubModelPath = subModelPath;}
   QString getSubModelPath() const {return mSubModelPath;}
   oms_modelState_enu_t getModelState() const {return mModelState;}
@@ -224,6 +227,7 @@ private:
   oms_busconnector_t *mpOMSBusConnector;
   oms_tlmbusconnector_t *mpOMSTLMBusConnector;
   const oms_fmu_info_t *mpFMUInfo;
+  const oms_external_tlm_model_info_t *mpExternalTLMModelInfo;
   QString mSubModelPath;
   oms_modelState_enu_t mModelState;
 signals:

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -3180,8 +3180,6 @@ void GraphicsView::contextMenuEvent(QContextMenuEvent *event)
           menu.addSeparator();
           menu.addAction(MainWindow::instance()->getAddSubModelAction());
           menu.addSeparator();
-          menu.addAction(MainWindow::instance()->getAddSubModelAction());
-          menu.addSeparator();
           menu.addAction(mpPropertiesAction);
         }
       }
@@ -6328,7 +6326,7 @@ void ModelWidget::drawOMSModelDiagramElements()
                                                                      pChildLibraryTreeItem->getSystemType());
           mpUndoStack->push(pAddSystemCommand);
         } else if (pChildLibraryTreeItem->isComponentElement()) {
-          AddSubModelCommand *pAddSubModelCommand = new AddSubModelCommand(pChildLibraryTreeItem->getName(), "", pChildLibraryTreeItem,
+          AddSubModelCommand *pAddSubModelCommand = new AddSubModelCommand(pChildLibraryTreeItem->getName(), "", "", pChildLibraryTreeItem,
                                                                            annotation, true, mpDiagramGraphicsView);
           mpUndoStack->push(pAddSubModelCommand);
         }

--- a/OMEdit/OMEdit/OMEditGUI/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/ElementPropertiesDialog.cpp
@@ -70,6 +70,13 @@ ElementPropertiesDialog::ElementPropertiesDialog(Component *pComponent, QWidget 
    * And then fix the OMSRenameCommand accordingly.
    */
   mpNameTextBox->setDisabled(true);
+
+  if(mpComponent->getLibraryTreeItem()->getExternalTLMModelInfo()) {
+      const oms_external_tlm_model_info_t *pExternalTLMModelInfo = mpComponent->getLibraryTreeItem()->getExternalTLMModelInfo();
+      mpStartScriptLabel = new Label(Helper::startScript);
+      mpStartScriptTextBox = new QLineEdit(QString(pExternalTLMModelInfo->startScript));
+      mpStartScriptTextBox->setDisabled(true); //! @todo Enable this to make start script changeable
+  }
   // tab widget
   mpTabWidget = new QTabWidget;
   // info tab
@@ -318,10 +325,14 @@ ElementPropertiesDialog::ElementPropertiesDialog(Component *pComponent, QWidget 
   pMainLayout->addWidget(mpHorizontalLine, 1, 0, 1, 2);
   pMainLayout->addWidget(mpNameLabel, 2, 0);
   pMainLayout->addWidget(mpNameTextBox, 2, 1);
-  if (mpComponent->getLibraryTreeItem()->getFMUInfo() || hasParameter || hasInput) {
-    pMainLayout->addWidget(mpTabWidget, 3, 0, 1, 2);
+  if(mpComponent->getLibraryTreeItem()->isExternalTLMModelComponent()) {
+      pMainLayout->addWidget(mpStartScriptLabel, 3, 0);
+      pMainLayout->addWidget(mpStartScriptTextBox, 3, 1);
   }
-  pMainLayout->addWidget(mpButtonBox, 4, 0, 1, 2, Qt::AlignRight);
+  if (mpComponent->getLibraryTreeItem()->getFMUInfo() || hasParameter || hasInput) {
+      pMainLayout->addWidget(mpTabWidget, 4, 0, 1, 2);
+  }
+  pMainLayout->addWidget(mpButtonBox, 5, 0, 1, 2, Qt::AlignRight);
   setLayout(pMainLayout);
 }
 

--- a/OMEdit/OMEdit/OMEditGUI/OMS/ElementPropertiesDialog.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/ElementPropertiesDialog.h
@@ -56,6 +56,8 @@ private:
   QFrame *mpHorizontalLine;
   Label *mpNameLabel;
   QLineEdit *mpNameTextBox;
+  Label *mpStartScriptLabel;
+  QLineEdit *mpStartScriptTextBox;
   QTabWidget *mpTabWidget;
   QGroupBox *mpGeneralGroupBox;
   Label *mpDescriptionLabel;

--- a/OMEdit/OMEdit/OMEditGUI/OMS/ModelDialog.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/ModelDialog.h
@@ -109,6 +109,8 @@ private:
   Label *mpPathLabel;
   QLineEdit *mpPathTextBox;
   QPushButton *mpBrowsePathButton;
+  Label *mpStartScriptLabel;
+  QLineEdit *mpStartScriptTextBox;
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;

--- a/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.cpp
@@ -453,6 +453,17 @@ bool OMSProxy::addSubModel(QString cref, QString fmuPath)
   return statusToBool(status);
 }
 
+bool OMSProxy::addExternalTLMModel(QString cref, QString startScript, QString modelPath)
+{
+    QString command = "oms_addExternalModel";
+    QStringList args;
+    args << "\"" + cref + "\"" << modelPath << "\"" << startScript;
+    LOG_COMMAND(command, args);
+    oms_status_enu_t status = oms_addExternalModel(cref.toUtf8().constData(), modelPath.toUtf8().constData(), startScript.toUtf8().constData());
+    logResponse(command, status, &commandTime);
+    return statusToBool(status);
+}
+
 /*!
  * \brief OMSProxy::addSystem
  * Adds a system to a model.
@@ -744,6 +755,24 @@ bool OMSProxy::getFMUInfo(QString cref, const oms_fmu_info_t** pFmuInfo)
   args << "\"" + cref + "\"";
   LOG_COMMAND(command, args);
   oms_status_enu_t status = oms_getFMUInfo(cref.toUtf8().constData(), pFmuInfo);
+  logResponse(command, status, &commandTime);
+  return statusToBool(status);
+}
+
+/*!
+ * \brief OMSProxy::getFMUInfo
+ * Gets the FMU info.
+ * \param cref
+ * \param pFmuInfo
+ * \return
+ */
+bool OMSProxy::getExternalTLMModelInfo(QString cref, const oms_external_tlm_model_info_t** pExternalTLMModelInfo)
+{
+  QString command = "getExternalTLMModelInfo";
+  QStringList args;
+  args << "\"" + cref + "\"";
+  LOG_COMMAND(command, args);
+  oms_status_enu_t status = oms_getExternalModelInfo(cref.toUtf8().constData(), pExternalTLMModelInfo);
   logResponse(command, status, &commandTime);
   return statusToBool(status);
 }

--- a/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.h
@@ -78,6 +78,7 @@ public:
   bool addConnectorToBus(QString busCref, QString connectorCref);
   bool addConnectorToTLMBus(QString busCref, QString connectorCref, QString type);
   bool addSubModel(QString cref, QString fmuPath);
+  bool addExternalTLMModel(QString cref, QString startScript, QString modelPath);
   bool addSystem(QString cref, oms_system_enu_t type);
   bool addTLMBus(QString cref, oms_tlm_domain_t domain, int dimensions, const oms_tlm_interpolation_t interpolation);
   bool addTLMConnection(QString crefA, QString crefB, double delay, double alpha, double linearimpedance, double angularimpedance);
@@ -92,6 +93,7 @@ public:
   bool getConnector(QString cref, oms_connector_t **pConnector);
   bool getElement(QString cref, oms_element_t **pElement);
   bool getElements(QString cref, oms_element_t ***pElements);
+  bool getExternalTLMModelInfo(QString cref, const oms_external_tlm_model_info_t** pExternalTLMModelInfo);
   bool getFixedStepSize(QString cref, double* stepSize);
   bool getFMUInfo(QString cref, const oms_fmu_info_t** pFmuInfo);
   bool getInteger(QString signal, int* value);

--- a/OMEdit/OMEdit/OMEditGUI/Resources/icons/import-tlmmodel.svg
+++ b/OMEdit/OMEdit/OMEditGUI/Resources/icons/import-tlmmodel.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32px"
+   height="32px"
+   id="svg5501"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="import-tlmmodel.svg">
+  <defs
+     id="defs5503">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6057">
+      <stop
+         style="stop-color:#c6c6c6;stop-opacity:1;"
+         offset="0"
+         id="stop6059" />
+      <stop
+         style="stop-color:#c6c6c6;stop-opacity:0;"
+         offset="1"
+         id="stop6061" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6057"
+       id="linearGradient6063"
+       x1="13.752699"
+       y1="32.133953"
+       x2="13.7527"
+       y2="-4.5696759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.158576,0,0,1,-0.01416136,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.197802"
+     inkscape:cx="-0.84067659"
+     inkscape:cy="14.221553"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1680"
+     inkscape:window-height="986"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5506">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       style="fill:url(#linearGradient6063);fill-opacity:1;fill-rule:nonzero;stroke:#22b14c;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect5547"
+       width="31.97056"
+       height="32.059864"
+       x="0.089303255"
+       y="0.1187433" />
+    <rect
+       style="fill:#008000;fill-opacity:1;fill-rule:nonzero;stroke:#22b14c;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect5331"
+       width="11.404231"
+       height="6.5824947"
+       x="20.642338"
+       y="19.741137" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold';letter-spacing:1.5px;word-spacing:9.83999729px;writing-mode:lr-tb;fill:#000000;fill-opacity:1;stroke:none"
+       x="3"
+       y="11.584887"
+       id="text6065"><tspan
+         sodipodi:role="line"
+         id="tspan6067"
+         x="3"
+         y="11.584887"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:13px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb"
+         dx="0 0 0">TLM</tspan></text>
+    <path
+       sodipodi:type="star"
+       style="fill:#008000;fill-opacity:1;fill-rule:nonzero;stroke:#22b14c;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="path6083"
+       sodipodi:sides="3"
+       sodipodi:cx="18.753679"
+       sodipodi:cy="17.622177"
+       sodipodi:r1="10.035793"
+       sodipodi:r2="5.0178967"
+       sodipodi:arg1="1.0593763"
+       sodipodi:arg2="2.1065739"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 23.665358,26.373895 8.7186302,17.499957 23.87705,8.9926799 z"
+       inkscape:transform-center-x="2.0120873"
+       inkscape:transform-center-y="-0.0071060672"
+       transform="matrix(0.80435497,-0.01115435,0.01122127,0.79955797,1.4733275,9.0885009)" />
+  </g>
+</svg>

--- a/OMEdit/OMEdit/OMEditGUI/Util/Helper.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Helper.cpp
@@ -158,6 +158,7 @@ QString Helper::output;
 QString Helper::parameters;
 QString Helper::inputs;
 QString Helper::name;
+QString Helper::startScript;
 QString Helper::comment;
 QString Helper::path;
 QString Helper::type;
@@ -450,6 +451,7 @@ void Helper::initHelperVariables()
   Helper::parameters = tr("Parameters");
   Helper::inputs = tr("Inputs");
   Helper::name = tr("Name:");
+  Helper::startScript = tr("Start Script:");
   Helper::comment = tr("Comment:");
   Helper::path = tr("Path:");
   Helper::type = tr("Type");
@@ -846,6 +848,8 @@ QString GUIMessages::getMessage(int type)
       return tr("Following error has occurred <b>%1</b> GDB arguments are <b>\"%2\"</b>");
     case INVALID_INSTANCE_NAME:
       return tr("Name <b>%1</b> is not a valid identifier.<br />A name must start with a letter, and all characters must be letters or digits. It may not be a reserved word.");
+    case ENTER_SCRIPT:
+      return tr("Please enter a script file.");
     default:
       return "";
   }

--- a/OMEdit/OMEdit/OMEditGUI/Util/Helper.h
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Helper.h
@@ -160,6 +160,7 @@ public:
   static QString parameters;
   static QString inputs;
   static QString name;
+  static QString startScript;
   static QString comment;
   static QString path;
   static QString type;
@@ -365,6 +366,7 @@ public:
   static QString addSystem;
   static QString addSystemTip;
   static QString addSubModel;
+  static QString addExternalTLMModel;
   static QString addSubModelTip;
   static QString addBus;
   static QString addBusTip;
@@ -484,7 +486,8 @@ public:
     INVALID_TRANSITION_CONDITION,
     MULTIPLE_DECLARATIONS_COMPONENT,
     GDB_ERROR,
-    INVALID_INSTANCE_NAME
+    INVALID_INSTANCE_NAME,
+    ENTER_SCRIPT
   };
 
   static QString getMessage(int type);

--- a/OMEdit/OMEdit/OMEditGUI/resource_omedit.qrc
+++ b/OMEdit/OMEdit/OMEditGUI/resource_omedit.qrc
@@ -210,5 +210,6 @@
         <file>Resources/icons/completerComponent.svg</file>
         <file>Resources/icons/completerClass.svg</file>
         <file>Resources/icons/completerAnnotation.svg</file>
+        <file>Resources/icons/import-tlmmodel.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
### Purpose

Add new external TLM models to OMSimulator models.

### Approach

Similar to how FMU submodels are added. Accessed from toolbuttons or context menu, with a dialog for choosing model path, start script and name. 

This requires OpenModelica/OMSimulator#700
