### PR TITLE
Implement Open Base Class context menu item for the Library tree

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
@@ -893,6 +893,11 @@ QString LibraryTreeItem::getHTMLDescription() const
       .arg(mClassInformation.restriction, mName, Utilities::escapeForHtmlNonSecure(mClassInformation.comment));
 }
 
+void LibraryTreeItem::openClass()
+{
+  MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->showModelWidget(this);
+}
+
 /*!
  * \brief LibraryTreeItem::handleLoaded
  * Handles the case when an undefined inherited class is loaded.
@@ -3321,6 +3326,7 @@ void LibraryTreeView::showContextMenu(QPoint point)
         case LibraryTreeItem::Modelica:
         default:
           menu.addAction(mpOpenClassAction);
+          putOpenBaseClassActionsToContextMenu(&menu, pLibraryTreeItem);
           menu.addAction(mpInformationAction);
           if (!pLibraryTreeItem->isSystemLibrary()) {
             menu.addSeparator();
@@ -3451,6 +3457,16 @@ void LibraryTreeView::showContextMenu(QPoint point)
     menu.addAction(mpNewFolderEmptyAction);
   }
   menu.exec(viewport()->mapToGlobal(point));
+}
+
+void LibraryTreeView::putOpenBaseClassActionsToContextMenu(QMenu *pMenu, LibraryTreeItem *pLibraryTreeItem)
+{
+  foreach (LibraryTreeItem *pItem, pLibraryTreeItem->getInheritedClasses()) {
+    QAction *pAction = new QAction(ResourceCache::getIcon(":/Resources/icons/modeling.png"), Helper::openBaseClass.arg(pItem->getName()), this);
+    pAction->setStatusTip(Helper::openBaseClassTip.arg(pItem->getNameStructure()));
+    connect(pAction, SIGNAL(triggered()), pItem, SLOT(openClass()));
+    pMenu->addAction(pAction);
+  }
 }
 
 /*!

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.h
@@ -244,6 +244,7 @@ signals:
   void iconUpdated();
   void coOrdinateSystemUpdated(GraphicsView *pGraphicsView);
 public slots:
+  void openClass();
   void handleLoaded(LibraryTreeItem *pLibraryTreeItem);
   void handleUnloaded();
   void handleShapeAdded(ShapeAnnotation *pShapeAnnotation, GraphicsView *pGraphicsView);
@@ -422,6 +423,7 @@ public slots:
   void libraryTreeItemExpanded(const QModelIndex &index);
   void libraryTreeItemDoubleClicked(const QModelIndex &index);
   void showContextMenu(QPoint point);
+  void putOpenBaseClassActionsToContextMenu(QMenu *pMenu, LibraryTreeItem *pLibraryTreeItem);
   void openClass();
   void openInformationDialog();
   void createNewModelicaClass();

--- a/OMEdit/OMEdit/OMEditGUI/Util/Helper.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Helper.cpp
@@ -291,6 +291,8 @@ QString Helper::findVariables;
 QString Helper::filterVariables;
 QString Helper::openClass;
 QString Helper::openClassTip;
+QString Helper::openBaseClass;
+QString Helper::openBaseClassTip;
 QString Helper::viewIcon;
 QString Helper::viewIconTip;
 QString Helper::viewDiagram;
@@ -584,6 +586,8 @@ void Helper::initHelperVariables()
   Helper::filterVariables = tr("Filter Variables");
   Helper::openClass = tr("Open Class");
   Helper::openClassTip = tr("Opens the class details");
+  Helper::openBaseClass = tr("Open base class: %1");
+  Helper::openBaseClassTip = tr("Opens base class: %1");
   Helper::viewIcon = tr("View Icon");
   Helper::viewIconTip = tr("Opens the class icon");
   Helper::viewDiagram = tr("View Diagram");

--- a/OMEdit/OMEdit/OMEditGUI/Util/Helper.h
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Helper.h
@@ -293,6 +293,8 @@ public:
   static QString filterVariables;
   static QString openClass;
   static QString openClassTip;
+  static QString openBaseClass;
+  static QString openBaseClassTip;
   static QString viewIcon;
   static QString viewIconTip;
   static QString viewDiagram;


### PR DESCRIPTION
While investigating #147 I stumbled upon inability to quickly navigate from item to item. In my case these were inherited classes. While this is quite complex problem when navigating from the editor view (because the text was probably changed), it is very easy to achieve from the context menu of Library tree item. This PR adds the simplest possible 1-level-deep Go To items.

Possible extensions:
* make it traverse the full hierarchy depth-first: trivially achievable with recursion (add one extra line) but what to do with diamond inheritance (prepend some character denoting nesting level?)
* focus on the just opened item (would probably mess thing up if mandatory)