### PR TITLE
Merged the mouse and keyboard delete functionality

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.h
@@ -63,7 +63,7 @@ public:
 private:
   Component *mpComponent;
 public slots:
-  void duplicate();
+  void duplicate() override;
 };
 
 #endif // BITMAPANNOTATION_H

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.h
@@ -58,7 +58,7 @@ public:
   QString getShapeAnnotation() override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
 public slots:
-  void duplicate();
+  void duplicate() override;
 };
 
 #endif // ELLIPSEANNOTATION_H

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/LineAnnotation.h
@@ -173,7 +173,7 @@ public slots:
   void updateTransitionAnnotation(QString oldCondition, bool oldImmediate, bool oldReset, bool oldSynchronize, int oldPriority);
   void redraw(const QString& annotation, std::function<void()> updateAnnotationFunction);
   void updateInitialStateAnnotation();
-  void duplicate();
+  void duplicate() override;
 };
 
 class ExpandableConnectorTreeItem : public QObject

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.h
@@ -65,7 +65,7 @@ public:
   void updateEndPoint(QPointF point);
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
 public slots:
-  void duplicate();
+  void duplicate() override;
 };
 
 #endif // POLYGONANNOTATION_H

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.h
@@ -62,7 +62,7 @@ public:
   QString getShapeAnnotation() override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
 public slots:
-  void duplicate();
+  void duplicate() override;
 };
 
 #endif // RECTANGLEANNOTATION_H

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
@@ -1242,15 +1242,6 @@ void ShapeAnnotation::deleteMe()
 }
 
 /*!
- * \brief ShapeAnnotation::duplicate
- * Reimplemented by each child shape class to duplicate the shape.
- */
-void ShapeAnnotation::duplicate()
-{
-  /* duplicate code is implemented in each child shape class. */
-}
-
-/*!
  * \brief ShapeAnnotation::bringToFront
  * Brings the shape to front of all other shapes.
  */
@@ -1787,10 +1778,9 @@ QVariant ShapeAnnotation::itemChange(GraphicsItemChange change, const QVariant &
       /* Only allow manipulations on shapes if the class is not a system library class OR shape is not an inherited component. */
       if (!mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() && !isInheritedShape()) {
         if (pLineAnnotation) {
-          connect(mpGraphicsView, SIGNAL(mouseManhattanize()), this, SLOT(manhattanizeShape()), Qt::UniqueConnection);
+          connect(mpGraphicsView, SIGNAL(manhattanize()), this, SLOT(manhattanizeShape()), Qt::UniqueConnection);
         }
-        connect(mpGraphicsView, SIGNAL(mouseDelete()), this, SLOT(deleteMe()), Qt::UniqueConnection);
-        connect(mpGraphicsView, SIGNAL(keyPressDelete()), this, SLOT(deleteMe()), Qt::UniqueConnection);
+        connect(mpGraphicsView, SIGNAL(deleteSignal()), this, SLOT(deleteMe()), Qt::UniqueConnection);
         if (lineType == LineAnnotation::ShapeType) {
           connect(mpGraphicsView, SIGNAL(mouseDuplicate()), this, SLOT(duplicate()), Qt::UniqueConnection);
           connect(mpGraphicsView->getBringToFrontAction(), SIGNAL(triggered()), this, SLOT(bringToFront()), Qt::UniqueConnection);
@@ -1822,10 +1812,9 @@ QVariant ShapeAnnotation::itemChange(GraphicsItemChange change, const QVariant &
       /* Only allow manipulations on shapes if the class is not a system library class OR shape is not an inherited component. */
       if (!mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() && !isInheritedShape()) {
         if (pLineAnnotation) {
-          disconnect(mpGraphicsView, SIGNAL(mouseManhattanize()), this, SLOT(manhattanizeShape()));
+          disconnect(mpGraphicsView, SIGNAL(manhattanize()), this, SLOT(manhattanizeShape()));
         }
-        disconnect(mpGraphicsView, SIGNAL(mouseDelete()), this, SLOT(deleteMe()));
-        disconnect(mpGraphicsView, SIGNAL(keyPressDelete()), this, SLOT(deleteMe()));
+        disconnect(mpGraphicsView, SIGNAL(deleteSignal()), this, SLOT(deleteMe()));
         if (lineType == LineAnnotation::ShapeType) {
           disconnect(mpGraphicsView, SIGNAL(mouseDuplicate()), this, SLOT(duplicate()));
           disconnect(mpGraphicsView->getBringToFrontAction(), SIGNAL(triggered()), this, SLOT(bringToFront()));

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
@@ -207,7 +207,7 @@ signals:
   void deleted();
 public slots:
   void deleteMe();
-  virtual void duplicate();
+  virtual void duplicate() = 0;
   void bringToFront();
   void bringForward();
   void sendToBack();

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.h
@@ -73,7 +73,7 @@ private:
   void updateTextStringHelper(QRegExp regExp);
 public slots:
   void updateTextString();
-  void duplicate();
+  void duplicate() override;
 };
 
 #endif // TEXTANNOTATION_H

--- a/OMEdit/OMEdit/OMEditGUI/Component/Component.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Component/Component.cpp
@@ -2696,7 +2696,7 @@ void Component::duplicate()
   mpComponentInfo->getModifiersMap(MainWindow::instance()->getOMCProxy(), mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure(), this);
   ComponentInfo *pComponentInfo = new ComponentInfo(mpComponentInfo);
   pComponentInfo->setName(name);
-  mpGraphicsView->addComponentToView(name, mpLibraryTreeItem, getOMCPlacementAnnotation(gridStep), QPointF(0, 0), pComponentInfo, true, true);
+  mpGraphicsView->addComponentToView(name, mpLibraryTreeItem, getOMCPlacementAnnotation(gridStep), QPointF(0, 0), pComponentInfo, true, true, true);
   Component *pDiagramComponent = mpGraphicsView->getModelWidget()->getDiagramGraphicsView()->getComponentsList().last();
   setSelected(false);
   if (mpGraphicsView->getViewType() == StringHandler::Diagram) {
@@ -3115,13 +3115,12 @@ QVariant Component::itemChange(GraphicsItemChange change, const QVariant &value)
       setCursor(Qt::SizeAllCursor);
       // Only allow manipulations on component if the class is not a system library class OR component is not an inherited component.
       if (!mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() && !isInheritedComponent()) {
-        connect(mpGraphicsView, SIGNAL(mouseDelete()), this, SLOT(deleteMe()), Qt::UniqueConnection);
+        connect(mpGraphicsView, SIGNAL(deleteSignal()), this, SLOT(deleteMe()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(mouseDuplicate()), this, SLOT(duplicate()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(mouseRotateClockwise()), this, SLOT(rotateClockwise()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(mouseRotateAntiClockwise()), this, SLOT(rotateAntiClockwise()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(mouseFlipHorizontal()), this, SLOT(flipHorizontal()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(mouseFlipVertical()), this, SLOT(flipVertical()), Qt::UniqueConnection);
-        connect(mpGraphicsView, SIGNAL(keyPressDelete()), this, SLOT(deleteMe()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(keyPressDuplicate()), this, SLOT(duplicate()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(keyPressRotateClockwise()), this, SLOT(rotateClockwise()), Qt::UniqueConnection);
         connect(mpGraphicsView, SIGNAL(keyPressRotateAntiClockwise()), this, SLOT(rotateAntiClockwise()), Qt::UniqueConnection);
@@ -3152,13 +3151,12 @@ QVariant Component::itemChange(GraphicsItemChange change, const QVariant &value)
       unsetCursor();
       /* Only allow manipulations on component if the class is not a system library class OR component is not an inherited component. */
       if (!mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() && !isInheritedComponent()) {
-        disconnect(mpGraphicsView, SIGNAL(mouseDelete()), this, SLOT(deleteMe()));
+        disconnect(mpGraphicsView, SIGNAL(deleteSignal()), this, SLOT(deleteMe()));
         disconnect(mpGraphicsView, SIGNAL(mouseDuplicate()), this, SLOT(duplicate()));
         disconnect(mpGraphicsView, SIGNAL(mouseRotateClockwise()), this, SLOT(rotateClockwise()));
         disconnect(mpGraphicsView, SIGNAL(mouseRotateAntiClockwise()), this, SLOT(rotateAntiClockwise()));
         disconnect(mpGraphicsView, SIGNAL(mouseFlipHorizontal()), this, SLOT(flipHorizontal()));
         disconnect(mpGraphicsView, SIGNAL(mouseFlipVertical()), this, SLOT(flipVertical()));
-        disconnect(mpGraphicsView, SIGNAL(keyPressDelete()), this, SLOT(deleteMe()));
         disconnect(mpGraphicsView, SIGNAL(keyPressDuplicate()), this, SLOT(duplicate()));
         disconnect(mpGraphicsView, SIGNAL(keyPressRotateClockwise()), this, SLOT(rotateClockwise()));
         disconnect(mpGraphicsView, SIGNAL(keyPressRotateAntiClockwise()), this, SLOT(rotateAntiClockwise()));

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
@@ -981,7 +981,6 @@ void LibraryTreeItem::handleShapeAdded(ShapeAnnotation *pShapeAnnotation, Graphi
  */
 void LibraryTreeItem::handleComponentAdded(Component *pComponent)
 {
-  qDebug() << "LibraryTreeItem::handleComponentAdded";
   if (mpModelWidget) {
     if (pComponent->getLibraryTreeItem() && pComponent->getLibraryTreeItem()->isConnector()) {
       mpModelWidget->getIconGraphicsView()->addInheritedComponentToList(mpModelWidget->createInheritedComponent(pComponent, mpModelWidget->getIconGraphicsView()));

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
@@ -197,7 +197,7 @@ public:
   QAction* getFlipVerticalAction() {return mpFlipVerticalAction;}
   bool addComponent(QString className, QPointF position);
   void addComponentToView(QString name, LibraryTreeItem *pLibraryTreeItem, QString annotation, QPointF position,
-                          ComponentInfo *pComponentInfo, bool addObject = true, bool openingClass = false);
+                          ComponentInfo *pComponentInfo, bool addObject, bool openingClass, bool emitComponentAdded);
   void addComponentToList(Component *pComponent) {mComponentsList.append(pComponent);}
   void addInheritedComponentToList(Component *pComponent) {mInheritedComponentsList.append(pComponent);}
   void addComponentToClass(Component *pComponent);
@@ -291,14 +291,13 @@ private:
   void checkEmitUpdateSelect(const bool showPropertiesAndSelect, ShapeAnnotation* shapeAnnotation);
   void copyItems(bool cut);
 signals:
-  void mouseManhattanize();
-  void mouseDelete();
+  void manhattanize();
+  void deleteSignal();
   void mouseDuplicate();
   void mouseRotateClockwise();
   void mouseRotateAntiClockwise();
   void mouseFlipHorizontal();
   void mouseFlipVertical();
-  void keyPressDelete();
   void keyPressRotateClockwise();
   void keyPressRotateAntiClockwise();
   void keyPressFlipHorizontal();


### PR DESCRIPTION
Made ShapeAnnotation::duplicate() pure virtual.
Don't allow making transitions from non-existing classes.
Emit component added signal when duplicating a component.