### PR TITLE
[NF] Fix node type of derived nodes.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -682,7 +682,6 @@ algorithm
   res := Restriction.fromSCode(SCodeUtil.getClassRestriction(element));
   cls := Class.EXPANDED_DERIVED(ext_node, mod, listArray(dims), prefs, attrs, res);
   node := InstNode.updateClass(cls, node);
-  node := InstNode.setNodeType(InstNodeType.DERIVED_CLASS(InstNode.nodeType(node)), node);
 end expandClassDerived;
 
 function instDerivedAttributes
@@ -808,6 +807,7 @@ algorithm
     case Class.EXPANDED_DERIVED()
       algorithm
         (node, par) := ClassTree.instantiate(node, parent);
+        node := InstNode.setNodeType(InstNodeType.DERIVED_CLASS(InstNode.nodeType(node)), node);
         Class.EXPANDED_DERIVED(baseClass = base_node) := InstNode.getClass(node);
 
         // Merge outer modifiers and attributes.

--- a/testsuite/flattening/modelica/scodeinst/ExtendsShort3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExtendsShort3.mo
@@ -1,0 +1,42 @@
+// name: ExtendsShort2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+package P1
+  package P2
+    model B
+      Real x;
+    equation
+      P3.f(x);
+    end B;
+  end P2;
+
+  package P3
+    function f
+      input Real x;
+    end f;
+  end P3;
+end P1;
+
+model ExtendsShort3
+  model M = P1.P2.B;
+  M a1;
+  M a2;
+end ExtendsShort3;
+
+// Result:
+// function P1.P3.f
+//   input Real x;
+// end P1.P3.f;
+//
+// class ExtendsShort3
+//   Real a1.x;
+//   Real a2.x;
+// equation
+//   P1.P3.f(a1.x);
+//   P1.P3.f(a2.x);
+// end ExtendsShort3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -373,6 +373,7 @@ ExtendSelf3.mo \
 ExtendsMod1.mo \
 ExtendsShort1.mo \
 ExtendsShort2.mo \
+ExtendsShort3.mo \
 ExtendsVisibility1.mo \
 ExtendsVisibility2.mo \
 ExtendsVisibility3.mo \


### PR DESCRIPTION
- Set the node type for derived nodes during instantiation instead of
  during expansion, since expansion only changes the class the node
  points to and not the node itself (which results in the node type not
  being set if the expanded class is reused).