### PR TITLE
Remove Lapack from sour-code FMU linker flag

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2222,9 +2222,9 @@ algorithm
       String str, fopenmp;
       list<String> strs1, strs2, strs3, names1, names2, names3;
 
-    // Lapack is always included
-    case Absyn.STRING("lapack") then ({},{});
-    case Absyn.STRING("Lapack") then ({},{});
+    case Absyn.STRING("lapack") then ({"-llapack -lblas"},{});
+    case Absyn.STRING("Lapack") then ({"-llapack -lblas"},{});
+    case Absyn.STRING("openblas") then ({"-lopenblass"},{});
 
     //pthreads is already linked under windows
     case Absyn.STRING("pthread") guard Autoconf.os=="Windows_NT"

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -740,7 +740,7 @@ if test "$DARWIN" = "1"; then
   # All libraries are dynamically linked; we don't need anything else
   RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $LD_LAPACK -lm"
   RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm$LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS -lm$LD_NOUNDEFINED"
   RT_LDFLAGS_SHARED=
   OMCRUNTIME_SHARED_LDFLAGS="$RT_LDFLAGS -Wl,-undefined -Wl,dynamic_lookup $LIBLPSOLVE55 -lzmq $LIBUUID $RT_LDFLAGS_OPTIONAL"
   LINK="cp -fr"
@@ -774,7 +774,7 @@ elif echo "$host" | grep -iq "mingw"; then
   RT_LDFLAGS_OPTIONAL="$RT_LDFLAGS_OPTIONAL"
   RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $RT_LDFLAGS"
   RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC -lcdaskr $RT_LDFLAGS_SIM"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm$LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS -lm$LD_NOUNDEFINED"
   LINK="cp -frl"
   # No RPATH in Windows :(
   RPATH=""
@@ -811,7 +811,7 @@ else
   # All libraries are dynamically linked; we don't need anything else
   RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $LD_LAPACK -lm -lomcgc -lpthread -rdynamic" # Some of our tests refer to the testsuite itself
   RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc -lpthread -rdynamic$LD_NOUNDEFINED"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm -lpthread -rdynamic$LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS -lm -lpthread -rdynamic$LD_NOUNDEFINED"
   LINK="cp -frl"
   LDFLAGS="$LDFLAGS -Wl,-rpath-link,$OMBUILDDIR/lib/$host_short/omc"
   RT_LDFLAGS_SHARED="-Wl,-rpath-link,$OMBUILDDIR/lib/$host_short/omc"


### PR DESCRIPTION
Related to [ticket #6017 ](https://trac.openmodelica.org/OpenModelica/ticket/6017).

Not a full solution but an improvement.
  - Not all FMUs need openblas or lapack installed any more.
  - Models with lapack functions will still need lapack installed on the
    target system that is simulating the FMU.