### PR TITLE
[NF] Prefix records with root path in EvalFunction.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -385,7 +385,7 @@ algorithm
         // This will also update the list of bindings since they share mutable expresions.
         ReplTree.map(local_repl, function applyBindingReplacement(repl = local_repl));
       then
-        Expression.makeRecord(InstNode.scopePath(cls_node), cls.ty, bindings);
+        Expression.makeRecord(InstNode.scopePath(cls_node, includeRoot = true), cls.ty, bindings);
 
     case Class.TYPED_DERIVED() then buildRecordBinding(cls.baseClass, repl);
   end match;


### PR DESCRIPTION
- Record names should always be prefixed with the root path if there is
  one.