### PR TITLE
Stop hybrid solver when it failed multiple times.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -1055,6 +1055,10 @@ int solveHybrd(DATA *data, threadData_t *threadData, int sysNumber)
       }
       /* take the best approximation */
       memcpy(systemData->nlsx, solverData->x, solverData->n*(sizeof(double)));
+
+      giveUp = 1;
+      success = 0;
+      break;
     }
   }
 


### PR DESCRIPTION
### Related Issues

[Trac ticket 6409](https://trac.openmodelica.org/OpenModelica/ticket/6409)

### Purpose

Make sure the while loop in the non-linear solver ends when reaching a maximum number of tries.

### Approach

Set `giveUp` to true, `success` to false and break the while loop when reaching the error message
```
Error solving nonlinear system XXX at time XXX
```
