### PR TITLE
fixes for #5827 and ffi

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -70,7 +70,10 @@ ReferenceFiles:
 	$(MAKE) -C testsuite/ReferenceFiles
 libs-for-testing: omc
 	$(MAKE) -C testsuite/libraries-for-testing/
-testsuite-depends: omc-diff ReferenceFiles libs-for-testing omsimulator
+ffi-test-lib: ffi-test-lib.skip
+ffi-test-lib.skip:
+	$(MAKE) -C testsuite/flattening/modelica/ffi/FFITest/Resources/BuildProjects/gcc
+testsuite-depends: omc-diff ReferenceFiles libs-for-testing omsimulator ffi-test-lib
 test: testsuite-depends
 	$(MAKE) omc-diff CC="$(CC)" CXX="$(CXX)"
 	cd testsuite/partest && echo "Running all $(./runtests.pl -counttests) tests"

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -246,18 +246,23 @@ case FUNCTIONCODE(makefileParams=MAKEFILE_PARAMS(__)) then
   # Platform: <%makefileParams.platform%>
 
   # Dynamic loading uses -O0 by default
-  SIM_OR_DYNLOAD_OPT_LEVEL=-O0
+  # define OMC_CFLAGS_OPTIMIZATION env variable to your desired optimization level to override this
+  OMC_CFLAGS_OPTIMIZATION=-O0
+  SIM_OR_DYNLOAD_OPT_LEVEL=$(OMC_CFLAGS_OPTIMIZATION)
   CC=<%if acceptParModelicaGrammar() then 'g++' else '<%makefileParams.ccompiler%>'%>
   CXX=<%makefileParams.cxxcompiler%>
   LINK=<%makefileParams.linker%>
   EXEEXT=<%makefileParams.exeext%>
   DLLEXT=<%makefileParams.dllext%>
-  DEBUG_FLAGS=<% if boolOr(acceptMetaModelicaGrammar(), Flags.isSet(Flags.GEN_DEBUG_SYMBOLS)) then " -g"%>
+  DEBUG_FLAGS=<% if boolOr(acceptMetaModelicaGrammar(), Flags.isSet(Flags.GEN_DEBUG_SYMBOLS)) then " -g" else "$(SIM_OR_DYNLOAD_OPT_LEVEL)" %>
   CFLAGS= $(DEBUG_FLAGS) <%makefileParams.cflags%>
   CPPFLAGS= -I"<%makefileParams.omhome%>/include/omc/c" <%makefileParams.includes ; separator=" "%><%
     if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS) then " -DOMC_GENERATE_RELOCATABLE_CODE"
   %>
-  LDFLAGS= -L"<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc" -Wl,<%ExtraStack%>-rpath,'<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc' <%ParModelicaExpLibs%> <%WinMingwExtraLibs%> <%makefileParams.ldflags%> <%makefileParams.runtimelibs%>
+  # define OMC_LDFLAGS_LINK_TYPE env variable to "static" to override this
+  OMC_LDFLAGS_LINK_TYPE=dynamic
+  RUNTIME_LIBS=<%makefileParams.runtimelibs%>
+  LDFLAGS= -L"<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc" -Wl,<%ExtraStack%>-rpath,'<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc' <%ParModelicaExpLibs%> <%WinMingwExtraLibs%> <%makefileParams.ldflags%> $(RUNTIME_LIBS)
   PERL=perl
   MAINFILE=<%name%>.c
 

--- a/OMCompiler/Compiler/runtime/omc_config.h
+++ b/OMCompiler/Compiler/runtime/omc_config.h
@@ -110,12 +110,8 @@
   #define DEFAULT_CFLAGS "-falign-functions ${MODELICAUSERCFLAGS}"
 #endif
 
-#if defined(__x86_64__)
-  /* -fPIC needed on x86_64! */
-  #define DEFAULT_LINKER DEFAULT_LD" -shared -Xlinker --export-all-symbols -fPIC"
-#else
-  #define DEFAULT_LINKER DEFAULT_LD" -shared -Xlinker --export-all-symbols"
-#endif
+/* for windows/mingw we don't need -fPIC for x86_64 target, also clang doesn't support it, gcc ignores it */
+#define DEFAULT_LINKER DEFAULT_LD" -shared -Xlinker --export-all-symbols"
 
 #define CONFIG_IPOPT_INC /* Without IPOPT */
 #define CONFIG_IPOPT_LIB /* Without IPOPT */

--- a/testsuite/flattening/modelica/ffi/FFITest/Resources/BuildProjects/gcc/Makefile
+++ b/testsuite/flattening/modelica/ffi/FFITest/Resources/BuildProjects/gcc/Makefile
@@ -2,8 +2,14 @@ CC = gcc
 CFLAGS = -fPIC -Wall -Wextra -O2 -g
 LDFLAGS = -shared
 RM = rm -f
+
+ifeq (MINGW,$(findstring MINGW,$(shell uname)))
+TARGET_LIB = FFITestLib.dll
+TARGET_DIR = win64
+else # linux
 TARGET_LIB = libFFITestLib.so
 TARGET_DIR = linux64
+endif
 
 OBJS = FFITestLib.o
 


### PR DESCRIPTION
- make the meta tests work again
- fix the build of FFITestLib.dll for windows/mingw tests
- remove -fPIC from linker flags, not needed for windows/mingw