### PR TITLE
fix ticket #6396

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -201,8 +201,16 @@ void buildOMC(CC, CXX, extraFlags, Boolean buildCpp, Boolean clean) {
      echo rm -rf ./M* ./OMCppM*
      echo cd ..
      echo rm -rf .sanity-check
+     echo echo Testing some models from testsuite, ffi, meta
      echo cd testsuite/flattening/libraries/biochem
      echo ../../../rtest --return-with-error-code EnzMM.mos
+     echo cd \${MSYS_WORKSPACE}
+     echo cd testsuite/flattening/modelica/ffi
+     echo ../../../rtest --return-with-error-code ModelicaInternal_countLines.mos
+     echo ../../../rtest --return-with-error-code Integer1.mos
+     echo cd \${MSYS_WORKSPACE}
+     echo cd testsuite/metamodelica/meta
+     echo ../../rtest --return-with-error-code AlgPatternm.mos
      echo echo Testing if we can compile in a path with spaces
      echo cd \${MSYS_WORKSPACE}
      echo mkdir -p ./path\\ with\\ space/

--- a/OMCompiler/Compiler/boot/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/boot/Makefile.omdev.mingw
@@ -47,7 +47,7 @@ LDFLAGS=-L./ $(LOMPARSE) $(LCOMPILERRUNTIME) -L"$(OMHOME)/lib/omc" \
 -lzmq \
 $(OMENCRYPTIONLIBS) \
 $(LDFLAGS_CURL) \
-$(EXTRA_LD_FLAGS)
+$(EXTRA_LD_FLAGS) -Wl,--export-all-symbols
 
 FMILIB = -L$(TOP_DIR)/3rdParty/FMIL/install/lib -lfmilib
 CPPFLAGS=-I"$(OMHOME)/include/omc/c" -I../Util/ -DADD_METARECORD_DEFINITIONS=


### PR DESCRIPTION
- export all symbols from libOpenModelicaCompiler.dll
- on Windows/mingw, if the function pointer cannot be found, search all loaded dlls in the current process
- add more tests (ffi, meta) to sanity checking for the CI/MinGW label