### PR TITLE
[NF] Flat Modelica improvements.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -42,8 +42,10 @@ import Type = NFType;
 import Record = NFRecord;
 
 protected
+import Binding = NFBinding;
 import BuiltinCall = NFBuiltinCall;
 import Ceval = NFCeval;
+import Component = NFComponent;
 import ComponentRef = NFComponentRef;
 import Config;
 import Dimension = NFDimension;
@@ -54,9 +56,7 @@ import Inst = NFInst;
 import List;
 import Lookup = NFLookup;
 import MetaModelica.Dangerous.listReverseInPlace;
-import Binding = NFBinding;
 import Class = NFClass;
-import Component = NFComponent;
 import NFFunction.Function;
 import NFFunction.FunctionMatchKind;
 import NFFunction.MatchedFunction;
@@ -68,6 +68,7 @@ import NFTyping.ExpOrigin;
 import Operator = NFOperator;
 import Prefixes = NFPrefixes;
 import SCodeUtil;
+import SimplifyExp = NFSimplifyExp;
 import Subscript = NFSubscript;
 import TypeCheck = NFTypeCheck;
 import Typing = NFTyping;
@@ -1427,6 +1428,7 @@ protected
       exp := Expression.replaceIterator(exp, iter_node, iter_exp);
     end for;
 
+    exp := SimplifyExp.simplify(exp);
     Expression.CALL(call = outCall) := exp;
   end devectorizeCall;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -857,7 +857,7 @@ public
 
       case CREF(origin = Origin.CREF)
         algorithm
-          subs := list(Subscript.simplify(s) for s in cref.subscripts);
+          subs := Subscript.simplifyList(cref.subscripts, Type.arrayDims(cref.ty));
         then
           CREF(cref.node, subs, cref.ty, cref.origin, simplifySubscripts(cref.restCref));
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -286,6 +286,20 @@ public
     end if;
   end toStringList;
 
+  function toFlatString
+    input Dimension dim;
+    output String str;
+  algorithm
+    str := match dim
+      case INTEGER() then String(dim.size);
+      case BOOLEAN() then "Boolean";
+      case ENUM() then Type.toFlatString(dim.enumType);
+      case EXP() then Expression.toFlatString(dim.exp);
+      case UNKNOWN() then ":";
+      case UNTYPED() then Expression.toFlatString(dim.dimension);
+    end match;
+  end toFlatString;
+
   function endExp
     "Returns an expression for the last index in a dimension."
     input Dimension dim;
@@ -324,6 +338,37 @@ public
       case EXP() then dim.exp;
     end match;
   end sizeExp;
+
+  function expIsLowerBound
+    "Returns true if the expression represents the lower bound of a dimension."
+    input Expression exp;
+    output Boolean isStart;
+  algorithm
+    isStart := match exp
+      case Expression.INTEGER() then exp.value == 1;
+      case Expression.BOOLEAN() then exp.value == false;
+      case Expression.ENUM_LITERAL() then exp.index == 1;
+      else false;
+    end match;
+  end expIsLowerBound;
+
+  function expIsUpperBound
+    "Returns true if the expression represents the upper bound of the given dimension."
+    input Expression exp;
+    input Dimension dim;
+    output Boolean isEnd;
+  algorithm
+    isEnd := match (exp, dim)
+      local
+        Type ty;
+
+      case (Expression.INTEGER(), INTEGER()) then exp.value == dim.size;
+      case (Expression.BOOLEAN(), _) then exp.value == true;
+      case (Expression.ENUM_LITERAL(), ENUM(enumType = ty as Type.ENUMERATION()))
+        then exp.index == listLength(ty.literals);
+      else false;
+    end match;
+  end expIsUpperBound;
 
   function variability
     input Dimension dim;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -495,7 +495,7 @@ algorithm
     case Statement.FOR()
       algorithm
         // Make a mutable expression with a placeholder value.
-        iter_exp := Expression.makeMutable(Expression.EMPTY(Type.UNKNOWN()));
+        iter_exp := Expression.makeMutable(Expression.EMPTY(InstNode.getType(stmt.iterator)));
         // Replace the iterator with the expression in the body of the for loop.
         stmt.body := list(
           Statement.mapExp(s, function Expression.replaceIterator(

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -201,6 +201,8 @@ public
       s := IOStream.append(s, ";\n");
     end for;
 
+    s := IOStream.append(s, "public\n");
+
     if not listEmpty(flat_model.initialEquations) then
       s := IOStream.append(s, "initial equation\n");
       s := Equation.toFlatStreamList(flat_model.initialEquations, "  ", s);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1366,6 +1366,7 @@ uniontype InstNode
     input output IOStream.IOStream s;
   algorithm
     s := match node
+      case COMPONENT_NODE() then Component.toFlatStream(node.name, Pointer.access(node.component), s);
       case CLASS_NODE() then Class.toFlatStream(Pointer.access(node.cls), node, s);
       else IOStream.append(s, toFlatString(node));
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -718,7 +718,8 @@ protected
 algorithm
   Expression.SUBSCRIPTED_EXP(e, subs, ty) := subscriptedExp;
   subscriptedExp := simplify(e);
-  subscriptedExp := Expression.applySubscripts(list(Subscript.simplify(s) for s in subs), subscriptedExp);
+  subs := Subscript.simplifyList(subs, Type.arrayDims(Expression.typeOf(e)));
+  subscriptedExp := Expression.applySubscripts(subs, subscriptedExp);
 end simplifySubscriptedExp;
 
 function simplifyTupleElement

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -835,8 +835,8 @@ public
       case Type.CLOCK() then "Clock";
       case Type.ENUMERATION() then "'" + AbsynUtil.pathString(ty.typePath) + "'";
       case Type.ENUMERATION_ANY() then "enumeration(:)";
-      case Type.ARRAY() then toString(ty.elementType) + "[" + stringDelimitList(List.map(ty.dimensions, Dimension.toString), ", ") + "]";
-      case Type.TUPLE() then "(" + stringDelimitList(List.map(ty.types, toString), ", ") + ")";
+      case Type.ARRAY() then toFlatString(ty.elementType) + "[" + stringDelimitList(List.map(ty.dimensions, Dimension.toFlatString), ", ") + "]";
+      case Type.TUPLE() then "(" + stringDelimitList(List.map(ty.types, toFlatString), ", ") + ")";
       case Type.NORETCALL() then "()";
       case Type.UNKNOWN() then "unknown()";
       case Type.COMPLEX() then "'" + AbsynUtil.pathString(InstNode.scopePath(ty.cls)) + "'";
@@ -889,13 +889,13 @@ public
           s := IOStream.append(s, ty.name);
           s := IOStream.append(s, "'\n");
 
-          s := IOStream.append(s, "input ");
+          s := IOStream.append(s, "  input ");
           s := IOStream.append(s, toString(ty.ty));
           s := IOStream.append(s, " exp;\n");
 
           index := 1;
           for sub in ty.subs loop
-            s := IOStream.append(s, "input ");
+            s := IOStream.append(s, "  input ");
             s := IOStream.append(s, toString(sub));
             s := IOStream.append(s, " s");
             s := IOStream.append(s, String(index));
@@ -903,7 +903,7 @@ public
             index := index + 1;
           end for;
 
-          s := IOStream.append(s, "output ");
+          s := IOStream.append(s, "  output ");
           s := IOStream.append(s, toString(ty.subscriptedTy));
           s := IOStream.append(s, " result = exp[");
           s := IOStream.append(s,

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -213,40 +213,15 @@ public
 
     if var.visibility == Visibility.PROTECTED then
       s := IOStream.append(s, "protected ");
+    else
+      s := IOStream.append(s, "public ");
     end if;
 
-    s := IOStream.append(s, Component.Attributes.toFlatString(var.attributes, var.ty));
+    s := Component.Attributes.toFlatStream(var.attributes, var.ty, s, ComponentRef.isSimple(var.name));
     s := IOStream.append(s, Type.toFlatString(var.ty));
     s := IOStream.append(s, " ");
     s := IOStream.append(s, ComponentRef.toFlatString(var.name));
-
-    if not listEmpty(var.typeAttributes) then
-      s := IOStream.append(s, "(");
-
-      first := true;
-      var_dims := Type.dimensionCount(var.ty);
-
-      for a in var.typeAttributes loop
-        if first then
-          first := false;
-        else
-          s := IOStream.append(s, ", ");
-        end if;
-
-        b := Util.tuple22(a);
-        binding_dims := Type.dimensionCount(Expression.typeOf(Expression.getBindingExp(Binding.getExp(b))));
-
-        if var_dims > binding_dims then
-          s := IOStream.append(s, "each ");
-        end if;
-
-        s := IOStream.append(s, Util.tuple21(a));
-        s := IOStream.append(s, " = ");
-        s := IOStream.append(s, Binding.toFlatString(b));
-      end for;
-
-      s := IOStream.append(s, ")");
-    end if;
+    s := Component.typeAttrsToFlatStream(var.typeAttributes, var.ty, s);
 
     if Binding.isBound(var.binding) then
       s := IOStream.append(s, " = ");


### PR DESCRIPTION
- Simplify away subscripts when devectorizing calls if possible.
- Recheck whether a subscript is a slice or not after modifying the
  contained expression via e.g. Subscript.map.
- Only dump 'input' prefix for top-level components.
- Dump type attributes for components in e.g. functions.
- Dump 'public' for public elements, otherwise everything will be
  private after the first private element.
- Fix dumping of array dimensions which was using normal toString.
- Change more dump functions to use IOStream.