### PR TITLE
[NF] Fix eval of record field with parent binding.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5254,6 +5254,8 @@ public
         then Expression.bindingExpMap(recordExp,
           function recordElement(elementName = elementName));
 
+      case EMPTY() then fail();
+
       else
         algorithm
           ty := typeOf(recordExp);


### PR DESCRIPTION
- Use the one true record field lookup function Expression.recordElement
  instead of buggy knockoff functions.