### PR TITLE
Fix ModelicaLibraryConfig_gcc.inc for newer CMake

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSICpp/CMakeLists.txt
@@ -925,9 +925,9 @@ IF(ZeroMQ_FOUND AND cppzmq_FOUND)
     message(STATUS "cppzmq version ${cppzmq_VERSION}")
     message (STATUS "Using ZMQ Header ${ZeroMQ_INCLUDE_DIR}" )
     message (STATUS "Using CPPZMQ Header ${cppzmq_INCLUDE_DIR}" )
-ELSE(ZeroMQ_found AND cppzmq_found)
+ELSE(ZeroMQ_FOUND AND cppzmq_FOUND)
     SET(USE_ZEROMQ OFF)
-ENDIF(ZeroMQ_found AND cppzmq_found)
+ENDIF(ZeroMQ_FOUND AND cppzmq_FOUND)
 
 #Write the defines into the ADDITIONAL_DEFINES variable
 # GET_DIRECTORY_PROPERTY(ADDITIONAL_DEFINES DEFINITIONS)

--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Modelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Modelica/CMakeLists.txt
@@ -181,7 +181,13 @@ ENDIF()
 
 SET(Boost_LIBRARIES_NEW)
 FOREACH(lib ${Boost_LIBRARIES_})
-  GET_FILENAME_COMPONENT(libNew "${lib}" NAME_WE)
+  # Convert "Boost:SomeCrazyLib" to "-lboost_SomeCrazyLib" for ModelicaConfig_gcc.inc
+  IF (${CMAKE_VERSION} VERSION_GREATER "3.16.0") # support newer cmake >= 3.16
+    GET_TARGET_PROPERTY(libNew "${lib}" LOCATION)
+    GET_FILENAME_COMPONENT(libNew "${libNew}" NAME_WE)
+  ELSE(${CMAKE_VERSION} VERSION_GREATER "3.16.0") # support older cmake <= 3.16
+    GET_FILENAME_COMPONENT(libNew "${lib}" NAME_WE)
+  ENDIF(${CMAKE_VERSION} VERSION_GREATER "3.16.0")
   STRING(REGEX REPLACE "^lib" "" libNew ${libNew})
   SET(Boost_LIBRARIES_NEW "${Boost_LIBRARIES_NEW} ${LINKER_LIB_PREFIX}${libNew}")
 ENDFOREACH()


### PR DESCRIPTION
Fix for ticket [#5948](https://trac.openmodelica.org/OpenModelica/ticket/5948)
  - Fix for CMake for C++ runtime on Ubuntu focal
  - Generate "-lboost_someCrazyStuff" from "Boost::someCrazyStuff"