### PR TITLE
fix ticket5670 FMU export with output Integer

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -12814,7 +12814,7 @@ protected
    BackendDAE.SparsePatternCrefs spTA, spTB;
    list<tuple<Integer, list<Integer>>> sparseInts;
    list<SimCode.FmiUnknown> allUnknowns, derivatives, outputs, discreteStates;
-   list<SimCodeVar.SimVar> varsA, varsB, clockedStates;
+   list<SimCodeVar.SimVar> varsA, varsB, varsC, varsD, clockedStates;
    list<DAE.ComponentRef> diffCrefsA, diffedCrefsA, derdiffCrefsA;
    list<DAE.ComponentRef> diffCrefsB, diffedCrefsB;
    DoubleEnded.MutableList<SimCodeVar.SimVar> delst;
@@ -12858,7 +12858,10 @@ algorithm
 
     // get output pattern
     varsA := List.filterOnTrue(inModelInfo.vars.algVars, isOutputSimVar);
-    intLst := list(getVariableIndex(v) for v in varsA);
+    varsB := List.filterOnTrue(inModelInfo.vars.intAlgVars, isOutputSimVar); // check for outputs in intAlgVar
+    varsC := List.filterOnTrue(inModelInfo.vars.boolAlgVars, isOutputSimVar); // check for outputs in boolAlgVar
+    varsD := List.filterOnTrue(inModelInfo.vars.stringAlgVars, isOutputSimVar); // check for outputs in stringAlgVars
+    intLst := list(getVariableIndex(v) for v in listAppend(listAppend(varsA,varsB),listAppend(varsC,varsD)));
     outputs := list(fmiUnknown for fmiUnknown guard(Util.boolOrList(list(isFmiUnknown(i, fmiUnknown) for i in intLst))) in allUnknowns);
 
     // get discrete states pattern

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -23,6 +23,7 @@ testDiscreteStructe.mos \
 testInitialEquationsFMI.mos \
 TestSourceCodeFMU.mos \
 ZeroStates.mos \
+ticket5670.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
@@ -1,0 +1,110 @@
+// name:  ticket5670
+// keywords: FMI 2.0 export
+// status: correct
+// teardown_command: rm -rf binaries sources modelDescription.xml modelDescription.tmp.xml Bug5670.xml
+
+loadString("
+model ticket5670
+  output Real y_float;
+  output Integer y_int;
+  output String y_string;
+  output Boolean y_bool;
+equation
+  y_int = 1;
+  y_float = 2.2;
+  y_string = \"test\";
+  y_bool = true;
+end ticket5670;
+");
+
+translateModel(ticket5670);
+getErrorString();
+
+// read only the modelVariables from xml
+system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" ticket5670_init.xml >Bug5670.xml"); getErrorString();
+readFile("Bug5670.xml"); getErrorString();
+
+translateModelFMU(ticket5670,version="2.0");
+getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq ticket5670.fmu modelDescription.xml > modelDescription.tmp.xml"); getErrorString();
+system("sed -n \"/<ModelStructure>/,/<\\/ModelStructure>/p\" modelDescription.tmp.xml > Bug5670.xml"); getErrorString();
+readFile("Bug5670.xml"); getErrorString();
+
+
+// Result:
+// true
+// true
+// ""
+// 0
+// ""
+// "  <ModelVariables>
+//
+//   <ScalarVariable
+//     name = \"y_float\"
+//     valueReference = \"1000\"
+//     variability = \"continuous\" isDiscrete = \"false\"
+//     causality = \"output\" isValueChangeable = \"false\"
+//     alias = \"noAlias\"
+//     classIndex = \"0\" classType = \"rAlg\"
+//     isProtected = \"false\" hideResult = \"false\"
+//     fileName = \"&lt;interactive&gt;\" startLine = \"3\" startColumn = \"3\" endLine = \"3\" endColumn = \"22\" fileWritable = \"true\">
+//     <Real start=\"2.2\" fixed=\"false\" useNominal=\"false\" />
+//   </ScalarVariable>
+//   <ScalarVariable
+//     name = \"y_int\"
+//     valueReference = \"1001\"
+//     variability = \"discrete\" isDiscrete = \"true\"
+//     causality = \"output\" isValueChangeable = \"false\"
+//     alias = \"noAlias\"
+//     classIndex = \"0\" classType = \"iAlg\"
+//     isProtected = \"false\" hideResult = \"false\"
+//     fileName = \"&lt;interactive&gt;\" startLine = \"4\" startColumn = \"3\" endLine = \"4\" endColumn = \"23\" fileWritable = \"true\">
+//     <Integer start=\"1\" fixed=\"false\" />
+//   </ScalarVariable>
+//   <ScalarVariable
+//     name = \"y_bool\"
+//     valueReference = \"1002\"
+//     variability = \"discrete\" isDiscrete = \"true\"
+//     causality = \"output\" isValueChangeable = \"false\"
+//     alias = \"noAlias\"
+//     classIndex = \"0\" classType = \"bAlg\"
+//     isProtected = \"false\" hideResult = \"false\"
+//     fileName = \"&lt;interactive&gt;\" startLine = \"6\" startColumn = \"3\" endLine = \"6\" endColumn = \"24\" fileWritable = \"true\">
+//     <Boolean start=\"true\" fixed=\"false\" />
+//   </ScalarVariable>
+//   <ScalarVariable
+//     name = \"y_string\"
+//     valueReference = \"1003\"
+//     variability = \"continuous\" isDiscrete = \"false\"
+//     causality = \"output\" isValueChangeable = \"false\"
+//     alias = \"noAlias\"
+//     classIndex = \"0\" classType = \"sAlg\"
+//     isProtected = \"false\" hideResult = \"false\"
+//     fileName = \"&lt;interactive&gt;\" startLine = \"5\" startColumn = \"3\" endLine = \"5\" endColumn = \"25\" fileWritable = \"true\">
+//     <String start=\"test\" fixed=\"false\" />
+//   </ScalarVariable>
+//
+//
+//
+//   </ModelVariables>
+// "
+// ""
+// "ticket5670.fmu"
+// ""
+// 0
+// ""
+// 0
+// ""
+// "  <ModelStructure>
+//     <Outputs>
+//       <Unknown index=\"2\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"6\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"8\" dependencies=\"\" dependenciesKind=\"\" />
+//     </Outputs>
+//   </ModelStructure>
+// "
+// ""
+// endResult


### PR DESCRIPTION
### Purpose
This fixes the fmu export in ModelStructure when output is of Integer, String or Boolean type.
see https://trac.openmodelica.org/OpenModelica/ticket/5670

Changed Files:
SimcodeUtil.mo :  In Function "createFMIModelStructure" Check for intAlgVars, StringAlgVars and BoolALgVars causality is output and add it to FMI export ModelStructure