### PR TITLE
fix the msvc build of SimulationRuntime/c

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/c/util/CMakeLists.txt
@@ -39,7 +39,7 @@ SET(util_headers ../gc/memory_pool.h
                  base_array.h
                  boolean_array.h
                  division.h
-                 doubleEnded.h
+                 doubleEndedList.h
                  index_spec.h
                  integer_array.h
                  jacobian_util.h


### PR DESCRIPTION
### Related Issues

- small fix to #7266

### Purpose

- broken windows builds due to MSVC build issues

### Approach

- correct the header name in CMakeLists.txt
