### PR TITLE
[NF] Fix mutually recursive constants detection.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -37,6 +37,7 @@ public
   import Type = NFType;
   import NFPrefixes.Variability;
   import ErrorTypes;
+  import Mutable;
 
 protected
   import Binding = NFBinding;
@@ -50,6 +51,12 @@ public
     NOT_EACH,
     EACH,
     REPEAT
+  );
+
+  type EvalState = enumeration(
+    NOT_EVALUATED,
+    EVALUATING,
+    EVALUATED
   );
 
   record UNBOUND
@@ -83,7 +90,7 @@ public
     Type bindingType;
     Variability variability;
     EachType eachType;
-    Boolean evaluated;
+    Mutable<EvalState> evalState;
     Boolean isFlattened;
     SourceInfo info;
   end TYPED_BINDING;
@@ -313,7 +320,7 @@ public
           ty := Expression.typeOf(exp);
           var := Expression.variability(exp);
         then
-          TYPED_BINDING(exp, ty, var, fieldBinding.eachType, fieldBinding.evaluated,
+          TYPED_BINDING(exp, ty, var, fieldBinding.eachType, fieldBinding.evalState,
                         fieldBinding.isFlattened, fieldBinding.info);
 
       case FLAT_BINDING()

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -3234,7 +3234,7 @@ algorithm
           fail();
         elseif isCastMatch(ty_match) then
           binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.eachType,
-            binding.evaluated, binding.isFlattened, binding.info);
+            binding.evalState, binding.isFlattened, binding.info);
         end if;
       then
         ();

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1065,7 +1065,8 @@ algorithm
           each_ty := NFBinding.EachType.NOT_EACH;
         end if;
       then
-        Binding.TYPED_BINDING(exp, ty, var, each_ty, false, false, binding.info);
+        Binding.TYPED_BINDING(exp, ty, var, each_ty,
+          Mutable.create(NFBinding.EvalState.NOT_EVALUATED), false, binding.info);
 
     case Binding.TYPED_BINDING() then binding;
     case Binding.UNBOUND() then binding;
@@ -1128,7 +1129,8 @@ algorithm
           fail();
         end if;
       then
-        Binding.TYPED_BINDING(exp, ty, var, NFBinding.EachType.NOT_EACH, false, false, info);
+        Binding.TYPED_BINDING(exp, ty, var, NFBinding.EachType.NOT_EACH,
+          Mutable.create(NFBinding.EvalState.NOT_EVALUATED), false, info);
 
   end match;
 end typeComponentCondition;


### PR DESCRIPTION
- Change the evaluation flag in Binding.TYPED_BINDING from a boolean to
  an enum to indicate bindings that are being evaluated instead of using
  a separate binding uniontype.