### PR TITLE
Remove the 'old' signal filter

### DIFF
--- a/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.cpp
@@ -1404,42 +1404,6 @@ bool OMSProxy::getResultFile(QString cref, char **pFilename, int *pBufferSize)
 }
 
 /*!
- * \brief OMSProxy::getSignalFilter
- * gets the signal filter regex.
- * \param cref
- * \param regex
- * \return
- */
-bool OMSProxy::getSignalFilter(QString cref, char **regex)
-{
-  QString command = "oms_getSignalFilter";
-  QStringList args;
-  args << "\"" + cref + "\"";
-  LOG_COMMAND(command, args);
-  oms_status_enu_t status = oms_getSignalFilter(cref.toUtf8().constData(), regex);
-  logResponse(command, status, &commandTime);
-  return statusToBool(status);
-}
-
-/*!
- * \brief OMSProxy::setSignalFilter
- * Sets the signal filter.
- * \param cref
- * \param regex
- * \return
- */
-bool OMSProxy::setSignalFilter(QString cref, QString regex)
-{
-  QString command = "oms_setSignalFilter";
-  QStringList args;
-  args << "\"" + cref + "\"" << "\"" + regex + "\"";
-  LOG_COMMAND(command, args);
-  oms_status_enu_t status = oms_setSignalFilter(cref.toUtf8().constData(), regex.toUtf8().constData());
-  logResponse(command, status, &commandTime);
-  return statusToBool(status);
-}
-
-/*!
  * \brief OMSProxy::setSolver
  * Sets the solver.
  * \param cref

--- a/OMEdit/OMEditLIB/OMS/OMSProxy.h
+++ b/OMEdit/OMEditLIB/OMS/OMSProxy.h
@@ -109,7 +109,6 @@ public:
                            char ***types, char ***descriptions);
   bool getTolerance(QString cref, double* absoluteTolerance, double* relativeTolerance);
   bool getVariableStepSize(QString cref, double* initialStepSize, double* minimumStepSize, double* maximumStepSize);
-  bool getSignalFilter(QString cref, char **regex);
   bool instantiate(QString cref);
   bool initialize(QString cref);
   bool list(QString cref, QString *pContents);
@@ -134,7 +133,6 @@ public:
   bool setReal(QString cref, double value);
   bool setResultFile(QString cref, QString filename, int bufferSize);
   bool getResultFile(QString cref, char **pFilename, int *pBufferSize);
-  bool setSignalFilter(QString cref, QString regex);
   bool setSolver(QString cref, oms_solver_enu_t solver);
   bool setStartTime(QString cref, double startTime);
   bool setStopTime(QString cref, double stopTime);

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
@@ -103,7 +103,6 @@ OMSSimulationDialog::OMSSimulationDialog(QWidget *pParent)
   pGeneralTabWidgetGridLayout->addWidget(mpResultFileBufferSizeSpinBox, 5, 1);
   pGeneralTabWidgetGridLayout->addWidget(mpLoggingIntervalLabel, 6, 0);
   pGeneralTabWidgetGridLayout->addWidget(mpLoggingIntervalTextBox, 6, 1);
-  pGeneralTabWidgetGridLayout->addWidget(mpSignalFilterLabel, 7, 0);
   pGeneralWidget->setLayout(pGeneralTabWidgetGridLayout);
   pTabWidget->addTab(pGeneralWidget, Helper::general);
   // Archived simulation tab layout

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
@@ -85,10 +85,6 @@ OMSSimulationDialog::OMSSimulationDialog(QWidget *pParent)
   // logging interval
   mpLoggingIntervalLabel = new Label(tr("Logging Interval:"));
   mpLoggingIntervalTextBox = new QLineEdit("0");
-  // signal filter
-  mpSignalFilterLabel = new Label(tr("Signal Filter:"));
-  mpSignalFilterTextBox = new QLineEdit;
-  mpSignalFilterTextBox->setToolTip(tr("Leave empty to include all signals otherwise use a regex to filter."));
   // Add the validators
   QDoubleValidator *pDoubleValidator = new QDoubleValidator(this);
   mpStartTimeTextBox->setValidator(pDoubleValidator);
@@ -108,7 +104,6 @@ OMSSimulationDialog::OMSSimulationDialog(QWidget *pParent)
   pGeneralTabWidgetGridLayout->addWidget(mpLoggingIntervalLabel, 6, 0);
   pGeneralTabWidgetGridLayout->addWidget(mpLoggingIntervalTextBox, 6, 1);
   pGeneralTabWidgetGridLayout->addWidget(mpSignalFilterLabel, 7, 0);
-  pGeneralTabWidgetGridLayout->addWidget(mpSignalFilterTextBox, 7, 1);
   pGeneralWidget->setLayout(pGeneralTabWidgetGridLayout);
   pTabWidget->addTab(pGeneralWidget, Helper::general);
   // Archived simulation tab layout
@@ -208,9 +203,6 @@ int OMSSimulationDialog::exec(const QString &modelCref, LibraryTreeItem *pLibrar
   // result file buffer size
   mpResultFileBufferSizeSpinBox->setValue(bufferSize);
   // signalFilter
-  char *regex = (char*)"";
-  OMSProxy::instance()->getSignalFilter(mModelCref, &regex);
-  mpSignalFilterTextBox->setText(QString(regex));
   mpOkButton->setEnabled(!mpLibraryTreeItem->isSystemLibrary());
 
   return QDialog::exec();
@@ -315,7 +307,6 @@ void OMSSimulationDialog::saveSimulationSettings()
   OMSProxy::instance()->setStopTime(mModelCref, mpStopTimeTextBox->text().toDouble());
   OMSProxy::instance()->setResultFile(mModelCref, mpResultFileTextBox->text(), mpResultFileBufferSizeSpinBox->value());
   OMSProxy::instance()->setLoggingInterval(mModelCref, mpLoggingIntervalTextBox->text().toDouble());
-  OMSProxy::instance()->setSignalFilter(mModelCref, mpSignalFilterTextBox->text());
 
   ModelWidget *pModelWidget = mpLibraryTreeItem->getModelWidget();
   pModelWidget->createOMSimulatorUndoCommand(QString("Simulation setup %1").arg(mModelCref));

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.cpp
@@ -201,7 +201,6 @@ int OMSSimulationDialog::exec(const QString &modelCref, LibraryTreeItem *pLibrar
   mpResultFileTextBox->setText(QString(fileName));
   // result file buffer size
   mpResultFileBufferSizeSpinBox->setValue(bufferSize);
-  // signalFilter
   mpOkButton->setEnabled(!mpLibraryTreeItem->isSystemLibrary());
 
   return QDialog::exec();

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.h
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.h
@@ -102,7 +102,6 @@ private:
   QSpinBox *mpResultFileBufferSizeSpinBox;
   Label *mpLoggingIntervalLabel;
   QLineEdit *mpLoggingIntervalTextBox;
-  Label *mpSignalFilterLabel;
   QTreeWidget *mpArchivedSimulationsTreeWidget;
   // buttons
   QPushButton *mpOkButton;

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.h
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationDialog.h
@@ -103,7 +103,6 @@ private:
   Label *mpLoggingIntervalLabel;
   QLineEdit *mpLoggingIntervalTextBox;
   Label *mpSignalFilterLabel;
-  QLineEdit *mpSignalFilterTextBox;
   QTreeWidget *mpArchivedSimulationsTreeWidget;
   // buttons
   QPushButton *mpOkButton;


### PR DESCRIPTION
This fixes compilation (OpenModelica/OMSimulator#915), but it crashes for some reason when opening the simulation options.

I removed it, because we are about to delete `oms_setSignalFilter` from the api. The signal filter will be available in OMEdit as soon as the full snapshot is implemented in OMEdit. (Text editing of all resources files.) GUI support for the signal filter has low priority and might be postponed.