### PR TITLE
[codegen] Improved handling of records and record arrays in the codegen.

### DIFF
--- a/OMCompiler/Compiler/FFrontEnd/FBuiltin.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FBuiltin.mo
@@ -237,28 +237,28 @@ protected constant SCode.Element clockType = SCode.CLASS("Clock",commonPrefixes,
 // The builtin variable time. See also variableIsBuiltin
 protected constant DAE.Var timeVar = DAE.TYPES_VAR("time",
           DAE.dummyAttrInput,
-          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE());
+          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE());
 
 /* Optimica Extensions. Theses variables are considered builtin for Optimica: startTime, finalTime, objectiveIntegrand and objective */
 /* Optimica Extensions. The builtin variable startTime. */
 protected constant DAE.Var startTimeVar = DAE.TYPES_VAR("startTime",
           DAE.dummyAttrInput,
-          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()) "- The `startTime\' variable" ;
+          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()) "- The `startTime\' variable" ;
 
 /* Optimica Extensions. The builtin variable finalTime. */
 protected constant DAE.Var finalTimeVar = DAE.TYPES_VAR("finalTime",
           DAE.dummyAttrInput,
-          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()) "- The `finalTime\' variable" ;
+          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()) "- The `finalTime\' variable" ;
 
 /* Optimica Extensions. The builtin variable objectiveIntegrand. */
 protected constant DAE.Var objectiveIntegrandVar = DAE.TYPES_VAR("objectiveIntegrand",
           DAE.dummyAttrInput,
-          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()) "- The `objectiveIntegrand\' variable" ;
+          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()) "- The `objectiveIntegrand\' variable" ;
 
 /* Optimica Extensions. The builtin variable objective. */
 protected constant DAE.Var objectiveVar = DAE.TYPES_VAR("objective",
           DAE.dummyAttrInput,
-          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()) "- The `objective\' variable" ;
+          DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()) "- The `objective\' variable" ;
 
 protected constant DAE.FuncArg argRealX = DAE.FUNCARG("x",DAE.T_REAL_DEFAULT,DAE.C_VAR(),DAE.NON_PARALLEL(),NONE());
 protected constant DAE.FuncArg argRealY = DAE.FUNCARG("y",DAE.T_REAL_DEFAULT,DAE.C_VAR(),DAE.NON_PARALLEL(),NONE());

--- a/OMCompiler/Compiler/FFrontEnd/FGraph.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraph.mo
@@ -561,6 +561,7 @@ algorithm
               DAE.ATTR(DAE.NON_CONNECTOR(), SCode.NON_PARALLEL(), variability, Absyn.BIDIR(), Absyn.NOT_INNER_OUTER(), SCode.PUBLIC()),
               ty,
               binding,
+              false,
               constOfForIteratorRange);
         r = lastScopeRef(g);
         g = FGraphBuildEnv.mkCompNode(c, r, FCore.BUILTIN(), g);

--- a/OMCompiler/Compiler/FFrontEnd/FNode.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FNode.mo
@@ -610,7 +610,7 @@ algorithm
                   n,
                   DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl,var,dir,io,vis),
                   DAE.T_UNKNOWN_DEFAULT,
-                  DAE.UNBOUND(),NONE());
+                  DAE.UNBOUND(),false,NONE());
       then
         (nd, i);
 

--- a/OMCompiler/Compiler/FrontEnd/CevalFunction.mo
+++ b/OMCompiler/Compiler/FrontEnd/CevalFunction.mo
@@ -1720,7 +1720,7 @@ protected function makeFunctionVariable
   output DAE.Var outVar;
   annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  outVar := DAE.TYPES_VAR(inName, DAE.dummyAttrVar, inType, inBinding, NONE());
+  outVar := DAE.TYPES_VAR(inName, DAE.dummyAttrVar, inType, inBinding, false, NONE());
 end makeFunctionVariable;
 
 protected function getBinding
@@ -2284,9 +2284,8 @@ protected
   DAE.Type ty;
   Option<DAE.Const> c;
 algorithm
-  DAE.TYPES_VAR(name, attr, ty, _, c) := inVar;
-  outVar := DAE.TYPES_VAR(name, attr, ty,
-    DAE.VALBOUND(inValue, DAE.BINDING_FROM_DEFAULT_VALUE()), c);
+  outVar := inVar;
+  outVar.binding := DAE.VALBOUND(inValue, DAE.BINDING_FROM_DEFAULT_VALUE());
 end updateRecordBinding;
 
 protected function updateRecordComponentBinding
@@ -2296,18 +2295,12 @@ protected function updateRecordComponentBinding
   input Values.Value inValue;
   output DAE.Var outVar;
 protected
-  DAE.Ident name;
-  DAE.Attributes attr;
-  DAE.Type ty;
-  DAE.Binding binding;
-  Option<DAE.Const> c;
   Values.Value val;
 algorithm
-  DAE.TYPES_VAR(name, attr, ty, binding, c) := inVar;
-  val := getBindingOrDefault(binding, ty);
+  outVar := inVar;
+  val := getBindingOrDefault(outVar.binding, outVar.ty);
   val := updateRecordComponentValue(inComponentId, inValue, val);
-  binding := DAE.VALBOUND(val, DAE.BINDING_FROM_DEFAULT_VALUE());
-  outVar := DAE.TYPES_VAR(name, attr, ty, binding, c);
+  outVar.binding := DAE.VALBOUND(val, DAE.BINDING_FROM_DEFAULT_VALUE());
 end updateRecordComponentBinding;
 
 protected function updateRecordComponentValue

--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -813,6 +813,10 @@ uniontype Var "- Variables"
     Attributes attributes "attributes";
     Type ty "type";
     Binding binding "equation modification";
+    Boolean bind_from_outside "true if the binding has come from out of scope. This happens for derived record classes.
+                                   e.g. record A = B(k=exp). here the modification 'exp' is a binding from outside. We need
+                                   this infor to correctly generate default constructors at codegen time. This binding exp
+                                   will have to be supplied from outside for a default constructor of the owner record type";
     Option<Const> constOfForIteratorRange "the constant-ness of the range if this is a for iterator, NONE() if is NOT a for iterator";
   end TYPES_VAR;
 end Var;
@@ -884,13 +888,13 @@ constant Type T_COMPLEX_DEFAULT     = T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")
 constant Type T_COMPLEX_DEFAULT_RECORD = T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("")), {}, NONE()) "default complex with record CiState";
 
 constant Type T_SOURCEINFO_DEFAULT_METARECORD = T_METARECORD(Absyn.QUALIFIED("SourceInfo",Absyn.IDENT("SOURCEINFO")), Absyn.IDENT("SourceInfo"), {}, 1, {
-    TYPES_VAR("fileName", dummyAttrVar, T_STRING_DEFAULT, UNBOUND(), NONE()),
-    TYPES_VAR("isReadOnly", dummyAttrVar, T_BOOL_DEFAULT, UNBOUND(), NONE()),
-    TYPES_VAR("lineNumberStart", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), NONE()),
-    TYPES_VAR("columnNumberStart", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), NONE()),
-    TYPES_VAR("lineNumberEnd", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), NONE()),
-    TYPES_VAR("columnNumberEnd", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), NONE()),
-    TYPES_VAR("lastModification", dummyAttrVar, T_REAL_DEFAULT, UNBOUND(), NONE())
+    TYPES_VAR("fileName", dummyAttrVar, T_STRING_DEFAULT, UNBOUND(), false, NONE()),
+    TYPES_VAR("isReadOnly", dummyAttrVar, T_BOOL_DEFAULT, UNBOUND(), false, NONE()),
+    TYPES_VAR("lineNumberStart", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), false, NONE()),
+    TYPES_VAR("columnNumberStart", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), false, NONE()),
+    TYPES_VAR("lineNumberEnd", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), false, NONE()),
+    TYPES_VAR("columnNumberEnd", dummyAttrVar, T_INTEGER_DEFAULT, UNBOUND(), false, NONE()),
+    TYPES_VAR("lastModification", dummyAttrVar, T_REAL_DEFAULT, UNBOUND(), false, NONE())
   }, true);
 constant Type T_SOURCEINFO_DEFAULT  = T_METAUNIONTYPE({Absyn.QUALIFIED("SourceInfo",Absyn.IDENT("SOURCEINFO"))},{},true,EVAL_SINGLETON_KNOWN_TYPE(T_SOURCEINFO_DEFAULT_METARECORD),Absyn.IDENT("SourceInfo"));
 

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -5958,6 +5958,7 @@ algorithm
               DAE.dummyAttrVar,
               DAE.T_UNKNOWN_DEFAULT,
               DAE.UNBOUND(),
+              false,
               NONE());
 end mkEmptyVar;
 

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -4839,7 +4839,7 @@ public function makeVar "Creates a Var given a name and Type"
   output DAE.Var v;
   annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  v := DAE.TYPES_VAR(name, DAE.dummyAttrVar, tp, DAE.UNBOUND(), NONE());
+  v := DAE.TYPES_VAR(name, DAE.dummyAttrVar, tp, DAE.UNBOUND(), false, NONE());
 end makeVar;
 
 public function dimensionsMult
@@ -9869,7 +9869,7 @@ algorithm
 end dimensionsKnownAndEqual;
 
 public function dimensionKnown
-  "Checks whether a dimensions is known or not."
+  "Checks whether a dimension is known or not."
   input DAE.Dimension dim;
   output Boolean known;
 algorithm
@@ -9896,8 +9896,7 @@ algorithm
 end dimensionKnownAndNonZero;
 
 public function dimensionsKnownAndNonZero
-  "Checks whether all dimensions are known or not.
-  TODO: mahge: imprive this for speed"
+  "Checks whether all dimensions are known or not."
   input list<DAE.Dimension> dims;
   output Boolean allKnown;
 algorithm
@@ -9925,6 +9924,13 @@ algorithm
     else false;
   end match;
 end dimensionUnknown;
+
+public function hasUnknownDims
+  input list<DAE.Dimension> dims;
+  output Boolean hasUnkown;
+algorithm
+  hasUnkown := List.mapBoolOr(dims, dimensionUnknown);
+end hasUnknownDims;
 
 public function subscriptEqual
 "Returns true if two subscript lists are equal."

--- a/OMCompiler/Compiler/FrontEnd/Inline.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inline.mo
@@ -1773,7 +1773,7 @@ algorithm
     case (_,_,_) then VarTransform.getReplacement(repl,cr);
     case (_,_,DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path),varLst=vars))
       equation
-        crs = List.map1(List.map(vars,Types.varName),ComponentReference.appendStringCref,cr);
+        crs = List.map1(List.map(vars,Types.getVarName),ComponentReference.appendStringCref,cr);
         exps = List.map1r(crs, VarTransform.getReplacement, repl);
       then DAE.CALL(path,exps,DAE.CALL_ATTR(ty,false,false,false,false,DAE.NO_INLINE(),DAE.NO_TAIL()));
   end matchcontinue;

--- a/OMCompiler/Compiler/FrontEnd/InnerOuter.mo
+++ b/OMCompiler/Compiler/FrontEnd/InnerOuter.mo
@@ -1264,6 +1264,7 @@ algorithm
       SCode.Visibility visibility;
       DAE.Type ty;
       DAE.Binding binding;
+      Boolean bndsrc;
 
       DAE.ConnectorType ct;
       SCode.Parallelism parallelism "parallelism";
@@ -1276,11 +1277,11 @@ algorithm
       equation
         // get the instance child
         r = FNode.childFromNode(node, FNode.itNodeName);
-        FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, cnstForRange)) = FNode.refData(r);
+        FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, bndsrc, cnstForRange)) = FNode.refData(r);
         DAE.ATTR(ct, parallelism, variability, direction, Absyn.INNER(), visibility) = attributes;
         attributes = DAE.ATTR(ct, parallelism, variability, direction, Absyn.OUTER(), visibility);
         // update the ref
-        r = FNode.updateRef(r, FNode.setData(FNode.fromRef(r),FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, cnstForRange))));
+        r = FNode.updateRef(r, FNode.setData(FNode.fromRef(r),FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, bndsrc, cnstForRange))));
         // env = switchInnerToOuterInGraph(env, inCr);
       then
         node;
@@ -1290,11 +1291,11 @@ algorithm
       equation
         // get the instance child
         r = FNode.childFromNode(node, FNode.itNodeName);
-        FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, cnstForRange)) = FNode.refData(r);
+        FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, bndsrc, cnstForRange)) = FNode.refData(r);
         DAE.ATTR(ct, parallelism, variability, direction, Absyn.INNER_OUTER(), visibility) = attributes;
         attributes = DAE.ATTR(ct, parallelism, variability, direction, Absyn.OUTER(), visibility);
         // update the ref
-        r = FNode.updateRef(r, FNode.setData(FNode.fromRef(r),FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, cnstForRange))));
+        r = FNode.updateRef(r, FNode.setData(FNode.fromRef(r),FCore.IT(DAE.TYPES_VAR(name, attributes, ty, binding, bndsrc, cnstForRange))));
         // env = switchInnerToOuterInGraph(env, inCr);
       then
         node;

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -623,6 +623,8 @@ algorithm
         ty = InstUtil.mktype(fq_class, ci_state_1, tys, bc_ty, equalityConstraint, c, InstUtil.extractComment(dae.elementLst));
         dae = InstUtil.updateDeducedUnits(callscope_1,store,dae);
 
+        ty = collectAndFixDerivedComplexOutsideBindings(ty, c);
+
         // Fixes partial functions.
         ty = InstUtil.fixInstClassType(ty,isPartialFn);
         // env_3 = FGraph.updateScope(env_3);
@@ -946,6 +948,72 @@ algorithm
     fail();
   end try;
 end instClassIn2;
+
+
+protected function collectAndFixDerivedComplexOutsideBindings
+  input DAE.Type inType;
+  input SCode.Element inClass;
+  output DAE.Type outType;
+protected
+  SCode.Mod derMod;
+  list<SCode.SubMod> submods;
+algorithm
+
+  if not SCodeUtil.isRecord(inClass)
+     or not SCodeUtil.isDerivedClass(inClass) then
+    outType := inType;
+    return;
+  end if;
+
+  derMod := SCodeUtil.getDerivedMod(inClass);
+  if SCodeUtil.isEmptyMod(derMod) then
+    outType := inType;
+    return;
+  end if;
+
+  try
+    SCode.MOD(subModLst = submods) := derMod;
+  else
+    Error.addMessage(Error.INTERNAL_ERROR, {"Unexpected Mod structure in collectAndFixDerivedComplexOutsideBindings."});
+    fail();
+  end try;
+
+  outType := match inType
+    local
+      list<DAE.Var> tvars;
+      Option<DAE.Exp> obind;
+      DAE.Exp bind_exp;
+
+    case DAE.T_COMPLEX() algorithm
+      tvars := {};
+      for var in inType.varLst loop
+
+        for submod in submods loop
+          if varIsModifiedInDerivedMod(var.name, submod) then
+            var.bind_from_outside := true;
+            break;
+          end if;
+        end for;
+
+        tvars := var::tvars;
+      end for;
+      tvars := listReverse(tvars);
+
+    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint);
+  end match;
+
+end collectAndFixDerivedComplexOutsideBindings;
+
+function varIsModifiedInDerivedMod
+  input String inName;
+  input SCode.SubMod inSubmod;
+  output Boolean b;
+algorithm
+  b := match inSubmod
+    case SCode.NAMEMOD() then stringEqual(inSubmod.ident, inName);
+  end match;
+end varIsModifiedInDerivedMod;
+
 
 protected function callingScopeCacheEq
   input InstTypes.CallingScope inCallingScope1;
@@ -1419,7 +1487,7 @@ algorithm
         (vbind,_) = Types.matchType(ValuesUtil.valueExp(v),bindTp,expectedTp,true);
         v = ValuesUtil.expValue(vbind);
       then DAE.TYPES_VAR(id,DAE.dummyAttrParam,t_1,
-        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),NONE());
+        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),false,NONE());
 
     case (_,_,_,SOME(v),_,expectedTp,DAE.PROP(bindTp as DAE.T_ARRAY(dims = {d}),c))
       equation
@@ -1431,7 +1499,7 @@ algorithm
         (vbind,_) = Types.matchType(ValuesUtil.valueExp(v),bindTp,expectedTp,true);
         v = ValuesUtil.expValue(vbind);
       then DAE.TYPES_VAR(id,DAE.dummyAttrParam,t_1,
-        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),NONE());
+        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),false,NONE());
 
     case (cache,env,_,_,_,expectedTp,DAE.PROP(bindTp,c))
       equation
@@ -1439,7 +1507,7 @@ algorithm
         (bind1,t_1) = Types.matchType(bind,bindTp,expectedTp,true);
         (cache,v) = Ceval.ceval(cache, env, bind1, false, Absyn.NO_MSG(), 0);
       then DAE.TYPES_VAR(id,DAE.dummyAttrParam,t_1,
-        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),NONE());
+        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),false,NONE());
 
     case (cache,env,_,_,_,expectedTp,DAE.PROP(bindTp as DAE.T_ARRAY(dims = {d}),c))
       equation
@@ -1449,7 +1517,7 @@ algorithm
         (bind1,t_1) = Types.matchType(bind,bindTp,expectedTp,true);
         (cache,v) = Ceval.ceval(cache,env, bind1, false, Absyn.NO_MSG(), 0);
       then DAE.TYPES_VAR(id,DAE.dummyAttrParam,t_1,
-        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),NONE());
+        DAE.EQBOUND(bind1,SOME(v),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),false,NONE());
 
     case(_,_,_,_,_,expectedTp,DAE.PROP(bindTp,c))
       equation
@@ -1462,7 +1530,7 @@ algorithm
         end if;
         (bind1,t_1) = Types.matchType(bind,bindTp,expectedTp,true);
       then DAE.TYPES_VAR(id,DAE.dummyAttrParam,t_1,
-        DAE.EQBOUND(bind1,NONE(),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),NONE());
+        DAE.EQBOUND(bind1,NONE(),DAE.C_PARAM(),DAE.BINDING_FROM_DEFAULT_VALUE()),false,NONE());
 
     case(_,_,_,_,_,_,DAE.PROP(_,c))
       equation
@@ -3196,7 +3264,7 @@ algorithm
     // The component was deleted, update its status in the environment so we can
     // look it up when instantiating connections.
     if isDeleted == true then
-      var := DAE.TYPES_VAR(el_name, DAE.dummyAttrVar, DAE.T_UNKNOWN_DEFAULT, DAE.UNBOUND(), NONE());
+      var := DAE.TYPES_VAR(el_name, DAE.dummyAttrVar, DAE.T_UNKNOWN_DEFAULT, DAE.UNBOUND(), false, NONE());
       env := FGraph.updateComp(env, var, FCore.VAR_DELETED(), FGraph.emptyGraph);
     end if;
   else
@@ -3514,7 +3582,7 @@ algorithm
 
         dae_attr = DAEUtil.translateSCodeAttrToDAEAttr(attr, prefixes);
         ty = Types.traverseType(ty, 1, Types.setIsFunctionPointer);
-        new_var = DAE.TYPES_VAR(name, dae_attr, ty, binding, NONE());
+        new_var = DAE.TYPES_VAR(name, dae_attr, ty, binding, false, NONE());
 
         // Type info present. Now we can also put the binding into the dae.
         // If the type is one of the simple, predifined types a simple variable
@@ -3589,7 +3657,7 @@ algorithm
         // true in update_frame means the variable is now instantiated.
         dae_attr = DAEUtil.translateSCodeAttrToDAEAttr(attr, prefixes);
         ty = Types.traverseType(ty, 1, Types.setIsFunctionPointer);
-        new_var = DAE.TYPES_VAR(name, dae_attr, ty, binding, NONE()) ;
+        new_var = DAE.TYPES_VAR(name, dae_attr, ty, binding, false, NONE()) ;
 
         // type info present Now we can also put the binding into the dae.
         // If the type is one of the simple, predifined types a simple variable
@@ -4305,7 +4373,7 @@ algorithm
     // The environment is extended with the new variable binding.
     (outCache, binding) :=
       InstBinding.makeBinding(outCache, outEnv, inAttr, mod, ty, inPrefix, inName, inInfo);
-    var := DAE.TYPES_VAR(inName, inDAttr, ty, binding, NONE());
+    var := DAE.TYPES_VAR(inName, inDAttr, ty, binding, false, NONE());
     outEnv := FGraph.updateComp(outEnv, var, FCore.VAR_TYPED(), comp_env);
     outUpdatedComps := BaseHashTable.add((inCref, 1), outUpdatedComps);
   end try;
@@ -5019,7 +5087,7 @@ algorithm
         io = SCodeUtil.prefixesInnerOuter(inPrefixes);
         vis = SCodeUtil.prefixesVisibility(inPrefixes);
 
-        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),NONE());
+        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),false,NONE());
         env = FGraph.updateComp(env, new_var, FCore.VAR_TYPED(), compenv);
         ErrorExt.rollBack("Inst.removeSelfReferenceAndUpdate");
       then
@@ -5057,7 +5125,7 @@ algorithm
         io = SCodeUtil.prefixesInnerOuter(inPrefixes);
         vis = SCodeUtil.prefixesVisibility(inPrefixes);
 
-        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),NONE());
+        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),false,NONE());
         env = FGraph.updateComp(env, new_var, FCore.VAR_TYPED(), compenv);
         ErrorExt.rollBack("Inst.removeSelfReferenceAndUpdate");
       then
@@ -5095,7 +5163,7 @@ algorithm
         io = SCodeUtil.prefixesInnerOuter(inPrefixes);
         vis = SCodeUtil.prefixesVisibility(inPrefixes);
 
-        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),NONE());
+        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),false,NONE());
         env = FGraph.updateComp(env, new_var, FCore.VAR_TYPED(), compenv);
         ErrorExt.rollBack("Inst.removeSelfReferenceAndUpdate");
       then
@@ -5134,7 +5202,7 @@ algorithm
         io = SCodeUtil.prefixesInnerOuter(inPrefixes);
         vis = SCodeUtil.prefixesVisibility(inPrefixes);
 
-        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),NONE());
+        new_var = DAE.TYPES_VAR(n,DAE.ATTR(DAEUtil.toConnectorTypeNoState(ct),prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),false,NONE());
         env = FGraph.updateComp(env, new_var, FCore.VAR_TYPED(), compenv);
         ErrorExt.rollBack("Inst.removeSelfReferenceAndUpdate");
       then
@@ -5173,7 +5241,7 @@ algorithm
 
         io = SCodeUtil.prefixesInnerOuter(inPrefixes);
         vis = SCodeUtil.prefixesVisibility(inPrefixes);
-        new_var = DAE.TYPES_VAR(n,DAE.ATTR(ct,prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),NONE());
+        new_var = DAE.TYPES_VAR(n,DAE.ATTR(ct,prl1,var1,dir,io,vis),ty,DAE.UNBOUND(),false,NONE());
         env = FGraph.updateComp(env, new_var, FCore.VAR_TYPED(), compenv);
         ErrorExt.delCheckpoint("Inst.removeSelfReferenceAndUpdate");
       then

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -76,26 +76,26 @@ public constant DAE.Type stateSelectType =
           DAE.T_ENUMERATION(NONE(),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},
           {
           DAE.TYPES_VAR("never",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(1),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),NONE()),
+             DAE.T_ENUMERATION(SOME(1),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),false,NONE()),
           DAE.TYPES_VAR("avoid",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(2),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),NONE()),
+             DAE.T_ENUMERATION(SOME(2),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),false,NONE()),
           DAE.TYPES_VAR("default",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(3),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),NONE()),
+             DAE.T_ENUMERATION(SOME(3),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),false,NONE()),
           DAE.TYPES_VAR("prefer",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(4),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),NONE()),
+             DAE.T_ENUMERATION(SOME(4),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),false,NONE()),
           DAE.TYPES_VAR("always",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(5),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),NONE())
+             DAE.T_ENUMERATION(SOME(5),Absyn.IDENT(""),{"never","avoid","default","prefer","always"},{},{}),DAE.UNBOUND(),false,NONE())
           },{});
 
 public constant DAE.Type uncertaintyType =
           DAE.T_ENUMERATION(NONE(),Absyn.IDENT(""),{"given","sought","refine"},
           {
            DAE.TYPES_VAR("given",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(1),Absyn.IDENT(""),{"given","sought","refine"},{},{}),DAE.UNBOUND(),NONE()),
+             DAE.T_ENUMERATION(SOME(1),Absyn.IDENT(""),{"given","sought","refine"},{},{}),DAE.UNBOUND(),false,NONE()),
            DAE.TYPES_VAR("sought",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(2),Absyn.IDENT(""),{"given","sought","refine"},{},{}),DAE.UNBOUND(),NONE()),
+             DAE.T_ENUMERATION(SOME(2),Absyn.IDENT(""),{"given","sought","refine"},{},{}),DAE.UNBOUND(),false,NONE()),
            DAE.TYPES_VAR("refine",DAE.dummyAttrParam,
-             DAE.T_ENUMERATION(SOME(3),Absyn.IDENT(""),{"given","sought","refine"},{},{}),DAE.UNBOUND(),NONE())
+             DAE.T_ENUMERATION(SOME(3),Absyn.IDENT(""),{"given","sought","refine"},{},{}),DAE.UNBOUND(),false,NONE())
           },{});
 
 public constant DAE.Type distributionType =
@@ -106,18 +106,21 @@ public constant DAE.Type distributionType =
                     DAE.ATTR(DAE.NON_CONNECTOR(),SCode.NON_PARALLEL(),SCode.PARAM(),Absyn.BIDIR(),Absyn.NOT_INNER_OUTER(),SCode.PUBLIC()),
                     DAE.T_STRING_DEFAULT,
                     DAE.UNBOUND(), // binding
+                    false,
                     NONE()),
                   DAE.TYPES_VAR(
                     "params",
                     DAE.ATTR(DAE.NON_CONNECTOR(),SCode.NON_PARALLEL(),SCode.PARAM(),Absyn.BIDIR(),Absyn.NOT_INNER_OUTER(),SCode.PUBLIC()),
                     DAE.T_ARRAY_REAL_NODIM,
                     DAE.UNBOUND(), // binding
+                    false,
                     NONE()),
                   DAE.TYPES_VAR(
                     "paramNames",
                     DAE.ATTR(DAE.NON_CONNECTOR(),SCode.NON_PARALLEL(),SCode.PARAM(),Absyn.BIDIR(),Absyn.NOT_INNER_OUTER(),SCode.PUBLIC()),
                     DAE.T_ARRAY_STRING_NODIM,
                     DAE.UNBOUND(), // binding
+                    false,
                     NONE())
                 },
                 NONE());

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -3405,8 +3405,7 @@ algorithm
                           envExpandable,
                           DAE.TYPES_VAR(componentName,
                                         DAE.ATTR(ct2,prl2,vt2,Absyn.BIDIR(),io2,vis2),
-                                        ty2,DAE.UNBOUND(),
-                                        NONE()),
+                                        ty2,DAE.UNBOUND(),false, NONE()),
                           SCode.COMPONENT(
                             componentName,
                             SCode.defaultPrefixes,
@@ -3493,7 +3492,7 @@ algorithm
                           DAE.TYPES_VAR(
                             componentName,
                             DAE.ATTR(ct2,prl2,vt2,Absyn.BIDIR(),io2,vis2),
-                            ty2,DAE.UNBOUND(),NONE()),
+                            ty2,DAE.UNBOUND(),false,NONE()),
                           SCode.COMPONENT(
                             componentName,
                             SCode.defaultPrefixes,
@@ -3730,7 +3729,7 @@ algorithm
         // update the topEnv
         updatedEnv = FGraph.updateComp(
                        realEnv,
-                       DAE.TYPES_VAR(currentName, veAttr, veTy, veBinding, veCnstForRange),
+                       DAE.TYPES_VAR(currentName, veAttr, veTy, veBinding, false, veCnstForRange),
                        FCore.VAR_TYPED(),
                        veEnv);
         updatedEnv = FGraph.pushScope(updatedEnv, forLoopScope);
@@ -3753,7 +3752,7 @@ algorithm
         // update the current environment!
         currentEnv = FGraph.updateComp(
                        realEnv,
-                       DAE.TYPES_VAR(currentName, veAttr, veTy, veBinding, veCnstForRange),
+                       DAE.TYPES_VAR(currentName, veAttr, veTy, veBinding, false, veCnstForRange),
                        FCore.VAR_TYPED(),
                        veEnv);
         currentEnv = FGraph.pushScope(currentEnv, forLoopScope);

--- a/OMCompiler/Compiler/FrontEnd/InstVar.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstVar.mo
@@ -881,6 +881,7 @@ algorithm
         //        see testsuite/mofiles/Sequence.mo
         (cache,env_1,ih,store,_,csets,ty,_,_,graph) =
           Inst.instClass(cache, env, ih, store, /* mod */ DAE.NOMOD(), pre, cl, inst_dims, impl, InstTypes.INNER_CALL(), graph, csets);
+
         //Make it an array type since we are not flattening
         ty_1 = InstUtil.makeArrayType(dims, ty);
         InstUtil.checkFunctionVarType(ty_1, ci_state, n, info);
@@ -913,6 +914,7 @@ algorithm
          //Instantiate type of the component, skip dae/not flattening
         (cache,env_1,ih,store,_,csets,ty,_,_,_) =
           Inst.instClass(cache, env, ih, store, mod, pre, cl, inst_dims, impl, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, csets);
+
         arrty = InstUtil.makeArrayType(dims, ty);
         InstUtil.checkFunctionVarType(arrty, ci_state, n, info);
         (cache,cr) = PrefixUtil.prefixCref(cache,env,ih,pre, ComponentReference.makeCrefIdent(n,arrty,{}));

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -3212,7 +3212,7 @@ protected
   DAE.Type tty, ty;
   list<DAE.Subscript> ss_1;
 algorithm
-  (DAE.TYPES_VAR(name,attr,ty,bind,cnstForRange),_,_,_,componentEnv) := lookupVar2(ht, ident, inEnv);
+  (DAE.TYPES_VAR(name,attr,ty,bind,_,cnstForRange),_,_,_,componentEnv) := lookupVar2(ht, ident, inEnv);
   ty_1 := checkSubscripts(ty, ss);
   tty := Types.simplifyType(ty);
   ss_1 := addArrayDimensions(tty,ss);
@@ -3240,7 +3240,7 @@ algorithm
     case DAE.CREF_IDENT()
       algorithm
         fields := Types.getMetaRecordFields(inType);
-        DAE.TYPES_VAR(name,attr,ty,binding,cnstForRange) := listGet(fields,Types.findVarIndex(cr.ident,fields)+1);
+        DAE.TYPES_VAR(name,attr,ty,binding,_,cnstForRange) := listGet(fields,Types.findVarIndex(cr.ident,fields)+1);
         for s in cr.subscriptLst loop
           ty := match ty
             case DAE.T_METAARRAY() then ty.ty;
@@ -3251,7 +3251,7 @@ algorithm
     case DAE.CREF_QUAL()
       algorithm
         fields := Types.getMetaRecordFields(inType);
-        DAE.TYPES_VAR(name,attr,ty,binding,cnstForRange) := listGet(fields,Types.findVarIndex(cr.ident,fields)+1);
+        DAE.TYPES_VAR(name,attr,ty,binding,_,cnstForRange) := listGet(fields,Types.findVarIndex(cr.ident,fields)+1);
         for s in cr.subscriptLst loop
           ty := match ty
             case DAE.T_METAARRAY() then ty.ty;

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -2789,7 +2789,7 @@ algorithm
       equation
          path = AbsynUtil.stripLast(name);
          ty = DAE.T_METARECORD(name,path,typeVars,index,fields,knownSingleton);
-         env = FGraph.mkComponentNode(env, DAE.TYPES_VAR(id,attr,ty,DAE.UNBOUND(),NONE()), SCode.COMPONENT(id,SCode.defaultPrefixes,SCode.defaultVarAttr,Absyn.TPATH(name,NONE()),SCode.NOMOD(),SCode.noComment,NONE(),AbsynUtil.dummyInfo), DAE.NOMOD(), FCore.VAR_DAE(), FGraph.empty());
+         env = FGraph.mkComponentNode(env, DAE.TYPES_VAR(id,attr,ty,DAE.UNBOUND(),false,NONE()), SCode.COMPONENT(id,SCode.defaultPrefixes,SCode.defaultVarAttr,Absyn.TPATH(name,NONE()),SCode.NOMOD(),SCode.noComment,NONE(),AbsynUtil.dummyInfo), DAE.NOMOD(), FCore.VAR_DAE(), FGraph.empty());
       then env;
     else env;
   end match;
@@ -2888,7 +2888,7 @@ algorithm
     case (env,ty::_,(id::rest)::aliases,_)
       equation
         attr = DAE.dummyAttrInput;
-        env = FGraph.mkComponentNode(env, DAE.TYPES_VAR(id,attr,ty,DAE.UNBOUND(),NONE()), SCode.COMPONENT(id,SCode.defaultPrefixes,SCode.defaultVarAttr,Absyn.TPATH(Absyn.IDENT("$dummy"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),info), DAE.NOMOD(), FCore.VAR_DAE(), FGraph.empty());
+        env = FGraph.mkComponentNode(env, DAE.TYPES_VAR(id,attr,ty,DAE.UNBOUND(),false,NONE()), SCode.COMPONENT(id,SCode.defaultPrefixes,SCode.defaultVarAttr,Absyn.TPATH(Absyn.IDENT("$dummy"),NONE()),SCode.NOMOD(),SCode.noComment,NONE(),info), DAE.NOMOD(), FCore.VAR_DAE(), FGraph.empty());
       then addAliasesToEnv(env,inTypes,rest::aliases,info);
   end match;
 end addAliasesToEnv;

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -4426,6 +4426,7 @@ algorithm
 
     case (SCode.DERIVED(ty, _, attr), _) then SCode.DERIVED(ty, inMod, attr);
     case (SCode.CLASS_EXTENDS(_, cdef), _) then SCode.CLASS_EXTENDS(inMod, cdef);
+    else inClassDef;
 
   end match;
 end setClassDefMod;

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -3499,7 +3499,7 @@ algorithm
         (cache, dims_1, dimprops) = elabExpList(cache, env, dims, impl,true, pre, info);
         (dims_1,_) = Types.matchTypes(dims_1, List.map(dimprops,Types.getPropType), DAE.T_INTEGER_DEFAULT, false);
         sty = Types.getPropType(prop);
-        sty = Types.liftArrayListExp(sty, dims_1);
+        sty = Types.liftTypeWithDimExps(sty, dims_1);
         exp_type = Types.simplifyType(sty);
         prop = DAE.PROP(sty, c1);
         exp = Expression.makePureBuiltinCall("fill", s_1 :: dims_1, exp_type);
@@ -3513,7 +3513,7 @@ algorithm
         false = Config.splitArrays();
         (cache, s_1, DAE.PROP(sty, c1)) = elabExpInExpression(cache, env, s, impl, true, pre, info);
         (cache, dims_1,_) = elabExpList(cache, env, dims, impl, true, pre, info);
-        sty = Types.liftArrayListExp(sty, dims_1);
+        sty = Types.liftTypeWithDimExps(sty, dims_1);
         exp_type = Types.simplifyType(sty);
         c1 = Types.constAnd(c1, DAE.C_PARAM());
         prop = DAE.PROP(sty, c1);
@@ -8766,7 +8766,7 @@ algorithm
         ty := Expression.typeof(exp);
         true := Types.dimensionsKnown(ty);
         binding := DAE.EQBOUND(exp, NONE(), DAE.C_CONST(), DAE.BINDING_FROM_DEFAULT_VALUE());
-      then (DAE.TYPES_VAR(name, DAE.dummyAttrParam, ty, binding, NONE()));
+      then (DAE.TYPES_VAR(name, DAE.dummyAttrParam, ty, binding, false, NONE()));
 
     // Otherwise, try to constant evaluate the expression.
     case SLOT(defaultArg = DAE.FUNCARG(name=name), arg = SOME(exp))
@@ -8777,10 +8777,10 @@ algorithm
         ty := Expression.typeof(exp);
         // Create a binding from the evaluated expression.
         binding := DAE.EQBOUND(exp, SOME(val), DAE.C_CONST(), DAE.BINDING_FROM_DEFAULT_VALUE());
-      then DAE.TYPES_VAR(name, DAE.dummyAttrParam, ty, binding, NONE());
+      then DAE.TYPES_VAR(name, DAE.dummyAttrParam, ty, binding, false, NONE());
 
     case SLOT(defaultArg = DAE.FUNCARG(name=name, ty=ty))
-      then (DAE.TYPES_VAR(name, DAE.dummyAttrParam, ty, DAE.UNBOUND(), NONE()));
+      then (DAE.TYPES_VAR(name, DAE.dummyAttrParam, ty, DAE.UNBOUND(), false, NONE()));
 
   end matchcontinue;
 end makeVarFromSlot;

--- a/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
@@ -142,7 +142,7 @@ protected function valueExpTypeExpVar "help function to valueExpType"
   output DAE.Var expVar;
   annotation(__OpenModelica_EarlyInline = true);
 algorithm
-  expVar := DAE.TYPES_VAR(name, DAE.dummyAttrVar, etp, DAE.UNBOUND(), NONE());
+  expVar := DAE.TYPES_VAR(name, DAE.dummyAttrVar, etp, DAE.UNBOUND(), false, NONE());
 end valueExpTypeExpVar;
 
 public function isZero "Returns true if value is zero"

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1157,6 +1157,7 @@ algorithm
     Component.Attributes.toDAE(attr, InstNode.visibility(component)),
     Type.toDAE(Component.getType(comp)),
     Binding.toDAE(Component.getBinding(comp)),
+    false,
     NONE()
   );
 end makeTypeVar;
@@ -1183,6 +1184,7 @@ algorithm
     Component.Attributes.toDAE(attr, vis),
     Type.toDAE(Component.getType(comp)),
     Binding.toDAE(Component.getBinding(comp)),
+    false,
     NONE()
   );
 end makeTypeRecordVar;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -131,28 +131,28 @@ import BlockCallRewrite;
 import Binding;
 
 protected constant DAE.Type simulationResultType_rtest = DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationResult")),{
-  DAE.TYPES_VAR("resultFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("simulationOptions",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE())
+  DAE.TYPES_VAR("resultFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("simulationOptions",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())
   },NONE());
 
 protected constant DAE.Type simulationResultType_full = DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationResult")),{
-  DAE.TYPES_VAR("resultFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("simulationOptions",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeFrontend",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeBackend",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeSimCode",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeTemplates",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeCompile",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeSimulation",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("timeTotal",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE())
+  DAE.TYPES_VAR("resultFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("simulationOptions",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeFrontend",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeBackend",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeSimCode",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeTemplates",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeCompile",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeSimulation",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("timeTotal",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE())
   },NONE());
 
 protected constant DAE.Type simulationResultType_drModelica = DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationResult")),{
-  DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("flatteningTime",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE()),
-  DAE.TYPES_VAR("simulationTime",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),NONE())
+  DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("flatteningTime",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
+  DAE.TYPES_VAR("simulationTime",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE())
   },NONE());
 
 //these are in reversed order than above

--- a/OMCompiler/Compiler/Script/StaticScript.mo
+++ b/OMCompiler/Compiler/Script/StaticScript.mo
@@ -376,8 +376,8 @@ algorithm
                                                      DAE.T_STRING_DEFAULT, args, DAE.SCONST(cname_str),pre,info);
         recordtype =
         DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationObject")),
-        {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-         DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE())},
+        {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+         DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())},
           NONE());
       then
         (cache,Expression.makePureBuiltinCall("translateModelCPP",
@@ -391,8 +391,8 @@ algorithm
                                                      DAE.T_STRING_DEFAULT, args, DAE.SCONST(cname_str),pre,info);
         recordtype =
           DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationObject")),
-          {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-           DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE())},
+          {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+           DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())},
            NONE());
       then
         (cache,Expression.makePureBuiltinCall("translateModelXML",
@@ -406,8 +406,8 @@ algorithm
           DAE.T_STRING_DEFAULT, args, DAE.SCONST(cname_str),pre,info);
         recordtype =
           DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationObject")),
-          {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE()),
-           DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),NONE())},
+          {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
+           DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())},
            NONE());
       then
         (cache,Expression.makePureBuiltinCall("exportDAEtoMatlab",

--- a/OMCompiler/Compiler/Script/SymbolTable.mo
+++ b/OMCompiler/Compiler/Script/SymbolTable.mo
@@ -391,6 +391,7 @@ algorithm
                     DAE.dummyAttrVar,
                     tp,
                     DAE.VALBOUND(v, DAE.BINDING_FROM_DEFAULT_VALUE()),
+                    false,
                     NONE()),
                   FCore.VAR_TYPED(),
                   empty_env);
@@ -402,7 +403,7 @@ algorithm
         empty_env = FGraph.empty();
         env = FGraph.mkComponentNode(
                  env,
-                 DAE.TYPES_VAR(id,DAE.dummyAttrVar,tp,DAE.VALBOUND(v,DAE.BINDING_FROM_DEFAULT_VALUE()),NONE()),
+                 DAE.TYPES_VAR(id,DAE.dummyAttrVar,tp,DAE.VALBOUND(v,DAE.BINDING_FROM_DEFAULT_VALUE()),false,NONE()),
                   SCode.COMPONENT(
                     id,
                     SCode.defaultPrefixes,

--- a/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
@@ -179,9 +179,10 @@ uniontype Variable
     DAE.ComponentRef name;
     DAE.Type ty;
     Option<DAE.Exp> value "default value";
-    list<DAE.Exp> instDims;
+    list<DAE.Dimension> instDims;
     DAE.VarParallelism parallelism;
     DAE.VarKind kind;
+    Boolean bind_from_outside;
   end VARIABLE;
 
   record FUNCTION_PTR
@@ -200,22 +201,21 @@ uniontype Context
   end SIMULATION_CONTEXT;
 
   record FUNCTION_CONTEXT
+    String cref_prefix;
+    Boolean is_parallel;
   end FUNCTION_CONTEXT;
 
   record ALGLOOP_CONTEXT
-     Boolean genInitialisation;
-     Boolean genJacobian;
+    Boolean genInitialisation;
+    Boolean genJacobian;
   end ALGLOOP_CONTEXT;
 
-   record JACOBIAN_CONTEXT
-     Option<HashTableCrefSimVar.HashTable> jacHT;
-   end JACOBIAN_CONTEXT;
+  record JACOBIAN_CONTEXT
+    Option<HashTableCrefSimVar.HashTable> jacHT;
+  end JACOBIAN_CONTEXT;
 
   record OTHER_CONTEXT
   end OTHER_CONTEXT;
-
-  record PARALLEL_FUNCTION_CONTEXT
-  end PARALLEL_FUNCTION_CONTEXT;
 
   record ZEROCROSSINGS_CONTEXT
   end ZEROCROSSINGS_CONTEXT;
@@ -236,13 +236,13 @@ end Context;
 
 public constant Context contextSimulationNonDiscrete  = SIMULATION_CONTEXT(false);
 public constant Context contextSimulationDiscrete     = SIMULATION_CONTEXT(true);
-public constant Context contextFunction               = FUNCTION_CONTEXT();
+public constant Context contextFunction               = FUNCTION_CONTEXT("", false);
 public constant Context contextJacobian               = JACOBIAN_CONTEXT(NONE());
 public constant Context contextAlgloopJacobian        = ALGLOOP_CONTEXT(false,true);
 public constant Context contextAlgloopInitialisation  = ALGLOOP_CONTEXT(true,false);
 public constant Context contextAlgloop                = ALGLOOP_CONTEXT(false,false);
 public constant Context contextOther                  = OTHER_CONTEXT();
-public constant Context contextParallelFunction       = PARALLEL_FUNCTION_CONTEXT();
+public constant Context contextParallelFunction       = FUNCTION_CONTEXT("", true);
 public constant Context contextZeroCross              = ZEROCROSSINGS_CONTEXT();
 public constant Context contextOptimization           = OPTIMIZATION_CONTEXT();
 public constant Context contextFMI                    = FMI_CONTEXT();
@@ -250,7 +250,7 @@ public constant Context contextDAEmode                = DAE_MODE_CONTEXT();
 public constant Context contextOMSI                   = OMSI_CONTEXT(NONE());
 
 constant list<DAE.Exp> listExpLength1 = {DAE.ICONST(0)} "For CodegenC.tpl";
-constant list<Variable> boxedRecordOutVars = VARIABLE(DAE.CREF_IDENT("",DAE.T_COMPLEX_DEFAULT_RECORD,{}),DAE.T_COMPLEX_DEFAULT_RECORD,NONE(),{},DAE.NON_PARALLEL(),DAE.VARIABLE())::{} "For CodegenC.tpl";
+constant list<Variable> boxedRecordOutVars = VARIABLE(DAE.CREF_IDENT("",DAE.T_COMPLEX_DEFAULT_RECORD,{}),DAE.T_COMPLEX_DEFAULT_RECORD,NONE(),{},DAE.NON_PARALLEL(),DAE.VARIABLE(), false)::{} "For CodegenC.tpl";
 
 // protected imports
 protected

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8130,8 +8130,6 @@ algorithm
       DAE.ComponentRef cref;
       DAE.Type ty;
       DAE.VarKind kind;
-      Option<DAE.Exp> val;
-      list<DAE.Exp> instDims;
       list<SimCodeFunction.Variable> rest;
     case({},_)
       equation
@@ -13754,13 +13752,10 @@ protected
   SimCode.SimCode simCode;
   Integer index;
 algorithm
-  if match context
-    case SimCodeFunction.FUNCTION_CONTEXT() then true;
-    case SimCodeFunction.PARALLEL_FUNCTION_CONTEXT() then true;
-    else false; end match
-  then
+  if SimCodeFunctionUtil.inFunctionContext(context) then
     return;
   end if;
+
   e := match e
     case DAE.CREF(ty=DAE.T_ARRAY())
       algorithm

--- a/OMCompiler/Compiler/Template/CodegenAdevs.tpl
+++ b/OMCompiler/Compiler/Template/CodegenAdevs.tpl
@@ -2023,6 +2023,9 @@ template functionHeaderImpl(String fname, list<Variable> fargs, list<Variable> o
 
   boxed version of the header if boxed = true, otherwise a normal header"
 ::=
+  let &preExp = buffer "" /*BUFD*/
+  let &varDecls = buffer "" /*BUFD*/
+  
   let fargsStr = if boxed then
       (fargs |> var => funArgBoxedDefinition(var) ;separator=", ")
     else
@@ -2044,7 +2047,7 @@ template functionHeaderImpl(String fname, list<Variable> fargs, list<Variable> o
       match var
       case VARIABLE(__) then
         let dimStr = match ty case T_ARRAY(__) then
-          '[<%dims |> dim => dimension(dim) ;separator=", "%>]'
+          '[<%dims |> dim => dimension(dim, contextFunction, &preExp, &varDecls) ;separator=", "%>]'
         let typeStr = if boxed then varTypeBoxed(var) else varType(var)
         '<%typeStr%> targ<%i1%>; /* <%crefStr(name)%><%dimStr%> */'
       case FUNCTION_PTR(__) then
@@ -2642,9 +2645,7 @@ case var as VARIABLE(__) then
   let addRoot = match typ case "modelica_metatype" then ' mmc_GC_add_root(&<%varName%>, mmc_GC_local_state, "<%varName%>");' else ''
   let &varDecls += if not outStruct then '<%typ%> <%varName%><%initVar%>;<%addRoot%><%\n%>' //else ""
   let varName = if outStruct then '<%outStruct%>.targ<%i%>' else '<%contextCref(var.name,contextFunction)%>'
-  let instDimsInit = (instDims |> exp =>
-      daeExp(exp, contextFunction, &varInits /*BUFC*/, &varDecls /*BUFD*/)
-    ;separator=", ")
+  let instDimsInit = (instDims |> dim => dimension(dim, contextFunction, &varInits /*BUFC*/, &varDecls /*BUFD*/) ;separator=", ")
   if instDims then
     (match var.value
     case SOME(exp) then
@@ -2741,15 +2742,13 @@ case var as VARIABLE(ty = T_STRING(__)) then
       let &varAssign += '<%dest%>.targ<%ix%> = <%contextCref(var.name,contextFunction)%>;<%\n%>'
       ""
 case var as VARIABLE(__) then
-  let instDimsInit = (instDims |> exp =>
-      daeExp(exp, contextFunction, &varInits /*BUFC*/, &varDecls /*BUFD*/)
-    ;separator=", ")
+  let instDimsInit = (instDims |> dim => dimension(dim, contextFunction, &varInits /*BUFC*/, &varDecls /*BUFD*/) ;separator=", ")
   if instDims then
     let &varInits += 'alloc_<%expTypeShort(var.ty)%>_array(&<%dest%>.targ<%ix%>, <%listLength(instDims)%>, <%instDimsInit%>);<%\n%>'
     let &varAssign += 'copy_<%expTypeShort(var.ty)%>_array_data(&<%contextCref(var.name,contextFunction)%>, &<%dest%>.targ<%ix%>);<%\n%>'
     ""
   else
-    let &varInits += initRecordMembers(var)
+    let &varInits += initRecordMembers(var, &varDecls)
     let &varAssign += '<%dest%>.targ<%ix%> = <%contextCref(var.name,contextFunction)%>;<%\n%>'
     ""
 case var as FUNCTION_PTR(__) then
@@ -2757,21 +2756,25 @@ case var as FUNCTION_PTR(__) then
     ""
 end varOutput;
 
-template initRecordMembers(Variable var)
+template initRecordMembers(Variable var, Text& varDecls)
 ::=
 match var
 case VARIABLE(ty = T_COMPLEX(complexClassType = RECORD(__))) then
   let varName = contextCref(name,contextFunction)
-  (ty.varLst |> v => recordMemberInit(v, varName) ;separator="\n")
+  (ty.varLst |> v => recordMemberInit(v, varName, &varDecls) ;separator="\n")
 end initRecordMembers;
 
-template recordMemberInit(Var v, Text varName)
+template recordMemberInit(Var v, Text varName, Text& varDecls)
 ::=
 match v
 case TYPES_VAR(ty = T_ARRAY(__)) then
+  let &preExp = buffer ""
   let arrayType = expType(ty, true)
-  let dims = (ty.dims |> dim => dimension(dim) ;separator=", ")
-  'alloc_<%arrayType%>(&<%varName%>.<%name%>, <%listLength(ty.dims)%>, <%dims%>);'
+  let dims = (ty.dims |> dim => dimension(dim, contextFunction, &preExp, &varDecls) ;separator=", ")
+  <<
+  <%preExp%>
+  alloc_<%arrayType%>(&<%varName%>.<%name%>, <%listLength(ty.dims)%>, <%dims%>);
+  >>
 end recordMemberInit;
 
 template extVarName(ComponentRef cr)
@@ -2903,8 +2906,7 @@ template extFunCallBiVarF77(Variable var, Text &preExp, Text &varDecls)
         '<%var_name%> = <%daeExp(v, contextFunction, &preExp /*BUFC*/, &varDecls /*BUFD*/)%>;<%\n%>'
       else ""
     let &preExp += defaultValue
-    let instDimsInit = (instDims |> exp =>
-        daeExp(exp, contextFunction, &preExp /*BUFC*/, &varDecls /*BUFD*/) ;separator=", ")
+    let instDimsInit = (instDims |> dim => dimension(dim, contextFunction, &preExp /*BUFC*/, &varDecls /*BUFD*/) ;separator=", ")
     if instDims then
       let type = expTypeArray(var.ty)
       let &preExp += 'alloc_<%type%>(&<%var_name%>, <%listLength(instDims)%>, <%instDimsInit%>);<%\n%>'
@@ -3754,7 +3756,7 @@ case ecr as CREF(ty=T_ARRAY(ty=aty,dims=dims)) then
     // object since they are represented only in a double array.
     let tmpArr = tempDecl(expTypeArray(aty), &varDecls /*BUFD*/)
     let dimsLenStr = listLength(dims)
-    let dimsValuesStr = (dims |> dim => dimension(dim) ;separator=", ")
+    let dimsValuesStr = (dims |> dim => dimension(dim, context, &preExp, &varDecls) ;separator=", ")
     let type = expTypeShort(aty)
     let &preExp += '<%type%>_array_create(&<%tmpArr%>, ((modelica_<%type%>*)&(<%arrayCrefCStr(ecr.componentRef)%>)), <%dimsLenStr%>, <%dimsValuesStr%>);<%\n%>'
     tmpArr
@@ -5354,13 +5356,19 @@ template expTypeFromOpFlag(Operator op, Integer flag)
   else "expTypeFromOpFlag:ERROR"
 end expTypeFromOpFlag;
 
-template dimension(Dimension d)
+template dimension(Dimension d, Context context, Text &preExp, Text &varDecls)
 ::=
   match d
-  case DAE.DIM_INTEGER(__) then integer
+  case DAE.DIM_BOOLEAN(__) then '2'
   case DAE.DIM_ENUM(__) then size
-  case DAE.DIM_UNKNOWN(__) then ":"
-  else "INVALID_DIMENSION"
+  case DAE.DIM_EXP(exp=e) then daeExp(e, context, &preExp, &varDecls)
+  case DAE.DIM_INTEGER(__) then
+    if intEq(integer, -1) then
+      error(sourceInfo(),"Negeative dimension(unknown dimensions) may not be part of generated code. This is most likely an error on the part of OpenModelica. Please submit a detailed bug-report.")
+    else
+      integer
+  case DAE.DIM_UNKNOWN(__) then error(sourceInfo(),"Unknown dimensions may not be part of generated code. This is most likely an error on the part of OpenModelica. Please submit a detailed bug-report.")
+  else error(sourceInfo(), 'dimension: INVALID_DIMENSION')
 end dimension;
 
 template algStmtAssignPattern(DAE.Statement stmt, Context context, Text &varDecls)

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -79,7 +79,7 @@ import ExpressionDumpTpl.*;
 
     let &records = buffer ""
     let &records += redirectToFile('<%fileNamePrefix%>_records.c')
-    let &records += recordsFile(fileNamePrefix, recordDecls)
+    let &records += recordsFile(fileNamePrefix, recordDecls, true /*isSimulation*/)
     let &records += closeFile()
 
     // adpro: write the main .c file last! Make on windows doesn't seem to realize that

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -2944,23 +2944,23 @@ template funParamDecl2(Variable var, SimCode simCode ,Text& extraFuncs,Text& ext
  match var
 case var as VARIABLE(__) then
   let varName = '<%contextCref(var.name, contextFunction, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
-  //let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+  //let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
   funParamDecl3(var,varName,instDims,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
 
 end funParamDecl2;
 
 
 
-template funParamDecl3(Variable var,String varName, list<DAE.Exp> instDims, SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+template funParamDecl3(Variable var,String varName, list<DAE.Dimension> instDims, SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
  let &varDecls = buffer "" /*BUFD*/ //should be empty
   let &varInits = buffer "" /*BUFD*/ //should be empty
-  let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+  let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
   match var
   case var as VARIABLE(__) then
   let type = '<%varType(var)%>'
-  let testinstDimsInit = (instDims |> exp => testDaeDimensionExp(exp);separator="")
-  let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+  let testinstDimsInit = (instDims |> dim => testDaeDimension(dim);separator="")
+  let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
   let arrayexpression1 = (if instDims then 'StatArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>,<%instDimsInit%>> <%varName%>;/*testarray*/<%\n%>'
   else '<%type%> <%varName%>')
   let arrayexpression2 = (if instDims then 'DynArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>> <%varName%>;<%\n%>'
@@ -3015,10 +3015,10 @@ match var
 case var as VARIABLE(__) then
   let varName = '<%contextCref(var.name, contextFunction, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
 
-  let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits, &varDecls,simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+  let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits, &varDecls,simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
 
   if instDims then
-    let testinstDimsInit = (instDims |> exp => testDaeDimensionExp(exp);separator="")
+    let testinstDimsInit = (instDims |> dim => testDaeDimension(dim);separator="")
     let temp = setDims(testinstDimsInit, varName , &varInits, instDimsInit)
 
 
@@ -5189,8 +5189,7 @@ template extFunCallBiVar(Variable var, Text &preExp, Text &varDecls, SimCode sim
       else ""
     if instDims then
       let nDims = listLength(instDims)
-      let dims = (instDims |> exp =>
-        daeExp(exp, contextFunction, &preExp, &varDecls, simCode,
+      let dims = (instDims |> dim => daeDimension(dim, contextFunction, &preExp, &varDecls, simCode,
                &extraFuncs, &extraFuncsDecl, extraFuncsNamespace,
                stateDerVectorName, useFlatArrayNotation);
         separator=", ")
@@ -5350,8 +5349,7 @@ case var as VARIABLE(__) then
   let marker = '<%contextCref(var.name,contextFunction,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
   let &varInits += '/* varOutputTuple varInits(<%marker%>) */ <%\n%>'
   let &varAssign += '// varOutput varAssign(<%marker%>) <%\n%>'
-  let instDimsInit = (instDims |> exp =>
-      daeExp(exp, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     ;separator=",")
   let assginBegin = 'get<<%ix%>>'
   if instDims then
@@ -5372,17 +5370,17 @@ let &varAssign += '/*iregendwas*/'
 end varOutputTuple;
 
 
-template varDeclForVarInit(Variable var,String varName, list<DAE.Exp> instDims, Text &varDecls, Text &varInits, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+template varDeclForVarInit(Variable var,String varName, list<DAE.Dimension> instDims, Text &varDecls, Text &varInits, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
-  //let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName,  useFlatArrayNotation);separator=",")
-  let instDimsInit = checkExpDimension(instDims)
+  //let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName,  useFlatArrayNotation);separator=",")
+  let instDimsInit = checkDimension(instDims)
     match var
         case var as VARIABLE(__) then
             let type = '<%varType(var)%>'
             let initVar =  match type case "modelica_metatype" then ' = NULL' else ''
             let addRoot =  match type case "modelica_metatype" then ' mmc_GC_add_root(&<%varName%>, mmc_GC_local_state, "<%varName%>");' else ''
-            //let testinstDimsInit = (instDims |> exp => testDaeDimensionExp(exp);separator="")
-            //let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+            //let testinstDimsInit = (instDims |> dim => testDaeDimension(dim);separator="")
+            //let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
             let arrayexpression1 = (if instDims then 'StatArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>,<%instDimsInit%>> <%varName%>;/*testarray5*/<%\n%>'
         else '<%type%> <%varName%><%initVar%>;<%addRoot%><%\n%>')
             let arrayexpression2 = (if instDims then 'DynArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>> <%varName%>;<%\n%>'
@@ -5416,14 +5414,14 @@ case var as VARIABLE(__) then
   <%preExp%>
   <%recordInit%>
   >>
-  let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+  let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits , &varDecls,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
 
 
   //let varName = if outStruct then 'ToDo: outStruct not implemented' else '<%contextCref(var.name,contextFunction,simCode , &extraFuncs , &extraFuncsDecl, stateDerVectorName, extraFuncsNamespace)%>'
   let _ = varDeclForVarInit(var, varName, instDims, &varDecls, &varInits, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
 
   if instDims then
-    let testinstDimsInit = (instDims |> exp => testDaeDimensionExp(exp);separator="")
+    let testinstDimsInit = (instDims |> dim => testDaeDimension(dim);separator="")
     let temp = setDims(testinstDimsInit, varName , &varInits, instDimsInit)
 
 
@@ -5640,7 +5638,7 @@ case var as VARIABLE(__) then
      /* uses StatArrray if possible else Dynarray as function array argument types
      let &varDecls = buffer ""
      let &varInits = buffer ""
-     let testinstDimsInit = (instDims |> exp => testDaeDimensionExp(exp);separator="")
+     let testinstDimsInit = (instDims |> dim => testDaeDimension(dim);separator="")
 
      match testinstDimsInit
      case "" then
@@ -5665,8 +5663,8 @@ case var as VARIABLE(__) then
       /*uses StatArrray if possible else Dynarray as function array argument types  */
      let &varDecls = buffer ""
      let &varInits = buffer ""
-     let DimsTest = (instDims |> exp => daeDimensionExp(exp);separator="")
-     let instDimsInit = (instDims |> exp => daeExp(exp, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
+     let DimsTest = (instDims |> dim => testDaeDimension(dim);separator="")
+     let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation);separator=",")
      match DimsTest
         case "" then if instDims then 'StatArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>, <%instDimsInit%>>& ' else expTypeFlag(var.ty, 5)
         else if instDims then 'DynArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>>&' else expTypeFlag(var.ty, 5)
@@ -5682,11 +5680,11 @@ case var as VARIABLE(__) then
       */
      let &varDecls = buffer "" /*should be empty herer*/
      let &varInits = buffer "" /*should be empty herer*/
-     let testinstDimsInit = (instDims |> exp => testDaeDimensionExp(exp);separator="")
+     let testinstDimsInit = (instDims |> dim => testDaeDimension(dim);separator="")
+     let instDimsInit = (instDims |> dim => daeDimension(dim, contextFunction, &varInits, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, "stateDerVectorName_not_given", false /*is false the default?*/);separator=",")
 
      match testinstDimsInit
      case "" then
-      let instDimsInit = (instDims |> exp => daeDimensionExp(exp);separator=",")
      if instDims then 'StatArrayDim<%listLength(instDims)%>< <%expTypeShort(var.ty)%>, <%instDimsInit%>> /*testarray2*/' else expTypeArrayIf(var.ty)
      else
      if instDims then 'DynArrayDim<%listLength(instDims)%><<%expTypeShort(var.ty)%>> ' else expTypeArrayIf(var.ty)
@@ -11569,38 +11567,33 @@ template equationForLoop(SimEqSystem eq, Context context, Text &varDecls, SimCod
       >>
 end equationForLoop;
 
+// Previously unknown dims were set to ICONST(-1) at SimCode creation 
+// we do not do that anymore. 
+// This used to return '' for ICONST no matter the value. I am not sure
+// if that is the right thing to do. For now we will just call the function
+// that was used to convert dims to expressions in SimCode creation
+// here as well, i.e., will still return '' for UNKNOWN_DIM since it 
+// will be converted to DAE.ICONST(-1).
+template testDaeDimension(DAE.Dimension dim)
+ "Generates code for an expression."
+::=
+  testDaeDimensionExp(Expression.dimensionSizeExpHandleUnkown(dim))
+end testDaeDimension;
 
 template testDaeDimensionExp(Exp exp)
  "Generates code for an expression."
 ::=
   match exp
   case e as ICONST(__)          then ''
-  case e as RCONST(__)          then '-1'
-  case e as BCONST(__)          then '-1'
-  case e as ENUM_LITERAL(__)    then '-1'
-  case e as CREF(__)            then '-1'
-  case e as CAST(__)            then '-1'
-  case e as CONS(__)            then '-1'
-  case e as SCONST(__)          then '-1'
-  case e as UNARY(__)           then '-1'
-  case e as LBINARY(__)         then '-1'
-  case e as LUNARY(__)          then '-1'
-  case e as BINARY(__)          then '-1'
-  case e as IFEXP(__)           then '-1'
-  case e as RELATION(__)        then '-1'
-  case e as CALL(__)            then '-1'
-  case e as RECORD(__)          then '-1'
-  case e as ASUB(__)            then '-1'
-  case e as MATRIX(__)          then '-1'
-  case e as RANGE(__)           then '-1'
-  case e as ASUB(__)            then '-1'
-  case e as TSUB(__)            then '-1'
-  case e as REDUCTION(__)       then '-1'
-  case e as ARRAY(__)           then '-1'
-  case e as SIZE(__)            then '-1'
-  case e as SHARED_LITERAL(__)  then '-1'
   else '-1'
 end testDaeDimensionExp;
+
+template daeDimension(DAE.Dimension dim, Context context, Text &preExp, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName, Boolean useFlatArrayNotation)
+ "Generates code for an expression."
+::=
+  daeExp(Expression.dimensionSizeExpHandleUnkown(dim), context, &preExp, &varDecls, simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+end daeDimension;
+
 
 template assertCommon(Exp condition, Exp message,Exp level, Context context, Text &varDecls, builtin.SourceInfo info, SimCode simCode,
                       Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)

--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -3035,22 +3035,22 @@ end functionClosure;
 template assertCommonVar(Text condVar, Text msgVar, Context context, Text &varDecls, builtin.SourceInfo info)
 ::=
   match context
-  case FUNCTION_CONTEXT(__) then
-    <<
-    if(!(<%condVar%>))
-    {
-
-      throw ModelicaSimulationError(MODEL_EQ_SYSTEM,  <%msgVar%>);
-    }
-    >>
   // OpenCL doesn't have support for variadic args. So message should be just a single string.
-  case PARALLEL_FUNCTION_CONTEXT(__) then
+  case FUNCTION_CONTEXT(is_parallel=true) then
     <<
     if(!(<%condVar%>))
     {
 
       throw ModelicaSimulationError(MODEL_EQ_SYSTEM, "Common assertion failed");
 
+    }
+    >>
+  case FUNCTION_CONTEXT(__) then
+    <<
+    if(!(<%condVar%>))
+    {
+
+      throw ModelicaSimulationError(MODEL_EQ_SYSTEM,  <%msgVar%>);
     }
     >>
   else

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -69,7 +69,7 @@ case sc as SIMCODE(modelInfo=modelInfo as MODELINFO(__)) then
   let()= textFile(simulationFunctionsHeaderFile(fileNamePrefix, modelInfo.functions, recordDecls), '<%fileNamePrefixTmpDir%>_functions.h')
   let()= textFile(simulationFunctionsFile(fileNamePrefix, modelInfo.functions), '<%fileNamePrefixTmpDir%>_functions.c')
   let()= textFile(externalFunctionIncludes(sc.externalFunctionIncludes), '<%fileNamePrefixTmpDir%>_includes.h')
-  let()= textFile(recordsFile(fileNamePrefix, recordDecls), '<%fileNamePrefixTmpDir%>_records.c')
+  let()= textFile(recordsFile(fileNamePrefix, recordDecls, true /*isSimulation*/), '<%fileNamePrefixTmpDir%>_records.c')
   let()= textFile(simulationHeaderFile(simCode), '<%fileNamePrefixTmpDir%>_model.h')
 
   let _ = generateSimulationFiles(simCode,guid,fileNamePrefixTmpDir,FMUVersion)

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -439,8 +439,8 @@ public constant Message WRONG_NUMBER_OF_SUBSCRIPTS = MESSAGE(154, TRANSLATION(),
   Util.gettext("Wrong number of subscripts in %s (%s subscripts for %s dimensions)."));
 public constant Message FUNCTION_ELEMENT_WRONG_KIND = MESSAGE(155, TRANSLATION(), ERROR(),
   Util.gettext("Element is not allowed in function context: %s"));
-public constant Message MISSING_DEFAULT_ARG = MESSAGE(156, TRANSLATION(), WARNING(),
-  Util.gettext("Missing default argument on function parameter %s."));
+public constant Message MISSING_BINDING_PROTECTED_RECORD_VAR = MESSAGE(156, TRANSLATION(), WARNING(),
+  Util.gettext("Protected record member %s has no binding and is not modifiable by a record constructor."));
 public constant Message DUPLICATE_CLASSES_TOP_LEVEL = MESSAGE(157, TRANSLATION(), ERROR(),
   Util.gettext("Duplicate classes on top level is not allowed (got %s)."));
 public constant Message WHEN_EQ_LHS = MESSAGE(158, TRANSLATION(), ERROR(),

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -1011,25 +1011,33 @@ algorithm
   outList := append_reverse(outList, l1);
 end mergeSorted;
 
-public function sortIntN
-  "Provides same functionality as sort, but for integer values between 1
-   and N. The complexity in this case is O(n)"
+public function countingSort
+ "Provides same functionality as sort, but for integer values between 1
+   and N. The complexity in this case is O(N + n).
+   This will terminate if the list contains an element > N."
   input list<Integer> inList;
-  input Integer inN;
+  input Integer N;
   output list<Integer> outSorted = {};
 protected
-  array<Boolean> a1;
+  array<Integer> a1;
 algorithm
-  a1 := arrayCreate(inN, false);
-  a1 := fold1r(inList,arrayUpdate,true,a1);
+  if listLength(inList) < 2 then
+    outSorted := inList;
+    return;
+  end if;
 
-  for i in inN:-1:1 loop
-    if a1[i] then
-      outSorted := i :: outSorted;
-    end if;
+  a1 := arrayCreate(N, 0);
+  for v in inList loop
+    a1[v] := intAdd(a1[v], 1);
+  end for;
+
+  for v in N:-1:1 loop
+    for c in 1:a1[v] loop
+      outSorted := v :: outSorted;
+    end for;
   end for;
   GC.free(a1);
-end sortIntN;
+end countingSort;
 
 public function unique<T>
   "Takes a list of elements and returns a list with duplicates removed, so that

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -87,6 +87,7 @@ struct base_array_s
   int ndims;
   _index_t *dim_size;
   void *data;
+  m_boolean flexible;
 };
 
 typedef struct base_array_s base_array_t;

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.c
@@ -32,6 +32,8 @@
 #include "boolean_array.h"
 #include "../gc/omc_gc.h"
 #include "omc_error.h"
+#include "generic_array.h"
+
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -89,17 +91,7 @@ void alloc_boolean_array_data(boolean_array_t* a)
 
 void copy_boolean_array_data(const boolean_array_t source, boolean_array_t *dest)
 {
-    size_t i, nr_of_elements;
-
-    assert(base_array_ok(&source));
-    assert(base_array_ok(dest));
-    assert(base_array_shape_eq(&source, dest));
-
-    nr_of_elements = base_array_nr_of_elements(source);
-
-    for(i = 0; i < nr_of_elements; ++i) {
-        boolean_set(dest, i, boolean_get(source, i));
-    }
+    boolean_array_copy_data(source,*dest);
 }
 
 void and_boolean_array(const boolean_array_t *source1, const boolean_array_t *source2, boolean_array_t *dest)
@@ -176,9 +168,7 @@ void copy_boolean_array_data_mem(const boolean_array_t source, modelica_boolean 
 
 void copy_boolean_array(const boolean_array_t source, boolean_array_t *dest)
 {
-    clone_base_array_spec(&source, dest);
-    alloc_boolean_array_data(dest);
-    copy_boolean_array_data(source,dest);
+    boolean_array_alloc_copy(source,*dest);
 }
 
 /*

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.h
@@ -31,17 +31,48 @@
 #ifndef GENERIC_ARRAY_H_
 #define GENERIC_ARRAY_H_
 
-#include "../openmodelica.h"
 #include "base_array.h"
-#include "../gc/omc_gc.h"
-#include "index_spec.h"
-#include <stdarg.h>
 
-void alloc_generic_array(base_array_t* dest, size_t sze, int ndims,...);
+typedef void (*constructor_func)(threadData_t* td,  void* dst);
+typedef void (*copy_func)(void* dst, void* src);
+
+void generic_array_create_flexible(base_array_t* dst, int ndims);
+
+
+void generic_array_create(threadData_t* td, base_array_t* dst, constructor_func ctor, int ndims, size_t sze, ...);
+void simple_array_create(threadData_t* td, base_array_t* dst, int ndims, size_t sze, ...);
+
+void generic_array_copy_data(const base_array_t src, base_array_t* dst, copy_func cper, size_t sze);
+void simple_array_copy_data(const base_array_t src, base_array_t* dst, size_t sze);
+
+#define real_array_copy_data(src,dst)               simple_array_copy_data(src, &dst, sizeof(modelica_real));
+#define integer_array_copy_data(src,dst)            simple_array_copy_data(src, &dst, sizeof(modelica_integer));
+#define string_array_copy_data(src,dst)             simple_array_copy_data(src, &dst, sizeof(modelica_string));
+#define boolean_array_copy_data(src,dst)            simple_array_copy_data(src, &dst, sizeof(modelica_boolean));
+
+void generic_array_alloc_copy(const base_array_t src, base_array_t* dst, copy_func cper, size_t sze);
+void simple_array_alloc_copy(const base_array_t src, base_array_t* dst, size_t sze);
+
+#define real_array_alloc_copy(src,dst)              simple_array_alloc_copy(src, &dst, sizeof(modelica_real));
+#define integer_array_alloc_copy(src,dst)           simple_array_alloc_copy(src, &dst, sizeof(modelica_integer));
+#define string_array_alloc_copy(src,dst)            simple_array_alloc_copy(src, &dst, sizeof(modelica_string));
+#define boolean_array_alloc_copy(src,dst)           simple_array_alloc_copy(src, &dst, sizeof(modelica_boolean));
+
+
+void* generic_array_get(const base_array_t* source, size_t sze,...);
+
+#define real_array_get(src,ndims,...)               (*(modelica_real*)(real_array_element_addr(&src, ndims, __VA_ARGS__)))
+#define integer_array_get(src,ndims,...)            (*(modelica_integer*)(integer_array_element_addr(&src, ndims, __VA_ARGS__)))
+#define string_array_get(src,ndims,...)             (*(modelica_string*)(string_array_element_addr(&src, ndims, __VA_ARGS__)))
+#define boolean_array_get(src,ndims,...)            (*(modelica_boolean*)(boolean_array_element_addr(&src, ndims, __VA_ARGS__)))
+
+void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t sze, ...);
+
+
+
 
 void* generic_array_element_addr(const base_array_t* source, size_t sze, int ndims,...);
 void* generic_array_element_addr1(const base_array_t* source, size_t sze, int dim1);
 
-void alloc_generic_array_data(base_array_t* a, size_t sze);
 
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.c
@@ -33,6 +33,7 @@
 #include "index_spec.h"
 #include "../gc/omc_gc.h"
 #include "division.h"
+#include "generic_array.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -93,17 +94,7 @@ void alloc_integer_array_data(integer_array_t* a)
 
 void copy_integer_array_data(const integer_array_t source, integer_array_t* dest)
 {
-    size_t i, nr_of_elements;
-
-    omc_assert_macro(base_array_ok(&source));
-    omc_assert_macro(base_array_ok(dest));
-    omc_assert_macro(base_array_shape_eq(&source, dest));
-
-    nr_of_elements = base_array_nr_of_elements(source);
-
-    for(i = 0; i < nr_of_elements; ++i) {
-        integer_set(dest, i, integer_get(source, i));
-    }
+    integer_array_copy_data(source,*dest);
 }
 
 void copy_integer_array_data_mem(const integer_array_t source,
@@ -122,9 +113,7 @@ void copy_integer_array_data_mem(const integer_array_t source,
 
 void copy_integer_array(const integer_array_t source, integer_array_t *dest)
 {
-    clone_base_array_spec(&source, dest);
-    alloc_integer_array_data(dest);
-    copy_integer_array_data(*&source, dest);
+    integer_array_alloc_copy(source,*dest);
 }
 
 static modelica_integer integer_le(modelica_integer x, modelica_integer y)

--- a/OMCompiler/SimulationRuntime/c/util/real_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.c
@@ -35,6 +35,7 @@
 #include "division.h"
 #include "integer_array.h"
 #include "omc_error.h"
+#include "generic_array.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -92,17 +93,7 @@ void alloc_real_array_data(real_array_t *a)
 
 void copy_real_array_data(const real_array_t source, real_array_t *dest)
 {
-    size_t i, nr_of_elements;
-
-    omc_assert_macro(base_array_ok(&source));
-    omc_assert_macro(base_array_ok(dest));
-    omc_assert_macro(base_array_shape_eq(&source, dest));
-
-    nr_of_elements = base_array_nr_of_elements(source);
-
-    for(i = 0; i < nr_of_elements; ++i) {
-        real_set(dest, i, real_get(source, i));
-    }
+    real_array_copy_data(source,*dest);
 }
 
 void copy_real_array_data_mem(const real_array_t source, modelica_real *dest)
@@ -120,9 +111,7 @@ void copy_real_array_data_mem(const real_array_t source, modelica_real *dest)
 
 void copy_real_array(const real_array_t source, real_array_t *dest)
 {
-    clone_base_array_spec(&source, dest);
-    alloc_real_array_data(dest);
-    copy_real_array_data(source,dest);
+    real_array_alloc_copy(source,*dest);
 }
 
 

--- a/OMCompiler/SimulationRuntime/c/util/string_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.c
@@ -34,6 +34,7 @@
 #include "index_spec.h"
 #include "modelica_string.h"
 #include "omc_error.h"
+#include "generic_array.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -91,17 +92,7 @@ void alloc_string_array_data(string_array_t* a)
 
 void copy_string_array_data(const string_array_t source, string_array_t *dest)
 {
-    size_t i, nr_of_elements;
-
-    assert(base_array_ok(&source));
-    assert(base_array_ok(dest));
-    assert(base_array_shape_eq(&source, dest));
-
-    nr_of_elements = base_array_nr_of_elements(source);
-
-    for(i = 0; i < nr_of_elements; ++i) {
-        string_set(dest, i, string_get(source, i));
-    }
+    string_array_copy_data(source,*dest);
 }
 
 void copy_string_array_data_mem(const string_array_t source, modelica_string *dest)
@@ -119,9 +110,7 @@ void copy_string_array_data_mem(const string_array_t source, modelica_string *de
 
 void copy_string_array(const string_array_t source, string_array_t *dest)
 {
-    clone_base_array_spec(&source, dest);
-    alloc_string_array_data(dest);
-    copy_string_array_data(source,dest);
+    string_array_alloc_copy(source,*dest);
 }
 
 /*

--- a/testsuite/flattening/modelica/records/RecordNonPublic.mo
+++ b/testsuite/flattening/modelica/records/RecordNonPublic.mo
@@ -25,4 +25,6 @@ end RecordNonPublic;
 // class RecordNonPublic
 //   protected Integer tr.i;
 // end RecordNonPublic;
+// Warning: Protected record member i has no binding and is not modifiable by a record constructor.
+//
 // endResult


### PR DESCRIPTION
- Every record now gets
  - A dedicated "default" constructor function for allocating its members.
    - this is used when the variable is declared. It initializes members to
      their default values.
    - Note that this is different from default Modelica record constructor.
      The modelica constructor is used explicitly. The "default" one is used
      always on declaration.
  - A dedicated copy function for copying its members.
  - An array typedef to base_array.
  - A macro for creating an array of the record.
    - This uses the constructor function to create each element of the array.
    - This uses generic array function with the record size.
  - A macro for copying an array
    - This uses the copy function to copy each element of the array.
  - A macro getter to access elements of the array.
    - this uses the proper casting on the returned type.

- We now keep bindings in TYPES_VARS in when creating a record declaration
  in SimCode structure. The bindings are used as default values by the "default"
  constructor.

- Bindings of a derived record declaration are handled properly now.
  - If a record is a derived record with modifications, then bindings of the modifications
    are available in the declration scope.
         record A = B(k=exp); A r; //  'exp' needs to be passed to the constructor
      => A_construct(A* r, exp) {...; r->k = exp; ...}
    This means a default constructor will need those bindings passed to it explicitly
    if it is to work correctly. Now every TYPES_VAR of a record has a Boolean attribute
    specifying whether it is bound from outside or not.

- When collecting used functions in the BACK-END we traverse bindings of record members.
  - Right now this is needed because some functions get in-lined and are not used by the
    equation system even though the model has instances of the record (since we generate
    constructors now we need them to be visible even if the record is never used in a function).
  - The proper way to fix this would be to check if a record is used in a function and
    only then generate a constructor. OR another option is to also traverse record member
    bindings when doing in-lining of functions (which is not done right now.)
    This seemed to be the simplest and probably quickest way even though we sometimes may
    generate a function even though it is not really used (very rarely).

- Fixed copying of records in the simulation context.

  - If a record is being copied to simulation vars we need special handling.
    This is because there is no structure to simvars. The variables are scattered.
    Therefore there is now a copy function that writes a given record to the corresponding
    element in the simvars arrays.

    The generated function <RecName>_copy_to_vars(RecType* src, .../*simvars locations*/) is used to achive this.

- Improved generation of component references in function context
  - We can now handle qualified crefs with subscripts anywhere in the cref.
  - This is done uniformly in functionContextCref template. Try to use this everywhere.

- CONTEXT_FUNCTION now has a cref prefix
  - This is prepended to any cref generated in function context. This gives us some scope
    control. E.g. it is used in record constructor functions to make all local variable accesses
    prepended to a specific record name that is passed as input to the function.

- instDims in SimCodeFunction.VARIABLE is now list<DAE.dimension> not  list<DAE.Expression>.
  - Helps to normalize handling of dimension expressions.
  - We really need to normalize the handling of dimension and subscript
  - Plus dimension and subscript related functions are not exchangeable.
    Constructs are interpreted differently as dimension compared to subscript
    and vice versa.

- Unknown size array handling.

  - Arrays of unknown size are arrays where at least one dimension is unknown.
  - If an unknown size array is declared with a default value, i.e. a binding,
    then it has fixed dimension sizes equal to the binding.
  - However if the unknown size array is declared with out a binding then it
    is considered flexible and can change sizes as needed.
  - The array representation in the runtime system ,i.e. base_array, now has a
    new memeber .flexible to signify this.

- Handle array expressions of records i.e. {c1,c2,..} properly
  - Array expressions of records are handled a bit more cleanly now.
  - Do not sort record member variables in the record declaration. This is just absurd.

- Some more minor fixes.
  - Casting of call expressions which return records is handled explicitly now.
  - Change handling of casts.
    - Casts to Modelica_integer are disabled for now.
    - Casts to records with different number of members are disabled for now.
    - Many more...