### PR TITLE
[NF] Partially revert 497427d.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2225,7 +2225,9 @@ algorithm
 
     case Type.COMPLEX(complexTy = ComplexType.RECORD(node))
       // Make sure it's really a record, and not e.g. a record inherited by a model.
-      guard InstNode.isRecord(node)
+      // TODO: This check should really be InstNode.isRecord(node), but that
+      //       causes issues with e.g. ComplexInput/ComplexOutput.
+      guard not InstNode.isModel(node)
       algorithm
         instRecordConstructor(node);
       then

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1611,6 +1611,17 @@ uniontype InstNode
       case COMPONENT_NODE() then isRecord(Component.classInstance(Pointer.access(node.component)));
     end match;
   end isRecord;
+
+  function isModel
+    input InstNode node;
+    output Boolean isModel;
+  algorithm
+    isModel := match node
+      case CLASS_NODE() then Restriction.isModel(Class.restriction(Pointer.access(node.cls)));
+      case COMPONENT_NODE() then isModel(Component.classInstance(Pointer.access(node.component)));
+      else false;
+    end match;
+  end isModel;
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
@@ -196,6 +196,16 @@ public
     end match;
   end isClock;
 
+  function isModel
+    input Restriction res;
+    output Boolean isModel;
+  algorithm
+    isModel := match res
+      case MODEL() then true;
+      else false;
+    end match;
+  end isModel;
+
   function toString
     input Restriction res;
     output String str;


### PR DESCRIPTION
- Relax the record check in Inst.instComplexType to only apply to
  models, since it currently causes issues for some connectors.