### PR TITLE
Fix buffer overflow in Jacobian dump

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -803,7 +803,7 @@ int ida_solver_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInf
   int saveJumpState;
   long int tmp;
   static unsigned int stepsOutputCounter = 1;
-  int stepsMode;
+  int stepsMode;    /* Has to be IDA_NORMAL (1) or IDA_ONE_STEP (2) */
   int restartAfterLSFail = 0;
 
   if (measure_time_flag) rt_tick(SIM_TIMER_SOLVER);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_error.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_error.c
@@ -785,34 +785,42 @@ void sundialsPrintSparseMatrix(SUNMatrix A, const char* name, const int logLevel
     indexvals = SM_INDEXVALS_S(A);
     indexptrs = SM_INDEXPTRS_S(A);
 
-    char *buffer = (char*)malloc(sizeof(char)*columns*20);
-
     infoStreamPrint(logLevel, 1, "##SUNDIALS## Sparse Matrix %s", name);
     infoStreamPrint(logLevel, 0, "Columns: N=%li, Rows: M=%li, CSC matrix, NNZ: %li, NP: %li", columns, rows, nnz, np);
 
     /* Print data array */
     lengthData = indexptrs[SUNSparseMatrix_NP(A)];
+
+    const int buffSize = 20;
+    char *buffer = (char*)malloc(sizeof(char)*lengthData*columns*buffSize);
+    char tmpBuffer[buffSize];
     buffer[0] = 0;
     for (i=0; i<lengthData-1; i++) {
-      sprintf(buffer, "%s%10g, ", buffer, data[i]);
+      snprintf(tmpBuffer, buffSize, "%10g, ", data[i]);
+      strncat(buffer, tmpBuffer, buffSize);
     }
-    sprintf(buffer, "%s%10g", buffer, data[lengthData-1]);
+    snprintf(tmpBuffer, buffSize, "%10g", data[lengthData-1]);
+    strncat(buffer, tmpBuffer, buffSize);
     infoStreamPrint(logLevel, 0, "data = {%s}", buffer);
 
     /* Print indexvals array */
     buffer[0] = 0;
     for (i=0; i<lengthData-1; i++) {
-      sprintf(buffer, "%s%li, ", buffer, indexvals[i]);
+      snprintf(tmpBuffer, buffSize, "%li, ", indexvals[i]);
+      strncat(buffer, tmpBuffer, buffSize);
     }
-    sprintf(buffer, "%s%li", buffer, indexvals[lengthData-1]);
+    snprintf(tmpBuffer, buffSize, "%li", indexvals[lengthData-1]);
+    strncat(buffer, tmpBuffer, buffSize);
     infoStreamPrint(logLevel, 0, "indexvals = {%s}", buffer);
 
     /* Print indexptrs array */
     buffer[0] = 0;
     for (i=0; i<SUNSparseMatrix_NP(A); i++) {
-      sprintf(buffer, "%s%li, ", buffer, indexptrs[i]);
+      snprintf(tmpBuffer, buffSize, "%li, ", indexptrs[i]);
+      strncat(buffer, tmpBuffer, buffSize);
     }
-    sprintf(buffer, "%s%li", buffer, indexptrs[SUNSparseMatrix_NP(A)]);
+    snprintf(tmpBuffer, buffSize, "%li", indexptrs[SUNSparseMatrix_NP(A)]);
+    strncat(buffer, tmpBuffer, buffSize);
     infoStreamPrint(logLevel, 0, "indexvals = {%s}", buffer);
 
     messageClose(logLevel);


### PR DESCRIPTION
  - Increase buffer size
  - Use snprintf to fix security issue and prevent buffer overflow