### PR TITLE
Preserve the last node to skip the unnecessary lookups

### DIFF
--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -2367,7 +2367,7 @@ int OMCProxy::readSimulationResultSize(QString fileName)
 QStringList OMCProxy::readSimulationResultVars(QString fileName)
 {
   QStringList variablesList = mpOMCInterface->readSimulationResultVars(fileName, true, false);
-  std::sort(variablesList.begin(), variablesList.end());
+  std::sort(variablesList.begin(), variablesList.end(), StringHandler::naturalSortForResultVariables);
   printMessagesStringInternal();
   // close the simulation result file.
   closeSimulationResultFile();

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
@@ -46,7 +46,7 @@ class TreeSearchFilters;
 class Label;
 
 typedef QPair<int,QString> IntStringPair;
-Q_DECLARE_METATYPE(IntStringPair);
+Q_DECLARE_METATYPE(IntStringPair)
 
 class VariablesTreeItem
 {
@@ -147,10 +147,9 @@ public:
   bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
   QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
   Qt::ItemFlags flags(const QModelIndex &index) const override;
-  VariablesTreeItem* findVariablesTreeItem(const QString &name, VariablesTreeItem *root) const;
+  VariablesTreeItem* findVariablesTreeItem(const QString &name, VariablesTreeItem *pVariablesTreeItem, Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive) const;
   QModelIndex variablesTreeItemIndex(const VariablesTreeItem *pVariablesTreeItem) const;
-  QModelIndex variablesTreeItemIndexHelper(const VariablesTreeItem *pVariablesTreeItem, const VariablesTreeItem *pParentVariablesTreeItem,
-                                           const QModelIndex &parentIndex) const;
+  QModelIndex variablesTreeItemIndexHelper(const VariablesTreeItem *pVariablesTreeItem, const VariablesTreeItem *pParentVariablesTreeItem, const QModelIndex &parentIndex) const;
   void parseInitXml(QXmlStreamReader &xmlReader);
   void insertVariablesItems(QString fileName, QString filePath, QStringList variablesList, SimulationOptions simulationOptions);
   bool removeVariableTreeItem(QString variable);

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -1589,6 +1589,29 @@ bool StringHandler::naturalSort(const QString &s1, const QString &s2) {
   }
 }
 
+QString StringHandler::cleanResultVariable(const QString &variable)
+{
+  QString str = variable;
+  if (str.startsWith("der(")) {
+    str.chop((str.lastIndexOf("der(")/4)+1);
+    str = str.mid(str.lastIndexOf("der(") + 4);
+  } else if (str.startsWith("previous(")) {
+    str.chop((str.lastIndexOf("previous(")/9)+1);
+    str = str.mid(str.lastIndexOf("previous(") + 9);
+  } else {
+    // do nothing
+  }
+  return str;
+}
+
+bool StringHandler::naturalSortForResultVariables(const QString &s1, const QString &s2)
+{
+  QString s3 = StringHandler::cleanResultVariable(s1);
+  QString s4 = StringHandler::cleanResultVariable(s2);
+
+  return StringHandler::naturalSort(s3, s4);
+}
+
 #ifdef WIN32
 /*!
  * \brief StringHandler::simulationProcessEnvironment

--- a/OMEdit/OMEditLIB/Util/StringHandler.h
+++ b/OMEdit/OMEditLIB/Util/StringHandler.h
@@ -147,6 +147,8 @@ public:
   static QStringList makeVariableParts(QString variable);
   static QStringList makeVariablePartsWithInd(QString variable);
   static bool naturalSort(const QString &s1, const QString &s2);
+  static QString cleanResultVariable(const QString &variable);
+  static bool naturalSortForResultVariables(const QString &s1, const QString &s2);
 #ifdef WIN32
   static QProcessEnvironment simulationProcessEnvironment();
 #endif


### PR DESCRIPTION
### Related Issues

Fixes #6350

### Purpose

Speed up the display of result variables in OMEdit

### Approach

Apply the natural sort on the result variables so we know they are always in order
Use the last created node and match the prefix to avoid the unnecessary lookups
