### PR TITLE
OMEdit: update DynamicSelect handling

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
@@ -105,7 +105,7 @@ void BitmapAnnotation::parseShapeAnnotation(QString annotation)
 {
   GraphicItem::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Bitmap.
-  QStringList list = StringHandler::getStrings(annotation);
+  QStringList list = StringHandler::getStringsMixed(annotation);
   if (list.size() < 5) {
     return;
   }

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.cpp
@@ -69,7 +69,7 @@ void EllipseAnnotation::parseShapeAnnotation(QString annotation)
   GraphicItem::parseShapeAnnotation(annotation);
   FilledShape::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Ellipse.
-  QStringList list = StringHandler::getStrings(annotation);
+  QStringList list = StringHandler::getStringsMixed(annotation);
   if (list.size() < 11) {
     return;
   }

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
@@ -367,7 +367,7 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
 {
   GraphicItem::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Line.
-  QStringList list = StringHandler::getStrings(annotation);
+  QStringList list = StringHandler::getStringsMixed(annotation);
   if (list.size() < 10) {
     return;
   }

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.cpp
@@ -80,7 +80,7 @@ void PolygonAnnotation::parseShapeAnnotation(QString annotation)
   GraphicItem::parseShapeAnnotation(annotation);
   FilledShape::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Polygon.
-  QStringList list = StringHandler::getStrings(annotation);
+  QStringList list = StringHandler::getStringsMixed(annotation);
   if (list.size() < 10) {
     return;
   }

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.cpp
@@ -112,7 +112,7 @@ void RectangleAnnotation::parseShapeAnnotation(QString annotation)
   GraphicItem::parseShapeAnnotation(annotation);
   FilledShape::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Rectangle.
-  QStringList list = StringHandler::getStrings(annotation);
+  QStringList list = StringHandler::getStringsMixed(annotation);
   if (list.size() < 11) {
     return;
   }

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
@@ -100,6 +100,10 @@ public:
 protected:
   QColor mLineColor;
   QColor mFillColor;
+  QString mDynamicFillColor; /* Dynamic variable for fillColor attribute */
+  QColor mDynamicFillColorIfTrue;  /* Dynamic fillColor if variable is true */
+  QColor mDynamicFillColorIfFalse; /* Dynamic fillColor if variable is false */
+  QColor mDynamicFillColorValue;   /* Calculated dynamic fillColor value */
   StringHandler::LinePattern mLinePattern;
   StringHandler::FillPattern mFillPattern;
   qreal mLineThickness;
@@ -241,6 +245,7 @@ public slots:
   void referenceShapeDeleted();
   void updateDynamicSelect(double time);
 protected:
+  double getVariable(QString varName, double time, bool *isOk);
   GraphicsView *mpGraphicsView;
   Component *mpParentComponent;
   QList<QPointF> mPoints;

--- a/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
@@ -150,7 +150,7 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
   GraphicItem::parseShapeAnnotation(annotation);
   FilledShape::parseShapeAnnotation(annotation);
   // parse the shape to get the list of attributes of Text.
-  QStringList list = StringHandler::getStrings(annotation);
+  QStringList list = StringHandler::getStringsMixed(annotation);
   if (list.size() < 15) {
     return;
   }
@@ -162,11 +162,14 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
       mExtents.replace(i, QPointF(extentPoints.at(0).toFloat(), extentPoints.at(1).toFloat()));
   }
   // 10th item of the list contains the textString.
-  if (list.at(9).startsWith("{")) {
-    // DynamicSelect
-    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(9)));
+  if (list.at(9).startsWith("DynamicSelect(")) {
+    QStringList args = StringHandler::getStringsMixed(StringHandler::removeFunctionInvocation(list.at(9)));
     if (args.count() > 0) {
       mOriginalTextString = StringHandler::removeFirstLastQuotes(args.at(0));
+    }
+    if (args.count() == 2 && args.at(1).startsWith("String(")) {
+      args = StringHandler::getStringsMixed(StringHandler::removeFunctionInvocation(args.at(1)));
+      args.prepend("");
     }
     if (args.count() > 1) {
       mDynamicTextString << args.at(1);  // variable name

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/PlotWindowContainer.cpp
@@ -368,7 +368,7 @@ void PlotWindowContainer::addArrayPlotWindow(bool maximized)
 PlotWindow* PlotWindowContainer::addInteractivePlotWindow(bool maximized, QString owner, int port)
 {
   try {
-    PlotWindow *pPlotWindow = new PlotWindow(QStringList(), this, true);
+    PlotWindow *pPlotWindow = new PlotWindow(QStringList(), this, true, false);
     pPlotWindow->setPlotType(PlotWindow::PLOTINTERACTIVE);
     pPlotWindow->setInteractiveOwner(owner);
     pPlotWindow->setInteractivePort(port);

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
@@ -1524,13 +1524,20 @@ void VariablesWidget::initializeVisualization(SimulationOptions simulationOption
  * \param time
  * \return
  */
-double VariablesWidget::readVariableValue(QString variable, double time)
+double VariablesWidget::readVariableValue(QString variable, double time, bool *isOk)
 {
   double value = 0.0;
+
+  bool dummyOk;
+  if (!isOk)
+    isOk = &dummyOk;
+  *isOk = false;
+
   if (mModelicaMatReader.file) {
     ModelicaMatVariable_t* var = omc_matlab4_find_var(&mModelicaMatReader, variable.toUtf8().constData());
     if (var) {
       omc_matlab4_val(&value, &mModelicaMatReader, var, time);
+      *isOk = true;
     }
   } else if (mpCSVData) {
     double *timeDataSet = read_csv_dataset(mpCSVData, "time");
@@ -1540,6 +1547,7 @@ double VariablesWidget::readVariableValue(QString variable, double time)
           double *varDataSet = read_csv_dataset(mpCSVData, variable.toUtf8().constData());
           if (varDataSet) {
             value = varDataSet[i];
+            *isOk = true;
             break;
           }
         }
@@ -1560,6 +1568,7 @@ double VariablesWidget::readVariableValue(QString variable, double time)
         QStringList values = currentLine.split(",");
         if (QString::number(time).compare(values[0]) == 0) {
           value = values[1].toDouble();
+          *isOk = true;
           break;
         }
       }

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
@@ -199,7 +199,7 @@ public:
   void interactiveReSimulation(QString modelName);
   void updateInitXmlFile(SimulationOptions simulationOptions);
   void initializeVisualization(SimulationOptions simulationOptions);
-  double readVariableValue(QString variable, double time);
+  double readVariableValue(QString variable, double time, bool *isOk = nullptr);
 private:
   TreeSearchFilters *mpTreeSearchFilters;
   Label *mpSimulationTimeLabel;

--- a/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
@@ -44,6 +44,8 @@
 class OMCProxy;
 class TreeSearchFilters;
 class Label;
+class OpcUaClient;
+class Variable;
 
 class VariablesTreeItem
 {
@@ -200,7 +202,11 @@ public:
   void updateInitXmlFile(SimulationOptions simulationOptions);
   void initializeVisualization(SimulationOptions simulationOptions);
   double readVariableValue(QString variable, double time, bool *isOk = nullptr);
+  void prefetchVariables();
 private:
+  QMap<QString, double> mPrefetchedValues;
+  QVector<Variable*> mVariablesToPrefetch;
+  QVector<double> mRawPrefetchedValues;
   TreeSearchFilters *mpTreeSearchFilters;
   Label *mpSimulationTimeLabel;
   QComboBox *mpSimulationTimeComboBox;
@@ -215,6 +221,13 @@ private:
   Label *mpSpeedLabel;
   QComboBox *mpSpeedComboBox;
   TimeManager *mpTimeManager;
+  enum TimeControlMode {
+    TimeManagerMode,
+    OpcUaPlaying,
+    OpcUaPause,
+  };
+  TimeControlMode mpPlayingState;
+
   VariableTreeProxyModel *mpVariableTreeProxyModel;
   VariablesTreeModel *mpVariablesTreeModel;
   VariablesTreeView *mpVariablesTreeView;
@@ -229,6 +242,7 @@ private:
   void closeResultFile();
   void openResultFile();
   void updateVisualization();
+  OpcUaClient *getOpcUaClient();
 public slots:
   void plotVariables(const QModelIndex &index, qreal curveThickness, int curveStyle,
                      OMPlot::PlotCurve *pPlotCurve = 0, OMPlot::PlotWindow *pPlotWindow = 0);

--- a/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
@@ -2013,7 +2013,7 @@ void SimulationDialog::simulationProcessFinished(SimulationOptions simulationOpt
       pOpcUaClient->getSampleThread()->exit();
     }
     if (pOpcUaClient && pOpcUaClient->getOpcUaWorker()) {
-      pOpcUaClient->getOpcUaWorker()->pauseInteractiveSimulation();
+      pOpcUaClient->getOpcUaWorker()->emitPauseInteractiveSimulation();
     }
     return;
   }

--- a/OMEdit/OMEdit/OMEditGUI/Util/StringHandler.h
+++ b/OMEdit/OMEdit/OMEditGUI/Util/StringHandler.h
@@ -107,12 +107,16 @@ public:
   static QString getTextAlignmentString(StringHandler::TextAlignment alignment);
   static QString getTextStyleString(StringHandler::TextStyle textStyle);
   static QString removeFirstLastCurlBrackets(QString value);
+  static QString removeFunctionInvocation(QString value);
   static QString removeFirstLastParentheses(QString value);
   static QString removeFirstLastSquareBrackets(QString value);
   static QString removeFirstLastQuotes(QString value);
   static QString removeFirstLastSingleQuotes(QString value);
   static QStringList getStrings(QString value);
+  static QStringList getStringsMixed(QString value);
   static QStringList getStrings(QString value, char start, char end);
+  static QStringList getStrings(QString value, QString start, QString end);
+  static void parseColor(QString value, QColor *pResult);
   /* Handles quoted identifiers A.B.'C.D' -> A.B, A.B.C.D -> A.B.C */
   static QString getLastWordAfterDot(QString value);
   static QString removeLastWordAfterDot(QString value);

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -44,8 +44,8 @@
 
 using namespace OMPlot;
 
-PlotWindow::PlotWindow(QStringList arguments, QWidget *parent, bool isInteractiveSimulation)
-  : QMainWindow(parent), mIsInteractiveSimulation(isInteractiveSimulation)
+PlotWindow::PlotWindow(QStringList arguments, QWidget *parent, bool isInteractiveSimulation, bool showInteractiveControlsIfAppropriate)
+  : QMainWindow(parent), mIsInteractiveSimulation(isInteractiveSimulation), mShowInteractiveControls(showInteractiveControlsIfAppropriate)
 {
   /* set the widget background white. so that the plot is more useable in books and publications. */
   QPalette p(palette());
@@ -291,13 +291,15 @@ void PlotWindow::setupToolbar()
     mpSimulationSpeedComboBox->setCompleter(0);
     mpSimulationSpeedComboBox->setValidator(pDoubleValidator);
     // add the interactive controls
-    toolBar->addWidget(mpStartSimulationToolButton);
-    toolBar->addSeparator();
-    toolBar->addWidget(mpPauseSimulationToolButton);
-    toolBar->addSeparator();
-    toolBar->addWidget(mpSimulationSpeedLabel);
-    toolBar->addWidget(mpSimulationSpeedComboBox);
-    toolBar->addSeparator();
+    if (mShowInteractiveControls) {
+      toolBar->addWidget(mpStartSimulationToolButton);
+      toolBar->addSeparator();
+      toolBar->addWidget(mpPauseSimulationToolButton);
+      toolBar->addSeparator();
+      toolBar->addWidget(mpSimulationSpeedLabel);
+      toolBar->addWidget(mpSimulationSpeedComboBox);
+      toolBar->addSeparator();
+    }
   }
   // Auto scale
   mpAutoScaleButton = new QToolButton(toolBar);

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -91,13 +91,14 @@ private:
   QFont mLegendFont;
   double mTime;
   bool mIsInteractiveSimulation;
+  bool mShowInteractiveControls;
   QString mInteractiveTreeItemOwner;
   int mInteractivePort;
   QwtSeriesData<QPointF>* mpInteractiveData;
   QString mInteractiveModelName;
   QMdiSubWindow *mpSubWindow;
 public:
-  PlotWindow(QStringList arguments = QStringList(), QWidget *parent = 0, bool isInteractiveSimulation = false);
+  PlotWindow(QStringList arguments = QStringList(), QWidget *parent = 0, bool isInteractiveSimulation = false, bool showInteractiveControlsIfAppropriate = true);
 
   ~PlotWindow();
 


### PR DESCRIPTION
Account for the fact that now DynamicSelect annotation is formatted as `DynamicSelect(...)` function invocation, not just `{...}`. Technically, its second agument is arbitrary expression. For now, just support

* `if <var> then <color1> else <color2>` -- for colors
* `String(value, precision, <unused>)` -- for TextAnnotation

Model for testing:
```modelica
model Test
  Modelica.Blocks.Interaction.Show.RealValue realValue1(number = time, use_numberPort = true)  annotation(
    Placement(visible = true, transformation(origin = {-2, 16}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
  Modelica.Blocks.Interaction.Show.BooleanValue booleanValue1(use_activePort = true)  annotation(
  
    Placement(visible = true, transformation(origin = {-2, -2}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
equation
  realValue1.numberPort = time * 10; 
  booleanValue1.activePort = time > 0.5;
annotation(
    uses(Modelica(version = "3.2.2")),
    Diagram(coordinateSystem(initialScale = 0.1)));
end Test;
```

Editing:
![Editor](https://user-images.githubusercontent.com/9654772/64918760-7becb280-d7ab-11e9-9cb9-5cb071dfef6f.png)

"Plotted" diagram:
![Plot](https://user-images.githubusercontent.com/9654772/64918836-6c219e00-d7ac-11e9-9e99-5272c3e208be.gif)
