### PR TITLE
[BE] remove empty initial equations

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendEquation.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendEquation.mo
@@ -3236,5 +3236,13 @@ algorithm
   end match;
 end createResidualExp;
 
+public function hasAnyUnknown
+  input BackendDAE.Equation eqn;
+  input BackendDAE.Variables vars;
+  output Boolean b;
+algorithm
+  b := not listEmpty(equationVars(eqn, vars));
+end hasAnyUnknown;
+
 annotation(__OpenModelica_Interface="backend");
 end BackendEquation;

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -1168,6 +1168,7 @@ protected
   list<BackendDAE.EqSystem> eqs;
   DoubleEnded.MutableList<BackendDAE.Var> dumpVars;
   DoubleEnded.MutableList<BackendDAE.Equation> removedEqns;
+  list<BackendDAE.Equation> filtered_initial_eqs;
 algorithm
   // filter empty systems
   eqs := {};
@@ -1177,7 +1178,8 @@ algorithm
     if BackendDAEUtil.nonEmptySystem(syst) then
       eqs := syst::eqs;
     else
-      DoubleEnded.push_list_back(removedEqns, BackendEquation.equationList(syst.orderedEqs));
+      filtered_initial_eqs := list(eqn for eqn guard(BackendEquation.hasAnyUnknown(eqn, inInitVars)) in BackendEquation.equationList(syst.orderedEqs));
+      DoubleEnded.push_list_back(removedEqns, filtered_initial_eqs);
       DoubleEnded.push_list_back(removedEqns, BackendEquation.equationList(syst.removedEqs));
     end if;
   end for;


### PR DESCRIPTION
 - filter the initial equations for equations that do not have initial unknowns and remove them
 - needed for data reconciliation since there might be initial equations for state derivatives of states that got removed during data recon