### PR TITLE
New SparsePatternCref type

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -783,15 +783,18 @@ type SymbolicJacobian = tuple<BackendDAE,               // symbolic equation sys
                               list<Var>,                // diff vars (independent vars)
                               list<Var>,                // diffed vars (residual vars)
                               list<Var>,                // all diffed vars (residual vars + dependent vars)
-                              list< .DAE.ComponentRef>    // original dependent variables
+                              list< .DAE.ComponentRef>  // original dependent variables
                               >;
 
+type SparsePatternCref = tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>;
+type SparsePatternCrefs = list<SparsePatternCref>;
+
 public
-type SparsePattern = tuple<list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>>, // column-wise sparse pattern
-                           list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>>, // row-wise sparse pattern
-                           tuple<list< .DAE.ComponentRef>,                            // diff vars
-                                 list< .DAE.ComponentRef>>,                           // diffed vars
-                           Integer>;                                                  // nonZeroElements
+type SparsePattern = tuple<SparsePatternCrefs,              // column-wise sparse pattern
+                           SparsePatternCrefs,              // row-wise sparse pattern
+                           tuple<list< .DAE.ComponentRef>,  // diff vars (independent vars) of associated jacobian
+                                 list< .DAE.ComponentRef>>, // diffed vars (residual vars) of associated jacobian
+                           Integer>;                        // nonZeroElements
 
 public
 constant SparsePattern emptySparsePattern = ({},{},({},{}),0);

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1507,8 +1507,7 @@ public function setEvaluationStage
   input BackendDAE.BackendDAE inBackendDAE;
   output BackendDAE.BackendDAE outBackendDAE;
 protected
-  //BackendDAE.SparsePattern sp;
-  list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> spCrefs, spCrefsT;
+  BackendDAE.SparsePatternCrefs spCrefs, spCrefsT;
   BackendDAE.Variables vars;
   list<BackendDAE.Var> varLst;
   BackendDAE.EquationArray eqns;

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -516,30 +516,17 @@ algorithm
   end match;
 end printExternalObjectClasses;
 
-protected function printSparsityPattern "author lochel"
-  input list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>> inPattern;
+public function printSparsityPatternCrefs
+  input BackendDAE.SparsePatternCrefs inPattern;
 algorithm
-  () := matchcontinue(inPattern)
-    local
-      tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>> curr;
-      list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>> rest;
-      .DAE.ComponentRef cr;
-      list< .DAE.ComponentRef> crList;
-      String crStr;
+  for e in inPattern loop
+    print(ComponentReference.printComponentRefStr(Util.tuple21(e)) +
+          " affects the following (" + intString(listLength(Util.tuple22(e))) +
+          ") outputs\n  ");
+    ComponentReference.printComponentRefList(Util.tuple22(e));
+  end for;
+end printSparsityPatternCrefs;
 
-    case (curr::rest) equation
-      (cr, crList) = curr;
-      crStr = ComponentReference.printComponentRefStr(cr);
-      print(crStr + " affects the following (" + intString(listLength(crList)) + ") outputs\n  ");
-      ComponentReference.printComponentRefList(crList);
-
-      printSparsityPattern(rest);
-    then ();
-
-    else
-    then ();
-  end matchcontinue;
-end printSparsityPattern;
 
 // =============================================================================
 // section for all graphviz* functions
@@ -812,11 +799,11 @@ algorithm
   print("\n");
 end dumpHashSet;
 
-public function dumpSparsityPattern "author lochel"
+public function dumpSparsityPattern
   input BackendDAE.SparsePattern inPattern;
   input String heading;
 protected
-  list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>> pattern,patternT;
+  BackendDAE.SparsePatternCrefs pattern,patternT;
   list< .DAE.ComponentRef> diffVars, diffedVars;
   Integer nnz;
 algorithm
@@ -824,15 +811,15 @@ algorithm
 
   print("\n" + heading + "\n" + UNDERLINE + "\n");
   print("Number of non zero elements: " + intString(nnz) + "\n");
-  print("independents [or inputs] (" + intString(listLength(diffVars)) + ")\n");
+  print("Independents [or inputs] (" + intString(listLength(diffVars)) + ")\n");
   ComponentReference.printComponentRefList(diffVars);
 
-  print("dependents [or outputs] (" + intString(listLength(diffedVars)) + ")\n");
+  print("Dependents [or outputs] (" + intString(listLength(diffedVars)) + ")\n");
   ComponentReference.printComponentRefList(diffedVars);
 
-  printSparsityPattern(pattern);
-  print("\n" + "transposed pattern" + "\n");
-  printSparsityPattern(patternT);
+  printSparsityPatternCrefs(pattern);
+  print("\n" + "Transposed pattern" + "\n");
+  printSparsityPatternCrefs(patternT);
 end dumpSparsityPattern;
 
 public function dumpSparseColoring
@@ -3756,7 +3743,7 @@ algorithm
       tuple<list<Integer>,list<Integer>,list<Integer>,list<Integer>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>,list<tuple<Integer,Integer>>> meqsys;
       tuple<list<tuple<Integer,Integer,Integer>>,list<tuple<Integer,Integer>>> teqsys,teqsys2;
       BackendDAE.InnerEquations innerEquations,innerEquations2;
-      list<tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>> patternLst;
+      BackendDAE.SparsePatternCrefs patternLst;
 
     case (BackendDAE.SINGLEEQUATION(),(seq,salg,sarr,sce,swe,sie,eqsys,meqsys,teqsys,teqsys2))
     then ((seq+1,salg,sarr,sce,swe,sie,eqsys,meqsys,teqsys,teqsys2));

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2021,7 +2021,7 @@ algorithm
         indepVars = createInDepVars(inDiffVars, false);
 
         if Flags.isSet(Flags.JAC_DUMP) then
-          print("Crete symbolic Jacobianis from:\n");
+          print("Create symbolic Jacobians from:\n");
           print(BackendDump.varListString(indepVars, "Independent Variables"));
           print(BackendDump.varListString(diffedVars, "Dependent Variables"));
           print("Basic equation system:\n");

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -4488,7 +4488,7 @@ algorithm
     BackendDAE.SparsePattern pattern;
     BackendDAE.SparseColoring sparseColoring;
     list<list<Integer>> coloring;
-    list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> sparsepatternComRefs, sparsepatternComRefsT;
+    BackendDAE.SparsePatternCrefs sparsepatternComRefs, sparsepatternComRefsT;
     list<tuple<Integer, list<Integer>>> sparseInts, sparseIntsT;
 
     BackendDAE.EqSystem syst;
@@ -4735,7 +4735,7 @@ algorithm
       list<SimCodeVar.SimVar> columnVarsKn;
       list<SimCodeVar.SimVar> seedVars, indexVars, seedIndexVars;
 
-      list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> sparsepattern, sparsepatternT;
+      BackendDAE.SparsePatternCrefs sparsepattern, sparsepatternT;
       list<list<DAE.ComponentRef>> colsColors;
       Integer maxColor;
 
@@ -5138,7 +5138,7 @@ end makeTmpRealSimCodeVar;
 
 protected function sortSparsePattern
   input list<SimCodeVar.SimVar> inSimVars;
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> inSparsePattern;
+  input BackendDAE.SparsePatternCrefs inSparsePattern;
   input Boolean useFMIIndex;
   output list<tuple<Integer, list<Integer>>> outSparse = {};
 protected
@@ -5228,7 +5228,7 @@ algorithm
 end dumpSparsePatternInt;
 
 protected function dumpSparsePattern
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> sparsePattern;
+  input BackendDAE.SparsePatternCrefs sparsePattern;
 protected
   DAE.ComponentRef cr;
   list<DAE.ComponentRef> crefs;
@@ -5262,7 +5262,7 @@ algorithm
     BackendDAE.SparsePattern pattern;
     BackendDAE.SparseColoring sparseColoring;
     list<list<Integer>> coloring;
-    list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> sparsepatternComRefs, sparsepatternComRefsT;
+    BackendDAE.SparsePatternCrefs sparsepatternComRefs, sparsepatternComRefsT;
     list<tuple<Integer, list<Integer>>> sparseInts, sparseIntsT;
 
     BackendDAE.EqSystem syst;
@@ -12813,7 +12813,7 @@ public function createFMIModelStructure
   output list<SimCode.JacobianMatrix> symJacs = {};
   output Integer uniqueEqIndex = inUniqueEqIndex;
 protected
-   list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> spTA, spTB;
+   BackendDAE.SparsePatternCrefs spTA, spTB;
    list<tuple<Integer, list<Integer>>> sparseInts;
    list<SimCode.FmiUnknown> allUnknowns, derivatives, outputs, discreteStates;
    list<SimCodeVar.SimVar> varsA, varsB, clockedStates;
@@ -12986,18 +12986,18 @@ end translateSparsePatterInts2FMIUnknown;
 
 protected function translateSparsePatterCref2DerCref
 "function translates the first cref of sparse pattern to der(cref)"
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> sparsePattern;
+  input BackendDAE.SparsePatternCrefs sparsePattern;
   input SimCode.HashTableCrefToSimVar inSimVarHT;
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> inAccum;
+  input BackendDAE.SparsePatternCrefs inAccum;
   input list<DAE.ComponentRef> inAccum2;
-  output list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> outSparsePattern;
+  output BackendDAE.SparsePatternCrefs outSparsePattern;
   output list<DAE.ComponentRef> outDerCrefs;
 algorithm
   (outSparsePattern, outDerCrefs) := match(sparsePattern)
     local
       DAE.ComponentRef cref;
       list<DAE.ComponentRef> crefs;
-      list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> rest;
+      BackendDAE.SparsePatternCrefs rest;
       SimCodeVar.SimVar simVar;
 
     case ({}) then (listReverse(inAccum), listReverse(inAccum2));
@@ -13015,14 +13015,14 @@ algorithm
 end translateSparsePatterCref2DerCref;
 
 protected function mergeSparsePatter
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> inA;
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> inB;
-  input list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> inAccum;
-  output list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> out;
+  input BackendDAE.SparsePatternCrefs inA;
+  input BackendDAE.SparsePatternCrefs inB;
+  input BackendDAE.SparsePatternCrefs inAccum;
+  output BackendDAE.SparsePatternCrefs out;
 algorithm
   out := match(inA, inB, inAccum)
   local
-    list<tuple<DAE.ComponentRef, list<DAE.ComponentRef>>> restA, restB;
+    BackendDAE.SparsePatternCrefs restA, restB;
     DAE.ComponentRef crefA, crefB;
     list<DAE.ComponentRef> listA, listB, listOut;
 

--- a/testsuite/openmodelica/debugDumps/dumpSparsePatternLin.mos
+++ b/testsuite/openmodelica/debugDumps/dumpSparsePatternLin.mos
@@ -26,16 +26,16 @@ buildModel(problem3); getErrorString();
 //  --- SparsityPattern ---
 // ========================================
 // Number of non zero elements: 4
-// independents [or inputs] (2)
+// Independents [or inputs] (2)
 // {x[1], x[2]}
-// dependents [or outputs] (2)
+// Dependents [or outputs] (2)
 // {$res1, $res2}
 // x[1] affects the following (2) outputs
 //   {$res2, $res1}
 // x[2] affects the following (2) outputs
 //   {$res2, $res1}
 //
-// transposed pattern
+// Transposed pattern
 // $res1 affects the following (2) outputs
 //   {x[1], x[2]}
 // $res2 affects the following (2) outputs
@@ -52,16 +52,16 @@ buildModel(problem3); getErrorString();
 //  --- SparsityPattern ---
 // ========================================
 // Number of non zero elements: 4
-// independents [or inputs] (2)
+// Independents [or inputs] (2)
 // {x[1], x[2]}
-// dependents [or outputs] (2)
+// Dependents [or outputs] (2)
 // {$res1, $res2}
 // x[1] affects the following (2) outputs
 //   {$res2, $res1}
 // x[2] affects the following (2) outputs
 //   {$res2, $res1}
 //
-// transposed pattern
+// Transposed pattern
 // $res1 affects the following (2) outputs
 //   {x[1], x[2]}
 // $res2 affects the following (2) outputs

--- a/testsuite/openmodelica/debugDumps/symjacdump.mos
+++ b/testsuite/openmodelica/debugDumps/symjacdump.mos
@@ -27,7 +27,7 @@ buildModel(testSymjacdump); getErrorString();
 // ""
 // true
 // ""
-// Crete symbolic Jacobianis from:
+// Create symbolic Jacobians from:
 // Independent Variables
 // ========================================
 // 1: x[2]:VARIABLE(start = 0.5 )  type: Real  [100]
@@ -1075,7 +1075,7 @@ buildModel(testSymjacdump); getErrorString();
 // 98: input x[98]:VARIABLE(start = 0.5 )  type: Real  [100]
 // 99: input x[99]:VARIABLE(start = 0.5 )  type: Real  [100]
 //
-// Crete symbolic Jacobianis from:
+// Create symbolic Jacobians from:
 // Independent Variables
 // ========================================
 // 1: x[99]:VARIABLE(start = 0.5 )  type: Real  [100]


### PR DESCRIPTION
## Changes
 - New types
    - `type SparsePatternCref = tuple< .DAE.ComponentRef, list< .DAE.ComponentRef>>`
    - `type SparsePatternCrefs = list<SparsePatternCref>`
    - To be used in BackEnd.
  - Changed printSparsityPattern to printSparsityPatternCrefs
  - Use new type in printSparsityPatternCrefs
  - Fixed typo and updated testsuite.