### PR TITLE
Automatically pick the right prefix value for axes values

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2884,7 +2884,7 @@ function plotParametric "Launches a plotParametric window using OMPlot. Returns 
   input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
-  input String xLabel = "time" "This text will be used as the horizontal label in the diagram.";
+  input String xLabel = "" "This text will be used as the horizontal label in the diagram.";
   input String yLabel = "" "This text will be used as the vertical label in the diagram.";
   input Real xRange[2] = {0.0,0.0} "Determines the horizontal interval that is visible in the diagram. {0,0} will select a suitable range.";
   input Real yRange[2] = {0.0,0.0} "Determines the vertical interval that is visible in the diagram. {0,0} will select a suitable range.";

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3107,7 +3107,7 @@ function plotParametric "Launches a plotParametric window using OMPlot. Returns 
   input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
-  input String xLabel = "time" "This text will be used as the horizontal label in the diagram.";
+  input String xLabel = "" "This text will be used as the horizontal label in the diagram.";
   input String yLabel = "" "This text will be used as the vertical label in the diagram.";
   input Real xRange[2] = {0.0,0.0} "Determines the horizontal interval that is visible in the diagram. {0,0} will select a suitable range.";
   input Real yRange[2] = {0.0,0.0} "Determines the vertical interval that is visible in the diagram. {0,0} will select a suitable range.";

--- a/OMCompiler/Compiler/runtime/unitparser.cpp
+++ b/OMCompiler/Compiler/runtime/unitparser.cpp
@@ -1190,7 +1190,6 @@ void UnitParser::initSIUnits() {
   addDerived("pressure", "millimeter of mercury", "mmHg", "Pa", Rational(0),
       Rational(133322387415, 1000000000), Rational(0), true);
 
-  addDerived("time", "millisecond", "ms", "s", Rational(-3), Rational(1), Rational(0), true);
   addDerived("time", "minute", "min", "s", Rational(0), Rational(60), Rational(0), true);
   addDerived("time", "hour", "h", "s", Rational(0), Rational(60 * 60), Rational(0), true);
   addDerived("time", "day", "d", "s", Rational(0), Rational(60 * 60 * 24), Rational(0), true);

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -788,6 +788,10 @@ void OptionsDialog::readPlottingSettings()
   if (mpSettings->contains("plotting/autoScale")) {
     mpPlottingPage->getAutoScaleCheckBox()->setChecked(mpSettings->value("plotting/autoScale").toBool());
   }
+  // read the prefix axes
+  if (mpSettings->contains("plotting/prefixAxes")) {
+    mpPlottingPage->getPrefixAxesCheckbox()->setChecked(mpSettings->value("plotting/prefixAxes").toBool());
+  }
   // read the plotting view mode
   if (mpSettings->contains("plotting/viewmode")) {
     mpPlottingPage->setPlottingViewMode(mpSettings->value("plotting/viewmode").toString());
@@ -1407,6 +1411,8 @@ void OptionsDialog::savePlottingSettings()
 {
   // save the auto scale
   mpSettings->setValue("plotting/autoScale", mpPlottingPage->getAutoScaleCheckBox()->isChecked());
+  // save the prefix axes
+  mpSettings->setValue("plotting/prefixAxes", mpPlottingPage->getPrefixAxesCheckbox()->isChecked());
   // save plotting view mode
   mpSettings->setValue("plotting/viewmode", mpPlottingPage->getPlottingViewMode());
   if (mpPlottingPage->getPlottingViewMode().compare(Helper::subWindow) == 0) {
@@ -4410,9 +4416,13 @@ PlottingPage::PlottingPage(OptionsDialog *pOptionsDialog)
   // auto scale
   mpAutoScaleCheckBox = new QCheckBox(tr("Auto Scale"));
   mpAutoScaleCheckBox->setToolTip(tr("Auto scale the plot to fit in view when variable is plotted."));
+  // prefix axes
+  mpPrefixAxesCheckbox = new QCheckBox(tr("Prefix Axes"));
+  mpPrefixAxesCheckbox->setToolTip(tr("Automatically pick the right prefix for axes values."));
   // set general groupbox layout
   QGridLayout *pGeneralGroupBoxLayout = new QGridLayout;
   pGeneralGroupBoxLayout->addWidget(mpAutoScaleCheckBox, 0, 0);
+  pGeneralGroupBoxLayout->addWidget(mpPrefixAxesCheckbox, 1, 0);
   mpGeneralGroupBox->setLayout(pGeneralGroupBoxLayout);
   // Plotting View Mode
   mpPlottingViewModeGroupBox = new QGroupBox(tr("Default Plotting View Mode"));

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -800,6 +800,7 @@ public:
   void setPlottingViewMode(QString value);
   QString getPlottingViewMode();
   QCheckBox* getAutoScaleCheckBox() {return mpAutoScaleCheckBox;}
+  QCheckBox* getPrefixAxesCheckbox() {return mpPrefixAxesCheckbox;}
   void setCurvePattern(int pattern);
   int getCurvePattern();
   void setCurveThickness(qreal thickness);
@@ -816,6 +817,7 @@ private:
   OptionsDialog *mpOptionsDialog;
   QGroupBox *mpGeneralGroupBox;
   QCheckBox *mpAutoScaleCheckBox;
+  QCheckBox *mpPrefixAxesCheckbox;
   QGroupBox *mpPlottingViewModeGroupBox;
   QRadioButton *mpPlottingTabbedViewRadioButton;
   QRadioButton *mpPlottingSubWindowViewRadioButton;

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -273,8 +273,9 @@ void PlotWindowContainer::addPlotWindow(bool maximized)
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setPrefixAxes(OptionsDialog::instance()->getPlottingPage()->getPrefixAxesCheckbox()->isChecked());
     pPlotWindow->setTimeUnit(MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox()->currentText());
-    pPlotWindow->setXLabel(QString("time (%1)").arg(pPlotWindow->getTimeUnit()));
+    pPlotWindow->setXLabel(QString("time"));
     pPlotWindow->installEventFilter(this);
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
@@ -306,6 +307,7 @@ void PlotWindowContainer::addParametricPlotWindow()
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setPrefixAxes(OptionsDialog::instance()->getPlottingPage()->getPrefixAxesCheckbox()->isChecked());
     pPlotWindow->setTimeUnit(MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox()->currentText());
     pPlotWindow->installEventFilter(this);
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
@@ -336,6 +338,7 @@ void PlotWindowContainer::addArrayPlotWindow(bool maximized)
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setPrefixAxes(OptionsDialog::instance()->getPlottingPage()->getPrefixAxesCheckbox()->isChecked());
     QComboBox* unitComboBox = MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox();
     if (unitComboBox->currentText() == ""){
         int currentIndex = unitComboBox->findText("s", Qt::MatchExactly);
@@ -378,8 +381,9 @@ PlotWindow* PlotWindowContainer::addInteractivePlotWindow(bool maximized, QStrin
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setPrefixAxes(OptionsDialog::instance()->getPlottingPage()->getPrefixAxesCheckbox()->isChecked());
     pPlotWindow->setTimeUnit(MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox()->currentText());
-    pPlotWindow->setXLabel(QString("time (%1)").arg(pPlotWindow->getTimeUnit()));
+    pPlotWindow->setXLabel(QString("time"));
     pPlotWindow->installEventFilter(this);
     QMdiSubWindow *pSubWindow = addSubWindow(pPlotWindow);
     PlottingPage *pPlottingPage = OptionsDialog::instance()->getPlottingPage();
@@ -414,6 +418,7 @@ void PlotWindowContainer::addArrayParametricPlotWindow()
     pPlotWindow->setTitle("");
     pPlotWindow->setLegendPosition("top");
     pPlotWindow->setAutoScale(OptionsDialog::instance()->getPlottingPage()->getAutoScaleCheckBox()->isChecked());
+    pPlotWindow->setPrefixAxes(OptionsDialog::instance()->getPlottingPage()->getPrefixAxesCheckbox()->isChecked());
     QComboBox* unitComboBox = MainWindow::instance()->getVariablesWidget()->getSimulationTimeComboBox();
     if (unitComboBox->currentText() == ""){
         int currentIndex = unitComboBox->findText("s", Qt::MatchExactly);

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2112,29 +2112,6 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
           }
         }
       }
-      // Set the plot labels if there is only on parametric plot curve.
-      if (pPlotWindow->getPlot()->getPlotCurvesList().size() == 1) {
-        PlotCurve *pLastPlotCurve = pPlotWindow->getPlot()->getPlotCurvesList().last();
-        // x label
-        QString xVariable = pLastPlotCurve->getXVariable();
-        QString xUnit = pLastPlotCurve->getXDisplayUnit();
-        if (xUnit.isEmpty()) {
-          pPlotWindow->setXLabel(xVariable);
-        } else {
-          pPlotWindow->setXLabel(xVariable + " (" + xUnit + ")");
-        }
-        // y label
-        QString yVariable = pLastPlotCurve->getYVariable();
-        QString yUnit = pLastPlotCurve->getYDisplayUnit();
-        if (yUnit.isEmpty()) {
-          pPlotWindow->setYLabel(yVariable);
-        } else {
-          pPlotWindow->setYLabel(yVariable + " (" + yUnit + ")");
-        }
-      } else {
-        pPlotWindow->setXLabel("");
-        pPlotWindow->setYLabel("");
-      }
     } else { // if plottype is INTERACTIVE then
       VariablesTreeItem *pVariablesTreeRootItem = pVariablesTreeItem;
       if (!pVariablesTreeItem->isRootItem()) {
@@ -2481,6 +2458,7 @@ void VariablesWidget::timeUnitChanged(QString unit)
     } else if (pPlotWindow->getPlotType() == PlotWindow::PLOT ||
                pPlotWindow->getPlotType() == PlotWindow::PLOTINTERACTIVE) {
       OMCInterface::convertUnits_res convertUnit = MainWindow::instance()->getOMCProxy()->convertUnits(pPlotWindow->getTimeUnit(), unit);
+      pPlotWindow->setTimeUnit(unit);
       if (convertUnit.unitsCompatible) {
         foreach (PlotCurve *pPlotCurve, pPlotWindow->getPlot()->getPlotCurvesList()) {
           for (int i = 0 ; i < pPlotCurve->mXAxisVector.size() ; i++) {
@@ -2488,8 +2466,6 @@ void VariablesWidget::timeUnitChanged(QString unit)
           }
           pPlotCurve->setData(pPlotCurve->getXAxisVector(), pPlotCurve->getYAxisVector(), pPlotCurve->getSize());
         }
-        pPlotWindow->setXLabel(QString("time (%1)").arg(unit));
-        pPlotWindow->setTimeUnit(unit);
         pPlotWindow->getPlot()->replot();
       }
     }

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
@@ -40,6 +40,7 @@
 #include "PlotZoomer.h"
 #include "PlotPanner.h"
 #include "PlotPicker.h"
+#include "ScaleDraw.h"
 #include "PlotCurve.h"
 
 namespace OMPlot
@@ -50,6 +51,7 @@ class PlotGrid;
 class PlotZoomer;
 class PlotPanner;
 class PlotPicker;
+class ScaleDraw;
 class PlotCurve;
 
 class Plot : public QwtPlot
@@ -59,6 +61,8 @@ private:
   PlotWindow *mpParentPlotWindow;
   Legend *mpLegend;
   PlotGrid *mpPlotGrid;
+  ScaleDraw *mpXScaleDraw;
+  ScaleDraw *mpYScaleDraw;
   PlotZoomer *mpPlotZoomer;
   PlotPanner *mpPlotPanner;
   PlotPicker *mpPlotPicker;
@@ -72,8 +76,10 @@ public:
   PlotWindow* getParentPlotWindow();
   void setLegend(Legend *pLegend);
   Legend* getLegend();
-  QwtPlotPicker* getPlotPicker();
+  PlotPicker *getPlotPicker();
   PlotGrid* getPlotGrid();
+  ScaleDraw *getXScaleDraw() const {return mpXScaleDraw;}
+  ScaleDraw *getYScaleDraw() const {return mpYScaleDraw;}
   PlotZoomer* getPlotZoomer();
   PlotPanner* getPlotPanner();
   QList<PlotCurve*> getPlotCurvesList();

--- a/OMPlot/OMPlot/OMPlotGUI/PlotMainWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotMainWindow.cpp
@@ -36,82 +36,79 @@
 using namespace OMPlot;
 
 PlotMainWindow::PlotMainWindow(QWidget *pParent)
-    : QMainWindow(pParent)
+  : QMainWindow(pParent)
 {
-    mpPlotWindowContainer = new PlotWindowContainer(this);
+  mpPlotWindowContainer = new PlotWindowContainer(this);
 
-    setWindowTitle(tr("OMPlot - OpenModelica Plot"));
-    setWindowIcon(QIcon(":/Resources/icons/omplot.png"));
+  setWindowTitle(tr("OMPlot - OpenModelica Plot"));
+  setWindowIcon(QIcon(":/Resources/icons/omplot.png"));
 
-    createActions();
-    createMenus();
+  createActions();
+  createMenus();
 
-    //Create the Statusbar
-    mpStatusBar = new QStatusBar();
-    mpStatusBar->setObjectName("statusBar");
-    setStatusBar(mpStatusBar);
-    // set plotwindowcontainer as central widget
-    setCentralWidget(mpPlotWindowContainer);
+  //Create the Statusbar
+  mpStatusBar = new QStatusBar();
+  mpStatusBar->setObjectName("statusBar");
+  setStatusBar(mpStatusBar);
+  // set plotwindowcontainer as central widget
+  setCentralWidget(mpPlotWindowContainer);
 }
 
 PlotWindowContainer* PlotMainWindow::getPlotWindowContainer()
 {
-    return mpPlotWindowContainer;
+  return mpPlotWindowContainer;
 }
 
 void PlotMainWindow::addPlotWindow(QStringList arguments)
 {
-    mpPlotWindowContainer->addPlotWindow(arguments);
+  mpPlotWindowContainer->addPlotWindow(arguments);
 }
 
 void PlotMainWindow::createActions()
 {
-    mpCloseAction = new QAction(tr("Close"), this);
-    mpCloseAction->setShortcut(QKeySequence("Ctrl+q"));
-    connect(mpCloseAction, SIGNAL(triggered()), SLOT(close()));
+  mpCloseAction = new QAction(tr("Close"), this);
+  mpCloseAction->setShortcut(QKeySequence("Ctrl+q"));
+  connect(mpCloseAction, SIGNAL(triggered()), SLOT(close()));
 
-    mpTabViewAction = new QAction(tr("Tab View"), this);
-    mpTabViewAction->setCheckable(true);
-    mpTabViewAction->setChecked(true);
-    connect(mpTabViewAction, SIGNAL(triggered(bool)), SLOT(switchWindowsView(bool)));
+  mpTabViewAction = new QAction(tr("Tab View"), this);
+  mpTabViewAction->setCheckable(true);
+  mpTabViewAction->setChecked(true);
+  connect(mpTabViewAction, SIGNAL(triggered(bool)), SLOT(switchWindowsView(bool)));
 }
 
 void PlotMainWindow::createMenus()
 {
-    //Create the menubar
-    mpMenuBar = new QMenuBar();
-    mpMenuBar->setGeometry(QRect(0,0,800,25));
-    mpMenuBar->setObjectName("menubar");
+  //Create the menubar
+  mpMenuBar = new QMenuBar();
+  mpMenuBar->setGeometry(QRect(0,0,800,25));
+  mpMenuBar->setObjectName("menubar");
 
-    //Create the File menu
-    mpMenuFile = new QMenu(mpMenuBar);
-    mpMenuFile->setObjectName("menuFile");
-    mpMenuFile->setTitle(tr("&File"));
-    //Add the actions to file menu
-    mpMenuFile->addAction(mpCloseAction);
-    // add file menu to menubar
-    mpMenuBar->addAction(mpMenuFile->menuAction());
-    //Create the Options menu
-    mpMenuOptions = new QMenu(mpMenuBar);
-    mpMenuOptions->setObjectName("menuFile");
-    mpMenuOptions->setTitle(tr("&Options"));
-    //Add the actions to Options menu
-    mpMenuOptions->addAction(mpTabViewAction);
-    // add options menu to menubar
-    mpMenuBar->addAction(mpMenuOptions->menuAction());
-    // add menubar to mainwindow
-    setMenuBar(mpMenuBar);
+  //Create the File menu
+  mpMenuFile = new QMenu(mpMenuBar);
+  mpMenuFile->setObjectName("menuFile");
+  mpMenuFile->setTitle(tr("&File"));
+  //Add the actions to file menu
+  mpMenuFile->addAction(mpCloseAction);
+  // add file menu to menubar
+  mpMenuBar->addAction(mpMenuFile->menuAction());
+  //Create the Options menu
+  mpMenuOptions = new QMenu(mpMenuBar);
+  mpMenuOptions->setObjectName("menuFile");
+  mpMenuOptions->setTitle(tr("&Options"));
+  //Add the actions to Options menu
+  mpMenuOptions->addAction(mpTabViewAction);
+  // add options menu to menubar
+  mpMenuBar->addAction(mpMenuOptions->menuAction());
+  // add menubar to mainwindow
+  setMenuBar(mpMenuBar);
 }
 
 void PlotMainWindow::switchWindowsView(bool mode)
 {
-    if (mode)
-    {
-        getPlotWindowContainer()->setViewMode(QMdiArea::TabbedView);
-    }
-    else
-    {
-        getPlotWindowContainer()->setViewMode(QMdiArea::SubWindowView);
-        getPlotWindowContainer()->getCurrentWindow()->show();
-    }
+  if (mode) {
+    getPlotWindowContainer()->setViewMode(QMdiArea::TabbedView);
+  } else {
+    getPlotWindowContainer()->setViewMode(QMdiArea::SubWindowView);
+    getPlotWindowContainer()->getCurrentWindow()->show();
+  }
 }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotMainWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotMainWindow.h
@@ -49,28 +49,27 @@
 namespace OMPlot
 {
 class PlotWindowContainer;
-
 class PlotMainWindow : public QMainWindow
 {
-    Q_OBJECT
+  Q_OBJECT
 public:
-    PlotMainWindow(QWidget *pParent = 0);
+  PlotMainWindow(QWidget *pParent = 0);
 
-    PlotWindowContainer* getPlotWindowContainer();
-    void addPlotWindow(QStringList arguments);
+  PlotWindowContainer* getPlotWindowContainer();
+  void addPlotWindow(QStringList arguments);
 private:
-    PlotWindowContainer *mpPlotWindowContainer;
-    QStatusBar *mpStatusBar;
-    QMenuBar *mpMenuBar;
-    QMenu *mpMenuFile;
-    QMenu *mpMenuOptions;
-    QAction *mpCloseAction;
-    QAction *mpTabViewAction;
+  PlotWindowContainer *mpPlotWindowContainer;
+  QStatusBar *mpStatusBar;
+  QMenuBar *mpMenuBar;
+  QMenu *mpMenuFile;
+  QMenu *mpMenuOptions;
+  QAction *mpCloseAction;
+  QAction *mpTabViewAction;
 
-    void createActions();
-    void createMenus();
+  void createActions();
+  void createMenus();
 public slots:
-    void switchWindowsView(bool mode);
+  void switchWindowsView(bool mode);
 };
 }
 

--- a/OMPlot/OMPlot/OMPlotGUI/PlotPanner.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotPanner.h
@@ -47,14 +47,14 @@ public:
 #else
   PlotPanner(QwtPlotCanvas *pCanvas, Plot *pParent);
 #endif
-    ~PlotPanner();
+  ~PlotPanner();
 public Q_SLOTS:
-    void updateView(int, int);
+  void updateView(int, int);
 private:
-    Plot *mpParentPlot;
+  Plot *mpParentPlot;
 protected:
-    virtual void widgetMousePressEvent(QMouseEvent *event);
-    virtual void widgetMouseReleaseEvent(QMouseEvent *event);
+  virtual void widgetMousePressEvent(QMouseEvent *event);
+  virtual void widgetMouseReleaseEvent(QMouseEvent *event);
 };
 }
 

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -36,6 +36,7 @@
 #include <qwt_text.h>
 #include <qwt_plot_curve.h>
 #include <qwt_plot_picker.h>
+#include <qwt_scale_draw.h>
 #include <qwt_picker_machine.h>
 #include <qwt_plot_grid.h>
 #include <qwt_curve_fitter.h>
@@ -79,6 +80,10 @@ private:
   QStringList mVariablesList;
   PlotType mPlotType;
   QString mGridType;
+  QString mXLabel;
+  QString mYLabel;
+  QString mXCustomLabel;
+  QString mYCustomLabel;
   QString mXUnit;
   QString mXDisplayUnit;
   QString mYUnit;
@@ -97,6 +102,7 @@ private:
   int mInteractivePort;
   QwtSeriesData<QPointF>* mpInteractiveData;
   QString mInteractiveModelName;
+  bool mPrefixAxes;
   QMdiSubWindow *mpSubWindow;
 public:
   PlotWindow(QStringList arguments = QStringList(), QWidget *parent = 0, bool isInteractiveSimulation = false);
@@ -133,8 +139,14 @@ public:
   QToolButton* getStartSimulationButton() {return mpStartSimulationToolButton;}
   QToolButton* getPauseSimulationButton() {return mpPauseSimulationToolButton;}
   QComboBox* getSimulationSpeedBox() {return mpSimulationSpeedComboBox;}
-  void setXLabel(QString label);
-  void setYLabel(QString label);
+  void setXLabel(const QString &label) {mXLabel = label;}
+  QString getXLabel() const {return mXLabel;}
+  void setYLabel(const QString &label) {mYLabel = label;}
+  QString getYLabel() const {return mYLabel;}
+  void setXCustomLabel(const QString &label) {mXCustomLabel = label;}
+  QString getXCustomLabel() const {return mXCustomLabel;}
+  void setYCustomLabel(const QString &label) {mYCustomLabel = label;}
+  QString getYCustomLabel() const {return mYCustomLabel;}
   void setXUnit(QString xUnit) {mXUnit = xUnit;}
   QString getXUnit() {return mXUnit;}
   void setXDisplayUnit(QString xDisplayUnit) {mXDisplayUnit = xDisplayUnit;}
@@ -161,6 +173,8 @@ public:
   QString getLegendPosition();
   void setFooter(QString footer);
   QString getFooter();
+  bool getPrefixAxes() const;
+  void setPrefixAxes(bool prefixAxes);
   void checkForErrors(QStringList variables, QStringList variablesPlotted);
   Plot* getPlot();
   void receiveMessage(QStringList arguments);
@@ -301,6 +315,7 @@ private:
   QLineEdit *mpYMinimumTextBox;
   QLabel *mpYMaximumLabel;
   QLineEdit *mpYMaximumTextBox;
+  QCheckBox *mpPrefixAxesCheckbox;
   /* buttons */
   QPushButton *mpOkButton;
   QPushButton *mpApplyButton;

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindowContainer.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindowContainer.cpp
@@ -36,69 +36,71 @@
 using namespace OMPlot;
 
 PlotWindowContainer::PlotWindowContainer(PlotMainWindow *pParent)
-    : QMdiArea(pParent)
+  : QMdiArea(pParent)
 {
-    mpPlotMainWindow = pParent;
-    setActivationOrder(QMdiArea::CreationOrder);
-    setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    setViewMode(QMdiArea::TabbedView);
+  mpPlotMainWindow = pParent;
+  setActivationOrder(QMdiArea::CreationOrder);
+  setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+  setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+  setViewMode(QMdiArea::TabbedView);
 }
 
 PlotMainWindow* PlotWindowContainer::getPlotMainWindow()
 {
-    return mpPlotMainWindow;
+  return mpPlotMainWindow;
 }
 
 QString PlotWindowContainer::getUniqueName(QString name, int number)
 {
-    QString newName;
-    newName = name + QString::number(number);
+  QString newName;
+  newName = name + QString::number(number);
 
-    foreach (QMdiSubWindow *pWindow, subWindowList())
-    {
-        PlotWindow *pPlotWindow = qobject_cast<PlotWindow*>(pWindow->widget());
-        if (pPlotWindow->windowTitle().compare(newName) == 0)
-        {
-            newName = getUniqueName(name, ++number);
-            break;
-        }
+  foreach (QMdiSubWindow *pWindow, subWindowList()) {
+    PlotWindow *pPlotWindow = qobject_cast<PlotWindow*>(pWindow->widget());
+    if (pPlotWindow->windowTitle().compare(newName) == 0) {
+      newName = getUniqueName(name, ++number);
+      break;
     }
-    return newName;
+  }
+  return newName;
 }
 
 PlotWindow* PlotWindowContainer::getCurrentWindow()
 {
-    if (subWindowList(QMdiArea::ActivationHistoryOrder).size() == 0)
-        return 0;
-    else
-        return qobject_cast<PlotWindow*>(subWindowList(QMdiArea::ActivationHistoryOrder).last()->widget());
+  if (subWindowList(QMdiArea::ActivationHistoryOrder).size() == 0) {
+    return 0;
+  } else {
+    return qobject_cast<PlotWindow*>(subWindowList(QMdiArea::ActivationHistoryOrder).last()->widget());
+  }
 }
 
 void PlotWindowContainer::addPlotWindow(QStringList arguments)
 {
-    PlotWindow *pPlotWindow = new PlotWindow(arguments, this);
-    if (pPlotWindow->getPlotType() == PlotWindow::PLOT or pPlotWindow->getPlotType() == PlotWindow::PLOTALL)
-        pPlotWindow->setWindowTitle(QString(getUniqueName()).append(" - x(t)"));
-    else
-        pPlotWindow->setWindowTitle(QString(getUniqueName()).append(" - x(y)"));
-    connect(pPlotWindow, SIGNAL(closingDown()), SLOT(checkSubWindows()));
-    setActiveSubWindow(addSubWindow(pPlotWindow));
-    if (viewMode() == QMdiArea::TabbedView)
-        pPlotWindow->showMaximized();
-    else
-        pPlotWindow->show();
-    getPlotMainWindow()->activateWindow();
+  PlotWindow *pPlotWindow = new PlotWindow(arguments, this);
+  if (pPlotWindow->getPlotType() == PlotWindow::PLOT or pPlotWindow->getPlotType() == PlotWindow::PLOTALL) {
+    pPlotWindow->setWindowTitle(QString(getUniqueName()).append(" - x(t)"));
+  } else {
+    pPlotWindow->setWindowTitle(QString(getUniqueName()).append(" - x(y)"));
+  }
+  connect(pPlotWindow, SIGNAL(closingDown()), SLOT(checkSubWindows()));
+  setActiveSubWindow(addSubWindow(pPlotWindow));
+  if (viewMode() == QMdiArea::TabbedView) {
+    pPlotWindow->showMaximized();
+  } else {
+    pPlotWindow->show();
+  }
+  getPlotMainWindow()->activateWindow();
 }
 
 void PlotWindowContainer::updateCurrentWindow(QStringList arguments)
 {
-    getCurrentWindow()->receiveMessage(arguments);
-    getPlotMainWindow()->activateWindow();
+  getCurrentWindow()->receiveMessage(arguments);
+  getPlotMainWindow()->activateWindow();
 }
 
 void PlotWindowContainer::checkSubWindows()
 {
-    if (subWindowList().size() < 2)
-        getPlotMainWindow()->close();
+  if (subWindowList().size() < 2) {
+    getPlotMainWindow()->close();
+  }
 }

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindowContainer.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindowContainer.h
@@ -42,19 +42,19 @@ namespace OMPlot
 class PlotMainWindow;
 class PlotWindowContainer : public QMdiArea
 {
-    Q_OBJECT
+  Q_OBJECT
 public:
-    PlotWindowContainer(PlotMainWindow *pParent);
+  PlotWindowContainer(PlotMainWindow *pParent);
 
-    PlotMainWindow* getPlotMainWindow();
-    QString getUniqueName(QString name = QString("Plot"), int number = 1);
-    PlotWindow* getCurrentWindow();
+  PlotMainWindow* getPlotMainWindow();
+  QString getUniqueName(QString name = QString("Plot"), int number = 1);
+  PlotWindow* getCurrentWindow();
 private:
-    PlotMainWindow *mpPlotMainWindow;
+  PlotMainWindow *mpPlotMainWindow;
 public slots:
-    void addPlotWindow(QStringList arguments);
-    void updateCurrentWindow(QStringList arguments);
-    void checkSubWindows();
+  void addPlotWindow(QStringList arguments);
+  void updateCurrentWindow(QStringList arguments);
+  void checkSubWindows();
 };
 }
 

--- a/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.h
+++ b/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.h
@@ -33,15 +33,22 @@
 #ifndef SCALEDRAW_H
 #define SCALEDRAW_H
 
-#include "qwt_scale_draw.h"
+#include "OMPlot.h"
 
 namespace OMPlot
 {
 class ScaleDraw : public QwtScaleDraw
 {
 public:
-  ScaleDraw();
+  ScaleDraw(Plot *pParent);
+  QString getAxesPrefix() const;
+  void setAxesPrefix(const QString &axesPrefix);
+  void invalidateCache();
   virtual QwtText label(double value) const;
+
+private:
+  Plot *mpParentPlot;
+  mutable QString mAxesPrefix;
 };
 }
 

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -743,6 +743,8 @@ Plot Window
 A plot window shows the plot curve of instance variables. Several plot curves can be plotted in the
 same plot window. See :numref:`omedit-plotting-perspective`.
 
+.. _omedit-plot-window-menu :
+
 Plot Window Menu
 ^^^^^^^^^^^^^^^^
 
@@ -769,6 +771,14 @@ Plot Window Menu
     -  *Titles* - Plot, axes and footer titles settings.
     -  *Legend* - Sets legend position and font.
     -  *Range* - Automatic or manual axes range.
+      -  *Auto Scale* - Automatically scales the horizontal and vertical axes.
+      -  *X-Axis*
+        -  *Minimum* - Minimum value for x-axis.
+        -  *Maximum* - Maximum value for x-axis.
+      -  *Y-Axis*
+        -  *Minimum* - Minimum value for y-axis.
+        -  *Maximum* - Maximum value for y-axis.
+    -  *Prefix Axes* - Automatically pick the right prefix for axes values.
 
 Re-simulating a Model
 ---------------------
@@ -1450,7 +1460,9 @@ Plotting
 
 -  General
 
-  -  *Auto Scale* – sets whether to auto scale the plots or not.
+  -  *Auto Scale* – Sets whether to auto scale the plots or not.
+  -  *Prefix Axes* – Automatically pick the right prefix for axes values for the new plot windows.
+     For existing plot windows use the :ref:`omedit-plot-window-menu`.
 
 -  Plotting View Mode
 


### PR DESCRIPTION
### Related Issues

Fixes #5447

### Purpose

Automatically pick the right prefix for units.

### Approach

See the lower and upper bounds of the axis and do the appropriate multiple of 10.
The feature is optional and is off by default. Enable it via `Tools->Options->Plotting->General->Prefix Axes`.
