### PR TITLE
add Config Flag FMI_SOURCES to filter <sources> in modelDescription.x…

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3835,6 +3835,16 @@ algorithm
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
 
+  // check for fmiSource=false or --fmiFilter=blackBox  and remove the sources directory before zipping to .fmu
+  if not Flags.getConfigBool(Flags.FMI_SOURCES) or Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+    if not System.removeDirectory(fmutmp + "/sources/") then
+      Error.addInternalError("Failed to remove directory: " + fmutmp , sourceInfo());
+    end if;
+    if 0 <> System.removeFile(logfile) then // windows is not removing the log files due to long name
+      Error.addInternalError("Failed to remove File: " + logfile , sourceInfo());
+    end if;
+  end if;
+
   cmd := "rm -f \"" + fmuTargetName + ".fmu\" && cd \"" +  fmutmp + "\" && zip -r \"../" + fmuTargetName + ".fmu\" *";
   if 0 <> System.systemCall(cmd, outFile=logfile) then
     Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {cmd + "\n\n" + System.readFile(logfile)});

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3835,17 +3835,14 @@ algorithm
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
 
-  // check for fmiSource=false or --fmiFilter=blackBox  and remove the sources directory before zipping to .fmu
+  // check for '--fmiSource=false' or '--fmiFilter=blackBox' and remove the sources directory before packing the fmu
   if not Flags.getConfigBool(Flags.FMI_SOURCES) or Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
     if not System.removeDirectory(fmutmp + "/sources/") then
       Error.addInternalError("Failed to remove directory: " + fmutmp , sourceInfo());
     end if;
-    if 0 <> System.removeFile(logfile) then // windows is not removing the log files due to long name
-      Error.addInternalError("Failed to remove File: " + logfile , sourceInfo());
-    end if;
   end if;
 
-  cmd := "rm -f \"" + fmuTargetName + ".fmu\" && cd \"" +  fmutmp + "\" && zip -r \"../" + fmuTargetName + ".fmu\" *";
+  cmd := "rm -f \"" + fmuTargetName + ".fmu\" && cd \"" + fmutmp + "\" && zip -r \"../" + fmuTargetName + ".fmu\" *";
   if 0 <> System.systemCall(cmd, outFile=logfile) then
     Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {cmd + "\n\n" + System.readFile(logfile)});
     ExecStat.execStat("buildModelFMU failed");

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -769,7 +769,12 @@ algorithm
         dgesvFiles :=  if varInfo.numLinearSystems > 0 or varInfo.numNonLinearSystems > 0 then RuntimeSources.dgesvFiles else {};
         defaultFiles := list(simCode.fileNamePrefix + f for f in RuntimeSources.defaultFileSuffixes);
         runtimeFiles := list(f for f guard Util.endsWith(f, ".c") in allFiles);
-        sourceFiles := listAppend(defaultFiles, runtimeFiles);
+        // check for fmiSource=false or --fmiFilter=blackBox
+        if not Flags.getConfigBool(Flags.FMI_SOURCES) or Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+          sourceFiles := {}; // set the sourceFiles to empty, to remove the sources in modeldescription.xml
+        else
+          sourceFiles := listAppend(defaultFiles, runtimeFiles);
+        end if;
         Tpl.tplNoret(function CodegenFMU.translateModel(in_a_FMUVersion=FMUVersion, in_a_FMUType=FMUType, in_a_sourceFiles=sourceFiles), simCode);
         extraFiles := SimCodeUtil.getFunctionIndex();
         copyFiles(listAppend(dgesvFiles, allFiles), source=Settings.getInstallationDirectoryPath() + "/include/omc/c/", destination=fmutmp+"/sources/");

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1357,6 +1357,9 @@ constant ConfigFlag FMI_FILTER = CONFIG_FLAG(142, "fmiFilter", NONE(), EXTERNAL(
   ENUM_FLAG(FMI_INTERNAL, {("none", FMI_NONE), ("internal", FMI_INTERNAL), ("protected", FMI_PROTECTED), ("blackBox", FMI_BLACKBOX)}),
   SOME(STRING_OPTION({"none", "internal", "protected", "blackBox"})),
   Gettext.gettext("Filters the FMI-ModelDescription Vars in the ModelDescription.xml"));
+constant ConfigFlag FMI_SOURCES = CONFIG_FLAG(143, "fmiSources", NONE(), EXTERNAL(),
+  BOOL_FLAG(true), NONE(),
+  Gettext.gettext("Export the FMUs without sources when set to --fmiSources= false, used along with --fmiFilter=blackBox"));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1359,7 +1359,7 @@ constant ConfigFlag FMI_FILTER = CONFIG_FLAG(142, "fmiFilter", NONE(), EXTERNAL(
   Gettext.gettext("Filters the FMI-ModelDescription Vars in the ModelDescription.xml"));
 constant ConfigFlag FMI_SOURCES = CONFIG_FLAG(143, "fmiSources", NONE(), EXTERNAL(),
   BOOL_FLAG(true), NONE(),
-  Gettext.gettext("Export the FMUs without sources when set to --fmiSources= false, used along with --fmiFilter=blackBox"));
+  Gettext.gettext("Defines if FMUs will be exported with sources or not. --fmiFilter=blackBox might override this, because black box FMUs do never contain their source code."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -398,7 +398,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.ZEROMQ_CLIENT_ID,
   Flags.FMI_VERSION,
   Flags.FLAT_MODELICA,
-  Flags.FMI_FILTER
+  Flags.FMI_FILTER,
+  Flags.FMI_SOURCES
 };
 
 public function new


### PR DESCRIPTION
### Purpose

This allows to export FMus without sources in the fmu , similar to blackBox, see https://trac.openmodelica.org/OpenModelica/ticket/5969

### ChangedFile 
Flags.mo  -- Added new Confi-Flag --fmiSources with default option true 
CevalScriptBackend.mo  -- Check for fmiSources = false and fmiFilter=blackBox and remove the source directory

## usage
```
omc --fmiSources=false  a.mos
(or)
omc --fmiFilter= blackBox a.mos
```

