### PR TITLE
[NF] Fix ExpandExp.expand for arrays.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -60,14 +60,16 @@ public
 
       case Expression.CREF(ty = Type.ARRAY()) then expandCref(exp);
 
-      case Expression.ARRAY(ty = Type.ARRAY(dimensions = _ :: _ :: {}))
+      // One-dimensional arrays are already expanded.
+      case Expression.ARRAY(ty = Type.ARRAY(dimensions = {})) then (exp, true);
+
+      case Expression.ARRAY()
         algorithm
           (expl, expanded) := expandList(exp.elements);
           exp.elements := expl;
         then
           (exp, expanded);
 
-      case Expression.ARRAY()    then (exp, true);
       case Expression.TYPENAME() then (expandTypename(exp.ty), true);
       case Expression.RANGE()    then expandRange(exp);
       case Expression.CALL()     then expandCall(exp.call, exp);


### PR DESCRIPTION
- Fixed match pattern in ExpandExp.expand that was supposed to match
  arrays with at least two dimensions, but which instead matched arrays
  with exactly two dimensions.