### PR TITLE
Fix some backend performance issues

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -5730,29 +5730,11 @@ algorithm
   end matchcontinue;
 end listAllIterationVariables2;
 
-protected function warnAboutVars "author: lochel"
-  input list<BackendDAE.Var> inVars;
-  output String outString;
+protected function warnAboutVars
+  input list<BackendDAE.Var> vars;
+  output String str;
 algorithm
-  outString := match(inVars)
-    local
-      BackendDAE.Var v;
-      list<BackendDAE.Var> vars;
-      String crStr;
-      String str;
-
-    case ({})
-    then "";
-
-    case (v::{}) equation
-      crStr = "  " + BackendDump.varString(v);
-    then crStr;
-
-    case (v::vars) equation
-      crStr = BackendDump.varString(v);
-      str = "  " + crStr + "\n" + warnAboutVars(vars);
-    then str;
-  end match;
+  str := stringDelimitList(list("  " + BackendDump.varString(v) for v in vars), "\n");
 end warnAboutVars;
 
 public function addTimeAsState

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -477,18 +477,19 @@ public function copyBackendDAE "author: Frenkel TUD, wbraun
   input BackendDAE.BackendDAE inDAE;
   output BackendDAE.BackendDAE outDAE;
 algorithm
-  outDAE := mapEqSystem(inDAE, copyEqSystemAndShared);
+  outDAE := mapEqSystem(inDAE, copyEqSystemTraverser);
+  outDAE.shared := copyBackendDAEShared(outDAE.shared);
 end copyBackendDAE;
 
-public function copyEqSystemAndShared
+public function copyEqSystemTraverser
   input BackendDAE.EqSystem inSystem;
   input BackendDAE.Shared inShared;
   output BackendDAE.EqSystem outSystem;
   output BackendDAE.Shared outShared;
 algorithm
   outSystem := copyEqSystem(inSystem);
-  outShared := copyBackendDAEShared(inShared);
-end copyEqSystemAndShared;
+  outShared := inShared;
+end copyEqSystemTraverser;
 
 public function copyEqSystem
   input BackendDAE.EqSystem inSystem;


### PR DESCRIPTION
- Copy the shared data in the DAE only once in
  BackendDAEUtil.copyBackendDAE, instead of once for each equation
  system.
- Rename copyEqSystemAndShared to copyEqSystemTraverser, since it no
  longer copies Shared.
- Rewrite BackendDAEOptimize.warnAboutVars to not be recursive, to avoid
  stack overflows.