### PR TITLE
Ask user to switch to new frontend on startup

### DIFF
--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -181,6 +181,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         case QMessageBox::AcceptRole:
           OptionsDialog::instance()->getSimulationPage()->getTranslationFlagsWidget()->getOldInstantiationCheckBox()->setChecked(false);
           Utilities::getApplicationSettings()->setValue("simulation/newInst", true);
+          OptionsDialog::instance()->saveSimulationSettings();
           break;
         case QMessageBox::RejectRole:
         default:

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -36,6 +36,9 @@
 #include "Util/Helper.h"
 #include "MainWindow.h"
 #include "Modeling/LibraryTreeWidget.h"
+//! @todo Remove this once new frontend is used as default and old frontend is removed.
+#include "Options/OptionsDialog.h"
+#include "Simulation/TranslationFlagsWidget.h"
 
 #include <locale.h>
 #include <QMessageBox>
@@ -163,6 +166,27 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
     pMainwindow->show();
     // hide the splash screen
     SplashScreen::instance()->finish(pMainwindow);
+    //! @todo Remove this once new frontend is used as default and old frontend is removed.
+    //! Fixes issue #7456
+    if (OptionsDialog::instance()->getSimulationPage()->getTranslationFlagsWidget()->getOldInstantiationCheckBox()->isChecked()) {
+      QMessageBox *pMessageBox = new QMessageBox;
+      pMessageBox->setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::question));
+      pMessageBox->setIcon(QMessageBox::Question);
+      pMessageBox->setAttribute(Qt::WA_DeleteOnClose);
+      pMessageBox->setText(tr("You have enabled old frontend for code generation which is not recommended. Do you want to switch to new frontend?"));
+      pMessageBox->addButton(tr("Switch to new frontend"), QMessageBox::AcceptRole);
+      pMessageBox->addButton(tr("Keep using old frontend"), QMessageBox::RejectRole);
+      int answer = pMessageBox->exec();
+      switch (answer) {
+        case QMessageBox::AcceptRole:
+          OptionsDialog::instance()->getSimulationPage()->getTranslationFlagsWidget()->getOldInstantiationCheckBox()->setChecked(false);
+          Utilities::getApplicationSettings()->setValue("simulation/newInst", true);
+          break;
+        case QMessageBox::RejectRole:
+        default:
+          break;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Related Issues

Fixes #7456

### Purpose

Suggest users to use new frontend.

### Approach

Show a popup on start to allow user to switch to new frontend.
