### PR TITLE
OMCompiler: Dont try to install translations

### DIFF
--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -124,7 +124,7 @@ docs:
 	mkdir -p $(builddir_doc)/omc/testmodels
 	cp -p Examples/*.* $(builddir_doc)/omc/testmodels/
 	rm -f $(builddir_doc)/omc/testmodels/CMake*.txt
-	$(MAKE) -C Compiler/Translation OMBUILDDIR=$(OMBUILDDIR) release
+	#$(MAKE) -C Compiler/Translation OMBUILDDIR=$(OMBUILDDIR) release
 
 GC_HEADERS=gc.h gc_allocator.h gc_amiga_redirects.h gc_backptr.h gc_config_macros.h gc_gcj.h gc_pthread_redirects.h
 libgc-dev: /usr/include/gc/gc_inline.h
@@ -534,7 +534,7 @@ install: install-dirs
 	# Java
 	cp -p /${builddir_java}/* ${INSTALL_JAVADIR}
 	# Translations
-	cp -rp /${builddir_locale}/* ${INSTALL_LOCALEDIR}/
+	#cp -rp /${builddir_locale}/* ${INSTALL_LOCALEDIR}/
 
 3rdParty/msgpack-0.5.8/Makefile:
 	cd 3rdParty/msgpack-0.5.8 && ./configure --prefix="`pwd`" "--host=$(host)" CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS) $(MSGPACK_CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS) "


### PR DESCRIPTION
omcompiler from openmodelica 1.17.0 fails at "make install" because the translation files were removed in https://github.com/OpenModelica/OpenModelica/commit/b6fd115e658ed8857ec382d7429b1c746c22ec6e
here I fixed it by commenting the build & install of translation

cc @perost 
