### PR TITLE
Fix purity handling in typing of fill

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1036,17 +1036,18 @@ protected
       (arg, arg_ty, arg_var, arg_pur) := Typing.typeExp(arg, context, info);
 
       if not (InstContext.inAlgorithm(context) or InstContext.inFunction(context)) then
-        if arg_var > Variability.PARAMETER or arg_pur == Purity.IMPURE or
-           Structural.isExpressionNotFixed(arg) then
+        if arg_var > Variability.PARAMETER then
           Error.addSourceMessageAndFail(Error.NON_PARAMETER_EXPRESSION_DIMENSION,
             {Expression.toString(arg), String(index),
              List.toString(fillArg :: dimensionArgs, Expression.toString,
                  ComponentRef.toString(fnRef), "(", ", ", ")", true)}, info);
         end if;
 
-        Structural.markExp(arg);
-        arg := Ceval.evalExp(arg);
-        arg_ty := Expression.typeOf(arg);
+        if arg_pur == Purity.PURE and not Structural.isExpressionNotFixed(arg) then
+          Structural.markExp(arg);
+          arg := Ceval.evalExp(arg);
+          arg_ty := Expression.typeOf(arg);
+        end if;
       else
         evaluated := false;
       end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFPrefixes.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFPrefixes.mo
@@ -503,7 +503,7 @@ function purityMin
   "Returns the least pure of the arguments."
   input Purity p1;
   input Purity p2;
-  output Purity p = if p1 > p2 then p2 else p1;
+  output Purity p = if p1 == Purity.IMPURE then p1 else p2;
 end purityMin;
 
 function directionFromSCode

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill3.mo
@@ -1,0 +1,37 @@
+// name: FuncBuiltinFill3
+// keywords: fill
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the builtin fill operator.
+//
+
+model FuncBuiltinFill3
+  parameter Integer a[:, :] = {{1}, {2}, {3}};
+  Real x[3, 3];
+equation
+  for i in 1:3 loop
+    x[:, 1:i] = zeros(3, a[i, 1]+0);
+  end for;
+end FuncBuiltinFill3;
+
+// Result:
+// class FuncBuiltinFill3
+//   parameter Integer a[1,1] = 1;
+//   parameter Integer a[2,1] = 2;
+//   parameter Integer a[3,1] = 3;
+//   Real x[1,1];
+//   Real x[1,2];
+//   Real x[1,3];
+//   Real x[2,1];
+//   Real x[2,2];
+//   Real x[2,3];
+//   Real x[3,1];
+//   Real x[3,2];
+//   Real x[3,3];
+// equation
+//   x[:,1:1] = fill(0.0, 3, a[1,1]);
+//   x[:,1:2] = fill(0.0, 3, a[2,1]);
+//   x[:,:] = fill(0.0, 3, a[3,1]);
+// end FuncBuiltinFill3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -470,6 +470,7 @@ FuncBuiltinDiv.mo \
 FuncBuiltinEdge.mo \
 FuncBuiltinFill.mo \
 FuncBuiltinFill2.mo \
+FuncBuiltinFill3.mo \
 FuncBuiltinFloor.mo \
 FuncBuiltinGetInstanceName.mo \
 FuncBuiltinHomotopy.mo \


### PR DESCRIPTION
- Allow dimension arguments of fill to be impure or not fixed.
- Fix logic in Prefixes.purityMin.