### PR TITLE
Use Euler for FMUs without states

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -741,6 +741,7 @@ static int callSolver(DATA* simData, threadData_t *threadData, string init_initM
       )
   {
     solverID = S_EULER;
+    infoStreamPrint(LOG_SOLVER, 0, "No states present, continuing without ODE solver.");
     if (compiledInDAEMode)
     {
       simData->callback->functionDAE = evaluateDAEResiduals_wrapperEventUpdate;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
@@ -192,6 +192,13 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
     solverInfo->solverMethod = S_EULER;
   }
 
+  /* If no states are present, we can use Euler's method since it is doing nothing. */
+  if (data->modelData->nStates < 1)
+  {
+    FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: No states present, continuing without ODE solver.")
+    solverInfo->solverMethod = S_EULER;
+  }
+
   switch (solverInfo->solverMethod)
   {
     case S_EULER:


### PR DESCRIPTION
CVODE will not be used for FMUs without any states.

Fix for [ticket #6082](https://trac.openmodelica.org/OpenModelica/ticket/6082).