### PR TITLE
Add a check for getAvailablePackageVersions

### DIFF
--- a/testsuite/libraries-for-testing/index.mos
+++ b/testsuite/libraries-for-testing/index.mos
@@ -18,6 +18,18 @@ if 0 <> system("cp index.json .openmodelica/libraries/") then
   print("Failed to cp index.json");
   exit(1);
 end if;
+vers:=OpenModelica.Scripting.getAvailablePackageVersions(Modelica, "3.2.3");
+if size(vers,1) <> 1 then
+  print("getAvailablePackageVersions(Modelica, \"3.2.3\") returned " + String(size(vers,1)) + " results\n");
+  print(getErrorString());
+  exit(1);
+end if;
+if vers[1] <> "3.2.3+maint.om" then
+  print("getAvailablePackageVersions(Modelica, \"3.2.3\") returned " + vers[1] + "\n");
+  print(getErrorString());
+  exit(1);
+end if;
+
 if not installPackage(BioChem, "1.0.1+msl.3.2.1", exactMatch=true) then
   print("BioChem 1.0.1+msl.3.2.1 failed
 ");

--- a/testsuite/libraries-for-testing/update.py
+++ b/testsuite/libraries-for-testing/update.py
@@ -89,6 +89,17 @@ if 0 <> system("cp index.json .openmodelica/libraries/") then
   print("Failed to cp index.json");
   exit(1);
 end if;
+vers:=OpenModelica.Scripting.getAvailablePackageVersions(Modelica, "3.2.3");
+if size(vers,1) <> 1 then
+  print("getAvailablePackageVersions(Modelica, \"3.2.3\") returned " + String(size(vers,1)) + " results\n");
+  print(getErrorString());
+  exit(1);
+end if;
+if vers[1] <> "3.2.3+maint.om" then
+  print("getAvailablePackageVersions(Modelica, \"3.2.3\") returned " + vers[1] + "\n");
+  print(getErrorString());
+  exit(1);
+end if;
 ''')
   for lib in desired.keys():
     for version in desired[lib]:


### PR DESCRIPTION
Since the package manager cannot be used in the testsuite, the check
is performed while creating the library structure.
