### PR TITLE
installPackage now considers build info

### DIFF
--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -411,7 +411,7 @@ algorithm
   candidates := versionsThatProvideTheWanted(pkg, version, printError=true);
   candidatesSemver := list(SemanticVersion.parse(candidate) for candidate in candidates);
   semver := SemanticVersion.parse(version);
-  exactMatches := list(candidate for candidate guard 0==SemanticVersion.compare(candidate, semver) in candidatesSemver);
+  exactMatches := list(candidate for candidate guard 0==SemanticVersion.compare(candidate, semver, compareBuildInformation=not stringEmpty(semver.meta)) in candidatesSemver);
   success := false;
 
   for pkgInfo in packagesToInstall loop

--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -411,7 +411,7 @@ algorithm
   candidates := versionsThatProvideTheWanted(pkg, version, printError=true);
   candidatesSemver := list(SemanticVersion.parse(candidate) for candidate in candidates);
   semver := SemanticVersion.parse(version);
-  exactMatches := list(candidate for candidate guard 0==SemanticVersion.compare(candidate, semver, compareBuildInformation=not stringEmpty(semver.meta)) in candidatesSemver);
+  exactMatches := list(candidate for candidate guard 0==SemanticVersion.compare(candidate, semver, compareBuildInformation=SemanticVersion.hasMetaInformation(semver)) in candidatesSemver);
   success := false;
 
   for pkgInfo in packagesToInstall loop

--- a/OMCompiler/Compiler/Util/SemanticVersion.mo
+++ b/OMCompiler/Compiler/Util/SemanticVersion.mo
@@ -143,6 +143,17 @@ algorithm
   end match;
 end isPrerelease;
 
+function hasMetaInformation
+  input Version v;
+  output Boolean b;
+algorithm
+  b := match v
+    case SEMVER(meta="") then false;
+    case NONSEMVER() then false;
+    else true;
+  end match;
+end hasMetaInformation;
+
 protected
 
 function compareIdentifierList

--- a/OMCompiler/Compiler/Util/SemanticVersion.mo
+++ b/OMCompiler/Compiler/Util/SemanticVersion.mo
@@ -148,7 +148,7 @@ function hasMetaInformation
   output Boolean b;
 algorithm
   b := match v
-    case SEMVER(meta="") then false;
+    case SEMVER(meta={}) then false;
     case NONSEMVER() then false;
     else true;
   end match;


### PR DESCRIPTION
If build metadata it is given to installPackage and exactMatch=true,
only such packages are installed.

If there is no such build metadata requsted, packages with build
metadata will still be considered matches.