### PR TITLE
Restrict closing the simulation output window

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -839,3 +839,17 @@ void SimulationOutputWidget::keyPressEvent(QKeyEvent *event)
   }
   QWidget::keyPressEvent(event);
 }
+
+/*!
+ * \brief SimulationOutputWidget::closeEvent
+ * Reimplementation of QWidget::closeEvent(). Ignores the event if compilation or simulation process is running.
+ * \param event
+ */
+void SimulationOutputWidget::closeEvent(QCloseEvent *event)
+{
+  if (mpSimulationProcessThread->isCompilationProcessRunning() || mpSimulationProcessThread->isSimulationProcessRunning()) {
+    event->ignore();
+  } else {
+    event->accept();
+  }
+}

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
@@ -131,6 +131,7 @@ public slots:
   void openTransformationBrowser(QUrl url);
 protected:
   virtual void keyPressEvent(QKeyEvent *event) override;
+  virtual void closeEvent(QCloseEvent *event) override;
 };
 
 #endif // SIMULATIONOUTPUTWIDGET_H


### PR DESCRIPTION
While the model is compiling or simulating then don't allow closing the simulation output window.