### PR TITLE
Fixes for directionalDerivatives of C FMI

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -490,6 +490,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
   comp->_has_jacobian = 0;
   comp->fmiDerJac = NULL;
   if (comp->fmuData->callback->initialPartialFMIDER != NULL){
+    comp->fmiDerJac = (ANALYTIC_JACOBIAN*) functions->allocateMemory(1, sizeof(ANALYTIC_JACOBIAN));
     if (! comp->fmuData->callback->initialPartialFMIDER(comp->fmuData, comp->threadData, comp->fmiDerJac)) {
       comp->_has_jacobian = 1;
     }
@@ -529,7 +530,23 @@ void fmi2FreeInstance(fmi2Component c)
   freeLinearSystems(comp->fmuData, comp->threadData);
 #endif
   /* free data struct */
-  deInitializeDataStruc(comp->fmuData);
+  deInitializeDataStruc(comp->fmuData);     /* TODO: Use comp->functions->freeMemory inside deInitializeDataStruc to be FMI comform */
+
+  /* Free jacobian data */
+  if (comp->_has_jacobian == 1) {
+    /* TODO: Use comp->functions->freeMemory insted of free,
+     * but generated code uses malloc / calloc instead of comp->functions->allocateMemory */
+    free(comp->fmiDerJac->seedVars);
+    free(comp->fmiDerJac->resultVars);
+    free(comp->fmiDerJac->tmpVars);
+
+    free(comp->fmiDerJac->sparsePattern->leadindex);
+    free(comp->fmiDerJac->sparsePattern->index);
+    free(comp->fmiDerJac->sparsePattern->colorCols);
+    free(comp->fmiDerJac->sparsePattern);
+
+    comp->functions->freeMemory(comp->fmiDerJac);
+  }
 
   comp->functions->freeMemory(comp->fmuData->modelData->resourcesDir);
 

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -13,6 +13,7 @@ outputState.mos \
 reset_omc.mos \
 reset.mos \
 test03.mos \
+testDirectionalDerivatives.mos \
 
 FAILINGTESTFILES = \
 

--- a/testsuite/omsimulator/testDirectionalDerivatives.mos
+++ b/testsuite/omsimulator/testDirectionalDerivatives.mos
@@ -1,0 +1,68 @@
+// name:  testDirectionalDerivatives
+// keywords: FMI 2.0 fmi2GetDirectionalDerivative OMSimulator
+// status: correct
+// teardown_command: rm -rf temp_testDirectionalDerivatives/ test_res.mat directionalDerivatives.csv directionalDerivatives.lua directionalDerivatives_systemCall.log Modelica.Electrical.Analog.Examples.CauerLowPassAnalog.fmu Modelica_Electrical_Analog_Examples_CauerLowPassAnalog.log
+//
+// Test initialization, simulation with fmi2GetDirectionalDerivative and deinitialization of FMU with OMSimulator
+
+loadModel(Modelica);
+getErrorString();
+
+setCommandLineOptions("-d=newInst,-disableDirectionalDerivatives");
+getErrorString();
+
+// Build 2.0 FMU
+buildModelFMU(Modelica.Electrical.Analog.Examples.CauerLowPassAnalog, version="2.0", fmuType="me_cs", platforms={"static"});
+getErrorString();
+
+// Simulate with OMSimulator
+
+writeFile("directionalDerivatives.lua","
+oms_setCommandLineOption(\"--suppressPath=true\")
+oms_setTempDirectory(\"./temp_testDirectionalDerivatives/\")
+
+oms_newModel(\"test\")
+oms_addSystem(\"test.root\", oms_system_sc)
+oms_addSubModel(\"test.root.system1\", \"Modelica.Electrical.Analog.Examples.CauerLowPassAnalog.fmu\")
+
+oms_setResultFile(\"test\", \"directionalDerivatives.csv\")
+
+oms_instantiate(\"test\")
+
+oms_initialize(\"test\")
+print(\"info:    Initialization\")
+print(\"info:    system1.C1.v: \" .. oms_getReal(\"test.root.system1.C1.v\"))
+
+oms_simulate(\"test\")
+print(\"info:    Simulation\")
+print(\"info:    system1.C1.v: \" .. oms_getReal(\"test.root.system1.C1.v\"))
+
+oms_terminate(\"test\");
+oms_delete(\"test\");
+"); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator directionalDerivatives.lua", "directionalDerivatives_systemCall.log");
+readFile("directionalDerivatives_systemCall.log");
+
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "Modelica.Electrical.Analog.Examples.CauerLowPassAnalog.fmu"
+// ""
+// true
+// ""
+// 0
+// "info:    maximum step size for 'test.root': 0.100000
+// info:    Result file: directionalDerivatives.csv (bufferSize=1)
+// info:    Initialization
+// info:    system1.C1.v: 0.0
+// info:    Simulation
+// info:    system1.C1.v: 6.2188841112434e-26
+// info:    Final Statistics for 'test.root':
+//          NumSteps = 12 NumRhsEvals  = 13 NumLinSolvSetups = 3
+//          NumNonlinSolvIters = 12 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// "
+// endResult


### PR DESCRIPTION
Fix for ticket 5889

  - Always write providesDirectionalDerivative=true or
    providesDirectionalDerivative=false to modelDescription.xml for FMUs.
  - Allocate and free memory for directional derivatives in C FMI
  - Added test to initilaize, simulate and deinitialize C FMU with
    OMSimulator and `-disableDirectionalDerivatives`
  - Updated tests