### PR TITLE
Improve handling of invalid class sections

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -5806,5 +5806,27 @@ algorithm
   end match;
 end hasNamedExternalCall;
 
+function classDefHasSections
+  "Returns true if the class definition directly contains any sections,
+   otherwise false."
+  input SCode.ClassDef cdef;
+  input Boolean checkExternal;
+  output Boolean res;
+algorithm
+  res := match cdef
+    case SCode.ClassDef.PARTS()
+      then not (listEmpty(cdef.normalEquationLst) and
+                listEmpty(cdef.initialEquationLst) and
+                listEmpty(cdef.normalAlgorithmLst) and
+                listEmpty(cdef.initialAlgorithmLst) and
+                (if checkExternal then isNone(cdef.externalDecl) else true));
+
+    case SCode.ClassDef.CLASS_EXTENDS()
+      then classDefHasSections(cdef.composition, checkExternal);
+
+    else false;
+  end match;
+end classDefHasSections;
+
 annotation(__OpenModelica_Interface="frontend");
 end SCodeUtil;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2837,14 +2837,24 @@ algorithm
       InstContext.Type icontext;
 
     case (_, Sections.EXTERNAL())
+      guard SCodeUtil.classDefHasSections(parts, checkExternal = true)
       algorithm
+        // Class with inherited external section that also contains other sections.
         Error.addSourceMessage(Error.MULTIPLE_SECTIONS_IN_FUNCTION,
           {InstNode.name(scope)}, InstNode.info(scope));
       then
         fail();
 
     case (SCode.PARTS(externalDecl = SOME(ext_decl)), _)
-      then instExternalDecl(ext_decl, scope, context);
+      algorithm
+        if SCodeUtil.classDefHasSections(parts, checkExternal = false) then
+          // Class with external section that also contains other sections.
+          Error.addSourceMessage(Error.MULTIPLE_SECTIONS_IN_FUNCTION,
+            {InstNode.name(scope)}, InstNode.info(scope));
+          fail();
+        end if;
+      then
+        instExternalDecl(ext_decl, scope, context);
 
     case (SCode.PARTS(), _)
       algorithm

--- a/testsuite/flattening/modelica/scodeinst/FunctionSections1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionSections1.mo
@@ -1,0 +1,29 @@
+// name: FunctionSections1
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Real x;
+  output Real y;
+algorithm
+  y := x;
+algorithm
+  y := x;
+end f;
+
+model FunctionSections1
+  Real x = f(time);
+end FunctionSections1;
+
+// Result:
+// Error processing file: FunctionSections1.mo
+// [flattening/modelica/scodeinst/FunctionSections1.mo:8:1-15:6:writable] Error: Function f has more than one algorithm section or external declaration.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionSections2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionSections2.mo
@@ -1,0 +1,33 @@
+// name: FunctionSections2
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+partial function base_f
+  input Real x;
+  output Real y;
+algorithm
+  y := x;
+end base_f;
+
+function f
+  extends base_f;
+algorithm
+  x := y;
+end f;
+
+model FunctionSections2
+  Real x = f(time);
+end FunctionSections2;
+
+// Result:
+// Error processing file: FunctionSections2.mo
+// [flattening/modelica/scodeinst/FunctionSections2.mo:15:1-19:6:writable] Error: Function f has more than one algorithm section or external declaration.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionSections3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionSections3.mo
@@ -1,0 +1,28 @@
+// name: FunctionSections3
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Real x;
+  output Real y;
+algorithm
+  y := x;
+external "C";
+end f;
+
+model FunctionSections3
+  Real x = f(time);
+end FunctionSections3;
+
+// Result:
+// Error processing file: FunctionSections3.mo
+// [flattening/modelica/scodeinst/FunctionSections3.mo:8:1-14:6:writable] Error: Function f has more than one algorithm section or external declaration.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionSections4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionSections4.mo
@@ -1,0 +1,31 @@
+// name: FunctionSections4
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+partial function base_f
+  input Real x;
+  output Real y;
+external "C";
+end base_f;
+
+function f
+  extends base_f;
+external "C";
+end f;
+
+model FunctionSections3
+  Real x = f(time);
+end FunctionSections3;
+
+// Result:
+// Error processing file: FunctionSections4.mo
+// [flattening/modelica/scodeinst/FunctionSections4.mo:14:1-17:6:writable] Error: Function f has more than one algorithm section or external declaration.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionSections5.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionSections5.mo
@@ -1,0 +1,33 @@
+// name: FunctionSections5
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+partial function base_f
+  input Real x;
+  output Real y;
+external "C";
+end base_f;
+
+function f
+  extends base_f;
+end f;
+
+model FunctionSections5
+  Real x = f(time);
+end FunctionSections5;
+
+// Result:
+// function f
+//   input Real x;
+//   output Real y;
+//
+//   external "C" y = base_f(x);
+// end f;
+//
+// class FunctionSections5
+//   Real x = f(time);
+// end FunctionSections5;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -572,6 +572,11 @@ FunctionRecordArg1.mo \
 FunctionRecordArg2.mo \
 FunctionRecursive1.mo \
 FunctionRecursive2.mo \
+FunctionSections1.mo \
+FunctionSections2.mo \
+FunctionSections3.mo \
+FunctionSections4.mo \
+FunctionSections5.mo \
 FunctionStreamPrefix.mo \
 IfConnect1.mo \
 IfConnect2.mo \


### PR DESCRIPTION
- Allow inheriting external sections as long as there are no other
  sections.
- Forbid mixing external sections with other sections in the same class
  (previously only inherited sections triggered an error).