### PR TITLE
[BE] add fallback case for time differentiation

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -3953,6 +3953,7 @@ algorithm
     case (DAE.CALL(path=Absyn.IDENT(name = "der"), expLst={e1}))
       equation
         (e2, shared) = Differentiate.differentiateExpTime(e1, vars, Mutable.access(inShared));
+        false = Expression.isZero(e2);
         Mutable.update(inShared, shared);
         (e2, _) = ExpressionSimplify.simplify(e2);
         (_, vars) = Expression.traverseExpBottomUp(e2, derCrefsExp, vars);

--- a/OMCompiler/Compiler/BackEnd/BackendEquation.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendEquation.mo
@@ -2921,6 +2921,10 @@ algorithm
       eqn.source = ElementSource.addSymbolicTransformation(eqn.source, inSymOp);
     then eqn;
 
+    case eqn as BackendDAE.FOR_EQUATION() equation
+      eqn.source = ElementSource.addSymbolicTransformation(eqn.source, inSymOp);
+    then eqn;
+
     else equation
       Error.addInternalError("BackendEquation.addOperation failed", sourceInfo());
     then fail();

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1288,6 +1288,14 @@ algorithm
       then
         (zero, inFunctionTree);
 
+    // Fallback case -> not known cref results in zero
+    // D(y)/dx => 0
+    case (DAE.CREF(ty = tp), _, _, BackendDAE.DIFFERENTIATION_TIME(), _)
+      equation
+        (zero,_) = Expression.makeZeroExpression(Expression.arrayDimension(tp));
+      then
+        (zero, inFunctionTree);
+
    else
       equation
         true = Flags.isSet(Flags.FAILTRACE);

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1288,7 +1288,7 @@ algorithm
       then
         (zero, inFunctionTree);
 
-    // Fallback case -> not known cref results in zero
+    // fallback case -> not known cref results in zero
     // D(y)/dx => 0
     case (DAE.CREF(ty = tp), _, _, BackendDAE.DIFFERENTIATION_TIME(), _)
       equation


### PR DESCRIPTION
 - differentiating an unknown cref results in 0

### Related Issues

trac ticket #6267 

### Purpose

make differentiation more robust for arrays

### Approach

this allows unflattened array parameters/constants to exist
if there is `p` saved in knowns it would fail on `p[1]` before, now it does not anymore

Indexed array unknowns don't work with this approach! Won't be viable in the new backend anyway, postponed to new backend. 
