### PR TITLE
[BE] update ASSC

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -817,8 +817,14 @@ type SparseColoring = list<list< .DAE.ComponentRef>>;   // colouring
 */
 type LinearIntegerJacobianRow = list<tuple<Integer, Integer>>;        // Actual jacobian entries sparse, <column, value>
 type LinearIntegerJacobianRhs = array<.DAE.Exp>;                      // RHS-Exp for full pivot algorithm. Replacement for eliminated equation.
-type LinearIntegerJacobianIndices = array<tuple<Integer, Integer>>;   // Index tuple (array, scalar) for equations
-type LinearIntegerJacobian = tuple<array<LinearIntegerJacobianRow>, LinearIntegerJacobianRhs, LinearIntegerJacobianIndices>;
+type LinearIntegerJacobianIndices = array<tuple<Integer, Integer>>;   // Index tuple <array, scalar> for equations
+
+/*
+  The full linear integer matrix
+  - additional boolean array to track which rows have been changed
+  - additional boolean array to track which variables are matched to the equations
+*/
+type LinearIntegerJacobian = tuple<array<LinearIntegerJacobianRow>, LinearIntegerJacobianRhs, LinearIntegerJacobianIndices, array<Boolean>, array<Boolean>>;
 
 public
 uniontype DifferentiateInputData

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -2465,16 +2465,16 @@ protected
   Integer i_arr, i_scal, index, value;
 algorithm
   (i_arr, i_scal) := indices;
-  print("(" + intString(i_arr) + "|" + intString(i_scal) + "|" + boolString(changed) +"):\t");
+  print("(" + intString(i_arr) + "|" + intString(i_scal) + "|" + boolString(changed) +"):    ");
   if listLength(linIntJacRow) < 1 then
-    print("EMPTY ROW \t");
+    print("EMPTY ROW     ");
   else
     for element in linIntJacRow loop
       (index, value) := element;
       print("[" + intString(index) + "|" + intString(value) + "] ");
     end for;
   end if;
-  print("\t|| RHS: " + ExpressionDump.printExpStr(rhs) + " \n");
+  print("    || RHS: " + ExpressionDump.printExpStr(rhs) + "\n");
 end dumpLinearIntegerJacobianSparseRow;
 
 public function dumpEqnsStr

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -2443,26 +2443,29 @@ protected
   array<BackendDAE.LinearIntegerJacobianRow> rowArr;
   BackendDAE.LinearIntegerJacobianRhs rhsArr;
   BackendDAE.LinearIntegerJacobianIndices idxArr;
+  array<Boolean> boolArr, matchedVarsArr;
 algorithm
-  (rowArr, rhsArr, idxArr) := linIntJac;
+  (rowArr, rhsArr, idxArr, boolArr, matchedVarsArr) := linIntJac;
   print("######################################################\n" +
         " LinearIntegerJacobian sparsity pattern: " + heading + "\n" +
-        "######################################################\n\n" +
-        "(scalar_index|array_index) [var_index, value] || RHS_EXPRESSION\n");
+        "######################################################\n" +
+        "(scal_idx|arr_idx|changed) [var_index, value] || RHS_EXPRESSION\n");
   for idx in 1:arrayLength(rowArr) loop
-    dumpLinearIntegerJacobianSparseRow(rowArr[idx], rhsArr[idx], idxArr[idx]);
+    dumpLinearIntegerJacobianSparseRow(rowArr[idx], rhsArr[idx], idxArr[idx], boolArr[idx]);
   end for;
+  print("\n");
 end dumpLinearIntegerJacobianSparse;
 
 protected function dumpLinearIntegerJacobianSparseRow
   input BackendDAE.LinearIntegerJacobianRow linIntJacRow;
   input DAE.Exp rhs;
   input tuple<Integer, Integer> indices;
+  input Boolean changed;
 protected
   Integer i_arr, i_scal, index, value;
 algorithm
   (i_arr, i_scal) := indices;
-  print("(" + intString(i_arr) + "|" + intString(i_scal) + "):\t");
+  print("(" + intString(i_arr) + "|" + intString(i_scal) + "|" + boolString(changed) +"):\t");
   if listLength(linIntJacRow) < 1 then
     print("EMPTY ROW \t");
   else

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4415,7 +4415,7 @@ algorithm
       for now also only resolve singularities and not replace full loop
       otherwise it sometimes leads to mixed determined systems
     */
-    if boolArr[r] and listEmpty(rowArr[r]) then
+    if boolArr[r] and (listEmpty(rowArr[r]) or Flags.getConfigBool(Flags.FULL_ASSC)) then
       (i_arr, i_scal) := idxArr[r];
       /* remove assignments */
       ass2[ass1[i_scal]] := -1;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1514,6 +1514,10 @@ constant ConfigFlag NO_ASSC = CONFIG_FLAG(132, "noASSC",
   NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
   Util.gettext("Disables analytical to structural singularity conversion."));
 
+constant ConfigFlag FULL_ASSC = CONFIG_FLAG(133, "fullASSC",
+  NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
+  Util.gettext("Disables analytical to structural singularity conversion."));
+
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
 // in this list, and the list is checked at initialization so that all flags are
@@ -1650,7 +1654,8 @@ constant list<ConfigFlag> allConfigFlags = {
   INITIAL_STATE_SELECTION,
   STRICT,
   LINEARIZATION_DUMP_LANGUAGE,
-  NO_ASSC
+  NO_ASSC,
+  FULL_ASSC
 };
 
 public function new

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -551,7 +551,7 @@ constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG(187, "nfExpandFuncArgs", fal
   Util.gettext("Expand all function arguments in the new frontend."));
 constant DebugFlag DUMP_JL = DEBUG_FLAG(188, "dumpJL", false,
   Util.gettext("Dumps the absyn representation of a program as a Julia representation"));
-constant DebugFlag CONVERT_ANALYTICAL_DUMP = DEBUG_FLAG(189, "convertAnalyticalDump", false,
+constant DebugFlag DUMP_ASSC = DEBUG_FLAG(189, "dumpASSC", false,
   Util.gettext("Dumps the conversion process of analytical to structural singularities."));
 constant DebugFlag SPLIT_CONSTANT_PARTS_SYMJAC = DEBUG_FLAG(190, "symJacConstantSplit", false,
   Util.gettext("Generates all symbolic Jacobians with splitted constant parts."));
@@ -750,7 +750,7 @@ constant list<DebugFlag> allDebugFlags = {
   WARNING_MINMAX_ATTRIBUTES,
   NF_EXPAND_FUNC_ARGS,
   DUMP_JL,
-  CONVERT_ANALYTICAL_DUMP,
+  DUMP_ASSC,
   SPLIT_CONSTANT_PARTS_SYMJAC
 };
 
@@ -818,7 +818,7 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     "removeEqualRHS",
     "removeSimpleEquations",
     "comSubExp",
-    "resolveLoops",
+    //"resolveLoops",
     "evalFunc",
     "encapsulateWhenConditions"
     }),
@@ -1510,9 +1510,9 @@ constant ConfigFlag LINEARIZATION_DUMP_LANGUAGE = CONFIG_FLAG(131, "linearizatio
   SOME(STRING_OPTION({"modelica","matlab","julia","python"})),
     Util.gettext("Sets the target language for the produced code of linearization. Only works with '--generateSymbolicLinearization' and 'linearize(modelName)'."));
 
-constant ConfigFlag CONVERT_ANALYTICAL_SINGULARITIES = CONFIG_FLAG(132, "convertAnalyticalSingularities",
+constant ConfigFlag NO_ASSC = CONFIG_FLAG(132, "noASSC",
   NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
-  Util.gettext("Allows the compiler to try to convert analytical to structural singularities."));
+  Util.gettext("Disables analytical to structural singularity conversion."));
 
 protected
 // This is a list of all configuration flags. A flag can not be used unless it's
@@ -1650,7 +1650,7 @@ constant list<ConfigFlag> allConfigFlags = {
   INITIAL_STATE_SELECTION,
   STRICT,
   LINEARIZATION_DUMP_LANGUAGE,
-  CONVERT_ANALYTICAL_SINGULARITIES
+  NO_ASSC
 };
 
 public function new

--- a/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
@@ -45,7 +45,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.initime:DISCRETE(unit = "s" )  type: Real 
+// 1: system.initime:DISCRETE(unit = "s" )  type: Real
 //
 //
 // Equations (1, 1)
@@ -63,7 +63,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: busBar1.phi:VARIABLE(unit = "rad" )  type: Real 
+// 1: busBar1.phi:VARIABLE(unit = "rad" )  type: Real
 //
 //
 // Equations (1, 1)
@@ -79,7 +79,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: busBar1.I:VARIABLE(unit = "A" nominal = 1.0 )  type: Real 
+// 1: busBar1.I:VARIABLE(unit = "A" nominal = 1.0 )  type: Real
 //
 //
 // Equations (1, 1)
@@ -95,7 +95,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: busBar1.V:VARIABLE(unit = "V" nominal = 1000.0 )  type: Real 
+// 1: busBar1.V:VARIABLE(unit = "V" nominal = 1000.0 )  type: Real
 //
 //
 // Equations (1, 1)
@@ -111,11 +111,11 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (5)
 // ========================================
-// 1: system.omega_internal:VARIABLE(flow=false protected = true )  type: Real 
-// 2: system.omega:VARIABLE(start = 314.1592653589793 unit = "rad/s" )  type: Real 
-// 3: system.thetaRef:VARIABLE(unit = "rad" )  "angle of reference frame" type: Real 
-// 4: system.thetaRel:VARIABLE(unit = "rad" )  "angle relative to reference frame" type: Real 
-// 5: system.theta:VARIABLE(start = 0.0 unit = "rad" )  "system angle" type: Real 
+// 1: system.omega_internal:VARIABLE(flow=false protected = true )  type: Real
+// 2: system.omega:VARIABLE(start = 314.1592653589793 unit = "rad/s" )  type: Real
+// 3: system.thetaRef:VARIABLE(unit = "rad" )  "angle of reference frame" type: Real
+// 4: system.thetaRel:VARIABLE(unit = "rad" )  "angle relative to reference frame" type: Real
+// 5: system.theta:VARIABLE(start = 0.0 unit = "rad" )  "system angle" type: Real
 //
 //
 // Equations (5, 5)
@@ -123,7 +123,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 1/1 (1): system.thetaRef / time = system.omega_internal   [dynamic |0|0|0|0|]
 // 2/2 (1): system.omega = 314.1592653589793   [dynamic |0|0|0|0|]
 // 3/3 (1): system.thetaRef = system.omega * time   [dynamic |0|0|0|0|]
-// 4/4 (1): 0.0 = -system.thetaRel   [unknown |0|0|0|0|]
+// 4/4 (1): system.thetaRel = system.theta - system.thetaRef   [binding |0|0|0|0|]
 // 5/5 (1): system.thetaRef = system.theta   [binding |0|0|0|0|]
 //
 //
@@ -135,7 +135,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: fixedVoltageSource1.phi:VARIABLE(unit = "rad" )  type: Real 
+// 1: fixedVoltageSource1.phi:VARIABLE(unit = "rad" )  type: Real
 //
 //
 // Equations (1, 1)
@@ -151,19 +151,19 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (13)
 // ========================================
-// 1: busBar1.p:VARIABLE(unit = "W" )  type: Real[1]  [1]
-// 2: busBar1.i:VARIABLE(start = busBar1.i_start unit = "A" nominal = 1.0 )  type: Real[1]  [1]
-// 3: busBar1.v:VARIABLE(start = busBar1.v_start unit = "V" nominal = 1000.0 )  type: Real[1]  [1]
-// 4: busBar1.terminal_n.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1]  [3,1]
-// 5: busBar1.terminal_n.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1]  [3,1]
-// 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1]  [1]
-// 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1]  [1]
-// 8: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1]  [3,1]
-// 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1]  [3,1]
-// 10: fixedLoad1.p:VARIABLE(unit = "W" )  type: Real[3, 1]  [3,1]
-// 11: fixedVoltageSource1.p:VARIABLE(unit = "W" )  type: Real[1]  [1]
-// 12: fixedVoltageSource1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1]  [1]
-// 13: fixedVoltageSource1.terminal.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1]  [1]
+// 1: busBar1.p:VARIABLE(unit = "W" )  type: Real[1] [1]
+// 2: busBar1.i:VARIABLE(start = busBar1.i_start unit = "A" nominal = 1.0 )  type: Real[1] [1]
+// 3: busBar1.v:VARIABLE(start = busBar1.v_start unit = "V" nominal = 1000.0 )  type: Real[1] [1]
+// 4: busBar1.terminal_n.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1] [3,1]
+// 5: busBar1.terminal_n.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1] [3,1]
+// 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1] [1]
+// 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1] [1]
+// 8: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1] [3,1]
+// 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1] [3,1]
+// 10: fixedLoad1.p:VARIABLE(unit = "W" )  type: Real[3, 1] [3,1]
+// 11: fixedVoltageSource1.p:VARIABLE(unit = "W" )  type: Real[1] [1]
+// 12: fixedVoltageSource1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1] [1]
+// 13: fixedVoltageSource1.terminal.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1] [1]
 //
 //
 // Equations (13, 13)
@@ -195,7 +195,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.w_h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable w_H" type: Real 
+// 1: system.receiveFreq.w_h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable w_H" type: Real
 //
 //
 // Equations (1, 1)
@@ -211,7 +211,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable H" type: Real 
+// 1: system.receiveFreq.h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable H" type: Real
 //
 //
 // Equations (1, 1)
@@ -227,7 +227,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.w_H:VARIABLE(flow=true unit = "rad" )  "angular velocity, inertia-weighted" type: Real 
+// 1: system.receiveFreq.w_H:VARIABLE(flow=true unit = "rad" )  "angular velocity, inertia-weighted" type: Real
 //
 //
 // Equations (1, 1)
@@ -243,7 +243,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.H:VARIABLE(flow=true unit = "s" )  "inertia constant" type: Real 
+// 1: system.receiveFreq.H:VARIABLE(flow=true unit = "s" )  "inertia constant" type: Real
 //
 //
 // Equations (1, 1)
@@ -261,24 +261,24 @@ val(fixedVoltageSource1.p[1], 1.0);
 // Known variables only depending on parameters and constants - globalKnownVars (20)
 // ========================================
 // 1: busBar1.n_n:PARAM(final = true )  = 3  type: Integer
-// 2: busBar1.i_start:PARAM(unit = "A" nominal = 1.0 )  = {0.0}  "Start value for current" type: Real[1]  [1]
-// 3: busBar1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {0.0}  "Start value for voltage drop" type: Real[1]  [1]
-// 4: fixedLoad1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {1.0}  "Start value for voltage drop" type: Real[3, 1]  [3,1]
-// 5: fixedLoad1.P:PARAM(unit = "W" )  = 1000000.0:1000000.0:3000000.0  "rms value of constant active power" type: Real[3]  [3]
-// 6: fixedLoad1.phi:PARAM(unit = "rad" )  = 0.1:0.1:0.3  "phase angle" type: Real[3]  [3]
-// 7: system.synRef:PARAM(final = true )  = true  type: Boolean 
-// 8: system.w_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nom r.p.m." type: Real 
-// 9: system.omega_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nominal angular frequency" type: Real 
-// 10: system.dynType:PARAM(min = PowerSystems.Types.Dynamics.FreeInitial max = PowerSystems.Types.Dynamics.SteadyState final = true )  = PowerSystems.Types.Dynamics.SteadyInitial  "transient or steady-state model" type: enumeration(FreeInitial, FixedInitial, SteadyInitial, SteadyState) 
-// 11: system.refType:PARAM(min = PowerSystems.Types.ReferenceFrame.Synchron max = PowerSystems.Types.ReferenceFrame.Inertial final = true )  = PowerSystems.Types.ReferenceFrame.Synchron  "reference frame (3-phase)" type: enumeration(Synchron, Inertial) 
-// 12: system.alpha0:PARAM(unit = "rad" final = true )  = 0.0  "phase angle" type: Real 
-// 13: system.f_lim:PARAM(unit = "Hz" final = true )  = {25.0, 100.0}  "limit frequencies (for supervision of average frequency)" type: Real[2]  [2]
-// 14: system.f_nom:PARAM(unit = "Hz" final = true )  = 50.0  "nominal frequency" type: Real 
-// 15: system.f:PARAM(unit = "Hz" final = true )  = 50.0  "frequency if type is parameter, else initial frequency" type: Real 
-// 16: system.fType:PARAM(min = PowerSystems.Types.SystemFrequency.Parameter max = PowerSystems.Types.SystemFrequency.Average final = true )  = PowerSystems.Types.SystemFrequency.Parameter  "system frequency type" type: enumeration(Parameter, Signal, Average) 
-// 17: fixedVoltageSource1.V:PARAM(unit = "V" nominal = 1000.0 )  = 10000.0  "value of constant voltage" type: Real 
-// 18: fixedVoltageSource1.definiteReference:PARAM(final = true )  = false  "serve as definite root" type: Boolean 
-// 19: fixedVoltageSource1.potentialReference:PARAM(final = true )  = true  "serve as potential root" type: Boolean 
+// 2: busBar1.i_start:PARAM(unit = "A" nominal = 1.0 )  = {0.0}  "Start value for current" type: Real[1] [1]
+// 3: busBar1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {0.0}  "Start value for voltage drop" type: Real[1] [1]
+// 4: fixedLoad1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {1.0}  "Start value for voltage drop" type: Real[3, 1] [3,1]
+// 5: fixedLoad1.P:PARAM(unit = "W" )  = 1000000.0:1000000.0:3000000.0  "rms value of constant active power" type: Real[3] [3]
+// 6: fixedLoad1.phi:PARAM(unit = "rad" )  = 0.1:0.1:0.3  "phase angle" type: Real[3] [3]
+// 7: system.synRef:PARAM(final = true )  = true  type: Boolean
+// 8: system.w_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nom r.p.m." type: Real
+// 9: system.omega_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nominal angular frequency" type: Real
+// 10: system.dynType:PARAM(min = PowerSystems.Types.Dynamics.FreeInitial max = PowerSystems.Types.Dynamics.SteadyState final = true )  = PowerSystems.Types.Dynamics.SteadyInitial  "transient or steady-state model" type: enumeration(FreeInitial, FixedInitial, SteadyInitial, SteadyState)
+// 11: system.refType:PARAM(min = PowerSystems.Types.ReferenceFrame.Synchron max = PowerSystems.Types.ReferenceFrame.Inertial final = true )  = PowerSystems.Types.ReferenceFrame.Synchron  "reference frame (3-phase)" type: enumeration(Synchron, Inertial)
+// 12: system.alpha0:PARAM(unit = "rad" final = true )  = 0.0  "phase angle" type: Real
+// 13: system.f_lim:PARAM(unit = "Hz" final = true )  = {25.0, 100.0}  "limit frequencies (for supervision of average frequency)" type: Real[2] [2]
+// 14: system.f_nom:PARAM(unit = "Hz" final = true )  = 50.0  "nominal frequency" type: Real
+// 15: system.f:PARAM(unit = "Hz" final = true )  = 50.0  "frequency if type is parameter, else initial frequency" type: Real
+// 16: system.fType:PARAM(min = PowerSystems.Types.SystemFrequency.Parameter max = PowerSystems.Types.SystemFrequency.Average final = true )  = PowerSystems.Types.SystemFrequency.Parameter  "system frequency type" type: enumeration(Parameter, Signal, Average)
+// 17: fixedVoltageSource1.V:PARAM(unit = "V" nominal = 1000.0 )  = 10000.0  "value of constant voltage" type: Real
+// 18: fixedVoltageSource1.definiteReference:PARAM(final = true )  = false  "serve as definite root" type: Boolean
+// 19: fixedVoltageSource1.potentialReference:PARAM(final = true )  = true  "serve as potential root" type: Boolean
 // 20: n:PARAM(final = true )  = 3  "number of loads" type: Integer
 //
 //
@@ -301,7 +301,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.H:VARIABLE(flow=true unit = "s" )  "inertia constant" type: Real 
+// 1: system.receiveFreq.H:VARIABLE(flow=true unit = "s" )  "inertia constant" type: Real
 //
 //
 // Equations (1, 1)
@@ -325,7 +325,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.w_H:VARIABLE(flow=true unit = "rad" )  "angular velocity, inertia-weighted" type: Real 
+// 1: system.receiveFreq.w_H:VARIABLE(flow=true unit = "rad" )  "angular velocity, inertia-weighted" type: Real
 //
 //
 // Equations (1, 1)
@@ -349,7 +349,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable H" type: Real 
+// 1: system.receiveFreq.h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable H" type: Real
 //
 //
 // Equations (1, 1)
@@ -373,7 +373,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.receiveFreq.w_h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable w_H" type: Real 
+// 1: system.receiveFreq.w_h:VARIABLE(flow=false )  "Dummy potential-variable to balance flow-variable w_H" type: Real
 //
 //
 // Equations (1, 1)
@@ -397,19 +397,19 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (13)
 // ========================================
-// 1: busBar1.p:VARIABLE(unit = "W" )  type: Real[1]  [1]
-// 2: busBar1.i:VARIABLE(start = busBar1.i_start unit = "A" nominal = 1.0 )  type: Real[1]  [1]
-// 3: busBar1.v:VARIABLE(start = busBar1.v_start unit = "V" nominal = 1000.0 )  type: Real[1]  [1]
-// 4: busBar1.terminal_n.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1]  [3,1]
-// 5: busBar1.terminal_n.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1]  [3,1]
-// 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1]  [1]
-// 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1]  [1]
-// 8: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1]  [3,1]
-// 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1]  [3,1]
-// 10: fixedLoad1.p:VARIABLE(unit = "W" )  type: Real[3, 1]  [3,1]
-// 11: fixedVoltageSource1.p:VARIABLE(unit = "W" )  type: Real[1]  [1]
-// 12: fixedVoltageSource1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1]  [1]
-// 13: fixedVoltageSource1.terminal.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1]  [1]
+// 1: busBar1.p:VARIABLE(unit = "W" )  type: Real[1] [1]
+// 2: busBar1.i:VARIABLE(start = busBar1.i_start unit = "A" nominal = 1.0 )  type: Real[1] [1]
+// 3: busBar1.v:VARIABLE(start = busBar1.v_start unit = "V" nominal = 1000.0 )  type: Real[1] [1]
+// 4: busBar1.terminal_n.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1] [3,1]
+// 5: busBar1.terminal_n.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1] [3,1]
+// 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1] [1]
+// 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1] [1]
+// 8: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[3, 1] [3,1]
+// 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[3, 1] [3,1]
+// 10: fixedLoad1.p:VARIABLE(unit = "W" )  type: Real[3, 1] [3,1]
+// 11: fixedVoltageSource1.p:VARIABLE(unit = "W" )  type: Real[1] [1]
+// 12: fixedVoltageSource1.terminal.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1] [1]
+// 13: fixedVoltageSource1.terminal.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1] [1]
 //
 //
 // Equations (13, 13)
@@ -473,7 +473,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: fixedVoltageSource1.phi:VARIABLE(unit = "rad" )  type: Real 
+// 1: fixedVoltageSource1.phi:VARIABLE(unit = "rad" )  type: Real
 //
 //
 // Equations (1, 1)
@@ -497,11 +497,11 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (5)
 // ========================================
-// 1: system.omega_internal:VARIABLE(flow=false protected = true )  type: Real 
-// 2: system.omega:VARIABLE(start = 314.1592653589793 unit = "rad/s" )  type: Real 
-// 3: system.thetaRef:VARIABLE(unit = "rad" )  "angle of reference frame" type: Real 
-// 4: system.thetaRel:VARIABLE(unit = "rad" )  "angle relative to reference frame" type: Real 
-// 5: system.theta:VARIABLE(start = 0.0 unit = "rad" )  "system angle" type: Real 
+// 1: system.omega_internal:VARIABLE(flow=false protected = true )  type: Real
+// 2: system.omega:VARIABLE(start = 314.1592653589793 unit = "rad/s" )  type: Real
+// 3: system.thetaRef:VARIABLE(unit = "rad" )  "angle of reference frame" type: Real
+// 4: system.thetaRel:VARIABLE(unit = "rad" )  "angle relative to reference frame" type: Real
+// 5: system.theta:VARIABLE(start = 0.0 unit = "rad" )  "system angle" type: Real
 //
 //
 // Equations (5, 5)
@@ -509,7 +509,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 1/1 (1): system.omega_internal = system.thetaRef / time   [dynamic |0|0|0|0|]
 // 2/2 (1): system.omega = 314.1592653589793   [dynamic |0|0|0|0|]
 // 3/3 (1): system.thetaRef = system.omega * time   [dynamic |0|0|0|0|]
-// 4/4 (1): system.thetaRel = 0.0   [unknown |0|0|0|0|]
+// 4/4 (1): system.thetaRel = system.theta - system.thetaRef   [binding |0|0|0|0|]
 // 5/5 (1): system.theta = system.thetaRef   [binding |0|0|0|0|]
 //
 //
@@ -525,10 +525,10 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // StrongComponents
 // ========================================
-// {4:4}
 // {2:2}
 // {3:3}
 // {5:5}
+// {4:4}
 // {1:1}
 //
 //
@@ -537,7 +537,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: busBar1.V:VARIABLE(unit = "V" nominal = 1000.0 )  type: Real 
+// 1: busBar1.V:VARIABLE(unit = "V" nominal = 1000.0 )  type: Real
 //
 //
 // Equations (1, 1)
@@ -561,7 +561,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: busBar1.I:VARIABLE(unit = "A" nominal = 1.0 )  type: Real 
+// 1: busBar1.I:VARIABLE(unit = "A" nominal = 1.0 )  type: Real
 //
 //
 // Equations (1, 1)
@@ -585,7 +585,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: busBar1.phi:VARIABLE(unit = "rad" )  type: Real 
+// 1: busBar1.phi:VARIABLE(unit = "rad" )  type: Real
 //
 //
 // Equations (1, 1)
@@ -609,7 +609,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (1)
 // ========================================
-// 1: system.initime:DISCRETE(unit = "s" )  type: Real 
+// 1: system.initime:DISCRETE(unit = "s" )  type: Real
 //
 //
 // Equations (1, 1)
@@ -637,24 +637,24 @@ val(fixedVoltageSource1.p[1], 1.0);
 // Known variables only depending on parameters and constants - globalKnownVars (20)
 // ========================================
 // 1: busBar1.n_n:PARAM(final = true )  = 3  type: Integer
-// 2: busBar1.i_start:PARAM(unit = "A" nominal = 1.0 )  = {0.0}  "Start value for current" type: Real[1]  [1]
-// 3: busBar1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {0.0}  "Start value for voltage drop" type: Real[1]  [1]
-// 4: fixedLoad1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {1.0}  "Start value for voltage drop" type: Real[3, 1]  [3,1]
-// 5: fixedLoad1.P:PARAM(unit = "W" )  = 1000000.0:1000000.0:3000000.0  "rms value of constant active power" type: Real[3]  [3]
-// 6: fixedLoad1.phi:PARAM(unit = "rad" )  = 0.1:0.1:0.3  "phase angle" type: Real[3]  [3]
-// 7: system.synRef:PARAM(final = true )  = true  type: Boolean 
-// 8: system.w_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nom r.p.m." type: Real 
-// 9: system.omega_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nominal angular frequency" type: Real 
-// 10: system.dynType:PARAM(min = PowerSystems.Types.Dynamics.FreeInitial max = PowerSystems.Types.Dynamics.SteadyState final = true )  = PowerSystems.Types.Dynamics.SteadyInitial  "transient or steady-state model" type: enumeration(FreeInitial, FixedInitial, SteadyInitial, SteadyState) 
-// 11: system.refType:PARAM(min = PowerSystems.Types.ReferenceFrame.Synchron max = PowerSystems.Types.ReferenceFrame.Inertial final = true )  = PowerSystems.Types.ReferenceFrame.Synchron  "reference frame (3-phase)" type: enumeration(Synchron, Inertial) 
-// 12: system.alpha0:PARAM(unit = "rad" final = true )  = 0.0  "phase angle" type: Real 
-// 13: system.f_lim:PARAM(unit = "Hz" final = true )  = {25.0, 100.0}  "limit frequencies (for supervision of average frequency)" type: Real[2]  [2]
-// 14: system.f_nom:PARAM(unit = "Hz" final = true )  = 50.0  "nominal frequency" type: Real 
-// 15: system.f:PARAM(unit = "Hz" final = true )  = 50.0  "frequency if type is parameter, else initial frequency" type: Real 
-// 16: system.fType:PARAM(min = PowerSystems.Types.SystemFrequency.Parameter max = PowerSystems.Types.SystemFrequency.Average final = true )  = PowerSystems.Types.SystemFrequency.Parameter  "system frequency type" type: enumeration(Parameter, Signal, Average) 
-// 17: fixedVoltageSource1.V:PARAM(unit = "V" nominal = 1000.0 )  = 10000.0  "value of constant voltage" type: Real 
-// 18: fixedVoltageSource1.definiteReference:PARAM(final = true )  = false  "serve as definite root" type: Boolean 
-// 19: fixedVoltageSource1.potentialReference:PARAM(final = true )  = true  "serve as potential root" type: Boolean 
+// 2: busBar1.i_start:PARAM(unit = "A" nominal = 1.0 )  = {0.0}  "Start value for current" type: Real[1] [1]
+// 3: busBar1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {0.0}  "Start value for voltage drop" type: Real[1] [1]
+// 4: fixedLoad1.v_start:PARAM(unit = "V" nominal = 1000.0 )  = {1.0}  "Start value for voltage drop" type: Real[3, 1] [3,1]
+// 5: fixedLoad1.P:PARAM(unit = "W" )  = 1000000.0:1000000.0:3000000.0  "rms value of constant active power" type: Real[3] [3]
+// 6: fixedLoad1.phi:PARAM(unit = "rad" )  = 0.1:0.1:0.3  "phase angle" type: Real[3] [3]
+// 7: system.synRef:PARAM(final = true )  = true  type: Boolean
+// 8: system.w_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nom r.p.m." type: Real
+// 9: system.omega_nom:PARAM(unit = "rad/s" final = true )  = 314.1592653589793  "nominal angular frequency" type: Real
+// 10: system.dynType:PARAM(min = PowerSystems.Types.Dynamics.FreeInitial max = PowerSystems.Types.Dynamics.SteadyState final = true )  = PowerSystems.Types.Dynamics.SteadyInitial  "transient or steady-state model" type: enumeration(FreeInitial, FixedInitial, SteadyInitial, SteadyState)
+// 11: system.refType:PARAM(min = PowerSystems.Types.ReferenceFrame.Synchron max = PowerSystems.Types.ReferenceFrame.Inertial final = true )  = PowerSystems.Types.ReferenceFrame.Synchron  "reference frame (3-phase)" type: enumeration(Synchron, Inertial)
+// 12: system.alpha0:PARAM(unit = "rad" final = true )  = 0.0  "phase angle" type: Real
+// 13: system.f_lim:PARAM(unit = "Hz" final = true )  = {25.0, 100.0}  "limit frequencies (for supervision of average frequency)" type: Real[2] [2]
+// 14: system.f_nom:PARAM(unit = "Hz" final = true )  = 50.0  "nominal frequency" type: Real
+// 15: system.f:PARAM(unit = "Hz" final = true )  = 50.0  "frequency if type is parameter, else initial frequency" type: Real
+// 16: system.fType:PARAM(min = PowerSystems.Types.SystemFrequency.Parameter max = PowerSystems.Types.SystemFrequency.Average final = true )  = PowerSystems.Types.SystemFrequency.Parameter  "system frequency type" type: enumeration(Parameter, Signal, Average)
+// 17: fixedVoltageSource1.V:PARAM(unit = "V" nominal = 1000.0 )  = 10000.0  "value of constant voltage" type: Real
+// 18: fixedVoltageSource1.definiteReference:PARAM(final = true )  = false  "serve as definite root" type: Boolean
+// 19: fixedVoltageSource1.potentialReference:PARAM(final = true )  = true  "serve as potential root" type: Boolean
 // 20: n:PARAM(final = true )  = 3  "number of loads" type: Integer
 //
 //

--- a/testsuite/openmodelica/debugDumps/lateInline.mos
+++ b/testsuite/openmodelica/debugDumps/lateInline.mos
@@ -393,34 +393,6 @@ buildModel(testOptdaedump); getErrorString();
 //
 //
 // ########################################
-// pre-optimization module resolveLoops (simulation)
-// ########################################
-//
-//
-// unspecified partition
-// ========================================
-//
-// Variables (2)
-// ========================================
-// 1: y:VARIABLE()  type: Real
-// 2: x:VARIABLE()  type: Real
-//
-//
-// Equations (2, 2)
-// ========================================
-// 1/1 (1): x = testOptdaedump.f(time)   [binding |0|0|0|0|]
-// 2/2 (1): y = exp(time ^ 3.0) + x   [binding |0|0|0|0|]
-//
-//
-// no matching
-//
-//
-//
-// BackendDAEType: simulation
-//
-//
-//
-// ########################################
 // pre-optimization module evalFunc (simulation)
 // ########################################
 //

--- a/testsuite/openmodelica/debugDumps/optdaedump.mos
+++ b/testsuite/openmodelica/debugDumps/optdaedump.mos
@@ -779,63 +779,6 @@ buildModel(testOptdaedump); getErrorString();
 //
 //
 // ########################################
-// pre-optimization module resolveLoops (simulation)
-// ########################################
-//
-//
-// unspecified partition
-// ========================================
-//
-// Variables (8)
-// ========================================
-// 1: iC:VARIABLE()  type: Real
-// 2: iL:STATE(1)()  type: Real
-// 3: i2:VARIABLE()  type: Real
-// 4: i1:VARIABLE()  type: Real
-// 5: i0:VARIABLE()  type: Real
-// 6: uC:STATE(1)()  type: Real
-// 7: uL:VARIABLE()  type: Real
-// 8: u1:VARIABLE()  type: Real
-//
-//
-// Equations (8, 8)
-// ========================================
-// 1/1 (1): uC = cos(time)   [dynamic |0|0|0|0|]
-// 2/2 (1): u1 = R1 * i1   [dynamic |0|0|0|0|]
-// 3/3 (1): u1 = uC - uL   [dynamic |0|0|0|0|]
-// 4/4 (1): uL = R2 * i2   [dynamic |0|0|0|0|]
-// 5/5 (1): uL = L * der(iL)   [dynamic |0|0|0|0|]
-// 6/6 (1): iC = C * der(uC)   [dynamic |0|0|0|0|]
-// 7/7 (1): i0 = i1 + iC   [dynamic |0|0|0|0|]
-// 8/8 (1): i1 = i2 + iL   [dynamic |0|0|0|0|]
-//
-//
-// no matching
-//
-//
-//
-// BackendDAEType: simulation
-//
-//
-// Known variables only depending on parameters and constants - globalKnownVars (5)
-// ========================================
-// 1: v0:VARIABLE()  = 0.0  type: Real
-// 2: R1:PARAM()  = 1.0  type: Real
-// 3: R2:PARAM()  = 2.0  type: Real
-// 4: L:PARAM()  = 0.5  type: Real
-// 5: C:PARAM()  = 3.0  type: Real
-//
-//
-// Alias Variables (4)
-// ========================================
-// 1: u0:VARIABLE()  = uC  type: Real
-// 2: u2:VARIABLE()  = uL  type: Real
-// 3: v1:VARIABLE()  = uC  type: Real
-// 4: v2:VARIABLE()  = uL  type: Real
-//
-//
-//
-// ########################################
 // pre-optimization module evalFunc (simulation)
 // ########################################
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.HeatingSystem.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.HeatingSystem.mos
@@ -47,15 +47,22 @@ runScript(modelTesting);getErrorString();
 // |                 | |       | | The non-linear solver tries to solve the problem that could take some time.
 // |                 | |       | | It could help to provide better start-values for the iteration variables.
 // |                 | |       | | For more information simulate with -lv LOG_NLS_V
-// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// stdout            | warning | While solving non-linear system an assertion failed during initialization.
+// |                 | |       | | The non-linear solver tries to solve the problem that could take some time.
+// |                 | |       | | It could help to provide better start-values for the iteration variables.
+// |                 | |       | | For more information simulate with -lv LOG_NLS_V
+// assert            | debug   | Solving non-linear system 220 failed at time=0.
+// |                 | |       | For more information please use -lv LOG_NLS.
+// assert            | warning | Failed to solve the initialization problem without homotopy method. If homotopy is available the homotopy method is used now.
+// LOG_SUCCESS       | info    | The initialization finished successfully with 4 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
 // Warning: The model contains alias variables with conflicting start and/or nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
 // ========================================
-// 1: pump.medium.h
-// 2: pump.medium.p
+// 1: pump.medium.p
+// 2: pump.medium.h
 // Please use -d=bltdump for more information.
 //
 // "true

--- a/testsuite/simulation/modelica/indexreduction/ASSC.mo
+++ b/testsuite/simulation/modelica/indexreduction/ASSC.mo
@@ -1,0 +1,14 @@
+model ASSC
+"test model for the ASSC algorithm
+ Analytical to Structural Singularity Conversion"
+  Real x(fixed = true), y;    // states
+  Real a, b, c; // algebraic variables
+equation
+  der(x) = sin(time);
+  der(y) = cos(time) + a;
+
+// anayltically singular algebraic loop
+  2*a + 2*b + c + x = 10;
+  a + b + y = 5;
+  a + b + c = 0;
+end ASSC;

--- a/testsuite/simulation/modelica/indexreduction/ASSC.mos
+++ b/testsuite/simulation/modelica/indexreduction/ASSC.mos
@@ -1,0 +1,109 @@
+// Name:     ASSC
+// keywords: index reduction
+// status:   correct
+// teardown_command: rm -rf ASSC *_init.xml *_records.c *.exe *.log *_res.mat *.c *.libs *.makefile *.o *.dll *.so *_functions.h *.h *_diff.csv output.log
+//
+//
+//
+
+loadFile("ASSC.mo"); getErrorString();
+setCommandLineOptions("-d=dumpASSC,bltdump");
+simulate(ASSC); getErrorString();
+
+
+// Result:
+// true
+// ""
+// true
+// ######################################################
+//  LinearIntegerJacobian sparsity pattern: Original
+// ######################################################
+// (scal_idx|arr_idx|changed) [var_index, value] || RHS_EXPRESSION
+// (5|5|false):	[2|1] [3|1] [1|1] 	|| RHS: 0
+// (4|4|false):	[2|1] [3|1] 	|| RHS: 5.0 - y
+// (3|3|false):	[2|2] [3|2] [1|1] 	|| RHS: 10.0 - x
+//
+// ######################################################
+//  LinearIntegerJacobian sparsity pattern: Solved
+// ######################################################
+// (scal_idx|arr_idx|changed) [var_index, value] || RHS_EXPRESSION
+// (5|5|false):	[2|1] [3|1] [1|1] 	|| RHS: 0
+// (4|4|true):	[1|-1] 	|| RHS: 5.0 - y
+// (3|3|true):	EMPTY ROW 		|| RHS: -5.0 + x - y
+//
+// [ASSC] The equation: 2.0 * (a + b) + c + x = 10.0
+// [ASSC] Gets replaced by equation: 0.0 = -5.0 + x - y
+// unmatched equations: 3
+//
+// Index Reduction neccessary!
+// MSS subsets:
+//  3
+//
+// ##############--MSSS--##############
+// Indices of constraint equations: 3
+//
+// ------------------3------------------
+// Constraint equation to be differentiated:
+// 0.0 = -5.0 + x - y
+// Differentiated equation:
+// 0.0 = der(x) - der(y)
+//
+// Update Incidence Matrix: 3
+//
+// ########################### STATE SELECTION ###########################
+// ########## Try static state selection ##########
+// Try to select dummy vars with natural matching (newer)
+// Select 1 dummy states from 2 candidates.
+//
+// Highest order derivatives (state candidates): (2)
+// ========================================
+// 1: y:STATE(1)()  type: Real
+// 2: x:STATE(1)(fixed = true )  type: Real
+//
+//
+// Constraint equations: (1)
+// ========================================
+// 1/1 (1): 0.0 = -5.0 + x - y   [unknown |0|0|0|0|]
+//
+// Adjacency Matrix Enhanced (row == equation)
+// ====================================
+// number of rows: 1
+// 1:(-2,constone) (-1,constone)
+//
+// Transpose Adjacency Matrix Enhanced (row == var)
+// =====================================
+// number of rows: 2
+// 1:(-1,constone)
+// 2:(-1,constone)
+//
+// Matching
+// ========================================
+// 2 variables and equations
+// var 1 is solved in eqn 1
+// var 2 is solved in eqn -1
+//
+// Matching
+// ========================================
+// 1 variables and equations
+// var 1 is solved in eqn 1
+// Perfect Matching, no dynamic index reduction needed! There are no unassigned equations.
+//
+//
+// Selected dummy states: (1)
+// ========================================
+// 1: y:STATE(1)()  type: Real
+//
+//
+// Selected continuous states: (1)
+// ========================================
+// 1: x:STATE(1)(fixed = true )  type: Real
+//
+// record SimulationResult
+//     resultFile = "ASSC_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ASSC', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/indexreduction/Makefile
+++ b/testsuite/simulation/modelica/indexreduction/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
+ASSC.mos \
 SingularPlanarLoop.mos \
 PantelidesSingular.mos \
 MoveWithInputs.mos

--- a/testsuite/simulation/modelica/linear_system/linSymSol.mos
+++ b/testsuite/simulation/modelica/linear_system/linSymSol.mos
@@ -65,7 +65,7 @@ val(res,1);
 // end SimulationResult;
 // ""
 // 0.0
-// 4.301237230969203e-14
+// 4.458418790403979e-14
 // true
 // record SimulationResult
 //     resultFile = "foo_res.mat",
@@ -73,7 +73,7 @@ val(res,1);
 //     messages = "LOG_LS            | info    | initialize linear system solvers
 // |                 | |       | | 3 linear systems
 // LOG_LS            | info    | Start solving Linear System 2 (size 4) at time 0 with Lapack Solver
-// LOG_LS            | info    | Start solving Linear System 14 (size 1) at time 0 with Lapack Solver
+// LOG_LS            | info    | Start solving Linear System 13 (size 1) at time 0 with Lapack Solver
 // LOG_LS            | info    | Start solving Linear System 20 (size 1) at time 0 with Lapack Solver
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
@@ -81,5 +81,5 @@ val(res,1);
 // end SimulationResult;
 // ""
 // 0.0
-// 6.632656836952361e-14
+// 6.636753559913227e-14
 // endResult

--- a/testsuite/simulation/modelica/resolveLoops/Circuit1x.mos
+++ b/testsuite/simulation/modelica/resolveLoops/Circuit1x.mos
@@ -27,7 +27,7 @@ simulate(Circuit1x); getErrorString();
 //  * Number of variables: 38
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions("-d=initialization").
 // Notification: Model statistics after passing the back-end for initialization:
-//  * Number of independent subsystems: 3
+//  * Number of independent subsystems: 2
 //  * Number of states: 0 ()
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)

--- a/testsuite/simulation/modelica/resolveLoops/Circuit2x.mos
+++ b/testsuite/simulation/modelica/resolveLoops/Circuit2x.mos
@@ -27,7 +27,7 @@ simulate(Circuit2x); getErrorString();
 //  * Number of variables: 38
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions("-d=initialization").
 // Notification: Model statistics after passing the back-end for initialization:
-//  * Number of independent subsystems: 3
+//  * Number of independent subsystems: 2
 //  * Number of states: 0 ()
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)

--- a/testsuite/simulation/modelica/resolveLoops/Circuit4x.mos
+++ b/testsuite/simulation/modelica/resolveLoops/Circuit4x.mos
@@ -27,12 +27,12 @@ simulate(Circuit4x); getErrorString();
 //  * Number of variables: 53
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions("-d=initialization").
 // Notification: Model statistics after passing the back-end for initialization:
-//  * Number of independent subsystems: 3
+//  * Number of independent subsystems: 2
 //  * Number of states: 0 ()
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
+// Notification: Strong component statistics for initialization (15):
 //  * Single equations (assignments): 13
 //  * Array equations: 0
 //  * Algorithm blocks: 0
@@ -40,10 +40,10 @@ simulate(Circuit4x); getErrorString();
 //  * When equations: 0
 //  * If-equations: 0
 //  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 1
+//  * Torn equation systems: 2
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(2,100.0%) 11}
+//  * Linear torn systems: 2 {(1,100.0%) 6,(1,100.0%) 5}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 3
@@ -51,18 +51,18 @@ simulate(Circuit4x); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (10):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
 //  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 1
+//  * Torn equation systems: 2
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(2,100.0%) 11}
+//  * Linear torn systems: 2 {(1,100.0%) 6,(1,100.0%) 4}
 //  * Non-linear torn systems: 0
 // "
 // endResult

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit1.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit1.mos
@@ -42,8 +42,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit1_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (32):
-//  * Single equations (assignments): 28
+// Notification: Strong component statistics for initialization (27):
+//  * Single equations (assignments): 23
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit1_res.m
 //  * Torn equation systems: 4
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 4 {(1,100.0%) 7,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 4 {(1,100.0%) 5,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 7
+//  * Number of independent subsystems: 5
 //  * Number of states: 2 (C2.v,C3.v)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (23):
-//  * Single equations (assignments): 19
+// Notification: Strong component statistics for simulation (17):
+//  * Single equations (assignments): 13
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,7 +72,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit1_res.m
 //  * Torn equation systems: 4
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 4 {(1,100.0%) 6,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 4 {(1,100.0%) 5,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3}
 //  * Non-linear torn systems: 0
 // "
 // {"Files Equal!"}

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit2.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit2.mos
@@ -44,8 +44,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit2_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (12):
-//  * Single equations (assignments): 10
+// Notification: Strong component statistics for initialization (11):
+//  * Single equations (assignments): 9
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -58,13 +58,13 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit2_res.m
 //  * Linear torn systems: 2 {(1,100.0%) 4,(1,100.0%) 3}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 4
+//  * Number of independent subsystems: 3
 //  * Number of states: 1 (inductor1.i)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (9):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (8):
+//  * Single equations (assignments): 6
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit3.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit3.mos
@@ -47,26 +47,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit3_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (26):
-//  * Single equations (assignments): 24
-//  * Array equations: 0
-//  * Algorithm blocks: 0
-//  * Record equations: 0
-//  * When equations: 0
-//  * If-equations: 0
-//  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 2
-//  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 2 {(1,100.0%) 2,(1,100.0%) 2}
-//  * Non-linear torn systems: 0
-// Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 1
-//  * Number of states: 2 (capacitor.v,capacitor1.v)
-//  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
-//  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
-//  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (18):
+// Notification: Strong component statistics for initialization (17):
 //  * Single equations (assignments): 16
 //  * Array equations: 0
 //  * Algorithm blocks: 0
@@ -74,10 +55,29 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit3_res.m
 //  * When equations: 0
 //  * If-equations: 0
 //  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 2
+//  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 2 {(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 1 {(2,100.0%) 12}
+//  * Non-linear torn systems: 0
+// Notification: Model statistics after passing the back-end for simulation:
+//  * Number of independent subsystems: 1
+//  * Number of states: 2 (capacitor.v,capacitor1.v)
+//  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
+//  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
+//  * Top-level inputs: 0
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
+//  * Array equations: 0
+//  * Algorithm blocks: 0
+//  * Record equations: 0
+//  * When equations: 0
+//  * If-equations: 0
+//  * Equation systems (linear and non-linear blocks): 0
+//  * Torn equation systems: 1
+//  * Mixed (continuous/discrete) equation systems: 0
+// Notification: Torn system details for strict tearing set:
+//  * Linear torn systems: 1 {(3,77.8%) 11}
 //  * Non-linear torn systems: 0
 // "
 // {"Files Equal!"}

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit4.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit4.mos
@@ -47,8 +47,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit4_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (60):
-//  * Single equations (assignments): 54
+// Notification: Strong component statistics for initialization (55):
+//  * Single equations (assignments): 49
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -58,7 +58,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit4_res.m
 //  * Torn equation systems: 6
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 6 {(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 6 {(1,100.0%) 2,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
@@ -66,8 +66,8 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit4_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (41):
-//  * Single equations (assignments): 35
+// Notification: Strong component statistics for simulation (36):
+//  * Single equations (assignments): 30
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -77,7 +77,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit4_res.m
 //  * Torn equation systems: 6
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 6 {(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 6 {(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 2}
 //  * Non-linear torn systems: 0
 // "
 // {"Files Equal!"}

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit5.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit5.mos
@@ -44,26 +44,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit5_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (16):
-//  * Single equations (assignments): 15
-//  * Array equations: 0
-//  * Algorithm blocks: 0
-//  * Record equations: 0
-//  * When equations: 0
-//  * If-equations: 0
-//  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 1
-//  * Mixed (continuous/discrete) equation systems: 0
-// Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 2}
-//  * Non-linear torn systems: 0
-// Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 5
-//  * Number of states: 1 (C1.v)
-//  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
-//  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
-//  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (11):
+// Notification: Strong component statistics for initialization (11):
 //  * Single equations (assignments): 10
 //  * Array equations: 0
 //  * Algorithm blocks: 0
@@ -74,7 +55,26 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit5_res.m
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 2}
+//  * Linear torn systems: 1 {(1,100.0%) 7}
+//  * Non-linear torn systems: 0
+// Notification: Model statistics after passing the back-end for simulation:
+//  * Number of independent subsystems: 1
+//  * Number of states: 1 (C1.v)
+//  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
+//  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
+//  * Top-level inputs: 0
+// Notification: Strong component statistics for simulation (6):
+//  * Single equations (assignments): 5
+//  * Array equations: 0
+//  * Algorithm blocks: 0
+//  * Record equations: 0
+//  * When equations: 0
+//  * If-equations: 0
+//  * Equation systems (linear and non-linear blocks): 0
+//  * Torn equation systems: 1
+//  * Mixed (continuous/discrete) equation systems: 0
+// Notification: Torn system details for strict tearing set:
+//  * Linear torn systems: 1 {(1,100.0%) 7}
 //  * Non-linear torn systems: 0
 // "
 // {"Files Equal!"}

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit6.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit6.mos
@@ -40,18 +40,18 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit6_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (60):
-//  * Single equations (assignments): 53
+// Notification: Strong component statistics for initialization (52):
+//  * Single equations (assignments): 48
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
 //  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 7
+//  * Torn equation systems: 4
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 7 {(1,100.0%) 10,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 4 {(4,62.5%) 19,(1,100.0%) 2,(1,100.0%) 3,(1,100.0%) 3}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
@@ -59,18 +59,18 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit6_res.m
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (39):
-//  * Single equations (assignments): 32
+// Notification: Strong component statistics for simulation (31):
+//  * Single equations (assignments): 27
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
 //  * When equations: 0
 //  * If-equations: 0
 //  * Equation systems (linear and non-linear blocks): 0
-//  * Torn equation systems: 7
+//  * Torn equation systems: 4
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 7 {(1,100.0%) 10,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 4 {(4,62.5%) 19,(1,100.0%) 3,(1,100.0%) 3,(1,100.0%) 2}
 //  * Non-linear torn systems: 0
 // "
 // {"Files Equal!"}

--- a/testsuite/simulation/modelica/start_value_selection/asmaFlow.mos
+++ b/testsuite/simulation/modelica/start_value_selection/asmaFlow.mos
@@ -535,33 +535,27 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // ========================================
 // $cse1
 //
-// Replacements: (20)
+// Replacements: (16)
 // ========================================
-// ground.p.i -> 0.0
 // aimc.airGapS.RotationMatrix[2,1] -> $cse1
 // aimc.strayLoad.w -> aimc.inertiaRotor.w
 // $DER.aimc.strayLoad.phi -> aimc.inertiaRotor.w
 // aimc.rs.resistor[3].v -> aimc.rs.v[3]
 // aimc.rs.resistor[2].v -> aimc.rs.v[2]
 // aimc.rs.resistor[1].v -> aimc.rs.v[1]
-// aimc.powerBalance.lossPowerStatorWinding -> aimc.thermalAmbient.Q_flowStatorWinding
-// aimc.powerBalance.lossPowerTotal -> aimc.thermalAmbient.Q_flowTotal
 // aimc.friction.w -> aimc.inertiaRotor.w
 // $DER.aimc.friction.phi -> aimc.inertiaRotor.w
 // aimc.inertiaStator.flange_a.tau -> 0.0
 // aimc.fixed.flange.tau -> -aimc.tauElectrical
 // aimc.wMechanical -> aimc.inertiaRotor.w
 // $DER.aimc.phiMechanical -> aimc.inertiaRotor.w
-// $DER.ground.p.i -> 0.0
 // $DER.aimc.airGapS.psi_mr[1] -> aimc.airGapS.spacePhasor_r.v_[1]
 // $DER.aimc.airGapS.psi_mr[2] -> aimc.airGapS.spacePhasor_r.v_[2]
 // $DER.aimc.airGapS.psi_ms[1] -> aimc.airGapS.spacePhasor_s.v_[1]
 // $DER.aimc.airGapS.psi_ms[2] -> aimc.airGapS.spacePhasor_s.v_[2]
 //
-// ExtendReplacements: (23)
+// ExtendReplacements: (18)
 // ========================================
-// ground -> 0.0
-// ground.p -> 0.0
 // aimc -> 0.0
 // aimc.airGapS -> 0.0
 // aimc.airGapS.RotationMatrix -> 0.0
@@ -571,15 +565,12 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // $DER.aimc.strayLoad -> 0.0
 // aimc.rs -> 0.0
 // aimc.rs.resistor -> 0.0
-// aimc.powerBalance -> 0.0
 // aimc.friction -> 0.0
 // $DER.aimc.friction -> 0.0
 // aimc.inertiaStator -> 0.0
 // aimc.inertiaStator.flange_a -> 0.0
 // aimc.fixed -> 0.0
 // aimc.fixed.flange -> 0.0
-// $DER.ground -> 0.0
-// $DER.ground.p -> 0.0
 // $DER.aimc.airGapS -> 0.0
 // $DER.aimc.airGapS.psi_mr -> 0.0
 // $DER.aimc.airGapS.psi_ms -> 0.0
@@ -589,8 +580,10 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // $res2.$pDERLSJac2.dummyVarLSJac2
 // $res1.$pDERLSJac2.dummyVarLSJac2
 //
-// Unreplaceable Crefs: (5)
+// Unreplaceable Crefs: (7)
 // ========================================
+// $res7.$pDERLSJac3.dummyVarLSJac3
+// $res6.$pDERLSJac3.dummyVarLSJac3
 // $res5.$pDERLSJac3.dummyVarLSJac3
 // $res4.$pDERLSJac3.dummyVarLSJac3
 // $res3.$pDERLSJac3.dummyVarLSJac3
@@ -607,84 +600,12 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 //
 // Variables (1)
 // ========================================
-// 1: star.pin_n.i:VARIABLE(flow=true unit = "A" )  "Current flowing into the pin" type: Real
-//
-//
-// Equations (1, 1)
-// ========================================
-// 1/1 (1): star.pin_n.i = 0.0   [binding |0|0|0|0|]
-//
-//
-// Matching
-// ========================================
-// 1 variables and equations
-// var 1 is solved in eqn 1
-//
-//
-// StrongComponents
-// ========================================
-// {1:1}
-//
-//
-// unspecified partition
-// ========================================
-//
-// Variables (1)
-// ========================================
-// 1: ground.p.i:DUMMY_STATE(flow=true unit = "A" )  "Current flowing into the pin" type: Real
-//
-//
-// Equations (1, 1)
-// ========================================
-// 1/1 (1): ground.p.i = 0.0   [binding |0|0|0|0|]
-//
-//
-// Matching
-// ========================================
-// 1 variables and equations
-// var 1 is solved in eqn 1
-//
-//
-// StrongComponents
-// ========================================
-// {1:1}
-//
-//
-// unspecified partition
-// ========================================
-//
-// Variables (1)
-// ========================================
 // 1: aimc.inertiaStator.flange_a.tau:VARIABLE(flow=true unit = "N.m" )  "Cut torque in the flange" type: Real
 //
 //
 // Equations (1, 1)
 // ========================================
 // 1/1 (1): aimc.inertiaStator.flange_a.tau = 0.0   [binding |0|0|0|0|]
-//
-//
-// Matching
-// ========================================
-// 1 variables and equations
-// var 1 is solved in eqn 1
-//
-//
-// StrongComponents
-// ========================================
-// {1:1}
-//
-//
-// unspecified partition
-// ========================================
-//
-// Variables (1)
-// ========================================
-// 1: $DER.ground.p.i:DUMMY_DER(flow=true fixed = false )  "Current flowing into the pin" type: Real
-//
-//
-// Equations (1, 1)
-// ========================================
-// 1/1 (1): $DER.ground.p.i = 0.0   [binding |0|0|0|0|]
 //
 //
 // Matching
@@ -845,7 +766,7 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // unspecified partition
 // ========================================
 //
-// Variables (93)
+// Variables (94)
 // ========================================
 // 1: sinevoltage1.i[3]:DUMMY_STATE(unit = "A" )  "Currents flowing into positive plugs" type: Real [3]
 // 2: sinevoltage1.i[2]:DUMMY_STATE(unit = "A" )  "Currents flowing into positive plugs" type: Real [3]
@@ -854,95 +775,96 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 5: sinevoltage1.v[2]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
 // 6: sinevoltage1.v[1]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
 // 7: speedSensor.flange.phi:STATE(1,aimc.inertiaRotor.w)(flow=false unit = "rad" )  "Absolute rotation angle of flange" type: Real
-// 8: aimc.thermalAmbient.Q_flowTotal:VARIABLE(unit = "W" final = true )  type: Real
-// 9: aimc.thermalAmbient.Q_flowRotorWinding:VARIABLE(unit = "W" final = true )  "Heat flow rate of rotor (squirrel cage)" type: Real
-// 10: aimc.thermalAmbient.Q_flowStatorWinding:VARIABLE(unit = "W" final = true )  "Heat flow rate of stator windings" type: Real
-// 11: aimc.airGapS.i_ms[2]:DUMMY_STATE(unit = "A" )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
-// 12: aimc.airGapS.i_ms[1]:DUMMY_STATE(unit = "A" )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
-// 13: aimc.airGapS.spacePhasor_r.v_[2]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
-// 14: aimc.airGapS.spacePhasor_r.v_[1]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
-// 15: aimc.airGapS.spacePhasor_s.v_[2]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
-// 16: aimc.airGapS.spacePhasor_s.v_[1]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
-// 17: aimc.airGapS.RotationMatrix[2,2]:DUMMY_STATE()  "Matrix of rotation from rotor to stator" type: Real [2,2]
-// 18: aimc.airGapS.psi_mr[2]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
-// 19: aimc.airGapS.psi_mr[1]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
-// 20: aimc.airGapS.psi_ms[2]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
-// 21: aimc.airGapS.psi_ms[1]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
-// 22: aimc.airGapS.gamma:DUMMY_STATE(unit = "rad" )  "Rotor displacement angle" type: Real
-// 23: aimc.strayLoad.iRMS:VARIABLE(unit = "A" )  type: Real
-// 24: aimc.strayLoad.phi:DUMMY_STATE(unit = "rad" )  "Angle between shaft and support" type: Real
-// 25: aimc.spacePhasorS.i[3]:DUMMY_STATE(unit = "A" )  "Instantaneous phase currents" type: Real [3]
-// 26: aimc.spacePhasorS.i[2]:DUMMY_STATE(unit = "A" )  "Instantaneous phase currents" type: Real [3]
-// 27: aimc.spacePhasorS.i[1]:DUMMY_STATE(unit = "A" )  "Instantaneous phase currents" type: Real [3]
-// 28: aimc.spacePhasorS.v[3]:VARIABLE(unit = "V" )  "Instantaneous phase voltages" type: Real [3]
-// 29: aimc.spacePhasorS.v[2]:VARIABLE(unit = "V" )  "Instantaneous phase voltages" type: Real [3]
-// 30: aimc.spacePhasorS.v[1]:VARIABLE(unit = "V" )  "Instantaneous phase voltages" type: Real [3]
-// 31: aimc.lszero.v:VARIABLE(unit = "V" )  "Voltage drop between the two pins (= p.v - n.v)" type: Real
-// 32: aimc.lssigma.spacePhasor_a.v_[2]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
-// 33: aimc.lssigma.spacePhasor_a.v_[1]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
-// 34: aimc.lssigma.i_[2]:DUMMY_STATE(unit = "A" )  type: Real [2]
-// 35: aimc.lssigma.i_[1]:DUMMY_STATE(unit = "A" )  type: Real [2]
-// 36: aimc.lssigma.v_[2]:VARIABLE(unit = "V" )  type: Real [2]
-// 37: aimc.lssigma.v_[1]:VARIABLE(unit = "V" )  type: Real [2]
-// 38: aimc.rs.resistor[3].LossPower:VARIABLE(unit = "W" )  "Loss power leaving component via HeatPort" type: Real [3]
-// 39: aimc.rs.resistor[2].LossPower:VARIABLE(unit = "W" )  "Loss power leaving component via HeatPort" type: Real [3]
-// 40: aimc.rs.resistor[1].LossPower:VARIABLE(unit = "W" )  "Loss power leaving component via HeatPort" type: Real [3]
-// 41: aimc.rs.plug_n.pin[3].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
-// 42: aimc.rs.plug_n.pin[2].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
-// 43: aimc.rs.plug_n.pin[1].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
-// 44: aimc.rs.v[3]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
-// 45: aimc.rs.v[2]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
-// 46: aimc.rs.v[1]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
-// 47: aimc.plug_sn.pin[3].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
-// 48: aimc.idq_rr[2]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Rotor space phasor current / rotor fixed frame" type: Real [2]
-// 49: aimc.idq_rr[1]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Rotor space phasor current / rotor fixed frame" type: Real [2]
-// 50: aimc.idq_rs[2]:DUMMY_STATE(unit = "A" )  "Rotor space phasor current / stator fixed frame" type: Real [2]
-// 51: aimc.idq_rs[1]:DUMMY_STATE(unit = "A" )  "Rotor space phasor current / stator fixed frame" type: Real [2]
-// 52: aimc.idq_sr[2]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Stator space phasor current / rotor fixed frame" type: Real [2]
-// 53: aimc.idq_sr[1]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Stator space phasor current / rotor fixed frame" type: Real [2]
-// 54: aimc.i_0_s:DUMMY_STATE(start = 0.0 unit = "A" stateSelect=StateSelect.prefer )  "Stator zero-sequence current" type: Real
-// 55: aimc.vs[3]:VARIABLE(unit = "V" )  "Stator instantaneous voltages" type: Real [3]
-// 56: aimc.vs[2]:VARIABLE(unit = "V" )  "Stator instantaneous voltages" type: Real [3]
-// 57: aimc.vs[1]:VARIABLE(unit = "V" )  "Stator instantaneous voltages" type: Real [3]
-// 58: aimc.powerBalance.powerInertiaRotor:VARIABLE(unit = "W" final = true )  "Rotor inertia power" type: Real
-// 59: aimc.powerBalance.powerMechanical:VARIABLE(unit = "W" final = true )  "Mechanical power" type: Real
-// 60: aimc.powerBalance.powerStator:VARIABLE(unit = "W" final = true )  "Electrical power (stator)" type: Real
-// 61: aimc.friction.phi:DUMMY_STATE(unit = "rad" )  "Angle between shaft and support" type: Real
-// 62: aimc.inertiaRotor.a:VARIABLE(unit = "rad/s2" )  "Absolute angular acceleration of component (= der(w))" type: Real
-// 63: aimc.inertiaRotor.w:STATE(1,aimc.inertiaRotor.a)(start = 0.0 unit = "rad/s" )  "Absolute angular velocity of component (= der(phi))" type: Real
-// 64: aimc.tauElectrical:VARIABLE(unit = "N.m" )  "Electromagnetic torque" type: Real
-// 65: aimc.phiMechanical:DUMMY_STATE(start = 0.0 unit = "rad" )  "Mechanical angle of rotor against stator" type: Real
-// 66: $DER.aimc.airGapS.gamma:DUMMY_DER(fixed = false )  "Rotor displacement angle" type: Real
-// 67: $DER.aimc.airGapS.RotationMatrix[2,1]:DUMMY_DER(fixed = false )  "Matrix of rotation from rotor to stator" type: Real [2,2]
-// 68: $DER.aimc.airGapS.RotationMatrix[2,2]:DUMMY_DER(fixed = false )  "Matrix of rotation from rotor to stator" type: Real [2,2]
-// 69: $DER.aimc.idq_rs[1]:DUMMY_DER(fixed = false )  "Rotor space phasor current / stator fixed frame" type: Real [2]
-// 70: $DER.aimc.idq_rs[2]:DUMMY_DER(fixed = false )  "Rotor space phasor current / stator fixed frame" type: Real [2]
-// 71: $DER.aimc.airGapS.i_ms[1]:DUMMY_DER(fixed = false )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
-// 72: $DER.aimc.airGapS.i_ms[2]:DUMMY_DER(fixed = false )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
-// 73: $DER.sinevoltage1.i[1]:DUMMY_DER(fixed = false )  "Currents flowing into positive plugs" type: Real [3]
-// 74: $DER.sinevoltage1.i[2]:DUMMY_DER(fixed = false )  "Currents flowing into positive plugs" type: Real [3]
-// 75: $DER.sinevoltage1.i[3]:DUMMY_DER(fixed = false )  "Currents flowing into positive plugs" type: Real [3]
-// 76: $DER.aimc.lssigma.i_[1]:DUMMY_DER(fixed = false )  type: Real [2]
-// 77: $DER.aimc.lssigma.i_[2]:DUMMY_DER(fixed = false )  type: Real [2]
-// 78: $DER.aimc.spacePhasorS.i[1]:DUMMY_DER(fixed = false )  "Instantaneous phase currents" type: Real [3]
-// 79: $DER.aimc.spacePhasorS.i[2]:DUMMY_DER(fixed = false )  "Instantaneous phase currents" type: Real [3]
-// 80: $DER.aimc.spacePhasorS.i[3]:DUMMY_DER(fixed = false )  "Instantaneous phase currents" type: Real [3]
-// 81: $DER.aimc.i_0_s:DUMMY_DER(fixed = false )  "Stator zero-sequence current" type: Real
-// 82: $cse1:VARIABLE(protected = true )  type: Real unreplaceable
-// 83: aimc.airGapS.RotationMatrix[2,1]:DUMMY_STATE(fixed = false )  "Matrix of rotation from rotor to stator" type: Real [2,2]
-// 84: aimc.rs.resistor[3].v:VARIABLE(unit = "V" fixed = false )  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
-// 85: aimc.rs.resistor[2].v:VARIABLE(unit = "V" fixed = false )  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
-// 86: aimc.rs.resistor[1].v:VARIABLE(unit = "V" fixed = false )  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
-// 87: aimc.powerBalance.lossPowerStatorWinding:VARIABLE(unit = "W" fixed = false final = true )  "Stator copper losses" type: Real
-// 88: aimc.powerBalance.lossPowerTotal:VARIABLE(unit = "W" fixed = false final = true )  "Total loss power" type: Real
-// 89: aimc.fixed.flange.tau:VARIABLE(flow=true unit = "N.m" fixed = false )  "Cut torque in the flange" type: Real
-// 90: $DER.aimc.airGapS.psi_mr[1]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
-// 91: $DER.aimc.airGapS.psi_mr[2]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
-// 92: $DER.aimc.airGapS.psi_ms[1]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
-// 93: $DER.aimc.airGapS.psi_ms[2]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
+// 8: ground.p.i:VARIABLE(flow=true unit = "A" )  "Current flowing into the pin" type: Real
+// 9: aimc.thermalAmbient.Q_flowTotal:VARIABLE(unit = "W" final = true )  type: Real
+// 10: aimc.thermalAmbient.Q_flowRotorWinding:VARIABLE(unit = "W" final = true )  "Heat flow rate of rotor (squirrel cage)" type: Real
+// 11: aimc.thermalAmbient.Q_flowStatorWinding:VARIABLE(unit = "W" final = true )  "Heat flow rate of stator windings" type: Real
+// 12: aimc.airGapS.i_ms[2]:DUMMY_STATE(unit = "A" )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
+// 13: aimc.airGapS.i_ms[1]:DUMMY_STATE(unit = "A" )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
+// 14: aimc.airGapS.spacePhasor_r.v_[2]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
+// 15: aimc.airGapS.spacePhasor_r.v_[1]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
+// 16: aimc.airGapS.spacePhasor_s.v_[2]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
+// 17: aimc.airGapS.spacePhasor_s.v_[1]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
+// 18: aimc.airGapS.RotationMatrix[2,2]:DUMMY_STATE()  "Matrix of rotation from rotor to stator" type: Real [2,2]
+// 19: aimc.airGapS.psi_mr[2]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
+// 20: aimc.airGapS.psi_mr[1]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
+// 21: aimc.airGapS.psi_ms[2]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
+// 22: aimc.airGapS.psi_ms[1]:DUMMY_STATE(unit = "Wb" )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
+// 23: aimc.airGapS.gamma:DUMMY_STATE(unit = "rad" )  "Rotor displacement angle" type: Real
+// 24: aimc.strayLoad.iRMS:VARIABLE(unit = "A" )  type: Real
+// 25: aimc.strayLoad.phi:DUMMY_STATE(unit = "rad" )  "Angle between shaft and support" type: Real
+// 26: aimc.spacePhasorS.i[3]:DUMMY_STATE(unit = "A" )  "Instantaneous phase currents" type: Real [3]
+// 27: aimc.spacePhasorS.i[2]:DUMMY_STATE(unit = "A" )  "Instantaneous phase currents" type: Real [3]
+// 28: aimc.spacePhasorS.i[1]:DUMMY_STATE(unit = "A" )  "Instantaneous phase currents" type: Real [3]
+// 29: aimc.spacePhasorS.v[3]:VARIABLE(unit = "V" )  "Instantaneous phase voltages" type: Real [3]
+// 30: aimc.spacePhasorS.v[2]:VARIABLE(unit = "V" )  "Instantaneous phase voltages" type: Real [3]
+// 31: aimc.spacePhasorS.v[1]:VARIABLE(unit = "V" )  "Instantaneous phase voltages" type: Real [3]
+// 32: aimc.lszero.v:VARIABLE(unit = "V" )  "Voltage drop between the two pins (= p.v - n.v)" type: Real
+// 33: aimc.lssigma.spacePhasor_a.v_[2]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
+// 34: aimc.lssigma.spacePhasor_a.v_[1]:VARIABLE(flow=false unit = "V" )  "1=real, 2=imaginary part" type: Real [2]
+// 35: aimc.lssigma.i_[2]:DUMMY_STATE(unit = "A" )  type: Real [2]
+// 36: aimc.lssigma.i_[1]:DUMMY_STATE(unit = "A" )  type: Real [2]
+// 37: aimc.lssigma.v_[2]:VARIABLE(unit = "V" )  type: Real [2]
+// 38: aimc.lssigma.v_[1]:VARIABLE(unit = "V" )  type: Real [2]
+// 39: aimc.rs.resistor[3].LossPower:VARIABLE(unit = "W" )  "Loss power leaving component via HeatPort" type: Real [3]
+// 40: aimc.rs.resistor[2].LossPower:VARIABLE(unit = "W" )  "Loss power leaving component via HeatPort" type: Real [3]
+// 41: aimc.rs.resistor[1].LossPower:VARIABLE(unit = "W" )  "Loss power leaving component via HeatPort" type: Real [3]
+// 42: aimc.rs.plug_n.pin[3].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
+// 43: aimc.rs.plug_n.pin[2].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
+// 44: aimc.rs.plug_n.pin[1].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
+// 45: aimc.rs.v[3]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
+// 46: aimc.rs.v[2]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
+// 47: aimc.rs.v[1]:VARIABLE(unit = "V" )  "Voltage drops between the two plugs" type: Real [3]
+// 48: aimc.plug_sn.pin[3].v:VARIABLE(flow=false unit = "V" )  "Potential at the pin" type: Real [3]
+// 49: aimc.idq_rr[2]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Rotor space phasor current / rotor fixed frame" type: Real [2]
+// 50: aimc.idq_rr[1]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Rotor space phasor current / rotor fixed frame" type: Real [2]
+// 51: aimc.idq_rs[2]:DUMMY_STATE(unit = "A" )  "Rotor space phasor current / stator fixed frame" type: Real [2]
+// 52: aimc.idq_rs[1]:DUMMY_STATE(unit = "A" )  "Rotor space phasor current / stator fixed frame" type: Real [2]
+// 53: aimc.idq_sr[2]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Stator space phasor current / rotor fixed frame" type: Real [2]
+// 54: aimc.idq_sr[1]:STATE(1)(unit = "A" stateSelect=StateSelect.prefer )  "Stator space phasor current / rotor fixed frame" type: Real [2]
+// 55: aimc.i_0_s:DUMMY_STATE(start = 0.0 unit = "A" stateSelect=StateSelect.prefer )  "Stator zero-sequence current" type: Real
+// 56: aimc.vs[3]:VARIABLE(unit = "V" )  "Stator instantaneous voltages" type: Real [3]
+// 57: aimc.vs[2]:VARIABLE(unit = "V" )  "Stator instantaneous voltages" type: Real [3]
+// 58: aimc.vs[1]:VARIABLE(unit = "V" )  "Stator instantaneous voltages" type: Real [3]
+// 59: aimc.powerBalance.lossPowerStatorWinding:VARIABLE(unit = "W" final = true )  "Stator copper losses" type: Real
+// 60: aimc.powerBalance.lossPowerTotal:VARIABLE(unit = "W" final = true )  "Total loss power" type: Real
+// 61: aimc.powerBalance.powerInertiaRotor:VARIABLE(unit = "W" final = true )  "Rotor inertia power" type: Real
+// 62: aimc.powerBalance.powerMechanical:VARIABLE(unit = "W" final = true )  "Mechanical power" type: Real
+// 63: aimc.powerBalance.powerStator:VARIABLE(unit = "W" final = true )  "Electrical power (stator)" type: Real
+// 64: aimc.friction.phi:DUMMY_STATE(unit = "rad" )  "Angle between shaft and support" type: Real
+// 65: aimc.inertiaRotor.a:VARIABLE(unit = "rad/s2" )  "Absolute angular acceleration of component (= der(w))" type: Real
+// 66: aimc.inertiaRotor.w:STATE(1,aimc.inertiaRotor.a)(start = 0.0 unit = "rad/s" )  "Absolute angular velocity of component (= der(phi))" type: Real
+// 67: aimc.tauElectrical:VARIABLE(unit = "N.m" )  "Electromagnetic torque" type: Real
+// 68: aimc.phiMechanical:DUMMY_STATE(start = 0.0 unit = "rad" )  "Mechanical angle of rotor against stator" type: Real
+// 69: $DER.aimc.airGapS.gamma:DUMMY_DER(fixed = false )  "Rotor displacement angle" type: Real
+// 70: $DER.aimc.airGapS.RotationMatrix[2,1]:DUMMY_DER(fixed = false )  "Matrix of rotation from rotor to stator" type: Real [2,2]
+// 71: $DER.aimc.airGapS.RotationMatrix[2,2]:DUMMY_DER(fixed = false )  "Matrix of rotation from rotor to stator" type: Real [2,2]
+// 72: $DER.aimc.idq_rs[1]:DUMMY_DER(fixed = false )  "Rotor space phasor current / stator fixed frame" type: Real [2]
+// 73: $DER.aimc.idq_rs[2]:DUMMY_DER(fixed = false )  "Rotor space phasor current / stator fixed frame" type: Real [2]
+// 74: $DER.aimc.airGapS.i_ms[1]:DUMMY_DER(fixed = false )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
+// 75: $DER.aimc.airGapS.i_ms[2]:DUMMY_DER(fixed = false )  "Magnetizing current space phasor with respect to the stator fixed frame" type: Real [2]
+// 76: $DER.sinevoltage1.i[1]:DUMMY_DER(fixed = false )  "Currents flowing into positive plugs" type: Real [3]
+// 77: $DER.sinevoltage1.i[2]:DUMMY_DER(fixed = false )  "Currents flowing into positive plugs" type: Real [3]
+// 78: $DER.sinevoltage1.i[3]:DUMMY_DER(fixed = false )  "Currents flowing into positive plugs" type: Real [3]
+// 79: $DER.aimc.lssigma.i_[1]:DUMMY_DER(fixed = false )  type: Real [2]
+// 80: $DER.aimc.lssigma.i_[2]:DUMMY_DER(fixed = false )  type: Real [2]
+// 81: $DER.aimc.spacePhasorS.i[1]:DUMMY_DER(fixed = false )  "Instantaneous phase currents" type: Real [3]
+// 82: $DER.aimc.spacePhasorS.i[2]:DUMMY_DER(fixed = false )  "Instantaneous phase currents" type: Real [3]
+// 83: $DER.aimc.spacePhasorS.i[3]:DUMMY_DER(fixed = false )  "Instantaneous phase currents" type: Real [3]
+// 84: $DER.aimc.i_0_s:DUMMY_DER(fixed = false )  "Stator zero-sequence current" type: Real
+// 85: $cse1:VARIABLE(protected = true )  type: Real unreplaceable
+// 86: aimc.airGapS.RotationMatrix[2,1]:DUMMY_STATE(fixed = false )  "Matrix of rotation from rotor to stator" type: Real [2,2]
+// 87: aimc.rs.resistor[3].v:VARIABLE(unit = "V" fixed = false )  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
+// 88: aimc.rs.resistor[2].v:VARIABLE(unit = "V" fixed = false )  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
+// 89: aimc.rs.resistor[1].v:VARIABLE(unit = "V" fixed = false )  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
+// 90: aimc.fixed.flange.tau:VARIABLE(flow=true unit = "N.m" fixed = false )  "Cut torque in the flange" type: Real
+// 91: $DER.aimc.airGapS.psi_mr[1]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
+// 92: $DER.aimc.airGapS.psi_mr[2]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the rotor fixed frame" type: Real [2]
+// 93: $DER.aimc.airGapS.psi_ms[1]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
+// 94: $DER.aimc.airGapS.psi_ms[2]:DUMMY_DER(fixed = false )  "Magnetizing flux phasor with respect to the stator fixed frame" type: Real [2]
 //
 //
-// Equations (93, 93)
+// Equations (94, 94)
 // ========================================
 // 1/1 (1): aimc.phiMechanical = speedSensor.flange.phi - aimc.fixed.phi0   [binding |0|0|0|0|]
 // 2/2 (1): aimc.friction.phi = speedSensor.flange.phi - aimc.fixed.phi0   [dynamic |0|0|0|0|]
@@ -952,197 +874,198 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 6/6 (1): $cse1 = sin(aimc.airGapS.gamma)   [unknown |0|0|0|0|]
 // 7/7 (1): aimc.lssigma.i_[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.idq_sr[1] - $cse1 * aimc.idq_sr[2]   [dynamic |0|0|0|0|]
 // 8/8 (1): aimc.lssigma.i_[2] = $cse1 * aimc.idq_sr[1] + aimc.airGapS.RotationMatrix[2,2] * aimc.idq_sr[2]   [dynamic |0|0|0|0|]
-// 9/9 (1): aimc.idq_rs[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[1] - $cse1 * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
-// 10/10 (1): aimc.airGapS.i_ms[1] = aimc.lssigma.i_[1] + aimc.idq_rs[1]   [dynamic |0|0|0|0|]
-// 11/11 (1): aimc.idq_rs[2] = $cse1 * aimc.idq_rr[1] + aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
-// 12/12 (1): aimc.airGapS.i_ms[2] = aimc.lssigma.i_[2] + aimc.idq_rs[2]   [dynamic |0|0|0|0|]
-// 13/13 (1): aimc.airGapS.psi_ms[2] = aimc.airGapS.L[2,1] * aimc.airGapS.i_ms[1] + aimc.airGapS.L[2,2] * aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
-// 14/14 (1): aimc.airGapS.psi_ms[1] = aimc.airGapS.L[1,1] * aimc.airGapS.i_ms[1] + aimc.airGapS.L[1,2] * aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
-// 15/15 (1): aimc.airGapS.psi_mr[2] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[2] - $cse1 * aimc.airGapS.psi_ms[1]   [dynamic |0|0|0|0|]
-// 16/16 (1): aimc.airGapS.psi_mr[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[1] + $cse1 * aimc.airGapS.psi_ms[2]   [dynamic |0|0|0|0|]
-// 17/17 (1): (-sinevoltage1.i[1]) - sinevoltage1.i[3] - sinevoltage1.i[2] = 0.0   [dynamic |0|0|0|0|]
-// 18/18 (1): aimc.spacePhasorS.i[2] * aimc.spacePhasorS.turnsRatio = sinevoltage1.i[2]   [dynamic |0|0|0|0|]
-// 19/19 (1): aimc.lssigma.i_[1] = aimc.spacePhasorS.TransformationMatrix[1,1] * aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[1,2] * aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[1,3] * aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
-// 20/20 (1): aimc.spacePhasorS.i[3] * aimc.spacePhasorS.turnsRatio = sinevoltage1.i[3]   [dynamic |0|0|0|0|]
-// 21/21 (1): aimc.lssigma.i_[2] = aimc.spacePhasorS.TransformationMatrix[2,1] * aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[2,2] * aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[2,3] * aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
-// 22/22 (1): aimc.spacePhasorS.i[1] * aimc.spacePhasorS.turnsRatio = sinevoltage1.i[1]   [dynamic |0|0|0|0|]
-// 23/23 (1): aimc.i_0_s = (aimc.spacePhasorS.i[1] + aimc.spacePhasorS.i[2] + aimc.spacePhasorS.i[3]) / (-3.0)   [dynamic |0|0|0|0|]
+// 9/9 (1): aimc.lssigma.i_[2] = aimc.spacePhasorS.TransformationMatrix[2,1] * aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[2,2] * aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[2,3] * aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
+// 10/10 (1): aimc.spacePhasorS.i[3] * aimc.spacePhasorS.turnsRatio = sinevoltage1.i[3]   [dynamic |0|0|0|0|]
+// 11/11 (1): sinevoltage1.i[1] + sinevoltage1.i[2] + sinevoltage1.i[3] = 0.0   [dynamic |0|0|0|0|]
+// 12/12 (1): aimc.spacePhasorS.i[2] * aimc.spacePhasorS.turnsRatio = sinevoltage1.i[2]   [dynamic |0|0|0|0|]
+// 13/13 (1): aimc.lssigma.i_[1] = aimc.spacePhasorS.TransformationMatrix[1,1] * aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[1,2] * aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[1,3] * aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
+// 14/14 (1): aimc.spacePhasorS.i[1] * aimc.spacePhasorS.turnsRatio = sinevoltage1.i[1]   [dynamic |0|0|0|0|]
+// 15/15 (1): aimc.i_0_s = (aimc.spacePhasorS.i[1] + aimc.spacePhasorS.i[2] + aimc.spacePhasorS.i[3]) / (-3.0)   [dynamic |0|0|0|0|]
+// 16/16 (1): aimc.idq_rs[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[1] - $cse1 * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
+// 17/17 (1): aimc.airGapS.i_ms[1] = aimc.lssigma.i_[1] + aimc.idq_rs[1]   [dynamic |0|0|0|0|]
+// 18/18 (1): aimc.idq_rs[2] = $cse1 * aimc.idq_rr[1] + aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
+// 19/19 (1): aimc.airGapS.i_ms[2] = aimc.lssigma.i_[2] + aimc.idq_rs[2]   [dynamic |0|0|0|0|]
+// 20/20 (1): aimc.airGapS.psi_ms[2] = aimc.airGapS.L[2,1] * aimc.airGapS.i_ms[1] + aimc.airGapS.L[2,2] * aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
+// 21/21 (1): aimc.airGapS.psi_ms[1] = aimc.airGapS.L[1,1] * aimc.airGapS.i_ms[1] + aimc.airGapS.L[1,2] * aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
+// 22/22 (1): aimc.airGapS.psi_mr[2] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[2] - $cse1 * aimc.airGapS.psi_ms[1]   [dynamic |0|0|0|0|]
+// 23/23 (1): aimc.airGapS.psi_mr[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[1] + $cse1 * aimc.airGapS.psi_ms[2]   [dynamic |0|0|0|0|]
 // 24/24 (1): sinevoltage1.v[3] = sinevoltage1.sineVoltage[3].signalSource.offset + (if time < sinevoltage1.sineVoltage[3].signalSource.startTime then 0.0 else sinevoltage1.sineVoltage[3].signalSource.amplitude * sin(6.283185307179586 * sinevoltage1.sineVoltage[3].signalSource.freqHz * (time - sinevoltage1.sineVoltage[3].signalSource.startTime) + sinevoltage1.sineVoltage[3].signalSource.phase))   [dynamic |0|0|0|0|]
 // 25/25 (1): sinevoltage1.v[2] = sinevoltage1.sineVoltage[2].signalSource.offset + (if time < sinevoltage1.sineVoltage[2].signalSource.startTime then 0.0 else sinevoltage1.sineVoltage[2].signalSource.amplitude * sin(6.283185307179586 * sinevoltage1.sineVoltage[2].signalSource.freqHz * (time - sinevoltage1.sineVoltage[2].signalSource.startTime) + sinevoltage1.sineVoltage[2].signalSource.phase))   [dynamic |0|0|0|0|]
 // 26/26 (1): sinevoltage1.v[1] = sinevoltage1.sineVoltage[1].signalSource.offset + (if time < sinevoltage1.sineVoltage[1].signalSource.startTime then 0.0 else sinevoltage1.sineVoltage[1].signalSource.amplitude * sin(6.283185307179586 * sinevoltage1.sineVoltage[1].signalSource.freqHz * (time - sinevoltage1.sineVoltage[1].signalSource.startTime) + sinevoltage1.sineVoltage[1].signalSource.phase))   [dynamic |0|0|0|0|]
 // 27/27 (1): der(speedSensor.flange.phi) = aimc.inertiaRotor.w   [dynamic |0|0|0|0|]
-// 28/28 (1): aimc.thermalAmbient.Q_flowRotorWinding = 1.5 * aimc.squirrelCageR.Rr_actual * (aimc.idq_rr[1] ^ 2.0 + aimc.idq_rr[2] ^ 2.0)   [dynamic |0|0|0|0|]
-// 29/29 (1): aimc.tauElectrical = 1.5 * /*Real*/(aimc.airGapS.p) * (aimc.lssigma.i_[2] * aimc.airGapS.psi_ms[1] - aimc.lssigma.i_[1] * aimc.airGapS.psi_ms[2])   [dynamic |0|0|0|0|]
-// 30/30 (1): $DER.aimc.airGapS.gamma = /*Real*/(aimc.airGapS.p) * aimc.inertiaRotor.w   [dynamic |0|0|0|0|]
-// 31/31 (1): $DER.aimc.airGapS.RotationMatrix[2,2] = (-$cse1) * $DER.aimc.airGapS.gamma   [dynamic |0|0|0|0|]
-// 32/32 (1): $DER.aimc.airGapS.RotationMatrix[2,1] = aimc.airGapS.RotationMatrix[2,2] * $DER.aimc.airGapS.gamma   [dynamic |0|0|0|0|]
-// 33/33 (1): aimc.strayLoad.iRMS = sqrt(sinevoltage1.i[1] ^ 2.0 / 3.0 + sinevoltage1.i[2] ^ 2.0 / 3.0 + sinevoltage1.i[3] ^ 2.0 / 3.0)   [binding |0|0|0|0|]
-// 34/34 (1): aimc.rs.v[3] = aimc.rs.resistor[3].R_actual * sinevoltage1.i[3]   [dynamic |0|0|0|0|]
-// 35/35 (1): aimc.rs.resistor[3].LossPower = aimc.rs.v[3] * sinevoltage1.i[3]   [dynamic |0|0|0|0|]
-// 36/36 (1): aimc.rs.plug_n.pin[3].v = (-sinevoltage1.v[3]) - aimc.rs.v[3]   [dynamic |0|0|0|0|]
-// 37/37 (1): aimc.rs.v[2] = aimc.rs.resistor[2].R_actual * sinevoltage1.i[2]   [dynamic |0|0|0|0|]
-// 38/38 (1): aimc.rs.resistor[2].LossPower = aimc.rs.v[2] * sinevoltage1.i[2]   [dynamic |0|0|0|0|]
-// 39/39 (1): aimc.rs.plug_n.pin[2].v = (-sinevoltage1.v[2]) - aimc.rs.v[2]   [dynamic |0|0|0|0|]
-// 40/40 (1): aimc.rs.v[1] = aimc.rs.resistor[1].R_actual * sinevoltage1.i[1]   [dynamic |0|0|0|0|]
-// 41/41 (1): aimc.rs.resistor[1].LossPower = aimc.rs.v[1] * sinevoltage1.i[1]   [dynamic |0|0|0|0|]
-// 42/42 (1): aimc.thermalAmbient.Q_flowStatorWinding = aimc.rs.resistor[1].LossPower + aimc.rs.resistor[2].LossPower + aimc.rs.resistor[3].LossPower   [dynamic |0|0|0|0|]
-// 43/43 (1): aimc.thermalAmbient.Q_flowTotal = aimc.thermalAmbient.Q_flowStatorWinding + aimc.thermalAmbient.Q_flowRotorWinding   [binding |0|0|0|0|]
-// 44/44 (1): aimc.rs.plug_n.pin[1].v = (-sinevoltage1.v[1]) - aimc.rs.v[1]   [dynamic |0|0|0|0|]
-// 45/45 (1): aimc.inertiaRotor.a = (aimc.tauElectrical + const.k) / aimc.inertiaRotor.J   [dynamic |0|0|0|0|]
-// 46/46 (1): aimc.powerBalance.powerInertiaRotor = aimc.inertiaRotor.J * aimc.inertiaRotor.a * aimc.inertiaRotor.w   [binding |0|0|0|0|]
-// 47/47 (1): der(aimc.inertiaRotor.w) = aimc.inertiaRotor.a   [dynamic |0|0|0|0|]
-// 48/48 (1): aimc.powerBalance.powerMechanical = (-aimc.inertiaRotor.w) * const.k   [binding |0|0|0|0|]
-// 49/49 (1): (-$DER.sinevoltage1.i[1]) - $DER.sinevoltage1.i[2] - $DER.sinevoltage1.i[3] = 0.0   [dynamic |0|0|0|0|]
-// 50/50 (1): $DER.aimc.spacePhasorS.i[3] * aimc.spacePhasorS.turnsRatio = $DER.sinevoltage1.i[3]   [dynamic |0|0|0|0|]
-// 51/51 (1): $DER.aimc.lssigma.i_[2] = aimc.spacePhasorS.TransformationMatrix[2,1] * $DER.aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[2,2] * $DER.aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[2,3] * $DER.aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
-// 52/52 (1): $DER.aimc.lssigma.i_[1] = aimc.spacePhasorS.TransformationMatrix[1,1] * $DER.aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[1,2] * $DER.aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[1,3] * $DER.aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
-// 53/53 (1): (-3.0) * $DER.aimc.i_0_s = $DER.aimc.spacePhasorS.i[1] + $DER.aimc.spacePhasorS.i[2] + $DER.aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
-// 54/54 (1): (-aimc.lszero.L) * $DER.aimc.i_0_s = aimc.lszero.v   [dynamic |0|0|0|0|]
-// 55/55 (1): 3.0 * aimc.lszero.v = aimc.spacePhasorS.v[1] + aimc.spacePhasorS.v[2] + aimc.spacePhasorS.v[3]   [dynamic |0|0|0|0|]
-// 56/56 (1): aimc.lssigma.spacePhasor_a.v_[2] = aimc.spacePhasorS.TransformationMatrix[2,1] * aimc.spacePhasorS.v[1] + aimc.spacePhasorS.TransformationMatrix[2,2] * aimc.spacePhasorS.v[2] + aimc.spacePhasorS.TransformationMatrix[2,3] * aimc.spacePhasorS.v[3]   [dynamic |0|0|0|0|]
-// 57/57 (1): aimc.lssigma.v_[2] = aimc.lssigma.spacePhasor_a.v_[2] - aimc.airGapS.spacePhasor_s.v_[2]   [dynamic |0|0|0|0|]
-// 58/58 (1): aimc.airGapS.spacePhasor_r.v_[2] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.spacePhasor_s.v_[2] + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[2] + (-$cse1) * aimc.airGapS.spacePhasor_s.v_[1] - $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.airGapS.psi_ms[1]   [dynamic |0|0|0|0|]
-// 59/59 (1): aimc.airGapS.spacePhasor_r.v_[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.spacePhasor_s.v_[1] + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[1] + $cse1 * aimc.airGapS.spacePhasor_s.v_[2] + $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.airGapS.psi_ms[2]   [dynamic |0|0|0|0|]
-// 60/60 (1): aimc.airGapS.spacePhasor_r.v_[1] = (-aimc.idq_rr[1]) * aimc.squirrelCageR.Rr_actual - der(aimc.idq_rr[1]) * aimc.squirrelCageR.Lrsigma   [dynamic |0|0|0|0|]
-// 61/61 (1): $DER.aimc.idq_rs[2] = $cse1 * der(aimc.idq_rr[1]) + $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_rr[1] + aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_rr[2]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
-// 62/62 (1): $DER.aimc.airGapS.i_ms[2] = $DER.aimc.lssigma.i_[2] + $DER.aimc.idq_rs[2]   [dynamic |0|0|0|0|]
-// 63/63 (1): aimc.lssigma.v_[2] = aimc.lssigma.L[2] * $DER.aimc.lssigma.i_[2]   [dynamic |0|0|0|0|]
-// 64/64 (1): $DER.aimc.idq_rs[1] = aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_rr[1]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[1] + (-$cse1) * der(aimc.idq_rr[2]) - $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
-// 65/65 (1): aimc.airGapS.spacePhasor_r.v_[2] = (-aimc.idq_rr[2]) * aimc.squirrelCageR.Rr_actual - der(aimc.idq_rr[2]) * aimc.squirrelCageR.Lrsigma   [dynamic |0|0|0|0|]
-// 66/66 (1): aimc.airGapS.spacePhasor_s.v_[1] = aimc.airGapS.L[1,1] * $DER.aimc.airGapS.i_ms[1] + aimc.airGapS.L[1,2] * $DER.aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
-// 67/67 (1): aimc.airGapS.spacePhasor_s.v_[2] = aimc.airGapS.L[2,1] * $DER.aimc.airGapS.i_ms[1] + aimc.airGapS.L[2,2] * $DER.aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
-// 68/68 (1): $DER.aimc.airGapS.i_ms[1] = $DER.aimc.lssigma.i_[1] + $DER.aimc.idq_rs[1]   [dynamic |0|0|0|0|]
-// 69/69 (1): aimc.lssigma.v_[1] = aimc.lssigma.spacePhasor_a.v_[1] - aimc.airGapS.spacePhasor_s.v_[1]   [dynamic |0|0|0|0|]
-// 70/70 (1): aimc.lssigma.v_[1] = aimc.lssigma.L[1] * $DER.aimc.lssigma.i_[1]   [dynamic |0|0|0|0|]
-// 71/71 (1): aimc.lssigma.spacePhasor_a.v_[1] = aimc.spacePhasorS.TransformationMatrix[1,1] * aimc.spacePhasorS.v[1] + aimc.spacePhasorS.TransformationMatrix[1,2] * aimc.spacePhasorS.v[2] + aimc.spacePhasorS.TransformationMatrix[1,3] * aimc.spacePhasorS.v[3]   [dynamic |0|0|0|0|]
-// 72/72 (1): aimc.spacePhasorS.v[3] / aimc.spacePhasorS.turnsRatio = aimc.rs.plug_n.pin[3].v - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
-// 73/73 (1): aimc.spacePhasorS.v[2] / aimc.spacePhasorS.turnsRatio = aimc.rs.plug_n.pin[2].v - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
-// 74/74 (1): aimc.spacePhasorS.v[1] / aimc.spacePhasorS.turnsRatio = aimc.rs.plug_n.pin[1].v - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
-// 75/75 (1): $DER.aimc.spacePhasorS.i[1] * aimc.spacePhasorS.turnsRatio = $DER.sinevoltage1.i[1]   [dynamic |0|0|0|0|]
-// 76/76 (1): $DER.aimc.spacePhasorS.i[2] * aimc.spacePhasorS.turnsRatio = $DER.sinevoltage1.i[2]   [dynamic |0|0|0|0|]
-// 77/77 (1): aimc.vs[1] = (-sinevoltage1.v[1]) - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
-// 78/78 (1): aimc.vs[2] = (-sinevoltage1.v[2]) - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
-// 79/79 (1): aimc.vs[3] = (-sinevoltage1.v[3]) - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
-// 80/80 (1): aimc.powerBalance.powerStator = Modelica.Electrical.Machines.SpacePhasors.Functions.activePower(aimc.vs, sinevoltage1.i)   [unknown |0|0|0|0|]
-// 81/81 (1): $DER.aimc.lssigma.i_[2] = $cse1 * der(aimc.idq_sr[1]) + $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_sr[1] + aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_sr[2]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_sr[2]   [dynamic |0|0|0|0|]
-// 82/82 (1): $DER.aimc.lssigma.i_[1] = aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_sr[1]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_sr[1] + (-$cse1) * der(aimc.idq_sr[2]) - $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_sr[2]   [dynamic |0|0|0|0|]
-// 83/83 (1): aimc.airGapS.RotationMatrix[2,1] = $cse1   [binding |0|0|0|0|]
-// 84/84 (1): aimc.rs.resistor[3].v = aimc.rs.v[3]   [binding |0|0|0|0|]
-// 85/85 (1): aimc.rs.resistor[2].v = aimc.rs.v[2]   [binding |0|0|0|0|]
-// 86/86 (1): aimc.rs.resistor[1].v = aimc.rs.v[1]   [binding |0|0|0|0|]
-// 87/87 (1): aimc.powerBalance.lossPowerStatorWinding = aimc.thermalAmbient.Q_flowStatorWinding   [binding |0|0|0|0|]
-// 88/88 (1): aimc.powerBalance.lossPowerTotal = aimc.thermalAmbient.Q_flowTotal   [binding |0|0|0|0|]
-// 89/89 (1): aimc.fixed.flange.tau = -aimc.tauElectrical   [binding |0|0|0|0|]
-// 90/90 (1): $DER.aimc.airGapS.psi_mr[1] = aimc.airGapS.spacePhasor_r.v_[1]   [binding |0|0|0|0|]
-// 91/91 (1): $DER.aimc.airGapS.psi_mr[2] = aimc.airGapS.spacePhasor_r.v_[2]   [binding |0|0|0|0|]
-// 92/92 (1): $DER.aimc.airGapS.psi_ms[1] = aimc.airGapS.spacePhasor_s.v_[1]   [binding |0|0|0|0|]
-// 93/93 (1): $DER.aimc.airGapS.psi_ms[2] = aimc.airGapS.spacePhasor_s.v_[2]   [binding |0|0|0|0|]
+// 28/28 (1): ground.p.i = (-sinevoltage1.i[2]) - sinevoltage1.i[1] - sinevoltage1.i[3]   [dynamic |0|0|0|0|]
+// 29/29 (1): aimc.thermalAmbient.Q_flowRotorWinding = 1.5 * aimc.squirrelCageR.Rr_actual * (aimc.idq_rr[1] ^ 2.0 + aimc.idq_rr[2] ^ 2.0)   [dynamic |0|0|0|0|]
+// 30/30 (1): aimc.tauElectrical = 1.5 * /*Real*/(aimc.airGapS.p) * (aimc.lssigma.i_[2] * aimc.airGapS.psi_ms[1] - aimc.lssigma.i_[1] * aimc.airGapS.psi_ms[2])   [dynamic |0|0|0|0|]
+// 31/31 (1): $DER.aimc.airGapS.gamma = /*Real*/(aimc.airGapS.p) * aimc.inertiaRotor.w   [dynamic |0|0|0|0|]
+// 32/32 (1): $DER.aimc.airGapS.RotationMatrix[2,2] = (-$cse1) * $DER.aimc.airGapS.gamma   [dynamic |0|0|0|0|]
+// 33/33 (1): $DER.aimc.airGapS.RotationMatrix[2,1] = aimc.airGapS.RotationMatrix[2,2] * $DER.aimc.airGapS.gamma   [dynamic |0|0|0|0|]
+// 34/34 (1): aimc.strayLoad.iRMS = sqrt(sinevoltage1.i[1] ^ 2.0 / 3.0 + sinevoltage1.i[2] ^ 2.0 / 3.0 + sinevoltage1.i[3] ^ 2.0 / 3.0)   [binding |0|0|0|0|]
+// 35/35 (1): aimc.rs.v[3] = aimc.rs.resistor[3].R_actual * sinevoltage1.i[3]   [dynamic |0|0|0|0|]
+// 36/36 (1): aimc.rs.resistor[3].LossPower = aimc.rs.v[3] * sinevoltage1.i[3]   [dynamic |0|0|0|0|]
+// 37/37 (1): aimc.rs.plug_n.pin[3].v = (-sinevoltage1.v[3]) - aimc.rs.v[3]   [dynamic |0|0|0|0|]
+// 38/38 (1): aimc.rs.v[2] = aimc.rs.resistor[2].R_actual * sinevoltage1.i[2]   [dynamic |0|0|0|0|]
+// 39/39 (1): aimc.rs.resistor[2].LossPower = aimc.rs.v[2] * sinevoltage1.i[2]   [dynamic |0|0|0|0|]
+// 40/40 (1): aimc.rs.plug_n.pin[2].v = (-sinevoltage1.v[2]) - aimc.rs.v[2]   [dynamic |0|0|0|0|]
+// 41/41 (1): aimc.rs.v[1] = aimc.rs.resistor[1].R_actual * sinevoltage1.i[1]   [dynamic |0|0|0|0|]
+// 42/42 (1): aimc.rs.resistor[1].LossPower = aimc.rs.v[1] * sinevoltage1.i[1]   [dynamic |0|0|0|0|]
+// 43/43 (1): aimc.thermalAmbient.Q_flowStatorWinding = aimc.rs.resistor[1].LossPower + aimc.rs.resistor[2].LossPower + aimc.rs.resistor[3].LossPower   [dynamic |0|0|0|0|]
+// 44/44 (1): aimc.thermalAmbient.Q_flowTotal = aimc.thermalAmbient.Q_flowStatorWinding + aimc.thermalAmbient.Q_flowRotorWinding   [binding |0|0|0|0|]
+// 45/45 (1): aimc.rs.plug_n.pin[1].v = (-sinevoltage1.v[1]) - aimc.rs.v[1]   [dynamic |0|0|0|0|]
+// 46/46 (1): aimc.powerBalance.lossPowerStatorWinding = aimc.rs.resistor[1].LossPower + aimc.rs.resistor[2].LossPower + aimc.rs.resistor[3].LossPower   [binding |0|0|0|0|]
+// 47/47 (1): aimc.powerBalance.lossPowerTotal = aimc.powerBalance.lossPowerStatorWinding + aimc.thermalAmbient.Q_flowRotorWinding   [binding |0|0|0|0|]
+// 48/48 (1): aimc.inertiaRotor.a = (aimc.tauElectrical + const.k) / aimc.inertiaRotor.J   [dynamic |0|0|0|0|]
+// 49/49 (1): aimc.powerBalance.powerInertiaRotor = aimc.inertiaRotor.J * aimc.inertiaRotor.a * aimc.inertiaRotor.w   [binding |0|0|0|0|]
+// 50/50 (1): der(aimc.inertiaRotor.w) = aimc.inertiaRotor.a   [dynamic |0|0|0|0|]
+// 51/51 (1): aimc.powerBalance.powerMechanical = (-aimc.inertiaRotor.w) * const.k   [binding |0|0|0|0|]
+// 52/52 (1): $DER.sinevoltage1.i[1] + $DER.sinevoltage1.i[2] + $DER.sinevoltage1.i[3] = 0.0   [dynamic |0|0|0|0|]
+// 53/53 (1): $DER.aimc.spacePhasorS.i[1] * aimc.spacePhasorS.turnsRatio = $DER.sinevoltage1.i[1]   [dynamic |0|0|0|0|]
+// 54/54 (1): $DER.aimc.lssigma.i_[2] = aimc.spacePhasorS.TransformationMatrix[2,1] * $DER.aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[2,2] * $DER.aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[2,3] * $DER.aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
+// 55/55 (1): $DER.aimc.lssigma.i_[1] = aimc.spacePhasorS.TransformationMatrix[1,1] * $DER.aimc.spacePhasorS.i[1] + aimc.spacePhasorS.TransformationMatrix[1,2] * $DER.aimc.spacePhasorS.i[2] + aimc.spacePhasorS.TransformationMatrix[1,3] * $DER.aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
+// 56/56 (1): (-3.0) * $DER.aimc.i_0_s = $DER.aimc.spacePhasorS.i[1] + $DER.aimc.spacePhasorS.i[2] + $DER.aimc.spacePhasorS.i[3]   [dynamic |0|0|0|0|]
+// 57/57 (1): (-aimc.lszero.L) * $DER.aimc.i_0_s = aimc.lszero.v   [dynamic |0|0|0|0|]
+// 58/58 (1): 3.0 * aimc.lszero.v = aimc.spacePhasorS.v[1] + aimc.spacePhasorS.v[2] + aimc.spacePhasorS.v[3]   [dynamic |0|0|0|0|]
+// 59/59 (1): aimc.lssigma.spacePhasor_a.v_[2] = aimc.spacePhasorS.TransformationMatrix[2,1] * aimc.spacePhasorS.v[1] + aimc.spacePhasorS.TransformationMatrix[2,2] * aimc.spacePhasorS.v[2] + aimc.spacePhasorS.TransformationMatrix[2,3] * aimc.spacePhasorS.v[3]   [dynamic |0|0|0|0|]
+// 60/60 (1): aimc.lssigma.v_[2] = aimc.lssigma.spacePhasor_a.v_[2] - aimc.airGapS.spacePhasor_s.v_[2]   [dynamic |0|0|0|0|]
+// 61/61 (1): aimc.airGapS.spacePhasor_r.v_[2] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.spacePhasor_s.v_[2] + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[2] + (-$cse1) * aimc.airGapS.spacePhasor_s.v_[1] - $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.airGapS.psi_ms[1]   [dynamic |0|0|0|0|]
+// 62/62 (1): aimc.airGapS.spacePhasor_r.v_[1] = aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.spacePhasor_s.v_[1] + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.airGapS.psi_ms[1] + $cse1 * aimc.airGapS.spacePhasor_s.v_[2] + $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.airGapS.psi_ms[2]   [dynamic |0|0|0|0|]
+// 63/63 (1): aimc.airGapS.spacePhasor_r.v_[1] = (-aimc.idq_rr[1]) * aimc.squirrelCageR.Rr_actual - der(aimc.idq_rr[1]) * aimc.squirrelCageR.Lrsigma   [dynamic |0|0|0|0|]
+// 64/64 (1): $DER.aimc.idq_rs[2] = $cse1 * der(aimc.idq_rr[1]) + $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_rr[1] + aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_rr[2]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
+// 65/65 (1): $DER.aimc.airGapS.i_ms[2] = $DER.aimc.lssigma.i_[2] + $DER.aimc.idq_rs[2]   [dynamic |0|0|0|0|]
+// 66/66 (1): aimc.lssigma.v_[2] = aimc.lssigma.L[2] * $DER.aimc.lssigma.i_[2]   [dynamic |0|0|0|0|]
+// 67/67 (1): $DER.aimc.idq_rs[1] = aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_rr[1]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_rr[1] + (-$cse1) * der(aimc.idq_rr[2]) - $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_rr[2]   [dynamic |0|0|0|0|]
+// 68/68 (1): aimc.airGapS.spacePhasor_r.v_[2] = (-aimc.idq_rr[2]) * aimc.squirrelCageR.Rr_actual - der(aimc.idq_rr[2]) * aimc.squirrelCageR.Lrsigma   [dynamic |0|0|0|0|]
+// 69/69 (1): aimc.airGapS.spacePhasor_s.v_[1] = aimc.airGapS.L[1,1] * $DER.aimc.airGapS.i_ms[1] + aimc.airGapS.L[1,2] * $DER.aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
+// 70/70 (1): aimc.airGapS.spacePhasor_s.v_[2] = aimc.airGapS.L[2,1] * $DER.aimc.airGapS.i_ms[1] + aimc.airGapS.L[2,2] * $DER.aimc.airGapS.i_ms[2]   [dynamic |0|0|0|0|]
+// 71/71 (1): $DER.aimc.airGapS.i_ms[1] = $DER.aimc.lssigma.i_[1] + $DER.aimc.idq_rs[1]   [dynamic |0|0|0|0|]
+// 72/72 (1): aimc.lssigma.v_[1] = aimc.lssigma.spacePhasor_a.v_[1] - aimc.airGapS.spacePhasor_s.v_[1]   [dynamic |0|0|0|0|]
+// 73/73 (1): aimc.lssigma.v_[1] = aimc.lssigma.L[1] * $DER.aimc.lssigma.i_[1]   [dynamic |0|0|0|0|]
+// 74/74 (1): aimc.lssigma.spacePhasor_a.v_[1] = aimc.spacePhasorS.TransformationMatrix[1,1] * aimc.spacePhasorS.v[1] + aimc.spacePhasorS.TransformationMatrix[1,2] * aimc.spacePhasorS.v[2] + aimc.spacePhasorS.TransformationMatrix[1,3] * aimc.spacePhasorS.v[3]   [dynamic |0|0|0|0|]
+// 75/75 (1): aimc.spacePhasorS.v[1] / aimc.spacePhasorS.turnsRatio = aimc.rs.plug_n.pin[1].v - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
+// 76/76 (1): aimc.spacePhasorS.v[3] / aimc.spacePhasorS.turnsRatio = aimc.rs.plug_n.pin[3].v - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
+// 77/77 (1): aimc.spacePhasorS.v[2] / aimc.spacePhasorS.turnsRatio = aimc.rs.plug_n.pin[2].v - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
+// 78/78 (1): $DER.aimc.spacePhasorS.i[2] * aimc.spacePhasorS.turnsRatio = $DER.sinevoltage1.i[2]   [dynamic |0|0|0|0|]
+// 79/79 (1): $DER.aimc.spacePhasorS.i[3] * aimc.spacePhasorS.turnsRatio = $DER.sinevoltage1.i[3]   [dynamic |0|0|0|0|]
+// 80/80 (1): aimc.vs[1] = (-sinevoltage1.v[1]) - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
+// 81/81 (1): aimc.vs[2] = (-sinevoltage1.v[2]) - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
+// 82/82 (1): aimc.vs[3] = (-sinevoltage1.v[3]) - aimc.plug_sn.pin[3].v   [dynamic |0|0|0|0|]
+// 83/83 (1): aimc.powerBalance.powerStator = Modelica.Electrical.Machines.SpacePhasors.Functions.activePower(aimc.vs, sinevoltage1.i)   [unknown |0|0|0|0|]
+// 84/84 (1): $DER.aimc.lssigma.i_[2] = $cse1 * der(aimc.idq_sr[1]) + $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_sr[1] + aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_sr[2]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_sr[2]   [dynamic |0|0|0|0|]
+// 85/85 (1): $DER.aimc.lssigma.i_[1] = aimc.airGapS.RotationMatrix[2,2] * der(aimc.idq_sr[1]) + $DER.aimc.airGapS.RotationMatrix[2,2] * aimc.idq_sr[1] + (-$cse1) * der(aimc.idq_sr[2]) - $DER.aimc.airGapS.RotationMatrix[2,1] * aimc.idq_sr[2]   [dynamic |0|0|0|0|]
+// 86/86 (1): aimc.airGapS.RotationMatrix[2,1] = $cse1   [binding |0|0|0|0|]
+// 87/87 (1): aimc.rs.resistor[3].v = aimc.rs.v[3]   [binding |0|0|0|0|]
+// 88/88 (1): aimc.rs.resistor[2].v = aimc.rs.v[2]   [binding |0|0|0|0|]
+// 89/89 (1): aimc.rs.resistor[1].v = aimc.rs.v[1]   [binding |0|0|0|0|]
+// 90/90 (1): aimc.fixed.flange.tau = -aimc.tauElectrical   [binding |0|0|0|0|]
+// 91/91 (1): $DER.aimc.airGapS.psi_mr[1] = aimc.airGapS.spacePhasor_r.v_[1]   [binding |0|0|0|0|]
+// 92/92 (1): $DER.aimc.airGapS.psi_mr[2] = aimc.airGapS.spacePhasor_r.v_[2]   [binding |0|0|0|0|]
+// 93/93 (1): $DER.aimc.airGapS.psi_ms[1] = aimc.airGapS.spacePhasor_s.v_[1]   [binding |0|0|0|0|]
+// 94/94 (1): $DER.aimc.airGapS.psi_ms[2] = aimc.airGapS.spacePhasor_s.v_[2]   [binding |0|0|0|0|]
 //
 //
 // Simple Equations (4, 0)
 // ========================================
 // 1/1 (0): algorithm
-//   assert(1.0 + aimc.rs.resistor[1].alpha * (aimc.thermalAmbient.constTs.k - aimc.rs.resistor[1].T_ref) >= 1e-015, "Temperature outside scope of model!");
+//   assert(1.0 + aimc.rs.resistor[1].alpha * (aimc.thermalAmbient.constTs.k - aimc.rs.resistor[1].T_ref) >= 1e-15, "Temperature outside scope of model!");
 //    [dynamic |0|0|0|0|]
 // 2/1 (0): algorithm
-//   assert(1.0 + aimc.rs.resistor[2].alpha * (aimc.thermalAmbient.constTs.k - aimc.rs.resistor[2].T_ref) >= 1e-015, "Temperature outside scope of model!");
+//   assert(1.0 + aimc.rs.resistor[2].alpha * (aimc.thermalAmbient.constTs.k - aimc.rs.resistor[2].T_ref) >= 1e-15, "Temperature outside scope of model!");
 //    [dynamic |0|0|0|0|]
 // 3/1 (0): algorithm
-//   assert(1.0 + aimc.rs.resistor[3].alpha * (aimc.thermalAmbient.constTs.k - aimc.rs.resistor[3].T_ref) >= 1e-015, "Temperature outside scope of model!");
+//   assert(1.0 + aimc.rs.resistor[3].alpha * (aimc.thermalAmbient.constTs.k - aimc.rs.resistor[3].T_ref) >= 1e-15, "Temperature outside scope of model!");
 //    [dynamic |0|0|0|0|]
 // 4/1 (0): algorithm
-//   assert(1.0 + aimc.squirrelCageR.alpha * (aimc.thermalAmbient.constTr.k - aimc.squirrelCageR.T_ref) >= 1e-015, "Temperature outside scope of model!");
+//   assert(1.0 + aimc.squirrelCageR.alpha * (aimc.thermalAmbient.constTr.k - aimc.squirrelCageR.T_ref) >= 1e-15, "Temperature outside scope of model!");
 //    [dynamic |0|0|0|0|]
 //
 //
 // Matching
 // ========================================
-// 93 variables and equations
-// var 1 is solved in eqn 17
-// var 2 is solved in eqn 18
-// var 3 is solved in eqn 22
+// 94 variables and equations
+// var 1 is solved in eqn 10
+// var 2 is solved in eqn 11
+// var 3 is solved in eqn 14
 // var 4 is solved in eqn 24
 // var 5 is solved in eqn 25
 // var 6 is solved in eqn 26
 // var 7 is solved in eqn 27
-// var 8 is solved in eqn 43
-// var 9 is solved in eqn 28
-// var 10 is solved in eqn 42
-// var 11 is solved in eqn 12
-// var 12 is solved in eqn 10
-// var 13 is solved in eqn 58
-// var 14 is solved in eqn 60
-// var 15 is solved in eqn 59
-// var 16 is solved in eqn 66
-// var 17 is solved in eqn 5
-// var 18 is solved in eqn 15
-// var 19 is solved in eqn 16
-// var 20 is solved in eqn 13
-// var 21 is solved in eqn 14
-// var 22 is solved in eqn 4
-// var 23 is solved in eqn 33
-// var 24 is solved in eqn 3
-// var 25 is solved in eqn 20
-// var 26 is solved in eqn 21
-// var 27 is solved in eqn 19
-// var 28 is solved in eqn 72
-// var 29 is solved in eqn 73
-// var 30 is solved in eqn 56
-// var 31 is solved in eqn 55
+// var 8 is solved in eqn 28
+// var 9 is solved in eqn 44
+// var 10 is solved in eqn 29
+// var 11 is solved in eqn 43
+// var 12 is solved in eqn 19
+// var 13 is solved in eqn 17
+// var 14 is solved in eqn 68
+// var 15 is solved in eqn 62
+// var 16 is solved in eqn 60
+// var 17 is solved in eqn 61
+// var 18 is solved in eqn 5
+// var 19 is solved in eqn 22
+// var 20 is solved in eqn 23
+// var 21 is solved in eqn 20
+// var 22 is solved in eqn 21
+// var 23 is solved in eqn 4
+// var 24 is solved in eqn 34
+// var 25 is solved in eqn 3
+// var 26 is solved in eqn 13
+// var 27 is solved in eqn 12
+// var 28 is solved in eqn 9
+// var 29 is solved in eqn 58
+// var 30 is solved in eqn 77
+// var 31 is solved in eqn 75
 // var 32 is solved in eqn 57
-// var 33 is solved in eqn 71
-// var 34 is solved in eqn 8
-// var 35 is solved in eqn 7
-// var 36 is solved in eqn 63
-// var 37 is solved in eqn 69
-// var 38 is solved in eqn 35
-// var 39 is solved in eqn 38
-// var 40 is solved in eqn 41
-// var 41 is solved in eqn 36
-// var 42 is solved in eqn 39
-// var 43 is solved in eqn 44
-// var 44 is solved in eqn 34
-// var 45 is solved in eqn 37
-// var 46 is solved in eqn 40
-// var 47 is solved in eqn 74
-// var 48 is solved in eqn 65
-// var 49 is solved in eqn 61
-// var 50 is solved in eqn 11
-// var 51 is solved in eqn 9
-// var 52 is solved in eqn 81
-// var 53 is solved in eqn 82
-// var 54 is solved in eqn 23
-// var 55 is solved in eqn 79
-// var 56 is solved in eqn 78
-// var 57 is solved in eqn 77
-// var 58 is solved in eqn 46
-// var 59 is solved in eqn 48
-// var 60 is solved in eqn 80
-// var 61 is solved in eqn 2
-// var 62 is solved in eqn 45
-// var 63 is solved in eqn 47
-// var 64 is solved in eqn 29
-// var 65 is solved in eqn 1
-// var 66 is solved in eqn 30
-// var 67 is solved in eqn 32
-// var 68 is solved in eqn 31
-// var 69 is solved in eqn 64
-// var 70 is solved in eqn 62
-// var 71 is solved in eqn 68
-// var 72 is solved in eqn 67
-// var 73 is solved in eqn 75
-// var 74 is solved in eqn 76
-// var 75 is solved in eqn 49
-// var 76 is solved in eqn 70
-// var 77 is solved in eqn 51
-// var 78 is solved in eqn 53
-// var 79 is solved in eqn 52
-// var 80 is solved in eqn 50
-// var 81 is solved in eqn 54
-// var 82 is solved in eqn 6
-// var 83 is solved in eqn 83
-// var 84 is solved in eqn 84
-// var 85 is solved in eqn 85
+// var 33 is solved in eqn 59
+// var 34 is solved in eqn 74
+// var 35 is solved in eqn 8
+// var 36 is solved in eqn 7
+// var 37 is solved in eqn 66
+// var 38 is solved in eqn 72
+// var 39 is solved in eqn 36
+// var 40 is solved in eqn 39
+// var 41 is solved in eqn 42
+// var 42 is solved in eqn 37
+// var 43 is solved in eqn 40
+// var 44 is solved in eqn 45
+// var 45 is solved in eqn 35
+// var 46 is solved in eqn 38
+// var 47 is solved in eqn 41
+// var 48 is solved in eqn 76
+// var 49 is solved in eqn 67
+// var 50 is solved in eqn 63
+// var 51 is solved in eqn 18
+// var 52 is solved in eqn 16
+// var 53 is solved in eqn 84
+// var 54 is solved in eqn 85
+// var 55 is solved in eqn 15
+// var 56 is solved in eqn 82
+// var 57 is solved in eqn 81
+// var 58 is solved in eqn 80
+// var 59 is solved in eqn 46
+// var 60 is solved in eqn 47
+// var 61 is solved in eqn 49
+// var 62 is solved in eqn 51
+// var 63 is solved in eqn 83
+// var 64 is solved in eqn 2
+// var 65 is solved in eqn 48
+// var 66 is solved in eqn 50
+// var 67 is solved in eqn 30
+// var 68 is solved in eqn 1
+// var 69 is solved in eqn 31
+// var 70 is solved in eqn 33
+// var 71 is solved in eqn 32
+// var 72 is solved in eqn 71
+// var 73 is solved in eqn 64
+// var 74 is solved in eqn 70
+// var 75 is solved in eqn 69
+// var 76 is solved in eqn 53
+// var 77 is solved in eqn 52
+// var 78 is solved in eqn 79
+// var 79 is solved in eqn 73
+// var 80 is solved in eqn 65
+// var 81 is solved in eqn 55
+// var 82 is solved in eqn 78
+// var 83 is solved in eqn 54
+// var 84 is solved in eqn 56
+// var 85 is solved in eqn 6
 // var 86 is solved in eqn 86
 // var 87 is solved in eqn 87
 // var 88 is solved in eqn 88
@@ -1151,74 +1074,76 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // var 91 is solved in eqn 91
 // var 92 is solved in eqn 92
 // var 93 is solved in eqn 93
+// var 94 is solved in eqn 94
 //
 //
 // StrongComponents
 // ========================================
-// {48:59}
-// {30:66}
-// {28:9}
+// {51:62}
+// {31:69}
+// {29:10}
 // {27:7}
 // {26:6}
 // {25:5}
 // {24:4}
-// {4:22}
-// {5:17}
-// {32:67}
-// {6:82}
-// {7:35}
-// {8:34}
-// {{{22:3}, {21:25}, {20:1}, {18:2}}
-// ,{17, 19:26, 27}} Size: 2 linear
+// {4:23}
+// {5:18}
+// {33:70}
+// {6:85}
+// {7:36}
+// {8:35}
+// {{{14:3}, {9:26}, {12:2}, {10:1}}
+// ,{13, 11:27, 28}} Size: 2 linear
 // For more information please use "-d=tearingdump".
-// {37:45}
-// {39:42}
-// {85:85}
-// {38:39}
-// {34:44}
-// {36:41}
-// {84:84}
-// {35:38}
-// {33:23}
-// {40:46}
-// {44:43}
-// {86:86}
-// {41:40}
-// {42:10}
-// {43:8}
-// {88:88}
+// {35:45}
+// {37:42}
 // {87:87}
-// {23:54}
-// {9:51}
-// {10:12}
-// {11:50}
-// {12:11}
-// {13:20}
-// {14:21}
-// {29:64}
-// {45:62}
-// {46:58}
-// {47:63}
+// {36:39}
+// {38:46}
+// {40:43}
+// {88:88}
+// {39:40}
+// {28:8}
+// {34:24}
+// {41:47}
+// {45:44}
 // {89:89}
-// {15:18}
-// {16:19}
-// {31:68}
-// {{{74:30}, {73:29}, {72:28}, {56:32}, {71:33}, {55:31}, {54:81}, {69:37}, {70:76}, {59:14}, {58:13}, {60:49}, {65:48}, {64:69}, {61:70}, {68:71}, {67:72}, {57:36}, {63:77}, {75:73}, {51:80}, {76:74}, {50:75}}
-// ,{62, 53, 49, 52, 66:79, 78, 15, 16, 47}} Size: 5 linear
+// {42:41}
+// {43:11}
+// {44:9}
+// {46:59}
+// {47:60}
+// {15:55}
+// {16:52}
+// {17:13}
+// {18:51}
+// {19:12}
+// {20:21}
+// {21:22}
+// {30:67}
+// {48:65}
+// {49:61}
+// {50:66}
+// {90:90}
+// {22:19}
+// {23:20}
+// {32:71}
+// {{{68:14}, {67:72}, {64:73}, {63:15}, {76:29}, {77:30}, {75:31}, {59:33}, {74:34}, {58:32}, {57:84}, {72:38}, {73:79}, {71:74}, {70:75}, {60:37}, {66:80}, {53:76}, {54:82}, {79:78}, {78:77}}
+// ,{62, 52, 65, 69, 56, 55, 61:83, 81, 16, 17, 48, 50, 49}} Size: 7 linear
 // For more information please use "-d=tearingdump".
 // {91:91}
+// {94:94}
+// {80:58}
+// {81:57}
+// {82:56}
+// {83:63}
 // {93:93}
-// {90:90}
-// {77:57}
-// {78:56}
-// {79:55}
-// {80:60}
 // {92:92}
-// {82, 81:52, 53} Size: 2 Jacobian Linear
-// {83:83}
-// {3:24}
-// {2:61}
-// {1:65}
+// {85, 84:53, 54} Size: 2 Jacobian Linear
+// {86:86}
+// {3:25}
+// {2:64}
+// {1:68}
 //
 //
 //
@@ -1228,7 +1153,7 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // Known variables only depending on parameters and constants - globalKnownVars (303)
 // ========================================
 // 1: aimc.fsNominal:PARAM(start = 50.0 unit = "Hz" )  = 50.0  "Nominal frequency" type: Real
-// 2: aimc.statorCoreParameters.wRef:PARAM(min = 1e-060 unit = "rad/s" )  = 6.283185307179586 * aimc.fsNominal  "Reference angular velocity that reference core losses PRef refer to" type: Real
+// 2: aimc.statorCoreParameters.wRef:PARAM(min = 1e-60 unit = "rad/s" )  = 6.283185307179586 * aimc.fsNominal  "Reference angular velocity that reference core losses PRef refer to" type: Real
 // 3: aimc.statorCore.w:PARAM(unit = "rad/s" fixed = true )  = aimc.statorCoreParameters.wRef  "Remagnetization angular velocity" type: Real
 // 4: const.k:PARAM(start = 1.0 )  = -15.0  "Constant output value" type: Real
 // 5: aimc.inertiaRotor.flange_b.tau:PARAM(flow=true unit = "N.m" fixed = true )  = const.k  "Cut torque in the flange" type: Real
@@ -1370,12 +1295,12 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 141: aimc.airGapS.m:PARAM(final = true )  = 3  "Number of phases" type: Integer
 // 142: aimc.internalThermalPort.m:PARAM(flow=false final = true )  = 3  "Number of stator phases" type: Integer
 // 143: aimc.strayLoad.strayLoadParameters.tauRef:PARAM(unit = "N.m" final = true )  = 0.0  "Reference stray load torque at reference angular velocity and reference current" type: Real
-// 144: aimc.strayLoadParameters.power_w:PARAM(min = 1e-060 )  = 1.0  "Exponent of stray load loss torque w.r.t. angular velocity" type: Real
-// 145: aimc.strayLoad.strayLoadParameters.power_w:PARAM(min = 1e-060 )  = aimc.strayLoadParameters.power_w  "Exponent of stray load loss torque w.r.t. angular velocity" type: Real
-// 146: aimc.strayLoadParameters.wRef:PARAM(min = 1e-060 unit = "rad/s" )  = 6.283185307179586 * aimc.fsNominal / /*Real*/(aimc.p)  "Reference angular velocity that PRef refers to" type: Real
-// 147: aimc.strayLoad.strayLoadParameters.wRef:PARAM(min = 1e-060 unit = "rad/s" )  = aimc.strayLoadParameters.wRef  "Reference angular velocity that PRef refers to" type: Real
-// 148: aimc.strayLoadParameters.IRef:PARAM(min = 1e-060 start = 100.0 unit = "A" )  "Reference RMS current that PRef refers to" type: Real
-// 149: aimc.strayLoad.strayLoadParameters.IRef:PARAM(min = 1e-060 unit = "A" )  = aimc.strayLoadParameters.IRef  "Reference RMS current that PRef refers to" type: Real
+// 144: aimc.strayLoadParameters.power_w:PARAM(min = 1e-60 )  = 1.0  "Exponent of stray load loss torque w.r.t. angular velocity" type: Real
+// 145: aimc.strayLoad.strayLoadParameters.power_w:PARAM(min = 1e-60 )  = aimc.strayLoadParameters.power_w  "Exponent of stray load loss torque w.r.t. angular velocity" type: Real
+// 146: aimc.strayLoadParameters.wRef:PARAM(min = 1e-60 unit = "rad/s" )  = 6.283185307179586 * aimc.fsNominal / /*Real*/(aimc.p)  "Reference angular velocity that PRef refers to" type: Real
+// 147: aimc.strayLoad.strayLoadParameters.wRef:PARAM(min = 1e-60 unit = "rad/s" )  = aimc.strayLoadParameters.wRef  "Reference angular velocity that PRef refers to" type: Real
+// 148: aimc.strayLoadParameters.IRef:PARAM(min = 1e-60 start = 100.0 unit = "A" )  "Reference RMS current that PRef refers to" type: Real
+// 149: aimc.strayLoad.strayLoadParameters.IRef:PARAM(min = 1e-60 unit = "A" )  = aimc.strayLoadParameters.IRef  "Reference RMS current that PRef refers to" type: Real
 // 150: aimc.strayLoad.strayLoadParameters.PRef:PARAM(min = 0.0 unit = "W" final = true )  = 0.0  "Reference stray load losses at IRef and wRef" type: Real
 // 151: aimc.strayLoad.useHeatPort:PARAM(final = true )  = true  "=true, if heatPort is enabled" type: Boolean
 // 152: aimc.strayLoad.plug_n.m:PARAM(flow=false min = 1 final = true )  = 3  "Number of phases" type: Integer
@@ -1393,22 +1318,22 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 164: aimc.spacePhasorS.TransformationMatrix[2,2]:PARAM(protected = true )  = 0.5773502691896257  type: Real [2,3]
 // 165: aimc.spacePhasorS.TransformationMatrix[2,1]:PARAM(protected = true )  = 0.0  type: Real [2,3]
 // 166: aimc.spacePhasorS.TransformationMatrix[1,3]:PARAM(protected = true )  = -0.3333333333333336  type: Real [2,3]
-// 167: aimc.spacePhasorS.TransformationMatrix[1,2]:PARAM(protected = true )  = -0.3333333333333332  type: Real [2,3]
+// 167: aimc.spacePhasorS.TransformationMatrix[1,2]:PARAM(protected = true )  = -0.3333333333333331  type: Real [2,3]
 // 168: aimc.spacePhasorS.TransformationMatrix[1,1]:PARAM(protected = true )  = 0.6666666666666666  type: Real [2,3]
 // 169: aimc.spacePhasorS.turnsRatio:PARAM()  = 1.0  "Turns ratio" type: Real
 // 170: aimc.spacePhasorS.pi:CONST()  = 3.141592653589793  type: Real
 // 171: aimc.spacePhasorS.m:CONST()  = 3  "Number of phases" type: Integer
-// 172: aimc.statorCore.turnsRatio:PARAM(min = 1e-060 )  = 1.0  "Effective number of stator turns / effective number of rotor turns (if used as rotor core)" type: Real
+// 172: aimc.statorCore.turnsRatio:PARAM(min = 1e-60 )  = 1.0  "Effective number of stator turns / effective number of rotor turns (if used as rotor core)" type: Real
 // 173: aimc.statorCoreParameters.m:PARAM()  = 3  "Number of phases (1 for DC, 3 for induction machines)" type: Integer
 // 174: aimc.statorCore.coreParameters.m:PARAM()  = aimc.statorCoreParameters.m  "Number of phases (1 for DC, 3 for induction machines)" type: Integer
 // 175: aimc.statorCore.m:PARAM(final = true )  = aimc.statorCore.coreParameters.m  "Number of phases" type: Integer
-// 176: aimc.statorCoreParameters.wMin:PARAM(unit = "rad/s" final = true )  = 1e-006 * aimc.statorCoreParameters.wRef  type: Real
+// 176: aimc.statorCoreParameters.wMin:PARAM(unit = "rad/s" final = true )  = 1e-06 * aimc.statorCoreParameters.wRef  type: Real
 // 177: aimc.statorCore.coreParameters.wMin:PARAM(unit = "rad/s" final = true )  = aimc.statorCoreParameters.wMin  type: Real
 // 178: aimc.statorCore.coreParameters.GcRef:PARAM(unit = "S" final = true )  = 0.0  "Reference conductance at reference frequency and voltage" type: Real
 // 179: aimc.statorCore.coreParameters.ratioHysteresis:PARAM(min = 0.0 max = 1.0 start = 0.775 final = true )  = 0.0  "Ratio of hysteresis losses with respect to the total core losses at VRef and fRef" type: Real
-// 180: aimc.statorCore.coreParameters.wRef:PARAM(min = 1e-060 unit = "rad/s" )  = aimc.statorCoreParameters.wRef  "Reference angular velocity that reference core losses PRef refer to" type: Real
-// 181: aimc.statorCoreParameters.VRef:PARAM(min = 1e-060 start = 100.0 unit = "V" )  "Reference inner RMS voltage that reference core losses PRef refer to" type: Real
-// 182: aimc.statorCore.coreParameters.VRef:PARAM(min = 1e-060 unit = "V" )  = aimc.statorCoreParameters.VRef  "Reference inner RMS voltage that reference core losses PRef refer to" type: Real
+// 180: aimc.statorCore.coreParameters.wRef:PARAM(min = 1e-60 unit = "rad/s" )  = aimc.statorCoreParameters.wRef  "Reference angular velocity that reference core losses PRef refer to" type: Real
+// 181: aimc.statorCoreParameters.VRef:PARAM(min = 1e-60 start = 100.0 unit = "V" )  "Reference inner RMS voltage that reference core losses PRef refer to" type: Real
+// 182: aimc.statorCore.coreParameters.VRef:PARAM(min = 1e-60 unit = "V" )  = aimc.statorCoreParameters.VRef  "Reference inner RMS voltage that reference core losses PRef refer to" type: Real
 // 183: aimc.statorCore.coreParameters.PRef:PARAM(min = 0.0 unit = "W" final = true )  = 0.0  "Reference core losses at reference inner voltage VRef" type: Real
 // 184: aimc.statorCore.useHeatPort:PARAM(final = true )  = true  "=true, if heatPort is enabled" type: Boolean
 // 185: aimc.Lssigma:PARAM(start = 0.1017764061411688 / (6.283185307179586 * aimc.fsNominal) unit = "H" )  = 0.004  "Stator stray inductance per phase" type: Real
@@ -1459,14 +1384,14 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 230: aimc.statorCoreParameters.ratioHysteresis:PARAM(min = 0.0 max = 1.0 start = 0.775 final = true )  = 0.0  "Ratio of hysteresis losses with respect to the total core losses at VRef and fRef" type: Real
 // 231: aimc.statorCoreParameters.PRef:PARAM(min = 0.0 unit = "W" final = true )  = 0.0  "Reference core losses at reference inner voltage VRef" type: Real
 // 232: aimc.friction.frictionParameters.tauLinear:PARAM(unit = "N.m" final = true )  = 0.0  "Torque corresponding with linear angular velocity range" type: Real
-// 233: aimc.frictionParameters.wRef:PARAM(min = 1e-060 unit = "rad/s" )  = 6.283185307179586 * aimc.fsNominal / /*Real*/(aimc.p)  "Reference angular velocity that the PRef refer to" type: Real
+// 233: aimc.frictionParameters.wRef:PARAM(min = 1e-60 unit = "rad/s" )  = 6.283185307179586 * aimc.fsNominal / /*Real*/(aimc.p)  "Reference angular velocity that the PRef refer to" type: Real
 // 234: aimc.frictionParameters.wLinear:PARAM(unit = "rad/s" final = true )  = 0.001 * aimc.frictionParameters.wRef  "Linear angular velocity range" type: Real
 // 235: aimc.friction.frictionParameters.wLinear:PARAM(unit = "rad/s" final = true )  = aimc.frictionParameters.wLinear  "Linear angular velocity range" type: Real
 // 236: aimc.friction.frictionParameters.linear:PARAM(final = true )  = 0.001  "Linear angular velocity range with respect to reference angular velocity" type: Real
 // 237: aimc.friction.frictionParameters.tauRef:PARAM(unit = "N.m" final = true )  = 0.0  "Reference friction torque at reference angular velocity" type: Real
-// 238: aimc.frictionParameters.power_w:PARAM(min = 1e-060 )  = 2.0  "Exponent of friction torque w.r.t. angular velocity" type: Real
-// 239: aimc.friction.frictionParameters.power_w:PARAM(min = 1e-060 )  = aimc.frictionParameters.power_w  "Exponent of friction torque w.r.t. angular velocity" type: Real
-// 240: aimc.friction.frictionParameters.wRef:PARAM(min = 1e-060 unit = "rad/s" )  = aimc.frictionParameters.wRef  "Reference angular velocity that the PRef refer to" type: Real
+// 238: aimc.frictionParameters.power_w:PARAM(min = 1e-60 )  = 2.0  "Exponent of friction torque w.r.t. angular velocity" type: Real
+// 239: aimc.friction.frictionParameters.power_w:PARAM(min = 1e-60 )  = aimc.frictionParameters.power_w  "Exponent of friction torque w.r.t. angular velocity" type: Real
+// 240: aimc.friction.frictionParameters.wRef:PARAM(min = 1e-60 unit = "rad/s" )  = aimc.frictionParameters.wRef  "Reference angular velocity that the PRef refer to" type: Real
 // 241: aimc.friction.frictionParameters.PRef:PARAM(min = 0.0 unit = "W" final = true )  = 0.0  "Reference friction losses at wRef" type: Real
 // 242: aimc.friction.useHeatPort:PARAM(final = true )  = true  "=true, if heatPort is enabled" type: Boolean
 // 243: aimc.inertiaStator.stateSelect:PARAM(min = StateSelect.never max = StateSelect.always )  = StateSelect.default  "Priority to use phi and w as states" type: enumeration(never, avoid, default, prefer, always)
@@ -1532,7 +1457,7 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 303: aimc.statorCore.wLimit:VARIABLE(unit = "rad/s" fixed = true protected = true )  = max(abs(aimc.statorCoreParameters.wRef), aimc.statorCore.coreParameters.wMin)  "Limited angular velocity" type: Real
 //
 //
-// Alias Variables (237)
+// Alias Variables (238)
 // ========================================
 // 1: aimc.flange.phi:VARIABLE(flow=false unit = "rad" )  = speedSensor.flange.phi  "Absolute rotation angle of flange" type: Real
 // 2: torque.flange.phi:VARIABLE(flow=false unit = "rad" )  = speedSensor.flange.phi  "Absolute rotation angle of flange" type: Real
@@ -1652,125 +1577,126 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // 116: aimc.rs.i[3]:VARIABLE(unit = "A" )  = sinevoltage1.i[3]  "Currents flowing into positive plugs" type: Real [3]
 // 117: aimc.is[3]:VARIABLE(unit = "A" )  = sinevoltage1.i[3]  "Stator instantaneous currents" type: Real [3]
 // 118: star.plug_p.pin[3].i:VARIABLE(flow=true unit = "A" )  = -sinevoltage1.i[3]  "Current flowing into the pin" type: Real [3]
-// 119: aimc.statorCore.spacePhasor.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 120: aimc.spacePhasorS.spacePhasor.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 121: aimc.statorCore.spacePhasor.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 122: aimc.spacePhasorS.spacePhasor.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 123: aimc.lszero.n.v:VARIABLE(flow=false unit = "V" )  = aimc.spacePhasorS.ground.v  "Potential at the pin" type: Real
-// 124: aimc.spacePhasorS.zero.v:VARIABLE(flow=false unit = "V" )  = aimc.lszero.v  "Potential at the pin" type: Real
-// 125: aimc.spacePhasorS.plug_p.pin[3].v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[3].v  "Potential at the pin" type: Real [3]
-// 126: aimc.rs.resistor[3].n.v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[3].v  "Potential at the pin" type: Real [3]
-// 127: aimc.spacePhasorS.plug_p.pin[2].v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[2].v  "Potential at the pin" type: Real [3]
-// 128: aimc.rs.resistor[2].n.v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[2].v  "Potential at the pin" type: Real [3]
-// 129: aimc.spacePhasorS.plug_p.pin[1].v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[1].v  "Potential at the pin" type: Real [3]
-// 130: aimc.rs.resistor[1].n.v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[1].v  "Potential at the pin" type: Real [3]
-// 131: aimc.strayLoad.plug_n.pin[3].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
-// 132: aimc.rs.resistor[3].p.v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
-// 133: aimc.strayLoad.plug_n.pin[2].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
-// 134: aimc.rs.resistor[2].p.v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
-// 135: aimc.strayLoad.plug_n.pin[1].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
-// 136: aimc.rs.resistor[1].p.v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
-// 137: aimc.lssigma.spacePhasor_b.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_s.v_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 138: aimc.lssigma.spacePhasor_b.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_s.v_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 139: aimc.squirrelCageR.spacePhasor_r.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_r.v_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 140: aimc.squirrelCageR.spacePhasor_r.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_r.v_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 141: aimc.airGapS.i_rr[2]:VARIABLE(unit = "A" )  = aimc.idq_rr[2]  "Rotor current space phasor with respect to the rotor fixed frame" type: Real [2]
-// 142: aimc.airGapS.spacePhasor_r.i_[2]:VARIABLE(flow=true unit = "A" )  = aimc.idq_rr[2]  "1=real, 2=imaginary part" type: Real [2]
-// 143: aimc.squirrelCageR.spacePhasor_r.i_[2]:DUMMY_STATE(flow=true unit = "A" )  = -aimc.idq_rr[2]  "1=real, 2=imaginary part" type: Real [2]
-// 144: aimc.ir[2]:VARIABLE(unit = "A" )  = aimc.idq_rr[2]  "Rotor cage currents" type: Real [2]
-// 145: aimc.airGapS.i_rr[1]:VARIABLE(unit = "A" )  = aimc.idq_rr[1]  "Rotor current space phasor with respect to the rotor fixed frame" type: Real [2]
-// 146: aimc.airGapS.spacePhasor_r.i_[1]:VARIABLE(flow=true unit = "A" )  = aimc.idq_rr[1]  "1=real, 2=imaginary part" type: Real [2]
-// 147: aimc.squirrelCageR.spacePhasor_r.i_[1]:DUMMY_STATE(flow=true unit = "A" )  = -aimc.idq_rr[1]  "1=real, 2=imaginary part" type: Real [2]
-// 148: aimc.ir[1]:VARIABLE(unit = "A" )  = aimc.idq_rr[1]  "Rotor cage currents" type: Real [2]
-// 149: aimc.lssigma.spacePhasor_a.i_[2]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 150: aimc.lssigma.spacePhasor_b.i_[2]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 151: aimc.airGapS.spacePhasor_s.i_[2]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 152: aimc.airGapS.i_ss[2]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[2]  "Stator current space phasor with respect to the stator fixed frame" type: Real [2]
-// 153: aimc.idq_ss[2]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[2]  "Stator space phasor current / stator fixed frame" type: Real [2]
-// 154: aimc.lssigma.spacePhasor_a.i_[1]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 155: aimc.lssigma.spacePhasor_b.i_[1]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 156: aimc.airGapS.spacePhasor_s.i_[1]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 157: aimc.airGapS.i_ss[1]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[1]  "Stator current space phasor with respect to the stator fixed frame" type: Real [2]
-// 158: aimc.idq_ss[1]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[1]  "Stator space phasor current / stator fixed frame" type: Real [2]
-// 159: aimc.thermalAmbient.temperatureFriction.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.powerBalance.lossPowerFriction  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 160: aimc.thermalAmbient.thermalPort.heatPortFriction.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.powerBalance.lossPowerFriction  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 161: aimc.thermalAmbient.temperatureStrayLoad.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.strayLoad.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 162: aimc.thermalAmbient.thermalPort.heatPortStrayLoad.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.strayLoad.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 163: aimc.thermalAmbient.thermalPort.heatPortRotorCore.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.internalThermalPort.heatPortRotorCore.Q_flow  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 164: aimc.thermalAmbient.temperatureRotorCore.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.internalThermalPort.heatPortRotorCore.Q_flow  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 165: aimc.thermalAmbient.Q_flowRotorCore:VARIABLE(unit = "W" final = true )  = aimc.internalThermalPort.heatPortRotorCore.Q_flow  "Heat flow rate of stator core losses" type: Real
-// 166: aimc.thermalAmbient.temperatureStatorCore.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.statorCore.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 167: aimc.thermalAmbient.thermalPort.heatPortStatorCore.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.statorCore.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 168: aimc.thermalAmbient.thermalPort.heatPortStatorWinding[1].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 169: aimc.thermalAmbient.thermalPort.heatPortStatorWinding[2].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 170: aimc.thermalAmbient.thermalPort.heatPortStatorWinding[3].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 171: aimc.thermalAmbient.temperatureRotorWinding.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.thermalAmbient.Q_flowRotorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 172: aimc.thermalAmbient.thermalPort.heatPortRotorWinding.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.thermalAmbient.Q_flowRotorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 173: aimc.thermalAmbient.temperatureStatorWinding.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.thermalAmbient.Q_flowStatorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 174: aimc.thermalAmbient.thermalCollectorStator.port_b.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = -aimc.thermalAmbient.Q_flowStatorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 175: aimc.inertiaRotor.flange_a.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.tauElectrical  "Cut torque in the flange" type: Real
-// 176: aimc.airGapS.flange.tau:VARIABLE(flow=true unit = "N.m" )  = -aimc.tauElectrical  "Cut torque in the flange" type: Real
-// 177: aimc.airGapS.tauElectrical:VARIABLE(unit = "N.m" )  = aimc.tauElectrical  type: Real
-// 178: aimc.airGapS.support.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.tauElectrical  "Cut torque in the flange" type: Real
-// 179: aimc.rs.resistor[1].heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 180: aimc.rs.heatPort[1].Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 181: aimc.rs.resistor[2].heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 182: aimc.rs.heatPort[2].Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 183: aimc.rs.resistor[3].heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 184: aimc.rs.heatPort[3].Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 185: aimc.spacePhasorS.zero.i:VARIABLE(flow=true unit = "A" )  = aimc.i_0_s  "Current flowing into the pin" type: Real
-// 186: aimc.lszero.p.i:VARIABLE(flow=true unit = "A" )  = -aimc.i_0_s  "Current flowing into the pin" type: Real
-// 187: aimc.lszero.i:DUMMY_STATE(start = 0.0 unit = "A" )  = -aimc.i_0_s  "Current flowing from pin p to pin n" type: Real
-// 188: aimc.lszero.n.i:VARIABLE(flow=true unit = "A" )  = aimc.i_0_s  "Current flowing into the pin" type: Real
-// 189: aimc.spacePhasorS.ground.i:VARIABLE(flow=true unit = "A" )  = -aimc.i_0_s  "Current flowing into the pin" type: Real
-// 190: terminalBox.star.pin_n.i:VARIABLE(flow=true unit = "A" )  = terminalBox.starpoint.i  "Current flowing into the pin" type: Real
-// 191: sinevoltage1.sineVoltage[3].signalSource.y:VARIABLE()  = sinevoltage1.v[3]  "Connector of Real output signal" type: Real [3]
-// 192: sinevoltage1.sineVoltage[2].signalSource.y:VARIABLE()  = sinevoltage1.v[2]  "Connector of Real output signal" type: Real [3]
-// 193: sinevoltage1.sineVoltage[1].signalSource.y:VARIABLE()  = sinevoltage1.v[1]  "Connector of Real output signal" type: Real [3]
-// 194: aimc.squirrelCageR.heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.thermalAmbient.Q_flowRotorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
-// 195: aimc.powerBalance.lossPowerRotorWinding:VARIABLE(unit = "W" final = true )  = aimc.thermalAmbient.Q_flowRotorWinding  "Rotor copper losses" type: Real
-// 196: aimc.airGapS.RotationMatrix[1,1]:VARIABLE()  = aimc.airGapS.RotationMatrix[2,2]  "Matrix of rotation from rotor to stator" type: Real [2,2]
-// 197: aimc.airGapS.RotationMatrix[1,2]:VARIABLE()  = -$cse1  "Matrix of rotation from rotor to stator" type: Real [2,2]
-// 198: aimc.strayLoad.support.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.strayLoad.tau  "Cut torque in the flange" type: Real
-// 199: aimc.powerBalance.lossPowerStrayLoad:VARIABLE(unit = "W" final = true )  = aimc.strayLoad.lossPower  "Stray load losses" type: Real
-// 200: aimc.powerBalance.lossPowerStatorCore:VARIABLE(unit = "W" final = true )  = aimc.statorCore.lossPower  "Stator core losses" type: Real
-// 201: aimc.airGapS.i_rs[2]:VARIABLE(unit = "A" )  = aimc.idq_rs[2]  "Rotor current space phasor with respect to the stator fixed frame" type: Real [2]
-// 202: aimc.airGapS.i_rs[1]:VARIABLE(unit = "A" )  = aimc.idq_rs[1]  "Rotor current space phasor with respect to the stator fixed frame" type: Real [2]
-// 203: aimc.airGapS.i_sr[2]:VARIABLE(unit = "A" )  = aimc.idq_sr[2]  "Stator current space phasor with respect to the rotor fixed frame" type: Real [2]
-// 204: aimc.airGapS.i_sr[1]:VARIABLE(unit = "A" )  = aimc.idq_sr[1]  "Stator current space phasor with respect to the rotor fixed frame" type: Real [2]
-// 205: aimc.friction.lossPower:VARIABLE(unit = "W" )  = aimc.powerBalance.lossPowerFriction  "Loss power leaving component via heatPort (> 0, if heat is flowing out of component)" type: Real
-// 206: aimc.friction.support.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.friction.tau  "Cut torque in the flange" type: Real
-// 207: speedSensor.w:VARIABLE(unit = "rad/s" )  = aimc.inertiaRotor.w  "Absolute angular velocity of flange as output signal" type: Real
-// 208: aimc.thermalAmbient.Q_flowFriction:VARIABLE(unit = "W" final = true )  = aimc.powerBalance.lossPowerFriction  "Heat flow rate of friction losses" type: Real
-// 209: aimc.lszero.p.v:VARIABLE(flow=false unit = "V" )  = aimc.lszero.v  "Potential at the pin" type: Real
-// 210: aimc.thermalAmbient.Q_flowStatorCore:VARIABLE(unit = "W" final = true )  = aimc.statorCore.lossPower  "Heat flow rate of stator core losses" type: Real
-// 211: aimc.thermalAmbient.Q_flowStrayLoad:VARIABLE(unit = "W" final = true )  = aimc.strayLoad.lossPower  "Heat flow rate of stray load losses" type: Real
-// 212: aimc.plug_sp.pin[1].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
-// 213: aimc.rs.plug_p.pin[1].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
-// 214: sinevoltage1.sineVoltage[1].v:VARIABLE(unit = "V" )  = sinevoltage1.v[1]  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
-// 215: aimc.plug_sp.pin[2].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
-// 216: aimc.rs.plug_p.pin[2].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
-// 217: sinevoltage1.sineVoltage[2].v:VARIABLE(unit = "V" )  = sinevoltage1.v[2]  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
-// 218: aimc.plug_sp.pin[3].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
-// 219: aimc.rs.plug_p.pin[3].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
-// 220: sinevoltage1.sineVoltage[3].v:VARIABLE(unit = "V" )  = sinevoltage1.v[3]  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
-// 221: aimc.spacePhasorS.spacePhasor.i_[1]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
-// 222: aimc.spacePhasorS.spacePhasor.i_[2]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
-// 223: aimc.thermalAmbient.thermalCollectorStator.port_a[3].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 224: aimc.thermalAmbient.thermalCollectorStator.port_a[2].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 225: aimc.thermalAmbient.thermalCollectorStator.port_a[1].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
-// 226: aimc.squirrelCageR.LossPower:VARIABLE(unit = "W" )  = aimc.thermalAmbient.Q_flowRotorWinding  "Loss power leaving component via HeatPort" type: Real
-// 227: aimc.thermalAmbient.thermalPort.heatPortStrayLoad.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStrayLoad.port.T  "Port temperature" type: Real
-// 228: aimc.internalThermalPort.heatPortStrayLoad.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStrayLoad.port.T  "Port temperature" type: Real
-// 229: aimc.strayLoad.heatPort.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 )  = aimc.thermalAmbient.temperatureStrayLoad.port.T  "Port temperature" type: Real
-// 230: aimc.thermalAmbient.thermalPort.heatPortStatorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStatorCore.port.T  "Port temperature" type: Real
-// 231: aimc.internalThermalPort.heatPortStatorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStatorCore.port.T  "Port temperature" type: Real
-// 232: aimc.statorCore.heatPort.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 )  = aimc.thermalAmbient.temperatureStatorCore.port.T  "Port temperature" type: Real
-// 233: aimc.thermalAmbient.thermalPort.heatPortRotorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureRotorCore.port.T  "Port temperature" type: Real
-// 234: aimc.internalThermalPort.heatPortRotorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureRotorCore.port.T  "Port temperature" type: Real
-// 235: aimc.thermalAmbient.thermalPort.heatPortFriction.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureFriction.port.T  "Port temperature" type: Real
-// 236: aimc.friction.heatPort.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 )  = aimc.thermalAmbient.temperatureFriction.port.T  "Port temperature" type: Real
-// 237: aimc.internalThermalPort.heatPortFriction.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureFriction.port.T  "Port temperature" type: Real
+// 119: star.pin_n.i:VARIABLE(flow=true unit = "A" )  = -ground.p.i  "Current flowing into the pin" type: Real
+// 120: aimc.statorCore.spacePhasor.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 121: aimc.spacePhasorS.spacePhasor.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 122: aimc.statorCore.spacePhasor.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 123: aimc.spacePhasorS.spacePhasor.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.lssigma.spacePhasor_a.v_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 124: aimc.lszero.n.v:VARIABLE(flow=false unit = "V" )  = aimc.spacePhasorS.ground.v  "Potential at the pin" type: Real
+// 125: aimc.spacePhasorS.zero.v:VARIABLE(flow=false unit = "V" )  = aimc.lszero.v  "Potential at the pin" type: Real
+// 126: aimc.spacePhasorS.plug_p.pin[3].v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[3].v  "Potential at the pin" type: Real [3]
+// 127: aimc.rs.resistor[3].n.v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[3].v  "Potential at the pin" type: Real [3]
+// 128: aimc.spacePhasorS.plug_p.pin[2].v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[2].v  "Potential at the pin" type: Real [3]
+// 129: aimc.rs.resistor[2].n.v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[2].v  "Potential at the pin" type: Real [3]
+// 130: aimc.spacePhasorS.plug_p.pin[1].v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[1].v  "Potential at the pin" type: Real [3]
+// 131: aimc.rs.resistor[1].n.v:VARIABLE(flow=false unit = "V" )  = aimc.rs.plug_n.pin[1].v  "Potential at the pin" type: Real [3]
+// 132: aimc.strayLoad.plug_n.pin[3].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
+// 133: aimc.rs.resistor[3].p.v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
+// 134: aimc.strayLoad.plug_n.pin[2].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
+// 135: aimc.rs.resistor[2].p.v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
+// 136: aimc.strayLoad.plug_n.pin[1].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
+// 137: aimc.rs.resistor[1].p.v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
+// 138: aimc.lssigma.spacePhasor_b.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_s.v_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 139: aimc.lssigma.spacePhasor_b.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_s.v_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 140: aimc.squirrelCageR.spacePhasor_r.v_[2]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_r.v_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 141: aimc.squirrelCageR.spacePhasor_r.v_[1]:VARIABLE(flow=false unit = "V" )  = aimc.airGapS.spacePhasor_r.v_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 142: aimc.airGapS.i_rr[2]:VARIABLE(unit = "A" )  = aimc.idq_rr[2]  "Rotor current space phasor with respect to the rotor fixed frame" type: Real [2]
+// 143: aimc.airGapS.spacePhasor_r.i_[2]:VARIABLE(flow=true unit = "A" )  = aimc.idq_rr[2]  "1=real, 2=imaginary part" type: Real [2]
+// 144: aimc.squirrelCageR.spacePhasor_r.i_[2]:DUMMY_STATE(flow=true unit = "A" )  = -aimc.idq_rr[2]  "1=real, 2=imaginary part" type: Real [2]
+// 145: aimc.ir[2]:VARIABLE(unit = "A" )  = aimc.idq_rr[2]  "Rotor cage currents" type: Real [2]
+// 146: aimc.airGapS.i_rr[1]:VARIABLE(unit = "A" )  = aimc.idq_rr[1]  "Rotor current space phasor with respect to the rotor fixed frame" type: Real [2]
+// 147: aimc.airGapS.spacePhasor_r.i_[1]:VARIABLE(flow=true unit = "A" )  = aimc.idq_rr[1]  "1=real, 2=imaginary part" type: Real [2]
+// 148: aimc.squirrelCageR.spacePhasor_r.i_[1]:DUMMY_STATE(flow=true unit = "A" )  = -aimc.idq_rr[1]  "1=real, 2=imaginary part" type: Real [2]
+// 149: aimc.ir[1]:VARIABLE(unit = "A" )  = aimc.idq_rr[1]  "Rotor cage currents" type: Real [2]
+// 150: aimc.lssigma.spacePhasor_a.i_[2]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 151: aimc.lssigma.spacePhasor_b.i_[2]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 152: aimc.airGapS.spacePhasor_s.i_[2]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 153: aimc.airGapS.i_ss[2]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[2]  "Stator current space phasor with respect to the stator fixed frame" type: Real [2]
+// 154: aimc.idq_ss[2]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[2]  "Stator space phasor current / stator fixed frame" type: Real [2]
+// 155: aimc.lssigma.spacePhasor_a.i_[1]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 156: aimc.lssigma.spacePhasor_b.i_[1]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 157: aimc.airGapS.spacePhasor_s.i_[1]:VARIABLE(flow=true unit = "A" )  = aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 158: aimc.airGapS.i_ss[1]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[1]  "Stator current space phasor with respect to the stator fixed frame" type: Real [2]
+// 159: aimc.idq_ss[1]:VARIABLE(unit = "A" )  = aimc.lssigma.i_[1]  "Stator space phasor current / stator fixed frame" type: Real [2]
+// 160: aimc.thermalAmbient.temperatureFriction.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.powerBalance.lossPowerFriction  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 161: aimc.thermalAmbient.thermalPort.heatPortFriction.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.powerBalance.lossPowerFriction  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 162: aimc.thermalAmbient.temperatureStrayLoad.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.strayLoad.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 163: aimc.thermalAmbient.thermalPort.heatPortStrayLoad.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.strayLoad.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 164: aimc.thermalAmbient.thermalPort.heatPortRotorCore.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.internalThermalPort.heatPortRotorCore.Q_flow  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 165: aimc.thermalAmbient.temperatureRotorCore.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.internalThermalPort.heatPortRotorCore.Q_flow  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 166: aimc.thermalAmbient.Q_flowRotorCore:VARIABLE(unit = "W" final = true )  = aimc.internalThermalPort.heatPortRotorCore.Q_flow  "Heat flow rate of stator core losses" type: Real
+// 167: aimc.thermalAmbient.temperatureStatorCore.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.statorCore.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 168: aimc.thermalAmbient.thermalPort.heatPortStatorCore.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.statorCore.lossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 169: aimc.thermalAmbient.thermalPort.heatPortStatorWinding[1].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 170: aimc.thermalAmbient.thermalPort.heatPortStatorWinding[2].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 171: aimc.thermalAmbient.thermalPort.heatPortStatorWinding[3].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 172: aimc.thermalAmbient.temperatureRotorWinding.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.thermalAmbient.Q_flowRotorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 173: aimc.thermalAmbient.thermalPort.heatPortRotorWinding.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.thermalAmbient.Q_flowRotorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 174: aimc.thermalAmbient.temperatureStatorWinding.port.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.thermalAmbient.Q_flowStatorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 175: aimc.thermalAmbient.thermalCollectorStator.port_b.Q_flow:VARIABLE(flow=true unit = "W" final = true )  = -aimc.thermalAmbient.Q_flowStatorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 176: aimc.inertiaRotor.flange_a.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.tauElectrical  "Cut torque in the flange" type: Real
+// 177: aimc.airGapS.flange.tau:VARIABLE(flow=true unit = "N.m" )  = -aimc.tauElectrical  "Cut torque in the flange" type: Real
+// 178: aimc.airGapS.tauElectrical:VARIABLE(unit = "N.m" )  = aimc.tauElectrical  type: Real
+// 179: aimc.airGapS.support.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.tauElectrical  "Cut torque in the flange" type: Real
+// 180: aimc.rs.resistor[1].heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 181: aimc.rs.heatPort[1].Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 182: aimc.rs.resistor[2].heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 183: aimc.rs.heatPort[2].Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 184: aimc.rs.resistor[3].heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 185: aimc.rs.heatPort[3].Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 186: aimc.spacePhasorS.zero.i:VARIABLE(flow=true unit = "A" )  = aimc.i_0_s  "Current flowing into the pin" type: Real
+// 187: aimc.lszero.p.i:VARIABLE(flow=true unit = "A" )  = -aimc.i_0_s  "Current flowing into the pin" type: Real
+// 188: aimc.lszero.i:DUMMY_STATE(start = 0.0 unit = "A" )  = -aimc.i_0_s  "Current flowing from pin p to pin n" type: Real
+// 189: aimc.lszero.n.i:VARIABLE(flow=true unit = "A" )  = aimc.i_0_s  "Current flowing into the pin" type: Real
+// 190: aimc.spacePhasorS.ground.i:VARIABLE(flow=true unit = "A" )  = -aimc.i_0_s  "Current flowing into the pin" type: Real
+// 191: terminalBox.star.pin_n.i:VARIABLE(flow=true unit = "A" )  = terminalBox.starpoint.i  "Current flowing into the pin" type: Real
+// 192: sinevoltage1.sineVoltage[3].signalSource.y:VARIABLE()  = sinevoltage1.v[3]  "Connector of Real output signal" type: Real [3]
+// 193: sinevoltage1.sineVoltage[2].signalSource.y:VARIABLE()  = sinevoltage1.v[2]  "Connector of Real output signal" type: Real [3]
+// 194: sinevoltage1.sineVoltage[1].signalSource.y:VARIABLE()  = sinevoltage1.v[1]  "Connector of Real output signal" type: Real [3]
+// 195: aimc.squirrelCageR.heatPort.Q_flow:VARIABLE(flow=true unit = "W" )  = -aimc.thermalAmbient.Q_flowRotorWinding  "Heat flow rate (positive if flowing from outside into the component)" type: Real
+// 196: aimc.powerBalance.lossPowerRotorWinding:VARIABLE(unit = "W" final = true )  = aimc.thermalAmbient.Q_flowRotorWinding  "Rotor copper losses" type: Real
+// 197: aimc.airGapS.RotationMatrix[1,1]:VARIABLE()  = aimc.airGapS.RotationMatrix[2,2]  "Matrix of rotation from rotor to stator" type: Real [2,2]
+// 198: aimc.airGapS.RotationMatrix[1,2]:VARIABLE()  = -$cse1  "Matrix of rotation from rotor to stator" type: Real [2,2]
+// 199: aimc.strayLoad.support.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.strayLoad.tau  "Cut torque in the flange" type: Real
+// 200: aimc.powerBalance.lossPowerStrayLoad:VARIABLE(unit = "W" final = true )  = aimc.strayLoad.lossPower  "Stray load losses" type: Real
+// 201: aimc.powerBalance.lossPowerStatorCore:VARIABLE(unit = "W" final = true )  = aimc.statorCore.lossPower  "Stator core losses" type: Real
+// 202: aimc.airGapS.i_rs[2]:VARIABLE(unit = "A" )  = aimc.idq_rs[2]  "Rotor current space phasor with respect to the stator fixed frame" type: Real [2]
+// 203: aimc.airGapS.i_rs[1]:VARIABLE(unit = "A" )  = aimc.idq_rs[1]  "Rotor current space phasor with respect to the stator fixed frame" type: Real [2]
+// 204: aimc.airGapS.i_sr[2]:VARIABLE(unit = "A" )  = aimc.idq_sr[2]  "Stator current space phasor with respect to the rotor fixed frame" type: Real [2]
+// 205: aimc.airGapS.i_sr[1]:VARIABLE(unit = "A" )  = aimc.idq_sr[1]  "Stator current space phasor with respect to the rotor fixed frame" type: Real [2]
+// 206: aimc.friction.lossPower:VARIABLE(unit = "W" )  = aimc.powerBalance.lossPowerFriction  "Loss power leaving component via heatPort (> 0, if heat is flowing out of component)" type: Real
+// 207: aimc.friction.support.tau:VARIABLE(flow=true unit = "N.m" )  = aimc.friction.tau  "Cut torque in the flange" type: Real
+// 208: speedSensor.w:VARIABLE(unit = "rad/s" )  = aimc.inertiaRotor.w  "Absolute angular velocity of flange as output signal" type: Real
+// 209: aimc.thermalAmbient.Q_flowFriction:VARIABLE(unit = "W" final = true )  = aimc.powerBalance.lossPowerFriction  "Heat flow rate of friction losses" type: Real
+// 210: aimc.lszero.p.v:VARIABLE(flow=false unit = "V" )  = aimc.lszero.v  "Potential at the pin" type: Real
+// 211: aimc.thermalAmbient.Q_flowStatorCore:VARIABLE(unit = "W" final = true )  = aimc.statorCore.lossPower  "Heat flow rate of stator core losses" type: Real
+// 212: aimc.thermalAmbient.Q_flowStrayLoad:VARIABLE(unit = "W" final = true )  = aimc.strayLoad.lossPower  "Heat flow rate of stray load losses" type: Real
+// 213: aimc.plug_sp.pin[1].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
+// 214: aimc.rs.plug_p.pin[1].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[1]  "Potential at the pin" type: Real [3]
+// 215: sinevoltage1.sineVoltage[1].v:VARIABLE(unit = "V" )  = sinevoltage1.v[1]  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
+// 216: aimc.plug_sp.pin[2].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
+// 217: aimc.rs.plug_p.pin[2].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[2]  "Potential at the pin" type: Real [3]
+// 218: sinevoltage1.sineVoltage[2].v:VARIABLE(unit = "V" )  = sinevoltage1.v[2]  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
+// 219: aimc.plug_sp.pin[3].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
+// 220: aimc.rs.plug_p.pin[3].v:VARIABLE(flow=false unit = "V" )  = -sinevoltage1.v[3]  "Potential at the pin" type: Real [3]
+// 221: sinevoltage1.sineVoltage[3].v:VARIABLE(unit = "V" )  = sinevoltage1.v[3]  "Voltage drop between the two pins (= p.v - n.v)" type: Real [3]
+// 222: aimc.spacePhasorS.spacePhasor.i_[1]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[1]  "1=real, 2=imaginary part" type: Real [2]
+// 223: aimc.spacePhasorS.spacePhasor.i_[2]:VARIABLE(flow=true unit = "A" )  = -aimc.lssigma.i_[2]  "1=real, 2=imaginary part" type: Real [2]
+// 224: aimc.thermalAmbient.thermalCollectorStator.port_a[3].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[3].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 225: aimc.thermalAmbient.thermalCollectorStator.port_a[2].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[2].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 226: aimc.thermalAmbient.thermalCollectorStator.port_a[1].Q_flow:VARIABLE(flow=true unit = "W" final = true )  = aimc.rs.resistor[1].LossPower  "Heat flow rate (positive if flowing from outside into the component)" type: Real [3]
+// 227: aimc.squirrelCageR.LossPower:VARIABLE(unit = "W" )  = aimc.thermalAmbient.Q_flowRotorWinding  "Loss power leaving component via HeatPort" type: Real
+// 228: aimc.thermalAmbient.thermalPort.heatPortStrayLoad.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStrayLoad.port.T  "Port temperature" type: Real
+// 229: aimc.internalThermalPort.heatPortStrayLoad.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStrayLoad.port.T  "Port temperature" type: Real
+// 230: aimc.strayLoad.heatPort.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 )  = aimc.thermalAmbient.temperatureStrayLoad.port.T  "Port temperature" type: Real
+// 231: aimc.thermalAmbient.thermalPort.heatPortStatorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStatorCore.port.T  "Port temperature" type: Real
+// 232: aimc.internalThermalPort.heatPortStatorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureStatorCore.port.T  "Port temperature" type: Real
+// 233: aimc.statorCore.heatPort.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 )  = aimc.thermalAmbient.temperatureStatorCore.port.T  "Port temperature" type: Real
+// 234: aimc.thermalAmbient.thermalPort.heatPortRotorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureRotorCore.port.T  "Port temperature" type: Real
+// 235: aimc.internalThermalPort.heatPortRotorCore.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureRotorCore.port.T  "Port temperature" type: Real
+// 236: aimc.thermalAmbient.thermalPort.heatPortFriction.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureFriction.port.T  "Port temperature" type: Real
+// 237: aimc.friction.heatPort.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 )  = aimc.thermalAmbient.temperatureFriction.port.T  "Port temperature" type: Real
+// 238: aimc.internalThermalPort.heatPortFriction.T:VARIABLE(flow=false min = 0.0 start = 288.15 unit = "K" nominal = 300.0 final = true )  = aimc.thermalAmbient.temperatureFriction.port.T  "Port temperature" type: Real
 //
 //
 // Zero Crossings (3)
@@ -1789,7 +1715,7 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 //
 // record SimulationResult
 //     resultFile = "asmaFlow_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 10000, tolerance = 1e-006, method = 'dassl', fileNamePrefix = 'asmaFlow', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 20.0, numberOfIntervals = 10000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'asmaFlow', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/tearing/Tearing10-cel.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-cel.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,7 +72,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // -2.791204333037424e-14

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC11.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC11.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,7 +72,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // -2.791204333037424e-14

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC12.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC12.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,11 +72,11 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
-// -2.842170943040401e-14
+// -2.944104163046354e-14
 // ""
-// -2.842170943040401e-13
+// -2.944104163046354e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC13.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC13.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,11 +72,11 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
-// -2.842170943040401e-14
+// -2.944104163046354e-14
 // ""
-// -2.842170943040401e-13
+// -2.944104163046354e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC21.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC21.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,11 +72,11 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
-// -2.842170943040401e-14
+// -2.944104163046354e-14
 // ""
-// -2.842170943040401e-13
+// -2.944104163046354e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC22.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC22.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,7 +72,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // -2.791204333037424e-14

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC23.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC23.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,7 +72,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // -2.791204333037424e-14

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC231.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC231.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,7 +72,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // -2.791204333037424e-14

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC3.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,12 +72,12 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // ""
-// -2.842170943040401e-14
+// -2.944104163046354e-14
 // ""
-// -2.842170943040401e-13
+// -2.944104163046354e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing10-celMC4.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-celMC4.mos
@@ -42,8 +42,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -53,16 +53,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -72,11 +72,11 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
-// -2.842170943040401e-14
+// -2.944104163046354e-14
 // ""
-// -2.842170943040401e-13
+// -2.944104163046354e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing10-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-minimal.mos
@@ -39,8 +39,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -50,16 +50,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(11,22.3%) 0}
+//  * Linear torn systems: 1 {(10,23.0%) 0}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -69,11 +69,11 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(11,22.3%) 0}
+//  * Linear torn systems: 1 {(10,23.0%) 0}
 //  * Non-linear torn systems: 0
 // "
-// -2.842170943040401e-14
+// -3.019806626980426e-14
 // ""
-// -2.842170943040401e-13
+// -2.984279490192421e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing10-omc.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing10-omc.mos
@@ -39,8 +39,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -50,16 +50,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(2,100.0%) 8}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -69,11 +69,11 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(2,100.0%) 8}
 //  * Non-linear torn systems: 0
 // "
-// -2.880022175007437e-14
+// -2.842170943040401e-14
 // ""
-// -2.880022175007437e-13
+// -2.842170943040401e-13
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing6-cel.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing6-cel.mos
@@ -49,8 +49,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -60,16 +60,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -79,7 +79,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // 0.4755282581475768

--- a/testsuite/simulation/modelica/tearing/Tearing6-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing6-celMC3.mos
@@ -49,8 +49,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -60,16 +60,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -79,7 +79,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(1,100.0%) 9}
 //  * Non-linear torn systems: 0
 // "
 // 0.4755282581475768

--- a/testsuite/simulation/modelica/tearing/Tearing6-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing6-minimal.mos
@@ -46,8 +46,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -57,16 +57,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(11,22.3%) 0}
+//  * Linear torn systems: 1 {(10,23.0%) 0}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -76,7 +76,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(11,22.3%) 0}
+//  * Linear torn systems: 1 {(10,23.0%) 0}
 //  * Non-linear torn systems: 0
 // "
 // 0.4755282581475768

--- a/testsuite/simulation/modelica/tearing/Tearing6-omc.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing6-omc.mos
@@ -46,8 +46,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (14):
-//  * Single equations (assignments): 13
+// Notification: Strong component statistics for initialization (15):
+//  * Single equations (assignments): 14
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -57,16 +57,16 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(2,100.0%) 8}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
-//  * Number of independent subsystems: 2
+//  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (8):
-//  * Single equations (assignments): 7
+// Notification: Strong component statistics for simulation (9):
+//  * Single equations (assignments): 8
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -76,7 +76,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(1,100.0%) 10}
+//  * Linear torn systems: 1 {(2,100.0%) 8}
 //  * Non-linear torn systems: 0
 // "
 // 0.4755282581475768

--- a/testsuite/simulation/modelica/tearing/Tearing7-omc.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing7-omc.mos
@@ -49,8 +49,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for initialization (19):
-//  * Single equations (assignments): 18
+// Notification: Strong component statistics for initialization (21):
+//  * Single equations (assignments): 20
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -60,7 +60,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(2,100.0%) 18}
+//  * Linear torn systems: 1 {(2,100.0%) 16}
 //  * Non-linear torn systems: 0
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
@@ -68,8 +68,8 @@ val(R1.v,0.2); getErrorString();
 //  * Number of discrete variables: 0 ('-d=discreteinfo' for list of discrete vars)
 //  * Number of discrete states: 0 ('-d=discreteinfo' for list of discrete states)
 //  * Top-level inputs: 0
-// Notification: Strong component statistics for simulation (10):
-//  * Single equations (assignments): 9
+// Notification: Strong component statistics for simulation (12):
+//  * Single equations (assignments): 11
 //  * Array equations: 0
 //  * Algorithm blocks: 0
 //  * Record equations: 0
@@ -79,7 +79,7 @@ val(R1.v,0.2); getErrorString();
 //  * Torn equation systems: 1
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 1 {(3,100.0%) 17}
+//  * Linear torn systems: 1 {(2,100.0%) 16}
 //  * Non-linear torn systems: 0
 // "
 // 0.3170188387650512


### PR DESCRIPTION
     - analytical to structural singularity conversion
     - full replacement of equations with --fullASSC
     - deactivateable with --noASSC
     - dump partially integrated in -d=bltdump, main dump in -d=dumpASSC
     - add testcase for ASSC
     - use array mapping for artifical sanity check
     - ASSC replaces reshuffleLoops/resolveLoops algorithm entirely. it is deactivated but not removed for now