### PR TITLE
[NF] Improve EvalConstants.isLocalFunctionVariable.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -465,7 +465,9 @@ function isLocalFunctionVariable
 protected
   InstNode node;
 algorithm
-  if ComponentRef.nodeVariability(cref) <= Variability.PARAMETER then
+  if ComponentRef.isPackageConstant(cref) then
+    res := false;
+  elseif ComponentRef.nodeVariability(cref) <= Variability.PARAMETER then
     node := InstNode.derivedParent(ComponentRef.node(ComponentRef.firstNonScope(cref)));
     res := InstNode.refEqual(fnNode, node);
   else


### PR DESCRIPTION
- Don't consider crefs with a class name in them to be references to
  local variables.