### PR TITLE
Clean up List.

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendInline.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendInline.mo
@@ -1125,7 +1125,7 @@ algorithm
 
 
   // replace inputs variables
-  argmap := List.threadTuple(listReverse(fnInputs), args);
+  argmap := List.zip(listReverse(fnInputs), args);
   (argmap,checkcr) := Inline.extendCrefRecords(argmap, HashTableCG.emptyHashTable());
   BackendDAEUtil.traverseBackendDAEExpsEqSystemWithUpdate(outEqs, replaceArgs, (argmap,checkcr,true));
 

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -852,7 +852,7 @@ algorithm
         (dexpLst,functions) = List.map3Fold(expLst, function differentiateExp(maxIter=maxIter), inDiffwrtCref, inInputData, inDiffType, inFunctionTree);
         (derivedRHS as DAE.TUPLE(expLstRHS), functions) = differentiateExp(rhs, inDiffwrtCref, inInputData, inDiffType, functions, maxIter);
         (DAE.TUPLE(expLstRHS),_) = ExpressionSimplify.simplify(derivedRHS);
-        exptl = List.threadTuple(dexpLst, expLstRHS);
+        exptl = List.zip(dexpLst, expLstRHS);
         optDerivedStatements1 = List.map2(exptl, makeAssignmentfromTuple, source, inFunctionTree);
         derivedStatements1 = List.flatten(List.map(optDerivedStatements1, List.fromOption));
         derivedStatements2 = listAppend(derivedStatements1, {currStatement});
@@ -2416,7 +2416,7 @@ algorithm
         end if;
 
         // create differentiated call arguments
-        expBoolLst = List.threadTuple(expl, blst);
+        expBoolLst = List.zip(expl, blst);
         expBoolLst = List.filterOnTrue(expBoolLst, Util.tuple22);
         expl1 = List.map(expBoolLst, Util.tuple21);
         if Flags.isSet(Flags.DEBUG_DIFFERENTIATION_VERBOSE) then

--- a/OMCompiler/Compiler/BackEnd/IndexReduction.mo
+++ b/OMCompiler/Compiler/BackEnd/IndexReduction.mo
@@ -3549,7 +3549,7 @@ algorithm
       equation
         n = diffcount-level;
         true = intGt(n,0);
-        cr = List.foldcallN(n, ComponentReference.crefPrefixDer, name);
+        cr = Util.foldcallN(n, ComponentReference.crefPrefixDer, name);
         // generate replacement
         e = Expression.crefExp(cr);
         ht = BaseHashTable.add(((name,n),e),iHt);

--- a/OMCompiler/Compiler/BackEnd/OpenTURNS.mo
+++ b/OMCompiler/Compiler/BackEnd/OpenTURNS.mo
@@ -379,7 +379,7 @@ algorithm
 
   Error.assertion(not listEmpty(varLst), "OpenTURNS.generateDistributions: No variable in the DAE has the distribution attribute! Check your model ...", AbsynUtil.dummyInfo);
   dists := List.map(varLst,BackendVariable.varDistribution);
-  (sLst,distributionVarLst) := List.map1_2(List.threadTuple(dists,List.map(varLst,BackendVariable.varCref)),generateDistributionVariable,dae2);
+  (sLst,distributionVarLst) := List.map1_2(List.zip(dists,List.map(varLst,BackendVariable.varCref)),generateDistributionVariable,dae2);
 
   // reverse to get them in the proper order
   distributionVarLst := listReverse(distributionVarLst);

--- a/OMCompiler/Compiler/FrontEnd/Inline.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inline.mo
@@ -827,7 +827,7 @@ algorithm
         if (Config.acceptMetaModelicaGrammar()) then // MetaModelica
           crefs = List.map(fn,getInputCrefs);
           crefs = List.select(crefs,removeWilds);
-          argmap = List.threadTuple(crefs,args);
+          argmap = List.zip(crefs,args);
           false = List.exist(fn,DAEUtil.isProtectedVar);
           newExp = getRhsExp(fn);
           // compare types
@@ -852,7 +852,7 @@ algorithm
             // compare types
             true = checkExpsTypeEquiv(e1, newExp);
             // input map cref again function args
-            argmap = List.threadTuple(crefs,args);
+            argmap = List.zip(crefs,args);
             (checkcr,_) = getInlineHashTableVarTransform();
             (argmap,checkcr) = extendCrefRecords(argmap,checkcr);
             // add noEvent to avoid events as usually for functions
@@ -870,7 +870,7 @@ algorithm
             newExp = Expression.makeTuple(list( getReplacementCheckComplex(repl,cr,ty) for cr in lst_cr));
             // compare types
             true = checkExpsTypeEquiv(e1, newExp);
-            argmap = List.threadTuple(crefs,args);
+            argmap = List.zip(crefs,args);
             (argmap,checkcr) = extendCrefRecords(argmap,checkcr);
             // add noEvent to avoid events as usually for functions
             // MSL 3.2.1 need GenerateEvents to disable this
@@ -977,7 +977,7 @@ algorithm
         newExp = Expression.makeTuple(list( VarTransform.getReplacement(repl,cr) for cr in lst_cr));
         // compare types
         true = checkExpsTypeEquiv(e1, newExp);
-        argmap = List.threadTuple(crefs,args);
+        argmap = List.zip(crefs,args);
         (argmap,checkcr) = extendCrefRecords(argmap,checkcr);
         // add noEvent to avoid events as usually for functions
         // MSL 3.2.1 need GenerateEvents to disable this
@@ -1290,7 +1290,7 @@ algorithm
       equation
         (res1,ht1) = extendCrefRecords(res,ht);
         crlst = List.map1(varLst,extendCrefRecords2,c);
-        new = List.threadTuple(crlst,expl);
+        new = List.zip(crlst,expl);
         (new1,ht2) = extendCrefRecords(new,ht1);
         res2 = listAppend(new1,res1);
       then ((c,e)::res2,ht2);
@@ -1298,7 +1298,7 @@ algorithm
       equation
         (res1,ht1) = extendCrefRecords(res,ht);
         crlst = List.map1(varLst,extendCrefRecords2,c);
-        new = List.threadTuple(crlst,expl);
+        new = List.zip(crlst,expl);
         (new1,ht2) = extendCrefRecords(new,ht1);
         res2 = listAppend(new1,res1);
       then ((c,e)::res2,ht2);

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -546,7 +546,7 @@ algorithm
         funcArgs2 = listAppend(funcArgs,funcArgsNamedFixed);
         Util.SUCCESS() = checkInvalidPatternNamedArgs(invalidArgs,fieldNameList,Util.SUCCESS(),info);
         (cache,patterns) = elabPatternTuple(cache,env,funcArgs2,fieldTypeList,info,lhs);
-        namedPatterns = List.thread3Tuple(patterns, fieldNameList, List.map(fieldTypeList,Types.simplifyType));
+        namedPatterns = List.zip3(patterns, fieldNameList, List.map(fieldTypeList,Types.simplifyType));
         namedPatterns = List.filterOnTrue(namedPatterns, filterEmptyPattern);
       then (cache,DAE.PAT_CALL_NAMED(fqPath,namedPatterns));
 
@@ -1585,11 +1585,9 @@ algorithm
       then (pat,extra);
     case DAE.PAT_CALL_NAMED(name,namedpats)
       equation
-        pats = List.map(namedpats,Util.tuple31);
-        fields = List.map(namedpats,Util.tuple32);
-        types = List.map(namedpats,Util.tuple33);
+        (pats, fields, types) = List.unzip3(namedpats);
         (pats,extra) = traversePatternList(pats, func, extra);
-        namedpats = List.thread3Tuple(pats, fields, types);
+        namedpats = List.zip3(pats, fields, types);
         pat = DAE.PAT_CALL_NAMED(name,namedpats);
         (pat,extra) = func(pat,extra);
       then (pat,extra);

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -1504,7 +1504,7 @@ algorithm
         conditions = List.map(branches, Util.tuple21);
         stmtsList = List.map(branches, Util.tuple22);
         algsLst = List.mapList(stmtsList, statementToAlgorithmItem);
-        abranches = List.threadTuple(conditions,algsLst);
+        abranches = List.zip(conditions,algsLst);
 
         algs2 = List.map(elseBranch,statementToAlgorithmItem);
       then Absyn.ALGORITHMITEM(Absyn.ALG_IF(boolExpr,algs1,abranches,algs2),NONE(),info);
@@ -1529,7 +1529,7 @@ algorithm
         (boolExpr::conditions) = List.map(branches, Util.tuple21);
         stmtsList = List.map(branches, Util.tuple22);
         (algs1::algsLst) = List.mapList(stmtsList, statementToAlgorithmItem);
-        abranches = List.threadTuple(conditions,algsLst);
+        abranches = List.zip(conditions,algsLst);
       then Absyn.ALGORITHMITEM(Absyn.ALG_WHEN_A(boolExpr,algs1,abranches),NONE(),info);
 
     case SCode.ALG_ASSERT()

--- a/OMCompiler/Compiler/FrontEnd/StateMachineFlatten.mo
+++ b/OMCompiler/Compiler/FrontEnd/StateMachineFlatten.mo
@@ -305,7 +305,7 @@ algorithm
 
   // We have some redundancy here (t[:].condition == c[:]) and thus need to update both
   i := 0;
-  for tc in List.threadTuple(t,c) loop
+  for tc in List.zip(t,c) loop
     i := i + 1;
     (t2, c2) := tc;
     TRANSITION(from, to, condition, immediate, reset, synchronize, priority) := t2;
@@ -441,7 +441,7 @@ algorithm
   stateVarCrefs := List.map(stateVarLst, DAEUtil.varCref);
   variableAttributesOptions := List.map(stateVarLst, DAEUtil.getVariableAttributes);
   startValuesOpt := List.map(variableAttributesOptions, getStartAttrOption);
-  varCrefStartVal := List.threadTuple(stateVarCrefs, startValuesOpt);
+  varCrefStartVal := List.zip(stateVarCrefs, startValuesOpt);
   crToExpOpt := HashTableCrToExpOption.emptyHashTableSized(listLength(varCrefStartVal) + 1);
   // create table that maps the cref of a variable to its start value
   crToExpOpt := List.fold(varCrefStartVal, BaseHashTable.add, crToExpOpt);

--- a/OMCompiler/Compiler/MidCode/DAEToMid.mo
+++ b/OMCompiler/Compiler/MidCode/DAEToMid.mo
@@ -73,7 +73,7 @@ uniontype State
 end State;
 
 function listZip<X,Y>
-  "List.threadTuple fails for lists of unequal length
+  "List.zip fails for lists of unequal length
    but truncating is the more common semantics."
   input  list<X>          xs;
   input  list<Y>          ys;
@@ -1139,7 +1139,7 @@ algorithm
 
     assert( listLength(inputsCref) == listLength(aliases), "MatchExpressionToMid: incorrect input: listLength(inputs) != listLength(aliases)" );
     inputsMidVar := {};
-    for daeExp_aliasList in List.threadTuple(inputsCref,aliases) loop
+    for daeExp_aliasList in List.zip(inputsCref,aliases) loop
 
       (daeExp,aliasList) := daeExp_aliasList;
       srcVar := RValueToVar(ExpToMid(daeExp, state), state);
@@ -1187,7 +1187,7 @@ algorithm
       one := GenTmpVar(DAE.T_INTEGER_DEFAULT,state);
       stateAddStmt(MidCode.ASSIGN(one, MidCode.LITERALINTEGER(1)) ,state);
       stateAddStmt(MidCode.ASSIGN(muxState, MidCode.BINARYOP(MidCode.ADD(),muxState,one)),state);
-      stateTerminate(labelFin, MidCode.SWITCH( muxState, List.threadTuple( List.intRange(listLength(cases)+1), listAppend(caseLabels,{labelFin}) )  ), state);
+      stateTerminate(labelFin, MidCode.SWITCH( muxState, List.zip( List.intRange(listLength(cases)+1), listAppend(caseLabels,{labelFin}) )  ), state);
     else
       stateTerminate(labelFin, MidCode.GOTO(if not listEmpty(caseLabels) then listHead(caseLabels) else labelFin), state);
     end if;
@@ -1246,9 +1246,9 @@ algorithm
           // NOTE: If the guard fails we will have made pattern assignments for a failing case. This is how it was done before as far as I can tell.
           if matchContinue
           then
-            patternToMidCode(state=state, matches=List.threadTuple(inputsMidVar,patterns), labelNoMatch=labelMux);
+            patternToMidCode(state=state, matches=List.zip(inputsMidVar,patterns), labelNoMatch=labelMux);
           else
-          patternToMidCode(state=state, matches=List.threadTuple(inputsMidVar,patterns)
+          patternToMidCode(state=state, matches=List.zip(inputsMidVar,patterns)
                           ,labelNoMatch= if not listEmpty(caseLabelIterator) then listHead(caseLabelIterator) else labelFail);
           end if;
           // then guard
@@ -1285,7 +1285,7 @@ algorithm
 
           Also outvars is unexpectedly removed of trailing wildcards and can be shorter than expList,
           including tuples of length 1 (probably 0 too, but who knows).
-          So we define and use listZip instead of threadTuple.
+          So we define and use listZip instead of List.zip.
 
           TODO: Document the unintuitive undocumented interface somewhere.
           */

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -17029,7 +17029,7 @@ algorithm
       list<Absyn.NamedArg> namedArgs,namedArgs1;
     case( Absyn.FUNCTIONARGS(expl,namedArgs))
       equation
-        (expl1,_) = List.mapFoldTuple(expl, transformFlatExpTrav, 0);
+        expl1 = list(AbsynUtil.traverseExp(e, transformFlatExp, 0) for e in expl);
         namedArgs1 = List.map(namedArgs,transformFlatNamedArg);
       then
         Absyn.FUNCTIONARGS(expl1,namedArgs1);
@@ -17051,22 +17051,6 @@ algorithm
       then Absyn.NAMEDARG(id,e11);
   end match;
 end transformFlatNamedArg;
-
-protected function transformFlatExpTrav
-"Transforms a flat expression by calling traverseExp"
-  input tuple<Absyn.Exp,Integer> inExp;
-  output tuple<Absyn.Exp,Integer> outExp;
-algorithm
-  outExp := match(inExp)
-    local
-      Absyn.Exp e,e1;
-      Integer i;
-    case( (e,i))
-      equation
-        (e1,i) = AbsynUtil.traverseExp(e,transformFlatExp,0);
-      then ((e1,i));
-  end match;
-end transformFlatExpTrav;
 
 protected function transformFlatExp
   input Absyn.Exp inExp;

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -14731,7 +14731,7 @@ algorithm
       list<Absyn.NamedArg> namedArgs,namedArgs1;
     case( Absyn.FUNCTIONARGS(expl,namedArgs))
       equation
-        (expl1,_) = List.mapFoldTuple(expl, transformFlatExpTrav, 0);
+        expl1 = list(AbsynUtil.traverseExp(e, transformFlatExp, 0) for e in expl);
         namedArgs1 = List.map(namedArgs,transformFlatNamedArg);
       then
         Absyn.FUNCTIONARGS(expl1,namedArgs1);

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4254,7 +4254,7 @@ template algStmtAssignPattern(DAE.Statement stmt, Context context, Text &varDecl
     let &assignments = buffer ""
     let &additionalOutputs = buffer ""
     let &matchPhase = buffer ""
-    let _ = threadTuple(patterns,tys) |> (pat,ty) => match pat
+    let _ = List.zip(patterns,tys) |> (pat,ty) => match pat
       case PAT_WILD(__) then
         let &additionalOutputs += ", NULL"
         ""
@@ -6091,7 +6091,7 @@ template daeExpRecord(Exp rec, Context context, Text &preExp, Text &varDecls, Te
   match rec
   case RECORD(__) then
   let name = tempDecl(underscorePath(path), &varDecls)
-  let ass = threadTuple(exps,comp) |>  (exp,compn) => '<%name%>._<%compn%> = <%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>;<%\n%>'
+  let ass = List.zip(exps,comp) |>  (exp,compn) => '<%name%>._<%compn%> = <%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>;<%\n%>'
   let &preExp += ass
   name
 end daeExpRecord;
@@ -7349,7 +7349,7 @@ case exp as MATCHEXPRESSION(__) then
   let &expInput = buffer ""
   // get the current index of tmpMeta and reserve N=listLength(inputs) values in it!
   let startIndexInputs = '<%System.tmpTickIndexReserve(0, 0)%>'
-  let ignore3 = (List.threadTuple(inputs,aliases) |> (e1,alias) hasindex i1 fromindex 1 =>
+  let ignore3 = (List.zip(inputs,aliases) |> (e1,alias) hasindex i1 fromindex 1 =>
     let typ = '<%expTypeFromExpModelica(e1)%>'
     let decl = tempDeclMatchInput(exp.matchType, typ, startIndexInputs, i1, &varDeclsInput)
     let &expInput += '<%decl%> = <%daeExp(e1, context, &preExpInput, &varDeclsInput, &auxFunction)%>;<%\n%>'

--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -1691,7 +1691,7 @@ template daeExpRecord(Exp rec, Context context, Text &preExp, Text &varDecls, Si
   match rec
   case RECORD(__) then
   let name = tempDecl(underscorePath(path) + "Type", &varDecls)
-  let ass = threadTuple(exps,comp) |>  (exp,compn) =>
+  let ass = List.zip(exps,comp) |>  (exp,compn) =>
     let compnStr = crefStr(makeUntypedCrefIdent(compn))
     '<%name%>.<%compnStr%> = <%daeExp(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>;<%\n%>'
   let &preExp += ass
@@ -2845,7 +2845,7 @@ case ARRAY(array = {}) then
 case ARRAY(ty=T_ARRAY(ty=ty,dims=dims),array=expl) then
   let typeShort = expTypeFromExpShort(exp)
   let fcallsuf = match listLength(dims) case 1 then "" case i then '_<%i%>D'
-  let body = (threadTuple(expl,dimsToAllIndexes(dims)) |>  (lhs,indxs) =>
+  let body = (List.zip(expl,dimsToAllIndexes(dims)) |>  (lhs,indxs) =>
                  let lhsstr = scalarLhsCref(lhs, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
                  let indxstr = (indxs |> i => '<%i%>' ;separator=",")
                  '<%lhsstr%> = <%typeShort%>_get<%fcallsuf%>(&<%rhsStr%>, <%indxstr%>);/*writeLhsCref2*/'

--- a/OMCompiler/Compiler/Template/CodegenCppCommonOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommonOld.tpl
@@ -1684,7 +1684,7 @@ template daeExpRecord(Exp rec, Context context, Text &preExp, Text &varDecls, Si
   match rec
   case RECORD(__) then
   let name = tempDecl(underscorePath(path) + "Type", &varDecls)
-  let ass = threadTuple(exps,comp) |>  (exp,compn) =>
+  let ass = List.zip(exps,comp) |>  (exp,compn) =>
     let compnStr = crefStr(makeUntypedCrefIdent(compn))
     '<%name%>.<%compnStr%> = <%daeExp(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>;<%\n%>'
   let &preExp += ass
@@ -2838,7 +2838,7 @@ case ARRAY(array = {}) then
 case ARRAY(ty=T_ARRAY(ty=ty,dims=dims),array=expl) then
   let typeShort = expTypeFromExpShort(exp)
   let fcallsuf = match listLength(dims) case 1 then "" case i then '_<%i%>D'
-  let body = (threadTuple(expl,dimsToAllIndexes(dims)) |>  (lhs,indxs) =>
+  let body = (List.zip(expl,dimsToAllIndexes(dims)) |>  (lhs,indxs) =>
                  let lhsstr = scalarLhsCref(lhs, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
                  let indxstr = (indxs |> i => '<%i%>' ;separator=",")
                  '<%lhsstr%> = <%typeShort%>_get<%fcallsuf%>(&<%rhsStr%>, <%indxstr%>);/*writeLhsCref2*/'

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -3393,13 +3393,13 @@ package List
     replaceable type Type_a subtypeof Any;
   end lastN;
 
-  function threadTuple
+  function zip
     replaceable type Type_b subtypeof Any;
     input list<Type_a> inTypeALst;
     input list<Type_b> inTypeBLst;
     output list<tuple<Type_a, Type_b>> outTplTypeATypeBLst;
     replaceable type Type_a subtypeof Any;
-  end threadTuple;
+  end zip;
 
   function position
     replaceable type Type_a subtypeof Any;

--- a/OMCompiler/Compiler/Util/Graph.mo
+++ b/OMCompiler/Compiler/Util/Graph.mo
@@ -64,7 +64,7 @@ public function buildGraph
     output list<NodeType> outEdges;
   end EdgeFunc;
 algorithm
-  outGraph := List.threadTuple(inNodes, List.map1(inNodes, inEdgeFunc, inEdgeArg));
+  outGraph := List.zip(inNodes, List.map1(inNodes, inEdgeFunc, inEdgeArg));
 end buildGraph;
 
 public function emptyGraph

--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1707,5 +1707,23 @@ algorithm
   end while;
 end msb;
 
+public function foldcallN<FT>
+  "Takes a value and a function operating on the value n times.
+     Example: foldcallN(1, intAdd, 4) => 4"
+  input Integer n;
+  input FoldFunc inFoldFunc;
+  input FT inStartValue;
+  output FT outResult = inStartValue;
+
+  partial function FoldFunc
+    input FT inFoldArg;
+    output FT outFoldArg;
+  end FoldFunc;
+algorithm
+  for i in 1:n loop
+    outResult := inFoldFunc(outResult);
+  end for;
+end foldcallN;
+
 annotation(__OpenModelica_Interface="util");
 end Util;

--- a/testsuite/openmodelica/bootstrapping/ExpressionTest.mo
+++ b/testsuite/openmodelica/bootstrapping/ExpressionTest.mo
@@ -99,7 +99,7 @@ package ExpressionTest "test function like
     simpl    := {Exp1_1, Exp2_1, Exp3_1, Exp4_1, Exp5_1, Exp6_1, Exp7_1, Exp8_1, Exp9_1, Exp10_1, Exp11_1, Exp12_1, Exp13_1, Exp14_1, Exp15_1, Exp16_1, Exp17_1, Exp18_1,Exp19_1, Exp20_1, Exp21_1, Exp22_1, ExpSum_1, ExpSumSimple, ExpProduct_1};
     baseStr  := List.map(base, ExpressionDump.printExpStr);
     simplStr := List.map(simpl, ExpressionDump.printExpStr);
-    List.map_0(List.threadTuple(baseStr,simplStr), printResult);
+    List.map_0(List.zip(baseStr,simplStr), printResult);
 
   end test;
 end ExpressionTest;

--- a/testsuite/openmodelica/bootstrapping/SimplifyTest.mo
+++ b/testsuite/openmodelica/bootstrapping/SimplifyTest.mo
@@ -269,6 +269,6 @@ package SimplifyTest "Run ExpressionSimplify.simplify on some sample expressions
     simpl    := ExpressionSimplify.simplifyList(base);
     baseStr  := List.map(base, ExpressionDump.printExpStr);
     simplStr := List.map(simpl, ExpressionDump.printExpStr);
-    List.map_0(List.threadTuple(baseStr,simplStr), printResult);
+    List.map_0(List.zip(baseStr,simplStr), printResult);
   end test;
 end SimplifyTest;

--- a/testsuite/openmodelica/bootstrapping/UtilTest.mo
+++ b/testsuite/openmodelica/bootstrapping/UtilTest.mo
@@ -105,12 +105,4 @@ algorithm
   outTuple := (i + 1, j + i);
 end incAdd;
 
-function mapFoldListTuple
-  input list<list<Integer>> l1;
-  output list<list<Integer>> l2;
-  output Integer lsum;
-algorithm
-  (l2, lsum) := List.mapFoldListTuple(l1, incAdd, 0);
-end mapFoldListTuple;
-
 end UtilTest;

--- a/testsuite/openmodelica/bootstrapping/UtilTest.mos
+++ b/testsuite/openmodelica/bootstrapping/UtilTest.mos
@@ -67,8 +67,6 @@ List.replaceAtWithList({"A", "B"}, 1, {"a", "b", "c"});
 getErrorString();
 UtilTest.splitOnFirstMatch({1, 2, 3, 4, 5});
 getErrorString();
-UtilTest.mapFoldListTuple({{1, 2, 3}, {4, 5, 6}, {7, 8}});
-getErrorString();
 List.replaceAt("A", 2, {"a", "b", "c"});
 getErrorString();
 List.replaceAtIndexFirst(2, "A", {"a", "b", "c"});
@@ -127,8 +125,6 @@ getErrorString();
 // {"a","A","B","c"}
 // ""
 // ({1,2},{3,4,5})
-// ""
-// ({{2,3,4},{5,6,7},{8,9}},36)
 // ""
 // {"a","A","c"}
 // ""


### PR DESCRIPTION
- Remove List.mapFoldTuple since using it was mostly just a sign of
  tuple misuse.
- Remove List.mapFoldListTuple for the same argument and the fact that
  it wasn't used anywhere.
- Remove List.threadTuple in favour of List.zip that does the same
  thing, and rename List.thread3Tuple => List.zip3.
- Remove List.first2FromTuple3 since it wasn't used and not a list
  function anyway.
- Move List.foldcallN to Util since it's not a list function.