### PR TITLE
Array connection improvements.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -236,6 +236,14 @@ public
     component := ENUM_LITERAL(Expression.ENUM_LITERAL(enumType, literalName, literalIndex));
   end newEnum;
 
+  function newIterator
+    input Type iterType;
+    input SourceInfo info;
+    output Component component;
+  algorithm
+    component := ITERATOR(iterType, Variability.IMPLICITLY_DISCRETE, info);
+  end newIterator;
+
   function definition
     input Component component;
     output SCode.Element definition;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -780,8 +780,7 @@ algorithm
   prefix_node := ComponentRef.node(prefix);
 
   for dim in dimensions loop
-    iter_comp := Component.ITERATOR(Type.INTEGER(),
-      Variability.IMPLICITLY_DISCRETE, InstNode.info(prefix_node));
+    iter_comp := Component.newIterator(Type.INTEGER(), InstNode.info(prefix_node));
     iter := InstNode.fromComponent("$i" + String(index), iter_comp, InstNode.parent(prefix_node));
     iterators := iter :: iterators;
     index := index + 1;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -160,8 +160,9 @@ algorithm
 
     case Equation.FOR(range = SOME(e))
       algorithm
-        if not Equation.containsExpList(eq.body, function Expression.containsIterator(iterator = eq.iterator)) then
-          body := simplifyEquations(eq.body);
+        body := simplifyEquations(eq.body);
+
+        if not Equation.containsExpList(body, function Expression.containsIterator(iterator = eq.iterator)) then
           equations := List.append_reverse(body, equations);
         else
           // TODO: This causes issues with the -nfScalarize tests for some reason.
@@ -170,13 +171,13 @@ algorithm
           //if Dimension.isOne(dim) then
           //  e := Expression.applySubscript(Subscript.INDEX(Expression.INTEGER(1)), e);
 
-          //  body := Equation.mapExpList(eq.body,
+          //  body := Equation.mapExpList(body,
           //    function Expression.replaceIterator(iterator = eq.iterator, iteratorValue = e));
           //  body := simplifyEquations(body);
           //  equations := List.append_reverse(body, equations);
           //elseif not Dimension.isZero(dim) then
             eq.range := SimplifyExp.simplifyOpt(eq.range);
-            eq.body := simplifyEquations(eq.body);
+            eq.body := body;
             equations := eq :: equations;
           //end if;
         end if;

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect1.mo
@@ -49,12 +49,8 @@ end ArrayConnect1;
 //   Real G.n.e;
 //   Real G.n.f;
 // equation
-//   for $i1 in 1:1 loop
-//     R[$i1].p.e = S.p.e;
-//   end for;
-//   for $i1 in 1:1 loop
-//     S.p.f + R[$i1].p.f = 0.0;
-//   end for;
+//   R[1].p.e = S.p.e;
+//   S.p.f + R[1].p.f = 0.0;
 //   for $i1 in 1:1000 loop
 //     C[$i1].n.e = S.n.e;
 //   end for;
@@ -69,11 +65,7 @@ end ArrayConnect1;
 //   for $i1 in 2:1000 loop
 //     C[$i1 - 1].p.f + R[$i1 - 1].n.f + R[$i1].p.f = 0.0;
 //   end for;
-//   for $i1 in 1000:1000 loop
-//     C[$i1].p.e = R[$i1].n.e;
-//   end for;
-//   for $i1 in 1000:1000 loop
-//     C[$i1].p.f + R[$i1].n.f = 0.0;
-//   end for;
+//   C[1000].p.e = R[1000].n.e;
+//   C[1000].p.f + R[1000].n.f = 0.0;
 // end ArrayConnect1;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect2.mo
@@ -52,25 +52,15 @@ end ArrayConnect2;
 //   Real G.n.e;
 //   Real G.n.f;
 // equation
-//   for $i1 in 1:1 loop
-//     R[$i1].p.e = S.p.e;
-//   end for;
-//   for $i1 in 1:1 loop
-//     S.p.f + R[$i1].p.f = 0.0;
-//   end for;
-//   for $i1 in 1000:1000 loop
-//     C[$i1].n.e = S.n.e;
-//   end for;
+//   R[1].p.e = S.p.e;
+//   S.p.f + R[1].p.f = 0.0;
+//   C[1000].n.e = S.n.e;
 //   for $i1 in 2:999 loop
 //     C[$i1].n.e = S.n.e;
 //   end for;
-//   for $i1 in 1:1 loop
-//     C[$i1].n.e = S.n.e;
-//   end for;
+//   C[1].n.e = S.n.e;
 //   G.p.e = S.n.e;
-//   for $i1 in 1:1 loop
-//     S.n.f + G.p.f + C[$i1].n.f + sum(C[2:1:999].n.f) + C[$i1 + 999].n.f = 0.0;
-//   end for;
+//   S.n.f + G.p.f + C[1].n.f + sum(C[2:1:999].n.f) + C[1000].n.f = 0.0;
 //   for $i1 in 1:999 loop
 //     R[$i1].n.e = R[$i1 + 1].p.e;
 //   end for;
@@ -80,11 +70,7 @@ end ArrayConnect2;
 //   for $i1 in 2:1000 loop
 //     C[$i1 - 1].p.f + R[$i1 - 1].n.f + R[$i1].p.f = 0.0;
 //   end for;
-//   for $i1 in 1000:1000 loop
-//     C[$i1].p.e = R[$i1].n.e;
-//   end for;
-//   for $i1 in 1000:1000 loop
-//     C[$i1].p.f + R[$i1].n.f = 0.0;
-//   end for;
+//   C[1000].p.e = R[1000].n.e;
+//   C[1000].p.f + R[1000].n.f = 0.0;
 // end ArrayConnect2;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect3.mo
@@ -62,9 +62,7 @@ end ArrayConnect3;
 //     end for;
 //   end for;
 //   for $i1 in 1:999 loop
-//     for $i2 in 1:99 loop
-//       cells[$i1,$i1].r.f + cells[$i1,$i1 + 1].l.f = 0.0;
-//     end for;
+//     cells[$i1,$i1].r.f + cells[$i1,$i1 + 1].l.f = 0.0;
 //   end for;
 //   for $i1 in 2:1000 loop
 //     for $i2 in 1:99 loop
@@ -72,49 +70,23 @@ end ArrayConnect3;
 //     end for;
 //   end for;
 //   for $i1 in 1:999 loop
-//     for $i2 in 1:99 loop
-//       cells[$i1,$i1].d.f + cells[$i1 + 1,$i1].u.f = 0.0;
-//     end for;
+//     cells[$i1,$i1].d.f + cells[$i1 + 1,$i1].u.f = 0.0;
 //   end for;
 //   for $i1 in 1:1000 loop
-//     for $i2 in 1:1 loop
-//       cells[$i1,$i2].l.e = cells[$i1,$i1 + 99].r.e;
-//     end for;
+//     cells[$i1,1].l.e = cells[$i1,$i1 + 99].r.e;
 //   end for;
 //   for $i1 in 1:1000 loop
-//     for $i2 in 100:100 loop
-//       cells[$i1,$i1].r.f + cells[$i1,$i1 - 99].l.f = 0.0;
-//     end for;
+//     cells[$i1,$i1].r.f + cells[$i1,$i1 - 99].l.f = 0.0;
 //   end for;
-//   for $i1 in 1000:1000 loop
-//     for $i2 in 1:99 loop
-//       cells[$i1,$i1].r.f = 0.0;
-//     end for;
-//   end for;
-//   for $i1 in 1000:1000 loop
-//     for $i2 in 2:100 loop
-//       cells[$i1,$i1].l.f = 0.0;
-//     end for;
-//   end for;
-//   for $i1 in 1000:1000 loop
-//     for $i2 in 1:100 loop
-//       cells[$i1,$i1].d.f = 0.0;
-//     end for;
-//   end for;
+//   cells[1000,1000].r.f = 0.0;
+//   cells[1000,1000].l.f = 0.0;
+//   cells[1000,1000].d.f = 0.0;
 //   for $i1 in 1:999 loop
-//     for $i2 in 100:100 loop
-//       cells[$i1,$i1].d.f = 0.0;
-//     end for;
+//     cells[$i1,$i1].d.f = 0.0;
 //   end for;
-//   for $i1 in 1:1 loop
-//     for $i2 in 1:100 loop
-//       cells[$i1,$i1].u.f = 0.0;
-//     end for;
-//   end for;
+//   cells[1,1].u.f = 0.0;
 //   for $i1 in 2:1000 loop
-//     for $i2 in 100:100 loop
-//       cells[$i1,$i1].u.f = 0.0;
-//     end for;
+//     cells[$i1,$i1].u.f = 0.0;
 //   end for;
 // end ArrayConnect3;
 // endResult


### PR DESCRIPTION
- Make sure all iterators get unique components when creating them and
  not sharing a constant literal, to make the simplification for
  removing unused for loops work correctly.
- Avoid creating unnecessary for loops for ranges with the same lower
  and upper bound.