### PR TITLE
[NF] Improve constants/parameters in records.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -726,9 +726,7 @@ algorithm
     args := arg :: args;
   end for;
 
-  fields := Record.collectRecordFields(typeNode);
-  ty := Type.setRecordFields(fields, recordType);
-  exp := Expression.RECORD(InstNode.scopePath(recordNode), ty, args);
+  exp := Expression.makeRecord(InstNode.scopePath(recordNode), recordType, args);
 end makeRecordBindingExp;
 
 function splitRecordArrayExp
@@ -739,7 +737,7 @@ protected
   list<Expression> expl;
 algorithm
   Expression.RECORD(path, ty, expl) := exp;
-  exp := Expression.RECORD(path, Type.arrayElementType(ty), expl);
+  exp := Expression.makeRecord(path, Type.arrayElementType(ty), expl);
   exp := Expression.fillType(ty, exp);
 end splitRecordArrayExp;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -158,14 +158,13 @@ uniontype Class
   end fromEnumeration;
 
   function makeRecordConstructor
-    input list<InstNode> inputs;
-    input list<InstNode> locals;
+    input list<InstNode> fields;
     input InstNode out;
     output Class cls;
   protected
     ClassTree tree;
   algorithm
-    tree := ClassTree.fromRecordConstructor(inputs, locals, out);
+    tree := ClassTree.fromRecordConstructor(fields, out);
     cls := INSTANCED_CLASS(Type.UNKNOWN(), tree, Sections.EMPTY(), Restriction.RECORD_CONSTRUCTOR());
   end makeRecordConstructor;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -736,8 +736,7 @@ public
     end instantiate;
 
     function fromRecordConstructor
-      input list<InstNode> inputs;
-      input list<InstNode> locals;
+      input list<InstNode> fields;
       input InstNode out;
       output ClassTree tree = EMPTY;
     protected
@@ -745,17 +744,11 @@ public
       Integer i = 1;
       array<InstNode> comps;
     algorithm
-      comps := arrayCreateNoInit(listLength(inputs) + listLength(locals) + 1, InstNode.EMPTY_NODE());
+      comps := arrayCreateNoInit(listLength(fields) + 1, InstNode.EMPTY_NODE());
 
-      for ci in inputs loop
+      for ci in fields loop
         comps[i] := ci;
         ltree := addLocalElement(InstNode.name(ci), LookupTree.Entry.COMPONENT(i), tree, ltree);
-        i := i + 1;
-      end for;
-
-      for cl in locals loop
-        comps[i] := cl;
-        ltree := addLocalElement(InstNode.name(cl), LookupTree.Entry.COMPONENT(i), tree, ltree);
         i := i + 1;
       end for;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -243,7 +243,7 @@ algorithm
   end for;
 
   // Create a new record expression from the list of arguments.
-  result := Expression.RECORD(Function.name(fn), ty, listReverseInPlace(expl));
+  result := Expression.makeRecord(Function.name(fn), ty, listReverseInPlace(expl));
 
   // Constant evaluate the expression if requested.
   if evaluate then
@@ -321,7 +321,7 @@ algorithm
   result := match ty
     case Type.ARRAY() guard Type.hasKnownSize(ty)
       then Expression.fillType(ty, Expression.EMPTY(Type.arrayElementType(ty)));
-    case Type.COMPLEX() then buildRecordBinding(ty.cls, repl);
+    case Type.COMPLEX() then buildRecordBinding(node, repl);
     else Expression.EMPTY(ty);
   end match;
 end buildBinding;
@@ -350,7 +350,8 @@ function buildRecordBinding
   input ReplTree.Tree repl;
   output Expression result;
 protected
-  Class cls = InstNode.getClass(recordNode);
+  InstNode cls_node = InstNode.classScope(recordNode);
+  Class cls = InstNode.getClass(cls_node);
   array<InstNode> comps;
   list<Expression> bindings;
   Expression exp;
@@ -364,7 +365,7 @@ algorithm
           bindings := Expression.makeMutable(getBindingExp(comps[i], repl)) :: bindings;
         end for;
       then
-        Expression.RECORD(InstNode.scopePath(recordNode), cls.ty, bindings);
+        Expression.makeRecord(InstNode.scopePath(cls_node), cls.ty, bindings);
 
     case Class.TYPED_DERIVED() then buildRecordBinding(cls.baseClass, repl);
   end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1048,6 +1048,15 @@ public
     exp := makeArray(ty, elements, isLiteral);
   end makeExpArray;
 
+  function makeRecord
+    input Absyn.Path recordName;
+    input Type recordType;
+    input list<Expression> fields;
+    output Expression exp;
+  algorithm
+    exp := RECORD(recordName, recordType, fields);
+  end makeRecord;
+
   function applySubscripts
     "Subscripts an expression with the given list of subscripts."
     input list<Subscript> subscripts;
@@ -1829,6 +1838,9 @@ public
           then
             ();
 
+        // TODO: Constants/parameters shouldn't be added to record expressions
+        //       since that causes issues with the backend, but removing them
+        //       currently causes even worse issues.
         case Record.Field.LOCAL()
           algorithm
             field_names := field.name :: field_names;
@@ -5173,7 +5185,7 @@ public
             fields := CREF(ty, field_cr) :: fields;
           end for;
         then
-          RECORD(InstNode.scopePath(cls), outExp.ty, fields);
+          makeRecord(InstNode.scopePath(cls), outExp.ty, fields);
 
       case ARRAY()
         algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2216,8 +2216,7 @@ protected
 algorithm
   cls_node := if SCodeUtil.isOperatorRecord(InstNode.definition(node))
     then InstNode.classScope(node) else InstNode.classScope(InstNode.getDerivedNode(node));
-  fields := Record.collectRecordFields(cls_node);
-  ty := ComplexType.RECORD(cls_node, fields);
+  ty := ComplexType.RECORD(cls_node, {});
 end makeRecordComplexType;
 
 function instComplexType

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
@@ -236,7 +236,7 @@ protected
     outExp := match exp
       case Expression.CALL(call = Call.TYPED_CALL(fn = fn, ty = ty, arguments = args))
         guard referenceEq(constructorFn.node, fn.node)
-        then Expression.RECORD(Function.name(constructorFn), ty, args);
+        then Expression.makeRecord(Function.name(constructorFn), ty, args);
 
       else exp;
     end match;


### PR DESCRIPTION
- Fill in the list of fields in record types during typing instead of
  during instantiation, to make sure the fields are collected from the
  instantiated record constructor and not a component node (which might
  have variability applied).
- Retain the order of variables in record constructors instead of
  adding constants/parameters last, since that causes issues when
  evaluating record constructors.