### PR TITLE
[NF] Handle empty type attributes with `each`.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2277,8 +2277,6 @@ algorithm
     local
       Binding binding;
 
-    case Modifier.MODIFIER(binding = Binding.UNBOUND()) then ();
-
     case Modifier.MODIFIER(binding = binding)
       algorithm
         binding := Binding.addParent(node, binding);
@@ -2294,6 +2292,7 @@ algorithm
       then
         fail();
 
+    else ();
   end match;
 end instBuiltinAttribute;
 

--- a/testsuite/flattening/modelica/scodeinst/BuiltinAttribute20.mo
+++ b/testsuite/flattening/modelica/scodeinst/BuiltinAttribute20.mo
@@ -1,0 +1,17 @@
+// name: BuiltinAttribute20
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model BuiltinAttribute20
+  Real x[3](each start);
+end BuiltinAttribute20;
+
+// Result:
+// class BuiltinAttribute20
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// end BuiltinAttribute20;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -54,6 +54,7 @@ BuiltinAttribute16.mo \
 BuiltinAttribute17.mo \
 BuiltinAttribute18.mo \
 BuiltinAttribute19.mo \
+BuiltinAttribute20.mo \
 BuiltinLookup1.mo \
 BuiltinTime.mo \
 BuiltinTimeSubscripted.mo \


### PR DESCRIPTION
- Handle modifiers such as `Real x[3](each final start)`.