### PR TITLE
[BE] apply ASSC on structural singular sets

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -727,6 +727,20 @@ algorithm
   end match;
 end isStateVar;
 
+public function isNonStateContinuous
+  input BackendDAE.Var inVar;
+  output Boolean outBoolean;
+algorithm
+  outBoolean := match (inVar)
+    case (BackendDAE.VAR(varKind = BackendDAE.VARIABLE())) then true;
+    case (BackendDAE.VAR(varKind = BackendDAE.STATE_DER())) then true;
+    case (BackendDAE.VAR(varKind = BackendDAE.DUMMY_DER())) then true;
+    case (BackendDAE.VAR(varKind = BackendDAE.DUMMY_STATE())) then true;
+    case (BackendDAE.VAR(varKind = BackendDAE.ALG_STATE())) then true;
+    else false;
+  end match;
+end isNonStateContinuous;
+
 public function isState
   input DAE.ComponentRef inCref;
   input BackendDAE.Variables inVars;
@@ -2776,6 +2790,12 @@ public function removeAliasVars "remove alias Vars"
 algorithm
   outShared := BackendDAEUtil.setSharedAliasVars(inShared, emptyVars());
 end removeAliasVars;
+
+public function varHash
+  input BackendDAE.Var var;
+  input Integer buckets;
+  output Integer hash = ComponentReference.hashComponentRefMod(var.varName, buckets);
+end varHash;
 
 public function removeVar
   "Removes a var from the vararray but does not scaling down the array"

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -5641,12 +5641,24 @@ algorithm
           /* set the system to processed so that it gets analyzed only once */
           syst := BackendDAEUtil.setAnalyticalToStructuralProcessed(syst, true);
 
-          /* create NORMAL() adjacency matrix for sorting first */
+          // ###### PHASE I:
+          //  analyze the structural singular subset for additional
+          //  analytical singularities and apply ASSC
+          unmatched_eqs := getUnassigned(ne, ass1_1, {});
+          meqns1 := getEqnsforIndexReduction(unmatched_eqs,ne,m,mt,ass1_1,ass2_1,inArg);
+
+          for set in meqns1 loop
+            (ass1_1, ass2_1, syst, changed) := BackendDAEUtil.analyticalToStructuralSingularity(set, ass1_1, ass2_1, syst, changed, true);
+          end for;
+
+          // ###### PHASE II:
+          //  analyze the strong components for
+          //  analytical singularities and apply ASSC
           (_, m1, _, _, _) := BackendDAEUtil.getAdjacencyMatrixScalar(isyst, BackendDAE.NORMAL(), NONE(), BackendDAEUtil.isInitializationDAE(ishared));
           comps := Sorting.Tarjan(m1, ass2_1);
 
           for comp in comps loop
-            (ass1_1, ass2_1, syst, changed) := BackendDAEUtil.analyticalToStructuralSingularity(comp, ass1_1, ass2_1, syst, changed);
+            (ass1_1, ass2_1, syst, changed) := BackendDAEUtil.analyticalToStructuralSingularity(comp, ass1_1, ass2_1, syst, changed, false);
           end for;
 
           /* only do matching again if anything has changed */
@@ -5658,9 +5670,7 @@ algorithm
             BackendDAEEXT.matching(nv,ne,algIndx,cheapMatching,1.0,0);
             BackendDAEEXT.getAssignment(ass1_1,ass2_1);
           end if;
-
         end if;
-
 
         /* get unmatched equations for index reduction */
         unmatched_eqs := getUnassigned(ne, ass1_1, {});

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4318,7 +4318,7 @@ uniontype LinearJacobian
             solveRow(linJac.rows[i], linJac.rows[j], 1.0, row_value);
             //perform multiplication inside? use simplification of multiplication afterwards?
             linJac.rhs[j] := DAE.BINARY(
-                                  DAE.BINARY(linJac.rhs[j], DAE.MUL(DAE.T_REAL_DEFAULT), DAE.RCONST(piv_value)),       // row_rhs * piv_elem
+                                  DAE.BINARY(linJac.rhs[j], DAE.MUL(DAE.T_REAL_DEFAULT), DAE.RCONST(piv_value)),  // row_rhs
                                   DAE.SUB(DAE.T_REAL_DEFAULT),                                                    // -
                                   DAE.BINARY(linJac.rhs[i], DAE.MUL(DAE.T_REAL_DEFAULT), DAE.RCONST(row_value))   // piv_rhs * row_elem
                               );
@@ -4440,8 +4440,10 @@ uniontype LinearJacobian
       if linJac.eq_marks[r] and (UnorderedMap.isEmpty(linJac.rows[r]) or Flags.getConfigBool(Flags.FULL_ASSC)) then
         (i_arr, i_scal) := linJac.ind[r];
         /* remove assignments */
-        ass2[ass1[i_scal]] := -1;
-        ass1[i_scal] := -1;
+        if ass1[i_scal] <> -1 then
+          ass2[ass1[i_scal]] := -1;
+          ass1[i_scal] := -1;
+        end if;
 
         /* replace equation */
         lhs := generateLHSfromList(


### PR DESCRIPTION
### Related Issues

ticket #5817

### Purpose

Resolve analytical singularities inside of structural singularities. Before we only analyzed strong components with ASSC,
but a set of equations can be analytical as well as structurally singular and that needs to be converted to a purely structural
singularity. 

### Approach

Use the list of MSSS equations just as we used the index lists for strong components. Only difference: Strong component variables can be found via the matching, MSSS variables have to be collected from the bodies of the equations (Might be collectible from pantelides marked variables, but in the current external CPP matching it is not easy to extract those marks).