### PR TITLE
fixes for ticket #6013 and #6129

### DIFF
--- a/OMCompiler/Compiler/Global/Global.mo
+++ b/OMCompiler/Compiler/Global/Global.mo
@@ -52,23 +52,24 @@ constant Integer symbolTable = 3;
 constant Integer instHashIndex = 9;
 constant Integer instNFInstCacheIndex = 10;
 constant Integer instNFNodeCacheIndex = 11;
-constant Integer builtinIndex = 12;
-constant Integer builtinEnvIndex = 13;
-constant Integer profilerTime1Index = 14;
-constant Integer profilerTime2Index = 15;
-constant Integer flagsIndex = 16;
-constant Integer builtinGraphIndex = 17;
-constant Integer rewriteRulesIndex = 18;
-constant Integer stackoverFlowIndex = 19;
-constant Integer gcProfilingIndex = 20;
-constant Integer inlineHashTable = 21; // TODO: Should be a local root?
-constant Integer currentInstVar = 22;
-constant Integer operatorOverloadingCache = 23;
-constant Integer optionSimCode = 24;
-constant Integer interactiveCache = 25;
-constant Integer isInStream = 26;
-constant Integer MMToJLListIndex = 27;
-constant Integer packageIndexCacheIndex = 28;
+constant Integer instNFLookupCacheIndex = 12;
+constant Integer builtinIndex = 13;
+constant Integer builtinEnvIndex = 14;
+constant Integer profilerTime1Index = 15;
+constant Integer profilerTime2Index = 16;
+constant Integer flagsIndex = 17;
+constant Integer builtinGraphIndex = 18;
+constant Integer rewriteRulesIndex = 19;
+constant Integer stackoverFlowIndex = 20;
+constant Integer gcProfilingIndex = 21;
+constant Integer inlineHashTable = 22; // TODO: Should be a local root?
+constant Integer currentInstVar = 23;
+constant Integer operatorOverloadingCache = 24;
+constant Integer optionSimCode = 25;
+constant Integer interactiveCache = 26;
+constant Integer isInStream = 27;
+constant Integer MMToJLListIndex = 28;
+constant Integer packageIndexCacheIndex = 29;
 
 // indexes in System.tick
 // ----------------------
@@ -99,6 +100,7 @@ algorithm
   setGlobalRoot(interactiveCache, NONE());
   setGlobalRoot(instNFInstCacheIndex, {});
   setGlobalRoot(instNFNodeCacheIndex, {});
+  setGlobalRoot(instNFLookupCacheIndex, {});
 end initialize;
 
 annotation(__OpenModelica_Interface="util");

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -42,6 +42,7 @@ encapsulated package NFClassTree
 protected
   import Array;
   import Error;
+  import Flags;
   import MetaModelica.Dangerous.*;
   import Class = NFClass;
   import Component = NFComponent;
@@ -534,7 +535,14 @@ public
                     // If the component is outer, link it with the corresponding
                     // inner component.
                     if Component.isOuter(comp) then
-                      node := linkInnerOuter(node, inst_scope);
+                      try
+                        node := linkInnerOuter(node, inst_scope);
+                      else
+                        // fail if not NF_API
+                        if not Flags.isSet(Flags.NF_API) then
+                          fail();
+                        end if;
+                      end try;
                     end if;
 
                     // Add the node to the component array.


### PR DESCRIPTION
- use NFInst.expand instead of NFInst.instantiate in NFApi.mkFullyQual
- fully qualify the path we search for and all the extends in the loaded
  libraries to make sure is the proper subtype of
- a bit slow but it can be improved later