### PR TITLE
Fix mod calculation for integer negative divisor

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/Core/Math/Functions.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/Core/Math/Functions.h
@@ -35,12 +35,13 @@ inline static int sgn(const double& c)
     return (c < 0) ? -1 : ((c == 0) ? 0 : 1);
 }
 
-/// Definition of Signum function
 double BOOST_EXTENSION_EXPORT_DECL division(const double& a, const double& b, bool throwEx, const char* text);
 
+/// Provides the modulus as defined in modelica (same sign as v2 and abs smaller than abs(v2))
 inline static int modelica_mod_int(int v1, int v2)
 {
-    return v1 % v2;
+    int tmp = v1 % v2;
+    return ((v2 > 0 && tmp < 0) || (v2 < 0 && tmp > 0)) ? (tmp + v2) : tmp;
 }
 
 inline static double semiLinear(double x, double positiveSlope, double negativeSlope)
@@ -86,7 +87,7 @@ inline static double euclidNorm(const int& length, const int* vector)
     return (sqrt((double)value));
 }
 
-/// Provides the scaled  errornorm (see Hairer, Norsett und Wanner; Section II.4 )
+/// Provides the scaled errornorm (see Hairer, Norsett und Wanner; Section II.4 )
 inline static double scaledErrNorm(const int& length, const double* vector, const double* tol)
 {
     double value = 0.0;

--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/Core/Math/Utility.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/Core/Math/Utility.h
@@ -49,9 +49,12 @@ static inline double modelica_mod_double(double x, double y)
     return (x - (floor(x / y) * y));
 }
 
+/* operator % in C++ does not work in the same way as mod defined by modelica, so
+ * we need to define our own mod. */
 static inline int modelica_mod_integer(int x, int y)
 {
-    return x % y;
+    int res = x % y;
+    return ((y > 0 && res < 0) || (y < 0 && res > 0)) ? (res + y) : res;
 }
 
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1402,8 +1402,8 @@ modelica_integer _event_mod_integer(modelica_integer x1, modelica_integer x2, mo
     data->simulationInfo->mathEventsValuePre[index] = (modelica_real)x1;
     data->simulationInfo->mathEventsValuePre[index+1] = (modelica_real)x2;
   }
-
-  return x1 - (x1 / x2) * x2;
+  modelica_integer tmp = x1 % x2;
+  return ((x2 > 0 && tmp < 0) || (x2 < 0 && tmp > 0)) ? (tmp + x2) : tmp;
 }
 
 /*! \fn _event_mod_real

--- a/OMCompiler/SimulationRuntime/c/util/utility.h
+++ b/OMCompiler/SimulationRuntime/c/util/utility.h
@@ -134,10 +134,11 @@ static inline modelica_real modelica_real_mod(modelica_real x, modelica_real y)
   return x-floor(x/y)*y;
 }
 
+/* Returns res such that 0 <= abs(res) < abs(y) and res has the same sign as y */
 static inline modelica_integer modelica_integer_mod(modelica_integer x, modelica_integer y)
 {
-  modelica_integer res = x%y;
-  return res < 0 ? res+y : res /* % returns the remainder, which might be negative */;
+  modelica_integer res = x % y;
+  return ((y > 0 && res < 0) || (y < 0 && res > 0)) ? (res + y) : res;
 }
 
 #endif

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/Functions.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/Functions.h
@@ -40,9 +40,11 @@ inline static int sgn (const double &c)
 /// Definition of Signum function
 double BOOST_EXTENSION_EXPORT_DECL division (const double &a,const double &b, bool throwEx,const char * text);
 
+/// Provides the modulus as defined in modelica (same sign as v2 and abs smaller than abs(v2))
 inline static int modelica_mod_int(int v1, int v2)
 {
-    return v1 % v2;
+    int tmp = v1 % v2;
+    return ((v2 > 0 && tmp < 0) || (v2 < 0 && tmp > 0)) ? (tmp + v2) : tmp;
 }
 
 inline static double semiLinear(double x,double positiveSlope,double negativeSlope)

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/Utility.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/Utility.h
@@ -48,9 +48,12 @@ static inline double modelica_mod_double(double x, double y)
   return (x - (floor(x/y) * y));
 }
 
+/* operator % in C++ does not work in the same way as mod defined by modelica, so
+ * we need to define our own mod. */
 static inline int modelica_mod_integer(int x, int y)
 {
-  return x % y;
+  int tmp = x % y;
+  return ((y > 0 && tmp < 0) || (y < 0 && tmp > 0)) ? (tmp + y) : tmp;
 }
 
 


### PR DESCRIPTION
According to the specification 3.7.1.1 the modulus has the same sign as the divisor. Unfortunately the % operator in C and C++ works in a different way. Basically division trunkates towards zero instead of rounding down towards negative infinity. So we need to manually check that the result is in the correct range.