### PR TITLE
Clean cached test data

### DIFF
--- a/testsuite/libraries-for-testing/Makefile
+++ b/testsuite/libraries-for-testing/Makefile
@@ -6,6 +6,7 @@ lib-for-testing: .openmodelica/libraries/$(STAMP)
 
 clean:
 	rm -rf .openmodelica/libraries
+	rm -rf .openmodelica/cache
 
 .openmodelica/libraries/$(STAMP): index.json index.mos
 	$(MAKE) clean


### PR DESCRIPTION
The cached data shall be cleaned as well with `make clean`, otherwise, a failed/interrumpted download would block the compilation/tests forever