### PR TITLE
Timeout the model update timer after 0.5 secs

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -566,6 +566,7 @@ public:
   void createOMSimulatorUndoCommand(const QString &commandText, const bool doSnapShot = true, const bool switchToEdited = true,
                                     const QString oldEditedCref = QString(""), const QString newEditedCref = QString(""));
   void createOMSimulatorRenameModelUndoCommand(const QString &commandText, const QString &cref, const QString &newCref);
+  void processPendingModelUpdate();
 private:
   ModelWidgetContainer *mpModelWidgetContainer;
   LibraryTreeItem *mpLibraryTreeItem;


### PR DESCRIPTION
### Purpose

Doing some operation and then saving the model immediately does not save the correct model change. That is because the model update timer is set to time out after 2 secs.

### Approach

Timeout the model update timer after half a second and make sure model update is always done on save and show text view.
