### PR TITLE
Add a sanity check that the build folder can be moved

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -191,6 +191,18 @@ void buildOMC(CC, CXX, extraFlags) {
   // OMSimulator requires HOME to be set and writeable
   sh "HOME='${env.WORKSPACE}' ${makeCommand()} -j${numPhysicalCPU()} --output-sync omc omc-diff omsimulator"
   sh 'find build/lib/*/omc/ -name "*.so" -exec strip {} ";"'
+  sh '''
+  mv build build.sanity-check
+  mkdir .sanity-check
+  cd .sanity-check
+  echo 'loadString("model M end M;");getErrorString();buildModel(M);getErrorString();' > test.mos
+  cat test.mos
+  ../build.sanity-check/bin/omc test.mos
+  ./M
+  cd ..
+  mv build.sanity-check build
+  rm -rf .sanity-check
+  '''
   }
 }
 

--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -91,7 +91,6 @@ const char* SettingsImpl__getInstallationDirectoryPath(void) {
 
 const char* SettingsImpl__getInstallationDirectoryPath(void) {
   int ret;
-  pid_t pid;
   static char *omhome = NULL;
   if (omhome) {
     return omhome;

--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -105,6 +105,10 @@ const char* SettingsImpl__getInstallationDirectoryPath(void) {
     omhome = omc_alloc_interface.malloc_strdup(info.dli_fname);
     stripbinpath(omhome);
   }
+  if (!(omhome && omhome[0])) {
+    fprintf(stderr, "Failed to get binary path from dladdr path: %s\n", info.dli_fname);
+    exit(EXIT_FAILURE);
+  }
   return omhome;
 }
 

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -2598,8 +2598,20 @@ int System_getTerminalWidth(void)
 
 #include "simulation_options.h"
 
-#define SB_SIZE 8192*2
+#define SB_SIZE 8192*4
 #define SB_SIZE_MINUS_ONE (SB_SIZE-1)
+
+/* snprintf check negative size */
+static size_t check_nonnegative(long sz)
+{
+  if (sz < 0) {
+    fprintf(stderr, "%s:%d got negative size: %ld, which should not happen\n", __FILE__, __LINE__, sz);
+    exit(EXIT_FAILURE);
+  }
+  return sz;
+}
+
+#define CHECK_NONNEGATIVE_BUFFER() check_nonnegative((long)SB_SIZE_MINUS_ONE-(cur-buf))
 
 char* System_getSimulationHelpTextSphinx(int detailed, int sphinx)
 {
@@ -2611,13 +2623,13 @@ char* System_getSimulationHelpTextSphinx(int detailed, int sphinx)
   for(i=1; i<FLAG_MAX; ++i)
   {
     if (sphinx) {
-      cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "\n.. _simflag-%s :\n\n", FLAG_NAME[i]);
+      cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "\n.. _simflag-%s :\n\n", FLAG_NAME[i]);
     }
     if (FLAG_TYPE[i] == FLAG_TYPE_FLAG) {
       if (sphinx) {
-        cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), ":ref:`-%s <simflag-%s>`\n%s\n", FLAG_NAME[i], FLAG_NAME[i], desc[i]);
+        cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), ":ref:`-%s <simflag-%s>`\n%s\n", FLAG_NAME[i], FLAG_NAME[i], desc[i]);
       } else {
-        cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "<-%s>\n%s\n", FLAG_NAME[i], desc[i]);
+        cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "<-%s>\n%s\n", FLAG_NAME[i], desc[i]);
       }
     } else if (FLAG_TYPE[i] == FLAG_TYPE_OPTION) {
       int numExtraFlags=0;
@@ -2625,9 +2637,9 @@ char* System_getSimulationHelpTextSphinx(int detailed, int sphinx)
       const char **flagName;
       const char **flagDesc;
       if (sphinx) {
-        cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), ":ref:`-%s=value <simflag-%s>` *or* -%s value \n%s\n", FLAG_NAME[i], FLAG_NAME[i], FLAG_NAME[i], desc[i]);
+        cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), ":ref:`-%s=value <simflag-%s>` *or* -%s value \n%s\n", FLAG_NAME[i], FLAG_NAME[i], FLAG_NAME[i], desc[i]);
       } else {
-        cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "<-%s=value> or <-%s value>\n%s\n", FLAG_NAME[i], FLAG_NAME[i], desc[i]);
+        cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "<-%s=value> or <-%s value>\n%s\n", FLAG_NAME[i], FLAG_NAME[i], desc[i]);
       }
 
       switch(i) {
@@ -2696,20 +2708,20 @@ char* System_getSimulationHelpTextSphinx(int detailed, int sphinx)
       }
 
       if (numExtraFlags) {
-        cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "\n");
+        cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "\n");
         if (flagName) {
           for (j=firstExtraFlag; j<numExtraFlags; j++) {
-            cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "  * %s (%s)\n", flagName[j], flagDesc[j]);
+            cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "  * %s (%s)\n", flagName[j], flagDesc[j]);
           }
         } else {
           for (j=firstExtraFlag; j<numExtraFlags; j++) {
-            cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "  * %s\n", flagDesc[j]);
+            cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "  * %s\n", flagDesc[j]);
           }
         }
       }
 
     } else {
-      cur += snprintf(cur, SB_SIZE_MINUS_ONE-(buf-cur), "[unknown flag-type] <-%s>\n", FLAG_NAME[i]);
+      cur += snprintf(cur, CHECK_NONNEGATIVE_BUFFER(), "[unknown flag-type] <-%s>\n", FLAG_NAME[i]);
     }
   }
   *cur = 0;

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -690,7 +690,7 @@ modelica_boolean setStackOverflowSignal(modelica_boolean inSignal)
   return inSignal;
 }
 
-#if defined(linux) || defined(__APPLE_CC__)
+#if defined(__linux__) || defined(__APPLE_CC__)
 #include <execinfo.h>
 metamodelica_string referenceDebugString(modelica_metatype fnptr)
 {

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_segv.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_segv.c
@@ -30,7 +30,7 @@
 
 /* Stack overflow handling */
 
-#if defined(linux) && !defined(_GNU_SOURCE)
+#if defined(__linux__) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE 1
 /* for pthread_getattr_np */
 #endif
@@ -57,7 +57,7 @@ int mmc_hasStacktraceMessages(threadData_t *threadData)
 
 pthread_key_t mmc_stack_overflow_jumper;
 
-#if defined(linux) || defined(__APPLE_CC__)
+#if defined(__linux__) || defined(__APPLE_CC__)
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>

--- a/OMCompiler/SimulationRuntime/c/util/rtclock.c
+++ b/OMCompiler/SimulationRuntime/c/util/rtclock.c
@@ -431,7 +431,7 @@ int64_t rt_ext_tp_sync_nanosec(rtclock_t* tick_tp, uint64_t nsec)
 static clockid_t omc_clock = OMC_CLOCK_MONOTONIC;
 
 int rt_set_clock(enum omc_rt_clock_t newClock) {
-#if defined(linux)
+#if defined(__linux__)
   omc_clock = newClock == OMC_CLOCK_REALTIME ? OMC_CLOCK_MONOTONIC : CLOCK_PROCESS_CPUTIME_ID;
 #else
   omc_clock = OMC_CLOCK_MONOTONIC;


### PR DESCRIPTION
`make install` assumes that `omc` will work even if the installation
directory is moved. This should check that the rpath works fine; it will
not check if files are linked directly against temporary files in the
source directories though.