### PR TITLE
Remove double negation

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -3184,9 +3184,7 @@ algorithm
     case((DAE.CREF(cr, _), e))
       then (cr,e);
     case((DAE.UNARY(DAE.UMINUS(_), DAE.CREF(cr, _)), e))
-      algorithm
-        e := Expression.negate(e);
-      then (cr,Expression.negate(e));
+      then (cr,Expression.negate(e)); // PHI: does this ever happen?
     else
       algorithm
         msg := "SimCodeUtil.makeSES_SIMPLE_ASSIGN failed for: " + ExpressionDump.printExpStr(Util.tuple21(inTpl))+" = "+ExpressionDump.printExpStr(Util.tuple22(inTpl))+"\n";


### PR DESCRIPTION
I found this line by accident and _corrected_ it.

### Purpose

I want to test if this influences anything. The double negation looks really wrong but I was unable to construct a model that is affected by this.

### Approach

Remove the negation and see what happens.
