### PR TITLE
Use annotation __OpenModelica_commandLineOptions in buildModelFMU

### DIFF
--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_01.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_01.mos
@@ -9,10 +9,11 @@ model fmi_attributes_01
   Real x(start=-1.0, fixed=true);
 equation
   (x + der(x))^2 = 3.0 - x^2 - der(x)^2;
+
+  annotation(__OpenModelica_commandLineOptions=\"-d=force-fmi-attributes\");
 end fmi_attributes_01;
 "); getErrorString();
 
-setDebugFlags("force-fmi-attributes"); getErrorString();
 translateModelFMU(fmi_attributes_01); getErrorString();
 
 // unzip to console, quiet, extra quiet
@@ -24,8 +25,6 @@ system("sed -n \"/<ModelStructure>/,/<\\/ModelStructure>/p\" fmi_attributes_01_t
 readFile("fmi_attributes_01.xml"); getErrorString();
 
 // Result:
-// true
-// ""
 // true
 // ""
 // "fmi_attributes_01.fmu"


### PR DESCRIPTION
### Related Issues

#7472 reported that buildModelFMU doesn't respect the annotation __OpenModelica_commandLineOptions. This is addressed by this pull request.