### PR TITLE
Cmake improvments

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -53,10 +53,6 @@ write_compiler_detection_header(
 SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 
 
-# options
-option(OMC_USE_CORBA "Should use corba." OFF)
-omc_add_to_report(OMC_USE_CORBA)
-
 option(OMC_USE_CCACHE "Use ccache to speedup compilations." ON)
 omc_add_to_report(OMC_USE_CCACHE)
 
@@ -71,9 +67,13 @@ endif()
 
 
 
+# options
+omc_option(OMC_USE_CORBA "Should use corba." OFF)
+
 omc_option(OMC_USE_LPSOLVE "Should we use lpsolve." OFF)
 omc_option(OMC_BUILD_LPSOLVE "Should we build our own 3rdParty/lpsolve." OFF)
 
+omc_option(OMC_USE_LAPACK "Should we use lapack." ON)
 
 
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
   target_compile_definitions(omcruntime PRIVATE NO_LPLIB)
 endif()
 
+target_include_directories(omcruntime PUBLIC ${Intl_INCLUDE_DIRS})
 target_include_directories(omcruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(omcruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
 
@@ -139,6 +140,7 @@ else()
   target_compile_definitions(omcruntime-boot PRIVATE NO_LPLIB)
 endif()
 
+target_include_directories(omcruntime-boot PUBLIC ${Intl_INCLUDE_DIRS})
 target_include_directories(omcruntime-boot PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(omcruntime-boot PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
 
@@ -170,6 +172,7 @@ target_link_libraries(omcbackendruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib::static)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
+target_include_directories(omcbackendruntime PUBLIC ${Intl_INCLUDE_DIRS})
 target_include_directories(omcbackendruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(omcbackendruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -1,7 +1,12 @@
 find_package(CURL REQUIRED)
 find_package(Intl REQUIRED)
 find_package(Iconv REQUIRED)
-find_package(LAPACK REQUIRED)
+
+if(OMC_USE_LAPACK)
+  find_package(LAPACK REQUIRED)
+endif()
+
+
 # find_package(ZLIB REQUIRED) # Not needed. We use the minizip lib from 3rdParty/FMIL instead
 
 # On Win32 we use system UUID lib which is one of the default libs that cmake adds to any target on Win32. On non Win32
@@ -61,7 +66,6 @@ target_compile_features(omcruntime PRIVATE cxx_std_11)
 target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
-target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
@@ -70,6 +74,12 @@ if(OMC_USE_LPSOLVE)
   target_link_libraries(omcruntime PUBLIC omc::3rd::lpsolve55)
 else()
   target_compile_definitions(omcruntime PRIVATE NO_LPLIB)
+endif()
+
+if(OMC_USE_LAPACK)
+  target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
+else()
+  target_compile_definitions(omcruntime PRIVATE NO_LAPACK)
 endif()
 
 target_include_directories(omcruntime PUBLIC ${Intl_INCLUDE_DIRS})
@@ -112,43 +122,6 @@ else() # No corba support requested. Use the stub file.
   target_sources(omcruntime PRIVATE corbaimpl_stub_omc.c)
 endif(OMC_USE_CORBA)
 
-# ######################################################################################################################
-# Library: omcruntime-boot
-add_library(omcruntime-boot STATIC)
-add_library(omc::compiler::runtime-boot ALIAS omcruntime-boot)
-
-target_sources(omcruntime-boot PRIVATE ${OMC_RUNTIIME_SOURCES})
-# No corba for boot lib
-target_sources(omcruntime-boot PRIVATE corbaimpl_stub_omc.c)
-
-target_compile_features(omcruntime-boot PRIVATE cxx_std_11)
-
-# Define OMC_BOOTSTRAPPING for the boot lib.
-target_compile_definitions(omcruntime-boot PRIVATE OMC_BOOTSTRAPPING)
-
-target_link_libraries(omcruntime-boot PUBLIC CURL::libcurl)
-target_link_libraries(omcruntime-boot PUBLIC ${Intl_LIBRARIES})
-target_link_libraries(omcruntime-boot PUBLIC Iconv::Iconv)
-target_link_libraries(omcruntime-boot PUBLIC ${LAPACK_LIBRARIES})
-target_link_libraries(omcruntime-boot PUBLIC omc::simrt::runtime)
-target_link_libraries(omcruntime-boot PUBLIC omc::3rd::libzmq)
-target_link_libraries(omcruntime-boot PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
-
-if(OMC_USE_LPSOLVE)
-  target_link_libraries(omcruntime-boot PUBLIC omc::3rd::lpsolve55)
-else()
-  target_compile_definitions(omcruntime-boot PRIVATE NO_LPLIB)
-endif()
-
-target_include_directories(omcruntime-boot PUBLIC ${Intl_INCLUDE_DIRS})
-target_include_directories(omcruntime-boot PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(omcruntime-boot PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
-
-# uuid is one of the default libs that cmake adds to any target on Win32. On non-Win systems we look for the library and
-# explicitly use it.
-if(NOT WIN32)
-  target_link_libraries(omcruntime-boot PUBLIC ${UUID_LIB})
-endif()
 
 # ######################################################################################################################
 # Library: omcbackendruntime

--- a/OMCompiler/Parser/.cmake/omc_antlr_target_macros.cmake
+++ b/OMCompiler/Parser/.cmake/omc_antlr_target_macros.cmake
@@ -15,8 +15,6 @@ macro(omc_add_antlr_grammar_target input_file output_dir)
     OUTPUT ${output_file_path_no_ext}.c
     OUTPUT ${output_file_path_no_ext}.h
   )
-  set_source_files_properties(${output_file_path_no_ext}.c GENERATED)
-  set_source_files_properties(${output_file_path_no_ext}.h GENERATED)
 
   set(ANTLR_GRAMMAR_${file_name_no_ext}_OUTPUT_SOURCES ${output_file_path_no_ext}.c)
   set(ANTLR_GRAMMAR_${file_name_no_ext}_OUTPUT_HEADERS ${output_file_path_no_ext}.h)
@@ -49,11 +47,6 @@ macro(omc_add_antlr_base_lexer_target input_file output_dir)
     OUTPUT ${output_file_base_path_no_ext}.c
     OUTPUT ${output_file_base_path_no_ext}.h
   )
-  set_source_files_properties(${output_file_path_no_ext}.c GENERATED)
-  set_source_files_properties(${output_file_path_no_ext}.h GENERATED)
-  set_source_files_properties(${output_file_base_path_no_ext}.c GENERATED)
-  set_source_files_properties(${output_file_base_path_no_ext}.h GENERATED)
-
 
   set(ANTLR_BASE_LEXER_${file_name_no_ext}_OUTPUT_SOURCES ${output_file_path_no_ext}.c ${output_file_base_path_no_ext}.c)
   set(ANTLR_BASE_LEXER_${file_name_no_ext}_OUTPUT_HEADERS ${output_file_path_no_ext}.h ${output_file_base_path_no_ext}.h)

--- a/OMCompiler/Parser/CMakeLists.txt
+++ b/OMCompiler/Parser/CMakeLists.txt
@@ -41,25 +41,3 @@ target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_include_directories(omparse PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h :/
-
-# ######################################################################################################################
-# Library: omparse-boot
-add_library(omparse-boot STATIC)
-add_library(omc::parser-boot ALIAS omparse-boot)
-
-target_sources(omparse-boot PRIVATE ${OM_PARSE_SOURCES})
-
-target_link_libraries(omparse-boot PUBLIC ${Intl_LIBRARIES})
-target_link_libraries(omparse-boot PUBLIC omc::compiler::runtime-boot)
-target_link_libraries(omparse-boot PUBLIC omc::simrt::runtime)
-target_link_libraries(omparse-boot PUBLIC omc::3rd::omantlr3)
-
-# Define OMC_BOOTSTRAPPING for the boot lib.
-target_compile_definitions(omparse-boot PRIVATE OMC_BOOTSTRAPPING)
-
-# # to find the generated antlr headers
-# # SYSTEM to disable warnings on the generated code.
-target_include_directories(omparse-boot SYSTEM PRIVATE ${GNERATED_DIRECTORY})
-target_include_directories(omparse-boot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_include_directories(omparse-boot PRIVATE ${OMCompiler_SOURCE_DIR}) #for revision.h


### PR DESCRIPTION
@mahge
Explicitly add libint include dirs to libraries.
3078aac

  - On MacOS the linitl headers seem to not be in the standard system
    include path.
    It is a good idea to explictly state needed include dirs anyway.

  - I will write a proper cmake imported target for libintl soon. Until
    then it is "old cmake" way of things.

@mahge
Make Lapack usage optional.
f666b9a

  - Since we need deprecated lapack functions and those might not be
    available everywhere it is a good idea to make lapack optional now.


@mahge
No need to mark files as generated.
8bf10fc

  - The files are listed as OUTPUT of a custom command. CMake is smart
    enough to deduce that they are "compile time generated" files. There
    is no need to explicitly state it.

@mahge
[cmake] Disable building of sundials examples
0236727

- There is no need to build (and install) them.

