### PR TITLE
Fetch interfaces for external TLM sub-models

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/MainWindow.cpp
@@ -3680,6 +3680,9 @@ void MainWindow::createActions()
   mpOMSSimulateAction = new QAction(QIcon(":/Resources/icons/tlm-simulate.svg"), Helper::simulate, this);
   mpOMSSimulateAction->setStatusTip(Helper::OMSSimulateTip);
   connect(mpOMSSimulateAction, SIGNAL(triggered()), SLOT(simulateOMSModel()));
+  // OMSimulator fetch interfaces action
+  mpOMSFetchInterfacesAction = new QAction(QIcon(":/ResourceS/icons/interface-data.svg"), Helper::fetchInterfaceData, this);
+  mpOMSFetchInterfacesAction->setStatusTip(Helper::fetchInterfaceDataTip);
   // Archived simulations
   mpOMSArchivedSimulationsAction = new QAction(Helper::archivedSimulations, this);
   mpOMSArchivedSimulationsAction->setStatusTip(Helper::archivedSimulations);

--- a/OMEdit/OMEdit/OMEditGUI/MainWindow.h
+++ b/OMEdit/OMEdit/OMEditGUI/MainWindow.h
@@ -199,6 +199,7 @@ public:
   QAction* getAddSubModelAction() {return mpAddSubModelAction;}
   QAction* getOMSInstantiateModelAction() {return mpOMSInstantiateModelAction;}
   QAction* getOMSSimulationSetupAction() {return mpOMSSimulateAction;}
+  QAction* getOMSFetchInterfacesAction() {return mpOMSFetchInterfacesAction;}
   QAction* getLogCurrentFileAction() {return mpLogCurrentFileAction;}
   QAction* getStageCurrentFileForCommitAction() {return mpStageCurrentFileForCommitAction;}
   QAction* getUnstageCurrentFileFromCommitAction() {return mpUnstageCurrentFileFromCommitAction;}
@@ -430,6 +431,7 @@ private:
   QAction *mpAddSubModelAction;
   QAction *mpOMSInstantiateModelAction;
   QAction *mpOMSSimulateAction;
+  QAction *mpOMSFetchInterfacesAction;
   QAction *mpOMSArchivedSimulationsAction;
   // Toolbars
   QMenu *mpRecentFilesMenu;

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -2482,7 +2482,7 @@ void GraphicsView::omsGraphicsViewContextMenu(QMenu *pMenu)
     pMenu->addAction(MainWindow::instance()->getAddBusAction());
     pMenu->addAction(MainWindow::instance()->getAddTLMBusAction());
     if(mpModelWidget->getLibraryTreeItem()->isExternalTLMModelComponent()) {
-        pMenu->addAction(MainWindow::instance()->getFetchInterfaceDataAction());
+        pMenu->addAction(MainWindow::instance()->getOMSFetchInterfacesAction());
     }
     if (mpModelWidget->getLibraryTreeItem()->isSystemElement()) {
       pMenu->addSeparator();
@@ -7241,7 +7241,7 @@ ModelWidgetContainer::ModelWidgetContainer(QWidget *pParent)
   connect(MainWindow::instance()->getAddBusAction(), SIGNAL(triggered()), SLOT(addBus()));
   connect(MainWindow::instance()->getAddTLMBusAction(), SIGNAL(triggered()), SLOT(addTLMBus()));
   connect(MainWindow::instance()->getAddSubModelAction(), SIGNAL(triggered()), SLOT(addSubModel()));
-  connect(MainWindow::instance()->getFetchInterfaceDataAction(), SIGNAL(triggered()), SLOT(fetchInterfaceData()));
+  connect(MainWindow::instance()->getOMSFetchInterfacesAction(), SIGNAL(triggered()), SLOT(fetchInterfaceData()));
 }
 
 void ModelWidgetContainer::addModelWidget(ModelWidget *pModelWidget, bool checkPreferedView)
@@ -7743,7 +7743,7 @@ void ModelWidgetContainer::currentModelWidgetChanged(QMdiSubWindow *pSubWindow)
   MainWindow::instance()->getExportFigaroAction()->setEnabled(enabled && modelica);
   MainWindow::instance()->getExportToOMNotebookAction()->setEnabled(enabled && modelica);
   MainWindow::instance()->getSimulationParamsAction()->setEnabled(enabled && compositeModel);
-  MainWindow::instance()->getFetchInterfaceDataAction()->setEnabled(enabled && !textView && (pLibraryTreeItem->isExternalTLMModelComponent()));
+  MainWindow::instance()->getFetchInterfaceDataAction()->setEnabled(enabled && compositeModel);
   MainWindow::instance()->getAlignInterfacesAction()->setEnabled(enabled && compositeModel);
   MainWindow::instance()->getTLMSimulationAction()->setEnabled(enabled && compositeModel);
   MainWindow::instance()->getAddSystemAction()->setEnabled(enabled && !iconGraphicsView && !textView && (omsModel || (omsSystem && (!pLibraryTreeItem->isSCSystem()))));
@@ -7754,6 +7754,7 @@ void ModelWidgetContainer::currentModelWidgetChanged(QMdiSubWindow *pSubWindow)
   MainWindow::instance()->getAddTLMBusAction()->setEnabled(enabled && !textView && ((omsSystem || omsSubmodel)  && (!pLibraryTreeItem->isTLMSystem())));
   MainWindow::instance()->getAddSubModelAction()->setEnabled(enabled && !iconGraphicsView && !textView && omsSystem);
   MainWindow::instance()->getOMSInstantiateModelAction()->setEnabled(enabled && (omsModel || omsSystem || omsSubmodel));
+  MainWindow::instance()->getOMSFetchInterfacesAction()->setEnabled(enabled && !textView && (pLibraryTreeItem->isExternalTLMModelComponent()));
   if (pLibraryTreeItem) {
     LibraryTreeItem *pTopLevelLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItem(StringHandler::getFirstWordBeforeDot(pLibraryTreeItem->getNameStructure()));
     MainWindow::instance()->getOMSInstantiateModelAction()->setChecked(pTopLevelLibraryTreeItem && pTopLevelLibraryTreeItem->isInstantiated());

--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
@@ -652,6 +652,7 @@ public slots:
   void addConnector();
   void addBus();
   void addTLMBus();
+  void fetchInterfaceData();
   void addSubModel();
 };
 

--- a/OMEdit/OMEdit/OMEditGUI/OMS/ModelDialog.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/ModelDialog.h
@@ -99,7 +99,7 @@ class AddSubModelDialog : public QDialog
 {
   Q_OBJECT
 public:
-  AddSubModelDialog(GraphicsView *pGraphicsView);
+    AddSubModelDialog(GraphicsView *pGraphicsView);
 private:
   GraphicsView *mpGraphicsView;
   Label *mpHeading;

--- a/OMEdit/OMEdit/OMEditGUI/OMS/ModelDialog.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/ModelDialog.h
@@ -99,7 +99,7 @@ class AddSubModelDialog : public QDialog
 {
   Q_OBJECT
 public:
-    AddSubModelDialog(GraphicsView *pGraphicsView);
+  AddSubModelDialog(GraphicsView *pGraphicsView);
 private:
   GraphicsView *mpGraphicsView;
   Label *mpHeading;

--- a/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.cpp
@@ -597,6 +597,27 @@ bool OMSProxy::deleteConnectorFromTLMBus(QString busCref, QString connectorCref)
   return statusToBool(status);
 }
 
+bool OMSProxy::fetchInterfaceData(QString cref, QStringList &names, QStringList &domains, QVector<int> &dimensions)
+{
+    QString command = "oms_fetchExternalModelInterfaces";
+    QStringList args;
+    args << cref;
+    LOG_COMMAND(command, args);
+    char** cnames = nullptr;
+    char** cdomains = nullptr;
+    int* cdimensions = nullptr;
+    oms_status_enu_t status = oms_fetchExternalModelInterfaces(cref.toUtf8().constData(), &cnames, &cdomains, &cdimensions);
+    logResponse(command, status, &commandTime);
+
+    for (int i = 0 ; cnames[i] ; i++) {
+      names.append(cnames[i]);
+      domains.append(cdomains[i]);
+      dimensions.append(cdimensions[i]);
+    }
+
+    return statusToBool(status);
+}
+
 /*!
  * \brief OMSProxy::getBoolean
  * Gets the boolean variable value.

--- a/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.h
+++ b/OMEdit/OMEdit/OMEditGUI/OMS/OMSProxy.h
@@ -86,6 +86,7 @@ public:
   bool deleteConnection(QString crefA, QString crefB);
   bool deleteConnectorFromBus(QString busCref, QString connectorCref);
   bool deleteConnectorFromTLMBus(QString busCref, QString connectorCref);
+  bool fetchInterfaceData(QString cref, QStringList &names, QStringList &domains, QVector<int> &dimensions);
   bool getBoolean(QString signal, bool* value);
   bool getBus(QString cref, oms_busconnector_t **pBusConnector);
   bool getComponentType(QString cref, oms_component_enu_t *pType);


### PR DESCRIPTION
Access from context menu within the external sub-model.

This uses the `oms_fetchExternalModelInterfaces` API function in OMSimulator.

Edit: I added a new QAction instead of using the existing one for fetching interfaces, since it is still used in the previous TLM implementation.