### PR TITLE
Tweak handling of binding expressions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1172,6 +1172,7 @@ public
           makeArray(ty, expl, literal);
 
       case Subscript.SPLIT_INDEX() then makeSubscriptedExp(subscript :: restSubscripts, exp);
+
     end match;
   end applySubscriptArray;
 
@@ -4809,10 +4810,15 @@ public
 
   function mapSplitExpressions3
     input output Expression exp;
+  protected
+    list<Subscript> subs;
   algorithm
     exp := match exp
-      case Expression.SUBSCRIPTED_EXP()
-        then Expression.applySubscripts(list(Subscript.eval(s) for s in exp.subscripts), exp.exp);
+      case Expression.MUTABLE() then Mutable.access(exp.exp);
+
+      case Expression.SUBSCRIPTED_EXP(subscripts = subs)
+        then Expression.applySubscripts(subs, exp.exp);
+
       else exp;
     end match;
   end mapSplitExpressions3;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -950,8 +950,7 @@ public
       case UNTYPED() then Expression.variability(subscript.exp);
       case INDEX() then Expression.variability(subscript.index);
       case SLICE() then Expression.variability(subscript.slice);
-      case WHOLE() then Variability.CONSTANT;
-      case SPLIT_INDEX() then Variability.CONSTANT;
+      else Variability.CONSTANT;
     end match;
   end variability;
 
@@ -972,8 +971,7 @@ public
       case UNTYPED() then Expression.purity(subscript.exp);
       case INDEX() then Expression.purity(subscript.index);
       case SLICE() then Expression.purity(subscript.slice);
-      case WHOLE() then Purity.IMPURE;
-      case SPLIT_INDEX() then Purity.IMPURE;
+      else Purity.IMPURE;
     end match;
   end purity;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -554,11 +554,7 @@ algorithm
           end if;
         end if;
 
-        if Expression.isArray(exp) and Expression.arrayAllEqual(exp) then
-          exp := Expression.arrayFirstScalar(exp);
-        end if;
-
-        dim := Dimension.fromExp(exp, var);
+        dim := Dimension.fromExp(simplifyDimExp(exp), var);
         arrayUpdate(dimensions, index, dim);
       then
         dim;
@@ -646,7 +642,7 @@ algorithm
               Structural.markExp(exp);
               exp := Ceval.evalExp(exp, Ceval.EvalTarget.DIMENSION(component, index, exp, info));
             then
-              Dimension.fromExp(exp, dim.var);
+              Dimension.fromExp(simplifyDimExp(exp), dim.var);
 
           case Dimension.UNKNOWN()
             algorithm
@@ -667,6 +663,24 @@ algorithm
 
   verifyDimension(dimension, component, info);
 end typeDimension;
+
+function simplifyDimExp
+  input output Expression dimExp;
+protected
+  Expression exp;
+algorithm
+  dimExp := match dimExp
+    case Expression.ARRAY()
+      guard Expression.arrayAllEqual(dimExp)
+      then Expression.arrayFirstScalar(dimExp);
+
+    case Expression.SUBSCRIPTED_EXP(split = true)
+      guard Expression.isArray(dimExp.exp) and Expression.arrayAllEqual(dimExp.exp)
+      then Expression.arrayFirstScalar(dimExp.exp);
+
+    else dimExp;
+  end match;
+end simplifyDimExp;
 
 function verifyDimension
   input Dimension dimension;

--- a/testsuite/flattening/modelica/scodeinst/CevalBinding5.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalBinding5.mo
@@ -1,0 +1,55 @@
+// name: CevalBinding5
+// status: correct
+// cflags: -d=newInst
+//
+// Simple test of component bindings.
+//
+
+model A
+  parameter R2 r2;
+  parameter Boolean b;
+initial equation
+  if b then
+  end if;
+end A;
+
+record R
+  parameter Real[:] x;
+end R;
+
+record R2
+  parameter R r(x = {0, 0});
+end R2;
+
+model B
+  parameter R2 r2;
+protected
+  final parameter Boolean b = abs(r2.r.x[1]) < 0;
+  A eff(final b = b);
+end B;
+
+model CevalBinding5
+  parameter R2[2] r2;
+  B[2] b(r2 = r2);
+end CevalBinding5;
+
+// Result:
+// class CevalBinding5
+//   parameter Real r2[1].r.x[1] = 0.0;
+//   parameter Real r2[1].r.x[2] = 0.0;
+//   parameter Real r2[2].r.x[1] = 0.0;
+//   parameter Real r2[2].r.x[2] = 0.0;
+//   parameter Real b[1].r2.r.x[1] = r2[1].r.x[1];
+//   parameter Real b[1].r2.r.x[2] = r2[1].r.x[2];
+//   protected final parameter Boolean b[1].b = abs(b[1].r2.r.x[1]) < 0.0;
+//   protected parameter Real b[1].eff.r2.r.x[1] = 0.0;
+//   protected parameter Real b[1].eff.r2.r.x[2] = 0.0;
+//   protected final parameter Boolean b[1].eff.b = false;
+//   parameter Real b[2].r2.r.x[1] = 0.0;
+//   parameter Real b[2].r2.r.x[2] = 0.0;
+//   protected final parameter Boolean b[2].b = false;
+//   protected parameter Real b[2].eff.r2.r.x[1] = 0.0;
+//   protected parameter Real b[2].eff.r2.r.x[2] = 0.0;
+//   protected final parameter Boolean b[2].eff.b = false;
+// end CevalBinding5;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -103,6 +103,7 @@ CevalBinding1.mo \
 CevalBinding2.mo \
 CevalBinding3.mo \
 CevalBinding4.mo \
+CevalBinding5.mo \
 CevalConstant1.mo \
 CevalCeil1.mo \
 CevalCos1.mo \


### PR DESCRIPTION
- Improve the evaluation of component references.
- Don't evaluate subscripts in Expression.mapSplitExpression3 to remove
  mutable expressions since they might not be evaluatable, just strip
  the mutable directly.