### PR TITLE
[NF] Change behaviour of ClassTree.flatten.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1131,11 +1131,10 @@ protected
 algorithm
   typeVars := match cls as InstNode.getClass(complexCls)
     case Class.INSTANCED_CLASS(restriction = Restriction.RECORD())
-      then list(makeTypeRecordVar(c) for c guard not InstNode.isEmpty(c)
-             in ClassTree.getComponents(cls.elements));
+      then list(makeTypeRecordVar(c) for c in ClassTree.getComponents(cls.elements));
 
     case Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE())
-      then list(makeTypeVar(c) for c guard not (InstNode.isOnlyOuter(c) or InstNode.isEmpty(c))
+      then list(makeTypeVar(c) for c guard not InstNode.isOnlyOuter(c)
              in ClassTree.getComponents(cls.elements));
 
     else {};

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -254,7 +254,7 @@ protected
   Visibility vis;
 algorithm
   // Remove components that are only outer.
-  if InstNode.isOnlyOuter(component) or InstNode.isEmpty(component) then
+  if InstNode.isOnlyOuter(component) then
     return;
   end if;
 
@@ -348,11 +348,9 @@ algorithm
     return;
   end if;
 
-  if not InstNode.isEmpty(compNode) then
-    comp := InstNode.component(compNode);
-    InstNode.updateComponent(Component.DELETED_COMPONENT(comp), compNode);
-    deleteClassComponents(Component.classInstance(comp));
-  end if;
+  comp := InstNode.component(compNode);
+  InstNode.updateComponent(Component.DELETED_COMPONENT(comp), compNode);
+  deleteClassComponents(Component.classInstance(comp));
 end deleteComponent;
 
 function deleteClassComponents
@@ -1711,10 +1709,6 @@ algorithm
     case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE(), sections = sections)
       algorithm
         for c in cls_tree.components loop
-          if InstNode.isEmpty(c) then
-            continue;
-          end if;
-
           comp := InstNode.component(c);
           funcs := collectTypeFuncs(Component.getType(comp), funcs);
           binding := Component.getBinding(comp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1675,38 +1675,36 @@ uniontype Function
     Type ty;
     Boolean dirty = false;
   algorithm
-    if not InstNode.isEmpty(node) then
-      comp := InstNode.component(node);
-      binding := Component.getBinding(comp);
-      binding2 := Binding.mapExp(binding, mapFn);
+    comp := InstNode.component(node);
+    binding := Component.getBinding(comp);
+    binding2 := Binding.mapExp(binding, mapFn);
 
-      if not referenceEq(binding, binding2) then
-        comp := Component.setBinding(binding2, comp);
-        dirty := true;
-      end if;
+    if not referenceEq(binding, binding2) then
+      comp := Component.setBinding(binding2, comp);
+      dirty := true;
+    end if;
 
-      () := match comp
-        case Component.TYPED_COMPONENT()
-          algorithm
-            ty := Type.mapDims(comp.ty, function Dimension.mapExp(func = mapFn));
+    () := match comp
+      case Component.TYPED_COMPONENT()
+        algorithm
+          ty := Type.mapDims(comp.ty, function Dimension.mapExp(func = mapFn));
 
-            if not referenceEq(ty, comp.ty) then
-              comp.ty := ty;
-              dirty := true;
-            end if;
+          if not referenceEq(ty, comp.ty) then
+            comp.ty := ty;
+            dirty := true;
+          end if;
 
-            cls := InstNode.getClass(comp.classInst);
-            ClassTree.applyComponents(Class.classTree(cls),
-              function mapExpParameter(mapFn = mapFn));
-          then
-            ();
+          cls := InstNode.getClass(comp.classInst);
+          ClassTree.applyComponents(Class.classTree(cls),
+            function mapExpParameter(mapFn = mapFn));
+        then
+          ();
 
-        else ();
-      end match;
+      else ();
+    end match;
 
-      if dirty then
-        InstNode.updateComponent(comp, node);
-      end if;
+    if dirty then
+      InstNode.updateComponent(comp, node);
     end if;
   end mapExpParameter;
 
@@ -1735,10 +1733,6 @@ protected
         algorithm
           for i in arrayLength(comps):-1:1 loop
             n := comps[i];
-
-            if InstNode.isEmpty(n) then
-              continue;
-            end if;
 
             // Sort the components based on their direction.
             () := match paramDirection(n)

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3267,9 +3267,7 @@ algorithm
     case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE())
       algorithm
         for c in cls_tree.components loop
-          if not InstNode.isEmpty(c) then
-            updateImplicitVariabilityComp(c, evalAllParams);
-          end if;
+          updateImplicitVariabilityComp(c, evalAllParams);
         end for;
 
         Sections.apply(cls.sections,

--- a/OMCompiler/Compiler/NFFrontEnd/NFPackage.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFPackage.mo
@@ -177,10 +177,8 @@ public
                                  sections = sections)
         algorithm
           for c in comps loop
-            if not InstNode.isEmpty(c) then
-              constants := collectBindingConstants(
-                Component.getBinding(InstNode.component(c)), constants);
-            end if;
+            constants := collectBindingConstants(
+              Component.getBinding(InstNode.component(c)), constants);
           end for;
 
           () := match sections

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -161,10 +161,6 @@ protected
   Component comp;
   InstNode comp_node = InstNode.resolveInner(component);
 algorithm
-  if InstNode.isEmpty(comp_node) then
-    return;
-  end if;
-
   if InstNode.isProtected(comp_node) then
     locals := comp_node :: locals;
     return;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -205,9 +205,7 @@ algorithm
     case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE())
       algorithm
         for c in cls_tree.components loop
-          if not InstNode.isEmpty(c) then
-            typeComponent(c, origin);
-          end if;
+          typeComponent(c, origin);
         end for;
 
         () := match c.ty
@@ -842,10 +840,6 @@ protected
   Variability comp_var, comp_eff_var, bind_var, bind_eff_var;
   Component.Attributes attrs;
 algorithm
-  if InstNode.isEmpty(component) then
-    return;
-  end if;
-
   c := InstNode.component(node);
 
   () := match c
@@ -2473,10 +2467,6 @@ function typeComponentSections
 protected
   Component comp;
 algorithm
-  if InstNode.isEmpty(component) then
-    return;
-  end if;
-
   comp := InstNode.component(component);
 
   () := match comp


### PR DESCRIPTION
- Change ClassTree.flatten to completely remove duplicate components,
  instead of replacing them with empty nodes. This is slightly slower
  when there are duplicates since the lookup tree also needs to be
  updated, but removes the need to check for empty nodes when
  iterating over components (so probably faster in general since
  duplicate elements are not that common).

  This also fixes issues with field lookup in record expressions, which
  did not take into account the possibility of gaps in the component
  arrays for records with duplicate fields, leading to the expression
  for the wrong field sometimes being returned.