### PR TITLE
Explicitly load MSL 3.2.3 for users guide examples

### DIFF
--- a/doc/UsersGuide/source/introduction.rst
+++ b/doc/UsersGuide/source/introduction.rst
@@ -320,7 +320,7 @@ can be done through the File->Load Modelica Library menu item:
 
 .. omc-mos::
 
-  loadModel(Modelica)
+  loadModel(Modelica, {"3.2.3"})
 
 We also load a file containing the dcmotor model:
 

--- a/doc/UsersGuide/source/omnotebook.rst
+++ b/doc/UsersGuide/source/omnotebook.rst
@@ -264,7 +264,7 @@ undesired behavior of the system.
 .. omc-mos ::
   :erroratend:
 
-  loadModel(Modelica)
+  loadModel(Modelica, {"3.2.3"})
   simulate(noFeedback, stopTime=100)
 
 .. omc-gnuplot :: omnotebook-open-loop
@@ -313,7 +313,7 @@ mechanism in between.
 .. omc-mos ::
   :erroratend:
 
-  loadModel(Modelica)
+  loadModel(Modelica, {"3.2.3"})
   simulate(withFeedback, stopTime=10)
 
 .. omc-gnuplot :: omnotebook-closed-loop


### PR DESCRIPTION

### Related Issues

Fixing #7522 

### Purpose

Remove error messages in User's Guide.

### Approach

Explicitly load MSL 3.2.3 for examples not working with MSL 4.0.0 without changing them.
