### PR TITLE
Fix class extends of short class definition

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -1321,20 +1321,13 @@ algorithm
         then
           Class.setPrefixes(prefs, orig_cls);
 
-      // Class extends of a long class declaration.
-      case (Class.EXPANDED_CLASS(), Class.PARTIAL_CLASS())
+      // Class extends of a normal class.
+      case (_, Class.PARTIAL_CLASS())
         algorithm
           node_ty := InstNodeType.BASE_CLASS(InstNode.parent(orig_node), InstNode.definition(orig_node));
           orig_node := InstNode.setNodeType(node_ty, orig_node);
           rdcl_cls.elements := ClassTree.setClassExtends(orig_node, rdcl_cls.elements);
           rdcl_cls.modifier := Modifier.merge(outerMod, rdcl_cls.modifier);
-          rdcl_cls.prefixes := prefs;
-        then
-          rdcl_cls;
-
-      // Class extends of a short class declaration.
-      case (Class.EXPANDED_DERIVED(), Class.PARTIAL_CLASS())
-        algorithm
           rdcl_cls.prefixes := prefs;
         then
           rdcl_cls;

--- a/testsuite/flattening/modelica/scodeinst/ClassExtends9.mo
+++ b/testsuite/flattening/modelica/scodeinst/ClassExtends9.mo
@@ -1,0 +1,38 @@
+// name: ClassExtends9
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+partial function f
+end f;
+
+package P1
+  replaceable function f = .f;
+end P1;
+
+package P2
+  extends P1;
+
+  redeclare function extends f
+    input Real x;
+    output Real y = x;
+  end f;
+end P2;
+
+model ClassExtends9
+equation
+  P2.f(time);
+end ClassExtends9;
+
+// Result:
+// function P2.f
+//   input Real x;
+//   output Real y = x;
+// end P2.f;
+//
+// class ClassExtends9
+// equation
+//   P2.f(time);
+// end ClassExtends9;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -202,6 +202,7 @@ ClassExtends5.mo \
 ClassExtends6.mo \
 ClassExtends7.mo \
 ClassExtends8.mo \
+ClassExtends9.mo \
 ClassExtendsBuiltin1.mo \
 ClassExtendsBuiltin2.mo \
 ClassExtendsBuiltin3.mo \


### PR DESCRIPTION
- Remove special case for class extends of short class definitions,
  it's wrong and the normal case works for them anyway.