### PR TITLE
Improve typing of function calls

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -257,6 +257,18 @@ public
     end match;
   end getExp;
 
+  function getExpOpt
+    input Binding binding;
+    output Option<Expression> exp;
+  algorithm
+    exp := match binding
+      case UNTYPED_BINDING() then SOME(binding.bindingExp);
+      case TYPED_BINDING() then SOME(binding.bindingExp);
+      case FLAT_BINDING() then SOME(binding.bindingExp);
+      else NONE();
+    end match;
+  end getExpOpt;
+
   function setExp
     input Expression exp;
     input output Binding binding;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -125,6 +125,7 @@ algorithm
     ctor_node := InstNode.replaceClass(Class.NOT_INSTANTIATED(), node);
   end try;
 
+  ctor_node := InstNode.setNodeType(NFInstNode.InstNodeType.ROOT_CLASS(InstNode.parent(node)), ctor_node);
   ctor_node := Inst.instantiate(ctor_node, context = context, instPartial = true);
   Inst.instExpressions(ctor_node, context = context);
 

--- a/testsuite/flattening/modelica/scodeinst/FuncDefaultArg3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncDefaultArg3.mo
@@ -1,0 +1,26 @@
+// name: FuncDefaultArg3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Real x[:];
+  input Real y = x[1];
+  output Real z[size(x, 1)] = y * x;
+end f;
+
+model FuncDefaultArg3
+  Real x[:] = f({2, 3, 4});
+end FuncDefaultArg3;
+
+// Result:
+// class FuncDefaultArg3
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x = {4.0, 6.0, 8.0};
+// end FuncDefaultArg3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncDefaultArg4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncDefaultArg4.mo
@@ -1,0 +1,26 @@
+// name: FuncDefaultArg4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+record R
+  Real x;
+end R;
+
+function f
+  input R r;
+  input Real x = r.x;
+  output Real y = r.x * x;
+end f;
+
+model FuncDefaultArg4
+  Real x = f(R(2));
+end FuncDefaultArg4;
+
+// Result:
+// class FuncDefaultArg4
+//   Real x = 4.0;
+// end FuncDefaultArg4;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncDefaultArg5.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncDefaultArg5.mo
@@ -1,0 +1,27 @@
+// name: FuncDefaultArg5
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Integer dim;
+  input Real x = f2(dim);
+  output Integer n = dim;
+end f;
+
+function f2
+  input Integer dim;
+  output Integer n = dim;
+end f2;
+
+model FuncDefaultArg5
+  parameter Real x = f(3);
+end FuncDefaultArg5;
+
+// Result:
+// class FuncDefaultArg5
+//   parameter Real x = 3.0;
+// end FuncDefaultArg5;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -518,6 +518,9 @@ FuncBuiltinZeros.mo \
 FuncClassParam.mo \
 FuncDefaultArg1.mo \
 FuncDefaultArg2.mo \
+FuncDefaultArg3.mo \
+FuncDefaultArg4.mo \
+FuncDefaultArg5.mo \
 FuncDuplicateParams1.mo \
 FuncExtends.mo \
 FuncInnerParam.mo \


### PR DESCRIPTION
- Type default arguments for each call with the input arguments taken
  into account, instead of typing them only once for the function.
- Improve the insertion of input arguments into the default arguments
  such that it handles subscripts and complex component references.
- Fixes #7384 and #7385.