### PR TITLE
Fix segmentationFault for constant Jacobian equations in parallel

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -132,6 +132,7 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
         linsys[i].parDynamicData[j].jacobian->seedVars = (modelica_real*) calloc(jacobian->sizeCols, sizeof(modelica_real));
         linsys[i].parDynamicData[j].jacobian->resultVars = (modelica_real*) calloc(jacobian->sizeRows, sizeof(modelica_real));
         linsys[i].parDynamicData[j].jacobian->tmpVars = (modelica_real*) calloc(jacobian->sizeTmpVars, sizeof(modelica_real));
+        linsys[i].parDynamicData[j].jacobian->constantEqns = jacobian->constantEqns;
         linsys[i].parDynamicData[j].jacobian->sparsePattern = jacobian->sparsePattern;
       }
 #else


### PR DESCRIPTION
Added `constantEqns` function pointer to deep copy for parallel Jacobian data. That was causing a segmentation fault when using parallel Jacobian evaluation.