### PR TITLE
Terminal process need a flag for new console

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -2652,8 +2652,7 @@ void MainWindow::openTerminal()
   QString terminalCommand = OptionsDialog::instance()->getGeneralSettingsPage()->getTerminalCommand();
   if (terminalCommand.isEmpty()) {
     QString message = GUIMessages::getMessage(GUIMessages::TERMINAL_COMMAND_NOT_SET).arg(Helper::toolsOptionsPath);
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, message, Helper::scriptingKind,
-                                                Helper::errorLevel));
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, message, Helper::scriptingKind, Helper::errorLevel));
     return;
   }
   QString arguments = OptionsDialog::instance()->getGeneralSettingsPage()->getTerminalCommandArguments();

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -380,7 +380,9 @@ private:
   QAction *mpCleanWorkingDirectoryAction;
   // Tools Menu
   QAction *mpShowOMCLoggerWidgetAction;
+#ifdef Q_OS_WIN
   QAction *mpShowOpenModelicaCommandPromptAction;
+#endif
   QAction *mpShowOMCDiffWidgetAction;
   QAction *mpOpenTemporaryDirectoryAction;
   QAction *mpOpenWorkingDirectoryAction;
@@ -513,7 +515,9 @@ public slots:
   void exportReadonlyPackage();
   void exportModelXML();
   void exportModelFigaro();
+#ifdef Q_OS_WIN
   void showOpenModelicaCommandPrompt();
+#endif
   void runOMSensPlugin();
   void exportModelToOMNotebook();
   void importModelfromOMNotebook();

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -1901,7 +1901,7 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
 #elif defined(Q_OS_MAC)
   mpTerminalCommandTextBox->setText("");
 #else
-  mpTerminalCommandTextBox->setText("");
+  mpTerminalCommandTextBox->setText("x-terminal-emulator");
 #endif
   mpTerminalCommandBrowseButton = new QPushButton(Helper::browse);
   mpTerminalCommandBrowseButton->setAutoDefault(false);

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -471,6 +471,36 @@ void CodeColorsWidget::pickColor()
   emit colorUpdated();
 }
 
+/*!
+ * \brief QDetachableProcess::QDetachableProcess
+ * Implementation from https://stackoverflow.com/questions/42051405/qprocess-with-cmd-command-does-not-result-in-command-line-window
+ * \param pParent
+ */
+QDetachableProcess::QDetachableProcess(QObject *pParent)
+  : QProcess(pParent)
+{
+#ifdef Q_OS_WIN
+  setCreateProcessArgumentsModifier([](QProcess::CreateProcessArguments *args) {
+    args->flags |= CREATE_NEW_CONSOLE;
+    args->startupInfo->dwFlags &=~ STARTF_USESTDHANDLES;
+  });
+#endif
+}
+
+/*!
+ * \brief QDetachableProcess::start
+ * Starts a process and detaches from it.
+ * \param program
+ * \param arguments
+ * \param mode
+ */
+void QDetachableProcess::start(const QString &program, const QStringList &arguments, QIODevice::OpenMode mode)
+{
+  QProcess::start(program, arguments, mode);
+  waitForStarted();
+  setProcessState(QProcess::NotRunning);
+}
+
 QString Utilities::escapeForHtmlNonSecure(const QString &str)
 {
   return QString(str)

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -440,6 +440,14 @@ public:
   }
 };
 
+class QDetachableProcess : public QProcess
+{
+  Q_OBJECT
+public:
+  QDetachableProcess(QObject *pParent = 0);
+  void start(const QString &program, const QStringList &arguments, OpenMode mode = ReadWrite);
+};
+
 namespace Utilities {
 
   enum LineEndingMode {


### PR DESCRIPTION
### Related Issues

Fixes #6413

### Purpose

Make it possible to open terminal window

### Approach

Pass CREATE_NEW_CONSOLE flag and remove STARTF_USESTDHANDLES flag for CreateProcess win32 api
Do not use QProcess::startDetached
