### PR TITLE
[NF] Fix subscripting of boxed/unboxed expressions.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1039,6 +1039,14 @@ public
         then bindingExpMap(exp,
           function applySubscript(subscript = subscript, restSubscripts = restSubscripts));
 
+      case UNBOX()
+        algorithm
+          outExp := applySubscript(subscript, exp.exp, restSubscripts);
+        then
+          unbox(outExp);
+
+      case BOX() then BOX(applySubscript(subscript, exp.exp, restSubscripts));
+
       else makeSubscriptedExp(subscript :: restSubscripts, exp);
     end match;
   end applySubscript;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1025,8 +1025,15 @@ public
                                subscript(ty.falseType, subs),
                                ty.matchedBranch);
 
-      case UNKNOWN()
-        then ty;
+      case METABOXED() then METABOXED(subscript(ty.ty, subs));
+      case UNKNOWN() then ty;
+
+      else
+        algorithm
+          Error.assertion(false, getInstanceName() +
+            " got unsubscriptable type " + toString(ty) + "\n", sourceInfo());
+        then
+          fail();
 
     end match;
   end subscript;


### PR DESCRIPTION
- Handle boxed types in Type.subscript.
- Add assertion in Type.subscript to catch unhandled types.
- Add special rules for unboxed/boxed values in
  Expression.applySubscript that subscripts the expressions they contain
  instead of creating unnecessary SUBSCRIPTED_EXPs.