### PR TITLE
Allow bad within-clauses

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1439,6 +1439,33 @@ algorithm
   end match;
 end pathEqual;
 
+public function pathEqualCaseInsensitive "Returns true if two paths are equal."
+  input Path inPath1;
+  input Path inPath2;
+  output Boolean outBoolean;
+algorithm
+  outBoolean := match (inPath1, inPath2)
+    local
+      String id1,id2;
+      Boolean res;
+      Path path1,path2;
+    // fully qual vs. path
+    case (FULLYQUALIFIED(path1),path2) then pathEqualCaseInsensitive(path1,path2);
+    // path vs. fully qual
+    case (path1,FULLYQUALIFIED(path2)) then pathEqualCaseInsensitive(path1,path2);
+    // ident vs. ident
+    case (IDENT(id1),IDENT(id2))
+      then stringEq(System.tolower(id1), System.tolower(id2));
+    // qual ident vs. qual ident
+    case (QUALIFIED(id1, path1),QUALIFIED(id2, path2))
+      equation
+        res = if stringEq(System.tolower(id1), System.tolower(id2)) then pathEqualCaseInsensitive(path1, path2) else false;
+      then res;
+    // other return false
+    else false;
+  end match;
+end pathEqualCaseInsensitive;
+
 public function typeSpecEqual
   "Author BZ 2009-01
    Check whether two type specs are equal or not."
@@ -4063,6 +4090,20 @@ algorithm
     else false;
   end match;
 end withinEqual;
+
+public function withinEqualCaseInsensitive
+  input Within within1;
+  input Within within2;
+  output Boolean b;
+algorithm
+  b := match (within1,within2)
+    local
+      Path p1,p2;
+    case (TOP(),TOP()) then true;
+    case (WITHIN(p1),WITHIN(p2)) then pathEqualCaseInsensitive(p1,p2);
+    else false;
+  end match;
+end withinEqualCaseInsensitive;
 
 public function withinString
   input Within w1;

--- a/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassLoader.mo
@@ -414,14 +414,18 @@ algorithm
       fail();
     end if;
   end if;
-  s1 := AbsynUtil.withinString(w1);
-  s2 := AbsynUtil.withinString(w2);
-  if not (AbsynUtil.withinEqual(w1,w2) or Config.languageStandardAtMost(Config.LanguageStandard.'2.x')) then
-    Error.addSourceMessage(Error.LIBRARY_UNEXPECTED_WITHIN, {s1,s2}, info);
-    fail();
-  elseif expectPackage and not AbsynUtil.isParts(body) then
+  if expectPackage and not AbsynUtil.isParts(body) then
     Error.addSourceMessage(Error.LIBRARY_EXPECTED_PARTS, {pack}, info);
     fail();
+  elseif not (AbsynUtil.withinEqual(w1,w2) or Config.languageStandardAtMost(Config.LanguageStandard.'2.x')) then
+     s1 := AbsynUtil.withinString(w1);
+     s2 := AbsynUtil.withinString(w2);
+     if AbsynUtil.withinEqualCaseInsensitive(w1,w2) then
+       Error.addSourceMessage(Error.LIBRARY_WITHIN_WRONG_CASE, {s1,s2}, info);
+     else
+       Error.addSourceMessage(Error.LIBRARY_UNEXPECTED_WITHIN, {s1,s2}, info);
+       fail();
+     end if;
   end if;
 end parsePackageFile;
 

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -796,6 +796,8 @@ public constant ErrorTypes.Message W_INVALID_ARGUMENT_TYPE_BRANCH_FIRST = ErrorT
   Gettext.gettext("The first argument '%s' of %s must have the form A.R, where A is a connector and R an over-determined type/record."));
 public constant ErrorTypes.Message W_INVALID_ARGUMENT_TYPE_BRANCH_SECOND = ErrorTypes.MESSAGE(362, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The second argument '%s' of %s must have the form A.R, where A is a connector and R an over-determined type/record."));
+public constant ErrorTypes.Message LIBRARY_WITHIN_WRONG_CASE = ErrorTypes.MESSAGE(363, ErrorTypes.GRAMMAR(), ErrorTypes.WARNING(),
+  Gettext.gettext("Expected the package to have %s but got %s (ignoring the potential error; the class might have been inserted at an unexpected location)."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));


### PR DESCRIPTION
Previously, we allowed case-insensitive matches for the package.mo; if
the subsequent classes are wrong we now also allow those (but only if
it is still a case-insensitive match).