### PR TITLE
Export compile commands from configuration.

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -13,6 +13,16 @@ set(OPENMODELICA_NEW_CMAKE_BUILD ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/.cmake/")
 include(omc_utils)
 
+# Add the compiler ids to the report for convenience.
+omc_add_to_report(CMAKE_CXX_COMPILER_ID)
+omc_add_to_report(CMAKE_C_COMPILER_ID)
+
+# Export compile commands (compile_commands.json) for each source file. This helps editors (e.g. vscode, emacs) have
+# a more accurate code navigation and intelisens. E.g includes can be pinpointed instead of
+# using glob expressions to parse everything.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING
       "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
@@ -40,10 +50,6 @@ omc_add_to_report(OMC_USE_CORBA)
 
 option(OMC_USE_CCACHE "Use ccache to speedup compilations." ON)
 omc_add_to_report(OMC_USE_CCACHE)
-
-
-
-
 
 
 

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -37,6 +37,14 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 omc_add_to_report(CMAKE_INSTALL_PREFIX)
 
+include(WriteCompilerDetectionHeader)
+write_compiler_detection_header(
+  FILE omc_compiler_detection.h
+  PREFIX OMC
+  COMPILERS GNU Clang MSVC
+  FEATURES cxx_static_assert
+)
+
 
 # Set the installation lib directory as an rpath for all installed
 # libs and executables.

--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -262,8 +262,6 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/SynchronousFeatures.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/Tearing.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/Uncertainties.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/UnitCheck.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/Unit.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/Vectorization.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/VisualXML.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/BackEnd/XMLDump.mo
@@ -442,10 +440,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableExpToIndexExp.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableCrToExpSourceTpl.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableCrToCrEqLst.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableCrToUnit.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableSimCodeEqCache.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableStringToUnit.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableUnitToString.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/PriorityQueue.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/SBAtomicSet.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/SBFunctions.mo

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -181,7 +181,7 @@ target_link_libraries(OpenModelicaCompiler PUBLIC omc::parser)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::runtime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::backendruntime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::graphstream)
-target_link_libraries(OpenModelicaCompiler PUBLIC OpenModelicaRuntimeC)
+target_link_libraries(OpenModelicaCompiler PUBLIC omc::simrt::runtime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::3rd::modelica_external_c)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::3rd::modelica_io)
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
 target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
-target_link_libraries(omcruntime PUBLIC OpenModelicaRuntimeC)
+target_link_libraries(omcruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcruntime PUBLIC omc::3rd::lpsolve55)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
@@ -108,7 +108,7 @@ set(OMC_BACKENDRUNTIIME_SOURCES
 target_sources(omcbackendruntime PRIVATE ${OMC_BACKENDRUNTIIME_SOURCES})
 
 target_link_libraries(omcbackendruntime PUBLIC ${Intl_LIBRARIES})
-target_link_libraries(omcbackendruntime PUBLIC OpenModelicaRuntimeC)
+target_link_libraries(omcbackendruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib::static)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
@@ -123,5 +123,5 @@ add_library(omc::compiler::graphstream ALIAS omcgraphstream)
 set(OMC_GRAPH_STREAM_SOURCES GraphStreamExt_omc.cpp)
 target_sources(omcgraphstream PRIVATE ${OMC_GRAPH_STREAM_SOURCES})
 
-target_link_libraries(omcgraphstream PUBLIC OpenModelicaRuntimeC)
+target_link_libraries(omcgraphstream PUBLIC omc::simrt::runtime)
 target_link_libraries(omcgraphstream PUBLIC omc::3rd::netstream)

--- a/OMCompiler/Parser/CMakeLists.txt
+++ b/OMCompiler/Parser/CMakeLists.txt
@@ -33,8 +33,8 @@ target_sources(omparse PRIVATE ${OM_PARSE_SOURCES})
 
 target_link_libraries(omparse PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omparse PUBLIC omc::compiler::runtime)
+target_link_libraries(omparse PUBLIC omc::simrt::runtime)
 target_link_libraries(omparse PUBLIC omc::3rd::omantlr3)
-target_link_libraries(omparse PUBLIC OpenModelicaRuntimeC)
 
 # To find the generated antlr headers. SYSTEM to disable warnings on the generated code.
 target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
@@ -51,8 +51,8 @@ target_sources(omparse-boot PRIVATE ${OM_PARSE_SOURCES})
 
 target_link_libraries(omparse-boot PUBLIC Intl)
 target_link_libraries(omparse-boot PUBLIC omc::compiler::runtime)
+target_link_libraries(omparse-boot PUBLIC omc::simrt::runtime)
 target_link_libraries(omparse-boot PUBLIC omc::3rd::omantlr3)
-target_link_libraries(omparse-boot PUBLIC OpenModelicaRuntimeC)
 
 # Define OMC_BOOTSTRAPPING for the boot lib.
 target_compile_definitions(omparse-boot PRIVATE OMC_BOOTSTRAPPING)

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -31,7 +31,7 @@ endif(WIN32)
 
 target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
 
-target_include_directories(OpenModelicaRuntimeC INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(OpenModelicaRuntimeC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.14)
 
 project(SimulationRuntimeC)
 
-
 file(GLOB OMC_SIMRT_UTIL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/util/*.c)
 file(GLOB OMC_SIMRT_UTIL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/util/*.h)
 
@@ -15,34 +14,27 @@ file(GLOB OMC_SIMRT_GC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/gc/*.h)
 file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
 file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 
+# ######################################################################################################################
+# Library: OpenModelicaRuntimeC
+add_library(OpenModelicaRuntimeC STATIC)
+add_library(omc::simrt::runtime ALIAS OpenModelicaRuntimeC)
 
-set(libOpenModelicaRuntimeC_BUILD_TYPE STATIC CACHE STRING "Type of OpenModelicaRuntimeC to build")
-omc_add_to_report(libOpenModelicaRuntimeC_BUILD_TYPE)
-
-add_library(OpenModelicaRuntimeC ${libOpenModelicaRuntimeC_BUILD_TYPE}
-                                    ${OMC_SIMRT_UTIL_SOURCES}
-                                    ${OMC_SIMRT_META_SOURCES}
-                                    ${OMC_SIMRT_GC_SOURCES})
+target_sources(OpenModelicaRuntimeC PRIVATE ${OMC_SIMRT_UTIL_SOURCES} ${OMC_SIMRT_META_SOURCES} ${OMC_SIMRT_GC_SOURCES})
+target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
 
 if(WIN32)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC dbghelp)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC regex)
 endif(WIN32)
 
-target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
-
 target_include_directories(OpenModelicaRuntimeC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+# ######################################################################################################################
+# Library: OpenModelicaFMIRuntimeC
+add_library(OpenModelicaFMIRuntimeC STATIC ${OMC_SIMRT_FMI_SOURCES})
+add_library(omc::simrt::fmiruntime ALIAS OpenModelicaFMIRuntimeC)
 
-
-set(libOpenModelicaFMIRuntimeC_BUILD_TYPE STATIC CACHE STRING "Type of OpenModelicaFMIRuntimeC to build" FORCE)
-omc_add_to_report(libOpenModelicaFMIRuntimeC_BUILD_TYPE)
-
-add_library(OpenModelicaFMIRuntimeC ${libOpenModelicaFMIRuntimeC_BUILD_TYPE}
-                                    ${OMC_SIMRT_FMI_SOURCES})
-
+target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES})
 
 target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib::static)
-target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC OpenModelicaRuntimeC)
-target_compile_options(OpenModelicaFMIRuntimeC PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Werror=implicit-function-declaration>)
-
+target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::simrt::runtime)


### PR DESCRIPTION

@mahge
Export compile commands from configuration.
2264e0c

  - This file can be used by editors helps editors (e.g. vscode, emacs)
    to have a more accurate code navigation and intellisense. e.g. includes
    can be pinpointed instead of using glob expressions to parse everything.

@mahge
Write out a compiler detection header.
285b8dc

  - We will use this for portability purposes. E.g. functions that differ
    in naming or usage can be normalized to omc_ functions using this header
    as a base.

  - Hopefully we can update our sources without breaking much to use the
    defines in this file instead of bare _MSC_VER like checks.

@mahge
Refactor and format SimulationRuntime/c cmakefile.
ad5970c

  - Provide and use aliases for libraries in built in SimulationRuntime/c.

  - Remove the option to build these libraries as shared. There is no point
    in building our runtime libs as shared libs.

@mahge
Remove source files removed by #6771.
be0b08f
