### PR TITLE
Fix OMC-OMSimulator API calls

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4428,107 +4428,107 @@ end oms_exportDependencyGraphs;
 
 function oms_extractFMIKind
   input String filename;
-  output Integer status;
   output Integer  kind;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_extractFMIKind;
 
 function oms_getBoolean
   input String cref;
-  output Integer status;
   output Boolean  value;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getBoolean;
 
 function oms_getFixedStepSize
   input String cref;
+  output Real stepSize;
   output Integer status;
-  output Real  stepSize;
 external "builtin";
 annotation(preferredView="text");
 end oms_getFixedStepSize;
 
 function oms_getInteger
   input String cref;
+  input Integer value;
   output Integer status;
-  input Integer  value;
 external "builtin";
 annotation(preferredView="text");
 end oms_getInteger;
 
 function oms_getModelState
   input String cref;
-  output Integer status;
   output Integer modelState;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getModelState;
 
 function oms_getReal
   input String cref;
+  output Real value;
   output Integer status;
-  output Real  value;
 external "builtin";
 annotation(preferredView="text");
 end oms_getReal;
 
 function oms_getSolver
   input String cref;
-  output Integer status;
   output Integer solver;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getSolver;
 
 function oms_getStartTime
   input String cref;
-  output Integer status;
   output Real startTime;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getStartTime;
 
 function oms_getStopTime
   input String cref;
-  output Integer status;
   output Real stopTime;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getStopTime;
 
 function oms_getSubModelPath
   input String cref;
-  output Integer status;
   output String path;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getSubModelPath;
 
 function oms_getSystemType
   input String cref;
-  output Integer status;
   output Integer type_;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getSystemType;
 
 function oms_getTolerance
   input String cref;
-  output Integer status;
   output Real absoluteTolerance;
   output Real relativeTolerance;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getTolerance;
 
 function oms_getVariableStepSize
   input String cref;
-  output Integer status;
   output Real initialStepSize;
   output Real minimumStepSize;
   output Real maximumStepSize;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getVariableStepSize;
@@ -4544,8 +4544,8 @@ end oms_faultInjection;
 
 function oms_importFile
   input String filename;
-  output Integer status;
   output String cref;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_importFile;
@@ -4566,16 +4566,16 @@ end oms_instantiate;
 
 function oms_list
   input String cref;
-  output Integer status;
   output String contents;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_list;
 
 function oms_listUnconnectedConnectors
   input String cref;
-  output Integer status;
   output String contents;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_listUnconnectedConnectors;
@@ -4597,8 +4597,8 @@ end oms_newModel;
 
 function oms_parseModelName
   input String contents;
-  output Integer status;
   output String cref;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_parseModelName;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4559,107 +4559,107 @@ end oms_exportDependencyGraphs;
 
 function oms_extractFMIKind
   input String filename;
-  output Integer status;
   output Integer  kind;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_extractFMIKind;
 
 function oms_getBoolean
   input String cref;
-  output Integer status;
   output Boolean  value;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getBoolean;
 
 function oms_getFixedStepSize
   input String cref;
+  output Real stepSize;
   output Integer status;
-  output Real  stepSize;
 external "builtin";
 annotation(preferredView="text");
 end oms_getFixedStepSize;
 
 function oms_getInteger
   input String cref;
+  input Integer value;
   output Integer status;
-  input Integer  value;
 external "builtin";
 annotation(preferredView="text");
 end oms_getInteger;
 
 function oms_getModelState
   input String cref;
-  output Integer status;
   output Integer modelState;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getModelState;
 
 function oms_getReal
   input String cref;
+  output Real value;
   output Integer status;
-  output Real  value;
 external "builtin";
 annotation(preferredView="text");
 end oms_getReal;
 
 function oms_getSolver
   input String cref;
-  output Integer status;
   output Integer solver;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getSolver;
 
 function oms_getStartTime
   input String cref;
-  output Integer status;
   output Real startTime;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getStartTime;
 
 function oms_getStopTime
   input String cref;
-  output Integer status;
   output Real stopTime;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getStopTime;
 
 function oms_getSubModelPath
   input String cref;
-  output Integer status;
   output String path;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getSubModelPath;
 
 function oms_getSystemType
   input String cref;
-  output Integer status;
   output Integer type_;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getSystemType;
 
 function oms_getTolerance
   input String cref;
-  output Integer status;
   output Real absoluteTolerance;
   output Real relativeTolerance;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getTolerance;
 
 function oms_getVariableStepSize
   input String cref;
-  output Integer status;
   output Real initialStepSize;
   output Real minimumStepSize;
   output Real maximumStepSize;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_getVariableStepSize;
@@ -4675,8 +4675,8 @@ end oms_faultInjection;
 
 function oms_importFile
   input String filename;
-  output Integer status;
   output String cref;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_importFile;
@@ -4697,16 +4697,16 @@ end oms_instantiate;
 
 function oms_list
   input String cref;
-  output Integer status;
   output String contents;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_list;
 
 function oms_listUnconnectedConnectors
   input String cref;
-  output Integer status;
   output String contents;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_listUnconnectedConnectors;
@@ -4728,8 +4728,8 @@ end oms_newModel;
 
 function oms_parseModelName
   input String contents;
-  output Integer status;
   output String cref;
+  output Integer status;
 external "builtin";
 annotation(preferredView="text");
 end oms_parseModelName;

--- a/OMCompiler/Compiler/Script/CevalScriptOMSimulator.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptOMSimulator.mo
@@ -213,81 +213,81 @@ algorithm
 
     case("oms_extractFMIKind",{Values.STRING(filename)})
       equation
-        (status,kind) = OMSimulator.oms_extractFMIKind(filename);
+        (kind,status) = OMSimulator.oms_extractFMIKind(filename);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.INTEGER(kind)});
+        Values.TUPLE({Values.INTEGER(kind),Values.INTEGER(status)});
 
     case("oms_getBoolean",{Values.STRING(cref)})
       equation
-        (status,b) = OMSimulator.oms_getBoolean(cref);
+        (b,status) = OMSimulator.oms_getBoolean(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.BOOL(b)});
+        Values.TUPLE({Values.BOOL(b),Values.INTEGER(status)});
 
     case("oms_getFixedStepSize",{Values.STRING(cref)})
       equation
-        (status,rvalue) = OMSimulator.oms_getFixedStepSize(cref);
+        (rvalue,status) = OMSimulator.oms_getFixedStepSize(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.REAL(rvalue)});
+        Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getInteger",{Values.STRING(cref)})
       equation
-        (status,ivalue) = OMSimulator.oms_getInteger(cref);
+        (ivalue,status) = OMSimulator.oms_getInteger(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.INTEGER(ivalue)});
+        Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getModelState",{Values.STRING(cref)})
       equation
-        (status,ivalue) = OMSimulator.oms_getModelState(cref);
+        (ivalue,status) = OMSimulator.oms_getModelState(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.INTEGER(ivalue)});
+        Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getReal",{Values.STRING(cref)})
       equation
-        (status,rvalue) = OMSimulator.oms_getReal(cref);
+        (rvalue,status) = OMSimulator.oms_getReal(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.REAL(rvalue)});
+        Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getSolver",{Values.STRING(cref)})
       equation
-        (status,ivalue) = OMSimulator.oms_getSolver(cref);
+        (ivalue,status) = OMSimulator.oms_getSolver(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.INTEGER(ivalue)});
+        Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getStartTime",{Values.STRING(cref)})
       equation
-        (status,rvalue) = OMSimulator.oms_getStartTime(cref);
+        (rvalue,status) = OMSimulator.oms_getStartTime(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.REAL(rvalue)});
+        Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getStopTime",{Values.STRING(cref)})
       equation
-        (status,rvalue) = OMSimulator.oms_getStopTime(cref);
+        (rvalue,status) = OMSimulator.oms_getStopTime(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.REAL(rvalue)});
+        Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getSubModelPath",{Values.STRING(cref)})
       equation
-        (status,path) = OMSimulator.oms_getSubModelPath(cref);
+        (path,status) = OMSimulator.oms_getSubModelPath(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.STRING(path)});
+        Values.TUPLE({Values.STRING(path),Values.INTEGER(status)});
 
     case("oms_getSystemType",{Values.STRING(cref)})
       equation
-        (status,ivalue) = OMSimulator.oms_getSystemType(cref);
+        (ivalue,status) = OMSimulator.oms_getSystemType(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.INTEGER(ivalue)});
+        Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getTolerance",{Values.STRING(cref)})
       equation
-        (status,rvalue) = OMSimulator.oms_getTolerance(cref);
+        (absoluteTolerance,relativeTolerance,status) = OMSimulator.oms_getTolerance(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.REAL(rvalue)});
+        Values.TUPLE({Values.REAL(absoluteTolerance),Values.REAL(relativeTolerance),Values.INTEGER(status)});
 
     case("oms_getVariableStepSize",{Values.STRING(cref)})
       equation
-        (status,rvalue) = OMSimulator.oms_getVariableStepSize(cref);
+        (initialStepSize,minimumStepSize,maximumStepSize,status) = OMSimulator.oms_getVariableStepSize(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.REAL(rvalue)});
+        Values.TUPLE({Values.REAL(initialStepSize),Values.REAL(minimumStepSize),Values.REAL(maximumStepSize),Values.INTEGER(status)});
 
     case("oms_faultInjection",{Values.STRING(signal), Values.ENUM_LITERAL(index=faultType), Values.REAL(faultValue)})
       equation
@@ -297,9 +297,9 @@ algorithm
 
     case("oms_importFile",{Values.STRING(filename)})
       equation
-        (status,cref) = OMSimulator.oms_importFile(filename);
+        (cref,status) = OMSimulator.oms_importFile(filename);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.STRING(cref)});
+        Values.TUPLE({Values.STRING(cref),Values.INTEGER(status)});
 
     case("oms_initialize",{Values.STRING(cref)})
       equation
@@ -315,15 +315,15 @@ algorithm
 
     case("oms_list",{Values.STRING(cref)})
       equation
-        (status,contents) = OMSimulator.oms_list(cref);
+        (contents,status) = OMSimulator.oms_list(cref);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.STRING(contents)});
+        Values.TUPLE({Values.STRING(contents),Values.INTEGER(status)});
 
     case("oms_listUnconnectedConnectors",{Values.STRING(cref)})
       equation
-        (status,contents) = OMSimulator.oms_listUnconnectedConnectors(cref);
+        (contents,status) = OMSimulator.oms_listUnconnectedConnectors(cref);
       then
-    Values.TUPLE({Values.INTEGER(status),Values.STRING(contents)});
+        Values.TUPLE({Values.STRING(contents),Values.INTEGER(status)});
 
     case("oms_loadSnapshot",{Values.STRING(cref), Values.STRING(snapshot)})
       equation
@@ -339,9 +339,9 @@ algorithm
 
     case("oms_parseModelName",{Values.STRING(contents)})
       equation
-        (status,cref) = OMSimulator.oms_parseModelName(contents);
+        (cref,status) = OMSimulator.oms_parseModelName(contents);
       then
-        Values.TUPLE({Values.INTEGER(status),Values.STRING(cref)});
+        Values.TUPLE({Values.STRING(cref),Values.INTEGER(status)});
 
     case("oms_removeSignalsFromResults",{Values.STRING(cref), Values.STRING(regex)})
       equation
@@ -503,7 +503,7 @@ algorithm
       equation
         status = OMSimulator.oms_terminate(cref);
       then
-    Values.INTEGER(status);
+        Values.INTEGER(status);
 
     case ("oms_getVersion",{})
       equation

--- a/OMCompiler/Compiler/Util/OMSimulator.mo
+++ b/OMCompiler/Compiler/Util/OMSimulator.mo
@@ -252,95 +252,95 @@ end oms_exportDependencyGraphs;
 
 function oms_extractFMIKind
   input String filename;
-  output Integer status;
   output Integer kind;
+  output Integer status;
   external "C" status = OMSimulator_oms_extractFMIKind(filename,kind) annotation(Library = "omcruntime");
 end oms_extractFMIKind;
 
 function oms_getBoolean
   input String cref;
-  output Integer status;
   output Boolean value;
+  output Integer status;
   external "C" status = OMSimulator_oms_getBoolean(cref,value) annotation(Library = "omcruntime");
 end oms_getBoolean;
 
 function oms_getFixedStepSize
   input String cref;
-  output Integer status;
   output Real stepSize;
+  output Integer status;
   external "C" status = OMSimulator_oms_getFixedStepSize(cref,stepSize) annotation(Library = "omcruntime");
 end oms_getFixedStepSize;
 
 function oms_getInteger
   input String cref;
-  output Integer status;
   output Integer value;
+  output Integer status;
   external "C" status = OMSimulator_oms_getInteger(cref,value) annotation(Library = "omcruntime");
 end oms_getInteger;
 
 function oms_getModelState
   input String cref;
-  output Integer status;
   output Integer modelState;
+  output Integer status;
   external "C" status = OMSimulator_oms_getModelState(cref,modelState) annotation(Library = "omcruntime");
 end oms_getModelState;
 
 function oms_getReal
   input String cref;
-  output Integer status;
   output Real value;
+  output Integer status;
   external "C" status = OMSimulator_oms_getReal(cref,value) annotation(Library = "omcruntime");
 end oms_getReal;
 
 function oms_getSolver
   input String cref;
-  output Integer status;
   output Integer solver;
+  output Integer status;
   external "C" status = OMSimulator_oms_getSolver(cref,solver) annotation(Library = "omcruntime");
 end oms_getSolver;
 
 function oms_getStartTime
   input String cref;
-  output Integer status;
   output Real startTime;
+  output Integer status;
   external "C" status = OMSimulator_oms_getStartTime(cref,startTime) annotation(Library = "omcruntime");
 end oms_getStartTime;
 
 function oms_getStopTime
   input String cref;
-  output Integer status;
   output Real stopTime;
+  output Integer status;
   external "C" status = OMSimulator_oms_getStopTime(cref,stopTime) annotation(Library = "omcruntime");
 end oms_getStopTime;
 
 function oms_getSubModelPath
   input String cref;
-  output Integer status;
   output String path;
+  output Integer status;
   external "C" status = OMSimulator_oms_getSubModelPath(cref,path) annotation(Library = "omcruntime");
 end oms_getSubModelPath;
 
 function oms_getSystemType
   input String cref;
-  output Integer status;
   output Integer type_;
+  output Integer status;
   external "C" status = OMSimulator_oms_getSystemType(cref,type_) annotation(Library = "omcruntime");
 end oms_getSystemType;
 
 function oms_getTolerance
   input String cref;
-  output Integer status;
   output Real absoluteTolerance;
   output Real relativeTolerance;
+  output Integer status;
   external "C" status = OMSimulator_oms_getTolerance(cref,absoluteTolerance,relativeTolerance) annotation(Library = "omcruntime");
 end oms_getTolerance;
 
 function oms_getVariableStepSize
   input String cref;
-  output Integer status;
   output Real initialStepSize;
   output Real minimumStepSize;
   output Real maximumStepSize;
+  output Integer status;
   external "C" status = OMSimulator_oms_getVariableStepSize(cref,initialStepSize,minimumStepSize,maximumStepSize) annotation(Library = "omcruntime");
 end oms_getVariableStepSize;
 
@@ -354,8 +354,8 @@ end oms_faultInjection;
 
 function oms_importFile
   input String filename;
-  output Integer status;
   output String cref;
+  output Integer status;
   external "C" status = OMSimulator_oms_importFile(filename,cref) annotation(Library = "omcruntime");
 end oms_importFile;
 
@@ -373,15 +373,15 @@ end oms_instantiate;
 
 function oms_list
   input String cref;
-  output Integer status;
   output String contents;
+  output Integer status;
   external "C" status = OMSimulator_oms_list(cref,contents) annotation(Library = "omcruntime");
 end oms_list;
 
 function oms_listUnconnectedConnectors
   input String cref;
-  output Integer status;
   output String contents;
+  output Integer status;
   external "C" status = OMSimulator_oms_listUnconnectedConnectors(cref,contents) annotation(Library = "omcruntime");
 end oms_listUnconnectedConnectors;
 
@@ -400,8 +400,8 @@ end oms_newModel;
 
 function oms_parseModelName
   input String contents;
-  output Integer status;
   output String cref;
+  output Integer status;
   external "C" status = OMSimulator_oms_parseModelName(contents,cref) annotation(Library = "omcruntime");
 end oms_parseModelName;
 

--- a/testsuite/omsimulator/DualMassOscillator.mos
+++ b/testsuite/omsimulator/DualMassOscillator.mos
@@ -62,14 +62,14 @@ oms_instantiate("DualMassOscillator");
 oms_setReal("DualMassOscillator.root.system2.s2_start", 2.5);
 
 oms_initialize("DualMassOscillator");
-(_,v1):=oms_getReal("DualMassOscillator.root.system1.s1");
-(_,v2):=oms_getReal("DualMassOscillator.root.system2.s2");
+(v1,_):=oms_getReal("DualMassOscillator.root.system1.s1");
+(v2,_):=oms_getReal("DualMassOscillator.root.system2.s2");
 print("info:    Initialization\n");
 print("info:      system1.s1: " + realString(v1)+"\n");
 print("info:      system2.s2: " + realString(v2)+"\n");
 oms_simulate("DualMassOscillator");
-(_,v1):=oms_getReal("DualMassOscillator.root.system1.s1");
-(_,v2):=oms_getReal("DualMassOscillator.root.system2.s2");
+(v1,_):=oms_getReal("DualMassOscillator.root.system1.s1");
+(v2,_):=oms_getReal("DualMassOscillator.root.system2.s2");
 print("info:    Simulation\n");
 print("info:      system1.s1: " + realString(v1)+"\n");
 print("info:      system2.s2: " + realString(v2)+"\n");

--- a/testsuite/omsimulator/initialization2_omc.mos
+++ b/testsuite/omsimulator/initialization2_omc.mos
@@ -39,10 +39,10 @@ oms_setResultFile("test", "");
 
 oms_instantiate("test");
 oms_initialize("test");
-(_,v1):=oms_getReal("test.root.A.y");
-(_,v2):=oms_getReal("test.root.B.x");
-(_,v3):=oms_getReal("test.root.B.y");
-(_,v4):=oms_getReal("test.root.B.u");
+(v1,_):=oms_getReal("test.root.A.y");
+(v2,_):=oms_getReal("test.root.B.x");
+(v3,_):=oms_getReal("test.root.B.y");
+(v4,_):=oms_getReal("test.root.B.u");
 
 print("info:    Initialization\n");
 print("info:      A.y: " + realString(v1)+ "\n");

--- a/testsuite/omsimulator/initialization_omc.mos
+++ b/testsuite/omsimulator/initialization_omc.mos
@@ -38,9 +38,9 @@ oms_instantiate("test");
 oms_setReal("test.root.A.x_start", 1.5);
 
 oms_initialize("test");
-(_,v1):=oms_getReal("test.root.A.x_start");
-(_,v2):=oms_getReal("test.root.A.x");
-(_,v3):=oms_getReal("test.root.A.w");
+(v1,_):=oms_getReal("test.root.A.x_start");
+(v2,_):=oms_getReal("test.root.A.x");
+(v3,_):=oms_getReal("test.root.A.w");
 
 print("info:    Initialization\n");
 print("info:      A.x_start: " + realString(v1)+"\n");
@@ -48,9 +48,9 @@ print("info:      A.x:       " + realString(v2)+"\n");
 print("info:      A.w:       " + realString(v3)+"\n");
 
 oms_simulate("test");
-(_,v1):=oms_getReal("test.root.A.x_start");
-(_,v2):=oms_getReal("test.root.A.x");
-(_,v3):=oms_getReal("test.root.A.w");
+(v1,_):=oms_getReal("test.root.A.x_start");
+(v2,_):=oms_getReal("test.root.A.x");
+(v3,_):=oms_getReal("test.root.A.w");
 
 print("info:    Simulation\n");
 print("info:      A.x_start: " + realString(v1)+"\n");

--- a/testsuite/omsimulator/outputState_omc.mos
+++ b/testsuite/omsimulator/outputState_omc.mos
@@ -37,16 +37,16 @@ oms_instantiate("test");
 oms_setReal("test.root.A.y_start", 1.5);
 
 oms_initialize("test");
-(_,v1):=oms_getReal("test.root.A.y");
-(_,v2):=oms_getReal("test.root.B.u");
+(v1,_):=oms_getReal("test.root.A.y");
+(v2,_):=oms_getReal("test.root.B.u");
 
 print("info:    Initialization\n");
 print("info:      A.y: " + realString(v1)+"\n");
 print("info:      B.u: " + realString(v1)+"\n");
 
 oms_simulate("test");
-(_,v1):=oms_getReal("test.root.A.y");
-(_,v2):=oms_getReal("test.root.B.u");
+(v1,_):=oms_getReal("test.root.A.y");
+(v2,_):=oms_getReal("test.root.B.u");
 
 print("info:    Simulation\n");
 print("info:      A.y: " + realString(v1)+"\n");

--- a/testsuite/omsimulator/reset_omc.mos
+++ b/testsuite/omsimulator/reset_omc.mos
@@ -27,16 +27,16 @@ oms_addSubModel("test.root.A", "reset.fmu");
 
 oms_instantiate("test");
 oms_initialize("test");
-(_,v1):=oms_getReal("test.root.A.x_start");
-(_,v2):=oms_getReal("test.root.A.x");
+(v1,_):=oms_getReal("test.root.A.x_start");
+(v2,_):=oms_getReal("test.root.A.x");
 
 print("info:    Initialization\n");
 print("info:      A.x_start: " + realString(v1)+"\n");
 print("info:      A.x:       " + realString(v2)+"\n");
 
 oms_simulate("test");
-(_,v1):=oms_getReal("test.root.A.x_start");
-(_,v2):=oms_getReal("test.root.A.x");
+(v1,_):=oms_getReal("test.root.A.x_start");
+(v2,_):=oms_getReal("test.root.A.x");
 
 print("info:    Simulation\n");
 print("info:      A.x_start: " + realString(v1)+"\n");
@@ -46,15 +46,15 @@ for i in 0:1 loop
   oms_reset("test");
   oms_setReal("test.root.A.x_start", 1.5);
   oms_initialize("test");
-  (_,v1):=oms_getReal("test.root.A.x_start");
-  (_,v2):=oms_getReal("test.root.A.x");
+  (v1,_):=oms_getReal("test.root.A.x_start");
+  (v2,_):=oms_getReal("test.root.A.x");
   print("info:    Initialization\n");
   print("info:      A.x_start: " + realString(v1)+"\n");
   print("info:      A.x:       " + realString(v2)+"\n");
 
   oms_simulate("test");
-  (_,v1):=oms_getReal("test.root.A.x_start");
-  (_,v2):=oms_getReal("test.root.A.x");
+  (v1,_):=oms_getReal("test.root.A.x_start");
+  (v2,_):=oms_getReal("test.root.A.x");
   print("info:    Simulation\n");
   print("info:      A.x_start: " + realString(v1)+"\n");
   print("info:      A.x:       " + realString(v2)+"\n");

--- a/testsuite/omsimulator/test03.mos
+++ b/testsuite/omsimulator/test03.mos
@@ -61,7 +61,7 @@ oms_addSystem("test.eoo", OpenModelica.Scripting.oms_system.oms_system_wc);
 oms_addSubModel("test.eoo.source", "Modelica.Blocks.Sources.Sine.fmu");
 
 // save snapshot
-(status,src) := oms_list("test");
+(src,status) := oms_list("test");
 print(src);
 
 // change model
@@ -73,7 +73,7 @@ oms_addSubModel("test.eoo.source", "Modelica.Blocks.Sources.Constant.fmu");
 status := oms_loadSnapshot("test", src);
 printStatus(status, 0);
 
-(status,src) := oms_list("test");
+(src,status) := oms_list("test");
 print(src);
 
 oms_instantiate("test");


### PR DESCRIPTION
### Purpose
This fixes OMC-OMSimulator API calls to follow the same pattern like OMSimulatorPython and OMSimulatorLua scripting interface

### changes
(ex) : (status,value) := oms_getReal(cref)  ===> (value,status) := oms_getReal(cref)  
 