### PR TITLE
Turn off vectorization of some builtin functions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1948,7 +1948,7 @@ protected
     Integer args_count;
     Expression e1, e2;
   algorithm
-    Call.TYPED_CALL(arguments = args) := Call.typeMatchNormalCall(call, context, info);
+    Call.TYPED_CALL(arguments = args) := Call.typeMatchNormalCall(call, context, info, vectorize = false);
     args_count := listLength(args);
 
     callExp := match args
@@ -2232,7 +2232,7 @@ protected
     Expression counter, resolution;
   algorithm
     ty_call as Call.TYPED_CALL(arguments = {_, counter, resolution}, ty = ty, var = var) :=
-      Call.typeMatchNormalCall(call, context, info);
+      Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(counter);
     Structural.markExp(resolution);
     callExp := Expression.CALL(Call.unboxArgs(ty_call));
@@ -2251,7 +2251,7 @@ protected
     Expression counter, resolution;
   algorithm
     ty_call as Call.TYPED_CALL(arguments = {_, counter, resolution}, ty = ty, var = var) :=
-      Call.typeMatchNormalCall(call, context, info);
+      Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(counter);
     Structural.markExp(resolution);
     callExp := Expression.CALL(Call.unboxArgs(ty_call));
@@ -2270,7 +2270,7 @@ protected
     Expression factor;
   algorithm
     ty_call as Call.TYPED_CALL(arguments = {_, factor}, ty = ty, var = var) :=
-      Call.typeMatchNormalCall(call, context, info);
+      Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(factor);
     callExp := Expression.CALL(Call.unboxArgs(ty_call));
   end typeSubSampleCall;
@@ -2288,7 +2288,7 @@ protected
     Expression factor;
   algorithm
     ty_call as Call.TYPED_CALL(arguments = {_, factor}, ty = ty, var = var) :=
-      Call.typeMatchNormalCall(call, context, info);
+      Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(factor);
     callExp := Expression.CALL(Call.unboxArgs(ty_call));
   end typeSuperSampleCall;

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -296,17 +296,19 @@ public
     input output NFCall call;
     input InstContext.Type context;
     input SourceInfo info;
+    input Boolean vectorize = true;
   protected
     NFCall argtycall;
   algorithm
     argtycall := typeNormalCall(call, context, info);
-    call := matchTypedNormalCall(argtycall, context, info);
+    call := matchTypedNormalCall(argtycall, context, info, vectorize);
   end typeMatchNormalCall;
 
   function matchTypedNormalCall
     input output NFCall call;
     input InstContext.Type context;
     input SourceInfo info;
+    input Boolean vectorize = true;
   protected
     Function func;
     list<Expression> args;
@@ -319,7 +321,7 @@ public
     Expression arg_exp;
   algorithm
     ARG_TYPED_CALL(call_scope = scope) := call;
-    matchedFunc := checkMatchingFunctions(call,info);
+    matchedFunc := checkMatchingFunctions(call, info, vectorize);
 
     func := matchedFunc.func;
     typed_args := matchedFunc.args;
@@ -2155,6 +2157,7 @@ protected
   function checkMatchingFunctions
     input NFCall call;
     input SourceInfo info;
+    input Boolean vectorize = true;
     output MatchedFunction matchedFunc;
   protected
     list<MatchedFunction> matchedFunctions, exactMatches;
@@ -2175,7 +2178,7 @@ protected
             allfuncs := list(fn for fn guard not Function.isDefaultRecordConstructor(fn) in allfuncs);
           end if;
         then
-          Function.matchFunctions(allfuncs, call.positional_args, call.named_args, info);
+          Function.matchFunctions(allfuncs, call.positional_args, call.named_args, info, vectorize);
     end match;
 
     if listEmpty(matchedFunctions) then


### PR DESCRIPTION
- Turn off vectorization for some non-vectorizable builtin functions
  with special handling to make sure an error message is given if
  they're called with vector arguments instead of just failing on them.