### PR TITLE
[NF] Record improvements.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -34,6 +34,7 @@ encapsulated package NFComponent
 import DAE;
 import NFBinding.Binding;
 import NFClass.Class;
+import NFClassTree.ClassTree;
 import Dimension = NFDimension;
 import NFInstNode.InstNode;
 import NFModifier.Modifier;
@@ -47,6 +48,7 @@ protected
 import List;
 import Prefixes = NFPrefixes;
 import SCodeUtil;
+import Restriction = NFRestriction;
 
 public
 constant Component.Attributes DEFAULT_ATTR =
@@ -469,9 +471,39 @@ uniontype Component
 
   function hasBinding
     input Component component;
+    input InstNode parent = InstNode.EMPTY_NODE();
     output Boolean b;
+  protected
+    Class cls;
+    array<InstNode> children;
   algorithm
-    b := Binding.isBound(getBinding(component));
+    if Binding.isBound(getBinding(component)) then
+      // Simple case, component has normal binding equation.
+      b := true;
+      return;
+    end if;
+
+    // Complex case, component might be a record instance where each field has
+    // its own binding equation.
+    cls := InstNode.getClass(classInstance(component));
+
+    if not Restriction.isRecord(Class.restriction(cls)) then
+      // Not record.
+      b := false;
+      return;
+    end if;
+
+    // Check if any child of this component is missing a binding.
+    children := ClassTree.getComponents(Class.classTree(cls));
+    for c in children loop
+      if InstNode.isComponent(c) and not hasBinding(InstNode.component(c)) then
+        b := false;
+        return;
+      end if;
+    end for;
+
+
+    b := true;
   end hasBinding;
 
   function getCondition

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3374,7 +3374,7 @@ algorithm
     elseif Component.isExternalObject(component) then
       // Except external objects.
       isStructural := false;
-    elseif Binding.isUnbound(compBinding) then
+    elseif not InstNode.hasBinding(compNode) then
       // Except parameters with no bindings.
       if not evalAllParams and not Flags.getConfigBool(Flags.CHECK_MODEL) then
         // Print a warning if a parameter has an Evaluate=true annotation but no binding.

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1632,6 +1632,18 @@ uniontype InstNode
       else false;
     end match;
   end isModel;
+
+  function hasBinding
+    input InstNode node;
+    output Boolean hasBinding;
+  algorithm
+    hasBinding := match node
+      case COMPONENT_NODE()
+        then Component.hasBinding(Pointer.access(node.component)) or hasBinding(derivedParent(node));
+      else false;
+    end match;
+  end hasBinding;
+
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -751,7 +751,7 @@ protected
   Expression exp;
   Binding parent_binding;
 algorithm
-  parent := InstNode.parent(component);
+  parent := InstNode.derivedParent(component);
 
   if InstNode.isComponent(parent) then
     // Get the binding of the component's parent.


### PR DESCRIPTION
- Improve the check for unbound parameters with Evaluate=true to
  generate fewer false warnings.
- Handle derived records better when trying to figure out the binding of
  a record field.