### PR TITLE
Fix for ticket #6205

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -6936,13 +6936,7 @@ template daeExpAsub(Exp inExp, Context context, Text &preExp,
     error(sourceInfo(),'ASUB_EASY_CASE type:<%unparseType(t)%> range:<%ExpressionDumpTpl.dumpExp(exp,"\"")%> index:<%ExpressionDumpTpl.dumpExp(idx,"\"")%>')
 
   case ASUB(exp=ecr as CREF(__), sub=subs) then
-    let arrName = daeExpCrefRhs(buildCrefExpFromAsub(ecr, subs), context,
-                              &preExp, &varDecls, &auxFunction)
-    match context
-    case FUNCTION_CONTEXT(__)  then
-        arrName
-    else
-        arrayScalarRhs(ecr.ty, subs, arrName, context, &preExp, &varDecls, &auxFunction)
+    daeExpCrefRhs(buildCrefExpFromAsub(ecr, subs), context, &preExp, &varDecls, &auxFunction)
 
   case ASUB(exp=e, sub=indexes) then
     let exp = daeExp(e, context, &preExp, &varDecls, &auxFunction)


### PR DESCRIPTION
### Related Issues

#6205

### Purpose

Slice subscripts on crefs had issues since they were sometimes converted to ASUBs by function inlining. Codegen for ASUBs works mostly fine except when they are slice subscripts.  

### Approach

  - Do not subscript already subscripted crefs. The function
    `SimCodeFunctionUtil.buildCrefExpFromAsub` has already applied the
    subscripts.

  - A proper fix would be to not create ASUBs for crefs in the first
    place only to change them back to crefs again. That fix will have to
    wait for now. This should work in the meantime.
