### PR TITLE
Enable text editing for OMSimulator models

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -560,14 +560,6 @@ void MainWindow::beforeClosingMainWindow()
 {
   mpOMCProxy->quitOMC();
   delete mpOMCProxy;
-  // Unload the OMSimulator models
-  LibraryTreeItem* pLibraryTreeItem = mpLibraryWidget->getLibraryTreeModel()->getRootLibraryTreeItem();
-  for (int i = 0; i < pLibraryTreeItem->childrenSize(); i++) {
-    LibraryTreeItem *pChildLibraryTreeItem = pLibraryTreeItem->child(i);
-    if (pChildLibraryTreeItem && pChildLibraryTreeItem->getLibraryType() == LibraryTreeItem::OMS) {
-      mpLibraryWidget->getLibraryTreeModel()->unloadOMSModel(pChildLibraryTreeItem, false);
-    }
-  }
   // delete the OMSProxy object
   OMSProxy::destroy();
   delete mpModelWidgetContainer;
@@ -1739,8 +1731,7 @@ void MainWindow::createNewOMSModel()
 void MainWindow::openOMSModelFile()
 {
   QStringList fileNames;
-  fileNames = StringHandler::getOpenFileNames(this, QString(Helper::applicationName).append(" - ").append(Helper::chooseFiles), NULL,
-                                              Helper::omsFileTypes, NULL);
+  fileNames = StringHandler::getOpenFileNames(this, QString(Helper::applicationName).append(" - ").append(Helper::chooseFiles), NULL, Helper::omsFileTypes, NULL);
   if (fileNames.isEmpty()) {
     return;
   }

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -314,7 +314,7 @@ public:
   void showHideProtectedClasses();
   bool unloadClass(LibraryTreeItem *pLibraryTreeItem, bool askQuestion = true);
   bool unloadCompositeModelOrTextFile(LibraryTreeItem *pLibraryTreeItem, bool askQuestion = true);
-  bool unloadOMSModel(LibraryTreeItem *pLibraryTreeItem, bool askQuestion = true);
+  bool unloadOMSModel(LibraryTreeItem *pLibraryTreeItem, bool doDelete = true, bool askQuestion = true);
   bool unloadLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, bool doDeleteClass);
   bool removeLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, LibraryTreeItem::LibraryType type);
   bool deleteTextFile(LibraryTreeItem *pLibraryTreeItem, bool askQuestion = true);

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
@@ -1063,6 +1063,24 @@ bool OMSProxy::loadModel(QString filename, QString* pModelName)
 }
 
 /*!
+ * \brief OMSProxy::loadSnapshot
+ * Loads the snapshot of the model.
+ * \param cref
+ * \param snapshot
+ * \return
+ */
+bool OMSProxy::loadSnapshot(QString cref, QString snapshot)
+{
+  QString command = "oms_loadSnapshot";
+  QStringList args;
+  args << "\"" + cref + "\"" << "\"" + snapshot + "\"";
+  LOG_COMMAND(command, args);
+  oms_status_enu_t status = oms_loadSnapshot(cref.toUtf8().constData(), snapshot.toUtf8().constData());
+  logResponse(command, status, &commandTime);
+  return statusToBool(status);
+}
+
+/*!
  * \brief OMSProxy::newModel
  * \param cref
  * \return
@@ -1578,43 +1596,4 @@ bool OMSProxy::terminate(QString cref)
   oms_status_enu_t status = oms_terminate(cref.toUtf8().constData());
   logResponse(command, status, &commandTime);
   return statusToBool(status);
-}
-
-/*!
- * \brief OMSProxy::parseString
- * Parses a model string and returns a model name.
- * \param contents
- * \param pModelName
- * \return
- */
-bool OMSProxy::parseString(QString contents, QString *pModelName)
-{
-  Q_UNUSED(contents);
-  Q_UNUSED(pModelName);
-  //  char* ident = NULL;
-  //  oms_status_enu_t status = oms2_parseString(contents.toUtf8().constData(), &ident);
-  //  if (ident) {
-  //    *pModelName = QString(ident);
-  //    free(ident);
-  //  }
-  //  return statusToBool(status);
-  return false;
-}
-
-/*!
- * \brief OMSProxy::loadString
- * Loads the model from a string.
- * \param contents
- * \param pModelName
- * \return
- */
-bool OMSProxy::loadString(QString contents, QString* pModelName)
-{
-  Q_UNUSED(contents);
-  Q_UNUSED(pModelName);
-  //  char* ident = NULL;
-  //  oms_status_enu_t status = oms2_loadString(contents.toUtf8().constData(), &ident);
-  //  *pModelName = QString(ident);
-  //  return statusToBool(status);
-  return false;
 }

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.h
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.h
@@ -112,6 +112,7 @@ public:
   bool initialize(QString cref);
   bool list(QString cref, QString *pContents);
   bool loadModel(QString filename, QString* pModelName);
+  bool loadSnapshot(QString cref, QString snapshot);
   bool newModel(QString cref);
   bool omsDelete(QString cref);
   bool saveModel(QString cref, QString filename);
@@ -142,9 +143,6 @@ public:
   void setWorkingDirectory(QString path);
   bool simulate_asynchronous(QString cref);
   bool terminate(QString cref);
-
-  bool parseString(QString contents, QString* pModelName);
-  bool loadString(QString contents, QString* pModelName);
 signals:
   void logGUIMessage(MessageItem messageItem);
 };


### PR DESCRIPTION
Right now its only possible to do the text change at the model level.
This uses the `oms_loadSnapshot` API. The whole model is reloaded.