### PR TITLE
fix for ticket:5954

### DIFF
--- a/OMCompiler/Compiler/Util/Settings.mo
+++ b/OMCompiler/Compiler/Util/Settings.mo
@@ -77,7 +77,7 @@ public function getTempDirectoryPath
   external "C" outString=Settings_getTempDirectoryPath() annotation(Library = "omcruntime");
 end getTempDirectoryPath;
 
-public function setInstallationDirectoryPath
+public function setInstallationDirectoryPath "set it to empty string to clear it"
   input String inString;
 
   external "C" SettingsImpl__setInstallationDirectoryPath(inString) annotation(Library = "omcruntime");
@@ -88,7 +88,7 @@ public function getInstallationDirectoryPath
   external "C"  outString=Settings_getInstallationDirectoryPath() annotation(Library = "omcruntime");
 end getInstallationDirectoryPath;
 
-public function setModelicaPath
+public function setModelicaPath "set it to empty string to clear it"
   input String inString;
   external "C" SettingsImpl__setModelicaPath(inString) annotation(Library = "omcruntime");
 end setModelicaPath;


### PR DESCRIPTION
 - do not query OPENMODELICAHOME and OPENMODELICALIBRARY anymore, use the dll/so location   Settings.get* functions will construct these once and the return the same if you don't clear them 

- set the installation path and the modelica path via Settings.set* functions if you want specific ones 

- add a way to clear the installation path and modelica path via sending empty path to Settings.set* functions 

- fix om_curl.c to read the ca-bundle.crt from OMDEV or the installation directory
