### PR TITLE
ticket:5666 Check component name against the list of keywords

### DIFF
--- a/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -354,8 +354,8 @@ bool GraphicsView::addComponent(QString className, QPointF position)
       // get the model defaultComponentName
       QString defaultName = pMainWindow->getOMCProxy()->getDefaultComponentName(pLibraryTreeItem->getNameStructure());
       QString name;
-      if (!defaultName.isEmpty() && checkComponentName(defaultName)) {
-        name = defaultName;
+      if (!defaultName.isEmpty()) {
+        name = getUniqueComponentName(StringHandler::toCamelCase(defaultName));
       } else {
         name = getUniqueComponentName(StringHandler::toCamelCase(pLibraryTreeItem->getName()));
       }
@@ -592,12 +592,20 @@ QString GraphicsView::getUniqueComponentName(QString componentName, int number)
 
 /*!
  * \brief GraphicsView::checkComponentName
+ * Checks the component name against the Modelica keywords as well.
  * Checks if the component with the same name already exists or not.
  * \param componentName
  * \return
  */
 bool GraphicsView::checkComponentName(QString componentName)
 {
+  // if component name is any keyword of Modelica
+  if (mpModelWidget->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::Modelica) {
+    if (ModelicaHighlighter::getKeywords().contains(componentName)) {
+      return false;
+    }
+  }
+  // if component with same name exists
   foreach (Component *pComponent, mComponentsList) {
     if (pComponent->getName().compare(componentName, Qt::CaseSensitive) == 0) {
       return false;

--- a/OMEdit/OMEdit/OMEditGUI/Util/Helper.cpp
+++ b/OMEdit/OMEdit/OMEditGUI/Util/Helper.cpp
@@ -717,7 +717,7 @@ QString GUIMessages::getMessage(int type)
     case CHECK_MESSAGES_BROWSER:
       return tr("Please check the Messages Browser for more error specific details.");
     case SAME_COMPONENT_NAME:
-      return tr("A component with the name <b>%1</b> already exists. Please choose another name.");
+      return tr("A component with the name <b>%1</b> already exists or is a Modelica keyword. Please choose another name.");
     case SAME_COMPONENT_CONNECT:
       return tr("You cannot connect a component to itself.");
     case NO_MODELICA_CLASS_OPEN:


### PR DESCRIPTION
Use the default component name, if there is any, to find a new unique name.