### PR TITLE
[FE,BE,SimCode] updates array parameter handling

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -1787,6 +1787,7 @@ algorithm
       list<Integer> ilst;
       DAE.InstDims subs;
       DAE.Type tp;
+      list<Option<DAE.VariableAttributes>> attr_lst;
     case (_,_,DAE.T_ARRAY(ty=tp,dims=dims),_)
       equation
         crlst = ComponentReference.expandCref(name,false);
@@ -1799,7 +1800,9 @@ algorithm
         subs = Expression.intSubscripts(ilst);
         */
         // the rest not
+        attr_lst = DAEUtil.scalarizeVariableAttributes(attr, Types.getDimensionProduct(varType));
         vars = List.map4(crlst,generateVar,varKind,tp,dims,NONE());
+        vars = List.threadMap(vars, attr_lst, setVarAttributes);
       then
         vars;
     case (_,_,_,_)

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -336,6 +336,201 @@ algorithm
   end match;
 end addEquationBoundString;
 
+public function scalarizeVariableAttributes
+  "Scalarize variable attributes and fail if sizes do not match.
+  Single entries are interpreted as if they had the each prefix.
+  NONE() entries are interpreted as if they had the each prefix."
+  input Option<DAE.VariableAttributes> attr;
+  input Integer size;
+  output list<Option<DAE.VariableAttributes>> attr_lst;
+algorithm
+  attr_lst := match attr
+    local
+      DAE.VariableAttributes va;
+      DAE.Exp exp;
+      list<DAE.Exp> quantity, unit, displayUnit, min, max, start, fixed, nominal, equationBound, startOrigin;
+
+    case SOME(va as DAE.VAR_ATTR_REAL()) algorithm
+      quantity        := match va.quantity        case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      unit            := match va.unit            case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      displayUnit     := match va.displayUnit     case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      min             := match va.min             case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      max             := match va.max             case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      start           := match va.start           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      fixed           := match va.fixed           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      nominal         := match va.nominal         case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      equationBound   := match va.equationBound   case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      startOrigin     := match va.startOrigin     case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+    then scalarizeRealAttributes(fixExpLst(quantity,size), fixExpLst(unit,size), fixExpLst(displayUnit,size), fixExpLst(min,size),
+      fixExpLst(max,size), fixExpLst(start,size), fixExpLst(fixed,size), fixExpLst(nominal,size), fixExpLst(equationBound,size),
+      fixExpLst(startOrigin,size), va.stateSelectOption, va.uncertainOption, va.distributionOption, va.isProtected, va.finalPrefix);
+
+    case SOME(va as DAE.VAR_ATTR_INT()) algorithm
+      quantity        := match va.quantity        case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      min             := match va.min             case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      max             := match va.max             case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      start           := match va.start           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      fixed           := match va.fixed           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      equationBound   := match va.equationBound   case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      startOrigin     := match va.startOrigin     case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+    then scalarizeIntAttributes(fixExpLst(quantity,size), fixExpLst(min,size),
+      fixExpLst(max,size), fixExpLst(start,size), fixExpLst(fixed,size), fixExpLst(equationBound,size),
+      fixExpLst(startOrigin,size), va.uncertainOption, va.distributionOption, va.isProtected, va.finalPrefix);
+
+    case SOME(va as DAE.VAR_ATTR_BOOL()) algorithm
+      quantity        := match va.quantity        case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      start           := match va.start           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      fixed           := match va.fixed           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      equationBound   := match va.equationBound   case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      startOrigin     := match va.startOrigin     case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+    then scalarizeBoolAttributes(fixExpLst(quantity,size), fixExpLst(start,size), fixExpLst(fixed,size), fixExpLst(equationBound,size),
+      fixExpLst(startOrigin,size), va.isProtected, va.finalPrefix);
+
+    case SOME(va as DAE.VAR_ATTR_CLOCK()) then List.fill(attr, size);
+
+    case SOME(va as DAE.VAR_ATTR_STRING()) algorithm
+      quantity        := match va.quantity        case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      start           := match va.start           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      fixed           := match va.fixed           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      equationBound   := match va.equationBound   case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      startOrigin     := match va.startOrigin     case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+    then scalarizeStringAttributes(fixExpLst(quantity,size), fixExpLst(start,size), fixExpLst(fixed,size), fixExpLst(equationBound,size),
+      fixExpLst(startOrigin,size), va.isProtected, va.finalPrefix);
+
+    case SOME(va as DAE.VAR_ATTR_ENUMERATION()) algorithm
+      quantity        := match va.quantity        case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      min             := match va.min             case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      max             := match va.max             case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      start           := match va.start           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      fixed           := match va.fixed           case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      equationBound   := match va.equationBound   case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+      startOrigin     := match va.startOrigin     case SOME(exp) then Expression.expandExpression(exp, false); else {}; end match;
+    then scalarizeEnumerationAttributes(fixExpLst(quantity,size), fixExpLst(min,size),
+      fixExpLst(max,size), fixExpLst(start,size), fixExpLst(fixed,size), fixExpLst(equationBound,size),
+      fixExpLst(startOrigin,size), va.isProtected, va.finalPrefix);
+
+    else List.fill(attr, size);
+  end match;
+  attr_lst := listReverse(attr_lst);
+end scalarizeVariableAttributes;
+
+protected function fixExpLst
+  "Wraps the exp list with Option<>
+  Single entries are interpreted as if they had the each prefix.
+  NONE() entries are interpreted as if they had the each prefix."
+  input list<DAE.Exp> exp_lst;
+  input Integer size;
+  output list<Option<DAE.Exp>> exp_opt_lst;
+algorithm
+  exp_opt_lst := match exp_lst
+    local
+      DAE.Exp exp;
+    case {}                                   then List.fill(NONE(), size);
+    case {exp}                                then List.fill(SOME(exp), size);
+    case _ guard(listLength(exp_lst) <> size) then fail();
+                                              else list(SOME(e) for e in exp_lst);
+  end match;
+end fixExpLst;
+
+protected function scalarizeRealAttributes
+  "creates scalarized real attributes from prepared lists"
+  input list<Option<DAE.Exp>> quantity, unit, displayUnit, min, max, start, fixed, nominal, equationBound, startOrigin;
+  input Option<DAE.StateSelect> stateSelectOption;
+  input Option<DAE.Uncertainty> uncertainOption;
+  input Option<DAE.Distribution> distributionOption;
+  input Option<Boolean> isProtected;
+  input Option<Boolean> finalPrefix;
+  input output list<Option<DAE.VariableAttributes>> attr_lst = {};
+algorithm
+  attr_lst := match (quantity, unit, displayUnit, min, max, start, fixed, nominal, equationBound, startOrigin)
+    local
+      Option<DAE.Exp> q, u, dU, mi, ma, s, f, n, eB, sO;
+      list<Option<DAE.Exp>> q_rest, u_rest, dU_rest, mi_rest, ma_rest, s_rest, f_rest, n_rest, eB_rest, sO_rest;
+    case (q::q_rest, u::u_rest, dU::dU_rest, mi::mi_rest, ma::ma_rest, s::s_rest, f::f_rest, n::n_rest, eB::eB_rest, sO::sO_rest)
+    then scalarizeRealAttributes(q_rest,u_rest,dU_rest,mi_rest,ma_rest,s_rest,f_rest,n_rest,eB_rest,sO_rest,
+          stateSelectOption,uncertainOption,distributionOption,isProtected,finalPrefix,
+          SOME(DAE.VAR_ATTR_REAL(q,u,dU,mi,ma,s,f,n,stateSelectOption,uncertainOption,distributionOption,
+          eB,isProtected,finalPrefix,sO))::attr_lst);
+    else attr_lst;
+  end match;
+end scalarizeRealAttributes;
+
+protected function scalarizeIntAttributes
+  "creates scalarized integer attributes from prepared lists"
+  input list<Option<DAE.Exp>> quantity, min, max, start, fixed, equationBound, startOrigin;
+  input Option<DAE.Uncertainty> uncertainOption;
+  input Option<DAE.Distribution> distributionOption;
+  input Option<Boolean> isProtected;
+  input Option<Boolean> finalPrefix;
+  input output list<Option<DAE.VariableAttributes>> attr_lst = {};
+algorithm
+  attr_lst := match (quantity, min, max, start, fixed, equationBound, startOrigin)
+    local
+      Option<DAE.Exp> q, mi, ma, s, f, eB, sO;
+      list<Option<DAE.Exp>> q_rest, mi_rest, ma_rest, s_rest, f_rest, eB_rest, sO_rest;
+    case (q::q_rest, mi::mi_rest, ma::ma_rest, s::s_rest, f::f_rest, eB::eB_rest, sO::sO_rest)
+    then scalarizeIntAttributes(q_rest,mi_rest,ma_rest,s_rest,f_rest,eB_rest,sO_rest,
+          uncertainOption,distributionOption,isProtected,finalPrefix,
+          SOME(DAE.VAR_ATTR_INT(q,mi,ma,s,f,uncertainOption,distributionOption,
+          eB,isProtected,finalPrefix,sO))::attr_lst);
+    else attr_lst;
+  end match;
+end scalarizeIntAttributes;
+
+protected function scalarizeBoolAttributes
+  "creates scalarized boolean attributes from prepared lists"
+  input list<Option<DAE.Exp>> quantity, start, fixed, equationBound, startOrigin;
+  input Option<Boolean> isProtected;
+  input Option<Boolean> finalPrefix;
+  input output list<Option<DAE.VariableAttributes>> attr_lst = {};
+algorithm
+  attr_lst := match (quantity, start, fixed, equationBound, startOrigin)
+    local
+      Option<DAE.Exp> q, s, f, eB, sO;
+      list<Option<DAE.Exp>> q_rest, s_rest, f_rest, eB_rest, sO_rest;
+    case (q::q_rest, s::s_rest, f::f_rest, eB::eB_rest, sO::sO_rest)
+    then scalarizeBoolAttributes(q_rest,s_rest,f_rest,eB_rest,sO_rest,isProtected,finalPrefix,
+          SOME(DAE.VAR_ATTR_BOOL(q,s,f,eB,isProtected,finalPrefix,sO))::attr_lst);
+    else attr_lst;
+  end match;
+end scalarizeBoolAttributes;
+
+protected function scalarizeStringAttributes
+  "creates scalarized string attributes from prepared lists"
+  input list<Option<DAE.Exp>> quantity, start, fixed, equationBound, startOrigin;
+  input Option<Boolean> isProtected;
+  input Option<Boolean> finalPrefix;
+  input output list<Option<DAE.VariableAttributes>> attr_lst = {};
+algorithm
+  attr_lst := match (quantity, start, fixed, equationBound, startOrigin)
+    local
+      Option<DAE.Exp> q, s, f, eB, sO;
+      list<Option<DAE.Exp>> q_rest, s_rest, f_rest, eB_rest, sO_rest;
+    case (q::q_rest, s::s_rest, f::f_rest, eB::eB_rest, sO::sO_rest)
+    then scalarizeStringAttributes(q_rest,s_rest,f_rest,eB_rest,sO_rest,isProtected,finalPrefix,
+          SOME(DAE.VAR_ATTR_STRING(q,s,f,eB,isProtected,finalPrefix,sO))::attr_lst);
+    else attr_lst;
+  end match;
+end scalarizeStringAttributes;
+
+protected function scalarizeEnumerationAttributes
+  "creates scalarized enumeration attributes from prepared lists"
+  input list<Option<DAE.Exp>> quantity, min, max, start, fixed, equationBound, startOrigin;
+  input Option<Boolean> isProtected;
+  input Option<Boolean> finalPrefix;
+  input output list<Option<DAE.VariableAttributes>> attr_lst = {};
+algorithm
+  attr_lst := match (quantity, min, max, start, fixed, equationBound, startOrigin)
+    local
+      Option<DAE.Exp> q, mi, ma, s, f, eB, sO;
+      list<Option<DAE.Exp>> q_rest, mi_rest, ma_rest, s_rest, f_rest, eB_rest, sO_rest;
+    case (q::q_rest, mi::mi_rest, ma::ma_rest, s::s_rest, f::f_rest, eB::eB_rest, sO::sO_rest)
+    then scalarizeEnumerationAttributes(q_rest,mi_rest,ma_rest,s_rest,f_rest,eB_rest,sO_rest,isProtected,finalPrefix,
+          SOME(DAE.VAR_ATTR_ENUMERATION(q,mi,ma,s,f,eB,isProtected,finalPrefix,sO))::attr_lst);
+    else attr_lst;
+  end match;
+end scalarizeEnumerationAttributes;
+
 public function getClassList "get list of classes from Var"
   input DAE.Element v;
   output list<Absyn.Path> lst;

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -12251,12 +12251,7 @@ algorithm
         expl := List.mapFlat(expl, function expandExpression(expandRecord = expandRecord));
       then expl;
 
-    else
-     algorithm
-        msg := "- Expression.expandExpression failed for " + ExpressionDump.printExpStr(inExp);
-        Error.addMessage(Error.INTERNAL_ERROR, {msg});
-      then
-        fail();
+    else {inExp};
   end match;
 
 end expandExpression;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -220,7 +220,7 @@ protected
   BackendDAE.Shared shared;
   BackendDAE.SymbolicJacobians symJacs;
   BackendDAE.Variables globalKnownVars;
-  Boolean ifcpp;
+  Boolean ifcpp = stringEqual(Config.simCodeTarget(), "Cpp");
   HashTableCrIListArray.HashTable varToArrayIndexMapping "maps each array-variable to a array of positions";
   HashTableCrILst.HashTable varToIndexMapping "maps each variable to an array position";
   Integer maxDelayedExpIndex, uniqueEqIndex, numberofEqns, numStateSets, numberOfJacobians, sccOffset;
@@ -298,7 +298,6 @@ algorithm
     dlow := inBackendDAE;
     System.tmpTickReset(0);
     uniqueEqIndex := 1;
-    ifcpp := (stringEqual(Config.simCodeTarget(), "Cpp"));
 
     backendMapping := setUpBackendMapping(inBackendDAE);
     if Flags.isSet(Flags.VISUAL_XML) then
@@ -340,8 +339,10 @@ algorithm
     end if;
 
     shared := dlow.shared;
-    shared.globalKnownVars := scalarizeGlobalKnownVars(shared.globalKnownVars);
-    dlow.shared := shared;
+    if not ifcpp then
+      shared.globalKnownVars := scalarizeGlobalKnownVars(shared.globalKnownVars);
+      dlow.shared := shared;
+    end if;
     BackendDAE.SHARED(
       globalKnownVars = globalKnownVars,
       constraints     = constraints,
@@ -370,7 +371,6 @@ algorithm
       SymEuler_help := Flags.getConfigEnum(Flags.SYM_SOLVER);
       FlagsUtil.setConfigEnum(Flags.SYM_SOLVER, 0);
     end if;
-
 
     if not ((Config.simCodeTarget() == "omsic")/*or (Config.simCodeTarget() ==  "omsicpp")*/)
     then
@@ -409,7 +409,6 @@ algorithm
         end match;
       end if;
     end if;
-
 
     if (SymEuler_help > 0) then
       FlagsUtil.setConfigEnum(Flags.SYM_SOLVER, SymEuler_help);


### PR DESCRIPTION
### Related Issues

 - fixes regressions from previous fixes on ticket #6267 (PR #7271)
 
### Purpose

- allow keeping array parameters up until simcode and preserve array function calls for them

### Approach

 - [FE] implement scalarization of variable attributes
 - [BE] update variable scalarization with attribute scalarization
 - [SimCode] apply scalarization on global known vars
