### PR TITLE
Return to the old handling of quoted identifiers

### DIFF
--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -864,10 +864,10 @@ literal in C. For example unescapedStringLength('\"')=1, unescapedStringLength('
 end unescapedStringLength;
 
 public function unquoteIdentifier
-  "Quoted identifiers which can use Modelica's allowed Q-CHARs need to be translated into canonical (valid c89 identifier) form
-   using ascii representations; for example,
-    '+' ->  QQ_2B_QQ
-    'xyz@d!' -> QQ_xyz40d21_QQ "
+  "Quoted identifiers, for example 'xyz' need to be translated into canonical form; for example _omcQuot_0x2778797A27
+  This name presents a unique mapping that is also reversible (so the debugger can show the quoted identifier's name.
+  The returned name is a valid C89 identifier.
+  "
   input String str;
   output String outStr;
   external "C" outStr=System_unquoteIdentifier(str) annotation(Library = "omcruntime");

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -693,7 +693,7 @@ extern char* System_unescapedString(char* str)
   return res;
 }
 
-extern char* System_unquoteIdentifier(char *str)
+extern const char* System_unquoteIdentifier(char *str)
 {
   return SystemImpl__unquoteIdentifier(str);
 }

--- a/testsuite/flattening/modelica/mosfiles/QuotedFunction.mo
+++ b/testsuite/flattening/modelica/mosfiles/QuotedFunction.mo
@@ -10,9 +10,9 @@ end 'オーペンモーデリッカー・ロックス';
 */
 
 function '\"\''
-  input Real '\"';
-  output Real '\'';
+  input Real '#';
+  output Real '23'; // Same hex code as # to test this better...
 algorithm
-  '\'' := sin('\"');
+  '23' := sin('#');
 end '\"\'';
 


### PR DESCRIPTION
This partially reverts 065a64f74f20b2db2b26f53075ad76094332f6ee