### PR TITLE
Improve handling and sanitization of quoted identifiers.

### DIFF
--- a/.CI/compliance-newinst.failures
+++ b/.CI/compliance-newinst.failures
@@ -8,7 +8,6 @@ ModelicaCompliance.Algorithms.For.MixedImplExplIterator
 ModelicaCompliance.Algorithms.For.RealRange
 ModelicaCompliance.Algorithms.For.ShadowedIterator
 ModelicaCompliance.Algorithms.For.StringRange
-ModelicaCompliance.Arrays.Declarations.BoolArray
 ModelicaCompliance.Arrays.Functions.Conversion.DimConversionMatrix
 ModelicaCompliance.Arrays.Functions.Reductions.Deduce
 ModelicaCompliance.Arrays.Operations.MatrixProduct.ArrayVectorVectorMul3
@@ -95,7 +94,6 @@ ModelicaCompliance.Connections.Stream.StreamConnectorMissingFlow
 ModelicaCompliance.Connections.Stream.StreamConnectorMultiFlow
 ModelicaCompliance.Connections.Stream.StreamOutsideConnector
 ModelicaCompliance.Equations.For.BoolRange
-ModelicaCompliance.Equations.For.BoolTypeRange
 ModelicaCompliance.Equations.For.ImplicitBoolIterator
 ModelicaCompliance.Equations.For.ImplicitEnumIterator
 ModelicaCompliance.Equations.For.ImplicitIntegerIterator

--- a/.CI/compliance.failures
+++ b/.CI/compliance.failures
@@ -2,7 +2,6 @@ ModelicaCompliance.Algorithms.For.RealRange
 ModelicaCompliance.Algorithms.For.ShadowedIterator
 ModelicaCompliance.Algorithms.For.StringRange
 ModelicaCompliance.Algorithms.For.VarArrayRange
-ModelicaCompliance.Arrays.Declarations.BoolArray
 ModelicaCompliance.Arrays.Functions.Size.ArrayDimSize4
 ModelicaCompliance.Arrays.Indexing.EnumArrayInvalidIndexing
 ModelicaCompliance.Classes.Balancing.CorrectBalance3
@@ -87,10 +86,6 @@ ModelicaCompliance.Connections.Restrictions.SizeScalarInvalid
 ModelicaCompliance.Connections.Stream.StreamOutsideConnector
 ModelicaCompliance.Equations.Equality.MultiOutputEqualityLess
 ModelicaCompliance.Equations.For.ArrayRange
-ModelicaCompliance.Equations.For.BoolRange
-ModelicaCompliance.Equations.For.BoolTypeRange
-ModelicaCompliance.Equations.For.ImplicitBoolIterator
-ModelicaCompliance.Equations.For.ImplicitMultiMixedIterator
 ModelicaCompliance.Functions.Derivative.PartialDerivative
 ModelicaCompliance.Functions.Restrictions.FunctionInnerOuter
 ModelicaCompliance.Functions.Restrictions.FunctionMultipleAlgorithm

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -3112,11 +3112,6 @@ algorithm
 
     case(cref::rest) equation
       ident = ComponentReference.printComponentRefStr(cref);
-      ident = System.unquoteIdentifier(ident);
-      ident = System.stringReplace(ident, ".", "$P");
-      ident = System.stringReplace(ident, ",", "$c");
-      ident = System.stringReplace(ident, "[", "$rB");
-      ident = System.stringReplace(ident, "]", "$lB");
       tp = Types.arrayElementType(ComponentReference.crefLastType(cref));
       crtmp = ComponentReference.makeCrefIdent("$TMP_" + ident + "_" + intString(iuniqueEqIndex), tp, {});
       repl = BackendVarTransform.addReplacement(iRepl, cref, DAE.CREF(crtmp, tp), SOME(BackendVarTransform.skipPreOperator));

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4532,7 +4532,7 @@ template contextIteratorName(Ident name, Context context)
 ::=
   match context
   case FUNCTION_CONTEXT(__) then "_" + System.unquoteIdentifier(name)
-  else System.forceQuotedIdentifier(name)
+  else System.unquoteIdentifier(name)
 end contextIteratorName;
 
 /* public */ template cref(ComponentRef cr)
@@ -4578,7 +4578,7 @@ end crefPre;
   case CREF_IDENT(ident = "xloc") then crefStr(cr)
   case CREF_IDENT(ident = "time") then "data->localData[0]->timeValue"
   case WILD(__) then ''
-  else System.forceQuotedIdentifier(crefStrNoUnderscore(cr))
+  else System.unquoteIdentifier(crefStrNoUnderscore(cr))
 end crefDefine;
 
 template crefToCStr(ComponentRef cr, Integer ix, Boolean isPre, Boolean isStart)
@@ -5973,7 +5973,7 @@ end daeExpIteratedCref;
 
 template iteratedCrefStr(ComponentRef cref)
 ::=
-  System.forceQuotedIdentifier(crefStrNoUnderscore(cref))
+  System.unquoteIdentifier(crefStrNoUnderscore(cref))
 end iteratedCrefStr;
 
 template resultVarAssignment(DAE.Type ty, Text lhs, Text rhs) "Tuple need to be considered"

--- a/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
@@ -120,13 +120,13 @@ template dumpEqs(list<SimEqSystem> eqs)
       <<
       equation index: <%equationIndex(eq)%>
       type: SIMPLE_ASSIGN
-      <%crefStr(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
+      <%dumpCref(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
       >>
     case e as SES_SIMPLE_ASSIGN_CONSTRAINTS(__) then
       <<
       equation index: <%equationIndex(eq)%>
       type: SIMPLE_ASSIGN_CONSTRAINTS
-      <%crefStr(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
+      <%dumpCref(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
       constraints: <%escapeCComments(dumpConstraints(e.cons))%>
       >>
     case e as SES_ARRAY_CALL_ASSIGN(lhs=lhs as CREF(__)) then
@@ -134,7 +134,7 @@ template dumpEqs(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: ARRAY_CALL_ASSIGN
 
-      <%crefStr(lhs.componentRef)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
+      <%dumpCref(lhs.componentRef)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
       >>
     case e as SES_ALGORITHM(statements={}) then
       <<
@@ -159,7 +159,7 @@ template dumpEqs(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: LINEAR
 
-      <%ls.vars |> SIMVAR(name=cr) => '<var><%crefStr(cr)%></var>' ; separator = "\n" %>
+      <%ls.vars |> SIMVAR(name=cr) => '<var><%dumpCref(cr)%></var>' ; separator = "\n" %>
       <row>
         <%ls.beqs |> exp => '<cell><%escapeCComments(dumpExp(exp,"\""))%></cell>' ; separator = "\n" %><%\n%>
       </row>
@@ -183,7 +183,7 @@ template dumpEqs(list<SimEqSystem> eqs)
       indexNonlinear: <%nls.indexNonLinearSystem%>
       type: NONLINEAR
 
-      vars: {<%nls.crefs |> cr => '<%crefStr(cr)%>' ; separator = ", "%>}
+      vars: {<%nls.crefs |> cr => '<%dumpCref(cr)%>' ; separator = ", "%>}
       eqns: {<%nls.eqs |> eq => '<%equationIndex(eq)%>' ; separator = ", "%>}
       >>
     case e as SES_MIXED(__) then
@@ -196,7 +196,7 @@ template dumpEqs(list<SimEqSystem> eqs)
 
       <mixed>
         <continuous index="<%equationIndex(e.cont)%>" />
-        <%e.discVars |> SIMVAR(name=cr) => '<var><%crefStr(cr)%></var>' ; separator = ","%>
+        <%e.discVars |> SIMVAR(name=cr) => '<var><%dumpCref(cr)%></var>' ; separator = ","%>
         <%e.discEqs |> eq => '<discrete index="<%equationIndex(eq)%>" />'%>
       </mixed>
       >>
@@ -216,7 +216,7 @@ template dumpEqs(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: WHEN
 
-      when {<%conditions |> cond => '<%crefStr(cond)%>' ; separator=", " %>} then
+      when {<%conditions |> cond => '<%dumpCref(cond)%>' ; separator=", " %>} then
         <%body%>
       end when;
       >>
@@ -234,7 +234,7 @@ template dumpEqs(list<SimEqSystem> eqs)
       let &forstatement = buffer ""
       let &forstatement += 'for ' + escapeCComments(dumpExp(e.iter,"\"")) + ' in ' + escapeCComments(dumpExp(e.startIt,"\""))
       let &forstatement += ' : ' + escapeCComments(dumpExp(e.endIt,"\"")) + ' loop<%\n%>'
-      let &forstatement += '  <%crefStr(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>; '
+      let &forstatement += '  <%dumpCref(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>; '
       let &forstatement += 'end for'
       <<
       equation index: <%equationIndex(e)%>
@@ -276,13 +276,13 @@ template dumpAlgSystemColumn (OMSIFunction column ,Text &columnBuffer, Text &var
   case OMSI_FUNCTION(__) then
     let &varsBuffer += (inputVars |> var as SIMVAR(__) =>
         <<
-        <%crefStr(name)%>
+        <%dumpCref(name)%>
         >>
         ; separator=", "
     )
 
     let _ = (equations |> equation as SES_SIMPLE_ASSIGN(__) =>
-        let &columnBuffer += crefStr(equation.cref) + " = " + escapeCComments(dumpExp(equation.exp,"\"")) + "\n"        // "
+        let &columnBuffer += dumpCref(equation.cref) + " = " + escapeCComments(dumpExp(equation.exp,"\"")) + "\n"        // "
         <<>>
     )
     <<>>
@@ -296,7 +296,7 @@ template dumpWhenOps(list<BackendDAE.WhenOperator> whenOps)
   case ((e as BackendDAE.ASSIGN(left=left as CREF(__)))::rest) then
     let restbody = dumpWhenOps(rest)
     <<
-    <%crefStr(left.componentRef)%> = <%escapeCComments(dumpExp(e.right,"\""))%>;
+    <%dumpCref(left.componentRef)%> = <%escapeCComments(dumpExp(e.right,"\""))%>;
     <%restbody%>
     >>
   case ((e as BackendDAE.ASSIGN(left=left))::rest) then
@@ -308,7 +308,7 @@ template dumpWhenOps(list<BackendDAE.WhenOperator> whenOps)
   case ((e as BackendDAE.REINIT(__))::rest) then
     let restbody = dumpWhenOps(rest)
     <<
-    reinit(<%crefStr(e.stateVar)%>,  <%escapeCComments(dumpExp(e.value,"\""))%>);
+    reinit(<%dumpCref(e.stateVar)%>,  <%escapeCComments(dumpExp(e.value,"\""))%>);
     <%restbody%>
     >>
   case ((e as BackendDAE.ASSERT(__))::rest) then
@@ -340,7 +340,7 @@ template dumpEqsAlternativeTearing(list<SimEqSystem> eqs)
       equation index: <%equationIndexAlternativeTearing(eq)%>
       type: LINEAR
 
-      <%at.vars |> SIMVAR(name=cr) => '<var><%crefStr(cr)%></var>' ; separator = "\n" %>
+      <%at.vars |> SIMVAR(name=cr) => '<var><%dumpCref(cr)%></var>' ; separator = "\n" %>
       <row>
         <%at.beqs |> exp => '<cell><%escapeCComments(dumpExp(exp,"\""))%></cell>' ; separator = "\n" %><%\n%>
       </row>
@@ -367,7 +367,7 @@ template dumpEqsAlternativeTearing(list<SimEqSystem> eqs)
       indexNonlinear: <%at.indexNonLinearSystem%>
       type: NONLINEAR
 
-      vars: {<%at.crefs |> cr => '<%crefStr(cr)%>' ; separator = ", "%>}
+      vars: {<%at.crefs |> cr => '<%dumpCref(cr)%>' ; separator = ", "%>}
       eqns: {<%at.eqs |> eq => '<%equationIndex(eq)%>' ; separator = ", "%>}
 
       This is the alternative tearing set with casual solvability rules.

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1610,11 +1610,6 @@ package System
     output String outStr;
   end unquoteIdentifier;
 
-  function forceQuotedIdentifier
-    input String str;
-    output String outStr;
-  end forceQuotedIdentifier;
-
   function dirname
     input String str;
     output String outStr;

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -864,18 +864,14 @@ literal in C. For example unescapedStringLength('\"')=1, unescapedStringLength('
 end unescapedStringLength;
 
 public function unquoteIdentifier
-  "Quoted identifiers, for example 'xyz' need to be translated into canonical form; for example _omcQuot_0x2778797A27"
+  "Quoted identifiers which can use Modelica's allowed Q-CHARs need to be translated into canonical (valid c89 identifier) form
+   using ascii representations; for example,
+    '+' ->  QQ_2B_QQ
+    'xyz@d!' -> QQ_xyz40d21_QQ "
   input String str;
   output String outStr;
   external "C" outStr=System_unquoteIdentifier(str) annotation(Library = "omcruntime");
 end unquoteIdentifier;
-
-public function forceQuotedIdentifier
-  "Forced quoted identifiers, for example xyz is translated into canonical form; for example _omcQuot_0x78797A"
-  input String str;
-  output String outStr;
-  external "C" outStr=System_forceQuotedIdentifier(str) annotation(Library = "omcruntime");
-end forceQuotedIdentifier;
 
 public function intMaxLit "Returns the maximum integer that can be represent using this version of the compiler"
   output Integer outInt;

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -695,9 +695,7 @@ extern char* System_unescapedString(char* str)
 
 extern char* System_unquoteIdentifier(char *str)
 {
-  char *res = SystemImpl__unquoteIdentifier(str);
-  if (res == NULL) return str;
-  return res;
+  return SystemImpl__unquoteIdentifier(str);
 }
 
 extern char* System_getCurrentTimeStr()

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -1720,40 +1720,122 @@ extern char* SystemImpl__unescapedString(const char* str)
   return res;
 }
 
-extern char* System_forceQuotedIdentifier(const char* str)
-{
-  const char lookupTbl[] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
-  char *res,*cur;
-  int len,i;
-  const int offset = 10;
-  const char _omcQuot[]="_omcQuot_";
-  len = strlen(str);
-  res = (char*) omc_alloc_interface.malloc_atomic(2*len+offset+64);
-  cur = res;
-  cur += sprintf(cur,"%s",_omcQuot);
-  for (i=0; i<len; i++) {
-    unsigned char c = str[i];
-    *cur = lookupTbl[c/16];
-    cur++;
-    *cur = lookupTbl[c%16];
-    cur++;
+
+static int compute_sanitized_string_size(const char* str) {
+  int i, count;
+
+  for (i=0, count=0; str[i]; i++, count++) {
+    char c = str[i];
+    // Each non-alphanum character needs one more char for its
+    // two char ascii representation.
+    if (!isalnum(c) && c != '_') {
+      count++;
+    }
   }
+
+  return count;
+}
+
+static char* sanitize_string(const char* src, char* dst, int nrchars) {
+  const char lookupTbl[] = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+
+  int i;
+  for (i = 0; i < nrchars; i++) {
+    unsigned char c = src[i];
+    if (isalnum(c) || c == '_') {
+      *dst = c;
+      dst++;
+    }
+    else {
+      *dst = lookupTbl[c/16];
+      dst++;
+      *dst = lookupTbl[c%16];
+      dst++;
+    }
+  }
+
+  return dst;
+}
+
+// This function assumes the input is actually a quoted string e.g 'gb' or 'ab[!%'
+extern char* System_sanitizeQuotedIdentifier(const char* str)
+{
+  char *res,*cur;
+
+  const char openquote[]="Q_";
+  const char closequote[]="_Q";
+  const int qsize = sizeof(openquote) - 1;
+
+  int nrchars_org = strlen(str);
+
+  // Each non-alphanum character needs one more char for its
+  // two char ascii representation.
+  int nrchars_needed = compute_sanitized_string_size(str);
+
+  // ignore the count for opening and closing quotes in the original string
+  nrchars_needed = nrchars_needed - 4;
+  nrchars_org = nrchars_org - 2;
+
+  nrchars_needed += 2*qsize; // opening and closing quoute rep.
+  nrchars_needed++; /*null terminator*/
+  res = (char*) omc_alloc_interface.malloc_atomic(nrchars_needed * sizeof(char));
+
+  cur = res;
+  cur += sprintf(cur, "%s", openquote);
+  cur = sanitize_string(str + 1, cur, nrchars_org);
+  cur += sprintf(cur,"%s", closequote);
   *cur = '\0';
+
+  ++cur;
+  assert((cur == res + nrchars_needed) && "Allocated memory does not exactly fit the unquoted string output");
+
   return res;
 }
 
-extern char* SystemImpl__unquoteIdentifier(const char* str)
+extern char* System_sanitizeIdentifier(const char* str)
 {
-  char c = *str;
-  if ((c == '\'')
-#if !defined(OPENMODELICA_BOOTSTRAPPING_STAGE_1)
-   || strstr(str, "$")
-#endif
-  )
-  {
-    return System_forceQuotedIdentifier(str);
+  char *res,*cur;
+
+  int nrchars_org = strlen(str);
+
+  // Each non-alphanum character needs one more char for its
+  // two char ascii representation.
+  int nrchars_needed = compute_sanitized_string_size(str);
+
+  // if the first char is not alphanum then the result will start with a number(ascii)
+  // we do not want that. So make it always start with a char.
+  const char openquote[]="D_";
+  const int qsize = sizeof(openquote) - 1;
+  nrchars_needed += qsize;
+
+  nrchars_needed++; /*null terminator*/
+  res = (char*) omc_alloc_interface.malloc_atomic(nrchars_needed * sizeof(char));
+
+  cur = res;
+  cur += sprintf(cur, "%s", openquote);
+  cur = sanitize_string(str, cur, nrchars_org);
+  *cur = '\0';
+
+  ++cur;
+  assert((cur == res + nrchars_needed) && "Allocated memory does not exactly fit the unquoted string output");
+
+  return res;
+}
+
+extern char* SystemImpl__unquoteIdentifier(char* str)
+{
+
+  if (str[0] == '\'') {
+    return System_sanitizeQuotedIdentifier(str);
   }
-  return NULL;
+
+#if !defined(OPENMODELICA_BOOTSTRAPPING_STAGE_1)
+  if (strstr(str, "$")) {
+    return System_sanitizeIdentifier(str);
+  }
+#endif
+
+  return str;
 }
 
 #define TIMER_MAX_STACK  1000


### PR DESCRIPTION
  - Do not use ascii codes for alpha numeric or underscore characters.
    This makes it easier to read the generated code for sanitized idents.

  - Allocate exactly the amount of memory we need for the sanitization.

  - Removed forceQuotedIdentifier. It is not needed. There is
    no need to force sanitization if it is not actually needed. The function
    gets misused as replacement for unquoteIdentifier.