### PR TITLE
Update Modelica.h

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Modelica.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Modelica.h
@@ -235,6 +235,6 @@ typedef ublas::matrix<double, ublas::column_major> matrix_t;
 #include <Core/DataExchange/SimDouble.h>
 #ifdef USE_REDUCE_DAE
 #include <Core/ReduceDAE/IReduceDAE.h>
-#include <core/ReduceDAE/ReduceDAESettings.h>
+#include <Core/ReduceDAE/ReduceDAESettings.h>
 #endif
 /** @} */ // end of group1


### PR DESCRIPTION
Typo. Core must be Capitalized in order to align with the folder structure. Issue Manifests only on Linux, because windows does not care for capitalization