### PR TITLE
[NF] Enforce function purity rules better.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -299,6 +299,16 @@ public
     end match;
   end isCall;
 
+  function isImpureCall
+    input Expression exp;
+    output Boolean isImpure;
+  algorithm
+    isImpure := match exp
+      case CALL() then Call.isImpure(exp.call);
+      else false;
+    end match;
+  end isImpureCall;
+
   function isTrue
     input Expression exp;
     output Boolean isTrue;
@@ -1800,6 +1810,25 @@ public
       else false;
     end match;
   end isNonAssociativeExp;
+
+  function getName
+    "Returns the 'name' of an Expression, for example the function name of a
+     call or the record class name of a record expression."
+    input Expression exp;
+    output String name;
+  algorithm
+    name := match exp
+      case RECORD() then AbsynUtil.pathString(exp.path);
+      case CALL() then AbsynUtil.pathString(Call.functionName(exp.call));
+      case CAST() then getName(exp.exp);
+      case BOX() then getName(exp.exp);
+      case UNBOX() then getName(exp.exp);
+      case MUTABLE() then getName(Mutable.access(exp.exp));
+      case PARTIAL_FUNCTION_APPLICATION() then ComponentRef.toString(exp.fn);
+      case BINDING_EXP() then getName(exp.exp);
+      else toString(exp);
+    end match;
+  end getName;
 
   function toDAEOpt
     input Option<Expression> exp;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -804,6 +804,8 @@ public constant ErrorTypes.Message EXPERIMENTAL_REQUIRED = ErrorTypes.MESSAGE(36
   Gettext.gettext("%s is an experimental feature and requires the --std=experimental flag."));
 public constant ErrorTypes.Message INVALID_NUMBER_OF_DIMENSIONS_FOR_PROMOTE = ErrorTypes.MESSAGE(366, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The second argument ‘%s‘ of promote may not be smaller than the number of dimensions (%s) of the first argument."));
+public constant ErrorTypes.Message PURE_FUNCTION_WITH_IMPURE_CALLS = ErrorTypes.MESSAGE(367, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
+  Gettext.gettext("Pure function ‘%s‘ contains a call to impure function ‘%s‘."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/flattening/modelica/scodeinst/ImpureCall1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImpureCall1.mo
@@ -1,0 +1,42 @@
+// name:     ImpureCall1
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+//
+
+impure function f
+  input Real x;
+  output Real y = x;
+end f;
+
+function f2
+  input Real x;
+  output Real y;
+algorithm
+  y := f(x);
+end f2;
+
+model ImpureCall1
+  Real x = f2(1.0);
+end ImpureCall1;
+
+// Result:
+// impure function f
+//   input Real x;
+//   output Real y = x;
+// end f;
+//
+// impure function f2
+//   input Real x;
+//   output Real y;
+// algorithm
+//   y := f(x);
+// end f2;
+//
+// class ImpureCall1
+//   Real x = f2(1.0);
+// end ImpureCall1;
+// [flattening/modelica/scodeinst/ImpureCall1.mo:13:1-18:7:writable] Warning: Pure function ‘f2‘ contains a call to impure function ‘f‘.
+//
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -587,6 +587,7 @@ ImportSubPackage2.mo \
 ImportUnqualified1.mo \
 ImportUnqualified2.mo \
 ImportUnqualified3.mo \
+ImpureCall1.mo \
 Inline1.mo \
 InnerOuter1.mo \
 InnerOuter2.mo \


### PR DESCRIPTION
- Give a warning if any pure function contains calls to impure
  functions, and mark such functions as impure themselves to make sure
  they're not constant evaluated.