### PR TITLE
Check for mutally cyclic components for MM

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -1420,7 +1420,7 @@ protected
   list<tuple<Element, list<Element>>> g;
 algorithm
   // no sorting for meta-modelica!
-  if not Config.acceptMetaModelicaGrammar() then
+  //if not Config.acceptMetaModelicaGrammar() then
     // sort the elements according to the dependencies
     g := Graph.buildGraph(inElements, getElementDependencies, (inElements,isFunctionScope));
     (outE, cycles) := Graph.topologicalSort(g, isElementEqual);
@@ -1428,7 +1428,7 @@ algorithm
     // append the elements in the cycles as they might not actually be cycles, but they depend on elements not in the list (i.e. package constants, etc)!
     inElements := listAppend(outE, List.map(cycles, Util.tuple21));
     checkCyclicalComponents(cycles, inEnv);
-  end if;
+//  end if;
 end sortElementList;
 
 protected function printGraph

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -1409,7 +1409,8 @@ end addNomod;
 
 public function sortElementList
   "Sorts constants and parameters by dependencies, so that they are instantiated
-  before they are used."
+  before they are used.
+  For MetaModelica we just check for cycles. We do not do reordering"
   input output list<Element> inElements;
   input FCore.Graph inEnv;
   input Boolean isFunctionScope;
@@ -1419,16 +1420,14 @@ protected
   list<tuple<Element, list<Element>>> cycles;
   list<tuple<Element, list<Element>>> g;
 algorithm
-  // no sorting for meta-modelica!
-  //if not Config.acceptMetaModelicaGrammar() then
-    // sort the elements according to the dependencies
-    g := Graph.buildGraph(inElements, getElementDependencies, (inElements,isFunctionScope));
-    (outE, cycles) := Graph.topologicalSort(g, isElementEqual);
-    // printGraph(inEnv, g, outE, cycles);
+  // sort the elements according to the dependencies
+  g := Graph.buildGraph(inElements, getElementDependencies, (inElements,isFunctionScope));
+  (outE, cycles) := Graph.topologicalSort(g, isElementEqual);
+  if not Config.acceptMetaModelicaGrammar() then
     // append the elements in the cycles as they might not actually be cycles, but they depend on elements not in the list (i.e. package constants, etc)!
     inElements := listAppend(outE, List.map(cycles, Util.tuple21));
-    checkCyclicalComponents(cycles, inEnv);
-//  end if;
+  end if;
+  checkCyclicalComponents(cycles, inEnv);
 end sortElementList;
 
 protected function printGraph

--- a/testsuite/metamodelica/meta/Makefile
+++ b/testsuite/metamodelica/meta/Makefile
@@ -77,6 +77,7 @@ MatchShadowing.mo \
 OptimizeContinue.mo \
 OptimizeMatchToIfExp.mo \
 OptionInteractive.mos \
+PackageConst1.mos \
 PartialFn1.mo \
 PartialFn2.mo \
 PartialFn3.mos \
@@ -133,7 +134,8 @@ Uniontype14.mos \
 Uniontype15.mos \
 UniontypeFunc1.mos \
 UniontypeConst1.mos \
-UniontypeConst2.mos
+UniontypeConst2.mos \
+UniontypeConst3.mos \
 # test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=

--- a/testsuite/metamodelica/meta/PackageConst1.mo
+++ b/testsuite/metamodelica/meta/PackageConst1.mo
@@ -1,0 +1,15 @@
+package PKT
+  constant Real CONST1 = CONST2 * 3;
+  constant Real CONST2 = CONST1 + 3;
+  function f
+    output Real ro;
+  algorithm
+    ro := CONST1 + CONST2;
+  end f;
+end PKT;
+
+function test
+  output Real x;
+algorithm
+  x := PKT.f();
+end test;

--- a/testsuite/metamodelica/meta/PackageConst1.mos
+++ b/testsuite/metamodelica/meta/PackageConst1.mos
@@ -1,0 +1,24 @@
+// name:     PackageConst1
+// keywords: package const recursion
+// status:   correct
+// cflags:   -g=MetaModelica -d=gen
+//
+// Tests self recursive constants inside of packages
+//
+
+loadFile("PackageConst1.mo"); getErrorString();
+test(); getErrorString();
+
+// Result:
+// true
+// ""
+//
+// "Error: Cyclically dependent constants or parameters found in scope PKT: {CONST2,CONST1} (ignore with -d=ignoreCycles).
+// [metamodelica/meta/PackageConst1.mo:14:3-14:15:writable] Error: Class PKT.f not found in scope test (looking for a function or record).
+// Error: Cyclically dependent constants or parameters found in scope PKT: {CONST2,CONST1} (ignore with -d=ignoreCycles).
+// [metamodelica/meta/PackageConst1.mo:14:3-14:15:writable] Error: Class PKT.f not found in scope test (looking for a function or record).
+// Error: Cyclically dependent constants or parameters found in scope PKT: {CONST2,CONST1} (ignore with -d=ignoreCycles).
+// [metamodelica/meta/PackageConst1.mo:14:3-14:15:writable] Error: Class PKT.f not found in scope test (looking for a function or record).
+// "
+
+// endResult

--- a/testsuite/metamodelica/meta/UniontypeConst3.mo
+++ b/testsuite/metamodelica/meta/UniontypeConst3.mo
@@ -1,0 +1,15 @@
+uniontype UT
+  constant Real CONST1 = CONST2 * 3;
+  constant Real CONST2 = CONST1 + 3;
+  function f
+    output Real ro;
+  algorithm
+    ro := CONST1 + CONST2;
+  end f;
+end UT;
+
+function test
+  output Real x;
+algorithm
+  x := UT.f();
+end test;

--- a/testsuite/metamodelica/meta/UniontypeConst3.mos
+++ b/testsuite/metamodelica/meta/UniontypeConst3.mos
@@ -1,0 +1,24 @@
+// name:     UniontypeConst3
+// keywords: uniontype const recursion
+// status:   correct
+// cflags:   -g=MetaModelica -d=gen
+//
+// Tests self recursive constants inside of uniontypes.
+//
+
+loadFile("UniontypeConst3.mo"); getErrorString();
+test(); getErrorString();
+
+// Result:
+// true
+// ""
+//
+//"Error: Cyclically dependent constants or parameters found in scope UT: {CONST2,CONST1} (ignore with -d=ignoreCycles).
+//[metamodelica/meta/UniontypeConst3.mo:14:3-14:14:writable] Error: Class UT.f not found in scope test (looking for a function or record).
+//Error: Cyclically dependent constants or parameters found in scope UT: {CONST2,CONST1} (ignore with -d=ignoreCycles).
+//[metamodelica/meta/UniontypeConst3.mo:14:3-14:14:writable] Error: Class UT.f not found in scope test (looking for a function or record).
+//Error: Cyclically dependent constants or parameters found in scope UT: {CONST2,CONST1} (ignore with -d=ignoreCycles).
+//[metamodelica/meta/UniontypeConst3.mo:14:3-14:14:writable] Error: Class UT.f not found in scope test (looking for a function or record).
+//"
+
+// endResult


### PR DESCRIPTION
This prevents omc spinning in a loop when dealing with mutually recursive components using: -g=MetaModelica 