### PR TITLE
Reinitialize CS solver for fmi2Reset

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -741,6 +741,11 @@ fmi2Status fmi2Reset(fmi2Component c)
     deInitializeDataStruc(comp->fmuData);
   }
 
+  /* Free CS simulator */
+  if (comp->solverInfo) {
+    FMI2CS_deInitializeSolverData(comp);
+  }
+
   /* Initialize modelData */
   useStream[LOG_STDOUT] = 1;
   useStream[LOG_ASSERT] = 1;
@@ -772,6 +777,13 @@ fmi2Status fmi2Reset(fmi2Component c)
   /* allocate memory for state selection */
   initializeStateSetJacobians(comp->fmuData, comp->threadData);
 #endif
+
+  /* Initialize solverInfo */
+  if (fmi2CoSimulation == comp->type) {
+    FMI2CS_initializeSolverData(comp);
+  } else {
+    comp->solverInfo = NULL;
+  }
 
   comp->_need_update = 1;
   comp->state = modelInstantiated;


### PR DESCRIPTION
Fixes #6703 (again)

We have to reinitialize the CS solver used when calling fmi2Reset.
For the explicit Euler nothing was allocated in the first place, but for CVODE it is.

It would be possible to don't free and allocate the memory again, but that is more error-prone and this approach will work for all solvers we might add in the future.