### PR TITLE
ticket:5537 Handle multiple parameter values in a TextAnnotation

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
@@ -538,13 +538,23 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
         /* Ticket:4204
          * If we have extend component then call Component::getParameterDisplayString from root component.
          */
-        if (mpComponent->getComponentType() == Component::Extend) {
-          textValue = mpComponent->getRootParentComponent()->getParameterDisplayString(variable);
-        } else {
-          textValue = mpComponent->getRootParentComponent()->getParameterDisplayString(variable);
-        }
+        textValue = mpComponent->getRootParentComponent()->getParameterDisplayString(variable);
         if (!textValue.isEmpty()) {
-          mTextString.replace(pos, regExp.matchedLength(), textValue);
+          QString unit = "";
+          QString displaytUnit = "";
+          Component *pComponent = mpComponent->getRootParentComponent()->getComponentByName(variable);
+          if (pComponent) {
+            displaytUnit = pComponent->getDerivedClassModifierValue("displaytUnit");
+            if (displaytUnit.isEmpty()) {
+              unit = pComponent->getDerivedClassModifierValue("unit");
+              displaytUnit = unit;
+            }
+          }
+          if (displaytUnit.isEmpty()) {
+            mTextString.replace(pos, regExp.matchedLength(), textValue);
+          } else {
+            mTextString.replace(pos, regExp.matchedLength(), QString("%1 %2").arg(textValue, displaytUnit));
+          }
         } else { /* if the value of %\\W* is empty then remove the % sign. */
           mTextString.replace(pos, 1, "");
         }
@@ -552,7 +562,7 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
         mTextString.replace(pos, 1, "");
       }
     }
-    pos += regExp.matchedLength();
+    pos = 0;
   }
 }
 

--- a/OMEdit/OMEdit/OMEditGUI/Component/Component.h
+++ b/OMEdit/OMEdit/OMEditGUI/Component/Component.h
@@ -239,6 +239,8 @@ public:
   void emitDeleted();
   void componentParameterHasChanged();
   QString getParameterDisplayString(QString parameterName);
+  QString getDerivedClassModifierValue(QString modifierName);
+  QString getInheritedDerivedClassModifierValue(Component *pComponent, QString modifierName);
   void shapeAdded();
   void shapeUpdated();
   void shapeDeleted();
@@ -251,6 +253,7 @@ public:
   bool isInBus() {return mpBusComponent != 0;}
   void setBusComponent(Component *pBusComponent);
   Component* getBusComponent() {return mpBusComponent;}
+  Component* getComponentByName(const QString &componentName);
 
   Transformation mTransformation;
   Transformation mOldTransformation;

--- a/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
@@ -95,36 +95,11 @@ Parameter::Parameter(Component *pComponent, bool showStartAttribute, QString tab
   setSaveSelectorFilter("-");
   setSaveSelectorCaption("-");
   createValueWidget();
-  /* Get unit value
-   * First check if unit is defined with in the component modifier.
-   * If no unit is found then check it in the derived class modifier value.
-   * A derived class can be inherited, so look recursively.
-   */
-  QString className = mpComponent->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getNameStructure();
-  QString unit = mpComponent->getComponentInfo()->getModifiersMap(pOMCProxy, className, mpComponent).value("unit");
-  if (unit.isEmpty()) {
-    if (!pOMCProxy->isBuiltinType(mpComponent->getComponentInfo()->getClassName())) {
-      unit = pOMCProxy->getDerivedClassModifierValue(mpComponent->getComponentInfo()->getClassName(), "unit");
-      if (unit.isEmpty()) {
-        unit = getModifierValueFromDerivedClass(mpComponent, "unit");
-      }
-    }
-  }
-  mUnit = StringHandler::removeFirstLastQuotes(unit);
-  /* Get displayUnit value
-   * First check if displayUnit is defined with in the component modifier.
-   * If no displayUnit is found then check it in the derived class modifier value.
-   * A derived class can be inherited, so look recursively.
-   */
-  QString displayUnit = mpComponent->getComponentInfo()->getModifiersMap(pOMCProxy, className, mpComponent).value("displayUnit");
-  if (displayUnit.isEmpty()) {
-    if (!pOMCProxy->isBuiltinType(mpComponent->getComponentInfo()->getClassName())) {
-      displayUnit = pOMCProxy->getDerivedClassModifierValue(mpComponent->getComponentInfo()->getClassName(), "displayUnit");
-      if (displayUnit.isEmpty()) {
-        displayUnit = getModifierValueFromDerivedClass(mpComponent, "displayUnit");
-      }
-    }
-  }
+  // Get unit value
+  QString unit = mpComponent->getDerivedClassModifierValue("unit");
+  mUnit = unit;
+  // Get displayUnit value
+  QString displayUnit = mpComponent->getDerivedClassModifierValue("displayUnit");
   if (displayUnit.isEmpty()) {
     displayUnit = unit;
   }
@@ -291,43 +266,6 @@ void Parameter::setFixedState(QString fixed, bool defaultValue)
 QString Parameter::getFixedState()
 {
   return mpFixedCheckBox->tickStateString();
-}
-
-/*!
- * \brief Parameter::getModifierValueFromDerivedClass
- * Returns the modifier value by reading the derived classes.
- * \param pComponent
- * \param modifierName
- * \return the modifier value.
- */
-QString Parameter::getModifierValueFromDerivedClass(Component *pComponent, QString modifierName)
-{
-  MainWindow *pMainWindow = MainWindow::instance();
-  OMCProxy *pOMCProxy = pMainWindow->getOMCProxy();
-  QString modifierValue = "";
-  if (!pComponent->getLibraryTreeItem()->getModelWidget()) {
-    pMainWindow->getLibraryWidget()->getLibraryTreeModel()->showModelWidget(pComponent->getLibraryTreeItem(), false);
-  }
-  foreach (Component *pInheritedComponent, pComponent->getInheritedComponentsList()) {
-    /* Ticket #4031
-     * Since we use the parent ComponentInfo for inherited classes so we should not use
-     * pInheritedComponent->getComponentInfo()->getClassName() to get the name instead we should use
-     * pInheritedComponent->getLibraryTreeItem()->getNameStructure() to get the correct name of inherited class.
-     * Also don't just return after reading from first inherited class. Check recursively.
-     */
-    if (pInheritedComponent->getLibraryTreeItem() &&
-        !pOMCProxy->isBuiltinType(pInheritedComponent->getLibraryTreeItem()->getNameStructure())) {
-      modifierValue = pOMCProxy->getDerivedClassModifierValue(pInheritedComponent->getLibraryTreeItem()->getNameStructure(),
-                                                              modifierName);
-      if (modifierValue.isEmpty()) {
-        modifierValue = getModifierValueFromDerivedClass(pInheritedComponent, modifierName);
-      }
-      if (!modifierValue.isEmpty()) {
-        return modifierValue;
-      }
-    }
-  }
-  return "";
 }
 
 /*!

--- a/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.h
+++ b/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.h
@@ -84,7 +84,6 @@ public:
   Label* getCommentLabel() {return mpCommentLabel;}
   void setFixedState(QString fixed, bool defaultValue);
   QString getFixedState();
-  QString getModifierValueFromDerivedClass(Component *pComponent, QString modifierName);
   void setEnabled(bool enable);
 private:
   Component *mpComponent;

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
@@ -429,6 +429,7 @@ public:
   QList<LibraryTreeItem*> getInheritedClassesList() {return mInheritedClassesList;}
   const QList<ComponentInfo*> &getComponentsList() {return mComponentsList;}
   QMap<QString, QString> getExtendsModifiersMap(QString extendsClass);
+  QMap<QString, QString> getDerivedClassModifiersMap();
   void fetchExtendsModifiers(QString extendsClass);
   void reDrawModelWidgetInheritedClasses();
   void drawBaseCoOrdinateSystem(ModelWidget *pModelWidget, GraphicsView *pGraphicsView);
@@ -490,6 +491,8 @@ private:
   bool mCreateModelWidgetComponents;
   bool mExtendsModifiersLoaded;
   QMap<QString, QMap<QString, QString> > mExtendsModifiersMap;
+  bool mDerivedClassModifiersLoaded;
+  QMap<QString, QString> mDerivedClassModifiersMap;
   QList<LibraryTreeItem*> mInheritedClassesList;
   QList<ComponentInfo*> mComponentsList;
   QStringList mComponentsAnnotationsList;

--- a/OMEdit/OMEdit/OMEditGUI/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/OMC/OMCProxy.cpp
@@ -2649,6 +2649,17 @@ QStringList OMCProxy::getAvailableLibraries()
 }
 
 /*!
+ * \brief OMCProxy::getDerivedClassModifierNames
+ * Gets the derived class modifier names.
+ * \param className
+ * \return
+ */
+QStringList OMCProxy::getDerivedClassModifierNames(QString className)
+{
+  return mpOMCInterface->getDerivedClassModifierNames(className);
+}
+
+/*!
  * \brief OMCProxy::getDerivedClassModifierValue
  * Gets the derived class modifier value.
  * \param className - the name of the derived class.

--- a/OMEdit/OMEdit/OMEditGUI/OMC/OMCProxy.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMC/OMCProxy.h
@@ -226,6 +226,7 @@ public:
   QString uriToFilename(QString uri);
   QString getModelicaPath();
   QStringList getAvailableLibraries();
+  QStringList getDerivedClassModifierNames(QString className);
   QString getDerivedClassModifierValue(QString className, QString modifierName);
   OMCInterface::convertUnits_res convertUnits(QString from, QString to);
   QList<QString> getDerivedUnits(QString baseUnit);


### PR DESCRIPTION
Display the unit of the parameter if available. The unit is only shown if parameter has some value.