### PR TITLE
Do not load the library if the required feature is missing

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Parser.mo
+++ b/OMCompiler/Compiler/FrontEnd/Parser.mo
@@ -190,8 +190,9 @@ end checkLVEToolLicense;
 function checkLVEToolFeature
   input Option<Integer> lveInstance;
   input String feature;
+  output Boolean status;
 algorithm
-  ParserExt.checkLVEToolFeature(lveInstance, feature);
+  status := ParserExt.checkLVEToolFeature(lveInstance, feature);
 end checkLVEToolFeature;
 
 function stopLibraryVendorExecutable

--- a/OMCompiler/Compiler/FrontEnd/ParserExt.mo
+++ b/OMCompiler/Compiler/FrontEnd/ParserExt.mo
@@ -136,8 +136,9 @@ end checkLVEToolLicense;
 public function checkLVEToolFeature
   input Option<Integer> lveInstance;
   input String feature;
+  output Boolean status;
 
-  external "C" ParserExt_checkLVEToolFeature(lveInstance, feature) annotation(Library = {"omparse","omantlr3","omcruntime"});
+  external "C" status=ParserExt_checkLVEToolFeature(lveInstance, feature) annotation(Library = {"omparse","omantlr3","omcruntime"});
 end checkLVEToolFeature;
 
 public function stopLibraryVendorExecutable

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -17529,7 +17529,10 @@ algorithm
       //print("License File is : " + licenseFile + "\n");
       features := getFeaturesAnnotation(topClassNameQualified, parsed);
       for feature in features loop
-        Parser.checkLVEToolFeature(lveInstance, feature);
+        if not Parser.checkLVEToolFeature(lveInstance, feature) then
+          topClassNamesQualified := {};
+          return;
+        end if;
       end for;
     end for;
     Parser.stopLibraryVendorExecutable(lveInstance);

--- a/OMCompiler/Parser/Parser_omc.c
+++ b/OMCompiler/Parser/Parser_omc.c
@@ -139,9 +139,9 @@ int ParserExt_checkLVEToolLicense(void** lveInstance, const char* packageName)
   return checkLVEToolLicense(lveInstance, packageName);
 }
 
-void ParserExt_checkLVEToolFeature(void** lveInstance, const char* feature)
+int ParserExt_checkLVEToolFeature(void** lveInstance, const char* feature)
 {
-  checkLVEToolFeature(lveInstance, feature);
+  return checkLVEToolFeature(lveInstance, feature);
 }
 
 void ParserExt_stopLibraryVendorExecutable(void** lveInstance)

--- a/OMCompiler/Parser/parse.c
+++ b/OMCompiler/Parser/parse.c
@@ -482,11 +482,12 @@ int checkLVEToolLicense(void** lveInstance, const char* packageName)
   return 0;
 }
 
-void checkLVEToolFeature(void** lveInstance, const char* feature)
+int checkLVEToolFeature(void** lveInstance, const char* feature)
 {
 #ifdef OMENCRYPTION
-  checkLVEToolFeatureImpl(lveInstance, feature);
+  return checkLVEToolFeatureImpl(lveInstance, feature);
 #endif
+  return 0;
 }
 
 void stopLibraryVendorExecutable(void** lveInstance)


### PR DESCRIPTION
### Related Issues

Fixes #7500

### Purpose

Do not load the library if feature license is not there.

### Approach

Check the feature license before loading the library.
