### PR TITLE
Create a unique folder to extract the contents of .mol

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1169,6 +1169,7 @@ end parseEncryptedPackage;
 function loadEncryptedPackage
   input String fileName;
   input String workdir = "<default>" "The output directory for imported encrypted files. <default> will put the files to current working directory.";
+  input Boolean skipUnzip = false "Skips the unzip of .mol if true. In that case we expect the files are already extracted e.g., because of parseEncryptedPackage() call.";
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -1468,7 +1468,7 @@ algorithm
     case (cache,_,"parseEncryptedPackage",Values.STRING(filename)::Values.STRING(workdir)::_,_)
       equation
         vals = {};
-        (b, filename_1) = unZipEncryptedPackageAndCheckFile(workdir, filename);
+        (b, filename_1) = unZipEncryptedPackageAndCheckFile(workdir, filename, false);
         if (b) then
           // clear the errors before!
           Error.clearMessages() "Clear messages";
@@ -1479,9 +1479,9 @@ algorithm
         end if;
       then (cache,ValuesUtil.makeArray(vals));
 
-    case (_,_,"loadEncryptedPackage",Values.STRING(filename)::Values.STRING(workdir)::_,_)
+    case (_,_,"loadEncryptedPackage",Values.STRING(filename)::Values.STRING(workdir)::Values.BOOL(bval)::_,_)
       equation
-        (b, filename_1) = unZipEncryptedPackageAndCheckFile(workdir, filename);
+        (b, filename_1) = unZipEncryptedPackageAndCheckFile(workdir, filename, bval);
         if (b) then
           execStatReset();
           filename_1 = Testsuite.friendlyPath(filename_1);
@@ -3193,6 +3193,7 @@ end findModelicaPath2;
 protected function unZipEncryptedPackageAndCheckFile
   input String inWorkdir;
   input String filename;
+  input Boolean skipUnzip;
   output Boolean success;
   output String outFilename;
 protected
@@ -3203,7 +3204,7 @@ algorithm
   if (System.regularFileExists(filename)) then
 	  if (Util.endsWith(filename, ".mol")) then
 	    workdir := if System.directoryExists(inWorkdir) then inWorkdir else System.pwd();
-	    if (0 == System.systemCall("unzip -q -o -d \"" + workdir + "\" \"" +  filename + "\"")) then
+	    if (skipUnzip or 0 == System.systemCall("unzip -q -o -d \"" + workdir + "\" \"" +  filename + "\"")) then
 	      s1 := System.basename(filename);
 	      s2 := Util.removeLast4Char(s1);
 	      s3 := listGet(Util.stringSplitAtChar(s2," "),1);

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -630,6 +630,13 @@ void MainWindow::beforeClosingMainWindow()
     }
     mFMUDirectoriesList.clear();
   }
+  // Delete the MOL directories
+  foreach (QString molDirectory, mMOLDirectoriesList) {
+    if (QDir().exists(molDirectory)) {
+      Utilities::removeDirectoryRecursivly(molDirectory);
+    }
+  }
+  mMOLDirectoriesList.clear();
   delete pSettings;
   // delete the OptionsDialog object
   OptionsDialog::destroy();

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -253,6 +253,7 @@ public:
                                    const char* variables);
 
   QList<QString> mFMUDirectoriesList;
+  QList<QString> mMOLDirectoriesList;
 private:
   bool mDebug;
   bool mTestsuiteRunning;

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3175,9 +3175,9 @@ QList<QString> OMCProxy::parseEncryptedPackage(QString fileName, QString working
  * \param workingDirectory
  * \return
  */
-bool OMCProxy::loadEncryptedPackage(QString fileName, QString workingDirectory)
+bool OMCProxy::loadEncryptedPackage(QString fileName, QString workingDirectory, bool skipUnzip)
 {
-  bool result = mpOMCInterface->loadEncryptedPackage(fileName, workingDirectory);
+  bool result = mpOMCInterface->loadEncryptedPackage(fileName, workingDirectory, skipUnzip);
   printMessagesStringInternal();
   return result;
 }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -265,7 +265,7 @@ public:
   QList<QList<QString > > getUses(QString className);
   bool buildEncryptedPackage(QString className, bool encrypt = true);
   QList<QString> parseEncryptedPackage(QString fileName, QString workingDirectory);
-  bool loadEncryptedPackage(QString fileName, QString workingDirectory);
+  bool loadEncryptedPackage(QString fileName, QString workingDirectory, bool skipUnzip);
 signals:
   void commandFinished();
 public slots:


### PR DESCRIPTION
Fixes ticket:5786 do not mix the contents of .mol while extracting different versions.

Added a boolean parameter to loadEncryptedPackage to skip unziping of .mol