### PR TITLE
Visualize the array plots

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Animation/TimeManager.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Animation/TimeManager.cpp
@@ -59,12 +59,7 @@ void TimeManager::updateTick()
 
 int TimeManager::getTimeFraction()
 {
-  return getTimeFraction(mTimeDiscretization);
-}
-
-int TimeManager::getTimeFraction(int discretization)
-{
-  return int(_visTime / (_endTime - _startTime)*discretization);
+  return int(_visTime / (_endTime - _startTime)*mTimeDiscretization);
 }
 
 double TimeManager::getEndTime() const

--- a/OMEdit/OMEdit/OMEditGUI/Animation/TimeManager.h
+++ b/OMEdit/OMEdit/OMEditGUI/Animation/TimeManager.h
@@ -87,7 +87,6 @@ class TimeManager
   /*! \brief Sets pause status to new value. */
   void setPause(const bool status);
   int getTimeFraction();
-  int getTimeFraction(int discretization);
   void setSpeedUp(double value);
   double getSpeedUp();
   QTimer* getUpdateSceneTimer() {return mpUpdateSceneTimer;}

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/DiagramWindow.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/DiagramWindow.cpp
@@ -34,6 +34,7 @@
 #include "DiagramWindow.h"
 #include "MainWindow.h"
 #include "Modeling/ModelWidgetContainer.h"
+#include "Plotting/PlotWindowContainer.h"
 #include "Plotting/VariablesWidget.h"
 
 /*!
@@ -134,4 +135,15 @@ void DiagramWindow::removeDiagram(ModelWidget *pModelWidget)
     delete mpGraphicsView;
     mpGraphicsView = 0;
   }
+}
+
+/*!
+ * \brief DiagramWindow::closeEvent
+ * Removes DiagramWindow from PlotWindowContainer.
+ * \param event
+ */
+void DiagramWindow::closeEvent(QCloseEvent *event)
+{
+  Q_UNUSED(event);
+  MainWindow::instance()->getPlotWindowContainer()->removeSubWindow(this);
 }

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/DiagramWindow.h
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/DiagramWindow.h
@@ -53,9 +53,8 @@ private:
   GraphicsScene *mpGraphicsScene;
   GraphicsView *mpGraphicsView;
   QVBoxLayout *mpMainLayout;
-signals:
-
-public slots:
+protected:
+  virtual void closeEvent(QCloseEvent *event);
 };
 
 #endif // DIAGRAMWINDOW_H

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
@@ -187,6 +187,7 @@ public:
   VariableTreeProxyModel* getVariableTreeProxyModel() {return mpVariableTreeProxyModel;}
   VariablesTreeModel* getVariablesTreeModel() {return mpVariablesTreeModel;}
   VariablesTreeView* getVariablesTreeView() {return mpVariablesTreeView;}
+  void enableVisualizationControls(bool enable);
   void insertVariablesItemsToTree(QString fileName, QString filePath, QStringList variablesList, SimulationOptions simulationOptions);
   void addSelectedInteractiveVariables(const QString &modelName, const QList<QString> &selectedVariables);
   void variablesUpdated();
@@ -204,6 +205,7 @@ private:
   Label *mpSimulationTimeLabel;
   QComboBox *mpSimulationTimeComboBox;
   QSlider *mpSimulationTimeSlider;
+  int mSliderRange;
   QToolBar *mpToolBar;
   QAction *mpRewindAction;
   QAction *mpPlayAction;

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -906,11 +906,11 @@ void PlotWindow::updateTimeText(QString unit)
   mpPlot->replot();
 }
 
-void PlotWindow::plotArray(double timePercent, PlotCurve *pPlotCurve)
+void PlotWindow::plotArray(double time, PlotCurve *pPlotCurve)
 {
   double *res;
   QString currentLine;
-  double time;
+  setTime(time);
   double timeUnitFactor = getTimeUnitFactor(getTimeUnit());
   if (mVariablesList.isEmpty() and getPlotType() == PlotWindow::PLOTARRAY)
     throw NoVariableException(QString("No variables specified!").toStdString().c_str());
@@ -942,11 +942,6 @@ void PlotWindow::plotArray(double timePercent, PlotCurve *pPlotCurve)
     //Read in timevector
     double timeVals[intervalSize];
     readPLTDataset(mpTextStream, "time", intervalSize, timeVals);
-    //calculate time
-    double startTime = timeVals[0];
-    double stopTime = timeVals[intervalSize-1];
-    time = startTime + (stopTime - startTime)*timePercent/100.0;
-    setTime(time);
     //Find indexes and alpha to interpolate data in particular time
     double alpha;
     int it = setupInterp(timeVals, time, intervalSize, alpha);
@@ -996,11 +991,6 @@ void PlotWindow::plotArray(double timePercent, PlotCurve *pPlotCurve)
       omc_free_csv_reader(csvReader);
       throw NoVariableException(tr("Variable doesnt exist: %1").arg("time").toStdString().c_str());
     }
-    //calculate time
-    double startTime = timeVals[0];
-    double stopTime = timeVals[csvReader->numsteps-1];
-    time = startTime + (stopTime - startTime)*timePercent/100.0;
-    setTime(time);
     double alpha;
     int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
     if (it < 0) {
@@ -1062,8 +1052,6 @@ void PlotWindow::plotArray(double timePercent, PlotCurve *pPlotCurve)
       //calculate time
       double startTime = omc_matlab4_startTime(&reader);
       double stopTime =  omc_matlab4_stopTime(&reader);
-      time = startTime + (stopTime - startTime)*timePercent/100.0;
-      setTime(time);
       if (reader.nvar < 1) {
         omc_free_matlab4_reader(&reader);
         throw NoVariableException("Variable doesnt exist: time");
@@ -1114,11 +1102,11 @@ void PlotWindow::plotArray(double timePercent, PlotCurve *pPlotCurve)
     }
 }
 
-void PlotWindow::plotArrayParametric(double timePercent, PlotCurve *pPlotCurve)
+void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
 {
   QString xVariable, yVariable, xTitle, yTitle;
   int pair = 0;
-  double time;
+  setTime(time);
   double timeUnitFactor = getTimeUnitFactor(getTimeUnit());
   if (mVariablesList.isEmpty())
     throw NoVariableException(QString("No variables specified!").toStdString().c_str());
@@ -1129,7 +1117,6 @@ void PlotWindow::plotArrayParametric(double timePercent, PlotCurve *pPlotCurve)
 
   for (pair = 0; pair < mVariablesList.size(); pair += 2)
   {
-    QStringList varPair;
     xVariable = mVariablesList.at(pair);
     yVariable = mVariablesList.at(pair+1);
     //    if (!editCase)
@@ -1175,11 +1162,6 @@ void PlotWindow::plotArrayParametric(double timePercent, PlotCurve *pPlotCurve)
       //Read in timevector
       double timeVals[intervalSize];
       readPLTDataset(mpTextStream, "time", intervalSize, timeVals);
-      //calculate time
-      double startTime = timeVals[0];
-      double stopTime = timeVals[intervalSize-1];
-      time = startTime + (stopTime - startTime)*timePercent/100.0;
-      setTime(time);
       //Find indexes and alpha to interpolate data in particular time
       double alpha;
       int it = setupInterp(timeVals, time, intervalSize, alpha);
@@ -1230,11 +1212,6 @@ void PlotWindow::plotArrayParametric(double timePercent, PlotCurve *pPlotCurve)
         omc_free_csv_reader(csvReader);
         throw NoVariableException(tr("Variable doesnt exist: %1").arg("time").toStdString().c_str());
       }
-      //calculate time
-      double startTime = timeVals[0];
-      double stopTime = timeVals[csvReader->numsteps-1];
-      time = startTime + (stopTime - startTime)*timePercent/100.0;
-      setTime(time);
       double alpha;
       int it = setupInterp(timeVals, time, csvReader->numsteps, alpha);
       if (it < 0) {
@@ -1311,8 +1288,6 @@ void PlotWindow::plotArrayParametric(double timePercent, PlotCurve *pPlotCurve)
       //calculate time
       double startTime = omc_matlab4_startTime(&reader);
       double stopTime =  omc_matlab4_stopTime(&reader);
-      time = startTime + (stopTime - startTime)*timePercent/100.0;
-      setTime(time);
       if (reader.nvar < 1) {
         omc_free_matlab4_reader(&reader);
         throw NoVariableException("Variable doesnt exist: time");

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -110,8 +110,8 @@ public:
   void setupToolbar();
   void plot(PlotCurve *pPlotCurve = 0);
   void plotParametric(PlotCurve *pPlotCurve = 0);
-  void plotArray(double timePercent, PlotCurve *pPlotCurve = 0);
-  void plotArrayParametric(double timePercent, PlotCurve *pPlotCurve = 0);
+  void plotArray(double time, PlotCurve *pPlotCurve = 0);
+  void plotArrayParametric(double time, PlotCurve *pPlotCurve = 0);
   QPair<QVector<double>*, QVector<double>*> plotInteractive(PlotCurve *pPlotCurve = 0);
   void setInteractiveOwner(const QString &interactiveTreeItemOwner);
   void setInteractivePort(const int port);


### PR DESCRIPTION
Fixes ticket:5611 avoid crashing when time is out of bounds.
Remove the DiagramWindow from PlotWindowContainer on closeEvent.
Enable/disable the visualization controls based on the active result file.