### PR TITLE
[NF] Handle records inherited by non-records better.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2224,6 +2224,8 @@ algorithm
       CachedData cache;
 
     case Type.COMPLEX(complexTy = ComplexType.RECORD(node))
+      // Make sure it's really a record, and not e.g. a record inherited by a model.
+      guard InstNode.isRecord(node)
       algorithm
         instRecordConstructor(node);
       then


### PR DESCRIPTION
- Don't try to instantiate the constructor for a record that's been
  inherited by a non-record, since it's not actually a record in that
  context.