### PR TITLE
Remove constrain operator.

### DIFF
--- a/OMCompiler/Compiler/FFrontEnd/FBuiltin.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FBuiltin.mo
@@ -620,17 +620,6 @@ algorithm
                                  FGraph.top(graph), "actualStream", graph);
   graph := mkTypeNode({DAE.T_FUNCTION(argsRealX,DAE.T_REAL_DEFAULT,DAE.FUNCTION_ATTRIBUTES_BUILTIN,Absyn.IDENT("inStream"))},
                                  FGraph.top(graph), "inStream", graph);
-  graph := mkTypeNode({
-      DAE.T_FUNCTION(argsRealXYZ,DAE.T_REAL_DEFAULT,DAE.FUNCTION_ATTRIBUTES_BUILTIN,Absyn.IDENT("constrain")),
-      DAE.T_FUNCTION({
-        DAE.FUNCARG("x",T_REAL_ARRAY_1_DEFAULT,DAE.C_VAR(),DAE.NON_PARALLEL(),NONE()),
-        DAE.FUNCARG("y",T_REAL_ARRAY_1_DEFAULT,DAE.C_VAR(),DAE.NON_PARALLEL(),NONE()),
-        DAE.FUNCARG("z",T_REAL_ARRAY_1_DEFAULT,DAE.C_VAR(),DAE.NON_PARALLEL(),NONE())},
-        T_REAL_ARRAY_1_DEFAULT,
-        DAE.FUNCTION_ATTRIBUTES_BUILTIN,
-        Absyn.IDENT("constrain"))
-      },
-      FGraph.top(graph), "constrain", graph);
 end initialGraphModelica;
 
 function initialGraphMetaModelica

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -5430,7 +5430,6 @@ algorithm
     case "ceil" then Absyn.FULLYQUALIFIED(Absyn.IDENT("ceil"));
     case "change" then Absyn.FULLYQUALIFIED(Absyn.IDENT("change"));
     case "classDirectory" then Absyn.FULLYQUALIFIED(Absyn.IDENT("classDirectory"));
-    case "constrain" then Absyn.FULLYQUALIFIED(Absyn.IDENT("constrain"));
     case "cos" then Absyn.FULLYQUALIFIED(Absyn.IDENT("cos"));
     case "cosh" then Absyn.FULLYQUALIFIED(Absyn.IDENT("cosh"));
     case "cross" then Absyn.FULLYQUALIFIED(Absyn.IDENT("cross"));

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -75,15 +75,6 @@ annotation(Documentation(info="<html>
 </html>"));
 end assert;
 
-function constrain
-  input Real i1;
-  input Real i2;
-  input Real i3;
-  output Real o1;
-external "builtin";
-annotation(version="Dymola / MSL 1.6");
-end constrain;
-
 function ceil "Round a real number towards plus infinity"
   input Real x;
   output Real y;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -79,15 +79,6 @@ annotation(Documentation(info="<html>
 </html>"));
 end assert;
 
-function constrain
-  input Real i1;
-  input Real i2;
-  input Real i3;
-  output Real o1;
-external "builtin";
-annotation(version="Dymola / MSL 1.6");
-end constrain;
-
 function ceil "Round a real number towards plus infinity"
   input Real x;
   output Real y;


### PR DESCRIPTION
- constrain is a nonstandard operator that apparently was used a long
  time ago by an old multibody library. Since it's nonstandard, not
  working and not documented I'm removing it to avoid it polluting the
  builtin namespace.