### PR TITLE
[FMI] Reset eventInfo only on entering event mode

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -219,7 +219,6 @@ fmi2Status fmi2EventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
   if (nullPointer(comp, "fmi2EventUpdate", "eventInfo", eventInfo)) {
     return fmi2Error;
   }
-  eventInfo->valuesOfContinuousStatesChanged = fmi2False;
 
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2EventUpdate: Start Event Update! Next Sample Event %g", eventInfo->nextEventTime)
 
@@ -260,15 +259,13 @@ fmi2Status fmi2EventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
       }
     }
 
-    if (checkForDiscreteChanges(comp->fmuData, comp->threadData) || comp->fmuData->simulationInfo->needToIterate || checkRelations(comp->fmuData) || eventInfo->valuesOfContinuousStatesChanged) {
+    if (checkForDiscreteChanges(comp->fmuData, comp->threadData) || comp->fmuData->simulationInfo->needToIterate || checkRelations(comp->fmuData)) {
       FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2EventUpdate: Need to iterate(discrete changes)!")
-      eventInfo->newDiscreteStatesNeeded  = fmi2True;
-      eventInfo->nominalsOfContinuousStatesChanged = fmi2False;
-      eventInfo->valuesOfContinuousStatesChanged  = fmi2True;
+      eventInfo->newDiscreteStatesNeeded = fmi2True;
+      eventInfo->valuesOfContinuousStatesChanged = fmi2True;
       eventInfo->terminateSimulation = fmi2False;
     } else {
-      eventInfo->newDiscreteStatesNeeded  = fmi2False;
-      eventInfo->nominalsOfContinuousStatesChanged = fmi2False;
+      eventInfo->newDiscreteStatesNeeded = fmi2False;
       eventInfo->terminateSimulation = fmi2False;
     }
     FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2EventUpdate: newDiscreteStatesNeeded %s",eventInfo->newDiscreteStatesNeeded?"true":"false");
@@ -1151,6 +1148,15 @@ fmi2Status fmi2EnterEventMode(fmi2Component c)
     return fmi2Error;
   FILTERED_LOG(comp, fmi2OK, LOG_EVENTS, "fmi2EnterEventMode")
   comp->state = modelEventMode;
+
+  // Reset eventInfo
+  comp->eventInfo.newDiscreteStatesNeeded = fmi2False;
+  comp->eventInfo.terminateSimulation = fmi2False;
+  comp->eventInfo.nominalsOfContinuousStatesChanged = fmi2False;
+  comp->eventInfo.valuesOfContinuousStatesChanged = fmi2False;
+  comp->eventInfo.nextEventTimeDefined = fmi2False;
+  comp->eventInfo.nextEventTime = 0;
+
   return fmi2OK;
 }
 
@@ -1163,13 +1169,6 @@ fmi2Status fmi2NewDiscreteStates(fmi2Component c, fmi2EventInfo* eventInfo)
   if (invalidState(comp, "fmi2NewDiscreteStates", modelEventMode, ~0))
     return fmi2Error;
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2NewDiscreteStates")
-
-  eventInfo->newDiscreteStatesNeeded = fmi2False;
-  eventInfo->terminateSimulation = fmi2False;
-  eventInfo->nominalsOfContinuousStatesChanged = fmi2False;
-  eventInfo->valuesOfContinuousStatesChanged = fmi2False;
-  eventInfo->nextEventTimeDefined = fmi2False;
-  eventInfo->nextEventTime = 0;
 
   returnValue = fmi2EventUpdate(comp, eventInfo);
 

--- a/testsuite/special/FmuExportCrossCompile/check-files.mos
+++ b/testsuite/special/FmuExportCrossCompile/check-files.mos
@@ -1,4 +1,4 @@
-for m in {"FmuExportCrossCompile","RoomHeating_OM_RH","WaterTank_Control","WaterTank_TestSingleWaterTank"} loop
+for m in {"FmuExportCrossCompile","RoomHeating_OM_RH","WaterTank_Control","WaterTank_TestSingleWaterTank","BouncingBall"} loop
 for os in {"linux32","linux64","win32","win64","darwin64","arm-linux-gnueabi"} loop // "darwin32"
 for t in {"me","cs"} loop
 

--- a/testsuite/special/FmuExportCrossCompile/fmuExportCrossCompile.mos
+++ b/testsuite/special/FmuExportCrossCompile/fmuExportCrossCompile.mos
@@ -16,6 +16,30 @@ if not loadFile("WaterTank.mo") then
   exit(1);
 end if;
 getErrorString();
+if not loadString("model BouncingBall
+  parameter Real e=0.7 \"coefficient of restitution\";
+  parameter Real g=9.81 \"gravity acceleration\";
+  Real h(fixed=true, start=1) \"height of ball\";
+  Real v(fixed=true) \"velocity of ball\";
+  Boolean flying(fixed=true, start=true) \"true, if ball is flying\";
+  Boolean impact;
+  Real v_new(fixed=true);
+  Integer foo;
+equation
+  impact = h <= 0.0;
+  foo = if impact then 1 else 2;
+  der(v) = if flying then -g else 0;
+  der(h) = v;
+  when {h <= 0.0 and v <= 0.0,impact} then
+    v_new = if edge(impact) then -e*pre(v) else 0;
+    flying = v_new > 0;
+    reinit(v, v_new);
+  end when;
+end BouncingBall;") then
+  print(getErrorString());
+  exit(1);
+end if;
+getErrorString();
 if not loadString("model FmuExportCrossCompile
   parameter Real e=0.7;
   parameter Real g=9.81;
@@ -59,7 +83,7 @@ platforms := if false then {
   "i686-w64-mingw32"
 };
 
-for c in {"FmuExportCrossCompile","RoomHeating_OM.RH","WaterTank.Control","WaterTank.TestSingleWaterTank"} loop
+for c in {"FmuExportCrossCompile","RoomHeating_OM.RH","WaterTank.Control","WaterTank.TestSingleWaterTank","BouncingBall"} loop
   c2 := stringReplace(c, ".", "_");
   print(c2+"
 ");


### PR DESCRIPTION
 Fix for [ticket 5367](https://trac.openmodelica.org/OpenModelica/ticket/5367).
  - `fmi2EnterEventMode` will reset `eventInfo`. Then the FMU integrator  will set `newDiscreteStatesNeeded=fmi2True`.
    Inside fmi2NewDiscreteStates value for `valuesOfContinuousStatesChanged` will stay true if it becomes true at some point.
  - `valuesOfContinuousStatesChanged` can't trigger another call to `fmi2EventUpdate` any more. Would lead to infinit loop.