### PR TITLE
[NF] Use component instance as parent.

### DIFF
--- a/.CI/compliance-newinst.failures
+++ b/.CI/compliance-newinst.failures
@@ -187,7 +187,6 @@ ModelicaCompliance.Scoping.InnerOuter.Array3
 ModelicaCompliance.Scoping.InnerOuter.Array4
 ModelicaCompliance.Scoping.InnerOuter.Array5
 ModelicaCompliance.Scoping.InnerOuter.MissingInnerAdded
-ModelicaCompliance.Scoping.InnerOuter.OuterInPackage
 ModelicaCompliance.Scoping.InnerOuter.PartialOuterWrong
 ModelicaCompliance.Scoping.InnerOuter.WrongSubType
 ModelicaCompliance.Scoping.NameLookup.Composite.FunctionInOperatorLookupViaComp.FunctionInOperatorLookupViaComp
@@ -203,6 +202,7 @@ ModelicaCompliance.Scoping.NameLookup.Imports.QualifiedImportNonPackage
 ModelicaCompliance.Scoping.NameLookup.Imports.RenamingImportNonPackage
 ModelicaCompliance.Scoping.NameLookup.Imports.UnqualifiedImportProtected
 ModelicaCompliance.Scoping.NameLookup.Simple.EnclosingClassLookupNonConstant
+ModelicaCompliance.Scoping.NameLookup.Simple.EnclosingClassLookupShadowedConstant
 ModelicaCompliance.Scoping.NameLookup.Simple.OutsideEncapsulation
 ModelicaCompliance.Scoping.NameLookup.Simple.OutsideEncapsulationMulti
 ModelicaCompliance.Scoping.Visibility.ModifyProtectedClass

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -50,6 +50,7 @@ protected
   import SCodeDump;
   import SCodeUtil;
   import NFInstNode.InstNodeType;
+  import Restriction = NFRestriction;
 
 public
   encapsulated package LookupTree
@@ -547,6 +548,7 @@ public
       DuplicateTree.Tree dups;
       Component comp;
       SCode.Element ext_def;
+      Boolean is_typish;
     algorithm
       // TODO: If we don't have any extends we could probably generate a flat
       // tree directly and skip a lot of this.
@@ -603,12 +605,17 @@ public
 
             // Copy the local classes into the new class array, and set the
             // class we're instantiating to be their parent.
-            for c in old_clss loop
-              if not InstNode.isOperator(c) then
-                c := InstNode.clone(c);
-              end if;
+            is_typish := Restriction.isType(cls.restriction) or
+                         Restriction.isOperatorRecord(cls.restriction) or
+                         Restriction.isOperator(cls.restriction);
 
-              c := InstNode.setParent(clsNode, c);
+            for c in old_clss loop
+              if is_typish then
+                c := InstNode.setParent(clsNode, c);
+              else
+                c := InstNode.clone(c);
+                c := InstNode.setParent(instance, c);
+              end if;
 
               // If the class is outer, check that it's valid and link it with
               // the corresponding inner class.

--- a/testsuite/flattening/modelica/scodeinst/eq5.mo
+++ b/testsuite/flattening/modelica/scodeinst/eq5.mo
@@ -29,11 +29,11 @@ end B;
 // Result:
 // class B
 //   constant Integer a[1].j = 1;
-//   constant Integer a[1].m.i = {1, 2, 3};
+//   constant Integer a[1].m.i = 1;
 //   constant Integer a[2].j = 2;
-//   constant Integer a[2].m.i = {1, 2, 3};
+//   constant Integer a[2].m.i = 2;
 //   constant Integer a[3].j = 3;
-//   constant Integer a[3].m.i = {1, 2, 3};
+//   constant Integer a[3].m.i = 3;
 //   Real x[1];
 //   Real x[2];
 //   Real x[3];


### PR DESCRIPTION
- Use the component instance as parent when instantiating a class tree
  instead of the class, unless the parent is some kind of type.