### PR TITLE
Don't use matchcontinue for tearing traverseComponents1

### DIFF
--- a/testsuite/openmodelica/debugDumps/dumpSparsePatternLin.mos
+++ b/testsuite/openmodelica/debugDumps/dumpSparsePatternLin.mos
@@ -76,9 +76,5 @@ buildModel(problem3); getErrorString();
 // The following (1) independents belong to one color
 // 1: {x[2]}
 // {"problem3","problem3_init.xml"}
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // endResult

--- a/testsuite/simulation/modelica/daemode/testDAEScaling.mos
+++ b/testsuite/simulation/modelica/daemode/testDAEScaling.mos
@@ -57,7 +57,5 @@ simulate(Test3, stopTime = 2, simflags="-noEquidistantTimeGrid");getErrorString(
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 199 exceeds maximum system size for tearing of nonlinear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // endResult

--- a/testsuite/simulation/modelica/linear_system/NPendulum.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum.mos
@@ -134,11 +134,7 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 // "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.
 // "
 // {"NPendulum.pendulum","NPendulum.pendulum_init.xml"}
-// "Notification: Tearing is skipped for strong component 1 because system size of 278 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 275 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 0
 // "stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.

--- a/testsuite/simulation/modelica/linear_system/NPendulum40.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum40.mos
@@ -30,13 +30,7 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res
 // true
 // true
 // {"NPendulum.pendulum40","NPendulum.pendulum40_init.xml"}
-// "Notification: Tearing is skipped for strong component 1 because system size of 1178 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 1175 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 3 because system size of 1175 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.

--- a/testsuite/simulation/modelica/linear_system/analyticJacProblem3.mos
+++ b/testsuite/simulation/modelica/linear_system/analyticJacProblem3.mos
@@ -3,7 +3,7 @@
 // status: correct
 // teardown_command: rm -rf linear_system.problem3* output.log
 // cflags: -d=-newInst
-// 
+//
 // Solving of a linear system of equations with analytical jacobian
 
 loadFile("linearTestPackage.mo"); getErrorString();
@@ -64,11 +64,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 1.0
@@ -80,11 +76,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 0.9999999999999999
@@ -96,11 +88,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 1.0
@@ -112,11 +100,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 9.999999999999998
 // 9.980736544657136
 // 1.0
@@ -128,11 +112,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 1.0
@@ -144,11 +124,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 9.999999999999998
 // 9.980736544657136
 // 1.0

--- a/testsuite/simulation/modelica/linear_system/problem2.mos
+++ b/testsuite/simulation/modelica/linear_system/problem2.mos
@@ -247,11 +247,7 @@ val(i2, 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 0.0
 // 2.804903282692988
 // 0.0
@@ -263,11 +259,7 @@ val(i2, 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 0.0
 // 2.804903282692988
 // 0.0
@@ -279,11 +271,7 @@ val(i2, 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 0.0
 // 2.804903282692989
 // 0.0
@@ -295,11 +283,7 @@ val(i2, 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 9.518569369879021e-28
 // 2.804903282692988
 // 2.655481430415245e-28
@@ -311,11 +295,7 @@ val(i2, 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 0.0
 // 2.804903282692988
 // 0.0
@@ -327,11 +307,7 @@ val(i2, 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 5 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 0.0
 // 2.804903282692988
 // 0.0

--- a/testsuite/simulation/modelica/linear_system/problem3.mos
+++ b/testsuite/simulation/modelica/linear_system/problem3.mos
@@ -68,11 +68,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 1.0
@@ -84,11 +80,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 0.9999999999999999
@@ -100,11 +92,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 1.0
@@ -116,11 +104,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 9.999999999999998
 // 9.980736544657136
 // 1.0
@@ -132,11 +116,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 10.0
 // 9.980736544657136
 // 1.0
@@ -148,11 +128,7 @@ val(x[2], 1.0);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// Notification: Tearing is skipped for strong component 2 because system size of 2 exceeds maximum system size for tearing of linear systems (0).
-// To adjust the maximum system size for tearing use --maxSizeLinearTearing=<size> and --maxSizeNonlinearTearing=<size>.
-// "
+// ""
 // 9.999999999999998
 // 9.980736544657136
 // 1.0


### PR DESCRIPTION
- Issue explicit error when giving illegal value for maxSizeNonlinearTearing or maxSizeLinearTearing
- Replacing `matchcontinue` with `match`
- Removing notification
  `Notification: Tearing is skipped for strong component 1 because system size of 2 exceeds maximum system size for tearing of 
  linear systems (0).`
  if tearing is disabled.