### PR TITLE
do not force CFLAGS (#5307)

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -13,7 +13,7 @@ else # new OMDev, use clang
 	CXX = clang++
 endif
 
-CFLAGS=-g -O2
+# CFLAGS=-g -O2
 
 defaultMakefileTarget = Makefile.omdev.mingw
 REALPATH = $(realpath .)
@@ -59,61 +59,61 @@ all: omc testsuite-depends omlibrary-core
 
 omc:
 	echo "Selected compiler: CC=$(CC), CXX=$(CXX)"
-	$(MAKE) -f $(defaultMakefileTarget) -C OMCompiler OMBUILDDIR=$(OMBUILDDIR) OMENCRYPTION=$(OMENCRYPTION) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -f $(defaultMakefileTarget) -C OMCompiler OMBUILDDIR=$(OMBUILDDIR) OMENCRYPTION=$(OMENCRYPTION) CC="$(CC)" CXX="$(CXX)"
 
 omc-diff:
-	$(MAKE) -C testsuite/ -f Makefile omc-diff OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C testsuite/ -f Makefile omc-diff OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 ReferenceFiles:
 	$(MAKE) -C testsuite/ReferenceFiles
 libs-for-testing: omc
 	$(MAKE) -C testsuite/libraries-for-testing/
 testsuite-depends: omc-diff ReferenceFiles libs-for-testing omsimulator
 test: testsuite-depends
-	$(MAKE) omc-diff CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) omc-diff CC="$(CC)" CXX="$(CXX)"
 	cd testsuite/partest && echo "Running all $(./runtests.pl -counttests) tests"
 	cd testsuite/partest && ./runtests.pl -with-txt
 fast-test: testsuite-depends
-	$(MAKE) omc-diff CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) omc-diff CC="$(CC)" CXX="$(CXX)"
 	cd testsuite/partest && echo "Running $(./runtests.pl -f -counttests) fast tests"
 	cd testsuite/partest && ./runtests.pl -f -with-txt
 
 omlibrary-core:
-	$(MAKE) -C libraries BUILD_DIR=$(OMBUILDDIR)/lib/omlibrary core CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C libraries BUILD_DIR=$(OMBUILDDIR)/lib/omlibrary core CC="$(CC)" CXX="$(CXX)"
 
 omlibrary-all:
-	$(MAKE) -C libraries BUILD_DIR=$(OMBUILDDIR)/lib/omlibrary all CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C libraries BUILD_DIR=$(OMBUILDDIR)/lib/omlibrary all CC="$(CC)" CXX="$(CXX)"
 
 omplot: omc qtclientsDLLs
-	$(MAKE) -C OMPlot -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C OMPlot -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omedit: omparser omplot omsimulator qtclientsDLLs
-	$(MAKE) -f $(defaultMakefileTarget) -C OMEdit OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -f $(defaultMakefileTarget) -C OMEdit OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omedit-testsuite: omedit testsuite-depends
 	$(MAKE) -f $(defaultMakefileTarget) -C OMEdit/Testsuite OMBUILDDIR=$(OMBUILDDIR)
 
 omparser:
-	$(MAKE) -C OMParser OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C OMParser OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omsimulator:
-	$(MAKE) -C OMSimulator config-3rdParty CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
-	$(MAKE) -C OMSimulator config-OMSimulator OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
-	$(MAKE) -C OMSimulator OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C OMSimulator config-3rdParty CC="$(CC)" CXX="$(CXX)"
+	$(MAKE) -C OMSimulator config-OMSimulator OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
+	$(MAKE) -C OMSimulator OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omnotebook: omc omplot qtclientsDLLs
-	$(MAKE) -f $(defaultMakefileTarget) -C OMNotebook/OMNotebook/OMNotebookGUI OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -f $(defaultMakefileTarget) -C OMNotebook/OMNotebook/OMNotebookGUI OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omshell: omc qtclientsDLLs
-	$(MAKE) -f $(defaultMakefileTarget) -C OMShell/OMShell/OMShellGUI OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -f $(defaultMakefileTarget) -C OMShell/OMShell/OMShellGUI OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omoptim: omc omplot qtclientsDLLs
-	$(MAKE) -f $(defaultMakefileTarget) -C OMOptim OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -f $(defaultMakefileTarget) -C OMOptim OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 omsens:
 	cp -rfp OMSens $(OMBUILDDIR)
 
 omsens_qt:
-	$(MAKE) -f $(defaultMakefileTarget) -C OMSens_Qt OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -f $(defaultMakefileTarget) -C OMSens_Qt OMBUILDDIR=$(OMBUILDDIR) CC="$(CC)" CXX="$(CXX)"
 
 qtclients: omplot omedit omnotebook omshell omoptim omsens_qt
 
@@ -239,10 +239,10 @@ runtimeCPPmsvcinstall:
 	$(MAKE) -C OMCompiler -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) BUILDTYPE=$(BUILDTYPE) runtimeCPPmsvcinstall
 
 runtimeCPPinstall: OMSICPPinstall
-	$(MAKE) -C OMCompiler -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) BUILDTYPE=$(BUILDTYPE) runtimeCPPinstall CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C OMCompiler -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) BUILDTYPE=$(BUILDTYPE) runtimeCPPinstall CC="$(CC)" CXX="$(CXX)"
 
 OMSICPPinstall:
-	$(MAKE) -C OMCompiler -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) BUILDTYPE=$(BUILDTYPE) OMSICPPinstall CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)"
+	$(MAKE) -C OMCompiler -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) BUILDTYPE=$(BUILDTYPE) OMSICPPinstall CC="$(CC)" CXX="$(CXX)"
 
 all-runtimes:
 	$(MAKE) -C OMCompiler -f $(defaultMakefileTarget) OMBUILDDIR=$(OMBUILDDIR) BUILDTYPE=$(BUILDTYPE) runtimeCPPinstall runtimeCPPmsvcinstall simulationruntimecmsvc

--- a/OMEdit/OMEditLIB/Debugger/Attach/ProcessListModel.cpp
+++ b/OMEdit/OMEditLIB/Debugger/Attach/ProcessListModel.cpp
@@ -114,11 +114,7 @@ QList<ProcessItem> ProcessListModel::getLocalProcesses()
     ProcessItem p;
     p.mProcessId = pe.th32ProcessID;
     // Image has the absolute path, but can fail.
-#if defined(__MINGW32__)
-    p.mProcessName = QString(pe.szExeFile);
-#else
     p.mProcessName = QString::fromWCharArray(pe.szExeFile);
-#endif
     const QString image = imageName(pe.th32ProcessID);
     p.mProcessPath = image.isEmpty() ? p.mProcessName : image;
     processes << p;


### PR DESCRIPTION
forcing CFLAGS from top level makefile will
- break qt clients badly (segfaults with corrupted stack)
- override some flags that it shouldn't
  (some functions would use char* instead of wchar*)