### PR TITLE
Fix initialization using start and fixed attribute

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -2174,7 +2174,12 @@ algorithm
           stateSetIdx = stringInt(stateSetIdxString);
           arrayUpdate(stateSetFixCounts, stateSetIdx, arrayGet(stateSetFixCounts, stateSetIdx) + 1);
         else
-          eqn = BackendDAE.EQUATION(crefExp, Expression.crefExp(startCR), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+          // if startExp is constant, generate "cref = $START.cref" otherwise "cref = startExp"
+          if Expression.isConstValue(startExp) then
+            eqn = BackendDAE.EQUATION(crefExp, Expression.crefExp(startCR), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+          else
+            eqn = BackendDAE.EQUATION(crefExp, startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+          end if;
           eqns = BackendEquation.add(eqn, eqns);
         end if;
       end if;
@@ -2378,7 +2383,12 @@ algorithm
       preVar = BackendVariable.setVarFixed(preVar, true);
       preVar = BackendVariable.setVarStartValueOption(preVar, SOME(DAE.CREF(cr, ty)));
 
-      eqn = BackendDAE.EQUATION(DAE.CREF(cr, ty), Expression.crefExp(startCR), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+      // if startExp is constant, generate "cref = $START.cref" otherwise "cref = startExp"
+      if Expression.isConstValue(startExp) then
+        eqn = BackendDAE.EQUATION(DAE.CREF(cr, ty), Expression.crefExp(startCR), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+      else
+        eqn = BackendDAE.EQUATION(DAE.CREF(cr, ty), startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+      end if;
 
       vars = if not isInput then BackendVariable.addVar(var, vars) else vars;
       fixvars = if isInput then BackendVariable.addVar(var, fixvars) else fixvars;
@@ -2426,7 +2436,12 @@ algorithm
       preVar = BackendVariable.setVarFixed(preVar, true);
       preVar = BackendVariable.setVarStartValueOption(preVar, SOME(DAE.CREF(cr, ty)));
 
-      eqn = BackendDAE.EQUATION(DAE.CREF(preCR, ty), DAE.CREF(cr, ty), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+      // if startExp is constant, generate "cref = $START.cref" otherwise "cref = startExp"
+      if Expression.isConstValue(startExp) then
+        eqn = BackendDAE.EQUATION(DAE.CREF(preCR, ty), DAE.CREF(cr, ty), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+      else
+        eqn = BackendDAE.EQUATION(DAE.CREF(preCR, ty), startExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL);
+      end if;
 
       vars = if not isInput then BackendVariable.addVar(var, vars) else vars;
       fixvars = if isInput then BackendVariable.addVar(var, fixvars) else fixvars;

--- a/testsuite/simulation/modelica/initialization/bug_2673.mos
+++ b/testsuite/simulation/modelica/initialization/bug_2673.mos
@@ -38,10 +38,10 @@ simulate(initializationTests.bug_2673, startTime=0.0, stopTime=0.0, simflags="-i
 //     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'initializationTests.bug_2673', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-iif=bug_2673.mat -iit=1.0 -lv=LOG_SOTI'",
 //     messages = "LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
 // |                 | |       | | states variables
-// |                 | |       | | | [1] Real x(start=2.47151, nominal=1) = 2.47151 (pre: 2.47151)
+// |                 | |       | | | [1] Real x(start=2.47151, nominal=1) = 5 (pre: 2.47151)
 // |                 | |       | | | [2] Real y(start=0.632122, nominal=1) = 0.632122 (pre: 0.632122)
 // |                 | |       | | derivatives variables
-// |                 | |       | | | [3] Real der(x) = -1.47151 (pre: -1.47151)
+// |                 | |       | | | [3] Real der(x) = -4 (pre: -1.47151)
 // |                 | |       | | | [4] Real der(y) = 0.367878 (pre: 0.367878)
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.


### PR DESCRIPTION
### Related Issues

* [ticket:2673](https://trac.openmodelica.org/OpenModelica/ticket/2673)

### Purpose
Fix the start value in initialization, from `$START.x` to the actual start expression if it is not a literal constant value. This is needed to calculate the FMI initial unknown dependencies

Example:
```
model fmi_attributes_03 
  Real x(fixed=true, start=x_start);
  parameter Real x_start = 1.0;
equation
  der(x) = 0.0;
end fmi_attributes_03
```

List of equations for initialization:
```
x = x_start;  // instead of "x = $START.x"
der(x) = 0;
```

