### PR TITLE
filter string parameters that does not have constant string to modeldescription.xml

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -7947,23 +7947,19 @@ algorithm
   outBoolean := isConstWork(inExp);
 end isConst;
 
-public function isExpConstantString
-"Returns true if an expression is a string constant"
-  input DAE.Exp inExp;
-  output Boolean outBoolean;
-algorithm
-  outBoolean := match (inExp)
-    case (DAE.SCONST()) then true;
-    else false;
-  end match;
-end isExpConstantString;
-
 public function isEvaluatedConst
 "Returns true if an expression is really a constant scalar value. no calls, casts, or something"
   input DAE.Exp inExp;
   output Boolean outBoolean;
 algorithm
-  outBoolean := isEvaluatedConstWork(inExp,true);
+  outBoolean := match inExp
+    case DAE.ICONST() then true;
+    case DAE.RCONST() then true;
+    case DAE.BCONST() then true;
+    case DAE.SCONST() then true;
+    case DAE.ENUM_LITERAL() then true;
+    else false;
+  end match;
 end isEvaluatedConst;
 
 public function getEvaluatedConstInteger
@@ -7983,25 +7979,6 @@ algorithm
     else fail();
   end match;
 end getEvaluatedConstInteger;
-
-protected function isEvaluatedConstWork
-"Returns true if an expression is really constant"
-  input DAE.Exp inExp;
-  input Boolean inRes;
-  output Boolean outBoolean;
-algorithm
-  outBoolean := match (inExp,inRes)
-    local
-      DAE.Exp e;
-    case (_,false) then false;
-    case (DAE.ICONST(),_) then true;
-    case (DAE.RCONST(),_) then true;
-    case (DAE.BCONST(),_) then true;
-    case (DAE.SCONST(),_) then true;
-    case (DAE.ENUM_LITERAL(),_) then true;
-    else false;
-  end match;
-end isEvaluatedConstWork;
 
 protected function isConstWork
 "Returns true if an expression is constant"

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -7947,6 +7947,17 @@ algorithm
   outBoolean := isConstWork(inExp);
 end isConst;
 
+public function isExpConstantString
+"Returns true if an expression is a string constant"
+  input DAE.Exp inExp;
+  output Boolean outBoolean;
+algorithm
+  outBoolean := match (inExp)
+    case (DAE.SCONST()) then true;
+    else false;
+  end match;
+end isExpConstantString;
+
 public function isEvaluatedConst
 "Returns true if an expression is really a constant scalar value. no calls, casts, or something"
   input DAE.Exp inExp;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8008,6 +8008,12 @@ algorithm
   if not Flags.isSet(Flags.DUMP_FORCE_FMI_INTERNAL_VARIABLES) and (ComponentReference.isInternalCref(simVar.name) and not BackendVariable.isStateVar(dlowVar) and not BackendVariable.isClockedStateVar(dlowVar)) then
     simVar.exportVar := false;
   end if;
+
+  // always filter variables which are parameters of type string and does not have constant string expression as start value (i.e) start = SOME(DAE.Exp.SCONST())
+  if BackendVariable.isStringParam(dlowVar) and not Expression.isExpConstantString(Util.getOption(simVar.initialValue)) then
+    simVar.exportVar := false;
+  end if ;
+
   //print("\n name :" + ComponentReference.printComponentRefStr(simVar.name) + "===>" + anyString(simVar.varKind) + "\n");
   // If it is an input variable, we give it an index
   if (not isalias) and BackendVariable.isVarOnTopLevelAndInputNoDerInput(dlowVar) then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8009,10 +8009,10 @@ algorithm
     simVar.exportVar := false;
   end if;
 
-  // always filter variables which are parameters of type string and does not have constant string expression as start value (i.e) start = SOME(DAE.Exp.SCONST())
-  if BackendVariable.isStringParam(dlowVar) and not Expression.isExpConstantString(Util.getOption(simVar.initialValue)) then
+  // filter parameters of type string that doesn't have constant start values
+  if BackendVariable.isStringParam(dlowVar) and isSome(simVar.initialValue) and not Expression.isEvaluatedConst(Util.getOption(simVar.initialValue)) then
     simVar.exportVar := false;
-  end if ;
+  end if;
 
   //print("\n name :" + ComponentReference.printComponentRefStr(simVar.name) + "===>" + anyString(simVar.varKind) + "\n");
   // If it is an input variable, we give it an index


### PR DESCRIPTION
### Purpose
Filter the String Parameter that does not have constant string expression,  to be exported in modelDescription.xml , as the initial attribute of the these variables are "exact" and the start expression are not string constant and they cannot be exported to modeldescription.xml according to fmi-specification