### PR TITLE
Fix ticket #6171

### DIFF
--- a/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
@@ -1325,8 +1325,10 @@ algorithm
   (exp,eqs) := branch;
   File.write(file,"[");
   serializeExp(file,exp);
-  File.write(file,",");
-  serializeList(file,eqs,serializeEquationIndex);
+  if not listEmpty(eqs) then
+    File.write(file,",");
+    serializeList(file,eqs,serializeEquationIndex);
+  end if;
   File.write(file,"]");
 end serializeIfBranch;
 


### PR DESCRIPTION
Auxiliary calculations sometimes create empty else branches.
The generated _info.json file had problems with that.