### PR TITLE
Let the user disable the new instantiation

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1132,11 +1132,11 @@ bool SimulationDialog::translateModel(QString simulationParameters)
   bool result = MainWindow::instance()->getOMCProxy()->translateModel(mClassName, simulationParameters);
   if (!result) {
     //! @todo Remove this once new frontend is used as default and old frontend is removed.
-    bool newFrontendEnabled = false;
+    bool newFrontendEnabled = true;
     QList<QString> options = MainWindow::instance()->getOMCProxy()->getCommandLineOptions();
     foreach (QString option, options) {
-      if (option.contains("newInst")) {
-        newFrontendEnabled = true;
+      if (option.contains("nonewInst")) {
+        newFrontendEnabled = false;
         break;
       }
     }

--- a/OMEdit/OMEditLIB/Simulation/TranslationFlagsWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/TranslationFlagsWidget.cpp
@@ -193,8 +193,8 @@ QString TranslationFlagsWidget::commandLineOptions()
     debugFlags.append("parmodauto");
   }
   // enable new instantiation
-  if (!mpOldInstantiationCheckBox->isChecked()) {
-    debugFlags.append("newInst");
+  if (mpOldInstantiationCheckBox->isChecked()) {
+    debugFlags.append("nonewInst");
   }
 
   QStringList preOptModules;


### PR DESCRIPTION
Fixes #6316
Since the new instantiation is on by default so set the flag `-d=nonewInst` if user wants to use the old instantiation.