### PR TITLE
Normalize array get functions.

### DIFF
--- a/.CI/compliance.failures
+++ b/.CI/compliance.failures
@@ -1,7 +1,6 @@
 ModelicaCompliance.Algorithms.For.RealRange
 ModelicaCompliance.Algorithms.For.ShadowedIterator
 ModelicaCompliance.Algorithms.For.StringRange
-ModelicaCompliance.Algorithms.For.VarArrayRange
 ModelicaCompliance.Arrays.Functions.Size.ArrayDimSize4
 ModelicaCompliance.Arrays.Indexing.EnumArrayInvalidIndexing
 ModelicaCompliance.Classes.Balancing.CorrectBalance3

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5293,7 +5293,7 @@ template daeExpCrefRhsFunContext(Exp ecr, Context context, Text &preExp,
                     >>
                   else
                     <<
-                    (*<%arrayType%>_element_addr<%match listLength(crefSubs(cr)) case 1 case 2 then subsLenStr%>(&<%arrName%>, <%subsLenStr%>, <%subsValuesStr%>))
+                    <%arrayType%>_get<%match listLength(crefSubs(cr)) case 1 case 2 then subsLenStr%>(<%arrName%>, <%subsLenStr%>, <%subsValuesStr%>)
                     >>
               case FUNCTION_CONTEXT(__) then
                 <<

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -2224,7 +2224,7 @@ case var as VARIABLE(__) then
     let &preExp = buffer ""
     let params = (arr.array |> e hasindex i1 fromindex 1 =>
       let prefix = if arr.scalar then '(<%expTypeFromExpModelica(e)%>)' else '&'
-      '(*((<%rec_name%>*)generic_array_element_addr1(&<%varName%>, sizeof(<%rec_name%>), <%i1%>))) = <%prefix%><%daeExp(e, contextFunction, &preExp, &varDecls, &auxFunction)%>;'
+      '<%rec_name%>_array_get(<%varName%>, 1, <%i1%>) = <%prefix%><%daeExp(e, contextFunction, &preExp, &varDecls, &auxFunction)%>;'
     ;separator="\n")
     <<
     <%preExp%>
@@ -4598,7 +4598,7 @@ template contextCrefOld(ComponentRef cr, Context context, Text &auxFunction, Int
       let dimsLenStr = listLength(crefSubs(cr))
       let dimsValuesStr = (crefSubs(cr) |> INDEX(__) => daeSubscriptExp(exp, context, &preExp, &varDecls, &auxFunction) ; separator=", ")
       <<
-      ((<%rec_name%>*)(generic_array_element_addr(&_<%ident%>, sizeof(<%rec_name%>), <%dimsLenStr%>, <%dimsValuesStr%>)))-><%contextCrefNoPrevExp(componentRef, context, &auxFunction)%>
+      <%rec_name%>_array_get(_<%ident%>, <%dimsLenStr%>, <%dimsValuesStr%>)-><%contextCrefNoPrevExp(componentRef, context, &auxFunction)%>
       >>
     else "_" + System.unquoteIdentifier(crefStr(cr))
     )
@@ -5287,9 +5287,8 @@ template daeExpCrefRhsFunContext(Exp ecr, Context context, Text &preExp,
                 match ty
                   case (T_ARRAY(ty = T_COMPLEX(complexClassType = record_state)))
                   case (T_COMPLEX(complexClassType = record_state)) then
-                    let rec_name = '<%underscorePath(ClassInf.getStateName(record_state))%>'
                     <<
-                     (*((<%rec_name%>*)(generic_array_element_addr(&<%arrName%>, sizeof(<%rec_name%>), <%subsLenStr%>, <%subsValuesStr%>))))
+                     <%arrayType%>_get(<%arrName%>, <%subsLenStr%>, <%subsValuesStr%>)
                     >>
                   else
                     <<
@@ -7096,7 +7095,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
       match typeof(r.expr)
         case T_COMPLEX(complexClassType = record_state) then
           let rec_name = '<%underscorePath(ClassInf.getStateName(record_state))%>'
-          '*((<%rec_name%>*)generic_array_element_addr1(&<%res%>, sizeof(<%rec_name%>), <%arrIndex%>++)) = <%reductionBodyExpr%>;'
+          '<%rec_name%>_array_get(<%res%>, 1, <%arrIndex%>++) = <%reductionBodyExpr%>;'
         case T_ARRAY(__) then
           let tmp = tempDecl("index_spec_t", &varDecls)
           let nridx_str = intAdd(1,listLength(dims))
@@ -7222,7 +7221,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           let addr = match iter.ty
             case T_ARRAY(ty=T_COMPLEX(complexClassType = record_state)) then
               let rec_name = '<%underscorePath(ClassInf.getStateName(record_state))%>'
-              '*((<%rec_name%>*)generic_array_element_addr1(&<%loopVar%>, sizeof(<%rec_name%>), <%firstIndex%>++))'
+              '<%rec_name%>_array_get(<%loopVar%>, 1, <%firstIndex%>++)'
             else
               '<%arrayType%>_get1(<%loopVar%>, 1, <%firstIndex%>++)'
           (if stringEq(guardCond,"") then

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -7106,7 +7106,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           indexed_assign_<%expTypeArray(ty)%>(<%reductionBodyExpr%>, &<%res%>, &<%tmp%>);
           >>
         else
-          '*(<%arrayTypeResult%>_element_addr1(&<%res%>, 1, <%arrIndex%>++)) = <%reductionBodyExpr%>;'
+          '<%arrayTypeResult%>_get1(<%res%>, 1, <%arrIndex%>++) = <%reductionBodyExpr%>;'
     else match ri.foldExp case SOME(fExp) then
       let &foldExpPre = buffer ""
       let fExpStr = daeExp(fExp, context, &bodyExpPre, &tmpVarDecls, &auxFunction)
@@ -7224,7 +7224,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
               let rec_name = '<%underscorePath(ClassInf.getStateName(record_state))%>'
               '*((<%rec_name%>*)generic_array_element_addr1(&<%loopVar%>, sizeof(<%rec_name%>), <%firstIndex%>++))'
             else
-              '*(<%arrayType%>_element_addr1(&<%loopVar%>, 1, <%firstIndex%>++))'
+              '<%arrayType%>_get1(<%loopVar%>, 1, <%firstIndex%>++)'
           (if stringEq(guardCond,"") then
           <<
           if(<%firstIndex%> <= size_of_dimension_base_array(<%loopVar%>, 1)) {

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -3469,7 +3469,7 @@ template algStmtForGeneric_impl(Exp exp, Ident iterator, String type,
       let stmtStuff = if iterIsArray then
           'simple_index_alloc_<%type%>1(&<%evar%>, <%tvar%>, &<%ivar%>);'
         else
-          '<%iterName%> = *(<%arrayType%>_element_addr1(&<%evar%>, 1, <%tvar%>));'
+          '<%iterName%> = <%arrayType%>_get1(<%evar%>, 1, <%tvar%>);'
       <<
       for(<%tvar%> = 1; <%tvar%> <= size_of_dimension_base_array(<%evar%>, 1); ++<%tvar%>)
       {
@@ -5341,7 +5341,7 @@ template arrayScalarRhs(Type ty, list<Exp> subs, String arrName, Context context
           >>
         else
           <<
-          (*<%arrayType%>_element_addr<%if intLt(listLength(subs), 3) then listLength(subs)%>(&<%arrName%>, <%subsLenStr%>, <%subsValuesStr%>))
+          <%arrayType%>_get<%if intLt(listLength(subs), 3) then listLength(subs)%>(<%arrName%>, <%subsLenStr%>, <%subsValuesStr%>)
           >>
 end arrayScalarRhs;
 

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.c
@@ -124,7 +124,7 @@ void generic_array_create(threadData_t* td, base_array_t* dst, constructor_func 
     dst->data = generic_alloc(nr_of_elements, sze);
 
     // If we get here then the dst array has known dims
-    // Whcih means it is not flexible.
+    // Which means it is not flexible.
     dst->flexible = 0;
 
     // Initialize each element of the complex array
@@ -145,7 +145,7 @@ void simple_array_create(threadData_t* td, base_array_t* dst, int ndims, size_t 
     dst->data = generic_alloc(nr_of_elements, sze);
 
     // If we get here then the dst array has known dims
-    // Whcih means it is not flexible.
+    // Which means it is not flexible.
     dst->flexible = 0;
 
     // Init to 0. IDK if this is what Modelica expects
@@ -161,7 +161,7 @@ void generic_array_alloc_copy(const base_array_t src_cp, base_array_t* dst, copy
     clone_base_array_spec(src, dst);
 
     // If we get here then it means the dst array had a default value (i.e., binding to src array)
-    // Whcih means even if it was unknown size, it is not flexible anymore and is
+    // Which means even if it was unknown size, it is not flexible anymore and is
     // same shape as the src array.
     dst->flexible = 0;
 
@@ -183,7 +183,7 @@ void simple_array_alloc_copy(const base_array_t src_cp, base_array_t* dst, size_
     clone_base_array_spec(src, dst);
 
     // If we get here then it means the dst array had a default value (i.e., binding to src array)
-    // Whcih means even if it was unknown size, it is not flexible anymore and is
+    // Which means even if it was unknown size, it is not flexible anymore and is
     // same shape as the src array.
     dst->flexible = 0;
 
@@ -225,6 +225,19 @@ void* generic_array_get(const base_array_t* src, size_t sze, ...) {
   void* trgt = generic_ptrget(src, calc_base_index_va(src, src->ndims, ap), sze);
   va_end(ap);
   return trgt;
+}
+
+void* generic_array_get1(const base_array_t* src, size_t sze, int sub1) {
+    omc_assert_macro(sub1 > 0 && sub1 <= src->dim_size[0]);
+
+    return generic_ptrget(src, sub1 - 1, sze);
+}
+
+void* generic_array_get2(const base_array_t* src, size_t sze, int sub1, int sub2) {
+    omc_assert_macro(sub1 > 0 && sub1 <= src->dim_size[0]);
+    omc_assert_macro(sub2 > 0 && sub2 <= src->dim_size[1]);
+
+    return generic_ptrget(src, ((sub1 - 1) * src->dim_size[1]) + (sub2 - 1), sze);
 }
 
 void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t sze, ...) {

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.h
@@ -61,10 +61,10 @@ void simple_array_alloc_copy(const base_array_t src, base_array_t* dst, size_t s
 
 void* generic_array_get(const base_array_t* source, size_t sze,...);
 
-#define real_array_get(src,ndims,...)               (*(modelica_real*)(real_array_element_addr(&src, ndims, __VA_ARGS__)))
-#define integer_array_get(src,ndims,...)            (*(modelica_integer*)(integer_array_element_addr(&src, ndims, __VA_ARGS__)))
-#define string_array_get(src,ndims,...)             (*(modelica_string*)(string_array_element_addr(&src, ndims, __VA_ARGS__)))
-#define boolean_array_get(src,ndims,...)            (*(modelica_boolean*)(boolean_array_element_addr(&src, ndims, __VA_ARGS__)))
+#define real_array_get(src,ndims,...)               (*(modelica_real*)(generic_array_get(&src, sizeof(modelica_real), __VA_ARGS__)))
+#define integer_array_get(src,ndims,...)            (*(modelica_integer*)(generic_array_get(&src, sizeof(modelica_integer), __VA_ARGS__)))
+#define string_array_get(src,ndims,...)             (*(modelica_string*)(generic_array_get(&src, sizeof(modelica_string), __VA_ARGS__)))
+#define boolean_array_get(src,ndims,...)            (*(modelica_boolean*)(generic_array_get(&src, sizeof(modelica_boolean), __VA_ARGS__)))
 
 void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t sze, ...);
 

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.h
@@ -60,11 +60,26 @@ void simple_array_alloc_copy(const base_array_t src, base_array_t* dst, size_t s
 
 
 void* generic_array_get(const base_array_t* source, size_t sze,...);
+// Versions with no variadic args for common dimensions 1 and 2
+void* generic_array_get1(const base_array_t* source, size_t sze, int dim1);
+void* generic_array_get2(const base_array_t* source, size_t sze, int dim1, int dim2);
 
 #define real_array_get(src,ndims,...)               (*(modelica_real*)(generic_array_get(&src, sizeof(modelica_real), __VA_ARGS__)))
+#define real_array_get1(src,ndims,dim1)             (*(modelica_real*)(generic_array_get1(&src, sizeof(modelica_real), dim1)))
+#define real_array_get2(src,ndims,dim1,dim2)        (*(modelica_real*)(generic_array_get2(&src, sizeof(modelica_real), dim1, dim2)))
+
 #define integer_array_get(src,ndims,...)            (*(modelica_integer*)(generic_array_get(&src, sizeof(modelica_integer), __VA_ARGS__)))
+#define integer_array_get1(src,ndims,dim1)          (*(modelica_integer*)(generic_array_get1(&src, sizeof(modelica_integer), dim1)))
+#define integer_array_get2(src,ndims,dim1,dim2)     (*(modelica_integer*)(generic_array_get2(&src, sizeof(modelica_integer), dim1, dim2)))
+
 #define string_array_get(src,ndims,...)             (*(modelica_string*)(generic_array_get(&src, sizeof(modelica_string), __VA_ARGS__)))
+#define string_array_get1(src,ndims,dim1)           (*(modelica_string*)(generic_array_get1(&src, sizeof(modelica_string), dim1)))
+#define string_array_get2(src,ndims,dim1,dim2)      (*(modelica_string*)(generic_array_get2(&src, sizeof(modelica_string), dim1, dim2)))
+
 #define boolean_array_get(src,ndims,...)            (*(modelica_boolean*)(generic_array_get(&src, sizeof(modelica_boolean), __VA_ARGS__)))
+#define boolean_array_get1(src,ndims,dim1)          (*(modelica_boolean*)(generic_array_get1(&src, sizeof(modelica_boolean), dim1)))
+#define boolean_array_get2(src,ndims,dim1,dim2)     (*(modelica_boolean*)(generic_array_get2(&src, sizeof(modelica_boolean), dim1, dim2)))
+
 
 void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t sze, ...);
 


### PR DESCRIPTION

@mahge
Normalize array get functions.
2239e6d

  - Use the generic_array_get function for al types.

  - If this works out we can remove most *_array_element_address functions
    and simplify simrt array methods a bit.

@mahge
Specialized get functions for 1 and 2 dimensions.
c5e8240

  - Added *_array_get1 and *_array_get2 for 1 and 2 sized dimensions
    respectively.
    This is just to avoid variadic ap lists for this common array
    cardinalities.

@mahge
Remove one _array_element function generation.
67b9724

  - We remove them one by by to simplify debugging since tests will
    probably fail at some point.

@mahge
Remove more *_array_element_addr generations.
5273e69

@mahge
Remove more *_array_element_addr generations.
370485c

@mahge
Remove generic_array_element_addr generations.
7a63655 


@mahge
Test failed successfully!
c2785ac

   -The test was supposed to fail but was passing so it was marked as
    "failing". Now it fails as expected but it fails at runtime instead
    of Flattening where it was expected to fail ideally I guess.

