### PR TITLE
Fix cpp undef array reduction

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -1102,7 +1102,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
     else match ri.foldExp case SOME(fExp) then
       let &foldExpPre = buffer ""
       let fExpStr = daeExp(fExp, context, &bodyExpPre, &tmpVarDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-      if not ri.defaultValue then
+      if foundFirst then
       <<
       if(<%foundFirst%>)
       {
@@ -1186,15 +1186,17 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           '<%res%>.setDims(<%length%>);'%>
 
        >>
-     else if ri.defaultValue then
-     <<
-     <%&preDefault%>
-     <%res%> = <%defaultValue%>; /* defaultValue */
-     >>
      else
-     <<
-     <%foundFirst%> = 0; /* <%dotPath(ri.path)%> lacks default-value */
-     >>)
+        (if foundFirst then
+        <<
+        <%foundFirst%> = 0; /* <%dotPath(ri.path)%> lacks default-value */
+        >>
+        else
+        <<
+        <%&preDefault%>
+        <%res%> = <%defaultValue%>; /* defaultValue */
+        >>)
+      )
   let loop =
     <<
     while(1) {
@@ -1220,7 +1222,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
     <%firstValue%>
     <% if resTail then '<%resTail%> = &<%res%>;' %>
     <%loop%>
-    <% if not ri.defaultValue then 'if (!<%foundFirst%>) throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Internal error");' %>
+    <% if foundFirst then 'if (!<%foundFirst%>) throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Internal error");' %>
     <% if resTail then '*<%resTail%> = NULL;' %>
     <% resTmp %> = <% res %>;
   }<%\n%>

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1373,7 +1373,7 @@ template fmuSourceMakefile(SimCode simCode, String FMUVersion)
  "Generates the contents of the makefile for the simulation case. Copy libexpat & correct linux fmu"
 ::=
   match simCode
-  case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simulationSettingsOpt = sopt) then
+  case SIMCODE(modelInfo=modelInfo as MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simulationSettingsOpt = sopt) then
   let includedir = '<%fileNamePrefix%>.fmutmp/sources/'
   let mkdir = match makefileParams.platform case "win32" case "win64" then '"mkdir.exe"' else 'mkdir'
   <<
@@ -1389,7 +1389,7 @@ template fmuSourceMakefile(SimCode simCode, String FMUVersion)
      match  Config.simCodeTarget()
      case "omsicpp" then
      <<
-     <%\t%>chmod +x <%fileNamePrefix%>.sh
+     <%\t%>chmod +x <%dotPath(modelInfo.name)%>.sh
      >>
      end match
   %>


### PR DESCRIPTION
Fix for [track ticket 6241](https://trac.openmodelica.org/OpenModelica/ticket/6241). 

Reapplying https://github.com/OpenModelica/OpenModelica/commit/7fc85eb69d5c28a5c279b254b7b24c3403b3bd4c for Cpp and OldCpp code generation.

Changing OMSICpp makefile to use sh file that's generated with dots in name, not underscores.
@niklwors My solution is not very nice but a quick hack. If you want it to use underscores in the names this is what you need to change.