### PR TITLE
Hotfix for failing libraries from commit 85d9636

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2750,7 +2750,12 @@ algorithm
 
   // Check if all nonlinear iteration variables have start values
   if BackendDAEUtil.isInitializationDAE(inShared) then
-      checkNonLinDependecies(outComp,inEqns);
+      try
+          checkNonLinDependecies(outComp,inEqns);
+      else
+          // ToDo Fix me! Like seriously!
+          Error.addInternalError("function calculateJacobianComponent failed to check all non-linear iteration variables for start values.", sourceInfo());
+      end try;
   end if;
 end calculateJacobianComponent;
 

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeInitialValues.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeInitialValues.mos
@@ -23,6 +23,7 @@ simulate(OverdeterminedInitialization.Fluid.DynamicPipeInitialValues); getErrorS
 // "
 // end SimulationResult;
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: Assuming fixed start value for the following 1 variables:
 //          m_flow_initial:DISCRETE(unit = "kg/s" fixed = false )  type: Real
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization sytem:

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization.mos
@@ -17,6 +17,7 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitializ
 // ""
 // {"OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization","OverdeterminedInitialization.Fluid.DynamicPipeLumpedPressureInitialization_init.xml"}
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: Assuming fixed start value for the following 1 variables:
 //          m_flow_initial:DISCRETE(unit = "kg/s" fixed = false )  type: Real
 // Warning: The initial conditions are over specified. The following 4 initial equations are redundant, so they are removed from the initialization sytem:

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial.mos
@@ -18,6 +18,7 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStat
 // {"OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial","OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial_init.xml"}
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Notification: The following initial equation is redundant and consistent due to simplifications in RemoveSimpleEquations and therefore removed from the initialization problem: der(pipe1.mediums[1].p) = 0.0 -> 0.0 = 0.0
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization sytem:
 //          $DER.pipe1.mediums[50].p = 0.0.
 // "

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial.mos
@@ -18,6 +18,7 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateIniti
 // {"OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial","OverdeterminedInitialization.Fluid.DynamicPipesSeriesSteadyStateInitial_init.xml"}
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Notification: The following initial equation is redundant and consistent due to simplifications in RemoveSimpleEquations and therefore removed from the initialization problem: der(pipe1.mediums[1].p) = 0.0 -> 0.0 = 0.0
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization sytem:
 //          $DER.pipe1.mediums[5].p = 0.0.
 // "

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.TwoVolumesFullInitial.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.TwoVolumesFullInitial.mos
@@ -18,6 +18,7 @@ buildModel(OverdeterminedInitialization.Fluid.TwoVolumesFullInitial); getErrorSt
 // {"OverdeterminedInitialization.Fluid.TwoVolumesFullInitial","OverdeterminedInitialization.Fluid.TwoVolumesFullInitial_init.xml"}
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: It was not possible to determine if the initialization problem is consistent, because of not evaluable parameters/start values during compile time: V1.medium.p = V1.p_start (V2.p_start = V1.p_start)
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization sytem:
 //          V1.medium.p = V1.p_start.
 // "

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.TwoVolumesFullInitialInconsistent.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.TwoVolumesFullInitialInconsistent.mos
@@ -26,6 +26,7 @@ simulate(OverdeterminedInitialization.Fluid.TwoVolumesFullInitialInconsistent); 
 // end SimulationResult;
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: It was not possible to determine if the initialization problem is consistent, because of not evaluable parameters/start values during compile time: V1.medium.p = V1.p_start (V2.p_start = V1.p_start)
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization sytem:
 //          V1.medium.p = V1.p_start.
 // Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.TwoVolumesFullSteadyStatePressureAndTemperature.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.TwoVolumesFullSteadyStatePressureAndTemperature.mos
@@ -17,6 +17,7 @@ buildModel(OverdeterminedInitialization.Fluid.TwoVolumesFullSteadyStatePressureA
 // ""
 // {"OverdeterminedInitialization.Fluid.TwoVolumesFullSteadyStatePressureAndTemperature","OverdeterminedInitialization.Fluid.TwoVolumesFullSteadyStatePressureAndTemperature_init.xml"}
 // "Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// [BackEnd/SymbolicJacobian.mo:0:0-0:0:writable] Error: Internal error function calculateJacobianComponent failed to check all non-linear iteration variables for start values.
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization sytem:
 //          $DER.V1.medium.p = 0.0.
 // "


### PR DESCRIPTION
Commit 85d9636 introduced around 480 regressions. This will suppress the error but doesn't solve the underlying problem with `checkNonLinDependecies` function.
But the failing models are simulating for now...