### PR TITLE
OMEdit: drawing-related optimizations

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Component/Component.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Component/Component.cpp
@@ -452,14 +452,6 @@ Component::Component(QString name, LibraryTreeItem *pLibraryTreeItem, QString an
   mIsInheritedComponent = false;
   mComponentType = Component::Root;
   mTransformationString = StringHandler::getPlacementAnnotation(annotation);
-  // Construct the temporary polygon that is used when scaling
-  mpResizerRectangle = new QGraphicsRectItem;
-  mpResizerRectangle->setZValue(-5000);  // set to a very low value
-  mpGraphicsView->addItem(mpResizerRectangle);
-  QPen pen;
-  pen.setStyle(Qt::DotLine);
-  pen.setColor(Qt::transparent);
-  mpResizerRectangle->setPen(pen);
   setOldScenePosition(QPointF(0, 0));
   setOldPosition(QPointF(0, 0));
   setComponentFlags(true);
@@ -534,7 +526,6 @@ Component::Component(LibraryTreeItem *pLibraryTreeItem, Component *pParentCompon
   mIsInheritedComponent = mpParentComponent->isInheritedComponent();
   mComponentType = Component::Extend;
   mTransformationString = "";
-  mpResizerRectangle = 0;
   createNonExistingComponent();
   mpDefaultComponentRectangle = 0;
   mpDefaultComponentText = 0;
@@ -570,7 +561,6 @@ Component::Component(Component *pComponent, Component *pParentComponent, Compone
   mTransformationString = mpReferenceComponent->getTransformationString();
   mDialogAnnotation = mpReferenceComponent->getDialogAnnotation();
   mChoicesAnnotation = mpReferenceComponent->getChoicesAnnotation();
-  mpResizerRectangle = 0;
   createNonExistingComponent();
   mpDefaultComponentRectangle = 0;
   mpDefaultComponentText = 0;
@@ -613,14 +603,6 @@ Component::Component(Component *pComponent, GraphicsView *pGraphicsView)
   mTransformationString = mpReferenceComponent->getTransformationString();
   mDialogAnnotation = mpReferenceComponent->getDialogAnnotation();
   mChoicesAnnotation = mpReferenceComponent->getChoicesAnnotation();
-  //Construct the temporary polygon that is used when scaling
-  mpResizerRectangle = new QGraphicsRectItem;
-  mpResizerRectangle->setZValue(5000);  // set to a very high value
-  mpGraphicsView->addItem(mpResizerRectangle);
-  QPen pen;
-  pen.setStyle(Qt::DotLine);
-  pen.setColor(Qt::transparent);
-  mpResizerRectangle->setPen(pen);
   setOldScenePosition(QPointF(0, 0));
   setOldPosition(QPointF(0, 0));
   setComponentFlags(true);
@@ -669,7 +651,6 @@ Component::Component(ComponentInfo *pComponentInfo, Component *pParentComponent)
   mTransformationString = "";
   mDialogAnnotation.clear();
   mChoicesAnnotation.clear();
-  mpResizerRectangle = 0;
   createNonExistingComponent();
   createDefaultComponent();
   mpStateComponentRectangle = 0;
@@ -2549,9 +2530,6 @@ void Component::prepareResizeComponent(ResizerItem *pResizerItem)
     mTransformationStartPosition = topRight;
     mPivotPoint = bottomLeft;
   }
-  mpResizerRectangle->setRect(boundingRect()); //Sets the current item to the temporary rect
-  mpResizerRectangle->setTransform(transform()); //Set the same matrix of this item to the temporary item
-  mpResizerRectangle->setPos(pos());
 }
 
 /*!
@@ -2595,7 +2573,6 @@ void Component::resizeComponent(QPointF newPosition)
   QTransform tmpTransform = QTransform().translate(pivot.x(), pivot.y()).rotate(0)
       .scale(mXFactor, mYFactor)
       .translate(-pivot.x(), -pivot.y());
-  mpResizerRectangle->setTransform(mTransform * tmpTransform); //Multiplies the previous transform * the temporary
   setTransform(mTransform * tmpTransform);
   // set the final resize on component.
   QPointF extent1, extent2;

--- a/OMEdit/OMEdit/OMEditGUI/Component/Component.h
+++ b/OMEdit/OMEdit/OMEditGUI/Component/Component.h
@@ -269,7 +269,6 @@ private:
   QStringList mDialogAnnotation;
   QStringList mChoicesAnnotation;
   QString mParameterValue;
-  QGraphicsRectItem *mpResizerRectangle;
   LineAnnotation *mpNonExistingComponentLine;
   RectangleAnnotation *mpDefaultComponentRectangle;
   TextAnnotation *mpDefaultComponentText;

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -1491,7 +1491,8 @@ bool GraphicsView::hasAnnotation()
  */
 void GraphicsView::addItem(QGraphicsItem *pGraphicsItem)
 {
-  if (!scene()->items().contains(pGraphicsItem)) {
+  if (!mAllItems.contains(pGraphicsItem)) {
+    mAllItems.insert(pGraphicsItem);
     scene()->addItem(pGraphicsItem);
   }
 }
@@ -1503,7 +1504,8 @@ void GraphicsView::addItem(QGraphicsItem *pGraphicsItem)
  */
 void GraphicsView::removeItem(QGraphicsItem *pGraphicsItem)
 {
-  if (scene()->items().contains(pGraphicsItem)) {
+  if (mAllItems.contains(pGraphicsItem)) {
+    mAllItems.remove(pGraphicsItem);
     scene()->removeItem(pGraphicsItem);
   }
 }

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
@@ -135,6 +135,8 @@ private:
   QAction *mpFlipVerticalAction;
   QAction *mpSetInitialStateAction;
   QAction *mpCancelTransitionAction;
+  // scene->items().contains(...) involves sorting on each items() call, avoid it
+  QSet<QGraphicsItem*> mAllItems;
 public:
   GraphicsView(StringHandler::ViewType viewType, ModelWidget *pModelWidget, bool visualizationView = false);
   CoOrdinateSystem mCoOrdinateSystem;


### PR DESCRIPTION
When dealing with large binding-like autogenerated models, model save may takes tens of seconds. Profiling shown that it seems to be due to one-by-one removal of model visual components followed by `scene()->clear()`. As I understand, these components are stored internally in a `QList` and (here is just an assumption) are removed from first to last, so complexity is quadratic. In the first commit I implemented a hackish but hopefully trivial to review solution with an instance-local variable. This sped saving up by 5-10 times in my case!

Next, when opening such a class, lots of `addItem()` calls occur. Each one involves `scene()->items().contains(...)`. But the `items()` method is in fact `items(Qt::SortOrder order = Qt::DescendingOrder)`, so to perform minimal possible change, I just added a `QSet` containing currently added components. The effect of this commit is much lesser (such as 3s -> 2s opening time decrease) and probably should be evaluated on whether to be integrated but the issue itself seems quite strange... Meanwhile, do we need to draw a model for two seconds that do not even contain a single draw-related annotation?..

PS: Just in case: Callgrind have a nice UI KCacheGrind, that can navigate you on call stack and even draw call diagrams annotated with invocation counts!