### PR TITLE
fix OMParser/Makefile for macOS

### DIFF
--- a/OMParser/Makefile
+++ b/OMParser/Makefile
@@ -11,7 +11,6 @@ CMAKE_TARGET = "Unix Makefiles"
 endif
 
 override CXXFLAGS += -Iinstall/include/antlr4-runtime -std=c++11 -DANTLR4CPP_STATIC
-override LDFLAGS +=-Linstall/lib -Bstatic -lantlr4-runtime -lstdc++ -Bdynamic -static-libgcc
 
 CPP_FILES=modelicaBaseListener.cpp  modelicaBaseVisitor.cpp  modelicaLexer.cpp  modelicaListener.cpp  modelicaParser.cpp  modelicaVisitor.cpp
 H_FILES=$(patsubst %.cpp,%.h,$(CPP_FILES))
@@ -21,6 +20,7 @@ all: libomcparserantlr4.a
 
 libomcparserantlr4.a: $(OBJS)
 	$(AR) -s -r $@ $(OBJS)
+	mkdir -p $(OMBUILDDIR)/lib/$(host_short)/omc/ $(OMBUILDDIR)/include/omc/
 	cp -pR $@ $(OMBUILDDIR)/lib/$(host_short)/omc/
 	cp -pR install/include/antlr4-runtime $(OMBUILDDIR)/include/omc/
 


### PR DESCRIPTION
Remove breaking linker flags for macOS. macOS has no `static-libgcc`, `-lstdc++` is unnecessary for macOS's clang, and `-lantlr4-runtime` this early causes CMake's build system check to fail.