### PR TITLE
ticket:5622 validate the text

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/MainWindow.cpp
@@ -2788,12 +2788,8 @@ void MainWindow::toggleShapesButton()
 void MainWindow::openRecentModelWidget()
 {
   /* if Model text is changed manually by user then validate it before opening recent ModelWidget. */
-  ModelWidget *pModelWidget = mpModelWidgetContainer->getCurrentModelWidget();
-  if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
-    LibraryTreeItem *pLibraryTreeItem = pModelWidget->getLibraryTreeItem();
-    if (!pModelWidget->validateText(&pLibraryTreeItem)) {
-      return;
-    }
+  if (!mpModelWidgetContainer->validateText()) {
+    return;
   }
   QAction *pAction = qobject_cast<QAction*>(sender());
   QToolButton *pToolButton = qobject_cast<QToolButton*>(sender());
@@ -3975,15 +3971,11 @@ void MainWindow::autoSaveHelper(LibraryTreeItem *pLibraryTreeItem)
  */
 void MainWindow::switchToWelcomePerspective()
 {
-  ModelWidget *pModelWidget = mpModelWidgetContainer->getCurrentModelWidget();
-  if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
-    LibraryTreeItem *pLibraryTreeItem = pModelWidget->getLibraryTreeItem();
-    if (!pModelWidget->validateText(&pLibraryTreeItem)) {
-      bool signalsState = mpPerspectiveTabbar->blockSignals(true);
-      mpPerspectiveTabbar->setCurrentIndex(1);
-      mpPerspectiveTabbar->blockSignals(signalsState);
-      return;
-    }
+  if (!mpModelWidgetContainer->validateText()) {
+    bool signalsState = mpPerspectiveTabbar->blockSignals(true);
+    mpPerspectiveTabbar->setCurrentIndex(1);
+    mpPerspectiveTabbar->blockSignals(signalsState);
+    return;
   }
   mpCentralStackedWidget->setCurrentWidget(mpWelcomePageWidget);
   mpModelWidgetContainer->currentModelWidgetChanged(0);
@@ -4051,16 +4043,13 @@ void MainWindow::switchToModelingPerspective()
  */
 void MainWindow::switchToPlottingPerspective()
 {
-  ModelWidget *pModelWidget = mpModelWidgetContainer->getCurrentModelWidget();
-  if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
-    LibraryTreeItem *pLibraryTreeItem = pModelWidget->getLibraryTreeItem();
-    if (!pModelWidget->validateText(&pLibraryTreeItem)) {
-      bool signalsState = mpPerspectiveTabbar->blockSignals(true);
-      mpPerspectiveTabbar->setCurrentIndex(1);
-      mpPerspectiveTabbar->blockSignals(signalsState);
-      return;
-    }
+  if (!mpModelWidgetContainer->validateText()) {
+    bool signalsState = mpPerspectiveTabbar->blockSignals(true);
+    mpPerspectiveTabbar->setCurrentIndex(1);
+    mpPerspectiveTabbar->blockSignals(signalsState);
+    return;
   }
+  ModelWidget *pModelWidget = mpModelWidgetContainer->getCurrentModelWidget();
   mpCentralStackedWidget->setCurrentWidget(mpPlotWindowContainer);
   mpModelWidgetContainer->currentModelWidgetChanged(0);
   mpUndoAction->setEnabled(false);

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
@@ -3275,30 +3275,38 @@ void LibraryTreeView::libraryTreeItemDoubleClicked(const QModelIndex &index)
         }
         return;
       }
-    } else if (pLibraryTreeItem->getLibraryType() == LibraryTreeItem::OMS
-               && (pLibraryTreeItem->getOMSConnector()
-                   || pLibraryTreeItem->getOMSBusConnector()
-                   || pLibraryTreeItem->getOMSTLMBusConnector())) {
-      return;
-    }
-    /* Check if we are in the plotting perspective
-     * If yes then we first load the model and switch to Modeling perspective like normal
-     * and then switches back to plotting perspective and show the DiagramWindow
-     * If we don't do that then the window title is messed up.
-     */
-    bool isPlottingPerspectiveActive = MainWindow::instance()->isPlottingPerspectiveActive();
-    mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
-    // if we are in the plotting perspective then open the Diagram Window
-    if (isPlottingPerspectiveActive) {
-      MainWindow::instance()->switchToPlottingPerspectiveSlot();
-      if (MainWindow::instance()->getPlotWindowContainer()->getDiagramSubWindowFromMdi()) {
-        if (pLibraryTreeItem->getModelWidget()) {
-          pLibraryTreeItem->getModelWidget()->loadDiagramView();
-          pLibraryTreeItem->getModelWidget()->loadConnections();
-        }
-        MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->drawDiagram(pLibraryTreeItem->getModelWidget());
+    } else if (pLibraryTreeItem->getLibraryType() == LibraryTreeItem::OMS) {
+      if ((pLibraryTreeItem->getOMSConnector() || pLibraryTreeItem->getOMSBusConnector() || pLibraryTreeItem->getOMSTLMBusConnector())) {
+        return;
+      } else {
+        mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
       }
-      MainWindow::instance()->getPlotWindowContainer()->addDiagramWindow(pLibraryTreeItem->getModelWidget());
+    } else if (pLibraryTreeItem->getLibraryType() == LibraryTreeItem::CompositeModel) {
+      mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
+    } else { // LibraryTreeItem::Modelica
+      /* if Model text is changed manually by user then validate it before opening double clicked ModelWidget. */
+      if (!MainWindow::instance()->getModelWidgetContainer()->validateText()) {
+        return;
+      }
+      /* Check if we are in the plotting perspective
+       * If yes then we first load the model and switch to Modeling perspective like normal
+       * and then switches back to plotting perspective and show the DiagramWindow
+       * If we don't do that then the window title is messed up.
+       */
+      bool isPlottingPerspectiveActive = MainWindow::instance()->isPlottingPerspectiveActive();
+      mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
+      // if we are in the plotting perspective then open the Diagram Window
+      if (isPlottingPerspectiveActive) {
+        MainWindow::instance()->switchToPlottingPerspectiveSlot();
+        if (MainWindow::instance()->getPlotWindowContainer()->getDiagramSubWindowFromMdi()) {
+          if (pLibraryTreeItem->getModelWidget()) {
+            pLibraryTreeItem->getModelWidget()->loadDiagramView();
+            pLibraryTreeItem->getModelWidget()->loadConnections();
+          }
+          MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->drawDiagram(pLibraryTreeItem->getModelWidget());
+        }
+        MainWindow::instance()->getPlotWindowContainer()->addDiagramWindow(pLibraryTreeItem->getModelWidget());
+      }
     }
   }
 }

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -7118,13 +7118,9 @@ bool ModelWidgetContainer::eventFilter(QObject *object, QEvent *event)
    */
   if ((event->type() == QEvent::MouseButtonPress && qobject_cast<QMenuBar*>(object)) ||
       (event->type() == QEvent::FocusIn && qobject_cast<DocumentationViewer*>(object))) {
-    ModelWidget *pModelWidget = getCurrentModelWidget();
-    if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
-      LibraryTreeItem *pLibraryTreeItem = pModelWidget->getLibraryTreeItem();
-      /* if Model text is changed manually by user then validate it. */
-      if (!pModelWidget->validateText(&pLibraryTreeItem)) {
-        return true;
-      }
+    /* if Model text is changed manually by user then validate it. */
+    if (!validateText()) {
+      return true;
     }
   }
   // Global key events with Ctrl modifier.
@@ -7279,6 +7275,21 @@ void ModelWidgetContainer::updateThreeDViewer(ModelWidget *pModelWidget)
 #endif
 
 /*!
+ * \brief ModelWidgetContainer::validateText
+ * Validates the text of the current ModelWidget editor.
+ * \return Returns true if validation is successful otherwise return false.
+ */
+bool ModelWidgetContainer::validateText()
+{
+  ModelWidget *pModelWidget = getCurrentModelWidget();
+  if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
+    LibraryTreeItem *pLibraryTreeItem = pModelWidget->getLibraryTreeItem();
+    return pModelWidget->validateText(&pLibraryTreeItem);
+  }
+  return true;
+}
+
+/*!
  * \brief ModelWidgetContainer::loadPreviousViewType
  * Opens the ModelWidget using the previous view type used by user.
  * \param pModelWidget
@@ -7323,14 +7334,13 @@ void ModelWidgetContainer::loadPreviousViewType(ModelWidget *pModelWidget)
 bool ModelWidgetContainer::openRecentModelWidget(QListWidgetItem *pListWidgetItem)
 {
   /* if Model text is changed manually by user then validate it before opening recent ModelWidget. */
-  ModelWidget *pModelWidget = getCurrentModelWidget();
-  if (pModelWidget && pModelWidget->getLibraryTreeItem()) {
-    LibraryTreeItem *pLibraryTreeItem = pModelWidget->getLibraryTreeItem();
-    if (!pModelWidget->validateText(&pLibraryTreeItem)) {
-      return false;
-    }
+  if (!validateText()) {
+    return false;
   }
   LibraryTreeItem *pLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItem(pListWidgetItem->data(Qt::UserRole).toString());
+  if (!pLibraryTreeItem) {
+    return false;
+  }
   addModelWidget(pLibraryTreeItem->getModelWidget(), false);
   return true;
 }

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
@@ -616,6 +616,7 @@ public:
 #if !defined(WITHOUT_OSG)
   void updateThreeDViewer(ModelWidget *pModelWidget);
 #endif
+  bool validateText();
 private:
   StringHandler::ViewType mPreviousViewType;
   bool mShowGridLines;


### PR DESCRIPTION
When users double clicks to open a new model then validate the text of the existing model before switching if it is changed.