### PR TITLE
OMEdit: cache some frequently created icons

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
@@ -34,6 +34,7 @@
 
 #include "BitmapAnnotation.h"
 #include "Modeling/Commands.h"
+#include "Util/ResourceCache.h"
 
 #include <QMessageBox>
 
@@ -96,7 +97,7 @@ BitmapAnnotation::BitmapAnnotation(QString classFileName, GraphicsView *pGraphic
   if (!mFileName.isEmpty() && QFile::exists(mFileName)) {
     mImage.load(mFileName);
   } else {
-    mImage = QImage(":/Resources/icons/bitmap-shape.svg");
+    mImage = ResourceCache::getImage(":/Resources/icons/bitmap-shape.svg");
   }
 }
 
@@ -126,7 +127,7 @@ void BitmapAnnotation::parseShapeAnnotation(QString annotation)
   } else if (!mFileName.isEmpty() && QFile::exists(mFileName)) {
     mImage.load(mFileName);
   } else {
-    mImage = QImage(":/Resources/icons/bitmap-shape.svg");
+    mImage = ResourceCache::getImage(":/Resources/icons/bitmap-shape.svg");
   }
 }
 

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
@@ -37,6 +37,7 @@
 #include "Modeling/ItemDelegate.h"
 #include "Modeling/Commands.h"
 #include "OMS/BusDialog.h"
+#include "Util/ResourceCache.h"
 
 #include <QMessageBox>
 
@@ -1389,10 +1390,10 @@ QVariant ExpandableConnectorTreeItem::data(int column, int role) const
         case Qt::DecorationRole:
           switch (mRestriction) {
             case StringHandler::ExpandableConnector:
-              return QIcon(":/Resources/icons/connect-mode.svg");
+              return ResourceCache::getIcon(":/Resources/icons/connect-mode.svg");
               break;
             case StringHandler::Connector:
-              return QIcon(":/Resources/icons/connector-icon.svg");
+              return ResourceCache::getIcon(":/Resources/icons/connector-icon.svg");
               break;
             default:
               return QVariant();

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
@@ -41,6 +41,7 @@
 #include "Component/ComponentProperties.h"
 #include "TLM/FetchInterfaceDataDialog.h"
 #include "Plotting/VariablesWidget.h"
+#include "Util/ResourceCache.h"
 
 /*!
  * \brief GraphicItem::setDefaults
@@ -390,7 +391,7 @@ void ShapeAnnotation::setDefaults()
   mOriginalFileName = "";
   mFileName = "";
   mImageSource = "";
-  mImage = QImage(":/Resources/icons/bitmap-shape.svg");
+  mImage = ResourceCache::getImage(":/Resources/icons/bitmap-shape.svg");
   mDynamicTextString.clear();
 }
 
@@ -474,7 +475,7 @@ void ShapeAnnotation::createActions()
   mpShapePropertiesAction->setStatusTip(tr("Shows the shape properties"));
   connect(mpShapePropertiesAction, SIGNAL(triggered()), SLOT(showShapeProperties()));
   // shape attributes
-  mpAlignInterfacesAction = new QAction(QIcon(":/Resources/icons/align-interfaces.svg"), Helper::alignInterfaces, mpGraphicsView);
+  mpAlignInterfacesAction = new QAction(ResourceCache::getIcon(":/Resources/icons/align-interfaces.svg"), Helper::alignInterfaces, mpGraphicsView);
   mpAlignInterfacesAction->setStatusTip(Helper::alignInterfacesTip);
   connect(mpAlignInterfacesAction, SIGNAL(triggered()), SLOT(alignInterfaces()));
   // shape attributes

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/ShapePropertiesDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/ShapePropertiesDialog.cpp
@@ -39,6 +39,7 @@
 #include "Options/OptionsDialog.h"
 #include "Options/NotificationsDialog.h"
 #include "Modeling/Commands.h"
+#include "Util/ResourceCache.h"
 
 #include <QHeaderView>
 #include <QColorDialog>
@@ -408,23 +409,23 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   // points navigation buttons
   mpMovePointUpButton = new QToolButton;
   mpMovePointUpButton->setObjectName("ShapePointsButton");
-  mpMovePointUpButton->setIcon(QIcon(":/Resources/icons/up.svg"));
+  mpMovePointUpButton->setIcon(ResourceCache::getIcon(":/Resources/icons/up.svg"));
   mpMovePointUpButton->setToolTip(tr("Move point up"));
   connect(mpMovePointUpButton, SIGNAL(clicked()), SLOT(movePointUp()));
   mpMovePointDownButton = new QToolButton;
   mpMovePointDownButton->setObjectName("ShapePointsButton");
-  mpMovePointDownButton->setIcon(QIcon(":/Resources/icons/down.svg"));
+  mpMovePointDownButton->setIcon(ResourceCache::getIcon(":/Resources/icons/down.svg"));
   mpMovePointDownButton->setToolTip(tr("Move point down"));
   connect(mpMovePointDownButton, SIGNAL(clicked()), SLOT(movePointDown()));
   // points manipulation buttons
   mpAddPointButton = new QToolButton;
   mpAddPointButton->setObjectName("ShapePointsButton");
-  mpAddPointButton->setIcon(QIcon(":/Resources/icons/add-icon.svg"));
+  mpAddPointButton->setIcon(ResourceCache::getIcon(":/Resources/icons/add-icon.svg"));
   mpAddPointButton->setToolTip(tr("Add new point"));
   connect(mpAddPointButton, SIGNAL(clicked()), SLOT(addPoint()));
   mpRemovePointButton = new QToolButton;
   mpRemovePointButton->setObjectName("ShapePointsButton");
-  mpRemovePointButton->setIcon(QIcon(":/Resources/icons/delete.svg"));
+  mpRemovePointButton->setIcon(ResourceCache::getIcon(":/Resources/icons/delete.svg"));
   mpRemovePointButton->setToolTip(tr("Remove point"));
   connect(mpRemovePointButton, SIGNAL(clicked()), SLOT(removePoint()));
   mpPointsButtonBox = new QDialogButtonBox(Qt::Vertical);

--- a/OMEdit/OMEdit/OMEditGUI/Component/Component.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Component/Component.cpp
@@ -40,6 +40,7 @@
 #include "Modeling/DocumentationWidget.h"
 #include "Plotting/VariablesWidget.h"
 #include "OMS/BusDialog.h"
+#include "Util/ResourceCache.h"
 
 #include <QMessageBox>
 #include <QMenu>
@@ -1936,7 +1937,7 @@ void Component::createActions()
   mpParametersAction->setStatusTip(tr("Shows the component parameters"));
   connect(mpParametersAction, SIGNAL(triggered()), SLOT(showParameters()));
   // Fetch interfaces action
-  mpFetchInterfaceDataAction = new QAction(QIcon(":/Resources/icons/interface-data.svg"), Helper::fetchInterfaceData, mpGraphicsView);
+  mpFetchInterfaceDataAction = new QAction(ResourceCache::getIcon(":/Resources/icons/interface-data.svg"), Helper::fetchInterfaceData, mpGraphicsView);
   mpFetchInterfaceDataAction->setStatusTip(tr("Fetch interface data for this external model"));
   connect(mpFetchInterfaceDataAction, SIGNAL(triggered()), SLOT(fetchInterfaceData()));
   // Todo: Connect /robbr
@@ -1945,7 +1946,7 @@ void Component::createActions()
   mpAttributesAction->setStatusTip(tr("Shows the component attributes"));
   connect(mpAttributesAction, SIGNAL(triggered()), SLOT(showAttributes()));
   // Open Class Action
-  mpOpenClassAction = new QAction(QIcon(":/Resources/icons/model.svg"), Helper::openClass, mpGraphicsView);
+  mpOpenClassAction = new QAction(ResourceCache::getIcon(":/Resources/icons/model.svg"), Helper::openClass, mpGraphicsView);
   mpOpenClassAction->setStatusTip(Helper::openClassTip);
   connect(mpOpenClassAction, SIGNAL(triggered()), SLOT(openClass()));
   // SubModel attributes Action

--- a/OMEdit/OMEdit/OMEditGUI/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Editors/BaseEditor.cpp
@@ -37,6 +37,7 @@
 #include "Modeling/ModelWidgetContainer.h"
 #include "Util/Helper.h"
 #include "Debugger/Breakpoints/BreakpointsWidget.h"
+#include "Util/ResourceCache.h"
 
 #include <QMenu>
 #include <QCompleter>
@@ -788,7 +789,7 @@ void PlainTextEdit::insertCompleterSymbols(QList<CompleterItem> symbols, const Q
 {
   for (int i = 0; i < symbols.size(); ++i) {
     QStandardItem *pStandardItem = new QStandardItem(symbols[i].mKey);
-    pStandardItem->setIcon(QIcon(iconResource));
+    pStandardItem->setIcon(ResourceCache::getIcon(iconResource));
     pStandardItem->setData(QVariant::fromValue(symbols[i]), Qt::UserRole);
     mpStandardItemModel->appendRow(pStandardItem);
   }
@@ -805,7 +806,7 @@ void PlainTextEdit::insertCompleterKeywords(QStringList keywords)
 {
   for (int i = 0; i < keywords.size(); ++i) {
     QStandardItem *pStandardItem = new QStandardItem(keywords[i]);
-    pStandardItem->setIcon(QIcon(":/Resources/icons/completerkeyword.svg"));
+    pStandardItem->setIcon(ResourceCache::getIcon(":/Resources/icons/completerkeyword.svg"));
     pStandardItem->setData(QVariant::fromValue(CompleterItem(keywords[i],keywords[i],"")),Qt::UserRole);
     mpStandardItemModel->appendRow(pStandardItem);
   }
@@ -822,7 +823,7 @@ void PlainTextEdit::insertCompleterTypes(QStringList types)
 {
   for (int k = 0; k < types.size(); ++k) {
     QStandardItem *pStandardItem = new QStandardItem(types[k]);
-    pStandardItem->setIcon(QIcon(":/Resources/icons/completerType.svg"));
+    pStandardItem->setIcon(ResourceCache::getIcon(":/Resources/icons/completerType.svg"));
     pStandardItem->setData(QVariant::fromValue(CompleterItem(types[k],types[k],"")),Qt::UserRole);
     mpStandardItemModel->appendRow(pStandardItem);
   }
@@ -839,7 +840,7 @@ void PlainTextEdit::insertCompleterCodeSnippets(QList<CompleterItem> items)
 {
   for (int var = 0; var < items.length(); ++var) {
     QStandardItem *pStandardItem = new QStandardItem(items[var].mKey);
-    pStandardItem->setIcon(QIcon(":/Resources/icons/completerCodeSnippets.svg"));
+    pStandardItem->setIcon(ResourceCache::getIcon(":/Resources/icons/completerCodeSnippets.svg"));
     pStandardItem->setData(QVariant::fromValue(items[var]),Qt::UserRole);
     mpStandardItemModel->appendRow(pStandardItem);
   }
@@ -2090,19 +2091,19 @@ void BaseEditor::createActions()
   // we only define the zooming actions if ModelWidget is NULL otherwise we use the zooming actions from toolbar.
   if (!mpModelWidget) {
     // reset zoom action
-    mpResetZoomAction = new QAction(QIcon(":/Resources/icons/zoomReset.svg"), Helper::resetZoom, this);
+    mpResetZoomAction = new QAction(ResourceCache::getIcon(":/Resources/icons/zoomReset.svg"), Helper::resetZoom, this);
     mpResetZoomAction->setStatusTip(Helper::resetZoom);
     mpResetZoomAction->setShortcut(QKeySequence("Ctrl+0"));
     connect(mpResetZoomAction, SIGNAL(triggered()), mpPlainTextEdit, SLOT(resetZoom()));
     mpPlainTextEdit->addAction(mpResetZoomAction);
     // zoom in action
-    mpZoomInAction = new QAction(QIcon(":/Resources/icons/zoomIn.svg"), Helper::zoomIn, this);
+    mpZoomInAction = new QAction(ResourceCache::getIcon(":/Resources/icons/zoomIn.svg"), Helper::zoomIn, this);
     mpZoomInAction->setStatusTip(Helper::zoomIn);
     mpZoomInAction->setShortcut(QKeySequence("Ctrl++"));
     connect(mpZoomInAction, SIGNAL(triggered()), mpPlainTextEdit, SLOT(zoomIn()));
     mpPlainTextEdit->addAction(mpZoomInAction);
     // zoom out action
-    mpZoomOutAction = new QAction(QIcon(":/Resources/icons/zoomOut.svg"), Helper::zoomOut, this);
+    mpZoomOutAction = new QAction(ResourceCache::getIcon(":/Resources/icons/zoomOut.svg"), Helper::zoomOut, this);
     mpZoomOutAction->setStatusTip(Helper::zoomOut);
     mpZoomOutAction->setShortcut(QKeySequence("Ctrl+-"));
     connect(mpZoomOutAction, SIGNAL(triggered()), mpPlainTextEdit, SLOT(zoomOut()));
@@ -2156,11 +2157,11 @@ QMenu* BaseEditor::createStandardContextMenu()
     pMenu->addAction(MainWindow::instance()->getRedoAction());
   } else {
     QAction *pUndoAction = pMenu->addAction(tr("Undo"), mpPlainTextEdit, SLOT(undo()));
-    pUndoAction->setIcon(QIcon(":/Resources/icons/undo.svg"));
+    pUndoAction->setIcon(ResourceCache::getIcon(":/Resources/icons/undo.svg"));
     pUndoAction->setShortcut(QKeySequence::Undo);
     pUndoAction->setEnabled(mpPlainTextEdit->isUndoAvailable());
     QAction *pRedoAction = pMenu->addAction(tr("Redo"), mpPlainTextEdit, SLOT(undo()));
-    pRedoAction->setIcon(QIcon(":/Resources/icons/redo.svg"));
+    pRedoAction->setIcon(ResourceCache::getIcon(":/Resources/icons/redo.svg"));
     pRedoAction->setShortcut(QKeySequence::Redo);
     pRedoAction->setEnabled(mpPlainTextEdit->isRedoAvailable());
   }
@@ -2763,7 +2764,7 @@ GotoLineDialog::GotoLineDialog(BaseEditor *pBaseEditor)
   : QDialog(pBaseEditor)
 {
   setWindowTitle(QString(Helper::applicationName).append(" - Go to Line"));
-  setWindowIcon(QIcon(":/Resources/icons/modeling.png"));
+  setWindowIcon(ResourceCache::getIcon(":/Resources/icons/modeling.png"));
   setAttribute(Qt::WA_DeleteOnClose);
   mpBaseEditor = pBaseEditor;
   mpLineNumberLabel = new Label;
@@ -2830,7 +2831,7 @@ InfoBar::InfoBar(QWidget *pParent)
   mpInfoLabel->setWordWrap(true);
   mpCloseButton = new QToolButton;
   mpCloseButton->setAutoRaise(true);
-  mpCloseButton->setIcon(QIcon(":/Resources/icons/delete.svg"));
+  mpCloseButton->setIcon(ResourceCache::getIcon(":/Resources/icons/delete.svg"));
   mpCloseButton->setToolTip(Helper::close);
   connect(mpCloseButton, SIGNAL(clicked()), SLOT(hide()));
   // set the layout

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
@@ -47,6 +47,7 @@
 #include "ModelicaClassDialog.h"
 #include "Git/GitCommands.h"
 #include "Git/CommitChangesDialog.h"
+#include "Util/ResourceCache.h"
 
 /*!
  * \class LibraryTreeItem
@@ -419,54 +420,54 @@ QString LibraryTreeItem::getTooltip() const {
 QIcon LibraryTreeItem::getLibraryTreeItemIcon() const
 {
   if (mLibraryType == LibraryTreeItem::CompositeModel) {
-    return QIcon(":/Resources/icons/tlm-icon.svg");
+    return ResourceCache::getIcon(":/Resources/icons/tlm-icon.svg");
   } else if (mLibraryType == LibraryTreeItem::OMS) {
     if (isTopLevel()) {
-      return QIcon(":/Resources/icons/model-icon.svg");
+      return ResourceCache::getIcon(":/Resources/icons/model-icon.svg");
     } else if (isSystemElement()) {
       if (isTLMSystem()) {
-        return QIcon(":/Resources/icons/tlm-system-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/tlm-system-icon.svg");
       } else if (isWCSystem()) {
-        return QIcon(":/Resources/icons/wc-system-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/wc-system-icon.svg");
       } else {
-        return QIcon(":/Resources/icons/sc-system-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/sc-system-icon.svg");
       }
     } else if (isFMUComponent()) {
-      return QIcon(":/Resources/icons/fmu-icon.svg");
+      return ResourceCache::getIcon(":/Resources/icons/fmu-icon.svg");
     } else if (isTableComponent()) {
       if (mSubModelPath.endsWith(".csv")) {
-        return QIcon(":/Resources/icons/csv.svg");
+        return ResourceCache::getIcon(":/Resources/icons/csv.svg");
       } else {
-        return QIcon(":/Resources/icons/mat.svg");
+        return ResourceCache::getIcon(":/Resources/icons/mat.svg");
       }
     } else if (mpOMSConnector) {
       switch (mpOMSConnector->type) {
         case oms_signal_type_real:
           switch (mpOMSConnector->causality) {
             case oms_causality_input:
-              return QIcon(":/Resources/icons/real-input-connector.svg");
+              return ResourceCache::getIcon(":/Resources/icons/real-input-connector.svg");
             case oms_causality_output:
-              return QIcon(":/Resources/icons/real-output-connector.svg");
+              return ResourceCache::getIcon(":/Resources/icons/real-output-connector.svg");
             default:
-              return QIcon(":/Resources/icons/package-icon.svg");
+              return ResourceCache::getIcon(":/Resources/icons/package-icon.svg");
           }
         case oms_signal_type_integer:
           switch (mpOMSConnector->causality) {
             case oms_causality_input:
-              return QIcon(":/Resources/icons/integer-input-connector.svg");
+              return ResourceCache::getIcon(":/Resources/icons/integer-input-connector.svg");
             case oms_causality_output:
-              return QIcon(":/Resources/icons/integer-output-connector.svg");
+              return ResourceCache::getIcon(":/Resources/icons/integer-output-connector.svg");
             default:
-              return QIcon(":/Resources/icons/package-icon.svg");
+              return ResourceCache::getIcon(":/Resources/icons/package-icon.svg");
           }
         case oms_signal_type_boolean:
           switch (mpOMSConnector->causality) {
             case oms_causality_input:
-              return QIcon(":/Resources/icons/boolean-input-connector.svg");
+              return ResourceCache::getIcon(":/Resources/icons/boolean-input-connector.svg");
             case oms_causality_output:
-              return QIcon(":/Resources/icons/boolean-output-connector.svg");
+              return ResourceCache::getIcon(":/Resources/icons/boolean-output-connector.svg");
             default:
-              return QIcon(":/Resources/icons/package-icon.svg");
+              return ResourceCache::getIcon(":/Resources/icons/package-icon.svg");
           }
         default:
           qDebug() << "Unhanled connector type" << mpOMSConnector->type;
@@ -477,47 +478,47 @@ QIcon LibraryTreeItem::getLibraryTreeItemIcon() const
     } else if (mpOMSTLMBusConnector) {
       switch (mpOMSTLMBusConnector->domain) {
         case oms_tlm_domain_input:
-          return QIcon(":/Resources/icons/tlm-input-bus-connector.svg");
+          return ResourceCache::getIcon(":/Resources/icons/tlm-input-bus-connector.svg");
         case oms_tlm_domain_output:
-          return QIcon(":/Resources/icons/tlm-output-bus-connector.svg");
+          return ResourceCache::getIcon(":/Resources/icons/tlm-output-bus-connector.svg");
         case oms_tlm_domain_rotational:
-          return QIcon(":/Resources/icons/tlm-rotational-bus-connector.svg");
+          return ResourceCache::getIcon(":/Resources/icons/tlm-rotational-bus-connector.svg");
         case oms_tlm_domain_hydraulic:
-          return QIcon(":/Resources/icons/tlm-hydraulic-bus-connector.svg");
+          return ResourceCache::getIcon(":/Resources/icons/tlm-hydraulic-bus-connector.svg");
         case oms_tlm_domain_electric:
-          return QIcon(":/Resources/icons/tlm-electric-bus-connector.svg");
+          return ResourceCache::getIcon(":/Resources/icons/tlm-electric-bus-connector.svg");
         case oms_tlm_domain_mechanical:
         default:
-          return QIcon(":/Resources/icons/tlm-mechanical-bus-connector.svg");
+          return ResourceCache::getIcon(":/Resources/icons/tlm-mechanical-bus-connector.svg");
       }
     }
   } else if (mLibraryType == LibraryTreeItem::Modelica) {
     switch (getRestriction()) {
       case StringHandler::Model:
-        return QIcon(":/Resources/icons/model-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/model-icon.svg");
       case StringHandler::Class:
-        return QIcon(":/Resources/icons/class-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/class-icon.svg");
       case StringHandler::Connector:
-        return QIcon(":/Resources/icons/connector-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/connector-icon.svg");
       case StringHandler::ExpandableConnector:
-        return QIcon(":/Resources/icons/connect-mode.svg");
+        return ResourceCache::getIcon(":/Resources/icons/connect-mode.svg");
       case StringHandler::Record:
-        return QIcon(":/Resources/icons/record-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/record-icon.svg");
       case StringHandler::Block:
-        return QIcon(":/Resources/icons/block-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/block-icon.svg");
       case StringHandler::Function:
-        return QIcon(":/Resources/icons/function-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/function-icon.svg");
       case StringHandler::Package:
-        return QIcon(":/Resources/icons/package-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/package-icon.svg");
       case StringHandler::Type:
       case StringHandler::Operator:
       case StringHandler::OperatorRecord:
       case StringHandler::OperatorFunction:
-        return QIcon(":/Resources/icons/type-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/type-icon.svg");
       case StringHandler::Optimization:
-        return QIcon(":/Resources/icons/optimization-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/optimization-icon.svg");
       default:
-        return QIcon(":/Resources/icons/type-icon.svg");
+        return ResourceCache::getIcon(":/Resources/icons/type-icon.svg");
     }
   }
   return QIcon();

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -54,6 +54,7 @@
 #include "OMS/ModelDialog.h"
 #include "OMS/BusDialog.h"
 #include "OMS/SystemSimulationInformationDialog.h"
+#include "Util/ResourceCache.h"
 
 #include <QNetworkReply>
 #include <QMessageBox>
@@ -1543,7 +1544,7 @@ void GraphicsView::createActions()
   mpRenameAction->setStatusTip(Helper::renameTip);
   connect(mpRenameAction, SIGNAL(triggered()), SLOT(showRenameDialog()));
   // Simulation Params Action
-  mpSimulationParamsAction = new QAction(QIcon(":/Resources/icons/simulation-parameters.svg"), Helper::simulationParams, this);
+  mpSimulationParamsAction = new QAction(ResourceCache::getIcon(":/Resources/icons/simulation-parameters.svg"), Helper::simulationParams, this);
   mpSimulationParamsAction->setStatusTip(Helper::simulationParamsTip);
   connect(mpSimulationParamsAction, SIGNAL(triggered()), SLOT(showSimulationParamsDialog()));
   // Actions for shapes and Components
@@ -1553,57 +1554,57 @@ void GraphicsView::createActions()
   mpManhattanizeAction->setDisabled(isSystemLibrary);
   connect(mpManhattanizeAction, SIGNAL(triggered()), SLOT(manhattanizeItems()));
   // Delete Action
-  mpDeleteAction = new QAction(QIcon(":/Resources/icons/delete.svg"), Helper::deleteStr, this);
+  mpDeleteAction = new QAction(ResourceCache::getIcon(":/Resources/icons/delete.svg"), Helper::deleteStr, this);
   mpDeleteAction->setStatusTip(tr("Deletes the item"));
   mpDeleteAction->setShortcut(QKeySequence::Delete);
   mpDeleteAction->setDisabled(isSystemLibrary);
   connect(mpDeleteAction, SIGNAL(triggered()), SLOT(deleteItems()));
   // Duplicate Action
-  mpDuplicateAction = new QAction(QIcon(":/Resources/icons/duplicate.svg"), Helper::duplicate, this);
+  mpDuplicateAction = new QAction(ResourceCache::getIcon(":/Resources/icons/duplicate.svg"), Helper::duplicate, this);
   mpDuplicateAction->setStatusTip(Helper::duplicateTip);
   mpDuplicateAction->setShortcut(QKeySequence("Ctrl+d"));
   mpDuplicateAction->setDisabled(isSystemLibrary);
   connect(mpDuplicateAction, SIGNAL(triggered()), SLOT(duplicateItems()));
   // Bring To Front Action
-  mpBringToFrontAction = new QAction(QIcon(":/Resources/icons/bring-to-front.svg"), tr("Bring to Front"), this);
+  mpBringToFrontAction = new QAction(ResourceCache::getIcon(":/Resources/icons/bring-to-front.svg"), tr("Bring to Front"), this);
   mpBringToFrontAction->setStatusTip(tr("Brings the item to front"));
   mpBringToFrontAction->setDisabled(isSystemLibrary);
   mpBringToFrontAction->setDisabled(true);
   // Bring Forward Action
-  mpBringForwardAction = new QAction(QIcon(":/Resources/icons/bring-forward.svg"), tr("Bring Forward"), this);
+  mpBringForwardAction = new QAction(ResourceCache::getIcon(":/Resources/icons/bring-forward.svg"), tr("Bring Forward"), this);
   mpBringForwardAction->setStatusTip(tr("Brings the item one level forward"));
   mpBringForwardAction->setDisabled(isSystemLibrary);
   mpBringForwardAction->setDisabled(true);
   // Send To Back Action
-  mpSendToBackAction = new QAction(QIcon(":/Resources/icons/send-to-back.svg"), tr("Send to Back"), this);
+  mpSendToBackAction = new QAction(ResourceCache::getIcon(":/Resources/icons/send-to-back.svg"), tr("Send to Back"), this);
   mpSendToBackAction->setStatusTip(tr("Sends the item to back"));
   mpSendToBackAction->setDisabled(isSystemLibrary);
   mpSendToBackAction->setDisabled(true);
   // Send Backward Action
-  mpSendBackwardAction = new QAction(QIcon(":/Resources/icons/send-backward.svg"), tr("Send Backward"), this);
+  mpSendBackwardAction = new QAction(ResourceCache::getIcon(":/Resources/icons/send-backward.svg"), tr("Send Backward"), this);
   mpSendBackwardAction->setStatusTip(tr("Sends the item one level backward"));
   mpSendBackwardAction->setDisabled(isSystemLibrary);
   mpSendBackwardAction->setDisabled(true);
   // Rotate ClockWise Action
-  mpRotateClockwiseAction = new QAction(QIcon(":/Resources/icons/rotateclockwise.svg"), tr("Rotate Clockwise"), this);
+  mpRotateClockwiseAction = new QAction(ResourceCache::getIcon(":/Resources/icons/rotateclockwise.svg"), tr("Rotate Clockwise"), this);
   mpRotateClockwiseAction->setStatusTip(tr("Rotates the item clockwise"));
   mpRotateClockwiseAction->setShortcut(QKeySequence("Ctrl+r"));
   mpRotateClockwiseAction->setDisabled(isSystemLibrary);
   connect(mpRotateClockwiseAction, SIGNAL(triggered()), SLOT(rotateClockwise()));
   // Rotate Anti-ClockWise Action
-  mpRotateAntiClockwiseAction = new QAction(QIcon(":/Resources/icons/rotateanticlockwise.svg"), tr("Rotate Anticlockwise"), this);
+  mpRotateAntiClockwiseAction = new QAction(ResourceCache::getIcon(":/Resources/icons/rotateanticlockwise.svg"), tr("Rotate Anticlockwise"), this);
   mpRotateAntiClockwiseAction->setStatusTip(tr("Rotates the item anticlockwise"));
   mpRotateAntiClockwiseAction->setShortcut(QKeySequence("Ctrl+Shift+r"));
   mpRotateAntiClockwiseAction->setDisabled(isSystemLibrary);
   connect(mpRotateAntiClockwiseAction, SIGNAL(triggered()), SLOT(rotateAntiClockwise()));
   // Flip Horizontal Action
-  mpFlipHorizontalAction = new QAction(QIcon(":/Resources/icons/flip-horizontal.svg"), tr("Flip Horizontal"), this);
+  mpFlipHorizontalAction = new QAction(ResourceCache::getIcon(":/Resources/icons/flip-horizontal.svg"), tr("Flip Horizontal"), this);
   mpFlipHorizontalAction->setStatusTip(tr("Flips the item horizontally"));
   mpFlipHorizontalAction->setShortcut(QKeySequence("h"));
   mpFlipHorizontalAction->setDisabled(isSystemLibrary);
   connect(mpFlipHorizontalAction, SIGNAL(triggered()), SLOT(flipHorizontal()));
   // Flip Vertical Action
-  mpFlipVerticalAction = new QAction(QIcon(":/Resources/icons/flip-vertical.svg"), tr("Flip Vertical"), this);
+  mpFlipVerticalAction = new QAction(ResourceCache::getIcon(":/Resources/icons/flip-vertical.svg"), tr("Flip Vertical"), this);
   mpFlipVerticalAction->setStatusTip(tr("Flips the item vertically"));
   mpFlipVerticalAction->setShortcut(QKeySequence("v"));
   mpFlipVerticalAction->setDisabled(isSystemLibrary);
@@ -3400,7 +3401,7 @@ void WelcomePageWidget::addRecentFilesListItems()
   {
     RecentFile recentFile = qvariant_cast<RecentFile>(files[i]);
     QListWidgetItem *listItem = new QListWidgetItem(mpRecentItemsList);
-    listItem->setIcon(QIcon(":/Resources/icons/next.svg"));
+    listItem->setIcon(ResourceCache::getIcon(":/Resources/icons/next.svg"));
     listItem->setText(recentFile.fileName);
     listItem->setData(Qt::UserRole, recentFile.encoding);
   }
@@ -3467,7 +3468,7 @@ void WelcomePageWidget::readLatestNewsXML(QNetworkReply *pNetworkReply)
                   break;
                 count++;
                 QListWidgetItem *listItem = new QListWidgetItem(mpLatestNewsListWidget);
-                listItem->setIcon(QIcon(":/Resources/icons/next.svg"));
+                listItem->setIcon(ResourceCache::getIcon(":/Resources/icons/next.svg"));
                 listItem->setText(title);
                 listItem->setData(Qt::UserRole, link);
                 break;
@@ -4048,28 +4049,28 @@ void ModelWidget::createModelWidgetComponents()
     // icon view tool button
     mpIconViewToolButton = new QToolButton;
     mpIconViewToolButton->setText(Helper::iconView);
-    mpIconViewToolButton->setIcon(QIcon(":/Resources/icons/model.svg"));
+    mpIconViewToolButton->setIcon(ResourceCache::getIcon(":/Resources/icons/model.svg"));
     mpIconViewToolButton->setToolTip(Helper::iconView);
     mpIconViewToolButton->setAutoRaise(true);
     mpIconViewToolButton->setCheckable(true);
     // diagram view tool button
     mpDiagramViewToolButton = new QToolButton;
     mpDiagramViewToolButton->setText(Helper::diagramView);
-    mpDiagramViewToolButton->setIcon(QIcon(":/Resources/icons/modeling.png"));
+    mpDiagramViewToolButton->setIcon(ResourceCache::getIcon(":/Resources/icons/modeling.png"));
     mpDiagramViewToolButton->setToolTip(Helper::diagramView);
     mpDiagramViewToolButton->setAutoRaise(true);
     mpDiagramViewToolButton->setCheckable(true);
     // modelica text view tool button
     mpTextViewToolButton = new QToolButton;
     mpTextViewToolButton->setText(Helper::textView);
-    mpTextViewToolButton->setIcon(QIcon(":/Resources/icons/modeltext.svg"));
+    mpTextViewToolButton->setIcon(ResourceCache::getIcon(":/Resources/icons/modeltext.svg"));
     mpTextViewToolButton->setToolTip(Helper::textView);
     mpTextViewToolButton->setAutoRaise(true);
     mpTextViewToolButton->setCheckable(true);
     // documentation view tool button
     mpDocumentationViewToolButton = new QToolButton;
     mpDocumentationViewToolButton->setText(Helper::documentationView);
-    mpDocumentationViewToolButton->setIcon(QIcon(":/Resources/icons/info-icon.svg"));
+    mpDocumentationViewToolButton->setIcon(ResourceCache::getIcon(":/Resources/icons/info-icon.svg"));
     mpDocumentationViewToolButton->setToolTip(Helper::documentationView);
     mpDocumentationViewToolButton->setAutoRaise(true);
     // view buttons box
@@ -4094,7 +4095,7 @@ void ModelWidget::createModelWidgetComponents()
     mpModelFilePathLabel->setElideMode(Qt::ElideMiddle);
     // documentation view tool button
     mpFileLockToolButton = new QToolButton;
-    mpFileLockToolButton->setIcon(QIcon(mpLibraryTreeItem->isReadOnly() ? ":/Resources/icons/lock.svg" : ":/Resources/icons/unlock.svg"));
+    mpFileLockToolButton->setIcon(ResourceCache::getIcon(mpLibraryTreeItem->isReadOnly() ? ":/Resources/icons/lock.svg" : ":/Resources/icons/unlock.svg"));
     mpFileLockToolButton->setText(mpLibraryTreeItem->isReadOnly() ? tr("Make writable") : tr("File is writable"));
     mpFileLockToolButton->setToolTip(mpFileLockToolButton->text());
     mpFileLockToolButton->setEnabled(mpLibraryTreeItem->isReadOnly() && !mpLibraryTreeItem->isSystemLibrary());
@@ -6555,7 +6556,7 @@ void ModelWidget::showIconView(bool checked)
   }
   QMdiSubWindow *pSubWindow = mpModelWidgetContainer->getCurrentMdiSubWindow();
   if (pSubWindow) {
-    pSubWindow->setWindowIcon(QIcon(":/Resources/icons/model.svg"));
+    pSubWindow->setWindowIcon(ResourceCache::getIcon(":/Resources/icons/model.svg"));
   }
   mpModelWidgetContainer->currentModelWidgetChanged(mpModelWidgetContainer->getCurrentMdiSubWindow());
   mpIconGraphicsView->setFocus(Qt::ActiveWindowFocusReason);
@@ -6590,7 +6591,7 @@ void ModelWidget::showDiagramView(bool checked)
   }
   QMdiSubWindow *pSubWindow = mpModelWidgetContainer->getCurrentMdiSubWindow();
   if (pSubWindow) {
-    pSubWindow->setWindowIcon(QIcon(":/Resources/icons/modeling.png"));
+    pSubWindow->setWindowIcon(ResourceCache::getIcon(":/Resources/icons/modeling.png"));
   }
   mpModelWidgetContainer->currentModelWidgetChanged(mpModelWidgetContainer->getCurrentMdiSubWindow());
   mpDiagramGraphicsView->setFocus(Qt::ActiveWindowFocusReason);
@@ -6622,7 +6623,7 @@ void ModelWidget::showTextView(bool checked)
     return;
   }
   if (QMdiSubWindow *pSubWindow = mpModelWidgetContainer->getCurrentMdiSubWindow()) {
-    pSubWindow->setWindowIcon(QIcon(":/Resources/icons/modeltext.svg"));
+    pSubWindow->setWindowIcon(ResourceCache::getIcon(":/Resources/icons/modeltext.svg"));
   }
   mpModelWidgetContainer->currentModelWidgetChanged(mpModelWidgetContainer->getCurrentMdiSubWindow());
   mpViewTypeLabel->setText(StringHandler::getViewType(StringHandler::ModelicaText));
@@ -6649,7 +6650,7 @@ void ModelWidget::makeFileWritAble()
   {
     mpLibraryTreeItem->setReadOnly(false);
     mpFileLockToolButton->setText(tr("File is writable"));
-    mpFileLockToolButton->setIcon(QIcon(":/Resources/icons/unlock.svg"));
+    mpFileLockToolButton->setIcon(ResourceCache::getIcon(":/Resources/icons/unlock.svg"));
     mpFileLockToolButton->setEnabled(false);
     mpFileLockToolButton->setToolTip(mpFileLockToolButton->text());
   }
@@ -6805,7 +6806,7 @@ void ModelWidgetContainer::addModelWidget(ModelWidget *pModelWidget, bool checkP
     int subWindowsSize = subWindowList(QMdiArea::ActivationHistoryOrder).size();
     QMdiSubWindow *pSubWindow = addSubWindow(pModelWidget);
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
-    pSubWindow->setWindowIcon(QIcon(":/Resources/icons/modeling.png"));
+    pSubWindow->setWindowIcon(ResourceCache::getIcon(":/Resources/icons/modeling.png"));
     if (pModelWidget->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::Modelica) {
       pModelWidget->loadDiagramView();
       pModelWidget->loadConnections();

--- a/OMEdit/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -206,7 +206,8 @@ SOURCES += main.cpp \
   OMS/InstantiateDialog.cpp \
   OMS/OMSSimulationDialog.cpp \
   OMS/OMSSimulationOutputWidget.cpp \
-  Animation/TimeManager.cpp
+  Animation/TimeManager.cpp \
+  Util/ResourceCache.cpp
 
 HEADERS  += Util/Helper.h \
   Util/Utilities.h \
@@ -298,7 +299,8 @@ HEADERS  += Util/Helper.h \
   OMS/OMSSimulationOptions.h \
   OMS/OMSSimulationDialog.h \
   OMS/OMSSimulationOutputWidget.h \
-  Animation/TimeManager.h
+  Animation/TimeManager.h \
+  Util/ResourceCache.h
 
 CONFIG(osg) {
 

--- a/OMEdit/OMEdit/OMEditGUI/Util/ResourceCache.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/ResourceCache.cpp
@@ -1,0 +1,56 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "ResourceCache.h"
+
+
+QHash<QString, QIcon> ResourceCache::mIconCache;
+QHash<QString, QImage> ResourceCache::mImageCache;
+
+QIcon ResourceCache::getIcon(QString resourceName)
+{
+  if (!mIconCache.contains(resourceName))
+    mIconCache[resourceName] = QIcon(resourceName);
+  return mIconCache[resourceName];
+}
+
+QImage ResourceCache::getImage(QString resourceName)
+{
+  if (!mImageCache.contains(resourceName))
+    mImageCache[resourceName] = QImage(resourceName);
+  return mImageCache[resourceName];
+}
+
+
+ResourceCache::ResourceCache()
+{
+
+}

--- a/OMEdit/OMEdit/OMEditGUI/Util/ResourceCache.h
+++ b/OMEdit/OMEdit/OMEditGUI/Util/ResourceCache.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef RESOURCECACHE_H
+#define RESOURCECACHE_H
+
+#include <QHash>
+#include <QIcon>
+
+/**
+ * @brief Lazy cache of loaded resources
+ *
+ * The purpose of this class is to be a drop-in replacement for direct creation of
+ * GUI entities such as SVG icons at least for use cases when they are loaded and
+ * parsed on every fetch of a model from the backend, for example.
+ *
+ * @warning This class should be used from the UI thread only because it contains
+ * mutable cache of loaded objects.
+ */
+class ResourceCache
+{
+public:
+  ResourceCache();
+  static QIcon getIcon(QString resourceName);
+  static QImage getImage(QString resourceName);
+private:
+  static QHash<QString, QIcon> mIconCache;
+  static QHash<QString, QImage> mImageCache;
+};
+
+#endif // RESOURCECACHE_H

--- a/OMEdit/OMEdit/OMEditGUI/Util/StringHandler.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/StringHandler.cpp
@@ -37,6 +37,7 @@
 #include "StringHandler.h"
 #include "Helper.h"
 #include "Utilities.h"
+#include "Util/ResourceCache.h"
 
 #include <QtCore/qmath.h>
 #include <QDir>
@@ -428,12 +429,12 @@ QComboBox* StringHandler::getLinePatternComboBox()
 {
   QComboBox *pLinePatternComboBox = new QComboBox;
   pLinePatternComboBox->setIconSize(QSize(58, 16));
-  pLinePatternComboBox->addItem(QIcon(":/Resources/icons/line-none.svg"), getLinePatternString(LineNone));
-  pLinePatternComboBox->addItem(QIcon(":/Resources/icons/line-solid.svg"), getLinePatternString(LineSolid));
-  pLinePatternComboBox->addItem(QIcon(":/Resources/icons/line-dash.svg"), getLinePatternString(LineDash));
-  pLinePatternComboBox->addItem(QIcon(":/Resources/icons/line-dot.svg"), getLinePatternString(LineDot));
-  pLinePatternComboBox->addItem(QIcon(":/Resources/icons/line-dash-dot.svg"), getLinePatternString(LineDashDot));
-  pLinePatternComboBox->addItem(QIcon(":/Resources/icons/line-dash-dot-dot.svg"), getLinePatternString(LineDashDotDot));
+  pLinePatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-none.svg"), getLinePatternString(LineNone));
+  pLinePatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-solid.svg"), getLinePatternString(LineSolid));
+  pLinePatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-dash.svg"), getLinePatternString(LineDash));
+  pLinePatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-dot.svg"), getLinePatternString(LineDot));
+  pLinePatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-dash-dot.svg"), getLinePatternString(LineDashDot));
+  pLinePatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-dash-dot-dot.svg"), getLinePatternString(LineDashDotDot));
   return pLinePatternComboBox;
 }
 
@@ -532,17 +533,17 @@ QString StringHandler::getFillPatternString(StringHandler::FillPattern type)
 QComboBox* StringHandler::getFillPatternComboBox()
 {
   QComboBox *pFillPatternComboBox = new QComboBox;
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-none.svg"), getFillPatternString(FillNone));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-solid.svg"), getFillPatternString(FillSolid));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-horizontal.svg"), getFillPatternString(FillHorizontal));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-vertical.svg"), getFillPatternString(FillVertical));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-cross.svg"), getFillPatternString(FillCross));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-forward.svg"), getFillPatternString(FillForward));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-backward.svg"), getFillPatternString(FillBackward));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-cross-diagnol.svg"), getFillPatternString(FillCrossDiag));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-horizontal-cylinder.svg"), getFillPatternString(FillHorizontalCylinder));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-vertical-cylinder.svg"), getFillPatternString(FillVerticalCylinder));
-  pFillPatternComboBox->addItem(QIcon(":/Resources/icons/fill-sphere.svg"), getFillPatternString(FillSphere));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-none.svg"), getFillPatternString(FillNone));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-solid.svg"), getFillPatternString(FillSolid));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-horizontal.svg"), getFillPatternString(FillHorizontal));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-vertical.svg"), getFillPatternString(FillVertical));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-cross.svg"), getFillPatternString(FillCross));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-forward.svg"), getFillPatternString(FillForward));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-backward.svg"), getFillPatternString(FillBackward));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-cross-diagnol.svg"), getFillPatternString(FillCrossDiag));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-horizontal-cylinder.svg"), getFillPatternString(FillHorizontalCylinder));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-vertical-cylinder.svg"), getFillPatternString(FillVerticalCylinder));
+  pFillPatternComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/fill-sphere.svg"), getFillPatternString(FillSphere));
   return pFillPatternComboBox;
 }
 
@@ -637,10 +638,10 @@ QComboBox* StringHandler::getStartArrowComboBox()
 {
   QComboBox *pStartArrowComboBox = new QComboBox;
   pStartArrowComboBox->setIconSize(QSize(58, 16));
-  pStartArrowComboBox->addItem(QIcon(":/Resources/icons/line-solid.svg"), getArrowString(ArrowNone));
-  pStartArrowComboBox->addItem(QIcon(":/Resources/icons/arrow-start-open.svg"), getArrowString(ArrowOpen));
-  pStartArrowComboBox->addItem(QIcon(":/Resources/icons/arrow-start-fill.svg"), getArrowString(ArrowFilled));
-  pStartArrowComboBox->addItem(QIcon(":/Resources/icons/arrow-start-open-half.svg"), getArrowString(ArrowHalf));
+  pStartArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-solid.svg"), getArrowString(ArrowNone));
+  pStartArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/arrow-start-open.svg"), getArrowString(ArrowOpen));
+  pStartArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/arrow-start-fill.svg"), getArrowString(ArrowFilled));
+  pStartArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/arrow-start-open-half.svg"), getArrowString(ArrowHalf));
   return pStartArrowComboBox;
 }
 
@@ -648,10 +649,10 @@ QComboBox* StringHandler::getEndArrowComboBox()
 {
   QComboBox *pEndArrowComboBox = new QComboBox;
   pEndArrowComboBox->setIconSize(QSize(58, 16));
-  pEndArrowComboBox->addItem(QIcon(":/Resources/icons/line-solid.svg"), getArrowString(ArrowNone));
-  pEndArrowComboBox->addItem(QIcon(":/Resources/icons/arrow-end-open.svg"), getArrowString(ArrowOpen));
-  pEndArrowComboBox->addItem(QIcon(":/Resources/icons/arrow-end-fill.svg"), getArrowString(ArrowFilled));
-  pEndArrowComboBox->addItem(QIcon(":/Resources/icons/arrow-end-open-half.svg"), getArrowString(ArrowHalf));
+  pEndArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/line-solid.svg"), getArrowString(ArrowNone));
+  pEndArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/arrow-end-open.svg"), getArrowString(ArrowOpen));
+  pEndArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/arrow-end-fill.svg"), getArrowString(ArrowFilled));
+  pEndArrowComboBox->addItem(ResourceCache::getIcon(":/Resources/icons/arrow-end-open-half.svg"), getArrowString(ArrowHalf));
   return pEndArrowComboBox;
 }
 


### PR DESCRIPTION
When profiling slow expanding of `OpenModelica.Scripting` with Valgrind I was surprised with lots of `QSvgRenderer::load` invocations, each parsing an XML document from SVG.

I'm not too familiar with Qt policies on instances sharing, but this PR seems to improve UI responsiveness. For example it decreased the `OpenModelica.Scripting` expanding time from ~4 to ~2 seconds (sure, on such a scale it is quite hard to give correct manual measurements).

Maybe someone could briefly glance at this quick-and-dirty PR on whether it should be further improved or just dropped -- in fact it is more like a question-issue with runnable example. :)

PS: I added these static method to `MainWindow` instead of `Helper` to not load the `QIcon` header from everywhere.