### PR TITLE
[BE] do not remove initial() in simulation system

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -2686,10 +2686,6 @@ algorithm
     local
       DAE.Exp e1, e2, e3, actual, simplified;
 
-    // replace initial() with false
-    case (DAE.CALL(path=Absyn.IDENT(name="initial")), _)
-    then (DAE.BCONST(false), inUseHomotopy);
-
     // replace homotopy(actual, simplified) with actual
     case (DAE.CALL(path=Absyn.IDENT(name="homotopy"), expLst=actual::_::_), _)
     then (actual, true);


### PR DESCRIPTION
 - fixes ticket #6186
 - the simulation system is once called on time=0 and should still consider initial() to be true so it has to be kept