### PR TITLE
Treat names with only prerelease special

### DIFF
--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -162,7 +162,7 @@ algorithm
   matches := false;
   for v in JSON.STRING(version)::providedVersions loop
     JSON.STRING(str) := v;
-    if SemanticVersion.compare(SemanticVersion.parse(str),wantedVersion) == 0 then
+    if SemanticVersion.compare(SemanticVersion.parse(str, nonsemverAsZeroZeroZero=true),wantedVersion) == 0 then
       matches := true;
       return;
     end if;
@@ -304,8 +304,8 @@ algorithm
     obj := getPackageIndex(printError);
     libobject := JSON.get(JSON.get(obj, "libs"), id);
     (vers as JSON.OBJECT(orderedKeys=versions)) := JSON.get(libobject, "versions");
-    wantedVersion := SemanticVersion.parse(version);
-    result := List.map(List.sort(list((version,SemanticVersion.parse(version),getSupportLevel(JSON.get(JSON.get(vers, version),"support"))) for version guard providesExpectedVersion(version, JSON.getOrDefault(JSON.get(vers, version), "provides", JSON.ARRAY({})), wantedVersion) in versions), compareVersionsAndSupportLevel), Util.tuple31);
+    wantedVersion := SemanticVersion.parse(version, nonsemverAsZeroZeroZero=true);
+    result := List.map(List.sort(list((version,SemanticVersion.parse(version, nonsemverAsZeroZeroZero=true),getSupportLevel(JSON.get(JSON.get(vers, version),"support"))) for version guard providesExpectedVersion(version, JSON.getOrDefault(JSON.get(vers, version), "provides", JSON.ARRAY({})), wantedVersion) in versions), compareVersionsAndSupportLevel), Util.tuple31);
   else
     return;
   end try;

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -2276,6 +2276,18 @@ static int getLoadModelPathFromSingleTarget(const char *searchTarget, modelicaPa
   for (i=0; i<numEntries; i++) {
     /* fprintf(stderr, "entry %s/%s\n", entries[i].dir, entries[i].file);
     fprintf(stderr, "is %ld.%ld.%ld.%ld %s\n", entries[i].version[0], entries[i].version[1], entries[i].version[2], entries[i].version[3], entries[i].versionExtra); */
+    if (version[0]==0 && version[1]==0 && version[2]==0) {
+      const char *entryVersionExtra = entries[i].versionExtra;
+      if (entryVersionExtra[0] == '-' && versionExtra[0] != '-') {
+        entryVersionExtra = entryVersionExtra+1;
+      }
+      if (0==strncmp(entryVersionExtra,versionExtra,strlen(versionExtra))) {
+        *outDir = entries[i].dir;
+        *outName = entries[i].file;
+        *isDir = entries[i].fileIsDir;
+        return 0;
+      }
+    }
     if (modelicaPathEntryVersionEqual(entries[i].version,version,MODELICAPATH_LEVELS) && 0==strncmp(entries[i].versionExtra,versionExtra,strlen(versionExtra))) {
       *outDir = entries[i].dir;
       *outName = entries[i].file;


### PR DESCRIPTION
This makes the package manager treat 0.0.0-name as something any version
with that prerelease tag as matching.

Similarly, loadModel will do the same. This allows you to not have to know
which version "trunk" or "master" is at.