### PR TITLE
Undefined variable units when using FMUs (ticket:6002)

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Unit.mo
+++ b/OMCompiler/Compiler/BackEnd/Unit.mo
@@ -102,21 +102,22 @@ public constant list<tuple<String, Unit>> LU_COMPLEXUNITS = {
 //("var",        UNIT(1e3, 0, 0, 2,-3, 0, 0, 1)), //Var=Watt
   ("Hz",         UNIT(1e0, 0, 0, 0,-1, 0, 0, 0)), //Hertz
   ("Ohm",        UNIT(1e3, 0, 0, 2,-3,-2, 0, 1)), //Ohm
-  ("F",         UNIT(1e-3, 0, 0,-2, 4, 2, 0,-1)), //Farad
+  ("F",          UNIT(1e-3, 0, 0,-2, 4, 2, 0,-1)), //Farad
   ("H",          UNIT(1e3, 0, 0, 2,-2,-2, 0, 1)), //Henry
   ("C",          UNIT(1e0, 0, 0, 0, 1, 1, 0, 0)), //Coulomb
   ("T",          UNIT(1e3, 0, 0, 0,-2,-1, 0, 1)), //Tesla
-  ("S",         UNIT(1e-3, 0, 0,-2, 3, 2, 0,-1)), //Siemens
+  ("S",          UNIT(1e-3, 0, 0,-2, 3, 2, 0,-1)), //Siemens
   ("Wb",         UNIT(1e3, 0, 0, 2,-2,-1, 0, 1)), //Weber
 //("lm",         UNIT(1e0, 0, 1, 0, 0, 0, 0, 0)), //Lumen=Candela
 //("lx",         UNIT(1e0, 0, 1,-2, 0, 0, 0, 0)), //Lux=lm/m^2
   ("N",          UNIT(1e3, 0, 0, 1,-2, 0, 0, 1)), //Newton
   ("Pa",         UNIT(1e3, 0, 0,-1,-2, 0, 0, 1)), //Pascal; displayUnit ="bar"
+  ("bar",        UNIT(1e8, 0, 0,-1,-2, 0, 0, 1)), //bar
   ("J",          UNIT(1e3, 0, 0, 2,-2, 0, 0, 1)), //Joule=N*m
   ("min",        UNIT(6e1, 0, 0, 0, 1, 0, 0, 0)), //Minute
-  ("h",        UNIT(3.6e3, 0, 0, 0, 1, 0, 0, 0)), //Stunde
-  ("d",       UNIT(8.64e4, 0, 0, 0, 1, 0, 0, 0)), //Tag
-  ("l",         UNIT(1e-3, 0, 0, 3, 0, 0, 0, 0)), //Liter
+  ("h",          UNIT(3.6e3, 0, 0, 0, 1, 0, 0, 0)), //Stunde
+  ("d",          UNIT(8.64e4, 0, 0, 0, 1, 0, 0, 0)), //Tag
+  ("l",          UNIT(1e-3, 0, 0, 3, 0, 0, 0, 0)), //Liter
   ("kg",         UNIT(1e3, 0, 0, 0, 0, 0, 0, 1)), //Kilogramm
 //("Bq",         UNIT(1e0, 0, 0, 0,-1, 0, 0, 0)), //Becquerel = Hertz
 //("Gy",         UNIT(1e0, 0, 0, 2,-2, 0, 0, 1)), //Gray

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -228,6 +228,9 @@ uniontype BaseUnit
     Real factor "prefix";
     Real offset "offset";
   end BASEUNIT;
+
+  record NOBASEUNIT "no baseunit definition available"
+  end NOBASEUNIT
 end BaseUnit;
 
 uniontype ModelInfo "Container for metadata about a Modelica model."

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -230,7 +230,7 @@ uniontype BaseUnit
   end BASEUNIT;
 
   record NOBASEUNIT "no baseunit definition available"
-  end NOBASEUNIT
+  end NOBASEUNIT;
 end BaseUnit;
 
 uniontype ModelInfo "Container for metadata about a Modelica model."

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -9150,6 +9150,7 @@ algorithm
           unitDefinitions := SimCode.UNITDEFINITION(var.unit, transformUnitToBaseUnit(unit)) :: unitDefinitions;
         else
           // catch the units which are not calculated
+          unitDefinitions := SimCode.UNITDEFINITION(var.unit, SimCode.NOBASEUNIT()) :: unitDefinitions;
         end try;
       end if;
     end if;

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -685,7 +685,7 @@ match unitDefinition
 case UNITDEFINITION(name = name, baseUnit = baseUnit) then
   <<
   <Unit <%unitDefinitionAttribute(name)%>>
-    <BaseUnit<%baseUnitAttributes(baseUnit)%>/>
+    <%baseUnitAttributes(baseUnit)%>
   </Unit>
   >>
 end UnitDefinitionsHelper1;
@@ -714,8 +714,9 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   let factor_Value = if not realAlmostEq(factor, 1.0, 1e-6) then ' factor="<% factor %>"' else ""
   let offset_Value = if not realAlmostEq(offset, 0.0, 1e-6) then ' offset="<% offset %>"' else ""
   <<
-  <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>
+  <BaseUnit <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>/>
   >>
+  case (NOBASEUNIT()) then "";
 end baseUnitAttributes;
 
 template fmiTypeDefinitions(SimCode simCode, String FMUVersion)

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -716,7 +716,7 @@ case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor =
   <<
   <BaseUnit <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>/>
   >>
-  case (NOBASEUNIT()) then "";
+case (NOBASEUNIT()) then ""
 end baseUnitAttributes;
 
 template fmiTypeDefinitions(SimCode simCode, String FMUVersion)

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -682,7 +682,7 @@ template UnitDefinitionsHelper1(UnitDefinition unitDefinition)
  "helper function to generates code for UnitDefinition for FMU target."
 ::=
 match unitDefinition
-case UNITDEFINITION(name = name, baseUnit = baseUnit) then
+case UNITDEFINITION(name=name, baseUnit=baseUnit) then
   <<
   <Unit <%unitDefinitionAttribute(name)%>>
     <%baseUnitAttributes(baseUnit)%>
@@ -693,7 +693,7 @@ end UnitDefinitionsHelper1;
 template unitDefinitionAttribute(String unitName)
  "Generates code for UnitDefinition Attribute for FMU target."
 ::=
-  let unitString = if unitName then 'name ="<%unitName%>"'
+  let unitString = if unitName then 'name="<%unitName%>"'
   <<
   <%unitString%>
   >>
@@ -703,16 +703,16 @@ template baseUnitAttributes(BaseUnit baseUnit)
  "Generates code for BaseUnit for FMU target."
 ::=
 match baseUnit
-case (BASEUNIT(mol = mol, cd = cd, m = m, s = s, A = A, K = K, kg = kg, factor = factor, offset = offset)) then
-  let mol_Value = if not intEq(mol, 0) then ' mol="<% mol %>"' else ""
-  let cd_Value = if not intEq(cd, 0) then ' cd="<% cd %>"' else ""
-  let m_Value = if not intEq(m, 0) then ' m="<% m %>"' else ""
-  let s_Value = if not intEq(s, 0) then ' s="<% s %>"' else ""
-  let A_Value = if not intEq(A, 0) then ' A="<% A %>"' else ""
-  let K_Value = if not intEq(K, 0) then ' K="<% K %>"' else ""
-  let kg_Value = if not intEq(kg, 0) then ' kg="<% kg %>"' else ""
-  let factor_Value = if not realAlmostEq(factor, 1.0, 1e-6) then ' factor="<% factor %>"' else ""
-  let offset_Value = if not realAlmostEq(offset, 0.0, 1e-6) then ' offset="<% offset %>"' else ""
+case (BASEUNIT(mol=mol, cd=cd, m=m, s=s, A=A, K=K, kg=kg, factor=factor, offset=offset)) then
+  let mol_Value = if not intEq(mol, 0) then 'mol="<% mol %>" ' else ""
+  let cd_Value = if not intEq(cd, 0) then 'cd="<% cd %>" ' else ""
+  let m_Value = if not intEq(m, 0) then 'm="<% m %>" ' else ""
+  let s_Value = if not intEq(s, 0) then 's="<% s %>" ' else ""
+  let A_Value = if not intEq(A, 0) then 'A="<% A %>" ' else ""
+  let K_Value = if not intEq(K, 0) then 'K="<% K %>" ' else ""
+  let kg_Value = if not intEq(kg, 0) then 'kg="<% kg %>" ' else ""
+  let factor_Value = if not realAlmostEq(factor, 1.0, 1e-6) then 'factor="<% factor %>" ' else ""
+  let offset_Value = if not realAlmostEq(offset, 0.0, 1e-6) then 'offset="<% offset %>" ' else ""
   <<
   <BaseUnit <%mol_Value%><%cd_Value%><%m_Value%><%s_Value%><%A_Value%><%K_Value%><%kg_Value%><%factor_Value%><%offset_Value%>/>
   >>

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -685,7 +685,7 @@ match unitDefinition
 case UNITDEFINITION(name = name, baseUnit = baseUnit) then
   <<
   <Unit <%unitDefinitionAttribute(name)%>>
-    <BaseUnit <%baseUnitAttributes(baseUnit)%>/>
+    <BaseUnit<%baseUnitAttributes(baseUnit)%>/>
   </Unit>
   >>
 end UnitDefinitionsHelper1;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -736,6 +736,9 @@ package SimCode
       Real factor "prefix";
       Real offset "offset";
     end BASEUNIT;
+
+    record NOBASEUNIT "no baseunit definition available"
+    end NOBASEUNIT
   end BaseUnit;
 
   uniontype VarInfo

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -738,7 +738,7 @@ package SimCode
     end BASEUNIT;
 
     record NOBASEUNIT "no baseunit definition available"
-    end NOBASEUNIT
+    end NOBASEUNIT;
   end BaseUnit;
 
   uniontype VarInfo

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -67,41 +67,41 @@ getErrorString();
 //     modelIdentifier=\"CSTRModel\" providesDirectionalDerivative=\"true\">
 //   </ModelExchange>
 //   <UnitDefinitions>
-//     <Unit name =\"s\">
-//       <BaseUnit  s=\"1\"/>
+//     <Unit name=\"s\">
+//       <BaseUnit s=\"1\" />
 //     </Unit>
-//     <Unit name =\"kg/m3\">
-//       <BaseUnit  m=\"-3\" kg=\"1\"/>
+//     <Unit name=\"kg/m3\">
+//       <BaseUnit m=\"-3\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"kg\">
-//       <BaseUnit  kg=\"1\"/>
+//     <Unit name=\"kg\">
+//       <BaseUnit kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"W/(m2.K)\">
-//       <BaseUnit  s=\"-3\" K=\"-1\" kg=\"1\"/>
+//     <Unit name=\"W/(m2.K)\">
+//       <BaseUnit s=\"-3\" K=\"-1\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"m3\">
-//       <BaseUnit  m=\"3\"/>
+//     <Unit name=\"m3\">
+//       <BaseUnit m=\"3\" />
 //     </Unit>
-//     <Unit name =\"J/mol\">
-//       <BaseUnit  mol=\"-1\" m=\"2\" s=\"-2\" kg=\"1\"/>
+//     <Unit name=\"J/mol\">
+//       <BaseUnit mol=\"-1\" m=\"2\" s=\"-2\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"J/(kg.K)\">
-//       <BaseUnit  m=\"2\" s=\"-2\" K=\"-1\"/>
+//     <Unit name=\"J/(kg.K)\">
+//       <BaseUnit m=\"2\" s=\"-2\" K=\"-1\" />
 //     </Unit>
-//     <Unit name =\"m2\">
-//       <BaseUnit  m=\"2\"/>
+//     <Unit name=\"m2\">
+//       <BaseUnit m=\"2\" />
 //     </Unit>
-//     <Unit name =\"1/h\">
-//       <BaseUnit  s=\"-1\" factor=\"0.0002777777777777778\"/>
+//     <Unit name=\"1/h\">
+//       <BaseUnit s=\"-1\" factor=\"0.0002777777777777778\" />
 //     </Unit>
-//     <Unit name =\"kJ/h\">
-//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"0.2777777777777779\"/>
+//     <Unit name=\"kJ/h\">
+//       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" factor=\"0.2777777777777779\" />
 //     </Unit>
-//     <Unit name =\"mol/l\">
-//       <BaseUnit  mol=\"1\" m=\"-3\" factor=\"1000.0\"/>
+//     <Unit name=\"mol/l\">
+//       <BaseUnit mol=\"1\" m=\"-3\" factor=\"1000.0\" />
 //     </Unit>
-//     <Unit name =\"degC\">
-//       <BaseUnit  K=\"1\"/>
+//     <Unit name=\"degC\">
+//       <BaseUnit K=\"1\" />
 //     </Unit>
 //   </UnitDefinitions>
 //   <TypeDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -67,76 +67,76 @@ val(evaporator_qm_S, 100);
 //     modelIdentifier=\"DrumBoilerModel\" providesDirectionalDerivative=\"true\">
 //   </ModelExchange>
 //   <UnitDefinitions>
-//     <Unit name =\"m/s2\">
+//     <Unit name=\"m/s2\">
 //       <BaseUnit m=\"1\" s=\"-2\" />
 //     </Unit>
-//     <Unit name =\"1/K\">
+//     <Unit name=\"1/K\">
 //       <BaseUnit K=\"-1\" />
 //     </Unit>
-//     <Unit name =\"s\">
+//     <Unit name=\"s\">
 //       <BaseUnit s=\"1\" />
 //     </Unit>
-//     <Unit name =\"kg/(s.Pa)\">
+//     <Unit name=\"kg/(s.Pa)\">
 //       <BaseUnit m=\"1\" s=\"1\" />
 //     </Unit>
-//     <Unit name =\"1\">
+//     <Unit name=\"1\">
 //       <BaseUnit />
 //     </Unit>
-//     <Unit name =\"N/mm2\">
+//     <Unit name=\"N/mm2\">
 //       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000000.0\" />
 //     </Unit>
-//     <Unit name =\"MW\">
+//     <Unit name=\"MW\">
 //       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000000.0\" />
 //     </Unit>
-//     <Unit name =\"bar\">
+//     <Unit name=\"bar\">
 //       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\" />
 //     </Unit>
-//     <Unit name =\"kg/kg\">
+//     <Unit name=\"kg/kg\">
 //       <BaseUnit />
 //     </Unit>
-//     <Unit name =\"degC\">
+//     <Unit name=\"degC\">
 //       <BaseUnit K=\"1\" />
 //     </Unit>
-//     <Unit name =\"J/(kg.K)\">
+//     <Unit name=\"J/(kg.K)\">
 //       <BaseUnit m=\"2\" s=\"-2\" K=\"-1\" />
 //     </Unit>
-//     <Unit name =\"kg/mol\">
+//     <Unit name=\"kg/mol\">
 //       <BaseUnit mol=\"-1\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"kg/s\">
+//     <Unit name=\"kg/s\">
 //       <BaseUnit s=\"-1\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"W\">
+//     <Unit name=\"W\">
 //       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"kg\">
+//     <Unit name=\"kg\">
 //       <BaseUnit kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"J/kg\">
+//     <Unit name=\"J/kg\">
 //       <BaseUnit m=\"2\" s=\"-2\" />
 //     </Unit>
-//     <Unit name =\"J\">
+//     <Unit name=\"J\">
 //       <BaseUnit m=\"2\" s=\"-2\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"kg/m3\">
+//     <Unit name=\"kg/m3\">
 //       <BaseUnit m=\"-3\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"m3/s\">
+//     <Unit name=\"m3/s\">
 //       <BaseUnit m=\"3\" s=\"-1\" />
 //     </Unit>
-//     <Unit name =\"K\">
+//     <Unit name=\"K\">
 //       <BaseUnit K=\"1\" />
 //     </Unit>
-//     <Unit name =\"km-1.s-3.g\">
+//     <Unit name=\"km-1.s-3.g\">
 //       <BaseUnit m=\"-1\" s=\"-3\" kg=\"1\" factor=\"1e-006\" />
 //     </Unit>
-//     <Unit name =\"m3.s-1\">
+//     <Unit name=\"m3.s-1\">
 //       <BaseUnit m=\"3\" s=\"-1\" />
 //     </Unit>
-//     <Unit name =\"Pa\">
+//     <Unit name=\"Pa\">
 //       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" />
 //     </Unit>
-//     <Unit name =\"m3\">
+//     <Unit name=\"m3\">
 //       <BaseUnit m=\"3\" />
 //     </Unit>
 //   </UnitDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -28,7 +28,7 @@ readFile("modelDescription.tmp.xml");
 importFMU("DrumBoilerModel.fmu"); getErrorString();
 loadFile("DrumBoilerModel_me_FMU.mo"); getErrorString();
 
-setCommandLineOptions("+simCodeTarget=C"); getErrorString();
+setCommandLineOptions("--simCodeTarget=C"); getErrorString();
 simulate(DrumBoilerModel_me_FMU, stopTime=100.0, simflags="-override=q_F=10,Y_Valve=1"); getErrorString();
 
 // inputs
@@ -68,73 +68,76 @@ val(evaporator_qm_S, 100);
 //   </ModelExchange>
 //   <UnitDefinitions>
 //     <Unit name =\"m/s2\">
-//       <BaseUnit  m=\"1\" s=\"-2\"/>
+//       <BaseUnit m=\"1\" s=\"-2\" />
 //     </Unit>
 //     <Unit name =\"1/K\">
-//       <BaseUnit  K=\"-1\"/>
+//       <BaseUnit K=\"-1\" />
 //     </Unit>
 //     <Unit name =\"s\">
-//       <BaseUnit  s=\"1\"/>
+//       <BaseUnit s=\"1\" />
 //     </Unit>
 //     <Unit name =\"kg/(s.Pa)\">
-//       <BaseUnit  m=\"1\" s=\"1\"/>
+//       <BaseUnit m=\"1\" s=\"1\" />
 //     </Unit>
 //     <Unit name =\"1\">
 //       <BaseUnit />
 //     </Unit>
 //     <Unit name =\"N/mm2\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000000.0\"/>
+//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"1000000.0\" />
 //     </Unit>
 //     <Unit name =\"MW\">
-//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000000.0\"/>
+//       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" factor=\"1000000.0\" />
+//     </Unit>
+//     <Unit name =\"bar\">
+//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\" />
 //     </Unit>
 //     <Unit name =\"kg/kg\">
 //       <BaseUnit />
 //     </Unit>
 //     <Unit name =\"degC\">
-//       <BaseUnit  K=\"1\"/>
+//       <BaseUnit K=\"1\" />
 //     </Unit>
 //     <Unit name =\"J/(kg.K)\">
-//       <BaseUnit  m=\"2\" s=\"-2\" K=\"-1\"/>
+//       <BaseUnit m=\"2\" s=\"-2\" K=\"-1\" />
 //     </Unit>
 //     <Unit name =\"kg/mol\">
-//       <BaseUnit  mol=\"-1\" kg=\"1\"/>
+//       <BaseUnit mol=\"-1\" kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"kg/s\">
-//       <BaseUnit  s=\"-1\" kg=\"1\"/>
+//       <BaseUnit s=\"-1\" kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"W\">
-//       <BaseUnit  m=\"2\" s=\"-3\" kg=\"1\"/>
+//       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"kg\">
-//       <BaseUnit  kg=\"1\"/>
+//       <BaseUnit kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"J/kg\">
-//       <BaseUnit  m=\"2\" s=\"-2\"/>
+//       <BaseUnit m=\"2\" s=\"-2\" />
 //     </Unit>
 //     <Unit name =\"J\">
-//       <BaseUnit  m=\"2\" s=\"-2\" kg=\"1\"/>
+//       <BaseUnit m=\"2\" s=\"-2\" kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"kg/m3\">
-//       <BaseUnit  m=\"-3\" kg=\"1\"/>
+//       <BaseUnit m=\"-3\" kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"m3/s\">
-//       <BaseUnit  m=\"3\" s=\"-1\"/>
+//       <BaseUnit m=\"3\" s=\"-1\" />
 //     </Unit>
 //     <Unit name =\"K\">
-//       <BaseUnit  K=\"1\"/>
+//       <BaseUnit K=\"1\" />
 //     </Unit>
 //     <Unit name =\"km-1.s-3.g\">
-//       <BaseUnit  m=\"-1\" s=\"-3\" kg=\"1\" factor=\"1e-006\"/>
+//       <BaseUnit m=\"-1\" s=\"-3\" kg=\"1\" factor=\"1e-006\" />
 //     </Unit>
 //     <Unit name =\"m3.s-1\">
-//       <BaseUnit  m=\"3\" s=\"-1\"/>
+//       <BaseUnit m=\"3\" s=\"-1\" />
 //     </Unit>
 //     <Unit name =\"Pa\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\"/>
+//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" />
 //     </Unit>
 //     <Unit name =\"m3\">
-//       <BaseUnit  m=\"3\"/>
+//       <BaseUnit m=\"3\" />
 //     </Unit>
 //   </UnitDefinitions>
 //   <TypeDefinitions>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -107,13 +107,13 @@ readFile("fmi_attributes_15_tmp.xml")
 //     </SourceFiles>
 //   </ModelExchange>
 //   <UnitDefinitions>
-//     <Unit name =\"xyz\">
+//     <Unit name=\"xyz\">
 //     </Unit>
-//     <Unit name =\"bar\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\"/>
+//     <Unit name=\"bar\">
+//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\" />
 //     </Unit>
-//     <Unit name =\"kg2\">
-//       <BaseUnit  kg=\"2\"/>
+//     <Unit name=\"kg2\">
+//       <BaseUnit kg=\"2\" />
 //     </Unit>
 //   </UnitDefinitions>
 //   <LogCategories>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -6,8 +6,10 @@
 loadString("
 model fmi_attributes_15
   Real x(unit = \"kg2\");
+  Real y(unit = \"bar\");
 equation
   x=10;
+  y=20;
 end fmi_attributes_15;
 "); getErrorString();
 
@@ -103,8 +105,11 @@ readFile("fmi_attributes_15_tmp.xml")
 //     </SourceFiles>
 //   </ModelExchange>
 //   <UnitDefinitions>
+//     <Unit name =\"bar\">
+//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\"/>
+//     </Unit>
 //     <Unit name =\"kg2\">
-//       <BaseUnit  kg=\"2\"/>
+//       <BaseUnit kg=\"2\"/>
 //     </Unit>
 //   </UnitDefinitions>
 //   <LogCategories>
@@ -120,7 +125,7 @@ readFile("fmi_attributes_15_tmp.xml")
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-006\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
@@ -128,6 +133,13 @@ readFile("fmi_attributes_15_tmp.xml")
 //     valueReference=\"0\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\" unit=\"kg2\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"2\" -->
+//   <ScalarVariable
+//     name=\"y\"
+//     valueReference=\"1\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\" unit=\"bar\"/>
 //   </ScalarVariable>
 //   </ModelVariables>
 //   <ModelStructure>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -7,9 +7,11 @@ loadString("
 model fmi_attributes_15
   Real x(unit = \"kg2\");
   Real y(unit = \"bar\");
+  Real z(unit = \"barr\");
 equation
   x=10;
   y=20;
+  z=30;
 end fmi_attributes_15;
 "); getErrorString();
 
@@ -140,6 +142,13 @@ readFile("fmi_attributes_15_tmp.xml")
 //     valueReference=\"1\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\" unit=\"bar\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"3\" -->
+//   <ScalarVariable
+//     name=\"z\"
+//     valueReference=\"2\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   </ModelVariables>
 //   <ModelStructure>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -7,7 +7,7 @@ loadString("
 model fmi_attributes_15
   Real x(unit = \"kg2\");
   Real y(unit = \"bar\");
-  Real z(unit = \"barr\");
+  Real z(unit = \"xyz\");
 equation
   x=10;
   y=20;
@@ -107,11 +107,13 @@ readFile("fmi_attributes_15_tmp.xml")
 //     </SourceFiles>
 //   </ModelExchange>
 //   <UnitDefinitions>
+//     <Unit name =\"xyz\">
+//     </Unit>
 //     <Unit name =\"bar\">
-//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\"/>
+//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\" factor=\"100000.0\"/>
 //     </Unit>
 //     <Unit name =\"kg2\">
-//       <BaseUnit kg=\"2\"/>
+//       <BaseUnit  kg=\"2\"/>
 //     </Unit>
 //   </UnitDefinitions>
 //   <LogCategories>
@@ -148,7 +150,7 @@ readFile("fmi_attributes_15_tmp.xml")
 //     name=\"z\"
 //     valueReference=\"2\"
 //     initial=\"exact\">
-//     <Real start=\"0.0\"/>
+//     <Real start=\"0.0\" unit=\"xyz\"/>
 //   </ScalarVariable>
 //   </ModelVariables>
 //   <ModelStructure>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -106,8 +106,8 @@ readFile("modelDescription.tmp.xml");
 //     </SourceFiles>
 //   </ModelExchange>
 //   <UnitDefinitions>
-//     <Unit name =\"Pa\">
-//       <BaseUnit  m=\"-1\" s=\"-2\" kg=\"1\"/>
+//     <Unit name=\"Pa\">
+//       <BaseUnit m=\"-1\" s=\"-2\" kg=\"1\" />
 //     </Unit>
 //   </UnitDefinitions>
 //   <LogCategories>


### PR DESCRIPTION
This addresses ticket:6002
1. Unit `bar` isn't defined
2. Unknown units should be exported in the `UnitDefinitions` but obviously without a `BaseUnit` representation.
