### PR TITLE
Information message about the usage of global translation flags

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
@@ -3623,7 +3623,9 @@ SimulationPage::SimulationPage(OptionsDialog *pOptionsDialog)
   // Translation Flags layout
   QGridLayout *pTranslationFlagsGridLayout = new QGridLayout;
   pTranslationFlagsGridLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-  pTranslationFlagsGridLayout->addWidget(mpTranslationFlagsWidget, 0, 0);
+  pTranslationFlagsGridLayout->addWidget(new Label("Global flags applied to the Simulation Setup dialog upon the first simulation of a model.\n"
+                                                   "For subsequent simulations, you can change them locally using the Simulation Setup dialog."), 0, 0);
+  pTranslationFlagsGridLayout->addWidget(mpTranslationFlagsWidget, 1, 0);
   mpTranslationFlagsGroupBox->setLayout(pTranslationFlagsGridLayout);
   // Target Language
   mpTargetLanguageLabel = new Label(tr("Target Language:"));


### PR DESCRIPTION
![message](https://user-images.githubusercontent.com/4007231/61373865-40149a00-a89b-11e9-8260-d90aefbee06e.png)

@casella this is related to [ticket:5569](https://trac.openmodelica.org/OpenModelica/ticket/5569). I added some information message to make it clear to the user. We can choose the suitable text but the idea is that the user should know that changing here will not effect the already simulated models as they will use their local flags.