### PR TITLE
fix ticket:6086 and ticket:5880

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -142,7 +142,7 @@ algorithm
   top := InstNode.setInnerOuterCache(top, CachedData.TOP_SCOPE(NodeTree.new(), cls));
 
   // Instantiate the class.
-  inst_cls := instantiate(cls, instPartial = Flags.getConfigBool(Flags.CHECK_MODEL));
+  inst_cls := instantiate(cls, instPartial = Flags.getConfigBool(Flags.CHECK_MODEL) or Flags.isSet(Flags.NF_API));
   checkPartialClass(cls);
 
   insertGeneratedInners(inst_cls, top);
@@ -205,7 +205,7 @@ function instantiate
 algorithm
   node := expand(node);
 
-  if instPartial or not InstNode.isPartial(node) then
+  if instPartial or not InstNode.isPartial(node) or Flags.isSet(Flags.NF_API) then
     node := instClass(node, Modifier.NOMOD(), NFComponent.DEFAULT_ATTR, true, 0, parent);
   end if;
 end instantiate;
@@ -958,7 +958,7 @@ algorithm
         inst := instantiate(node);
 
         // Cache the instantiated node and instantiate expressions in it too.
-        if not InstNode.isPartial(inst) then
+        if not InstNode.isPartial(inst) or Flags.isSet(Flags.NF_API) then
           InstNode.setPackageCache(node, CachedData.PACKAGE(inst));
           instExpressions(inst);
         end if;
@@ -1501,7 +1501,7 @@ algorithm
         ty := InstNode.getClass(ty_node);
         res := Class.restriction(ty);
 
-        if not isRedeclared then
+        if not isRedeclared and not Flags.isSet(Flags.NF_API) then
           checkPartialComponent(node, attr, ty_node, Class.isPartial(ty), res, info);
         end if;
 
@@ -3578,7 +3578,7 @@ end markImplicitWhenExp_traverser;
 function checkPartialClass
   input InstNode node;
 algorithm
-  if InstNode.isPartial(node) and not Flags.getConfigBool(Flags.CHECK_MODEL) then
+  if InstNode.isPartial(node) and not (Flags.getConfigBool(Flags.CHECK_MODEL) or Flags.isSet(Flags.NF_API)) then
     Error.addSourceMessage(Error.INST_PARTIAL_CLASS,
       {InstNode.name(node)}, InstNode.info(node));
     fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -544,7 +544,8 @@ algorithm
   if not selfReference then
     node := Inst.instPackage(node);
 
-    if InstNode.isPartial(node) then
+    // allow lookup in partial nodes if -d=nfAPI is on
+    if InstNode.isPartial(node) and not Flags.isSet(Flags.NF_API) then
       state := LookupState.ERROR(LookupState.PARTIAL_CLASS());
       return;
     end if;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3344,6 +3344,7 @@ function runFrontEndWorkNF
 protected
   Absyn.Program placement_p;
   SCode.Program builtin_p, scode_p, graphic_p;
+  Boolean b;
 algorithm
   (_, builtin_p) := FBuiltin.getInitialFunctions();
   scode_p := listAppend(builtin_p, SymbolTable.getSCode());
@@ -3356,7 +3357,16 @@ algorithm
     scode_p := listAppend(scode_p, graphic_p);
   end if;
 
-  (flatModel, functions, flatString) := NFInst.instClassInProgram(className, scode_p, dumpFlat);
+  // make sure we don't run the default instantiateModel using -d=nfAPI
+  // only the stuff going via NFApi.mo should have this flag activated
+  b := FlagsUtil.set(Flags.NF_API, false);
+  try
+    (flatModel, functions, flatString) := NFInst.instClassInProgram(className, scode_p, dumpFlat);
+	FlagsUtil.set(Flags.NF_API, b);
+  else
+    FlagsUtil.set(Flags.NF_API, b);
+	fail();
+  end try;
 end runFrontEndWorkNF;
 
 protected function translateModel " author: x02lucpo


### PR DESCRIPTION
- allow partial lookup and partial model instantiation when -d=nfAPI is on (#6086)
- disable -d=nfAPI when building and simulating the model the normal way via
  checkModel, instantiateModel, simulate, translateModel or buildMOdel
  (these are all goinvg via CevalScriptBackend.runFrontEnd)