### PR TITLE
Fix simplification of homotopy

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -122,7 +122,6 @@ public
       case "edge" then typeEdgeCall(call, next_context, info);
       case "fill" then typeFillCall(call, next_context, info);
       case "getInstanceName" then typeGetInstanceName(call);
-      case "homotopy" then typeHomotopyCall(call, next_context, info);
       //case "hold" guard Config.synchronousFeaturesAllowed() then typeHoldCall(call, next_context, info);
       //case "initialState" guard Config.synchronousFeaturesAllowed() then typeInitialStateCall(call, next_context, info);
       case "initial" then typeDiscreteCall(call, next_context, info);
@@ -2293,28 +2292,6 @@ protected
     Structural.markExp(factor);
     callExp := Expression.CALL(Call.unboxArgs(ty_call));
   end typeSuperSampleCall;
-
-  function typeHomotopyCall
-    input Call call;
-    input InstContext.Type context;
-    input SourceInfo info;
-    output Expression callExp;
-    output Type ty;
-    output Variability var;
-    output Purity purity = Purity.IMPURE;
-  protected
-    Call ty_call;
-    list<Expression> args;
-  algorithm
-    ty_call as Call.TYPED_CALL(arguments = args, ty = ty, var = var) :=
-      Call.typeMatchNormalCall(call, context, info);
-
-    callExp := match Flags.getConfigString(Flags.REPLACE_HOMOTOPY)
-      case "actual" then listHead(args);
-      case "simplified" then listHead(listRest(args));
-      else Expression.CALL(Call.unboxArgs(ty_call));
-    end match;
-  end typeHomotopyCall;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFBuiltinCall;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1585,7 +1585,6 @@ uniontype Function
           // can have variable number of arguments
           case "fill" then true;
           case "getInstanceName" then true;
-          case "homotopy" then true;
           // Always discrete.
           case "initial" then true;
           case "inStream" then true;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -236,6 +236,7 @@ algorithm
         exp;
 
     case "fill"      then simplifyFill(listHead(args), listRest(args), call);
+    case "homotopy"  then simplifyHomotopy(args, call);
     case "ones"      then simplifyFill(Expression.INTEGER(1), args, call);
     case "sum"       then simplifySumProduct(listHead(args), call, isSum = true);
     case "product"   then simplifySumProduct(listHead(args), call, isSum = false);
@@ -333,6 +334,18 @@ algorithm
     exp := Expression.CALL(call);
   end if;
 end simplifyFill;
+
+function simplifyHomotopy
+  input list<Expression> args;
+  input Call call;
+  output Expression exp;
+algorithm
+  exp := match Flags.getConfigString(Flags.REPLACE_HOMOTOPY)
+    case "actual" then listHead(args);
+    case "simplified" then listHead(listRest(args));
+    else Expression.CALL(call);
+  end match;
+end simplifyHomotopy;
 
 function simplifyArrayConstructor
   input Call call;


### PR DESCRIPTION
- Simplify homotopy in SimplifyExp instead of during typing, to avoid
  vectorization issues.