### PR TITLE
Add API for a package manager

### DIFF
--- a/.openmodelica.aspell
+++ b/.openmodelica.aspell
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 74 UTF-8
+personal_ws-1.1 en 75 UTF-8
 subscripted
 UTF
 RML
@@ -72,3 +72,4 @@ evalRecursionLimit
 cgraphGraphVizFile
 cardinality
 URI
+SHA

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         stage('gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.13-qt4-xenial'
+              image 'docker.openmodelica.org/build-deps:v1.16-qt4-xenial'
               label 'linux'
               alwaysPull true
               args "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
@@ -64,7 +64,7 @@ pipeline {
         stage('clang') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
               args "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
@@ -135,7 +135,7 @@ pipeline {
         stage('checks') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
               args "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
@@ -318,7 +318,7 @@ pipeline {
         stage('build-gui-clang-qt5') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
             }
@@ -334,7 +334,7 @@ pipeline {
         stage('build-gui-gcc-qt4') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.13-qt4-xenial'
+              image 'docker.openmodelica.org/build-deps:v1.16-qt4-xenial'
               label 'linux'
               alwaysPull true
             }
@@ -387,7 +387,7 @@ pipeline {
         stage('testsuite-clang-parmod') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
               // No runtest.db cache necessary; the tests run in serial and do not load libraries!
@@ -409,7 +409,7 @@ pipeline {
         stage('testsuite-clang-metamodelica') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
             }
           }
@@ -427,7 +427,7 @@ pipeline {
         stage('testsuite-matlab-translator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
             }
@@ -449,7 +449,7 @@ pipeline {
         stage('test-clang-icon-generator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               args "--mount type=volume,source=runtest-clang-icon-generator,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -480,7 +480,7 @@ pipeline {
         stage('clang-qt5') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
             }
@@ -573,7 +573,7 @@ pipeline {
         stage('fmuchecker-results') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
             }
@@ -599,7 +599,7 @@ pipeline {
         stage('upload-compliance') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
             }
@@ -617,7 +617,7 @@ pipeline {
         stage('upload-doc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.15'
+              image 'docker.openmodelica.org/build-deps:v1.16'
               label 'linux'
               alwaysPull true
             }

--- a/OMCompiler/COPYING
+++ b/OMCompiler/COPYING
@@ -314,3 +314,7 @@ or online http://opensource.org/licenses/LGPL-2.1.
            This product includes software developed by the University of Chicago,
            as Operator of Argonne National Laboratory.
            Disclaimer: http://www.netlib.org/minpack/disclaimer
+
+Dynamically links against (not exhaustive):
+
+[MIT-like] libcurl

--- a/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
@@ -51,6 +51,7 @@ import Error;
 import Flags;
 import HashTableStringToProgram;
 import List;
+import PackageManagement;
 import Parser;
 import Settings;
 import System;
@@ -143,28 +144,31 @@ protected
   String mp, name, pwd, cmd, version, userLibraries;
   Boolean isDir, impactOK;
   Absyn.Class cl;
+  list<String> versionsThatProvideTheWanted, commands;
 algorithm
   try
     (mp,name,isDir) := System.getLoadModelPath(id,prios,mps,requireExactVersion);
   else
-    pwd := System.pwd();
-    userLibraries := Settings.getHomeDir(Testsuite.isRunning()) + "/.openmodelica/libraries/";
-    true := System.directoryExists(userLibraries);
-    true := listMember(userLibraries, mps);
-    System.cd(userLibraries);
     version := match prios
-      case version::_ guard version <> "default" then version;
-      else "";
+      case version::_ then version;
+      else "default";
     end match;
-    cmd := "impact install \"" + id + (if version<>"" then "#" + version else "") + "\"";
-    impactOK := 0==System.systemCall(cmd, "/dev/null");
-    System.cd(pwd);
-    if impactOK then
-      Error.addMessage(Error.NOTIFY_IMPACT_FOUND, {id, (if version <> "" then (" "+version) else ""), userLibraries});
-      (mp,name,isDir) := System.getLoadModelPath(id,prios,mps,true);
-    else
-      fail();
+    versionsThatProvideTheWanted := PackageManagement.versionsThatProvideTheWanted(id, version, printError=false);
+    if not listEmpty(versionsThatProvideTheWanted) then
+      if version=="default" or version=="" then
+        commands := {"  packageInstall("+id+")"};
+      else
+        commands := {
+          "  packageInstall("+id+", \""+version+"\", exactMatch=false)",
+          "  packageInstall("+id+", \""+version+"\", exactMatch="+String(listMember(version,versionsThatProvideTheWanted))+")"
+        };
+      end if;
+      if listHead(versionsThatProvideTheWanted) <> version then
+        commands := "  packageInstall("+id+", \""+listHead(versionsThatProvideTheWanted)+"\", exactMatch=true)" :: commands;
+      end if;
+      Error.addMessage(Error.NOTIFY_PKG_FOUND, {stringDelimitList(commands, "\n")});
     end if;
+    fail();
   end try;
   // print("System.getLoadModelPath: " + id + " {" + stringDelimitList(prios,",") + "} " + stringDelimitList(mps,",") + " => " + mp + " " + name + " " + boolString(isDir));
   Config.setLanguageStandardFromMSL(name);

--- a/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
@@ -53,7 +53,6 @@ import HashTableStringToProgram;
 import List;
 import PackageManagement;
 import Parser;
-import Settings;
 import System;
 import Testsuite;
 import Util;

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3851,6 +3851,44 @@ annotation(
   preferredView="text");
 end getAvailableLibraries;
 
+function installPackage
+  input TypeName pkg;
+  input String version = "";
+  input Boolean exactMatch = false;
+  output Boolean result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Installs the package with the best matching version (or only the specified version if exactMatch is given).
+  To update the index, call <code>updatePackageIndex()</code>.
+</html>"),
+  preferredView="text");
+end installPackage;
+
+function updatePackageIndex
+  output Boolean result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Updates the package index from the internet.
+  This adds new packages to be able to install or upgrade packages.
+  To upgrade installed packages, call <code>upgradeInstalledPackages()</code>.
+</html>"),
+  preferredView="text");
+end updatePackageIndex;
+
+function upgradeInstalledPackages
+  input Boolean installNewestVersions = true;
+  output Boolean result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Upgrades installed packages that have been registered by the package manager.
+  To update the index, call <code>updatePackageIndex()</code>.
+</html>"),
+  preferredView="text");
+end upgradeInstalledPackages;
+
 function getUses
   input TypeName pack;
   output String[:,:] uses;

--- a/OMCompiler/Compiler/Global/Global.mo
+++ b/OMCompiler/Compiler/Global/Global.mo
@@ -68,6 +68,7 @@ constant Integer optionSimCode = 24;
 constant Integer interactiveCache = 25;
 constant Integer isInStream = 26;
 constant Integer MMToJLListIndex = 27;
+constant Integer packageIndexCacheIndex = 28;
 
 // indexes in System.tick
 // ----------------------

--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -89,6 +89,12 @@ end FALSE;
 record NULL
 end NULL;
 
+function emptyObject
+  output JSON obj;
+algorithm
+  obj := OBJECT({},{},AvlTree.EMPTY());
+end emptyObject;
+
 function toString
   input JSON value;
   output String str;
@@ -124,6 +130,45 @@ algorithm
   reportErrors(errTokens);
   value := parse_value_check_empty(tokens);
 end parseFile;
+
+function hasKey
+  input JSON obj;
+  input String str;
+  output Boolean b;
+algorithm
+  b := match obj
+    case OBJECT() then AvlTree.hasKey(obj.dict, str);
+  end match;
+end hasKey;
+
+function get
+  input JSON obj;
+  input String str;
+  output JSON out;
+algorithm
+  out := match obj
+    case OBJECT() then AvlTree.get(obj.dict, str);
+  end match;
+end get;
+
+function getOrDefault
+  input JSON obj;
+  input String str;
+  input JSON default;
+  output JSON out;
+algorithm
+  out := matchcontinue obj
+    case OBJECT() then AvlTree.get(obj.dict, str);
+    else default;
+  end matchcontinue;
+end getOrDefault;
+
+function getString
+  input JSON obj;
+  output String str;
+algorithm
+  JSON.STRING(str) := obj;
+end getString;
 
 function parse
   input String content;

--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -1,0 +1,535 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2020, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package PackageManagement
+
+import BaseAvlTree;
+import BaseAvlSet;
+import JSON;
+import SemanticVersion;
+
+protected
+
+import Autoconf;
+import Curl;
+import Error;
+import Global;
+import List;
+import Settings;
+import System;
+import Testsuite;
+import Util;
+import Unzip;
+
+public
+
+encapsulated package AvailableLibraries
+  import BaseAvlTree;
+  import VersionMap;
+  extends BaseAvlTree;
+  redeclare type Key = String;
+  redeclare type Value = PackageManagement.VersionMap.Tree;
+  redeclare function extends keyStr
+  algorithm
+    outString := inKey;
+  end keyStr;
+  redeclare function extends valueStr
+  algorithm
+    outString := PackageManagement.VersionMap.printTreeStr(inValue);
+  end valueStr;
+  redeclare function extends keyCompare
+  algorithm
+    outResult := stringCompare(inKey1, inKey2);
+  end keyCompare;
+end AvailableLibraries;
+
+encapsulated package VersionMap
+  import BaseAvlTree;
+  import SemanticVersion;
+  extends BaseAvlTree;
+  redeclare type Key = SemanticVersion.Version;
+  redeclare type Value = String;
+  redeclare function extends keyStr
+  algorithm
+    outString := SemanticVersion.toString(inKey);
+  end keyStr;
+  redeclare function extends valueStr
+  algorithm
+    outString := inValue;
+  end valueStr;
+  redeclare function extends keyCompare
+  algorithm
+    outResult := SemanticVersion.compare(inKey1, inKey2, compareBuildInformation=true);
+  end keyCompare;
+end VersionMap;
+
+constant String metaDataFileName = "openmodelica.metadata.json";
+
+function getInstalledLibraries
+  output AvailableLibraries.Tree tree;
+protected
+  String mp, gd, first, ver, lib;
+  list<String> mps, files, dirs, rest;
+  VersionMap.Tree versions;
+algorithm
+  mp := Settings.getModelicaPath(Testsuite.isRunning());
+  gd := Autoconf.groupDelimiter;
+  mps := System.strtok(mp, gd);
+  tree := AvailableLibraries.new();
+  files := {};
+  dirs := {};
+  for mp in mps loop
+    files := listAppend(list(mp + "/" + file for file in System.moFiles(mp)), files);
+    dirs := listAppend(list(mp + "/" + dir for dir in getLibrarySubdirectories(mp)), dirs);
+  end for;
+  for path in listAppend(files, dirs) loop
+    lib := System.basename(path);
+    if Util.endsWith(lib, ".mo") then
+      lib := Util.removeLast3Char(lib);
+    end if;
+    first::rest := System.strtok(lib, " ");
+    ver := stringDelimitList(rest, " ");
+    versions := if AvailableLibraries.hasKey(tree, first) then AvailableLibraries.get(tree, first) else VersionMap.new();
+    versions := VersionMap.add(versions, SemanticVersion.parse(ver), path, conflictFunc=VersionMap.addConflictReplace);
+    tree := AvailableLibraries.add(tree, first, versions, conflictFunc=AvailableLibraries.addConflictReplace);
+  end for;
+end getInstalledLibraries;
+
+function getLibrarySubdirectories "This function returns a list of subdirectories that contain a package.mo file."
+  input String inPath;
+  output list<String> outSubdirectories = {};
+protected
+  list<String> allSubdirectories = System.subDirectories(inPath);
+  String pd = Autoconf.pathDelimiter;
+algorithm
+  for dir in allSubdirectories loop
+    if System.regularFileExists(inPath + pd + dir + pd + "package.mo") then
+      outSubdirectories := dir::outSubdirectories;
+    end if;
+  end for;
+end getLibrarySubdirectories;
+
+function providesExpectedVersion
+  input String version;
+  input JSON provides;
+  input SemanticVersion.Version wantedVersion;
+  output Boolean matches;
+protected
+  list<JSON> providedVersions;
+  String str;
+algorithm
+  _ := match wantedVersion
+    case SemanticVersion.NONSEMVER(str) guard str == "default" or str == ""
+      algorithm
+        matches := true; /* Any version matches the empty */
+        return;
+      then fail();
+    else ();
+  end match;
+  JSON.ARRAY(providedVersions) := provides;
+  matches := false;
+  for v in JSON.STRING(version)::providedVersions loop
+    JSON.STRING(str) := v;
+    if SemanticVersion.compare(SemanticVersion.parse(str),wantedVersion) == 0 then
+      matches := true;
+      return;
+    end if;
+  end for;
+end providesExpectedVersion;
+
+constant list<String> supportLevels = {"fullSupport", "support", "experimental", "obsolete", "unknown", "noSupport"};
+type SupportLevel = enumeration(noSupport, unknown, obsolete, experimental, support, fullSupport);
+
+function getSupportLevel
+  input JSON obj;
+  output SupportLevel support;
+algorithm
+  support := match obj
+    case JSON.STRING("fullSupport") then SupportLevel.fullSupport;
+    case JSON.STRING("support") then SupportLevel.support;
+    case JSON.STRING("experimental") then SupportLevel.experimental;
+    case JSON.STRING("obsolete") then SupportLevel.obsolete;
+    case JSON.STRING("unknown") then SupportLevel.unknown;
+    case JSON.STRING("noSupport") then SupportLevel.noSupport;
+    else
+      algorithm
+        Error.addInternalError("Unknown support level " + JSON.toString(obj), sourceInfo());
+      then fail();
+  end match;
+end getSupportLevel;
+
+function compareVersionsAndSupportLevel
+  input tuple<String,SemanticVersion.Version,SupportLevel> x1, x2;
+  output Boolean c;
+protected
+  SupportLevel s1, s2;
+  SemanticVersion.Version v1, v2;
+algorithm
+  (_, v1, s1) := x1;
+  (_, v2, s2) := x2;
+  if s1 < s2 then
+    c := true;
+    return;
+  elseif s1 > s2 then
+    c := false;
+    return;
+  end if;
+  if SemanticVersion.isPrerelease(v1) <> SemanticVersion.isPrerelease(v2) then
+    c := SemanticVersion.isPrerelease(v2);
+    return;
+  end if;
+  c := SemanticVersion.compare(v1, v2, compareBuildInformation=true) < 0;
+end compareVersionsAndSupportLevel;
+
+function updateIndex
+  output Boolean success;
+protected
+  String userLibraries, packageIndex;
+  constant String url = "https://libraries.openmodelica.org/index/v1/index.json";
+algorithm
+  userLibraries := getUserLibraryPath();
+  Util.createDirectoryTree(userLibraries);
+  packageIndex := userLibraries + "index.json";
+  if not Curl.multiDownload({(url,packageIndex)}) then
+    Error.addMessage(Error.ERROR_PKG_INDEX_FAILED_DOWNLOAD, {url,packageIndex});
+    success := false;
+  else
+    Error.addSourceMessage(Error.NOTIFY_PKG_INDEX_DOWNLOAD, {url}, makeSourceInfo(getIndexPath()));
+    success := true;
+  end if;
+  setGlobalRoot(Global.packageIndexCacheIndex, 0);
+end updateIndex;
+
+function upgradeInstalledPackages
+  input Boolean installNewestVersions;
+  output Boolean success;
+protected
+  AvailableLibraries.Tree installedLibraries;
+  VersionMap.Tree versions;
+algorithm
+  success := true;
+  installedLibraries := getInstalledLibraries();
+  for pkg in AvailableLibraries.listKeys(installedLibraries) loop
+    versions := AvailableLibraries.get(installedLibraries, pkg);
+    for version in VersionMap.listKeys(versions) loop
+      success := success and installPackage(pkg, SemanticVersion.toString(version), exactMatch=true);
+    end for;
+    if installNewestVersions then
+      success := success and installPackage(pkg, "", exactMatch=false);
+    end if;
+  end for;
+end upgradeInstalledPackages;
+
+function getPackageIndex
+  input Boolean printError;
+  output JSON obj;
+protected
+  String userLibraries, packageIndex, gd, mp;
+  list<String> mps;
+algorithm
+  try
+    obj := getGlobalRoot(Global.packageIndexCacheIndex);
+    return;
+  else
+  end try;
+  mp := Settings.getModelicaPath(Testsuite.isRunning());
+  gd := Autoconf.groupDelimiter;
+  mps := System.strtok(mp, gd);
+  userLibraries := getUserLibraryPath();
+  packageIndex := userLibraries + "index.json";
+  obj := JSON.emptyObject();
+  if not listMember(userLibraries, mps) then
+    if printError then
+      Error.addMessage(Error.ERROR_PKG_INDEX_NOT_ON_PATH, {mp, userLibraries});
+    end if;
+    return;
+  end if;
+  if not System.regularFileExists(packageIndex) then
+    if not updateIndex() then
+      return;
+    end if;
+  end if;
+  try
+    obj := JSON.parseFile(packageIndex);
+    setGlobalRoot(Global.packageIndexCacheIndex, obj);
+  else
+    Error.addSourceMessage(Error.ERROR_PKG_INDEX_NOT_PARSED, {packageIndex}, makeSourceInfo(getIndexPath()));
+  end try;
+end getPackageIndex;
+
+function versionsThatProvideTheWanted
+  input String id;
+  input String version;
+  input Boolean printError;
+  output list<String> result;
+protected
+  JSON obj, libobject, vers;
+  list<String> versions;
+  SemanticVersion.Version wantedVersion;
+algorithm
+  result := {};
+  try
+    obj := getPackageIndex(printError);
+    libobject := JSON.get(JSON.get(obj, "libs"), id);
+    (vers as JSON.OBJECT(orderedKeys=versions)) := JSON.get(libobject, "versions");
+    wantedVersion := SemanticVersion.parse(version);
+    result := List.map(List.sort(list((version,SemanticVersion.parse(version),getSupportLevel(JSON.get(JSON.get(vers, version),"support"))) for version guard providesExpectedVersion(version, JSON.getOrDefault(JSON.get(vers, version), "provides", JSON.ARRAY({})), wantedVersion) in versions), compareVersionsAndSupportLevel), Util.tuple31);
+  else
+    return;
+  end try;
+end versionsThatProvideTheWanted;
+
+function installPackage
+  input String pkg;
+  input String version;
+  input Boolean exactMatch;
+  output Boolean success;
+protected
+  list<PackageInstallInfo> packageList, packagesToInstall;
+  list<tuple<String,String>> urlPathList, urlPathListToDownload;
+  String cachePath, path, destPath, destPathPkgMo, destPathPkgInfo, oldSha;
+algorithm
+  (success,packageList) := installPackageWork(pkg, version, exactMatch, false, {});
+  packagesToInstall := list(p for p guard p.needsInstall in packageList);
+  cachePath := getCachePath();
+
+  for pack in packagesToInstall loop
+    Util.createDirectoryTree(cachePath);
+  end for;
+
+  urlPathList := List.sort(list((p.urlToZipFile, cachePath + System.basename(p.urlToZipFile)) for p in packagesToInstall), compareUrlBool);
+  urlPathListToDownload := list(tpl for tpl guard not System.regularFileExists(Util.tuple22(tpl)) in urlPathList);
+  if not Curl.multiDownload(urlPathListToDownload) then
+    fail();
+  end if;
+
+  for pack in packagesToInstall loop
+    destPath := getUserLibraryPath() + pack.pkg + " " + SemanticVersion.toString(pack.version);
+
+    System.removeDirectory(destPath);
+    System.createDirectory(destPath);
+
+    destPathPkgMo := destPath + "/package.mo";
+    destPathPkgInfo := destPath + "/" + metaDataFileName;
+    if Util.endsWith(pack.path, ".mo") then
+      destPath := destPathPkgMo;
+    end if;
+    oldSha := "";
+    if System.regularFileExists(destPathPkgInfo) then
+      try
+        oldSha := JSON.getString(JSON.get(JSON.parseFile(destPathPkgInfo),"sha"));
+      else
+      end try;
+    end if;
+
+    Unzip.unzipPath(cachePath + System.basename(pack.urlToZipFile), pack.path, destPath);
+    if System.regularFileExists(destPathPkgMo) then
+      if oldSha == "" then
+        Error.addSourceMessage(Error.NOTIFY_PKG_INSTALL_DONE, {pack.sha}, makeSourceInfo(destPathPkgMo));
+      else
+        Error.addSourceMessage(Error.NOTIFY_PKG_UPGRADE_DONE, {pack.sha, oldSha}, makeSourceInfo(destPathPkgMo));
+      end if;
+    else
+      Error.addMessage(Error.ERROR_PKG_INSTALL_NO_PACKAGE_MO, {cachePath + System.basename(pack.urlToZipFile), destPathPkgMo});
+      System.removeDirectory(destPath);
+      fail();
+    end if;
+    System.writeFile(destPathPkgInfo, JSON.toString(pack.json)+"\n");
+  end for;
+end installPackage;
+
+protected
+
+function compareUrlBool
+  input tuple<String,String> tpl1, tpl2;
+  output Boolean b;
+protected
+  String s1, s2;
+algorithm
+  (s1,_) := tpl1;
+  (s2,_) := tpl2;
+  b := stringCompare(s1, s2) > 0;
+end compareUrlBool;
+
+uniontype PackageInstallInfo
+  record PKG_INSTALL_INFO
+    Boolean needsInstall;
+    String pkg;
+    SemanticVersion.Version version;
+    String urlToZipFile;
+    String path;
+    String sha;
+    JSON json;
+  end PKG_INSTALL_INFO;
+end PackageInstallInfo;
+
+function installPackageWork
+  input String pkg;
+  input String version;
+  input Boolean exactMatch;
+  input Boolean fallbackOnNonExactMatch;
+  output Boolean success;
+  input output list<PackageInstallInfo> packagesToInstall;
+protected
+  AvailableLibraries.Tree installedLibraries;
+  VersionMap.Tree installedVersions;
+  list<String> candidates, usesPackages;
+  list<SemanticVersion.Version> candidatesSemver, exactMatches;
+  String versionToInstall, usedVersion, path, sha, jsonPath;
+  SemanticVersion.Version semverToInstall, semver;
+  JSON index, versionObj, versionsObj, usesObj;
+  Boolean indexHasPkg;
+  PackageInstallInfo packageToInstall;
+algorithm
+  candidates := versionsThatProvideTheWanted(pkg, version, printError=true);
+  candidatesSemver := list(SemanticVersion.parse(candidate) for candidate in candidates);
+  semver := SemanticVersion.parse(version);
+  exactMatches := list(candidate for candidate guard 0==SemanticVersion.compare(candidate, semver) in candidatesSemver);
+  success := false;
+
+  for pkgInfo in packagesToInstall loop
+    if pkgInfo.pkg == pkg then
+      if SemanticVersion.compare(pkgInfo.version, semver)==0 or max(0==SemanticVersion.compare(pkgInfo.version, candidate) for candidate in candidatesSemver) then
+        success := true;
+        return;
+      end if;
+      Error.addMessage(Error.WARNING_PKG_CONFLICTING_VERSIONS, {pkg, SemanticVersion.toString(pkgInfo.version), version});
+      success := false;
+      return;
+    end if;
+  end for;
+
+  // We know which version we want now. Check with the installed ones
+  installedLibraries := getInstalledLibraries();
+
+  if exactMatch and listEmpty(candidates) then
+    versionToInstall := version;
+    semverToInstall := semver;
+  elseif exactMatch and not listEmpty(exactMatches) then
+    semverToInstall := listHead(exactMatches);
+    versionToInstall := SemanticVersion.toString(semverToInstall);
+  else
+    versionToInstall := listHead(candidates);
+    semverToInstall := listHead(candidatesSemver);
+  end if;
+  index := getPackageIndex(printError=true);
+  indexHasPkg := true;
+  sha := "";
+
+  if AvailableLibraries.hasKey(installedLibraries, pkg) then
+    installedVersions := AvailableLibraries.get(installedLibraries, pkg);
+    if VersionMap.hasKey(installedVersions, semverToInstall) or (version=="" and not indexHasPkg) then
+      success := true;
+      path := if VersionMap.hasKey(installedVersions, semverToInstall) then VersionMap.get(installedVersions, semverToInstall) else "#DUMMY#";
+      jsonPath := path + "/" + metaDataFileName;
+      if System.regularFileExists(jsonPath) then
+        sha := JSON.getString(JSON.get(JSON.parseFile(jsonPath), "sha"));
+      end if;
+      packageToInstall := PKG_INSTALL_INFO(false, pkg, semverToInstall, "", "", sha, JSON.emptyObject());
+      indexHasPkg := JSON.hasKey(JSON.get(index, "libs"), pkg);
+    end if;
+  end if;
+
+  if not success then
+    if listEmpty(candidates) then
+      Error.addSourceMessage(Error.ERROR_PKG_NOT_FOUND_VERSION, {pkg, version}, makeSourceInfo(getIndexPath()));
+      return;
+    end if;
+
+    if exactMatch and not max(0==SemanticVersion.compare(semver, candidate) for candidate in candidatesSemver) then
+      if not fallbackOnNonExactMatch then
+        Error.addSourceMessage(Error.ERROR_PKG_NOT_EXACT_MATCH, {pkg, version, stringDelimitList(candidates, ", ")}, makeSourceInfo(getIndexPath()));
+        return;
+      end if;
+      versionToInstall := listHead(candidates);
+      semverToInstall := listHead(candidatesSemver);
+    end if;
+  end if;
+
+  if not indexHasPkg then
+    packagesToInstall := packageToInstall :: packagesToInstall;
+    return;
+  end if;
+
+  versionsObj := JSON.get(JSON.get(JSON.get(index, "libs"), pkg), "versions");
+  if success and not JSON.hasKey(versionsObj, versionToInstall) then
+    packagesToInstall := packageToInstall :: packagesToInstall;
+    return;
+  end if;
+  versionObj := JSON.get(versionsObj, versionToInstall);
+
+  if (not success) or (sha <> "" and sha <> JSON.getString(JSON.get(versionObj, "sha"))) then
+    success := true;
+    packageToInstall := PKG_INSTALL_INFO(true, pkg, semverToInstall, JSON.getString(JSON.get(versionObj, "zipfile")), JSON.getString(JSON.get(versionObj, "path")), JSON.getString(JSON.get(versionObj, "sha")), versionObj);
+  end if;
+
+  (usesObj as JSON.OBJECT(orderedKeys=usesPackages)) := JSON.getOrDefault(versionObj, "uses", JSON.emptyObject());
+
+  packagesToInstall := packageToInstall :: packagesToInstall;
+
+  for usesPackage in usesPackages loop
+    JSON.STRING(usedVersion) := JSON.get(usesObj, usesPackage);
+    (success, packagesToInstall) := installPackageWork(usesPackage, usedVersion, exactMatch, true, packagesToInstall);
+    if not success then
+      return;
+    end if;
+  end for;
+end installPackageWork;
+
+function getUserLibraryPath
+  output String path;
+algorithm
+  path := Settings.getHomeDir(Testsuite.isRunning()) + "/.openmodelica/libraries/";
+end getUserLibraryPath;
+
+function getIndexPath
+  output String path;
+algorithm
+  path := Settings.getHomeDir(Testsuite.isRunning()) + "/.openmodelica/libraries/index.json";
+end getIndexPath;
+
+function getCachePath
+  output String path;
+algorithm
+  path := Settings.getHomeDir(Testsuite.isRunning()) + "/.openmodelica/cache/";
+end getCachePath;
+
+protected
+
+function makeSourceInfo
+  input String fileName;
+  output SourceInfo info;
+algorithm
+  info := SOURCEINFO(fileName, true, 0, 0, 0, 0, 0.0);
+end makeSourceInfo;
+
+annotation(__OpenModelica_Interface="frontend");
+end PackageManagement;

--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -32,7 +32,6 @@
 encapsulated package PackageManagement
 
 import BaseAvlTree;
-import BaseAvlSet;
 import JSON;
 import SemanticVersion;
 

--- a/OMCompiler/Compiler/Stubs/PackageManagement.mo
+++ b/OMCompiler/Compiler/Stubs/PackageManagement.mo
@@ -56,7 +56,7 @@ function installPackage
   output Boolean res;
 algorithm
   res := false;
-end getInstalledLibraries;
+end installPackage;
 
 function updateIndex
   output Boolean res;
@@ -70,11 +70,6 @@ function upgradeInstalledPackages
 algorithm
   res := false;
 end upgradeInstalledPackages;
-
-OMCompiler/Compiler/Script/CevalScriptBackend.mo:        v := Values.BOOL(PackageManagement.installPackage(str1, str2, b));
-OMCompiler/Compiler/Script/CevalScriptBackend.mo:        v := Values.BOOL(PackageManagement.updateIndex());
-OMCompiler/Compiler/Script/CevalScriptBackend.mo:        v := Values.BOOL(PackageManagement.upgradeInstalledPackages(b));
-
 
 annotation(__OpenModelica_Interface="frontend");
 end PackageManagement;

--- a/OMCompiler/Compiler/Stubs/PackageManagement.mo
+++ b/OMCompiler/Compiler/Stubs/PackageManagement.mo
@@ -1,0 +1,80 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2020, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package PackageManagement
+
+encapsulated package AvailableLibraries
+  function listKeys
+    input output list<String> lst;
+  end listKeys;
+end AvailableLibraries;
+
+function versionsThatProvideTheWanted
+  input String id;
+  input String version;
+  input Boolean printError;
+  output list<String> result;
+algorithm
+  result := {};
+end versionsThatProvideTheWanted;
+
+function getInstalledLibraries
+  output list<String> lst;
+end getInstalledLibraries;
+
+function installPackage
+  input String str1, str2;
+  input Boolean b;
+  output Boolean res;
+algorithm
+  res := false;
+end getInstalledLibraries;
+
+function updateIndex
+  output Boolean res;
+algorithm
+  res := false;
+end updateIndex;
+
+function upgradeInstalledPackages
+  input Boolean b;
+  output Boolean res;
+algorithm
+  res := false;
+end upgradeInstalledPackages;
+
+OMCompiler/Compiler/Script/CevalScriptBackend.mo:        v := Values.BOOL(PackageManagement.installPackage(str1, str2, b));
+OMCompiler/Compiler/Script/CevalScriptBackend.mo:        v := Values.BOOL(PackageManagement.updateIndex());
+OMCompiler/Compiler/Script/CevalScriptBackend.mo:        v := Values.BOOL(PackageManagement.upgradeInstalledPackages(b));
+
+
+annotation(__OpenModelica_Interface="frontend");
+end PackageManagement;

--- a/OMCompiler/Compiler/Util/Curl.mo
+++ b/OMCompiler/Compiler/Util/Curl.mo
@@ -1,0 +1,44 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2020, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package Curl
+
+import Config;
+
+function multiDownload
+  input list<tuple<String,String>> urlFileList;
+  input Integer maxParallel = Config.noProc();
+  output Boolean success;
+  external "C" success = om_curl_multi_download(urlFileList, maxParallel);
+end multiDownload;
+
+annotation(__OpenModelica_Interface="util");
+end Curl;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -630,8 +630,8 @@ public constant ErrorTypes.Message ENUM_DUPLICATES = ErrorTypes.MESSAGE(277, Err
   Gettext.gettext("Enumeration has duplicate names: %s in list of names %s."));
 public constant ErrorTypes.Message RESERVED_IDENTIFIER = ErrorTypes.MESSAGE(278, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Identifier %s is reserved for the built-in element with the same name."));
-public constant ErrorTypes.Message NOTIFY_IMPACT_FOUND = ErrorTypes.MESSAGE(279, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
-  Gettext.gettext("The impact package manager downloaded package %s%s to directory %s."));
+public constant ErrorTypes.Message NOTIFY_PKG_FOUND = ErrorTypes.MESSAGE(279, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("You can install the requested package using one of the commands:\n%s."));
 public constant ErrorTypes.Message DERIVATIVE_FUNCTION_CONTEXT = ErrorTypes.MESSAGE(280, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("The der() operator is not allowed in function context (possible solutions: pass the derivative as an explicit input; use a block instead of function)."));
 public constant ErrorTypes.Message RETURN_OUTSIDE_FUNCTION = ErrorTypes.MESSAGE(281, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -991,6 +991,30 @@ public constant ErrorTypes.Message STATE_STATESELECT_NEVER_FORCED = ErrorTypes.M
   Gettext.gettext("Following variables have attribute stateSelect=StateSelect.never, but cant be statically chosen. %s"));
 public constant ErrorTypes.Message STATE_STATESELECT_PREFER_REVERT = ErrorTypes.MESSAGE(600, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. %s"));
+public constant ErrorTypes.Message ERROR_PKG_NOT_IDENT = ErrorTypes.MESSAGE(601, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("The package manager only accepts simple identifiers (%s has a dot in it)."));
+public constant ErrorTypes.Message ERROR_PKG_NOT_FOUND_VERSION = ErrorTypes.MESSAGE(602, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("The package index did not contain an entry for package %s that provides version %s."));
+public constant ErrorTypes.Message ERROR_PKG_NOT_EXACT_MATCH = ErrorTypes.MESSAGE(603, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("The package index did not contain an entry for package %s of version %s. There are other versions that claim to be compatible: %s."));
+public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_ON_PATH = ErrorTypes.MESSAGE(604, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("The MODELICAPATH (%s) does not contain %s, so the package index cannot be used."));
+public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_FOUND = ErrorTypes.MESSAGE(605, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("The package index does not exist: %s."));
+public constant ErrorTypes.Message ERROR_PKG_INDEX_NOT_PARSED = ErrorTypes.MESSAGE(606, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("The package index %s could not be parsed."));
+public constant ErrorTypes.Message ERROR_PKG_INDEX_FAILED_DOWNLOAD = ErrorTypes.MESSAGE(607, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+  Gettext.gettext("Failed to download package index %s to file %s."));
+public constant ErrorTypes.Message NOTIFY_PKG_INDEX_DOWNLOAD = ErrorTypes.MESSAGE(608, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("Downloaded package index from URL %s."));
+public constant ErrorTypes.Message NOTIFY_PKG_INSTALL_DONE = ErrorTypes.MESSAGE(609, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("Package installed successfully (SHA %s)."));
+public constant ErrorTypes.Message NOTIFY_PKG_UPGRADE_DONE = ErrorTypes.MESSAGE(609, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("Package upgraded successfully (SHA %s from %s)."));
+public constant ErrorTypes.Message ERROR_PKG_INSTALL_NO_PACKAGE_MO = ErrorTypes.MESSAGE(611, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("After extracting %s, %s does not exist. Removing the failed installation."));
+public constant ErrorTypes.Message WARNING_PKG_CONFLICTING_VERSIONS = ErrorTypes.MESSAGE(612, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  Gettext.gettext("Conflicting versions for loading package %s: %s is to be installed, but another package requires version %s which is not provided by this version."));
 
 public constant ErrorTypes.Message MATCH_SHADOWING = ErrorTypes.MESSAGE(5001, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Local variable '%s' shadows another variable."));

--- a/OMCompiler/Compiler/Util/SemanticVersion.mo
+++ b/OMCompiler/Compiler/Util/SemanticVersion.mo
@@ -1,0 +1,178 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2020, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package SemanticVersion
+
+protected
+
+import Util;
+import System;
+
+public
+
+uniontype Version
+record SEMVER
+  Integer major, minor, patch;
+  list<String> prerelease, meta;
+end SEMVER;
+record NONSEMVER
+  String version;
+end NONSEMVER;
+end Version;
+
+function parse
+  input String s;
+  output Version v;
+protected
+  Integer n;
+  String major, minor, patch, prerelease, meta;
+  list<String> prereleaseLst, metaLst, matches;
+  constant String semverRegex = "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]*|)([+][0-9A-Za-z.-]*|)$";
+algorithm
+  (n, matches) := System.regex(s, semverRegex, maxMatches=6, extended=true);
+  if n <> 6 then
+    v := NONSEMVER(s);
+    return;
+  end if;
+  {_,major,minor,patch,prerelease,meta} := matches;
+  prereleaseLst := if stringLength(prerelease) > 0 then Util.stringSplitAtChar(Util.stringRest(prerelease), ".") else {};
+  metaLst := if stringLength(meta) > 0 then Util.stringSplitAtChar(Util.stringRest(meta), ".") else {};
+  v := SEMVER(stringInt(major),stringInt(minor),stringInt(patch),prereleaseLst,metaLst);
+end parse;
+
+function compare
+  input Version v1, v2;
+  input Boolean comparePrerelease = true;
+  input Boolean compareBuildInformation = false;
+  output Integer c;
+algorithm
+  c := match (v1, v2)
+    case (NONSEMVER(),NONSEMVER()) then stringCompare(v1.version, v2.version);
+    case (NONSEMVER(),_) then -1;
+    case (_,NONSEMVER()) then 1;
+    case (SEMVER(),SEMVER())
+      algorithm
+        c := Util.intCompare(v1.major, v2.major);
+        if c <> 0 then
+          return;
+        end if;
+        c := Util.intCompare(v1.minor, v2.minor);
+        if c <> 0 then
+          return;
+        end if;
+        c := Util.intCompare(v1.patch, v2.patch);
+        if c <> 0 then
+          return;
+        end if;
+
+        c := compareIdentifierList(v1.prerelease, v2.prerelease);
+        if c == 0 and compareBuildInformation then
+          c := compareIdentifierList(v1.meta, v2.meta);
+        end if;
+      then c;
+  end match;
+end compare;
+
+function toString
+  input Version v;
+  output String out;
+algorithm
+  out := match v
+    case SEMVER()
+      algorithm
+        out := String(v.major) + "." + String(v.minor) + "." + String(v.patch);
+        if not listEmpty(v.prerelease) then
+          out := out + "-" + stringDelimitList(v.prerelease, ".");
+        end if;
+        if not listEmpty(v.meta) then
+          out := out + "+" + stringDelimitList(v.meta, ".");
+        end if;
+      then out;
+    case NONSEMVER() then v.version;
+  end match;
+end toString;
+
+function isPrerelease
+  input Version v;
+  output Boolean b;
+algorithm
+  b := match v
+    case SEMVER(prerelease=_::_) then true;
+    else false;
+  end match;
+end isPrerelease;
+
+protected
+
+function compareIdentifierList
+  input list<String> w1, w2;
+  output Integer c;
+protected
+  list<String> l1, l2;
+  String s1, s2;
+algorithm
+  l1 := w1;
+  l2 := w2;
+  if listEmpty(l1) and not listEmpty(l2) then
+    c := 1;
+  end if;
+  if listEmpty(l2) and not listEmpty(l1) then
+    c := -1;
+  end if;
+  while not (listEmpty(l1) and listEmpty(l2)) loop
+    (c, l1, l2) := match (l1, l2)
+      case ({},_::_) then (-1, l1, l2);
+      case (_::_,{}) then (1, l1, l2);
+      case (s1::l1, s2::l2) then (compareIdentifier(s1, s2), l1, l2);
+    end match;
+    if c <> 0 then
+      return;
+    end if;
+  end while;
+  c := 0;
+end compareIdentifierList;
+
+function compareIdentifier
+  input String s1, s2;
+  output Integer c;
+algorithm
+  if Util.isIntegerString(s1) then
+    c := if Util.isIntegerString(s2) then Util.intCompare(stringInt(s1), stringInt(s2)) else -1;
+    return;
+  end if;
+  if Util.isIntegerString(s2) then
+    c := 1;
+  end if;
+  c := stringCompare(s1, s2);
+end compareIdentifier;
+
+annotation(__OpenModelica_Interface="util");
+end SemanticVersion;

--- a/OMCompiler/Compiler/Util/Unzip.mo
+++ b/OMCompiler/Compiler/Util/Unzip.mo
@@ -1,0 +1,43 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2020, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package Unzip
+
+function unzipPath
+  input String fileName;
+  input String pathToExtract;
+  input String destinationPath;
+  output Boolean success;
+  external "C" success = om_unzip(fileName, pathToExtract, destinationPath);
+end unzipPath;
+
+annotation(__OpenModelica_Interface="util");
+end Unzip;

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1446,6 +1446,16 @@ algorithm
   b := i == 1;
 end isCIdentifier;
 
+public function isIntegerString
+  input String str;
+  output Boolean b;
+protected
+  Integer i;
+algorithm
+  (i,_) := System.regex(str, "^[0-9][0-9]*$", 0, true, false);
+  b := i == 1;
+end isIntegerString;
+
 public function stringTrunc
 "@author:adrpo
  if the string is bigger than len keep only until len

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -226,6 +226,7 @@ if true then /* Suppress output */
     "../Stubs/NFApi.mo",
     "../Stubs/NFInstDump.mo",
     "../Stubs/NFUnitCheck.mo",
+    "../Stubs/PackageManagement.mo",
     "../Stubs/Refactor.mo",
     "../Stubs/RewriteRules.mo",
     "../Stubs/SimCode.mo",

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -388,6 +388,7 @@ if true then /* Suppress output */
     "../Script/Binding.mo",
     "../Script/OpenModelicaScriptingAPI.mo",
     "../Script/CevalScriptBackend.mo",
+    "../Script/PackageManagement.mo",
     "../Script/MMToJuliaUtil.mo",
     "../Script/MMToJuliaKeywords.mo",
 
@@ -437,6 +438,7 @@ if true then /* Suppress output */
     "../Util/AvlTreeString.mo",
     "../Util/AvlSetInt.mo",
 
+    "../Util/Curl.mo",
     "../Util/DiffAlgorithm.mo",
     "../Util/FMI.mo",
     "../Util/FMIExt.mo",
@@ -454,8 +456,10 @@ if true then /* Suppress output */
     "../Util/HashTableStringToUnit.mo",
     "../Util/HashTableUnitToString.mo",
     "../Util/PriorityQueue.mo",
+    "../Util/SemanticVersion.mo",
     "../Util/SimulationResults.mo",
     "../Util/TaskGraphResults.mo",
+    "../Util/Unzip.mo",
 
     "../../SimulationRuntime/c/RuntimeSources.mo"
   };

--- a/OMCompiler/Compiler/boot/Makefile.in
+++ b/OMCompiler/Compiler/boot/Makefile.in
@@ -35,7 +35,7 @@ RPATH=@RPATH@
 STATIC=@BOOTSTRAP_STATIC@
 BOOTSTRAP_OMC=@OMBUILDDIR@/bin/omc
 defaultMakefileTarget=Makefile
-OMCRUNTIMEAR1=../runtime/libomcruntime-boot.a
+OMCRUNTIMEAR1=../runtime/libomcruntime-boot$(SHREXT)
 OMCRUNTIMEAR2=$(OMHOME)/$(LIB_OMC)/libomcruntime$(SHREXT)
 
 

--- a/OMCompiler/Compiler/boot/Makefile.in
+++ b/OMCompiler/Compiler/boot/Makefile.in
@@ -35,7 +35,7 @@ RPATH=@RPATH@
 STATIC=@BOOTSTRAP_STATIC@
 BOOTSTRAP_OMC=@OMBUILDDIR@/bin/omc
 defaultMakefileTarget=Makefile
-OMCRUNTIMEAR1=../runtime/libomcruntime-boot$(SHREXT)
+OMCRUNTIMEAR1=../runtime/libomcruntime-boot.a
 OMCRUNTIMEAR2=$(OMHOME)/$(LIB_OMC)/libomcruntime$(SHREXT)
 
 

--- a/OMCompiler/Compiler/boot/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/boot/Makefile.omdev.mingw
@@ -35,6 +35,7 @@ LDFLAGS=-L./ $(LOMPARSE) $(LCOMPILERRUNTIME) -L"$(OMHOME)/lib/omc" \
 -lgfortran -ltre -lomniORB420_rt -lomnithread40_rt \
 -lzmq \
 $(OMENCRYPTIONLIBS) \
+-lcurl \
 $(EXTRA_LD_FLAGS)
 
 FMILIB = -L$(TOP_DIR)/3rdParty/FMIL/install/lib -lfmilib

--- a/OMCompiler/Compiler/runtime/Makefile.common
+++ b/OMCompiler/Compiler/runtime/Makefile.common
@@ -25,7 +25,7 @@ OMC_OBJ_SHARED = Error_omc$(OBJEXT) \
   Lapack_omc.o Settings_omc$(OBJEXT) \
   UnitParserExt_omc.o unitparser.o \
   IOStreamExt_omc.o Socket_omc.o ZeroMQ_omc.o getMemorySize.o OMSimulator_omc.o \
-  is_utf8.o
+  is_utf8.o om_curl.o om_unzip.o
 
 OMC_OBJ_STUBS = corbaimpl_stub_omc.o
 

--- a/OMCompiler/Compiler/runtime/Makefile.common
+++ b/OMCompiler/Compiler/runtime/Makefile.common
@@ -11,6 +11,8 @@ builddir_inc=$(OMBUILDDIR)/include
 builddir_doc=$(OMBUILDDIR)/doc
 builddir_share=$(OMBUILDDIR)/share
 
+LDFLAGS += ../../3rdParty/FMIL/build/Config.cmake/Minizip/libminizip.a
+
 SimRuntimeCDir = $(top_builddir)/SimulationRuntime/c/
 
 ifndef OMDEV

--- a/OMCompiler/Compiler/runtime/Makefile.common
+++ b/OMCompiler/Compiler/runtime/Makefile.common
@@ -49,7 +49,7 @@ ifeq ($(wildcard $(OMC)),)
 OBJEXT=.boot.o
 BOOTH=../boot/tarball-include/OpenModelicaBootstrappingHeader.h
 CPPFLAGS += -I../boot/tarball-include
-install_bootstrapping: libomcruntime-boot.a libomcgraphstream.a libomcbackendruntime.a
+install_bootstrapping: libomcruntime-boot$(SHREXT) libomcgraphstream.a libomcbackendruntime.a
 else
 install_bootstrapping:
 	@echo "Skipping libomcruntime-boot.a since we already have an OMC executable"

--- a/OMCompiler/Compiler/runtime/Makefile.common
+++ b/OMCompiler/Compiler/runtime/Makefile.common
@@ -49,7 +49,7 @@ ifeq ($(wildcard $(OMC)),)
 OBJEXT=.boot.o
 BOOTH=../boot/tarball-include/OpenModelicaBootstrappingHeader.h
 CPPFLAGS += -I../boot/tarball-include
-install_bootstrapping: libomcruntime-boot$(SHREXT) libomcgraphstream.a libomcbackendruntime.a
+install_bootstrapping: libomcruntime-boot.a libomcgraphstream.a libomcbackendruntime.a
 else
 install_bootstrapping:
 	@echo "Skipping libomcruntime-boot.a since we already have an OMC executable"

--- a/OMCompiler/Compiler/runtime/om_curl.c
+++ b/OMCompiler/Compiler/runtime/om_curl.c
@@ -1,0 +1,102 @@
+#include <curl/curl.h>
+#include "meta/meta_modelica.h"
+#include "util/omc_file.h"
+#include "errorext.h"
+
+typedef struct {
+  const char *url;
+  const char *filename;
+  FILE *fout;
+} pair;
+
+static size_t writeDataCallback(char *data, size_t n, size_t l, void *fout)
+{
+  return fwrite(data, n, l, (FILE*) fout);
+}
+
+static void* addTransfer(CURLM *cm, void *urlPathList, int *result)
+{
+  if (listEmpty(urlPathList)) {
+    return urlPathList;
+  }
+  CURL *eh = curl_easy_init();
+  void *first = MMC_CAR(urlPathList);
+  void *rest = MMC_CDR(urlPathList);
+  const char *url = MMC_STRINGDATA(MMC_CAR(first));
+  const char *file = MMC_STRINGDATA(MMC_CDR(first));
+  FILE *fout = fopen(file, "wb");
+
+  if (fout == NULL) {
+    c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Failed to open file for writing: %s", &file, 1);
+    *result = 0;
+    return rest;
+  }
+
+  pair *p = (pair*) malloc(sizeof(pair));
+  p->url = url;
+  p->fout = fout;
+  p->filename = file;
+
+  curl_easy_setopt(eh, CURLOPT_FOLLOWLOCATION, 1);
+  curl_easy_setopt(eh, CURLOPT_WRITEFUNCTION, writeDataCallback);
+  curl_easy_setopt(eh, CURLOPT_URL, url);
+  curl_easy_setopt(eh, CURLOPT_FAILONERROR, 1);
+
+  curl_easy_setopt(eh, CURLOPT_PRIVATE, p);
+  curl_easy_setopt(eh, CURLOPT_WRITEDATA, fout);
+  curl_multi_add_handle(cm, eh);
+
+  return rest;
+}
+
+int om_curl_multi_download(void *urlPathList, int maxParallel)
+{
+  CURLM *cm;
+  CURLMsg *msg;
+  unsigned int transfers = 0;
+  int msgs_left = -1;
+  int still_alive = 1;
+  int result = 1;
+  curl_global_init(CURL_GLOBAL_ALL);
+  cm = curl_multi_init();
+
+  curl_multi_setopt(cm, CURLMOPT_MAXCONNECTS, maxParallel);
+
+  for (transfers = 0; transfers < maxParallel; transfers++) {
+    urlPathList = addTransfer(cm, urlPathList, &result);
+  }
+
+  do {
+    curl_multi_perform(cm, &still_alive);
+
+    while ((msg = curl_multi_info_read(cm, &msgs_left))) {
+      pair *p;
+      CURL *e = msg->easy_handle;
+      curl_easy_getinfo(e, CURLINFO_PRIVATE, &p);
+      FILE *fout = p->fout;
+      const char *url = p->url;
+      free(p);
+      if (msg->msg == CURLMSG_DONE) {
+        fclose(fout);
+        curl_multi_remove_handle(cm, e);
+        curl_easy_cleanup(e);
+        urlPathList = addTransfer(cm, urlPathList, &result);
+        if (msg->data.result != CURLE_OK) {
+          const char *msgs[2] = {curl_easy_strerror(msg->data.result), url};
+          c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Curl error for URL %s: %s", msgs, 2);
+          omc_unlink(p->filename);
+          result = 0;
+        }
+      } else { /* There should not be any other message types... Ignore it? */
+      }
+    }
+    if (still_alive) {
+      curl_multi_wait(cm, NULL, 0, 1000, NULL);
+    }
+  } while (still_alive || !listEmpty(urlPathList));
+
+  curl_multi_cleanup(cm);
+  curl_global_cleanup();
+
+  return result;
+}

--- a/OMCompiler/Compiler/runtime/om_unzip.c
+++ b/OMCompiler/Compiler/runtime/om_unzip.c
@@ -1,0 +1,146 @@
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "../../3rdParty/FMIL/ThirdParty/Minizip/minizip/unzip.h"
+#include "util/modelica_string.h"
+#include "errorext.h"
+
+#define dir_delimter '/'
+#define MAX_FILENAME 2048
+#define READ_SIZE 8192
+
+int om_unzip(const char *zipFileName, const char *pathToExtract, const char *destPath)
+{
+  unz_file_info file_info;
+  char filename[MAX_FILENAME], commonPrefix[MAX_FILENAME];
+  unzFile *zipfile = unzOpen(zipFileName);
+  if (zipfile == NULL) {
+    c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Failed to open file: %s", &zipFileName, 1);
+    return 0;
+  }
+  unz_global_info global_info;
+  if (unzGetGlobalInfo(zipfile, &global_info) != UNZ_OK) {
+    c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to read file global info: %s", &zipFileName, 1);
+    unzClose(zipfile);
+    return 0;
+  }
+  char read_buffer[READ_SIZE];
+
+  uLong i, j;
+  size_t commonLength, pathToExtractLen = strlen(pathToExtract);
+  for (i = 0; i < global_info.number_entry; ++i ) {
+    if (unzGetCurrentFileInfo(zipfile, &file_info, filename, MAX_FILENAME, NULL, 0, NULL, 0 ) != UNZ_OK) {
+      c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to read file info: %s", &zipFileName, 1);
+      unzClose(zipfile);
+      return 0;
+    }
+    if (i == 0) {
+      commonLength = strlen(filename);
+      strcpy(commonPrefix, filename);
+    } else {
+      for (j = 0; j < commonLength; j++) {
+        if (commonPrefix[j] != filename[j]) {
+          commonLength = j;
+          break;
+        }
+      }
+    }
+    if ((i+1) < global_info.number_entry && unzGoToNextFile( zipfile ) != UNZ_OK) {
+      const char *msgs[2] = {zipFileName, filename};
+      c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to read next file after %s in %s", msgs, 2);
+      unzClose(zipfile);
+      return 0;
+    }
+  }
+  while (commonLength >= 1 && commonPrefix[commonLength-1] != '/') {
+    commonLength--;
+  }
+  commonPrefix[commonLength] = '\0';
+  if (commonPrefix > 0 && commonLength > pathToExtractLen && (0==strncmp(commonPrefix-pathToExtractLen-1, pathToExtract, pathToExtractLen))) {
+    commonLength = 0;
+    commonPrefix[0] = '\0';
+  }
+  if (unzGoToFirstFile(zipfile) != UNZ_OK) {
+    c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to reset to first file in %s", &zipFileName, 1);
+    unzClose(zipfile);
+    return 0;
+  }
+
+  // Loop to extract all files
+  for (i = 0; i < global_info.number_entry; ++i ) {
+    const char *filenameStart = NULL, *renamedPrefix = NULL;
+    // Get info about current file.
+    if (unzGetCurrentFileInfo(zipfile, &file_info, filename, MAX_FILENAME, NULL, 0, NULL, 0 ) != UNZ_OK ) {
+      c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to reset to first file in %s", &zipFileName, 1);
+      unzClose(zipfile);
+      return 0;
+    }
+    filenameStart = filename + commonLength;
+    const size_t filename_length = strlen(filenameStart);
+
+    if (strlen(filenameStart) < pathToExtractLen || (filenameStart[pathToExtractLen] != '\0' && filenameStart[pathToExtractLen] != '/') || 0 != strncmp(filenameStart, pathToExtract, pathToExtractLen)) {
+      /* Do nothing; not a path we want to copy */
+    } else if (filenameStart[ filename_length-1 ] == dir_delimter) {
+      /* Directory */
+      GC_asprintf(&renamedPrefix, "%s%s%s", destPath, filenameStart[pathToExtractLen] == '/' || filenameStart[pathToExtractLen] == '\0' ? "" : "/", filenameStart+pathToExtractLen);
+      mkdir(renamedPrefix, S_IRWXU);
+    } else {
+      /* File */
+      GC_asprintf(&renamedPrefix, "%s%s%s", destPath, filenameStart[pathToExtractLen] == '/' || filenameStart[pathToExtractLen] == '\0' ? "" : "/", filenameStart+pathToExtractLen);
+      // Entry is a file, so extract it.
+      if (unzOpenCurrentFile(zipfile) != UNZ_OK) {
+        const char *msgs[2] = {zipFileName, filename};
+        c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to open file %s in %s", &zipFileName, 2);
+        unzClose(zipfile);
+        return 0;
+      }
+
+      FILE *fout = fopen(renamedPrefix, "wb");
+      if (fout == NULL) {
+        c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Failed to open file for writing %s", &renamedPrefix, 1);
+        unzCloseCurrentFile(zipfile);
+        unzClose(zipfile);
+        return 0;
+      }
+
+      int error = UNZ_OK;
+      do {
+        error = unzReadCurrentFile(zipfile, read_buffer, READ_SIZE);
+        if (error < 0) {
+          c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to open read data in %s", &zipFileName, 1);
+          unzCloseCurrentFile(zipfile);
+          unzClose(zipfile);
+          return 0;
+        }
+
+        // Write data to file.
+        if (error > 0) {
+          if (1 != fwrite(read_buffer, error, 1, fout)) {
+            const char *msgs[2] = {strerror(errno), renamedPrefix};
+            c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Failed to write data to %s: %s", msgs, 2);
+            unzCloseCurrentFile(zipfile);
+            unzClose(zipfile);
+            return 0;
+          }
+        }
+      } while (error > 0);
+
+      fclose(fout);
+    }
+
+    unzCloseCurrentFile(zipfile);
+
+    /* Next entry */
+    if ((i+1) < global_info.number_entry) {
+      if (unzGoToNextFile(zipfile) != UNZ_OK) {
+        const char *msgs[2] = {zipFileName, filename};
+        c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "minizip failed to read next file after %s in %s", msgs, 2);
+        unzClose(zipfile);
+        return 0;
+      }
+    }
+  }
+
+  unzClose(zipfile);
+  return 1;
+}

--- a/OMCompiler/Compiler/runtime/om_unzip.c
+++ b/OMCompiler/Compiler/runtime/om_unzip.c
@@ -4,6 +4,7 @@
 #include "../../3rdParty/FMIL/ThirdParty/Minizip/minizip/unzip.h"
 #include "util/modelica_string.h"
 #include "errorext.h"
+#include "systemimpl.h"
 
 #define dir_delimter '/'
 #define MAX_FILENAME 2048
@@ -83,7 +84,7 @@ int om_unzip(const char *zipFileName, const char *pathToExtract, const char *des
     } else if (filenameStart[ filename_length-1 ] == dir_delimter) {
       /* Directory */
       GC_asprintf(&renamedPrefix, "%s%s%s", destPath, filenameStart[pathToExtractLen] == '/' || filenameStart[pathToExtractLen] == '\0' ? "" : "/", filenameStart+pathToExtractLen);
-      mkdir(renamedPrefix, S_IRWXU);
+      SystemImpl__createDirectory(renamedPrefix);
     } else {
       /* File */
       GC_asprintf(&renamedPrefix, "%s%s%s", destPath, filenameStart[pathToExtractLen] == '/' || filenameStart[pathToExtractLen] == '\0' ? "" : "/", filenameStart+pathToExtractLen);

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -590,7 +590,7 @@ SUNDIALS_TARGET="sundials"
 AC_CHECK_HEADERS(curl/curl.h, [], [AC_MSG_ERROR(Missing header files)])
 
 LIBS=""
-AC_CHECK_LIB(curl,curl_global_init, [OMCRUNTIME_SHARED_LDFLAGS="$OMCRUNTIME_SHARED_LDFLAGS -lcurl"], [AC_MSG_ERROR([Missing libcurl])])
+AC_CHECK_LIB(curl,curl_global_init, [RT_LDFLAGS_OPTIONAL="$RT_LDFLAGS_OPTIONAL -lcurl"], [AC_MSG_ERROR([Missing libcurl])])
 
 AC_CHECK_HEADERS(locale.h libintl.h,[],[HAVE_GETTEXT="#define NO_GETTEXT 1"])
 

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -590,7 +590,7 @@ SUNDIALS_TARGET="sundials"
 AC_CHECK_HEADERS(curl/curl.h, [], [AC_MSG_ERROR(Missing header files)])
 
 LIBS=""
-AC_CHECK_LIB(curl,curl_global_init, [OMC_LIBS="$OMC_LIBS -lcurl"], [AC_MSG_ERROR([Missing libcurl])])
+AC_CHECK_LIB(curl,curl_global_init, [OMCRUNTIME_SHARED_LDFLAGS="$OMCRUNTIME_SHARED_LDFLAGS -lcurl"], [AC_MSG_ERROR([Missing libcurl])])
 
 AC_CHECK_HEADERS(locale.h libintl.h,[],[HAVE_GETTEXT="#define NO_GETTEXT 1"])
 

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -587,6 +587,11 @@ SUNDIALS_LDFLAGS="-lsundials_idas -lsundials_kinsol -lsundials_nvecserial $LD_LA
 FINAL_MESSAGES="$FINAL_MESSAGES\nSimulations may use sundials suite: Yes"
 SUNDIALS_TARGET="sundials"
 
+AC_CHECK_HEADERS(curl/curl.h, [], [AC_MSG_ERROR(Missing header files)])
+
+LIBS=""
+AC_CHECK_LIB(curl,curl_global_init, [OMC_LIBS="$OMC_LIBS -lcurl"], [AC_MSG_ERROR([Missing libcurl])])
+
 AC_CHECK_HEADERS(locale.h libintl.h,[],[HAVE_GETTEXT="#define NO_GETTEXT 1"])
 
 if test -z "$HAVE_GETTEXT"; then

--- a/doc/UsersGuide/source/index.rst
+++ b/doc/UsersGuide/source/index.rst
@@ -41,6 +41,7 @@ Generated on |date| at |time|
   omjulia
   jupyteropenmodelica
   scripting_api
+  packagemanager
   omchelptext
   simulationflags
   technical_details


### PR DESCRIPTION
- `installPackage(Buidlings, "6.0.0")`
- `updatePackageIndex()`
- `upgradeInstalledPackages(installNewestVersions=true)`

The `getAvailableLibraries` and `loadModel` APIs no longer look for the
impact binary, and `getAvailableLibraries()` only lists installed
libraries.