### PR TITLE
[NF] Fix simplification of mod(x, 0).

### DIFF
--- a/.CI/compliance-newinst.failures
+++ b/.CI/compliance-newinst.failures
@@ -158,7 +158,6 @@ ModelicaCompliance.Operators.Special.Delay
 ModelicaCompliance.Operators.Special.DelayIncorrect3
 ModelicaCompliance.Operators.Special.DerConstantIncorrect1
 ModelicaCompliance.Operators.Special.DerConstantIncorrect2
-ModelicaCompliance.Operators.Special.Homotopy
 ModelicaCompliance.Redeclare.ClassExtends.ClassExtendsNonReplaceable
 ModelicaCompliance.Redeclare.ClassExtends.NonRedeclareClassExtends
 ModelicaCompliance.Redeclare.ClassExtends.ReplaceableNotInherited

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -170,7 +170,10 @@ algorithm
         // Use Ceval for builtin pure functions with literal arguments.
         if builtin then
           if is_pure and List.all(args, Expression.isLiteral) then
-            callExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
+            try
+              callExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
+            else
+            end try;
           else
             // do not expand builtin calls if we should not scalarize
             if Flags.isSet(Flags.NF_SCALARIZE) then


### PR DESCRIPTION
- Print error in Ceval.evalBuiltinMod when the second argument is 0.
- Ignore failures when trying to constant evaluate calls during
  expression simplification, since failure to simplify an expression
  shouldn't be an error.