### PR TITLE
Improve handling of fill/ones/zeros

### DIFF
--- a/.openmodelica.aspell
+++ b/.openmodelica.aspell
@@ -74,3 +74,4 @@ cardinality
 URI
 SHA
 differentiable
+evaluable

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -235,10 +235,13 @@ algorithm
       then
         exp;
 
+    case "fill"      then simplifyFill(listHead(args), listRest(args), call);
+    case "ones"      then simplifyFill(Expression.INTEGER(1), args, call);
     case "sum"       then simplifySumProduct(listHead(args), call, isSum = true);
     case "product"   then simplifySumProduct(listHead(args), call, isSum = false);
     case "transpose" then simplifyTranspose(listHead(args), call);
     case "vector"    then simplifyVector(listHead(args), call);
+    case "zeros"     then simplifyFill(Expression.INTEGER(0), args, call);
 
     else Expression.CALL(call);
   end match;
@@ -317,6 +320,19 @@ algorithm
     exp := Expression.CALL(call);
   end if;
 end simplifyVector;
+
+function simplifyFill
+  input Expression fillArg;
+  input list<Expression> dimArgs;
+  input Call call;
+  output Expression exp;
+algorithm
+  if List.all(dimArgs, Expression.isLiteral) then
+    exp := Ceval.evalBuiltinFill2(fillArg, dimArgs);
+  else
+    exp := Expression.CALL(call);
+  end if;
+end simplifyFill;
 
 function simplifyArrayConstructor
   input Call call;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -676,8 +676,8 @@ public constant ErrorTypes.Message CYCLIC_DIMENSIONS = ErrorTypes.MESSAGE(300, E
   Gettext.gettext("Dimension %s of %s, '%s', could not be evaluated due to a cyclic dependency."));
 public constant ErrorTypes.Message INVALID_DIMENSION_TYPE = ErrorTypes.MESSAGE(301, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Dimension '%s' of type %s is not an integer expression or an enumeration or Boolean type name."));
-public constant ErrorTypes.Message RAGGED_DIMENSION = ErrorTypes.MESSAGE(302, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Ragged dimensions are not yet supported (from dimension '%s')"));
+public constant ErrorTypes.Message NON_PARAMETER_EXPRESSION_DIMENSION = ErrorTypes.MESSAGE(302, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  Gettext.gettext("Expression ‘%s‘ that determines the size of dimension ‘%s‘ of ‘%s‘ is not an evaluable parameter expression."));
 public constant ErrorTypes.Message INVALID_TYPENAME_USE = ErrorTypes.MESSAGE(303, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Type name '%s' is not allowed in this context."));
 public constant ErrorTypes.Message FOUND_WRONG_INNER_ELEMENT = ErrorTypes.MESSAGE(305, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill2.mo
@@ -1,0 +1,22 @@
+// name: FuncBuiltinFill2
+// keywords: fill
+// status: incorrect
+// cflags: -d=newInst
+//
+// Tests the builtin fill operator.
+//
+
+model FuncBuiltinFill2
+  Integer n = 3;
+  Real x[3] = fill(0, n);
+end FuncBuiltinFill2;
+
+// Result:
+// Error processing file: FuncBuiltinFill2.mo
+// [flattening/modelica/scodeinst/FuncBuiltinFill2.mo:11:3-11:25:writable] Error: Expression ‘n‘ that determines the size of dimension ‘1‘ of ‘fill(0, n)‘ is not an evaluable parameter expression.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -459,6 +459,7 @@ FuncBuiltinDiagonal.mo \
 FuncBuiltinDiv.mo \
 FuncBuiltinEdge.mo \
 FuncBuiltinFill.mo \
+FuncBuiltinFill2.mo \
 FuncBuiltinFloor.mo \
 FuncBuiltinGetInstanceName.mo \
 FuncBuiltinHomotopy.mo \


### PR DESCRIPTION
- Require that the arguments determining the dimension sizes of
  fill/ones/zeros calls are evaluatable except in functions.