### PR TITLE
Fix the rendering on bitmap

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -160,9 +160,19 @@ void BitmapAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *
   }
 }
 
+/*!
+ * \brief BitmapAnnotation::drawBitmapAnnotaion
+ * Draws the bitmap.
+ * \param painter
+ */
 void BitmapAnnotation::drawBitmapAnnotaion(QPainter *painter)
 {
-  painter->drawImage(getBoundingRect().normalized(), mImage.mirrored());
+  QRectF rect = getBoundingRect().normalized();
+  QImage image = mImage.scaled(rect.width(), rect.height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  QPointF centerPoint = rect.center() - image.rect().center();
+  QRectF target(centerPoint.x(), centerPoint.y(), image.width(), image.height());
+
+  painter->drawImage(target, mImage.mirrored());
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -531,6 +531,12 @@ void ShapeAnnotation::applyLinePattern(QPainter *painter)
   if (mBorderPattern == StringHandler::BorderRaised || mBorderPattern == StringHandler::BorderSunken) {
     thickness = Utilities::convertMMToPixel(0.25);
   }
+  // Make the display of Library Browser icons sharper. Very low line thickness is hardly visible on high resolution.
+  if (mLineThickness < 1.0 && ((mpGraphicsView && mpGraphicsView->useSharpLibraryPixmap())
+                               || (mpParentComponent && mpParentComponent->getGraphicsView()->useSharpLibraryPixmap()))) {
+    thickness = Utilities::convertMMToPixel(1.0);
+  }
+
   QPen pen(mLineColor, thickness, StringHandler::getLinePatternType(mLinePattern), Qt::SquareCap, Qt::MiterJoin);
   /* The specification doesn't say anything about it.
    * But just to keep this consist with Dymola we use Qt::BevelJoin for Line shapes.
@@ -544,10 +550,10 @@ void ShapeAnnotation::applyLinePattern(QPainter *painter)
    */
   pen.setCosmetic(true);
   /* Ticket #2272, Ticket #2268.
-   * If thickness is greater than 2 then don't make the pen cosmetic since cosmetic pens don't change the width with respect to zoom.
-   * Use non cosmetic pens for Libraries Browser and shapes inside component when thickness is greater than 2.
+   * If thickness is greater than 4 then don't make the pen cosmetic since cosmetic pens don't change the width with respect to zoom.
+   * Use non cosmetic pens for Libraries Browser and shapes inside component when thickness is greater than 4.
    */
-  if (thickness > 2
+  if (thickness > 4
       && ((mpGraphicsView && mpGraphicsView->isRenderingLibraryPixmap())
           || mpParentComponent)) {
     pen.setCosmetic(false);

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -1686,56 +1686,41 @@ void LibraryTreeModel::loadLibraryTreeItemPixmap(LibraryTreeItem *pLibraryTreeIt
   }
   GraphicsView *pGraphicsView = pLibraryTreeItem->getModelWidget()->getIconGraphicsView();
   if (pGraphicsView && pGraphicsView->hasAnnotation()) {
-    qreal left = pGraphicsView->mMergedCoOrdinateSystem.getLeft();
-    qreal bottom = pGraphicsView->mMergedCoOrdinateSystem.getBottom();
-    qreal right = pGraphicsView->mMergedCoOrdinateSystem.getRight();
-    qreal top = pGraphicsView->mMergedCoOrdinateSystem.getTop();
-    QRectF rectangle = QRectF(qMin(left, right), qMin(bottom, top), qFabs(left - right), qFabs(bottom - top));
-    if (rectangle.width() < 1) {
-      rectangle = QRectF(-100.0, -100.0, 200.0, 200.0);
-    }
-    qreal adjust = 25;
-    rectangle.setX(rectangle.x() - adjust);
-    rectangle.setY(rectangle.y() - adjust);
-    rectangle.setWidth(rectangle.width() + adjust);
-    rectangle.setHeight(rectangle.height() + adjust);
-    int libraryIconSize = OptionsDialog::instance()->getGeneralSettingsPage()->getLibraryIconSizeSpinBox()->value();
-    QPixmap libraryPixmap(QSize(libraryIconSize, libraryIconSize));
-    libraryPixmap.fill(QColor(Qt::transparent));
-    QPainter libraryPainter(&libraryPixmap);
-    libraryPainter.setRenderHint(QPainter::Antialiasing);
-    libraryPainter.setRenderHint(QPainter::SmoothPixmapTransform);
+    QRectF source = Utilities::adjustSceneRectangle(pGraphicsView->mMergedCoOrdinateSystem.getExtentRectangle(), 0.125);
     /* Ticket #5554
      * Create an equal size square for rendering the scene.
      * Don't stretch to fit a square.
      */
-    QRect windowRect;
-    windowRect = rectangle.toRect();
-    if (rectangle.width() != rectangle.height()) {
-      int x = qMax(rectangle.width(), rectangle.height());
-      windowRect.setX(-x/2);
-      windowRect.setY(-x/2);
-      windowRect.setWidth(x);
-      windowRect.setHeight(x);
+    if (source.width() != source.height()) {
+      int widhtOrHeight = qMax(source.width(), source.height());
+      source = QRectF(source.center().x() - (widhtOrHeight/2), source.center().y() - (widhtOrHeight/2), widhtOrHeight, widhtOrHeight);
     }
-    libraryPainter.setWindow(windowRect);
+    // library icon pixmap
+    QPixmap libraryPixmap(source.size().toSize());
+    libraryPixmap.fill(QColor(Qt::transparent));
+    QPainter libraryPainter(&libraryPixmap);
+    libraryPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     libraryPainter.scale(1.0, -1.0);
+    libraryPainter.translate(0, ((-source.top()) - source.bottom()));
+    libraryPainter.setWindow(source.toRect());
     // drag pixmap
     QPixmap dragPixmap(QSize(50, 50));
     dragPixmap.fill(QColor(Qt::transparent));
     QPainter dragPainter(&dragPixmap);
-    dragPainter.setRenderHint(QPainter::Antialiasing);
-    dragPainter.setRenderHint(QPainter::SmoothPixmapTransform);
-    dragPainter.setWindow(windowRect);
+    dragPainter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     dragPainter.scale(1.0, -1.0);
+    dragPainter.translate(0, ((-source.top()) - source.bottom()));
+    dragPainter.setWindow(source.toRect());
     pGraphicsView->setRenderingLibraryPixmap(true);
+    pGraphicsView->setSharpLibraryPixmap(true);
     // render library pixmap
-    pGraphicsView->scene()->render(&libraryPainter, rectangle, rectangle);
-    // render drag pixmap
-    pGraphicsView->scene()->render(&dragPainter, rectangle, rectangle);
-    pGraphicsView->setRenderingLibraryPixmap(false);
+    pGraphicsView->scene()->render(&libraryPainter, source, source);
     libraryPainter.end();
+    pGraphicsView->setSharpLibraryPixmap(false);
+    // render drag pixmap
+    pGraphicsView->scene()->render(&dragPainter, source, source);
     dragPainter.end();
+    pGraphicsView->setRenderingLibraryPixmap(false);
     pLibraryTreeItem->setPixmap(libraryPixmap);
     pLibraryTreeItem->setDragPixmap(dragPixmap);
   } else {

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -101,6 +101,7 @@ GraphicsView::GraphicsView(StringHandler::ViewType viewType, ModelWidget *pModel
   /* Ticket #3275
    * Set the scroll bars policy to always on to avoid unnecessary resize events.
    */
+  setRenderHint(QPainter::SmoothPixmapTransform);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   setFrameShape(QFrame::StyledPanel);
@@ -164,6 +165,7 @@ GraphicsView::GraphicsView(StringHandler::ViewType viewType, ModelWidget *pModel
   mpClickedState = 0;
   setIsMovingComponentsAndShapes(false);
   setRenderingLibraryPixmap(false);
+  setSharpLibraryPixmap(false);
   mElementsList.clear();
   mOutOfSceneElementsList.clear();
   mConnectionsList.clear();
@@ -201,19 +203,7 @@ bool GraphicsView::isCreatingShape()
 
 void GraphicsView::setExtentRectangle(const QRectF rectangle)
 {
-  // Yes the top of the rectangle is bottom for us since the coordinate system is inverted.
-  qreal left = rectangle.left();
-  qreal bottom = rectangle.top();
-  qreal right = rectangle.right();
-  qreal top = rectangle.bottom();
-  QRectF sceneRectangle(left, bottom, qFabs(left - right), qFabs(bottom - top));
-  /* Ticket:4340 Extend vertical space
-   * Make the drawing area 25% bigger than the actual size. So we can better use the panning feature.
-   */
-  const qreal factor = 0.25;
-  const qreal widthFactor = rectangle.width() * factor;
-  const qreal heightFactor = rectangle.width() * factor;
-  sceneRectangle.adjust(-widthFactor, -heightFactor, widthFactor, heightFactor);
+  QRectF sceneRectangle = Utilities::adjustSceneRectangle(rectangle, 0.25);
   setSceneRect(sceneRectangle);
   centerOn(sceneRectangle.center());
 }
@@ -8618,7 +8608,7 @@ void ModelWidgetContainer::printModel()
       // open print dialog
       if (pPrintDialog->exec() == QDialog::Accepted) {
         QPainter painter(&printer);
-        painter.setRenderHints(QPainter::Antialiasing);
+        painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
         pGraphicsView->render(&painter);
         painter.end();
       }

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -109,6 +109,7 @@ private:
   Element *mpClickedState;
   bool mIsMovingComponentsAndShapes;
   bool mRenderingLibraryPixmap;
+  bool mSharpLibraryPixmap;
   QList<Element*> mElementsList;
   // A list of components that are not deleted but are removed from scene.
   QList<Element*> mOutOfSceneElementsList;
@@ -191,6 +192,8 @@ public:
   bool isMovingComponentsAndShapes() {return mIsMovingComponentsAndShapes;}
   void setRenderingLibraryPixmap(bool renderingLibraryPixmap) {mRenderingLibraryPixmap = renderingLibraryPixmap;}
   bool isRenderingLibraryPixmap() {return mRenderingLibraryPixmap;}
+  void setSharpLibraryPixmap(bool sharpLibraryPixmap) {mSharpLibraryPixmap = sharpLibraryPixmap;}
+  bool useSharpLibraryPixmap() {return mSharpLibraryPixmap;}
   QList<ShapeAnnotation*> getShapesList() {return mShapesList;}
   QList<ShapeAnnotation*> getInheritedShapesList() {return mInheritedShapesList;}
   QAction* getManhattanizeAction() {return mpManhattanizeAction;}

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -1290,3 +1290,27 @@ QString Utilities::convertSymbolToUnit(const QString symbol)
     return symbol;
   }
 }
+
+/*!
+ * \brief Utilities::adjustRectangle
+ * Adjusts the
+ * \param rectangle
+ * \param factor
+ * \return
+ */
+QRectF Utilities::adjustSceneRectangle(const QRectF sceneRectangle, const qreal factor)
+{
+  // Yes the top of the rectangle is bottom for us since the coordinate system is inverted.
+  qreal left = sceneRectangle.left();
+  qreal bottom = sceneRectangle.top();
+  qreal right = sceneRectangle.right();
+  qreal top = sceneRectangle.bottom();
+  QRectF rectangle(left, bottom, qFabs(left - right), qFabs(bottom - top));
+  /* Ticket:4340 Extend vertical space
+   * Make the drawing area 25% bigger than the actual size. So we can better use the panning feature.
+   */
+  const qreal widthFactor = sceneRectangle.width() * factor;
+  const qreal heightFactor = sceneRectangle.width() * factor;
+  rectangle.adjust(-widthFactor, -heightFactor, widthFactor, heightFactor);
+  return rectangle;
+}

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -544,6 +544,7 @@ namespace Utilities {
   QStringList variantListToStringList(const QVariantList lst);
   QString convertUnitToSymbol(const QString displayUnit);
   QString convertSymbolToUnit(const QString symbol);
+  QRectF adjustSceneRectangle(const QRectF sceneRectangle, const qreal factor);
 } // namespace Utilities
 
 #endif // UTILITIES_H


### PR DESCRIPTION
### Related Issues

Fixes #7490

### Purpose

The bitmaps are stretched to the extents.

### Approach

Scale the bitmap to better fit in the extents.
