### PR TITLE
Make type handling of ranges sane.

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1492,6 +1492,7 @@ protected
   DAE.Type ty;
 algorithm
   DAE.RANGE(ty=ty, start=start, stop=stop) := range;
+  ty := Types.unliftArray(ty);
   iterExp := DAE.CREF(DAE.CREF_IDENT(iter, ty, {}), ty);
   forEq := BackendDAE.FOR_EQUATION(iterExp, start, stop, eq,
                                    BackendEquation.equationSource(eq),

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -4427,9 +4427,9 @@ algorithm
         (begin_1,_) = typeConvert(begin, ty1, ty2, printFailtrace);
         (step_1,_) = typeConvert(step, ty1, ty2, printFailtrace);
         (stop_1,_) = typeConvert(stop, ty1, ty2, printFailtrace);
-        at = simplifyType(ty2);
+        at = simplifyType(DAE.T_ARRAY(ty2, {dim1}));
       then
-        (DAE.RANGE(at,begin_1,SOME(step_1),stop_1),DAE.T_ARRAY(ty2,{dim1}));
+        (DAE.RANGE(at,begin_1,SOME(step_1),stop_1), DAE.T_ARRAY(ty2, {dim1}));
 
     // Range expressions, e.g. 1:10
     case (DAE.RANGE(start = begin,step = NONE(),stop = stop),
@@ -4440,9 +4440,9 @@ algorithm
         true = Expression.dimensionsKnownAndEqual(dim1, dim2);
         (begin_1,_) = typeConvert(begin, ty1, ty2, printFailtrace);
         (stop_1,_) = typeConvert(stop, ty1, ty2, printFailtrace);
-        at = simplifyType(ty2);
+        at = simplifyType(DAE.T_ARRAY(ty2, {dim1}));
       then
-        (DAE.RANGE(at,begin_1,NONE(),stop_1),DAE.T_ARRAY(ty2,{dim1}));
+        (DAE.RANGE(at,begin_1,NONE(),stop_1), DAE.T_ARRAY(ty2, {dim1}));
 
     // Matrix expressions: expression dimension [dim1,dim11], expected dimension [dim2,dim22]
     case (DAE.MATRIX(integer = nmax,matrix = ell),

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1730,7 +1730,7 @@ public
 
       case RANGE()
         then DAE.RANGE(
-               Type.toDAE(Type.arrayElementType(exp.ty)),
+               Type.toDAE(exp.ty),
                toDAE(exp.start),
                if isSome(exp.step)
                then SOME(toDAE(Util.getOption(exp.step)))

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -668,7 +668,7 @@ algorithm
               prefix_node.parent, InstNodeType.NORMAL_COMP());
         end match;
         {Dimension.INTEGER(size = stop)} := dimensions;
-        range := Expression.RANGE(Type.INTEGER(), Expression.INTEGER(1), NONE(), Expression.INTEGER(stop));
+        range := Expression.RANGE(Type.ARRAY(Type.INTEGER(), dimensions), Expression.INTEGER(1), NONE(), Expression.INTEGER(stop));
         veqn := Equation.mapExp(eqn, function addIterator(prefix = prefix, subscript = Subscript.INDEX(Expression.CREF(Type.INTEGER(), ComponentRef.makeIterator(iter, Type.INTEGER())))));
       then
         Equation.FOR(iter, SOME(range), {veqn}, Equation.source(eqn));
@@ -702,7 +702,7 @@ algorithm
               prefix_node.parent, InstNodeType.NORMAL_COMP());
         end match;
         {Dimension.INTEGER(size = stop)} := dimensions;
-        range := Expression.RANGE(Type.INTEGER(), Expression.INTEGER(1), NONE(), Expression.INTEGER(stop));
+        range := Expression.RANGE(Type.ARRAY(Type.INTEGER(), dimensions), Expression.INTEGER(1), NONE(), Expression.INTEGER(stop));
         body := Statement.mapExpList(alg.statements, function addIterator(prefix = prefix, subscript = Subscript.INDEX(Expression.CREF(Type.INTEGER(), ComponentRef.makeIterator(iter, Type.INTEGER())))));
       then
         Algorithm.ALGORITHM({Statement.FOR(iter, SOME(range), body, alg.source)}, alg.source);

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -6885,7 +6885,7 @@ template daeExpAsub(Exp inExp, Context context, Text &preExp,
     >>
     res
 
-  case ASUB(exp=range as RANGE(ty=T_INTEGER(),step=NONE()), sub={idx}) then
+  case ASUB(exp=range as RANGE(ty=T_ARRAY(ty = T_INTEGER()),step=NONE()), sub={idx}) then
     let res = tempDecl("modelica_integer", &varDecls)
     let idx1 = daeExp(idx, context, &preExp, &varDecls, &auxFunction)
     let start = daeExp(range.start, context, &preExp, &varDecls, &auxFunction)


### PR DESCRIPTION
- Make the type in DAE.RANGE always be the actual type of the range
  like the comment on it says, instead of having some parts of the
  compiler assume it's the element type while other parts assume it's
  the range type.