### PR TITLE
Improve introduction of documentation

### DIFF
--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,5 +1,5 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.14
+FROM docker.openmodelica.org/build-deps:v1.16.1
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -374,6 +374,8 @@ pipeline {
             }
             sh '''
             export OPENMODELICAHOME=$PWD/build
+            test ! -d $PWD/build/lib/omlibrary
+            cp -a testsuite/libraries-for-testing/.openmodelica/libraries $PWD/build/lib/omlibrary
             for target in html pdf epub; do
               if ! make -C doc/UsersGuide $target; then
                 killall omc || true

--- a/doc/UsersGuide/source/conf.py
+++ b/doc/UsersGuide/source/conf.py
@@ -24,6 +24,7 @@ sys.setrecursionlimit(2000)
 
 if not 'OPENMODELICAHOME' in os.environ:
   os.environ['OPENMODELICAHOME'] = os.path.abspath('../../../build')
+os.environ['PATH'] = "%s/build/bin:%s" % (os.environ['OPENMODELICAHOME'],os.environ['PATH'])
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -45,6 +46,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinxcontrib.bibtex',
     'sphinxcontrib.inlinesyntaxhighlight',
+    'sphinxcontrib.programoutput',
     'sphinxcontribopenmodelica'
 ]
 

--- a/doc/UsersGuide/source/introduction.rst
+++ b/doc/UsersGuide/source/introduction.rst
@@ -215,9 +215,6 @@ Here we give a few example sessions.
 Example Session 1
 ^^^^^^^^^^^^^^^^^
 
-To get help on using OMShell and OpenModelica, type "help()" and press
-enter.
-
 .. omc-mos::
 
   model A Integer t = 1.5; end A; //The type is Integer but 1.5 is of Real Type
@@ -226,8 +223,7 @@ enter.
 Example Session 2
 ^^^^^^^^^^^^^^^^^
 
-To get help on using OMShell and OpenModelica, type "help()" and press
-enter.
+If you do not see the error-message when running the example, use the command :code:`getErrorString()`.
 
 .. omc-loadstring ::
 
@@ -960,67 +956,37 @@ quit() Leave and quit the OpenModelica environment
 Running the compiler from command line
 --------------------------------------
 
-The OpenModelica compiler can also be used from command line, in Windows
-cmd.exe.
+The OpenModelica compiler can also be used from command line, in Windows cmd.exe or a Unix shell.
+The following examples assume omc is on the PATH; if it is not, you can run :code:`C:\\OpenModelica 1.16.0\\build\\bin\\omc.exe` or similar (depending on where you installed OpenModelica).
 
-**Example Session 1 – obtaining information about command line
-parameters**
+Example Session 1 – obtaining information about command line parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| C:\\dev> C:\\OpenModelica1.9.2 \\bin\\omc -h
-| OpenModelica Compiler 1.9.2
-| Copyright © 2015 Open Source Modelica Consortium (OSMC)
-| Distributed under OMSC-PL and GPL, see https://www.openmodelica.org/
-| Usage: omc [Options] (Model.mo \| Script.mos) [Libraries \| .mo-files]
-| ...
+.. command-output :: omc --help
+  :ellipsis: 6,-2
 
-**Example Session 2 - create an TestModel.mo file and run omc on it**
+Example Session 2 – create an TestModel.mo file and run omc on it
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| C:\\dev> echo model TestModel parameter Real x = 1; end TestModel; >
-  TestModel.mo
-| C:\\dev> C:\\OpenModelica1.9.2 \\bin\\omc TestModel.mo
-| class TestModel
-|  parameter Real x = 1.0;
-| end TestModel;
-| C:\\dev>
+.. literalinclude:: TestModel.mo
+  :language: modelica
 
-**Example Session 3 - create an script.mos file and run omc on it**
+.. command-output :: omc TestModel.mo
 
-| Create a file script.mos using your editor containing these commands:
-| // start script.mos
-| loadModel(Modelica); getErrorString();
-| simulate(Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum);
-  getErrorString();
-| // end script.mos
-| C:\\dev> notepad script.mos
-| C:\\dev> C:\\OpenModelica1.9.2 \\bin\\omc script.mos
-| true
-| ""
-| record SimulationResult
-|  resultFile =
-  "C:/dev/Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum\_res.mat",
-|  simulationOptions = "startTime = 0.0, stopTime = 5.0,
-  numberOfIntervals = 500, tolerance = 1e-006, method = 'dassl',
-  fileNamePrefix =
-  'Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum', options =
-  '', outputFormat = 'mat', variableFilter = '.\*', cflags = '',
-  simflags = ''",
-|  messages = "",
-|  timeFrontend = 1.245787339209033,
-|  timeBackend = 20.51007138993843,
-|  timeSimCode = 0.1510248469321959,
-|  timeTemplates = 0.5052317333954395,
-|  timeCompile = 5.128213942691722,
-|  timeSimulation = 0.4049189573103951,
-|  timeTotal = 27.9458487395605
-| end SimulationResult;
-| ""
+Example Session 3 – create a mos-script and run omc on it
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: TestScript.mos
+  :language: modelica
+
+.. command-output :: omc TestScript.mos
 
 In order to obtain more information from the compiler one can use the
 command line options **--showErrorMessages -d=failtrace** when running
 the compiler:
 
-C:\\dev> C:\\OpenModelica1.9.2 \\bin\\omc --showErrorMessages
--d=failtrace script.mos
+.. command-output :: omc --showErrorMessages -d=failtrace TestScript.mos
+  :ellipsis: 4,-4
 
 .. |omlogo| image:: logo.*
   :alt: OpenModelica logotype

--- a/doc/UsersGuide/source/requirements.txt
+++ b/doc/UsersGuide/source/requirements.txt
@@ -4,4 +4,5 @@ natsort
 sphinx
 sphinxcontrib-bibtex
 sphinxcontrib-inlinesyntaxhighlight
+sphinxcontrib-programoutput
 ompython


### PR DESCRIPTION
* Actually install the libraries so the documentation examples work
* Clarify that error-messages should be shown in some documentation examples
* Run the command-line omc examples through the actual OMC for up-to-date output

https://trac.openmodelica.org/OpenModelica/ticket/6042