### PR TITLE
Update and rename AbsynUtil.mo to Util

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Util
+++ b/OMCompiler/Compiler/FrontEnd/Util
@@ -32,9 +32,7 @@
 encapsulated package AbsynUtil
 
 protected import Absyn.*;
-protected import Dump;
 protected import Error;
-protected import Flags;
 protected import List;
 protected import System;
 protected import Util;


### PR DESCRIPTION
Removed unused imports. These imports are not used and are not needed for this file