### PR TITLE
[NF] Don't trust SCodeUtil re. stream operators.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1801,6 +1801,8 @@ protected
 
     {fn} := Function.typeRefCache(fn_ref);
     callExp := typeActualInStreamCall2(name, fn, arg, var, info);
+
+    System.setHasStreamConnectors(true);
   end typeActualInStreamCall;
 
   function typeActualInStreamCall2

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -126,6 +126,8 @@ algorithm
   end if;
 
   System.setUsesCardinality(false);
+  System.setHasOverconstrainedConnectors(false);
+  System.setHasStreamConnectors(false);
 
   // Create a root node from the given top-level classes.
   top := makeTopNode(program);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2159,14 +2159,6 @@ algorithm
           typeComponentSections(InstNode.resolveOuter(c), origin);
         end for;
 
-        // we need to update the ClassTree and add the expandable virtual components from the connects
-        if System.getHasExpandableConnectors() then
-          // collect the expandable virtual components from the connect equations
-
-          // create the components inside the existing expandable connectors
-        end if;
-
-
         InstNode.updateClass(typed_cls, classNode);
       then
         ();


### PR DESCRIPTION
- Set the "has stream operators" flag when typing an inStream or
  actualStream call, rather than trusting what SCodeUtil has set.
  SCodeUtil operates on all loaded models rather than only the used
  classes, and the flag might be overwritten by API calls before the
  NF is called.