### PR TITLE
Pass arguement by value for make_inde_spec

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenAdevs.tpl
+++ b/OMCompiler/Compiler/Template/CodegenAdevs.tpl
@@ -3734,7 +3734,7 @@ template daeExpCrefRhsIndexSpec(list<Subscript> subs, Context context,
         let tmp = tempDecl("modelica_integer", &varDecls /*BUFD*/)
         let &preExp += '<%tmp%> = size_of_dimension_integer_array(&<%expPart%>, 1);<%\n%>'
         <<
-        (int) <%tmp%>, integer_array_make_index_array(&<%expPart%>), 'A'
+        <%tmp%>, integer_array_make_index_array(<%expPart%>), 'A'
         >>
     ;separator=", ")
   let tmp = tempDecl("index_spec_t", &varDecls /*BUFD*/)

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5401,7 +5401,7 @@ template daeExpCrefIndexSpec(list<Subscript> subs, Context context,
         let expPart = daeExp(exp, context, &preExp, &varDecls, &auxFunction)
         let tmp = tempDecl("modelica_integer", &varDecls)
         let &preExp += '<%tmp%> = size_of_dimension_base_array(<%expPart%>, 1);<%\n%>'
-        let str = <<(int) <%tmp%>, integer_array_make_index_array(&<%expPart%>), 'A'>>
+        let str = <<<%tmp%>, integer_array_make_index_array(<%expPart%>), 'A'>>
         str
     ;separator=", ")
   let tmp = tempDecl("index_spec_t", &varDecls)

--- a/OMCompiler/Compiler/Template/CodegenSparseFMI.tpl
+++ b/OMCompiler/Compiler/Template/CodegenSparseFMI.tpl
@@ -3286,7 +3286,7 @@ template daeExpCrefRhsIndexSpec(list<Subscript> subs, Context context,
         let tmp = tempDecl("modelica_integer", &varDecls /*BUFD*/)
         let &preExp += '<%tmp%> = size_of_dimension_integer_array(&<%expPart%>, 1);<%\n%>'
         <<
-        (int) <%tmp%>, integer_array_make_index_array(&<%expPart%>), 'A'
+        <%tmp%>, integer_array_make_index_array(<%expPart%>), 'A'
         >>
     ;separator=", ")
   let tmp = tempDecl("index_spec_t", &varDecls /*BUFD*/)

--- a/OMCompiler/Compiler/Template/CodegenXML.tpl
+++ b/OMCompiler/Compiler/Template/CodegenXML.tpl
@@ -2280,7 +2280,7 @@ template daeExpCrefRhsIndexSpecXml(list<Subscript> subs, Context context,
         let expPart = daeExpXml(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/)
         let tmp = tempDeclXml("modelica_integer", &varDecls /*BUFD*/)
         let &preExp += '<%tmp%> = size_of_dimension_integer_array(&<%expPart%>, 1);<%\n%>'
-        let str = <<(int) <%tmp%>, integer_array_make_index_array(&<%expPart%>), 'A'>>
+        let str = <<<%tmp%>, integer_array_make_index_array(<%expPart%>), 'A'>>
         str
     ;separator=", ")
   let tmp = tempDeclXml("index_spec_t", &varDecls /*BUFD*/)
@@ -2440,7 +2440,7 @@ template daeExpCrefLhsIndexSpecXml(list<Subscript> subs, Context context,
         let expPart = daeExpXml(exp, context, &afterExp /*BUFC*/, &varDecls /*BUFD*/)
         let tmp = tempDeclXml("modelica_integer", &varDecls /*BUFD*/)
         let &afterExp += '<%tmp%> = size_of_dimension_integer_array(&<%expPart%>, 1);<%\n%>'
-        let str = <<(int) <%tmp%>, integer_array_make_index_array(&<%expPart%>), 'A'>>
+        let str = <<<%tmp%>, integer_array_make_index_array(<%expPart%>), 'A'>>
         str
     ;separator=", ")
   let tmp = tempDeclXml("index_spec_t", &varDecls /*BUFD*/)

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.c
@@ -1553,13 +1553,13 @@ void symmetric_integer_array(const integer_array_t * a,integer_array_t* dest)
 
 /* integer_array_make_index_array
  *
- * Creates an integer array if indices to be used by e.g.
+ * Creates an integer array of indices to be used by e.g.
  ** create_index_spec defined in index_spec.c
  */
 
-_index_t* integer_array_make_index_array(const integer_array_t *arr)
+_index_t* integer_array_make_index_array(const integer_array_t arr)
 {
-    return arr->data;
+    return arr.data;
 }
 
 /* Converts the elements of an integer_array to int and packs them. I.e. if the

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.h
@@ -267,7 +267,7 @@ extern void cross_integer_array(const integer_array_t * x,const integer_array_t 
 extern void cross_alloc_integer_array(const integer_array_t * x,const integer_array_t * y,integer_array_t* dest);
 extern void skew_integer_array(const integer_array_t * x,integer_array_t* dest);
 
-extern _index_t* integer_array_make_index_array(const integer_array_t *arr);
+extern _index_t* integer_array_make_index_array(const integer_array_t arr);
 
 static inline void clone_reverse_integer_array_spec(const integer_array_t * source,
                                                     integer_array_t* dest)


### PR DESCRIPTION
  - Ideally this should accept by pointer. However, the way we have
    it now it does not always get an lvalue to pass around. Sometimes
    it gets a function call as arguement.
  - Until we normalize all array ops to return to a tmp variable and then
    provide that variable for further usage, we have to do this.