### PR TITLE
Use some epsilon for comparing nearly equal values.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -57,6 +57,9 @@
   #include <omp.h>
 #endif
 
+
+#define COMP_EPS 1e-12
+
 int maxEventIterations = 20;
 double linearSparseSolverMaxDensity = 0.2;
 int linearSparseSolverMinSize = DEFAULT_FLAG_LSS_MIN_SIZE;
@@ -1328,7 +1331,7 @@ modelica_boolean GreaterEqZC(double a, double b, modelica_boolean direction)
 
 modelica_boolean Less(double a, double b)
 {
-  return a < b;
+  return a + COMP_EPS <= b;
 }
 
 modelica_boolean LessEq(double a, double b)
@@ -1338,7 +1341,7 @@ modelica_boolean LessEq(double a, double b)
 
 modelica_boolean Greater(double a, double b)
 {
-  return a > b;
+  return a >= b + COMP_EPS;
 }
 
 modelica_boolean GreaterEq(double a, double b)


### PR DESCRIPTION


### Related Issues

Closing #6419

### Purpose

We get in an endless loop because the relations of #6419 are changing in each iteration because the values compared are nearly equal or equal.

### Approach

Now for Less or Greater to return true the first value has to be "really" smaller or "really" bigger than the other value.
Using epsilon 1e-12.
