### PR TITLE
[OMCompiler] Fix some leaks in C runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1197,6 +1197,7 @@ void deInitializeDataStruc(DATA *data)
   free(data->simulationInfo->relationsPre);
   free(data->simulationInfo->storedRelations);
   free(data->simulationInfo->zeroCrossingIndex);
+  free(data->simulationInfo->mathEventsValuePre);
 
   /* free buffer for old state variables */
   free(data->simulationInfo->realVarsOld);
@@ -1237,6 +1238,11 @@ void deInitializeDataStruc(DATA *data)
 
   /* free buffer for state sets */
   omc_alloc_interface.free_uncollectable(data->simulationInfo->daeModeData);
+
+  /* buffer for inline Data */
+  free(data->simulationInfo->inlineData->algVars);
+  free(data->simulationInfo->inlineData->algOldVars);
+  omc_alloc_interface.free_uncollectable(data->simulationInfo->inlineData);
 
   /* free inputs and output */
   free(data->simulationInfo->inputVars);


### PR DESCRIPTION
Simulating an FMU in a loop we noticed the memory keeps increasing.

I only fixed the most direct ones, but valgrind notices other leaks in simulation_info_json.c, synchronous.c, memory_pool.c:
[valgrind.log](https://github.com/OpenModelica/OpenModelica/files/6432699/valgrind.log)

I used 1.17.0 but some leaks were already fixed in master like #7141
cc @AnHeuermann 

I think you can reproduce with any model , but here is the one I used (cs/2.0): 
```
model IshigamiFunction
  final parameter Real a = 7;
  final parameter Real b = 0.05;
  parameter Real x1 = 1;
  parameter Real x2 = 1;
  parameter Real x3 = 1;
  Real f;
equation
  f = sin(x1) + a * sin(x2)^2 + b * x3^4 * sin(x1);
end IshigamiFunction;
```

cc @Claire-Eleutheriane
