### PR TITLE
fix ticket #6307

### DIFF
--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -13944,7 +13944,7 @@ algorithm
     _ := match (el)
         local
           Absyn.Element elt;
-        case Absyn.ELEMENTITEM(element = elt)
+        case Absyn.ELEMENTITEM(element = elt as Absyn.ELEMENT(specification = Absyn.COMPONENTS()))
           algorithm
             outAbsynElementLst := elt :: outAbsynElementLst;
           then ();

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -11544,7 +11544,7 @@ algorithm
         (outCache, outEnv, outGraphicProgram, outGraphicEnvCache);
 
     // No cache, make partial or full cache as needed.
-    case Interactive.Interactive.GRAPHIC_ENV_NO_CACHE()
+    case Interactive.GRAPHIC_ENV_NO_CACHE()
       algorithm
         if AbsynUtil.onlyLiteralsInAnnotationMod(inAnnotationMod) then
           outGraphicProgram := modelicaAnnotationProgram(Config.getAnnotationVersion());
@@ -11639,12 +11639,12 @@ algorithm
         ErrorExt.setCheckpoint("buildEnvForGraphicProgram");
         try
         (cache, env, graphic_prog) :=
-          buildEnvForGraphicProgram(Interactive.Interactive.GRAPHIC_ENV_NO_CACHE(inFullProgram, inModelPath), mod);
+          buildEnvForGraphicProgram(Interactive.GRAPHIC_ENV_NO_CACHE(inFullProgram, inModelPath), mod);
           ErrorExt.rollBack("buildEnvForGraphicProgram");
         else
           ErrorExt.delCheckpoint("buildEnvForGraphicProgram");
           // Fallback to only the graphical primitives left in the program
-          (cache, env, graphic_prog) := buildEnvForGraphicProgram(Interactive.Interactive.GRAPHIC_ENV_NO_CACHE(inFullProgram, inModelPath), {});
+          (cache, env, graphic_prog) := buildEnvForGraphicProgram(Interactive.GRAPHIC_ENV_NO_CACHE(inFullProgram, inModelPath), {});
         end try;
 
         smod := AbsynToSCode.translateMod(SOME(Absyn.CLASSMOD(stripped_mod, Absyn.NOMOD())),

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -89,6 +89,7 @@ Ticket5871.mos \
 Ticket6167.mos \
 Ticket6287and6288.mos \
 Ticket6300.mos \
+Ticket6307.mos \
 ReadOnlyPkg.mos
 
 # test that currently fail. Move up when fixed.

--- a/testsuite/openmodelica/interactive-API/Ticket6307.mos
+++ b/testsuite/openmodelica/interactive-API/Ticket6307.mos
@@ -1,0 +1,59 @@
+// name: Ticket6307.mos
+// keywords:
+// status: correct
+//
+// Tests if -d=nfAPI will give the correct response for getComponentAnnotations
+//
+
+setCommandLineOptions("-d=nfAPI"); getErrorString();
+
+loadString("
+model Ticket6307
+  model M
+    parameter Real x = 1;
+  end M;
+  replaceable model M1 = M(x=2) annotation(choicesAllMatching=true);
+  Real a annotation(choicesAllMatching=true);
+  Real b annotation(choicesAllMatching=true);
+end Ticket6307;
+"); getErrorString();
+
+getComponents(Ticket6307); getErrorString();
+getComponentAnnotations(Ticket6307); getErrorString();
+
+getElements(Ticket6307); getErrorString();
+getElementAnnotations(Ticket6307); getErrorString();
+
+setCommandLineOptions("-d=nfAPI"); getErrorString();
+
+getComponents(Ticket6307); getErrorString();
+getComponentAnnotations(Ticket6307); getErrorString();
+
+getElements(Ticket6307); getErrorString();
+getElementAnnotations(Ticket6307); getErrorString();
+
+
+// Result:
+// true
+// ""
+// true
+// ""
+// {{Real,a,"", "public", false, false, false, false, "unspecified", "none", "unspecified",{}},{Real,b,"", "public", false, false, false, false, "unspecified", "none", "unspecified",{}}}
+// ""
+// {{choicesAllMatching=true},{choicesAllMatching=true}}
+// ""
+// {{"cl", "model", Ticket6307.M, M1, "", "public", false, false, false, true, "unspecified", "none", "unspecified", $Any, {}},{"co", "-", Real, a, "", "public", false, false, false, false, "unspecified", "none", "unspecified", $Any, {}},{"co", "-", Real, b, "", "public", false, false, false, false, "unspecified", "none", "unspecified", $Any, {}}}
+// ""
+// {{choicesAllMatching=true},{choicesAllMatching=true},{choicesAllMatching=true}}
+// ""
+// true
+// ""
+// {{Real,a,"", "public", false, false, false, false, "unspecified", "none", "unspecified",{}},{Real,b,"", "public", false, false, false, false, "unspecified", "none", "unspecified",{}}}
+// ""
+// {{choicesAllMatching=true},{choicesAllMatching=true}}
+// ""
+// {{"cl", "model", Ticket6307.M, M1, "", "public", false, false, false, true, "unspecified", "none", "unspecified", $Any, {}},{"co", "-", Real, a, "", "public", false, false, false, false, "unspecified", "none", "unspecified", $Any, {}},{"co", "-", Real, b, "", "public", false, false, false, false, "unspecified", "none", "unspecified", $Any, {}}}
+// ""
+// {{choicesAllMatching=true},{choicesAllMatching=true},{choicesAllMatching=true}}
+// ""
+// endResult


### PR DESCRIPTION
- keep only the annotations for components in getComponentAnnotations so it returns the same number of items as getComponents
- this bug only happens if you use the old API getComponentAnnotations with -d=nfAPI
- add a test