### PR TITLE
Fix #4894

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
@@ -1848,7 +1848,7 @@ protected
   SCode.ClassDef cd;
   Absyn.TypeSpec ts;
 algorithm
-  ts := Absyn.TCOMPLEX(Absyn.IDENT("polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE());
+  ts := Absyn.TCOMPLEX(Absyn.IDENT("$polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE());
   cd := SCode.DERIVED(ts,SCode.NOMOD(),
                       SCode.ATTR({},SCode.POTENTIAL(), SCode.NON_PARALLEL(), SCode.VAR(),Absyn.BIDIR(),Absyn.NONFIELD()));
   elt := SCode.CLASS(
@@ -1899,7 +1899,7 @@ algorithm
       then ();
     case (Absyn.TCOMPLEX(typeSpecs=tss),_)
       equation
-        if listMember(ts.path, {Absyn.IDENT("list"),Absyn.IDENT("List"),Absyn.IDENT("array"),Absyn.IDENT("Array"),Absyn.IDENT("polymorphic"),Absyn.IDENT("Option")}) then
+        if listMember(ts.path, {Absyn.IDENT("list"),Absyn.IDENT("List"),Absyn.IDENT("array"),Absyn.IDENT("Array"),Absyn.IDENT("$polymorphic"),Absyn.IDENT("Option")}) then
           str = AbsynUtil.typeSpecString(ts);
           Error.addSourceMessage(Error.TCOMPLEX_MULTIPLE_NAMES,{str},info);
           List.map1_0(tss, checkTypeSpec, info);

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -2573,7 +2573,7 @@ algorithm
       then (cache,env,ih,store,DAE.emptyDae,csets,ClassInf.META_ARRAY(Absyn.IDENT(className)),{},bc,oDA,NONE(),graph);
 
     case (cache,env,ih,store,mods,pre,_,_,
-          SCode.DERIVED(typeSpec=Absyn.TCOMPLEX(Absyn.IDENT("polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE()),modifications = mod, attributes=DA),
+          SCode.DERIVED(typeSpec=Absyn.TCOMPLEX(Absyn.IDENT("$polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE()),modifications = mod, attributes=DA),
           _,_,_,_,inst_dims,impl,_,graph,_,_,_,_,_)
       equation
         // true = Config.acceptMetaModelicaGrammar(); // We use this for builtins also
@@ -2585,7 +2585,7 @@ algorithm
       then (cache,env,ih,store,DAE.emptyDae,csets,ClassInf.META_POLYMORPHIC(Absyn.IDENT(className)),{},bc,oDA,NONE(),graph);
 
     case (_,_,_,_,mods,_,_,_,
-          SCode.DERIVED(typeSpec=Absyn.TCOMPLEX(path=Absyn.IDENT("polymorphic")),modifications=mod),
+          SCode.DERIVED(typeSpec=Absyn.TCOMPLEX(path=Absyn.IDENT("$polymorphic")),modifications=mod),
           _,_,_,_,_,_,_,_,_,_,_,_,_)
       equation
         // true = Config.acceptMetaModelicaGrammar(); // We use this for builtins also
@@ -4716,7 +4716,7 @@ algorithm
     case "list" algorithm isKnownBuiltin:=Config.acceptMetaModelicaGrammar(); then Absyn.IDENT("list");
     case "Option" algorithm isKnownBuiltin:=Config.acceptMetaModelicaGrammar(); then Absyn.IDENT("Option");
     case "tuple" algorithm isKnownBuiltin:=Config.acceptMetaModelicaGrammar(); then Absyn.IDENT("tuple");
-    case "polymorphic" algorithm isKnownBuiltin:=Config.acceptMetaModelicaGrammar(); then Absyn.IDENT("polymorphic");
+    case "$polymorphic" algorithm isKnownBuiltin:=Config.acceptMetaModelicaGrammar(); then Absyn.IDENT("polymorphic");
     case "array" algorithm isKnownBuiltin:=Config.acceptMetaModelicaGrammar(); then Absyn.IDENT("array");
     else algorithm isKnownBuiltin:=false; then Absyn.IDENT("");
   end match;

--- a/OMCompiler/Compiler/FrontEnd/NFSCodeDependency.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFSCodeDependency.mo
@@ -1321,7 +1321,7 @@ algorithm
         ();
 
     // A polymorphic type, i.e. replaceable type Type subtypeof Any.
-    case (Absyn.TCOMPLEX(path = Absyn.IDENT("polymorphic")), _, _)
+    case (Absyn.TCOMPLEX(path = Absyn.IDENT("$polymorphic")), _, _)
       then ();
 
     // A MetaModelica type such as list or tuple.

--- a/OMCompiler/Compiler/FrontEnd/NFSCodeFlattenImports.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFSCodeFlattenImports.mo
@@ -292,7 +292,7 @@ algorithm
         Absyn.TPATH(path, ad);
 
     // A polymorphic type, i.e. replaceable type Type subtypeof Any.
-    case (Absyn.TCOMPLEX(path = Absyn.IDENT("polymorphic")), _, _)
+    case (Absyn.TCOMPLEX(path = Absyn.IDENT("$polymorphic")), _, _)
       then inTypeSpec;
 
     // A MetaModelica type such as list or tuple.

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -461,7 +461,7 @@ algorithm
     case SCode.CLASS(restriction = SCode.R_TYPE(),
                      classDef = SCode.DERIVED(
                        typeSpec = Absyn.TCOMPLEX(
-                         path = Absyn.IDENT(name = "polymorphic")))) then true;
+                         path = Absyn.IDENT(name = "$polymorphic")))) then true;
 
     else false;
   end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -102,7 +102,7 @@ encapsulated package Elements
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
     SCode.noComment, AbsynUtil.dummyInfo);
 
-  constant SCode.Element ANY = SCode.CLASS("polymorphic",
+  constant SCode.Element ANY = SCode.CLASS("$polymorphic",
     SCode.defaultPrefixes, SCode.NOT_ENCAPSULATED(), SCode.NOT_PARTIAL(), SCode.R_TYPE(),
     SCode.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
     SCode.noComment, AbsynUtil.dummyInfo);
@@ -126,7 +126,7 @@ constant array<NFInstNode.CachedData> EMPTY_NODE_CACHE = listArrayLiteral({
 // InstNodes for the builtin types. These have empty class trees to prevent
 // access to the attributes via dot notation (which is not needed for
 // modifiers and illegal in other cases).
-constant InstNode POLYMORPHIC_NODE = InstNode.CLASS_NODE("polymorphic",
+constant InstNode POLYMORPHIC_NODE = InstNode.CLASS_NODE("$polymorphic",
   Elements.ANY, Visibility.PUBLIC,
   Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.POLYMORPHIC(""), ClassTree.EMPTY_TREE(),
     Modifier.NOMOD(), NFClass.DEFAULT_PREFIXES, Restriction.TYPE())),

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -682,7 +682,7 @@ algorithm
     case "Boolean" then NFBuiltin.BOOLEAN_NODE;
     case "String" then NFBuiltin.STRING_NODE;
     case "Clock" then NFBuiltin.CLOCK_NODE;
-    case "polymorphic" then NFBuiltin.POLYMORPHIC_NODE;
+    case "$polymorphic" then NFBuiltin.POLYMORPHIC_NODE;
   end match;
 end lookupSimpleBuiltinName;
 

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -17308,7 +17308,7 @@ algorithm
   res := match (class_)
   local
     String ident;
-    case Absyn.CLASS(name = ident, body = Absyn.DERIVED(typeSpec = Absyn.TCOMPLEX(Absyn.IDENT("polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE())), restriction = Absyn.R_TYPE())
+    case Absyn.CLASS(name = ident, body = Absyn.DERIVED(typeSpec = Absyn.TCOMPLEX(Absyn.IDENT("$polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE())), restriction = Absyn.R_TYPE())
     then "(replaceable type " + ident + ")";
   end match;
 end getDefinitionsReplaceableClass;

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -15165,7 +15165,7 @@ algorithm
   res := match (class_)
   local
     String ident;
-    case Absyn.CLASS(name = ident, body = Absyn.DERIVED(typeSpec = Absyn.TCOMPLEX(Absyn.IDENT("polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE())), restriction = Absyn.R_TYPE())
+    case Absyn.CLASS(name = ident, body = Absyn.DERIVED(typeSpec = Absyn.TCOMPLEX(Absyn.IDENT("$polymorphic"),{Absyn.TPATH(Absyn.IDENT("Any"),NONE())},NONE())), restriction = Absyn.R_TYPE())
     then "(replaceable type " + ident + ")";
   end match;
 end getDefinitionsReplaceableClass;

--- a/OMCompiler/Compiler/Template/AbsynToJulia.tpl
+++ b/OMCompiler/Compiler/Template/AbsynToJulia.tpl
@@ -784,7 +784,7 @@ match path
       case "list" then 'List'
       case "array" then 'Array'
       case "tuple" then 'Tuple'
-      case "polymorphic" then 'Any'
+      case "$polymorphic" then 'Any'
       case "Mutable" then 'MutableType'
       else '<%name%>'
   else

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -330,7 +330,7 @@ class_specifier2 returns [void* ast, const char *s2]
 | EQUALS cs=overloading { $ast=cs; }
 | SUBTYPEOF ts=type_specifier
    {
-     $ast = Absyn__DERIVED(Absyn__TCOMPLEX(Absyn__IDENT(mmc_mk_scon("polymorphic")),mmc_mk_cons_typed(Absyn_TypeSpec, $ts.ast, mmc_mk_nil()),mmc_mk_nil()),
+     $ast = Absyn__DERIVED(Absyn__TCOMPLEX(Absyn__IDENT(mmc_mk_scon("\$polymorphic")),mmc_mk_cons_typed(Absyn_TypeSpec, $ts.ast, mmc_mk_nil()),mmc_mk_nil()),
                            Absyn__ATTR(MMC_FALSE,MMC_FALSE,Absyn__NON_5fPARALLEL,Absyn__VAR,Absyn__BIDIR,Absyn__NONFIELD,mmc_mk_nil()),mmc_mk_nil(),mmc_mk_none());
    }
 )


### PR DESCRIPTION
- Rename polymorphic (used internally for polymorphic types in
  MetaModelica and ModelicaBuiltin) to $polymorphic, to make sure it's
  not a valid Modelica identifier that could otherwise cause potential
  issues for users.