### PR TITLE
partial handling of ticket #5827

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1347,6 +1347,8 @@ template fmuMakefile(String target, SimCode simCode, String FMUVersion, list<Str
       AR=@AR@
       CFLAGS=@CFLAGS@
       LD=$(CC) -shared
+      # define OMC_LDFLAGS_LINK_TYPE env variable to override this
+      OMC_LDFLAGS_LINK_TYPE=static
       LDFLAGS=@LDFLAGS@ @LIBS@
       DLLEXT=@DLLEXT@
       NEED_RUNTIME=@NEED_RUNTIME@

--- a/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -5,6 +5,8 @@ encapsulated package Autoconf
 
   constant String bstatic = "-Wl,-Bstatic";
   constant String bdynamic = "-Wl,-Bdynamic";
+
+  constant String linkType = " -Wl,-B$(OMC_LDFLAGS_LINK_TYPE) " "OMC_LDFLAGS_LINK_TYPE is set in the Makefile, can be overrided when calling make";
   constant String configureCommandLine = "Manually created Makefiles for OMDev";
   constant String os = "Windows_NT";
   constant String make = "make";
@@ -16,7 +18,7 @@ encapsulated package Autoconf
   constant String ldflags_sundials = " -lsundials_nvecserial -lsundials_sunmatrixdense -lsundials_sunmatrixsparse" +
                                      " -lsundials_sunlinsoldense -lsundials_sunlinsolklu -lsundials_sunlinsollapackdense -lsundials_sunlinsolspbcgs -lsundials_sunlinsolspfgmr -lsundials_sunlinsolspgmr -lsundials_sunlinsolsptfqmr -lsundials_sunnonlinsolnewton" +
                                      " -lsundials_cvode -lsundials_cvodes -lsundials_idas -lsundials_kinsol";
-  constant String ldflags_basic = " -Wl,-Bstatic -lomcgc -lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis" +
+  constant String ldflags_basic = linkType + "-lomcgc -lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis" +
                                   ldflags_sundials +
                                   ldflags_suitesparse +
                                   " -lipopt -lcoinmumps -lpthread -lm " +
@@ -26,8 +28,8 @@ encapsulated package Autoconf
                                   "-luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack -Wl,-Bdynamic";
 
   constant String ldflags_runtime = " -lOpenModelicaRuntimeC" + ldflags_basic;
-  constant String ldflags_runtime_sim = " -Wl,-Bstatic -lSimulationRuntimeC -Wl,-Bdynamic" + ldflags_basic + " -lwsock32 -lstdc++";
-  constant String ldflags_runtime_fmu = " -Wl,-Bstatic -lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm " +
+  constant String ldflags_runtime_sim = linkType + "-lSimulationRuntimeC -Wl,-Bdynamic" + ldflags_basic + " -lwsock32 -lstdc++";
+  constant String ldflags_runtime_fmu = linkType + "-lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm " +
                                         libFortran +
                                         "-lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex " +
                                         libMsvcrt + "-luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lhdf5 -lz -lszip -Wl,-Bdynamic";


### PR DESCRIPTION
- use variable OMC_LDFLAGS_LINK_TYPE to set the linker to static/dynamic, default:
  OMC_LDFLAGS_LINK_TYPE=dynamic for simulation executables,
  OMC_LDFLAGS_LINK_TYPE=static for FMI
- use variable OMC_CFLAGS_OPTIMIZATION to set the optimization level, default to OMC_CFLAGS_OPTIMIZATION=-Os
- these two variables can be overrided by the user if needed, we should support this in OMEdit
- currently OMC_LDFLAGS_LINK_TYPE only affects windows/mingw, OMC_CFLAGS_OPTIMIZATION can be used in Linux as well