### PR TITLE
Relax extends rules for ExternalObject

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -1172,6 +1172,7 @@ public
         case EXPANDED_TREE() then arrayLength(tree.classes);
         case INSTANTIATED_TREE() then arrayLength(tree.classes);
         case FLAT_TREE() then arrayLength(tree.classes);
+        else 0;
       end match;
     end classCount;
 
@@ -1184,6 +1185,7 @@ public
         case EXPANDED_TREE() then arrayLength(tree.components) - arrayLength(tree.exts);
         case INSTANTIATED_TREE() then arrayLength(tree.components);
         case FLAT_TREE() then arrayLength(tree.components);
+        else 0;
       end match;
     end componentCount;
 
@@ -1191,6 +1193,17 @@ public
       input ClassTree tree;
       output Integer count = arrayLength(getExtends(tree));
     end extendsCount;
+
+    function recursiveElementCount
+      input ClassTree tree;
+      output Integer count;
+    algorithm
+      count := classCount(tree) + componentCount(tree);
+
+      for ext in getExtends(tree) loop
+        count := count + ClassTree.recursiveElementCount(Class.classTree(InstNode.getClass(ext)));
+      end for;
+    end recursiveElementCount;
 
     function checkDuplicates
       input ClassTree tree;
@@ -1316,6 +1329,7 @@ public
         case PARTIAL_TREE() then tree.exts;
         case EXPANDED_TREE() then tree.exts;
         case INSTANTIATED_TREE() then tree.exts;
+        else listArray({});
       end match;
     end getExtends;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -604,7 +604,8 @@ algorithm
         // An external object may not contain extends other than the ExternalObject one.
         if arrayLength(tree.exts) > 1 then
           for ext in tree.exts loop
-            if InstNode.name(ext) <> "ExternalObject" then
+            if InstNode.name(ext) <> "ExternalObject" and
+               ClassTree.recursiveElementCount(Class.classTree(InstNode.getClass(ext))) <> 0 then
               InstNode.CLASS_NODE(nodeType = InstNodeType.BASE_CLASS(definition =
                 SCode.EXTENDS(baseClassPath = base_path))) := ext;
               Error.addSourceMessage(Error.EXTERNAL_OBJECT_INVALID_ELEMENT,

--- a/testsuite/flattening/modelica/scodeinst/ExternalObject5.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObject5.mo
@@ -1,0 +1,30 @@
+// name: ExternalObject5
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+partial package Icon
+  annotation(Icon());
+end Icon;
+
+class ExternalObject5
+  extends ExternalObject;
+  extends Icon;
+
+  function constructor
+    output ExternalObject5 obj;
+    external "C" obj = initObject();
+  end constructor;
+
+  function destructor
+    input ExternalObject5 obj;
+    external "C" destroyObject(obj);
+  end destructor;
+end ExternalObject5;
+
+// Result:
+// class ExternalObject5
+// end ExternalObject5;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -417,6 +417,7 @@ ExternalObject1.mo \
 ExternalObject2.mo \
 ExternalObject3.mo \
 ExternalObject4.mo \
+ExternalObject5.mo \
 ExternalObjectInvalidElement1.mo \
 ExternalObjectInvalidStructor1.mo \
 ExternalObjectMissingStructor1.mo \


### PR DESCRIPTION
- Allow classes extending from ExternalObject to also extend from other
  classes as long as they contain no components or classes, to allow
  e.g. inheriting Icon annotations.