### PR TITLE
CMake improvments and refactoring

### DIFF
--- a/OMCompiler/Compiler/.cmake/dep_toucher.cmake
+++ b/OMCompiler/Compiler/.cmake/dep_toucher.cmake
@@ -3,6 +3,6 @@
 file(READ ${REV_DEP_FILE} DEPENDEE_LIST)
 
 foreach(OMC_MM_SOURCE ${DEPENDEE_LIST})
-    # message("Touching ${INTERFACE_FILES_DIR}/${OMC_MM_SOURCE}.interface.mo.tmp")
-    file(TOUCH_NOCREATE ${INTERFACE_FILES_DIR}/${OMC_MM_SOURCE}.interface.mo.tmp)
+    # message("Touching ${INTERFACE_FILES_DIR}/${OMC_MM_SOURCE}.interface.mo.stamp")
+    file(TOUCH_NOCREATE ${INTERFACE_FILES_DIR}/${OMC_MM_SOURCE}.interface.mo.stamp)
 endforeach()

--- a/OMCompiler/Compiler/.cmake/mm_check_interface.in.mos
+++ b/OMCompiler/Compiler/.cmake/mm_check_interface.in.mos
@@ -1,7 +1,7 @@
 echo(false);
 mm_src_file := "@MM_INPUT_SOURCE_DIR@/@MM_PACKAGE_NAME@.mo";
 
-tmp_interface_file := "@MM_OUTPUT_DIR@/@MM_PACKAGE_NAME@.interface.mo.tmp";
+tmp_interface_file := "@MM_OUTPUT_DIR@/@MM_PACKAGE_NAME@.interface.mo.stamp";
 interface_file := "@MM_OUTPUT_DIR@/@MM_PACKAGE_NAME@.interface.mo";
 depends_file := "@MM_OUTPUT_DIR@/@MM_PACKAGE_NAME@.depends";
 public_imports_file := "@MM_OUTPUT_DIR@/@MM_PACKAGE_NAME@.public.imports";

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -42,7 +42,7 @@ macro(add_interface_check_step mo_source_file)
 
         COMMAND ${OMC_EXE} -g=MetaModelica -n=1 ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.check_interface.mos
 
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.tmp
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.stamp
         BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo
         COMMENT "Checking interface for ${mo_source_file}"
     )
@@ -50,7 +50,7 @@ macro(add_interface_check_step mo_source_file)
     set(OMC_MM_SOURCE_FILE_NAMES ${OMC_MM_SOURCE_FILE_NAMES} ${file_name_no_ext})
 
     set(OMC_MM_INTERFACE_FILES ${OMC_MM_INTERFACE_FILES} ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo)
-    set(OMC_MM_STAMP_FILES ${OMC_MM_STAMP_FILES} ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.tmp)
+    set(OMC_MM_STAMP_FILES ${OMC_MM_STAMP_FILES} ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.stamp)
 
 
     add_custom_command(
@@ -78,7 +78,7 @@ macro(add_compile_step mo_source_file)
     get_filename_component(source_dir ${mo_source_file} DIRECTORY)
 
     add_custom_command(
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.tmp
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.interface.mo.stamp
                 ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.compile.mos
 
         COMMAND ${OMC_EXE} -g=MetaModelica -n=1 ${CMAKE_CURRENT_BINARY_DIR}/${file_name_no_ext}.compile.mos

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -1,69 +1,47 @@
-
 find_package(CURL REQUIRED)
 find_package(Intl REQUIRED)
 find_package(Iconv REQUIRED)
 find_package(LAPACK REQUIRED)
 # find_package(ZLIB REQUIRED) # Not needed. We use the minizip lib from 3rdParty/FMIL instead
 
-
-# On Win32 we use system UUID lib which is one of the default libs that cmake adds to any target on Win32.
-# On non Win32 systems we need to link explicitly to uuid. However,
-# there is no FindUUID yet. We can add one later.
-# Instead we use find library for now. It should be okay for now since I am guessing uuid headers
-# should be in the default include dirs anyway.
+# On Win32 we use system UUID lib which is one of the default libs that cmake adds to any target on Win32. On non Win32
+# systems we need to link explicitly to uuid. However, there is no FindUUID yet. We can add one later. Instead we use
+# find library for now. It should be okay for now since I am guessing uuid headers should be in the default include dirs
+# anyway.
 if(NOT WIN32)
-    find_library(UUID_LIB NAMES uuid REQUIRED)
+  find_library(UUID_LIB NAMES uuid REQUIRED)
 endif()
 
-
-
-# make a directory specifically for generated files. If we are asked
-# for corba support we will generate some files here.
-set (GENERATED_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
-file(MAKE_DIRECTORY ${GENERATED_DIRECTORY})
-
-
-set(OMC_RUNTIIME_SOURCES Error_omc.cpp Print_omc.c ErrorMessage.cpp
-                            System_omc Lapack_omc.cpp Settings_omc.cpp
-                            UnitParserExt_omc.cpp unitparser.cpp
-                            IOStreamExt_omc.cpp Socket_omc.c
-                            ZeroMQ_omc.c getMemorySize.c OMSimulator_omc.c
-                            is_utf8.c om_curl.c om_unzip.c
-                            ptolemyio_omc.cpp SimulationResults_omc.c
-                            systemimplmisc.cpp
-                            )
-
-
-if(OMC_USE_CORBA)
-  if(MINGW)
-    # setup omniORB for MinGW OMDev
-    include(.cmake/omdev_omniorb_setup.cmake)
-    # Include the macro for compiling corba targets.
-    include(.cmake/omc_omniorb_corba_target.cmake)
-    # add a corba target for omc_communication.idl. The outputs will be put in the
-    # generated files directory.
-    omc_add_omniorb_corba_target(${OMNIIDL_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/omc_communication.idl ${GENERATED_DIRECTORY})
-    # add corba sources to source files list.
-    set(OMC_RUNTIIME_SOURCES ${OMC_RUNTIIME_SOURCES} ${GENERATED_DIRECTORY}/omc_communication.cc omc_communication_impl.cpp Corba_omc.cpp)
-  else(MINGW) # Not MinGW
-    message(FATAL "Corba support for non-MinGW omc builds is not yet implemented.")
-    # set(OMC_RUNTIIME_SOURCES ${OMC_RUNTIIME_SOURCES} ${GENERATED_DIRECTORY}/omc_communication.cc omc_communication_impl.cpp Corba_omc.cpp)
-  endif(MINGW)
-
-else(OMC_USE_CORBA) # No corba support requested.
-    set(OMC_RUNTIIME_SOURCES ${OMC_RUNTIIME_SOURCES} corbaimpl_stub_omc.c)
-endif(OMC_USE_CORBA)
-
-
-
-
-
-
-add_library(omcruntime STATIC ${OMC_RUNTIIME_SOURCES})
+# ######################################################################################################################
+# Library: omcruntime
+add_library(omcruntime STATIC)
 add_library(omc::compiler::runtime ALIAS omcruntime)
+
+set(OMC_RUNTIIME_SOURCES
+    Error_omc.cpp
+    Print_omc.c
+    ErrorMessage.cpp
+    System_omc
+    Lapack_omc.cpp
+    Settings_omc.cpp
+    UnitParserExt_omc.cpp
+    unitparser.cpp
+    IOStreamExt_omc.cpp
+    Socket_omc.c
+    ZeroMQ_omc.c
+    getMemorySize.c
+    OMSimulator_omc.c
+    is_utf8.c
+    om_curl.c
+    om_unzip.c
+    ptolemyio_omc.cpp
+    SimulationResults_omc.c
+    systemimplmisc.cpp)
+
+target_sources(omcruntime PRIVATE ${OMC_RUNTIIME_SOURCES})
 target_compile_features(omcruntime PRIVATE cxx_std_11)
 
-target_link_libraries(omcruntime PUBLIC curl)
+target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
 target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
@@ -72,49 +50,78 @@ target_link_libraries(omcruntime PUBLIC omc::3rd::lpsolve55)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
 
-# uuid is one of the default libs that cmake adds to any target on Win32.
-# On non-Win systems we look for the library and explicitly use it.
+target_include_directories(omcruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(omcruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
+
+# uuid is one of the default libs that cmake adds to any target on Win32. On non-Win systems we look for the library and
+# explicitly use it.
 if(NOT WIN32)
-    target_link_libraries(omcruntime PUBLIC ${UUID_LIB})
+  target_link_libraries(omcruntime PUBLIC ${UUID_LIB})
 endif()
 
-if(OMC_USE_CORBA AND MINGW)
+# Corba support
+if(OMC_USE_CORBA)
+  if(MINGW)
+    # setup omniORB for MinGW OMDev
+    include(.cmake/omdev_omniorb_setup.cmake)
+    # Include the macro for compiling corba targets.
+    include(.cmake/omc_omniorb_corba_target.cmake)
+
+    # Make a directory specifically for generated files
+    set(GENERATED_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
+    file(MAKE_DIRECTORY ${GENERATED_DIRECTORY})
+
+    # add a corba target for omc_communication.idl. The outputs will be put in the generated files directory.
+    omc_add_omniorb_corba_target(${OMNIIDL_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/omc_communication.idl
+                                 ${GENERATED_DIRECTORY})
+    # Add the generated files to the sources of the library
+    target_sources(omcruntime PRIVATE ${GENERATED_DIRECTORY}/omc_communication.cc omc_communication_impl.cpp
+                                      Corba_omc.cpp)
+
     target_link_libraries(omcruntime PUBLIC omdev::omniORB::omniORB420_rt)
     target_link_libraries(omcruntime PUBLIC omdev::omniORB::omnithread40_rt)
     target_compile_definitions(omcruntime PRIVATE USE_CORBA)
     target_include_directories(omcruntime PRIVATE ${GENERATED_DIRECTORY})
-endif(OMC_USE_CORBA AND MINGW)
+  else() # Not MinGW
+    message(FATAL "Corba support for non-MinGW omc builds is not yet implemented.")
+  endif()
+else() # No corba support requested. Use the stub file.
+  target_sources(omcruntime PRIVATE corbaimpl_stub_omc.c)
+endif(OMC_USE_CORBA)
 
-
-target_include_directories(omcruntime INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(omcruntime PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h
-
-
-
-
-
-set(OMC_BACKENDRUNTIIME_SOURCES HpcOmSchedulerExt_omc.cpp HpcOmBenchmarkExt_omc.cpp
-                                TaskGraphResults_omc.cpp BackendDAEEXT_omc.cpp
-                                matching.c matching_cheap.c Dynload_omc.cpp FMI_omc.c cJSON.c
-                            )
-add_library(omcbackendruntime STATIC ${OMC_BACKENDRUNTIIME_SOURCES})
+# ######################################################################################################################
+# Library: omcbackendruntime
+add_library(omcbackendruntime STATIC)
 add_library(omc::compiler::backendruntime ALIAS omcbackendruntime)
+
+set(OMC_BACKENDRUNTIIME_SOURCES
+    HpcOmSchedulerExt_omc.cpp
+    HpcOmBenchmarkExt_omc.cpp
+    TaskGraphResults_omc.cpp
+    BackendDAEEXT_omc.cpp
+    matching.c
+    matching_cheap.c
+    Dynload_omc.cpp
+    FMI_omc.c
+    cJSON.c)
+
+target_sources(omcbackendruntime PRIVATE ${OMC_BACKENDRUNTIIME_SOURCES})
 
 target_link_libraries(omcbackendruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcbackendruntime PUBLIC OpenModelicaRuntimeC)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib::static)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
-target_include_directories(omcbackendruntime INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(omcbackendruntime PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h
+target_include_directories(omcbackendruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(omcbackendruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
 
-
-
-
+# ######################################################################################################################
+# Library: omcgraphstream
+add_library(omcgraphstream STATIC)
+add_library(omc::compiler::graphstream ALIAS omcgraphstream)
 
 set(OMC_GRAPH_STREAM_SOURCES GraphStreamExt_omc.cpp)
-add_library(omcgraphstream STATIC ${OMC_GRAPH_STREAM_SOURCES})
-add_library(omc::compiler::graphstream ALIAS omcgraphstream)
+target_sources(omcgraphstream PRIVATE ${OMC_GRAPH_STREAM_SOURCES})
 
 target_link_libraries(omcgraphstream PUBLIC OpenModelicaRuntimeC)
 target_link_libraries(omcgraphstream PUBLIC omc::3rd::netstream)

--- a/OMCompiler/Parser/.cmake/omc_antlr_target_macros.cmake
+++ b/OMCompiler/Parser/.cmake/omc_antlr_target_macros.cmake
@@ -1,4 +1,4 @@
-macro(ADD_ANTLR_GRAMMAR_TARGET input_file output_dir)
+macro(omc_add_antlr_grammar_target input_file output_dir)
 
   get_filename_component(file_name_no_ext ${input_file} NAME_WE)
   set(output_file_path_no_ext ${output_dir}/${file_name_no_ext}Parser)
@@ -26,10 +26,10 @@ macro(ADD_ANTLR_GRAMMAR_TARGET input_file output_dir)
 
   message(STATUS "added antrl target ${output_file_path_no_ext}")
 
-endmacro(ADD_ANTLR_GRAMMAR_TARGET)
+endmacro(omc_add_antlr_grammar_target)
 
 
-macro(ADD_ANTLR_BASE_LEXER_TARGET input_file output_dir)
+macro(omc_add_antlr_base_lexer_target input_file output_dir)
 
   get_filename_component(file_name_no_ext ${input_file} NAME_WE)
   set(output_file_path_no_ext ${output_dir}/${file_name_no_ext})
@@ -64,4 +64,4 @@ macro(ADD_ANTLR_BASE_LEXER_TARGET input_file output_dir)
   # set(ANTLR_BASE_LEXER_${file_name_no_ext}_OUTPUTS ${output_file_path_no_ext}.c ${output_file_base_path_no_ext}.c)
 
   message(STATUS "added antrl (BaseModelica_Lexer dependent) target ${output_file_path_no_ext}")
-endmacro(ADD_ANTLR_BASE_LEXER_TARGET)
+endmacro(omc_add_antlr_base_lexer_target)

--- a/OMCompiler/Parser/CMakeLists.txt
+++ b/OMCompiler/Parser/CMakeLists.txt
@@ -40,6 +40,9 @@ target_link_libraries(omparse PUBLIC omc::3rd::omantlr3)
 target_link_libraries(omparse PUBLIC OpenModelicaRuntimeC)
 
 
+# # to find the generated antlr headers
+# # SYSTEM to disable warnings on the generated code.
+target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_include_directories(omparse PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h :/
@@ -58,7 +61,7 @@ target_compile_definitions(omparse-boot PRIVATE OMC_BOOTSTRAPPING)
 
 # # to find the generated antlr headers
 # # SYSTEM to disable warnings on the generated code.
-# target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
+target_include_directories(omparse-boot SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse-boot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_include_directories(omparse-boot PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h

--- a/OMCompiler/Parser/CMakeLists.txt
+++ b/OMCompiler/Parser/CMakeLists.txt
@@ -1,56 +1,54 @@
-
 cmake_minimum_required(VERSION 3.14)
-# project(OMParser)
 
 find_package(Java REQUIRED Runtime)
 # omc_add_to_report(Java_JAVA_EXECUTABLE)
 find_package(Intl REQUIRED)
 
-
-
 set(OM_PARSE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/Parser_omc.c)
 
-
-set (GNERATED_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
+set(GNERATED_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${GNERATED_DIRECTORY})
 
-include(omc_antlr_target_macros.cmake)
+include(.cmake/omc_antlr_target_macros.cmake)
 
-ADD_ANTLR_BASE_LEXER_TARGET(${CMAKE_CURRENT_SOURCE_DIR}/Modelica_3_Lexer.g ${GNERATED_DIRECTORY})
+omc_add_antlr_base_lexer_target(${CMAKE_CURRENT_SOURCE_DIR}/Modelica_3_Lexer.g ${GNERATED_DIRECTORY})
 set(OM_PARSE_SOURCES ${OM_PARSE_SOURCES} ${ANTLR_BASE_LEXER_Modelica_3_Lexer_OUTPUT_SOURCES})
 
-ADD_ANTLR_BASE_LEXER_TARGET(${CMAKE_CURRENT_SOURCE_DIR}/ParModelica_Lexer.g ${GNERATED_DIRECTORY})
+omc_add_antlr_base_lexer_target(${CMAKE_CURRENT_SOURCE_DIR}/ParModelica_Lexer.g ${GNERATED_DIRECTORY})
 set(OM_PARSE_SOURCES ${OM_PARSE_SOURCES} ${ANTLR_BASE_LEXER_ParModelica_Lexer_OUTPUT_SOURCES})
 
-ADD_ANTLR_BASE_LEXER_TARGET(${CMAKE_CURRENT_SOURCE_DIR}/MetaModelica_Lexer.g ${GNERATED_DIRECTORY})
+omc_add_antlr_base_lexer_target(${CMAKE_CURRENT_SOURCE_DIR}/MetaModelica_Lexer.g ${GNERATED_DIRECTORY})
 set(OM_PARSE_SOURCES ${OM_PARSE_SOURCES} ${ANTLR_BASE_LEXER_MetaModelica_Lexer_OUTPUT_SOURCES})
 
-ADD_ANTLR_GRAMMAR_TARGET(${CMAKE_CURRENT_SOURCE_DIR}/Modelica.g ${GNERATED_DIRECTORY})
+omc_add_antlr_grammar_target(${CMAKE_CURRENT_SOURCE_DIR}/Modelica.g ${GNERATED_DIRECTORY})
 set(OM_PARSE_SOURCES ${OM_PARSE_SOURCES} ${GNERATED_DIRECTORY}/ModelicaParser.c)
 
-# message(STATUS ${OM_PARSE_SOURCES})
 
-
-######################### add libomparser ###########################
-add_library(omparse STATIC ${OM_PARSE_SOURCES})
+# ######################################################################################################################
+# Library: omparse
+add_library(omparse STATIC)
 add_library(omc::parser ALIAS omparse)
+
+target_sources(omparse PRIVATE ${OM_PARSE_SOURCES})
+
 target_link_libraries(omparse PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omparse PUBLIC omc::compiler::runtime)
 target_link_libraries(omparse PUBLIC omc::3rd::omantlr3)
 target_link_libraries(omparse PUBLIC OpenModelicaRuntimeC)
 
-
-# # to find the generated antlr headers
-# # SYSTEM to disable warnings on the generated code.
+# To find the generated antlr headers. SYSTEM to disable warnings on the generated code.
 target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_include_directories(omparse PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h :/
-######################### end libomparser ###########################
+target_include_directories(omparse PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h :/
 
+# ######################################################################################################################
+# Library: omparse-boot
+add_library(omparse-boot STATIC)
+add_library(omc::parser-boot ALIAS omparse-boot)
 
-######################### add libomparser-boot ###########################
-add_library(omparse-boot STATIC ${OM_PARSE_SOURCES})
+target_sources(omparse-boot PRIVATE ${OM_PARSE_SOURCES})
+
 target_link_libraries(omparse-boot PUBLIC Intl)
 target_link_libraries(omparse-boot PUBLIC omc::compiler::runtime)
 target_link_libraries(omparse-boot PUBLIC omc::3rd::omantlr3)
@@ -59,10 +57,8 @@ target_link_libraries(omparse-boot PUBLIC OpenModelicaRuntimeC)
 # Define OMC_BOOTSTRAPPING for the boot lib.
 target_compile_definitions(omparse-boot PRIVATE OMC_BOOTSTRAPPING)
 
-# # to find the generated antlr headers
-# # SYSTEM to disable warnings on the generated code.
+# To find the generated antlr headers. SYSTEM to disable warnings on the generated code.
 target_include_directories(omparse-boot SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse-boot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_include_directories(omparse-boot PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h
-######################### end libomparser-boot ###########################
+target_include_directories(omparse-boot PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h


### PR DESCRIPTION

@mahge
Refactor and format Compiler/runtime/CMakeLists
5d30aa0

@mahge
Rename generated interface base file to .stamp.
6db7ddd

  - It is used as a baseline for checking if interface of MM file is
    changed. Its timestamp is also used to signify that the interface has
    been checked since the MM file was modified. So stamp is a more
    appropriate extension.

@mahge
Add the generated directory as include directory.
a6743d1

  - The antrl generated files go into a folder in the build tree.
    This was not added to include before. It was working only because the
    normal (autotools, non-cmake) build generated those files in the
    source directory and the header was picked.

  - We add them before the current source directory to make sure that they
    are included even if there are files generated by the normal autotools
    build.

@mahge
Refactor and format Parser/CMakeLists
0f08730

  - The file containing macros is now moved to .cmake directory.
  - macros have been prefixed with omc_

