### PR TITLE
Subclass QNetworkAccessManager to provide proxy authentication

### DIFF
--- a/OMEdit/OMEditLIB/CrashReport/CrashReportDialog.cpp
+++ b/OMEdit/OMEditLIB/CrashReport/CrashReportDialog.cpp
@@ -35,6 +35,7 @@
 #include "Util/Helper.h"
 #include "omc_config.h"
 #include "GDBBacktrace.h"
+#include "Util/NetworkAccessManager.h"
 
 #include <QGridLayout>
 #include <QMessageBox>
@@ -298,17 +299,16 @@ void CrashReportDialog::sendReport()
   // create the request
   QUrl url("https://dev.openmodelica.org/omeditcrashreports/cgi-bin/server.py");
   QNetworkRequest networkRequest(url);
-  QNetworkAccessManager *pNetworkAccessManager = new QNetworkAccessManager;
+  NetworkAccessManager *pNetworkAccessManager = new NetworkAccessManager;
   connect(pNetworkAccessManager, SIGNAL(finished(QNetworkReply*)), SLOT(reportSent(QNetworkReply*)));
   QNetworkReply *pNetworkReply = pNetworkAccessManager->post(networkRequest, pHttpMultiPart);
-  pNetworkReply->ignoreSslErrors();
   pHttpMultiPart->setParent(pNetworkReply); // delete the pHttpMultiPart with the pNetworkReply
 }
 
 /*!
  * \brief CrashReportDialog::reportSent
  * \param pNetworkReply
- * Slot activated when QNetworkAccessManager finished signal is raised.\n
+ * Slot activated when NetworkAccessManager finished signal is raised.\n
  * Shows an error message if crash report was not send correctly.\n
  * Deletes QNetworkReply object which deletes the QHttpMultiPart and QFile objects attached with it.
  */
@@ -318,8 +318,7 @@ void CrashReportDialog::reportSent(QNetworkReply *pNetworkReply)
   mpProgressBar->hide();
   if (pNetworkReply->error() != QNetworkReply::NoError) {
     QMessageBox::critical(0, QString(Helper::applicationName).append(" - ").append(Helper::error),
-                          QString("Following error has occurred while sending crash report \n\n%1").arg(pNetworkReply->errorString()),
-                          Helper::ok);
+                          QString("Following error has occurred while sending crash report \n\n%1").arg(pNetworkReply->errorString()), Helper::ok);
   }
   pNetworkReply->deleteLater();
   accept();

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -82,6 +82,8 @@
 MainWindow::MainWindow(QWidget *parent)
   : QMainWindow(parent), mExitApplicationStatus(false)
 {
+  // Make sure we honor the system's proxy settings
+  QNetworkProxyFactory::setUseSystemConfiguration(true);
   // This is a very convoluted way of asking for the default system font in Qt
   QFont systmFont("Monospace");
   systmFont.setStyleHint(QFont::System);

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -68,6 +68,7 @@ class RectangleAnnotation;
 class EllipseAnnotation;
 class TextAnnotation;
 class BitmapAnnotation;
+class NetworkAccessManager;
 
 class GraphicsScene : public QGraphicsScene
 {
@@ -421,7 +422,7 @@ private:
   QListWidget *mpLatestNewsListWidget;
   QPushButton *mpReloadLatestNewsButton;
   Label *mpVisitWebsiteLabel;
-  QNetworkAccessManager *mpLatestNewsNetworkAccessManager;
+  NetworkAccessManager *mpLatestNewsNetworkAccessManager;
   QSplitter *mpSplitter;
   QFrame *mpBottomFrame;
   QPushButton *mpCreateModelButton;

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -167,7 +167,8 @@ SOURCES += Util/Helper.cpp \
   OMS/OMSSimulationDialog.cpp \
   OMS/OMSSimulationOutputWidget.cpp \
   Animation/TimeManager.cpp \
-  Util/ResourceCache.cpp
+  Util/ResourceCache.cpp \
+  Util/NetworkAccessManager.cpp
 
 HEADERS  += Util/Helper.h \
   Util/Utilities.h \
@@ -262,7 +263,8 @@ HEADERS  += Util/Helper.h \
   Animation/TimeManager.h \
   Interfaces/InformationInterface.h \
   Interfaces/ModelInterface.h \
-  Util/ResourceCache.h
+  Util/ResourceCache.h \
+  Util/NetworkAccessManager.h
 
 CONFIG(osg) {
 

--- a/OMEdit/OMEditLIB/Traceability/TraceabilityInformationURI.cpp
+++ b/OMEdit/OMEditLIB/Traceability/TraceabilityInformationURI.cpp
@@ -5,6 +5,7 @@
 #include "Options/OptionsDialog.h"
 #include "Modeling/ModelWidgetContainer.h"
 #include "Git/GitCommands.h"
+#include "Util/NetworkAccessManager.h"
 
 /*!
  * \class TraceabilityInformationURI
@@ -120,16 +121,15 @@ void TraceabilityInformationURI::sendTraceabilityInformation(QString jsonMessage
   QNetworkRequest networkRequest(url);
   networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json" );
   networkRequest.setRawHeader( "Accept-Charset", "UTF-8");
-  QNetworkAccessManager * pNetworkAccessManager = new QNetworkAccessManager;
-  QNetworkReply *pNetworkReply =   pNetworkAccessManager->post(networkRequest, traceabilityInformation);
-  pNetworkReply->ignoreSslErrors();
+  NetworkAccessManager *pNetworkAccessManager = new NetworkAccessManager;
+  pNetworkAccessManager->post(networkRequest, traceabilityInformation);
   connect(pNetworkAccessManager, SIGNAL(finished(QNetworkReply*)),this, SLOT(traceabilityInformationSent(QNetworkReply*)));
 }
 
 /*!
  * \brief TraceabilityInformationURI::traceabilityInformationSent
  * \param pNetworkReply
- * Slot activated when QNetworkAccessManager finished signal is raised.\n
+ * Slot activated when NetworkAccessManager finished signal is raised.\n
  * Shows an error message if the traceability information was not send correctly.\n
  * Deletes QNetworkReply object
  */
@@ -137,8 +137,7 @@ void TraceabilityInformationURI::traceabilityInformationSent(QNetworkReply *pNet
 {
   if (pNetworkReply->error() != QNetworkReply::NoError) {
     QMessageBox::critical(0, QString(Helper::applicationName).append(" - ").append(Helper::error),
-                          QString("Following error has occurred while sending the traceability information \n\n%1").arg(pNetworkReply->errorString()),
-                          Helper::ok);
+                          QString("Following error has occurred while sending the traceability information \n\n%1").arg(pNetworkReply->errorString()), Helper::ok);
   }
   else
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::CompositeModel,

--- a/OMEdit/OMEditLIB/Util/NetworkAccessManager.cpp
+++ b/OMEdit/OMEditLIB/Util/NetworkAccessManager.cpp
@@ -1,0 +1,127 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
+ * OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+#include "NetworkAccessManager.h"
+#include "Helper.h"
+#include "Utilities.h"
+
+#include <QNetworkProxy>
+#include <QNetworkReply>
+#include <QAuthenticator>
+#include <QDialogButtonBox>
+#include <QGridLayout>
+
+
+NetworkAccessManager::NetworkAccessManager(QObject *parent)
+  : QNetworkAccessManager(parent), mProxyAuthenticationAlreadyCalled(false)
+{
+
+}
+
+void NetworkAccessManager::proxyAuthentication(const QNetworkProxy &proxy, QAuthenticator *pAuthenticator)
+{
+  QSettings *pSettings = Utilities::getApplicationSettings();
+  if (!mProxyAuthenticationAlreadyCalled && pSettings->contains("proxy/username") && pSettings->contains("proxy/password")) {
+    pAuthenticator->setUser(pSettings->value("proxy/username").toString());
+    pAuthenticator->setPassword(pSettings->value("proxy/password").toString());
+    mProxyAuthenticationAlreadyCalled = true;
+    return;
+  }
+
+  ProxyCredentialsDialog *pProxyCredentialsDialog = new ProxyCredentialsDialog(proxy.hostName());
+  int answer = pProxyCredentialsDialog->exec();
+
+  switch (answer) {
+    case QDialog::Rejected:
+      disconnect(this, SIGNAL(proxyAuthenticationRequired(QNetworkProxy,QAuthenticator*)), this, SLOT(proxyAuthentication(QNetworkProxy,QAuthenticator*)));
+      break;
+    case QDialog::Accepted:
+    default:
+      pAuthenticator->setUser(pProxyCredentialsDialog->getUsernameTextBox()->text());
+      pAuthenticator->setPassword(pProxyCredentialsDialog->getPasswordTextBox()->text());
+      if (pProxyCredentialsDialog->getSaveCredentialsCheckBox()->isChecked()) {
+        pSettings->setValue("proxy/username", pProxyCredentialsDialog->getUsernameTextBox()->text());
+        pSettings->setValue("proxy/password", pProxyCredentialsDialog->getPasswordTextBox()->text());
+      }
+      break;
+  }
+  delete pProxyCredentialsDialog;
+}
+
+void NetworkAccessManager::requestFinished(QNetworkReply *pNetworkReply)
+{
+  Q_UNUSED(pNetworkReply);
+  mProxyAuthenticationAlreadyCalled = false;
+}
+
+QNetworkReply* NetworkAccessManager::createRequest(QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *outgoingData)
+{
+  connect(this, SIGNAL(proxyAuthenticationRequired(QNetworkProxy,QAuthenticator*)), SLOT(proxyAuthentication(QNetworkProxy,QAuthenticator*)), Qt::UniqueConnection);
+  connect(this, SIGNAL(finished(QNetworkReply*)), SLOT(requestFinished(QNetworkReply*)), Qt::UniqueConnection);
+
+  QNetworkReply *pNetworkReply = QNetworkAccessManager::createRequest(operation, request, outgoingData);
+  pNetworkReply->ignoreSslErrors();
+  return pNetworkReply;
+}
+
+ProxyCredentialsDialog::ProxyCredentialsDialog(const QString &proxyName, QWidget *parent)
+  : QDialog(parent)
+{
+  setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, tr("Proxy Authentication")));
+  setMinimumWidth(400);
+  // controls
+  mpUsernameTextBox = new QLineEdit;
+  mpPasswordTextBox = new QLineEdit;
+  mpPasswordTextBox->setEchoMode(QLineEdit::Password);
+  mpSaveCredentialsCheckBox = new QCheckBox(tr("Save Credentials"));
+  // Create the buttons
+  QPushButton *pOkButton = new QPushButton(Helper::ok);
+  pOkButton->setAutoDefault(true);
+  connect(pOkButton, SIGNAL(clicked()), SLOT(accept()));
+  QPushButton *pCancelButton = new QPushButton(Helper::cancel);
+  pCancelButton->setAutoDefault(false);
+  connect(pCancelButton, SIGNAL(clicked()), SLOT(reject()));
+  // create buttons box
+  QDialogButtonBox *pButtonBox = new QDialogButtonBox(Qt::Horizontal);
+  pButtonBox->addButton(pOkButton, QDialogButtonBox::ActionRole);
+  pButtonBox->addButton(pCancelButton, QDialogButtonBox::ActionRole);
+  // layout
+  QGridLayout *pMainGridLayout = new QGridLayout;
+  pMainGridLayout->addWidget(new Label(tr("The proxy %1 requires a username and password.").arg(proxyName)), 0, 0, 1, 2);
+  pMainGridLayout->addWidget(new Label(tr("Username:")), 1, 0);
+  pMainGridLayout->addWidget(mpUsernameTextBox, 1, 1);
+  pMainGridLayout->addWidget(new Label(tr("Password:")), 2, 0);
+  pMainGridLayout->addWidget(mpPasswordTextBox, 2, 1);
+  pMainGridLayout->addWidget(mpSaveCredentialsCheckBox, 3, 0, 1, 2);
+  pMainGridLayout->addWidget(pButtonBox, 4, 0, 1, 2, Qt::AlignRight);
+  setLayout(pMainGridLayout);
+}

--- a/OMEdit/OMEditLIB/Util/NetworkAccessManager.h
+++ b/OMEdit/OMEditLIB/Util/NetworkAccessManager.h
@@ -1,0 +1,99 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
+ * OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+/*
+ * @author Adeel Asghar <adeel.asghar@liu.se>
+ */
+#ifndef NETWORKACCESSMANAGER_H
+#define NETWORKACCESSMANAGER_H
+
+#include <QNetworkAccessManager>
+#include <QDialog>
+#include <QLineEdit>
+#include <QCheckBox>
+
+/*!
+ * \class NetworkAccessManager
+ * \brief Subclass QNetworkAccessManager to provide proxy authentication mechanism.
+ */
+class NetworkAccessManager : public QNetworkAccessManager
+{
+  Q_OBJECT
+public:
+  NetworkAccessManager(QObject *parent = 0);
+private:
+  /*!
+   * \brief mProxyAuthenticationAlreadyCalled used to check if QNetworkAccessManager::proxyAuthenticationRequired() SIGNAL is raised more than once.
+   */
+  bool mProxyAuthenticationAlreadyCalled;
+private slots:
+  /*!
+   * \brief proxyAuthentication
+   * Opens the ProxyCredentialsDialog and allows the user to provide proxy credentials.
+   * \param proxy
+   * \param pAuthenticator
+   */
+  void proxyAuthentication(const QNetworkProxy &proxy, QAuthenticator *pAuthenticator);
+  /*!
+   * \brief requestFinished
+   * Resets the mProxyAuthenticationAlreadyCalled flag once the request is finished.
+   * \param pNetworkReply
+   */
+  void requestFinished(QNetworkReply *pNetworkReply);
+protected:
+  /*!
+   * \brief createRequest
+   * Reimplementation of QNetworkAccessManager::createRequest()
+   * \param operation
+   * \param request
+   * \param outgoingData
+   * \return
+   */
+  virtual QNetworkReply* createRequest(QNetworkAccessManager::Operation operation, const QNetworkRequest &request, QIODevice *outgoingData) override;
+};
+
+/*!
+ * \class ProxyCredentialsDialog
+ * \brief A dialog for asking the proxy credentials from user.
+ */
+class ProxyCredentialsDialog : public QDialog
+{
+  Q_OBJECT
+public:
+  explicit ProxyCredentialsDialog(const QString &proxyName, QWidget *parent = nullptr);
+  QLineEdit* getUsernameTextBox() const {return mpUsernameTextBox;}
+  QLineEdit* getPasswordTextBox() const {return mpPasswordTextBox;}
+  QCheckBox* getSaveCredentialsCheckBox() const {return mpSaveCredentialsCheckBox;}
+private:
+  QLineEdit *mpUsernameTextBox;
+  QLineEdit *mpPasswordTextBox;
+  QCheckBox *mpSaveCredentialsCheckBox;
+};
+
+#endif // NETWORKACCESSMANAGER_H


### PR DESCRIPTION
Fixes ticket:5935 if the user resides behind a proxy server then ask the user for proxy credentials.
Save the credentials to settings file.