### PR TITLE
Handle internal errors in scripting API and OMEdit.

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1829,7 +1829,7 @@ type ErrorKind = enumeration(
   runtime "simulation/function runtime error",
   scripting "runtime scripting /interpretation error"
 );
-type ErrorLevel = enumeration(notification,warning,error);
+type ErrorLevel = enumeration(internal,notification,warning,error);
 
 record ErrorMessage
   SourceInfo info;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2006,7 +2006,7 @@ type ErrorKind = enumeration(
   runtime "simulation/function runtime error",
   scripting "runtime scripting /interpretation error"
 );
-type ErrorLevel = enumeration(notification,warning,error);
+type ErrorLevel = enumeration(internal,notification,warning,error);
 
 record ErrorMessage
   SourceInfo info;

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -1924,9 +1924,10 @@ protected function errorLevelToValue
   output Values.Value val;
 algorithm
   val := match severity
-    case ErrorTypes.ERROR() then makeErrorEnumLiteral("ErrorLevel","error",1);
-    case ErrorTypes.WARNING() then makeErrorEnumLiteral("ErrorLevel","warning",2);
-    case ErrorTypes.NOTIFICATION() then makeErrorEnumLiteral("ErrorLevel","notification",3);
+    case ErrorTypes.INTERNAL() then makeErrorEnumLiteral("ErrorLevel","internal",1);
+    case ErrorTypes.ERROR() then makeErrorEnumLiteral("ErrorLevel","error",2);
+    case ErrorTypes.WARNING() then makeErrorEnumLiteral("ErrorLevel","warning",3);
+    case ErrorTypes.NOTIFICATION() then makeErrorEnumLiteral("ErrorLevel","notification",4);
     else
       equation
         print("errorLevelToValue failed\n");

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -212,6 +212,9 @@ void MessageWidget::addGUIMessage(MessageItem messageItem)
   // set the CSS class depending on message type
   QString messageCSSClass;
   switch (messageItem.getErrorType()) {
+    case StringHandler::Internal:
+      messageCSSClass = "error";
+      break;
     case StringHandler::Warning:
       messageCSSClass = "warning";
       break;
@@ -467,6 +470,9 @@ void MessagesWidget::addGUIMessage(MessageItem messageItem)
   }
 
   switch (messageItem.getErrorType()) {
+    case StringHandler::Internal:
+      mpErrorMessageWidget->addGUIMessage(messageItem);
+      mpAllMessageWidget->addGUIMessage(messageItem);
     case StringHandler::Notification:
       mpNotificationMessageWidget->addGUIMessage(messageItem);
       mpAllMessageWidget->addGUIMessage(messageItem);

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -80,6 +80,7 @@ qreal Helper::shapesStrokeWidth = 2.0;
 int Helper::headingFontSize = 18;
 QString Helper::ModelicaSimulationOutputFormats = "mat,plt,csv";
 QString Helper::clockOptions = ",RT,CYC,CPU";
+QString Helper::internalLevel = ".OpenModelica.Scripting.ErrorLevel.internal";
 QString Helper::notificationLevel = ".OpenModelica.Scripting.ErrorLevel.notification";
 QString Helper::warningLevel = ".OpenModelica.Scripting.ErrorLevel.warning";
 QString Helper::errorLevel = ".OpenModelica.Scripting.ErrorLevel.error";

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -90,6 +90,7 @@ public:
   static int headingFontSize;
   static QString ModelicaSimulationOutputFormats;
   static QString clockOptions;
+  static QString internalLevel;
   static QString notificationLevel;
   static QString warningLevel;
   static QString errorLevel;

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -323,7 +323,9 @@ QString StringHandler::getErrorKindString(OpenModelicaErrorKinds errorKind)
 
 StringHandler::OpenModelicaErrors StringHandler::getErrorType(QString errorType)
 {
-  if (errorType.compare(Helper::notificationLevel) == 0) {
+  if (errorType.compare(Helper::internalLevel) == 0) {
+    return StringHandler::Internal;
+  } else if (errorType.compare(Helper::notificationLevel) == 0) {
     return StringHandler::Notification;
   } else if (errorType.compare(Helper::warningLevel) == 0) {
     return StringHandler::Warning;
@@ -337,6 +339,8 @@ StringHandler::OpenModelicaErrors StringHandler::getErrorType(QString errorType)
 QString StringHandler::getErrorTypeDisplayString(StringHandler::OpenModelicaErrors errorType)
 {
   switch (errorType) {
+    case StringHandler::Internal:
+      return tr("Internal Error");
     case StringHandler::Notification:
       return tr("Notification");
     case StringHandler::Warning:
@@ -352,6 +356,8 @@ QString StringHandler::getErrorTypeDisplayString(StringHandler::OpenModelicaErro
 QString StringHandler::getErrorTypeString(StringHandler::OpenModelicaErrors errorType)
 {
   switch (errorType) {
+    case StringHandler::Internal:
+      return Helper::internalLevel;
     case StringHandler::Warning:
       return Helper::warningLevel;
     case StringHandler::OMError:

--- a/OMEdit/OMEditLIB/Util/StringHandler.h
+++ b/OMEdit/OMEditLIB/Util/StringHandler.h
@@ -48,7 +48,7 @@ public:
   enum ViewType {Icon, Diagram, ModelicaText, NoView};
   enum ModelicaClasses {Model, Class, ExpandableConnector, Connector, Record, Block, Function, Package, Primitive, Type, Operator,
                         OperatorRecord, OperatorFunction, Optimization, Parameter, Constant, Protected, Enumeration};
-  enum OpenModelicaErrors {Notification, Warning, OMError, NoOMError};
+  enum OpenModelicaErrors {Internal, Notification, Warning, OMError, NoOMError};
   enum OpenModelicaErrorKinds {Syntax, Grammar, Translation, Symbolic, Simulation, Scripting, NoOMErrorKind};
   enum LinePattern {LineNone, LineSolid, LineDash, LineDot, LineDashDot, LineDashDotDot};
   enum FillPattern {FillNone, FillSolid, FillHorizontal, FillVertical, FillCross, FillForward, FillBackward, FillCrossDiag,


### PR DESCRIPTION
- Add internal to the ErrorLevel enumeration and fix
  CevalScript.errorLevelToValue so that it handles
  ErrorTypes.INTERNAL().
- Add handling for ErrorLevel.internal in OMEdit.