### PR TITLE
Give error for extends loop.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -604,6 +604,15 @@ public
 
         case Class.PARTIAL_BUILTIN() then ();
 
+        case Class.INSTANCED_CLASS()
+          guard InstNode.isBaseClass(clsNode)
+          algorithm
+            InstNodeType.BASE_CLASS(definition = ext_def) := InstNode.nodeType(clsNode);
+            Error.addSourceMessage(Error.EXTENDS_LOOP,
+              {SCodeUtil.getElementName(ext_def)}, InstNode.info(clsNode));
+          then
+            fail();
+
         else
           algorithm
             Error.assertion(false, getInstanceName() + " got invalid class", sourceInfo());

--- a/testsuite/flattening/modelica/scodeinst/ExtendsLoop1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExtendsLoop1.mo
@@ -1,0 +1,21 @@
+// name: ExtendsLoop1
+// keywords:
+// status: incorrect
+// cflags: -d=newInst -i=ExtendsLoop1.M
+//
+
+model ExtendsLoop1
+  model M
+    extends ExtendsLoop1;
+  end M;
+end ExtendsLoop1;
+
+// Result:
+// Error processing file: ExtendsLoop1.mo
+// [flattening/modelica/scodeinst/ExtendsLoop1.mo:9:5-9:25:writable] Error: extends ExtendsLoop1 causes an instantiation loop.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -382,6 +382,7 @@ ExtendConnector1.mo \
 ExtendImport1.mo \
 ExtendImport2.mo \
 ExtendInherited1.mo \
+ExtendsLoop1.mo \
 ExtendReplaceable1.mo \
 ExtendReplaceable2.mo \
 ExtendReplaceable3.mo \


### PR DESCRIPTION
- Give error for a model extending from one of the scopes it's defined
  in.