### PR TITLE
Use the model name instead of fully qualified path

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.h
@@ -221,6 +221,7 @@ private:
   QString mClassName;
   QString mFileName;
   bool mIsReSimulate;
+  QString mWorkingDirectory;
   // interactive simulation
   QMap<int, OpcUaClient*> mOpcUaClientsMap;
 

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.h
@@ -221,7 +221,6 @@ private:
   QString mClassName;
   QString mFileName;
   bool mIsReSimulate;
-  QString mWorkingDirectory;
   // interactive simulation
   QMap<int, OpcUaClient*> mOpcUaClientsMap;
 

--- a/OMEdit/OMEditLIB/Simulation/SimulationProcessThread.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationProcessThread.cpp
@@ -280,7 +280,6 @@ void SimulationProcessThread::readSimulationStandardError()
  */
 void SimulationProcessThread::simulationProcessError(QProcess::ProcessError error)
 {
-  Q_UNUSED(error);
   mIsSimulationProcessRunning = false;
   /* this signal is raised when we kill the simulation process forcefully. */
   if (isSimulationProcessKilled()) {
@@ -288,6 +287,9 @@ void SimulationProcessThread::simulationProcessError(QProcess::ProcessError erro
     return;
   }
   emit sendSimulationOutput(mpSimulationProcess->errorString(), StringHandler::Error, true);
+  if (error == QProcess::FailedToStart) {
+    emit sendSimulationFinished(0, QProcess::NormalExit);
+  }
   exit();
 }
 


### PR DESCRIPTION
Fixes #5796. Avoid creating long path by only using the model name