### PR TITLE
Do not call update of model directly instead use a timer

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -1578,36 +1578,6 @@ void LibraryTreeModel::updateLibraryTreeItemClassText(LibraryTreeItem *pLibraryT
 }
 
 /*!
- * \brief LibraryTreeModel::updateLibraryTreeItemClassTextManually
- * Updates the Parent Modelica class text after user has made changes manually in the text view.
- * \param pLibraryTreeItem
- * \param contents
- */
-void LibraryTreeModel::updateLibraryTreeItemClassTextManually(LibraryTreeItem *pLibraryTreeItem, QString contents)
-{
-  // set the library node not saved.
-  pLibraryTreeItem->setIsSaved(false);
-  updateLibraryTreeItem(pLibraryTreeItem);
-  // update the containing parent LibraryTreeItem class text.
-  LibraryTreeItem *pParentLibraryTreeItem = getContainingFileParentLibraryTreeItem(pLibraryTreeItem);
-  // we also mark the containing parent class unsaved because it is very important for saving of single file packages.
-  pParentLibraryTreeItem->setIsSaved(false);
-  updateLibraryTreeItem(pParentLibraryTreeItem);
-  OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
-  pParentLibraryTreeItem->setClassText(contents);
-  if (pParentLibraryTreeItem->getModelWidget()) {
-    pParentLibraryTreeItem->getModelWidget()->setWindowTitle(QString(pParentLibraryTreeItem->getName()).append("*"));
-  }
-  // if we first updated the parent class then the child classes needs to be updated as well.
-  if (pParentLibraryTreeItem != pLibraryTreeItem) {
-    pOMCProxy->loadString(pParentLibraryTreeItem->getClassText(this), pParentLibraryTreeItem->getFileName(), Helper::utf8,
-                          pParentLibraryTreeItem->getSaveContentsType() == LibraryTreeItem::SaveFolderStructure, false);
-    updateChildLibraryTreeItemClassText(pParentLibraryTreeItem, contents, pParentLibraryTreeItem->getFileName());
-    pParentLibraryTreeItem->setClassInformation(pOMCProxy->getClassInformation(pParentLibraryTreeItem->getNameStructure()));
-  }
-}
-
-/*!
  * \brief LibraryTreeModel::updateChildLibraryTreeItemClassText
  * Updates the class text of child LibraryTreeItems
  * \param pLibraryTreeItem
@@ -1621,9 +1591,7 @@ void LibraryTreeModel::updateChildLibraryTreeItemClassText(LibraryTreeItem *pLib
     if (pChildLibraryTreeItem && pChildLibraryTreeItem->getFileName().compare(fileName) == 0) {
       pChildLibraryTreeItem->setClassInformation(MainWindow::instance()->getOMCProxy()->getClassInformation(pChildLibraryTreeItem->getNameStructure()));
       readLibraryTreeItemClassTextFromText(pChildLibraryTreeItem, contents);
-      if (pChildLibraryTreeItem->childrenSize() > 0) {
-        updateChildLibraryTreeItemClassText(pChildLibraryTreeItem, contents, fileName);
-      }
+      updateChildLibraryTreeItemClassText(pChildLibraryTreeItem, contents, fileName);
     }
   }
 }

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -297,7 +297,6 @@ public:
   void removeNonExistingLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem) {mNonExistingLibraryTreeItemsList.removeOne(pLibraryTreeItem);}
   void updateLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem);
   void updateLibraryTreeItemClassText(LibraryTreeItem *pLibraryTreeItem);
-  void updateLibraryTreeItemClassTextManually(LibraryTreeItem *pLibraryTreeItem, QString contents);
   void updateChildLibraryTreeItemClassText(LibraryTreeItem *pLibraryTreeItem, QString contents, QString fileName);
   void readLibraryTreeItemClassText(LibraryTreeItem *pLibraryTreeItem);
   LibraryTreeItem* getContainingFileParentLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem);

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -553,7 +553,6 @@ public:
   void clearSelection();
   void updateClassAnnotationIfNeeded();
   void updateModelText();
-  void updateModelicaTextManually(QString contents);
   void updateUndoRedoActions();
   bool writeCoSimulationResultFile(QString fileName);
   bool writeVisualXMLFile(QString fileName, bool canWriteVisualXMLFile = false);
@@ -604,6 +603,7 @@ private:
   QMap<int, IconDiagramMap> mInheritedClassesDiagramMap;
   QList<ElementInfo*> mElementsList;
   QStringList mElementsAnnotationsList;
+  QTimer mUpdateModelTimer;
 
   void createUndoStack();
   void handleCanUndoRedoChanged();
@@ -637,6 +637,7 @@ private slots:
   void showIconView(bool checked);
   void showDiagramView(bool checked);
   void showTextView(bool checked);
+  void updateModel();
 public slots:
   void makeFileWritAble();
   void showDocumentationView();

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -1008,8 +1008,7 @@ void DuplicateClassDialog::syncDuplicatedModelWithOMC(LibraryTreeItem *pLibraryT
  * \param pSourceLibraryTreeItem
  * \param classText
  */
-void DuplicateClassDialog::folderToOneFilePackage(LibraryTreeItem *pDestinationLibraryTreeItem, LibraryTreeItem *pSourceLibraryTreeItem,
-                                                  QString *classText)
+void DuplicateClassDialog::folderToOneFilePackage(LibraryTreeItem *pDestinationLibraryTreeItem, LibraryTreeItem *pSourceLibraryTreeItem, QString *classText)
 {
   LibraryTreeModel *pLibraryTreeModel = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel();
   for (int i = 0 ; i < pSourceLibraryTreeItem->childrenSize() ; i++) {
@@ -1022,8 +1021,7 @@ void DuplicateClassDialog::folderToOneFilePackage(LibraryTreeItem *pDestinationL
       QString lineToRemove = QString("within %1;").arg(pDestinationLibraryTreeItem->getNameStructure());
       *classText += StringHandler::removeLine(diffClassText, lineToRemove) + "\n";
     } else {
-      QString afterChildClassText = MainWindow::instance()->getOMCProxy()->listFile(pDestinationChildLibraryTreeItem->getNameStructure(),
-                                                                                    false);
+      QString afterChildClassText = MainWindow::instance()->getOMCProxy()->listFile(pDestinationChildLibraryTreeItem->getNameStructure(), false);
       QString beforeChildClassText = pSourceChildLibraryTreeItem->getClassText(pLibraryTreeModel);
       QString parentClassText = MainWindow::instance()->getOMCProxy()->diffModelicaFileListings(beforeChildClassText, afterChildClassText);
       QString lineToRemove = QString("within %1;").arg(pDestinationLibraryTreeItem->getNameStructure());

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -394,8 +394,8 @@ void OMCProxy::logResponse(QString command, QString response, double elapsed)
   if (isLoggingEnabled()) {
     QString firstLine("");
     for (int i = 0; i < command.length(); i++) {
-      if (command[i] != '\n') {
-        firstLine.append(command[i]);
+      if (command.at(i) != '\n') {
+        firstLine.append(command.at(i));
       } else {
         break;
       }
@@ -1853,7 +1853,7 @@ QString OMCProxy::listFile(QString className, bool nestedClasses)
  * \param after
  * \return
  */
-QString OMCProxy::diffModelicaFileListings(QString before, QString after)
+QString OMCProxy::diffModelicaFileListings(const QString &before, const QString &after)
 {
   QString result = "";
   // check if both strings are same
@@ -1861,7 +1861,7 @@ QString OMCProxy::diffModelicaFileListings(QString before, QString after)
   if (before.compare(after) != 0 && OptionsDialog::instance()->getModelicaEditorPage()->getPreserveTextIndentationCheckBox()->isChecked()) {
     QString escapedBefore = StringHandler::escapeString(before);
     QString escapedAfter = StringHandler::escapeString(after);
-    sendCommand("diffModelicaFileListings(\"" + escapedBefore + "\", \"" + escapedAfter + "\", OpenModelica.Scripting.DiffFormat.plain)");
+    sendCommand(QString("diffModelicaFileListings(\"%1\", \"%2\", OpenModelica.Scripting.DiffFormat.plain)").arg(escapedBefore, escapedAfter));
     result = StringHandler::unparse(getResult());
     /* ticket:5413 Don't show the error of diffModelicaFileListings
      * Instead show the following warning. The developers can read the actual error message from the log file.

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -172,7 +172,7 @@ public:
   bool saveTotalModel(QString fileName, QString className);
   QString list(QString className);
   QString listFile(QString className, bool nestedClasses = true);
-  QString diffModelicaFileListings(QString before, QString after);
+  QString diffModelicaFileListings(const QString &before, const QString &after);
   QString instantiateModel(QString className);
   bool addClassAnnotation(QString className, QString annotation);
   QString getDefaultComponentName(QString className);


### PR DESCRIPTION
### Related Issues

Fixes #5620

### Purpose

Moving diagrams is too slow.

### Approach

Instead of directly updating the model on each operation, use a timer to schedule a model update. If another model update command is triggered before the timer has timed out, it will restart the timer. The timer guarantees one model update for several operations.
