### PR TITLE
fix ticket6262

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -760,14 +760,12 @@ algorithm
      parameter Real x_start = 6.0;
   */
   for var in BackendVariable.varList(dae.shared.globalKnownVars) loop
-    if BackendVariable.isInput(var) and not Expression.isConstValue(BackendVariable.varStartValue(var)) then
+    if BackendVariable.isInput(var) and not Expression.isConstValue(BackendVariable.varStartValue(var)) and not Types.isArray(BackendVariable.varType(var)) then
       bindExp := BackendVariable.varStartValue(var);
       (v, _) := BackendVariable.getVarSingle(Expression.expCref(bindExp), dae.shared.globalKnownVars);
       var := BackendVariable.setVarStartValueOption(var, v.bindExp);
-      globalKnownVarList := var :: globalKnownVarList;
-    else
-      globalKnownVarList := var :: globalKnownVarList;
     end if;
+    globalKnownVarList := var :: globalKnownVarList;
   end for;
   dae := BackendDAEUtil.setDAEGlobalKnownVars(dae, BackendVariable.listVar(globalKnownVarList));
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -42,6 +42,7 @@ testInitialEquationsFMI.mos \
 TestSourceCodeFMU.mos \
 ticket5670.mos \
 ZeroStates.mos \
+ticket6262.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket6262.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket6262.mos
@@ -1,0 +1,59 @@
+// name:     ticket6262
+// status: correct
+// teardown_command: rm -rf ticket6262.fmu ticket6262.log ticket6262.xml ticket6262_tmp.xml
+
+loadString("
+model ticket6262
+  input Real x(start = x_start);
+  parameter Real x_start = 6.0;
+  Real y;
+equation
+  y = x;
+end ticket6262;
+"); getErrorString();
+
+translateModelFMU(ticket6262, version = "2.0"); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq ticket6262.fmu modelDescription.xml > ticket6262_tmp.xml"); getErrorString();
+system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" ticket6262_tmp.xml > ticket6262.xml"); getErrorString();
+readFile("ticket6262.xml"); getErrorString()
+
+// Result:
+// true
+// ""
+// "ticket6262.fmu"
+// ""
+// 0
+// ""
+// 0
+// ""
+// "  <ModelVariables>
+//   <!-- Index of variable = \"1\" -->
+//   <ScalarVariable
+//     name=\"x\"
+//     valueReference=\"0\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"6.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"2\" -->
+//   <ScalarVariable
+//     name=\"x_start\"
+//     valueReference=\"1\"
+//     variability=\"fixed\"
+//     causality=\"parameter\"
+//     >
+//     <Real start=\"6.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"3\" -->
+//   <ScalarVariable
+//     name=\"y\"
+//     valueReference=\"0\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   </ModelVariables>
+// "
+// ""
+// endResult


### PR DESCRIPTION
### Relate Issue

https://trac.openmodelica.org/OpenModelica/ticket/6262

### Purpose:

This PR fixes start values for inputs, when start exp has non constant bindings associated with a parameter.

### Example

```
model ticket6262
  input Real x(start = x_start);
  parameter Real x_start = 6.0;
  Real y;
equation
  y = x;
end ticket6262;
```