### PR TITLE
Remove partest-link from partest

### DIFF
--- a/testsuite/openmodelica/typed-API/UriLookup.mos
+++ b/testsuite/openmodelica/typed-API/UriLookup.mos
@@ -1,7 +1,7 @@
 // name: UriLookup
 // status: correct
 // cflags: +d=nogen -d=-newInst
-// partest-link: UriLookup
+// depends: UriLookup
 
 setModelicaPath("./UriLookup");getErrorString();
 loadModel(A);getErrorString();

--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -159,7 +159,6 @@ sub enter_sandbox {
     elsif (/loadFile.*\(\"(.*)\"\)/)   { make_link($1); }
     elsif (/runScript.*\(\"(.*)\"\)/)  { make_link($1); }
     elsif (/importFMU.*\(\"(.*)\"\)/)  { make_link($1); }
-    elsif (/partest-link: *([A-Za-z0-9.]*)/) { make_link($1); }
     elsif (/system\(\"(gcc|g\+\+).*\s(\w*\.\w*)\s(\w*\.\w*)/) {
       my $header = lib_to_header($2);
       make_link($header);


### PR DESCRIPTION
- Remove support for the partest-link directive in partest,
  depends should be used instead.