### PR TITLE
Fix function evaluation in the backend with the NF

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -2146,24 +2146,30 @@ algorithm
 
     // try function interpretation
     case (cache,env, DAE.CALL(path = funcpath, attr = DAE.CALL_ATTR(builtin = false)), vallst, _, msg, _)
-      equation
-        true = Flags.isSet(Flags.EVAL_FUNC);
+      algorithm
+        true := Flags.isSet(Flags.EVAL_FUNC);
         failure(cevalIsExternalObjectConstructor(cache, funcpath, env, msg));
         // bcall1(Flags.isSet(Flags.DYN_LOAD), print,"[dynload]: try constant evaluation: " + AbsynUtil.pathString(funcpath) + "\n");
-        (cache,
-         sc as SCode.CLASS(partialPrefix = SCode.NOT_PARTIAL()),
-         env) = Lookup.lookupClass(cache, env, funcpath);
-        isCevaluableFunction(sc);
-        (cache, env, _) = InstFunction.implicitFunctionInstantiation(
-          cache,
-          env,
-          InnerOuter.emptyInstHierarchy,
-          DAE.NOMOD(),
-          DAE.NOPRE(),
-          sc,
-          {});
-        func = FCore.getCachedInstFunc(cache, funcpath);
-        (cache, newval) = CevalFunction.evaluate(cache, env, func, vallst);
+
+        try
+          func := FCore.getCachedInstFunc(cache, funcpath);
+        else
+          (cache,
+           sc as SCode.CLASS(partialPrefix = SCode.NOT_PARTIAL()),
+           env) := Lookup.lookupClass(cache, env, funcpath);
+          isCevaluableFunction(sc);
+          (cache, env, _) := InstFunction.implicitFunctionInstantiation(
+            cache,
+            env,
+            InnerOuter.emptyInstHierarchy,
+            DAE.NOMOD(),
+            DAE.NOPRE(),
+            sc,
+            {});
+          func := FCore.getCachedInstFunc(cache, funcpath);
+        end try;
+
+        (cache, newval) := CevalFunction.evaluate(cache, env, func, vallst);
         // bcall1(Flags.isSet(Flags.DYN_LOAD), print, "[dynload]: constant evaluation SUCCESS: " + AbsynUtil.pathString(funcpath) + "\n");
       then
         (cache, newval);

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3345,7 +3345,7 @@ algorithm
 
         cache := FCore.emptyCache();
         FCore.setCachedFunctionTree(cache, funcs);
-        env := FGraph.empty();
+        env := FGraph.new("graph", FCore.dummyTopModel);
       then (cache, env, dae);
 
    case (cache,env,_)

--- a/testsuite/openmodelica/xml/XmlDumpComment.mos
+++ b/testsuite/openmodelica/xml/XmlDumpComment.mos
@@ -13400,7 +13400,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </attributesValues>
 // </variable>
 // <variable id=\"598\" name=\"body.Q_start[1]\" variability=\"parameter\" direction=\"none\" type=\"Real\" fixed=\"true\" flow=\"NonConnector\" stream=\"NonStreamConnector\" comment=\"Quaternion orientation object from world frame to frame_a at initial time\">
-// <bindExpression string=\"Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T(body.R_start.T, {0.0, 0.0, 0.0, 1.0})\">
+// <bindExpression string=\"{0.0, 0.0, 0.0, 1.0}\">
 // </bindExpression>
 // <classesNames>
 // <element>
@@ -13412,7 +13412,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </classesNames>
 // </variable>
 // <variable id=\"599\" name=\"body.Q_start[2]\" variability=\"parameter\" direction=\"none\" type=\"Real\" fixed=\"true\" flow=\"NonConnector\" stream=\"NonStreamConnector\" comment=\"Quaternion orientation object from world frame to frame_a at initial time\">
-// <bindExpression string=\"Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T(body.R_start.T, {0.0, 0.0, 0.0, 1.0})\">
+// <bindExpression string=\"{0.0, 0.0, 0.0, 1.0}\">
 // </bindExpression>
 // <classesNames>
 // <element>
@@ -13424,7 +13424,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </classesNames>
 // </variable>
 // <variable id=\"600\" name=\"body.Q_start[3]\" variability=\"parameter\" direction=\"none\" type=\"Real\" fixed=\"true\" flow=\"NonConnector\" stream=\"NonStreamConnector\" comment=\"Quaternion orientation object from world frame to frame_a at initial time\">
-// <bindExpression string=\"Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T(body.R_start.T, {0.0, 0.0, 0.0, 1.0})\">
+// <bindExpression string=\"{0.0, 0.0, 0.0, 1.0}\">
 // </bindExpression>
 // <classesNames>
 // <element>
@@ -13436,7 +13436,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </classesNames>
 // </variable>
 // <variable id=\"601\" name=\"body.Q_start[4]\" variability=\"parameter\" direction=\"none\" type=\"Real\" fixed=\"true\" flow=\"NonConnector\" stream=\"NonStreamConnector\" comment=\"Quaternion orientation object from world frame to frame_a at initial time\">
-// <bindExpression string=\"Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T(body.R_start.T, {0.0, 0.0, 0.0, 1.0})\">
+// <bindExpression string=\"{0.0, 0.0, 0.0, 1.0}\">
 // </bindExpression>
 // <classesNames>
 // <element>


### PR DESCRIPTION
- Create a dummy environment in CevalScriptBackend.runFrontEndWork
  instead of returning an empty environment, otherwise opening a new
  scope will fail.
- Try to look up the function to evaluate in the cache before trying to
  instantiate it in CevalScript.cevalCallFunctionEvaluateOrGenerate2,
  since it will often already have been instantiated and trying to
  look it up in the environment will fail when using the NF.