### PR TITLE
Fix code generation for boolean subscripts

### DIFF
--- a/.CI/compliance.flaky
+++ b/.CI/compliance.flaky
@@ -1,2 +1,1 @@
-ModelicaCompliance.Algorithms.For.ImplicitMultiMixedIterator
 ModelicaCompliance.Functions.Calls.Vectorization.VectorizationMultiInputIllegal

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5128,6 +5128,7 @@ template subscriptToMStr(Subscript subscript)
   case INDEX(__) then
    match exp
     case ICONST(integer=i) then i
+    case BCONST(bool=i) then i
     case ENUM_LITERAL(index=i) then i
     else
       let &varDecls = buffer ""
@@ -7566,7 +7567,7 @@ template daeSubscriptExp(Exp exp, Context context, Text &preExp, Text &varDecls,
 ::=
   let res = daeExp(exp,context,&preExp,&varDecls,&auxFunction)
   match expTypeFromExpModelica(exp)
-    case "modelica_boolean" then '(<%res%>+1)'
+    case "modelica_boolean" then '(_index_t)(<%res%>+1)'
     else res
   end match
 end daeSubscriptExp;

--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -149,6 +149,7 @@ template subscriptStr(Subscript subscript)
 ::=
   match subscript
   case INDEX(exp=ICONST(integer=i)) then i
+  case INDEX(exp=BCONST(bool=i)) then i
   case INDEX(exp=ENUM_LITERAL(name=n)) then dotPath(n)
   case INDEX(exp=CREF()) then printExpStr(exp)
   case SLICE(exp=ICONST(integer=i)) then i


### PR DESCRIPTION
- Cast boolean subscripts to _index_t, otherwise they're too small for
  va_arg to work properly.