### PR TITLE
[NF] Call typing fixes.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -940,7 +940,9 @@ protected
     for arg in dimensionArgs loop
       (arg, arg_ty, arg_var) := Typing.typeExp(arg, origin, info);
 
-      if arg_var <= Variability.STRUCTURAL_PARAMETER and not Expression.containsIterator(arg, origin) then
+      if arg_var <= Variability.STRUCTURAL_PARAMETER and
+         not ExpOrigin.flagSet(origin, ExpOrigin.FUNCTION) and
+         not Expression.containsIterator(arg, origin) then
         arg := Ceval.evalExp(arg);
         arg_ty := Expression.typeOf(arg);
       else
@@ -965,7 +967,7 @@ protected
     {fn} := Function.typeRefCache(fnRef);
     ty := Type.liftArrayLeftList(fillType, dims);
 
-    if evaluated and ExpOrigin.flagNotSet(origin, ExpOrigin.FUNCTION) then
+    if evaluated then
       callExp := Ceval.evalBuiltinFill(ty_args);
     else
       callExp := Expression.CALL(Call.makeTypedCall(NFBuiltinFuncs.FILL_FUNC, ty_args, variability, ty));

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -386,10 +386,7 @@ uniontype Call
       var := Variability.IMPLICITLY_DISCRETE;
     end if;
 
-    if intBitAnd(origin, ExpOrigin.FUNCTION) == 0 then
-      ty := evaluateCallType(ty, func, args);
-    end if;
-
+    ty := evaluateCallType(ty, func, args);
     call := makeTypedCall(func, args, var, ty);
 
     // If the matching was a vectorized one then create a map call
@@ -1428,7 +1425,11 @@ protected
         algorithm
           ptree := buildParameterTree(fnArgs, ptree);
           exp := Expression.map(dim.exp, function evaluateCallTypeDimExp(ptree = ptree));
-          exp := Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS());
+
+          try
+            exp := Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS());
+          else
+          end try;
         then
           Dimension.fromExp(exp, Variability.CONSTANT);
 
@@ -1520,6 +1521,7 @@ protected
           fail();
     end match;
   end getSpecialReturnType;
+
 end Call;
 
 annotation(__OpenModelica_Interface="frontend");


### PR DESCRIPTION
- Don't evaluate `fill` inside functions.
- Evaluate call types also inside functions to make sure dimension
  expressions are replaced with the corresponding arguments, but allow
  the constant evaluation of such expressions to fail.