### PR TITLE
Clean up Absyn.Path function in AbsynUtil a bit

### DIFF
--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -1557,7 +1557,7 @@ algorithm
         // Update the path.
         s := AbsynUtil.pathLastIdent(funcOut.path);
         s := s + "_eval" + intString(idx);
-        funcOut.path := AbsynUtil.pathReplaceIdent(AbsynUtil.makeNotFullyQualified(funcOut.path), s);
+        funcOut.path := AbsynUtil.pathSetLastIdent(AbsynUtil.makeNotFullyQualified(funcOut.path), s);
 
         // Update the type.
         funcOut.type_ := updateFunctionType(funcOut.type_, outputs, origOutputs);

--- a/OMCompiler/Compiler/FFrontEnd/FCore.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FCore.mo
@@ -733,7 +733,7 @@ algorithm
   else
     lastId := AbsynUtil.pathLastIdent(inPath);
     lastId := getRecordConstructorName(lastId);
-    outPath := AbsynUtil.pathSetLastIdent(inPath, AbsynUtil.makeIdentPathFromString(lastId));
+    outPath := AbsynUtil.pathSetLastIdent(inPath, lastId);
   end if;
 end getRecordConstructorPath;
 

--- a/OMCompiler/Compiler/FrontEnd/InstFunction.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstFunction.mo
@@ -838,7 +838,7 @@ algorithm
           cache = InstUtil.addFunctionsToDAE(cache, {func}, SCode.NOT_PARTIAL());
 
           // add the instance record constructor too!
-          path = AbsynUtil.pathSetLastIdent(path, AbsynUtil.makeIdentPathFromString(name));
+          path = AbsynUtil.pathSetLastIdent(path, name);
           fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo);
           fargs = Types.makeFargsList(inputs);
           funcTy = DAE.T_FUNCTION(fargs, fixedTy, DAE.FUNCTION_ATTRIBUTES_DEFAULT, path);

--- a/OMCompiler/Compiler/FrontEnd/SCodeSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeSimplify.mo
@@ -171,7 +171,7 @@ algorithm
     // handle extends Modelica.Icons.*
     case (SCode.EXTENDS(baseClassPath = bcp)::rest)
       equation
-        true = AbsynUtil.pathContains(bcp, Absyn.IDENT("Icons"));
+        true = AbsynUtil.pathContains(bcp, "Icons");
         els = simplifyElements(rest);
       then
         els;


### PR DESCRIPTION
- Add pathSetFirstIdent.
- Change behaviour of pathSetLastIdent to replace the last identifier
  with a string instead of a path, since that's what the name implies
  and also how it's actually used.
- Change behaviour of pathContains to take a string identifier instead
  of a path and rename it pathContainsIdent, since that's how it's used.
- Remove pathReplaceIdent and change the only use of the function to use
  pathSetLastIdent instead, since that's what it did.
- Remove unused and rather specialized functions pathTwoLastIdents,
  prefixOptPath, and pathReplaceFirstIdent.