### PR TITLE
Codegen/fix sim context record assignments

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1305,11 +1305,19 @@ algorithm
     // create SimCodeVars for algebraic states
     algStateVars := BackendVariable.listVar(inBackendDAE.shared.daeModeData.algStateVars);
     ((algebraicStateVars, _)) :=  BackendVariable.traverseBackendDAEVars(algStateVars, SimCodeUtil.traversingdlowvarToSimvar, ({}, BackendVariable.emptyVars()));
-    SimCode.VARINFO(numStateVars=nStates) := modelInfo.varInfo;
 
     algebraicStateVars := SimCodeUtil.sortSimVarsAndWriteIndex(algebraicStateVars, crefToSimVarHT);
-    (algebraicStateVars, _) := SimCodeUtil.setVariableIndexHelper(algebraicStateVars, 2*nStates);
-    crefToSimVarHT:= List.fold(algebraicStateVars,HashTableCrefSimVar.addSimVarToHashTable,crefToSimVarHT);
+
+    /* This lines seem to be not neccsary and actually problematic.
+       The algebraicStateVars are already in the simvars. Which means they are already addded
+       to the hastable somewhere above. Here we try to add them again but with wrong indexs because
+       setVariableIndexHelper does not actually update the indices we want. If you want to enable this
+      for some reason use rewriteIndex.
+    */
+    // SimCode.VARINFO(numStateVars=nStates) := modelInfo.varInfo;
+    // // (algebraicStateVars, _) := SimCodeUtil.setVariableIndexHelper(algebraicStateVars, 2*nStates);
+    // (algebraicStateVars, _) := SimCodeUtil.rewriteIndex(algebraicStateVars, 2*nStates);
+    // crefToSimVarHT:= List.fold(algebraicStateVars,HashTableCrefSimVar.addSimVarToHashTable,crefToSimVarHT);
 
     // create DAE mode Sparse pattern and TODO: Jacobians
     // sparsity pattern generation
@@ -1323,7 +1331,9 @@ algorithm
     modelInfo := SimCodeUtil.addNumEqns(modelInfo, uniqueEqIndex-listLength(jacobianEquations));
 
     // update hash table
-    crefToSimVarHT := SimCodeUtil.createCrefToSimVarHT(modelInfo);
+    // mahge: This creates a new crefToSimVarHT discarding everything added upto here
+    // The updated variable 'numEquations' (by SimCodeUtil.addNumEqns) is not even used in createCrefToSimVarHT :/
+    // crefToSimVarHT := SimCodeUtil.createCrefToSimVarHT(modelInfo);
 
     simCode := SimCode.SIMCODE(modelInfo,
                               {}, // Set by the traversal below...

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -858,21 +858,23 @@ template defineSimVarArray(SimVar simVar, String arrayName)
   case SIMVAR(arrayCref=SOME(c),aliasvar=NOALIAS()) then
     <<
     /* <%crefStrNoUnderscore(c)%> */
-    #define <%cref(c)%> data->simulationInfo->daeModeData-><%arrayName%>[<%index%>]
+    // #define <%cref(c)%> data->simulationInfo->daeModeData-><%arrayName%>[<%index%>]
 
     /* <%crefStrNoUnderscore(name)%> */
-    #define <%cref(name)%> data->simulationInfo->daeModeData-><%arrayName%>[<%index%>]
+    // #define <%cref(name)%> data->simulationInfo->daeModeData-><%arrayName%>[<%index%>]
 
     >>
   case SIMVAR(aliasvar=NOALIAS()) then
     <<
     /* <%crefStrNoUnderscore(name)%> */
-    #define <%cref(name)%> data->simulationInfo->daeModeData-><%arrayName%>[<%index%>]
+    // #define <%cref(name)%> data->simulationInfo->daeModeData-><%arrayName%>[<%index%>]
 
     >>
   end match
 end defineSimVarArray;
 
+// TODO: This is probably not relevant anymore can be removed. We access residual and auxialry
+// variables of daemode using cref2simvar now. No need to define them.
 template simulationFile_dae_header(SimCode simCode)
 "DAEmode header generation"
 ::=
@@ -5939,22 +5941,23 @@ match ty
       error(sourceInfo(), 'No runtime support for this sort of array call: <%cref(left)%> = <%dumpExp(right,"\"")%>')
     end match
   case T_COMPLEX(varLst = varLst, complexClassType=RECORD(__)) then
-    let &preExp = buffer ""
-    let exp = daeExp(right, context, &preExp, &varDecls, &auxFunction)
-    let tmp = tempDecl(expTypeModelica(ty),&varDecls)
-    <<
-    <%preExp%>
-    <%tmp%> = <%exp%>;
-    <% varLst |> var as TYPES_VAR(__) =>
-      match var.ty
-      case T_ARRAY(__) then
-        copyArrayData(var.ty, '<%tmp%>._<%var.name%>', appendStringCref(var.name,left), context, &preExp, &varDecls, &auxFunction)
-      else
-        let varPart = contextCref(appendStringCref(var.name,left),context, &auxFunction)
-        '<%varPart%> = <%tmp%>._<%var.name%>;'
-    ; separator="\n"
-    %>
-    >>
+    error(sourceInfo(), 'No runtime support for this record assignment: <%cref(left)%> = <%dumpExp(right,"\"")%>')
+    // let &preExp = buffer ""
+    // let exp = daeExp(right, context, &preExp, &varDecls, &auxFunction)
+    // let tmp = tempDecl(expTypeModelica(ty),&varDecls)
+    // <<
+    // <%preExp%>
+    // <%tmp%> = <%exp%>;
+    // <% varLst |> var as TYPES_VAR(__) =>
+    //   match var.ty
+    //   case T_ARRAY(__) then
+    //     copyArrayData(var.ty, '<%tmp%>._<%var.name%>', appendStringCref(var.name,left), context, &preExp, &varDecls, &auxFunction)
+    //   else
+    //     let varPart = contextCref(appendStringCref(var.name,left),context, &auxFunction)
+    //     '<%varPart%> = <%tmp%>._<%var.name%>;'
+    // ; separator="\n"
+    // %>
+    // >>
   else
     let &preExp = buffer ""
     let exp = daeExp(right, context, &preExp, &varDecls, &auxFunction)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1262,6 +1262,13 @@ package SimCodeFunctionUtil
     output DAE.Exp outExp;
   end makeCrefRecordExp;
 
+  function splitRecordAssignmentToMemberAssignments
+    input DAE.ComponentRef lhs_cref;
+    input DAE.Type lhs_type;
+    input String rhs_cref_str;
+    output list<DAE.Statement> outAssigns;
+  end splitRecordAssignmentToMemberAssignments;
+
   function derComponentRef
     input DAE.ComponentRef inCref;
     output DAE.ComponentRef derCref;


### PR DESCRIPTION
 Improve code generation for assignment of records in simulation context.

  - We now split up the record memebers and then create assignments for each member.
    We used to textually generate '=' assignments for the memebers.
    This does not work if the member is a record or an array.
    Instead we now actually create assignment expressions and then send them back to the template
    functions.