### PR TITLE
Copy #6174 fixes to 1.16

### DIFF
--- a/testsuite/flattening/modelica/mosfiles/TestLoadModel.mos
+++ b/testsuite/flattening/modelica/mosfiles/TestLoadModel.mos
@@ -88,10 +88,9 @@ loadModel(Invalid);getErrorString();
 // {"3.4 beta1"}
 // true
 // "3.4"
-// false
-// "Error: Failed to load package Modelica (3.4) using MODELICAPATH TestLibrary/.
-// "
-// {}
+// true
+// ""
+// {"3.4 beta1"}
 // true
 // "3.5 beta1"
 // true

--- a/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/common.mos
+++ b/testsuite/simulation/libraries/3rdParty/Modelica_DeviceDrivers/common.mos
@@ -4,5 +4,5 @@
 
 packageName := $TypeName(Modelica_DeviceDrivers);
 packageVersion := "";
-setCommandLineOptions("+d=nogen +std=3.3 +d=initialization");
+setCommandLineOptions("-d=-gen,initialization --std=3.3");
 referenceFileDir := "Modelica_DeviceDrivers"; // Default directory of reference files

--- a/testsuite/simulation/libraries/common/ModelTesting.mos
+++ b/testsuite/simulation/libraries/common/ModelTesting.mos
@@ -21,9 +21,10 @@ compareVars := {"revolute1.phi","revolute1.w","revolute1.a","revolute2.phi","rev
 echo(false);
 // setCommandLineOptions("+d=failtrace,showStatement +showErrorMessages"); getErrorString();
 
-b:=loadModel(packageName,{packageVersion});
+b:=loadModel(packageName,{if packageVersion == "" then "default" else packageVersion});
 if not b then
-  print("loadModel("+typeNameString(packageName)+","+packageVersion+")\n");
+  print("loadModel("+typeNameString(packageName)+",\""+packageVersion+"\") failed:\n");
+  print(getErrorString());
   print(OpenModelica.Scripting.cd() + "\n");
   exit(1);
 end if;


### PR DESCRIPTION
Return true/false if there is a numerical version. And otherwise only
check the versionExtra.

Fixes #6174