### PR TITLE
Improve inner generation of components

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1329,5 +1329,23 @@ public
     end match;
   end mapFoldExpShallow;
 
+  function removeOuterCrefPrefix
+    input output ComponentRef cref;
+  algorithm
+    () := match cref
+      case ComponentRef.CREF()
+        algorithm
+          if InstNode.isGeneratedInner(cref.node) then
+            cref.restCref := EMPTY();
+          else
+            cref.restCref := removeOuterCrefPrefix(cref.restCref);
+          end if;
+        then
+          ();
+
+      else ();
+    end match;
+  end removeOuterCrefPrefix;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFComponentRef;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -625,9 +625,6 @@ algorithm
   cls := Lookup.lookupClassName(classPath, top, NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
   cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), cls);
 
-  // Initialize the storage for automatically generated inner elements.
-  top := InstNode.setInnerOuterCache(top, CachedData.TOP_SCOPE(NodeTree.new(), cls));
-
   // Instantiate the class.
   inst_cls := NFInst.instantiate(cls, context = NFInstContext.RELAXED);
 
@@ -767,12 +764,8 @@ algorithm
   cls := Lookup.lookupClassName(classPath, top, NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
   cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), cls);
 
-  // Initialize the storage for automatically generated inner elements.
-  top := InstNode.setInnerOuterCache(top, CachedData.TOP_SCOPE(NodeTree.new(), cls));
-
   // Expand the class.
   expanded_cls := NFInst.expand(cls);
-  NFInst.insertGeneratedInners(expanded_cls, top, NFInstContext.RELAXED);
 
   if Flags.isSet(Flags.EXEC_STAT) then
     execStat("NFApi.frontEndLookup_dispatch("+ name +")");

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterMissing8.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterMissing8.mo
@@ -1,0 +1,25 @@
+// name: InnerOuterMissing8
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model A
+  model B
+    Real x;
+  end B;
+
+  outer B b;
+end A;
+
+model InnerOuterMissing8
+  A a;
+end InnerOuterMissing8;
+
+// Result:
+// class InnerOuterMissing8
+//   Real b.x;
+// end InnerOuterMissing8;
+// [flattening/modelica/scodeinst/InnerOuterMissing8.mo:12:3-12:12:writable] Warning: An inner declaration for outer component b could not be found and was automatically generated.
+//
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -632,6 +632,7 @@ InnerOuterMissing4.mo \
 InnerOuterMissing5.mo \
 InnerOuterMissing6.mo \
 InnerOuterMissing7.mo \
+InnerOuterMissing8.mo \
 InnerOuterNotInner1.mo \
 InStreamArray.mo \
 InStreamFlowThreshold.mo \


### PR DESCRIPTION
- Mark generated inner elements and use that to remove the outer prefix
  from crefs involving generated inner components, and change the
  instantiation scope of generated inner component to be the scope
  they're declared in instead of the root class.
- Simplify the caching of generated inners by removing the TOP_SCOPE
  cache type and use an UnorderedMap in the TOP_SCOPE node type instead.