### PR TITLE
Fix mixed solver on relation jittering

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -888,16 +888,17 @@ int solveNLS(DATA *data, threadData_t *threadData, int sysNumber)
       if (success){
         success=2;
       }
-    }
 
-    if (!success) {
-      nonlinsys->solverData = mixedSolverData->hybridData;
-      success = solveHybrd(data, threadData, sysNumber);
-    }
+      if (!success) {
+        nonlinsys->solverData = mixedSolverData->hybridData;
+        success = solveHybrd(data, threadData, sysNumber);
+      }
 
-    /* update iteration variables of nonlinsys->nlsx */
-    if (success){
-      nonlinsys->getIterationVars(data, nonlinsys->nlsx);
+      /* update iteration variables of nonlinsys->nlsx */
+      if (success){
+        /* phi: why do we need to do this, and why does it change the value? */
+        nonlinsys->getIterationVars(data, nonlinsys->nlsx);
+      }
     }
 
     /*catch */

--- a/testsuite/simulation/modelica/tearing/Tearing18-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing18-minimal.mos
@@ -29,9 +29,6 @@ val(x8,1.0); getErrorString();
 //     resultFile = "Tearing18_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing18', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | debug   | Solving non-linear system 34 failed at time=0.086.
-// |                 | |       | For more information please use -lv LOG_NLS.
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -82,16 +79,16 @@ val(x8,1.0); getErrorString();
 // "
 // -0.9589242746631385
 // ""
-// 1.489535057843215
+// 1.489535057843214
 // ""
-// -0.294476257366079
+// -0.2944762573660781
 // ""
 // -1.018493952318733
 // ""
-// 0.1102524957021611
+// 0.1102524957021606
 // ""
-// 3.489535057843215
+// 3.489535057843214
 // ""
-// 0.340964233657884
+// 0.3409642336578833
 // ""
 // endResult


### PR DESCRIPTION
### Related Issues

issue #6419, PR #7542

### Purpose

Try to avoid jumping between two close solutions in the nls_mixed

### Approach
On success of the homotopy solver we skip copying the iteration variables
```C
nonlinsys->getIterationVars(data, nonlinsys->nlsx);
```
this seems to solve the problem.

I don't understand it, so this is just a test!