### PR TITLE
do not export clocks in typeDefinitions in modelDescription.xml

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -479,8 +479,6 @@ match simVar
   let valueReference = getValueReference(simVar, simCode, false)
   let description = if comment then 'description="<%Util.escapeModelicaStringToXmlString(comment)%>"'
   let variability_ = if getClockIndex(simVar, simCode) then "discrete" else getVariability2(variability)
-  let clockIndex = getClockIndex(simVar, simCode)
-  let previous = match varKind case CLOCKED_STATE(__) then '<%getVariableIndex(cref2simvar(previousName, simCode))%>'
   let caus = getCausality2(causality)
   let initial = getInitialType2(initial_)
   <<
@@ -489,8 +487,6 @@ match simVar
   <%description%>
   <%if boolNot(stringEq(variability_, "")) then 'variability="'+variability_+'"' %>
   <%if boolNot(stringEq(caus, "")) then 'causality="'+caus+'"' %>
-  <%if boolNot(stringEq(clockIndex, "")) then 'clockIndex="'+clockIndex+'"' %>
-  <%if boolNot(stringEq(previous, "")) then 'previous="'+previous+'"' %>
   <%if boolNot(stringEq(initial, "")) then 'initial="'+initial+'"' %>
   >>
 end ScalarVariableAttribute2;
@@ -734,7 +730,7 @@ end fmiTypeDefinitions;
 template TypeDefinitionsHelper(SimCode simCode, list<SimCodeVar.SimVar> vars, String FMUVersion)
  "Generates code for TypeDefinitions for FMU target."
 ::=
-  let clocks = if isFMIVersion10(FMUVersion) then "" else TypeDefinitionsClocks(simCode)
+  let clocks = if boolOr(isFMIVersion10(FMUVersion), isFMIVersion20(FMUVersion)) then "" else TypeDefinitionsClocks(simCode)
   if boolOr(intGt(listLength(vars), 0), boolNot(stringEq(clocks, ""))) then
   <<
   <TypeDefinitions>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
@@ -78,13 +78,6 @@ readFile("modelDescription.tmp.xml");
 //   <ModelExchange
 //     modelIdentifier=\"ArrayEquationsTest\">
 //   </ModelExchange>
-//   <TypeDefinitions>
-//     <Clocks>
-//       <Clock><Inferred
-//               interval=\"0.1\"
-//               /></Clock>
-//     </Clocks>
-//   </TypeDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -98,7 +91,7 @@ readFile("modelDescription.tmp.xml");
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-006\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
@@ -535,7 +528,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[1]\"
 //     valueReference=\"64\"
 //     variability=\"discrete\"
-//     previous=\"1\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -544,7 +536,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[2]\"
 //     valueReference=\"65\"
 //     variability=\"discrete\"
-//     previous=\"2\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -553,7 +544,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[3]\"
 //     valueReference=\"66\"
 //     variability=\"discrete\"
-//     previous=\"3\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -562,7 +552,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[4]\"
 //     valueReference=\"67\"
 //     variability=\"discrete\"
-//     previous=\"4\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -571,7 +560,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[5]\"
 //     valueReference=\"68\"
 //     variability=\"discrete\"
-//     previous=\"5\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -580,7 +568,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[6]\"
 //     valueReference=\"69\"
 //     variability=\"discrete\"
-//     previous=\"6\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -589,7 +576,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[7]\"
 //     valueReference=\"70\"
 //     variability=\"discrete\"
-//     previous=\"7\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -598,7 +584,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[8]\"
 //     valueReference=\"71\"
 //     variability=\"discrete\"
-//     previous=\"8\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -607,7 +592,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[9]\"
 //     valueReference=\"72\"
 //     variability=\"discrete\"
-//     previous=\"9\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -616,7 +600,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1[10]\"
 //     valueReference=\"73\"
 //     variability=\"discrete\"
-//     previous=\"10\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -625,7 +608,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[1]\"
 //     valueReference=\"74\"
 //     variability=\"discrete\"
-//     previous=\"11\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -634,7 +616,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[2]\"
 //     valueReference=\"75\"
 //     variability=\"discrete\"
-//     previous=\"12\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -643,7 +624,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[3]\"
 //     valueReference=\"76\"
 //     variability=\"discrete\"
-//     previous=\"13\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -652,7 +632,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[4]\"
 //     valueReference=\"77\"
 //     variability=\"discrete\"
-//     previous=\"14\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -661,7 +640,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[5]\"
 //     valueReference=\"78\"
 //     variability=\"discrete\"
-//     previous=\"15\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -670,7 +648,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[6]\"
 //     valueReference=\"79\"
 //     variability=\"discrete\"
-//     previous=\"16\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -679,7 +656,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[7]\"
 //     valueReference=\"80\"
 //     variability=\"discrete\"
-//     previous=\"17\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -688,7 +664,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[8]\"
 //     valueReference=\"81\"
 //     variability=\"discrete\"
-//     previous=\"18\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -697,7 +672,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[9]\"
 //     valueReference=\"82\"
 //     variability=\"discrete\"
-//     previous=\"19\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -706,7 +680,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2[10]\"
 //     valueReference=\"83\"
 //     variability=\"discrete\"
-//     previous=\"20\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -715,7 +688,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[1]\"
 //     valueReference=\"84\"
 //     variability=\"discrete\"
-//     previous=\"21\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -724,7 +696,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[2]\"
 //     valueReference=\"85\"
 //     variability=\"discrete\"
-//     previous=\"22\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -733,7 +704,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[3]\"
 //     valueReference=\"86\"
 //     variability=\"discrete\"
-//     previous=\"23\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -742,7 +712,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[4]\"
 //     valueReference=\"87\"
 //     variability=\"discrete\"
-//     previous=\"24\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -751,7 +720,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[5]\"
 //     valueReference=\"88\"
 //     variability=\"discrete\"
-//     previous=\"25\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -760,7 +728,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[6]\"
 //     valueReference=\"89\"
 //     variability=\"discrete\"
-//     previous=\"26\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -769,7 +736,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[7]\"
 //     valueReference=\"90\"
 //     variability=\"discrete\"
-//     previous=\"27\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -778,7 +744,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[8]\"
 //     valueReference=\"91\"
 //     variability=\"discrete\"
-//     previous=\"28\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -787,7 +752,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[9]\"
 //     valueReference=\"92\"
 //     variability=\"discrete\"
-//     previous=\"29\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -796,7 +760,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3[10]\"
 //     valueReference=\"93\"
 //     variability=\"discrete\"
-//     previous=\"30\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -805,7 +768,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[1]\"
 //     valueReference=\"94\"
 //     variability=\"discrete\"
-//     previous=\"31\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -814,7 +776,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[2]\"
 //     valueReference=\"95\"
 //     variability=\"discrete\"
-//     previous=\"32\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -823,7 +784,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[3]\"
 //     valueReference=\"96\"
 //     variability=\"discrete\"
-//     previous=\"33\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -832,7 +792,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[4]\"
 //     valueReference=\"97\"
 //     variability=\"discrete\"
-//     previous=\"34\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -841,7 +800,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[5]\"
 //     valueReference=\"98\"
 //     variability=\"discrete\"
-//     previous=\"35\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -850,7 +808,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[6]\"
 //     valueReference=\"99\"
 //     variability=\"discrete\"
-//     previous=\"36\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -859,7 +816,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[7]\"
 //     valueReference=\"100\"
 //     variability=\"discrete\"
-//     previous=\"37\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -868,7 +824,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[8]\"
 //     valueReference=\"101\"
 //     variability=\"discrete\"
-//     previous=\"38\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -877,7 +832,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[9]\"
 //     valueReference=\"102\"
 //     variability=\"discrete\"
-//     previous=\"39\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -886,7 +840,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4[10]\"
 //     valueReference=\"103\"
 //     variability=\"discrete\"
-//     previous=\"40\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -896,7 +849,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"104\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -906,7 +858,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"105\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -916,7 +867,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"106\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -926,7 +876,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"107\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -96,7 +96,7 @@ getErrorString();
 //       <BaseUnit s=\"-1\" factor=\"0.0002777777777777778\" />
 //     </Unit>
 //     <Unit name=\"kJ/h\">
-//       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" factor=\"0.2777777777777779\" />
+//       <BaseUnit m=\"2\" s=\"-3\" kg=\"1\" factor=\"0.2777777777777778\" />
 //     </Unit>
 //     <Unit name=\"mol/l\">
 //       <BaseUnit mol=\"1\" m=\"-3\" factor=\"1000.0\" />
@@ -105,13 +105,6 @@ getErrorString();
 //       <BaseUnit K=\"1\" />
 //     </Unit>
 //   </UnitDefinitions>
-//   <TypeDefinitions>
-//     <Clocks>
-//       <Clock><Inferred
-//               interval=\"20.0\"
-//               /></Clock>
-//     </Clocks>
-//   </TypeDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -125,7 +118,7 @@ getErrorString();
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-006\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
@@ -133,7 +126,6 @@ getErrorString();
 //     valueReference=\"0\"
 //     description=\"Coolant temperature\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real nominal=\"100.0\" unit=\"degC\"/>
 //   </ScalarVariable>
@@ -143,7 +135,6 @@ getErrorString();
 //     valueReference=\"1\"
 //     description=\"Concentration\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real unit=\"mol/l\"/>
 //   </ScalarVariable>
@@ -153,7 +144,6 @@ getErrorString();
 //     valueReference=\"2\"
 //     description=\"Concentration\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real unit=\"mol/l\"/>
 //   </ScalarVariable>
@@ -162,7 +152,6 @@ getErrorString();
 //     name=\"previous(T)\"
 //     valueReference=\"3\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real nominal=\"100.0\" unit=\"degC\"/>
 //   </ScalarVariable>
@@ -171,7 +160,6 @@ getErrorString();
 //     name=\"der(_D_outputAlias_TK)\"
 //     valueReference=\"4\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -180,7 +168,6 @@ getErrorString();
 //     name=\"der(_D_outputAlias_cA)\"
 //     valueReference=\"5\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -189,7 +176,6 @@ getErrorString();
 //     name=\"der(_D_outputAlias_cB)\"
 //     valueReference=\"6\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -198,7 +184,6 @@ getErrorString();
 //     name=\"der(T)\"
 //     valueReference=\"7\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -208,8 +193,6 @@ getErrorString();
 //     valueReference=\"11\"
 //     description=\"Coolant temperature\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"1\"
 //     initial=\"exact\">
 //     <Real start=\"112.9\" nominal=\"100.0\" unit=\"degC\"/>
 //   </ScalarVariable>
@@ -219,8 +202,6 @@ getErrorString();
 //     valueReference=\"12\"
 //     description=\"Concentration\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"2\"
 //     initial=\"exact\">
 //     <Real start=\"2.14\" unit=\"mol/l\"/>
 //   </ScalarVariable>
@@ -230,8 +211,6 @@ getErrorString();
 //     valueReference=\"13\"
 //     description=\"Concentration\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"3\"
 //     initial=\"exact\">
 //     <Real start=\"1.09\" unit=\"mol/l\"/>
 //   </ScalarVariable>
@@ -249,7 +228,6 @@ getErrorString();
 //     name=\"QK_flow_sampled\"
 //     valueReference=\"15\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -258,8 +236,6 @@ getErrorString();
 //     name=\"T\"
 //     valueReference=\"16\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"4\"
 //     initial=\"exact\">
 //     <Real start=\"114.2\" nominal=\"100.0\" unit=\"degC\"/>
 //   </ScalarVariable>
@@ -279,7 +255,6 @@ getErrorString();
 //     description=\"Coolant temperature\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real nominal=\"100.0\" unit=\"degC\"/>
 //   </ScalarVariable>
@@ -299,7 +274,6 @@ getErrorString();
 //     description=\"Concentration\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real unit=\"mol/l\"/>
 //   </ScalarVariable>
@@ -310,7 +284,6 @@ getErrorString();
 //     description=\"Concentration\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real unit=\"mol/l\"/>
 //   </ScalarVariable>
@@ -319,7 +292,6 @@ getErrorString();
 //     name=\"k[1]\"
 //     valueReference=\"22\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -328,7 +300,6 @@ getErrorString();
 //     name=\"k[2]\"
 //     valueReference=\"23\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -337,7 +308,6 @@ getErrorString();
 //     name=\"k[3]\"
 //     valueReference=\"24\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -469,7 +439,7 @@ getErrorString();
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
-//     <Real start=\"2511944.444444445\"/>
+//     <Real start=\"2511944.444444444\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"37\" -->
 //   <ScalarVariable
@@ -497,7 +467,7 @@ getErrorString();
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
-//     <Real start=\"934.2000000000001\" min=\"0.0\" unit=\"kg/m3\"/>
+//     <Real start=\"934.2\" min=\"0.0\" unit=\"kg/m3\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"40\" -->
 //   <ScalarVariable

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testClockDescription.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testClockDescription.mos
@@ -63,33 +63,6 @@ readFile("modelDescription.tmp.xml");
 //   <ModelExchange
 //     modelIdentifier=\"SubClocks\">
 //   </ModelExchange>
-//   <TypeDefinitions>
-//     <Clocks>
-//       <Clock><Inferred
-//               intervalCounter=\"9\"
-//               shiftCounter=\"2\"
-//               resolution=\"6\"
-//               /></Clock>
-//       <Clock><Inferred
-//               intervalCounter=\"36\"
-//               shiftCounter=\"2\"
-//               resolution=\"12\"
-//               /></Clock>
-//       <Clock><Inferred
-//               intervalCounter=\"4\"
-//               shiftCounter=\"2\"
-//               resolution=\"4\"
-//               /></Clock>
-//       <Clock><Inferred
-//               intervalCounter=\"2\"
-//               resolution=\"2\"
-//               /></Clock>
-//       <Clock><Inferred
-//               interval=\"0.5\"
-//               shiftCounter=\"1\"
-//               /></Clock>
-//     </Clocks>
-//   </TypeDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -110,7 +83,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x1\"
 //     valueReference=\"0\"
 //     variability=\"discrete\"
-//     clockIndex=\"4\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -119,7 +91,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x2\"
 //     valueReference=\"1\"
 //     variability=\"discrete\"
-//     clockIndex=\"3\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -128,7 +99,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x3\"
 //     valueReference=\"2\"
 //     variability=\"discrete\"
-//     clockIndex=\"2\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -137,7 +107,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x4\"
 //     valueReference=\"3\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -146,7 +115,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"x5\"
 //     valueReference=\"4\"
 //     variability=\"discrete\"
-//     clockIndex=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testModelDescription.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testModelDescription.mos
@@ -48,14 +48,6 @@ readFile("modelDescription.tmp.xml");
 //   <ModelExchange
 //     modelIdentifier=\"SIDTest\">
 //   </ModelExchange>
-//   <TypeDefinitions>
-//     <Clocks>
-//       <Clock><Inferred
-//               interval=\"0.2\"
-//               shiftCounter=\"3\"
-//               /></Clock>
-//     </Clocks>
-//   </TypeDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -69,14 +61,13 @@ readFile("modelDescription.tmp.xml");
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-006\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
 //     name=\"previous(xd)\"
 //     valueReference=\"0\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -93,8 +84,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"xd\"
 //     valueReference=\"3\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -104,7 +93,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"4\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/ticket6296.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/ticket6296.mos
@@ -202,7 +202,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[1]\"
 //     valueReference=\"31\"
 //     variability=\"discrete\"
-//     previous=\"1\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -211,7 +210,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[2]\"
 //     valueReference=\"32\"
 //     variability=\"discrete\"
-//     previous=\"2\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -220,7 +218,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[3]\"
 //     valueReference=\"33\"
 //     variability=\"discrete\"
-//     previous=\"3\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -229,7 +226,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[4]\"
 //     valueReference=\"34\"
 //     variability=\"discrete\"
-//     previous=\"4\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -238,7 +234,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[5]\"
 //     valueReference=\"35\"
 //     variability=\"discrete\"
-//     previous=\"5\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -247,7 +242,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[6]\"
 //     valueReference=\"36\"
 //     variability=\"discrete\"
-//     previous=\"6\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -256,7 +250,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[7]\"
 //     valueReference=\"37\"
 //     variability=\"discrete\"
-//     previous=\"7\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -265,7 +258,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[8]\"
 //     valueReference=\"38\"
 //     variability=\"discrete\"
-//     previous=\"8\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -274,7 +266,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[9]\"
 //     valueReference=\"39\"
 //     variability=\"discrete\"
-//     previous=\"9\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -283,7 +274,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     name=\"x1[10]\"
 //     valueReference=\"40\"
 //     variability=\"discrete\"
-//     previous=\"10\"
 //     initial=\"exact\">
 //     <Real/>
 //   </ScalarVariable>
@@ -293,7 +283,6 @@ readFile("ArrayEquationsTest.xml"); getErrorString()
 //     valueReference=\"41\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
@@ -120,11 +120,6 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./meta/meta_modelica_catch.c\" />
 //     </SourceFiles>
 //   </ModelExchange>
-//   <TypeDefinitions>
-//     <Clocks>
-//       <Clock><Inferred/></Clock>
-//     </Clocks>
-//   </TypeDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -173,7 +168,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"previous(_D_outputAlias_y1)\"
 //     valueReference=\"4\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -182,7 +176,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"previous(_D_outputAlias_y2)\"
 //     valueReference=\"5\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -191,7 +184,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"der(_D_outputAlias_y1)\"
 //     valueReference=\"6\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -200,7 +192,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"der(_D_outputAlias_y2)\"
 //     valueReference=\"7\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -209,8 +200,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"_D_outputAlias_y1\"
 //     valueReference=\"8\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -219,8 +208,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"_D_outputAlias_y2\"
 //     valueReference=\"9\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"6\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -237,7 +224,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"ud\"
 //     valueReference=\"11\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -247,7 +233,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"12\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -257,7 +242,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"13\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
@@ -116,11 +116,6 @@ readFile("modelDescription.tmp.xml");
 //       <File name=\"./meta/meta_modelica_catch.c\" />
 //     </SourceFiles>
 //   </ModelExchange>
-//   <TypeDefinitions>
-//     <Clocks>
-//       <Clock><Inferred/></Clock>
-//     </Clocks>
-//   </TypeDefinitions>
 //   <LogCategories>
 //     <Category name=\"logEvents\" />
 //     <Category name=\"logSingularLinearSystems\" />
@@ -141,7 +136,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"previous(_D_outputAlias_y1)\"
 //     valueReference=\"0\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -150,7 +144,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"previous(_D_outputAlias_y2)\"
 //     valueReference=\"1\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -159,7 +152,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"der(_D_outputAlias_y1)\"
 //     valueReference=\"2\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -168,7 +160,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"der(_D_outputAlias_y2)\"
 //     valueReference=\"3\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -177,8 +168,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"_D_outputAlias_y1\"
 //     valueReference=\"4\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -187,8 +176,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"_D_outputAlias_y2\"
 //     valueReference=\"5\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
-//     previous=\"2\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -205,7 +192,6 @@ readFile("modelDescription.tmp.xml");
 //     name=\"ud\"
 //     valueReference=\"7\"
 //     variability=\"discrete\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -215,7 +201,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"8\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -225,7 +210,6 @@ readFile("modelDescription.tmp.xml");
 //     valueReference=\"9\"
 //     variability=\"discrete\"
 //     causality=\"output\"
-//     clockIndex=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>


### PR DESCRIPTION
### Related issue
https://trac.openmodelica.org/OpenModelica/ticket/6371

### Purpose
This PR filters exporting of `clocks` in `TypeDefinitions ` and also filters exporting of `scalarVariable` attribute `clockIndex` and `previous`   in `modelDescription.xml` according to FMI-2.0.2.

### example
According to FMI.2.0.2 the following attributes are allowed in `scalarVariable`
```
<scalarVariable
   name = ,
   description =,
   valueReference =,
   variability = ,
   causality =,
   initial =,
   canHandleMultipleSetPerTimeInstant />
```