### PR TITLE
Simplify listAppendDestroy

### DIFF
--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -429,16 +429,11 @@ modelica_metatype listAppendDestroy(modelica_metatype lstFirstDestroyed, modelic
   if (MMC_NILTEST(lstFirstDestroyed)) {
     return listSecondKept;
   }
-  while (!MMC_NILTEST(lst))
-  {
-    /* reached the end, set the element */
-    if (MMC_NILTEST(MMC_CDR(lst)))
-    {
-      MMC_CDR(lst) = listSecondKept;
-      break;
-    }
+  while (!MMC_NILTEST(MMC_CDR(lst))) {
     lst = MMC_CDR(lst);
   }
+  /* reached the end, set the element */
+  MMC_CDR(lst) = listSecondKept;
   return lstFirstDestroyed;
 }
 


### PR DESCRIPTION

### Related

#7303

### Purpose

Simplifying for efficiency

### Approach

Thanks to the check for an empty list at the beginning, the loop needs no additional check so I'm removing it.
