### PR TITLE
Recompile OMEdit executable if needed

### DIFF
--- a/OMEdit/OMEdit.pro
+++ b/OMEdit/OMEdit.pro
@@ -30,8 +30,6 @@
 
 TEMPLATE = subdirs
 
-CONFIG += ordered
-
 SUBDIRS = OMEditLIB \
   OMEditGUI
 

--- a/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -36,6 +36,8 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 TARGET = OMEdit
 TEMPLATE = app
 
+PRE_TARGETDEPS += ../bin/libOMEdit.a
+
 LIBS += -L../bin -lOMEdit
 
 OMEDIT_ROOT = ../


### PR DESCRIPTION
OMEdit executable links with OMEdit static library so sometimes new changes are not reflected since main.cpp is not always recompiled.
Force compilation of main.cpp