### PR TITLE
Fix testsuite clean and added test rule

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,7 +5,7 @@ defaultMakefileTarget = Makefile.unix
 all: @ALL_TARGETS@ @OMLIBRARY_TARGET@
 
 .PRECIOUS: Makefile
-.PHONY: omc omlibrary-all omlibrary-core omplot omedit omedit-testsuite omparser omnotebook omoptim omshell omc-diff omsimulator ReferenceFiles libs-for-testing testsuite-depends omsens_qt
+.PHONY: omc omlibrary-all omlibrary-core omplot omedit omedit-testsuite omparser omnotebook omoptim omshell omc-diff omsimulator ReferenceFiles libs-for-testing test fast-test testsuite-depends omsens_qt
 
 omc: omc.skip
 omc.skip:
@@ -51,7 +51,15 @@ ReferenceFiles.skip:
 libs-for-testing: libs-for-testing.skip
 libs-for-testing.skip: omc
 	$(MAKE) -C testsuite/libraries-for-testing/
-testsuite-depends: omc-diff ReferenceFiles libs-for-testing
+testsuite-depends: omc-diff ReferenceFiles libs-for-testing omsimulator
+test: testsuite-depends
+	$(MAKE) omc-diff
+	cd testsuite/partest && echo "Running all $(./runtests.pl -counttests) tests"
+	cd testsuite/partest && ./runtests.pl -with-txt
+fast-test: testsuite-depends
+	$(MAKE) omc-diff
+	cd testsuite/partest && echo "Running $(./runtests.pl -f -counttests) fast tests"
+	cd testsuite/partest && ./runtests.pl -f -with-txt
 omsens_qt: omsens_qt.skip
 omsens_qt.skip:
 	$(MAKE) -f $(defaultMakefileTarget) -C OMSens_Qt || true

--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -37,7 +37,7 @@ BUILDTYPE=Debug
 endif
 
 
-.PHONY: omc omc-diff omlibrary-core omplot omedit omedit-testsuite omparser omsimulator omnotebook omshell omoptim omsens omsens_qt qtclientsDLLs qtclientsDLLs simulationruntimecmsvc runtimeCPPinstall runtimeCPPmsvcinstall OMSICPPinstall all-runtimes nox testsuite-depends libs-for-testing
+.PHONY: omc omc-diff omlibrary-core omplot omedit omedit-testsuite omparser omsimulator omnotebook omshell omoptim omsens omsens_qt qtclientsDLLs qtclientsDLLs simulationruntimecmsvc runtimeCPPinstall runtimeCPPmsvcinstall OMSICPPinstall all-runtimes nox test fast-test testsuite-depends libs-for-testing
 
 all: omc testsuite-depends omlibrary-core
 
@@ -50,7 +50,15 @@ ReferenceFiles:
 	$(MAKE) -C testsuite/ReferenceFiles
 libs-for-testing: omc
 	$(MAKE) -C testsuite/libraries-for-testing/
-testsuite-depends: omc-diff ReferenceFiles libs-for-testing
+testsuite-depends: omc-diff ReferenceFiles libs-for-testing omsimulator
+test: testsuite-depends
+	$(MAKE) omc-diff
+	cd testsuite/partest && echo "Running all $(./runtests.pl -counttests) tests"
+	cd testsuite/partest && ./runtests.pl -with-txt
+fast-test: testsuite-depends
+	$(MAKE) omc-diff
+	cd testsuite/partest && echo "Running $(./runtests.pl -f -counttests) fast tests"
+	cd testsuite/partest && ./runtests.pl -f -with-txt
 
 omlibrary-core:
 	$(MAKE) -C libraries BUILD_DIR=$(OMBUILDDIR)/lib/omlibrary core

--- a/OMCompiler/README-Windows-WSL.md
+++ b/OMCompiler/README-Windows-WSL.md
@@ -50,9 +50,5 @@ make -j4    # Or 4 with the number of cores you have
 
 ## Test your build
 ```bash
-make omc-diff testsuite-depends -j4
-cd testsuite/runtests && ./runtests.pl
+make test -j4
 ```
-
-Tested on Windows 10 with Ubutnu 18.04 TLS.<br>
-Failing tests: 5 of 3995

--- a/OMCompiler/README.Linux.md
+++ b/OMCompiler/README.Linux.md
@@ -78,8 +78,7 @@ make
 After the compilation the results are in the path/to/trunk/build.
 To run the testsuite, you need to use the superproject [OpenModelica.git](https://github.com/OpenModelica/OpenModelica), or clone [OpenModelica-testsuite.git](https://github.com/OpenModelica/OpenModelica-testsuite) into the root directory under the name `testsuite`.
 ```
-make -C testsuite omc-diff ReferenceFiles
-cd testsuite/runtests && ./runtests.pl
+make test
 ```
 
 If you run into problems read the GENERAL NOTES below and if that does not help, subscribe to the [OpenModelicaInterest list](https://www.openmodelica.org/index.php/home/mailing-list) and then sent us an email at [OpenModelicaInterest@ida.liu.se](mailto:OpenModelicaInterest@ida.liu.se).

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -696,9 +696,11 @@ clean_g_2 :
 	$(MAKE) -C simulation/modelica/NFunitcheck -f Makefile clean
 
 clean_g_3 :
-	$(MAKE) -C flattening/libraries/msl22/modelicaAdditions -f Makefile clean
+	if [ -d "flattening/libraries/msl22/" ]; then \
+	  $(MAKE) -C flattening/libraries/msl22/modelicaAdditions -f Makefile clean \
+	  $(MAKE) -C flattening/libraries/msl22 -f Makefile clean; \
+	fi
 	$(MAKE) -C flattening/libraries/biochem -f Makefile clean
-	$(MAKE) -C flattening/libraries/msl22 -f Makefile clean
 	$(MAKE) -C openmodelica/bootstrapping -f Makefile clean
 	$(MAKE) -C openmodelica/linearization -f Makefile clean
 	$(MAKE) -C openmodelica/modelicaML -f Makefile clean
@@ -709,10 +711,16 @@ clean_g_4:
 	$(MAKE) -C flattening/libraries/3rdParty/PlanarMechanics -f Makefile clean
 	$(MAKE) -C flattening/libraries/3rdParty/siemens -f Makefile clean
 	$(MAKE) -C flattening/libraries/3rdParty/SiemensPower -f Makefile clean
-	$(MAKE) -C flattening/libraries/msl31 -f Makefile clean
-	$(MAKE) -C flattening/libraries/msl31/multibody -f Makefile clean
-	$(MAKE) -C flattening/libraries/msl32 -f Makefile clean
-	$(MAKE) -C flattening/libraries/msl32_cpp -f Makefile clean
+	if [ -d "flattening/libraries/msl31/" ]; then \
+	  $(MAKE) -C flattening/libraries/msl31 -f Makefile clean \
+	  $(MAKE) -C flattening/libraries/msl31/multibody -f Makefile clean; \
+	fi
+	if [ -d "flattening/libraries/msl32/" ]; then \
+	  $(MAKE) -C flattening/libraries/msl32 -f Makefile clean; \
+	fi
+	if [ -d "flattening/libraries/msl32_cpp/" ]; then \
+	  $(MAKE) -C flattening/libraries/msl32_cpp -f Makefile clean; \
+	fi
 	$(MAKE) -C openmodelica/cppruntime/libraries/msl32 -f Makefile clean
 	$(MAKE) -C openmodelica/fmi/CoSimulation/2.0 -f Makefile clean
 	$(MAKE) -C openmodelica/fmi/CoSimulationStandAlone -f Makefile clean

--- a/testsuite/flattening/modelica/algorithms-functions/Makefile
+++ b/testsuite/flattening/modelica/algorithms-functions/Makefile
@@ -140,6 +140,7 @@ Vectorizable2.mo
 # Add them here or they will be cleaned.
 DEPENDENCIES = \
 *.mo \
+*.mos \
 Makefile
 
 CLEAN = `ls | grep -w -v -f deps.tmp`

--- a/testsuite/openmodelica/bootstrapping/Makefile
+++ b/testsuite/openmodelica/bootstrapping/Makefile
@@ -34,7 +34,8 @@ SusanTestSmall.tpl \
 main.c \
 main_records.c \
 main_separate.c \
-refactor-mc-to-m.sh
+refactor-mc-to-m.sh \
+test.json
 
 # Remove executables on Linux (no extension)
 # CLEAN = $(TESTFILES:.mos=) $(TESTFILES:.mos=_*) $(TESTFILES:.mos=.cpp) $(TESTFILES:.mos=.makefile) $(TESTFILES:.mos=.libs) $(TESTFILES:.mos=.log) output.log *.dll *.exe *.so

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/Makefile
@@ -25,10 +25,10 @@ test:
 	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
 	@$(TEST) $(TESTFILES)
 
-clean :
+clean:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
 	@rm -rf $(CLEAN)
-	@rm *_me_FMU.mo
+	@rm -f *_me_FMU.mo
 
 getdeps:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -34,7 +34,7 @@ test:
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
 	@rm -rf $(CLEAN)
-	@rm *_me_FMU.mo
+	@rm -f *_me_FMU.mo
 
 getdeps:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp

--- a/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/Makefile
@@ -28,7 +28,7 @@ test:
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
 	@rm -rf $(CLEAN)
-	@rm *_me_FMU.mo
+	@rm -f *_me_FMU.mo
 
 getdeps:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -54,6 +54,7 @@ testExperimentalFMU.mos \
 DEPENDENCIES = \
 *.mo \
 *.mos \
+FMUResourceTest \
 Makefile \
 
 CLEAN = `ls | grep -w -v -f deps.tmp`

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -96,6 +96,9 @@ FAILINGTESTFILES=differentiate.mos
 DEPENDENCIES = \
 *.mo \
 *.mos \
+ReadOnlyPkg \
+TestDirPkg \
+TestTicket5871 \
 Makefile
 
 

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -15,9 +15,8 @@
 # NOTE: This is the official OpenModelica way of running the testsuite, so
 #       you should run this before committing any changes.
 #
-# NOTE: This script has been tested on Linux and OSX so far, and will
-#       probably work on all other platforms except Windows without any
-#       modifications.
+# NOTE: This script has been tested on Linux, Windows and OSX so far, and will
+#       probably work on all other platforms.
 #
 # TODO: MetaModelicaDev in meta is not run yet, since those tests are organized
 #       a bit differently.

--- a/testsuite/simulation/libraries/msl32/Makefile
+++ b/testsuite/simulation/libraries/msl32/Makefile
@@ -289,10 +289,17 @@ DEPENDENCIES = \
 *.mo \
 *.mos \
 Makefile \
+cleanAll.cmd \
+cleanAllButMat.cmd \
+measureCompilerPerformance.py \
 ReferenceFiles \
-simulateAll.sh \
+simulate_parallel.cmd \
+simulate.cmd \
+simulateAll_Parallel.cmd \
 simulateAll.cmd \
-sortResults.py
+simulateAll.sh \
+sortResults.py \
+status.txt \
 
 CLEAN = `ls | grep -w -v -f deps.tmp`
 

--- a/testsuite/simulation/modelica/external_functions/Makefile
+++ b/testsuite/simulation/modelica/external_functions/Makefile
@@ -28,22 +28,23 @@ DEPENDENCIES = \
 *.mo \
 *.mos \
 Makefile \
-ExtObj.c \
-ExtObj.h \
-ExtObjStringParam.ext.c \
-ExtObjStringParam.ext.h \
-ExternalFunc1.c \
 ExternalFunc1_ext.h \
+ExternalFunc1.c \
 ExternalFunc2.c \
 ExternalFunc2.h \
 ExternalRHSFlag.c \
+ExtObj.c \
+ExtObj.h \
+ExtObjOrder.h \
+ExtObjStringParam.ext.c \
+ExtObjStringParam.ext.h \
 Func.c \
 Func.h \
 InOutStrings_fkn1.cc \
 InOutStrings_fkn2.cc \
+ModelicaUtilities.myExtFunction.c \
+QualifiedCrefArg-f.c \
 testTables.txt \
-ModelicaUtilities.myExtFunction.c
-
 
 
 CLEAN = `ls | grep -w -v -f deps.tmp`

--- a/testsuite/simulation/modelica/tearing/Makefile
+++ b/testsuite/simulation/modelica/tearing/Makefile
@@ -120,7 +120,8 @@ DEPENDENCIES = \
 *.mo \
 *.mos \
 *.sh \
-Makefile
+Makefile \
+msl32-models.txt
 
 
 CLEAN = `ls | grep -w -v -f deps.tmp`


### PR DESCRIPTION
Cleaning up a bit so `git status` is not so cluttered.
Also `make -C testsuite clean` was failing.
Added `make test` and `make fast-test` to make it really simple to test your build. For Windows I added the same to mingw makefile.

  - Add missing dependencies in testsuite makefiles so clean is not
    removing tracked files.
  - Add omsimulator to test dependencies
  - Add test and fast-test to main makefile for an easy test run.
  - Updated Linux and WSL README with new test rule.