### PR TITLE
Fix subscripting of arrays

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -887,6 +887,7 @@ Subscript3.mo \
 Subscript4.mo \
 Subscript5.mo \
 Subscript6.mo \
+Subscript7.mo \
 SubscriptCevalIndex1.mo \
 SubscriptCevalIndexRange1.mo \
 SubscriptCevalSlice1.mo \

--- a/testsuite/flattening/modelica/scodeinst/Subscript7.mo
+++ b/testsuite/flattening/modelica/scodeinst/Subscript7.mo
@@ -1,0 +1,30 @@
+// name: Subscript7
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+model Subscript7
+  parameter Real[3, :] x = {{1.0, 0, 0}, {0, 1.0, 0}, {0, 0, 1.0}} annotation(Evaluate=true);
+  parameter Real[:, :] y = {x[:, i + 1] - x[:, i] for i in 1:2};
+end Subscript7;
+
+// Result:
+// class Subscript7
+//   final parameter Real x[1,1] = 1.0;
+//   final parameter Real x[1,2] = 0.0;
+//   final parameter Real x[1,3] = 0.0;
+//   final parameter Real x[2,1] = 0.0;
+//   final parameter Real x[2,2] = 1.0;
+//   final parameter Real x[2,3] = 0.0;
+//   final parameter Real x[3,1] = 0.0;
+//   final parameter Real x[3,2] = 0.0;
+//   final parameter Real x[3,3] = 1.0;
+//   parameter Real y[1,1] = -1.0;
+//   parameter Real y[1,2] = 1.0;
+//   parameter Real y[1,3] = 0.0;
+//   parameter Real y[2,1] = 0.0;
+//   parameter Real y[2,2] = -1.0;
+//   parameter Real y[2,3] = 1.0;
+// end Subscript7;
+// endResult


### PR DESCRIPTION
- Reevaluate the literalness when subscripting an array, since
  subscripting a literal array might create a non-literal array if the
  subscripts are not literals.

Fixes #7385 when the flag `-d=evaluateAllParameters` is used.