### PR TITLE
[NF] Reenable call type evaluation in functions.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -344,10 +344,7 @@ public
       var := Variability.IMPLICITLY_DISCRETE;
     end if;
 
-    if ExpOrigin.flagNotSet(origin, ExpOrigin.FUNCTION) then
-      ty := evaluateCallType(ty, func, args);
-    end if;
-
+    ty := evaluateCallType(ty, func, args);
     call := makeTypedCall(func, args, var, ty);
 
     // If the matching was a vectorized one then create a map call


### PR DESCRIPTION
- Disabling it causes issues, and wasn't actually needed anyway.