### PR TITLE
Implement ErrorExt.getCheckpointMessages.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -900,7 +900,7 @@ algorithm
           end if;
         else
           if Binding.isBound(c.condition) then
-            binding := Binding.INVALID_BINDING(binding, ErrorExt.getMessages());
+            binding := Binding.INVALID_BINDING(binding, ErrorExt.getCheckpointMessages());
           else
             ErrorExt.delCheckpoint(getInstanceName());
             fail();
@@ -3017,7 +3017,7 @@ algorithm
       bl2 := Equation.makeBranch(cond, eql, var) :: bl2;
     else
       bl2 := Equation.INVALID_BRANCH(Equation.makeBranch(cond, eql, var),
-                                     ErrorExt.getMessages()) :: bl2;
+                                     ErrorExt.getCheckpointMessages()) :: bl2;
     end try;
     ErrorExt.delCheckpoint(getInstanceName());
   end for;

--- a/OMCompiler/Compiler/Util/ErrorExt.mo
+++ b/OMCompiler/Compiler/Util/ErrorExt.mo
@@ -91,10 +91,18 @@ function getNumWarningMessages
 end getNumWarningMessages;
 
 function getMessages
+  "Returns all error messages and pops them from the message queue."
   output list<ErrorTypes.TotalMessage> res;
 
   external "C" res=Error_getMessages(OpenModelica.threadData()) annotation(Library = "omcruntime");
 end getMessages;
+
+function getCheckpointMessages
+  "Returns all error messages since the last checkpoint and pops them from the message queue."
+  output list<ErrorTypes.TotalMessage> res;
+
+  external "C" res=ErrorImpl__getCheckpointMessages(OpenModelica.threadData()) annotation(Library = "omcruntime");
+end getCheckpointMessages;
 
 function clearMessages
   external "C" ErrorImpl__clearMessages(OpenModelica.threadData()) annotation(Library = "omcruntime");


### PR DESCRIPTION
- Added ErrorExt.getCheckpointMessages that returns and pops only the
  messages added since the last checkpoint.
- Use getCheckpointMessages in NFTyping instead of getMessages, since
  that was the original intent and using getMessages will sometimes
  cause e.g. execstat messages to be eaten.