### PR TITLE
Add scroll bars to MSL version selection dialog

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -4629,7 +4629,14 @@ MSLVersionDialog::MSLVersionDialog(QWidget *parent)
   pMainGridLayout->addLayout(pRadioButtonsLayout, 3, 0);
   pMainGridLayout->addWidget(pPostInfoLabel, 4, 0);
   pMainGridLayout->addWidget(pOkButton, 5, 0, Qt::AlignRight);
-  setLayout(pMainGridLayout);
+  mpWidget = new QWidget;
+  mpWidget->setLayout(pMainGridLayout);
+  QScrollArea *pScrollArea = new QScrollArea;
+  pScrollArea->setWidgetResizable(true);
+  pScrollArea->setWidget(mpWidget);
+  QVBoxLayout *pMainLayout = new QVBoxLayout;
+  pMainLayout->addWidget(pScrollArea);
+  setLayout(pMainLayout);
 }
 
 /*!
@@ -4671,4 +4678,16 @@ void MSLVersionDialog::setMSLVersion()
 void MSLVersionDialog::reject()
 {
   // do nothing here.
+}
+
+/*!
+ * \brief MSLVersionDialog::sizeHint
+ * \return
+ */
+QSize MSLVersionDialog::sizeHint() const
+{
+  QSize size = QWidget::sizeHint();
+  size.rwidth() = mpWidget->width();
+  size.rheight() = mpWidget->height() + 50; // add 50 for dialog frame and title bar
+  return size;
 }

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -597,12 +597,17 @@ private:
   QRadioButton *mpMSL3RadioButton;
   QRadioButton *mpMSL4RadioButton;
   QRadioButton *mpNoMSLRadioButton;
+  QWidget *mpWidget;
 private slots:
   void setMSLVersion();
 
   // QDialog interface
 public slots:
   virtual void reject() override;
+
+  // QWidget interface
+public:
+  virtual QSize sizeHint() const override;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
### Related Issues

#6379

### Purpose

Show the MSL version selection window on smaller screens.

### Approach

Added scroll bars to the window.
