### PR TITLE
ticket:5618 Disable the unit drop down when we have a symbolic parameter

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
@@ -132,28 +132,40 @@ void Parameter::updateNameLabel()
  * \param value
  * \param defaultValue
  * \param fromUnit
- * \param valueChanged
+ * \param valueModified
  * \param adjustSize
+ * \param unitComboBoxChanged
  */
-void Parameter::setValueWidget(QString value, bool defaultValue, QString fromUnit, bool valueModified, bool adjustSize)
+void Parameter::setValueWidget(QString value, bool defaultValue, QString fromUnit, bool valueModified, bool adjustSize, bool unitComboBoxChanged)
 {
-  // convert the value to display unit
-  if (!fromUnit.isEmpty() && mpUnitComboBox->currentText().compare(fromUnit) != 0) {
-    bool ok = true;
-    qreal realValue = value.toDouble(&ok);
-    // if the modifier is a literal constant
-    if (ok) {
-      OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
-      OMCInterface::convertUnits_res convertUnit = pOMCProxy->convertUnits(fromUnit, mpUnitComboBox->currentText());
-      if (convertUnit.unitsCompatible) {
-        realValue = Utilities::convertUnit(realValue, convertUnit.offset, convertUnit.scaleFactor);
-        value = QString::number(realValue);
+  /* ticket:5618 if we don't have a literal constant and array of constants
+   * then we assume its an expression and don't do any conversions.
+   * So just show the unit in the unit drop down list
+   */
+  if (!unitComboBoxChanged) {
+    enableDisableUnitComboBox(value);
+  }
+  if (Utilities::isValueLiteralConstant(value)) {
+    // convert the value to display unit
+    if (!fromUnit.isEmpty() && mpUnitComboBox->currentText().compare(fromUnit) != 0) {
+      bool ok = true;
+      qreal realValue = value.toDouble(&ok);
+      // if the modifier is a literal constant
+      if (ok) {
+        OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
+        OMCInterface::convertUnits_res convertUnit = pOMCProxy->convertUnits(fromUnit, mpUnitComboBox->currentText());
+        if (convertUnit.unitsCompatible) {
+          realValue = Utilities::convertUnit(realValue, convertUnit.offset, convertUnit.scaleFactor);
+          value = QString::number(realValue);
+        }
+      } else { // if expression
+        value = Utilities::arrayExpressionUnitConversion(MainWindow::instance()->getOMCProxy(), value, fromUnit, mpUnitComboBox->currentText());
       }
-    } else { // if expression
-      value = Utilities::arrayExpressionUnitConversion(MainWindow::instance()->getOMCProxy(), value, fromUnit, mpUnitComboBox->currentText());
     }
   }
-  mDefaultValue = defaultValue;
+  if (defaultValue) {
+    mDefaultValue = value;
+  }
   QFontMetrics fm = QFontMetrics(QFont());
   switch (mValueType) {
     case Parameter::Boolean:
@@ -243,16 +255,6 @@ QString Parameter::getValue()
   }
 }
 
-/*!
- * \brief Parameter::getDefaultValue
- * Returns the default value.
- * \return
- */
-QString Parameter::getDefaultValue()
-{
-  return mDefaultValue;
-}
-
 void Parameter::setFixedState(QString fixed, bool defaultValue)
 {
   mOriginalFixedValue = fixed;
@@ -321,8 +323,30 @@ void Parameter::createValueWidget()
     case Parameter::Normal:
     default:
       mpValueTextBox = new QLineEdit;
+      connect(mpValueTextBox, SIGNAL(textEdited(QString)), SLOT(valueTextBoxEdited(QString)));
       break;
   }
+}
+
+/*!
+ * \brief Parameter::enableDisableUnitComboBox
+ * Enables/disables the unit combobox.
+ * \param value
+ */
+void Parameter::enableDisableUnitComboBox(const QString &value)
+{
+  /* Enable/disable the unit combobox based on the literalConstant
+   * Set the display unit as current when value is literalConstant otherwise use unit
+   */
+  bool literalConstant = Utilities::isValueLiteralConstant(value);
+  mpUnitComboBox->setEnabled(literalConstant);
+  bool state = mpUnitComboBox->blockSignals(true);
+  int index = mpUnitComboBox->findText(literalConstant ? mDisplayUnit : mUnit, Qt::MatchExactly);
+  if (index > -1 && index != mpUnitComboBox->currentIndex()) {
+    mpUnitComboBox->setCurrentIndex(index);
+    mPreviousUnit = mpUnitComboBox->currentText();
+  }
+  mpUnitComboBox->blockSignals(state);
 }
 
 /*!
@@ -372,13 +396,12 @@ void Parameter::fileSelectorButtonClicked()
  */
 void Parameter::unitComboBoxChanged(QString text)
 {
-  QString defaultValue = getDefaultValue();
-  if (!defaultValue.isEmpty()) {
-    setValueWidget(getDefaultValue(), true, mPreviousUnit, false);
+  if (!mDefaultValue.isEmpty()) {
+    setValueWidget(mDefaultValue, true, mPreviousUnit, false, true, true);
   }
   QString value = getValue();
   if (!value.isEmpty()) {
-    setValueWidget(getValue(), false, mPreviousUnit, true);
+    setValueWidget(value, false, mPreviousUnit, true, true, true);
   }
   mPreviousUnit = text;
 }
@@ -404,6 +427,24 @@ void Parameter::valueComboBoxChanged(int index)
 void Parameter::valueCheckBoxChanged(bool toggle)
 {
   mValueCheckBoxModified = true;
+}
+
+/*!
+ * \brief Parameter::valueTextBoxEdited
+ * This slot is only called when user manually edits the text.\n
+ * \param text
+ */
+void Parameter::valueTextBoxEdited(const QString &text)
+{
+  // if we don't have the text we use the default value otherwise the text
+  QString value;
+  if (text.isEmpty()) {
+    value = mDefaultValue;
+  } else {
+    value = text;
+  }
+
+  enableDisableUnitComboBox(value);
 }
 
 void Parameter::showFixedMenu()

--- a/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.h
+++ b/OMEdit/OMEdit/OMEditGUI/Component/ComponentProperties.h
@@ -62,12 +62,11 @@ public:
   FixedCheckBox* getFixedCheckBox() {return mpFixedCheckBox;}
   QString getOriginalFixedValue() {return mOriginalFixedValue;}
   void setValueType(ValueType valueType) {mValueType = valueType;}
-  void setValueWidget(QString value, bool defaultValue, QString fromUnit, bool valueModified = false, bool adjustSize = true);
+  void setValueWidget(QString value, bool defaultValue, QString fromUnit, bool valueModified = false, bool adjustSize = true, bool unitComboBoxChanged = false);
   ValueType getValueType() {return mValueType;}
   QWidget* getValueWidget();
   bool isValueModified();
   QString getValue();
-  QString getDefaultValue();
   QToolButton* getFileSelectorButton() {return mpFileSelectorButton;}
   void setLoadSelectorFilter(QString loadSelectorFilter) {mLoadSelectorFilter = loadSelectorFilter;}
   QString getLoadSelectorFilter() {return mLoadSelectorFilter;}
@@ -111,11 +110,13 @@ private:
   Label *mpCommentLabel;
 
   void createValueWidget();
+  void enableDisableUnitComboBox(const QString &value);
 public slots:
   void fileSelectorButtonClicked();
   void unitComboBoxChanged(QString text);
   void valueComboBoxChanged(int index);
   void valueCheckBoxChanged(bool toggle);
+  void valueTextBoxEdited(const QString &text);
   void showFixedMenu();
   void trueFixedClicked();
   void falseFixedClicked();

--- a/OMEdit/OMEdit/OMEditGUI/Util/Utilities.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Utilities.cpp
@@ -516,6 +516,24 @@ qreal Utilities::convertUnit(qreal value, qreal offset, qreal scaleFactor)
 }
 
 /*!
+ * \brief Utilities::isValueLiteralConstant
+ * \param value
+ * \return
+ */
+bool Utilities::isValueLiteralConstant(QString value)
+{
+  bool ok = true;
+  value.toDouble(&ok);
+  if (ok) return true;
+
+  QStringList valuesArray = StringHandler::removeFirstLastCurlBrackets(value).split(",");
+  foreach (QString valueElement, valuesArray) {
+    valueElement.toDouble(&ok);
+  }
+  return ok;
+}
+
+/*!
  * \brief Utilities::arrayExpressionUnitConversion
  * If the expression is like an array of constants see ticket:4840
  * \param pOMCProxy

--- a/OMEdit/OMEdit/OMEditGUI/Util/Utilities.h
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Utilities.h
@@ -441,6 +441,7 @@ namespace Utilities {
   QSettings* getApplicationSettings();
   void parseCompositeModelText(MessageHandler *pMessageHandler, QString contents);
   qreal convertUnit(qreal value, qreal offset, qreal scaleFactor);
+  bool isValueLiteralConstant(QString value);
   QString arrayExpressionUnitConversion(OMCProxy *pOMCProxy, QString modifierValue, QString fromUnit, QString toUnit);
   Label* getHeadingLabel(QString heading);
   QFrame* getHeadingLine();


### PR DESCRIPTION
Unit conversions are only done for literal constants. When we have an expression then we just use the default unit.