### PR TITLE
[BE] analytical to structural singularity conv

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -73,12 +73,13 @@ uniontype EqSystem "An independent system of equations (and their corresponding 
   record EQSYSTEM
     Variables orderedVars                   "ordered Variables, only states and alg. vars";
     EquationArray orderedEqs                "ordered Equations";
-    Option<IncidenceMatrix> m;
-    Option<IncidenceMatrixT> mT;
+    Option<AdjacencyMatrix> m;
+    Option<AdjacencyMatrixT> mT;
+    Option<AdjacencyMatrixMapping> mapping  "current type of adjacency matrix, boolean is true if scalar";
     Matching matching;
-    StateSets stateSets                    "the state sets of the system";
+    StateSets stateSets                     "the state sets of the system";
     BaseClockPartitionKind partitionKind;
-    EquationArray removedEqs               "these are equations that cannot solve for a variable.
+    EquationArray removedEqs                "these are equations that cannot solve for a variable.
                                             e.g. assertions, external function calls, algorithm sections without effect";
   end EQSYSTEM;
 end EqSystem;
@@ -684,6 +685,14 @@ public
 type AdjacencyMatrix = IncidenceMatrix;
 type AdjacencyMatrixT = IncidenceMatrixT;
 
+type AdjacencyMatrixMapping = tuple<array<list<Integer>>, array<Integer>, IndexType, Boolean, Boolean>
+"a mapping for adjacency matrices that contains:
+ array<list<Integer>>: array index -> scalar index list
+ array<Integer>      : scalar index -> array index (not unique)
+ IndexType           : the occurence condition type for the current adjacency matrix
+ Boolean             : true if scalar
+ Boolean             : true if analytical to structural singularity processing has already been done";
+
 public
 type AdjacencyMatrixElementEnhancedEntry = tuple<Integer,Solvability,Constraints>;
 type AdjacencyMatrixElementEnhanced = list<AdjacencyMatrixElementEnhancedEntry>;
@@ -803,6 +812,13 @@ constant SparsePattern emptySparsePattern = ({},{},({},{}),0);
 public
 type SparseColoring = list<list< .DAE.ComponentRef>>;   // colouring
 
+/*
+  Type only for transformation from analytical to structural singularity.
+*/
+type LinearIntegerJacobianRow = array<Integer>;                       // Actual jacobian entries
+type LinearIntegerJacobianRhs = array<.DAE.Exp>;                      // RHS-Exp for full pivot algorithm. Replacement for eliminated equation.
+type LinearIntegerJacobianIndices = array<tuple<Integer, Integer>>;   // Index tuple (array, scalar) for equations
+type LinearIntegerJacobian = tuple<array<LinearIntegerJacobianRow>, LinearIntegerJacobianRhs, LinearIntegerJacobianIndices>;
 
 public
 uniontype DifferentiateInputData

--- a/OMCompiler/Compiler/BackEnd/BackendDAETransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAETransform.mo
@@ -100,7 +100,7 @@ algorithm
       ass1 := varAssignmentNonScalar(ass1, mapIncRowEqn);
 
       // Frenkel TUD: Do not hand over the scalar incidence Matrix because following modules does not check if scalar or not
-      syst := BackendDAE.EQSYSTEM(syst.orderedVars, syst.orderedEqs, NONE(), NONE(), BackendDAE.MATCHING(ass1, ass2, comps), syst.stateSets, syst.partitionKind, syst.removedEqs);
+      syst := BackendDAE.EQSYSTEM(syst.orderedVars, syst.orderedEqs, NONE(), NONE(), NONE(), BackendDAE.MATCHING(ass1, ass2, comps), syst.stateSets, syst.partitionKind, syst.removedEqs);
     then (syst, comps);
 
     else algorithm

--- a/OMCompiler/Compiler/BackEnd/BackendEquation.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendEquation.mo
@@ -3210,6 +3210,31 @@ algorithm
   end match;
 end allAlgorithmsLst;
 
+public function createResidualExp
+  input BackendDAE.Equation eqn;
+  output DAE.Exp res;
+algorithm
+  res := match eqn
+    local
+      DAE.Exp e1, e2;
+      DAE.ComponentRef cr;
+    case BackendDAE.EQUATION(exp = e1, scalar = e2)
+      then Expression.createResidualExp(e1, e2);
+    case BackendDAE.ARRAY_EQUATION(left = e1, right = e2)
+      then Expression.createResidualExp(e1, e2);
+    case BackendDAE.SOLVED_EQUATION(componentRef = cr, exp = e2)
+      then Expression.createResidualExp(DAE.CREF(cr, ComponentReference.crefTypeFull(cr)), e2);
+    case BackendDAE.RESIDUAL_EQUATION(exp = e1)
+      then e1;
+    case BackendDAE.COMPLEX_EQUATION(left = e1, right = e2)
+      then Expression.createResidualExp(e1, e2);
+    /*
+      Need FOR_EXPRESSION for this?
+    case BackendDAE.FOR_EQUATION()
+    */
+    else fail();
+  end match;
+end createResidualExp;
 
 annotation(__OpenModelica_Interface="backend");
 end BackendEquation;

--- a/OMCompiler/Compiler/BackEnd/Causalize.mo
+++ b/OMCompiler/Compiler/BackEnd/Causalize.mo
@@ -146,14 +146,18 @@ protected
   array<Integer> ass1,ass2;
   BackendDAEFunc.matchingAlgorithmFunc matchingFunc;
   BackendDAE.EqSystem syst;
+  array<list<Integer>> mapEqnIncRow;
+  array<Integer> mapIncRowEqn;
+  BackendDAE.IndexType indexType;
+  Boolean scalar, processed;
 algorithm
-  BackendDAE.EQSYSTEM(m=SOME(m), mT=SOME(mT)) := iSyst;
+  BackendDAE.EQSYSTEM(m=SOME(m), mT=SOME(mT), mapping=SOME((mapEqnIncRow, mapIncRowEqn, indexType, scalar, processed))) := iSyst;
   (matchingFunc,_) :=  matchingAlgorithm;
   // get absolute Incidence Matrix
   m := AdjacencyMatrix.absAdjacencyMatrix(m);
   mT := AdjacencyMatrix.absAdjacencyMatrix(mT);
   // try to match
-  syst := BackendDAEUtil.setEqSystMatrices(iSyst, SOME(m), SOME(mT));
+  syst := BackendDAEUtil.setEqSystMatrices(iSyst, SOME(m), SOME(mT), SOME((mapEqnIncRow, mapIncRowEqn, BackendDAE.ABSOLUTE(), scalar, processed)));
   syst.matching := BackendDAE.NO_MATCHING();
   // do matching
   (syst as BackendDAE.EQSYSTEM(matching=BackendDAE.MATCHING(ass1=ass1, ass2=ass2)), _, _) :=

--- a/OMCompiler/Compiler/BackEnd/IndexReduction.mo
+++ b/OMCompiler/Compiler/BackEnd/IndexReduction.mo
@@ -449,7 +449,7 @@ algorithm
 
     case (false, _::_, (_, _, _, mapIncRowEqn, _)) equation
       if Flags.isSet(Flags.BLT_DUMP) then
-        print("Reduce Index failed! System is structurally singulare and cannot handled because number of unassigned continuous equations is larger than number of states.\nmarked equations:\n");
+        print("Reduce Index failed! System is structurally singulare and cannot be handled because number of unassigned continuous equations is larger than number of states.\nmarked equations:\n");
         // get from scalar eqns indexes the indexes in the equation array
         BackendDump.debuglst(eqns, intString, " ", "\n");
       end if;
@@ -457,7 +457,7 @@ algorithm
       eqns1 = List.uniqueIntN(eqns1, arrayLength(mapIncRowEqn));
       if Flags.isSet(Flags.BLT_DUMP) then
         print(BackendDump.dumpMarkedEqns(inSystem, eqns1));
-        print("unassgined states:\n");
+        print("\n\nunassgined states:\n");
       end if;
       varlst = List.map1r(unassignedStates, BackendVariable.getVarAt, BackendVariable.daeVars(inSystem));
       if Flags.isSet(Flags.BLT_DUMP) then

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4118,5 +4118,228 @@ algorithm
 end fixedVarsFromNonlinearCount;
 
 
+// =============================================================================
+// section for analytical to symbolical singularity transformation
+//
+// Generates linear integer jacobian
+// =============================================================================
+
+public function generateLinearIntegerJacobian
+  "author: kabdelhak FHB 10-2019
+   Generates a jacobian from algebraic loops which are linear and have integer coefficents
+   w.r.t. all loopVars. Fails if these criteria are not met."
+  input list<tuple<BackendDAE.Equation, tuple<Integer, Integer>>> loopEqs;
+  input list<BackendDAE.Var> loopVars;
+  output BackendDAE.LinearIntegerJacobian linIntJac;
+protected
+  Integer eqn_index = 1, var_index = 1;
+  array<BackendDAE.LinearIntegerJacobianRow> rowArr;
+  BackendDAE.LinearIntegerJacobianRhs rhsArr;
+  BackendDAE.LinearIntegerJacobianIndices idxArr;
+  list<Integer> tmp_row;
+  list<array<Integer>> tmp_mat = {};
+  list<DAE.Exp> tmp_rhs = {};
+  list<tuple<Integer, Integer>> tmp_idx = {};
+  BackendDAE.Equation eqn;
+  tuple<Integer, Integer> index;
+  DAE.Exp res, pDer;
+  BackendVarTransform.VariableReplacements varRep;
+algorithm
+  /* Add a replacement rule var->0 for each loopVar, so that the RHS can be determined afterwards */
+  varRep := BackendVarTransform.emptyReplacements();
+  for loopVar in loopVars loop
+    varRep := BackendVarTransform.addReplacement(varRep, BackendVariable.varCref(loopVar), DAE.ICONST(0), NONE());
+  end for;
+
+  /* Loop over all equations and create residual expression. */
+  for loopEq in loopEqs loop
+    var_index := 1;
+    tmp_row := {};
+    (eqn, index) := loopEq;
+    res := BackendEquation.createResidualExp(eqn);
+    /* Loop over all variables and differentiate residual expression for each. */
+    try
+      for loopVar in loopVars loop
+        pDer := Differentiate.differentiateExpSolve(res, BackendVariable.varCref(loopVar), NONE());
+        (pDer, _) := ExpressionSimplify.simplify(pDer);
+        tmp_row := Expression.getEvaluatedConstInteger(pDer) :: tmp_row;
+      end for;
+      /*
+        Save the full row.
+          - row entries
+          - rhs
+          - equation index
+        Perform var replacements, multiply by -1 and simplify for rhs.
+        NOTE: Multiplication with -1 is not really necessary for the
+              conversion of analytical to structural singularity, but
+              would be necessary if used for anything else.
+      */
+      tmp_mat := listArray(tmp_row) :: tmp_mat;
+      res := BackendVarTransform.replaceExp(res, varRep, NONE());
+      tmp_rhs := ExpressionSimplify.simplify(DAE.BINARY(DAE.ICONST(-1), DAE.MUL(DAE.T_UNKNOWN_DEFAULT), res)) :: tmp_rhs;
+      tmp_idx := index :: tmp_idx;
+      eqn_index := eqn_index + 1;
+    else
+      /*
+        Differentiation not possible or not convertible to an integer.
+        Purposely fails.
+      */
+    end try;
+  end for;
+  /* convert and store all data */
+  rowArr := listArray(tmp_mat);
+  rhsArr := listArray(tmp_rhs);
+  idxArr := listArray(tmp_idx);
+  linIntJac := (rowArr, rhsArr, idxArr);
+end generateLinearIntegerJacobian;
+
+public function emptyOrSingleLinearIntegerJacobian
+  "author: kabdelhak FHB 10-2019
+   Returns true if the linear integerjacobian is empty or has only one single row."
+  input BackendDAE.LinearIntegerJacobian linIntJac;
+  output Boolean empty;
+protected
+  array<BackendDAE.LinearIntegerJacobianRow> rowArr;
+  BackendDAE.LinearIntegerJacobianRhs rhsArr;
+  BackendDAE.LinearIntegerJacobianIndices idxArr;
+algorithm
+  (rowArr, rhsArr, idxArr) := linIntJac;
+  empty := (arrayLength(rowArr) < 2) and (arrayLength(rhsArr) < 2) and (arrayLength(idxArr) < 2);
+end emptyOrSingleLinearIntegerJacobian;
+
+public function solveLinearIntegerJacobian
+  "author: kabdelhak FHB 10-2019
+   Performs a gaussian elimination algorithm on the jacobian without reducing the
+   pivot elements to one to maintain the integer structure. This guarantees that
+   no numerical errors can occur and analytical singularities will be detected.
+   Also keeps track of the RHS for later equation replacement."
+  input output BackendDAE.LinearIntegerJacobian linIntJac;
+protected
+  array<BackendDAE.LinearIntegerJacobianRow> rowArr;
+  BackendDAE.LinearIntegerJacobianRhs rhsArr;
+  BackendDAE.LinearIntegerJacobianIndices idxArr;
+  array<Boolean> col_marks;
+  BackendDAE.LinearIntegerJacobianRow pivotRow, row;
+algorithm
+  (rowArr, rhsArr, idxArr) := linIntJac;
+  /*
+    create column mark vector to track in which column a pivot
+    element has already been chosen.
+  */
+  col_marks := arrayCreate(arrayLength(rhsArr), false);
+  /*
+    Gaussian Algorithm without rearrangeing rows
+    and without reducing pivot elemts to one.
+  */
+  for i in 1:arrayLength(rowArr) loop
+    pivotRow := rowArr[i];
+    for m in 1:arrayLength(col_marks) loop
+      if not col_marks[m] and pivotRow[m] <> 0 then
+        (rowArr, rhsArr) := solveLinearIntegerJacobianRow(rowArr, rhsArr, i, m);
+        col_marks[m] := true;
+        break;
+      end if;
+    end for;
+  end for;
+  linIntJac := (rowArr, rhsArr, idxArr);
+end solveLinearIntegerJacobian;
+
+protected function solveLinearIntegerJacobianRow
+"author: kabdelhak FHB 10-2019
+ Performs gaussian elimination for one pivot row and all following rows to reduce.
+ new_row = old_row * pivot_element - pivot_row * row_element
+ Example:
+   pivot idx: 2, because the first is zero
+   pivot row:     |  0 -1 -4 |
+   row-to change: | -3  2  3 |
+   new_row:       |  3  0  5 |"
+  input output array<BackendDAE.LinearIntegerJacobianRow> rowArr;
+  input output BackendDAE.LinearIntegerJacobianRhs rhsArr;
+  input Integer pivIdx;
+  input Integer col;
+protected
+  BackendDAE.LinearIntegerJacobianRow pivot_row, row;
+  array<Integer> row_arr, piv_arr;
+  Integer row_elem, piv_elem;
+algorithm
+  pivot_row := rowArr[pivIdx];
+  piv_elem := pivot_row[col];
+  for j in pivIdx+1:arrayLength(rowArr) loop
+    row := rowArr[j];
+    row_elem := row[col];
+    if row_elem <> 0 then
+      for i in 1:arrayLength(row) loop
+        row[i] := row[i] * piv_elem - pivot_row[i] * row_elem;
+      end for;
+
+      //perform multiplication inside? use simplification of multiplication afterwards?
+      rhsArr[j] := DAE.BINARY(
+                     DAE.BINARY(rhsArr[j], DAE.MUL(DAE.T_INTEGER_DEFAULT), DAE.ICONST(piv_elem)),       // row_rhs * piv_elem
+                     DAE.SUB(DAE.T_INTEGER_DEFAULT),                                                    // -
+                     DAE.BINARY(rhsArr[pivIdx], DAE.MUL(DAE.T_INTEGER_DEFAULT), DAE.ICONST(row_elem))   // piv_rhs * row_elem
+                   );
+    // Is it better to simplify once at the end or every time? Is traverser needed?
+    //rhsArr[j] := Expression.traverseExpBottomUp(rhsArr[j], ExpressionSimplify.simplifyTraverseHelper, "");
+    rhsArr[j] := ExpressionSimplify.simplify(rhsArr[j]);
+    end if;
+  end for;
+end solveLinearIntegerJacobianRow;
+
+public function resolveAnalyticalSingularities
+"author: kabdelhak FHB 10-2019
+ Resolves analytical singularities by replacing the equations with
+ zero rows in the jacobian with new equations. Needs preceeding
+ solving of the linear integer jacobian."
+  input BackendDAE.LinearIntegerJacobian linIntJac;
+  input output array<Integer> ass1;
+  input output array<Integer> ass2;
+  input output BackendDAE.EqSystem syst;
+protected
+  array<BackendDAE.LinearIntegerJacobianRow> rowArr;
+  BackendDAE.LinearIntegerJacobianRhs rhsArr;
+  BackendDAE.LinearIntegerJacobianIndices idxArr;
+  BackendDAE.LinearIntegerJacobianRow row;
+  Boolean fullZero;
+  Integer i_arr, i_scal;
+  DAE.Exp zeroExp;
+  BackendDAE.Equation newEqn;
+  list<Integer> updateList = {};
+algorithm
+  (rowArr, rhsArr, idxArr) := linIntJac;
+  for r in 1:arrayLength(rowArr) loop
+    row := rowArr[r];
+    /* check if row is full zero */
+    fullZero := true;
+    for i in 1:arrayLength(row) loop
+      if row[i] <> 0 then
+        fullZero := false;
+        break;
+      end if;
+    end for;
+
+    if fullZero then
+      (i_arr, i_scal) := idxArr[r];
+      /* remove assignments */
+      ass2[ass1[i_arr]] := -1;
+      ass1[i_arr] := -1;
+      /* replace equation */
+      zeroExp := DAE.RCONST(0);//Expression.makeZeroExpression({DAE.DIM_INTEGER(BackendEquation.equationSize(BackendEquation.get(syst.orderedEqs, i_scal)))});
+      newEqn := BackendEquation.generateEquation(rhsArr[r], zeroExp);
+      /* dump replacements */
+      if Flags.isSet(Flags.CONVERT_ANALYTICAL_DUMP) or Flags.isSet(Flags.BLT_DUMP) then
+        print("Linear dependent equation: " + BackendDump.equationString(BackendEquation.get(syst.orderedEqs, i_scal)) + "\n");
+        print("Gets replaced by equation: " + BackendDump.equationString(newEqn) + "\n");
+      end if;
+      syst.orderedEqs := BackendEquation.setAtIndex(syst.orderedEqs, i_scal, newEqn);
+      updateList := i_arr :: updateList;
+    end if;
+    /* update adjacency matrix and transposed adjacency matrix */
+    syst := BackendDAEUtil.updateIncidenceMatrix(syst, BackendDAE.NORMAL(), NONE(), updateList);
+    if not listEmpty(updateList) and not Flags.isSet(Flags.CONVERT_ANALYTICAL_DUMP) and Flags.isSet(Flags.BLT_DUMP) then
+      print("--- For more information please use -d=dumpAnalyticalToStructural.---\n\n");
+    end if;
+  end for;
+end resolveAnalyticalSingularities;
+
 annotation(__OpenModelica_Interface="backend");
 end SymbolicJacobian;

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -7951,6 +7951,24 @@ algorithm
   outBoolean := isEvaluatedConstWork(inExp,true);
 end isEvaluatedConst;
 
+public function getEvaluatedConstInteger
+"Returns the constant integer value, fails for incorrect types."
+  input DAE.Exp inExp;
+  output Integer val;
+algorithm
+  val := match inExp
+    local
+      Integer integer;
+    case DAE.ICONST(integer = integer)
+      then integer;
+    case DAE.RCONST()
+      algorithm
+        SOME(integer) := realExpIntLit(inExp);
+      then integer;
+    else fail();
+  end match;
+end getEvaluatedConstInteger;
+
 protected function isEvaluatedConstWork
 "Returns true if an expression is really constant"
   input DAE.Exp inExp;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -551,6 +551,8 @@ constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG(187, "nfExpandFuncArgs", fal
   Util.gettext("Expand all function arguments in the new frontend."));
 constant DebugFlag DUMP_JL = DEBUG_FLAG(188, "dumpJL", false,
   Util.gettext("Dumps the absyn representation of a program as a Julia representation"));
+constant DebugFlag CONVERT_ANALYTICAL_DUMP = DEBUG_FLAG(189, "convertAnalyticalDump", false,
+  Util.gettext("Dumps the conversion process of analytical to structural singularities."));
 
 // This is a list of all debug flags, to keep track of which flags are used. A
 // flag can not be used unless it's in this list, and the list is checked at
@@ -745,7 +747,8 @@ constant list<DebugFlag> allDebugFlags = {
   FMI20_DEPENDENCIES,
   WARNING_MINMAX_ATTRIBUTES,
   NF_EXPAND_FUNC_ARGS,
-  DUMP_JL
+  DUMP_JL,
+  CONVERT_ANALYTICAL_DUMP
 };
 
 public
@@ -1504,6 +1507,10 @@ constant ConfigFlag LINEARIZATION_DUMP_LANGUAGE = CONFIG_FLAG(131, "linearizatio
   SOME(STRING_OPTION({"modelica","matlab","julia","python"})),
     Util.gettext("Sets the target language for the produced code of linearization. Only works with '--generateSymbolicLinearization' and 'linearize(modelName)'."));
 
+constant ConfigFlag CONVERT_ANALYTICAL_SINGULARITIES = CONFIG_FLAG(132, "convertAnalyticalSingularities",
+  NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
+  Util.gettext("Allows the compiler to try to convert analytical to structural singularities."));
+
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
 // in this list, and the list is checked at initialization so that all flags are
@@ -1639,7 +1646,8 @@ constant list<ConfigFlag> allConfigFlags = {
   SHOW_STRUCTURAL_ANNOTATIONS,
   INITIAL_STATE_SELECTION,
   STRICT,
-  LINEARIZATION_DUMP_LANGUAGE
+  LINEARIZATION_DUMP_LANGUAGE,
+  CONVERT_ANALYTICAL_SINGULARITIES
 };
 
 public function new

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -4596,6 +4596,20 @@ algorithm
   outTuples := listReverse(outTuples);
 end zip;
 
+public function zip2<T1, T2>
+  "Takes a lists and a single elem and returns a list of two-element tuples contaning the
+  elements in the same order. Fails if the lists are not of the same length.
+  Example: zip2(1, {2, 4, -1}) =>  {(1, 2), (1, 4), (1, -1)}"
+  input T1 inElem;
+  input list<T2> inList2;
+  output list<tuple<T1, T2>> outTuples = {};
+algorithm
+  for t2 in inList2 loop
+    outTuples := (inElem, t2)::outTuples;
+  end for;
+  outTuples := listReverse(outTuples);
+end zip2;
+
 public function unzip<T1, T2>
   "Takes a list of two-element tuples and splits the tuples into two separate
    lists. Example: unzip({(1, 2), (3, 4)}) => ({1, 3}, {2, 4})"


### PR DESCRIPTION
 - related to ticket #5452
 - implements experimental analytical to structural conversion algorithm, available with `--convertAnalyticalSingularities`
 - change `BackendDAE.EQSYSTEM()` by making new information about adjacency matrices available at all times:
   - array to scalar index-list mapping
   - scalar to array index mapping (not unique)
   - occurence rules (`indexType`)
   - `Boolean`: true if scalar
   - `Boolean`: true if analytical to structural singularity processing has already been done