### PR TITLE
Reset the inherited classes before fetching the new ones

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -5314,6 +5314,10 @@ bool ModelWidget::modelicaEditorTextChanged(LibraryTreeItem **pLibraryTreeItem)
   }
   /* if user has changed the class contents then refresh it. */
   if (className.compare(mpLibraryTreeItem->getNameStructure()) == 0) {
+    /* before calling the updateChildClasses() which calls reDrawModelWidget()
+     * we need to remove the inherited classes connect signal/slot of all classes.
+     */
+    ModelWidget::removeInheritedClasses(mpLibraryTreeItem);
     mpLibraryTreeItem->setClassInformation(pOMCProxy->getClassInformation(mpLibraryTreeItem->getNameStructure()));
     reDrawModelWidget();
     mpLibraryTreeItem->setClassText(modelicaText);
@@ -5321,10 +5325,6 @@ bool ModelWidget::modelicaEditorTextChanged(LibraryTreeItem **pLibraryTreeItem)
       pParentLibraryTreeItem->setClassText(stringToLoad);
       updateModelText();
     }
-    /* before calling the updateChildClasses() which calls reDrawModelWidget()
-     * we need to remove the inherited classes connect signal/slot of all classes.
-     */
-    ModelWidget::removeInheritedClasses(mpLibraryTreeItem);
     // update child classes
     updateChildClasses(mpLibraryTreeItem);
   } else {


### PR DESCRIPTION
### Related Issues

#6414

### Purpose

Load the icon of the class

### Approach

Do not reset the fetched inherited classes
