### PR TITLE
Add scripting API for conversion versions

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3862,6 +3862,18 @@ Returns the libraries used by the package {{\"Library1\",\"Version\"},{\"Library
   preferredView="text");
 end getUses;
 
+function getConversionsFromVersions
+  input TypeName pack;
+  output String[:] withoutConversion;
+  output String[:] withConversion;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+Returns the versions this library can convert from with and without conversions.
+</html>"),
+  preferredView="text");
+end getConversionsFromVersions;
+
 function getDerivedClassModifierNames "Returns the derived class modifier names.
   Example command:
   type Resistance = Real(final quantity=\"Resistance\",final unit=\"Ohm\");

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1951,6 +1951,7 @@ algorithm
       SimCode.SimulationSettings simSettings;
       Boolean dumpExtractionSteps, requireExactVersion;
       list<tuple<Absyn.Path,list<String>,Boolean>> uses;
+      list<String> withoutConversion, withConversion;
       Config.LanguageStandard oldLanguageStd;
       SCode.Element cl;
       list<SCode.Element> cls, elts;
@@ -2353,6 +2354,14 @@ algorithm
         (absynClass as Absyn.CLASS()) = Interactive.getPathedClassInProgram(classpath, SymbolTable.getAbsyn());
         uses = Interactive.getUsesAnnotation(Absyn.PROGRAM({absynClass},Absyn.TOP()));
         v = ValuesUtil.makeArray(List.map(uses,makeUsesArray));
+      then
+        (cache,v);
+
+    case (cache,_,"getConversionsFromVersions",{Values.CODE(Absyn.C_TYPENAME(classpath))},_)
+      equation
+        (absynClass as Absyn.CLASS()) = Interactive.getPathedClassInProgram(classpath, SymbolTable.getAbsyn());
+        (withoutConversion,withConversion) = Interactive.getConversionAnnotation(absynClass);
+        v = Values.TUPLE({ValuesUtil.makeArray(List.map(withoutConversion,ValuesUtil.makeString)), ValuesUtil.makeArray(List.map(withConversion,ValuesUtil.makeString))});
       then
         (cache,v);
 

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1080,6 +1080,10 @@ public constant ErrorTypes.Message SERIALIZED_SIZE = ErrorTypes.MESSAGE(5046, Er
   Gettext.gettext("%s uses %s of memory (%s without GC overhead; %s is consumed by not performing String sharing)."));
 public constant ErrorTypes.Message META_MATCH_CONSTANT = ErrorTypes.MESSAGE(5047, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("Match input %s is a constant value."));
+public constant ErrorTypes.Message CONVERSION_MISSING_FROM_VERSION = ErrorTypes.MESSAGE(5048, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  Gettext.gettext("Conversion-annotation is missing version for from-conversion: %s."));
+public constant ErrorTypes.Message CONVERSION_UNKNOWN_ANNOTATION = ErrorTypes.MESSAGE(5049, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  Gettext.gettext("Conversion-annotation contains unknown element: %s."));
 
 
 public constant ErrorTypes.Message COMPILER_ERROR = ErrorTypes.MESSAGE(5999, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),

--- a/testsuite/openmodelica/interactive-API/ConversionVersions.mos
+++ b/testsuite/openmodelica/interactive-API/ConversionVersions.mos
@@ -1,0 +1,28 @@
+// status: correct
+
+loadString("package P1
+  annotation(conversion(from(version={x,y,z})));
+end P1;");
+getConversionsFromVersions(P1);getErrorString();
+loadString("package P2
+  annotation(conversion(xfrom()));
+end P2;");
+getConversionsFromVersions(P2);getErrorString();
+loadString("package P3
+  annotation(conversion(noneFromVersion=\"1.2.3\",from(version=\"1.2.4\"),from(version={\"1.2.5\",\"1.2.6\"}),noneFromVersion=\"1.2.7\"));
+end P3;");
+getConversionsFromVersions(P3);getErrorString();
+
+// Result:
+// true
+// ({},{})
+// "[<interactive>:2:25-2:46:writable] Warning: Conversion-annotation is missing version for from-conversion: from(version = {x, y, z}).
+// "
+// true
+// ({},{})
+// "[<interactive>:2:25-2:32:writable] Warning: Conversion-annotation contains unknown element: xfrom.
+// "
+// true
+// ({"1.2.3","1.2.7"},{"1.2.4","1.2.5","1.2.6"})
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -18,6 +18,7 @@ Bug3979.mos \
 Bug4209.mos \
 Bug4248.mos \
 ConvertUnits.mos \
+ConversionVersions.mos \
 CopyClass.mos \
 choicesAllMatching.mos \
 DefaultComponentName.mos \


### PR DESCRIPTION
This allows for example to see which versions do not need to be
converted if a newer MSL is loaded.