### PR TITLE
Improve handling of package constants

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4478,6 +4478,13 @@ public
 
       case RECORD() then listGet(recordExp.elements, index);
 
+      case CREF()
+        algorithm
+          Type.COMPLEX(cls = node) := Type.arrayElementType(typeOf(recordExp));
+          node := Class.nthComponent(index, InstNode.getClass(node));
+        then
+          fromCref(ComponentRef.prefixCref(node, InstNode.getType(node), {}, recordExp.cref));
+
       case ARRAY(elements = {}, ty = Type.ARRAY(elementType = Type.COMPLEX(cls = node)))
         then makeEmptyArray(InstNode.getType(Class.nthComponent(index, InstNode.getClass(node))));
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -174,13 +174,13 @@ algorithm
   // Apply simplifications to the model.
   flatModel := SimplifyModel.simplify(flatModel);
 
-  // Collect a tree of all functions that are still used in the flat model.
-  functions := Flatten.collectFunctions(flatModel);
-
   // Collect package constants that couldn't be substituted with their values
   // (e.g. because they where used with non-constant subscripts), and add them
   // to the model.
-  flatModel := Package.collectConstants(flatModel, functions);
+  flatModel := Package.collectConstants(flatModel);
+
+  // Collect a tree of all functions that are still used in the flat model.
+  functions := Flatten.collectFunctions(flatModel);
 
   // Dump the flat model to a stream if dumpFlat = true.
   flatString := if dumpFlat then

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -77,7 +77,7 @@ public
     node := ComponentRef.node(cref);
     comp := InstNode.component(node);
     ty := ComponentRef.getSubscriptedType(cref);
-    binding := Component.getBinding(comp);
+    binding := Component.getImplicitBinding(comp);
     vis := InstNode.visibility(node);
     attr := Component.getAttributes(comp);
     cmt := Component.comment(comp);
@@ -104,6 +104,7 @@ public
         Expression.arrayScalarElements(ExpandExp.expandCref(Expression.fromCref(var.name))));
 
       v := var;
+      v.ty := Type.arrayElementType(v.ty);
       vars := {};
       binding := var.binding;
 

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -697,12 +697,8 @@ algorithm
   flat_model := EvalConstants.evaluate(flat_model);
   flat_model := UnitCheck.checkUnits(flat_model);
   flat_model := SimplifyModel.simplify(flat_model);
+  flat_model := Package.collectConstants(flat_model);
   funcs := Flatten.collectFunctions(flat_model);
-
-  // Collect package constants that couldn't be substituted with their values
-  // (e.g. because they where used with non-constant subscripts), and add them
-  // to the model.
-  flat_model := Package.collectConstants(flat_model, funcs);
 
   // Scalarize array components in the flat model.
   if Flags.isSet(Flags.NF_SCALARIZE) then

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -728,6 +728,7 @@ OperatorOverloadError1.mo \
 OperatorOverloadSum1.mo \
 PackageConstant1.mo \
 PackageConstant3.mo \
+PackageConstant4.mo \
 ParameterBug.mos \
 PartialApplication1.mo \
 PartialApplicationInvalidArg1.mo \

--- a/testsuite/flattening/modelica/scodeinst/PackageConstant3.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageConstant3.mo
@@ -18,15 +18,21 @@ package P
   end ext_func;
 end P;
 
-model M
+model PackageConstant3
   Real x = P.r[1].x;
-end M;
+end PackageConstant3;
 
 // Result:
-// class M
+// function P.ext_func
+//   output Real x;
+//
+//   external "C" x = ext_func();
+// end P.ext_func;
+//
+// class PackageConstant3
 //   parameter Real P.r[1].x = P.ext_func();
 //   parameter Real P.r[2].x = P.ext_func();
 //   parameter Real P.r[3].x = P.ext_func();
 //   Real x = P.r[1].x;
-// end M;
+// end PackageConstant3;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/PackageConstant4.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageConstant4.mo
@@ -1,0 +1,38 @@
+// name: PackageConstant4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+package P
+  record R
+    Real x;
+  end R;
+
+  parameter R r1(x = ext_func());
+  parameter R r2[1] = {r1};
+
+  function ext_func
+    output Real x;
+
+    external "C";
+  end ext_func;
+end P;
+
+model PackageConstant4
+  Real x = P.r2[1].x;
+end PackageConstant4;
+
+// Result:
+// function P.ext_func
+//   output Real x;
+//
+//   external "C" x = ext_func();
+// end P.ext_func;
+//
+// class PackageConstant4
+//   parameter Real P.r1.x = P.ext_func();
+//   parameter Real P.r2[1].x = P.r1.x;
+//   Real x = P.r2[1].x;
+// end PackageConstant4;
+// endResult


### PR DESCRIPTION
- Try to fetch the binding of a package constant from its parent if it
  doesn't have a binding and is a record field.
- Add case for cref in Expression.nthRecordElement that returns a new
  cref instead of a record element expression.
- Disable collection of package constants in functions, since it doesn't
  work properly anyway.
- Move collection of package constants before collection of functions,
  so that function in package constants are also collected.