### PR TITLE
Issue #6078, OPENMODELICALIBRARY env.var overrides the Modelica path

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -174,6 +174,8 @@ void buildOMC(CC, CXX, extraFlags) {
      echo cd \${MSYS_WORKSPACE}
      echo make -f Makefile.omdev.mingw \${MAKETHREADS} BUILDTYPE=Release all-runtimes
      echo echo Check that omc can be started and a model can be build for NF OF with runtimes C Cpp FMU
+     echo echo Unset OPENMODELICALIBRARY to make sure the default is used
+     echo unset OPENMODELICALIBRARY
      echo echo Attempt to build things using \$OPENMODELICAHOME
      echo ./build/bin/omc --version
      echo mkdir .sanity-check
@@ -199,7 +201,6 @@ void buildOMC(CC, CXX, extraFlags) {
      echo mkdir -p ./path\\ with\\ space/
      echo mv build ./path\\ with\\ space/
      echo export OPENMODELICAHOME="\${MSYS_WORKSPACE}/path with space/build"
-     echo export OPENMODELICALIBRARY="\${MSYS_WORKSPACE}/path with space/build/lib/omlibrary"
      echo echo Attempt to build things using \$OPENMODELICAHOME
      echo ./path\\ with\\ space/build/bin/omc --version
      echo cd ./path\\ with\\ space/
@@ -315,8 +316,6 @@ void buildAndRunOMEditTestsuite(stash) {
      echo cd \${MSYS_WORKSPACE}
      echo export MAKETHREADS=-j16
      echo set -e
-     echo export OPENMODELICAHOME="\${MSYS_WORKSPACE}/build"
-     echo export OPENMODELICALIBRARY="\${MSYS_WORKSPACE}/build/lib/omlibrary"
      echo time make -f Makefile.omdev.mingw \${MAKETHREADS} omedit-testsuite
      echo export "APPDATA=\${PWD}/testsuite/libraries-for-testing"
      echo cd build/bin

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1497,7 +1497,8 @@ function setModelicaPath "The Modelica Library Path - MODELICAPATH in the langua
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
-See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what the MODELICAPATH is used for.
+<p>See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what the MODELICAPATH is used for.</p>
+<p>Set it to empty string to clear it: setModelicaPath(\"\");</p>
 </html>"),
   preferredView="text");
 end setModelicaPath;
@@ -1506,8 +1507,9 @@ function getModelicaPath "Get the Modelica Library Path."
   output String modelicaPath;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>The MODELICAPATH is list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
+<p>The MODELICAPATH is a list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
 <p>To override the default path (<a href=\"modelica://OpenModelica.Scripting.getInstallationDirectoryPath\">OPENMODELICAHOME</a>/lib/omlibrary/:~/.openmodelica/libraries/), set the environment variable OPENMODELICALIBRARY=...</p>
+<p>On Windows the HOME directory '~' is replaced by %APPDATA%</p>
 </html>"),
   preferredView="text");
 end getModelicaPath;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1686,7 +1686,8 @@ function setModelicaPath "The Modelica Library Path - MODELICAPATH in the langua
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
-See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what the MODELICAPATH is used for.
+<p>See <a href=\"modelica://OpenModelica.Scripting.loadModel\">loadModel()</a> for a description of what the MODELICAPATH is used for.</p>
+<p>Set it to empty string to clear it: setModelicaPath(\"\");</p>
 </html>"),
   preferredView="text");
 end setModelicaPath;
@@ -1695,8 +1696,9 @@ function getModelicaPath "Get the Modelica Library Path."
   output String modelicaPath;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>The MODELICAPATH is list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
+<p>The MODELICAPATH is a list of paths to search when trying to  <a href=\"modelica://OpenModelica.Scripting.loadModel\">load a library</a>. It is a string separated by colon (:) on all OSes except Windows, which uses semicolon (;).</p>
 <p>To override the default path (<a href=\"modelica://OpenModelica.Scripting.getInstallationDirectoryPath\">OPENMODELICAHOME</a>/lib/omlibrary/:~/.openmodelica/libraries/), set the environment variable OPENMODELICALIBRARY=...</p>
+<p>On Windows the HOME directory '~' is replaced by %APPDATA%</p>
 </html>"),
   preferredView="text");
 end getModelicaPath;

--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -190,6 +190,7 @@ char* Settings_getHomeDir(int runningTestsuite)
 
 /*
  * - if already set, use it
+ * - if not set, use OPENMODELICALIBRARY
  * - if not set, get the installation path and use that
  */
 char* SettingsImpl__getModelicaPath(int runningTestsuite) {
@@ -198,24 +199,33 @@ char* SettingsImpl__getModelicaPath(int runningTestsuite) {
   }
 
   {
-    /* get the install directory */
-    const char *omhome = SettingsImpl__getInstallationDirectoryPath();
-    if (omhome == NULL)
-      return NULL;
-    int lenOmhome = strlen(omhome);
-    const char *homePath = Settings_getHomeDir(0);
-    assert(homePath != NULL || !runningTestsuite);
-    if (runningTestsuite) {
-      int lenHome = strlen(homePath);
-      omc_modelicaPath = (char*) malloc(lenHome+26);
-      snprintf(omc_modelicaPath, lenHome+26,"%s/.openmodelica/libraries/", homePath);
-    } else if (homePath == NULL) {
-      omc_modelicaPath = (char*) malloc(lenOmhome+15);
-      snprintf(omc_modelicaPath, lenOmhome+15,"%s/lib/omlibrary", omhome);
-    } else {
-      int lenHome = strlen(homePath);
-      omc_modelicaPath = (char*) omc_alloc_interface.malloc_atomic(lenOmhome+lenHome+41);
-      snprintf(omc_modelicaPath, lenOmhome+lenHome+41,"%s/lib/omlibrary%s%s/.openmodelica/libraries/", omhome, OMC_GROUP_DELIMITER, homePath);
+
+    const char *path = getenv("OPENMODELICALIBRARY");
+    if (path != NULL)
+    {
+        omc_modelicaPath = strdup(path);
+    }
+    else
+    {
+      /* get the install directory */
+      const char *omhome = SettingsImpl__getInstallationDirectoryPath();
+      if (omhome == NULL)
+        return NULL;
+      int lenOmhome = strlen(omhome);
+      const char *homePath = Settings_getHomeDir(0);
+      assert(homePath != NULL || !runningTestsuite);
+      if (runningTestsuite) {
+        int lenHome = strlen(homePath);
+        omc_modelicaPath = (char*)malloc(lenHome+26);
+        snprintf(omc_modelicaPath, lenHome+26,"%s/.openmodelica/libraries/", homePath);
+      } else if (homePath == NULL) {
+        omc_modelicaPath = (char*)malloc(lenOmhome+15);
+        snprintf(omc_modelicaPath, lenOmhome+15,"%s/lib/omlibrary", omhome);
+      } else {
+        int lenHome = strlen(homePath);
+        omc_modelicaPath = (char*)omc_alloc_interface.malloc_atomic(lenOmhome+lenHome+41);
+        snprintf(omc_modelicaPath, lenOmhome+lenHome+41,"%s/lib/omlibrary%s%s/.openmodelica/libraries/", omhome, OMC_GROUP_DELIMITER, homePath);
+      }
     }
 
     omc_modelicaPath = covertToForwardSlashesInPlace(omc_modelicaPath);


### PR DESCRIPTION
- if set OPENMODELICALIBRARY will be used in getModelicaPath() API
- update the scripting functions documentation
- further work is needed on Windows to allow older and newer versions to co-exist