### PR TITLE
Improve handling of the class loader

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -2032,13 +2032,17 @@ typedef struct {
   int fileIsDir;
 } modelicaPathEntry;
 
-void splitVersion(const char *version, long *versionNum, char **versionExtra)
+int splitVersion(const char *version, long *versionNum, char **versionExtra)
 {
   const char *buf = version;
   char *next;
   long l;
   int cont,i=0,len;
   memset(versionNum,0,sizeof(long)*MODELICAPATH_LEVELS);
+  if (!isdigit(version[0])) {
+    *versionExtra = omc_alloc_interface.malloc_strdup(buf);
+    return 0;
+  }
   do {
     /* fprintf(stderr, "look versionNum %s\n", buf); */
     l = strtol(buf,&next,10);
@@ -2057,6 +2061,7 @@ void splitVersion(const char *version, long *versionNum, char **versionExtra)
   if (len >= 2 && 0==strcmp("mo", *versionExtra+len-2)) {
     (*versionExtra)[len-2] = '\0';
   }
+  return 1;
 }
 
 static int regularFileExistsInDirectory(const char *dir1, const char *dir2, const char *file)
@@ -2172,12 +2177,13 @@ static int modelicaPathEntryVersionGreater(long *ver1, long *ver2, int numToTest
 
 static int getLoadModelPathFromSingleTarget(const char *searchTarget, modelicaPathEntry *entries, int numEntries, int exactVersion, const char **outDir, char **outName, int *isDir)
 {
-  int i, j, foundIndex = -1;
+  int i, j, foundIndex = -1, foundDigitVersion;
   long version[MODELICAPATH_LEVELS] = {0}, foundVersion[MODELICAPATH_LEVELS] = {0};
   char *versionExtra;
-  splitVersion(searchTarget,version,&versionExtra);
+  /* fprintf(stderr, "searchTarget %s\n", searchTarget); */
+  foundDigitVersion = splitVersion(searchTarget,version,&versionExtra);
   /* fprintf(stderr, "expected %ld.%ld.%ld.%ld %s ; exact=%d\n", version[0], version[1], version[2], version[3], versionExtra, exactVersion); */
-  if (version > 0 && !*versionExtra) {
+  if (foundDigitVersion && !*versionExtra) {
     /* Makes us load 3.2.1 if 3.2.0.0 is not available.
      * Note that all 4 levels are present and 3.2 is equivalent to 3.2.0.0
      * Search one additional level for each time we fail.
@@ -2204,17 +2210,15 @@ static int getLoadModelPathFromSingleTarget(const char *searchTarget, modelicaPa
       }
     }
   }
-  if (*versionExtra) {
-    /* fprintf(stderr, "Look for version %lx versionExtra: %s\n", version, versionExtra); */
-    for (i=0; i<numEntries; i++) {
-      /* fprintf(stderr, "entry %s/%s\n", entries[i].dir, entries[i].file);
-      fprintf(stderr, "is %ld.%ld.%ld.%ld %s\n", entries[i].version[0], entries[i].version[1], entries[i].version[2], entries[i].version[3], entries[i].versionExtra); */
-      if (modelicaPathEntryVersionEqual(entries[i].version,version,MODELICAPATH_LEVELS) && 0==strncmp(entries[i].versionExtra,versionExtra,strlen(versionExtra))) {
-        *outDir = entries[i].dir;
-        *outName = entries[i].file;
-        *isDir = entries[i].fileIsDir;
-        return 0;
-      }
+  /* fprintf(stderr, "Look for version %lx versionExtra: %s\n", version, versionExtra); */
+  for (i=0; i<numEntries; i++) {
+    /* fprintf(stderr, "entry %s/%s\n", entries[i].dir, entries[i].file);
+    fprintf(stderr, "is %ld.%ld.%ld.%ld %s\n", entries[i].version[0], entries[i].version[1], entries[i].version[2], entries[i].version[3], entries[i].versionExtra); */
+    if (modelicaPathEntryVersionEqual(entries[i].version,version,MODELICAPATH_LEVELS) && 0==strncmp(entries[i].versionExtra,versionExtra,strlen(versionExtra))) {
+      *outDir = entries[i].dir;
+      *outName = entries[i].file;
+      *isDir = entries[i].fileIsDir;
+      return 0;
     }
   }
   return 1;

--- a/testsuite/flattening/modelica/mosfiles/TestLoadModel.mos
+++ b/testsuite/flattening/modelica/mosfiles/TestLoadModel.mos
@@ -89,10 +89,9 @@ loadModel(Invalid);getErrorString();
 // {"3.4 beta1"}
 // true
 // "3.4"
-// false
-// "Error: Failed to load package Modelica (3.4) using MODELICAPATH TestLibrary/.
-// "
-// {}
+// true
+// ""
+// {"3.4 beta1"}
 // true
 // "3.5 beta1"
 // true

--- a/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/common.mos
+++ b/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/common.mos
@@ -4,5 +4,5 @@
 
 packageName := $TypeName(Modelica_DeviceDrivers);
 packageVersion := "";
-setCommandLineOptions("+d=nogen +std=3.3 +d=initialization");
+setCommandLineOptions("-d=-gen,initialization --std=3.3");
 referenceFileDir := "Modelica_DeviceDrivers"; // Default directory of reference files

--- a/testsuite/simulation/libraries/common/ModelTesting.mos
+++ b/testsuite/simulation/libraries/common/ModelTesting.mos
@@ -21,9 +21,10 @@ compareVars := {"revolute1.phi","revolute1.w","revolute1.a","revolute2.phi","rev
 echo(false);
 // setCommandLineOptions("+d=failtrace,showStatement +showErrorMessages"); getErrorString();
 
-b:=loadModel(packageName,{packageVersion});
+b:=loadModel(packageName,{if packageVersion == "" then "default" else packageVersion});
 if not b then
-  print("loadModel("+typeNameString(packageName)+","+packageVersion+")\n");
+  print("loadModel("+typeNameString(packageName)+",\""+packageVersion+"\") failed:\n");
+  print(getErrorString());
   print(OpenModelica.Scripting.cd() + "\n");
   exit(1);
 end if;


### PR DESCRIPTION
Return true/false if there is a numerical version. And otherwise only
check the versionExtra.

Fixes #6174