### PR TITLE
[NF] Don't evaluate expressions with homotopy.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -508,6 +508,7 @@ uniontype Call
     output Boolean isImpure;
   algorithm
     isImpure := match call
+      case UNTYPED_CALL() then Function.isImpure(listHead(Function.getRefCache(call.ref)));
       case TYPED_CALL() then Function.isImpure(call.fn) or Function.isOMImpure(call.fn);
       else false;
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -286,7 +286,7 @@ annotation(Documentation(info="<html>
 </html>"));
 end log10;
 
-function homotopy
+impure function homotopy
   input Real actual;
   input Real simplified;
   output Real outValue;


### PR DESCRIPTION
- Mark homotopy as impure.
- Fix Call.isImpure so that it works on untyped calls too.