### PR TITLE
Avoid needless copy in solveInitialSystem

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -228,7 +228,7 @@ algorithm
     // add initial assignmnents to all algorithms
     initdae := BackendDAEOptimize.addInitialStmtsToAlgorithms(initdae, true);
 
-    if useHomotopy then
+    if useHomotopy and Config.globalHomotopy() then
       initdae0 := BackendDAEUtil.copyBackendDAE(initdae);
     end if;
 


### PR DESCRIPTION
- initdae0 is only used in two if-statements, so the first if-statement
  should have the same condition as the second to avoid making a copy of
  the initialization system when it's not going to be used.