### PR TITLE
Logging for homotopy path

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -267,6 +267,7 @@ static int symbolic_initialization(DATA *data, threadData_t *threadData)
   {
     long step;
     char buffer[4096];
+    double lambda;
 
     infoStreamPrint(LOG_INIT, 0, "Global homotopy with equidistant step size started.");
 
@@ -277,9 +278,10 @@ static int symbolic_initialization(DATA *data, threadData_t *threadData)
       sprintf(buffer, "%s_equidistant_global_homotopy.csv", mData->modelFilePrefix);
       infoStreamPrint(LOG_INIT, 0, "The homotopy path will be exported to %s.", buffer);
       pFile = omc_fopen(buffer, "wt");
-      fprintf(pFile, "\"sep=%s\"\n%s", sep, "\"lambda\"");
-      for(i=0; i<mData->nVariablesReal; ++i)
+      fprintf(pFile, "\"lambda\"");
+      for(i=0; i<mData->nVariablesReal; ++i) {
         fprintf(pFile, "%s\"%s\"", sep, mData->realVarsData[i].info.name);
+      }
       fprintf(pFile, "\n");
     }
 #endif
@@ -288,10 +290,13 @@ static int symbolic_initialization(DATA *data, threadData_t *threadData)
     for(step=0; step<init_lambda_steps; ++step)
     {
       data->simulationInfo->lambda = ((double)step)/(init_lambda_steps-1);
-      infoStreamPrint(LOG_INIT, 0, "homotopy parameter lambda = %g", data->simulationInfo->lambda);
+      lambda = data->simulationInfo->lambda;
+      infoStreamPrint(LOG_INIT, 0, "homotopy parameter lambda = %g", lambda);
 
-      if(data->simulationInfo->lambda > 1.0) {
+      if(data->simulationInfo->lambda > 1.0)
+      {
         data->simulationInfo->lambda = 1.0;
+        lambda = 1.0;
       }
 
       if(0 == step)
@@ -299,12 +304,12 @@ static int symbolic_initialization(DATA *data, threadData_t *threadData)
       else
         data->callback->functionInitialEquations(data, threadData);
 
-      infoStreamPrint(LOG_INIT, 0, "homotopy parameter lambda = %g done\n---------------------------", data->simulationInfo->lambda);
+      infoStreamPrint(LOG_INIT, 0, "homotopy parameter lambda = %g done\n---------------------------", lambda);
 
 #if !defined(OMC_NO_FILESYSTEM)
       if(ACTIVE_STREAM(LOG_INIT))
       {
-        fprintf(pFile, "%.16g", data->simulationInfo->lambda);
+        fprintf(pFile, "%.16g", lambda);
         for(i=0; i<mData->nVariablesReal; ++i)
           fprintf(pFile, "%s%.16g", sep, data->localData[0]->realVars[i]);
         fprintf(pFile, "\n");

--- a/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
@@ -647,13 +647,13 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | homotopy process
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.333333 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.666667 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 1
 // LOG_INIT          | info    | homotopy parameter lambda = 1 done
@@ -736,13 +736,13 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | homotopy process
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.333333 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.666667 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 1
 // LOG_INIT          | info    | homotopy parameter lambda = 1 done
@@ -825,13 +825,13 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | homotopy process
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.333333 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.666667 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 1
 // LOG_INIT          | info    | homotopy parameter lambda = 1 done
@@ -914,13 +914,13 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | homotopy process
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.333333 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.666667 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 1
 // LOG_INIT          | info    | homotopy parameter lambda = 1 done
@@ -1003,13 +1003,13 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // LOG_INIT          | info    | homotopy process
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.333333 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT          | info    | homotopy parameter lambda = 1 done
+// LOG_INIT          | info    | homotopy parameter lambda = 0.666667 done
 // |                 | |       | ---------------------------
 // LOG_INIT          | info    | homotopy parameter lambda = 1
 // LOG_INIT          | info    | homotopy parameter lambda = 1 done


### PR DESCRIPTION
  - Save csv file without "sep=," in first line. OMEdit can't open the file
    with that.
  - Workaround for `homotopy parameter lambda` print to work with asserts.

Needed for ticket 5139 to find remaining errors.