### PR TITLE
Add a flag for ZMQ to listen on all interfaces

### DIFF
--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -642,7 +642,7 @@ protected
   String str,replystr,suffix;
 algorithm
   suffix := Flags.getConfigString(Flags.ZEROMQ_FILE_SUFFIX);
-  zmqSocket := ZeroMQ.initialize(if suffix=="" then "" else ("."+suffix));
+  zmqSocket := ZeroMQ.initialize(if suffix=="" then "" else ("."+suffix), Flags.isSet(Flags.ZMQ_LISTEN_TO_ALL));
   false := valueEq(SOME(0), zmqSocket);
   while true loop
     str := ZeroMQ.handleRequest(zmqSocket);

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -564,6 +564,8 @@ constant DebugFlag ARRAY_CONNECT = DEBUG_FLAG(194, "arrayConnect", false,
   Gettext.gettext("Use experimental array connection handler."));
 constant DebugFlag COMBINE_SUBSCRIPTS = DEBUG_FLAG(195, "combineSubscripts", false,
   Gettext.gettext("Move all subscripts to the end of component references."));
+constant DebugFlag ZMQ_LISTEN_TO_ALL = DEBUG_FLAG(196, "zmqDangerousAcceptConnectionsFromAnywhere", false,
+  Gettext.gettext("When opening a zmq connection, listen on all interfaces instead of only connections from 127.0.0.1."));
 
 public
 // CONFIGURATION FLAGS
@@ -1232,8 +1234,8 @@ constant ConfigFlag INTERACTIVE = CONFIG_FLAG(114, "interactive",
   NONE(), EXTERNAL(), STRING_FLAG("none"),SOME(
     STRING_DESC_OPTION({
     ("none", Gettext.gettext("do nothing")),
-    ("corba", Gettext.gettext("Starts omc as a server listening on the socket interface.")),
-    ("tcp", Gettext.gettext("Starts omc as a server listening on the Corba interface.")),
+    ("corba", Gettext.gettext("Starts omc as a server listening on the Corba interface.")),
+    ("tcp", Gettext.gettext("Starts omc as a server listening on the socket interface.")),
     ("zmq", Gettext.gettext("Starts omc as a ZeroMQ server listening on the socket interface."))
     })),
   Gettext.gettext("Sets the interactive mode for omc."));

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -251,7 +251,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DUMP_FORCE_FMI_ATTRIBUTES,
   Flags.DUMP_DATARECONCILIATION,
   Flags.ARRAY_CONNECT,
-  Flags.COMBINE_SUBSCRIPTS
+  Flags.COMBINE_SUBSCRIPTS,
+  Flags.ZMQ_LISTEN_TO_ALL
 };
 
 protected

--- a/OMCompiler/Compiler/Util/ZeroMQ.mo
+++ b/OMCompiler/Compiler/Util/ZeroMQ.mo
@@ -40,10 +40,11 @@ encapsulated package ZeroMQ
   Implemented in ./runtime/zeromqimpl.c"
 
 public function initialize
-  input String fileSuffix="";
+  input String fileSuffix;
+  input Boolean listenToAll;
   output Option<Integer> zmqSocket;
 
-  external "C" zmqSocket = ZeroMQ_initialize(fileSuffix) annotation(Library = "omcruntime");
+  external "C" zmqSocket = ZeroMQ_initialize(fileSuffix, listenToAll) annotation(Library = "omcruntime");
 end initialize;
 
 public function handleRequest

--- a/OMCompiler/Compiler/runtime/zeromqimpl.c
+++ b/OMCompiler/Compiler/runtime/zeromqimpl.c
@@ -40,14 +40,14 @@
 
 char* zeroMQFilePath = 0;
 
-void* ZeroMQ_initialize(const char *zeroMQFileSuffix)
+void* ZeroMQ_initialize(const char *zeroMQFileSuffix, int listenToAll)
 {
   // Create a pointer for storing the ZeroMQ socket
   void *mmcZmqSocket = mmc_mk_some(0);
   // Create the ZeroMQ context
   void *context = zmq_ctx_new();
   void *zmqSocket = zmq_socket(context, ZMQ_REP);
-  int rc = zmq_bind(zmqSocket, "tcp://127.0.0.1:*");
+  int rc = zmq_bind(zmqSocket, listenToAll ? "tcp://*:*" : "tcp://127.0.0.1:*");
   if (rc != 0) {
     printf("Error creating ZeroMQ Server. zmq_bind failed: %s\n", strerror(errno));
     return mmcZmqSocket;


### PR DESCRIPTION
`-d=zmqDangerousAcceptConnectionsFromAnywhere` because this really is
a dangerous thing to do. It is acceptable in docker/etc though which is
the intended use-case.