### PR TITLE
add for-equation support in symbolic jacobian

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -3950,6 +3950,17 @@ algorithm
         (varlst, _) = BackendVariable.getVar(cr, vars);
         vars = updateStatesVars(vars, varlst, false);
       then (e1, vars);
+    // case for FOR_LOOP
+    case DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={e1 as DAE.CREF(componentRef=cr)})
+      equation
+        // Throw away indices before searching var and add $DER
+        false = Flags.isSet(Flags.NF_SCALARIZE);
+        true = ComponentReference.crefHaveSubs(cr); // make special function for iterSubs?
+        cr = ComponentReference.crefStripIterSub(cr);
+        (v, _) = BackendVariable.getVarSingle(cr, vars);
+        (vars, _) = updateStatesVar(vars, v, e1);
+      then (exp, vars);
+    // exp is not a cref -> differentiate
     case (DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={e1}))
       equation
         (e2, shared) = Differentiate.differentiateExpTime(e1, vars, Mutable.access(inShared));

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -1749,7 +1749,7 @@ algorithm
       equation
         s1 = ExpressionDump.printExpStr(iter) + " in " + ExpressionDump.printExpStr(start) + " : " + ExpressionDump.printExpStr(stop);
         s2 = equationString(eqn);
-        res = stringAppendList({"for ", s1, " loop \n    ", s2, "; end for; "});
+        res = stringAppendList({"for ", s1, " loop\n    ", s2, "; end for;"});
       then
         res;
   end match;

--- a/OMCompiler/Compiler/BackEnd/BackendEquation.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendEquation.mo
@@ -2961,6 +2961,10 @@ algorithm
       eqn.source = ElementSource.addSymbolicTransformation(eqn.source, inSymOp);
     then eqn;
 
+    case eqn as BackendDAE.FOR_EQUATION() equation
+      eqn.source = ElementSource.addSymbolicTransformation(eqn.source, inSymOp);
+    then eqn;
+
     else equation
       Error.addInternalError("BackendEquation.addOperation failed", sourceInfo());
     then fail();

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -3478,15 +3478,16 @@ protected
   BackendDAE.VariableArray arr;
   Integer buckets, hash_idx;
   list<BackendDAE.CrefIndex> cr_indices;
-  DAE.ComponentRef cr;
+  DAE.ComponentRef cr, crefStripped;
 algorithm
+  crefStripped := if Flags.isSet(Flags.NF_SCALARIZE) then inCref else ComponentReference.crefStripIterSub(inCref);
   BackendDAE.VARIABLES(crefIndices=indices, varArr=arr, bucketSize=buckets) := inVariables;
-  hash_idx := ComponentReference.hashComponentRefMod(inCref, buckets) + 1;
+  hash_idx := ComponentReference.hashComponentRefMod(crefStripped, buckets) + 1;
   cr_indices := indices[hash_idx];
-  BackendDAE.CREFINDEX(index=outIndex) := List.getMemberOnTrue(inCref, cr_indices, crefIndexEqualCref);
+  BackendDAE.CREFINDEX(index=outIndex) := List.getMemberOnTrue(crefStripped, cr_indices, crefIndexEqualCref);
   outIndex := outIndex + 1;
   outVar as BackendDAE.VAR(varName = cr) := vararrayNth(arr, outIndex);
-  true := ComponentReference.crefEqualNoStringCompare(cr, inCref);
+  true := ComponentReference.crefEqualNoStringCompare(cr, crefStripped);
 end getVar2;
 
 protected function crefIndexEqualCref

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -300,6 +300,7 @@ algorithm
       list<list<BackendDAE.Equation>> eqnslst;
       list<DAE.Statement> statementLst;
       DAE.Expand expand;
+      BackendDAE.Equation forEq, body;
       BackendDAE.WhenEquation whenEqn;
       BackendDAE.EquationAttributes eqAttr;
 
@@ -337,7 +338,7 @@ algorithm
       then
         (BackendDAE.EQUATION(e1_1, e2_1, source, eqAttr), funcs);
 
-    // RESIDUAL_EQUATION
+    // residual equations
     case BackendDAE.RESIDUAL_EQUATION(exp=e1, source=source, attr=eqAttr)
       equation
 
@@ -405,12 +406,22 @@ algorithm
       then
         (BackendDAE.IF_EQUATION(expExpLst, eqnslst, eqns, source, eqAttr), funcs);
 
+    // when-equations
     case BackendDAE.WHEN_EQUATION(size=size, whenEquation=whenEqn, source=source, attr=eqAttr)
       equation
         (whenEqn, funcs) = differentiateWhenEquations(whenEqn, inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
 
       then
         (BackendDAE.WHEN_EQUATION(size, whenEqn, source, eqAttr), funcs);
+
+    // for-equations
+    case forEq as BackendDAE.FOR_EQUATION()
+      algorithm
+        (body, funcs) := differentiateEquationFragile(forEq.body, inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
+        forEq.body := body;
+      then
+        (forEq, funcs);
+
     else equation
       Error.addSourceMessage(Error.NON_EXISTING_DERIVATIVE, {BackendDump.equationString(inEquation), ComponentReference.crefStr(inDiffwrtCref)}, sourceInfo());
      then fail();

--- a/OMCompiler/Compiler/BackEnd/InlineArrayEquations.mo
+++ b/OMCompiler/Compiler/BackEnd/InlineArrayEquations.mo
@@ -64,7 +64,11 @@ public function inlineArrayEqn "
   input BackendDAE.BackendDAE inDAE;
   output BackendDAE.BackendDAE outDAE;
 algorithm
-  (outDAE, _) := BackendDAEUtil.mapEqSystemAndFold(inDAE, inlineArrayEqn1, false);
+  if Flags.isSet(Flags.NF_SCALARIZE) then
+    (outDAE, _) := BackendDAEUtil.mapEqSystemAndFold(inDAE, inlineArrayEqn1, false);
+  else
+    outDAE := inDAE;
+  end if;
 end inlineArrayEqn;
 
 protected function inlineArrayEqn1

--- a/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -1054,7 +1054,7 @@ algorithm
           BackendDump.debugStrExpStrExpStr("Found Array Equation ", e1, " = ", e2, " to handle.\n");
         end if;
       then
-        simpleArrayEquationAcausal(e1, e2, Expression.typeof(e1), (source, eqAttr), inTpl);
+        if Flags.isSet(Flags.NF_SCALARIZE) then simpleArrayEquationAcausalScalarized(e1, e2, Expression.typeof(e1), (source, eqAttr), inTpl) else simpleArrayEquationAcausal(e1, e2, (source, eqAttr), false, inTpl);
 
     case (BackendDAE.SOLVED_EQUATION(componentRef=cr, exp=e2, source=source, attr=eqAttr), _)
       equation
@@ -1151,101 +1151,101 @@ algorithm
 
     // a = {b1, b2, b3, ..}
     case (DAE.CREF(), DAE.ARRAY(ty=ty), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.CREF(), DAE.MATRIX(ty=ty), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // -a = {b1, b2, b3, ..}
     case (DAE.UNARY(DAE.UMINUS_ARR(_), DAE.CREF()), DAE.ARRAY(ty=ty), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.UNARY(DAE.UMINUS_ARR(_), DAE.CREF()), DAE.MATRIX(ty=ty), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // a = -{b1, b2, b3, ..}
     case (DAE.CREF(), DAE.UNARY(DAE.UMINUS_ARR(_), DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.CREF(), DAE.UNARY(DAE.UMINUS_ARR(_), DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // -a = -{b1, b2, b3, ..}
     case (DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.CREF()), DAE.UNARY(DAE.UMINUS_ARR(_), e2 as DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     case (DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.CREF()), DAE.UNARY(DAE.UMINUS_ARR(_), e2 as DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     // {a1, a2, a3, ..} = b
     case (DAE.ARRAY(ty=ty), DAE.CREF(), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.MATRIX(ty=ty), DAE.CREF(), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // -{a1, a2, a3, ..} = b
     case (DAE.UNARY(DAE.UMINUS_ARR(_), DAE.ARRAY(ty=ty)), DAE.CREF(), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.UNARY(DAE.UMINUS_ARR(_), DAE.MATRIX(ty=ty)), DAE.CREF(), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // {a1, a2, a3, ..} = -b
     case (DAE.ARRAY(ty=ty), DAE.UNARY(DAE.UMINUS_ARR(_), DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.MATRIX(ty=ty), DAE.UNARY(DAE.UMINUS_ARR(_), DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // -{a1, a2, a3, ..} = -b
     case (DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.ARRAY(ty=ty)), DAE.UNARY(DAE.UMINUS_ARR(_), e2 as DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     case (DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.MATRIX(ty=ty)), DAE.UNARY(DAE.UMINUS_ARR(_), e2 as DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     // not a = {b1, b2, b3, ..}
     case (DAE.LUNARY(DAE.NOT(_), DAE.CREF()), DAE.ARRAY(ty=ty), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.LUNARY(DAE.NOT(_), DAE.CREF()), DAE.MATRIX(ty=ty), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // a = not {b1, b2, b3, ..}
     case (DAE.CREF(), DAE.LUNARY(DAE.NOT(_), DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.CREF(), DAE.LUNARY(DAE.NOT(_), DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // not a = not {b1, b2, b3, ..}
     case (DAE.LUNARY(DAE.NOT(_), e1 as DAE.CREF()), DAE.LUNARY(DAE.NOT(_), e2 as DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     case (DAE.LUNARY(DAE.NOT(_), e1 as DAE.CREF()), DAE.LUNARY(DAE.NOT(_), e2 as DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     // {a1, a2, a3, ..} = not b
     case (DAE.ARRAY(ty=ty), DAE.LUNARY(DAE.NOT(_), DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.MATRIX(ty=ty), DAE.LUNARY(DAE.NOT(_), DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // not {a1, a2, a3, ..} = b
     case (DAE.LUNARY(DAE.NOT(_), DAE.ARRAY(ty=ty)), DAE.CREF(), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     case (DAE.LUNARY(DAE.NOT(_), DAE.MATRIX(ty=ty)), DAE.CREF(), _, _, _)
-      then simpleArrayEquationAcausal(lhs, rhs, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(lhs, rhs, ty, eqnAttributes, inTpl);
 
     // not {a1, a2, a3, ..} = not b
     case (DAE.LUNARY(DAE.NOT(_), e1 as DAE.ARRAY(ty=ty)), DAE.LUNARY(DAE.NOT(_), e2 as DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     case (DAE.LUNARY(DAE.NOT(_), e1 as DAE.MATRIX(ty=ty)), DAE.LUNARY(DAE.NOT(_), e2 as DAE.CREF()), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     // time independent equations
     else
@@ -1254,8 +1254,52 @@ algorithm
   end match;
 end simpleEquationAcausal;
 
+protected function simpleArrayEquationAcausal
+  input DAE.Exp lhs;
+  input DAE.Exp rhs;
+  input EquationSourceAndAttributes eqnAttributes;
+  input Boolean selfCalled "this is a flag to know if we are selfcalled to save memory in case of non simple equation";
+  input AccTuple inTpl;
+  output AccTuple outTpl;
+algorithm
+  outTpl := match (lhs, rhs, eqnAttributes, selfCalled, inTpl)
+    local
+      DAE.ComponentRef cr1, cr2;
+      DAE.Exp e1, e2;
+      DAE.Operator op;
 
-protected function simpleArrayEquationAcausal "author Frenkel TUD 2012-12
+    // a = b;
+    case (DAE.CREF(componentRef = cr1), DAE.CREF(componentRef = cr2), _, _, _)
+      then addSimpleEquationAcausal(cr1, lhs, false, cr2, rhs, false, eqnAttributes, selfCalled, inTpl);
+
+    // a = -b;
+    case (DAE.CREF(componentRef = cr1), DAE.UNARY(op as DAE.UMINUS_ARR(_), DAE.CREF(componentRef = cr2)), _, _, _)
+      then addSimpleEquationAcausal(cr1, DAE.UNARY(op, lhs), false, cr2, rhs, true, eqnAttributes, selfCalled, inTpl);
+
+    // -a = b;
+    case (DAE.UNARY(op as DAE.UMINUS_ARR(_), DAE.CREF(componentRef = cr1)), DAE.CREF(componentRef = cr2), _, _, _)
+      then addSimpleEquationAcausal(cr1, lhs, true, cr2,  DAE.UNARY(op, rhs), false, eqnAttributes, selfCalled, inTpl);
+
+    // -a = -b;
+    case (DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.CREF(componentRef = cr1)), DAE.UNARY(DAE.UMINUS_ARR(_), e2 as DAE.CREF(componentRef = cr2)), _, _, _)
+      then addSimpleEquationAcausal(cr1, e1, false, cr2, e2, false, eqnAttributes, selfCalled, inTpl);
+
+    // a = not b;
+    case (DAE.CREF(componentRef = cr1), DAE.LUNARY(op as DAE.NOT(_), DAE.CREF(componentRef = cr2)), _, _, _)
+      then addSimpleEquationAcausal(cr1, DAE.LUNARY(op, lhs), false, cr2, rhs, true, eqnAttributes, selfCalled, inTpl);
+
+    // not a = b;
+    case (DAE.LUNARY(op as DAE.NOT(_), DAE.CREF(componentRef = cr1)), DAE.CREF(componentRef = cr2), _, _, _)
+      then addSimpleEquationAcausal(cr1, lhs, true, cr2, DAE.LUNARY(op, lhs), false, eqnAttributes, selfCalled, inTpl);
+
+    // not a = not b;
+    case (DAE.LUNARY(DAE.NOT(_), e1 as DAE.CREF(componentRef = cr1)), DAE.LUNARY(DAE.NOT(_), e2 as DAE.CREF(componentRef = cr2)), _, _, _)
+      then addSimpleEquationAcausal(cr1, e1, false, cr2, e2, false, eqnAttributes, selfCalled, inTpl);
+
+  end match;
+end simpleArrayEquationAcausal;
+
+protected function simpleArrayEquationAcausalScalarized "author Frenkel TUD 2012-12
   helper for simpleEquationAcausal"
   input DAE.Exp lhs;
   input DAE.Exp rhs;
@@ -1311,7 +1355,7 @@ algorithm
   else
   end if;
   outTpl := List.threadFold2(elst1, elst2, simpleEquationAcausal, eqnAttributes, true, inTpl);
-end simpleArrayEquationAcausal;
+end simpleArrayEquationAcausalScalarized;
 
 protected function simpleEquationAcausalLst "author: Frenkel TUD 2012-12
   helper for simpleEquationAcausal"
@@ -1353,7 +1397,7 @@ algorithm
       guard
         Expression.isZero(lhs)
       then List.fold2(elst2, simpleExpressionAcausal, eqnAttributes, true, inTpl);
-     // lhs = 0
+    // lhs = 0
     case (_, _, _, _, _)
       guard
         Expression.isZero(rhs)
@@ -1481,27 +1525,27 @@ algorithm
 
     // a + {b1, b2, b3} = 0 => a = -{b1, b2, b3}
     case (DAE.BINARY(e1 as DAE.CREF(), DAE.ADD_ARR(tp), e2 as DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, DAE.UNARY(DAE.UMINUS_ARR(tp), e2), ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, DAE.UNARY(DAE.UMINUS_ARR(tp), e2), ty, eqnAttributes, inTpl);
     case (DAE.BINARY(e1 as DAE.CREF(), DAE.ADD_ARR(tp), e2 as DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, DAE.UNARY(DAE.UMINUS_ARR(tp), e2), ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, DAE.UNARY(DAE.UMINUS_ARR(tp), e2), ty, eqnAttributes, inTpl);
 
     // a - {b1, b2, b3} = 0 => a = {b1, b2, b3}
     case (DAE.BINARY(e1 as DAE.CREF(), DAE.SUB_ARR(_), e2 as DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
     case (DAE.BINARY(e1 as DAE.CREF(), DAE.SUB_ARR(_), e2 as DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     // -a + {b1, b2, b3} = 0 => a = {b1, b2, b3}
     case (DAE.BINARY(DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.CREF()), DAE.ADD_ARR(_), e2 as DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
     case (DAE.BINARY(DAE.UNARY(DAE.UMINUS_ARR(_), e1 as DAE.CREF()), DAE.ADD_ARR(_), e2 as DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, e2, ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, e2, ty, eqnAttributes, inTpl);
 
     // -a - {b1, b2, b3} = 0 => -a = {b1, b2, b3}
     case (DAE.BINARY(e1 as DAE.UNARY(DAE.UMINUS_ARR(_), DAE.CREF()), DAE.SUB_ARR(_), e2 as DAE.ARRAY(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, DAE.UNARY(DAE.UMINUS_ARR(ty), e2), ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, DAE.UNARY(DAE.UMINUS_ARR(ty), e2), ty, eqnAttributes, inTpl);
     case (DAE.BINARY(e1 as DAE.UNARY(DAE.UMINUS_ARR(_), DAE.CREF()), DAE.SUB_ARR(_), e2 as DAE.MATRIX(ty=ty)), _, _, _)
-      then simpleArrayEquationAcausal(e1, DAE.UNARY(DAE.UMINUS_ARR(ty), e2), ty, eqnAttributes, inTpl);
+      then simpleArrayEquationAcausalScalarized(e1, DAE.UNARY(DAE.UMINUS_ARR(ty), e2), ty, eqnAttributes, inTpl);
 
     // time independent equations
     else

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -110,10 +110,11 @@ protected protected function hashSubscripts "help function, hashing subscripts m
   output Integer hash;
 algorithm
   hash := match(tp,subs)
-  case(_,{}) then 0;
-  // TODO: Currently, the types of component references are wrong, they consider the subscripts but they should not.
-  // For example, given Real a[10,10];  the component reference 'a[1,2]' should have type Real[10,10] but it has type Real.
-  else hashSubscripts2(List.fill(1,listLength(subs)),/*DAEUtil.expTypeArrayDimensions(tp),*/subs,1);
+    case (_, _) guard(not Flags.isSet(Flags.NF_SCALARIZE)) then 0;
+    case (_,{}) then 0;
+    // TODO: Currently, the types of component references are wrong, they consider the subscripts but they should not.
+    // For example, given Real a[10,10];  the component reference 'a[1,2]' should have type Real[10,10] but it has type Real.
+    else hashSubscripts2(List.fill(1,listLength(subs)),/*DAEUtil.expTypeArrayDimensions(tp),*/subs,1);
   end match;
 end hashSubscripts;
 
@@ -4024,7 +4025,9 @@ algorithm
   // and move last cref type to the last cref.
   subs := crefLastSubs(inCref);
   outCref := crefStripLastSubs(inCref);
-  outCref := replaceSubsWithString(outCref);
+  if Flags.isSet(Flags.NF_SCALARIZE) then
+    outCref := replaceSubsWithString(outCref);
+  end if;
   if debug then print("after full type: " + Types.printTypeStr(crefTypeFull(crefStripIterSub(outCref))) + "\n"); end if;
   outCref := crefSetLastType(outCref, DAE.T_UNKNOWN_DEFAULT);
   if debug then print("after strip: " + printComponentRefListStr(expandCref(outCref, true)) + "\n"); end if;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -14274,6 +14274,13 @@ algorithm
     elts := fillScalarElements(elt, dims, 1, {}, {});
     elts := setVariableIndexHelper(elts, index, fmi_index);
   then elts;
+  case SimCodeVar.SIMVAR(type_=DAE.T_ARRAY(), index=index) algorithm
+    dims := List.map(List.lastN(var.numArrayElement, listLength(var.numArrayElement)), stringInt);
+    elt := var;
+    elt.type_ := Types.arrayElementType(var.type_);
+    elts := fillScalarElements(elt, dims, 1, {}, {});
+    elts := setVariableIndexHelper(elts, index, index);
+  then elts;
   else {var};
   end match;
 end getScalarElements;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8849,7 +8849,7 @@ algorithm
     case(SimCode.SES_FOR_LOOP(index=idx,iter=iterator, startIt=startIt, endIt=endIt, cref=cref, exp=exp))
       equation
         s = intString(idx) +" FOR-LOOP: "+" for "+ExpressionDump.printExpStr(iterator)+" in ("+ExpressionDump.printExpStr(startIt)+":"+ExpressionDump.printExpStr(endIt)+") loop\n";
-        s = s+ComponentReference.printComponentRefStr(cref) + "=" + ExpressionDump.printExpStr(exp)+" [" +DAEDump.daeTypeStr(Expression.typeof(exp))+ "]\n";
+        s = s+ComponentReference.printComponentRefStr(cref) + "=" + ExpressionDump.printExpStr(exp) + "[" +DAEDump.daeTypeStr(Expression.typeof(exp))+ "]\n";
         s = s+"end for;";
     then s;
 

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -12947,7 +12947,11 @@ match simVar
     if createDebugCode then
       'template jacobianVarDefine: createDebugCode for arrays not implemented'
     else
-      '#define <%cref(name,false)%>(Idx) _<%getOption(matrixName)%>jac_<%typeName%>(<%index%>+((Idx)-1))' /* TODO currently only works for one-dimensional arrays */
+      /* TODO currently only works for one-dimensional arrays */
+      <<
+      #define <%cref(name,false)%>_arr (_<%getOption(matrixName)%>jac_<%typeName%>(<%index%>))
+      #define <%cref(name,false)%>(Idx) _<%getOption(matrixName)%>jac_<%typeName%>(<%index%>+((Idx)-1))
+      >>
 end jacobianVarDefine;
 
 

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -302,7 +302,7 @@ case SIMCODE(modelInfo=MODELINFO(__)) then
     >>
     %>
 
-    <%variableDefinitionsJacobians(jacobianMatrixes, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)%>
+    <%if Flags.isSet(NF_SCALARIZE) then '' else variableDefinitionsJacobians(jacobianMatrixes, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)%>
 
     /*testmaessig aus der Cruntime*/
     void initializeColoredJacobianA();
@@ -12899,9 +12899,6 @@ end generateJacobianMatrix;
 template variableDefinitionsJacobians(list<JacobianMatrix> JacobianMatrixes, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text &jacobianVarsInit, Boolean createDebugCode)
  "Generates defines for jacobian vars."
 ::=
-if Flags.isSet(NF_SCALARIZE) then
-  ''
-else
   let analyticVars = (JacobianMatrixes |> JAC_MATRIX(__) =>
     let seedVarsResult = (seedVars |> var => jacobianVarDefine(var, &jacobianVarsInit, createDebugCode)
       ;separator="\n";empty)

--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -544,7 +544,7 @@ template daeExpCrefRhsArrayBox2(Text arrayData, DAE.Type ty, Boolean isRowMajorD
     let &tmpdecl = buffer "" /*BUFD*/
     let arrayVar = tempDecl(arrayType, &tmpdecl /*BUFD*/)
     let arrayAssign = if isRowMajorData then
-      'assignRowMajorData(&<%arrayData%>, <%arrayVar%>)' else
+      'assignRowMajorData(&<%arrayData%>_arr, <%arrayVar%>)' else
       '<%arrayVar%>.assign(&<%arrayData%>)'
     let &preExp +=
       <<
@@ -2846,7 +2846,7 @@ template assignJacArray(String lhsStr, String rhsStr, DAE.Type ty)
     let arrayWrapper = 'tmp<%System.tmpTick()%>'
     <<
     /*assign through wrapper array*/
-    StatArrayDim<%nDimsFlat(dims, elty, 0)%><<%expTypeShort(elty)%>, <%dimstr%>, true> <%arrayWrapper%>(&<%lhsStr%>);
+    StatArrayDim<%nDimsFlat(dims, elty, 0)%><<%expTypeShort(elty)%>, <%dimstr%>, true> <%arrayWrapper%>(&<%lhsStr%>_arr);
     assignRowMajorData(<%rhsStr%>.getData(), <%arrayWrapper%>);
     >>
 end assignJacArray;

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -290,7 +290,7 @@ case SIMCODE(modelInfo=MODELINFO(__)) then
     >>
     %>
 
-    <%variableDefinitionsJacobians_skip(jacobianMatrixes, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)%>
+    <%if Flags.isSet(NF_SCALARIZE) then '' else variableDefinitionsJacobians(jacobianMatrixes, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)%>
 
     /*testmaessig aus der Cruntime*/
     void initializeColoredJacobianA();
@@ -9746,10 +9746,7 @@ template equationString(SimEqSystem eq, Context context, Text &varDecls, SimCode
      throw ModelicaSimulationError(ALGLOOP_EQ_SYSTEM,"Mixed systems are not supported yet");
     >>
   case e as SES_FOR_LOOP(__)
-    then
-    <<
-    FOR LOOPS ARE NOT IMPLEMENTED
-    >>
+    then equationForLoop(e, context, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation, assignToStartValues)
   case e as SES_IFEQUATION(__)
     then
     <<
@@ -13022,63 +13019,59 @@ case _ then
 end generateJacobianMatrix;
 
 
-template variableDefinitionsJacobians_skip(list<JacobianMatrix> JacobianMatrixes, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text &jacobianVarsInit, Boolean createDebugCode)
- "Skips generation of defines for jacobian vars."
-::=
- ''
-end variableDefinitionsJacobians_skip;
-
-
 template variableDefinitionsJacobians(list<JacobianMatrix> JacobianMatrixes, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text &jacobianVarsInit, Boolean createDebugCode)
  "Generates defines for jacobian vars."
 ::=
-  let analyticVars = (JacobianMatrixes |> JAC_MATRIX(columns=jacColumn, seedVars=vars, matrixName=name, jacobianIndex=jacIndex)  =>
-    let varsDef = variableDefinitionsJacobians2(jacIndex, jacColumn, seedVars, name, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)
+  let analyticVars = (JacobianMatrixes |> JAC_MATRIX(__) =>
+    let seedVarsResult = (seedVars |> var => jacobianVarDefine(var, &jacobianVarsInit, createDebugCode)
+      ;separator="\n";empty)
+    let columnVarsResult = (columns |> JAC_COLUMN(__) =>
+        (columnVars |> var => jacobianVarDefine(var, &jacobianVarsInit, createDebugCode)
+        ;separator="\n";empty)
+      ;separator="\n\n")
     <<
-    <%varsDef%>
+    /*seed vars <%matrixName%>*/
+    <%seedVarsResult%>
+    /*other jac vars <%matrixName%>*/
+    <%columnVarsResult%>
     >>
     ;separator="\n";empty)
-
-    <<
-    /* Jacobian Variables */
-    <%analyticVars%>
-    >>
+  <<
+  /* Jacobian Variables */
+  <%analyticVars%>
+  >>
 end variableDefinitionsJacobians;
 
-template variableDefinitionsJacobians2(Integer indexJacobian, list<JacobianColumn> jacobianColumn, list<SimVar> seedVars, String name, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text& jacobianVarsInit, Boolean createDebugCode)
- "Generates Matrixes for Linear Model."
-::=
-  let seedVarsResult = (seedVars |> var hasindex index0 =>
-    jacobianVarDefine(var, indexJacobian, index0, name, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)
-    ;separator="\n";empty)
-  let columnVarsResult = (jacobianColumn |> JAC_COLUMN(columnVars=vars) =>
-      (vars |> var hasindex index0 => jacobianVarDefine(var, indexJacobian, index0, name, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, &jacobianVarsInit, createDebugCode)
-      ;separator="\n";empty)
-    ;separator="\n\n")
-
-<<
-<%seedVarsResult%>
-<%columnVarsResult%>
->>
-end variableDefinitionsJacobians2;
-
-
-template jacobianVarDefine(SimVar simVar, Integer indexJac, Integer index0, String matrixName, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text& jacobianVarsInit, Boolean createDebugCode)
+template jacobianVarDefine(SimVar simVar, Text& jacobianVarsInit, Boolean createDebugCode)
 ""
 ::=
 match simVar
-  case SIMVAR(aliasvar=NOALIAS(),name=name,index=index) then
-    let jacobianVar = '_<%crefToCStr(name, false)%>'
+  case SIMVAR(aliasvar = NOALIAS(), numArrayElement = {}, arrayCref = NONE()) then
     let typeName = match varKind
-                     case BackendDAE.JAC_VAR() then 'jac_y(<%index%>)'
-                     case BackendDAE.JAC_DIFF_VAR() then 'jac_tmp(<%index%>)'
-                     case BackendDAE.SEED_VAR() then 'jac_x(<%index0%>)'
-                     else 'UNKNOWN KIND'
-    let &jacobianVarsInit += if createDebugCode then ', <%jacobianVar%>(_<%matrixName%><%typeName%>)<%\n%>'
+      case JAC_VAR() then 'y'
+      case JAC_DIFF_VAR() then 'tmp'
+      case SEED_VAR() then 'x'
+      else 'UNKNOWN KIND'
+    let &jacobianVarsInit += if createDebugCode then ', <%cref(name,false)%>(_<%getOption(matrixName)%>jac_<%typeName%>(<%index%>))<%\n%>'
     if createDebugCode then
-       'double& <%jacobianVar%>;' else
-       '#define <%jacobianVar%> _<%matrixName%><%typeName%>'
-  end match
+      'double& <%cref(name,false)%>;'
+    else
+      '#define <%cref(name,false)%> _<%getOption(matrixName)%>jac_<%typeName%>(<%index%>)'
+  /* newInst with arrays */
+  case SIMVAR(type_ = T_ARRAY(), numArrayElement = num) then
+    let typeName = match varKind
+      case JAC_VAR() then 'y'
+      case JAC_DIFF_VAR() then 'tmp'
+      case SEED_VAR() then 'x'
+      else 'UNKNOWN KIND'
+    if createDebugCode then
+      'template jacobianVarDefine: createDebugCode for arrays not implemented'
+    else
+      /* TODO currently only works for one-dimensional arrays */
+      <<
+      #define <%cref(name,false)%>_arr (_<%getOption(matrixName)%>jac_<%typeName%>(<%index%>))
+      #define <%cref(name,false)%>(Idx) _<%getOption(matrixName)%>jac_<%typeName%>(<%index%>+((Idx)-1))
+      >>
 end jacobianVarDefine;
 
 

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -501,20 +501,24 @@ end initParams;
 
 template initValsDefault(SimVar var, String arrayName) ::=
   match var
+    case SIMVAR(type_ = T_ARRAY()) then
+      '<%getScalarElements(var) |> v => initValsDefault(v, arrayName) ;separator="\n"%>'
     case SIMVAR(index=index, type_=type_) then
-    let str = 'comp->fmuData->modelData-><%arrayName%>Data[<%index%>].attribute.start'
-    '<%str%> = <%initValDefault(var)%>;'
+      let str = 'comp->fmuData->modelData-><%arrayName%>Data[<%index%>].attribute.start'
+      '<%str%> = <%initValDefault(var)%>;'
 end initValsDefault;
 
 template initParamsDefault(SimVar var, String arrayName) ::=
   match var
+    case SIMVAR(type_ = T_ARRAY()) then
+      '<%getScalarElements(var) |> v => initParamsDefault(v, arrayName) ;separator="\n"%>'
     case SIMVAR(__) then
-    let str = 'comp->fmuData->modelData-><%arrayName%>Data[<%index%>].attribute.start'
-    match initialValue
-      case SOME(v as SCONST(__)) then
-      '<%str%> = mmc_mk_scon_persist(<%initVal(v)%>); /* TODO: these are not freed currently, see #6161 */'
-      else
-      '<%str%> = <%initValDefault(var)%>;'
+      let str = 'comp->fmuData->modelData-><%arrayName%>Data[<%index%>].attribute.start'
+      match initialValue
+        case SOME(v as SCONST(__)) then
+          '<%str%> = mmc_mk_scon_persist(<%initVal(v)%>); /* TODO: these are not freed currently, see #6161 */'
+        else
+          '<%str%> = <%initValDefault(var)%>;'
 end initParamsDefault;
 
 template initValDefault(SimVar var) ::=
@@ -3221,6 +3225,8 @@ template ScalarVariableFMU(SimVar simVar, String classType)
  "Generates code for ScalarVariable file for FMU target."
 ::=
   match simVar
+    case SIMVAR(type_ = T_ARRAY()) then
+      '<%getScalarElements(simVar) |> var => ScalarVariableFMU(var, classType) ;separator="\n"%>'
     case SIMVAR(source = SOURCE(info = info)) then
       let valueReference = System.tmpTick()
       let ci = System.tmpTickIndex(2)

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -27,6 +27,7 @@ recordTupleReturnTest.mos \
 RefArrayDim2.mos \
 solveTest.mos \
 testArrayEquations.mos \
+testForLoopJacobian.mos \
 testMatrixIO.mos \
 testMatrixState.mos \
 testReduction.mos \

--- a/testsuite/openmodelica/cppruntime/testForLoopJacobian.mo
+++ b/testsuite/openmodelica/cppruntime/testForLoopJacobian.mo
@@ -1,0 +1,23 @@
+package testForLoopJacobian
+  model Component
+    parameter Real amp;
+    Real x;
+    Real y;
+  equation
+    der(x) + y = amp * sin(time) - der(x);
+    0 = der(x) + amp * x;
+  end Component;
+
+  model Example
+    parameter Integer n = 10;
+    Component[n] a(each x(start=1, fixed=true), amp=1:n);
+    Real[n] x(each start=1, each fixed=true);
+    Real[n] y;
+  equation
+    for i in 1:n loop
+      der(x[i]) + y[i] = i * sin(time) - der(x[i]);
+      0 = der(x[i]) + i * x[i];
+    end for;
+  end Example;
+end testForLoopJacobian;
+

--- a/testsuite/openmodelica/cppruntime/testForLoopJacobian.mos
+++ b/testsuite/openmodelica/cppruntime/testForLoopJacobian.mos
@@ -1,0 +1,138 @@
+// name:     testForLoopJacobian
+// keywords: array equations, for loops, symbolic jacobian
+// status: correct
+// teardown_command: rm -f *testForLoopJacobian.Example*
+
+loadFile("testForLoopJacobian.mo"); getErrorString();
+setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
+setCommandLineOptions("--generateSymbolicJacobian"); getErrorString();
+setCommandLineOptions("-d=symjacdump"); getErrorString();
+setCommandLineOptions("-d=newInst"); getErrorString();
+setCommandLineOptions("-d=-nfScalarize"); getErrorString();
+simulate(testForLoopJacobian.Example); getErrorString();
+
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// Create symbolic Jacobians from:
+// Independent Variables
+// ========================================
+// 1: a.x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 2: x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// Dependent Variables
+// ========================================
+// 1: a.x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 2: x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// Basic equation system:
+// differentiated equations
+// ========================================
+// 1/1 (10): for $i in 1 : 10 loop
+//     0.0 = der(a[$i].x) + a[$i].amp * a[$i].x; end for;
+// 2/11 (10): for i in 1 : 10 loop
+//     0.0 = der(x[i]) + /*Real*/(i) * x[i]; end for;
+// related variables
+// ========================================
+// 1: a.x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 2: x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// known variables
+// ========================================
+// 1: a.amp:PARAM()  = 1.0:10.0  type: Real[10] [10]
+// 2: n:PARAM(final = true )  = 10  type: Integer
+// Symbolic Jacobian:
+//
+// unknown partition
+// ========================================
+//
+// Variables (2)
+// ========================================
+// 1: $DER.a.x.$pDERA.dummyVarA:STATE_DER(start = 1.0 fixed = true )  type: Real[10] [10] unreplaceable
+// 2: $DER.x.$pDERA.dummyVarA:STATE_DER(start = 1.0 fixed = true )  type: Real[10] [10] unreplaceable
+//
+//
+// Equations (2, 2)
+// ========================================
+// 1/1 (10): for $i in 1 : 10 loop
+//     0.0 = $DER.a[$i].x.$pDERA.dummyVarA + a[$i].amp * a[$i].x.SeedA; end for;   [dynamic |0|0|0|0|]
+// 2/11 (10): for i in 1 : 10 loop
+//     0.0 = $DER.x.$pDERA.dummyVarA[i] + /*Real*/(i) * x.SeedA[i]; end for;   [dynamic |0|0|0|0|]
+//
+//
+// no matching
+//
+//
+//
+// BackendDAEType: jacobian
+//
+//
+// Known variables only depending on parameters and constants - globalKnownVars (6)
+// ========================================
+// 1: input a.x.SeedA:STATE_DER()  type: Real unreplaceable
+// 2: input x.SeedA:STATE_DER()  type: Real[10] unreplaceable
+// 3: a.x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 4: x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 5: a.amp:PARAM()  = 1.0:10.0  type: Real[10] [10]
+// 6: n:PARAM(final = true )  = 10  type: Integer
+//
+// Symbolic Jacobian:
+//
+// unknown partition
+// ========================================
+//
+// Variables (2)
+// ========================================
+// 1: $DER.a.x.$pDERA.dummyVarA:STATE_DER(start = 1.0 fixed = true )  type: Real[10] [10] unreplaceable
+// 2: $DER.x.$pDERA.dummyVarA:STATE_DER(start = 1.0 fixed = true )  type: Real[10] [10] unreplaceable
+//
+//
+// Equations (2, 2)
+// ========================================
+// 1/1 (10): for $i in 1 : 10 loop
+//     0.0 = $DER.a[$i].x.$pDERA.dummyVarA + a[$i].amp * a[$i].x.SeedA; end for;   [dynamic |0|0|0|0|]
+// 2/11 (10): for i in 1 : 10 loop
+//     0.0 = $DER.x.$pDERA.dummyVarA[i] + /*Real*/(i) * x.SeedA[i]; end for;   [dynamic |0|0|0|0|]
+//
+//
+// Matching
+// ========================================
+// 2 variables and equations
+// var 1 is solved in eqn 1
+// var 2 is solved in eqn 2
+//
+//
+// StrongComponents
+// ========================================
+// {2:2}
+// {1:1}
+//
+//
+//
+// BackendDAEType: jacobian
+//
+//
+// Known variables only depending on parameters and constants - globalKnownVars (6)
+// ========================================
+// 1: n:PARAM(final = true )  = 10  type: Integer
+// 2: a.amp:PARAM()  = 1.0:10.0  type: Real[10] [10]
+// 3: x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 4: a.x:STATE(1)(start = 1.0 fixed = true )  type: Real[10] [10]
+// 5: input x.SeedA:STATE_DER()  type: Real[10] unreplaceable
+// 6: input a.x.SeedA:STATE_DER()  type: Real unreplaceable
+//
+// record SimulationResult
+//     resultFile = "testForLoopJacobian.Example_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'testForLoopJacobian.Example', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
@@ -59,7 +59,7 @@ val(y[10], 1.0);
 // ========================================
 // 1: output y:VARIABLE(flow=false )  type: Real[10] [10]
 // 2: integrator1.u:VARIABLE(flow=false )  "Connector of Real input signal" type: Real[10] [10]
-// 3: integrator1.y:VARIABLE(flow=false start = integrator1.y_start )  "Connector of Real output signal" type: Real[10] [10]
+// 3: integrator1.y:STATE(1)(flow=false start = integrator1.y_start )  "Connector of Real output signal" type: Real[10] [10]
 // 4: assignClock1.y:VARIABLE(flow=false )  "Connector of clocked, Real output signal" type: Real[10] [10]
 // 5: assignClock1.u:VARIABLE(flow=false )  "Connector of clocked, Real input signal" type: Real[10] [10]
 //


### PR DESCRIPTION
should make for faster symbolic manipulations and smaller target code.
- needs -d=-nfScalarize to take effect
- works only for one dimensional arrays and only for target cpp yet
- in codegen: use #define to map cref names onto jacobian variables
- in SimCode: increment simvar index not by 1 but by dimension size