### PR TITLE
Force hybrid solver to stop when reaching to much restarts.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -117,6 +117,10 @@ int allocateHybrdData(size_t size, void** voiddata)
 int freeHybrdData(void **voiddata)
 {
   DATA_HYBRD* data = (DATA_HYBRD*) *voiddata;
+  if (data == NULL)
+  {
+    return -1;
+  }
 
   free(data->resScaling);
   free(data->fvecScaled);
@@ -1056,8 +1060,10 @@ int solveHybrd(DATA *data, threadData_t *threadData, int sysNumber)
       /* take the best approximation */
       memcpy(systemData->nlsx, solverData->x, solverData->n*(sizeof(double)));
 
-      giveUp = 1;
-      success = 0;
+      /* Setting giveUp to true and status to false is not enough to end the simulation... */
+      if(retries*retries2*retries3 > 100) {
+        omc_throw(threadData);
+      }
       break;
     }
   }


### PR DESCRIPTION
Force stop of hybrid solver after enough failures.

### Related Issues

[Trac ticket #6409](https://trac.openmodelica.org/OpenModelica/ticket/6409)

### Purpose

Force hybrid solver to stop after to many restarts.

### Approach

Not an elegant one. `giveUp` and `success` are ignored by the while loop and I didn't want to fix it. So we just throw.
After that I had to fix a segmentation fault in `freeHybrdData`. Now it can handle NULL pointers.
Maybe this leaks some memory, as there should not be a NULL pointer given to `freeHybrdData` in the first case.
But since we are stopping the simulation there is not much harm in it and I didn't spend time to check this.
