### PR TITLE
[NF] Mark parameter ranges as structural.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1839,6 +1839,10 @@ algorithm
 
   rangeType := TypeCheck.getRangeType(start_exp, ostep_exp, stop_exp, rangeType, info);
   rangeExp := Expression.RANGE(rangeType, start_exp, ostep_exp, stop_exp);
+
+  if variability <= Variability.PARAMETER and not ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) then
+    Inst.markStructuralParamsExp(rangeExp);
+  end if;
 end typeRange;
 
 function typeTuple


### PR DESCRIPTION
- Mark parameter ranges as structural in a model context, to make sure
  they get a known dimension.