### PR TITLE
[BE] update strict stateSelect.always

### DIFF
--- a/.CI/compliance-newinst.failures
+++ b/.CI/compliance-newinst.failures
@@ -14,7 +14,6 @@ ModelicaCompliance.Classes.Declarations.Long.QuotedIdentifiers.?abfnrtv
 ModelicaCompliance.Classes.Declarations.PartialSimulationModel
 ModelicaCompliance.Classes.Declarations.Short.PartialClass
 ModelicaCompliance.Classes.Enumeration.EnumUnspecified
-ModelicaCompliance.Classes.Predefined.AttributeStateSelectInvalidAlways
 ModelicaCompliance.Classes.Predefined.AttributeStateSelectInvalidNever
 ModelicaCompliance.Classes.Predefined.ReservedBooleanComp
 ModelicaCompliance.Classes.Predefined.ReservedClass.Boolean

--- a/.CI/compliance.failures
+++ b/.CI/compliance.failures
@@ -7,7 +7,6 @@ ModelicaCompliance.Arrays.Indexing.EnumArrayInvalidIndexing
 ModelicaCompliance.Classes.Balancing.CorrectBalance3
 ModelicaCompliance.Classes.Declarations.Long.QuotedIdentifiers.?abfnrtv
 ModelicaCompliance.Classes.Declarations.Short.PartialClass
-ModelicaCompliance.Classes.Predefined.AttributeStateSelectInvalidAlways
 ModelicaCompliance.Classes.Predefined.AttributeStateSelectInvalidNever
 ModelicaCompliance.Classes.Predefined.ReservedClass.Boolean
 ModelicaCompliance.Classes.Predefined.ReservedClass.Integer

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -1874,8 +1874,15 @@ public function setVarKind "author: PA
   input BackendDAE.VarKind inVarKind;
   output BackendDAE.Var outVar = inVar;
 algorithm
-  outVar.varKind := inVarKind;
-  // referenceUpdate(inVar, 2, new_kind);
+  // kabdelhak: state select always variables cannot be dummy states
+  // ticket #3689
+  outVar.varKind := match inVarKind
+    case BackendDAE.DUMMY_STATE() guard(varStateSelectAlways(inVar))
+      algorithm
+        Error.addMessage(Error.NON_STATE_STATESELECT_ALWAYS, {ComponentReference.crefStr(BackendVariable.varCref(inVar))});
+    then fail();
+    else inVarKind;
+  end match;
 end setVarKind;
 
 public function setVarTS "Sets the BackendDAE.TearingSelect of a variable"

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -995,8 +995,8 @@ public constant ErrorTypes.Message NF_CAT_FIRST_ARG_EVAL = ErrorTypes.MESSAGE(59
   Gettext.gettext("The first argument of cat must be possible to evaluate during compile-time. Expression %s has variability %s."));
 public constant ErrorTypes.Message COMMA_OPERATOR_DIFFERENT_SIZES = ErrorTypes.MESSAGE(591, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Arguments of concatenation comma operator have different sizes for the first dimension: %s has dimension %s and %s has dimension %s."));
-public constant ErrorTypes.Message NON_STATE_STATESELECT_ALWAYS = ErrorTypes.MESSAGE(592, ErrorTypes.SYMBOLIC(), ErrorTypes.WARNING(),
-  Gettext.gettext("Variable %s has attribute stateSelect=StateSelect.always, but was selected as a continuous variable."));
+public constant ErrorTypes.Message NON_STATE_STATESELECT_ALWAYS = ErrorTypes.MESSAGE(592, ErrorTypes.SYMBOLIC(), ErrorTypes.ERROR(),
+  Gettext.gettext("Variable %s has attribute stateSelect=StateSelect.always, but can't be selected as a state."));
 public constant ErrorTypes.Message STATE_STATESELECT_NEVER = ErrorTypes.MESSAGE(593, ErrorTypes.SYMBOLIC(), ErrorTypes.WARNING(),
   Gettext.gettext("Variable %s has attribute stateSelect=StateSelect.never, but was selected as a state"));
 public constant ErrorTypes.Message FUNCTION_HIGHER_VARIABILITY_BINDING = ErrorTypes.MESSAGE(594, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -52,8 +52,8 @@ getErrorString();
 // true
 // ""
 // "CSTRModel.fmu"
-// "[openmodelica/cppruntime/fmu/modelExchange/2.0/CSTR.mo:24:3-28:72:writable] Warning: Variable cA has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
-// [openmodelica/cppruntime/fmu/modelExchange/2.0/CSTR.mo:24:3-28:72:writable] Warning: Variable $outputAlias_cA.$pDERFMIDER.dummyVarFMIDER has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
+// "[openmodelica/cppruntime/fmu/modelExchange/2.0/CSTR.mo:24:3-28:72:writable] Error: Variable cA has attribute stateSelect=StateSelect.always, but can't be selected as a state.
+// [openmodelica/cppruntime/fmu/modelExchange/2.0/CSTR.mo:24:3-28:72:writable] Error: Variable $outputAlias_cA.$pDERFMIDER.dummyVarFMIDER has attribute stateSelect=StateSelect.always, but can't be selected as a state.
 // "
 // 0
 // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>

--- a/testsuite/simulation/libraries/3rdParty/MathematicalAspects/10_Test3PhaseSystemsDummyInit.mos
+++ b/testsuite/simulation/libraries/3rdParty/MathematicalAspects/10_Test3PhaseSystemsDummyInit.mos
@@ -26,10 +26,10 @@ res := OpenModelica.Scripting.compareSimulationResults("Test3PhaseSystemsDummyIn
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "[simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Warning: Variable $DER.i_abc[1] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
-// [simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Warning: Variable $DER.i_abc[2] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
-// [simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Warning: Variable $DER.i_abc[1] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
-// [simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Warning: Variable $DER.i_abc[2] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
+// "[simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Error: Variable $DER.i_abc[1] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
+// [simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Error: Variable $DER.i_abc[2] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
+// [simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Error: Variable $DER.i_abc[1] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
+// [simulation/libraries/3rdParty/MathematicalAspects/Test3PhaseSystemsDummyInit.mo:4:3-4:71:writable] Error: Variable $DER.i_abc[2] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
 // "
 // {"Files Equal!"}
 // "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.

--- a/testsuite/simulation/libraries/msl31/Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheel.mos
+++ b/testsuite/simulation/libraries/msl31/Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheel.mos
@@ -39,8 +39,8 @@ runScript(modelTesting);getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
-// [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Parts.mo:2404:7-2406:80:writable] Warning: Variable $DER.wheel1.der_angles[2] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
-// [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Parts.mo:2404:7-2406:80:writable] Warning: Variable $DER.wheel1.der_angles[1] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
+// [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Parts.mo:2404:7-2406:80:writable] Error: Variable $DER.wheel1.der_angles[2] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
+// [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Parts.mo:2404:7-2406:80:writable] Error: Variable $DER.wheel1.der_angles[1] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
 //
 // "true
 // "

--- a/testsuite/simulation/libraries/msl31/Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar2.mos
+++ b/testsuite/simulation/libraries/msl31/Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar2.mos
@@ -27,7 +27,7 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Mechanics.Multi
 // Notification: It was not possible to check the given initialization system for consistency symbolically, because the relevant equations are part of an algebraic loop. This is not supported yet.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Warning: The initial conditions are over specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->OMCFlags, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
-// [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Joints.mo:269:5-279:3:writable] Warning: Variable j1.phi has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
+// [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Joints.mo:269:5-279:3:writable] Error: Variable j1.phi has attribute stateSelect=StateSelect.always, but can't be selected as a state.
 // "
 // {"Files Equal!"}
 // "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.

--- a/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheel.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Elementary.RollingWheel.mos
@@ -37,8 +37,8 @@ runScript(modelTesting);getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!
-// [Modelica 3.2.1+maint.om/Mechanics/MultiBody/Parts.mo:2674:5-2678:74:writable] Warning: Variable $DER.wheel1.der_angles[2] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
-// [Modelica 3.2.1+maint.om/Mechanics/MultiBody/Parts.mo:2674:5-2678:74:writable] Warning: Variable $DER.wheel1.der_angles[1] has attribute stateSelect=StateSelect.always, but was selected as a continuous variable.
+// [Modelica 3.2.1+maint.om/Mechanics/MultiBody/Parts.mo:2674:5-2678:74:writable] Error: Variable $DER.wheel1.der_angles[2] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
+// [Modelica 3.2.1+maint.om/Mechanics/MultiBody/Parts.mo:2674:5-2678:74:writable] Error: Variable $DER.wheel1.der_angles[1] has attribute stateSelect=StateSelect.always, but can't be selected as a state.
 //
 // "true
 // "


### PR DESCRIPTION
 - fixes ticket #3689
 - updates removeSimpleEquations to not convert states to dummy states if they have stateSelect.always
 - update error message for not allowed stateSelect.always variables