### PR TITLE
[NF] Fix Type.setArrayElementType.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -544,7 +544,7 @@ public
     output Type ty;
   algorithm
     ty := match arrayTy
-      case ARRAY() then ARRAY(elementTy, arrayTy.dimensions);
+      case ARRAY() then liftArrayLeftList(elementTy, arrayTy.dimensions);
       else elementTy;
     end match;
   end setArrayElementType;


### PR DESCRIPTION
- Use liftArrayLeftList in setArrayElementType instead of just creating
  a new array type, to avoid creating nested array types when the
  element type itself is an array.