### PR TITLE
Fixing wrong minimalTearing

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -159,7 +159,7 @@ protected function callTearingMethod
   input BackendDAE.Shared ishared;
   input list<Integer> eindex;
   input list<Integer> vindx;
-  input Option<list<tuple<Integer, Integer, BackendDAE.Equation>>> ojac;
+  input BackendDAE.FullJacobian ojac;
   input BackendDAE.JacobianType jacType;
   input Boolean mixedSystem;
   input Integer strongComponentIndex;
@@ -221,7 +221,7 @@ algorithm
       case MINIMAL_TEARING()
           algorithm
            if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
-             print("\nTearing type: total\n");
+             print("\nTearing type: minimal\n");
            end if;
            ocomp := minimalTearing(isyst, ishared, eindex, vindx, jacType, mixedSystem);
            if debug then execStat("Tearing.minimalTearing"); end if;
@@ -1853,7 +1853,7 @@ try
   // dumpTearingSetGlobalIndexes(BackendDAE.TEARINGSET(iterationVars, residualequations, listReverse(innerEquations), BackendDAE.EMPTY_JACOBIAN()),size," - STRICT SET");
 
   // Return torn system
-  ocomp := BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(iterationVars, residualequations, listReverse(innerEquations), BackendDAE.EMPTY_JACOBIAN()), NONE(), linear, mixedSystem);
+  ocomp := BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(listReverse(iterationVars), listReverse(residualequations), listReverse(innerEquations), BackendDAE.EMPTY_JACOBIAN()), NONE(), linear, mixedSystem);
 else
   Error.addInternalError("function minimalTearing failed", sourceInfo());
   fail();

--- a/testsuite/simulation/modelica/tearing/Tearing18-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing18-minimal.mos
@@ -29,7 +29,7 @@ val(x8,1.0); getErrorString();
 //     resultFile = "Tearing18_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing18', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | debug   | Solving non-linear system 34 failed at time=0.246.
+// assert            | debug   | Solving non-linear system 34 failed at time=0.086.
 // |                 | |       | For more information please use -lv LOG_NLS.
 // stdout            | warning | Integrator attempt to handle a problem with a called assert.
 // LOG_SUCCESS       | info    | The simulation finished successfully.


### PR DESCRIPTION
The Jacobian and the residual equations / iteration vars have to be in the same order.

So it seems we tried to use the (more or less) "transposed" Jacobian to solve the equation systems. This can be good enough for most systems, but when you have an eigenvalue of 1e-17 this can lead to a problem, as in https://trac.openmodelica.org/OpenModelica/ticket/6285.