### PR TITLE
Fix memory leak of model info xml data

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -393,7 +393,9 @@ void modelInfoInit(MODEL_DATA_XML* xml)
     // fprintf(stderr, "Loaded the JSON (%ld kB)...\n", (long) (s.st_size+1023)/1024);
   }
 #endif
+  assert(xml->functionNames == NULL);
   xml->functionNames = (FUNCTION_INFO*) calloc(xml->nFunctions, sizeof(FUNCTION_INFO));
+  assert(xml->equationInfo == NULL);
   xml->equationInfo = (EQUATION_INFO*) calloc(1+xml->nEquations, sizeof(EQUATION_INFO));
   xml->equationInfo[0].id = 0;
   xml->equationInfo[0].profileBlockIndex = -1;
@@ -408,6 +410,17 @@ void modelInfoInit(MODEL_DATA_XML* xml)
 #if !defined(OMC_NO_FILESYSTEM)
   omc_mmap_close_read(mmap_reader);
 #endif
+}
+
+/**
+ * @brief Deinitialize memory allocated by modelInfoInit
+ *
+ * @param xml   Pointer to model info xml data.
+ */
+void modelInfoDeinit(MODEL_DATA_XML* xml)
+{
+  free(xml->functionNames); xml->functionNames = NULL;
+  free(xml->functionNames); xml->functionNames = NULL;
 }
 
 FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix)

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.h
@@ -37,10 +37,11 @@
 extern "C" {
 #endif
 
-extern FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML*,size_t);
-extern void modelInfoInit(MODEL_DATA_XML*);
-extern EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML*,size_t);
-extern EQUATION_INFO modelInfoGetEquationIndexByProfileBlock(MODEL_DATA_XML*,size_t);
+void modelInfoInit(MODEL_DATA_XML* xml);
+void modelInfoDeinit(MODEL_DATA_XML* xml);
+FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix);
+EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix);
+EQUATION_INFO modelInfoGetEquationIndexByProfileBlock(MODEL_DATA_XML* xml, size_t ix);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1280,6 +1280,9 @@ void deInitializeDataStruc(DATA *data)
     FREE_VARS(nSensitivityVars, realSensitivityData)
   }
 
+  /* Free model info xml data */
+  modelInfoDeinit(&(data->modelData->modelDataXml));
+
   TRACE_POP
 }
 


### PR DESCRIPTION
### Related Issues

Fixes #7444 

### Purpose

Don't leak so much memory.

### Approach

Free memory of model info xml data allocated for logging stats and equation info.
