### PR TITLE
Fix #7156

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/Inline2.mo
+++ b/testsuite/flattening/modelica/scodeinst/Inline2.mo
@@ -1,0 +1,34 @@
+// name: Inline2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+operator record Complex
+  Real re, im;
+
+  encapsulated operator 'constructor'
+    function fromReal
+      import Complex;
+      input Real re;
+      input Real im = 0.0;
+      output Complex result(re = re, im = im);
+    algorithm
+    end fromReal;
+  end 'constructor';
+end Complex;
+
+model Inline2
+  parameter Real a = 1;
+  parameter Real b = 2;
+  final parameter Complex c = Complex(a, b);
+end Inline2;
+
+// Result:
+// class Inline2
+//   parameter Real a = 1.0;
+//   parameter Real b = 2.0;
+//   final parameter Real c.re = a;
+//   final parameter Real c.im = b;
+// end Inline2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -609,6 +609,7 @@ ImportUnqualified2.mo \
 ImportUnqualified3.mo \
 ImpureCall1.mo \
 Inline1.mo \
+Inline2.mo \
 InnerOuter1.mo \
 InnerOuter2.mo \
 InnerOuter3.mo \


### PR DESCRIPTION
- Try to inline operator record constructors instead of evaluating them
  when trying to split them during flattening.