### PR TITLE
[NF] Fix some Expression.map*Opt functions.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -2068,10 +2068,10 @@ public
   protected
     Expression e;
   algorithm
-    if isSome(exp) then
-      SOME(e) := exp;
-      outExp := SOME(map(e, func));
-    end if;
+    outExp := match exp
+      case SOME(e) then SOME(map(e, func));
+      else exp;
+    end match;
   end mapOpt;
 
   function mapCall
@@ -2414,10 +2414,10 @@ public
   protected
     Expression e;
   algorithm
-    if isSome(exp) then
-      SOME(e) := exp;
-      outExp := SOME(func(e));
-    end if;
+    outExp := match exp
+      case SOME(e) then SOME(func(e));
+      else exp;
+    end match;
   end mapShallowOpt;
 
   function mapCrefShallow
@@ -3354,11 +3354,15 @@ public
   protected
     Expression e;
   algorithm
-    if isSome(exp) then
-      SOME(e) := exp;
-      (e, arg) := mapFold(e, func, arg);
-      outExp := SOME(e);
-    end if;
+    outExp := match exp
+      case SOME(e)
+        algorithm
+          (e, arg) := mapFold(e, func, arg);
+        then
+          SOME(e);
+
+      else exp;
+    end match;
   end mapFoldOpt;
 
   function mapFoldCall<ArgT>


### PR DESCRIPTION
- Fix mapOpt, mapShallowOpt and mapFoldOpt in Expression, which would
  return an uninitialized value when given a NONE().