### PR TITLE
Fix ExpressionSimplify.simplifyReduction

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -5498,8 +5498,8 @@ algorithm
         foldName2 = Util.getTempVariableIndex();
         resultName2 = Util.getTempVariableIndex();
         ty1 = Expression.unliftArray(ty);
-        expr = DAE.REDUCTION(DAE.REDUCTIONINFO(path,Absyn.COMBINE(),ty1,NONE(),foldName,resultName,NONE()),expr,iterators);
-        expr = DAE.REDUCTION(DAE.REDUCTIONINFO(path,Absyn.COMBINE(),ty,NONE(),foldName2,resultName2,NONE()),expr,{iter});
+        expr = DAE.REDUCTION(DAE.REDUCTIONINFO(path,Absyn.COMBINE(),ty1,NONE(),foldName2,resultName2,NONE()),expr,{iter});
+        expr = DAE.REDUCTION(DAE.REDUCTIONINFO(path,Absyn.COMBINE(),ty,NONE(),foldName,resultName,NONE()),expr,iterators);
       then expr;
     // rest can also handle multiple iterators
     case DAE.REDUCTION(reductionInfo = DAE.REDUCTIONINFO(path = path, iterType = Absyn.COMBINE(), foldName=foldName, resultName=resultName, exprType = ty, foldExp=NONE(), defaultValue = defaultValue), expr = expr, iterators = iter::(iterators as _::_))

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -1325,9 +1325,9 @@ algorithm
 
     // Elaborate the iterators.
     (outCache, env, reduction_iters, dims, iter_const, has_guard_exp) :=
-      elabCallReductionIterators(inCache, env, listReverse(inIterators),
+      elabCallReductionIterators(inCache, env, inIterators,
         inReductionExp, inImplicit, inDoVect, inPrefix, inInfo);
-    dims := fixDimsIterType(inIterType, listReverse(dims));
+    dims := fixDimsIterType(inIterType, dims);
 
     // Elaborate the expression.
     (outCache, exp, DAE.PROP(exp_ty, exp_const)) :=


### PR DESCRIPTION
- Fix the case for multiple iterators in an array constructor, which
  creates a nested array constructor in the wrong order.