### PR TITLE
Improve error for name lookup in partial class

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -700,6 +700,23 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
     end match;
   end getDerivedComments;
 
+  function constrainingClassPath
+    "Returns the path of the constraining class for a given class, either the
+     declared constraining class or the path of the class itself if there's no
+     declared constraining class."
+    input InstNode clsNode;
+    output Absyn.Path path;
+  protected
+    InstNode cls_node = lastBaseClass(clsNode);
+    Prefixes prefs = getPrefixes(InstNode.getClass(cls_node));
+  algorithm
+    path := match prefs
+      case Prefixes.PREFIXES(replaceablePrefix = SCode.Replaceable.REPLACEABLE(
+        cc = SOME(SCode.ConstrainClass.CONSTRAINCLASS(constrainingClass = path)))) then path;
+      else InstNode.enclosingScopePath(cls_node);
+    end match;
+  end constrainingClassPath;
+
   function hasOperator
     input String name;
     input Class cls;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -598,6 +598,28 @@ uniontype InstNode
     end match;
   end parentScope;
 
+  function enclosingScopePath
+    "Returns the enclosing scopes of a node as a path."
+    input InstNode node;
+    output Absyn.Path path;
+  algorithm
+    path := AbsynUtil.stringListPath(
+      list(InstNode.name(n) for n in enclosingScopeList(node)));
+  end enclosingScopePath;
+
+  function enclosingScopeList
+    "Returns the enclosing scopes of a node as a list of nodes."
+    input InstNode node;
+    output list<InstNode> res = {};
+  protected
+    InstNode scope = node;
+  algorithm
+    while not isTopScope(scope) loop
+      res := scope :: res;
+      scope := classScope(parentScope(scope));
+    end while;
+  end enclosingScopeList;
+
   function classScope
     input InstNode node;
     output InstNode scope;
@@ -629,6 +651,16 @@ uniontype InstNode
       else topScope(parentScope(node));
     end match;
   end topScope;
+
+  function isTopScope
+    input InstNode node;
+    output Boolean res;
+  algorithm
+    res := match node
+      case CLASS_NODE(nodeType = InstNodeType.TOP_SCOPE()) then true;
+      else false;
+    end match;
+  end isTopScope;
 
   function topComponent
     input InstNode node;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
@@ -203,6 +203,7 @@ uniontype LookupState
       local
         String name_str;
         SourceInfo info2;
+        InstNode node2;
 
       // Found the expected kind of element.
       case (COMP(),         COMP())  then ();
@@ -304,8 +305,17 @@ uniontype LookupState
       case (ERROR(errorState = PARTIAL_CLASS()), _)
         algorithm
           if not InstContext.inRelaxed(context) then
-            Error.addSourceMessage(Error.LOOKUP_IN_PARTIAL_CLASS,
-              {InstNode.name(node)}, info);
+            node2 := listHead(InstNode.scopeList(node));
+
+            if InstNode.isComponent(node2) then
+              Error.addMultiSourceMessage(Error.USE_OF_PARTIAL_CLASS,
+                {InstNode.name(node2), InstNode.name(node), AbsynUtil.pathString(Class.constrainingClassPath(node))},
+                {InstNode.info(node), InstNode.info(node2)});
+            else
+              Error.addSourceMessage(Error.LOOKUP_IN_PARTIAL_CLASS,
+                {InstNode.name(node)}, info);
+            end if;
+
             fail();
           end if;
         then

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -774,6 +774,7 @@ PartialApplicationInvalidArg2.mo \
 PartialClass1.mo \
 PartialFunction1.mo \
 PartialLookup1.mo \
+PartialLookup2.mo \
 PartialType1.mo \
 PartialType2.mo \
 PartialType3.mo \

--- a/testsuite/flattening/modelica/scodeinst/PartialLookup2.mo
+++ b/testsuite/flattening/modelica/scodeinst/PartialLookup2.mo
@@ -1,0 +1,31 @@
+// name:     PartialLookup2
+// keywords: lookup partial redeclare
+// status:   incorrect
+// cflags: -d=newInst
+//
+// Checks that it's not allowed to look up a name in a partial class.
+//
+
+model A
+  partial package PP
+    model B end B;
+  end PP;
+
+  PP.B b;
+end A;
+
+model PartialLookup2
+  A a;
+end PartialLookup2;
+
+// Result:
+// Error processing file: PartialLookup2.mo
+// [flattening/modelica/scodeinst/PartialLookup2.mo:10:3-12:9:writable] Notification: From here:
+// [flattening/modelica/scodeinst/PartialLookup2.mo:18:3-18:6:writable] Error: component a contains the definition of a partial class PP.
+// Please redeclare it to any package compatible with A.PP.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult


### PR DESCRIPTION
- Implement the "component x contains the definition of a partial class
  C" error message from the old frontend in the new.