### PR TITLE
[NF] Improve call type evaluation.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -344,7 +344,10 @@ public
       var := Variability.IMPLICITLY_DISCRETE;
     end if;
 
-    ty := evaluateCallType(ty, func, args);
+    if ExpOrigin.flagNotSet(origin, ExpOrigin.FUNCTION) then
+      ty := evaluateCallType(ty, func, args);
+    end if;
+
     call := makeTypedCall(func, args, var, ty);
 
     // If the matching was a vectorized one then create a map call


### PR DESCRIPTION
- Don't evaluate dimensions in calls inside functions.
- Avoid evaluating the whole expression when having a conditional array
  type as dimension.