### PR TITLE
[NF] Fix variability of array() and reductions.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -979,7 +979,7 @@ protected
   protected
     Expression arg, range;
     Type iter_ty;
-    Variability iter_var;
+    Variability iter_var, exp_var;
     InstNode iter;
     list<Dimension> dims = {};
     list<tuple<InstNode, Expression>> iters = {};
@@ -1011,7 +1011,8 @@ protected
 
           // ExpOrigin.FOR is used here as a marker that this expression may contain iterators.
           next_origin := intBitOr(next_origin, ExpOrigin.FOR);
-          (arg, ty) := Typing.typeExp(call.exp, next_origin, info);
+          (arg, ty, exp_var) := Typing.typeExp(call.exp, next_origin, info);
+          variability := Variability.variabilityMax(variability, exp_var);
           ty := Type.liftArrayLeftList(ty, dims);
         then
           (TYPED_ARRAY_CONSTRUCTOR(ty, variability, arg, iters), ty, variability);
@@ -1034,7 +1035,7 @@ protected
     Expression range, arg;
     Option<Expression> default_exp, fold_exp;
     InstNode iter;
-    Variability iter_var;
+    Variability iter_var, exp_var;
     list<tuple<InstNode, Expression>> iters = {};
     ExpOrigin.Type next_origin;
     Function fn;
@@ -1058,7 +1059,8 @@ protected
 
           // ExpOrigin.FOR is used here as a marker that this expression may contain iterators.
           next_origin := intBitOr(next_origin, ExpOrigin.FOR);
-          (arg, ty) := Typing.typeExp(call.exp, next_origin, info);
+          (arg, ty, exp_var) := Typing.typeExp(call.exp, next_origin, info);
+          variability := Variability.variabilityMax(variability, exp_var);
           {fn} := Function.typeRefCache(call.ref);
           TypeCheck.checkReductionType(ty, Function.name(fn), call.exp, info);
 

--- a/testsuite/flattening/modelica/scodeinst/ArrayConstructorComplex1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConstructorComplex1.mo
@@ -1,0 +1,32 @@
+// name: ArrayConstructorComplex1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+operator record Complex  "Complex number with overloaded operators"
+  replaceable Real re "Real part of complex number";
+  replaceable Real im "Imaginary part of complex number";
+end Complex;
+
+model ArrayConstructorComplex1
+  Complex[3] u;
+  Complex[3] uInternal = {if false then u[k] else u[k] for k in 1:3};
+end ArrayConstructorComplex1;
+
+// Result:
+// class ArrayConstructorComplex1
+//   Real u[1].re "Real part of complex number";
+//   Real u[1].im "Imaginary part of complex number";
+//   Real u[2].re "Real part of complex number";
+//   Real u[2].im "Imaginary part of complex number";
+//   Real u[3].re "Real part of complex number";
+//   Real u[3].im "Imaginary part of complex number";
+//   Real uInternal[1].re = u[1].re "Real part of complex number";
+//   Real uInternal[1].im = u[1].im "Imaginary part of complex number";
+//   Real uInternal[2].re = u[2].re "Real part of complex number";
+//   Real uInternal[2].im = u[2].im "Imaginary part of complex number";
+//   Real uInternal[3].re = u[3].re "Real part of complex number";
+//   Real uInternal[3].im = u[3].im "Imaginary part of complex number";
+// end ArrayConstructorComplex1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -9,6 +9,7 @@ ActualStreamVariability1.mo \
 Algorithm1.mo \
 Algorithm2.mo \
 Algorithm3.mo \
+ArrayConstructorComplex1.mo \
 arrfunc.mo \
 Assert1.mo \
 Assert2.mo \


### PR DESCRIPTION
- Take the variability of the argument expression in array constructors
  and reductions into account when determining the overall variability,
  and not only the variability of the range expressions.