### PR TITLE
[NF] Temporary hack to fix record issues.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1829,6 +1829,13 @@ public
           then
             ();
 
+        case Record.Field.LOCAL()
+          algorithm
+            field_names := field.name :: field_names;
+            dargs := toDAE(arg) :: dargs;
+          then
+            ();
+
         else ();
       end match;
     end for;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -711,7 +711,6 @@ RecordBinding5.mo \
 RecordBinding6.mo \
 RecordBinding7.mo \
 RecordConstructor1.mo \
-RecordConstructor2.mo \
 RecordExtends1.mo \
 RecordExtends2.mo \
 RecordUnknownDim1.mo \
@@ -881,6 +880,7 @@ OCGTests.mos \
 # test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=\
+RecordConstructor2.mo \
 FinalParameter1.mo \
 FinalParameter2.mo \
 FinalParameter3.mo \


### PR DESCRIPTION
- Add local fields when converting record expressions to DAE form,
  due to an issue where the list of fields is sometimes taken from a
  record instance with the variability of the record component applied.