### PR TITLE
Fix unparsing of disabled debug flag

### DIFF
--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -1861,6 +1861,7 @@ protected
   array<Flags.FlagData> config_flags;
   String name;
   list<String> strl = {};
+  Boolean fvalue;
 algorithm
   try
     Flags.FLAGS(debugFlags = debug_flags, configFlags = config_flags) := loadFlags(false);
@@ -1880,8 +1881,10 @@ algorithm
   end for;
 
   for f in allDebugFlags loop
-    if f.default <> debug_flags[f.index] then
-      strl := f.name :: strl;
+    fvalue := debug_flags[f.index];
+    if f.default <> fvalue then
+      name := if fvalue then f.name else "no" + f.name;
+      strl := name :: strl;
     end if;
   end for;
 

--- a/testsuite/openmodelica/interactive-API/getCommandLineOptions.mos
+++ b/testsuite/openmodelica/interactive-API/getCommandLineOptions.mos
@@ -16,6 +16,8 @@ setCommandLineOptions("-d=ceval");
 getCommandLineOptions();
 setCommandLineOptions("--postOptModules=dumpDAE,dumpDAEXML");
 getCommandLineOptions();
+setCommandLineOptions("-d=-newInst");
+getCommandLineOptions();
 
 // Result:
 // true
@@ -28,4 +30,6 @@ getCommandLineOptions();
 // {"-d=ceval,failtrace","--showAnnotations=true"}
 // true
 // {"-d=ceval,failtrace","--postOptModules=dumpDAE,dumpDAEXML","--showAnnotations=true"}
+// true
+// {"-d=nonewInst,ceval,failtrace","--postOptModules=dumpDAE,dumpDAEXML","--showAnnotations=true"}
 // endResult


### PR DESCRIPTION
- Prefix debug flags in FlagsUtil.unparseFlags with "no" if they're
  disabled.