### PR TITLE
update start values with FocusOut event

### DIFF
--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -423,12 +423,12 @@ bool ElementPropertiesDialog::eventFilter(QObject *pObject, QEvent *pEvent)
 
       if (parameterIndex != -1) {
         QString pParameterLabelText = mParameterLabels.at(parameterIndex)->text();
-        updateStartValues(pParameterLabelText, pLineEdit);
+        restoreDefaultStartValue(pParameterLabelText, pLineEdit);
       }
 
       if (inputIndex != -1) {
         QString pInputLabelText = mInputLabels.at(inputIndex)->text();
-        updateStartValues(pInputLabelText, pLineEdit);
+        restoreDefaultStartValue(pInputLabelText, pLineEdit);
       }
     }
   }
@@ -436,9 +436,10 @@ bool ElementPropertiesDialog::eventFilter(QObject *pObject, QEvent *pEvent)
 }
 
 /*
- * helper function to updateStartValues read from modeldescription.xml
+ * helper function to restore default start values read from modeldescription.xml for fmus
+ * and 0 for other systems
  */
-void ElementPropertiesDialog::updateStartValues(QString pName, QLineEdit * pLineEdit)
+void ElementPropertiesDialog::restoreDefaultStartValue(QString pName, QLineEdit * pLineEdit)
 {
   if (mpComponent->getLibraryTreeItem()->getOMSElement() && mpComponent->getLibraryTreeItem()->getOMSElement()->connectors) {
     oms_connector_t** pInterfaces = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
@@ -446,11 +447,11 @@ void ElementPropertiesDialog::updateStartValues(QString pName, QLineEdit * pLine
       QString nameStructure = QString("%1.%2").arg(mpComponent->getLibraryTreeItem()->getNameStructure(), QString(pInterfaces[i]->name));
       if (pInterfaces[i]->causality == oms_causality_parameter && QString(pInterfaces[i]->name)== pName) {
         OMSProxy::instance()->omsDelete(nameStructure + ":start");
-        updateStartValuesHelper(pInterfaces[i], nameStructure, pLineEdit);
+        restoreDefaultStartValueHelper(pInterfaces[i], nameStructure, pLineEdit);
         break;
       } else if (pInterfaces[i]->causality == oms_causality_input && QString(pInterfaces[i]->name)== pName) {
         OMSProxy::instance()->omsDelete(nameStructure + ":start");
-        updateStartValuesHelper(pInterfaces[i], nameStructure, pLineEdit);
+        restoreDefaultStartValueHelper(pInterfaces[i], nameStructure, pLineEdit);
         break;
       }
     }
@@ -458,9 +459,10 @@ void ElementPropertiesDialog::updateStartValues(QString pName, QLineEdit * pLine
 }
 
 /*
- * helper function to updateStartValues read from modeldescription.xml
+ * helper function to restore default start values read from modeldescription.xml for fmus
+ * and 0 for other systems
  */
-void ElementPropertiesDialog::updateStartValuesHelper(oms_connector_t* pConnector, QString pName, QLineEdit *pLineEdit)
+void ElementPropertiesDialog::restoreDefaultStartValueHelper(oms_connector_t* pConnector, QString pName, QLineEdit *pLineEdit)
 {
   bool status = false;
   if (pConnector->type == oms_signal_type_real) {

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -489,5 +489,4 @@ void ElementPropertiesDialog::deleteStartValueAndRestoreDefault(const QString na
   if (!status) {
     pLineEdit->setPlaceholderText("unknown");
   }
-  return;
 }

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -448,11 +448,11 @@ void ElementPropertiesDialog::restoreDefaultStartValue(QString pName, QLineEdit 
       if (pInterfaces[i]->causality == oms_causality_parameter && QString(pInterfaces[i]->name)== pName) {
         OMSProxy::instance()->omsDelete(nameStructure + ":start");
         restoreDefaultStartValueHelper(pInterfaces[i], nameStructure, pLineEdit);
-        break;
+        return;
       } else if (pInterfaces[i]->causality == oms_causality_input && QString(pInterfaces[i]->name)== pName) {
         OMSProxy::instance()->omsDelete(nameStructure + ":start");
         restoreDefaultStartValueHelper(pInterfaces[i], nameStructure, pLineEdit);
-        break;
+        return;
       }
     }
   }

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -439,13 +439,13 @@ bool ElementPropertiesDialog::eventFilter(QObject *pObject, QEvent *pEvent)
  * helper function to restore default start values read from modeldescription.xml for fmus
  * and 0 for other systems
  */
-void ElementPropertiesDialog::deleteStartValueAndRestoreDefault(QString pName, QLineEdit * pLineEdit)
+void ElementPropertiesDialog::deleteStartValueAndRestoreDefault(const QString name, QLineEdit * pLineEdit)
 {
   if (mpComponent->getLibraryTreeItem()->getOMSElement() && mpComponent->getLibraryTreeItem()->getOMSElement()->connectors) {
     oms_connector_t** pInterfaces = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
     for (int i = 0 ; pInterfaces[i] ; i++) {
       QString nameStructure = QString("%1.%2").arg(mpComponent->getLibraryTreeItem()->getNameStructure(), QString(pInterfaces[i]->name));
-      if (QString(pInterfaces[i]->name).compare(pName) == 0) {
+      if (QString(pInterfaces[i]->name).compare(name) == 0) {
         if (oms_causality_parameter == pInterfaces[i]->causality || oms_causality_input == pInterfaces[i]->causality) {
           OMSProxy::instance()->omsDelete(nameStructure + ":start");
           //restoreDefaultStartValueHelper(pInterfaces[i], nameStructure, pLineEdit);

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -450,35 +450,39 @@ bool ElementPropertiesDialog::eventFilter(QObject *pObject, QEvent *pEvent)
  */
 void ElementPropertiesDialog::deleteStartValueAndRestoreDefault(const QString name, QLineEdit * pLineEdit)
 {
-  oms_connector_t** pInterfaces = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
+  oms_connector_t** pConnectors = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
   int i=0;
-  while (pInterfaces[i] && QString(pInterfaces[i]->name).compare(name) != 0) {
+  while (pConnectors[i] && QString(pConnectors[i]->name).compare(name) != 0) {
     i++;
   }
 
-  if (!pInterfaces[i]) {
+  // no element found
+  if (!pConnectors[i]) {
     return;
   }
 
-  if (oms_causality_parameter != pInterfaces[i]->causality && oms_causality_input != pInterfaces[i]->causality) {
+  auto& pConnector = pConnectors[i];
+
+  // only considering parameters and inputs
+  if (oms_causality_parameter != pConnector->causality && oms_causality_input != pConnector->causality) {
     return;
   }
 
-  QString nameStructure = QString("%1.%2").arg(mpComponent->getLibraryTreeItem()->getNameStructure(), QString(pInterfaces[i]->name));
+  QString nameStructure = QString("%1.%2").arg(mpComponent->getLibraryTreeItem()->getNameStructure(), QString(pConnector->name));
   OMSProxy::instance()->omsDelete(nameStructure + ":start");
 
   bool status = false;
-  if (pInterfaces[i]->type == oms_signal_type_real) {
+  if (pConnector->type == oms_signal_type_real) {
     double value;
     if ((status = OMSProxy::instance()->getReal(nameStructure, &value))) {
       pLineEdit->setText(QString::number(value));
     }
-  } else if (pInterfaces[i]->type == oms_signal_type_integer) {
+  } else if (pConnector->type == oms_signal_type_integer) {
     int value;
     if ((status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
       pLineEdit->setText(QString::number(value));
     }
-  } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
+  } else if (pConnector->type == oms_signal_type_boolean) {
     bool value;
     if ((status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
       pLineEdit->setText(QString::number(value));

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.cpp
@@ -415,23 +415,32 @@ bool ElementPropertiesDialog::eventFilter(QObject *pObject, QEvent *pEvent)
 {
   QLineEdit *pLineEdit = qobject_cast<QLineEdit*>(pObject);
 
-  if (pLineEdit && pEvent->type() == QEvent::FocusOut) {
-    if (pLineEdit->text().isEmpty()) {
-      // search the lineEdit index in parameters or inputs
-      int parameterIndex = mParameterLineEdits.indexOf(pLineEdit);
-      int inputIndex = mInputLineEdits.indexOf(pLineEdit);
-
-      if (parameterIndex != -1) {
-        QString parameterLabelText = mParameterLabels.at(parameterIndex)->text();
-        deleteStartValueAndRestoreDefault(parameterLabelText, pLineEdit);
-      }
-
-      if (inputIndex != -1) {
-        QString inputLabelText = mInputLabels.at(inputIndex)->text();
-        deleteStartValueAndRestoreDefault(inputLabelText, pLineEdit);
-      }
-    }
+  if (pLineEdit && pEvent->type() != QEvent::FocusOut) {
+    return QWidget::eventFilter(pObject, pEvent);
   }
+
+  if (!pLineEdit->text().isEmpty()) {
+    return QWidget::eventFilter(pObject, pEvent);
+  }
+
+  if (!mpComponent->getLibraryTreeItem()->getOMSElement() || !mpComponent->getLibraryTreeItem()->getOMSElement()->connectors) {
+    return QWidget::eventFilter(pObject, pEvent);
+  }
+
+  // search the lineEdit index in parameters
+  int parameterIndex = mParameterLineEdits.indexOf(pLineEdit);
+  if (parameterIndex != -1) {
+    QString parameterLabelText = mParameterLabels.at(parameterIndex)->text();
+    deleteStartValueAndRestoreDefault(parameterLabelText, pLineEdit);
+  }
+
+  // search the lineEdit index in inputs
+  int inputIndex = mInputLineEdits.indexOf(pLineEdit);
+  if (inputIndex != -1) {
+    QString inputLabelText = mInputLabels.at(inputIndex)->text();
+    deleteStartValueAndRestoreDefault(inputLabelText, pLineEdit);
+  }
+
   return QWidget::eventFilter(pObject, pEvent);
 }
 
@@ -441,45 +450,44 @@ bool ElementPropertiesDialog::eventFilter(QObject *pObject, QEvent *pEvent)
  */
 void ElementPropertiesDialog::deleteStartValueAndRestoreDefault(const QString name, QLineEdit * pLineEdit)
 {
-  if (mpComponent->getLibraryTreeItem()->getOMSElement() && mpComponent->getLibraryTreeItem()->getOMSElement()->connectors) {
-    oms_connector_t** pInterfaces = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
-    for (int i = 0 ; pInterfaces[i] ; i++) {
-      QString nameStructure = QString("%1.%2").arg(mpComponent->getLibraryTreeItem()->getNameStructure(), QString(pInterfaces[i]->name));
-      if (QString(pInterfaces[i]->name).compare(name) == 0) {
-        if (oms_causality_parameter == pInterfaces[i]->causality || oms_causality_input == pInterfaces[i]->causality) {
-          OMSProxy::instance()->omsDelete(nameStructure + ":start");
-          //restoreDefaultStartValueHelper(pInterfaces[i], nameStructure, pLineEdit);
-          bool status = false;
-          if (pInterfaces[i]->type == oms_signal_type_real) {
-            double value;
-            if ((status = OMSProxy::instance()->getReal(nameStructure, &value))) {
-              pLineEdit->setText(QString::number(value));
-            }
-          } else if (pInterfaces[i]->type == oms_signal_type_integer) {
-            int value;
-            if ((status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
-              pLineEdit->setText(QString::number(value));
-            }
-          } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
-            bool value;
-            if ((status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
-              pLineEdit->setText(QString::number(value));
-            }
-          } else if (pInterfaces[i]->type == oms_signal_type_string) {
-            qDebug() << "ElementPropertiesDialog::ElementPropertiesDialog() oms_signal_type_string not implemented yet.";
-          } else if (pInterfaces[i]->type == oms_signal_type_enum) {
-            qDebug() << "ElementPropertiesDialog::ElementPropertiesDialog() oms_signal_type_enum not implemented yet.";
-          } else if (pInterfaces[i]->type == oms_signal_type_bus) {
-            qDebug() << "ElementPropertiesDialog::ElementPropertiesDialog() oms_signal_type_bus not implemented yet.";
-          } else {
-            qDebug() << "ElementPropertiesDialog::ElementPropertiesDialog() unknown oms_signal_type_enu_t.";
-          }
-          if (!status) {
-            pLineEdit->setPlaceholderText("unknown");
-          }
-          return;
-        }
-      }
-    }
+  oms_connector_t** pInterfaces = mpComponent->getLibraryTreeItem()->getOMSElement()->connectors;
+  int i=0;
+  while (pInterfaces[i] && QString(pInterfaces[i]->name).compare(name) != 0) {
+    i++;
   }
+
+  if (!pInterfaces[i]) {
+    return;
+  }
+
+  if (oms_causality_parameter != pInterfaces[i]->causality && oms_causality_input != pInterfaces[i]->causality) {
+    return;
+  }
+
+  QString nameStructure = QString("%1.%2").arg(mpComponent->getLibraryTreeItem()->getNameStructure(), QString(pInterfaces[i]->name));
+  OMSProxy::instance()->omsDelete(nameStructure + ":start");
+
+  bool status = false;
+  if (pInterfaces[i]->type == oms_signal_type_real) {
+    double value;
+    if ((status = OMSProxy::instance()->getReal(nameStructure, &value))) {
+      pLineEdit->setText(QString::number(value));
+    }
+  } else if (pInterfaces[i]->type == oms_signal_type_integer) {
+    int value;
+    if ((status = OMSProxy::instance()->getInteger(nameStructure, &value))) {
+      pLineEdit->setText(QString::number(value));
+    }
+  } else if (pInterfaces[i]->type == oms_signal_type_boolean) {
+    bool value;
+    if ((status = OMSProxy::instance()->getBoolean(nameStructure, &value))) {
+      pLineEdit->setText(QString::number(value));
+    }
+  } else {
+    qDebug() << "ElementPropertiesDialog::deleteStartValueAndRestoreDefault() unknown signal type";
+  }
+  if (!status) {
+    pLineEdit->setPlaceholderText("unknown");
+  }
+  return;
 }

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
@@ -41,6 +41,7 @@ class ElementPropertiesDialog : public QDialog
   Q_OBJECT
 public:
   ElementPropertiesDialog(Element *pComponent, QWidget *pParent = 0);
+  bool eventFilter(QObject *pObject, QEvent *pEvent);
 private:
   Element *mpComponent;
   Label *mpHeading;
@@ -91,6 +92,8 @@ private:
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;
+  void updateStartValues(QString pName, QLineEdit * pLineEdit);
+  void updateStartValuesHelper(oms_connector_t* pConnector, QString pName, QLineEdit * pLineEdit);
 private slots:
   void updateProperties();
 };

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
@@ -92,8 +92,7 @@ private:
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;
-  void restoreDefaultStartValue(QString pName, QLineEdit * pLineEdit);
-  void restoreDefaultStartValueHelper(oms_connector_t* pConnector, QString pName, QLineEdit * pLineEdit);
+  void deleteStartValueAndRestoreDefault(QString pName, QLineEdit * pLineEdit);
 private slots:
   void updateProperties();
 };

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
@@ -92,7 +92,7 @@ private:
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;
-  void deleteStartValueAndRestoreDefault(QString pName, QLineEdit * pLineEdit);
+  void deleteStartValueAndRestoreDefault(const QString name, QLineEdit * pLineEdit);
 private slots:
   void updateProperties();
 };

--- a/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
+++ b/OMEdit/OMEditLIB/OMS/ElementPropertiesDialog.h
@@ -92,8 +92,8 @@ private:
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;
-  void updateStartValues(QString pName, QLineEdit * pLineEdit);
-  void updateStartValuesHelper(oms_connector_t* pConnector, QString pName, QLineEdit * pLineEdit);
+  void restoreDefaultStartValue(QString pName, QLineEdit * pLineEdit);
+  void restoreDefaultStartValueHelper(oms_connector_t* pConnector, QString pName, QLineEdit * pLineEdit);
 private slots:
   void updateProperties();
 };


### PR DESCRIPTION
### Purpose

This PR implements the functionality to update start values from `modeldescription.xml` in `parameter and input QlineEdit` when a focus out event is detected and the text is empty.