### PR TITLE
Don't apply the filter using the path

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.h
@@ -68,6 +68,8 @@ private:
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;
+
+  void findAndSelectLibraryTreeItem(const QRegExp &regExp);
 private slots:
   void searchClasses();
   void useModelicaClass();


### PR DESCRIPTION
When opening the browse for classes dialog don't apply the filter using the path instead just select the class specified by the path