### PR TITLE
Fix #7486

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1050,7 +1050,7 @@ public
         algorithm
           outExp := applySubscript(subscript, exp.exp, restSubscripts);
         then
-          CAST(Type.copyElementType(exp.ty, typeOf(outExp)), outExp);
+          CAST(Type.copyElementType(typeOf(outExp), exp.ty), outExp);
 
       else makeSubscriptedExp(subscript :: restSubscripts, exp);
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -666,8 +666,8 @@ public
   function copyElementType
     "Sets the element type of the destination type to the element type of the
      source type."
-    input Type srcType;
     input Type dstType;
+    input Type srcType;
     output Type ty;
   algorithm
     ty := setArrayElementType(dstType, arrayElementType(srcType));

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -3476,8 +3476,8 @@ algorithm
            listLength(trueType.dimensions) == listLength(falseType.dimensions) then
           // If the branches have the same element type and number of dimensions
           // but the dimensions aren't the same, create a conditional array type.
-          compatibleType := Type.CONDITIONAL_ARRAY(Type.setArrayElementType(trueType, compatibleType),
-                                                   Type.setArrayElementType(falseType, compatibleType),
+          compatibleType := Type.CONDITIONAL_ARRAY(Type.copyElementType(trueType, compatibleType),
+                                                   Type.copyElementType(falseType, compatibleType),
                                                    NFType.Branch.NONE);
           matchKind := MatchKind.EXACT;
         end if;

--- a/testsuite/flattening/modelica/scodeinst/IfExpression8.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfExpression8.mo
@@ -1,0 +1,26 @@
+// name: IfExpression8
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model IfExpression8
+  parameter Integer n = 3;
+  parameter Integer m = 2;
+  Real x[:, :] = if n == 3 then ones(n, m) else ones(n, n);
+end IfExpression8;
+
+// Result:
+// class IfExpression8
+//   final parameter Integer n = 3;
+//   final parameter Integer m = 2;
+//   Real x[1,1];
+//   Real x[1,2];
+//   Real x[2,1];
+//   Real x[2,2];
+//   Real x[3,1];
+//   Real x[3,2];
+// equation
+//   x = {{1.0, 1.0}, {1.0, 1.0}, {1.0, 1.0}};
+// end IfExpression8;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/IfExpression9.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfExpression9.mo
@@ -1,0 +1,20 @@
+// name: IfExpression9
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model IfExpression9
+  parameter Boolean b = true;
+  Real x[2] = if b then {1, 2} + x else {3, 4, 5} + x;
+end IfExpression9;
+
+// Result:
+// class IfExpression9
+//   parameter Boolean b = true;
+//   Real x[1];
+//   Real x[2];
+// equation
+//   x = {1.0 + x[1], 2.0 + x[2]};
+// end IfExpression9;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -608,6 +608,7 @@ IfExpression3.mo \
 IfExpression4.mo \
 IfExpression5.mo \
 IfExpression7.mo \
+IfExpression8.mo \
 IfEquationInvalidCond1.mo \
 ih1.mo \
 ih2.mo \
@@ -990,6 +991,7 @@ FinalParameter2.mo \
 FinalParameter3.mo \
 CevalRecordArray3.mo \
 IfExpression6.mo \
+IfExpression9.mo \
 RedeclareConstant1.mo \
 Connect3.mo \
 ProtectedMod1.mo \


### PR DESCRIPTION
- Use Type.copyElementType in TypeCheck.matchIfBranches instead of
  Type.setArrayElementType, to avoid adding dimensions to the created
  type when the dimensions only partially match.
- Swap the arguments for copyElementType to be analogous to
  setArrayElementType.