### PR TITLE
Improved handling of propagated array modifiers.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -1035,6 +1035,7 @@ protected
           (arg, ty, exp_var) := Typing.typeExp(call.exp, next_origin, info);
           variability := Variability.variabilityMax(variability, exp_var);
           ty := Type.liftArrayLeftList(ty, dims);
+          variability := Variability.variabilityMax(variability, exp_var);
         then
           (TYPED_ARRAY_CONSTRUCTOR(ty, variability, arg, iters), ty, variability);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -867,8 +867,7 @@ uniontype Component
       return;
     end if;
 
-    fixed := fixed and Expression.isTrue(Binding.getExp(binding));
-
+    fixed := fixed and Expression.isTrue(Expression.getBindingExp(Binding.getExp(binding)));
   end getFixedAttribute;
 
   function getUnitAttribute
@@ -877,18 +876,21 @@ uniontype Component
     output String unitString;
   protected
     Binding binding;
+    Expression unit;
   algorithm
     binding := Class.lookupAttributeBinding("unit", InstNode.getClass(classInstance(component)));
 
-    unitString := match binding
-      case Binding.TYPED_BINDING(bindingExp = Expression.STRING(value = unitString)) then unitString;
-      case Binding.FLAT_BINDING(bindingExp = Expression.STRING(value = unitString)) then unitString;
+    if Binding.isUnbound(binding) then
+      unitString := defaultUnit;
+      return;
+    end if;
+
+    unit := Expression.getBindingExp(Binding.getExp(binding));
+
+    unitString := match unit
+      case Expression.STRING() then unit.value;
       else defaultUnit;
     end match;
-
-    if stringEmpty(unitString) then
-      unitString := defaultUnit;
-    end if;
   end getUnitAttribute;
 
   function isDeleted

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -599,6 +599,7 @@ algorithm
 
   if isSome(nominal_oexp) then
     SOME(nominal_exp) := nominal_oexp;
+    nominal_exp := Expression.getBindingExp(nominal_exp);
     flow_threshold := Expression.BINARY(flowThreshold, Operator.makeMul(Type.REAL()), nominal_exp);
   else
     flow_threshold := flowThreshold;
@@ -806,7 +807,7 @@ algorithm
 
   if isSome(attr_oexp) then
     SOME(attr_exp) := attr_oexp;
-    isZero := Expression.isZero(attr_exp);
+    isZero := Expression.isZero(Expression.getBindingExp(attr_exp));
   else
     isZero := false;
   end if;
@@ -888,8 +889,10 @@ protected
   Real min_val, max_val;
 algorithm
   flow_cls := InstNode.getClass(ComponentRef.node(flowCref));
-  omin := SimplifyExp.simplifyOpt(Class.lookupAttributeValue("min", flow_cls));
-  omax := SimplifyExp.simplifyOpt(Class.lookupAttributeValue("max", flow_cls));
+  omin := Class.lookupAttributeValue("min", flow_cls);
+  omin := SimplifyExp.simplifyOpt(Util.applyOption(omin, Expression.getBindingExp));
+  omax := Class.lookupAttributeValue("max", flow_cls);
+  omax := SimplifyExp.simplifyOpt(Util.applyOption(omax, Expression.getBindingExp));
 
   direction := match (omin, omax)
     // No attributes, flow direction can't be decided.

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -157,6 +157,7 @@ algorithm
         if ComponentRef.nodeVariability(cref) <= constVariability then
           // Evaluate all constants and structural parameters.
           outExp := Ceval.evalCref(cref, outExp, Ceval.EvalTarget.IGNORE_ERRORS(), evalSubscripts = false);
+          outExp := Expression.stripBindingInfo(outExp);
           outChanged := true;
         elseif outChanged then
           // If the cref's subscripts changed, recalculate its type.
@@ -437,6 +438,7 @@ algorithm
       algorithm
         if ComponentRef.isPackageConstant(e.cref) then
           outExp := Ceval.evalCref(e.cref, e, Ceval.EvalTarget.IGNORE_ERRORS(), evalSubscripts = false);
+          outExp := Expression.stripBindingInfo(outExp);
           outChanged := true;
         elseif outChanged then
           // If the cref's subscripts changed, recalculate its type.

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -236,7 +236,7 @@ algorithm
   binding := Component.getBinding(InstNode.component(node));
 
   if Binding.isBound(binding) then
-    bindingExp := Binding.getExp(binding);
+    bindingExp := Expression.getBindingExp(Binding.getExp(binding));
   else
     bindingExp := buildBinding(node, repl);
   end if;
@@ -1007,7 +1007,8 @@ algorithm
       algorithm
         dims := ModelicaExternalC.ModelicaIO_readMatrixSizes(s1, s2);
       then
-        Expression.ARRAY(Type.INTEGER(), {Expression.INTEGER(dims[1]), Expression.INTEGER(dims[2])}, true);
+        Expression.ARRAY(Type.ARRAY(Type.INTEGER(), {Dimension.fromInteger(2)}),
+                         {Expression.INTEGER(dims[1]), Expression.INTEGER(dims[2])}, true);
 
     case ("ModelicaIO_readRealMatrix",
         {Expression.STRING(s1), Expression.STRING(s2), Expression.INTEGER(i), Expression.INTEGER(i2), Expression.BOOLEAN(b)})

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -67,17 +67,17 @@ public
         then
           (exp, expanded);
 
-      case Expression.ARRAY() then (exp, true);
+      case Expression.ARRAY()    then (exp, true);
       case Expression.TYPENAME() then (expandTypename(exp.ty), true);
-      case Expression.RANGE() then expandRange(exp);
-      case Expression.CALL() then expandCall(exp.call, exp);
-      case Expression.SIZE() then expandSize(exp);
-      case Expression.BINARY() then expandBinary(exp, exp.operator);
-      case Expression.UNARY() then expandUnary(exp.exp, exp.operator);
-      case Expression.LBINARY() then expandLogicalBinary(exp);
-      case Expression.LUNARY() then expandLogicalUnary(exp.exp, exp.operator);
+      case Expression.RANGE()    then expandRange(exp);
+      case Expression.CALL()     then expandCall(exp.call, exp);
+      case Expression.SIZE()     then expandSize(exp);
+      case Expression.BINARY()   then expandBinary(exp, exp.operator);
+      case Expression.UNARY()    then expandUnary(exp.exp, exp.operator);
+      case Expression.LBINARY()  then expandLogicalBinary(exp);
+      case Expression.LUNARY()   then expandLogicalUnary(exp.exp, exp.operator);
       case Expression.RELATION() then (exp, true);
-      case Expression.CAST() then expandCast(exp.exp, exp.ty);
+      case Expression.CAST()     then expandCast(exp.exp, exp.ty);
       else expandGeneric(exp);
     end match;
   end expand;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -51,6 +51,7 @@ protected
   import ValuesUtil;
   import MetaModelica.Dangerous.listReverseInPlace;
   import Types;
+  import RangeIterator = NFRangeIterator;
 
 public
   import Absyn.Path;
@@ -335,6 +336,25 @@ public
     Type ty;
   end PARTIAL_FUNCTION_APPLICATION;
 
+  record BINDING_EXP
+    "Represents a binding expression, for example:
+       model A
+         Real x[2];
+       end A;
+
+       model B
+         A a[3](x = {{1, 2}, {3, 4}, {5, 6}});
+       end B;
+     is represented as:
+       BINDING_EXP({{1, 2}, {3, 4}, {5, 6}}, Real[3, 2], Real[2], {x, a}, false);
+    "
+    Expression exp;
+    Type expType      "The actual type of exp.";
+    Type bindingType "The type of the propagated binding.";
+    list<InstNode> parents;
+    Boolean isEach;
+  end BINDING_EXP;
+
   function isArray
     input Expression exp;
     output Boolean isArray;
@@ -507,12 +527,6 @@ public
           end if;
         then
           comp;
-
-      case CLKCONST(clk1)
-        algorithm
-          CLKCONST(clk2) := exp2;
-        then
-          ClockKind.compare(clk1, clk2);
 
       case CREF()
         algorithm
@@ -688,17 +702,6 @@ public
         then
           comp;
 
-      case PARTIAL_FUNCTION_APPLICATION()
-        algorithm
-          PARTIAL_FUNCTION_APPLICATION(fn = cr, args = expl) := exp2;
-          comp := ComponentRef.compare(exp1.fn, cr);
-
-          if comp == 0 then
-            comp := compareList(exp1.args, expl);
-          end if;
-        then
-          comp;
-
       case BOX()
         algorithm
           BOX(exp = e2) := exp2;
@@ -716,6 +719,29 @@ public
           EMPTY(ty = ty) := exp2;
         then
           valueCompare(exp1.ty, ty);
+
+      case CLKCONST(clk1)
+        algorithm
+          CLKCONST(clk2) := exp2;
+        then
+          ClockKind.compare(clk1, clk2);
+
+      case PARTIAL_FUNCTION_APPLICATION()
+        algorithm
+          PARTIAL_FUNCTION_APPLICATION(fn = cr, args = expl) := exp2;
+          comp := ComponentRef.compare(exp1.fn, cr);
+
+          if comp == 0 then
+            comp := compareList(exp1.args, expl);
+          end if;
+        then
+          comp;
+
+      case BINDING_EXP()
+        algorithm
+          BINDING_EXP(exp = e2) := exp2;
+        then
+          compare(exp1.exp, e2);
 
       else
         algorithm
@@ -804,6 +830,7 @@ public
       case MUTABLE()         then typeOf(Mutable.access(exp.exp));
       case EMPTY()           then exp.ty;
       case PARTIAL_FUNCTION_APPLICATION() then exp.ty;
+      case BINDING_EXP()     then exp.bindingType;
       else Type.UNKNOWN();
     end match;
   end typeOf;
@@ -853,7 +880,7 @@ public
     input output Expression exp;
     input Type ty;
   protected
-    Type t, ety;
+    Type t, t2, ety;
     list<Expression> el;
   algorithm
     ety := Type.arrayElementType(ty);
@@ -903,6 +930,13 @@ public
 
       // Casting a cast expression overrides its current cast type.
       case (CAST(), _) then typeCast(exp.exp, ty);
+
+      case (BINDING_EXP(), _)
+        algorithm
+          t := Type.setArrayElementType(exp.expType, ety);
+          t2 := Type.setArrayElementType(exp.bindingType, ety);
+        then
+          BINDING_EXP(typeCast(exp.exp, ety), t, t2, exp.parents, exp.isEach);
 
       // Other expressions are handled by making a CAST expression.
       else
@@ -1003,6 +1037,18 @@ public
     end if;
   end makeRealMatrix;
 
+  function makeExpArray
+    input list<Expression> elements;
+    input Boolean isLiteral = false;
+    output Expression exp;
+  protected
+    Type ty;
+  algorithm
+    ty := typeOf(listHead(elements));
+    ty := Type.ARRAY(ty, {Dimension.fromInteger(listLength(elements))});
+    exp := makeArray(ty, elements, isLiteral);
+  end makeExpArray;
+
   function applySubscripts
     "Subscripts an expression with the given list of subscripts."
     input list<Subscript> subscripts;
@@ -1042,6 +1088,10 @@ public
         then applySubscriptCall(subscript, exp, restSubscripts);
 
       case IF() then applySubscriptIf(subscript, exp, restSubscripts);
+
+      case BINDING_EXP()
+        then bindingExpMap(exp,
+          function applySubscript(subscript = subscript, restSubscripts = restSubscripts));
 
       else makeSubscriptedExp(subscript :: restSubscripts, exp);
     end match;
@@ -1169,17 +1219,27 @@ public
     input Subscript index;
     input list<Subscript> restSubscripts;
     output Expression outExp;
+  algorithm
+    outExp := applyIndexExpArray(exp, Subscript.toExp(index), restSubscripts);
+  end applyIndexSubscriptArray;
+
+  function applyIndexExpArray
+    input Expression exp;
+    input Expression index;
+    input list<Subscript> restSubscripts;
+    output Expression outExp;
   protected
-    Expression index_exp = Subscript.toExp(index);
     list<Expression> expl;
   algorithm
-    if isScalarLiteral(index_exp) then
+    if isScalarLiteral(index) then
       ARRAY(elements = expl) := exp;
-      outExp := applySubscripts(restSubscripts, listGet(expl, toInteger(index_exp)));
+      outExp := applySubscripts(restSubscripts, listGet(expl, toInteger(index)));
+    elseif isBindingExp(index) then
+      outExp := bindingExpMap(index, function applyIndexExpArray(exp = exp, restSubscripts = restSubscripts));
     else
-      outExp := makeSubscriptedExp(index :: restSubscripts, exp);
+      outExp := makeSubscriptedExp(Subscript.INDEX(index) :: restSubscripts, exp);
     end if;
-  end applyIndexSubscriptArray;
+  end applyIndexExpArray;
 
   function applySubscriptRange
     input Subscript subscript;
@@ -1563,6 +1623,7 @@ public
       case PARTIAL_FUNCTION_APPLICATION()
         then "function " + ComponentRef.toString(exp.fn) + "(" + stringDelimitList(
           list(n + " = " + Expression.toString(a) threaded for a in exp.args, n in exp.argNames), ", ") + ")";
+      case BINDING_EXP() then toString(exp.exp);
 
       else anyString(exp);
     end match;
@@ -1736,6 +1797,8 @@ public
                                list(toDAE(arg) for arg in exp.args),
                                Type.toDAE(exp.ty),
                                Type.toDAE(Type.FUNCTION(fn, NFType.FunctionType.FUNCTIONAL_VARIABLE)));
+
+      case BINDING_EXP() then toDAE(exp.exp);
 
       else
         algorithm
@@ -1981,6 +2044,12 @@ public
           exp.args := list(map(e, func) for e in exp.args);
         then
           exp;
+
+      case BINDING_EXP()
+        algorithm
+          e1 := map(exp.exp, func);
+        then
+          if referenceEq(exp.exp, e1) then exp else BINDING_EXP(e1, exp.expType, exp.bindingType, exp.parents, exp.isEach);
 
       else exp;
     end match;
@@ -2324,6 +2393,12 @@ public
         then
           exp;
 
+      case BINDING_EXP()
+        algorithm
+          e1 := func(exp.exp);
+        then
+          if referenceEq(exp.exp, e1) then exp else BINDING_EXP(e1, exp.expType, exp.bindingType, exp.parents, exp.isEach);
+
       else exp;
     end match;
   end mapShallow;
@@ -2655,6 +2730,7 @@ public
       case BOX() then fold(exp.exp, func, arg);
       case MUTABLE() then fold(Mutable.access(exp.exp), func, arg);
       case PARTIAL_FUNCTION_APPLICATION() then foldList(exp.args, func, arg);
+      case BINDING_EXP() then fold(exp.exp, func, arg);
       else arg;
     end match;
 
@@ -2915,6 +2991,7 @@ public
       case BOX() algorithm apply(exp.exp, func); then ();
       case MUTABLE() algorithm apply(Mutable.access(exp.exp), func); then ();
       case PARTIAL_FUNCTION_APPLICATION() algorithm applyList(exp.args, func); then ();
+      case BINDING_EXP() algorithm apply(exp.exp, func); then ();
       else ();
     end match;
 
@@ -3251,6 +3328,12 @@ public
           exp.args := expl;
         then
           exp;
+
+      case BINDING_EXP()
+        algorithm
+          (e1, arg) := mapFold(exp.exp, func, arg);
+        then
+          if referenceEq(exp.exp, e1) then exp else BINDING_EXP(e1, exp.expType, exp.bindingType, exp.parents, exp.isEach);
 
       else exp;
     end match;
@@ -3595,6 +3678,12 @@ public
           exp.args := expl;
         then
           exp;
+
+      case BINDING_EXP()
+        algorithm
+          (e1, arg) := func(exp.exp, arg);
+        then
+          if referenceEq(exp.exp, e1) then exp else BINDING_EXP(e1, exp.expType, exp.bindingType, exp.parents, exp.isEach);
 
       else exp;
     end match;
@@ -4326,6 +4415,8 @@ public
   end isRecordOrRecordArray;
 
   function fillType
+    "Creates an array with the given type, filling it with the given scalar
+     expression."
     input Type ty;
     input Expression fillExp;
     output Expression exp = fillExp;
@@ -4344,6 +4435,45 @@ public
       exp := Expression.makeArray(arr_ty, expl, literal = isLiteral(exp));
     end for;
   end fillType;
+
+  function liftArray
+    "Creates an array with the given dimension, where each element is the given
+     expression. Example: liftArray([3], 1) => {1, 1, 1}"
+    input Dimension dim;
+    input output Expression exp;
+          output Type arrayType = typeOf(exp);
+  protected
+    list<Expression> expl = {};
+  algorithm
+    for i in 1:Dimension.size(dim) loop
+      expl := exp :: expl;
+    end for;
+
+    arrayType := Type.liftArrayLeft(arrayType, dim);
+    exp := Expression.makeArray(arrayType, expl, literal = isLiteral(exp));
+  end liftArray;
+
+  function liftArrayList
+    "Creates an array from the given list of dimensions, where each element is
+     the given expression. Example:
+       liftArrayList([2, 3], 1) => {{1, 1, 1}, {1, 1, 1}}"
+    input list<Dimension> dims;
+    input output Expression exp;
+          output Type arrayType = typeOf(exp);
+  protected
+    list<Expression> expl;
+    Boolean is_literal = isLiteral(exp);
+  algorithm
+    for dim in listReverse(dims) loop
+      expl := {};
+      for i in 1:Dimension.size(dim) loop
+        expl := exp :: expl;
+      end for;
+
+      arrayType := Type.liftArrayLeft(arrayType, dim);
+      exp := Expression.makeArray(arrayType, expl, literal = is_literal);
+    end for;
+  end liftArrayList;
 
   function makeZero
     input Type ty;
@@ -4735,6 +4865,7 @@ public
       case RECORD_ELEMENT() then variability(exp.recordExp);
       case BOX() then variability(exp.exp);
       case PARTIAL_FUNCTION_APPLICATION() then Variability.CONTINUOUS;
+      case BINDING_EXP() then variability(exp.exp);
       else
         algorithm
           Error.assertion(false, getInstanceName() + " got unknown expression.", sourceInfo());
@@ -4862,6 +4993,9 @@ public
         then
           exp;
 
+      case Expression.BINDING_EXP()
+        then bindingExpMap(exp, function tupleElement(ty = ty, index = index));
+
       else Expression.TUPLE_ELEMENT(exp, index, ty);
     end match;
   end tupleElement;
@@ -4905,6 +5039,10 @@ public
                                    Dimension.fromInteger(listLength(expl)));
         then
           Expression.makeArray(ty, expl, recordExp.literal);
+
+      case BINDING_EXP()
+        then Expression.bindingExpMap(recordExp,
+          function recordElement(elementName = elementName));
 
       else
         algorithm
@@ -4950,6 +5088,9 @@ public
         then
           RECORD_ELEMENT(recordExp, index, InstNode.name(node),
                          Type.liftArrayLeftList(InstNode.getType(node), Type.arrayDims(recordExp.ty)));
+
+      case BINDING_EXP()
+        then bindingExpMap(recordExp, function nthRecordElement(index = index));
 
       else
         algorithm
@@ -5030,6 +5171,259 @@ public
   algorithm
     exp := Expression.ENUM_LITERAL(ty, Type.nthEnumLiteral(ty, n), n);
   end nthEnumLiteral;
+
+  function isBindingExp
+    input Expression exp;
+    output Boolean isBindingExp;
+  algorithm
+    isBindingExp := match exp
+      case BINDING_EXP() then true;
+      else false;
+    end match;
+  end isBindingExp;
+
+  function getBindingExp
+    "Returns the expression contained in a binding expression, if the given
+     expression is a binding expression."
+    input Expression bindingExp;
+    output Expression outExp;
+  algorithm
+    outExp := match bindingExp
+      case BINDING_EXP() then getBindingExp(bindingExp.exp);
+      else bindingExp;
+    end match;
+  end getBindingExp;
+
+  function stripBindingInfo
+    "Replaces all binding expressions in the given expression with the
+     expressions they contain."
+    input Expression exp;
+    output Expression outExp;
+  algorithm
+    outExp := map(exp, getBindingExp);
+  end stripBindingInfo;
+
+  function propagatedDimCount
+    "Returns the number of dimensions a binding expression has been propagated
+     through."
+    input Expression exp;
+    output Integer dimCount;
+  algorithm
+    dimCount := match exp
+      case BINDING_EXP(isEach = false)
+        algorithm
+          if Type.isKnown(exp.expType) then
+            dimCount := Type.dimensionCount(exp.expType) -
+                        Type.dimensionCount(exp.bindingType);
+          else
+            dimCount := 0;
+            for parent in listRest(exp.parents) loop
+              dimCount := dimCount + Type.dimensionCount(InstNode.getType(parent));
+            end for;
+          end if;
+        then
+          dimCount;
+
+      else 0;
+    end match;
+  end propagatedDimCount;
+
+  function bindingExpType
+    "Calculates the expression type and binding type of an expression given the
+     number of dimensions it's been propagated through."
+    input Expression exp;
+    input Integer propagatedDimCount;
+    output Type expType;
+    output Type bindingType;
+  algorithm
+    expType := typeOf(exp);
+    bindingType := if propagatedDimCount > 0 then
+      Type.unliftArrayN(propagatedDimCount, expType) else expType;
+  end bindingExpType;
+
+  function vectorize
+    "Constructs an array with the given dimensions by calling the given
+     function on the given expression for each combination of subscripts defined
+     by the dimensions."
+    input Expression exp;
+    input list<Dimension> dims;
+    input FuncT func;
+    input list<Subscript> accumSubs = {};
+    output Expression outExp;
+
+    partial function FuncT
+      input output Expression exp;
+      input list<Subscript> subs;
+    end FuncT;
+  protected
+    RangeIterator iter;
+    Dimension dim;
+    list<Dimension> rest_dims;
+    list<Expression> expl;
+    Expression e;
+  algorithm
+    if listEmpty(dims) then
+      outExp := func(exp, listReverse(accumSubs));
+    else
+      expl := {};
+      dim :: rest_dims := dims;
+      iter := RangeIterator.fromDim(dim);
+
+      while RangeIterator.hasNext(iter) loop
+        (iter, e) := RangeIterator.next(iter);
+        e := vectorize(exp, rest_dims, func, Subscript.INDEX(e) :: accumSubs);
+        expl := e :: expl;
+      end while;
+
+      outExp := Expression.makeExpArray(listReverseInPlace(expl));
+    end if;
+  end vectorize;
+
+  function bindingExpMap
+    "Calls the given function on each element of a binding expression."
+    input Expression exp;
+    input EvalFunc evalFunc;
+    output Expression result;
+
+    partial function EvalFunc
+      input output Expression exp;
+    end EvalFunc;
+  protected
+    Expression max_prop_exp;
+    Integer max_prop_count;
+  algorithm
+    (max_prop_exp, max_prop_count) := mostPropagatedSubExp(exp);
+
+    if max_prop_count >= 0 then
+      result := bindingExpMap2(exp, evalFunc, max_prop_count, max_prop_exp);
+    else
+      result := evalFunc(exp);
+    end if;
+  end bindingExpMap;
+
+  function bindingExpMap2
+    input Expression exp;
+    input EvalFunc evalFunc;
+    input Integer mostPropagatedCount;
+    input Expression mostPropagatedExp;
+    output Expression result;
+
+    partial function EvalFunc
+      input output Expression exp;
+    end EvalFunc;
+  protected
+    Type exp_ty, bind_ty;
+    list<Dimension> dims;
+    Expression e;
+    list<InstNode> parents;
+    Boolean is_each;
+  algorithm
+    BINDING_EXP(exp = e, expType = exp_ty, parents = parents, isEach = is_each) := mostPropagatedExp;
+    dims := List.firstN(Type.arrayDims(exp_ty), mostPropagatedCount);
+    result := vectorize(exp, dims, function bindingExpMap3(evalFunc = evalFunc));
+    (exp_ty, bind_ty) := bindingExpType(result, mostPropagatedCount);
+    result := BINDING_EXP(result, exp_ty, bind_ty, parents, is_each);
+  end bindingExpMap2;
+
+  function bindingExpMap3
+    input Expression exp;
+    input EvalFunc evalFunc;
+    input list<Subscript> subs;
+    output Expression result;
+
+    partial function EvalFunc
+      input output Expression exp;
+    end EvalFunc;
+  protected
+    Expression e1, e2;
+    Operator op;
+  algorithm
+    result := map(exp, function bindingExpMap4(subs = subs));
+    result := evalFunc(result);
+  end bindingExpMap3;
+
+  function bindingExpMap4
+    input Expression exp;
+    input list<Subscript> subs;
+    output Expression outExp;
+  algorithm
+    outExp := match exp
+      local
+        Integer prop_count;
+        list<Subscript> prop_subs;
+
+      case Expression.BINDING_EXP()
+        algorithm
+          prop_count := propagatedDimCount(exp);
+          prop_subs := List.lastN(subs, prop_count);
+        then
+          applySubscripts(prop_subs, exp.exp);
+
+      else exp;
+    end match;
+  end bindingExpMap4;
+
+  function mostPropagatedSubExp
+    "Returns the most propagated subexpression of the given expression, as well
+     as the number of dimensions it's been propagated through. Returns the
+     expression itself and -1 as the number of dimensions if it doesn't contain
+     any binding expressions."
+    input Expression exp;
+    output Expression maxPropExp;
+    output Integer maxPropCount;
+  algorithm
+    // TODO: Optimize this, there's no need to check for bindings in e.g. literal arrays.
+    (maxPropCount, maxPropExp) :=
+      Expression.fold(exp, mostPropagatedSubExp_traverser, (-1, exp));
+  end mostPropagatedSubExp;
+
+  function mostPropagatedSubExpBinary
+    "Returns the most propagated subexpression in either of the two given
+     expressions, as well as the number of dimensions it's been propagated
+     through. Returns the first expression and -1 as the number of dimensions
+     if neither expression contains any binding expressions."
+    input Expression exp1;
+    input Expression exp2;
+    output Expression maxPropExp;
+    output Integer maxPropCount;
+  algorithm
+    // TODO: Optimize this, there's no need to check for bindings in e.g. literal arrays.
+    (maxPropCount, maxPropExp) :=
+      Expression.fold(exp1, mostPropagatedSubExp_traverser, (-1, exp1));
+    (maxPropCount, maxPropExp) :=
+      Expression.fold(exp2, mostPropagatedSubExp_traverser, (maxPropCount, maxPropExp));
+  end mostPropagatedSubExpBinary;
+
+  function mostPropagatedSubExp_traverser
+    input Expression exp;
+    input output tuple<Integer, Expression> mostPropagated;
+  protected
+    Integer max_prop, exp_prop;
+  algorithm
+    if Expression.isBindingExp(exp) then
+      (max_prop, _) := mostPropagated;
+      exp_prop := propagatedDimCount(exp);
+
+      if exp_prop > max_prop then
+        mostPropagated := (exp_prop, exp);
+      end if;
+    end if;
+  end mostPropagatedSubExp_traverser;
+
+  function addBindingExpParent
+    input InstNode parent;
+    input output Expression exp;
+  algorithm
+    () := match exp
+      case BINDING_EXP()
+        algorithm
+          exp.parents := parent :: exp.parents;
+        then
+          ();
+
+      else ();
+    end match;
+  end addBindingExpParent;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFExpression;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -125,14 +125,17 @@ public
       local
         list<Expression> expl;
 
-      case Binding.TYPED_BINDING() guard Binding.isClassBinding(binding)
+      case Binding.TYPED_BINDING(eachType = NFBinding.EachType.REPEAT)
         algorithm
           expl := Expression.arrayScalarElements(binding.bindingExp);
         then
           if listLength(expl) == 1 then EACH_ITERATOR(listHead(expl)) else REPEAT_ITERATOR(expl, expl);
 
+      case Binding.TYPED_BINDING(eachType = NFBinding.EachType.EACH)
+        then EACH_ITERATOR(binding.bindingExp);
+
       case Binding.TYPED_BINDING()
-        then if binding.isEach then EACH_ITERATOR(binding.bindingExp) else fromExp(binding.bindingExp);
+        then fromExp(binding.bindingExp);
 
       case Binding.FLAT_BINDING()
         then EACH_ITERATOR(binding.bindingExp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2325,8 +2325,9 @@ algorithm
     case Binding.RAW_BINDING()
       algorithm
         bind_exp := instExp(binding.bindingExp, binding.scope, binding.info);
+        bind_exp := Expression.BINDING_EXP(bind_exp, Type.UNKNOWN(), Type.UNKNOWN(), binding.parents, binding.isEach);
       then
-        Binding.UNTYPED_BINDING(bind_exp, false, binding.scope, binding.parents, binding.isEach, binding.info);
+        Binding.UNTYPED_BINDING(bind_exp, false, binding.scope, binding.isEach, binding.info);
 
     else binding;
   end match;
@@ -3388,7 +3389,7 @@ algorithm
   end if;
 
   if Binding.hasExp(binding) then
-    isNotFixed := isExpressionNotFixed(Binding.getExp(binding), requireFinal, maxDepth);
+    isNotFixed := isExpressionNotFixed(Expression.getBindingExp(Binding.getExp(binding)), requireFinal, maxDepth);
   else
     isNotFixed := true;
   end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -129,7 +129,7 @@ algorithm
       end for;
     end if;
   else
-    var.binding := Binding.mapExp(var.binding, expandComplexCref);
+    var.binding := Binding.mapExp(var.binding, expandComplexCref_traverser);
     vars := var :: vars;
   end if;
 end scalarizeVariable;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -172,6 +172,7 @@ algorithm
           if is_pure and List.all(args, Expression.isLiteral) then
             try
               callExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
+              callExp := Expression.stripBindingInfo(callExp);
             else
             end try;
           else
@@ -211,6 +212,7 @@ algorithm
 
   try
     outExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
+    outExp := Expression.stripBindingInfo(outExp);
     ErrorExt.delCheckpoint(getInstanceName());
   else
     if Flags.isSet(Flags.FAILTRACE) then
@@ -411,6 +413,7 @@ function simplifyBinaryOp
 algorithm
   if Expression.isLiteral(exp1) and Expression.isLiteral(exp2) then
     outExp := Ceval.evalBinaryOp(ExpandExp.expand(exp1), op, ExpandExp.expand(exp2));
+    outExp := Expression.stripBindingInfo(outExp);
   else
     outExp := match op.op
       case Op.ADD then simplifyBinaryAdd(exp1, op, exp2);
@@ -533,6 +536,7 @@ function simplifyUnaryOp
 algorithm
   if Expression.isLiteral(exp) then
     outExp := Ceval.evalUnaryOp(exp, op);
+    outExp := Expression.stripBindingInfo(outExp);
   else
     outExp := Expression.UNARY(op, exp);
   end if;
@@ -629,6 +633,7 @@ algorithm
 
   if Expression.isLiteral(se) then
     unaryExp := Ceval.evalLogicUnaryOp(se, op);
+    unaryExp := Expression.stripBindingInfo(unaryExp);
   elseif not referenceEq(e, se) then
     unaryExp := Expression.LUNARY(op, se);
   end if;
@@ -646,6 +651,7 @@ algorithm
 
   if Expression.isLiteral(se1) and Expression.isLiteral(se2) then
     relationExp := Ceval.evalRelationOp(se1, op, se2);
+    relationExp := Expression.stripBindingInfo(relationExp);
   elseif not (referenceEq(e1, se1) and referenceEq(e2, se2)) then
     relationExp := Expression.RELATION(se1, op, se2);
   end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -606,6 +606,12 @@ public
     end match;
   end dimensionCount;
 
+  function dimensionDiff
+    input Type ty1;
+    input Type ty2;
+    output Integer diff = dimensionCount(ty1) - dimensionCount(ty2);
+  end dimensionDiff;
+
   function hasKnownSize
     input Type ty;
     output Boolean isKnown;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -186,7 +186,7 @@ algorithm
           exp := NFInst.instExp(absynExp, inst_cls, info);
           (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
           // exp := NFCeval.evalExp(exp);
-          exp := SimplifyExp.simplify(exp);
+          exp := SimplifyExp.simplify(Expression.stripBindingInfo(exp));
           str := Expression.toString(exp);
         then
           stringAppendList({annName, "=", str});
@@ -233,7 +233,7 @@ algorithm
               exp := NFInst.instExp(absynExp, inst_cls, info);
               (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
               // exp := NFCeval.evalExp(exp);
-              exp := SimplifyExp.simplify(exp);
+              exp := SimplifyExp.simplify(Expression.stripBindingInfo(exp));
               str := str + ", " + Expression.toString(exp);
             else
               // just don't fail!
@@ -369,7 +369,7 @@ algorithm
           exp := NFInst.instExp(absynExp, inst_cls, info);
           (exp, ty, var) := Typing.typeExp(exp, ExpOrigin.CLASS, info);
           // exp := NFCeval.evalExp(exp);
-          exp := SimplifyExp.simplify(exp);
+          exp := SimplifyExp.simplify(Expression.stripBindingInfo(exp));
           str := Expression.toString(exp);
         then
           stringAppendList({annName, "=", str});


### PR DESCRIPTION
- Added new BINDING_EXP expression, which is now used to track e.g. the
  parents of a binding instead of keeping that information in a Binding.
- Made the Ceval module aware of binding expressions, such that it can
  use the binding information to correctly subscript evaluated component
  references.
- Improved the flattening of propagated array modifiers.