### PR TITLE
Treat modelica_fnptr as metatype for for loop iter

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -3417,6 +3417,7 @@ match stmt
 case STMT_FOR(__) then
   let iterType = match expType(type_, iterIsArray)
     case "modelica_string" then "modelica_metatype"
+    case "modelica_fnptr" then "modelica_metatype"
     case s then s
   let arrayType = expTypeArray(type_)
   let tvar = match iterType


### PR DESCRIPTION
  - The proper fix might be to actually wrap T_FUNCTION_REFERENCE_VAR in
    DAE.T_METATYPE.
    This works for now. Let's what the CI says.