### PR TITLE
[NF] Minor fixes.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -3078,8 +3078,7 @@ protected
   list<Type> types = {};
   Type ty;
 algorithm
-  e := evalExpPartial(exp);
-  (e, ranges, iters) := createIterationRanges(e, iterators);
+  (e, ranges, iters) := createIterationRanges(exp, iterators);
 
   // Precompute all the types we're going to need for the arrays created.
   ty := Expression.typeOf(e);
@@ -3174,8 +3173,7 @@ protected
   list<Mutable<Expression>> iters;
   ReductionFn red_fn;
 algorithm
-  e := evalExpPartial(exp);
-  (e, ranges, iters) := createIterationRanges(e, iterators);
+  (e, ranges, iters) := createIterationRanges(exp, iterators);
 
   (red_fn, default_exp) := match AbsynUtil.pathString(Function.name(fn))
     case "sum" then (evalBinaryAdd, Expression.makeZero(ty));

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1045,7 +1045,7 @@ public
     Type ty;
   algorithm
     ty := typeOf(listHead(elements));
-    ty := Type.ARRAY(ty, {Dimension.fromInteger(listLength(elements))});
+    ty := Type.liftArrayLeft(ty, Dimension.fromInteger(listLength(elements)));
     exp := makeArray(ty, elements, isLiteral);
   end makeExpArray;
 


### PR DESCRIPTION
- Remove superfluous calls to evalExpPartial in
  Ceval.evalArrayConstructor and Ceval.evalReduction.
- Fix makeExpArray so it doesn't create nested array types.