### PR TITLE
 Remove bind from outside markings for default constructors.

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -836,7 +836,8 @@ constant Attributes dummyAttrInput = ATTR(NON_CONNECTOR(), SCode.NON_PARALLEL(),
 public uniontype BindingSource "where this binding came from: either default binding or start value"
   record BINDING_FROM_DEFAULT_VALUE "the binding came from the default value" end BINDING_FROM_DEFAULT_VALUE;
   record BINDING_FROM_START_VALUE "the binding came from the start value" end BINDING_FROM_START_VALUE;
-  record BINDING_FROM_RECORD_SUBMODS "the EQ binding is created from the submods of a record declration" end BINDING_FROM_RECORD_SUBMODS;
+  record BINDING_FROM_RECORD_SUBMODS "the EQ binding is created from the submods of a record VARIABLE declration e.g. 'R r(i=2)' tranformed by instantiation to 'R r = R(i=2)' " end BINDING_FROM_RECORD_SUBMODS;
+  record BINDING_FROM_DERIVED_RECORD_DECL "the binding is created from the submods of a DERIVED record DECLARATION e.g. 'record K = R(i=3)'" end BINDING_FROM_DERIVED_RECORD_DECL;
 end BindingSource;
 
 public

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -990,6 +990,7 @@ algorithm
         for submod in submods loop
           if varIsModifiedInDerivedMod(var.name, submod) then
             var.bind_from_outside := true;
+            var.binding := markBindingFromDerivedRecordMods(var.binding);
             break;
           end if;
         end for;
@@ -1002,6 +1003,18 @@ algorithm
   end match;
 
 end markDerivedRecordOutsideBindings;
+
+function markBindingFromDerivedRecordMods
+  input output DAE.Binding bind;
+algorithm
+  _ := match bind
+    case DAE.EQBOUND() algorithm
+      bind.source := DAE.BINDING_FROM_DERIVED_RECORD_DECL();
+    then ();
+
+    else ();
+  end match;
+end markBindingFromDerivedRecordMods;
 
 function varIsModifiedInDerivedMod
   input String inName;

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1616,8 +1616,10 @@ algorithm
 
         if not listMember(name, rt_1) then
           rt_1 := name :: rt_1;
-          vars := List.map(varlst, typesVar);
           (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
+
+          vars := List.map(varlst, typesVar);
+          vars := List.map(vars, simCodeVarRemoveBindFromOutside);
           recDecl := SimCodeFunction.RECORD_DECL_FULL(name, NONE(), path, vars);
           accRecDecls := List.appendElt(recDecl, accRecDecls);
         end if;
@@ -1711,6 +1713,17 @@ algorithm
       then SimCodeFunction.VARIABLE(cref_, ty, bindExp, {}, prl, DAE.VARIABLE(), inTypesVar.bind_from_outside);
   end match;
 end typesVar;
+
+protected function simCodeVarRemoveBindFromOutside
+  input output SimCodeFunction.Variable var;
+algorithm
+  _ := match (var)
+    case SimCodeFunction.VARIABLE()
+      algorithm
+        var.bind_from_outside := false;
+      then ();
+  end match;
+end simCodeVarRemoveBindFromOutside;
 
 protected function checkSourceAndGetBindingExp
   input DAE.Binding inBinding;

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -792,14 +792,14 @@ algorithm
     case (_, DAE.RECORD_CONSTRUCTOR(source = source, type_ = DAE.T_FUNCTION(funcArg = args, funcResultType = restype as DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(name)))), rt, recordDecls, includes, includeDirs, libs,libPaths)
       equation
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
-        (recordDecls, rt_1) = elaborateRecordDeclarationsForRecord(restype, recordDecls, rt);
+        // (recordDecls, rt_1) = elaborateRecordDeclarationsForRecord(restype, recordDecls, rt);
         DAE.T_COMPLEX(varLst = varlst) = restype;
         // varlst = List.filterOnTrue(varlst, Types.isProtectedVar);
         varlst = List.filterOnFalse(varlst, Types.isModifiableTypesVar);
         varDecls = List.map(varlst, typesVar);
         info = ElementSource.getElementSourceFileInfo(source);
       then
-        (SimCodeFunction.RECORD_CONSTRUCTOR(name, funArgs, varDecls, SCode.PUBLIC(), info), rt_1, recordDecls, includes, includeDirs, libs,libPaths);
+        (SimCodeFunction.RECORD_CONSTRUCTOR(name, funArgs, varDecls, SCode.PUBLIC(), info), rt, recordDecls, includes, includeDirs, libs,libPaths);
 
         // failure
     case (_, fn, _, _, _, _, _,_)

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -364,6 +364,7 @@ template functionHeader(Function fn, Boolean inFunc, Boolean isSimulation, Text 
       let funArgsStr = (funArgs |> var as VARIABLE(__) => ', <%varType(var)%> omc_<%crefStr(name)%>')
       let vis = (match visibility case PUBLIC() then "DLLExport")
       <<
+      /*
       <% if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS)
         then
         <<
@@ -379,6 +380,7 @@ template functionHeader(Function fn, Boolean inFunc, Boolean isSimulation, Text 
       %>
 
       <%functionHeaderBoxed(fname, funArgs, boxedRecordOutVars, inFunc, false, visibility, false, isSimulation, staticPrototypes)%>
+      */
       >>
 end functionHeader;
 
@@ -1715,6 +1717,7 @@ case RECORD_CONSTRUCTOR(__) then
     )
   let boxedFn = functionBodyBoxed(fn, isSimulation)
   <<
+  /*
   <%auxFunction%>
   <%fname%> omc<%if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS) then "impl"%>_<%fname%>(threadData_t *threadData<%funArgs |> VARIABLE(__) => ', <%expTypeArrayIf(ty)%> omc_<%crefStr(name)%>'%>)
   {
@@ -1726,6 +1729,7 @@ case RECORD_CONSTRUCTOR(__) then
   <%if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS) then 'omctd_<%fname%> omc_<%fname%> = omcimpl_<%fname%>;'%>
 
   <%boxedFn%>
+  */
   >>
 end functionBodyRecordConstructor;
 

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -364,7 +364,6 @@ template functionHeader(Function fn, Boolean inFunc, Boolean isSimulation, Text 
       let funArgsStr = (funArgs |> var as VARIABLE(__) => ', <%varType(var)%> omc_<%crefStr(name)%>')
       let vis = (match visibility case PUBLIC() then "DLLExport")
       <<
-      /*
       <% if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS)
         then
         <<
@@ -380,7 +379,6 @@ template functionHeader(Function fn, Boolean inFunc, Boolean isSimulation, Text 
       %>
 
       <%functionHeaderBoxed(fname, funArgs, boxedRecordOutVars, inFunc, false, visibility, false, isSimulation, staticPrototypes)%>
-      */
       >>
 end functionHeader;
 
@@ -519,7 +517,7 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       void <%cpy_func_name%>(void* v_src, void* v_dst);
       #define <%cpy_macro_name%>(src,dst) <%cpy_func_name%>(&src, &dst)
 
-      <%rec_name%> <%modelica_ctor_name%>(threadData_t *threadData <%modelica_ctor_inputs%>);
+      // <%rec_name%> <%modelica_ctor_name%>(threadData_t *threadData <%modelica_ctor_inputs%>);
 
       /* This function is used to copy a records members to simvars. Since simvars
         have no structure yet we can not directly copy records. Insted we pass the
@@ -565,6 +563,7 @@ template recordCopyFromVarsDef(String rec_name, list<Variable> variables)
   let _ = (variables |> var => recordMemberCopy(var, src_pref, dst_pref, &varCopies, &auxFunction) ;separator="\n")
   let inputs = variables |> var as VARIABLE(__) => (", " + varType(var) + functionContextCref(var.name, contextFunction, src_pref, &auxFunction))
   <<
+  /*
   <%rec_name%> omc_<%rec_name%>(threadData_t *threadData <%inputs%>) {
     <%rec_name%> dst;
     // TODO Improve me. No need to initalize the record memebers with defaults in <%rec_name%>_construct
@@ -573,6 +572,7 @@ template recordCopyFromVarsDef(String rec_name, list<Variable> variables)
     <%varCopies%>
     return dst;
   }
+  */
   >>
 end recordCopyFromVarsDef;
 
@@ -1715,7 +1715,6 @@ case RECORD_CONSTRUCTOR(__) then
     )
   let boxedFn = functionBodyBoxed(fn, isSimulation)
   <<
-  /*
   <%auxFunction%>
   <%fname%> omc<%if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS) then "impl"%>_<%fname%>(threadData_t *threadData<%funArgs |> VARIABLE(__) => ', <%expTypeArrayIf(ty)%> omc_<%crefStr(name)%>'%>)
   {
@@ -1727,7 +1726,6 @@ case RECORD_CONSTRUCTOR(__) then
   <%if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS) then 'omctd_<%fname%> omc_<%fname%> = omcimpl_<%fname%>;'%>
 
   <%boxedFn%>
-  */
   >>
 end functionBodyRecordConstructor;
 

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -519,7 +519,7 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       void <%cpy_func_name%>(void* v_src, void* v_dst);
       #define <%cpy_macro_name%>(src,dst) <%cpy_func_name%>(&src, &dst)
 
-      // <%rec_name%> <%modelica_ctor_name%>(threadData_t *threadData <%modelica_ctor_inputs%>);
+      <%rec_name%> <%modelica_ctor_name%>(threadData_t *threadData <%modelica_ctor_inputs%>);
 
       /* This function is used to copy a records members to simvars. Since simvars
         have no structure yet we can not directly copy records. Insted we pass the
@@ -565,7 +565,6 @@ template recordCopyFromVarsDef(String rec_name, list<Variable> variables)
   let _ = (variables |> var => recordMemberCopy(var, src_pref, dst_pref, &varCopies, &auxFunction) ;separator="\n")
   let inputs = variables |> var as VARIABLE(__) => (", " + varType(var) + functionContextCref(var.name, contextFunction, src_pref, &auxFunction))
   <<
-  /*
   <%rec_name%> omc_<%rec_name%>(threadData_t *threadData <%inputs%>) {
     <%rec_name%> dst;
     // TODO Improve me. No need to initalize the record memebers with defaults in <%rec_name%>_construct
@@ -574,7 +573,6 @@ template recordCopyFromVarsDef(String rec_name, list<Variable> variables)
     <%varCopies%>
     return dst;
   }
-  */
   >>
 end recordCopyFromVarsDef;
 
@@ -5405,7 +5403,7 @@ template daeExpCrefIndexSpec(list<Subscript> subs, Context context,
         let expPart = daeExp(exp, context, &preExp, &varDecls, &auxFunction)
         let tmp = tempDecl("modelica_integer", &varDecls)
         let &preExp += '<%tmp%> = size_of_dimension_base_array(<%expPart%>, 1);<%\n%>'
-        let str = <<(int) <%tmp%>, integer_array_make_index_array(&<%expPart%>), 'A'>>
+        let str = <<<%tmp%>, integer_array_make_index_array(<%expPart%>), 'A'>>
         str
     ;separator=", ")
   let tmp = tempDecl("index_spec_t", &varDecls)


### PR DESCRIPTION
  - The default constructor should not use outside bindings.
  - constructors with outisde inputs are generated explicitly
    with a name that contains the index of the variable.
  - We remove the outside binding markings from the types_vars
    even for the default constructor so that they are not picked
    by the codegen function when generating the body for the default
    constructors.