### PR TITLE
Record constructor improvements

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1172,6 +1172,10 @@ algorithm
     case Class.INSTANCED_CLASS(restriction = Restriction.RECORD())
       then list(makeTypeRecordVar(c) for c in ClassTree.getComponents(cls.elements));
 
+    case Class.INSTANCED_CLASS(restriction = Restriction.RECORD_CONSTRUCTOR())
+      then list(makeTypeRecordVar(c) for c guard not InstNode.isOutput(c)
+             in ClassTree.getComponents(cls.elements));
+
     case Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE())
       then list(makeTypeVar(c) for c guard not InstNode.isOnlyOuter(c)
              in ClassTree.getComponents(cls.elements));

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1816,7 +1816,8 @@ uniontype Function
     end for;
 
     params := listReverse(params);
-    ty := if boxTypes then Type.box(fn.returnType) else fn.returnType;
+    ty := if isDefaultRecordConstructor(fn) then InstNode.getType(fn.node) else fn.returnType;
+    ty := if boxTypes then Type.box(ty) else ty;
     outType := DAE.T_FUNCTION(params, Type.toDAE(ty), fn.attributes, fn.path);
   end makeDAEType;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -54,6 +54,7 @@ import Inst = NFInst;
 import Lookup = NFLookup;
 import TypeCheck = NFTypeCheck;
 import Typing = NFTyping;
+import NFPrefixes.Direction;
 import NFPrefixes.Variability;
 import NFPrefixes.Visibility;
 import NFFunction.Function;
@@ -62,6 +63,7 @@ import ComplexType = NFComplexType;
 import ComponentRef = NFComponentRef;
 import NFFunction.FunctionStatus;
 import MetaModelica.Dangerous.listReverseInPlace;
+import UnorderedSet;
 
 public
 
@@ -101,13 +103,12 @@ function instDefaultConstructor
   input InstContext.Type context;
   input SourceInfo info;
 protected
-  list<InstNode> inputs, locals, all_params;
+  list<InstNode> inputs, locals, all_params, sorted_locals;
   DAE.FunctionAttributes attr;
   Pointer<FunctionStatus> status;
   InstNode ctor_node, out_rec;
   Component out_comp;
   Class ctor_cls;
-  InstNode ty_node;
 algorithm
   // The node we get is usually a record instance, with applied modifiers and so on.
   // So the first thing we do is to create a "pure" instance of the record.
@@ -132,6 +133,18 @@ algorithm
   // Collect the record fields.
   (inputs, locals, all_params) := collectRecordParams(ctor_node);
 
+  // TODO: The local fields can contain depenencies on each other which requires
+  //       reordering them such that they can be initialized before they're used.
+  //       But the code generation uses the type of the record constructor both
+  //       for generating the record struct and the record constructor, so we
+  //       can't currently reorder variables here without also messing up the
+  //       order of the record itself. Not sorting them is not an option since
+  //       that would lead to code that compiles but with undefined behaviour,
+  //       so instead we sort them and give an error if the ordering changed.
+  //sorted_locals := Function.sortLocals(locals, info);
+  //all_params := listAppend(inputs, sorted_locals);
+  checkLocalFieldOrder(locals, ctor_node, info);
+
   // Create the output record element, using the instance created above as both parent and type.
   out_comp := Component.UNTYPED_COMPONENT(ctor_node, listArray({}),
                 NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
@@ -141,6 +154,7 @@ algorithm
   // Make a record constructor class and create a node for the constructor.
   ctor_cls := Class.makeRecordConstructor(all_params, out_rec);
   ctor_node := InstNode.replaceClass(ctor_cls, ctor_node);
+  InstNode.classApply(ctor_node, Class.setType, Type.COMPLEX(ctor_node, ComplexType.CLASS()));
 
   // Create the constructor function and add it to the function cache.
   attr := DAE.FUNCTION_ATTRIBUTES_DEFAULT;
@@ -148,6 +162,37 @@ algorithm
   InstNode.cacheAddFunc(node, Function.FUNCTION(path, ctor_node, inputs,
     {out_rec}, locals, {}, Type.UNKNOWN(), attr, {}, status, Pointer.create(0)), false);
 end instDefaultConstructor;
+
+function checkLocalFieldOrder
+  "Checks if the local variables in a record constructor requires reordering,
+   and issues an error in that case since we can't handle it yet."
+  input list<InstNode> locals;
+  input InstNode recNode;
+  input SourceInfo info;
+protected
+  UnorderedSet<InstNode> locals_set;
+  list<InstNode> locs, deps;
+  InstNode loc;
+algorithm
+  if listLength(locals) <= 1 then
+    return;
+  end if;
+
+  loc :: locs := listReverse(locals);
+  locals_set := UnorderedSet.fromList({loc}, InstNode.hash, InstNode.refEqual);
+
+  for l in locs loop
+    deps := Function.getLocalDependencies(l, locals_set);
+
+    if not listEmpty(deps) then
+      Error.addSourceMessage(Error.UNSUPPORTED_RECORD_REORDERING,
+        {InstNode.name(recNode)}, info);
+      fail();
+    end if;
+
+    UnorderedSet.add(l, locals_set);
+  end for;
+end checkLocalFieldOrder;
 
 function collectRecordParams
   input InstNode recNode;
@@ -205,6 +250,7 @@ algorithm
     return;
   end if;
 
+  stripConstructorAttributes(comp_node);
   comp := InstNode.component(comp_node);
 
   if Component.isConst(comp) and Component.hasBinding(comp) then
@@ -213,6 +259,18 @@ algorithm
     inputs := comp_node :: inputs;
   end if;
 end collectRecordParam;
+
+function stripConstructorAttributes
+  input InstNode field;
+protected
+  Component comp = InstNode.component(field);
+  Component.Attributes attr;
+algorithm
+  attr := Component.getAttributes(comp);
+  attr.direction := Direction.NONE;
+  comp := Component.setAttributes(attr, comp);
+  InstNode.updateComponent(comp, field);
+end stripConstructorAttributes;
 
 function collectRecordFields
   input InstNode recNode;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRestriction.mo
@@ -90,6 +90,7 @@ public
       case MODEL() then ClassInf.State.MODEL(path);
       case OPERATOR() then ClassInf.State.FUNCTION(path, false);
       case RECORD() then ClassInf.State.RECORD(path);
+      case RECORD_CONSTRUCTOR() then ClassInf.State.RECORD(path);
       case TYPE() then ClassInf.State.TYPE(path);
       case CLOCK() then ClassInf.State.TYPE_CLOCK(path);
       else ClassInf.State.UNKNOWN(path);

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -848,6 +848,8 @@ public constant ErrorTypes.Message CONVERSION_MISMATCHED_PLACEHOLDER = ErrorType
   Gettext.gettext("Mismatched % in conversion modifier ‘%s‘."));
 public constant ErrorTypes.Message CONVERSION_MISSING_PLACEHOLDER_VALUE = ErrorTypes.MESSAGE(388, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("No replacement value for placeholder ‘%s‘ could be found."));
+public constant ErrorTypes.Message UNSUPPORTED_RECORD_REORDERING = ErrorTypes.MESSAGE(389, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  Gettext.gettext("The record constructor for ‘%s‘ requires reordering of local fields to initialize them in the correct order, which is not yet supported."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -3,6 +3,7 @@ TEST = ../../../rtest -v
 TESTFILES = \
 ATotal.mos \
 InOutRecord.mos \
+RecordConstructor1.mos \
 TestComplexSum1.mos \
 TestComplexSum2.mos \
 Ticket5134.mos

--- a/testsuite/simulation/modelica/records/RecordConstructor1.mos
+++ b/testsuite/simulation/modelica/records/RecordConstructor1.mos
@@ -1,0 +1,39 @@
+// name:     RecordConstructor1
+// keywords: record
+// status:   correct
+// cflags:   -d=newInst
+
+loadString("
+  record R
+    Real x = 2.0;
+  protected
+    Real y = x;
+  end R;
+
+  function f
+    input R r;
+    output Real x;
+  algorithm
+    x := r.x;
+  end f;
+
+  model RecordConstructor1_model
+    R r;
+    Real x = f(r);
+  end RecordConstructor1_model;
+"); getErrorString();
+
+simulate(RecordConstructor1_model); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "RecordConstructor1_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'RecordConstructor1_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
- Use the correct prefix when generating code for setting the values of
  local variables in record constructors.
- Generate code for initializing the local variables in record
  constructors after the public variables have been initialized, since
  the local variables might depend on the public ones.
- Implement support for sorting local variables in record constructors
  based on their dependencies, but disable it for now and give an error
  if reordering is required since the code generation can't handle it at
  the moment.