### PR TITLE
Handle preExp and varDecls for crefs with subs.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -5501,7 +5501,7 @@ case SES_SIMPLE_ASSIGN_CONSTRAINTS(__) then
   <<
   <%modelicaLine(eqInfo(eq))%>
   <%preExp%>
-  <%contextCref(cref, context, auxFunction)%> = <%expPart%>;
+  <%contextCref(cref, context, &preExp, &varDecls, auxFunction)%> = <%expPart%>;
     <%postExp%>
   <%endModelicaLine()%>
   >>
@@ -5634,7 +5634,7 @@ case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = at) th
     <%returnval2%>
   }
   /* write solution */
-  <%ls.vars |> SIMVAR(__) hasindex i0 => '<%contextCref(name, context, auxFunctions)%> = aux_x[<%i0%>];' ;separator="\n"%>
+  <%ls.vars |> SIMVAR(__) hasindex i0 => '<%contextCrefNoPrevExp(name, context, auxFunctions)%> = aux_x[<%i0%>];' ;separator="\n"%>
   <% if profileSome() then 'SIM_PROF_ACC_EQ(modelInfoGetEquation(&data->modelData->modelDataXml,<%ls.index%>).profileBlockIndex);' %>
 
   <%returnval%>
@@ -5660,12 +5660,12 @@ case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = SOME(a
   <% if profileSome() then 'SIM_PROF_TICK_EQ(modelInfoGetEquation(&data->modelData->modelDataXml,<%at.index%>).profileBlockIndex);' %>
   if (data->simulationInfo->linearSystemData[<%at.indexLinearSystem%>].checkConstraints(data, threadData) == 1)
   {
-    double aux_x[<%listLength(at.vars)%>] = { <%at.vars |> SIMVAR(__) hasindex i0 => '<%contextCref(name, context, auxFunctions)%>' ;separator=","%> };
+    double aux_x[<%listLength(at.vars)%>] = { <%at.vars |> SIMVAR(__) hasindex i0 => '<%contextCrefNoPrevExp(name, context, auxFunctions)%>' ;separator=","%> };
     retValue = solve_linear_system(data, threadData, <%at.indexLinearSystem%>, &aux_x[0]);
     /* The casual tearing set found a solution */
     if (retValue == 0){
       /* write solution */
-      <%at.vars |> SIMVAR(__) hasindex i0 => '<%contextCref(name, context, auxFunctions)%> = aux_x[<%i0%>];' ;separator="\n"%>
+      <%at.vars |> SIMVAR(__) hasindex i0 => '<%contextCrefNoPrevExp(name, context, auxFunctions)%> = aux_x[<%i0%>];' ;separator="\n"%>
       <% if profileSome() then 'SIM_PROF_ACC_EQ(modelInfoGetEquation(&data->modelData->modelDataXml,<%at.index%>).profileBlockIndex);' %>
     }
   }
@@ -5970,7 +5970,7 @@ match ty
     //   case T_ARRAY(__) then
     //     copyArrayData(var.ty, '<%tmp%>._<%var.name%>', appendStringCref(var.name,left), context, &preExp, &varDecls, &auxFunction)
     //   else
-    //     let varPart = contextCref(appendStringCref(var.name,left),context, &auxFunction)
+    //     let varPart = contextCref(appendStringCref(var.name,left), context, &preExp, &varDecls, &auxFunction)
     //     '<%varPart%> = <%tmp%>._<%var.name%>;'
     // ; separator="\n"
     // %>

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4447,7 +4447,7 @@ template contextCrefNoPrevExp(ComponentRef cr, Context context, Text &auxFunctio
   contextCref(cr, context, &preExp, &varDecls, auxFunction)
 end contextCrefNoPrevExp;
 
-template contextCref(ComponentRef cr, Context context, Text &varDecls, Text &preExp, Text &auxFunction)
+template contextCref(ComponentRef cr, Context context, Text &preExp, Text &varDecls, Text &auxFunction)
   "Generates code for a component reference depending on which context we're in."
 ::=
   match context

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -40,6 +40,7 @@ PolynomialEvaluator2.mos \
 PolynomialEvaluator3.mos \
 ticket2336.mos \
 ticket5114.mos \
+ticket_5994.mos \
 VariableRangeSubscript.mos \
 VectorizeOneReturnValue.mos \
 Xpowers1.mos \

--- a/testsuite/simulation/modelica/arrays/ticket_5994.mo
+++ b/testsuite/simulation/modelica/arrays/ticket_5994.mo
@@ -1,0 +1,13 @@
+package Ticket_5994
+  function modifyArray
+      input Real values[:];
+      output Real result[size(values, 1)];
+    algorithm
+      result[size(values, 1)] := 42.0;
+  end modifyArray;
+
+  model Test
+    Real sample[:] = {1.0, 2.0, 3.0};
+    Real modified[:] = modifyArray(values = sample);
+  end Test;
+end Ticket_5994;

--- a/testsuite/simulation/modelica/arrays/ticket_5994.mos
+++ b/testsuite/simulation/modelica/arrays/ticket_5994.mos
@@ -1,0 +1,27 @@
+// name: Ticket_5994
+// status: correct
+// teardown_command: rm -f Ticket_5994.Test*
+
+loadFile("ticket_5994.mo");
+getErrorString();
+
+simulate(Ticket_5994.Test);
+getErrorString();
+
+val(modified[3],0);
+getErrorString();
+
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Ticket_5994.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-006, method = 'dassl', fileNamePrefix = 'Ticket_5994.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 42.0
+// ""


### PR DESCRIPTION
  - This fixes ticket:5994.

  - We used to throw away any extra expressions and variable declarations
    needed for crefs with (complicated) subscripts,  i.e., if it has some complicated 
    subscript that can not  be generated inline.

  - If you are sure you have a _path_ (a cref with no subs) then you can use
    `contextCrefNoPrevExp` (e.g. variable names are just paths. They are just
    represented as cref). Otherwise `contextCref ` now needs a `preExp` and `varDecls`
    buffer passed to it.

  - Avoid unnecessary code generation.
    - The path we took for crefs with subscripts in function context
      used to create unnecessary temporaries and expressions which we did
      not notice because they were were thrown away after being created.

    - Split up the LHS cref generation template function to take different paths for 
      normal and parallel functions.

  - Add a test case for Ticket:5994.


   

  - Remaining issues

    - There are still cases where cref code generation does not get all needed information
       like buffers and correct context. This needs to be updated.
    - Generation of LHS crefs for parmodelica parallel functions needs to be updated 
      for recent changes.
    - contextCrefOld template function needs to be removed after replacing its uses by
      contextCref or an appropriate function. 