### PR TITLE
OriginItem paint event is called even before we set visible false

### DIFF
--- a/OMEdit/OMEditLIB/Element/CornerItem.cpp
+++ b/OMEdit/OMEditLIB/Element/CornerItem.cpp
@@ -422,8 +422,8 @@ void OriginItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if ((mpShapeAnnotation && mpShapeAnnotation->getGraphicsView()->isRenderingLibraryPixmap())
-      || (mpComponent && mpComponent->getGraphicsView()->isRenderingLibraryPixmap())) {
+  if ((mpShapeAnnotation && mpShapeAnnotation->getGraphicsView() && mpShapeAnnotation->getGraphicsView()->isRenderingLibraryPixmap())
+      || (mpComponent && mpComponent->getGraphicsView() && mpComponent->getGraphicsView()->isRenderingLibraryPixmap())) {
     return;
   }
   painter->setRenderHint(QPainter::Antialiasing);


### PR DESCRIPTION
For such OriginItem shape we don't have GraphicsView so check for NULL.