### PR TITLE
[NF] Implement ModelicaStrings external functions.

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Ceval.mo
+++ b/OMCompiler/Compiler/FrontEnd/Ceval.mo
@@ -1364,12 +1364,12 @@ algorithm
 
     case ("ModelicaStrings_scanReal",{Values.STRING(str),Values.INTEGER(i),Values.BOOL(b)},_)
       equation
-        (i,r) = ModelicaExternalC.Strings_advanced_scanReal(str,i,b);
+        (i,r) = ModelicaExternalC.Strings_scanReal(str,i,b);
       then Values.TUPLE({Values.INTEGER(i),Values.REAL(r)});
 
     case ("ModelicaStrings_skipWhiteSpace",{Values.STRING(str),Values.INTEGER(i)},_)
       equation
-        i = ModelicaExternalC.Strings_advanced_skipWhiteSpace(str,i);
+        i = ModelicaExternalC.Strings_skipWhiteSpace(str,i);
       then Values.INTEGER(i);
 
     case ("OpenModelica_regex",{Values.STRING(str),Values.STRING(re),Values.INTEGER(i),Values.BOOL(extended),Values.BOOL(insensitive)},_)

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -966,23 +966,40 @@ algorithm
 
     case ("ModelicaStrings_scanReal", {Expression.STRING(s1), Expression.INTEGER(i), Expression.BOOLEAN(b)})
       algorithm
-        (i, r) := ModelicaExternalC.Strings_advanced_scanReal(s1, i, b);
+        (i, r) := ModelicaExternalC.Strings_scanReal(s1, i, b);
       then
-        Expression.TUPLE(Type.TUPLE({Type.INTEGER(), Type.BOOLEAN()}, NONE()),
+        Expression.TUPLE(Type.TUPLE({Type.INTEGER(), Type.REAL()}, NONE()),
                          {Expression.INTEGER(i), Expression.REAL(r)});
 
     case ("ModelicaStrings_scanInteger", {Expression.STRING(s1), Expression.INTEGER(i), Expression.BOOLEAN(b)})
       algorithm
-        (i, i2) := ModelicaExternalC.Strings_advanced_scanInteger(s1, i, b);
+        (i, i2) := ModelicaExternalC.Strings_scanInteger(s1, i, b);
       then
         Expression.TUPLE(Type.TUPLE({Type.INTEGER(), Type.INTEGER()}, NONE()),
                          {Expression.INTEGER(i), Expression.INTEGER(i2)});
 
+    case ("ModelicaStrings_scanString", {Expression.STRING(s1), Expression.INTEGER(i)})
+      algorithm
+        (i, s2) := ModelicaExternalC.Strings_scanString(s1, i);
+      then
+        Expression.TUPLE(Type.TUPLE({Type.INTEGER(), Type.STRING()}, NONE()),
+                         {Expression.INTEGER(i), Expression.STRING(s2)});
+
+    case ("ModelicaStrings_scanIdentifier", {Expression.STRING(s1), Expression.INTEGER(i)})
+      algorithm
+        (i, s2) := ModelicaExternalC.Strings_scanIdentifier(s1, i);
+      then
+        Expression.TUPLE(Type.TUPLE({Type.INTEGER(), Type.STRING()}, NONE()),
+                         {Expression.INTEGER(i), Expression.STRING(s2)});
+
     case ("ModelicaStrings_skipWhiteSpace", {Expression.STRING(s1), Expression.INTEGER(i)})
-      then Expression.INTEGER(ModelicaExternalC.Strings_advanced_skipWhiteSpace(s1, i));
+      then Expression.INTEGER(ModelicaExternalC.Strings_skipWhiteSpace(s1, i));
 
     case ("ModelicaStrings_substring", {Expression.STRING(s1), Expression.INTEGER(i), Expression.INTEGER(i2)})
       then Expression.STRING(System.substring(s1, i, i2));
+
+    case ("ModelicaStrings_hashString", {Expression.STRING(s1)})
+      then Expression.INTEGER(ModelicaExternalC.Strings_hashString(s1));
 
     case ("OpenModelica_regex", _) then evaluateOpenModelicaRegex(args);
 

--- a/OMCompiler/Compiler/Util/ModelicaExternalC.mo
+++ b/OMCompiler/Compiler/Util/ModelicaExternalC.mo
@@ -85,7 +85,7 @@ function Strings_compare
   external "C" result=ModelicaStrings_compare(string1,string2,caseSensitive) annotation(Library = "ModelicaExternalC");
 end Strings_compare;
 
-function Strings_advanced_scanReal
+function Strings_scanReal
   input String string;
   input Integer startIndex;
   input Boolean unsigned;
@@ -93,9 +93,9 @@ function Strings_advanced_scanReal
   output Real number;
 
   external "C" ModelicaStrings_scanReal(string,startIndex,unsigned,nextIndex,number) annotation(Library = "ModelicaExternalC");
-end Strings_advanced_scanReal;
+end Strings_scanReal;
 
-function Strings_advanced_scanInteger
+function Strings_scanInteger
   input String string;
   input Integer startIndex;
   input Boolean unsigned;
@@ -104,15 +104,42 @@ function Strings_advanced_scanInteger
 
   external "C"
   ModelicaStrings_scanInteger(string,startIndex,unsigned,nextIndex,number) annotation(Library = "ModelicaExternalC");
-end Strings_advanced_scanInteger;
+end Strings_scanInteger;
 
-function Strings_advanced_skipWhiteSpace
+function Strings_scanString
+  input String string;
+  input Integer startIndex;
+  output Integer nextIndex;
+  output String string2;
+
+  external "C"
+  ModelicaStrings_scanString(string,startIndex,nextIndex,string2) annotation(Library = "ModelicaExternalC");
+end Strings_scanString;
+
+function Strings_scanIdentifier
+  input String string;
+  input Integer startIndex;
+  output Integer nextIndex;
+  output String identifier;
+
+  external "C"
+  ModelicaStrings_scanIdentifier(string,startIndex,nextIndex,identifier) annotation(Library = "ModelicaExternalC");
+end Strings_scanIdentifier;
+
+function Strings_skipWhiteSpace
   input String string;
   input Integer startIndex(min = 1) = 1;
   output Integer nextIndex;
 
   external "C" nextIndex = ModelicaStrings_skipWhiteSpace(string,startIndex) annotation(Library = "ModelicaExternalC");
-end Strings_advanced_skipWhiteSpace;
+end Strings_skipWhiteSpace;
+
+function Strings_hashString
+  input String string;
+  output Integer hash;
+
+  external "C" hash = ModelicaStrings_hashString(string) annotation(Library = "ModelicaExternalC");
+end Strings_hashString;
 
 function ModelicaIO_readMatrixSizes
   input String fileName;


### PR DESCRIPTION
- Add the remaining ModelicaStrings functions from ModelicaExternalC.
- Rename Strings_advanced_* to Strings_*, the functions should be named
  after the external functions they implement, not after the library
  functions that use them.
- Fix return type of scanReal.