### PR TITLE
fix ElementPropertiesDialog before instantiation

### DIFF
--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -170,9 +170,6 @@ ElementPropertiesDialog::ElementPropertiesDialog(Element *pComponent, QWidget *p
   pParametersScrollArea->setWidget(pParametersWidget);
   mParameterLabels.clear();
   mParameterLineEdits.clear();
-  LibraryTreeItem *pModelLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItem(
-                                             StringHandler::getFirstWordBeforeDot(mpComponent->getLibraryTreeItem()->getNameStructure()));
-  bool modelInstantiated = pModelLibraryTreeItem && pModelLibraryTreeItem->isOMSModelInstantiated();
   bool hasParameter = false;
   if (mpComponent->getLibraryTreeItem()->getOMSElement() && mpComponent->getLibraryTreeItem()->getOMSElement()->connectors) {
     oms_connector_t** pInterfaces = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
@@ -189,21 +186,21 @@ ElementPropertiesDialog::ElementPropertiesDialog(Element *pComponent, QWidget *p
           QDoubleValidator *pDoubleValidator = new QDoubleValidator(this);
           pParameterLineEdit->setValidator(pDoubleValidator);
           double value;
-          if (modelInstantiated && (status = OMSProxy::instance()->getReal(nameStructure, &value))) {
+          if ((status = OMSProxy::instance()->getReal(nameStructure, &value))) {
             pParameterLineEdit->setText(QString::number(value));
           }
         } else if (pInterfaces[i]->type == oms_signal_type_integer) {
           QIntValidator *pIntValidator = new QIntValidator(this);
           pParameterLineEdit->setValidator(pIntValidator);
           int value;
-          if (modelInstantiated && (status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
+          if ((status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
             pParameterLineEdit->setText(QString::number(value));
           }
         } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
           QIntValidator *pIntValidator = new QIntValidator(this);
           pParameterLineEdit->setValidator(pIntValidator);
           bool value;
-          if (modelInstantiated && (status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
+          if ((status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
             pParameterLineEdit->setText(QString::number(value));
           }
         } else if (pInterfaces[i]->type == oms_signal_type_string) {
@@ -258,21 +255,21 @@ ElementPropertiesDialog::ElementPropertiesDialog(Element *pComponent, QWidget *p
           QDoubleValidator *pDoubleValidator = new QDoubleValidator(this);
           pInputLineEdit->setValidator(pDoubleValidator);
           double value;
-          if (modelInstantiated && (status = OMSProxy::instance()->getReal(nameStructure, &value))) {
+          if ((status = OMSProxy::instance()->getReal(nameStructure, &value))) {
             pInputLineEdit->setText(QString::number(value));
           }
         } else if (pInterfaces[i]->type == oms_signal_type_integer) {
           QIntValidator *pIntValidator = new QIntValidator(this);
           pInputLineEdit->setValidator(pIntValidator);
           int value;
-          if (modelInstantiated && (status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
+          if ((status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
             pInputLineEdit->setText(QString::number(value));
           }
         } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
           QIntValidator *pIntValidator = new QIntValidator(this);
           pInputLineEdit->setValidator(pIntValidator);
           bool value;
-          if (modelInstantiated && (status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
+          if ((status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
             pInputLineEdit->setText(QString::number(value));
           }
         } else if (pInterfaces[i]->type == oms_signal_type_string) {
@@ -301,7 +298,6 @@ ElementPropertiesDialog::ElementPropertiesDialog(Element *pComponent, QWidget *p
   // Create the buttons
   mpOkButton = new QPushButton(Helper::ok);
   mpOkButton->setAutoDefault(true);
-  mpOkButton->setEnabled(modelInstantiated);
   connect(mpOkButton, SIGNAL(clicked()), this, SLOT(updateProperties()));
   mpCancelButton = new QPushButton(Helper::cancel);
   mpCancelButton->setAutoDefault(false);

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -351,38 +351,50 @@ void ElementPropertiesDialog::updateProperties()
       if (pInterfaces[i]->causality == oms_causality_parameter) {
         QString parameterValue = mParameterLineEdits.at(parametersIndex)->text();
         parametersIndex++;
-        if (pInterfaces[i]->type == oms_signal_type_real) {
-          OMSProxy::instance()->setReal(nameStructure, parameterValue.toDouble());
-        } else if (pInterfaces[i]->type == oms_signal_type_integer) {
-          OMSProxy::instance()->setInteger(nameStructure, parameterValue.toInt());
-        } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
-          OMSProxy::instance()->setBoolean(nameStructure, parameterValue.toInt());
-        } else if (pInterfaces[i]->type == oms_signal_type_string) {
-          qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_string not implemented yet.";
-        } else if (pInterfaces[i]->type == oms_signal_type_enum) {
-          qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_enum not implemented yet.";
-        } else if (pInterfaces[i]->type == oms_signal_type_bus) {
-          qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_bus not implemented yet.";
-        } else {
-          qDebug() << "ElementPropertiesDialog::updateProperties() unknown oms_signal_type_enu_t.";
+        if (parameterValue.isEmpty()) {
+          // delete start values only
+          OMSProxy::instance()->omsDelete(nameStructure + ":start");
+        }
+        else {
+          if (pInterfaces[i]->type == oms_signal_type_real) {
+            OMSProxy::instance()->setReal(nameStructure, parameterValue.toDouble());
+          } else if (pInterfaces[i]->type == oms_signal_type_integer) {
+            OMSProxy::instance()->setInteger(nameStructure, parameterValue.toInt());
+          } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
+            OMSProxy::instance()->setBoolean(nameStructure, parameterValue.toInt());
+          } else if (pInterfaces[i]->type == oms_signal_type_string) {
+            qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_string not implemented yet.";
+          } else if (pInterfaces[i]->type == oms_signal_type_enum) {
+            qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_enum not implemented yet.";
+          } else if (pInterfaces[i]->type == oms_signal_type_bus) {
+            qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_bus not implemented yet.";
+          } else {
+            qDebug() << "ElementPropertiesDialog::updateProperties() unknown oms_signal_type_enu_t.";
+          }
         }
       } else if (pInterfaces[i]->causality == oms_causality_input) {
         QString inputValue = mInputLineEdits.at(inputsIndex)->text();
         inputsIndex++;
-        if (pInterfaces[i]->type == oms_signal_type_real) {
-          OMSProxy::instance()->setReal(nameStructure, inputValue.toDouble());
-        } else if (pInterfaces[i]->type == oms_signal_type_integer) {
-          OMSProxy::instance()->setInteger(nameStructure, inputValue.toInt());
-        } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
-          OMSProxy::instance()->setBoolean(nameStructure, inputValue.toInt());
-        } else if (pInterfaces[i]->type == oms_signal_type_string) {
-          qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_string not implemented yet.";
-        } else if (pInterfaces[i]->type == oms_signal_type_enum) {
-          qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_enum not implemented yet.";
-        } else if (pInterfaces[i]->type == oms_signal_type_bus) {
-          qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_bus not implemented yet.";
-        } else {
-          qDebug() << "ElementPropertiesDialog::updateProperties() unknown oms_signal_type_enu_t.";
+        if (inputValue.isEmpty()){
+          // delete start values only
+          OMSProxy::instance()->omsDelete(nameStructure + ":start");
+        }
+        else{
+          if (pInterfaces[i]->type == oms_signal_type_real) {
+            OMSProxy::instance()->setReal(nameStructure, inputValue.toDouble());
+          } else if (pInterfaces[i]->type == oms_signal_type_integer) {
+            OMSProxy::instance()->setInteger(nameStructure, inputValue.toInt());
+          } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
+            OMSProxy::instance()->setBoolean(nameStructure, inputValue.toInt());
+          } else if (pInterfaces[i]->type == oms_signal_type_string) {
+            qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_string not implemented yet.";
+          } else if (pInterfaces[i]->type == oms_signal_type_enum) {
+            qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_enum not implemented yet.";
+          } else if (pInterfaces[i]->type == oms_signal_type_bus) {
+            qDebug() << "ElementPropertiesDialog::updateProperties() oms_signal_type_bus not implemented yet.";
+          } else {
+            qDebug() << "ElementPropertiesDialog::updateProperties() unknown oms_signal_type_enu_t.";
+          }
         }
       }
     }

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -354,8 +354,7 @@ void ElementPropertiesDialog::updateProperties()
         if (parameterValue.isEmpty()) {
           // delete start values only
           OMSProxy::instance()->omsDelete(nameStructure + ":start");
-        }
-        else {
+        } else {
           if (pInterfaces[i]->type == oms_signal_type_real) {
             OMSProxy::instance()->setReal(nameStructure, parameterValue.toDouble());
           } else if (pInterfaces[i]->type == oms_signal_type_integer) {
@@ -378,8 +377,7 @@ void ElementPropertiesDialog::updateProperties()
         if (inputValue.isEmpty()){
           // delete start values only
           OMSProxy::instance()->omsDelete(nameStructure + ":start");
-        }
-        else{
+        } else {
           if (pInterfaces[i]->type == oms_signal_type_real) {
             OMSProxy::instance()->setReal(nameStructure, inputValue.toDouble());
           } else if (pInterfaces[i]->type == oms_signal_type_integer) {

--- a/OMEdit/OMEditLIB/OMS/ModelDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ModelDialog.cpp
@@ -533,6 +533,8 @@ AddConnectorDialog::AddConnectorDialog(GraphicsView *pGraphicsView)
   mpCausalityComboBox = new QComboBox;
   mpCausalityComboBox->addItem("Input", oms_causality_input);
   mpCausalityComboBox->addItem("Output", oms_causality_output);
+  mpCausalityComboBox->addItem("Parameter", oms_causality_parameter);
+
   // type
   mpTypeLabel = new Label(Helper::type);
   mpTypeComboBox = new QComboBox;


### PR DESCRIPTION
### Related issue 
https://github.com/OpenModelica/OMSimulator/pull/810

### Purpose
This PR fixes the `getReal(), getInteger() and getBoolean()` methods before instantition, so that the start values are displayed in the ElementProperties Dialog in OMEdit.
