### PR TITLE
update html report with intermediate equations

### DIFF
--- a/OMCompiler/SimulationRuntime/c/dataReconciliation/dataReconciliation.h
+++ b/OMCompiler/SimulationRuntime/c/dataReconciliation/dataReconciliation.h
@@ -37,7 +37,7 @@
 extern "C" {
 #endif
 
-int dataReconciliation(DATA* data, threadData_t *threadData);
+int dataReconciliation(DATA* data, threadData_t *threadData, int status);
 
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -595,12 +595,12 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
     alarm(0);
   }
 
-  if(0 == retVal && omc_flag[FLAG_DATA_RECONCILE])
+  if (omc_flag[FLAG_DATA_RECONCILE])
   {
-  infoStreamPrint(LOG_STDOUT, 0, "DataReconciliation Starting!");
-  infoStreamPrint(LOG_STDOUT, 0, "%s", data->modelData->modelName);
-  retVal = dataReconciliation(data, threadData);
-  infoStreamPrint(LOG_STDOUT, 0, "DataReconciliation Completed!");
+    infoStreamPrint(LOG_STDOUT, 0, "DataReconciliation Starting!");
+    infoStreamPrint(LOG_STDOUT, 0, "%s", data->modelData->modelName);
+    retVal = dataReconciliation(data, threadData, retVal);
+    infoStreamPrint(LOG_STDOUT, 0, "DataReconciliation Completed!");
   }
 
   if(0 == retVal && create_linearmodel) {

--- a/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/resources/DataReconciliationSimpleTests.TSP_FourFlows1_Inputs.csv
+++ b/testsuite/openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/resources/DataReconciliationSimpleTests.TSP_FourFlows1_Inputs.csv
@@ -1,5 +1,10 @@
 Variable Names,Measured Value-x,HalfWidthConfidenceInterval,xi,xk,rx_ik
 singularPressureLoss1.Q, 2.10, 1.96
+// comments check
 singularPressureLoss2.Q, 1.10, 1.91
+// empty line check
+,,,,,,,,
+// another empty line check
+, , , , , ,
 singularPressureLoss3.Q, 0.95, 1.91
 singularPressureLoss4.Q, 2.00, 1.91


### PR DESCRIPTION
### Purpose

This PR implements the functionality to update the data Reconciliation `Html Report` with 

- print runtime convergence errors to html report
- add set-S equations to html report
- In measurement input files, lines beginning with `//` are considered as empty lines (comments)
