### PR TITLE
[BE] update binary differentiation

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -3245,6 +3245,34 @@ algorithm
   end matchcontinue;
 end getVarSingle;
 
+public function getVarTryHard
+  "author: kabdelhak
+  This function tries to get a variable with from a given cref as hard as possible
+  by removing subscripts and considering array representations. Should be replaced
+  with proper array handling."
+  input DAE.ComponentRef cref;
+  input BackendDAE.Variables vars;
+  output Option<list<BackendDAE.Var>> var_lst_opt;
+protected
+  BackendDAE.Var var;
+  list<BackendDAE.Var> var_lst;
+  DAE.ComponentRef strippedCref;
+algorithm
+  try
+    (var, _) := getVarSingle(cref, vars);
+    var_lst_opt := SOME({var});
+  else try
+    (var_lst, _) := getVar(cref, vars);
+    var_lst_opt := SOME(var_lst);
+  else try
+    strippedCref := ComponentReference.crefStripSubsExceptModelSubs(cref);
+    var := BackendVariable.getVarSingle(strippedCref, vars);
+    var_lst_opt := SOME({var});
+  else
+    var_lst_opt := NONE();
+  end try; end try; end try;
+end getVarTryHard;
+
 protected function replaceVarWithWholeDim
   "Helper function to traverseExp. Traverses any expressions in a
   component reference (i.e. in it's subscripts)."

--- a/testsuite/simulation/modelica/algorithms_functions/Makefile
+++ b/testsuite/simulation/modelica/algorithms_functions/Makefile
@@ -16,6 +16,7 @@ bug_2286.mos \
 bug_2286_literal.mos \
 bug2888.mos \
 bug_5659.mos \
+bug_6068.mos \
 ComplexSystem.mos \
 DoubleWhenSequential.mos \
 ForIterator1.mos \

--- a/testsuite/simulation/modelica/algorithms_functions/bug_6068.mos
+++ b/testsuite/simulation/modelica/algorithms_functions/bug_6068.mos
@@ -1,0 +1,36 @@
+// name:     bug_6068
+// keywords: Function Constant Logarithm 6068
+// status: correct
+// teardown_command: rm -rf FuncLocalConstantsDer_* FuncLocalConstantsDer FuncLocalConstantsDer.exe FuncLocalConstantsDer.cpp FuncLocalConstantsDer.makefile FuncLocalConstantsDer.libs FuncLocalConstantsDer.log output.log
+
+// this is a test for ticket 6068
+loadString("
+model FuncLocalConstantsDer
+  Real x,y(stateSelect = StateSelect.prefer);
+  function f
+    input Real x;
+    output Real y;
+  protected
+    final constant Real[2,2] r = fill(2.0, 2, 2);
+  algorithm
+    y := x^r[1,2];
+  end f;
+  equation
+  x = sin(time);
+  y = f(x);
+end FuncLocalConstantsDer;
+"); getErrorString();
+
+simulate(FuncLocalConstantsDer, stopTime=10.0);
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "FuncLocalConstantsDer_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'FuncLocalConstantsDer', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// endResult


### PR DESCRIPTION
 - fixes ticket #6068
 - add two exponential differentiation rules
 - x^p and p^x where p is a parameter (treat just like constants)