### PR TITLE
Use Qt's builtin json functionality if possible

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -78,7 +78,6 @@
 #include "omc_config.h"
 #include "Util/NetworkAccessManager.h"
 
-#include <qjson/parser.h>
 #include <QtSvg/QSvgGenerator>
 
 MainWindow::MainWindow(QWidget *parent)
@@ -1355,8 +1354,7 @@ void MainWindow::printStandardOutAndErrorFilesMessages()
       QString outputFileData = outputFile.readAll();
       if (!outputFileData.isEmpty()) {
         outputFilePosition = outputFile.pos();
-        MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, outputFileData,
-                                                              Helper::scriptingKind, Helper::notificationLevel));
+        MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, outputFileData, Helper::scriptingKind, Helper::notificationLevel));
       }
     }
     outputFile.close();
@@ -4551,15 +4549,15 @@ AboutOMEditDialog::AboutOMEditDialog(MainWindow *pMainWindow)
  */
 void AboutOMEditDialog::readOMContributors(QNetworkReply *pNetworkReply)
 {
-  QJson::Parser parser;
-  bool ok;
   QList<QVariant> result;
   const QByteArray jsonData = pNetworkReply->readAll();
-  result = parser.parse(jsonData, &ok).toList();
-  if (!ok) {
+  JsonDocument jsonDocument;
+  if (!jsonDocument.parse(jsonData)) {
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, "Failed to parse json of github contributors.", Helper::scriptingKind, Helper::errorLevel));
+    MainWindow::instance()->printStandardOutAndErrorFilesMessages();
+  } else {
+    result = jsonDocument.result.toList();
   }
-
   QString contributors;
   foreach (QVariant variant, result) {
     QVariantMap map = variant.toMap();

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -546,11 +546,12 @@ bool JsonDocument::parse(const QString &fileName)
 bool JsonDocument::parse(const QByteArray &jsonData)
 {
   bool success = true;
+  QString msg("Failed to parse json %1 with error %2");
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   QJsonParseError jsonParserError;
   QJsonDocument doc = QJsonDocument::fromJson(jsonData, &jsonParserError);
   if (doc.isNull()) {
-    errorString = QString("Failed to parse json %1 with error %2").arg(jsonData, jsonParserError.errorString());
+    errorString = QString(msg).arg(jsonData, jsonParserError.errorString());
     success = false;
   } else {
     result = doc.toVariant();
@@ -559,7 +560,7 @@ bool JsonDocument::parse(const QByteArray &jsonData)
   QJson::Parser parser;
   result = parser.parse(jsonData, &success);
   if (!success) {
-    errorString = GUIMessages::getMessage(GUIMessages::ERROR_OPENING_FILE).arg(file.fileName(), parser.errorString());
+    errorString = QString(msg).arg(jsonData, parser.errorString());
   }
 #endif // QT_VERSION_CHECK
   return success;

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -448,6 +448,18 @@ public:
   void start(const QString &program, const QStringList &arguments, OpenMode mode = ReadWrite);
 };
 
+class JsonDocument : public QObject
+{
+  Q_OBJECT
+public:
+  JsonDocument(QObject *pParent = 0);
+  bool parse(const QString &fileName);
+  bool parse(const QByteArray &jsonData);
+
+  QVariant result;
+  QString errorString;
+};
+
 namespace Utilities {
 
   enum LineEndingMode {


### PR DESCRIPTION
### Related Issues

#6350

### Purpose

Speed up the reading of `model_info.json` file.

### Approach

Parsing of big json files is not so efficient wih the custom json parser.
Avoid using custom QJson parser on latest Qt versions.