### PR TITLE
[CRuntime] Fix segmentation fault for parallel symbolic Jacobians

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/jacobianSymbolical.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/jacobianSymbolical.c
@@ -109,6 +109,7 @@ void genericColoredSymbolicJacobianEvaluation(int rows, int columns, SPARSE_PATT
                                               threadData_t* threadData,
                                               void (*setJacElement)(int, int, int, double, void*, int))
 {
+
 #ifdef USE_PARJAC
   GC_allow_register_threads();
 #endif

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -125,7 +125,6 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
       {
         // ToDo Simplify this. Only have one location for jacobian
         linsys[i].parDynamicData[j].jacobian = (ANALYTIC_JACOBIAN*) malloc(sizeof(ANALYTIC_JACOBIAN));
-        //linsys[i].initialAnalyticalJacobian(data, threadData, linsys[i].parDynamicData[j].jacobian);
         linsys[i].parDynamicData[j].jacobian->sizeCols = jacobian->sizeCols;
         linsys[i].parDynamicData[j].jacobian->sizeRows = jacobian->sizeRows;
         linsys[i].parDynamicData[j].jacobian->sizeTmpVars = jacobian->sizeTmpVars;

--- a/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
+++ b/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
@@ -29,6 +29,13 @@ diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
 getErrorString();
 
 // Test IDA
+system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=ida -jacobian=symbolical", "out.log"); getErrorString();
+readFile("out.log"); remove("out.log");
+diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
+                      getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler.mat","diff"
+                      vars={"evaporator.p", "evaporator.der(p)", "evaporator.V_l", "evaporator.der(V_l)", "controller.x", "controller.der(x)"});
+getErrorString();
+
 system(realpath(".") + "/Modelica.Fluid.Examples.DrumBoiler.DrumBoiler -s=ida -jacobian=coloredSymbolical", "out.log"); getErrorString();
 readFile("out.log"); remove("out.log");
 diffSimulationResults("Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_res.mat",
@@ -56,6 +63,15 @@ getErrorString();
 // 0
 // ""
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// (true,{})
+// ""
+// 0
+// ""
+// "stdout | warning | Symbolic Jacobians without coloring are currently not supported by IDA. Colored symbolical Jacobian will be used.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true


### PR DESCRIPTION
  - Evaluate constant equations only outside of parallel region and only
    for `data->simulationInfo->analyticJacobians[index]`.
    Was causing problems when enabling parallelization for symbolic jacobians
    without constant parts for sparse models.
  - Fixed missing evaluation for constant equation inside IDA solver
  - Updated testcase to check IDA with non-colored symbolic jacobian with
    constant parts.