### PR TITLE
Fix artificial limits in the JSON lexer

### DIFF
--- a/OMCompiler/Compiler/Lexers/lexerJSON.l
+++ b/OMCompiler/Compiler/Lexers/lexerJSON.l
@@ -3,7 +3,6 @@
 /* grammar according to json.org */
 protected
 import Error;
-import StringUtil;
 public
 %}
 


### PR DESCRIPTION
This needs to be ported to 1.16 and 1.17 maintenance as well, since the package index will not parse due to too long strings in a URL now.