### PR TITLE
More record fixes

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -5250,7 +5250,7 @@ algorithm
       equation
         true = AbsynUtil.pathEqual(path,path1);
         rabs = intAbs(r);
-        // if not negatet rowmark then
+        // if not negated rowmark then
         false = intEq(rowmark[rabs],-mark);
         // solved?
         BackendDAE.VAR(varName=cr1) = BackendVariable.getVarAt(vars, rabs);
@@ -5262,7 +5262,29 @@ algorithm
       equation
         true = AbsynUtil.pathEqual(path,path1);
         rabs = intAbs(r);
-        // if not negatet rowmark then
+        // if not negated rowmark then
+        false = intEq(rowmark[rabs],-mark);
+        // solved?
+        BackendDAE.VAR(varName=cr1) = BackendVariable.getVarAt(vars, rabs);
+        true = expCrefLstHasCref(explst,cr1);
+        false = Expression.expHasCrefNoPreorDer(e1,cr1);
+      then
+        adjacencyRowEnhanced1(rest,e1,e2,vars,globalKnownVars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve,size,shared);
+    case(r::rest,DAE.RECORD(path=path,exps=explst),_,_,_,_,_,_)
+      equation
+        rabs = intAbs(r);
+        // if not negated rowmark then
+        false = intEq(rowmark[rabs],-mark);
+        // solved?
+        BackendDAE.VAR(varName=cr1) = BackendVariable.getVarAt(vars, rabs);
+        true = expCrefLstHasCref(explst,cr1);
+        false = Expression.expHasCrefNoPreorDer(e2,cr1);
+      then
+        adjacencyRowEnhanced1(rest,e1,e2,vars,globalKnownVars,mark,rowmark,(r,BackendDAE.SOLVABILITY_SOLVED(),{})::inRow,trytosolve,size,shared);
+    case(r::rest,_,DAE.RECORD(path=path,exps=explst),_,_,_,_,_)
+      equation
+        rabs = intAbs(r);
+        // if not negated rowmark then
         false = intEq(rowmark[rabs],-mark);
         // solved?
         BackendDAE.VAR(varName=cr1) = BackendVariable.getVarAt(vars, rabs);
@@ -5273,7 +5295,7 @@ algorithm
     case(r::rest,DAE.TUPLE(PR=explst),DAE.CALL(),_,_,_,_,_)
       equation
         rabs = intAbs(r);
-        // if not negatet rowmark then
+        // if not negated rowmark then
         false = intEq(rowmark[rabs],-mark);
         // solved?
         BackendDAE.VAR(varName=cr1) = BackendVariable.getVarAt(vars, rabs);

--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -1023,6 +1023,7 @@ algorithm
       DAE.CallAttributes attr;
       DAE.Ident ident;
       HashTable2.HashTable derConst;
+      list<String> fields;
 
       // Note: Most of these functions check if a subexpression did a replacement.
       // If it did not, we do not create a new copy of the expression (to save some memory).
@@ -1115,6 +1116,11 @@ algorithm
         (expl_1,true) = replaceExpList(expl, repl, cond);
       then
         (DAE.CALL(path,expl_1,attr),true);
+    case (DAE.RECORD(path, expl, fields, t), repl, cond)
+      algorithm
+        (expl, true) := replaceExpList(expl, repl, cond);
+      then
+        (DAE.RECORD(path, expl, fields, t), true);
     // INTEGER_CLOCK
     case (DAE.CLKCONST(DAE.INTEGER_CLOCK(intervalCounter=e, resolution=resolution)), repl, cond)
       equation

--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -656,6 +656,15 @@ algorithm
         end for;
     then();
 
+    case(DAE.RECORD(exps = expLst))
+      algorithm
+        for exp in expLst loop
+          if Expression.isNotWild(exp) then
+            globalKnownVarHT := addConstantCseVarsToGlobalKnownVarHT(exp, globalKnownVarHT);
+          end if;
+        end for;
+    then();
+
     case DAE.CREF(componentRef=cr, ty = DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(_)))
       algorithm
         globalKnownVarHT := BaseHashSet.add(cr, globalKnownVarHT);
@@ -1616,7 +1625,6 @@ algorithm
     then outVarLst;
 
     case DAE.RECORD(exps=expLst) equation
-      print("This should never appear\n");
       outVarLst = List.fold(expLst, createVarsForExp, inAccumVarLst);
     then outVarLst;
 

--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -497,7 +497,7 @@ algorithm
 
         // get the input exps from the call
         exps = List.map2(exps0, evaluateConstantFunctionCallExp, funcsIn, evalConstArgsOnly);
-        scalarExp = List.map1(exps, expandComplexEpressions, funcsIn);
+        scalarExp = List.map1(exps, expandComplexExpressions, funcsIn);
         allInputExps = List.flatten(scalarExp);
           //print("allInputExps\n"+stringDelimitList(List.map(allInputExps,ExpressionDump.printExpStr),"\n")+"\n");
 
@@ -749,7 +749,7 @@ algorithm
 
         // get the input exps from the call
         exps = List.map2(expsIn, evaluateConstantFunctionCallExp, funcsIn, false);
-        scalarExp = List.map1(exps,expandComplexEpressions,funcsIn);//these exps are evaluated as well
+        scalarExp = List.map1(exps,expandComplexExpressions,funcsIn);//these exps are evaluated as well
         allInputExps = List.flatten(scalarExp);
           //print("allInputExps\n"+stringDelimitList(List.map(allInputExps,ExpressionDump.printExpStr),"\n")+"\n");
 
@@ -946,7 +946,7 @@ algorithm
   end matchcontinue;
 end evaluateConstantFunction;
 
-protected function expandComplexEpressions "gets the complex contents or if its not complex, then the exp itself, if its a call, get the scalar outputs.
+protected function expandComplexExpressions "gets the complex contents or if its not complex, then the exp itself, if its a call, get the scalar outputs.
 it would be possible to evaluate the exp before.
 author:Waurich TUD 2014-05"
   input DAE.Exp e;
@@ -987,7 +987,7 @@ algorithm
         //print(ExpressionDump.dumpExpStr(e,0)+"\n");
       then {e};
   end matchcontinue;
-end expandComplexEpressions;
+end expandComplexExpressions;
 
 protected function expandComplexElementsToCrefs "gets the complex contents or if its not complex, then the element itself and converts them to crefs.
 author:Waurich TUD 2014-05"
@@ -3470,6 +3470,8 @@ algorithm
 
     case BackendDAE.COMPLEX_EQUATION(left = DAE.TUPLE(lhs), right = DAE.TUPLE(rhs))
       algorithm
+        lhs := List.mapFlat(lhs, Expression.getComplexContents);
+        rhs := List.mapFlat(rhs, Expression.getComplexContents);
         eq :: eqs := list(makeBackendEquation(lh, rh) threaded for lh in lhs, rh in rhs);
       then
         (eq, listAppend(eqs, addEqsIn));

--- a/OMCompiler/Compiler/BackEnd/MathematicaDump.mo
+++ b/OMCompiler/Compiler/BackEnd/MathematicaDump.mo
@@ -344,6 +344,14 @@ algorithm
       then
         s_2;
 
+    case (DAE.RECORD(path = fcn,exps = args),_,_)
+      equation
+        fs = AbsynUtil.pathString(fcn);
+        argstr = stringDelimitList(List.map2(args, printExpMmaStr,vars,knvars),",");
+        s_2 = "FunctionCall[\""+ fs +"\"]["+argstr+"]";
+      then
+        s_2;
+
     case (DAE.ARRAY(array = es),_,_)
       equation
         s = stringDelimitList(List.map2(es, printExpMmaStr,vars,knvars),",");

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -138,12 +138,9 @@ algorithm
   //       But the code generation uses the type of the record constructor both
   //       for generating the record struct and the record constructor, so we
   //       can't currently reorder variables here without also messing up the
-  //       order of the record itself. Not sorting them is not an option since
-  //       that would lead to code that compiles but with undefined behaviour,
-  //       so instead we sort them and give an error if the ordering changed.
+  //       order of the record itself.
   //sorted_locals := Function.sortLocals(locals, info);
   //all_params := listAppend(inputs, sorted_locals);
-  checkLocalFieldOrder(locals, ctor_node, info);
 
   // Create the output record element, using the instance created above as both parent and type.
   out_comp := Component.UNTYPED_COMPONENT(ctor_node, listArray({}),

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -585,8 +585,8 @@ end recordCopyDef;
 
 template recordModelicaCallConstrctor(String rec_name, list<Variable> variables)
  "Generates code for creating and initializing a record given values for
-  ALL its memebers. This is basically what we used to generate before. However
-  that one did not handle arrays and record record memebers properly. This
+  ALL its members. This is basically what we used to generate before. However
+  that one did not handle arrays and record record members properly. This
   should replace that function. For now it is commented until I have time to
   clean out uses of the other one and replace it with this.
 
@@ -618,7 +618,7 @@ template recordModelicaCallConstrctor(String rec_name, list<Variable> variables)
   /*
   <%rec_name%> omc_<%rec_name%>(threadData_t *threadData <%inputs%>) {
     <%rec_name%> dst;
-    // TODO Improve me. No need to initalize the record memebers with defaults in <%rec_name%>_construct
+    // TODO Improve me. No need to initalize the record members with defaults in <%rec_name%>_construct
     // We should just do the allocs here and then copy the input parameters as default values instead.
     <%rec_name%>_construct(threadData, dst);
     <%varCopies%>
@@ -657,7 +657,7 @@ end recordMemberCopy;
 
 template recordConstructorDef(String ctor_name, String rec_name, list<Variable> variables)
  "Generates code for constructing a record. This means allocating memory for all
-  memebers of the record and then initializing them with their default values. Sometimes
+  members of the record and then initializing them with their default values. Sometimes
   we can have modelica derived records (e.g. record A = B(c=exp)), this will be a new
   record type whcih needs an exp to be passed to to be initialized correctly. This is
   also handled by these function. Check markDerivedRecordOutsideBindings and makeTypeRecordVar
@@ -2966,7 +2966,19 @@ match lhsexp
   at least it should have been a record_constructor not a normal call. sigh. */
   case CALL(path=path,expLst=expLst,attr=CALL_ATTR(ty=ty as T_COMPLEX(varLst = varLst, complexClassType=RECORD(__)))) then
     let tmp = tempDecl(expTypeModelica(ty),&varDecls)
-    /*TODO handle array record memebers. see algStmtAssign*/
+    /*TODO handle array record members. see algStmtAssign*/
+    <<
+    <%preExp%>
+    <%tmp%> = <%rhsExpStr%>;
+    <% varLst |> var as TYPES_VAR(__) hasindex i1 fromindex 1 =>
+      let re = daeExpCrefLhs(listGet(expLst,i1), context, &preExp, &varDecls, &auxFunction, false)
+      '<%re%> = <%tmp%>._<%var.name%>;'
+    ; separator="\n"
+    %>
+    >>
+  case RECORD(path=path,exps=expLst,ty=ty as T_COMPLEX(varLst = varLst, complexClassType=RECORD(__))) then
+    let tmp = tempDecl(expTypeModelica(ty),&varDecls)
+    /*TODO handle array record members. see algStmtAssign*/
     <<
     <%preExp%>
     <%tmp%> = <%rhsExpStr%>;
@@ -2987,7 +2999,7 @@ template algStmtAssignRecordWithRhsExpStr(DAE.Exp lhsexp, Text &rhsExpStr, Conte
 match lhsexp
   case CREF(componentRef = cr, ty=DAE.T_COMPLEX(varLst = varLst, complexClassType=RECORD(__))) then
     let tmp = tempDecl(expTypeModelica(ty),&varDecls)
-    /*TODO handle array record memebers. see algStmtAssign*/
+    /*TODO handle array record members. see algStmtAssign*/
     <<
     <%preExp%>
     <%tmp%> = <%rhsExpStr%>;
@@ -3115,7 +3127,7 @@ template tupleReturnVariableUpdates(Exp inExp, Context context, Text &varDecls, 
   case CREF(componentRef = cr, ty=DAE.T_COMPLEX(varLst = varLst, complexClassType=RECORD(__))) then
     let rhsStr = tempDecl(expTypeArrayIf(ty), &varDecls)
     let &varCopy +=
-      /*TODO handle array record memebers. see algStmtAssign*/
+      /*TODO handle array record members. see algStmtAssign*/
       <<
       <%preExp%>
       <% varLst |> var as TYPES_VAR(__) hasindex i1 fromindex 0 =>
@@ -3132,7 +3144,22 @@ template tupleReturnVariableUpdates(Exp inExp, Context context, Text &varDecls, 
     let rhsStr = tempDecl(expTypeArrayIf(ty), &varDecls)
     let tmp = tempDecl(expTypeModelica(ty),&varDecls)
     let &varCopy +=
-      /*TODO handle array record memebers. see algStmtAssign*/
+      /*TODO handle array record members. see algStmtAssign*/
+      <<
+      <%preExp%>
+      <% varLst |> var as TYPES_VAR(__) hasindex i1 fromindex 1 =>
+        let re = daeExp(listGet(expLst,i1), context, &preExp, &varDecls, &auxFunction)
+        '<%re%> = <%rhsStr%>._<%var.name%>;'
+      ; separator="\n"
+      %>
+      >> /*varCopy end*/
+    '&<%rhsStr%>'
+  case RECORD(path=path,exps=expLst,ty=ty as T_COMPLEX(varLst = varLst)) then
+    let &preExp = buffer ""
+    let rhsStr = tempDecl(expTypeArrayIf(ty), &varDecls)
+    let tmp = tempDecl(expTypeModelica(ty),&varDecls)
+    let &varCopy +=
+      /*TODO handle array record members. see algStmtAssign*/
       <<
       <%preExp%>
       <% varLst |> var as TYPES_VAR(__) hasindex i1 fromindex 1 =>

--- a/testsuite/flattening/modelica/scodeinst/FunctionRecordArg4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionRecordArg4.mo
@@ -32,7 +32,7 @@ end FunctionRecordArg4;
 //
 // function R "Automatically generated record constructor for R"
 //   protected Integer n = 2;
-//   protected Real[2] x = fill(1.0, n);
+//   protected Real[2] x = {1.0, 1.0};
 //   output R res;
 // end R;
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.IdealGases.SimpleNaturalGas.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.IdealGases.SimpleNaturalGas.mos
@@ -40,13 +40,7 @@ runScript(modelTesting);getErrorString();
 // Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
 // ========================================
-// 1: volume.medium.Xi[6]
-// 2: volume.medium.Xi[5]
-// 3: volume.medium.Xi[4]
-// 4: volume.medium.Xi[3]
-// 5: volume.medium.Xi[2]
-// 6: volume.medium.Xi[1]
-// 7: volume.medium.T
+// 1: volume.medium.T
 // Please use -d=bltdump for more information.
 //
 // "true

--- a/testsuite/simulation/modelica/hpcom/Modelica.Electrical.Spice3.Examples.Graetz.mos
+++ b/testsuite/simulation/modelica/hpcom/Modelica.Electrical.Spice3.Examples.Graetz.mos
@@ -36,7 +36,6 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Electrical.Spic
 // Using list Scheduler for the DAE system
 // Using list Scheduler for the ODE system
 // Using list Scheduler for the ZeroFunc system
-// There is no parallel potential in the ODE system model!
 // HpcOm is still under construction.
 // record SimulationResult
 //     resultFile = "Modelica.Electrical.Spice3.Examples.Graetz_res.mat",

--- a/testsuite/simulation/modelica/inheritances/Ticket4258a.mos
+++ b/testsuite/simulation/modelica/inheritances/Ticket4258a.mos
@@ -33,10 +33,6 @@ simulate(simple_BasicHX_water_gas); getErrorString();
 // 4: WT_Nachreformer.pipe_1.mediums[3].T
 // 5: WT_Nachreformer.pipe_1.mediums[4].T
 // Please use -d=bltdump for more information.
-// Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
-// ========================================
-// 1: WT_Nachreformer.pipe_2.flowModel.m_flows[5]
-// Please use -d=bltdump for more information.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // endResult

--- a/testsuite/simulation/modelica/inheritances/Ticket4258b.mos
+++ b/testsuite/simulation/modelica/inheritances/Ticket4258b.mos
@@ -21,20 +21,8 @@ buildModel(Eco); getErrorString();
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
 // ========================================
-// 1: FGchannel.mediums[1].Xi[1]
-// 2: FGchannel.mediums[1].Xi[2]
-// 3: FGchannel.mediums[1].Xi[3]
-// 4: FGchannel.mediums[1].Xi[4]
-// 5: FGchannel.mediums[1].Xi[5]
-// 6: FGchannel.mediums[1].Xi[6]
-// 7: FGchannel.mediums[1].T
-// 8: FGchannel.mediums[2].Xi[1]
-// 9: FGchannel.mediums[2].Xi[2]
-// 10: FGchannel.mediums[2].Xi[3]
-// 11: FGchannel.mediums[2].Xi[4]
-// 12: FGchannel.mediums[2].Xi[5]
-// 13: FGchannel.mediums[2].Xi[6]
-// 14: FGchannel.mediums[2].T
+// 1: FGchannel.mediums[1].T
+// 2: FGchannel.mediums[2].T
 // Please use -d=bltdump for more information.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "


### PR DESCRIPTION
- Always try to evaluate constants in record constructors, since having
  unevaluated constants is not well supported.
- Move the check for record constructor locals that need to be reordered
  to after constants have been evaluated.
- Change Expression.traversingextendArrExp to create a DAE.RECORD
  instead of a DAE.CALL when a record needs to be constructed, since
  a record constructor call might not take all the arguments if some of
  them are local.
- Handle DAE.RECORD in a lot of places that only expect records as
  record constructor calls.