### PR TITLE
[NF] Don't trust global connector flags.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -126,6 +126,8 @@ algorithm
   end if;
 
   System.setUsesCardinality(false);
+  System.setHasOverconstrainedConnectors(false);
+  System.setHasStreamConnectors(false);
 
   // Create a root node from the given top-level classes.
   top := makeTopNode(program);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -395,6 +395,10 @@ algorithm
     end for;
 
     connectorTy := ComplexType.CONNECTOR(pots, flows, streams);
+
+    if not listEmpty(streams) then
+      System.setHasStreamConnectors(true);
+    end if;
   end if;
 end makeConnectorType;
 
@@ -2158,14 +2162,6 @@ algorithm
         for c in components loop
           typeComponentSections(InstNode.resolveOuter(c), origin);
         end for;
-
-        // we need to update the ClassTree and add the expandable virtual components from the connects
-        if System.getHasExpandableConnectors() then
-          // collect the expandable virtual components from the connect equations
-
-          // create the components inside the existing expandable connectors
-        end if;
-
 
         InstNode.updateClass(typed_cls, classNode);
       then


### PR DESCRIPTION
- Set the "has stream operators" flag when typing a stream connector,
  rather than trusting what SCodeUtil has set. SCodeUtil operates on
  all loaded models rather than only the used classes, and the flag
  might be overwritten by API calls before the NF is called.
- Clear the overconstrained connector flag at the start of
  instantiation, since the NF already sets it itself.