### PR TITLE
better handling of zero size arrays in the C runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/base_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/base_array.c
@@ -179,11 +179,14 @@ int index_spec_fit_base_array(const index_spec_t *s, const base_array_t *a)
     }
     for(i = 0; i < s->ndims; ++i) {
         if(s->dim_size[i] == 0) {
-            if((s->index[i][0] <= 0) || (s->index[i][0] > a->dim_size[i])) {
-                fprintf(stderr,
-                        "scalar s->index[%d][0] == %d incorrect, a->dim_size[%d] == %d\n",
-                        i, (int) s->index[i][0], i, (int) a->dim_size[i]); fflush(stderr);
-                return 0;
+            if (s->index[i] != NULL)
+            {
+              if((s->index[i][0] < 0) || (s->index[i][0] > a->dim_size[i])) {
+                  fprintf(stderr,
+                          "scalar s->index[%d][0] == %d incorrect, a->dim_size[%d] == %d\n",
+                          i, (int) s->index[i][0], i, (int) a->dim_size[i]); fflush(stderr);
+                  return 0;
+              }
             }
         }
 
@@ -392,8 +395,12 @@ void index_alloc_base_array_size(const real_array_t * source,
            ++j;
          }
     }
-    dest->ndims = j;
+
+    dest->ndims = imax(j,1);
     dest->dim_size = size_alloc(dest->ndims);
+    for(i = 0; i < dest->ndims; ++i) {
+      dest->dim_size[i] = 0;
+    }
 
     for(i = 0, j = 0; i < source_spec->ndims; ++i) {
         if(source_spec->dim_size[i] != 0) { /* is 'W' or 'A' */

--- a/OMCompiler/SimulationRuntime/c/util/index_spec.c
+++ b/OMCompiler/SimulationRuntime/c/util/index_spec.c
@@ -59,8 +59,8 @@ int index_spec_ok(const index_spec_t* s)
           fprintf(stderr,"index_spec_ok: the index spec dimension size for dimension %d is negative: %d!\n", i, (int)s->dim_size[i]); fflush(stderr);
           return 0;
         }
-        if((s->index[i] == 0) && (s->dim_size[i] != 1)) {
-            fprintf(stderr,"index[%d] == 0, size == %d\n", i, (unsigned int) s->dim_size[i]); fflush(stderr);
+        if((s->index[i] == 0) && (s->dim_size[i] != 1 && s->dim_size[i] != 0)) {
+            fprintf(stderr,"index_spec_ok: index[%d] == 0, size == %d\n", i, (unsigned int) s->dim_size[i]); fflush(stderr);
             return 0;
         }
     }

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.c
@@ -69,7 +69,7 @@ void integer_array_create(integer_array_t *dest, modelica_integer *data,
 
 void simple_alloc_1d_integer_array(integer_array_t* dest, int n)
 {
-    simple_alloc_1d_base_array(dest, n, integer_alloc(n));
+    simple_alloc_1d_base_array(dest, n, n ? integer_alloc(n) : NULL);
 }
 
 void simple_alloc_2d_integer_array(integer_array_t* dest, int r, int c)

--- a/OMCompiler/SimulationRuntime/c/util/real_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.c
@@ -304,6 +304,10 @@ void index_real_array(const real_array_t * source,
     omc_assert_macro(index_spec_ok(source_spec));
     omc_assert_macro(index_spec_fit_base_array(source_spec,source));
 
+    /* adrpo: if destination is an Real[0] just return */
+    if (dest->ndims == 1 && dest->dim_size[0] == 0)
+      return;
+
     /*for(i = 0, j = 0; i < source->ndims; ++i)
     {
       printf("source_spec->index_type[%d] = %c\n", i, source_spec->index_type[i]);
@@ -318,7 +322,7 @@ void index_real_array(const real_array_t * source,
             ++j;
         }
     }
-    omc_assert_macro(j == dest->ndims);
+    omc_assert_macro(imax(j,1) == dest->ndims);
 
     idx_vec1 = size_alloc(source->ndims);  /*indices in the source array*/
     /* idx_vec2 = size_alloc(dest->ndims); / * indices in the destination array* / */
@@ -329,7 +333,7 @@ void index_real_array(const real_array_t * source,
     }
     for(i = 0; i < source_spec->ndims; ++i) {
         if(source_spec->index[i] != NULL) { /* is 'S' or 'A' */
-            idx_size[i] = imax(source_spec->dim_size[i],1); /* the imax() is not needed, because there is (idx[d] >= size[d]) in the next_index(), but ... */
+            idx_size[i] = imax(source_spec->dim_size[i], 1); /* the imax() is not needed, because there is (idx[d] >= size[d]) in the next_index(), but ... */
         } else { /* is 'W' */
             idx_size[i] = source->dim_size[i];
         }

--- a/testsuite/simulation/modelica/arrays/Makefile
+++ b/testsuite/simulation/modelica/arrays/Makefile
@@ -55,6 +55,7 @@ Bug3916.mos
 FAILINGTESTFILES= \
 ArrayFieldSlice.mos \
 bug_2300.mos \
+Ticket7455.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/simulation/modelica/arrays/Ticket7455.mos
+++ b/testsuite/simulation/modelica/arrays/Ticket7455.mos
@@ -1,0 +1,81 @@
+// name: Ticket7455.mos
+// status: correct
+//
+
+loadString("
+model ZeroArraySizeHandling
+  function massFraction_mixingRatio \"conversion function\"
+    input Real[:] mixingRatio;
+    output Real[size(mixingRatio, 1)-1] massFraction=mixingRatio[1:end - 1]/sum(mixingRatio);
+  end massFraction_mixingRatio;
+
+  function externC
+    input Real[:] u;
+    input Integer nc \"Number of components\";
+    output Real a;
+  external \"C\" a = myExternC(u, nc)
+  annotation(Include = \"
+    double myExternC(const double* u, int nc)
+    {
+      return -2.0;
+    }
+    \");
+  end externC;
+
+  function callMe
+    input Real[:] u;
+    output Real a;
+  algorithm
+     a := externC(massFraction_mixingRatio(u), 0);
+  end callMe;
+
+  parameter Real x[1] = {1};
+  Real y(start = 1, fixed = true);
+equation
+  der(y) = y * callMe(x);
+end ZeroArraySizeHandling;
+"); getErrorString();
+
+instantiateModel(ZeroArraySizeHandling); getErrorString();
+simulate(ZeroArraySizeHandling); getErrorString();
+
+// Result:
+// true
+// ""
+// "function ZeroArraySizeHandling.callMe
+//   input Real[:] u;
+//   output Real a;
+// algorithm
+//   a := ZeroArraySizeHandling.externC(ZeroArraySizeHandling.massFraction_mixingRatio(u), 0);
+// end ZeroArraySizeHandling.callMe;
+//
+// function ZeroArraySizeHandling.externC
+//   input Real[:] u;
+//   input Integer nc \"Number of components\";
+//   output Real a;
+//
+//   external \"C\" a = myExternC(u, nc);
+// end ZeroArraySizeHandling.externC;
+//
+// function ZeroArraySizeHandling.massFraction_mixingRatio \"conversion function\"
+//   input Real[:] mixingRatio;
+//   output Real[size(mixingRatio, 1) - 1] massFraction = mixingRatio[1:size(mixingRatio, 1) - 1] / sum(mixingRatio);
+// end ZeroArraySizeHandling.massFraction_mixingRatio;
+//
+// class ZeroArraySizeHandling
+//   parameter Real x[1] = 1.0;
+//   Real y(start = 1.0, fixed = true);
+// equation
+//   der(y) = y * ZeroArraySizeHandling.callMe(x);
+// end ZeroArraySizeHandling;
+// "
+// ""
+// record SimulationResult
+//     resultFile = "ZeroArraySizeHandling_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ZeroArraySizeHandling', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
- issued appeared when running model (see also #7450):
  TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2
- Should handle functions as below, called with `massFraction_mixingRatio({1})` better
```mo
function massFraction_mixingRatio "conversion function"
  input Real[:] mixingRatio;
  output Real[size(mixingRatio, 1)-1] massFraction=mixingRatio[1:end - 1]/sum(mixingRatio);
end massFraction_mixingRatio;
```
