### PR TITLE
Fix #6252

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -63,7 +63,6 @@ import NFModifier.Modifier;
 import Sections = NFSections;
 import NFOCConnectionGraph;
 import Prefixes = NFPrefixes;
-import NFPrefixes.Visibility;
 import RangeIterator = NFRangeIterator;
 import Subscript = NFSubscript;
 import Type = NFType;
@@ -78,7 +77,7 @@ import Face = NFConnector.Face;
 import System;
 import ComplexType = NFComplexType;
 import NFInstNode.CachedData;
-import NFPrefixes.Variability;
+import NFPrefixes.{Direction, Variability, Visibility};
 import Variable = NFVariable;
 import ElementSource;
 import Ceval = NFCeval;
@@ -450,6 +449,16 @@ algorithm
         ElementSource.createElementSource(info));
       sections := Sections.prependEquation(eq, sections);
       binding := NFBinding.EMPTY_BINDING;
+
+      // Moving the binding of an input variable to an equation can change how
+      // the variable is counted when counting variables and equations, but
+      // since there's no way to override such a binding from outside the model
+      // we can remove the input prefix to keep the balance.
+      if comp_attr.direction == Direction.INPUT and ComponentRef.isEmpty(prefix) then
+        comp_attr.direction := Direction.NONE;
+        Error.addSourceMessage(Error.TOP_LEVEL_INPUT_WITH_BINDING,
+          {ComponentRef.toString(name)}, info);
+      end if;
     end if;
   end if;
 

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -832,6 +832,8 @@ public constant ErrorTypes.Message TOP_LEVEL_OUTER = ErrorTypes.MESSAGE(379, Err
   Gettext.gettext("The model can't be instantiated due to top-level outer component ‘%s‘, it may only be used as part of a simulation model."));
 public constant ErrorTypes.Message MISSING_INNER_NAME_CONFLICT = ErrorTypes.MESSAGE(380, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("An inner declaration for outer component ‘%s‘ could not be found, and could not be automatically generated due to a existing declaration of that name."));
+public constant ErrorTypes.Message TOP_LEVEL_INPUT_WITH_BINDING = ErrorTypes.MESSAGE(381, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("Top-level input ‘%s‘ has a binding equation and will not be accessible as an input of the model."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -868,6 +868,7 @@ Time1.mo \
 Time2.mo \
 Time3.mo \
 TopLevelInputs1.mo \
+TopLevelInputs2.mo \
 TupleInvalid1.mo \
 TupleInvalid2.mo \
 TupleInvalid3.mo \

--- a/testsuite/flattening/modelica/scodeinst/TopLevelInputs2.mo
+++ b/testsuite/flattening/modelica/scodeinst/TopLevelInputs2.mo
@@ -1,0 +1,24 @@
+// name: TopLevelInputs2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Top-level inputs with bindings should not be counted as top-level inputs
+// without bindings if their binding is moved to an equation section.
+//
+
+model TopLevelInputs2
+  input Real x[:] = {1, 2, 3};
+end TopLevelInputs2;
+
+// Result:
+// class TopLevelInputs2
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x = {1.0, 2.0, 3.0};
+// end TopLevelInputs2;
+// [flattening/modelica/scodeinst/TopLevelInputs2.mo:11:3-11:30:writable] Notification: Top-level input ‘x‘ has a binding equation and will not be accessible as an input of the model.
+//
+// endResult


### PR DESCRIPTION
- Remove the input prefix from inputs with bindings if the binding
  is moved to an equation.