### PR TITLE
ticket:5927 fix the crash in linearization for Matlab

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -4707,17 +4707,17 @@ template functionlinearmodelMatlab(ModelInfo modelInfo, String modelNamePrefix) 
     const char *<%symbolName(modelNamePrefix,"linear_model_frame")%>()
     {
       return "function [sys, x0, u0, n, m, p] = <%symbolName(modelNamePrefix,"GetLinearModel")%>()\n"
-      "%% der(x) = A * x + B * u\n%% y = C * x + D * u \n"
-      "  n = <%varInfo.numStateVars%>; %% number of states \n  m = <%varInfo.numInVars%>; %% number of inputs \n  p = <%varInfo.numOutVars%>; %% number of outputs \n"
+      "%% der(x) = A * x + B * u\n%% y = C * x + D * u\n"
+      "  n = <%varInfo.numStateVars%>; %% number of states\n  m = <%varInfo.numInVars%>; %% number of inputs\n  p = <%varInfo.numOutVars%>; %% number of outputs\n"
       "\n"
       "  x0 = %s;\n"
       "  u0 = %s;\n"
-      "  Ts = %g; %% stop time\n"
       "\n"
       <%matrixA%>
       <%matrixB%>
       <%matrixC%>
       <%matrixD%>
+      "  Ts = %g; %% stop time\n\n"
       "  %% The Control System Toolbox is required for this. Alternatively just return the matrices A,B,C,D instead.\n"
       "  sys = ss(A,B,C,D,Ts,'StateName',{<%getVarNameMatlab(vars.stateVars, "x")%>}, 'InputName',{<%getVarNameMatlab(vars.inputVars, "u")%>}, 'OutputName', {<%getVarNameMatlab(vars.outputVars, "y")%>});\n"
       "end";
@@ -4746,7 +4746,7 @@ template functionlinearmodelJulia(ModelInfo modelInfo, String modelNamePrefix) "
     {
       return "function <%symbolName(modelNamePrefix,"GetLinearModel")%>()\n"
       "#= der(x) = A * x + B * u =#\n#= y = C * x + D * u =#\n"
-      "  local n = <%varInfo.numStateVars%> #= number of states =#\n  local m = <%varInfo.numInVars%> #= number of inputs =#\n  local p = <%varInfo.numOutVars%> #= number of outputs =#  \n"
+      "  local n = <%varInfo.numStateVars%> #= number of states =#\n  local m = <%varInfo.numInVars%> #= number of inputs =#\n  local p = <%varInfo.numOutVars%> #= number of outputs =#\n"
       "\n"
       "  local x0 = %s\n"
       "  local u0 = %s\n"

--- a/testsuite/openmodelica/linearization/test_dump_languages.mos
+++ b/testsuite/openmodelica/linearization/test_dump_languages.mos
@@ -97,7 +97,6 @@ readFile("linear_simple_test.py"); getErrorString();
 //
 //   x0 = {1.626558527192664, 2.380918053900121};
 //   u0 = {0};
-//   Ts = 0.5; % stop time
 //
 //   A =	[-2.887152375617477, -1.62655852935388;
 // 	-2.380918056675567, -2.388394731625707];
@@ -108,6 +107,8 @@ readFile("linear_simple_test.py"); getErrorString();
 //   C =	[0, 0];
 //
 //   D =	[4.007476581092785];
+//
+//   Ts = 0.5; % stop time
 //
 //   % The Control System Toolbox is required for this. Alternatively just return the matrices A,B,C,D instead.
 //   sys = ss(A,B,C,D,Ts,'StateName',{'x_num_x(1)','x_num_x(2)'}, 'InputName',{'u_u'}, 'OutputName', {'y_y'});
@@ -156,7 +157,7 @@ readFile("linear_simple_test.py"); getErrorString();
 // true
 // record SimulationResult
 //     resultFile = "simple_test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'simple_test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 500, tolerance = 1e-006, method = 'dassl', fileNamePrefix = 'simple_test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "stdout            | info    | Linearization will be performed at point of time: 0.500000
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.


### PR DESCRIPTION
- %g was given a string
- remove trailing spaces before \n in CodegenC.tpl
- update test