### PR TITLE
Add synchronous features to C FMUs

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -859,15 +859,16 @@ void storeRelations(DATA* data)
   TRACE_POP
 }
 
-/*! \fn getNextSampleTimeFMU
+/**
+ * @brief Get time of next sample event if one is defined.
  *
- *  function return next sample time.
+ * Function returns 0 if a time is defined and -1 otherwise.
  *
- *  \param [in]  [data]
- *
- *  \author wbraun
+ * @param data                  Data
+ * @param nextSampleEvent       On output time of next sample event.
+ * @return int                  1 if a sample event is defined, 0 otherwise
  */
-double getNextSampleTimeFMU(DATA *data)
+int getNextSampleTimeFMU(DATA *data, double *nextSampleEvent)
 {
   TRACE_PUSH
 
@@ -875,11 +876,12 @@ double getNextSampleTimeFMU(DATA *data)
   {
     infoStreamPrint(LOG_EVENTS, 0, "Next event time = %f", data->simulationInfo->nextSampleEvent);
     TRACE_POP
-    return data->simulationInfo->nextSampleEvent;
+    *nextSampleEvent = data->simulationInfo->nextSampleEvent;
+    return 1 /* TRUE */;
   }
 
   TRACE_POP
-  return -1;
+  return 0 /* FALSE */;
 }
 
 /*! \fn initializeDataStruc

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -149,7 +149,7 @@ void activateHysteresis(DATA* data);
 void storeRelations(DATA* data);
 void setZCtol(double relativeTol);
 
-double getNextSampleTimeFMU(DATA *data);
+int getNextSampleTimeFMU(DATA *data, double *nextSampleEvent);
 
 void storeOldValues(DATA *data);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
@@ -88,8 +88,6 @@ void freeSynchronous(DATA* data)
 }
 
 
-//#if !defined(OMC_MINIMAL_RUNTIME)
-
 /**
  * @brief Insert given timer into ordered list of timers.
  *
@@ -147,23 +145,6 @@ void checkForSynchronous(DATA *data, SOLVER_INFO* solverInfo)
   TRACE_POP
 }
 
-/*
-void printSubClock(SUBCLOCK_INFO* subClock)
-{
-  printf("sub-clock\n");
-  printf("shift: %ld / %ld\n", subClock->shift.m, subClock->shift.n);
-  printf("factor: %ld / %ld\n", subClock->factor.m, subClock->factor.n);
-  printf("solverMethod: %s\n", subClock->solverMethod);
-  printf("holdEvents: %s\n\n", subClock->holdEvents ? "true" : "false");
-  fflush(stdout);
-}
-
-void printRATIONAL(RATIONAL* r)
-{
-  printf("RATIONAL: %ld / %ld\n", r->m, r->n);
-  fflush(stdout);
-}
-*/
 
 void fireClock(DATA* data, threadData_t *threadData, long idx, double curTime)
 {
@@ -194,6 +175,7 @@ void fireClock(DATA* data, threadData_t *threadData, long idx, double curTime)
   }
   TRACE_POP
 }
+
 
 static void handleBaseClock(DATA* data, threadData_t *threadData, long idx, double curTime)
 {
@@ -256,8 +238,7 @@ int handleTimers(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
   TRACE_POP
   return ret;
 }
-
-#else /* #if !defined(OMC_MINIMAL_RUNTIME) */
+#endif /* #if !defined(OMC_MINIMAL_RUNTIME) */
 
 /**
  * @brief Handle timer clocks and return next time a timer will fire
@@ -317,7 +298,6 @@ int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, in
   TRACE_POP
   return ret;
 }
-#endif /* #if !defined(OMC_MINIMAL_RUNTIME) */
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
@@ -196,7 +196,7 @@ static void handleBaseClock(DATA* data, threadData_t *threadData, long idx, doub
   SYNC_TIMER timer;
   timer.idx = idx;
   timer.type = SYNC_BASE_CLOCK;
-  timer.activationTime = curTime + clkData->interval;;
+  timer.activationTime = curTime + clkData->interval;
   insertTimer(data->simulationInfo->intvlTimers, &timer);
 
   clkData->timepoint = curTime;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.h
@@ -58,6 +58,7 @@ void freeSynchronous(DATA* data);
 void checkForSynchronous(DATA *data, SOLVER_INFO* solverInfo);
 void fireClock(DATA* data, threadData_t *threadData, long idx, double curTime);
 int handleTimers(DATA *data, threadData_t *threadData, SOLVER_INFO* solverInfo);
+int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, int *nextTimerDefined ,double *nextTimerActivationTime);
 
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -46,6 +46,7 @@
 #include "../simulation/solver/fmi_events.h"
 #include "../simulation/simulation_info_json.h"
 #include "../simulation/simulation_input_xml.h"
+#include "../simulation/solver/synchronous.h"
 #include "../simulation/options.h"
 #include "../util/simulation_options.h"
 #include "../util/omc_error.h"
@@ -215,6 +216,11 @@ fmi2Status fmi2EventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
   int i, done=0;
   ModelInstance* comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
+  fmi2Real nextSampleEvent;
+  fmi2Boolean nextSampleEventDefined;
+  fmi2Boolean nextTimerDefined;
+  fmi2Real nextTimerActivationTime;
+  int syncRet;
 
   if (nullPointer(comp, "fmi2EventUpdate", "eventInfo", eventInfo)) {
     return fmi2Error;
@@ -259,7 +265,10 @@ fmi2Status fmi2EventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
       }
     }
 
-    if (checkForDiscreteChanges(comp->fmuData, comp->threadData) || comp->fmuData->simulationInfo->needToIterate || checkRelations(comp->fmuData)) {
+    /* Handle clock timers */
+    syncRet = handleTimersFMI(comp->fmuData, comp->threadData, comp->fmuData->localData[0]->timeValue, &nextTimerDefined, &nextTimerActivationTime);
+
+    if (checkForDiscreteChanges(comp->fmuData, comp->threadData) || comp->fmuData->simulationInfo->needToIterate || checkRelations(comp->fmuData) || syncRet==2 ) {
       FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2EventUpdate: Need to iterate(discrete changes)!")
       eventInfo->newDiscreteStatesNeeded = fmi2True;
       eventInfo->valuesOfContinuousStatesChanged = fmi2True;
@@ -280,14 +289,23 @@ fmi2Status fmi2EventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
     storePreValues(comp->fmuData);
     updateRelationsPre(comp->fmuData);
 
-    //Get Next Event Time
-    double nextSampleEvent=0;
-    nextSampleEvent = getNextSampleTimeFMU(comp->fmuData);
-    if (nextSampleEvent == -1) {
-      eventInfo->nextEventTimeDefined = fmi2False;
-    } else {
+    nextSampleEventDefined = getNextSampleTimeFMU(comp->fmuData, &nextSampleEvent);
+
+    /* Get next event time */
+    if (nextSampleEventDefined && !nextTimerDefined) {
       eventInfo->nextEventTimeDefined = fmi2True;
       eventInfo->nextEventTime = nextSampleEvent;
+    }
+    else if (!nextSampleEventDefined && nextTimerDefined) {
+      eventInfo->nextEventTimeDefined = fmi2True;
+      eventInfo->nextEventTime = nextTimerActivationTime;
+    }
+    else if (nextSampleEventDefined && nextTimerDefined) {
+      eventInfo->nextEventTimeDefined = fmi2True;
+      eventInfo->nextEventTime = fmin(nextSampleEvent,nextTimerActivationTime);
+    }
+    else {
+      eventInfo->nextEventTimeDefined = fmi2False;
     }
     FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2EventUpdate: Checked for Sample Events! Next Sample Event %g",eventInfo->nextEventTime)
 
@@ -621,6 +639,9 @@ void fmi2FreeInstance(fmi2Component c)
     FMI2CS_deInitializeSolverData(comp);
   }
 
+  /* Free synchronus data */
+  freeSynchronous(comp->fmuData);
+
   /* free simuation data */
   comp->functions->freeMemory(comp->fmuData->modelData);
   comp->functions->freeMemory(comp->fmuData->simulationInfo);
@@ -676,7 +697,8 @@ fmi2Status fmi2ExitInitializationMode(fmi2Component c)
   ModelInstance *comp = (ModelInstance *)c;
   threadData_t *threadData = comp->threadData;
   jmp_buf *old_jmp = threadData->mmc_jumper;
-  double nextSampleEvent;
+  fmi2Real nextSampleEvent;
+  fmi2Boolean nextSampleEventDefined;
   int done=0;
 
   threadData->currentErrorStage = ERROR_SIMULATION;
@@ -715,17 +737,16 @@ fmi2Status fmi2ExitInitializationMode(fmi2Component c)
   comp->eventInfo.valuesOfContinuousStatesChanged = fmi2True;
 
   /* get next event time (sample calls) */
-  nextSampleEvent = 0;
-  nextSampleEvent = getNextSampleTimeFMU(comp->fmuData);
-  if (nextSampleEvent == -1)
-  {
-    comp->eventInfo.nextEventTimeDefined = fmi2False;
-  }
-  else
+  nextSampleEventDefined = getNextSampleTimeFMU(comp->fmuData, &nextSampleEvent);
+  if (nextSampleEventDefined)
   {
     comp->eventInfo.nextEventTimeDefined = fmi2True;
     comp->eventInfo.nextEventTime = nextSampleEvent;
     fmi2EventUpdate(comp, &(comp->eventInfo));
+  }
+  else
+  {
+    comp->eventInfo.nextEventTimeDefined = fmi2False;
   }
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2EnterInitializationMode: succeed")
   res = fmi2OK;

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -84,8 +84,8 @@ const char* stateToString(ModelInstance *comp)
     case modelContinuousTimeMode: return "Continuous-Time Mode";
     case modelTerminated: return "Terminated";
     case modelError: return "Error";
+    default: return "Unknown";
   }
-  return "Unknown";
 }
 
 static fmi2Boolean invalidNumber(ModelInstance *comp, const char *f, const char *arg, int n, int nExpected)
@@ -514,7 +514,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
     FILTERED_LOG(comp, fmi2OK, LOG_STATUSWARNING, "fmi2Instantiate: Ignoring unknown resource URI: %s", fmuResourceLocation)
   }
 
-  /* intialize modelData */
+  /* initialize modelData */
   useStream[LOG_STDOUT] = 1;
   useStream[LOG_ASSERT] = 1;
   fmu2_model_interface_setupDataStruc(comp->fmuData, comp->threadData);

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -18,6 +18,8 @@ resetWithLoops.mos \
 test03.mos \
 testDirectionalDerivatives.mos \
 testLoopsOverFMUs.mos \
+testSynchronousFMU_01.mos \
+testSynchronousFMU_02.mos
 
 FAILINGTESTFILES = \
 
@@ -42,7 +44,7 @@ test:
 # Cleans all files that are not listed as dependencies
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
-	@rm -f $(CLEAN)
+	@rm -rf $(CLEAN)
 
 # Run this if you want to list out the files (dependencies).
 # do it after cleaning and updating the folder

--- a/testsuite/omsimulator/testSynchronousFMU_01.mos
+++ b/testsuite/omsimulator/testSynchronousFMU_01.mos
@@ -1,0 +1,60 @@
+// name:     testSynchronousFMU_01.mos
+// status:   correct
+// teardown_command: rm -rf tempSynchronous01/
+//
+// Test FMU with clock from Modelica_Synchronous with MSL 3.2.3.
+
+
+setCommandLineOptions("--std=3.5"); getErrorString();
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+loadModel(Modelica_Synchronous); getErrorString();
+
+echo(false);
+mkdir("tempSynchronous01/"); cd("tempSynchronous01/");
+echo(true);
+
+// Refernce results without FMU
+simulate(Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample, stopTime=0.25, outputFormat="csv"); getErrorString();
+
+// Build FMU with Synchronous features
+buildModelFMU(Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample, version="2.0", fmuType="me"); getErrorString();
+
+// Simulate FMU with OMSimulator
+system(getInstallationDirectoryPath() + "/bin/OMSimulator Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample.fmu"
+  +" --stopTime=0.25 --tolerance=1e-8 --deleteTempFiles=true --tempDir=temp"
+  +" --resultFile=Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample-oms_res.csv --stripRoot=true --suppressPath=true --skipCSVHeader=true",
+  "testSynchronousFMU_systemCall.log"); getErrorString();
+//readFile("testSynchronousFMU_systemCall.log"); getErrorString();
+
+// Compare results
+diffSimulationResults(
+  "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample_res.csv",
+  "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample-oms_res.csv",
+  "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample_diff.csv",
+  1e-8, 1e-4, 0.002,
+  {"sample1.y"}); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// record SimulationResult
+//     resultFile = "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.25, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "Modelica_Synchronous.Examples.Elementary.ClockSignals.SubSample.fmu"
+// ""
+// 0
+// ""
+// (true,{})
+// ""
+// endResult

--- a/testsuite/omsimulator/testSynchronousFMU_02.mos
+++ b/testsuite/omsimulator/testSynchronousFMU_02.mos
@@ -1,0 +1,55 @@
+// name:     testSynchronousFMU_02.mos
+// status:   correct
+// teardown_command: rm -rf tempSynchronous02/
+//
+// Test FMU with clock from Modelica.Clocked with MSL 4.0.0.
+
+loadModel(Modelica, {"4.0.0"}); getErrorString();
+setCommandLineOptions("-d=newInst, --std=latest"); getErrorString();
+
+echo(false);
+mkdir("tempSynchronous02/"); cd("tempSynchronous02/");
+echo(true);
+
+// Refernce results without FMU
+simulate(Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks, stopTime=4, outputFormat="csv"); getErrorString();
+
+// Build FMU with Synchronous features
+buildModelFMU(Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks, version="2.0", fmuType="me"); getErrorString();
+
+// Simulate FMU with OMSimulator
+system(getInstallationDirectoryPath() + "/bin/OMSimulator Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks.fmu"
+  +" --stopTime=4 --tolerance=1e-8 --deleteTempFiles=true --tempDir=temp"
+  +" --resultFile=Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks-oms_res.csv --stripRoot=true --suppressPath=true --skipCSVHeader=true",
+  "testSynchronousFMU_systemCall.log"); getErrorString();
+//readFile("testSynchronousFMU_systemCall.log"); getErrorString();
+
+// Compare results
+diffSimulationResults(
+  "Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks_res.csv",
+  "Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks-oms_res.csv",
+  "Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks_diff.csv",
+  1e-8, 1e-4, 0.002,
+  {"PI.y"}); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// record SimulationResult
+//     resultFile = "Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks_res.csv",
+//     simulationOptions = "startTime = 0.0, stopTime = 4.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks', options = '', outputFormat = 'csv', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// "Modelica.Clocked.Examples.CascadeControlledDrive.AbsoluteClocks.fmu"
+// ""
+// 0
+// ""
+// (true,{})
+// ""
+// endResult

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/BooleanNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/BooleanNetwork1.mos
@@ -1,6 +1,6 @@
 // name:     BooleanNetwork1
 // keywords: BooleanNetwork1 FMI-Export FMI-Import
-// status:   correct
+// status:   erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml BooleanNetwork1.fmu BooleanNetwork1_me_FMU.mo BooleanNetwork1.lib* BooleanNetwork1.so BooleanNetwork1.dll BooleanNetwork1_*.c BooleanNetwork1_*.h BooleanNetwork1_*.o BooleanNetwork1_*.json
 // cflags: -d=-newInst
 // Boolean variables, Boolean input variable, no continuous-time states, time events

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBall.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBall.mos
@@ -1,6 +1,6 @@
 // name:     BouncingBall
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml BouncingBall.fmu BouncingBall_* BouncingBall.libs BouncingBall.lib BouncingBall.so BouncingBall.dll BouncingBall.c BouncingBall.makefile
 // cflags: -d=-newInst
 // Event handling in FMU Import

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBallSourceFMU.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBallSourceFMU.mos
@@ -1,5 +1,5 @@
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf modelDescription.xml BouncingBall.fmu BouncingBall.fmutmp
 // cflags: -d=-newInst
 // Event handling in FMU Import

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBall_me_FMU.mo
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBall_me_FMU.mo
@@ -1,0 +1,264 @@
+model BouncingBall_me_FMU
+  constant String fmuWorkingDir = "/home/andreas/workspace/OpenModelica/testsuite/openmodelica/fmi/ModelExchange/1.0";
+  parameter Integer logLevel = 3 "log level used during the loading of FMU" annotation (Dialog(tab="FMI", group="Enable logging"));
+  parameter Boolean debugLogging = false "enables the FMU simulation logging" annotation (Dialog(tab="FMI", group="Enable logging"));
+  Real h "height of ball";
+  Real v "velocity of ball";
+  Real der_h_ "der(height of ball)";
+  Real der_v_ "der(velocity of ball)";
+  Real v_new;
+  parameter Real e = 0.7 "coefficient of restitution";
+  parameter Real g = 9.81 "gravity acceleration";
+  Boolean _D_whenCondition1 "h <= 0.0";
+protected
+  FMI1ModelExchange fmi1me = FMI1ModelExchange(logLevel, fmuWorkingDir, "BouncingBall", debugLogging);
+  constant Integer numberOfContinuousStates = 2;
+  Real fmi_x[numberOfContinuousStates] "States";
+  Real fmi_x_new[numberOfContinuousStates](each fixed = true) "New States";
+  constant Integer numberOfEventIndicators = 1;
+  Real fmi_z[numberOfEventIndicators] "Events Indicators";
+  Boolean fmi_z_positive[numberOfEventIndicators](each fixed = true);
+  parameter Real flowStartTime(fixed=false);
+  Real flowTime;
+  parameter Real flowInitialized(fixed=false);
+  parameter Real flowParamsStart(fixed=false);
+  parameter Real flowInitInputs(fixed=false);
+  Real flowStatesInputs;
+  Boolean callEventUpdate;
+  constant Boolean intermediateResults = false;
+  Boolean newStatesAvailable(fixed = true);
+  Real triggerDSSEvent;
+  Real nextEventTime;
+initial equation
+  flowStartTime = fmi1Functions.fmi1SetTime(fmi1me, time, 1);
+  flowInitialized = fmi1Functions.fmi1Initialize(fmi1me, flowParamsStart+flowInitInputs+flowStartTime);
+  fmi_x = fmi1Functions.fmi1GetContinuousStates(fmi1me, numberOfContinuousStates, flowParamsStart+flowInitialized);
+initial algorithm
+  flowParamsStart := 1;
+  flowParamsStart := fmi1Functions.fmi1SetRealParameter(fmi1me, {5.0, 6.0}, {e, g});
+  flowInitInputs := 1;
+initial equation
+equation
+  flowTime = fmi1Functions.fmi1SetTime(fmi1me, time, flowInitialized);
+  flowStatesInputs = fmi1Functions.fmi1SetContinuousStates(fmi1me, fmi_x, flowParamsStart + flowTime);
+  der(fmi_x) = fmi1Functions.fmi1GetDerivatives(fmi1me, numberOfContinuousStates, flowStatesInputs);
+  fmi_z  = fmi1Functions.fmi1GetEventIndicators(fmi1me, numberOfEventIndicators, flowStatesInputs);
+  for i in 1:size(fmi_z,1) loop
+    fmi_z_positive[i] = if not terminal() then fmi_z[i] > 0 else pre(fmi_z_positive[i]);
+  end for;
+  callEventUpdate = fmi1Functions.fmi1CompletedIntegratorStep(fmi1me, flowStatesInputs);
+  triggerDSSEvent = noEvent(if callEventUpdate then flowStatesInputs+1.0 else flowStatesInputs-1.0);
+  nextEventTime = fmi1Functions.fmi1nextEventTime(fmi1me, flowStatesInputs);
+  {h, v, der_h_, der_v_, v_new} = fmi1Functions.fmi1GetReal(fmi1me, {0.0, 1.0, 2.0, 3.0, 4.0}, flowStatesInputs);
+  {_D_whenCondition1} = fmi1Functions.fmi1GetBoolean(fmi1me, {0.0}, flowStatesInputs);
+algorithm
+  when {change(fmi_z_positive[1]), triggerDSSEvent > flowStatesInputs, nextEventTime < time, terminal()} then
+    newStatesAvailable := fmi1Functions.fmi1EventUpdate(fmi1me, intermediateResults);
+    if newStatesAvailable then
+      fmi_x_new := fmi1Functions.fmi1GetContinuousStates(fmi1me, numberOfContinuousStates, flowStatesInputs);
+      reinit(fmi_x[2], fmi_x_new[2]);
+      reinit(fmi_x[1], fmi_x_new[1]);
+    end if;
+  end when;
+  annotation(experiment(StartTime=0.0, StopTime=1.0, Tolerance=1e-06));
+  annotation (Icon(graphics={
+      Rectangle(
+        extent={{-100,100},{100,-100}},
+        lineColor={0,0,0},
+        fillColor={240,240,240},
+        fillPattern=FillPattern.Solid,
+        lineThickness=0.5),
+      Text(
+        extent={{-100,40},{100,0}},
+        lineColor={0,0,0},
+        textString="%name"),
+      Text(
+        extent={{-100,-50},{100,-90}},
+        lineColor={0,0,0},
+        textString="V1.0")}));
+protected
+  class FMI1ModelExchange
+    extends ExternalObject;
+      function constructor
+        input Integer logLevel;
+        input String workingDirectory;
+        input String instanceName;
+        input Boolean debugLogging;
+        output FMI1ModelExchange fmi1me;
+        external "C" fmi1me = FMI1ModelExchangeConstructor_OMC(logLevel, workingDirectory, instanceName, debugLogging) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end constructor;
+
+      function destructor
+        input FMI1ModelExchange fmi1me;
+        external "C" FMI1ModelExchangeDestructor_OMC(fmi1me) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+      end destructor;
+  end FMI1ModelExchange;
+
+
+
+  package fmi1Functions
+    function fmi1Initialize
+      input FMI1ModelExchange fmi1me;
+      input Real preInitialized;
+      output Real postInitialized=preInitialized;
+      external "C" fmi1Initialize_OMC(fmi1me) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1Initialize;
+
+    function fmi1SetTime
+      input FMI1ModelExchange fmi1me;
+      input Real inTime;
+      input Real inFlow;
+      output Real outFlow = inFlow;
+      external "C" fmi1SetTime_OMC(fmi1me, inTime) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetTime;
+
+    function fmi1GetContinuousStates
+      input FMI1ModelExchange fmi1me;
+      input Integer numberOfContinuousStates;
+      input Real inFlowParams;
+      output Real fmi_x[numberOfContinuousStates];
+      external "C" fmi1GetContinuousStates_OMC(fmi1me, numberOfContinuousStates, inFlowParams, fmi_x) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetContinuousStates;
+
+    function fmi1SetContinuousStates
+      input FMI1ModelExchange fmi1me;
+      input Real fmi_x[:];
+      input Real inFlowParams;
+      output Real outFlowStates;
+      external "C" outFlowStates = fmi1SetContinuousStates_OMC(fmi1me, size(fmi_x, 1), inFlowParams, fmi_x) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetContinuousStates;
+
+    function fmi1GetDerivatives
+      input FMI1ModelExchange fmi1me;
+      input Integer numberOfContinuousStates;
+      input Real inFlowStates;
+      output Real fmi_x[numberOfContinuousStates];
+      external "C" fmi1GetDerivatives_OMC(fmi1me, numberOfContinuousStates, inFlowStates, fmi_x) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetDerivatives;
+
+    function fmi1GetEventIndicators
+      input FMI1ModelExchange fmi1me;
+      input Integer numberOfEventIndicators;
+      input Real inFlowStates;
+      output Real fmi_z[numberOfEventIndicators];
+      external "C" fmi1GetEventIndicators_OMC(fmi1me, numberOfEventIndicators, inFlowStates, fmi_z) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetEventIndicators;
+
+    function fmi1GetReal
+      input FMI1ModelExchange fmi1me;
+      input Real realValuesReferences[:];
+      input Real inFlowStatesInput;
+      output Real realValues[size(realValuesReferences, 1)];
+      external "C" fmi1GetReal_OMC(fmi1me, size(realValuesReferences, 1), realValuesReferences, inFlowStatesInput, realValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetReal;
+
+    function fmi1SetReal
+      input FMI1ModelExchange fmi1me;
+      input Real realValueReferences[:];
+      input Real realValues[size(realValueReferences, 1)];
+      output Real outValues[size(realValueReferences, 1)] = realValues;
+      external "C" fmi1SetReal_OMC(fmi1me, size(realValueReferences, 1), realValueReferences, realValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetReal;
+
+    function fmi1SetRealParameter
+      input FMI1ModelExchange fmi1me;
+      input Real realValueReferences[:];
+      input Real realValues[size(realValueReferences, 1)];
+      output Real out_Value = 1;
+      external "C" fmi1SetReal_OMC(fmi1me, size(realValueReferences, 1), realValueReferences, realValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetRealParameter;
+
+    function fmi1GetInteger
+      input FMI1ModelExchange fmi1me;
+      input Real integerValueReferences[:];
+      input Real inFlowStatesInput;
+      output Integer integerValues[size(integerValueReferences, 1)];
+      external "C" fmi1GetInteger_OMC(fmi1me, size(integerValueReferences, 1), integerValueReferences, inFlowStatesInput, integerValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetInteger;
+
+    function fmi1SetInteger
+      input FMI1ModelExchange fmi1me;
+      input Real integerValuesReferences[:];
+      input Integer integerValues[size(integerValuesReferences, 1)];
+      output Integer outValues[size(integerValuesReferences, 1)] = integerValues;
+      external "C" fmi1SetInteger_OMC(fmi1me, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetInteger;
+
+    function fmi1SetIntegerParameter
+      input FMI1ModelExchange fmi1me;
+      input Real integerValuesReferences[:];
+      input Integer integerValues[size(integerValuesReferences, 1)];
+      output Real out_Value = 1;
+      external "C" fmi1SetInteger_OMC(fmi1me, size(integerValuesReferences, 1), integerValuesReferences, integerValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetIntegerParameter;
+
+    function fmi1GetBoolean
+      input FMI1ModelExchange fmi1me;
+      input Real booleanValuesReferences[:];
+      input Real inFlowStatesInput;
+      output Boolean booleanValues[size(booleanValuesReferences, 1)];
+      external "C" fmi1GetBoolean_OMC(fmi1me, size(booleanValuesReferences, 1), booleanValuesReferences, inFlowStatesInput, booleanValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetBoolean;
+
+    function fmi1SetBoolean
+      input FMI1ModelExchange fmi1me;
+      input Real booleanValueReferences[:];
+      input Boolean booleanValues[size(booleanValueReferences, 1)];
+      output Boolean outValues[size(booleanValueReferences, 1)] = booleanValues;
+      external "C" fmi1SetBoolean_OMC(fmi1me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetBoolean;
+
+    function fmi1SetBooleanParameter
+      input FMI1ModelExchange fmi1me;
+      input Real booleanValueReferences[:];
+      input Boolean booleanValues[size(booleanValueReferences, 1)];
+      output Real out_Value = 1;
+      external "C" fmi1SetBoolean_OMC(fmi1me, size(booleanValueReferences, 1), booleanValueReferences, booleanValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetBooleanParameter;
+
+    function fmi1GetString
+      input FMI1ModelExchange fmi1me;
+      input Real stringValuesReferences[:];
+      input Real inFlowStatesInput;
+      output String stringValues[size(stringValuesReferences, 1)];
+      external "C" fmi1GetString_OMC(fmi1me, size(stringValuesReferences, 1), stringValuesReferences, inFlowStatesInput, stringValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1GetString;
+
+    function fmi1SetString
+      input FMI1ModelExchange fmi1me;
+      input Real stringValueReferences[:];
+      input String stringValues[size(stringValueReferences, 1)];
+      output String outValues[size(stringValueReferences, 1)] = stringValues;
+      external "C" fmi1SetString_OMC(fmi1me, size(stringValueReferences, 1), stringValueReferences, stringValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetString;
+
+    function fmi1SetStringParameter
+      input FMI1ModelExchange fmi1me;
+      input Real stringValueReferences[:];
+      input String stringValues[size(stringValueReferences, 1)];
+      output Real out_Value = 1;
+      external "C" fmi1SetString_OMC(fmi1me, size(stringValueReferences, 1), stringValueReferences, stringValues, 1) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1SetStringParameter;
+
+    function fmi1EventUpdate
+      input FMI1ModelExchange fmi1me;
+      input Boolean intermediateResults;
+      output Boolean outNewStatesAvailable;
+      external "C" outNewStatesAvailable = fmi1EventUpdate_OMC(fmi1me, intermediateResults) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1EventUpdate;
+
+    function fmi1nextEventTime
+      input FMI1ModelExchange fmi1me;
+      input Real inFlowStates;
+      output Real outNewnextTime;
+      external "C" outNewnextTime = fmi1nextEventTime_OMC(fmi1me, inFlowStates) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1nextEventTime;
+
+    function fmi1CompletedIntegratorStep
+      input FMI1ModelExchange fmi1me;
+      input Real inFlowStates;
+      output Boolean outCallEventUpdate;
+      external "C" outCallEventUpdate = fmi1CompletedIntegratorStep_OMC(fmi1me, inFlowStates) annotation(Library = {"OpenModelicaFMIRuntimeC", "fmilib"});
+    end fmi1CompletedIntegratorStep;
+  end fmi1Functions;
+end BouncingBall_me_FMU;

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/CoupledClutches.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/CoupledClutches.mos
@@ -1,6 +1,6 @@
 // name:     CoupledClutches
 // keywords: CoupledClutches FMI-Export FMI-Import
-// status:   correct
+// status:   erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml CoupledClutches.fmu CoupledClutches_me_FMU.mo CoupledClutches.lib* CoupledClutches.so CoupledClutches.dll CoupledClutches_*.c CoupledClutches_*.h CoupledClutches_*.o CoupledClutches_*.json
 // cflags: -d=-newInst
 // Real variables, Real input variable, continuous-time states, state events, event iteration

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/EnumerationTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/EnumerationTest.mos
@@ -1,6 +1,6 @@
 // name:     EnumerationTest
 // keywords: Enumeration FMI-Export FMI-Import
-// status:   correct
+// status:   erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml EnumerationTest.fmu _EnumerationTest* EnumerationTest_me_FMU.mo EnumerationTest.libs EnumerationTest.lib EnumerationTest.so EnumerationTest.dll EnumerationTest.c EnumerationTest.o EnumerationTest.makefile output.log EnumerationTest_*.c EnumerationTest_*.h EnumerationTest_*.o EnumerationTest_*.json EnumerationTest/*
 // cflags: -d=-newInst
 //

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/HelloFMIWorld.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/HelloFMIWorld.mos
@@ -1,6 +1,6 @@
 // name:     HelloFMIWorld
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml HelloFMIWorld.fmu HelloFMIWorld_* HelloFMIWorld.libs HelloFMIWorld.lib HelloFMIWorld.so HelloFMIWorld.dll HelloFMIWorld.c HelloFMIWorld.makefile
 // cflags: -d=-newInst
 // Event handling

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/InOutTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/InOutTest.mos
@@ -1,6 +1,6 @@
 // name:     InOutTest
 // keywords: FMU Export Import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml InOutTest.fmu InOutTest_* testInOut_* InOutTest_me_FMU.mo InOutTest.libs testInOut.libs InOutTest.lib testInOut.lib InOutTest.so testInOut.so InOutTest.dll testInOut.dll InOutTest.c testInOut.c testInOut.makefile
 // cflags: -d=-newInst
 // Simulation Results

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/IntegerNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/IntegerNetwork1.mos
@@ -1,6 +1,6 @@
 // name:     IntegerNetwork1
 // keywords: IntegerNetwork1 FMI-Export FMI-Import
-// status:   correct
+// status:   erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml IntegerNetwork1.fmu IntegerNetwork1_me_FMU.mo IntegerNetwork1.lib* IntegerNetwork1.so IntegerNetwork1.dll IntegerNetwork1_*.c IntegerNetwork1_*.h IntegerNetwork1_*.o IntegerNetwork1_*.json
 // cflags: -d=-newInst
 // Integer variables, Integer input variables, no continuous-time states, time events, state events

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/JuliansBib.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/JuliansBib.mos
@@ -1,6 +1,6 @@
 // name: JuliansBib
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml JuliansBib_Connector_Hebelarm_einfach.fmu JuliansBib_Connector_Hebelarm_einfach_* JuliansBib_Connector_Hebelarm_einfach_* JuliansBib_Connector_Hebelarm_einfach.libs JuliansBib_Connector_Hebelarm_einfach.lib JuliansBib_Connector_Hebelarm_einfach JuliansBib_Connector_Hebelarm_einfach.exe JuliansBib_Connector_Hebelarm_einfach.so JuliansBib_Connector_Hebelarm_einfach.dll JuliansBib_Connector_Hebelarm_einfach.c JuliansBib_Connector_Hebelarm_einfach.makefile JuliansBib.Connector_Hebelarm_einfach_*
 // cflags: -d=-newInst
 

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Makefile
@@ -1,6 +1,10 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
+
+# test that currently fail. Move up when fixed.
+# Run make testfailing
+FAILINGTESTFILES= \
 BouncingBall.mos \
 BouncingBallSourceFMU.mos \
 EnumerationTest.mos \
@@ -19,10 +23,6 @@ CoupledClutches.mos \
 BooleanNetwork1.mos \
 IntegerNetwork1.mos \
 StringParameters.mos
-
-# test that currently fail. Move up when fixed.
-# Run make testfailing
-FAILINGTESTFILES= \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.
@@ -47,7 +47,7 @@ test:
 # Cleans all files that are not listed as dependencies
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
-	@rm -f $(CLEAN)
+	@rm -rf $(CLEAN)
 
 # Run this if you want to list out the files (dependencies).
 # do it after cleaning and updating the folder

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Blocks.Sources.BooleanPulse.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Blocks.Sources.BooleanPulse.mos
@@ -1,6 +1,6 @@
 // name:     Modelica.Blocks.Sources.BooleanPulse
 // keywords: simulation MSL Examples
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml Modelica_Blocks_Sources_BooleanPulse.fmu Modelica_Blocks_Sources_BooleanPulse_* Modelica.Blocks.Sources.BooleanPulse_* Modelica_Blocks_Sources_BooleanPulse_me_FMU.mo Modelica_Blocks_Sources_BooleanPulse.libs Modelica_Blocks_Sources_BooleanPulse.lib Modelica_Blocks_Sources_BooleanPulse.so Modelica_Blocks_Sources_BooleanPulse.dll Modelica_Blocks_Sources_BooleanPulse.c Modelica_Blocks_Sources_BooleanPulse.makefile
 // cflags: -d=-newInst
 // Simulation Results

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
@@ -1,6 +1,6 @@
 // name:     Modelica_Electrical_Analog_Examples_ChuaCircuit
 // keywords: simulation MSL Examples
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml Modelica_Electrical_Analog_Examples_ChuaCircuit.fmu Modelica_Electrical_Analog_Examples_ChuaCircuit_* Modelica_Electrical_Analog_Examples_ChuaCircuit_me_FMU.mo Modelica_Electrical_Analog_Examples_ChuaCircuit.libs Modelica_Electrical_Analog_Examples_ChuaCircuit.lib Modelica_Electrical_Analog_Examples_ChuaCircuit.so Modelica_Electrical_Analog_Examples_ChuaCircuit.dll Modelica_Electrical_Analog_Examples_ChuaCircuit.c Modelica_Electrical_Analog_Examples_ChuaCircuit.makefile
 // cflags: -d=-newInst
 // Simulation Results

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
@@ -1,6 +1,6 @@
 // name:     Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum
 // keywords: simulation MSL Examples
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.fmu Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum_* Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum_me_FMU.mo Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.libs Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.lib BouncingBall.so Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.dll Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.c Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.makefile Modelica_from_nxy_*
 // cflags: -d=-newInst
 // Simulation Results

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
@@ -1,6 +1,6 @@
 // name:     Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum
 // keywords: simulation MSL Examples
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.fmu Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum_* Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum_me_FMU.mo Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.libs Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.lib Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.so Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.dll Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.c Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.makefile Modelica_from_nxy_*
 // cflags: -d=-newInst
 // Simulation Results

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Pendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Pendulum.mos
@@ -1,6 +1,6 @@
 // name: PendulumFMU
 // keywords: fmi export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf Pendulum.c Pendulum Pendulum.exe Pendulum.libs Pendulum.lib Pendulum.fmu Pendulum.log Pendulum.makefile Pendulum_*.*
 // cflags: -d=-newInst
 //

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/SampleExample.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/SampleExample.mos
@@ -1,6 +1,6 @@
 // name:     SampleEvent
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml SampleEvent.fmu SampleEvent_* SampleEvent_me_FMU.mo SampleEvent.libs SampleEvent.lib SampleEvent.so SampleEvent.dll SampleEvent.c SampleEvent.makefile
 // cflags: -d=-newInst
 // Event handling

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/StringParameters.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/StringParameters.mos
@@ -1,6 +1,6 @@
 // name:     StringParameters
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml StringParameters.fmu StringParameters_* StringParameters.libs StringParameters.lib StringParameters.so StringParameters.dll StringParameters.c StringParameters.makefile
 // cflags: -d=-newInst
 // Event handling in FMU Import

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/TanksConnectedPI.mo
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/TanksConnectedPI.mo
@@ -1,6 +1,6 @@
 // name:      TanksConnectedPI
 // keywords: <insert keywords here>
-// status:   correct
+// status:   erroneous
 //
 // <insert description here>
 //

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/TanksConnectedPI.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/TanksConnectedPI.mos
@@ -1,6 +1,6 @@
 // name:     TanksConnectedPI
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml TanksConnectedPI.fmu _TanksConnectedPI* TanksConnectedPI_* TanksConnectedPI.libs TanksConnectedPI.lib TanksConnectedPI TanksConnectedPI.exe TanksConnectedPI.so TanksConnectedPI.dll TanksConnectedPI.c TanksConnectedPI.makefile output.log TanksConnectedPI/*
 // cflags: -d=-newInst
 //

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/testAssert.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/testAssert.mos
@@ -1,6 +1,6 @@
 // name:     testAssert
 // keywords: fmu export import
-// status: correct
+// status: erroneous
 // teardown_command: rm -rf binaries sources modelDescription.xml testAssertFMI* output.log testAssertFMI/*
 // cflags: -d=-newInst
 


### PR DESCRIPTION
## Changes
- C FMUs can now handle clocks.
- Improving function argument names of `function_updateSynchronous `and `function_equationsSynchronous`
- Adding new test cases for FMUs with clocks (MSL 3.2.3 and MSL 4.0.0).

## Related ticket
- [track ticket #6371](https://trac.openmodelica.org/OpenModelica/ticket/6371 )

This commit should fix most failing FMU simulations in https://libraries.openmodelica.org/branches/master-fmi/Modelica_4.0.0/Modelica_4.0.0.html. At least those that are working with the default C runtime.