### PR TITLE
Cmake improvments

### DIFF
--- a/OMCompiler/.cmake/omc_utils.cmake
+++ b/OMCompiler/.cmake/omc_utils.cmake
@@ -12,3 +12,8 @@ macro(omc_add_subdirectory var)
   add_subdirectory(${var})
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endmacro(omc_add_subdirectory)
+
+macro(omc_option var help_text value)
+  option(${var} ${help_text} ${value})
+  omc_add_to_report(${var})
+endmacro(omc_option)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -61,7 +61,6 @@ option(OMC_USE_CCACHE "Use ccache to speedup compilations." ON)
 omc_add_to_report(OMC_USE_CCACHE)
 
 
-
 find_program(CCACHE_PROGRAM ccache)
 if(OMC_USE_CCACHE AND CCACHE_PROGRAM)
     message(STATUS "Found ccache. It will be used for compilation C/C++ sources")
@@ -69,6 +68,11 @@ if(OMC_USE_CCACHE AND CCACHE_PROGRAM)
     set(CMAKE_C_COMPILER_LAUNCHER   ${CCACHE_PROGRAM})
     omc_add_to_report(CCACHE_PROGRAM)
 endif()
+
+
+
+omc_option(OMC_USE_LPSOLVE "Should we use lpsolve." OFF)
+omc_option(OMC_BUILD_LPSOLVE "Should we build our own 3rdParty/lpsolve." OFF)
 
 
 

--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -113,7 +113,7 @@ set(OMC_MM_ALWAYS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/GenerateAPIFunctionsTpl.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/SCodeDumpTpl.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplAbsyn.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplCodegen.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/susan_codegen/TplCodegen.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplMain.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/Tpl.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Template/TplParser.mo

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -269,6 +269,7 @@ set(WITH_UUID "#define WITH_LIBUUID 1")
 
 set(USE_GRAPH 0)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/revision.h.in ${CMAKE_CURRENT_SOURCE_DIR}/revision.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.unix.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.unix.h)
 
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -63,9 +63,14 @@ target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
 target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC omc::simrt::runtime)
-target_link_libraries(omcruntime PUBLIC omc::3rd::lpsolve55)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
+
+if(OMC_USE_LPSOLVE)
+  target_link_libraries(omcruntime PUBLIC omc::3rd::lpsolve55)
+else()
+  target_compile_definitions(omcruntime PRIVATE NO_LPLIB)
+endif()
 
 target_include_directories(omcruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(omcruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
@@ -125,9 +130,14 @@ target_link_libraries(omcruntime-boot PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime-boot PUBLIC Iconv::Iconv)
 target_link_libraries(omcruntime-boot PUBLIC ${LAPACK_LIBRARIES})
 target_link_libraries(omcruntime-boot PUBLIC omc::simrt::runtime)
-target_link_libraries(omcruntime-boot PUBLIC omc::3rd::lpsolve55)
 target_link_libraries(omcruntime-boot PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime-boot PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
+
+if(OMC_USE_LPSOLVE)
+  target_link_libraries(omcruntime-boot PUBLIC omc::3rd::lpsolve55)
+else()
+  target_compile_definitions(omcruntime-boot PRIVATE NO_LPLIB)
+endif()
 
 target_include_directories(omcruntime-boot PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(omcruntime-boot PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -223,8 +223,10 @@ omc_add_to_report(OMC_TARGET_SYSTEM_NAME)
 set(OPENMODELICA_SPEC_PLATFORM ${CMAKE_SYSTEM_PROCESSOR}-${OMC_TARGET_SYSTEM_NAME})
 
 if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+  set(OMC_TARGET_ARCH_IS_64 TRUE)
   set(MODELICA_SPEC_PLATFORM "${OMC_TARGET_SYSTEM_NAME}64")
-else() 
+else()
+  set(OMC_TARGET_ARCH_IS_64 FALSE)
   set(MODELICA_SPEC_PLATFORM "${OMC_TARGET_SYSTEM_NAME}32")
 endif()
 
@@ -276,7 +278,21 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.unix.h.in ${CMAKE_CURRENT_SOUR
 # Generate Autoconf.mo here since we have some of the variables already defined for config.unix.h above. 
 
 if(WIN32)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.omdev.mingw ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo COPY_ONLY)
+
+  if(OMC_TARGET_ARCH_IS_64)
+    set(ISMINGW64 "true")
+  else()
+    set(ISMINGW64 "false")
+  endif()
+
+  if(${CMAKE_CXX_COMPILER_VERSION} STREQUAL "5.3.0")
+    set(IS_NEW_OMDEV "false")
+  else()
+    set(IS_NEW_OMDEV "true")
+  endif()
+
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.omdev.mingw ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo)
+
 else()
   check_c_compiler_flag("-Wl,-Bstatic  -Wl,-Bdynamic" BSTATIC_INT)
   if(BSTATIC_INT)


### PR DESCRIPTION

@mahge
Make building lp_solve optional.
7f7b5f6

    - lp_solve needs bison and flex. These are not available in our
    build-dep packages or docker files we distribute. So make this optional
    for now.

@mahge
TplCodegen.mo generated in Compiler/susan_codegen.
315ea5b

  - TplCodegen.tpl is located in Compiler/susan_codegen. So we generate
    it in that folder and use it from there. No need to copy it to
    Compiler/template like the normal Makefiles do.

@mahge
Generate revision.h from cmake.
fc76fbb
@mahge
Autoconf.mo.omdev.mingw also needs to be generated
a0accc0

  - Autoconf.mo.omdev.mingw now needs generation as well. Not just copy
    only.

