### PR TITLE
Update code quoting of identifiers

### DIFF
--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -864,10 +864,12 @@ literal in C. For example unescapedStringLength('\"')=1, unescapedStringLength('
 end unescapedStringLength;
 
 public function unquoteIdentifier
-  "Quoted identifiers which can use Modelica's allowed Q-CHARs need to be translated into canonical (valid c89 identifier) form
-   using ascii representations; for example,
-    '+' ->  QQ_2B_QQ
-    'xyz@d!' -> QQ_xyz40d21_QQ "
+  "Quoted identifiers, for example 'xyz' need to be translated into canonical form; for example _omcQ_27xyz_27
+
+   The prefix is _omcQ, there is no suffix. The escape character is _ (an identifier with _ would be _5F)
+
+   This name presents a unique mapping that is also reversible (so the debugger can show the quoted identifier's nam.
+   The returned name is a valid C89 identifier."
   input String str;
   output String outStr;
   external "C" outStr=System_unquoteIdentifier(str) annotation(Library = "omcruntime");

--- a/testsuite/flattening/modelica/mosfiles/QuotedFunction.mo
+++ b/testsuite/flattening/modelica/mosfiles/QuotedFunction.mo
@@ -10,9 +10,9 @@ end 'オーペンモーデリッカー・ロックス';
 */
 
 function '\"\''
-  input Real '\"';
-  output Real '\'';
+  input Real '#';
+  output Real '23';
 algorithm
-  '\'' := sin('\"');
+  '23' := sin('#');
 end '\"\'';
 


### PR DESCRIPTION
* No longer crashes on odd quoted identifiers that do not end with '
* Identifiers can now be reversed again (to see the actual name in the debugger)