### PR TITLE
Update OMSimulator

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4756,6 +4756,7 @@ end oms_listUnconnectedConnectors;
 function oms_loadSnapshot
   input String cref;
   input String snapshot;
+  output String newCref;
   output Integer status;
 external "builtin";
 annotation(preferredView="text");
@@ -4767,14 +4768,6 @@ function oms_newModel
 external "builtin";
 annotation(preferredView="text");
 end oms_newModel;
-
-function oms_parseModelName
-  input String contents;
-  output String cref;
-  output Integer status;
-external "builtin";
-annotation(preferredView="text");
-end oms_parseModelName;
 
 function oms_removeSignalsFromResults
   input String cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4964,6 +4964,7 @@ end oms_listUnconnectedConnectors;
 function oms_loadSnapshot
   input String cref;
   input String snapshot;
+  output String newCref;
   output Integer status;
 external "builtin";
 annotation(preferredView="text");
@@ -4975,14 +4976,6 @@ function oms_newModel
 external "builtin";
 annotation(preferredView="text");
 end oms_newModel;
-
-function oms_parseModelName
-  input String contents;
-  output String cref;
-  output Integer status;
-external "builtin";
-annotation(preferredView="text");
-end oms_parseModelName;
 
 function oms_removeSignalsFromResults
   input String cref;

--- a/OMCompiler/Compiler/Script/CevalScriptOMSimulator.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptOMSimulator.mo
@@ -338,21 +338,15 @@ algorithm
 
     case("oms_loadSnapshot",{Values.STRING(cref), Values.STRING(snapshot)})
       equation
-        status = OMSimulator.oms_loadSnapshot(cref,snapshot);
+        (newCref,status) = OMSimulator.oms_loadSnapshot(cref,snapshot);
       then
-        Values.INTEGER(status);
+        Values.TUPLE({Values.STRING(newCref),Values.INTEGER(status)});
 
     case("oms_newModel",{Values.STRING(cref)})
       equation
         status = OMSimulator.oms_newModel(cref);
       then
         Values.INTEGER(status);
-
-    case("oms_parseModelName",{Values.STRING(contents)})
-      equation
-        (cref,status) = OMSimulator.oms_parseModelName(contents);
-      then
-        Values.TUPLE({Values.STRING(cref),Values.INTEGER(status)});
 
     case("oms_removeSignalsFromResults",{Values.STRING(cref), Values.STRING(regex)})
       equation

--- a/OMCompiler/Compiler/Util/OMSimulator.mo
+++ b/OMCompiler/Compiler/Util/OMSimulator.mo
@@ -403,8 +403,9 @@ end oms_listUnconnectedConnectors;
 function oms_loadSnapshot
   input String cref;
   input String snapshot;
+  output String newCref;
   output Integer status;
-  external "C" status = OMSimulator_oms_loadSnapshot(cref,snapshot) annotation(Library = "omcruntime");
+  external "C" status = OMSimulator_oms_loadSnapshot(cref,snapshot,newCref) annotation(Library = "omcruntime");
 end oms_loadSnapshot;
 
 function oms_newModel
@@ -412,13 +413,6 @@ function oms_newModel
   output Integer status;
   external "C" status = OMSimulator_oms_newModel(cref) annotation(Library = "omcruntime");
 end oms_newModel;
-
-function oms_parseModelName
-  input String contents;
-  output String cref;
-  output Integer status;
-  external "C" status = OMSimulator_oms_parseModelName(contents,cref) annotation(Library = "omcruntime");
-end oms_parseModelName;
 
 function oms_removeSignalsFromResults
   input String cref;

--- a/OMCompiler/Compiler/runtime/OMSimulator_omc.c
+++ b/OMCompiler/Compiler/runtime/OMSimulator_omc.c
@@ -187,14 +187,11 @@ static fnptr_oms_list oms_list = NULL;
 typedef int (*fnptr_oms_listUnconnectedConnectors)(const char*,char**);
 static fnptr_oms_listUnconnectedConnectors oms_listUnconnectedConnectors = NULL;
 
-typedef int (*fnptr_oms_loadSnapshot)(const char*,const char*);
+typedef int (*fnptr_oms_loadSnapshot)(const char*,const char*,char**);
 static fnptr_oms_loadSnapshot oms_loadSnapshot = NULL;
 
 typedef int (*fnptr_oms_newModel)(const char*);
 static fnptr_oms_newModel oms_newModel = NULL;
-
-typedef int (*fnptr_oms_parseModelName)(const char*,char**);
-static fnptr_oms_parseModelName oms_parseModelName = NULL;
 
 typedef int (*fnptr_oms_removeSignalsFromResults)(const char*,const char*);
 static fnptr_oms_removeSignalsFromResults oms_removeSignalsFromResults = NULL;
@@ -328,7 +325,6 @@ void resolveFunctionNames()
   oms_listUnconnectedConnectors = (fnptr_oms_listUnconnectedConnectors)AddressOf(OMSimulatorDLL, "oms_listUnconnectedConnectors");
   oms_loadSnapshot = (fnptr_oms_loadSnapshot)AddressOf(OMSimulatorDLL, "oms_loadSnapshot");
   oms_newModel = (fnptr_oms_newModel)AddressOf(OMSimulatorDLL, "oms_newModel");
-  oms_parseModelName = (fnptr_oms_parseModelName)AddressOf(OMSimulatorDLL, "oms_parseModelName");
   oms_removeSignalsFromResults = (fnptr_oms_removeSignalsFromResults)AddressOf(OMSimulatorDLL, "oms_removeSignalsFromResults");
   oms_rename = (fnptr_oms_rename)AddressOf(OMSimulatorDLL, "oms_rename");
   oms_reset = (fnptr_oms_reset)AddressOf(OMSimulatorDLL, "oms_reset");
@@ -900,14 +896,14 @@ extern const int OMSimulator_oms_listUnconnectedConnectors(const char* cref, cha
   return status;
 }
 
-extern const int OMSimulator_oms_loadSnapshot(const char* cref, const char* snapshot)
+extern const int OMSimulator_oms_loadSnapshot(const char* cref, const char* snapshot, char** newCref)
 {
   if(!oms_loadSnapshot)
   {
     printf("could not locate the function oms_loadSnapshot\n");
     exit(0);
   }
-  int status = oms_loadSnapshot(cref,snapshot);
+  int status = oms_loadSnapshot(cref, snapshot, newCref);
   return status;
 }
 
@@ -919,17 +915,6 @@ extern const int OMSimulator_oms_newModel(const char* cref)
     exit(0);
   }
   int status = oms_newModel(cref);
-  return status;
-}
-
-extern const int OMSimulator_oms_parseModelName(const char* contents, char** cref)
-{
-  if(!oms_parseModelName)
-  {
-    printf("could not locate the function oms_parseModelName\n");
-    exit(0);
-  }
-  int status = oms_parseModelName(contents,cref);
   return status;
 }
 
@@ -1229,4 +1214,3 @@ extern const int OMSimulator_oms_terminate(const char* cref)
   int status = oms_terminate(cref);
   return status;
 }
-

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
@@ -1092,7 +1092,7 @@ bool OMSProxy::loadSnapshot(QString cref, QString snapshot)
   QStringList args;
   args << "\"" + cref + "\"" << "\"" + snapshot + "\"";
   LOG_COMMAND(command, args);
-  oms_status_enu_t status = oms_loadSnapshot(cref.toUtf8().constData(), snapshot.toUtf8().constData());
+  oms_status_enu_t status = oms_loadSnapshot(cref.toUtf8().constData(), snapshot.toUtf8().constData(), nullptr);
   logResponse(command, status, &commandTime);
   return statusToBool(status);
 }

--- a/testsuite/omsimulator/test03.mos
+++ b/testsuite/omsimulator/test03.mos
@@ -71,7 +71,7 @@ oms_delete("test.eoo.source");
 oms_addSubModel("test.eoo.source", "Modelica.Blocks.Sources.Constant.fmu");
 
 // restore model from snapshot
-status := oms_loadSnapshot("test", src);
+(newCref,status) := oms_loadSnapshot("test", src);
 printStatus(status, 0);
 
 (src,status) := oms_list("test");

--- a/testsuite/omsimulator/test03.mos
+++ b/testsuite/omsimulator/test03.mos
@@ -143,7 +143,6 @@ unloadOMSimulator();
 // 		</ssd:Annotations>
 // 	</ssd:DefaultExperiment>
 // </ssd:SystemStructureDescription>
-// info:    Delete source
 // status:  [correct] ok
 // <?xml version="1.0"?>
 // <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">


### PR DESCRIPTION
```
* b9c857b simulation server: OMSimulatorServer.py (#931)     [Lennart Ochel, 4 minutes ago]
* 50daf1c Add more functions to the new api (#941)           [Lennart Ochel, 2 hours ago]
* a138290 Modify loadSnapshot so that it can be used to re.. [Lennart Ochel, 4 hours ago]
* 38125cf Remove obsolete simulation information (#938)      [Lennart Ochel, 6 hours ago]
* e7a7b05 Remove text notification of deleted components (.. [Lennart Ochel, 6 hours ago]
* b35f6bc Update 3rdParty (#936)                             [Lennart Ochel, 7 hours ago]
* 366873c Remove unsupported function parseModelName (#939)  [Lennart Ochel, 8 hours ago]
* ea8c7d5 Fix getTime and doStep (#937)                      [Lennart Ochel, 9 hours ago]
```