### PR TITLE
Free partially initialized linear systems for fmi2Reset

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -379,10 +379,6 @@ int freeLinearSystems(DATA *data, threadData_t *threadData)
   for(i=0; i<data->modelData->nLinearSystems; ++i)
   {
     /* free system and solver data */
-    for (j=0; j<omc_get_max_threads(); ++j)
-    {
-      free(linsys[i].parDynamicData[j].b);
-    }
     free(linsys[i].nominal);
     free(linsys[i].min);
     free(linsys[i].max);
@@ -392,6 +388,18 @@ int freeLinearSystems(DATA *data, threadData_t *threadData)
       ANALYTIC_JACOBIAN* jacobian = &(data->simulationInfo->analyticJacobians[linsys[i].jacobianIndex]);
       freeAnalyticJacobian(jacobian);
       /* Note: The Jacobian of data->simulationInfo itself will be free later. */
+
+    if (linsys[i].parDynamicData == NULL)
+    {
+      break;
+    }
+    else
+    {
+      for (j=0; j<omc_get_max_threads(); ++j)
+      {
+        free(linsys[i].parDynamicData[j].b);
+      }
+    }
 
 #ifdef USE_PARJAC
       for (j=0; j<omc_get_max_threads(); ++j) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -379,9 +379,9 @@ int freeLinearSystems(DATA *data, threadData_t *threadData)
   for(i=0; i<data->modelData->nLinearSystems; ++i)
   {
     /* free system and solver data */
-    free(linsys[i].nominal);
-    free(linsys[i].min);
-    free(linsys[i].max);
+    free(linsys[i].nominal); linsys[i].nominal = NULL;
+    free(linsys[i].min); linsys[i].min = NULL;
+    free(linsys[i].max); linsys[i].max = NULL;
 
     /* ToDo Implement unique function to free a ANALYTIC_JACOBIAN */
     if (1 == linsys[i].method) {
@@ -397,7 +397,7 @@ int freeLinearSystems(DATA *data, threadData_t *threadData)
     {
       for (j=0; j<omc_get_max_threads(); ++j)
       {
-        free(linsys[i].parDynamicData[j].b);
+        free(linsys[i].parDynamicData[j].b); linsys[i].parDynamicData[j].b = NULL;
       }
     }
 

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
@@ -42,7 +42,9 @@ void freeAnalyticJacobian(ANALYTIC_JACOBIAN *jac) {
 }
 
 void freeSparsePattern(SPARSE_PATTERN *spp) {
-  free(spp->index); spp->index = NULL;
-  free(spp->colorCols); spp->colorCols = NULL;
-  free(spp->leadindex); spp->leadindex = NULL;
+  if (spp != NULL) {
+    free(spp->index); spp->index = NULL;
+    free(spp->colorCols); spp->colorCols = NULL;
+    free(spp->leadindex); spp->leadindex = NULL;
+  }
 }


### PR DESCRIPTION
fixes #6703

  - Fixes segmentation fault while freeing linear systems that are not fully initialized
  - Check if parDynamicData is allocated, is NULL otherwise
  - Check if sparsity pattern was allocated before freeing parts of it