### PR TITLE
Fix fmi2Reset for models with loops

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -334,6 +334,11 @@ int updateStaticDataOfLinearSystems(DATA *data, threadData_t *threadData)
 
   for(i=0; i<data->modelData->nLinearSystems; ++i)
   {
+    // check if LS is initialized
+    if (linsys[i].nominal == NULL || linsys[i].min == NULL || linsys[i].max==NULL)
+    {
+      throwStreamPrint(threadData, "Static data of Linear system not initialized for linear system %i",i);
+    }
     linsys[i].initializeStaticLSData(data, threadData, &linsys[i]);
   }
 

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -472,8 +472,6 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
   modelInfoInit(&(comp->fmuData->modelData->modelDataXml));
 #endif
 
-  /* read input vars */
-  /* input_function(comp->fmuData); */
 #if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
   /* allocate memory for non-linear system solvers */
   initializeNonlinearSystems(comp->fmuData, comp->threadData);
@@ -548,16 +546,16 @@ void fmi2FreeInstance(fmi2Component c)
   if (comp->_has_jacobian == 1) {
     /* TODO: Use comp->functions->freeMemory insted of free,
      * but generated code uses malloc / calloc instead of comp->functions->allocateMemory */
-    free(comp->fmiDerJac->seedVars);
-    free(comp->fmiDerJac->resultVars);
-    free(comp->fmiDerJac->tmpVars);
+    free(comp->fmiDerJac->seedVars); comp->fmiDerJac->seedVars = NULL;
+    free(comp->fmiDerJac->resultVars); comp->fmiDerJac->resultVars = NULL;
+    free(comp->fmiDerJac->tmpVars); comp->fmiDerJac->tmpVars = NULL;
 
-    free(comp->fmiDerJac->sparsePattern->leadindex);
-    free(comp->fmiDerJac->sparsePattern->index);
-    free(comp->fmiDerJac->sparsePattern->colorCols);
-    free(comp->fmiDerJac->sparsePattern);
+    free(comp->fmiDerJac->sparsePattern->leadindex); comp->fmiDerJac->sparsePattern->leadindex = NULL;
+    free(comp->fmiDerJac->sparsePattern->index); comp->fmiDerJac->sparsePattern->index = NULL;
+    free(comp->fmiDerJac->sparsePattern->colorCols); comp->fmiDerJac->sparsePattern->colorCols = NULL;
+    free(comp->fmiDerJac->sparsePattern); comp->fmiDerJac->sparsePattern = NULL;
 
-    comp->functions->freeMemory(comp->fmiDerJac);
+    comp->functions->freeMemory(comp->fmiDerJac); comp->fmiDerJac=NULL;
   }
 
   comp->functions->freeMemory(comp->fmuData->modelData->resourcesDir);
@@ -723,22 +721,56 @@ fmi2Status fmi2Reset(fmi2Component c)
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2Reset")
 
   setThreadData(comp);
-
+  /* Free modelData */
   if (!(comp->state & modelTerminated)) {
+    /* call external objects destructors */
+    comp->fmuData->callback->callExternalObjectDestructors(comp->fmuData, comp->threadData);
+#if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
+    /* free nonlinear system data */
+    freeNonlinearSystems(comp->fmuData, comp->threadData);
+#endif
+#if !defined(OMC_NUM_MIXED_SYSTEMS) || OMC_NUM_MIXED_SYSTEMS>0
+    /* free mixed system data */
+    freeMixedSystems(comp->fmuData, comp->threadData);
+#endif
+#if !defined(OMC_NUM_LINEAR_SYSTEMS) || OMC_NUM_LINEAR_SYSTEMS>0
+    /* free linear system data */
+    freeLinearSystems(comp->fmuData, comp->threadData);
+#endif
+    /* free data struct */
     deInitializeDataStruc(comp->fmuData);
   }
-  /* intialize modelData */
-  fmu2_model_interface_setupDataStruc(comp->fmuData, comp->threadData);
+
+  /* Initialize modelData */
   useStream[LOG_STDOUT] = 1;
   useStream[LOG_ASSERT] = 1;
+  fmu2_model_interface_setupDataStruc(comp->fmuData, comp->threadData);
   initializeDataStruc(comp->fmuData, comp->threadData);
-  /* reset the values to start */
+
+  /* reset model data with default start data */
   setDefaultStartValues(comp);
   setAllParamsToStart(comp->fmuData);
   setAllVarsToStart(comp->fmuData);
   comp->fmuData->callback->read_input_fmu(comp->fmuData->modelData, comp->fmuData->simulationInfo);
 #if !defined(OMC_MINIMAL_METADATA)
   modelInfoInit(&(comp->fmuData->modelData->modelDataXml));
+#endif
+
+#if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
+  /* allocate memory for non-linear system solvers */
+  initializeNonlinearSystems(comp->fmuData, comp->threadData);
+#endif
+#if !defined(OMC_NUM_LINEAR_SYSTEMS) || OMC_NUM_LINEAR_SYSTEMS>0
+  /* allocate memory for non-linear system solvers */
+  initializeLinearSystems(comp->fmuData, comp->threadData);
+#endif
+#if !defined(OMC_NUM_MIXED_SYSTEMS) || OMC_NUM_MIXED_SYSTEMS>0
+  /* allocate memory for mixed system solvers */
+  initializeMixedSystems(comp->fmuData, comp->threadData);
+#endif
+#if !defined(OMC_NO_STATESELECTION)
+  /* allocate memory for state selection */
+  initializeStateSetJacobians(comp->fmuData, comp->threadData);
 #endif
 
   comp->_need_update = 1;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
@@ -269,7 +269,7 @@ int FMI2CS_deInitializeSolverData(ModelInstance* comp)
       retValue = -1;
   }
 
-  comp->functions->freeMemory(comp->solverInfo);
+  comp->functions->freeMemory(comp->solverInfo); comp->solverInfo = NULL;
 
   return retValue;
 }

--- a/testsuite/omsimulator/DualMassOscillator.mos
+++ b/testsuite/omsimulator/DualMassOscillator.mos
@@ -1,6 +1,6 @@
 // name:     DualMassOscillator.mos
 // status:   correct
-// teardown_command: rm -rf temp_dualmassoscillator/ DualMassOscillator.mat
+// teardown_command: rm -rf temp_dualmassoscillator/ DualMassOscillator.mat DualMassOscillator_System1.log DualMassOscillator_System2.log DualMassOscillator.System1.fmu DualMassOscillator.System2.fmu
 // cflags: -d=-newInst
 
 setCommandLineOptions("-g=MetaModelica");

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -14,6 +14,7 @@ outputState_omc.mos \
 outputState.mos \
 reset_omc.mos \
 reset.mos \
+resetWithLoops.mos \
 test03.mos \
 testDirectionalDerivatives.mos \
 

--- a/testsuite/omsimulator/resetWithLoops.mos
+++ b/testsuite/omsimulator/resetWithLoops.mos
@@ -1,0 +1,74 @@
+// keywords: fmu export import reset
+// status: correct
+// teardown_command: rm -rf resetWithLoops-fmu/ model_res.mat resetWithLoops.lua resetWithLoops.fmu resetWithLoops.log resetWithLoops_systemCall.log temp-resetWithLoops
+// cflags: -d=-newInst
+
+loadModel(Modelica); getErrorString();
+
+system("mkdir -p resetWithLoops-fmu");
+echo(false); cd("resetWithLoops-fmu"); echo(true);
+buildModelFMU(Modelica.Electrical.Analog.Examples.Rectifier); getErrorString();
+echo(false); cd(".."); echo(true);
+
+writeFile("resetWithLoops.lua","
+oms_setCommandLineOption(\"--suppressPath=true\")
+oms_setTempDirectory(\"./temp-resetWithLoops/\")
+
+oms_newModel(\"model\")
+oms_addSystem(\"model.root\", oms_system_sc)
+-- instantiate FMUs
+oms_addSubModel(\"model.root.system1\", \"resetWithLoops-fmu/Modelica.Electrical.Analog.Examples.Rectifier.fmu\")
+print(\"Instantiate\")
+oms_instantiate(\"model\")
+-- initialize FMU
+print(\"Initialize\")
+oms_initialize(\"model\")
+
+-- reset FMU
+print(\"Reset\")
+oms_reset(\"model\")
+
+-- Simualte FMU
+print(\"Initialize\")
+oms_initialize(\"model\")
+print(\"Simulate\")
+oms_simulate(\"model\")
+print(\"Terminate and Delete\")
+oms_terminate(\"model\")
+oms_delete(\"model\")
+print(\"Success\")
+"); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator resetWithLoops.lua", "resetWithLoops_systemCall.log");
+readFile("resetWithLoops_systemCall.log");
+
+// Result:
+// true
+// ""
+// 0
+// true
+// "Modelica.Electrical.Analog.Examples.Rectifier.fmu"
+// ""
+// true
+// true
+// ""
+// 0
+// "Instantiate
+// Initialize
+// info:    maximum step size for 'model.root': 0.100000
+// info:    Result file: model_res.mat (bufferSize=10)
+// Reset
+// info:    Final Statistics for 'model.root':
+//          NumSteps = 0 NumRhsEvals  = 0 NumLinSolvSetups = 0
+//          NumNonlinSolvIters = 0 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// Initialize
+// info:    maximum step size for 'model.root': 0.100000
+// info:    Result file: model_res.mat (bufferSize=10)
+// Simulate
+// Terminate and Delete
+// info:    Final Statistics for 'model.root':
+//          NumSteps = 1 NumRhsEvals  = 5 NumLinSolvSetups = 2
+//          NumNonlinSolvIters = 4 NumNonlinSolvConvFails = 0 NumErrTestFails = 1
+// Success
+// "
+// endResult

--- a/testsuite/omsimulator/test03.mos
+++ b/testsuite/omsimulator/test03.mos
@@ -1,6 +1,6 @@
 // name:     test03.mos
 // status:   correct
-// teardown_command: rm -rf test03/ test_res.mat
+// teardown_command: rm -rf test03/ test_res.mat Modelica_Blocks_Sources_* Modelica.Blocks.Sources.Constant.fmu Modelica.Blocks.Sources.Sine.fmu
 // cflags: -d=-newInst
 
 setCommandLineOptions("-g=MetaModelica");


### PR DESCRIPTION
Fixes #6703  

  - When we call `deInitializeDataStruc` we also have to deinitialize (non-)linear systems and external objects.
 - Added testcase to testsuite/resetWithLoops.mos to test reset without simulation run and with loops.