### PR TITLE
Fix Cpp array constructor (#7535)

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -176,7 +176,7 @@ end contextFunName;
 template contextIteratorName(Ident name, Context context)
   "Generates code for an iterator variable."
 ::=
-  name + "_"
+  System.unquoteIdentifier(name) + "_"
 end contextIteratorName;
 
 template crefWithIndex(ComponentRef cr, Context context, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl,

--- a/OMCompiler/Compiler/Template/CodegenCppCommonOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommonOld.tpl
@@ -176,7 +176,7 @@ end contextFunName;
 template contextIteratorName(Ident name, Context context)
   "Generates code for an iterator variable."
 ::=
-  name + "_"
+  System.unquoteIdentifier(name) + "_"
 end contextIteratorName;
 
 template crefWithIndex(ComponentRef cr, Context context, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl,


### PR DESCRIPTION
`System.unquoteIdentifier` translates `$i1` to `_omcQ_24i1_`. It appeared to be applied during the use of the variable, but not for its declaration.