### PR TITLE
add getSignalFilter to OMSSimulationDialog

### DIFF
--- a/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
@@ -1419,6 +1419,24 @@ bool OMSProxy::getResultFile(QString cref, char **pFilename, int *pBufferSize)
 }
 
 /*!
+ * \brief OMSProxy::getSignalFilter
+ * gets the signal filter regex.
+ * \param cref
+ * \param regex
+ * \return
+ */
+bool OMSProxy::getSignalFilter(QString cref, char **regex)
+{
+  QString command = "oms_getSignalFilter";
+  QStringList args;
+  args << "\"" + cref + "\"";
+  LOG_COMMAND(command, args);
+  oms_status_enu_t status = oms_getSignalFilter(cref.toUtf8().constData(), regex);
+  logResponse(command, status, &commandTime);
+  return statusToBool(status);
+}
+
+/*!
  * \brief OMSProxy::setSignalFilter
  * Sets the signal filter.
  * \param cref

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.h
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.h
@@ -109,6 +109,7 @@ public:
                            char ***types, char ***descriptions);
   bool getTolerance(QString cref, double* absoluteTolerance, double* relativeTolerance);
   bool getVariableStepSize(QString cref, double* initialStepSize, double* minimumStepSize, double* maximumStepSize);
+  bool getSignalFilter(QString cref, char **regex);
   bool instantiate(QString cref);
   bool initialize(QString cref);
   bool list(QString cref, QString *pContents);

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
@@ -295,9 +295,7 @@ void OMSSimulationDialog::saveSimulationSettings()
   OMSProxy::instance()->setStopTime(mModelCref, mpStopTimeTextBox->text().toDouble());
   OMSProxy::instance()->setResultFile(mModelCref, mpResultFileTextBox->text(), mpResultFileBufferSizeSpinBox->value());
   OMSProxy::instance()->setLoggingInterval(mModelCref, mpLoggingIntervalTextBox->text().toDouble());
-  if (!mpSignalFilterTextBox->text().isEmpty()) {
-    OMSProxy::instance()->setSignalFilter(mModelCref, mpSignalFilterTextBox->text());
-  }
+  OMSProxy::instance()->setSignalFilter(mModelCref, mpSignalFilterTextBox->text());
 
   ModelWidget *pModelWidget = mpLibraryTreeItem->getModelWidget();
   pModelWidget->createOMSimulatorUndoCommand(QString("Simulation setup %1").arg(mModelCref));

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
@@ -203,7 +203,10 @@ int OMSSimulationDialog::exec(const QString &modelCref, LibraryTreeItem *pLibrar
   mpResultFileTextBox->setText(QString(fileName));
   // result file buffer size
   mpResultFileBufferSizeSpinBox->setValue(bufferSize);
-
+  // signalFilter
+  char *regex = (char*)"";
+  OMSProxy::instance()->getSignalFilter(mModelCref, &regex);
+  mpSignalFilterTextBox->setText(QString(regex));
   mpOkButton->setEnabled(!mpLibraryTreeItem->isSystemLibrary());
 
   return QDialog::exec();


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/750

### Purpose
This PR allows setting signal filters .via the Simulation setup dialog in OMEdit from a ssp file

### Remark
This should be merged after https://github.com/OpenModelica/OMSimulator/pull/753
