### PR TITLE
Handle the path names starting with dot

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -171,6 +171,9 @@ void ElementInfo::parseComponentInfoString(QString value)
   // read the class name
   if (list.size() > 0) {
     mClassName = list.at(0);
+    if (mClassName.startsWith(".")) {
+      mClassName.remove(0, 1);
+    }
   } else {
     return;
   }
@@ -295,6 +298,9 @@ void ElementInfo::parseElementInfoString(QString value)
   // read the class name, i.e. type name
   if (list.size() > 2) {
     mClassName = list.at(2);
+    if (mClassName.startsWith(".")) {
+      mClassName.remove(0, 1);
+    }
   } else {
     return;
   }


### PR DESCRIPTION
### Related Issues

Fixes #7378

### Purpose

Handle the absolute path name starting with dot.

### Approach

Strip the leading dot from the path name so OMEdit can find the class.
