### PR TITLE
[NF/Codegen] Fix handling of record variables with modifications on d…

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Ceval.mo
+++ b/OMCompiler/Compiler/FrontEnd/Ceval.mo
@@ -103,7 +103,7 @@ public function ceval "
   input FCore.Graph inEnv;
   input DAE.Exp inExp;
   input Boolean inBoolean "impl";
-  input Absyn.Msg inMsg = Absyn.NO_MSG();
+  input Absyn.Msg inMsg = Absyn.MSG(AbsynUtil.dummyInfo);
   input Integer numIter = 0 "Maximum recursion depth";
   output FCore.Cache outCache;
   output Values.Value outValue;
@@ -887,7 +887,7 @@ algorithm
 
     case DAE.PROP(constFlag = DAE.C_CONST(), type_ = tp)
       algorithm
-        (cache, v) := ceval(cache, inEnv, exp, impl, Absyn.NO_MSG(), 0);
+        (cache, v) := ceval(cache, inEnv, exp, impl, Absyn.MSG(inInfo), 0);
         exp := ValuesUtil.valueExp(v);
         exp := ValuesUtil.fixZeroSizeArray(exp, tp);
       then (cache, exp, prop);
@@ -895,7 +895,7 @@ algorithm
     case DAE.PROP_TUPLE()
       algorithm
         DAE.C_CONST() := Types.propAllConst(prop);
-        (cache, v) := ceval(cache, inEnv, exp, false, Absyn.NO_MSG(), 0);
+        (cache, v) := ceval(cache, inEnv, exp, false, Absyn.MSG(inInfo), 0);
         exp := ValuesUtil.valueExp(v);
       then (cache, exp, prop);
 
@@ -911,7 +911,7 @@ algorithm
       // Structural parameters and the like... we can ceval them if we want to
       guard Expression.isConst(exp) and not Config.acceptMetaModelicaGrammar()
       algorithm
-        (_, v) := ceval(cache, inEnv, exp, impl, Absyn.NO_MSG(), 0);
+        (_, v) := ceval(cache, inEnv, exp, impl, Absyn.MSG(inInfo), 0);
         exp := ValuesUtil.valueExp(v);
         exp := ValuesUtil.fixZeroSizeArray(exp, Types.getPropType(prop));
       then (cache, exp, prop);
@@ -5112,7 +5112,7 @@ algorithm
   structuralParameters := (AvlSetCR.EMPTY(),{});
   functionTree := Mutable.create(functions);
   cache := FCore.CACHE(NONE(), functionTree, structuralParameters, Absyn.IDENT(""));
-  (_,val) := ceval(cache, FGraph.empty(), exp, false, Absyn.NO_MSG(),0);
+  (_,val) := ceval(cache, FGraph.empty(), exp, false, Absyn.MSG(AbsynUtil.dummyInfo),0);
   oexp := ValuesUtil.valueExp(val);
 end cevalSimpleWithFunctionTreeReturnExp;
 

--- a/OMCompiler/Compiler/FrontEnd/Ceval.mo
+++ b/OMCompiler/Compiler/FrontEnd/Ceval.mo
@@ -4308,6 +4308,7 @@ algorithm
     // A variable without a binding -> error in a simulation model
     // and we can only check that at the DAE level!
     case (_, _, _, _, _, DAE.UNBOUND(), NONE(), _, _, _, _, false, Absyn.MSG(), _)
+      /*
       equation
         str = ComponentReference.printComponentRefStr(inCref);
         scope_str = FGraph.printGraphPathStr(inEnv);
@@ -4326,8 +4327,9 @@ algorithm
         // but unfortunately DAE depends on Values and they should probably be merged !
         // Actually, at a second thought we SHOULD NOT HAVE VALUES AT ALL, WE SHOULD HAVE
         // JUST ONE DAE.Exp.CONSTANT_EXPRESSION(exp, constantness, type)!
+        */
       then
-        (inCache, v);
+        fail();
 
     // A variable with a binding -> constant evaluate the binding
     case (_, _, _, DAE.ATTR(variability=variability), _, _, _, _, _, _, _, _, _, _)

--- a/OMCompiler/Compiler/FrontEnd/ClassInf.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassInf.mo
@@ -94,6 +94,7 @@ uniontype State "- Machine states, the string contains the classname."
   record FUNCTION
     Absyn.Path path;
     Boolean isImpure;
+    Boolean isRecordConstructor;
   end FUNCTION;
 
   record ENUMERATION
@@ -421,10 +422,11 @@ algorithm
     case (SCode.R_CONNECTOR(isExpandable),p) then CONNECTOR(p,isExpandable);
     case (SCode.R_TYPE(),p) then TYPE(p);
     case (SCode.R_PACKAGE(),p) then PACKAGE(p);
-    case (SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(isImpure)),p) then FUNCTION(p, isImpure);
-    case (SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(isImpure)),p) then FUNCTION(p, isImpure);
-    case (SCode.R_FUNCTION(_),p) then FUNCTION(p, false);
-    case (SCode.R_OPERATOR(),p) then FUNCTION(p, false);
+    case (SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(isImpure)),p) then FUNCTION(p, isImpure, false);
+    case (SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(isImpure)),p) then FUNCTION(p, isImpure, false);
+    case (SCode.R_FUNCTION(SCode.FR_RECORD_CONSTRUCTOR()),p) then FUNCTION(p, false, true);
+    case (SCode.R_FUNCTION(_),p) then FUNCTION(p, false, false);
+    case (SCode.R_OPERATOR(),p) then FUNCTION(p, false, false);
     case (SCode.R_ENUMERATION(),p) then ENUMERATION(p);
     case (SCode.R_PREDEFINED_INTEGER(),p) then TYPE_INTEGER(p);
     case (SCode.R_PREDEFINED_REAL(),p) then TYPE_REAL(p);
@@ -705,6 +707,17 @@ algorithm
     else false;
   end match;
 end isFunction;
+
+public function isRecordConstructor
+"returns true if state is FUNCTION."
+  input State inState;
+  output Boolean b;
+algorithm
+  b := match (inState)
+    case FUNCTION(isRecordConstructor = true) then true;
+    else false;
+  end match;
+end isRecordConstructor;
 
 public function isFunctionOrRecord "Fails for states that are not FUNCTION or RECORD."
   input State inState;

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -3643,6 +3643,8 @@ algorithm
 
         dae_attr = DAEUtil.translateSCodeAttrToDAEAttr(attr, prefixes);
         ty = Types.traverseType(ty, 1, Types.setIsFunctionPointer);
+
+        binding = removePrefixFromBinding(binding, pre);
         new_var = DAE.TYPES_VAR(name, dae_attr, ty, binding, false, NONE());
 
         // Type info present. Now we can also put the binding into the dae.
@@ -3763,6 +3765,25 @@ algorithm
         fail();
   end matchcontinue;
 end instElement;
+
+protected function removePrefixFromBinding
+  input DAE.Binding inBind;
+  input Prefix.Prefix inPrefix;
+  output DAE.Binding outBind;
+algorithm
+  outBind := match (inBind, inPrefix)
+	  local
+	    DAE.Binding bind;
+      Prefix.Prefix pref;
+
+	    case (bind as DAE.EQBOUND(), pref as Prefix.PREFIX(compPre=Prefix.PRE())) algorithm
+        bind.exp := PrefixUtil.removeCompPrefixFromExps(bind.exp, pref.compPre);
+      then
+        bind;
+
+	    else inBind;
+	  end match;
+end removePrefixFromBinding;
 
 protected function updateCompeltsMods
 "never fail and *NEVER* display any error messages as this function

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -516,7 +516,7 @@ public function instClass
   input Prefix.Prefix inPrefix;
   input SCode.Element inClass;
   input list<list<DAE.Dimension>> inInstDims;
-  input Boolean inBoolean;
+  input Boolean inImplicit;
   input InstTypes.CallingScope inCallingScope;
   input ConnectionGraph.ConnectionGraph inGraph;
   input Connect.Sets inSets;
@@ -532,7 +532,7 @@ public function instClass
   output ConnectionGraph.ConnectionGraph outGraph;
 algorithm
   (cache,outEnv,outIH,outStore,outDae,outSets,outType,outState,optDerAttr,outGraph):=
-  matchcontinue (inCache,inEnv,inIH,inStore,inMod,inPrefix,inClass,inInstDims,inBoolean,inCallingScope,inGraph,inSets)
+  matchcontinue (inCache,inEnv,inIH,inStore,inMod,inPrefix,inClass,inInstDims,inImplicit,inCallingScope,inGraph,inSets)
     local
       FCore.Graph env,env_1,env_3;
       DAE.Mod mod;
@@ -573,7 +573,7 @@ algorithm
         end if;
         // call normal instantiation
         (cache,env,ih,store,dae,csets,ty,ci_state_1,oDA,graph) =
-           instClass(inCache, inEnv, inIH, store, inMod, inPrefix, c, inInstDims, inBoolean, inCallingScope, inGraph, inSets);
+           instClass(inCache, inEnv, inIH, store, inMod, inPrefix, c, inInstDims, inImplicit, inCallingScope, inGraph, inSets);
       then
         (cache,env,ih,store,dae,csets,ty,ci_state_1,oDA,graph);
 
@@ -625,6 +625,7 @@ algorithm
         dae = InstUtil.updateDeducedUnits(callscope_1,store,dae);
 
         ty = markDerivedRecordOutsideBindings(ty, c);
+        ty = markTypesVarsOutsideBindings(ty,mod);
 
         // Fixes partial functions.
         ty = InstUtil.fixInstClassType(ty,isPartialFn);
@@ -1014,6 +1015,65 @@ algorithm
     case SCode.NAMEMOD() then stringEqual(inSubmod.ident, inName);
   end match;
 end varIsModifiedInDerivedMod;
+
+protected function markTypesVarsOutsideBindings
+  input DAE.Type inType;
+  input DAE.Mod inMod;
+  output DAE.Type outType = inType;
+protected
+  list<DAE.SubMod> submods;
+algorithm
+
+  if not Types.isRecord(inType) then
+     return;
+  end if;
+
+  try
+    DAE.MOD(subModLst = submods) := inMod;
+  else
+    return;
+  end try;
+
+  if listEmpty(submods) then
+    return;
+  end if;
+
+
+  outType := match inType
+    local
+      list<DAE.Var> tvars;
+      Option<DAE.Exp> obind;
+      DAE.Exp bind_exp;
+
+    case DAE.T_COMPLEX() algorithm
+      tvars := {};
+      for var in inType.varLst loop
+
+        for submod in submods loop
+          if varIsModifiedInMod(var.name, submod) then
+            var.bind_from_outside := true;
+            break;
+          end if;
+        end for;
+
+        tvars := var::tvars;
+      end for;
+      tvars := listReverse(tvars);
+
+    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint);
+  end match;
+
+end markTypesVarsOutsideBindings;
+
+function varIsModifiedInMod
+  input String inName;
+  input DAE.SubMod inSubmod;
+  output Boolean b;
+algorithm
+  b := match inSubmod
+    case DAE.NAMEMOD() then stringEqual(inSubmod.ident, inName);
+  end match;
+end varIsModifiedInMod;
 
 
 protected function callingScopeCacheEq
@@ -1742,7 +1802,7 @@ public function instClassdef "
   input SCode.Partial inPartialPrefix;
   input SCode.Encapsulated inEncapsulatedPrefix;
   input list<list<DAE.Dimension>> inInstDims9;
-  input Boolean inBoolean10;
+  input Boolean inImplicit;
   input InstTypes.CallingScope inCallingScope;
   input ConnectionGraph.ConnectionGraph inGraph;
   input Connect.Sets inSets;
@@ -1764,7 +1824,7 @@ public function instClassdef "
 algorithm
   (outCache,outEnv,outIH,outStore,outDae,outSets,outState,outTypesVarLst,outTypesTypeOption,optDerAttr,outEqualityConstraint,outGraph):=
   instClassdef2(inCache,inEnv,inIH,store,inMod2,inPrefix3,inState5,className,inClassDef6,inRestriction7,inVisibility,
-    inPartialPrefix,inEncapsulatedPrefix,inInstDims9,inBoolean10,inCallingScope,inGraph,inSets,instSingleCref,comment,info,Mutable.create(false));
+    inPartialPrefix,inEncapsulatedPrefix,inInstDims9,inImplicit,inCallingScope,inGraph,inSets,instSingleCref,comment,info,Mutable.create(false));
 end instClassdef;
 
 protected function instClassdefBasicType "
@@ -1783,7 +1843,7 @@ type"
   input SCode.Restriction inRestriction7;
   input SCode.Visibility inVisibility;
   input list<list<DAE.Dimension>> inInstDims9;
-  input Boolean inBoolean10;
+  input Boolean inImplicit;
   input ConnectionGraph.ConnectionGraph inGraph;
   input Connect.Sets inSets;
   input Option<DAE.ComponentRef> instSingleCref;
@@ -1803,7 +1863,7 @@ type"
   output ConnectionGraph.ConnectionGraph outGraph;
 algorithm
   (outCache,outEnv,outIH,outStore,outDae,outSets,outState,outTypesVarLst,outTypesTypeOption,optDerAttr,outEqualityConstraint,outGraph):=
-  matchcontinue (inCache,inEnv,inIH,inStore,inMod2,inPrefix3,inState5,className,inClassDef6,inRestriction7,inVisibility,inInstDims9,inBoolean10,inGraph,inSets,instSingleCref,info,stopInst)
+  matchcontinue (inCache,inEnv,inIH,inStore,inMod2,inPrefix3,inState5,className,inClassDef6,inRestriction7,inVisibility,inInstDims9,inImplicit,inGraph,inSets,instSingleCref,info,stopInst)
     local
       list<SCode.Element> cdefelts,compelts,extendselts,els;
       FCore.Graph env1,env2,env3,env;
@@ -1911,7 +1971,7 @@ protected function instClassdef2 "
   input SCode.Partial inPartialPrefix;
   input SCode.Encapsulated inEncapsulatedPrefix;
   input list<list<DAE.Dimension>> inInstDims9;
-  input Boolean inBoolean10;
+  input Boolean inImplicit;
   input InstTypes.CallingScope inCallingScope;
   input ConnectionGraph.ConnectionGraph inGraph;
   input Connect.Sets inSets;
@@ -1933,7 +1993,7 @@ protected function instClassdef2 "
   output ConnectionGraph.ConnectionGraph outGraph;
 algorithm
   (outCache,outEnv,outIH,outStore,outDae,outSets,outState,outTypesVarLst,oty,optDerAttr,outEqualityConstraint,outGraph):=
-  matchcontinue (inCache,inEnv,inIH,inStore,inMod2,inPrefix3,inState5,className,inClassDef6,inRestriction7,inVisibility,inPartialPrefix,inEncapsulatedPrefix,inInstDims9,inBoolean10,inCallingScope,inGraph,inSets,instSingleCref,comment,info,stopInst)
+  matchcontinue (inCache,inEnv,inIH,inStore,inMod2,inPrefix3,inState5,className,inClassDef6,inRestriction7,inVisibility,inPartialPrefix,inEncapsulatedPrefix,inInstDims9,inImplicit,inCallingScope,inGraph,inSets,instSingleCref,comment,info,stopInst)
     local
       list<SCode.Element> cdefelts,compelts,extendselts,els,extendsclasselts,compelts_2_elem;
       FCore.Graph env1,env2,env3,env,env5,cenv,cenv_2,env_2,parentEnv,parentClassEnv;
@@ -3714,14 +3774,14 @@ protected function updateCompeltsMods
   input Prefix.Prefix inPrefix;
   input list<tuple<SCode.Element, DAE.Mod>> inComponents;
   input ClassInf.State inState;
-  input Boolean inBoolean;
+  input Boolean inImplicit;
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
   output list<tuple<SCode.Element, DAE.Mod>> outComponents;
 algorithm
   (outCache,outEnv,outIH,outComponents) :=
-  matchcontinue (inCache,inEnv,inIH,inPrefix,inComponents,inState,inBoolean)
+  matchcontinue (inCache,inEnv,inIH,inPrefix,inComponents,inState,inImplicit)
 
     /*
     case (_,_,_,_,_,_,_)
@@ -3734,7 +3794,7 @@ algorithm
       equation
         ErrorExt.setCheckpoint("updateCompeltsMods");
         (outCache,outEnv,outIH,outComponents) =
-          updateCompeltsMods_dispatch(inCache,inEnv,inIH,inPrefix,inComponents,inState,inBoolean);
+          updateCompeltsMods_dispatch(inCache,inEnv,inIH,inPrefix,inComponents,inState,inImplicit);
         ErrorExt.rollBack("updateCompeltsMods") "roll back any errors";
       then
         (outCache,outEnv,outIH,outComponents);
@@ -3758,14 +3818,14 @@ protected function updateCompeltsMods_dispatch
   input Prefix.Prefix inPrefix;
   input list<tuple<SCode.Element, DAE.Mod>> inComponents;
   input ClassInf.State inState;
-  input Boolean inBoolean;
+  input Boolean inImplicit;
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
   output InnerOuter.InstHierarchy outIH;
   output list<tuple<SCode.Element, DAE.Mod>> outComponents;
 algorithm
   (outCache,outEnv,outIH,outComponents):=
-  matchcontinue (inCache,inEnv,inIH,inPrefix,inComponents,inState,inBoolean)
+  matchcontinue (inCache,inEnv,inIH,inPrefix,inComponents,inState,inImplicit)
     local
       FCore.Graph env,env2,env3;
       Prefix.Prefix pre;
@@ -4632,7 +4692,7 @@ public function instList
   input ClassInf.State inState;
   input InstFunc instFunc;
   input list<Type_a> inTypeALst;
-  input Boolean inBoolean;
+  input Boolean inImplicit;
   input Boolean unrollForLoops "we should unroll for loops if they are part of an algorithm in a model";
   input ConnectionGraph.ConnectionGraph inGraph;
   output FCore.Cache outCache;
@@ -4650,7 +4710,7 @@ public function instList
     input Connect.Sets inSets;
     input ClassInf.State inState;
     input Type_a inTypeA;
-    input Boolean inBoolean;
+    input Boolean inImplicit;
     input Boolean unrollForLoops "we should unroll for loops if they are part of an algorithm in a model";
     input ConnectionGraph.ConnectionGraph inGraph;
     output FCore.Cache outCache;
@@ -4665,7 +4725,7 @@ public function instList
   replaceable type Type_a subtypeof Any;
 algorithm
   (outCache,outEnv,outIH,outDae,outSets,outState,outGraph):=
-  match (inCache,inEnv,inIH,inPrefix,inSets,inState,instFunc,inTypeALst,inBoolean,unrollForLoops,inGraph)
+  match (inCache,inEnv,inIH,inPrefix,inSets,inState,instFunc,inTypeALst,inImplicit,unrollForLoops,inGraph)
     local
       FCore.Graph env,env_1,env_2;
       DAE.Mod mod;
@@ -4740,7 +4800,7 @@ protected function instClassAttributes
   input FCore.Graph inEnv;
   input Prefix.Prefix inPrefix;
   input list<Absyn.NamedArg> inAttrs;
-  input Boolean inBoolean;
+  input Boolean inImplicit;
   input SourceInfo inInfo;
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
@@ -4748,7 +4808,7 @@ protected function instClassAttributes
 algorithm
 
   (outCache,outEnv,outDae):=
-  match (inCache,inEnv,inPrefix,inAttrs,inBoolean,inInfo)
+  match (inCache,inEnv,inPrefix,inAttrs,inImplicit,inInfo)
     local
       FCore.Cache cache;
       FCore.Graph env;
@@ -4760,7 +4820,7 @@ algorithm
     case (_,_,_,_,_,_)
       equation
         clsAttrs = DAE.DAE({DAE.CLASS_ATTRIBUTES(DAE.OPTIMIZATION_ATTRS(NONE(),NONE(),NONE(),NONE()))});
-        (cache,env,dae) = instClassAttributes2(inCache,inEnv,inPrefix,inAttrs,inBoolean,inInfo,clsAttrs);
+        (cache,env,dae) = instClassAttributes2(inCache,inEnv,inPrefix,inAttrs,inImplicit,inInfo,clsAttrs);
       then (cache,env,dae);
     else
       equation
@@ -4776,7 +4836,7 @@ protected function instClassAttributes2
   input FCore.Graph inEnv;
   input Prefix.Prefix inPrefix;
   input list<Absyn.NamedArg> inAttrs;
-  input Boolean inBoolean;
+  input Boolean inImplicit;
   input SourceInfo inInfo;
   input DAE.DAElist inClsAttrs;
   output FCore.Cache outCache;
@@ -4785,7 +4845,7 @@ protected function instClassAttributes2
 algorithm
 
   (outCache,outEnv,outDae):=
-  match (inCache,inEnv,inPrefix,inAttrs,inBoolean,inInfo,inClsAttrs)
+  match (inCache,inEnv,inPrefix,inAttrs,inImplicit,inInfo,inClsAttrs)
     local
       FCore.Graph env,env_2;
       Prefix.Prefix pre;

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -624,7 +624,7 @@ algorithm
         ty = InstUtil.mktype(fq_class, ci_state_1, tys, bc_ty, equalityConstraint, c, InstUtil.extractComment(dae.elementLst));
         dae = InstUtil.updateDeducedUnits(callscope_1,store,dae);
 
-        ty = collectAndFixDerivedComplexOutsideBindings(ty, c);
+        ty = markDerivedRecordOutsideBindings(ty, c);
 
         // Fixes partial functions.
         ty = InstUtil.fixInstClassType(ty,isPartialFn);
@@ -951,7 +951,7 @@ algorithm
 end instClassIn2;
 
 
-protected function collectAndFixDerivedComplexOutsideBindings
+protected function markDerivedRecordOutsideBindings
   input DAE.Type inType;
   input SCode.Element inClass;
   output DAE.Type outType;
@@ -1003,7 +1003,7 @@ algorithm
     then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint);
   end match;
 
-end collectAndFixDerivedComplexOutsideBindings;
+end markDerivedRecordOutsideBindings;
 
 function varIsModifiedInDerivedMod
   input String inName;

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -655,6 +655,7 @@ algorithm
     // A record might have bindings for each component instead of a single
     // binding for the whole record, in which case we need to assemble them into
     // a binding.
+    /*
     case (cache, _, DAE.MOD(subModLst = sub_mods as _ :: _), _)
       equation
         (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path = tpath),
@@ -662,6 +663,7 @@ algorithm
         binding = makeRecordBinding(cache, inEnv, tpath, inType, complex_vars, sub_mods, inInfo);
       then
         (cache, binding);
+        */
 
     case (cache,_,DAE.MOD(binding = NONE()),_) then (cache,DAE.UNBOUND());
     /* adrpo: CHECK! do we need this here? numerical values

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -655,7 +655,7 @@ algorithm
     // A record might have bindings for each component instead of a single
     // binding for the whole record, in which case we need to assemble them into
     // a binding.
-    /*
+    
     case (cache, _, DAE.MOD(subModLst = sub_mods as _ :: _), _)
       equation
         (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path = tpath),
@@ -663,7 +663,7 @@ algorithm
         binding = makeRecordBinding(cache, inEnv, tpath, inType, complex_vars, sub_mods, inInfo);
       then
         (cache, binding);
-        */
+        
 
     case (cache,_,DAE.MOD(binding = NONE()),_) then (cache,DAE.UNBOUND());
     /* adrpo: CHECK! do we need this here? numerical values

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -783,12 +783,15 @@ algorithm
         DAE.EQBOUND(exp = exp, evaluatedExp = SOME(val)) := binding;
       else
         // Couldn't find a submod, and the variable doesn't have a binding.
+        /*
         ety := Types.simplifyType(ty);
         ty := Types.liftArrayListDims(ty, dims);
         scope := FGraph.printGraphPathStr(inEnv);
         ty_str := Types.printTypeStr(ty);
         exp := DAE.EMPTY(scope, DAE.CREF_IDENT(name, ety, {}), ety, ty_str);
         val := Values.EMPTY(scope, name, Types.typeToValue(ty), ty_str);
+        */
+        fail();
       end if;
 
       accum_exps := exp :: accum_exps;

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -655,7 +655,6 @@ algorithm
     // A record might have bindings for each component instead of a single
     // binding for the whole record, in which case we need to assemble them into
     // a binding.
-    /*
     case (cache, _, DAE.MOD(subModLst = sub_mods as _ :: _), _)
       equation
         (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path = tpath),
@@ -663,7 +662,6 @@ algorithm
         binding = makeRecordBinding(cache, inEnv, tpath, inType, complex_vars, sub_mods, inInfo);
       then
         (cache, binding);
-        */
 
     case (cache,_,DAE.MOD(binding = NONE()),_) then (cache,DAE.UNBOUND());
     /* adrpo: CHECK! do we need this here? numerical values

--- a/OMCompiler/Compiler/FrontEnd/InstFunction.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstFunction.mo
@@ -410,7 +410,7 @@ algorithm
         vis = SCode.PUBLIC();
         (cache,tempenv,ih,_,_,_,_,_,_,_,_,_) =
           Inst.instClassdef(cache, env_1, ih, UnitAbsyn.noStore, mod, pre,
-            ClassInf.FUNCTION(fpath,isImpure), n,parts, restr, vis, partialPrefix,
+            ClassInf.FUNCTION(fpath,isImpure, false), n,parts, restr, vis, partialPrefix,
             encapsulatedPrefix, inst_dims, true, InstTypes.INNER_CALL(),
             ConnectionGraph.EMPTY, Connect.emptySet, NONE(), cmt, info) "how to get this? impl" ;
         (cache,ih,extdecl) = instExtDecl(cache, tempenv, ih, n, scExtdecl, daeElts, ty1, true, pre,info) "impl" ;
@@ -801,6 +801,8 @@ algorithm
       list<DAE.FuncArg> fargs;
       DAE.EqualityConstraint eqCo;
       String name, newName;
+      SCode.Restriction restr;
+      ClassInf.State ci_state;
 
       case(_, _, _)
         equation
@@ -818,11 +820,26 @@ algorithm
           newName = FGraph.getInstanceOriginalName(recordEnv, name);
           recordCl = SCodeUtil.setClassName(newName, recordCl);
 
+          restr = SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(false));
+          // recordCl = SCodeUtil.setClassRestriction(restr, recordCl);
+
+/*
           (cache,_,_,_,_,_,recType,_,_,_) = Inst.instClass(inCache,recordEnv, InnerOuter.emptyInstHierarchy,
-            UnitAbsynBuilder.emptyInstStore(), DAE.NOMOD(), Prefix.NOPRE(), recordCl,
-            {}, true, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, Connect.emptySet);
+           UnitAbsynBuilder.emptyInstStore(), DAE.NOMOD(), Prefix.NOPRE(), recordCl,
+            {}, false, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, Connect.emptySet);
 
           DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo) = recType;
+*/
+
+          recordEnv = FGraph.openScope(recordEnv, SCodeUtil.getClassEncapsulation(recordCl), newName, FGraph.restrictionToScopeType(restr));
+          // ci_state = ClassInf.start(restr,FGraph.getGraphName(recordEnv));
+          ci_state = ClassInf.FUNCTION(FGraph.getGraphName(recordEnv), false, true);
+
+	        (cache,_,_,_,_,_,ci_state,vars,_,_,eqCo,_) = Inst.instClassIn(inCache, recordEnv, InnerOuter.emptyInstHierarchy,
+	          UnitAbsynBuilder.emptyInstStore(), DAE.NOMOD(), Prefix.NOPRE(), ci_state, recordCl, SCode.PUBLIC(),
+	          {}, true, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, Connect.emptySet, NONE());
+
+          path = ClassInf.getStateName(ci_state);
 
           vars = Types.filterRecordComponents(vars, SCodeUtil.elementInfo(recordCl));
           (inputs,locals) = List.extractOnTrue(vars, Types.isModifiableTypesVar);

--- a/OMCompiler/Compiler/FrontEnd/InstFunction.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstFunction.mo
@@ -823,14 +823,14 @@ algorithm
           restr = SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(false));
           // recordCl = SCodeUtil.setClassRestriction(restr, recordCl);
 
-/*
+
           (cache,_,_,_,_,_,recType,_,_,_) = Inst.instClass(inCache,recordEnv, InnerOuter.emptyInstHierarchy,
            UnitAbsynBuilder.emptyInstStore(), DAE.NOMOD(), Prefix.NOPRE(), recordCl,
             {}, false, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, Connect.emptySet);
 
           DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo) = recType;
-*/
 
+/*
           recordEnv = FGraph.openScope(recordEnv, SCodeUtil.getClassEncapsulation(recordCl), newName, FGraph.restrictionToScopeType(restr));
           // ci_state = ClassInf.start(restr,FGraph.getGraphName(recordEnv));
           ci_state = ClassInf.FUNCTION(FGraph.getGraphName(recordEnv), false, true);
@@ -840,7 +840,7 @@ algorithm
 	          {}, true, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, Connect.emptySet, NONE());
 
           path = ClassInf.getStateName(ci_state);
-
+*/
           vars = Types.filterRecordComponents(vars, SCodeUtil.elementInfo(recordCl));
           (inputs,locals) = List.extractOnTrue(vars, Types.isModifiableTypesVar);
           inputs = List.map(inputs,Types.setVarDefaultInput);

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -3105,10 +3105,16 @@ end checkModificationOnOuter;
 public function checkFunctionVar
   "Checks that a function variable is valid."
   input String inName;
+  input ClassInf.State ci_state;
   input SCode.Attributes inAttributes;
   input SCode.Prefixes inPrefixes;
   input SourceInfo inInfo;
 algorithm
+
+  if ClassInf.isRecordConstructor(ci_state) then
+    return;
+  end if;
+
   _ := match(inName, inAttributes, inPrefixes, inInfo)
     // Public non-formal parameters are not allowed, but since they're used in
     // the MSL we just issue a warning for now.

--- a/OMCompiler/Compiler/FrontEnd/InstVar.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstVar.mo
@@ -829,11 +829,11 @@ algorithm
         //   R1 r2(v1=1, v1=2);     // <= Here
         // end out;
         // see testsuit/mofiles/RecordBindings.mo.
-        /*
+
      case (cache,env,ih,store,ci_state,mod as DAE.MOD(binding = NONE()),pre,n,cl as SCode.CLASS(restriction = SCode.R_RECORD(_)),attr,pf,dims,_,inst_dims,impl,comment,info,graph,csets)
       equation
         true = ClassInf.isFunction(ci_state);
-        InstUtil.checkFunctionVar(n, attr, pf, info);
+        InstUtil.checkFunctionVar(n, ci_state, attr, pf, info);
 
 
         //Instantiate type of the component, skip dae/not flattening (but extract functions)
@@ -865,7 +865,7 @@ algorithm
         store = UnitAbsynBuilder.instAddStore(store,ty,cr);
       then
         (cache,env_1,ih,store,dae,csets,ty_1,graph);
-        */
+
 
     // mahge: function variables with eqMod modifications.
     // FIXHERE: They might have subMods too (variable attributes). see testsuite/mofiles/Sequence.mo

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -2088,7 +2088,7 @@ algorithm
         (_, env) = traversePatternList(elabPatterns2, addEnvKnownAsBindings, env);
         eqAlgs = Static.fromEquationsToAlgAssignments(cp);
         algs = AbsynToSCode.translateClassdefAlgorithmitems(eqAlgs);
-        (cache,body) = InstSection.instStatements(cache, env, InnerOuter.emptyInstHierarchy, pre, ClassInf.FUNCTION(Absyn.IDENT("match"), false), algs, ElementSource.addElementSourceFileInfo(DAE.emptyElementSource,patternInfo), SCode.NON_INITIAL(), true, InstTypes.neverUnroll);
+        (cache,body) = InstSection.instStatements(cache, env, InnerOuter.emptyInstHierarchy, pre, ClassInf.FUNCTION(Absyn.IDENT("match"), false, false), algs, ElementSource.addElementSourceFileInfo(DAE.emptyElementSource,patternInfo), SCode.NON_INITIAL(), true, InstTypes.neverUnroll);
         (cache,body,elabResult,resultInfo,resType) = elabResultExp(cache,env,body,result,impl,performVectorization,pre,resultInfo);
         (cache,dPatternGuard) = elabPatternGuard(cache,env,patternGuard,impl,performVectorization,pre,patternInfo);
         localsTree = AvlSetString.join(matchExpLocalTree, caseLocalTree);
@@ -2535,7 +2535,7 @@ algorithm
         // Transform the element list into a list of element,NOMOD
         ld_mod = InstUtil.addNomod(ld2);
 
-        dummyFunc = ClassInf.FUNCTION(Absyn.IDENT("dummieFunc"), false);
+        dummyFunc = ClassInf.FUNCTION(Absyn.IDENT("dummieFunc"), false, false);
         (cache,env2,_) = InstUtil.addComponentsToEnv(cache, env2,
           InnerOuter.emptyInstHierarchy, DAE.NOMOD(), Prefix.NOPRE(),
           dummyFunc, ld_mod, impl);

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -2878,6 +2878,13 @@ algorithm
   end match;
 end boolEncapsulated;
 
+public function getClassEncapsulation
+  input SCode.Element inElement;
+  output SCode.Encapsulated outEncapsulation;
+algorithm
+  SCode.CLASS(encapsulatedPrefix = outEncapsulation) := inElement;
+end getClassEncapsulation;
+
 public function partialBool
   input SCode.Partial inPartial;
   output Boolean bPartial;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
@@ -86,9 +86,9 @@ public
       case CONNECTOR() then ClassInf.State.CONNECTOR(path, res.isExpandable);
       case ENUMERATION() then ClassInf.State.ENUMERATION(path);
       case EXTERNAL_OBJECT() then ClassInf.State.EXTERNAL_OBJ(path);
-      case FUNCTION() then ClassInf.State.FUNCTION(path, false);
+      case FUNCTION() then ClassInf.State.FUNCTION(path, false, false);
       case MODEL() then ClassInf.State.MODEL(path);
-      case OPERATOR() then ClassInf.State.FUNCTION(path, false);
+      case OPERATOR() then ClassInf.State.FUNCTION(path, false, false);
       case RECORD() then ClassInf.State.RECORD(path);
       case TYPE() then ClassInf.State.TYPE(path);
       case CLOCK() then ClassInf.State.TYPE_CLOCK(path);

--- a/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
@@ -122,6 +122,12 @@ uniontype RecordDeclaration
     list<Variable> variables "only name and type";
   end RECORD_DECL_FULL;
 
+  record RECORD_DECL_ADD_CONSTRCTOR
+    String ctor_name "A unique name for the new constor. e.g. R_1_3() if it needs the 1st an 3rd members as inputs";
+    String name "The record's name";
+    list<Variable> variables "The members with the ones that need outisde binding marked. e.g 1st and 3rd elements will have bind_from_outside=true ";
+  end RECORD_DECL_ADD_CONSTRCTOR;
+
   record RECORD_DECL_DEF
     Absyn.Path path "definition path .. encoded?";
     list<String> fieldNames;

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -456,6 +456,8 @@ algorithm
       list<list<DAE.Type>> tyss;
     case (SimCodeFunction.RECORD_DECL_FULL(aliasName=SOME(name)),_)
       then List.select1(allDecls, isRecordDecl, name);
+    case (SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(name=name),_)
+      then List.select1(allDecls, isRecordDecl, name);
     case (SimCodeFunction.RECORD_DECL_FULL(variables=vars),_)
       equation
         tys = list(getVarType(v) for v in vars);
@@ -1545,37 +1547,44 @@ protected function elaborateRecordDeclarationsForRecord
 algorithm
   (outRecordDecls, outReturnTypes) := match (inRecordType, inAccRecordDecls, inReturnTypes)
     local
-      Absyn.Path path, name;
+      Absyn.Path path;
       list<DAE.Var> varlst;
-      String    sname;
-      list<String> rt, rt_1, rt_2, fieldNames;
+      String name,sname;
+      list<String> rt, rt_1, fieldNames;
       list<SimCodeFunction.RecordDeclaration> accRecDecls;
       list<SimCodeFunction.Variable> vars;
-      Integer index;
+      Integer varnum;
       SimCodeFunction.RecordDeclaration recDecl;
 
-    case (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(name), varLst = varlst), accRecDecls, rt)
-      equation
-        sname = AbsynUtil.pathStringUnquoteReplaceDot(name, "_");
-        if not listMember(sname, rt) then
-          /* Dont remove the bindings. We need them for creating a default constructor.
-            Not as in modelica defalut. But as in just declared without being initialized.
-            That case still needs to have default values since we no longer initialize
-            members for every instance everywhere. It is in one default constrctor function now.*/
-          // vars = List.map(varlst, typesVarNoBinding);
-          vars = List.map(varlst, typesVar);
-          /* Why do we sort the member?? They are sorted here in the declration while 
-            every type in every cref has the original ordering. They should keep their original ordering
-            */
-          // vars = List.sort(vars,compareVariable);
-          rt_1 = sname :: rt;
-          (accRecDecls, rt_2) = elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
-          recDecl = SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), name, vars);
-          accRecDecls = List.appendElt(recDecl, accRecDecls);
-        else
-          rt_2 = rt;
+    case (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path), varLst = varlst), accRecDecls, rt)
+      algorithm
+        name := AbsynUtil.pathStringUnquoteReplaceDot(path, "_");
+        rt_1 := rt;
+
+        if not listMember(name, rt_1) then
+          rt_1 := name :: rt_1;
+          vars := List.map(varlst, typesVar);
+          (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
+          recDecl := SimCodeFunction.RECORD_DECL_FULL(name, NONE(), path, vars);
+          accRecDecls := List.appendElt(recDecl, accRecDecls);
         end if;
-      then (accRecDecls, rt_2);
+
+        sname := name;
+        varnum := 1;
+        for var in varlst loop
+          if var.bind_from_outside then
+            sname := sname + "_" + intString(varnum);
+          end if;
+          varnum := intAdd(varnum,1);
+        end for;
+
+        if not listMember(sname, rt_1) then
+          rt_1 := sname :: rt_1;
+          vars := List.map(varlst, typesVar);
+          recDecl := SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(sname, name, vars);
+          accRecDecls := List.appendElt(recDecl, accRecDecls);
+        end if;
+      then (accRecDecls, rt_1);
 
     case (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(_)), accRecDecls, rt)
     then (accRecDecls, rt);
@@ -1590,11 +1599,11 @@ algorithm
           fieldNames = List.map(varlst, generateVarName);
           accRecDecls = SimCodeFunction.RECORD_DECL_DEF(path, fieldNames) :: accRecDecls;
           rt_1 = sname::rt;
-          (accRecDecls, rt_2) = elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
+          (accRecDecls, rt_1) = elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
         else
-          rt_2 = rt;
+          rt_1 = rt;
         end if;
-      then (accRecDecls, rt_2);
+      then (accRecDecls, rt_1);
 
     case (_, accRecDecls, rt)
     then (accRecDecls, rt);
@@ -2631,8 +2640,8 @@ algorithm
 end generateSubPalceholders;
 
 
-/* This functions are used to get/append cref prefixes in function contexts.The cref prefix is appended 
-  to all crefs generated. We use this to generate dependent names in some cases (for example when generating 
+/* This functions are used to get/append cref prefixes in function contexts.The cref prefix is appended
+  to all crefs generated. We use this to generate dependent names in some cases (for example when generating
   code for record constructors) so that every cref we generate while this is set has this prefix applied to it*/
 public function getCurrentCrefPrefix
   input SimCodeFunction.Context context;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -677,7 +677,7 @@ template recordVarAllocInit(Option<Exp> value, ComponentRef var_cref, Boolean bi
   let ctor_additional_inputs = match var_type
     case ty as DAE.T_COMPLEX() then
       (ty.varLst |> sv  hasindex i1 fromindex 1 =>
-            recordInitOutsideBindings(sv, i1, &ctor_suffix, &preExp, &varDecls, &auxFunction); empty /* increase the counter! */
+            recordInitOutsideBindings(sv, i1, &ctor_suffix, context, &preExp, &varDecls, &auxFunction); empty /* increase the counter! */
       )
     end match
 
@@ -707,12 +707,12 @@ template recordVarAllocInit(Option<Exp> value, ComponentRef var_cref, Boolean bi
 
 end recordVarAllocInit;
 
-template recordInitOutsideBindings(Var subvar, Integer ix, Text& ctor_suffix, Text &preExp, Text &varDecls, Text &auxFunction)
+template recordInitOutsideBindings(Var subvar, Integer ix, Text& ctor_suffix, Context context, Text &preExp, Text &varDecls, Text &auxFunction)
 ::=
 match subvar
   case TYPES_VAR(binding=EQBOUND(exp=exp), bind_from_outside = true) then
     let &ctor_suffix += "_"  + ix
-    ", " + daeExp(exp, contextFunction, &preExp, &varDecls, &auxFunction)
+    ", " + daeExp(exp, context, &preExp, &varDecls, &auxFunction)
   case TYPES_VAR(bind_from_outside = true) then
     error(sourceInfo(), 'Record has binding from outside but found a non EQBOUND binding. Implement me.')
 end match
@@ -2347,7 +2347,7 @@ case VARIABLE(ty = T_COMPLEX(complexClassType = RECORD(__), varLst = members)) t
   let typeName = varType(var)
 
   let ctor_additional_inputs = (ty.varLst |> sv  hasindex i1 fromindex 1 =>
-            recordInitOutsideBindings(sv, i1, &ctor_suffix, &preExp, &varDecls, &auxFunction); empty /* increase the counter! */
+            recordInitOutsideBindings(sv, i1, &ctor_suffix, contextFunction, &preExp, &varDecls, &auxFunction); empty /* increase the counter! */
                                 )
   <<
   <%preExp%>

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -881,6 +881,11 @@ package SimCodeFunction
       Absyn.Path defPath;
       list<Variable> variables;
     end RECORD_DECL_FULL;
+    record RECORD_DECL_ADD_CONSTRCTOR
+      String ctor_name;
+      String name;
+      list<Variable> variables;
+    end RECORD_DECL_ADD_CONSTRCTOR;
     record RECORD_DECL_DEF
       Absyn.Path path;
       list<String> fieldNames;


### PR DESCRIPTION
Fix handling of record variables with modifications on declaration in functions.

  - Fix the new Front-end to mark modification bindings.

  - We now create additional constructors for each unique modification use of a record.
    e.g. R r(a=1), r(b=2) will use two different constructors.
    We only create these constructors if they are actually needed.

  - There are some optimizations and cleanups that can be done.
    Will be fixed afterwards.