### PR TITLE
[NF] Forbid local public function variables.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1802,19 +1802,10 @@ protected
           {InstNode.name(component)}, InstNode.info(component));
         fail();
       end if;
-    else
-
-      if vis == Visibility.PUBLIC then
-        if var > Variability.PARAMETER then
-          Error.addSourceMessage(Error.NON_FORMAL_PUBLIC_FUNCTION_VAR,
-            {InstNode.name(component)}, InstNode.info(component));
-          fail();
-        else
-          // @adrpo: alow public constants and parameters in functions
-          Error.addStrictMessage(Error.NON_FORMAL_PUBLIC_FUNCTION_VAR,
-            {InstNode.name(component)}, InstNode.info(component));
-        end if;
-      end if;
+    elseif vis == Visibility.PUBLIC then
+      Error.addSourceMessageAsError(Error.NON_FORMAL_PUBLIC_FUNCTION_VAR,
+        {InstNode.name(component)}, InstNode.info(component));
+      fail();
     end if;
   end paramDirection;
 

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1268,6 +1268,17 @@ algorithm
   end match;
 end addSourceMessage;
 
+function addSourceMessageAsError
+  input ErrorTypes.Message msg;
+  input ErrorTypes.MessageTokens tokens;
+  input SourceInfo info;
+protected
+  ErrorTypes.Message m = msg;
+algorithm
+  m.severity := ErrorTypes.ERROR();
+  addSourceMessage(m, tokens, info);
+end addSourceMessageAsError;
+
 function addStrictMessage
   input ErrorTypes.Message errorMsg;
   input ErrorTypes.MessageTokens tokens;

--- a/testsuite/flattening/modelica/scodeinst/FunctionNonInputOutputParameter.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionNonInputOutputParameter.mo
@@ -1,6 +1,6 @@
 // name: FunctionNonInputOutputParameter
 // keywords:
-// status: correct
+// status: incorrect
 // cflags: -d=newInst
 //
 
@@ -19,9 +19,11 @@ end FunctionNonInputOutputParameter;
 
 
 // Result:
-// class FunctionNonInputOutputParameter
-//   parameter Real p = 4.0;
-// end FunctionNonInputOutputParameter;
-// [flattening/modelica/scodeinst/FunctionNonInputOutputParameter.mo:11:3-11:23:writable] Warning: Invalid public variable z, function variables that are not input/output must be protected.
+// Error processing file: FunctionNonInputOutputParameter.mo
+// [flattening/modelica/scodeinst/FunctionNonInputOutputParameter.mo:11:3-11:23:writable] Error: Invalid public variable z, function variables that are not input/output must be protected.
 //
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
 // endResult


### PR DESCRIPTION
- Change the warning for public non-input/output function variables back
  to an error.