### PR TITLE
[RT] Remove assignment inside assert.

### DIFF
--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -91,7 +91,8 @@ static void stripbinpath(char *omhome)
   }
 
   do {
-    assert(tmp = strrchr(omhome,'/'));
+    tmp = strrchr(omhome,'/');
+    assert(tmp);
     *tmp = '\0';
   } while (strcmp(tmp+1,"bin") && strcmp(tmp+1,"lib"));
   return;


### PR DESCRIPTION
  - expressions in assert should ideally have no extra side effects.
  - Assert is a macro and can be disabled (to no op) by defining NDEBUG.
    Some build configurations define NDEBUG on release or optimized builds.