### PR TITLE
Fix #6134.

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/ExternalBuiltin1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalBuiltin1.mo
@@ -1,0 +1,26 @@
+// name: ExternalBuiltin1
+// keywords: external builtin
+// status: correct
+// cflags: -d=newInst
+//
+// Checks that external "builtin" functions are handled correctly.
+//
+
+package Math
+  function atan2
+    input Real u1;
+    input Real u2;
+    output Real y;
+    external "builtin" y = atan2(u1, u2);
+  end atan2;
+end Math;
+
+model ExternalBuiltin1
+  Real x = Math.atan2(time, time);
+end ExternalBuiltin1;
+
+// Result:
+// class ExternalBuiltin1
+//   Real x = atan2(time, time);
+// end ExternalBuiltin1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ExternalBuiltin2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalBuiltin2.mo
@@ -1,0 +1,28 @@
+// name: ExternalBuiltin2
+// keywords: external builtin
+// status: correct
+// cflags: -d=newInst
+//
+// Checks that external "builtin" functions are handled correctly when used in a
+// short class definition.
+//
+
+package Math
+  function atan2
+    input Real u1;
+    input Real u2;
+    output Real y;
+    external "builtin" y = atan2(u1, u2);
+  end atan2;
+end Math;
+
+model ExternalBuiltin2
+  function atan2 = Math.atan2;
+  Real x = Math.atan2(time, time);
+end ExternalBuiltin2;
+
+// Result:
+// class ExternalBuiltin2
+//   Real x = atan2(time, time);
+// end ExternalBuiltin2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -387,6 +387,8 @@ ExtendsVisibility2.mo \
 ExtendsVisibility3.mo \
 ExtendsVisibility4.mo \
 ExtendsVisibility5.mo \
+ExternalBuiltin1.mo \
+ExternalBuiltin2.mo \
 ExternalFunctionExplicit1.mo \
 ExternalFunctionExplicit2.mo \
 ExternalFunctionExplicit3.mo \


### PR DESCRIPTION
- Use the last base class when inferring function attributes to
  correctly handle inherited external "builtin" functions.
- Change NFFunction.getBuiltin to check for __OpenModelica_BuiltinPtr
  annotation like the old frontend, instead of just any builtin element,
  and rename it to getBuiltinPtr to avoid confusion.