### PR TITLE
add new dataStructures for UnitDefinitions to export in modelDescription.xml

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -387,6 +387,14 @@ algorithm
   annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
 end realAbs;
 
+function realAlmostEq
+  input Real a;
+  input Real b;
+  input Real absTol = 1e-6;
+  output Boolean c = realGt(absTol, realAbs(a-b));
+  annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
+end realAlmostEq;
+
 function realNeg
   input Real x;
   output Real y;

--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -391,7 +391,9 @@ function realAlmostEq
   input Real a;
   input Real b;
   input Real absTol = 1e-6;
-  output Boolean c = absTol > abs(a-b);
+  output Boolean c;
+algorithm
+  c := absTol > abs(a-b);
   annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
 end realAlmostEq;
 

--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -387,6 +387,14 @@ algorithm
   annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
 end realAbs;
 
+function realAlmostEq
+  input Real a;
+  input Real b;
+  input Real absTol = 1e-6;
+  output Boolean c = absTol > abs(a-b);
+  annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
+end realAlmostEq;
+
 function realNeg
   input Real x;
   output Real y;

--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -387,14 +387,6 @@ algorithm
   annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
 end realAbs;
 
-function realAlmostEq
-  input Real a;
-  input Real b;
-  input Real absTol = 1e-6;
-  output Boolean c = realGt(absTol, realAbs(a-b));
-  annotation(__OpenModelica_EarlyInline = true, __OpenModelica_BuiltinPtr = true);
-end realAlmostEq;
-
 function realNeg
   input Real x;
   output Real y;

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -207,6 +207,28 @@ uniontype DelayedExpression
   end DELAYED_EXPRESSIONS;
 end DelayedExpression;
 
+uniontype UnitDefinition "unitDefinitions for fmi modelDescription.xml"
+  record UNITDEFINITION
+    String name;
+    BaseUnit baseUnit;
+    //TODO DisplayUnit
+  end UNITDEFINITION;
+end UnitDefinition;
+
+uniontype BaseUnit
+  record BASEUNIT
+    Integer mol "exponent";
+    Integer cd  "exponent";
+    Integer m   "exponent";
+    Integer s   "exponent";
+    Integer A   "exponent";
+    Integer K   "exponent";
+    Integer g   "exponent";
+    Real factor "prefix";
+    Real offset "offset";
+  end BASEUNIT;
+end BaseUnit;
+
 uniontype ModelInfo "Container for metadata about a Modelica model."
   record MODELINFO
     Absyn.Path name;
@@ -224,6 +246,7 @@ uniontype ModelInfo "Container for metadata about a Modelica model."
     Boolean hasLargeLinearEquationSystems; // True if model has large linear eq. systems that are crucial for performance.
     list<SimEqSystem> linearSystems;
     list<SimEqSystem> nonLinearSystems;
+    list<UnitDefinition> unitDefinitions "export unitDefintion in modelDescription.xml";
   end MODELINFO;
 end ModelInfo;
 

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -223,7 +223,7 @@ uniontype BaseUnit
     Integer s   "exponent";
     Integer A   "exponent";
     Integer K   "exponent";
-    Integer g   "exponent";
+    Integer kg  "exponent";
     Real factor "prefix";
     Real offset "offset";
   end BASEUNIT;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -9153,10 +9153,10 @@ public function transformUnitToBaseUnit
   output SimCode.BaseUnit baseUnit;
 protected
   Integer mol, cd, m, s, A, K, kg;
-  Real factors;
+  Real factor;
 algorithm
-  Unit.UNIT(factors, mol, cd, m, s, A, K, kg) := unit;
-  baseUnit := SimCode.BASEUNIT(mol, cd, m, s, A, K, kg, factors, 0.0);
+  Unit.UNIT(factor, mol, cd, m, s, A, K, kg) := unit;
+  baseUnit := SimCode.BASEUNIT(mol, cd, m, s, A, K, kg, factor*10^(-3*kg), 0.0);
 end transformUnitToBaseUnit;
 
 public function createCrefToSimVarHT "author: unknown and marcusw

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -9152,11 +9152,11 @@ public function transformUnitToBaseUnit
   input Unit.Unit unit;
   output SimCode.BaseUnit baseUnit;
 protected
-  Integer mol, cd, m, s, A, K, g;
+  Integer mol, cd, m, s, A, K, kg;
   Real factors;
 algorithm
-  Unit.UNIT(factors, mol, cd, m, s, A, K, g) := unit;
-  baseUnit := SimCode.BASEUNIT(mol, cd, m, s, A, K, g, factors, 0.0);
+  Unit.UNIT(factors, mol, cd, m, s, A, K, kg) := unit;
+  baseUnit := SimCode.BASEUNIT(mol, cd, m, s, A, K, kg, factors, 0.0);
 end transformUnitToBaseUnit;
 
 public function createCrefToSimVarHT "author: unknown and marcusw

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -9136,8 +9136,12 @@ algorithm
       // check if the var has unit and also check if the unit is already added to hashset
       if not stringEq(var.unit, "") and not BaseHashSet.has(var.unit, unitNameKeys) then
         unitNameKeys := BaseHashSet.add(var.unit, unitNameKeys);
-        unit := Unit.parseUnitString(var.unit); // get the SI- units information
-        unitDefinitions := SimCode.UNITDEFINITION(var.unit, transformUnitToBaseUnit(unit)) :: unitDefinitions;
+        try
+          unit := Unit.parseUnitString(var.unit); // get the SI- units information
+          unitDefinitions := SimCode.UNITDEFINITION(var.unit, transformUnitToBaseUnit(unit)) :: unitDefinitions;
+        else
+          // catch the units which are not calculated
+        end try;
       end if;
     end if;
   end for;

--- a/OMCompiler/Compiler/Template/CodegenFMU2.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU2.tpl
@@ -65,6 +65,7 @@ case SIMCODE(__) then
     <%fmiModelDescriptionAttributes(simCode,guid)%>>
     <%if isFMIMEType(FMUType) then ModelExchange(simCode, sourceFiles)%>
     <%if isFMICSType(FMUType) then CoSimulation(simCode, sourceFiles)%>
+    <%UnitDefinitions(simCode)%>
     <%fmiTypeDefinitions(simCode, "2.0")%>
     <% if Flags.isSet(Flags.FMU_EXPERIMENTAL) then
     <<

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -711,8 +711,8 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   let A_Value = if not intEq(A, 0) then ' A="<% A %>"' else ""
   let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
   let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
-  let factor_Value = if not realGt(1e-6, realAbs(realSub(factor, 1.0))) then ' factor="<% factor %>"' else ""
-  let offset_Value = if not realGt(1e-6, realAbs(realSub(offset, 0.0))) then ' offset="<% offset %>"' else ""
+  let factor_Value = if not realAlmostEq(factor, 1.0, 1e-6) then ' factor="<% factor %>"' else ""
+  let offset_Value = if not realAlmostEq(offset, 0.0, 1e-6) then ' offset="<% offset %>"' else ""
   <<
   <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>
   >>

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -711,8 +711,8 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   let A_Value = if not intEq(A, 0) then ' A="<% A %>"' else ""
   let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
   let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
-  let factor_Value = if not realAlmostEq(factor, 1.0, 1e-6) then ' factor="<% factor %>"' else ""
-  let offset_Value = if not realAlmostEq(offset, 0.0, 1e-6) then ' offset="<% offset %>"' else ""
+  let factor_Value = if not realGt(1e-6, realAbs(realSub(factor, 1.0))) then ' factor="<% factor %>"' else ""
+  let offset_Value = if not realGt(1e-6, realAbs(realSub(offset, 0.0))) then ' offset="<% offset %>"' else ""
   <<
   <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>
   >>

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -712,8 +712,9 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
   let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
   let factor_Value = if not intEq(realInt(factor), 1) then ' factor="<% factor %>"' else ""
+  let offset_Value = if not intEq(realInt(offset), 0) then ' offset="<% offset %>"' else ""
   <<
-  <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%>
+  <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>
   >>
 end baseUnitAttributes;
 

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -64,6 +64,7 @@ case SIMCODE(__) then
     modelIdentifier="<%modelIdentifier%>"<%pdd%>>
     <%SourceFiles(sourceFiles)%>
   </ModelExchange>
+  <%UnitDefinitions(simCode)%>
   >>
 end ModelExchange;
 
@@ -659,12 +660,24 @@ template UnitDefinitions(SimCode simCode)
  "Generates code for UnitDefinitions file for FMU target."
 ::=
 match simCode
-case SIMCODE(__) then
-  <<
-  <UnitDefinitions>
-  </UnitDefinitions>
-  >>
+case SIMCODE(modelInfo=modelInfo) then
+match modelInfo
+case MODELINFO(unitDefinitions = unitDefinitions) then
+    <<
+      <%UnitDefinitionsHelper(unitDefinitions)%>
+    >>
 end UnitDefinitions;
+
+template UnitDefinitionsHelper(list<UnitDefinition> unitDefinitions)
+ "Generates code for UnitDefinition for FMU target."
+::=
+  if unitDefinitions then
+    <<
+    <UnitDefinitions>
+    </UnitDefinitions>
+    >>
+   /*TODO! Populate the list of units */
+end UnitDefinitionsHelper;
 
 template fmiTypeDefinitions(SimCode simCode, String FMUVersion)
  "Generates code for TypeDefinitions for FMU target."

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -711,8 +711,8 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   let A_Value = if not intEq(A, 0) then ' A="<% A %>"' else ""
   let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
   let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
-  let factor_Value = if not intEq(realInt(factor), 1) then ' factor="<% factor %>"' else ""
-  let offset_Value = if not intEq(realInt(offset), 0) then ' offset="<% offset %>"' else ""
+  let factor_Value = if not realEq(factor, 1.0) then ' factor="<% factor %>"' else ""
+  let offset_Value = if not realEq(offset, 0.0) then ' offset="<% offset %>"' else ""
   <<
   <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>
   >>

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -711,8 +711,8 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   let A_Value = if not intEq(A, 0) then ' A="<% A %>"' else ""
   let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
   let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
-  let factor_Value = if not realEq(factor, 1.0) then ' factor="<% factor %>"' else ""
-  let offset_Value = if not realEq(offset, 0.0) then ' offset="<% offset %>"' else ""
+  let factor_Value = if not realAlmostEq(factor, 1.0, 1e-6) then ' factor="<% factor %>"' else ""
+  let offset_Value = if not realAlmostEq(offset, 0.0, 1e-6) then ' offset="<% offset %>"' else ""
   <<
   <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>
   >>

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -64,7 +64,6 @@ case SIMCODE(__) then
     modelIdentifier="<%modelIdentifier%>"<%pdd%>>
     <%SourceFiles(sourceFiles)%>
   </ModelExchange>
-  <%UnitDefinitions(simCode)%>
   >>
 end ModelExchange;
 
@@ -663,21 +662,60 @@ match simCode
 case SIMCODE(modelInfo=modelInfo) then
 match modelInfo
 case MODELINFO(unitDefinitions = unitDefinitions) then
-    <<
-      <%UnitDefinitionsHelper(unitDefinitions)%>
-    >>
+  <<
+  <%UnitDefinitionsHelper(unitDefinitions)%>
+  >>
 end UnitDefinitions;
 
 template UnitDefinitionsHelper(list<UnitDefinition> unitDefinitions)
  "Generates code for UnitDefinition for FMU target."
 ::=
   if unitDefinitions then
-    <<
-    <UnitDefinitions>
-    </UnitDefinitions>
-    >>
-   /*TODO! Populate the list of units */
+  <<
+  <UnitDefinitions>
+    <%unitDefinitions |> unitDefinition => UnitDefinitionsHelper1(unitDefinition) ;separator="\n"%>
+  </UnitDefinitions>
+  >>
 end UnitDefinitionsHelper;
+
+template UnitDefinitionsHelper1(UnitDefinition unitDefinition)
+ "helper function to generates code for UnitDefinition for FMU target."
+::=
+match unitDefinition
+case UNITDEFINITION(name = name, baseUnit = baseUnit) then
+  <<
+  <Unit <%unitDefinitionAttribute(name)%>>
+    <BaseUnit <%baseUnitAttributes(baseUnit)%>/>
+  </Unit>
+  >>
+end UnitDefinitionsHelper1;
+
+template unitDefinitionAttribute(String unitName)
+ "Generates code for UnitDefinition Attribute for FMU target."
+::=
+  let unitString = if unitName then 'name ="<%unitName%>"'
+  <<
+  <%unitString%>
+  >>
+end unitDefinitionAttribute;
+
+template baseUnitAttributes(BaseUnit baseUnit)
+ "Generates code for BaseUnit for FMU target."
+::=
+match baseUnit
+case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor = factor, offset = offset)) then
+  let mol_Value = if not intEq(mol, 0) then ' mol="<% mol %>"' else ""
+  let cd_Value = if not intEq(cd, 0) then ' cd="<% cd %>"' else ""
+  let m_Value = if not intEq(m, 0) then ' m="<% m %>"' else ""
+  let s_Value = if not intEq(s, 0) then ' s="<% s %>"' else ""
+  let A_Value = if not intEq(A, 0) then ' A="<% A %>"' else ""
+  let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
+  let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
+  let factor_Value = if not intEq(realInt(factor), 1) then ' factor="<% factor %>"' else ""
+  <<
+  <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%>
+  >>
+end baseUnitAttributes;
 
 template fmiTypeDefinitions(SimCode simCode, String FMUVersion)
  "Generates code for TypeDefinitions for FMU target."

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -91,6 +91,12 @@ package builtin
     output Boolean c;
   end intEq;
 
+  function realEq
+    input Real a;
+    input Real b;
+    output Boolean c;
+  end realEq;
+
   function intNe
     input Integer a;
     input Integer b;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -97,16 +97,12 @@ package builtin
     output Boolean c;
   end realEq;
 
-  function realGt
-    input Real x1;
-    input Real x2;
-    output Boolean b;
-  end realGt;
-
-  function realAbs
-    input Real x;
-    output Real y;
-  end realAbs;
+  function realAlmostEq
+    input Real a;
+    input Real b;
+    input Real absTol;
+    output Boolean c;
+  end realAlmostEq;
 
   function intNe
     input Integer a;
@@ -184,12 +180,6 @@ package builtin
     input Real y;
     output Real z;
   end realDiv;
-
-  function realSub
-    input Real r1;
-    input Real r2;
-    output Real r;
-  end realSub;
 
   function stringLength
     input String str;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -718,9 +718,9 @@ package SimCode
       Integer s   "exponent";
       Integer A   "exponent";
       Integer K   "exponent";
-      Integer g   "exponent";
+      Integer kg  "exponent";
       Real factor "prefix";
-      Real offset;
+      Real offset "offset";
     end BASEUNIT;
   end BaseUnit;
 

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -97,12 +97,16 @@ package builtin
     output Boolean c;
   end realEq;
 
-  function realAlmostEq
-    input Real a;
-    input Real b;
-    input Real absTol;
-    output Boolean c;
-  end realAlmostEq;
+  function realGt
+    input Real x1;
+    input Real x2;
+    output Boolean b;
+  end realGt;
+
+  function realAbs
+    input Real x;
+    output Real y;
+  end realAbs;
 
   function intNe
     input Integer a;
@@ -180,6 +184,12 @@ package builtin
     input Real y;
     output Real z;
   end realDiv;
+
+  function realSub
+    input Real r1;
+    input Real r2;
+    output Real r;
+  end realSub;
 
   function stringLength
     input String str;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -698,8 +698,31 @@ package SimCode
       Integer nSubClocks;
       list<SimEqSystem> linearSystems;
       list<SimEqSystem> nonLinearSystems;
+      list<UnitDefinition> unitDefinitions "export unitDefintion in modelDescription.xml";
     end MODELINFO;
   end ModelInfo;
+
+  uniontype UnitDefinition "unitDefinitions for fmi modelDescription.xml"
+    record UNITDEFINITION
+      String name;
+      BaseUnit baseUnit;
+      //TODO DisplayUnit
+    end UNITDEFINITION;
+  end UnitDefinition;
+
+  uniontype BaseUnit
+    record BASEUNIT
+      Integer mol "exponent";
+      Integer cd  "exponent";
+      Integer m   "exponent";
+      Integer s   "exponent";
+      Integer A   "exponent";
+      Integer K   "exponent";
+      Integer g   "exponent";
+      Real factor "prefix";
+      Real offset;
+    end BASEUNIT;
+  end BaseUnit;
 
   uniontype VarInfo
     record VARINFO

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -97,6 +97,13 @@ package builtin
     output Boolean c;
   end realEq;
 
+  function realAlmostEq
+    input Real a;
+    input Real b;
+    input Real absTol;
+    output Boolean c;
+  end realAlmostEq;
+
   function intNe
     input Integer a;
     input Integer b;

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -71,19 +71,19 @@ getErrorString();
 //       <BaseUnit  s=\"1\"/>
 //     </Unit>
 //     <Unit name =\"kg/m3\">
-//       <BaseUnit  m=\"-3\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  m=\"-3\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"kg\">
-//       <BaseUnit  kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"W/(m2.K)\">
-//       <BaseUnit  s=\"-3\" K=\"-1\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  s=\"-3\" K=\"-1\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"m3\">
 //       <BaseUnit  m=\"3\"/>
 //     </Unit>
 //     <Unit name =\"J/mol\">
-//       <BaseUnit  mol=\"-1\" m=\"2\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  mol=\"-1\" m=\"2\" s=\"-2\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"J/(kg.K)\">
 //       <BaseUnit  m=\"2\" s=\"-2\" K=\"-1\"/>
@@ -95,7 +95,7 @@ getErrorString();
 //       <BaseUnit  s=\"-1\" factor=\"0.0002777777777777778\"/>
 //     </Unit>
 //     <Unit name =\"kJ/h\">
-//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"277.7777777777778\"/>
+//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"0.2777777777777779\"/>
 //     </Unit>
 //     <Unit name =\"mol/l\">
 //       <BaseUnit  mol=\"1\" m=\"-3\" factor=\"1000.0\"/>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -66,6 +66,44 @@ getErrorString();
 //   <ModelExchange
 //     modelIdentifier=\"CSTRModel\" providesDirectionalDerivative=\"true\">
 //   </ModelExchange>
+//   <UnitDefinitions>
+//     <Unit name =\"s\">
+//       <BaseUnit  s=\"1\"/>
+//     </Unit>
+//     <Unit name =\"kg/m3\">
+//       <BaseUnit  m=\"-3\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"kg\">
+//       <BaseUnit  kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"W/(m2.K)\">
+//       <BaseUnit  s=\"-3\" K=\"-1\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"m3\">
+//       <BaseUnit  m=\"3\"/>
+//     </Unit>
+//     <Unit name =\"J/mol\">
+//       <BaseUnit  mol=\"-1\" m=\"2\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"J/(kg.K)\">
+//       <BaseUnit  m=\"2\" s=\"-2\" K=\"-1\"/>
+//     </Unit>
+//     <Unit name =\"m2\">
+//       <BaseUnit  m=\"2\"/>
+//     </Unit>
+//     <Unit name =\"1/h\">
+//       <BaseUnit  s=\"-1\" factor=\"0.0002777777777777778\"/>
+//     </Unit>
+//     <Unit name =\"kJ/h\">
+//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"277.7777777777778\"/>
+//     </Unit>
+//     <Unit name =\"mol/l\">
+//       <BaseUnit  mol=\"1\" m=\"-3\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"degC\">
+//       <BaseUnit  K=\"1\"/>
+//     </Unit>
+//   </UnitDefinitions>
 //   <TypeDefinitions>
 //     <Clocks>
 //       <Clock><Inferred

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -83,10 +83,10 @@ val(evaporator_qm_S, 100);
 //       <BaseUnit />
 //     </Unit>
 //     <Unit name =\"N/mm2\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000000000.0\"/>
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000000.0\"/>
 //     </Unit>
 //     <Unit name =\"MW\">
-//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000000000.0\"/>
+//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000000.0\"/>
 //     </Unit>
 //     <Unit name =\"kg/kg\">
 //       <BaseUnit />
@@ -98,25 +98,25 @@ val(evaporator_qm_S, 100);
 //       <BaseUnit  m=\"2\" s=\"-2\" K=\"-1\"/>
 //     </Unit>
 //     <Unit name =\"kg/mol\">
-//       <BaseUnit  mol=\"-1\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  mol=\"-1\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"kg/s\">
-//       <BaseUnit  s=\"-1\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  s=\"-1\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"W\">
-//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"kg\">
-//       <BaseUnit  kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"J/kg\">
 //       <BaseUnit  m=\"2\" s=\"-2\"/>
 //     </Unit>
 //     <Unit name =\"J\">
-//       <BaseUnit  m=\"2\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  m=\"2\" s=\"-2\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"kg/m3\">
-//       <BaseUnit  m=\"-3\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  m=\"-3\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"m3/s\">
 //       <BaseUnit  m=\"3\" s=\"-1\"/>
@@ -125,13 +125,13 @@ val(evaporator_qm_S, 100);
 //       <BaseUnit  K=\"1\"/>
 //     </Unit>
 //     <Unit name =\"km-1.s-3.g\">
-//       <BaseUnit  m=\"-1\" s=\"-3\" kg=\"1\" factor=\"0.001\"/>
+//       <BaseUnit  m=\"-1\" s=\"-3\" kg=\"1\" factor=\"1e-006\"/>
 //     </Unit>
 //     <Unit name =\"m3.s-1\">
 //       <BaseUnit  m=\"3\" s=\"-1\"/>
 //     </Unit>
 //     <Unit name =\"Pa\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\"/>
 //     </Unit>
 //     <Unit name =\"m3\">
 //       <BaseUnit  m=\"3\"/>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -66,6 +66,77 @@ val(evaporator_qm_S, 100);
 //   <ModelExchange
 //     modelIdentifier=\"DrumBoilerModel\" providesDirectionalDerivative=\"true\">
 //   </ModelExchange>
+//   <UnitDefinitions>
+//     <Unit name =\"m/s2\">
+//       <BaseUnit  m=\"1\" s=\"-2\"/>
+//     </Unit>
+//     <Unit name =\"1/K\">
+//       <BaseUnit  K=\"-1\"/>
+//     </Unit>
+//     <Unit name =\"s\">
+//       <BaseUnit  s=\"1\"/>
+//     </Unit>
+//     <Unit name =\"kg/(s.Pa)\">
+//       <BaseUnit  m=\"1\" s=\"1\"/>
+//     </Unit>
+//     <Unit name =\"1\">
+//       <BaseUnit />
+//     </Unit>
+//     <Unit name =\"N/mm2\">
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000000000.0\"/>
+//     </Unit>
+//     <Unit name =\"MW\">
+//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000000000.0\"/>
+//     </Unit>
+//     <Unit name =\"kg/kg\">
+//       <BaseUnit />
+//     </Unit>
+//     <Unit name =\"degC\">
+//       <BaseUnit  K=\"1\"/>
+//     </Unit>
+//     <Unit name =\"J/(kg.K)\">
+//       <BaseUnit  m=\"2\" s=\"-2\" K=\"-1\"/>
+//     </Unit>
+//     <Unit name =\"kg/mol\">
+//       <BaseUnit  mol=\"-1\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"kg/s\">
+//       <BaseUnit  s=\"-1\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"W\">
+//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"kg\">
+//       <BaseUnit  kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"J/kg\">
+//       <BaseUnit  m=\"2\" s=\"-2\"/>
+//     </Unit>
+//     <Unit name =\"J\">
+//       <BaseUnit  m=\"2\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"kg/m3\">
+//       <BaseUnit  m=\"-3\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"m3/s\">
+//       <BaseUnit  m=\"3\" s=\"-1\"/>
+//     </Unit>
+//     <Unit name =\"K\">
+//       <BaseUnit  K=\"1\"/>
+//     </Unit>
+//     <Unit name =\"km-1.s-3.g\">
+//       <BaseUnit  m=\"-1\" s=\"-3\" kg=\"1\" factor=\"0.001\"/>
+//     </Unit>
+//     <Unit name =\"m3.s-1\">
+//       <BaseUnit  m=\"3\" s=\"-1\"/>
+//     </Unit>
+//     <Unit name =\"Pa\">
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//     <Unit name =\"m3\">
+//       <BaseUnit  m=\"3\"/>
+//     </Unit>
+//   </UnitDefinitions>
 //   <TypeDefinitions>
 //     <SimpleType name=\"Modelica.Blocks.Types.Init\">
 //       <Enumeration>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -18,6 +18,7 @@ fmi_attributes_11.mos \
 fmi_attributes_12.mos \
 fmi_attributes_13.mos \
 fmi_attributes_14.mos \
+fmi_attributes_15.mos \
 FMIExercise.mos \
 FMUResourceTest.mos \
 HelloFMIWorld.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -1,0 +1,137 @@
+// name: fmi_attributes_15.mos
+// keywords: FMI 2.0 export
+// status: correct
+// teardown_command: rm -rf fmi_attributes_15.fmu fmi_attributes_15.log fmi_attributes_15_tmp.xml fmi_attributes_15.fmutmp/
+
+loadString("
+model fmi_attributes_15
+  Real x(unit = \"kg2\");
+equation
+  x=10;
+end fmi_attributes_15;
+"); getErrorString();
+
+translateModelFMU(fmi_attributes_15); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq fmi_attributes_15.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > fmi_attributes_15_tmp.xml"); getErrorString();
+readFile("fmi_attributes_15_tmp.xml")
+
+
+// Result:
+// true
+// ""
+// "fmi_attributes_15.fmu"
+// ""
+// 0
+// ""
+// "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+// <fmiModelDescription
+//   fmiVersion=\"2.0\"
+//   modelName=\"fmi_attributes_15\"
+//   description=\"\"
+//   variableNamingConvention=\"structured\"
+//   numberOfEventIndicators=\"0\">
+//   <ModelExchange
+//     modelIdentifier=\"fmi_attributes_15\">
+//     <SourceFiles>
+//       <File name=\"fmi_attributes_15.c\" />
+//       <File name=\"fmi_attributes_15_functions.c\" />
+//       <File name=\"fmi_attributes_15_records.c\" />
+//       <File name=\"fmi_attributes_15_01exo.c\" />
+//       <File name=\"fmi_attributes_15_02nls.c\" />
+//       <File name=\"fmi_attributes_15_03lsy.c\" />
+//       <File name=\"fmi_attributes_15_04set.c\" />
+//       <File name=\"fmi_attributes_15_05evt.c\" />
+//       <File name=\"fmi_attributes_15_06inz.c\" />
+//       <File name=\"fmi_attributes_15_07dly.c\" />
+//       <File name=\"fmi_attributes_15_08bnd.c\" />
+//       <File name=\"fmi_attributes_15_09alg.c\" />
+//       <File name=\"fmi_attributes_15_10asr.c\" />
+//       <File name=\"fmi_attributes_15_11mix.c\" />
+//       <File name=\"fmi_attributes_15_12jac.c\" />
+//       <File name=\"fmi_attributes_15_13opt.c\" />
+//       <File name=\"fmi_attributes_15_14lnz.c\" />
+//       <File name=\"fmi_attributes_15_15syn.c\" />
+//       <File name=\"fmi_attributes_15_16dae.c\" />
+//       <File name=\"fmi_attributes_15_17inl.c\" />
+//       <File name=\"fmi_attributes_15_init_fmu.c\" />
+//       <File name=\"fmi_attributes_15_FMU.c\" />
+//       <File name=\"./util/read_matlab4.c\" />
+//       <File name=\"./util/read_csv.c\" />
+//       <File name=\"./util/libcsv.c\" />
+//       <File name=\"gc/memory_pool.c\" />
+//       <File name=\"gc/omc_gc.c\" />
+//       <File name=\"./util/base_array.c\" />
+//       <File name=\"./util/boolean_array.c\" />
+//       <File name=\"./util/omc_error.c\" />
+//       <File name=\"./util/omc_file.c\" />
+//       <File name=\"./util/division.c\" />
+//       <File name=\"./util/generic_array.c\" />
+//       <File name=\"./util/index_spec.c\" />
+//       <File name=\"./util/integer_array.c\" />
+//       <File name=\"./util/list.c\" />
+//       <File name=\"./util/modelica_string.c\" />
+//       <File name=\"./util/real_array.c\" />
+//       <File name=\"./util/ringbuffer.c\" />
+//       <File name=\"./util/string_array.c\" />
+//       <File name=\"./util/utility.c\" />
+//       <File name=\"./util/varinfo.c\" />
+//       <File name=\"./util/ModelicaUtilities.c\" />
+//       <File name=\"./util/omc_msvc.c\" />
+//       <File name=\"./util/omc_numbers.c\" />
+//       <File name=\"./util/parallel_helper.c\" />
+//       <File name=\"./util/simulation_options.c\" />
+//       <File name=\"./util/rational.c\" />
+//       <File name=\"./util/modelica_string_lit.c\" />
+//       <File name=\"./util/omc_init.c\" />
+//       <File name=\"./util/omc_mmap.c\" />
+//       <File name=\"./util/jacobian_util.c\" />
+//       <File name=\"./math-support/pivot.c\" />
+//       <File name=\"./simulation/simulation_info_json.c\" />
+//       <File name=\"./simulation/options.c\" />
+//       <File name=\"./simulation/simulation_omc_assert.c\" />
+//       <File name=\"./simulation/omc_simulation_util.c\" />
+//       <File name=\"./simulation/solver/delay.c\" />
+//       <File name=\"./simulation/solver/fmi_events.c\" />
+//       <File name=\"./simulation/solver/omc_math.c\" />
+//       <File name=\"./simulation/solver/model_help.c\" />
+//       <File name=\"./simulation/solver/stateset.c\" />
+//       <File name=\"./simulation/solver/synchronous.c\" />
+//       <File name=\"./simulation/solver/initialization/initialization.c\" />
+//       <File name=\"./meta/meta_modelica_catch.c\" />
+//     </SourceFiles>
+//   </ModelExchange>
+//   <UnitDefinitions>
+//     <Unit name =\"kg2\">
+//       <BaseUnit  kg=\"2\"/>
+//     </Unit>
+//   </UnitDefinitions>
+//   <LogCategories>
+//     <Category name=\"logEvents\" />
+//     <Category name=\"logSingularLinearSystems\" />
+//     <Category name=\"logNonlinearSystems\" />
+//     <Category name=\"logDynamicStateSelection\" />
+//     <Category name=\"logStatusWarning\" />
+//     <Category name=\"logStatusDiscard\" />
+//     <Category name=\"logStatusError\" />
+//     <Category name=\"logStatusFatal\" />
+//     <Category name=\"logStatusPending\" />
+//     <Category name=\"logAll\" />
+//     <Category name=\"logFmi2Call\" />
+//   </LogCategories>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-006\"/>
+//   <ModelVariables>
+//   <!-- Index of variable = \"1\" -->
+//   <ScalarVariable
+//     name=\"x\"
+//     valueReference=\"0\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\" unit=\"kg2\"/>
+//   </ScalarVariable>
+//   </ModelVariables>
+//   <ModelStructure>
+//   </ModelStructure>
+// </fmiModelDescription>
+// "
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -107,7 +107,7 @@ readFile("modelDescription.tmp.xml");
 //   </ModelExchange>
 //   <UnitDefinitions>
 //     <Unit name =\"Pa\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\"/>
 //     </Unit>
 //   </UnitDefinitions>
 //   <LogCategories>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -105,6 +105,11 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./meta/meta_modelica_catch.c\" />
 //     </SourceFiles>
 //   </ModelExchange>
+//   <UnitDefinitions>
+//     <Unit name =\"Pa\">
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000.0\"/>
+//     </Unit>
+//   </UnitDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -118,7 +123,7 @@ readFile("modelDescription.tmp.xml");
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-006\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable

--- a/testsuite/simulation/libraries/3rdParty/HumMod/HumModTest_OMC_total.mo
+++ b/testsuite/simulation/libraries/3rdParty/HumMod/HumModTest_OMC_total.mo
@@ -168,7 +168,7 @@ end VascularElasticBloodCompartment;
 
 model LungBloodFlow
 Physiolibrary.Interfaces.RealInput_ CardiacOutput;
-parameter Real BasicRLShuntPercentage(final unit = "%") = 2 "basic percentage of total blood flow not exposed to lung air";
+parameter Real BasicRLShuntPercentage = 2 "basic percentage of total blood flow not exposed to lung air";
 parameter Real RightHemithorax_Pressure(final unit = "mmHg") = -4;
 parameter Real LeftHemithorax_Pressure(final unit = "mmHg") = -4;
 Real PressureGradientRightLeft(final unit = "mmHg") "difference between right and left hemithorax pressure";
@@ -8504,14 +8504,14 @@ y = k;
 end Constant;
 
 block FractConstant  "Generate constant signal in part from 1"
-parameter Real k(start = 1, final unit = "%") "Part in percent";
+parameter Real k(start = 1) "Part in percent";
 Physiolibrary.Interfaces.RealOutput_ y(final unit = "1") "Connector of Real output signal";
 equation
 y = k / 100;
 end FractConstant;
 
 block Fract2Constant  "Generate constant signal y as part on interval <0,1> and signal 1-y"
-parameter Real k(start = 1, final unit = "%") "Part in percent";
+parameter Real k(start = 1) "Part in percent";
 Physiolibrary.Interfaces.RealOutput_ y(final unit = "1") "Connector of Real output signal";
 Physiolibrary.Interfaces.RealOutput_ y2(final unit = "1") "Connector of Real output signal";
 equation
@@ -9127,7 +9127,7 @@ end SimpleReaction2;
 
 model UnlimitedStorage
 Physiolibrary.ConcentrationFlow.NegativeConcentrationFlow q_out;
-parameter Real concentration(final unit = "%");
+parameter Real concentration;
 equation
 q_out.conc = 0.01 * concentration;
 end UnlimitedStorage;


### PR DESCRIPTION
### Purpose 
This PR aims to export unitDefinition in ModelDescription.xml 

### Reference
https://trac.openmodelica.org/OpenModelica/ticket/5920
https://trac.openmodelica.org/OpenModelica/ticket/5845

### changedFiles
SimCode.mo  --- added dataStructure UnionDefinition to ModelInfo
SimCodeUtil.mo --- added functionality which parses the list of Units from SimVars and store it in list<UnitDefinition>