### PR TITLE
Add header and function check macros.

### DIFF
--- a/OMCompiler/.cmake/omc_check_exists.cmake
+++ b/OMCompiler/.cmake/omc_check_exists.cmake
@@ -1,0 +1,42 @@
+include(CheckFunctionExists)
+include(CheckIncludeFiles)
+include(CheckIncludeFile)
+include(CheckTypeSize)
+
+
+# Checks if a sub-standard function exists.
+# e.g checks "ctime_s" and defines HAVE_CTIME_S to 1 or 0
+macro(omc_check_function_exists_and_define func_name)
+  string(TOUPPER ${func_name} DEFINE_SUFFIX)
+  check_function_exists(${func_name} HAVE_${DEFINE_SUFFIX})
+endmacro(omc_check_function_exists_and_define)
+
+
+# Checks a list of sub-standard functions and defines HAVE_* for each one.
+macro(omc_check_functions_exist_and_define_each func_names)
+  foreach(func_name ${func_names})
+    string(TOUPPER ${func_name} DEFINE_SUFFIX)
+    check_function_exists(${func_name} HAVE_${DEFINE_SUFFIX})
+  endforeach()
+endmacro(omc_check_functions_exist_and_define_each)
+
+
+# Checks if a sub-standard header file exists.
+# e.g checks "unistd.h" and defines HAVE_UNISTD_H to 1 or 0
+# "." and "/" in input names are changed to underscore
+# e.g check(sys/socket.h) -> HAVE_SYS_SOCKET_H
+macro(omc_check_header_exists_and_define header_name)
+  string(TOUPPER ${header_name} DEFINE_SUFFIX)
+  string(REPLACE "." "_" DEFINE_SUFFIX ${DEFINE_SUFFIX})
+  string(REPLACE "/" "_" DEFINE_SUFFIX ${DEFINE_SUFFIX})
+  check_include_file(${header_name} HAVE_${DEFINE_SUFFIX})
+  # message(STATUS "************* ${header_name} ${HAVE_${DEFINE_SUFFIX}} ")
+endmacro(omc_check_header_exists_and_define)
+
+
+# Checks a list of sub-standard header files and defines HAVE_* for each one.
+macro(omc_check_headers_exist_and_define_each header_names)
+  foreach(header_name ${header_names})
+    omc_check_header_exists_and_define(${header_name})
+  endforeach()
+endmacro(omc_check_headers_exist_and_define_each)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -12,13 +12,14 @@ set(OPENMODELICA_NEW_CMAKE_BUILD ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/.cmake/")
 include(omc_utils)
+include(omc_check_exists)
 
 # Add the compiler ids to the report for convenience.
 omc_add_to_report(CMAKE_CXX_COMPILER_ID)
 omc_add_to_report(CMAKE_C_COMPILER_ID)
 
 # Export compile commands (compile_commands.json) for each source file. This helps editors (e.g. vscode, emacs) have
-# a more accurate code navigation and intelisens. E.g includes can be pinpointed instead of
+# a more accurate code navigation and intellisense. E.g includes can be pinpointed instead of
 # using glob expressions to parse everything.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/OMCompiler/Compiler/.cmake/template_compilation.cmake
+++ b/OMCompiler/Compiler/.cmake/template_compilation.cmake
@@ -49,7 +49,7 @@ macro(omc_add_template_target)
     # Add the output to the list of all mo files generated from templates.
     set(TPL_OUTPUT_MO_FILES ${TPL_OUTPUT_MO_FILES} ${output_mo_file})
 
-    message(STATUS "Added Susan template target ${template_file}")
+    # message(STATUS "Added Susan template target ${template_file}")
 
 endmacro(omc_add_template_target)
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -13,6 +13,20 @@ if(NOT WIN32)
 endif()
 
 
+# Existence checks
+#################################################################################################
+
+# Some example portability checks. Add more just like this if you need more.
+# e.g this will define HAVE_TIME_H 1 if found or HAVE_TIME_H 0 otherwise
+omc_check_header_exists_and_define(time.h)
+# e.g this will define HAVE_CTIME_S 1 if found or HAVE_CTIME_S 0 otherwise
+omc_check_function_exists_and_define(ctime_s)
+omc_check_function_exists_and_define(ctime_r)
+
+
+
+# Libraries
+##################################################################################################
 set(OMC_RUNTIIME_SOURCES
     Error_omc.cpp
     Dynload_omc.cpp
@@ -185,8 +199,8 @@ target_link_libraries(omcgraphstream-boot PUBLIC omc::3rd::netstream)
 
 
 ################################################################################
-# This is a lazy apporach to generating runtime/config.unix.h and Compiler/Util/Autoconf.mo
-# Needs to be refactorted quite a bit. The variable names should be updated to be more
+# This is a lazy approach to generating runtime/config.unix.h and Compiler/Util/Autoconf.mo
+# Needs to be refactored quite a bit. The variable names should be updated to be more
 # unique and descriptive. 
 # However, If I do that I need to update the .in files which means the normal compilation is
 # also affected. As a result I would have to change a few things since many things depend on


### PR DESCRIPTION
  - omc_check_function_exists_and_define

    Checks if a sub-standard function exists.
    e.g checks "ctime_s" and defines HAVE_CTIME_S to 1 or 0

  - omc_check_functions_exist_and_define_each

    Checks a list of sub-standard functions and defines HAVE_* for each one.

  - omc_check_header_exists_and_define

    Checks if a sub-standard header file exists.
    e.g checks "unistd.h" and defines HAVE_UNISTD_H to 1 or 0
    "." and "/" in input names are changed to underscore
    e.g check(sys/socket.h) -> HAVE_SYS_SOCKET_H

  - omc_check_headers_exist_and_define_each

    Checks a list of sub-standard header files and defines HAVE_* for each one.