### PR TITLE
[BE] update differentiate semiLinear

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -5202,7 +5202,7 @@ algorithm
     case(r::rest,_,_,_,_,_,_,_)
       // case: state derivative
       equation
-        // if not negatet rowmark then linear or nonlinear
+        // if not negated rowmark then linear or nonlinear
         true = intGt(r,0);
         false = intEq(rowmark[r],-mark);
         // de/dvar
@@ -5231,7 +5231,7 @@ algorithm
     case(r::rest,_,_,_,_,_,_,_)
       equation
         rabs = intAbs(r);
-        // if not negatet rowmark then linear or nonlinear
+        // if not negated rowmark then linear or nonlinear
         false = intEq(rowmark[rabs],-mark);
         // de/dvar
         BackendDAE.VAR(varName=cr) = BackendVariable.getVarAt(vars, rabs);
@@ -5377,7 +5377,14 @@ algorithm
    end if;
    true := solved or derived;
    if debug then
-     print("tryToSolveOrDerive" + ExpressionDump.printExpStr(e) + " -> " +  ExpressionDump.printExpStr(f) + " == " + ExpressionDump.printExpStr(Expression.crefExp(cr)) + "\n");
+     if solved then
+       print("[SOLVED] ");
+     elseif derived then
+       print("[DERIVED] ");
+     else
+       print("[?BROKEN?] ");
+     end if;
+     print("tryToSolveOrDerive " + ExpressionDump.printExpStr(e) + " -> " +  ExpressionDump.printExpStr(f) + " == " + ExpressionDump.printExpStr(Expression.crefExp(cr)) + "\n");
    end if;
 end tryToSolveOrDerive;
 

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -620,9 +620,17 @@ algorithm
     then (res, functionTree);
 
     // differentiate homotopy
-    case DAE.CALL(path=p as Absyn.IDENT(name="homotopy"), expLst={actual, simplified}, attr=attr) equation
-      (e1, functionTree) = differentiateExp(actual, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, maxIter);
+    case DAE.CALL(path=p as Absyn.IDENT(name="homotopy"), expLst={actual, simplified}, attr=attr) algorithm
+      (e1, functionTree) := differentiateExp(actual, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, maxIter);
     then (e1, functionTree);
+
+    /*
+      do not differentiate semiLinear, if the second or third expression contains the diff cref
+      ticket: #5595
+    */
+    case DAE.CALL(path=p as Absyn.IDENT(name="semiLinear"), expLst={e1, e2, e3}, attr=attr)
+      guard(Expression.expHasCref(e2, inDiffwrtCref) or  Expression.expHasCref(e3, inDiffwrtCref))
+    then fail();
 
     // differentiate call
     case DAE.CALL() equation


### PR DESCRIPTION
 - ticket #5595
 - do not differentiate semiLinear(x, a, b) for cref y, if a or b contain y