### PR TITLE
Fix #7439

### DIFF
--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.IdealGases.SimpleNaturalGas.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.IdealGases.SimpleNaturalGas.mos
@@ -40,7 +40,13 @@ runScript(modelTesting);getErrorString();
 // Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
 // ========================================
-// 1: volume.medium.T
+// 1: volume.medium.Xi[6]
+// 2: volume.medium.Xi[5]
+// 3: volume.medium.Xi[4]
+// 4: volume.medium.Xi[3]
+// 5: volume.medium.Xi[2]
+// 6: volume.medium.Xi[1]
+// 7: volume.medium.T
 // Please use -d=bltdump for more information.
 //
 // "true

--- a/testsuite/simulation/modelica/inheritances/Ticket4258a.mos
+++ b/testsuite/simulation/modelica/inheritances/Ticket4258a.mos
@@ -33,6 +33,10 @@ simulate(simple_BasicHX_water_gas); getErrorString();
 // 4: WT_Nachreformer.pipe_1.mediums[3].T
 // 5: WT_Nachreformer.pipe_1.mediums[4].T
 // Please use -d=bltdump for more information.
+// Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
+// ========================================
+// 1: WT_Nachreformer.pipe_2.flowModel.m_flows[5]
+// Please use -d=bltdump for more information.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // endResult

--- a/testsuite/simulation/modelica/inheritances/Ticket4258b.mos
+++ b/testsuite/simulation/modelica/inheritances/Ticket4258b.mos
@@ -21,8 +21,20 @@ buildModel(Eco); getErrorString();
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Warning: Some equations could not be differentiated for following variables having attribute stateSelect=StateSelect.prefer. They will be treated as if they had stateSelect=StateSelect.default
 // ========================================
-// 1: FGchannel.mediums[1].T
-// 2: FGchannel.mediums[2].T
+// 1: FGchannel.mediums[1].Xi[1]
+// 2: FGchannel.mediums[1].Xi[2]
+// 3: FGchannel.mediums[1].Xi[3]
+// 4: FGchannel.mediums[1].Xi[4]
+// 5: FGchannel.mediums[1].Xi[5]
+// 6: FGchannel.mediums[1].Xi[6]
+// 7: FGchannel.mediums[1].T
+// 8: FGchannel.mediums[2].Xi[1]
+// 9: FGchannel.mediums[2].Xi[2]
+// 10: FGchannel.mediums[2].Xi[3]
+// 11: FGchannel.mediums[2].Xi[4]
+// 12: FGchannel.mediums[2].Xi[5]
+// 13: FGchannel.mediums[2].Xi[6]
+// 14: FGchannel.mediums[2].T
 // Please use -d=bltdump for more information.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "


### PR DESCRIPTION
- Change back to using List.map1BoolOr in Expression.expContains, since
  using List.isMemberOnTrue swaps the arguments.