### PR TITLE
MinGW fixes to bring test failures back to their "usual" numbers

### DIFF
--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1480,17 +1480,20 @@ end anyReturnTrue;
 
 public function absoluteOrRelative
 "@author: adrpo
- returns the given path if it exists if not it considers it relative and returns that"
+ returns the given path if it exists
+ if not it considers it relative and if it exists returns that
+ if the releative path does not exists it returns the given path"
  input String inFileName;
- output String outFileName;
+ output String outFileName = inFileName;
 protected
- String pwd, pd;
+ String pwd, pd, f;
 algorithm
  pwd := System.pwd();
  pd := Autoconf.pathDelimiter;
- outFileName := if System.regularFileExists(inFileName)
-                then inFileName
-                else stringAppendList({pwd,pd,inFileName});
+ if not System.regularFileExists(inFileName) then
+   f := stringAppendList({pwd,pd,inFileName});
+   outFileName := if System.regularFileExists(f) then f else outFileName;
+ end if;
 end absoluteOrRelative;
 
 public function intLstString

--- a/OMCompiler/SimulationRuntime/c/fmi/FMICommon.h
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMICommon.h
@@ -34,6 +34,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#if defined(__MINGW32__)
+#define FMILIB_STATIC_LIB_ONLY 1
+#endif
+
 #include "fmilib.h"
 #include "../ModelicaUtilities.h"
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
@@ -49,6 +49,8 @@
 
 #include "cvode_solver.h"
 
+#ifdef WITH_SUNDIALS
+
 /* Macros for better readability */
 #define CVODE_LMM_MAX 2
 const char *CVODE_LMM_NAME[CVODE_LMM_MAX + 1] = {
@@ -926,3 +928,5 @@ int cvode_solver_step(DATA *data, threadData_t *threadData, SOLVER_INFO *solverI
 
   return retVal;
 }
+
+#endif /* #ifdef WITH_SUNDIALS */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.h
@@ -31,9 +31,17 @@
 #ifndef CVODE_SOLVER_H
 #define CVODE_SOLVER_H
 
-/* link sundials static on Windows */
-#if defined(__MINGW32__) || defined(_MSV_VER)
+#include "simulation_data.h"
+#include "util/simulation_options.h"
+#include "omc_config.h" /* for WITH_SUNDIALS */
+
+#ifdef WITH_SUNDIALS
+
+/* adrpo: on mingw link with static sundials */
+#if defined(__MINGW32__)
+#if !defined(LINK_SUNDIALS_STATIC)
 #define LINK_SUNDIALS_STATIC 1
+#endif
 #endif
 
 #include "cvode/cvode.h"             /* prototypes for CVODE fcts., consts. */
@@ -41,9 +49,6 @@
 #include "cvode/cvode_dense.h"       /* prototype for CVODE dense matrix functions and constants */
 #include "nvector/nvector_serial.h"  /* serial N_Vector types, fcts., macros */
 #include "sundials/sundials_types.h" /* definition of type realtype */
-
-#include "simulation_data.h"
-#include "util/simulation_options.h"
 
 typedef struct CVODE_USERDATA
 {
@@ -99,5 +104,7 @@ typedef struct CVODE_SOLVER
 int cvode_solver_initial(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, CVODE_SOLVER *cvodeData);
 int cvode_solver_deinitial(CVODE_SOLVER *cvodeData);
 int cvode_solver_step(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo);
+
+#endif  /* #ifdef WITH_SUNDIALS */
 
 #endif /* #ifndef CVODE_SOLVER_H */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -64,11 +64,6 @@
 
 #ifdef WITH_SUNDIALS
 
-/* adrpo: on mingw link with static sundials */
-#if defined(__MINGW32__)
-#define LINK_SUNDIALS_STATIC
-#endif
-
 /* readability */
 #define SCALE_MODE 0
 #define RESCALE_MODE 1
@@ -2009,4 +2004,4 @@ static int idaReScaleData(IDA_SOLVER *idaData)
 }
 
 
-#endif
+#endif /* #ifdef WITH_SUNDIALS */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.h
@@ -38,12 +38,15 @@
 #include "simulation_data.h"
 #include "util/simulation_options.h"
 #include "simulation/solver/solver_main.h"
+#include "omc_config.h" /* for WITH_SUNDIALS */
 
 #ifdef WITH_SUNDIALS
 
 /* adrpo: on mingw link with static sundials */
 #if defined(__MINGW32__)
-#define LINK_SUNDIALS_STATIC
+#if !defined(LINK_SUNDIALS_STATIC)
+#define LINK_SUNDIALS_STATIC 1
+#endif
 #endif
 
 #include <sundials/sundials_nvector.h>

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/radau.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/radau.h
@@ -37,14 +37,17 @@
 
 #include "simulation_data.h"
 #include "solver_main.h"
-#include "omc_config.h"
+#include "omc_config.h" /* for WITH_SUNDIALS */
 
 #ifdef WITH_SUNDIALS
 
-  /* adrpo: on mingw link with static sundials */
-  #if defined(__MINGW32__)
-  #define LINK_SUNDIALS_STATIC
-  #endif
+/* adrpo: on mingw link with static sundials */
+#if defined(__MINGW32__)
+#if !defined(LINK_SUNDIALS_STATIC)
+#define LINK_SUNDIALS_STATIC 1
+#endif
+#endif
+
 
   #define DEFAULT_IMPRK_ORDER 5
 

--- a/testsuite/simulation/libraries/common/ModelTesting.mos
+++ b/testsuite/simulation/libraries/common/ModelTesting.mos
@@ -190,7 +190,7 @@ elseif (modelTestingType == OpenModelicaModelTesting.Kind.VerifiedSimulation) or
         res := false;
       end if;
     elseif diffAlgorithm == OpenModelicaModelTesting.DiffAlgorithm.diffSimulationResults then
-      print(if debug then "Trying diffSimulationResults.\n" else "");
+      print(if debug then "Trying diffSimulationResults(" + resultFile + ", " + referenceFile + ").\n" else "");
       (res,failVars) := OpenModelica.Scripting.diffSimulationResults(resultFile,referenceFile,csvFile+"diff.",relTol,vars=compareVars);
       print(if debug then "diffSimulationResults returns "+String(res)+".\n" else "");
     else


### PR DESCRIPTION

- more homogenous handling of LINK_SUNDIALS_STATIC for ida_solver, cvode_solver and radau
- signal that we link with static fmilib in FMICommon.h (define FMILIB_STATIC_LIB_ONLY)
- more debugging in testsuite/simulation/libraries/common/ModelTesting.mos
- change Util.absoluteOrRelative to check for the relative path and if
  it doesn't exist return the original path to generate better error
  messages