### PR TITLE
Removed unused imports from AbsynUtil

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -32,9 +32,7 @@
 encapsulated package AbsynUtil
 
 protected import Absyn.*;
-protected import Dump;
 protected import Error;
-protected import Flags;
 protected import List;
 protected import System;
 protected import Util;

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -32,6 +32,7 @@
 encapsulated package AbsynUtil
 
 protected import Absyn.*;
+protected import Dump;
 protected import Error;
 protected import List;
 protected import System;


### PR DESCRIPTION
These imports are not needed