### PR TITLE
[Template] update linearization file names

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -4644,8 +4644,7 @@ template functionlinearmodel(ModelInfo modelInfo, String modelNamePrefix) "templ
     <<
     const char *<%symbolName(modelNamePrefix,"linear_model_frame")%>()
     {
-      return "model linear_<%underscorePath(name)%>\n  parameter Integer n = <%varInfo.numStateVars%> \"number of states\";\n  parameter Integer m = <%varInfo.numInVars%> \"number of inputs\";\n  parameter Integer p = <%varInfo.numOutVars%> \"number of outputs\";\n"
-      "\n"
+      return "model linearized_model \"<%modelNamePrefix%>\" \n  parameter Integer n = <%varInfo.numStateVars%> \"number of states\";\n  parameter Integer m = <%varInfo.numInVars%> \"number of inputs\";\n  parameter Integer p = <%varInfo.numOutVars%> \"number of outputs\";\n"
       "  parameter Real x0[n] = %s;\n"
       "  parameter Real u0[m] = %s;\n"
       "\n"
@@ -4661,12 +4660,11 @@ template functionlinearmodel(ModelInfo modelInfo, String modelNamePrefix) "templ
       <%getVarName(vars.stateVars, "x")%>
       <%getVarName(vars.inputVars, "u")%>
       <%getVarName(vars.outputVars, "y")%>
-      "equation\n  der(x) = A * x + B * u;\n  y = C * x + D * u;\nend linear_<%underscorePath(name)%>;\n";
+      "equation\n  der(x) = A * x + B * u;\n  y = C * x + D * u;\nend linearized_model;\n";
     }
     const char *<%symbolName(modelNamePrefix,"linear_model_datarecovery_frame")%>()
     {
-      return "model linear_<%underscorePath(name)%>\n  parameter Integer n = <%varInfo.numStateVars%> \"number of states\";\n  parameter Integer m = <%varInfo.numInVars%> \"number of inputs\";\n  parameter Integer p = <%varInfo.numOutVars%> \"number of outputs\";\n  parameter Integer nz = <%varInfo.numAlgVars%> \"data recovery variables\";\n"
-      "\n"
+      return "model linearized_model \"<%modelNamePrefix%>\" \n parameter Integer n = <%varInfo.numStateVars%> \"number of states\";\n  parameter Integer m = <%varInfo.numInVars%> \"number of inputs\";\n  parameter Integer p = <%varInfo.numOutVars%> \"number of outputs\";\n  parameter Integer nz = <%varInfo.numAlgVars%> \"data recovery variables\";\n"
       "  parameter Real x0[<%varInfo.numStateVars%>] = %s;\n"
       "  parameter Real u0[<%varInfo.numInVars%>] = %s;\n"
       "  parameter Real z0[<%varInfo.numAlgVars%>] = %s;\n"
@@ -4687,7 +4685,7 @@ template functionlinearmodel(ModelInfo modelInfo, String modelNamePrefix) "templ
       <%getVarName(vars.inputVars, "u")%>
       <%getVarName(vars.outputVars, "y")%>
       <%getVarName(vars.algVars, "z")%>
-      "equation\n  der(x) = A * x + B * u;\n  y = C * x + D * u;\n  z = Cz * x + Dz * u;\nend linear_<%underscorePath(name)%>;\n";
+      "equation\n  der(x) = A * x + B * u;\n  y = C * x + D * u;\n  z = Cz * x + Dz * u;\nend linearized_model;\n";
     }
     >>
   end match
@@ -4706,7 +4704,8 @@ template functionlinearmodelMatlab(ModelInfo modelInfo, String modelNamePrefix) 
     <<
     const char *<%symbolName(modelNamePrefix,"linear_model_frame")%>()
     {
-      return "function [sys, x0, u0, n, m, p] = <%symbolName(modelNamePrefix,"GetLinearModel")%>()\n"
+      return "function [sys, x0, u0, n, m, p, Ts] = linearized_model()\n"
+      "%% <%modelNamePrefix%>\n"
       "%% der(x) = A * x + B * u\n%% y = C * x + D * u\n"
       "  n = <%varInfo.numStateVars%>; %% number of states\n  m = <%varInfo.numInVars%>; %% number of inputs\n  p = <%varInfo.numOutVars%>; %% number of outputs\n"
       "\n"
@@ -4719,7 +4718,7 @@ template functionlinearmodelMatlab(ModelInfo modelInfo, String modelNamePrefix) 
       <%matrixD%>
       "  Ts = %g; %% stop time\n\n"
       "  %% The Control System Toolbox is required for this. Alternatively just return the matrices A,B,C,D instead.\n"
-      "  sys = ss(A,B,C,D,Ts,'StateName',{<%getVarNameMatlab(vars.stateVars, "x")%>}, 'InputName',{<%getVarNameMatlab(vars.inputVars, "u")%>}, 'OutputName', {<%getVarNameMatlab(vars.outputVars, "y")%>});\n"
+      "  sys = ss(A,B,C,D,'StateName',{<%getVarNameMatlab(vars.stateVars, "x")%>}, 'InputName',{<%getVarNameMatlab(vars.inputVars, "u")%>}, 'OutputName', {<%getVarNameMatlab(vars.outputVars, "y")%>});\n"
       "end";
     }
     const char *<%symbolName(modelNamePrefix,"linear_model_datarecovery_frame")%>()
@@ -4744,7 +4743,8 @@ template functionlinearmodelJulia(ModelInfo modelInfo, String modelNamePrefix) "
     <<
     const char *<%symbolName(modelNamePrefix,"linear_model_frame")%>()
     {
-      return "function <%symbolName(modelNamePrefix,"GetLinearModel")%>()\n"
+      return "function linearized_model()\n"
+      "#= <%modelNamePrefix%> =#\n"
       "#= der(x) = A * x + B * u =#\n#= y = C * x + D * u =#\n"
       "  local n = <%varInfo.numStateVars%> #= number of states =#\n  local m = <%varInfo.numInVars%> #= number of inputs =#\n  local p = <%varInfo.numOutVars%> #= number of outputs =#\n"
       "\n"
@@ -4784,7 +4784,8 @@ template functionlinearmodelPython(ModelInfo modelInfo, String modelNamePrefix) 
     <<
     const char *<%symbolName(modelNamePrefix,"linear_model_frame")%>()
     {
-      return "def <%symbolName(modelNamePrefix,"GetLinearModel")%>()\n"
+      return "def linearized_model()\n"
+      "# <%modelNamePrefix%>\n"
       "# der(x) = A * x + B * u \n# y = C * x + D * u \n"
       "  n = <%varInfo.numStateVars%> # number of states\n  m = <%varInfo.numInVars%> # number of inputs\n  p = <%varInfo.numOutVars%> # number of outputs\n"
       "\n"

--- a/OMCompiler/SimulationRuntime/c/linearization/linearize.cpp
+++ b/OMCompiler/SimulationRuntime/c/linearization/linearize.cpp
@@ -590,45 +590,11 @@ int linearize(DATA* data, threadData_t *threadData)
       case OMC_LINEARIZE_DUMP_LANGUAGE_JULIA: ext = ".jl";  break;
       case OMC_LINEARIZE_DUMP_LANGUAGE_PYTHON: ext = ".py";  break;
     }
-  /* Use the result file name rather than the model name so that the linear file name can be changed with the -r flag, however strip _res.mat from the filename */
-  filename = string(data->modelData->resultFileName) + string(ext);
-	pos = filename.rfind("_res.mat");
-	if (pos != std::string::npos)
-	{
-      // not found, use the modelFilePrefix
-	  filename = string(data->modelData->modelFilePrefix) + string(ext);
-	}
-	else
-	{
-      filename = filename.substr(0, pos) + string(ext);
-	}
-#if defined(__MINGW32__) || defined(_MSC_VER)
-    pos1 = filename.rfind('\\');
-	pos2 = filename.rfind('/');
-	if (pos1 < pos2)
-	{
-      pos = pos2;
-	}
-	else
-	{
-      pos = pos1;
-	}
-    if(pos >= filename.length()) {
-      filename = "linear_" + filename;
-    }else{
-      filename.replace(pos, 1, "/linear_");
-    }
-#else
-    if(filename.rfind('/') >= filename.length()) {
-      filename = "linear_" + filename;
-    }else{
-      filename.replace(filename.rfind('/'), 1, "/linear_");
-    }
-#endif
+    /* ticket #5927: Don't use the model name to prevent bad names for certain languages. */
+    filename = "linearized_model" + string(ext);
 
     FILE *fout = omc_fopen(filename.c_str(),"wb");
     assertStreamPrint(threadData,0!=fout,"Cannot open File %s",filename.c_str());
-
 
     if(do_data_recovery > 0){
         fprintf(fout, data->callback->linear_model_datarecovery_frame(), strX.c_str(), strU.c_str(), strZ0.c_str(), strA.c_str(), strB.c_str(), strC.c_str(), strD.c_str(), strCz.c_str(), strDz.c_str());
@@ -638,6 +604,7 @@ int linearize(DATA* data, threadData_t *threadData)
     if(ACTIVE_STREAM(LOG_STATS)) {
       infoStreamPrint(LOG_STATS, 0, data->callback->linear_model_frame(), strX.c_str(), strU.c_str(), strA.c_str(), strB.c_str(), strC.c_str(), strD.c_str(), (double) data->simulationInfo->stopTime);
     }
+
     fflush(fout);
     fclose(fout);
 

--- a/testsuite/openmodelica/linearization/linmodel.mos
+++ b/testsuite/openmodelica/linearization/linmodel.mos
@@ -1,8 +1,8 @@
 // name:     Linearization of linear model
 // keywords: linearization, linear model
 // status:   correct
-// teardown_command: rm -rf linearmodel.* linearmodel_* output.log linear_linearmodel.* linear_linearmodel_* linear_linearmodel linearmodel
-// 
+// teardown_command: rm -rf linearmodel.* linearmodel_* output.log linearized_model.* linearized_model_* linearized_model linearmodel
+//
 //  Case for linearization of VanDerPol model
 //
 loadFile("linmodel.mo");
@@ -11,25 +11,25 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 linearize(linearmodel, stopTime=0);
 getErrorString();
-loadFile("linear_linearmodel.mo");
-list(linear_linearmodel);
-simulate(linear_linearmodel);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_linearmodel.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-// 
+//
 //  Case for numeric linearization of VanDerPol model
 //
 //linearize with numeric linearization and data recovery
 simulate(linearmodel, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_linearmodel.mo");
-list(linear_linearmodel);
-simulate(linear_linearmodel);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_linearmodel.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -47,7 +47,7 @@ readFile("linear_linearmodel.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_linearmodel
+// "model linearized_model \"linearmodel\"
 //   parameter Integer n = 4 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -67,10 +67,10 @@ readFile("linear_linearmodel.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_linearmodel;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_linearmodel_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_linearmodel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -94,7 +94,7 @@ readFile("linear_linearmodel.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_linearmodel
+// "model linearized_model \"linearmodel\"
 //   parameter Integer n = 4 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -120,10 +120,10 @@ readFile("linear_linearmodel.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_linearmodel;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_linearmodel_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_linearmodel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/simLotkaVolterra.mos
+++ b/testsuite/openmodelica/linearization/simLotkaVolterra.mos
@@ -1,8 +1,8 @@
 // name:     LotkaVolterra linearization
 // keywords: LotkaVolterra, linearization
 // status:   correct
-// teardown_command: rm -rf LotkaVolterra.* LotkaVolterra_* output.log linear_LotkaVolterra.* linear_LotkaVolterra_* linear_LotkaVolterra LotkaVolterra
-// 
+// teardown_command: rm -rf LotkaVolterra.* LotkaVolterra_* output.log linearized_model.* linearized_model_* linearized_model LotkaVolterra
+//
 //  Case for linearization of LotkaVolterra model
 //
 loadFile("modelLotkaVolterra.mo");
@@ -11,25 +11,25 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 linearize(LotkaVolterra, stopTime=0);
 getErrorString();
-loadFile("linear_LotkaVolterra.mo");
-list(linear_LotkaVolterra);
-simulate(linear_LotkaVolterra);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_LotkaVolterra.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
 simulate(LotkaVolterra, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_LotkaVolterra.mo");
-list(linear_LotkaVolterra);
-simulate(linear_LotkaVolterra);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_LotkaVolterra.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -47,7 +47,7 @@ readFile("linear_LotkaVolterra.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_LotkaVolterra
+// "model linearized_model \"LotkaVolterra\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -65,10 +65,10 @@ readFile("linear_LotkaVolterra.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_LotkaVolterra;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_LotkaVolterra_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_LotkaVolterra', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -92,7 +92,7 @@ readFile("linear_LotkaVolterra.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_LotkaVolterra
+// "model linearized_model \"LotkaVolterra\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -116,10 +116,10 @@ readFile("linear_LotkaVolterra.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_LotkaVolterra;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_LotkaVolterra_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_LotkaVolterra', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/simNonlinear.mos
+++ b/testsuite/openmodelica/linearization/simNonlinear.mos
@@ -1,8 +1,8 @@
 // name:     nonlinsys linearization
 // keywords: nonlinsys, linearization
 // status:   correct
-// teardown_command: rm -rf p.nonlinsys.* p.nonlinsys_* output.log linear_p_nonlinsys.* linear_p.nonlinsys.mo linear_p_nonlinsys_* linear_p_nonlinsys p.nonlinsys
-// 
+// teardown_command: rm -rf p.nonlinsys.* p.nonlinsys_* output.log linearized_model.* linearized_model.mo linearized_model_* linearized_model p.nonlinsys
+//
 //  Case for linearization of nonlinsys model
 //
 loadFile("modelnonlinsys.mo");
@@ -12,25 +12,25 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 linearize(p.nonlinsys, stopTime=0);
 getErrorString();
-loadFile("linear_p.nonlinsys.mo");
-list(linear_p_nonlinsys);
-simulate(linear_p_nonlinsys);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_p_nonlinsys.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-// 
+//
 //  Case for numeric linearization of nonlinsys model
 //
 //linearize with numeric linearization and data recovery
 simulate(p.nonlinsys, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_p.nonlinsys.mo");
-list(linear_p_nonlinsys);
-simulate(linear_p_nonlinsys);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_p_nonlinsys.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -48,7 +48,7 @@ readFile("linear_p_nonlinsys.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_p_nonlinsys
+// "model linearized_model \"p_nonlinsys\"
 //   parameter Integer n = 3 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 2 \"number of outputs\";
@@ -70,10 +70,10 @@ readFile("linear_p_nonlinsys.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_p_nonlinsys;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_p_nonlinsys_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_p_nonlinsys', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -97,7 +97,7 @@ readFile("linear_p_nonlinsys.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_p_nonlinsys
+// "model linearized_model \"p_nonlinsys\"
 //   parameter Integer n = 3 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 2 \"number of outputs\";
@@ -131,10 +131,10 @@ readFile("linear_p_nonlinsys.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_p_nonlinsys;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_p_nonlinsys_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_p_nonlinsys', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/simTwoTank.mos
+++ b/testsuite/openmodelica/linearization/simTwoTank.mos
@@ -1,8 +1,8 @@
 // name:     twoflattankmodel linearization
 // keywords: twoflattankmodel, linearization
 // status:   correct
-// teardown_command: rm -rf twoflattankmodel.* twoflattankmodel_* output.log linear_twoflattankmodel.* linear_twoflattankmodel_* linear_twoflattankmodel twoflattankmodel
-// 
+// teardown_command: rm -rf twoflattankmodel.* twoflattankmodel_* output.log linearized_model.* linearized_model_* linearized_model twoflattankmodel
+//
 //  Case for linearization of twoflattankmodel model
 //
 loadFile("modelTwoflattankmodel.mo");
@@ -12,25 +12,25 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 linearize(twoflattankmodel, stopTime=0);
 getErrorString();
-loadFile("linear_twoflattankmodel.mo");
-list(linear_twoflattankmodel);
-simulate(linear_twoflattankmodel,method="dassl");
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model,method="dassl");
 getErrorString();
-readFile("linear_twoflattankmodel.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-// 
+//
 //  Case for numeric linearization of twoflattankmodel model
 //
 //linearize with numeric linearization and data recovery
 simulate(twoflattankmodel, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_twoflattankmodel.mo");
-list(linear_twoflattankmodel);
-simulate(linear_twoflattankmodel);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_twoflattankmodel.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -48,7 +48,7 @@ readFile("linear_twoflattankmodel.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_twoflattankmodel
+// "model linearized_model \"twoflattankmodel\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 1 \"number of outputs\";
@@ -68,10 +68,10 @@ readFile("linear_twoflattankmodel.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_twoflattankmodel;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_twoflattankmodel_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_twoflattankmodel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -95,7 +95,7 @@ readFile("linear_twoflattankmodel.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_twoflattankmodel
+// "model linearized_model \"twoflattankmodel\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 1 \"number of outputs\";
@@ -124,10 +124,10 @@ readFile("linear_twoflattankmodel.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_twoflattankmodel;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_twoflattankmodel_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_twoflattankmodel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/simVanDerPol.mos
+++ b/testsuite/openmodelica/linearization/simVanDerPol.mos
@@ -1,32 +1,32 @@
 // name:     VanDerPol linearization
 // keywords: VanDerPol, linearization
 // status:   correct
-// teardown_command: rm -rf VanDerPol.* VanDerPol_* output.log linear_VanDerPol.* linear_VanDerPol_* linear_VanDerPol VanDerPol
-// 
+// teardown_command: rm -rf VanDerPol.* VanDerPol_* output.log linearized_model.* linearized_model_* linearized_model VanDerPol
+//
 //  Case for numeric linearization of VanDerPol model
 //
 //linearize with numeric linearization and data recovery
 loadFile("modelVanDerPol.mo");
 simulate(VanDerPol, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_VanDerPol.mo");
-list(linear_VanDerPol);
-simulate(linear_VanDerPol);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_VanDerPol.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for linearization of VanDerPol model
 //
 setCommandLineOptions("+generateSymbolicLinearization");
 //linearize
 linearize(VanDerPol,stopTime=0);
 getErrorString();
-loadFile("linear_VanDerPol.mo");
-list(linear_VanDerPol);
-simulate(linear_VanDerPol);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_VanDerPol.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -42,7 +42,7 @@ readFile("linear_VanDerPol.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_VanDerPol
+// "model linearized_model \"VanDerPol\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -66,10 +66,10 @@ readFile("linear_VanDerPol.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_VanDerPol;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_VanDerPol_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_VanDerPol', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -92,7 +92,7 @@ readFile("linear_VanDerPol.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_VanDerPol
+// "model linearized_model \"VanDerPol\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -110,10 +110,10 @@ readFile("linear_VanDerPol.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_VanDerPol;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_VanDerPol_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_VanDerPol', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/simextfunction.mos
+++ b/testsuite/openmodelica/linearization/simextfunction.mos
@@ -1,8 +1,8 @@
 // name:     extfunctions linearization
 // keywords: extfunctions, linearization
 // status:   correct
-// teardown_command: rm -rf extfunction.* extfunction_* output.log linear_extfunction.* linear_extfunction_* linear_extfunction extfunction
-// 
+// teardown_command: rm -rf extfunction.* extfunction_* output.log linearized_model.* linearized_model_* linearized_model extfunction
+//
 //  Case for numeric linearization of extfunctions model
 //
 
@@ -12,47 +12,47 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 simulate(extfunction, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_extfunction.mo");
-list(linear_extfunction);
-simulate(linear_extfunction);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_extfunction.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
 //linearize with numeric linearization and data recovery at time 0
 simulate(extfunction, simflags="-l=1 -l_datarec");
 getErrorString();
-loadFile("linear_extfunction.mo");
-list(linear_extfunction);
-simulate(linear_extfunction);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_extfunction.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for linearization of extfunctions model
 //
 setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
-//linearize at point in time 0 
+//linearize at point in time 0
 linearize(extfunction, stopTime=0);
 getErrorString();
-loadFile("linear_extfunction.mo");
-list(linear_extfunction);
-simulate(linear_extfunction);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_extfunction.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-//linearize at point in time 1 
+//linearize at point in time 1
 linearize(extfunction, stopTime=1);
 getErrorString();
-loadFile("linear_extfunction.mo");
-list(linear_extfunction);
-simulate(linear_extfunction);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_extfunction.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -70,7 +70,7 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_extfunction
+// "model linearized_model \"extfunction\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -96,10 +96,10 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_extfunction;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_extfunction_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_extfunction', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -123,7 +123,7 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_extfunction
+// "model linearized_model \"extfunction\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -149,10 +149,10 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_extfunction;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_extfunction_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_extfunction', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -176,7 +176,7 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_extfunction
+// "model linearized_model \"extfunction\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -194,10 +194,10 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_extfunction;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_extfunction_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_extfunction', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -221,7 +221,7 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_extfunction
+// "model linearized_model \"extfunction\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -239,10 +239,10 @@ readFile("linear_extfunction.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_extfunction;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_extfunction_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_extfunction', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/smallValues.mos
+++ b/testsuite/openmodelica/linearization/smallValues.mos
@@ -1,8 +1,8 @@
 // name:     small values in linearization
 // keywords: VanDerPolSmallValueSmallValue, linearization, small value
 // status:   correct
-// teardown_command: rm -rf VanDerPolSmallValue.* VanDerPolSmallValue_* output.log linear_VanDerPolSmallValue.* linear_VanDerPolSmallValue_* linear_VanDerPolSmallValue VanDerPolSmallValue
-// 
+// teardown_command: rm -rf VanDerPolSmallValue.* VanDerPolSmallValue_* output.log linearized_model.* linearized_model_* linearized_model VanDerPolSmallValue
+//
 //  Case for linearization of VanDerPolSmallValue model
 //
 loadFile("smallValue.mo");
@@ -11,25 +11,25 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 linearize(VanDerPolSmallValue, stopTime=0);
 getErrorString();
-loadFile("linear_VanDerPolSmallValue.mo");
-list(linear_VanDerPolSmallValue);
-simulate(linear_VanDerPolSmallValue);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_VanDerPolSmallValue.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-// 
+//
 //  Case for numeric linearization of VanDerPolSmallValue model
 //
 //linearize with numeric linearization and data recovery
 simulate(VanDerPolSmallValue, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_VanDerPolSmallValue.mo");
-list(linear_VanDerPolSmallValue);
-simulate(linear_VanDerPolSmallValue);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_VanDerPolSmallValue.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -47,7 +47,7 @@ readFile("linear_VanDerPolSmallValue.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_VanDerPolSmallValue
+// "model linearized_model \"VanDerPolSmallValue\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -65,10 +65,10 @@ readFile("linear_VanDerPolSmallValue.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_VanDerPolSmallValue;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_VanDerPolSmallValue_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_VanDerPolSmallValue', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -92,7 +92,7 @@ readFile("linear_VanDerPolSmallValue.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_VanDerPolSmallValue
+// "model linearized_model \"VanDerPolSmallValue\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -116,10 +116,10 @@ readFile("linear_VanDerPolSmallValue.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_VanDerPolSmallValue;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_VanDerPolSmallValue_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_VanDerPolSmallValue', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/testArrayAlg.mos
+++ b/testsuite/openmodelica/linearization/testArrayAlg.mos
@@ -1,7 +1,7 @@
 // name:     testArrayAlgDiff
 // keywords: differentiation linearization array algorithm
 // status:   correct
-// teardown_command: rm -rf ticket4545* output.log linear_ticket4545*
+// teardown_command: rm -rf ticket4545* output.log linearized_model*
 //
 //
 
@@ -11,8 +11,8 @@ package ticket4545
     Real x[2](each start = 0, each fixed = true);
     discrete Real u[2](each start = 0, each fixed = true);
     Real y[2];
-  equation 
-    for i in 1:2 loop 
+  equation
+    for i in 1:2 loop
       der(x[i]) = u[i]+y[i];
       y[i] = 0.5*x[i];
     end for;
@@ -32,8 +32,8 @@ setCommandLineOptions("--generateSymbolicLinearization");
 getErrorString();
 linearize(ticket4545.Test_vector, stopTime=0);
 getErrorString();
-loadFile("linear_ticket4545.Test_vector.mo");
-list(linear_ticket4545_Test__vector);
+loadFile("linearized_model.mo");
+list(linearized_model);
 getErrorString();
 
 
@@ -54,7 +54,7 @@ getErrorString();
 // end SimulationResult;
 // ""
 // true
-// "model linear_ticket4545_Test__vector
+// "model linearized_model \"ticket4545_Test_vector\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -72,6 +72,6 @@ getErrorString();
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_ticket4545_Test__vector;"
+// end linearized_model;"
 // ""
 // endResult

--- a/testsuite/openmodelica/linearization/testDrumBoiler.mos
+++ b/testsuite/openmodelica/linearization/testDrumBoiler.mos
@@ -14,8 +14,8 @@ end testDrumBoilerLin;
 setCommandLineOptions("--generateSymbolicLinearization");
 linearize(testDrumBoilerLin, stopTime=0.0);getErrorString();
 
-loadFile("linear_testDrumBoilerLin.mo");
-list(linear_testDrumBoilerLin);
+loadFile("linearized_model.mo");
+list(linearized_model);
 
 
 // Result:
@@ -35,7 +35,7 @@ list(linear_testDrumBoilerLin);
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // "
 // true
-// "model linear_testDrumBoilerLin
+// "model linearized_model \"testDrumBoilerLin\"
 //   parameter Integer n = 3 \"number of states\";
 //   parameter Integer m = 2 \"number of inputs\";
 //   parameter Integer p = 4 \"number of outputs\";
@@ -60,5 +60,5 @@ list(linear_testDrumBoilerLin);
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_testDrumBoilerLin;"
+// end linearized_model;"
 // endResult

--- a/testsuite/openmodelica/linearization/testMathFuncs.mos
+++ b/testsuite/openmodelica/linearization/testMathFuncs.mos
@@ -1,8 +1,8 @@
 // name:     testMathFuncs linearization
 // keywords: differentiation linearization
 // status:   correct
-// teardown_command: rm -rf mathFuncsTest* output.log linear_mathFuncsTest*
-//  
+// teardown_command: rm -rf mathFuncsTest* output.log linearized_model*
+//
 //
 
 
@@ -18,31 +18,31 @@ equation
   r3 = rem(x,y);
   r4 = ceil(x*y);
   r5 = floor(x*y);
-  r6 = integer(x*y);      
+  r6 = integer(x*y);
 end mathFuncsTest;
 ");
 
-// 
+//
 //  Case for numeric linearization of mathFuncsTest model
 //
 //linearize with numeric linearization and data recovery
 simulate(mathFuncsTest, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_mathFuncsTest.mo");
-list(linear_mathFuncsTest);
-simulate(linear_mathFuncsTest);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_mathFuncsTest.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Symbolically linearize
 setCommandLineOptions("+generateSymbolicLinearization");
 linearize(mathFuncsTest,stopTime=0);
 getErrorString();
-loadFile("linear_mathFuncsTest.mo");
-list(linear_mathFuncsTest);
-simulate(linear_mathFuncsTest);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_mathFuncsTest.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 
 // Result:
@@ -59,7 +59,7 @@ readFile("linear_mathFuncsTest.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_mathFuncsTest
+// "model linearized_model \"mathFuncsTest\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 6 \"number of outputs\";
@@ -97,10 +97,10 @@ readFile("linear_mathFuncsTest.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_mathFuncsTest;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_mathFuncsTest_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_mathFuncsTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -123,7 +123,7 @@ readFile("linear_mathFuncsTest.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_mathFuncsTest
+// "model linearized_model \"mathFuncsTest\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 6 \"number of outputs\";
@@ -147,10 +147,10 @@ readFile("linear_mathFuncsTest.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_mathFuncsTest;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_mathFuncsTest_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_mathFuncsTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/testRecordDiff.mos
+++ b/testsuite/openmodelica/linearization/testRecordDiff.mos
@@ -1,7 +1,7 @@
 // name:     testRecordDiff linearization
 // keywords: differentiation linearization records
 // status:   correct
-// teardown_command: rm -rf recordDiffTest* output.log linear_recordDiffTest*
+// teardown_command: rm -rf recordDiffTest* output.log linearized_model*
 //
 //
 
@@ -39,8 +39,8 @@ setCommandLineOptions("--generateSymbolicLinearization");
 linearize(recordDiffTest, stopTime=0.0);
 getErrorString();
 
-loadFile("linear_recordDiffTest.mo");
-list(linear_recordDiffTest);
+loadFile("linearized_model.mo");
+list(linearized_model);
 
 
 // Result:
@@ -59,7 +59,7 @@ list(linear_recordDiffTest);
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_recordDiffTest
+// "model linearized_model \"recordDiffTest\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 1 \"number of outputs\";
@@ -77,5 +77,5 @@ list(linear_recordDiffTest);
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_recordDiffTest;"
+// end linearized_model;"
 // endResult

--- a/testsuite/openmodelica/linearization/testSortFunction.mos
+++ b/testsuite/openmodelica/linearization/testSortFunction.mos
@@ -20,8 +20,8 @@ end SortTest;
 setCommandLineOptions("--generateSymbolicLinearization");
 linearize(SortTest, stopTime=1.0);getErrorString();
 
-loadFile("linear_SortTest.mo");
-list(linear_SortTest);
+loadFile("linearized_model.mo");
+list(linearized_model);
 
 
 // Result:
@@ -41,7 +41,7 @@ list(linear_SortTest);
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_SortTest
+// "model linearized_model \"SortTest\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 4 \"number of outputs\";
@@ -63,5 +63,5 @@ list(linear_SortTest);
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_SortTest;"
+// end linearized_model;"
 // endResult

--- a/testsuite/openmodelica/linearization/testSteamPipe.mos
+++ b/testsuite/openmodelica/linearization/testSteamPipe.mos
@@ -15,8 +15,8 @@ end testSteamPipeLin;
 setCommandLineOptions("--generateSymbolicLinearization");
 linearize(testSteamPipeLin, stopTime=0.0);getErrorString();
 
-loadFile("linear_testSteamPipeLin.mo");
-list(linear_testSteamPipeLin);
+loadFile("linearized_model.mo");
+list(linearized_model);
 
 
 // Result:
@@ -36,7 +36,7 @@ list(linear_testSteamPipeLin);
 // end SimulationResult;
 // ""
 // true
-// "model linear_testSteamPipeLin
+// "model linearized_model \"testSteamPipeLin\"
 //   parameter Integer n = 4 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -56,5 +56,5 @@ list(linear_testSteamPipeLin);
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_testSteamPipeLin;"
+// end linearized_model;"
 // endResult

--- a/testsuite/openmodelica/linearization/test_01.mos
+++ b/testsuite/openmodelica/linearization/test_01.mos
@@ -2,9 +2,9 @@
 // keywords: <...>
 // status:   correct
 // teardown_command: rm -rf *simple_test* output.log
-// 
+//
 // <insert description here>
-// 
+//
 
 loadFile("test_01.mo");
 
@@ -15,23 +15,23 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, startTime=0.0, stopTime=10.0, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, startTime=0.0, stopTime=10.0, method="euler");
 getErrorString();
-readFile("linear_simple__test.log");
-list(linear_simple__test);
+readFile("linearized_model.log");
+list(linearized_model);
 
-// 
+//
 //  Case for numeric linearization
 //
 //linearize with numeric linearization and data recovery
 simulate(simple_test, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, startTime=0.0, stopTime=10.0, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, startTime=0.0, stopTime=10.0, method="euler");
 getErrorString();
-readFile("linear_simple__test.log");
-list(linear_simple__test);
+readFile("linearized_model.log");
+list(linearized_model);
 
 // Result:
 // true
@@ -52,8 +52,8 @@ list(linear_simple__test);
 // ""
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -63,7 +63,7 @@ list(linear_simple__test);
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -81,7 +81,7 @@ list(linear_simple__test);
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // record SimulationResult
 //     resultFile = "simple_test_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'simple_test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-l=0 -l_datarec'",
@@ -95,8 +95,8 @@ list(linear_simple__test);
 // "
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -106,7 +106,7 @@ list(linear_simple__test);
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -132,5 +132,5 @@ list(linear_simple__test);
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // endResult

--- a/testsuite/openmodelica/linearization/test_02.mos
+++ b/testsuite/openmodelica/linearization/test_02.mos
@@ -2,7 +2,7 @@
 // keywords: <...>
 // status:   correct
 // teardown_command: rm -rf *simple_test* output.log
-// 
+//
 // <insert description here>
 //
 
@@ -15,24 +15,24 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
 
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
 simulate(simple_test, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -53,15 +53,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // ""
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -79,7 +79,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -96,15 +96,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // "
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -128,7 +128,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/test_03.mos
+++ b/testsuite/openmodelica/linearization/test_03.mos
@@ -2,7 +2,7 @@
 // keywords: <...>
 // status:   correct
 // teardown_command: rm -rf *simple_test* output.log
-// 
+//
 // <insert description here>
 //
 
@@ -15,24 +15,24 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
 
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
 simulate(simple_test, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -53,15 +53,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // ""
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -78,7 +78,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -95,15 +95,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // "
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -128,7 +128,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/test_04.mos
+++ b/testsuite/openmodelica/linearization/test_04.mos
@@ -2,7 +2,7 @@
 // keywords: <...>
 // status:   correct
 // teardown_command: rm -rf *simple_test* output.log
-// 
+//
 // <insert description here>
 //
 
@@ -14,24 +14,24 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test,method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model,method="euler");
 getErrorString();
 
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
 simulate(simple_test, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -52,15 +52,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // ""
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 1 \"number of outputs\";
@@ -80,7 +80,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -97,15 +97,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // "
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 1 \"number of outputs\";
@@ -133,7 +133,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/test_05.mos
+++ b/testsuite/openmodelica/linearization/test_05.mos
@@ -2,7 +2,7 @@
 // keywords: <...>
 // status:   correct
 // teardown_command: rm -rf *simple_test* output.log
-// 
+//
 // <insert description here>
 //
 
@@ -15,24 +15,24 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
 
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
 simulate(simple_test, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, method="euler");
 getErrorString();
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model);
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -53,15 +53,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // ""
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -79,7 +79,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -96,15 +96,15 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // "
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -128,7 +128,7 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/test_06.mos
+++ b/testsuite/openmodelica/linearization/test_06.mos
@@ -1,38 +1,32 @@
 // name:     test_06.mos
 // keywords: <...>
 // status:   correct
-// teardown_command: rm -rf *simple_test* output.log
-// 
+// teardown_command: rm -rf *simple_test* linearized_model* output.log
+//
 // <insert description here>
 //
 
 loadFile("test_06.mo");
 
-setCommandLineOptions("--generateSymbolicLinearization");
-getErrorString();
-linearize(simple_test, stopTime=0);
-getErrorString();
-setCommandLineOptions("--generateSymbolicLinearization=false");
-getErrorString();
+setCommandLineOptions("--generateSymbolicLinearization"); getErrorString();
+linearize(simple_test, stopTime=0); getErrorString();
+setCommandLineOptions("--generateSymbolicLinearization=false"); getErrorString();
 
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
-getErrorString();
+loadFile("linearized_model.mo"); getErrorString();
+simulate(linearized_model, method="euler"); getErrorString();
 
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+list(linearized_model); getErrorString();
+readFile("linearized_model.log"); getErrorString(); // Check that output log is empty
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
-simulate(simple_test, simflags="-l=0 -l_datarec");
-getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, method="euler");
-getErrorString();
-list(linear_simple__test);
-readFile("linear_simple__test.log"); // Check that output log is empty
+simulate(simple_test, simflags="-l=0 -l_datarec"); getErrorString();
+loadFile("linearized_model.mo"); getErrorString();
+simulate(linearized_model, method="euler"); getErrorString();
+list(linearized_model); getErrorString();
+readFile("linearized_model.log"); getErrorString(); // Check that output log is empty
 
 // Result:
 // true
@@ -53,16 +47,17 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // true
 // ""
 // true
+// ""
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -79,10 +74,12 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
+// ""
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
+// ""
 // record SimulationResult
 //     resultFile = "simple_test_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'simple_test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-l=0 -l_datarec'",
@@ -96,16 +93,17 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
+// ""
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -131,8 +129,10 @@ readFile("linear_simple__test.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
+// ""
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
+// ""
 // endResult

--- a/testsuite/openmodelica/linearization/test_07.mos
+++ b/testsuite/openmodelica/linearization/test_07.mos
@@ -2,9 +2,9 @@
 // keywords: <...>
 // status:   correct
 // teardown_command: rm -rf *simple_test* output.log
-// 
+//
 // <insert description here>
-// 
+//
 
 loadFile("test_07.mo");
 
@@ -15,24 +15,24 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_simple_test.mo");
+loadFile("linearized_model.mo");
 getErrorString();
-simulate(linear_simple__test, startTime=0.0, stopTime=10.0, method="euler");
+simulate(linearized_model, startTime=0.0, stopTime=10.0, method="euler");
 getErrorString();
-readFile("linear_simple__test.log");
-list(linear_simple__test);
+readFile("linearized_model.log");
+list(linearized_model);
 
-// 
+//
 //  Case for numeric linearization of LotkaVolterra model
 //
 //linearize with numeric linearization and data recovery
 simulate(simple_test, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_simple_test.mo");
-simulate(linear_simple__test, startTime=0.0, stopTime=10.0, method="euler");
+loadFile("linearized_model.mo");
+simulate(linearized_model, startTime=0.0, stopTime=10.0, method="euler");
 getErrorString();
-readFile("linear_simple__test.log"); // Check that output log is empty
-list(linear_simple__test);
+readFile("linearized_model.log"); // Check that output log is empty
+list(linearized_model);
 
 // Result:
 // true
@@ -54,8 +54,8 @@ list(linear_simple__test);
 // true
 // ""
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -65,7 +65,7 @@ list(linear_simple__test);
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -83,7 +83,7 @@ list(linear_simple__test);
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // record SimulationResult
 //     resultFile = "simple_test_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'simple_test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-l=0 -l_datarec'",
@@ -97,8 +97,8 @@ list(linear_simple__test);
 // "
 // true
 // record SimulationResult
-//     resultFile = "linear_simple__test_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linear_simple__test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'euler', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -108,7 +108,7 @@ list(linear_simple__test);
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -134,5 +134,5 @@ list(linear_simple__test);
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_simple__test;"
+// end linearized_model;"
 // endResult

--- a/testsuite/openmodelica/linearization/test_dump_languages.mos
+++ b/testsuite/openmodelica/linearization/test_dump_languages.mos
@@ -10,19 +10,19 @@ loadFile("test_dump_languages.mo"); getErrorString();
 
 setCommandLineOptions("--linearizationDumpLanguage=modelica");
 linearize(simple_test, stopTime=0.5); getErrorString();
-readFile("linear_simple_test.mo"); getErrorString();
+readFile("linearized_model.mo"); getErrorString();
 
 setCommandLineOptions("--linearizationDumpLanguage=matlab");
 linearize(simple_test, stopTime=0.5); getErrorString();
-readFile("linear_simple_test.m"); getErrorString();
+readFile("linearized_model.m"); getErrorString();
 
 setCommandLineOptions("--linearizationDumpLanguage=julia");
 linearize(simple_test, stopTime=0.5); getErrorString();
-readFile("linear_simple_test.jl"); getErrorString();
+readFile("linearized_model.jl"); getErrorString();
 
 setCommandLineOptions("--linearizationDumpLanguage=python");
 linearize(simple_test, stopTime=0.5); getErrorString();
-readFile("linear_simple_test.py"); getErrorString();
+readFile("linearized_model.py"); getErrorString();
 
 // Result:
 // true
@@ -39,11 +39,10 @@ readFile("linear_simple_test.py"); getErrorString();
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "model linear_simple__test
+// "model linearized_model \"simple_test\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 1 \"number of inputs\";
 //   parameter Integer p = 1 \"number of outputs\";
-//
 //   parameter Real x0[n] = {1.626558527192664, 2.380918053900121};
 //   parameter Real u0[m] = {0};
 //
@@ -73,7 +72,7 @@ readFile("linear_simple_test.py"); getErrorString();
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_simple__test;
+// end linearized_model;
 // "
 // ""
 // true
@@ -88,7 +87,8 @@ readFile("linear_simple_test.py"); getErrorString();
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "function [sys, x0, u0, n, m, p] = simple_test_GetLinearModel()
+// "function [sys, x0, u0, n, m, p, Ts] = linearized_model()
+// % simple_test
 // % der(x) = A * x + B * u
 // % y = C * x + D * u
 //   n = 2; % number of states
@@ -111,7 +111,7 @@ readFile("linear_simple_test.py"); getErrorString();
 //   Ts = 0.5; % stop time
 //
 //   % The Control System Toolbox is required for this. Alternatively just return the matrices A,B,C,D instead.
-//   sys = ss(A,B,C,D,Ts,'StateName',{'x_num_x(1)','x_num_x(2)'}, 'InputName',{'u_u'}, 'OutputName', {'y_y'});
+//   sys = ss(A,B,C,D,'StateName',{'x_num_x(1)','x_num_x(2)'}, 'InputName',{'u_u'}, 'OutputName', {'y_y'});
 // end"
 // ""
 // true
@@ -126,7 +126,8 @@ readFile("linear_simple_test.py"); getErrorString();
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "function simple_test_GetLinearModel()
+// "function linearized_model()
+// #= simple_test =#
 // #= der(x) = A * x + B * u =#
 // #= y = C * x + D * u =#
 //   local n = 2 #= number of states =#
@@ -166,7 +167,8 @@ readFile("linear_simple_test.py"); getErrorString();
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "def simple_test_GetLinearModel()
+// "def linearized_model()
+// # simple_test
 // # der(x) = A * x + B * u
 // # y = C * x + D * u
 //   n = 2 # number of states

--- a/testsuite/openmodelica/linearization/testknownvar.mos
+++ b/testsuite/openmodelica/linearization/testknownvar.mos
@@ -1,8 +1,8 @@
 // name:     Jacobian for Knownvars
 // keywords: linearization, Jacobian
 // status:   correct
-// teardown_command: rm -rf TestKV* linear_TestKV* output.log
-// 
+// teardown_command: rm -rf TestKV* linearized_model* output.log
+//
 //  Case for generating Jacobian for symstem with more simply equations
 //  test for Bugfixe
 //
@@ -18,23 +18,23 @@ getErrorString();
 setCommandLineOptions("--generateSymbolicLinearization=false");
 getErrorString();
 
-loadFile("linear_TestKV.mo");
-list(linear_TestKV);
-simulate(linear_TestKV);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_TestKV.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
-// 
+//
 //  Case for numeric linearization of TestKV model
 //
 //linearize with numeric linearization and data recovery
 simulate(TestKV, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_TestKV.mo");
-list(linear_TestKV);
-simulate(linear_TestKV);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_TestKV.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Result:
 // true
@@ -54,7 +54,7 @@ readFile("linear_TestKV.log"); // Check that output log is empty
 // true
 // ""
 // true
-// "model linear_TestKV
+// "model linearized_model \"TestKV\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -71,10 +71,10 @@ readFile("linear_TestKV.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_TestKV;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_TestKV_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_TestKV', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -96,7 +96,7 @@ readFile("linear_TestKV.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_TestKV
+// "model linearized_model \"TestKV\"
 //   parameter Integer n = 1 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -120,10 +120,10 @@ readFile("linear_TestKV.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_TestKV;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_TestKV_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_TestKV', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/linearization/ticket3701.mos
+++ b/testsuite/openmodelica/linearization/ticket3701.mos
@@ -1,8 +1,8 @@
 // name:     parFuncDiffZero
 // keywords: differentiation partial functions matrix argument
 // status:   correct
-// teardown_command: rm -rf A* output.log linear_A*
-//  
+// teardown_command: rm -rf A* output.log linearized_model*
+//
 //
 
 
@@ -30,26 +30,26 @@ end A;
 ");
 getErrorString();
 
-// 
+//
 //  Case for numeric linearization
 //
 //linearize with numeric linearization and data recovery
 simulate(A, simflags="-l=0 -l_datarec");
 getErrorString();
-loadFile("linear_A.mo");
-list(linear_A);
-simulate(linear_A);
+loadFile("linearized_model.mo");
+list(linearized_model);
+simulate(linearized_model);
 getErrorString();
-readFile("linear_A.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 // Symbolically linearize
 setCommandLineOptions("+generateSymbolicLinearization");
 linearize(A,stopTime=0);
 getErrorString();
-loadFile("linear_A.mo");
-list(linear_A);
+loadFile("linearized_model.mo");
+list(linearized_model);
 getErrorString();
-readFile("linear_A.log"); // Check that output log is empty
+readFile("linearized_model.log"); // Check that output log is empty
 
 
 // Result:
@@ -67,7 +67,7 @@ readFile("linear_A.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_A
+// "model linearized_model \"A\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -94,10 +94,10 @@ readFile("linear_A.log"); // Check that output log is empty
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
 //   z = Cz * x + Dz * u;
-// end linear_A;"
+// end linearized_model;"
 // record SimulationResult
-//     resultFile = "linear_A_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linear_A', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -120,7 +120,7 @@ readFile("linear_A.log"); // Check that output log is empty
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // true
-// "model linear_A
+// "model linearized_model \"A\"
 //   parameter Integer n = 2 \"number of states\";
 //   parameter Integer m = 0 \"number of inputs\";
 //   parameter Integer p = 0 \"number of outputs\";
@@ -138,7 +138,7 @@ readFile("linear_A.log"); // Check that output log is empty
 // equation
 //   der(x) = A * x + B * u;
 //   y = C * x + D * u;
-// end linear_A;"
+// end linearized_model;"
 // ""
 // "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.

--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -146,7 +146,7 @@ sub enter_sandbox {
     if    (/$stop_expr/)               { last; }
     elsif (/setup_command.*\s(.*\.c)/) { make_link($1); }
     elsif (/depends: *([A-Za-z0-9_.-]*)/) { make_link($1); }
-    elsif (/loadFile.*\(\"linear_simple_test\.mo\"\)/) {}
+    elsif (/loadFile.*\(\"linearized_model\.mo\"\)/) {}
     elsif (/loadFile.*\(\"(.*)\"\)/)   { make_link($1); }
     elsif (/runScript.*\(\"(.*)\"\)/)  { make_link($1); }
     elsif (/importFMU.*\(\"(.*)\"\)/)  { make_link($1); }
@@ -241,7 +241,7 @@ while(<$test_log>) {
   elsif(/== Failed to set baseline.*time: (\d*)/) {
     $nfailed = 1;
     $time = $2;
-  }  
+  }
   elsif(/.*time: (\d*)/) {
     $nfailed = 0;
     $time = $1;
@@ -341,4 +341,3 @@ if ($exit_status == 0) {
   }
   exit $time;
 }
-


### PR DESCRIPTION
 - use linearized_model as file and function name for all target languages
 - prevents invalid constructs (different file and function name)
 - avoids convoluted and too large names
 - ticket #5927