### PR TITLE
Use the greek omega instead of Ohm

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -559,6 +559,7 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
             mTextString.replace(pos, regExp.matchedLength(), textValue);
             pos += textValue.length();
           } else {
+            displaytUnit = Utilities::convertUnitToSymbol(displaytUnit);
             QString textValueWithDisplayUnit = QString("%1 %2").arg(textValue, displaytUnit);
             mTextString.replace(pos, regExp.matchedLength(), textValueWithDisplayUnit);
             pos += textValueWithDisplayUnit.length();

--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -115,7 +115,7 @@ private:
   void enableDisableUnitComboBox(const QString &value);
 public slots:
   void fileSelectorButtonClicked();
-  void unitComboBoxChanged(QString text);
+  void unitComboBoxChanged(int index);
   void valueComboBoxChanged(int index);
   void valueCheckBoxChanged(bool toggle);
   void valueTextBoxEdited(const QString &text);

--- a/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
@@ -319,7 +319,9 @@ QWidget* ItemDelegate::createEditor(QWidget *pParent, const QStyleOptionViewItem
       // create the display units combobox
       QComboBox *pComboBox = new QComboBox(pParent);
       pComboBox->setEnabled(!pVariablesTreeItem->getDisplayUnits().isEmpty());
-      pComboBox->addItems(pVariablesTreeItem->getDisplayUnits());
+      foreach (QString unit, pVariablesTreeItem->getDisplayUnits()) {
+        pComboBox->addItem(Utilities::convertUnitToSymbol(unit), unit);
+      }
       connect(pComboBox, SIGNAL(currentIndexChanged(QString)), SLOT(unitComboBoxChanged(QString)));
       return pComboBox;
     }
@@ -349,10 +351,16 @@ QWidget* ItemDelegate::createEditor(QWidget *pParent, const QStyleOptionViewItem
 void ItemDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
   if (parent() && qobject_cast<VariablesTreeView*>(parent()) && index.column() == 3) {
-    QString value = index.model()->data(index, Qt::DisplayRole).toString();
+    VariablesTreeView *pVariablesTreeView = qobject_cast<VariablesTreeView*>(parent());
+    VariableTreeProxyModel *pVariableTreeProxyModel = pVariablesTreeView->getVariablesWidget()->getVariableTreeProxyModel();
+    QModelIndex sourceIndex = pVariableTreeProxyModel->mapToSource(index);
+    VariablesTreeItem *pVariablesTreeItem = static_cast<VariablesTreeItem*>(sourceIndex.internalPointer());
     QComboBox* comboBox = static_cast<QComboBox*>(editor);
     //set the index of the combo box
-    comboBox->setCurrentIndex(comboBox->findText(value, Qt::MatchExactly));
+    int currentIndex = comboBox->findData(pVariablesTreeItem->getDisplayUnit());
+    if (currentIndex > -1) {
+      comboBox->setCurrentIndex(currentIndex);
+    }
   } else if (parent() && qobject_cast<ConnectorsTreeView*>(parent()) && index.column() == 1) {
     ConnectorItem *pConnectorItem = static_cast<ConnectorItem*>(index.internalPointer());
     QString value = index.model()->data(index, Qt::DisplayRole).toString();

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -220,9 +220,9 @@ bool VariablesTreeItem::setData(int column, const QVariant &value, int role)
     }
     return true;
   } else if (column == 3 && role == Qt::EditRole) {
-    if (mDisplayUnit.compare(value.toString()) != 0) {
+    if (mDisplayUnit.compare(Utilities::convertSymbolToUnit(value.toString())) != 0) {
       mPreviousUnit = mDisplayUnit;
-      mDisplayUnit = value.toString();
+      mDisplayUnit = Utilities::convertSymbolToUnit(value.toString());
     }
     return true;
   }
@@ -281,7 +281,7 @@ QVariant VariablesTreeItem::data(int column, int role) const
       switch (role) {
         case Qt::DisplayRole:
         case Qt::ToolTipRole:
-          return mUnit;
+          return Utilities::convertUnitToSymbol(mUnit);
         default:
           return QVariant();
       }
@@ -289,7 +289,7 @@ QVariant VariablesTreeItem::data(int column, int role) const
       switch (role) {
         case Qt::DisplayRole:
         case Qt::ToolTipRole:
-          return mDisplayUnit;
+          return Utilities::convertUnitToSymbol(mDisplayUnit);
         default:
           return QVariant();
       }
@@ -454,7 +454,7 @@ bool VariablesTreeModel::setData(const QModelIndex &index, const QVariant &value
       }
     }
   } else if (index.column() == 3) { // display unit
-    if (!signalsBlocked() && displayUnit.compare(value.toString()) != 0) {
+    if (!signalsBlocked() && displayUnit.compare(Utilities::convertSymbolToUnit(value.toString())) != 0) {
       emit unitChanged(index);
     }
   }
@@ -1907,8 +1907,8 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
         pPlotWindow->setCurveWidth(curveThickness);
         pPlotWindow->setCurveStyle(curveStyle);
         pPlotWindow->setVariablesList(QStringList(pVariablesTreeItem->getPlotVariable()));
-        pPlotWindow->setYUnit(pVariablesTreeItem->getUnit());
-        pPlotWindow->setYDisplayUnit(pVariablesTreeItem->getDisplayUnit());
+        pPlotWindow->setYUnit(Utilities::convertUnitToSymbol(pVariablesTreeItem->getUnit()));
+        pPlotWindow->setYDisplayUnit(Utilities::convertUnitToSymbol(pVariablesTreeItem->getDisplayUnit()));
         if (pPlotWindow->getPlotType() == PlotWindow::PLOT) {
           pPlotWindow->plot(pPlotCurve);
         } else {/* ie. (pPlotWindow->getPlotType() == PlotWindow::PLOTARRAY)*/
@@ -2027,10 +2027,10 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
             pPlotWindow->setCurveWidth(curveThickness);
             pPlotWindow->setCurveStyle(curveStyle);
             pPlotWindow->setVariablesList(QStringList() << plotParametricCurve.xVariable.variableName << plotParametricVariable.variableName);
-            pPlotWindow->setXUnit(plotParametricCurve.xVariable.unit);
-            pPlotWindow->setXDisplayUnit(plotParametricCurve.xVariable.displayUnit);
-            pPlotWindow->setYUnit(plotParametricVariable.unit);
-            pPlotWindow->setYDisplayUnit(plotParametricVariable.displayUnit);
+            pPlotWindow->setXUnit(Utilities::convertUnitToSymbol(plotParametricCurve.xVariable.unit));
+            pPlotWindow->setXDisplayUnit(Utilities::convertUnitToSymbol(plotParametricCurve.xVariable.displayUnit));
+            pPlotWindow->setYUnit(Utilities::convertUnitToSymbol(plotParametricVariable.unit));
+            pPlotWindow->setYDisplayUnit(Utilities::convertUnitToSymbol(plotParametricVariable.displayUnit));
             if (pPlotWindow->getPlotType() == PlotWindow::PLOTPARAMETRIC) {
               pPlotWindow->plotParametric(pPlotCurve);
             } else { /* ie. (pPlotWindow->getPlotType() == PlotWindow::PLOTARRAYPARAMETRIC)*/
@@ -2133,8 +2133,8 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
             pPlotWindow->setCurveStyle(curveStyle);
             QString plotVariable = pVariablesTreeItem->getPlotVariable();
             pPlotWindow->setVariablesList(QStringList(plotVariable));
-            pPlotWindow->setYUnit(pVariablesTreeItem->getUnit());
-            pPlotWindow->setYDisplayUnit(pVariablesTreeItem->getDisplayUnit());
+            pPlotWindow->setYUnit(Utilities::convertUnitToSymbol(pVariablesTreeItem->getUnit()));
+            pPlotWindow->setYDisplayUnit(Utilities::convertUnitToSymbol(pVariablesTreeItem->getDisplayUnit()));
             pPlotWindow->setInteractiveModelName(pVariablesTreeItem->getFileName());
             OpcUaClient *pOpcUaClient = MainWindow::instance()->getSimulationDialog()->getOpcUaClient(port);
             if (pOpcUaClient) {
@@ -2202,8 +2202,7 @@ void VariablesWidget::unitChanged(const QModelIndex &index)
     if (!pPlotWindow) {
       return;
     }
-    OMCInterface::convertUnits_res convertUnit = MainWindow::instance()->getOMCProxy()->convertUnits(pVariablesTreeItem->getPreviousUnit(),
-                                                                                                     pVariablesTreeItem->getDisplayUnit());
+    OMCInterface::convertUnits_res convertUnit = MainWindow::instance()->getOMCProxy()->convertUnits(pVariablesTreeItem->getPreviousUnit(), pVariablesTreeItem->getDisplayUnit());
     if (convertUnit.unitsCompatible) {
       /* update value */
       QVariant stringValue = pVariablesTreeItem->data(1, Qt::EditRole);

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -1259,3 +1259,34 @@ QStringList Utilities::variantListToStringList(const QVariantList lst)
   }
   return strs;
 }
+
+/*!
+ * \brief Utilities::convertUnitToSymbol
+ * Converts the unit to a symbol.
+ * \param displayUnit
+ * \return
+ */
+QString Utilities::convertUnitToSymbol(const QString displayUnit)
+{
+  if (displayUnit.compare(QStringLiteral("Ohm")) == 0) {
+    return QChar(937);
+  } else {
+    return displayUnit;
+  }
+}
+
+/*!
+ * \brief Utilities::convertSymbolToUnit
+ * Converts the symbol to unit.
+ * \param symbol
+ * \return
+ */
+QString Utilities::convertSymbolToUnit(const QString symbol)
+{
+  // Greek Omega
+  if (symbol.compare(QChar(937)) == 0) {
+    return "Ohm";
+  } else {
+    return symbol;
+  }
+}

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -541,9 +541,9 @@ namespace Utilities {
   QList<QPointF> liangBarskyClipper(float xmin, float ymin, float xmax, float ymax, float x1, float y1, float x2, float y2);
   void removeDirectoryRecursivly(QString path);
   qreal mapToCoOrdinateSystem(qreal value, qreal startA, qreal endA, qreal startB, qreal endB);
-
   QStringList variantListToStringList(const QVariantList lst);
-
+  QString convertUnitToSymbol(const QString displayUnit);
+  QString convertSymbolToUnit(const QString symbol);
 } // namespace Utilities
 
 #endif // UTILITIES_H


### PR DESCRIPTION
### Related Issues

Fixes #7406

### Purpose

Use the greek omega instead of Ohm

### Approach

Update the display of Ohm unit to greek omega symbol. Right now only Ohm is converted but the main infrastructure is there and can be extended easily for other symbols if needed in future.
