### PR TITLE
[NF] Improve record call simplification.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -70,6 +70,7 @@ import Typing = NFTyping;
 import Util;
 import Subscript = NFSubscript;
 import Operator = NFOperator;
+import EvalFunction = NFEvalFunction;
 
 public
   uniontype CallAttributes
@@ -583,30 +584,8 @@ uniontype Call
     output Expression exp;
   algorithm
     exp := match call
-      local
-        Expression arg;
-        list<Expression> call_args, local_args, args;
-        list<Record.Field> fields;
-
-      case TYPED_CALL(arguments = call_args)
-        algorithm
-          local_args := Function.getLocalArguments(call.fn);
-          fields := Type.recordFields(ty);
-          args := {};
-
-          for field in fields loop
-            if Record.Field.isInput(field) then
-              arg :: call_args := call_args;
-            else
-              arg :: local_args := local_args;
-            end if;
-
-            args := arg :: args;
-          end for;
-
-          args := listReverseInPlace(args);
-        then
-          Expression.RECORD(Function.name(call.fn), ty, args);
+      case TYPED_CALL()
+        then EvalFunction.evaluateRecordConstructor(call.fn, ty, call.arguments, evaluate = false);
 
       else
         algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1271,6 +1271,23 @@ uniontype InstNode
     end match;
   end refEqual;
 
+  function refCompare
+    input InstNode node1;
+    input InstNode node2;
+    output Integer res;
+  algorithm
+    res := match (node1, node2)
+      case (CLASS_NODE(), CLASS_NODE())
+        then Util.referenceCompare(Pointer.access(node1.cls), Pointer.access(node2.cls));
+      case (COMPONENT_NODE(), COMPONENT_NODE())
+        then Util.referenceCompare(Pointer.access(node1.component), Pointer.access(node2.component));
+      case (CLASS_NODE(), COMPONENT_NODE())
+        then Util.referenceCompare(Pointer.access(node1.cls), Pointer.access(node2.component));
+      case (COMPONENT_NODE(), CLASS_NODE())
+        then Util.referenceCompare(Pointer.access(node1.component), Pointer.access(node2.cls));
+    end match;
+  end refCompare;
+
   function nameEqual
     input InstNode node1;
     input InstNode node2;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -83,6 +83,16 @@ encapsulated uniontype Field
       else false;
     end match;
   end isInput;
+
+  function name
+    input Field field;
+    output String name;
+  algorithm
+    name := match field
+      case INPUT() then field.name;
+      case LOCAL() then field.name;
+    end match;
+  end name;
 end Field;
 
 function instDefaultConstructor

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1625,5 +1625,19 @@ algorithm
   outTuple := if referenceEq(t1, t1_new) then inTuple else (t1_new, t2, t3);
 end applyTuple31;
 
+function referenceCompare<T1, T2>
+  "Returns -1, 0, or 1 depending on whether the memory address of ref1 is less,
+   equal, or greater than the address of ref2."
+  input T1 ref1;
+  input T2 ref2;
+  output Integer result;
+external "C" result = referenceCompareExt(ref1, ref2) annotation(Include="
+  static inline int referenceCompareExt(void *ref1, void *ref2)
+  {
+    return (ref1 < ref2) ? -1 : (ref1 > ref2);
+  }
+");
+end referenceCompare;
+
 annotation(__OpenModelica_Interface="util");
 end Util;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -709,6 +709,7 @@ RecordBinding3.mo \
 RecordBinding4.mo \
 RecordBinding5.mo \
 RecordBinding6.mo \
+RecordBinding7.mo \
 RecordConstructor1.mo \
 RecordConstructor2.mo \
 RecordExtends1.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordBinding7.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordBinding7.mo
@@ -1,0 +1,29 @@
+// name: RecordBinding7
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record R
+  Real x;
+  constant Real y = x / 2.0;
+  Real z;
+end R;
+
+model RecordBinding7
+  constant R r = R(1.0, 3.0);
+  constant Real x = r.x;
+  constant Real y = r.y;
+  constant Real z = r.z;
+end RecordBinding7;
+
+// Result:
+// class RecordBinding7
+//   constant Real r.x = 1.0;
+//   constant Real r.y = 0.5;
+//   constant Real r.z = 3.0;
+//   constant Real x = 1.0;
+//   constant Real y = 0.5;
+//   constant Real z = 3.0;
+// end RecordBinding7;
+// endResult


### PR DESCRIPTION
- Replace references to record fields in the bindings with the actual
  arguments when converting a record constructor call into a record
  expression.
- Use the InstNode:s themselves as keys in EvalFunction.ReplTree instead
  of just their names, to avoid incorrectly replacing references that
  just happens to have the same name.