### PR TITLE
[NF] Clocked operators improvements.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -360,15 +360,15 @@ public
     end match;
   end addSubscript;
 
-  function applySubscripts
+  function mergeSubscripts
     input list<Subscript> subscripts;
     input output ComponentRef cref;
     input Boolean applyToScope = false;
   algorithm
-    ({}, cref) := applySubscripts2(subscripts, cref, applyToScope);
-  end applySubscripts;
+    ({}, cref) := mergeSubscripts2(subscripts, cref, applyToScope);
+  end mergeSubscripts;
 
-  function applySubscripts2
+  function mergeSubscripts2
     input output list<Subscript> subscripts;
     input output ComponentRef cref;
     input Boolean applyToScope;
@@ -381,7 +381,7 @@ public
       case CREF(subscripts = cref_subs)
         guard applyToScope or cref.origin == Origin.CREF
         algorithm
-          (subscripts, rest_cref) := applySubscripts2(subscripts, cref.restCref, applyToScope);
+          (subscripts, rest_cref) := mergeSubscripts2(subscripts, cref.restCref, applyToScope);
 
           if not listEmpty(subscripts) then
             (cref_subs, subscripts) :=
@@ -392,7 +392,7 @@ public
 
       else (subscripts, cref);
     end match;
-  end applySubscripts2;
+  end mergeSubscripts2;
 
   function hasSubscripts
     input ComponentRef cref;
@@ -525,6 +525,29 @@ public
           fail();
     end match;
   end transferSubscripts;
+
+  function applySubscripts
+    input ComponentRef cref;
+    input FuncT func;
+
+    partial function FuncT
+      input Subscript subscript;
+    end FuncT;
+  algorithm
+    () := match cref
+      case CREF(origin = Origin.CREF)
+        algorithm
+          for sub in cref.subscripts loop
+            func(sub);
+          end for;
+
+          applySubscripts(cref.restCref, func);
+        then
+          ();
+
+      else ();
+    end match;
+  end applySubscripts;
 
   function foldSubscripts<ArgT>
     input ComponentRef cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1060,7 +1060,7 @@ public
     ComponentRef cr;
     Type ty;
   algorithm
-    cr := ComponentRef.applySubscripts(subscript :: restSubscripts, cref);
+    cr := ComponentRef.mergeSubscripts(subscript :: restSubscripts, cref);
     ty := ComponentRef.getSubscriptedType(cr);
     outExp := CREF(ty, cr);
   end applySubscriptCref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -54,7 +54,6 @@ import ExecStat.execStat;
 import ExpressionIterator = NFExpressionIterator;
 import Expression = NFExpression;
 import Flags;
-import Inst = NFInst;
 import List;
 import Call = NFCall;
 import Class = NFClass;
@@ -92,6 +91,7 @@ import InstNodeType = NFInstNode.InstNodeType;
 import ExpandableConnectors = NFExpandableConnectors;
 import SCodeUtil;
 import DAE;
+import Structural = NFStructural;
 
 public
 type FunctionTree = FunctionTreeImpl.Tree;
@@ -747,7 +747,7 @@ algorithm
       algorithm
         restString := ComponentRef.toString(restCref);
         if prefixLength <= stringLength(restString) and prefixString == substring(restString, 1, prefixLength) then
-          exp.cref := ComponentRef.applySubscripts({subscript}, exp.cref, applyToScope = true);
+          exp.cref := ComponentRef.mergeSubscripts({subscript}, exp.cref, applyToScope = true);
         end if;
       then
         exp;
@@ -957,7 +957,7 @@ algorithm
   cond_var := Expression.variability(cond);
 
   if Expression.variability(cond) == Variability.PARAMETER then
-    Inst.markStructuralParamsExp(cond);
+    Structural.markExp(cond);
   end if;
 end flattenConditionalArrayIfExp;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1467,6 +1467,7 @@ uniontype Function
           // Can have variable number of arguments.
           case "array" then true;
           case "actualStream" then true;
+          case "backSample" then true;
           case "branch" then true;
           case "cardinality" then true;
           case "cat" then true;
@@ -1516,10 +1517,13 @@ uniontype Function
           case "scalar" then true;
           // First argument can have any number of dimensions.
           case "size" then true;
+          case "shiftSample" then true;
           // Needs to check that second argument is real or array of real or record of reals.
           case "smooth" then true;
+          case "subSample" then true;
           // needs unboxing and return type fix.
           case "sum" then true;
+          case "superSample" then true;
           // unbox args and set return type.
           case "symmetric" then true;
           // Always discrete.

--- a/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
@@ -1,0 +1,368 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package NFStructural
+  "Contains utility functions for handling structural parameters."
+
+  import Component = NFComponent;
+  import Binding = NFBinding;
+  import NFInstNode.InstNode;
+  import NFPrefixes.Variability;
+  import Subscript = NFSubscript;
+  import Expression = NFExpression;
+  import ComponentRef = NFComponentRef;
+  import Call = NFCall;
+  import Dimension = NFDimension;
+
+protected
+  import Flags;
+
+public
+  function isStructuralComponent
+    input Component component;
+    input Component.Attributes compAttrs;
+    input Binding compBinding;
+    input InstNode compNode;
+    input Boolean evalAllParams;
+    output Boolean isStructural;
+  protected
+    Boolean is_fixed;
+  algorithm
+    if compAttrs.variability <> Variability.PARAMETER then
+      // Only parameters can be structural.
+      isStructural := false;
+    elseif evalAllParams or Component.getEvaluateAnnotation(component) then
+      // If -d=evaluateAllParameters is set or the parameter has an Evaluate=true
+      // annotation we should probably evaluate the parameter, which we do by
+      // marking it as structural.
+      if not Component.getFixedAttribute(component) then
+        // Except non-fixed parameters.
+        isStructural := false;
+      elseif Component.isExternalObject(component) then
+        // Except external objects.
+        isStructural := false;
+      elseif not InstNode.hasBinding(compNode) then
+        // Except parameters with no bindings.
+        if not evalAllParams and not Flags.getConfigBool(Flags.CHECK_MODEL) then
+          // Print a warning if a parameter has an Evaluate=true annotation but no binding.
+          Error.addSourceMessage(Error.UNBOUND_PARAMETER_EVALUATE_TRUE,
+            {InstNode.name(compNode)}, InstNode.info(compNode));
+        end if;
+
+        isStructural := false;
+      elseif isBindingNotFixed(compBinding, requireFinal = false) then
+        // Except parameters that depend on non-fixed parameters.
+        isStructural := false;
+      else
+        // All other parameters are considered structural in this case.
+        isStructural := true;
+      end if;
+    //elseif Component.isFinal(component) and Component.getFixedAttribute(component) then
+    //  // If a parameter is fixed and final we might also want to evaluate it,
+    //  // since its binding can't be modified. But only if all parameters it
+    //  // depends on are also fixed and final.
+    //  if Binding.isUnbound(compBinding) or isBindingNotFixed(compBinding, requireFinal = true) then
+    //    isStructural := false;
+    //  else
+    //    isStructural := true;
+    //  end if;
+    else
+      isStructural := false;
+    end if;
+  end isStructuralComponent;
+
+  function isBindingNotFixed
+    input Binding binding;
+    input Boolean requireFinal;
+    input Integer maxDepth = 4;
+    output Boolean isNotFixed;
+  algorithm
+    if maxDepth == 0 then
+      isNotFixed := true;
+      return;
+    end if;
+
+    if Binding.hasExp(binding) then
+      isNotFixed := isExpressionNotFixed(Expression.getBindingExp(Binding.getExp(binding)), requireFinal, maxDepth);
+    else
+      isNotFixed := true;
+    end if;
+  end isBindingNotFixed;
+
+  function isComponentBindingNotFixed
+    input Component component;
+    input InstNode node;
+    input Boolean requireFinal;
+    input Integer maxDepth;
+    input Boolean isRecord = false;
+    output Boolean isNotFixed;
+  protected
+    Binding binding;
+    InstNode parent;
+  algorithm
+    binding := Component.getBinding(component);
+
+    if Binding.isUnbound(binding) then
+      if isRecord or InstNode.isRecord(node) then
+        // TODO: Check whether the record fields have bindings or not.
+        isNotFixed := false;
+      else
+        parent := InstNode.parent(node);
+
+        if InstNode.isComponent(parent) and InstNode.isRecord(parent) then
+          isNotFixed := isComponentBindingNotFixed(InstNode.component(parent), parent, requireFinal, maxDepth, true);
+        else
+          isNotFixed := true;
+        end if;
+      end if;
+    else
+      isNotFixed := isBindingNotFixed(binding, requireFinal, maxDepth);
+    end if;
+  end isComponentBindingNotFixed;
+
+  function isExpressionNotFixed
+    input Expression exp;
+    input Boolean requireFinal = false;
+    input Integer maxDepth = 4;
+    output Boolean isNotFixed;
+  algorithm
+    isNotFixed := match exp
+      local
+        InstNode node;
+        Component c;
+        Variability var;
+        Expression e;
+
+      case Expression.CREF()
+        algorithm
+          node := ComponentRef.node(exp.cref);
+
+          if InstNode.isComponent(node) then
+            c := InstNode.component(node);
+            var := Component.variability(c);
+
+            if var <= Variability.STRUCTURAL_PARAMETER then
+              isNotFixed := false;
+            elseif var == Variability.PARAMETER and
+                   (not requireFinal or Component.isFinal(c)) and
+                   not Component.isExternalObject(c) and
+                   Component.getFixedAttribute(c) then
+              isNotFixed := isComponentBindingNotFixed(c, node, requireFinal, maxDepth - 1);
+            else
+              isNotFixed := true;
+            end if;
+          else
+            isNotFixed := true;
+          end if;
+        then
+          isNotFixed or
+          Expression.containsShallow(exp,
+            function isExpressionNotFixed(requireFinal = requireFinal, maxDepth = maxDepth));
+
+      case Expression.SIZE()
+        algorithm
+          if isSome(exp.dimIndex) then
+            isNotFixed := isExpressionNotFixed(Util.getOption(exp.dimIndex), requireFinal, maxDepth);
+          else
+            isNotFixed := false;
+          end if;
+        then
+          isNotFixed;
+
+      case Expression.CALL()
+        algorithm
+          if Call.isImpure(exp.call) or Call.isExternal(exp.call) then
+            isNotFixed := true;
+          else
+            isNotFixed := Expression.containsShallow(exp,
+              function isExpressionNotFixed(requireFinal = requireFinal, maxDepth = maxDepth));
+          end if;
+        then
+          isNotFixed;
+
+      else Expression.containsShallow(exp,
+        function isExpressionNotFixed(requireFinal = requireFinal, maxDepth = maxDepth));
+    end match;
+  end isExpressionNotFixed;
+
+  function markDimension
+    input Dimension dimension;
+  algorithm
+    () := match dimension
+      case Dimension.UNTYPED()
+        algorithm
+          markExp(dimension.dimension);
+        then
+          ();
+
+      case Dimension.EXP()
+        algorithm
+          markExp(dimension.exp);
+        then
+          ();
+
+      else ();
+    end match;
+  end markDimension;
+
+  function markExp
+    input Expression exp;
+    import NFComponentRef.Origin;
+  algorithm
+    () := match exp
+      local
+        InstNode node;
+        Component comp;
+        Expression e;
+
+      case Expression.CREF(cref = ComponentRef.CREF(node = node, origin = Origin.CREF))
+        algorithm
+          if InstNode.isComponent(node) then
+            comp := InstNode.component(node);
+
+            if Component.variability(comp) == Variability.PARAMETER then
+              markComponent(comp, node);
+            end if;
+          end if;
+
+          Expression.applyShallow(exp, markExp);
+        then
+          ();
+
+      case Expression.SIZE()
+        algorithm
+          // The expression in the size expression should not be marked as
+          // structural, since only the type of it matters to determine the size.
+          // Subscripts in the expression should be marked as structural though.
+          markSubscriptsInExp(exp.exp);
+
+          // The optional index should be marked as structural.
+          if isSome(exp.dimIndex) then
+            SOME(e) := exp.dimIndex;
+            markExp(e);
+          end if;
+        then
+          ();
+
+      else
+        algorithm
+          Expression.applyShallow(exp, markExp);
+        then
+          ();
+    end match;
+  end markExp;
+
+  function markSubscriptsInExp
+    input Expression exp;
+  algorithm
+    () := match exp
+      case Expression.CREF()
+        algorithm
+          ComponentRef.applySubscripts(exp.cref, markSubscript);
+        then
+          ();
+
+      else
+        algorithm
+          Expression.applyShallow(exp, markSubscriptsInExp);
+        then
+          ();
+    end match;
+  end markSubscriptsInExp;
+
+  function markComponent
+    input Component component;
+    input InstNode node;
+  protected
+    Component comp;
+    Option<Expression> binding;
+  algorithm
+    comp := Component.setVariability(Variability.STRUCTURAL_PARAMETER, component);
+    InstNode.updateComponent(comp, node);
+
+    binding := Binding.untypedExp(Component.getBinding(comp));
+    if isSome(binding) then
+      markExp(Util.getOption(binding));
+    end if;
+  end markComponent;
+
+  function markExpSize
+    input Expression exp;
+  algorithm
+    Expression.apply(exp, markExpSize_traverser);
+  end markExpSize;
+
+  function markExpSize_traverser
+    input Expression exp;
+  algorithm
+    () := match exp
+      local
+        list<tuple<InstNode, Expression>> iters;
+
+      case Expression.CALL(call = Call.UNTYPED_ARRAY_CONSTRUCTOR(iters = iters))
+        algorithm
+          for iter in iters loop
+            markExp(Util.tuple22(iter));
+          end for;
+        then
+          ();
+
+      else ();
+    end match;
+  end markExpSize_traverser;
+
+  function markSubscripts
+    input Expression exp;
+  algorithm
+    () := match exp
+      case Expression.CREF()
+        algorithm
+          ComponentRef.applySubscripts(exp.cref, markSubscript);
+        then
+          ();
+
+      else ();
+    end match;
+  end markSubscripts;
+
+  function markSubscript
+    input Subscript sub;
+  algorithm
+    () := match sub
+        case Subscript.UNTYPED() algorithm markExp(sub.exp); then ();
+        case Subscript.INDEX() algorithm markExp(sub.index); then ();
+        case Subscript.SLICE() algorithm markExp(sub.slice); then ();
+      else ();
+    end match;
+  end markSubscript;
+
+  annotation(__OpenModelica_Interface="frontend");
+end NFStructural;

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -369,6 +369,7 @@ if true then /* Suppress output */
     "../NFFrontEnd/NFSimplifyModel.mo",
     "../NFFrontEnd/NFSections.mo",
     "../NFFrontEnd/NFStatement.mo",
+    "../NFFrontEnd/NFStructural.mo",
     "../NFFrontEnd/NFSubscript.mo",
     "../NFFrontEnd/NFPackage.mo",
     "../NFFrontEnd/NFType.mo",


### PR DESCRIPTION
- Mark the parameter arguments of backSample, shiftSample, subSample,
  and superSample as structural so that they're evaluated by the
  frontend, since the clock partitioning in the backend expects this.
- Move the structural parameter utility functions from Inst to its own
  package, to avoid the need for other packages to depend on Inst when
  they just want to mark some parameters as structural.