### PR TITLE
Refactor argument mapping in EvalFunction

### DIFF
--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -254,6 +254,15 @@ public
     value := if index > 0 then SOME(Vector.getNoBounds(map.values, index)) else NONE();
   end get;
 
+  function getOrFail
+    "Return the value associated with the given key, or fails if no such value exists."
+    input K key;
+    input UnorderedMap<K, V> map;
+    output V value;
+  algorithm
+    value := Vector.get(map.values, find(key, map));
+  end getOrFail;
+
   function getKey
     "Returns SOME(key) if the key exists in the map, otherwise NONE()."
     input K key;

--- a/OMCompiler/Compiler/Util/UnorderedSet.mo
+++ b/OMCompiler/Compiler/Util/UnorderedSet.mo
@@ -188,6 +188,18 @@ public
     outKey := find(key, set);
   end get;
 
+  function getOrFail
+    "Returns a key if it exists in the set, otherwise fails."
+    input T key;
+    input UnorderedSet<T> set;
+    output T outKey;
+  protected
+    Option<T> okey;
+  algorithm
+    okey := find(key, set);
+    SOME(outKey) := okey;
+  end getOrFail;
+
   function contains
     "Returns whether the given key exists in the set or not."
     input T key;


### PR DESCRIPTION
- Change the argument mapping functions in EvalFunction to use an
  UnorderedMap instead of an AvlTree, and make it more generic so it can
  be used by future external function evaluation.
- Add getOrFail function to UnorderedMap/UnorderedSet.