### PR TITLE
[NF] Add workaround for ModelicaError purity.

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -5776,5 +5776,21 @@ algorithm
   end match;
 end mergeSCodeMods;
 
+function hasNamedExternalCall
+  input String name;
+  input SCode.ClassDef def;
+  output Boolean hasCall;
+algorithm
+  hasCall := match def
+    local
+      String fn_name;
+
+    case SCode.PARTS(externalDecl = SOME(SCode.EXTERNALDECL(funcName = SOME(fn_name))))
+      then fn_name == name;
+    case SCode.CLASS_EXTENDS() then hasNamedExternalCall(name, def.composition);
+    else false;
+  end match;
+end hasNamedExternalCall;
+
 annotation(__OpenModelica_Interface="frontend");
 end SCodeUtil;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -2146,7 +2146,7 @@ protected
         DAE.InlineType inline_ty;
         DAE.FunctionBuiltin builtin;
 
-      // External function.
+      // External builtin function.
       case SCode.FunctionRestriction.FR_EXTERNAL_FUNCTION(is_impure)
         algorithm
           in_params := list(InstNode.name(i) for i in inputs);
@@ -2194,6 +2194,10 @@ protected
               Config.languageStandardAtLeast(Config.LanguageStandard.'3.3') or
               not listEmpty(outputs)) or
             SCodeUtil.commentHasBooleanNamedAnnotation(cmt, "__ModelicaAssociation_Impure");
+
+          if SCodeUtil.hasNamedExternalCall("ModelicaError", SCodeUtil.getClassDef(def)) then
+            is_impure := false;
+          end if;
         then
           DAE.FUNCTION_ATTRIBUTES(inline_ty, hasOMPure(cmt), is_impure, is_partial,
             getBuiltin(def), DAE.FP_NON_PARALLEL());


### PR DESCRIPTION
- Set ModelicaError external call to be pure to temporarily work around
  issues with function purity.