### PR TITLE
#5983 Cleanup black box FMUs

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3806,9 +3806,11 @@ algorithm
       configureLogFile := "\""+configureLogFile+"\"";
     end if;
     // do not create static.log in resource directory when --fmiFilter=blackBox
+    /*
     if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
       configureFMU(platform, fmutmp, configureLogFile, isWindows);
-    end if;
+    end if;*/
+    configureFMU(platform, fmutmp, configureLogFile, isWindows);
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3805,9 +3805,9 @@ algorithm
     if isWindows then
       configureLogFile := "\""+configureLogFile+"\"";
     end if;
-    // do not create static.log in resource directory when --fmiFilter=blackBox
-    if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), Flags.FMI_BLACKBOX) then
-      configureFMU(platform, fmutmp, configureLogFile, isWindows);
+    configureFMU(platform, fmutmp, configureLogFile, isWindows);
+    if Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+      System.removeFile(configureLogFile);
     end if;
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
@@ -3815,7 +3815,7 @@ algorithm
   // check for '--fmiSource=false' or '--fmiFilter=blackBox' and remove the sources directory before packing the fmu
   if not Flags.getConfigBool(Flags.FMI_SOURCES) or Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
     if not System.removeDirectory(fmutmp + "/sources/") then
-      Error.addInternalError("Failed to remove directory: " + fmutmp , sourceInfo());
+      Error.addInternalError("Failed to remove directory: " + fmutmp, sourceInfo());
     end if;
   end if;
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3802,9 +3802,6 @@ algorithm
 
   for platform in platforms loop
     configureLogFile := System.realpath(fmutmp)+"/resources/"+System.stringReplace(listGet(Util.stringSplitAtChar(platform," "),1),"/","-")+".log";
-    if isWindows then
-      configureLogFile := "\""+configureLogFile+"\"";
-    end if;
     configureFMU(platform, fmutmp, configureLogFile, isWindows);
     if Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
       System.removeFile(configureLogFile);

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3806,11 +3806,9 @@ algorithm
       configureLogFile := "\""+configureLogFile+"\"";
     end if;
     // do not create static.log in resource directory when --fmiFilter=blackBox
-    /*
-    if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+    if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), Flags.FMI_BLACKBOX) then
       configureFMU(platform, fmutmp, configureLogFile, isWindows);
-    end if;*/
-    configureFMU(platform, fmutmp, configureLogFile, isWindows);
+    end if;
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3805,7 +3805,10 @@ algorithm
     if isWindows then
       configureLogFile := "\""+configureLogFile+"\"";
     end if;
-    configureFMU(platform, fmutmp, configureLogFile, isWindows);
+    // do not create static.log in resource directory when --fmiFilter=blackBox
+    if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+      configureFMU(platform, fmutmp, configureLogFile, isWindows);
+    end if;
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);
   end for;
 

--- a/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
@@ -82,36 +82,33 @@ algorithm
         else
           fileName = code.fileNamePrefix + "_info.json";
         end if;
-        /* do not create the _info.json file in resource directory when blackBox option is set */
-        if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), Flags.FMI_BLACKBOX) then
-          File.open(file,fileName,File.Mode.Write);
-          File.write(file, "{\"format\":\"Transformational debugger info\",\"version\":1,\n\"info\":{\"name\":");
-          serializePath(file, mi.name);
-          File.write(file, ",\"description\":\"");
-          File.writeEscape(file, mi.description, escape=JSON);
-          File.write(file, "\"},\n\"variables\":{\n");
-          serializeVars(file,vars,withOperations);
-          File.write(file, "\n},\n\"equations\":[");
-          // Handle no comma for the first equation
-          File.write(file,"{\"eqIndex\":0,\"tag\":\"dummy\"}");
-          min(serializeEquation(file,eq,"initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations));
-          min(serializeEquation(file,eq,"initial-lambda0",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations_lambda0));
-          min(serializeEquation(file,eq,"removed-initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.removedInitialEquations));
-          min(serializeEquation(file,eq,"regular",withOperations) for eq in SimCodeUtil.sortEqSystems(code.allEquations));
-          min(serializeEquation(file,eq,"synchronous",withOperations) for eq in SimCodeUtil.sortEqSystems(SimCodeUtil.getClockedEquations(SimCodeUtil.getSubPartitions(code.clockedPartitions))));
-          min(serializeEquation(file,eq,"start",withOperations) for eq in SimCodeUtil.sortEqSystems(code.startValueEquations));
-          min(serializeEquation(file,eq,"nominal",withOperations) for eq in SimCodeUtil.sortEqSystems(code.nominalValueEquations));
-          min(serializeEquation(file,eq,"min",withOperations) for eq in SimCodeUtil.sortEqSystems(code.minValueEquations));
-          min(serializeEquation(file,eq,"max",withOperations) for eq in SimCodeUtil.sortEqSystems(code.maxValueEquations));
-          min(serializeEquation(file,eq,"parameter",withOperations) for eq in SimCodeUtil.sortEqSystems(code.parameterEquations));
-          min(serializeEquation(file,eq,"assertions",withOperations) for eq in SimCodeUtil.sortEqSystems(code.algorithmAndEquationAsserts));
-          min(serializeEquation(file,eq,"inline",withOperations) for eq in SimCodeUtil.sortEqSystems(code.inlineEquations));
-          min(serializeEquation(file,eq,"residuals",withOperations) for eq in SimCodeUtil.sortEqSystems(List.flatten(SimCodeUtil.getSimCodeDAEModeDataEqns(code.daeModeData))));
-          min(serializeEquation(file,eq,"jacobian",withOperations) for eq in SimCodeUtil.sortEqSystems(code.jacobianEquations));
-          File.write(file, "\n],\n\"functions\":[");
-          serializeList(file,mi.functions,serializeFunction);
-          File.write(file, "\n]\n}");
-        end if;
+        File.open(file,fileName,File.Mode.Write);
+        File.write(file, "{\"format\":\"Transformational debugger info\",\"version\":1,\n\"info\":{\"name\":");
+        serializePath(file, mi.name);
+        File.write(file, ",\"description\":\"");
+        File.writeEscape(file, mi.description, escape=JSON);
+        File.write(file, "\"},\n\"variables\":{\n");
+        serializeVars(file,vars,withOperations);
+        File.write(file, "\n},\n\"equations\":[");
+        // Handle no comma for the first equation
+        File.write(file,"{\"eqIndex\":0,\"tag\":\"dummy\"}");
+        min(serializeEquation(file,eq,"initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations));
+        min(serializeEquation(file,eq,"initial-lambda0",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations_lambda0));
+        min(serializeEquation(file,eq,"removed-initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.removedInitialEquations));
+        min(serializeEquation(file,eq,"regular",withOperations) for eq in SimCodeUtil.sortEqSystems(code.allEquations));
+        min(serializeEquation(file,eq,"synchronous",withOperations) for eq in SimCodeUtil.sortEqSystems(SimCodeUtil.getClockedEquations(SimCodeUtil.getSubPartitions(code.clockedPartitions))));
+        min(serializeEquation(file,eq,"start",withOperations) for eq in SimCodeUtil.sortEqSystems(code.startValueEquations));
+        min(serializeEquation(file,eq,"nominal",withOperations) for eq in SimCodeUtil.sortEqSystems(code.nominalValueEquations));
+        min(serializeEquation(file,eq,"min",withOperations) for eq in SimCodeUtil.sortEqSystems(code.minValueEquations));
+        min(serializeEquation(file,eq,"max",withOperations) for eq in SimCodeUtil.sortEqSystems(code.maxValueEquations));
+        min(serializeEquation(file,eq,"parameter",withOperations) for eq in SimCodeUtil.sortEqSystems(code.parameterEquations));
+        min(serializeEquation(file,eq,"assertions",withOperations) for eq in SimCodeUtil.sortEqSystems(code.algorithmAndEquationAsserts));
+        min(serializeEquation(file,eq,"inline",withOperations) for eq in SimCodeUtil.sortEqSystems(code.inlineEquations));
+        min(serializeEquation(file,eq,"residuals",withOperations) for eq in SimCodeUtil.sortEqSystems(List.flatten(SimCodeUtil.getSimCodeDAEModeDataEqns(code.daeModeData))));
+        min(serializeEquation(file,eq,"jacobian",withOperations) for eq in SimCodeUtil.sortEqSystems(code.jacobianEquations));
+        File.write(file, "\n],\n\"functions\":[");
+        serializeList(file,mi.functions,serializeFunction);
+        File.write(file, "\n]\n}");
       then (true,fileName);
     else
       equation

--- a/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
@@ -82,33 +82,36 @@ algorithm
         else
           fileName = code.fileNamePrefix + "_info.json";
         end if;
-        File.open(file,fileName,File.Mode.Write);
-        File.write(file, "{\"format\":\"Transformational debugger info\",\"version\":1,\n\"info\":{\"name\":");
-        serializePath(file, mi.name);
-        File.write(file, ",\"description\":\"");
-        File.writeEscape(file, mi.description, escape=JSON);
-        File.write(file, "\"},\n\"variables\":{\n");
-        serializeVars(file,vars,withOperations);
-        File.write(file, "\n},\n\"equations\":[");
-        // Handle no comma for the first equation
-        File.write(file,"{\"eqIndex\":0,\"tag\":\"dummy\"}");
-        min(serializeEquation(file,eq,"initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations));
-        min(serializeEquation(file,eq,"initial-lambda0",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations_lambda0));
-        min(serializeEquation(file,eq,"removed-initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.removedInitialEquations));
-        min(serializeEquation(file,eq,"regular",withOperations) for eq in SimCodeUtil.sortEqSystems(code.allEquations));
-        min(serializeEquation(file,eq,"synchronous",withOperations) for eq in SimCodeUtil.sortEqSystems(SimCodeUtil.getClockedEquations(SimCodeUtil.getSubPartitions(code.clockedPartitions))));
-        min(serializeEquation(file,eq,"start",withOperations) for eq in SimCodeUtil.sortEqSystems(code.startValueEquations));
-        min(serializeEquation(file,eq,"nominal",withOperations) for eq in SimCodeUtil.sortEqSystems(code.nominalValueEquations));
-        min(serializeEquation(file,eq,"min",withOperations) for eq in SimCodeUtil.sortEqSystems(code.minValueEquations));
-        min(serializeEquation(file,eq,"max",withOperations) for eq in SimCodeUtil.sortEqSystems(code.maxValueEquations));
-        min(serializeEquation(file,eq,"parameter",withOperations) for eq in SimCodeUtil.sortEqSystems(code.parameterEquations));
-        min(serializeEquation(file,eq,"assertions",withOperations) for eq in SimCodeUtil.sortEqSystems(code.algorithmAndEquationAsserts));
-        min(serializeEquation(file,eq,"inline",withOperations) for eq in SimCodeUtil.sortEqSystems(code.inlineEquations));
-        min(serializeEquation(file,eq,"residuals",withOperations) for eq in SimCodeUtil.sortEqSystems(List.flatten(SimCodeUtil.getSimCodeDAEModeDataEqns(code.daeModeData))));
-        min(serializeEquation(file,eq,"jacobian",withOperations) for eq in SimCodeUtil.sortEqSystems(code.jacobianEquations));
-        File.write(file, "\n],\n\"functions\":[");
-        serializeList(file,mi.functions,serializeFunction);
-        File.write(file, "\n]\n}");
+        /* do not create the _info.json file in resource directory when blackBox option is set */
+        if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+          File.open(file,fileName,File.Mode.Write);
+          File.write(file, "{\"format\":\"Transformational debugger info\",\"version\":1,\n\"info\":{\"name\":");
+          serializePath(file, mi.name);
+          File.write(file, ",\"description\":\"");
+          File.writeEscape(file, mi.description, escape=JSON);
+          File.write(file, "\"},\n\"variables\":{\n");
+          serializeVars(file,vars,withOperations);
+          File.write(file, "\n},\n\"equations\":[");
+          // Handle no comma for the first equation
+          File.write(file,"{\"eqIndex\":0,\"tag\":\"dummy\"}");
+          min(serializeEquation(file,eq,"initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations));
+          min(serializeEquation(file,eq,"initial-lambda0",withOperations) for eq in SimCodeUtil.sortEqSystems(code.initialEquations_lambda0));
+          min(serializeEquation(file,eq,"removed-initial",withOperations) for eq in SimCodeUtil.sortEqSystems(code.removedInitialEquations));
+          min(serializeEquation(file,eq,"regular",withOperations) for eq in SimCodeUtil.sortEqSystems(code.allEquations));
+          min(serializeEquation(file,eq,"synchronous",withOperations) for eq in SimCodeUtil.sortEqSystems(SimCodeUtil.getClockedEquations(SimCodeUtil.getSubPartitions(code.clockedPartitions))));
+          min(serializeEquation(file,eq,"start",withOperations) for eq in SimCodeUtil.sortEqSystems(code.startValueEquations));
+          min(serializeEquation(file,eq,"nominal",withOperations) for eq in SimCodeUtil.sortEqSystems(code.nominalValueEquations));
+          min(serializeEquation(file,eq,"min",withOperations) for eq in SimCodeUtil.sortEqSystems(code.minValueEquations));
+          min(serializeEquation(file,eq,"max",withOperations) for eq in SimCodeUtil.sortEqSystems(code.maxValueEquations));
+          min(serializeEquation(file,eq,"parameter",withOperations) for eq in SimCodeUtil.sortEqSystems(code.parameterEquations));
+          min(serializeEquation(file,eq,"assertions",withOperations) for eq in SimCodeUtil.sortEqSystems(code.algorithmAndEquationAsserts));
+          min(serializeEquation(file,eq,"inline",withOperations) for eq in SimCodeUtil.sortEqSystems(code.inlineEquations));
+          min(serializeEquation(file,eq,"residuals",withOperations) for eq in SimCodeUtil.sortEqSystems(List.flatten(SimCodeUtil.getSimCodeDAEModeDataEqns(code.daeModeData))));
+          min(serializeEquation(file,eq,"jacobian",withOperations) for eq in SimCodeUtil.sortEqSystems(code.jacobianEquations));
+          File.write(file, "\n],\n\"functions\":[");
+          serializeList(file,mi.functions,serializeFunction);
+          File.write(file, "\n]\n}");
+        end if;
       then (true,fileName);
     else
       equation

--- a/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
@@ -83,7 +83,7 @@ algorithm
           fileName = code.fileNamePrefix + "_info.json";
         end if;
         /* do not create the _info.json file in resource directory when blackBox option is set */
-        if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+        if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), Flags.FMI_BLACKBOX) then
           File.open(file,fileName,File.Mode.Write);
           File.write(file, "{\"format\":\"Transformational debugger info\",\"version\":1,\n\"info\":{\"name\":");
           serializePath(file, mi.name);

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -745,8 +745,11 @@ algorithm
             fail();
           end if;
         else
-          if 0 <> System.systemCall("mv '"+simCode.fileNamePrefix+"_info.json"+"' '" + fmutmp+"/resources/" + "'") then
-            Error.addInternalError("Failed to info.json file", sourceInfo());
+          // check for _info.json file in resource directory  when --fmiFilter=blackBox is not set
+          if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+            if 0 <> System.systemCall("mv '"+simCode.fileNamePrefix+"_info.json"+"' '" + fmutmp+"/resources/" + "'") then
+              Error.addInternalError("Failed to info.json file", sourceInfo());
+            end if;
           end if;
         end if;
         SimCodeUtil.resetFunctionIndex();

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -266,7 +266,7 @@ protected
   list<tuple<String, String>> program;
   Integer numCheckpoints;
   String fmuVersion;
- 
+
 algorithm
   numCheckpoints:=ErrorExt.getNumCheckpoints();
   try
@@ -514,7 +514,7 @@ algorithm
         end for;
       then ();
 
-   
+
 
     case "Adevs" equation
       Tpl.tplNoret(CodegenAdevs.translateModel, simCode);
@@ -681,7 +681,7 @@ protected function callTargetTemplatesOMSICpp
   protected
   String fmuVersion;
   String fmuType;
- 
+
 algorithm
     fmuVersion:="2.0";
     fmuType:="me";
@@ -746,9 +746,9 @@ algorithm
           end if;
         else
           // check for _info.json file in resource directory  when --fmiFilter=blackBox is not set
-          if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), Flags.FMI_BLACKBOX) then
-            if 0 <> System.systemCall("mv '"+simCode.fileNamePrefix+"_info.json"+"' '" + fmutmp+"/resources/" + "'") then
-              Error.addInternalError("Failed to info.json file", sourceInfo());
+          if Flags.getConfigEnum(Flags.FMI_FILTER) <> Flags.FMI_BLACKBOX then
+            if 0 <> System.systemCall("mv '" + simCode.fileNamePrefix + "_info.json"+"' '" + fmutmp+"/resources/" + "'") then
+              Error.addInternalError("Failed to move " + simCode.fileNamePrefix + "_info.json file", sourceInfo());
             end if;
           end if;
         end if;
@@ -843,10 +843,10 @@ algorithm
         runTplWriteFile(func = function CodegenOMSIC.generateOMSIC(a_simCode=simCode), file=simCode.fullPathPrefix+"/"+fileprefix+"_omsic.c");
 
         runTpl(func = function CodegenOMSI_common.generateEquationsCode(a_simCode=simCode, a_FileNamePrefix=fileprefix));
-        
+
            runTpl(func = function CodegenOMSICpp.translateModel(a_simCode=simCode, a_FMUVersion=FMUVersion, a_FMUType=FMUType));
       then ();
-    
+
     case (_,"Cpp")
       equation
         if(Flags.isSet(Flags.HPCOM)) then

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -746,7 +746,7 @@ algorithm
           end if;
         else
           // check for _info.json file in resource directory  when --fmiFilter=blackBox is not set
-          if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+          if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), Flags.FMI_BLACKBOX) then
             if 0 <> System.systemCall("mv '"+simCode.fileNamePrefix+"_info.json"+"' '" + fmutmp+"/resources/" + "'") then
               Error.addInternalError("Failed to info.json file", sourceInfo());
             end if;

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1166,9 +1166,9 @@ match platform
   <%\t%>$(LD) -o <%modelNamePrefix%>$(DLLEXT) $(OFILES) $(RUNTIMEFILES) <%dirExtra%> <%libsPos1%> @BSTATIC@ <%libsPos2%> @BDYNAMIC@ $(LDFLAGS)
   <%\t%>cp <%fileNamePrefix%>$(DLLEXT) <%fileNamePrefix%>_FMU.libs ../binaries/$(FMIPLATFORM)/
   endif
-  if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
-  <%\t%>head -n20 Makefile > ../resources/$(FMIPLATFORM).summary
-  endif
+  <%if intLt(Flags.getConfigEnum(Flags.FMI_FILTER), 4) then
+  '<%\t%>head -n20 Makefile > ../resources/$(FMIPLATFORM).summary'
+   %>
   ifeq (@LIBTYPE_STATIC@,1)
   <%\t%>rm -f <%modelNamePrefix%>.a
   <%\t%>$(AR) -rsu <%modelNamePrefix%>.a $(OFILES) $(RUNTIMEFILES)

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1166,7 +1166,9 @@ match platform
   <%\t%>$(LD) -o <%modelNamePrefix%>$(DLLEXT) $(OFILES) $(RUNTIMEFILES) <%dirExtra%> <%libsPos1%> @BSTATIC@ <%libsPos2%> @BDYNAMIC@ $(LDFLAGS)
   <%\t%>cp <%fileNamePrefix%>$(DLLEXT) <%fileNamePrefix%>_FMU.libs ../binaries/$(FMIPLATFORM)/
   endif
+  if not Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
   <%\t%>head -n20 Makefile > ../resources/$(FMIPLATFORM).summary
+  endif
   ifeq (@LIBTYPE_STATIC@,1)
   <%\t%>rm -f <%modelNamePrefix%>.a
   <%\t%>$(AR) -rsu <%modelNamePrefix%>.a $(OFILES) $(RUNTIMEFILES)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -3874,6 +3874,7 @@ package Flags
   constant ConfigFlag ZEROMQ_JOB_ID;
   constant ConfigFlag ZEROMQ_SERVER_ID;
   constant ConfigFlag ZEROMQ_CLIENT_ID;
+  constant ConfigFlag FMI_FILTER;
 
   function isSet
     input DebugFlag inFlag;

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -630,8 +630,8 @@ int SystemImpl__systemCall(const char* str, const char* outFile)
   fflush(NULL); /* flush output so the testsuite is deterministic */
 #if defined(__MINGW32__) || defined(_MSC_VER)
   if (*outFile) {
-    char *command = (char *)omc_alloc_interface.malloc_atomic(strlen(str) + strlen(outFile) + 10);
-    sprintf(command, "%s >> %s 2>&1", str, outFile);
+    char *command = (char *)omc_alloc_interface.malloc_atomic(strlen(str) + strlen(outFile) + 12);
+    sprintf(command, "%s >> \"%s\" 2>&1", str, outFile);
     status = runProcess(command);
     GC_free((void*)command);
   } else {

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -78,15 +78,25 @@ int omc_stat(const char *filename, struct stat *statbuf)
 
 int omc_unlink(const char *filename)
 {
+  int result = 0;
 #if defined(__MINGW32__) || defined(_MSC_VER)
   MULTIBYTE_TO_WIDECHAR_LENGTH(filename, unicodeFilenameLength);
   MULTIBYTE_TO_WIDECHAR_VAR(filename, unicodeFilename, unicodeFilenameLength);
-  int result = _wunlink(unicodeFilename);
+  result = _wunlink(unicodeFilename);
   MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodeFilename);
-  return result;
 #else /* unix */
-  return unlink(filename);
+  result = unlink(filename);
 #endif
+  /* uncomment for debugging
+  if (result == -1)
+  {
+    const char* s = "Could not delete file: ";
+    char *msg = (char*)malloc(strlen(s) + strlen(filename) + 1);
+    sprintf(msg, "%s%s", s, filename);
+    perror(msg);
+  }
+  */
+  return result;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Purpose
This cleans up the files in FMU resource directory,  when used with --fmiFilter=blackBox, see https://trac.openmodelica.org/OpenModelica/ticket/5983

### changed Files, 
SerializeModelInfo.mo  -- generate the _info.json in resource directory, if fmiFilter=blackBox not set
CevalScriptBackend.mo -- generate the static.log in resource directory, if fmiFilter=blackBox not set
CodeGenFmu.tpl   -- generate .summary file in resource directory, if fmiFilter=blackBox not set

