### PR TITLE
[NF] Flat Modelica improvements.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -708,6 +708,11 @@ public
       case CREF()
         algorithm
           str := InstNode.name(cref.node) + Subscript.toFlatStringList(cref.subscripts);
+
+          if Type.isRecord(cref.ty) and not listEmpty(strl) then
+            strl := ("'" + listHead(strl)) :: listRest(strl);
+            str := str + "'";
+          end if;
         then
           toFlatString_impl(cref.restCref, str :: strl);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1651,7 +1651,7 @@ public
       case BOOLEAN() then boolString(exp.value);
 
       case ENUM_LITERAL(ty = t as Type.ENUMERATION())
-        then AbsynUtil.pathString(t.typePath) + "." + exp.name;
+        then "'" + AbsynUtil.pathString(t.typePath) + "'." + exp.name;
 
       case CLKCONST(clk) then ClockKind.toString(clk);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -177,7 +177,6 @@ algorithm
 
   if Flags.getConfigBool(Flags.FLAT_MODELICA) then
     FlatModel.printFlatString(flat_model, FunctionTree.listValues(funcs));
-    print("\n");
   end if;
 
   // Scalarize array components in the flat model.

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -207,6 +207,7 @@ public
   protected
     Boolean first;
     Binding b;
+    Integer var_dims, binding_dims;
   algorithm
     s := IOStream.append(s, indent);
 
@@ -223,6 +224,8 @@ public
       s := IOStream.append(s, "(");
 
       first := true;
+      var_dims := Type.dimensionCount(var.ty);
+
       for a in var.typeAttributes loop
         if first then
           first := false;
@@ -231,8 +234,9 @@ public
         end if;
 
         b := Util.tuple22(a);
+        binding_dims := Type.dimensionCount(Expression.typeOf(Expression.getBindingExp(Binding.getExp(b))));
 
-        if Binding.isEach(b) then
+        if var_dims > binding_dims then
           s := IOStream.append(s, "each ");
         end if;
 


### PR DESCRIPTION
- Reconstruct record instances from the field variables before dumping
  the flat model.
- Split component references at record boundaries when dumping them
  (i.e. 'R'.'T' instead of 'R.T').
- Quote the type name when dumping enumeration literal expressions.
- Fix dumping of 'each' for type attributes.