### PR TITLE
Update OMSimulator

### DIFF
--- a/testsuite/omsimulator/test03.mos
+++ b/testsuite/omsimulator/test03.mos
@@ -98,14 +98,6 @@ unloadOMSimulator();
 // <?xml version="1.0"?>
 // <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 // 	<ssd:System name="eoo">
-// 		<ssd:Annotations>
-// 			<ssc:Annotation type="org.openmodelica">
-// 				<oms:SimulationInformation>
-// 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-// 				</oms:SimulationInformation>
-// 			</ssc:Annotation>
-// 		</ssd:Annotations>
-// 		<ssd:Connectors />
 // 		<ssd:Elements>
 // 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 // 				<ssd:Connectors>
@@ -131,12 +123,22 @@ unloadOMSimulator();
 // 				</ssd:Connectors>
 // 			</ssd:Component>
 // 		</ssd:Elements>
-// 		<ssd:Connections />
+// 		<ssd:Annotations>
+// 			<ssc:Annotation type="org.openmodelica">
+// 				<oms:Annotations>
+// 					<oms:SimulationInformation>
+// 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+// 					</oms:SimulationInformation>
+// 				</oms:Annotations>
+// 			</ssc:Annotation>
+// 		</ssd:Annotations>
 // 	</ssd:System>
 // 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 // 		<ssd:Annotations>
 // 			<ssc:Annotation type="org.openmodelica">
-// 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+// 				<oms:Annotations>
+// 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+// 				</oms:Annotations>
 // 			</ssc:Annotation>
 // 		</ssd:Annotations>
 // 	</ssd:DefaultExperiment>
@@ -146,14 +148,6 @@ unloadOMSimulator();
 // <?xml version="1.0"?>
 // <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 // 	<ssd:System name="eoo">
-// 		<ssd:Annotations>
-// 			<ssc:Annotation type="org.openmodelica">
-// 				<oms:SimulationInformation>
-// 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-// 				</oms:SimulationInformation>
-// 			</ssc:Annotation>
-// 		</ssd:Annotations>
-// 		<ssd:Connectors />
 // 		<ssd:Elements>
 // 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 // 				<ssd:Connectors>
@@ -179,12 +173,22 @@ unloadOMSimulator();
 // 				</ssd:Connectors>
 // 			</ssd:Component>
 // 		</ssd:Elements>
-// 		<ssd:Connections />
+// 		<ssd:Annotations>
+// 			<ssc:Annotation type="org.openmodelica">
+// 				<oms:Annotations>
+// 					<oms:SimulationInformation>
+// 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+// 					</oms:SimulationInformation>
+// 				</oms:Annotations>
+// 			</ssc:Annotation>
+// 		</ssd:Annotations>
 // 	</ssd:System>
 // 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 // 		<ssd:Annotations>
 // 			<ssc:Annotation type="org.openmodelica">
-// 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+// 				<oms:Annotations>
+// 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+// 				</oms:Annotations>
 // 			</ssc:Annotation>
 // 		</ssd:Annotations>
 // 	</ssd:DefaultExperiment>


### PR DESCRIPTION
```log
* fb8a7a2 [Andreas   ] Activating all tests on MINGW (#896)
* a692b7c [Andreas   ] Fixing error introduced in 6aace93 (#899)
* 6aace93 [Andreas   ] Changed Dll search meachanism with Python 3.8 (#..
* 6616083 [Lennart ..] Use `generic_string` to avoid os specific path d..
* 434ccf9 [Adrian Pop] fix gcc build on new OMDev, link with the tlm li..
* e62288d [Lennart ..] Enable new tests (#895)
* 29a1dff [arun3688  ] add oms_exportSSMTemplate to export SSM template..
* 745c59f [Adrian Pop] remove CentOS6 stage as it reached the end of li..
* 4317b42 [arun3688  ] add <oms:Annotations> to handle all oms annotati..
* a355ad0 [arun3688  ] export <ssd:annotation> to end, inorder to be va..
* 5635948 [Lennart ..] Next attempt to make Jenkins upload the artifact..
* 61cd393 [Andreas   ] Use origin/master to test if we are on the maste..
* 3d4bb9c [Lennart ..] Rename dev/ to nightly/ (#883)
* d3a82d9 [Lennart ..] Detect release directory for pip's setup.py (#882)
* 5fb1b32 [Lennart ..] Update Jenkins (#881)
* 4ceb1c1 [Lennart ..] Update OMTLMSimulator (#880)
* e489739 [Lennart ..] Test cross-compiled mingw64 and msvc64 (#855)
* 54e874f [arun3688  ] do not export empty ssd tags to ssp (#876)
```