### PR TITLE
[BE] do not remove initial asserts

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -2267,7 +2267,7 @@ algorithm
     local
       BackendDAE.Variables vars, globalKnownVars;
       BackendDAE.EquationArray eqns, initialEqs;
-      list<BackendDAE.Equation> eqnslst, asserts;
+      list<BackendDAE.Equation> eqnslst, asserts, initial_asserts;
       BackendDAE.EqSystem syst;
       BackendDAE.Shared shared;
       Boolean systChanged;
@@ -2284,8 +2284,12 @@ algorithm
         // traverse the initial equations
         eqnslst := BackendEquation.equationList(initialEqs);
         // traverse equations in reverse order, than branch equations of if equaitions need no reverse
-        ((eqnslst,asserts,true)) := List.fold31(listReverse(eqnslst), simplifyIfEquationsFinder, globalKnownVars, {},{},systChanged);
-        shared.initialEqs := BackendEquation.listEquation(eqnslst);
+        ((eqnslst,initial_asserts,true)) := List.fold31(listReverse(eqnslst), simplifyIfEquationsFinder, globalKnownVars, {},{},systChanged);
+
+        // ticket #5599
+        // leave initial asserts in the initial equation block
+        // this just removes the surrounding unnecessary if condition
+        shared.initialEqs := BackendEquation.listEquation(listAppend(initial_asserts, eqnslst));
 
         syst := BackendDAEUtil.clearEqSyst(syst);
         syst := BackendEquation.requationsAddDAE(asserts, syst);

--- a/testsuite/simulation/modelica/initialization/testIfAssert.mos
+++ b/testsuite/simulation/modelica/initialization/testIfAssert.mos
@@ -35,7 +35,7 @@ getErrorString();
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'A', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: A
 // assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | if x < lb then der(x) < 49.0 else true
+// |                 | |       | if x < lb then $DER.x < 49.0 else true
 // assert            | error   | Call lb assert
 // assert            | info    | simulation terminated by an assertion at initialization
 // "


### PR DESCRIPTION
  - fixes ticket #5599
  - prevents removal of initial asserts to removed equations
  - sideeffect: fixes dropping of asserts in removed equations of regular system