### PR TITLE
Fix memory leak in solveNewton

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
@@ -148,31 +148,21 @@ int freeNewtonData(void **voiddata)
   return 0;
 }
 
-/*! \fn solve system with Newton-Raphson
+/**
+ * @brief Solve system with Newton-Raphson.
  *
- *  \param [in]   [n] size of equation
- *                [eps] tolerance for x
- *                [h] tolerance for f'
- *                [k] maximum number of iterations
- *                [work] work array size of (n*X)
- *                [f] user provided function
- *                [data] userdata
- *                [info]
- *          [calculate_jacobian] flag which decides whether Jacobian is calculated
- *          (0)  once for the first calculation
- *          (i)  every i steps (=1 means original newton method)
- *          (-1) never, factorization has to be given in A
- *
+ * @param f             Residual function.
+ * @param solverData    Solver data for containing information for Newton solver.
+ * @param userdata      Void pointer containing user data for supplied function f and damping heuristics.
+ * @return int          Returns 0.
  */
 int _omc_newton(int(*f)(int*, double*, double*, void*, int), DATA_NEWTON* solverData, void* userdata)
 {
-  DATA_USER* uData = (DATA_USER*) userdata;
-  DATA* data = (DATA*) uData->data;
   int i, j, k = 0, l = 0, nrsh = 1;
-  int *n = &(solverData->n);
+  int *n = &(solverData->n);    /* size of equation */
   double *x = solverData->x;
   double *fvec = solverData->fvec;
-  double *eps = &(solverData->ftol);
+  double *eps = &(solverData->ftol);  /* tolerance for x */
   double *fdeps = &(solverData->epsfcn);
   int * maxfev = &(solverData->maxfev);
   double *fjac = solverData->fjac;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.h
@@ -41,15 +41,18 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Struct containing information about equation system to be solved with Newton-Raphson method.
+ */
 typedef struct DATA_NEWTON
 {
-  int initialized; /* 1 = initialized, else = 0*/
+  int initialized; /**< 1 = initialized, else = 0*/
   double* resScaling;
   double* fvecScaled;
 
   int newtonStrategy;
 
-  int n;
+  int n;              /**< size of equation */
   double* x;
   double* fvec;
   double xtol;
@@ -63,8 +66,8 @@ typedef struct DATA_NEWTON
   int* iwork;
   int calculate_jacobian;
   int factorization;
-  int numberOfIterations; /* over the whole simulation time */
-  int numberOfFunctionEvaluations; /* over the whole simulation time */
+  int numberOfIterations;           /**< over the whole simulation time */
+  int numberOfFunctionEvaluations;  /**< over the whole simulation time */
 
   /* damped newton */
   double* x_new;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -203,20 +203,13 @@ int solveNewton(DATA *data, threadData_t *threadData, int sysNumber)
   modelica_boolean *relationsPreBackup = NULL;
   int casualTearingSet = data->simulationInfo->nonlinearSystemData[sysNumber].strictTearingFunctionCall != NULL;
 
-  DATA_USER* userdata = (DATA_USER*)malloc(sizeof(DATA_USER));
-  assert(userdata != NULL);
-
-  userdata->data = (void*)data;
-  userdata->threadData = threadData;
-  userdata->sysNumber = sysNumber;
+  DATA_USER userdata = {.data = (void*)data, .threadData = threadData, .sysNumber = sysNumber};
 
   /*
    * We are given the number of the non-linear system.
    * We want to look it up among all equations.
    */
   eqSystemNumber = systemData->equationIndex;
-
-  local_tol = solverData->ftol;
 
   relationsPreBackup = (modelica_boolean*) malloc(data->modelData->nRelations*sizeof(modelica_boolean));
 
@@ -264,7 +257,7 @@ int solveNewton(DATA *data, threadData_t *threadData, int sysNumber)
 
     giveUp = 1;
     solverData->newtonStrategy = data->simulationInfo->newtonStrategy;
-    _omc_newton(wrapper_fvec_newton, solverData, (void*)userdata);
+    _omc_newton(wrapper_fvec_newton, solverData, &userdata);
 
     /* check for proper inputs */
     if(solverData->info == 0)


### PR DESCRIPTION
### Purpose

We are leaking memory every time `solveNewton()` is called. We malloc something, but never free it.

### Approach

Don't malloc any more.
