### PR TITLE
Fix fmi export of initial unknowns

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -13548,13 +13548,13 @@ algorithm
     // check for param Vars, as we are only interested in causality = calculatedParameters
     if BackendVariable.isParam(var) then
       lhs := BackendVariable.varExp(var);
-      rhs := BackendVariable.varBindExp(var);
+      rhs := BackendVariable.varBindExpStartValueNoFail(var) "bindings are optional";
       eqn := BackendDAE.EQUATION(lhs, rhs, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_BINDING);
       BackendEquation.add(eqn, currentSystem.orderedEqs);
       //var := BackendVariable.setBindExp(var,NONE());
       //var := BackendVariable.setVarFixed(var,false);
       //var := BackendVariable.setVarKind(var, BackendDAE.VARIABLE());
-      currentSystem := BackendVariable.addVarDAE(var,currentSystem);
+      currentSystem := BackendVariable.addVarDAE(var, currentSystem);
     else
       shared := BackendVariable.addGlobalKnownVarDAE(var, shared);
     end if;

--- a/testsuite/omsimulator/DualMassOscillator.mos
+++ b/testsuite/omsimulator/DualMassOscillator.mos
@@ -72,9 +72,9 @@ unloadOMSimulator();
 // info:      system1.s1: 1.0
 // info:      system2.s2: 2.5
 // info:    Simulation
-// info:      system1.s1: 0.9106515389854031
-// info:      system2.s2: 1.95628759706625
+// info:      system1.s1: 0.9106854898769722
+// info:      system2.s2: 1.956251983576969
 // info:    Final Statistics for 'DualMassOscillator.root':
-//          NumSteps = 660 NumRhsEvals  = 909 NumLinSolvSetups = 121
-//          NumNonlinSolvIters = 908 NumNonlinSolvConvFails = 0 NumErrTestFails = 55
+//          NumSteps = 656 NumRhsEvals  = 911 NumLinSolvSetups = 120
+//          NumNonlinSolvIters = 910 NumNonlinSolvConvFails = 0 NumErrTestFails = 57
 // endResult

--- a/testsuite/omsimulator/DualMassOscillator.mos
+++ b/testsuite/omsimulator/DualMassOscillator.mos
@@ -72,9 +72,9 @@ unloadOMSimulator();
 // info:      system1.s1: 1.0
 // info:      system2.s2: 2.5
 // info:    Simulation
-// info:      system1.s1: 0.9106854898769722
-// info:      system2.s2: 1.956251983576969
+// info:      system1.s1: 0.9106515389854031
+// info:      system2.s2: 1.95628759706625
 // info:    Final Statistics for 'DualMassOscillator.root':
-//          NumSteps = 656 NumRhsEvals  = 911 NumLinSolvSetups = 120
-//          NumNonlinSolvIters = 910 NumNonlinSolvConvFails = 0 NumErrTestFails = 57
+//          NumSteps = 660 NumRhsEvals  = 909 NumLinSolvSetups = 121
+//          NumNonlinSolvIters = 908 NumNonlinSolvConvFails = 0 NumErrTestFails = 55
 // endResult

--- a/testsuite/omsimulator/testDirectionalDerivatives.mos
+++ b/testsuite/omsimulator/testDirectionalDerivatives.mos
@@ -61,7 +61,7 @@ readFile("directionalDerivatives_systemCall.log");
 // info:    Initialization
 // info:    system1.C1.v: 0.0
 // info:    Simulation
-// info:    system1.C1.v: 6.2188841112434e-26
+// info:    system1.C1.v: 0.0
 // info:    Final Statistics for 'test.root':
 //          NumSteps = 12 NumRhsEvals  = 13 NumLinSolvSetups = 3
 //          NumNonlinSolvIters = 12 NumNonlinSolvConvFails = 0 NumErrTestFails = 0

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_08.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_08.mos
@@ -76,6 +76,10 @@ readFile("fmi_attributes_08.xml"); getErrorString();
 //     <Derivatives>
 //       <Unknown index=\"2\" dependencies=\"\" dependenciesKind=\"\" />
 //     </Derivatives>
+//     <InitialUnknowns>
+//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"2\" dependencies=\"4\" dependenciesKind=\"dependent\" />
+//     </InitialUnknowns>
 //   </ModelStructure>
 // "
 // ""


### PR DESCRIPTION
### Related Issues

OpenModelica didn't export any initial unknowns for example `Modelica.Blocks.Math.Gain` because the parameter k doesn't have a binding.
