### PR TITLE
[NF] Record improvements.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -694,6 +694,23 @@ uniontype Class
     end if;
   end hasOperator;
 
+  function makeRecordExp
+    input InstNode clsNode;
+    output Expression exp;
+  protected
+    Class cls;
+    Type ty;
+    InstNode ty_node;
+    array<InstNode> fields;
+    list<Expression> args;
+  algorithm
+    cls := InstNode.getClass(clsNode);
+    ty as Type.COMPLEX(complexTy = ComplexType.RECORD(ty_node)) := getType(cls, clsNode);
+    fields := ClassTree.getComponents(classTree(cls));
+    args := list(Binding.getExp(Component.getImplicitBinding(InstNode.component(f))) for f in fields);
+    exp := Expression.makeRecord(InstNode.scopePath(ty_node), ty, args);
+  end makeRecordExp;
+
   function toFlatStream
     input Class cls;
     input InstNode clsNode;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -453,6 +453,31 @@ uniontype Component
     end match;
   end getBinding;
 
+  function getImplicitBinding
+    "Returns the component's binding. If the component does not have a binding
+     and is a record instance it will try to create a binding from the
+     component's children."
+    input Component component;
+    output Binding binding;
+  protected
+    InstNode cls_node;
+    Expression record_exp;
+  algorithm
+    binding := getBinding(component);
+
+    if Binding.isUnbound(binding) then
+      cls_node := classInstance(component);
+
+      if InstNode.isRecord(cls_node) then
+        try
+          record_exp := Class.makeRecordExp(cls_node);
+          binding := Binding.FLAT_BINDING(record_exp, Expression.variability(record_exp));
+        else
+        end try;
+      end if;
+    end if;
+  end getImplicitBinding;
+
   function setBinding
     input Binding binding;
     input output Component component;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -77,6 +77,7 @@ import Array;
 import ElementSource;
 import SCodeUtil;
 import IOStream;
+import ComplexType = NFComplexType;
 
 public
 type NamedArg = tuple<String, Expression>;
@@ -1969,7 +1970,7 @@ protected
   algorithm
     try
       comp := InstNode.component(component);
-      default := Binding.typedExp(Component.getBinding(comp));
+      default := Binding.typedExp(Component.getImplicitBinding(comp));
       name := InstNode.name(component);
 
       // Remove $in_ for OM input output arguments.

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -712,7 +712,9 @@ RecordBinding4.mo \
 RecordBinding5.mo \
 RecordBinding6.mo \
 RecordBinding7.mo \
+RecordBinding8.mo \
 RecordConstructor1.mo \
+RecordConstructor2.mo \
 RecordExtends1.mo \
 RecordExtends2.mo \
 RecordUnknownDim1.mo \
@@ -882,7 +884,6 @@ OCGTests.mos \
 # test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=\
-RecordConstructor2.mo \
 FinalParameter1.mo \
 FinalParameter2.mo \
 FinalParameter3.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordBinding8.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordBinding8.mo
@@ -1,0 +1,32 @@
+// name: RecordBinding8
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record R1
+  Real x = 1.0;
+end R1;
+
+record R2
+  R1 r1;
+end R2;
+
+function f
+  input R2 r2;
+  output Real x = r2.r1.x;
+end f;
+
+model RecordBinding8
+  Real x;
+equation
+  x = f();
+end RecordBinding8;
+
+// Result:
+// class RecordBinding8
+//   Real x;
+// equation
+//   x = 1.0;
+// end RecordBinding8;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/RecordConstructor2.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordConstructor2.mo
@@ -29,6 +29,6 @@ end RecordConstructor2;
 //   Real r.x;
 //   constant Real r.y = 1.0;
 // algorithm
-//   r := R(time);
+//   r := R(time, 1.0);
 // end RecordConstructor2;
 // endResult


### PR DESCRIPTION
- Fix evaluation of record field crefs so that getting the binding from
  the parent's parent (and so on) works properly.
- When determining the default argument for a function parameter of
  record type, try to create an argument from the record's fields if the
  parameter itself does not have a binding.