### PR TITLE
[NF] Enable flat output with instantiateModel.

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Algorithm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Algorithm.mo
@@ -288,7 +288,7 @@ algorithm
           case DAE.CALL(attr=DAE.CALL_ATTR(builtin=true), path=Absyn.IDENT("listAppend"), expLst=(e1 as DAE.CREF())::_)
             guard Expression.expEqual(lhs, e1)
             algorithm
-              if Flags.isSet(Flags.LIST_REVERSE_WRONG_ORDER) and not max(SCodeUtil.commentHasBooleanNamedAnnotation(comment, "__OpenModelica_DisableListAppendWarning") for comment in ElementSource.getCommentsFromSource(source)) then
+              if Flags.isSet(Flags.LIST_REVERSE_WRONG_ORDER) and not max(SCodeUtil.commentHasBooleanNamedAnnotation(comment, "__OpenModelica_DisableListAppendWarning") for comment in ElementSource.getComments(source)) then
                 Error.addSourceMessage(Error.LIST_REVERSE_WRONG_ORDER, {ExpressionDump.printExpStr(e1)}, ElementSource.getElementSourceFileInfo(source));
                 fail();
               end if;

--- a/OMCompiler/Compiler/FrontEnd/DAEDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEDump.mo
@@ -989,7 +989,7 @@ algorithm
 
     case (DAE.INITIAL_ASSERT(condition=e1,message = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -1000,7 +1000,7 @@ algorithm
 
     case (DAE.INITIAL_TERMINATE(message=e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s = stringAppendList({"  terminate(",s1,") ", sourceStr, ";\n"});
@@ -1035,7 +1035,7 @@ algorithm
 
     case (DAE.EQUATION(exp = e1,scalar = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -1045,7 +1045,7 @@ algorithm
 
      case (DAE.EQUEQUATION(cr1=cr1,cr2=cr2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ComponentReference.printComponentRefStr(cr1);
         s2 = ComponentReference.printComponentRefStr(cr2);
@@ -1055,7 +1055,7 @@ algorithm
 
     case(DAE.ARRAY_EQUATION(exp=e1,array=e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -1065,7 +1065,7 @@ algorithm
 
     case(DAE.COMPLEX_EQUATION(lhs=e1,rhs=e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -1075,7 +1075,7 @@ algorithm
 
     case (DAE.DEFINE(componentRef = c,exp = e,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ComponentReference.printComponentRefStr(c);
         s2 = stringAppend("  ", s1);
@@ -1088,7 +1088,7 @@ algorithm
 
     case (DAE.ASSERT(condition=e1,message = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -1098,7 +1098,7 @@ algorithm
 
     case (DAE.TERMINATE(message=e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         str = stringAppendList({"  terminate(",s1,") ", sourceStr, ";\n"});
@@ -1107,7 +1107,7 @@ algorithm
 
     case (DAE.NORETCALL(exp=e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         str = stringAppendList({"  ", s1, sourceStr, ";\n"});
@@ -3847,7 +3847,7 @@ algorithm
 
     case (DAE.DEFINE(componentRef = c,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ComponentReference.printComponentRefStr(c);
         str = stringAppend(s1, sourceStr + ";\n");
@@ -3856,7 +3856,7 @@ algorithm
 
     case (DAE.INITIALDEFINE(componentRef = c,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ComponentReference.printComponentRefStr(c);
         str = stringAppend(s1, sourceStr + ";\n");
@@ -3865,7 +3865,7 @@ algorithm
 
     case (DAE.EQUATION(exp = e1,scalar = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -3875,7 +3875,7 @@ algorithm
 
      case (DAE.EQUEQUATION(cr1=cr1,cr2=cr2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ComponentReference.printComponentRefStr(cr1);
         s2 = ComponentReference.printComponentRefStr(cr2);
@@ -3885,7 +3885,7 @@ algorithm
 
     case(DAE.ARRAY_EQUATION(exp=e1,array=e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -3895,7 +3895,7 @@ algorithm
 
     case(DAE.INITIAL_ARRAY_EQUATION(exp=e1,array=e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -3905,7 +3905,7 @@ algorithm
 
     case(DAE.COMPLEX_EQUATION(lhs=e1,rhs=e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -3915,7 +3915,7 @@ algorithm
 
     case(DAE.INITIAL_COMPLEX_EQUATION(lhs=e1,rhs=e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -3925,7 +3925,7 @@ algorithm
 
     case (DAE.WHEN_EQUATION(condition = e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         str = stringAppendList({"WHEN_EQUATION:  ", s1, sourceStr, ";\n"});
@@ -3934,7 +3934,7 @@ algorithm
 
     case (DAE.IF_EQUATION(source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         str = stringAppendList({"IF_EQUATION:  ", sourceStr, ";\n"});
       then
@@ -3942,7 +3942,7 @@ algorithm
 
     case (DAE.INITIAL_IF_EQUATION(source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         str = stringAppendList({"INITIAL_IF_EQUATION:  ", sourceStr, ";\n"});
       then
@@ -3950,7 +3950,7 @@ algorithm
 
     case (DAE.INITIALEQUATION(exp1 = e1,exp2 = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -3960,7 +3960,7 @@ algorithm
 
     case (DAE.ALGORITHM(source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         str = stringAppendList({"ALGO  ", sourceStr, ";\n"});
       then
@@ -3968,7 +3968,7 @@ algorithm
 
     case (DAE.INITIALALGORITHM(source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         str = stringAppendList({"INITIALALGORITHM  ", sourceStr, ";\n"});
       then
@@ -3976,7 +3976,7 @@ algorithm
 
     case (DAE.COMP(source = src, dAElist = elst))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = stringDelimitList(List.map(elst,DAEDump.dumpDebugElementStr),"\n");
         str = stringAppendList({"COMP  ",s1, sourceStr, ";\n"});
@@ -3985,7 +3985,7 @@ algorithm
 
     case (DAE.EXTOBJECTCLASS(path = path, source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = AbsynUtil.pathString(path);
         str = stringAppendList({"EXTOBJ  ",s1,"  ", sourceStr, ";\n"});
@@ -3994,7 +3994,7 @@ algorithm
 
     case (DAE.ASSERT(condition=e1,message = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -4004,7 +4004,7 @@ algorithm
 
     case (DAE.INITIAL_ASSERT(condition=e1,message = e2,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         s2 = ExpressionDump.printExpStr(e2);
@@ -4014,7 +4014,7 @@ algorithm
 
     case (DAE.TERMINATE(message=e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         str = stringAppendList({"  terminate(",s1,") ", sourceStr, ";\n"});
@@ -4023,7 +4023,7 @@ algorithm
 
     case (DAE.INITIAL_TERMINATE(message=e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         str = stringAppendList({"  /* initial */ terminate(",s1,") ", sourceStr, ";\n"});
@@ -4032,7 +4032,7 @@ algorithm
 
     case (DAE.REINIT(source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         str = stringAppendList({"  reinit(",") ", sourceStr, ";\n"});
       then
@@ -4040,7 +4040,7 @@ algorithm
 
     case (DAE.NORETCALL(exp=e1,source = src))
       equation
-        cmt = ElementSource.getCommentsFromSource(src);
+        cmt = ElementSource.getComments(src);
         sourceStr = cmtListToString(cmt);
         s1 = ExpressionDump.printExpStr(e1);
         str = stringAppendList({"  ", s1, sourceStr, ";\n"});

--- a/OMCompiler/Compiler/FrontEnd/ElementSource.mo
+++ b/OMCompiler/Compiler/FrontEnd/ElementSource.mo
@@ -137,7 +137,7 @@ algorithm
   end match;
 end addAnnotation;
 
-function getCommentsFromSource
+function getComments
   input DAE.ElementSource source;
   output list<SCode.Comment> outComments;
 algorithm
@@ -148,7 +148,19 @@ algorithm
     case (DAE.SOURCE(comment = comment)) then comment;
 
   end match;
-end getCommentsFromSource;
+end getComments;
+
+function getOptComment
+  "Returns the first added comment if there is one, otherwise NONE."
+  input DAE.ElementSource source;
+  output Option<SCode.Comment> outComment;
+algorithm
+  if not listEmpty(source.comment) then
+    outComment := SOME(List.last(source.comment));
+  else
+    outComment := NONE();
+  end if;
+end getOptComment;
 
 function addSymbolicTransformation
   input output DAE.ElementSource source;

--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -444,7 +444,7 @@ algorithm
 
         Print.clearBuf();
         execStat("Transformations before Dump");
-        s := if Config.silent() or Flags.getConfigBool(Flags.FLAT_MODELICA) then "" else DAEDump.dumpStr(d, funcs);
+        s := if Config.silent() or Config.flatModelica() then "" else DAEDump.dumpStr(d, funcs);
         execStat("DAEDump done");
         Print.printBuf(s);
         if Flags.isSet(Flags.DAE_DUMP_GRAPHV) then
@@ -530,7 +530,8 @@ algorithm
   // If no class was explicitly specified, instantiate the last class in the
   // program. Otherwise, instantiate the given class name.
   cname := if stringEmpty(cls) then AbsynUtil.lastClassname(SymbolTable.getAbsyn()) else AbsynUtil.stringPath(cls);
-  (cache, env, SOME(dae)) := CevalScriptBackend.runFrontEnd(FCore.emptyCache(), FGraph.empty(), cname, true);
+  (cache, env, SOME(dae)) := CevalScriptBackend.runFrontEnd(FCore.emptyCache(),
+    FGraph.empty(), cname, relaxedFrontEnd = true, dumpFlat = Config.flatModelica());
 end instantiate;
 
 protected function optimizeDae

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -70,8 +70,6 @@ public
 function convert
   input FlatModel flatModel;
   input FunctionTree functions;
-  input String name;
-  input SourceInfo info;
   output DAE.DAElist dae;
   output DAE.FunctionTree daeFunctions;
 protected
@@ -86,10 +84,10 @@ algorithm
   elems := convertAlgorithms(flatModel.algorithms, elems);
   elems := convertInitialAlgorithms(flatModel.initialAlgorithms, elems);
 
-  class_elem := DAE.COMP(name, elems, ElementSource.createElementSource(info), flatModel.comment);
+  class_elem := DAE.COMP(flatModel.name, elems, flatModel.source, ElementSource.getOptComment(flatModel.source));
   dae := DAE.DAE({class_elem});
 
-  execStat(getInstanceName() + "(" + name + ")");
+  execStat(getInstanceName());
 end convert;
 
 protected

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -49,6 +49,7 @@ protected
   import NFClassTree.ClassTree;
   import Component = NFComponent;
   import NFComponentRef.ComponentRef;
+  import DAE.ElementSource;
   import MetaModelica.Dangerous.listReverseInPlace;
 
   import FlatModel = NFFlatModel;
@@ -90,7 +91,7 @@ public
     list<Equation> initialEquations;
     list<Algorithm> algorithms;
     list<Algorithm> initialAlgorithms;
-    Option<SCode.Comment> comment;
+    ElementSource source;
   end FLAT_MODEL;
 
   function toString

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -158,7 +158,6 @@ function handleOverconstrainedConnections
    - Connections.uniqueRootIndices"
   input output FlatModel flatModel;
   input Connections conns;
-  input String modelNameQualified;
   output FlatEdges outBroken;
 protected
   ComponentRef lhs, rhs, cref;
@@ -238,7 +237,7 @@ algorithm
   // now we have the graph, remove the broken connects and evaluate the equation operators
   eql := listReverseInPlace(eql);
   ieql := flatModel.initialEquations;
-  (eql, ieql, connected, broken) := handleOverconstrainedConnections_dispatch(graph, modelNameQualified, eql, ieql);
+  (eql, ieql, connected, broken) := handleOverconstrainedConnections_dispatch(graph, flatModel.name, eql, ieql);
 
   eql := removeBrokenConnects(eql, connected, broken);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -59,7 +59,6 @@ import ExpandExp = NFExpandExp;
 public
 function scalarize
   input output FlatModel flatModel;
-  input String name;
 protected
   list<Variable> vars = {};
   list<Equation> eql = {}, ieql = {};
@@ -77,7 +76,7 @@ algorithm
   flatModel.algorithms := list(scalarizeAlgorithm(a) for a in flatModel.algorithms);
   flatModel.initialAlgorithms := list(scalarizeAlgorithm(a) for a in flatModel.initialAlgorithms);
 
-  execStat(getInstanceName() + "(" + name + ")");
+  execStat(getInstanceName());
 end scalarize;
 
 protected

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -181,15 +181,14 @@ end ExpOrigin;
 public
 function typeClass
   input InstNode cls;
-  input String name;
 algorithm
   typeClassType(cls, NFBinding.EMPTY_BINDING, ExpOrigin.CLASS, cls);
   typeComponents(cls, ExpOrigin.CLASS);
-  execStat("NFTyping.typeComponents(" + name + ")");
+  execStat("NFTyping.typeComponents");
   typeBindings(cls, cls, ExpOrigin.CLASS);
-  execStat("NFTyping.typeBindings(" + name + ")");
+  execStat("NFTyping.typeBindings");
   typeClassSections(cls, ExpOrigin.CLASS);
-  execStat("NFTyping.typeClassSections(" + name + ")");
+  execStat("NFTyping.typeClassSections");
 end typeClass;
 
 function typeComponents

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -635,14 +635,14 @@ protected
   SCode.Mod smod;
 algorithm
   // Type the class.
-  Typing.typeClass(inst_cls, name);
+  Typing.typeClass(inst_cls);
 
   // Flatten and simplify the model.
   flat_model := Flatten.flatten(inst_cls, name);
   flat_model := EvalConstants.evaluate(flat_model);
   flat_model := UnitCheck.checkUnits(flat_model);
   flat_model := SimplifyModel.simplify(flat_model);
-  funcs := Flatten.collectFunctions(flat_model, name);
+  funcs := Flatten.collectFunctions(flat_model);
 
   // Collect package constants that couldn't be substituted with their values
   // (e.g. because they where used with non-constant subscripts), and add them
@@ -651,7 +651,7 @@ algorithm
 
   // Scalarize array components in the flat model.
   if Flags.isSet(Flags.NF_SCALARIZE) then
-    flat_model := Scalarize.scalarize(flat_model, name);
+    flat_model := Scalarize.scalarize(flat_model);
   else
     // Remove empty arrays from variables
     flat_model.variables := List.filterOnFalse(flat_model.variables, Variable.isEmptyArray);
@@ -660,7 +660,7 @@ algorithm
   VerifyModel.verify(flat_model);
 
   // Convert the flat model to a DAE.
-  (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs, name, InstNode.info(inst_cls));
+  (dae, daeFuncs) := ConvertDAE.convert(flat_model, funcs);
 end frontEndBack;
 
   annotation(__OpenModelica_Interface="backend");

--- a/OMCompiler/Compiler/Stubs/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Stubs/CevalScriptBackend.mo
@@ -11,6 +11,7 @@ function runFrontEnd
   input FCore.Graph inEnv;
   input Absyn.Path className;
   input Boolean relaxedFrontEnd "Do not check for illegal simulation models, so we allow instantation of packages, etc";
+  input Boolean dumpFlat = false;
   output FCore.Cache cache;
   output FCore.Graph env;
   output Option<DAE.DAElist> dae;

--- a/OMCompiler/Compiler/Util/Config.mo
+++ b/OMCompiler/Compiler/Util/Config.mo
@@ -642,5 +642,18 @@ algorithm
   outRes := intGe(languageStandardInt(std), 33);
 end synchronousFeaturesAllowed;
 
+public function flatModelica
+  output Boolean value;
+algorithm
+  value := Flags.getConfigBool(Flags.FLAT_MODELICA);
+
+  // Ignore the flag unless the new frontend is enabled, otherwise it won't work.
+  if value and not Flags.isSet(Flags.SCODE_INST) then
+    Error.addMessage(Error.INVALID_FLAG_CONDITION,
+      {"-f", "flat modelica requires flag -d=newInst to be set"});
+    value := false;
+  end if;
+end flatModelica;
+
 annotation(__OpenModelica_Interface="util");
 end Config;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -798,6 +798,8 @@ public constant ErrorTypes.Message W_INVALID_ARGUMENT_TYPE_BRANCH_SECOND = Error
   Gettext.gettext("The second argument '%s' of %s must have the form A.R, where A is a connector and R an over-determined type/record."));
 public constant ErrorTypes.Message LIBRARY_WITHIN_WRONG_CASE = ErrorTypes.MESSAGE(363, ErrorTypes.GRAMMAR(), ErrorTypes.WARNING(),
   Gettext.gettext("Expected the package to have %s but got %s (ignoring the potential error; the class might have been inserted at an unexpected location)."));
+public constant ErrorTypes.Message INVALID_FLAG_CONDITION = ErrorTypes.MESSAGE(364, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  Gettext.gettext("Flag %s ignored: %s."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));


### PR DESCRIPTION
- Break out the instantiateModel handling from
  CevalScriptBackend.cevalInteractiveFunctions3 to its own function and
  make it handle flat modelica output when -f is set.
- Change NFInst.instClassInProgram to return NF structures instead of
  DAE, and convert to DAE in CevalScriptBackend.runFrontEndWork instead.
- Rename getCommentsFromSource to getComments in ElementSource, since
  the FromSource part can be inferred from it being in ElementSource.
- Added ElementSource.getOptComment to fetch the first added comment.
- Simplify flat model handling by changing the Comment in FlatModel into
  a ElementSource, to also embed the SourceInfo in the flat model.
- Remove the name of the class from all the execStat calls in the NF
  except for the first to simplify the interface between the modules,
  since it doesn't provide any extra information.