### PR TITLE
[NF] Fix type of ModelicaIO_readMatrixSizes.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1007,7 +1007,8 @@ algorithm
       algorithm
         dims := ModelicaExternalC.ModelicaIO_readMatrixSizes(s1, s2);
       then
-        Expression.ARRAY(Type.INTEGER(), {Expression.INTEGER(dims[1]), Expression.INTEGER(dims[2])}, true);
+        Expression.ARRAY(Type.ARRAY(Type.INTEGER(), {Dimension.fromInteger(2)}),
+                         {Expression.INTEGER(dims[1]), Expression.INTEGER(dims[2])}, true);
 
     case ("ModelicaIO_readRealMatrix",
         {Expression.STRING(s1), Expression.STRING(s2), Expression.INTEGER(i), Expression.INTEGER(i2), Expression.BOOLEAN(b)})


### PR DESCRIPTION
- Fix the type when evaluating ModelicaIO_readMatrixSizes,
  the resulting expressions should be Integer[2] and not Integer.