### PR TITLE
Handle mutually dependent function inverses

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -136,7 +136,7 @@ constant InstNode INTEGER_DUMMY_NODE = NFInstNode.CLASS_NODE("Integer",
 constant Function INTEGER_FUNCTION = Function.FUNCTION(Path.IDENT("Integer"),
   INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, {
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}), Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("IntegerFunc",
   DUMMY_ELEMENT, Visibility.PUBLIC,
@@ -161,7 +161,7 @@ constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("significantDigits", SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 4, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(r, format="-0.6g")
@@ -169,7 +169,7 @@ constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("format", SlotType.NAMED, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(i, minimumLength=0, leftJustified=true)
@@ -178,7 +178,7 @@ constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("i", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(b, minimumLength=0, leftJustified=true)
@@ -187,7 +187,7 @@ constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("b", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(e, minimumLength=0, leftJustified=true)
@@ -196,7 +196,7 @@ constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
@@ -221,77 +221,77 @@ constant ComponentRef STRING_CREF =
 
 constant Function ABS_REAL = Function.FUNCTION(Path.IDENT("abs"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MAX_INT = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MAX_REAL = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function DIV_INT = Function.FUNCTION(Path.IDENT("div"),
   InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FLOOR = Function.FUNCTION(Path.IDENT("floor"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INTEGER_REAL = Function.FUNCTION(Path.IDENT("integer"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INTEGER_ENUM = Function.FUNCTION(Path.IDENT("Integer"),
   InstNode.EMPTY_NODE(), {ENUM_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function POSITIVE_MAX_REAL = Function.FUNCTION(Path.IDENT("$OMC$PositiveMax"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function IN_STREAM = Function.FUNCTION(Path.IDENT("inStream"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function PROMOTE = Function.FUNCTION(Path.IDENT("promote"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function CAT = Function.FUNCTION(Path.IDENT("cat"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ARRAY_FUNC = Function.FUNCTION(Path.IDENT("array"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FILL_FUNC = Function.FUNCTION(Path.IDENT("fill"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SMOOTH = Function.FUNCTION(Path.IDENT("smooth"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SUM = Function.FUNCTION(Path.IDENT("sum"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 
@@ -309,7 +309,8 @@ constant InstNode CLOCK_DUMMY_NODE = NFInstNode.CLASS_NODE("Clock",
 
 // Clock() - inferred clock
 constant Function CLOCK_INFERED = Function.FUNCTION(Path.IDENT("Clock"),
-  CLOCK_DUMMY_NODE, {}, {CLOCK_PARAM}, {}, {}, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  CLOCK_DUMMY_NODE, {}, {CLOCK_PARAM}, {}, {}, Type.CLOCK(),
+  DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(intervalCounter, resolution = 1) - clock with Integer interval
@@ -317,14 +318,14 @@ constant Function CLOCK_INT = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {INT_PARAM, INT_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT("intervalCounter", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("resolution", SlotType.GENERIC, SOME(Expression.INTEGER(1)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(interval) - clock with Real interval
 constant Function CLOCK_REAL = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {REAL_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT("interval", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(condition, startInterval = 0.0) - Boolean clock, triggered by zero-crossing events
@@ -332,7 +333,7 @@ constant Function CLOCK_BOOL = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {BOOL_PARAM, REAL_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT("condition", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("startInterval", SlotType.GENERIC, SOME(Expression.REAL(0.0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(c, solverMethod) - Solver clock
@@ -340,7 +341,7 @@ constant Function CLOCK_SOLVER = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {CLOCK_PARAM, STRING_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT("c", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT("solverMethod", SlotType.GENERIC, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {},
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -264,7 +264,7 @@ uniontype Function
     Type returnType;
     DAE.FunctionAttributes attributes;
     list<FunctionDerivative> derivatives;
-    list<FunctionInverse> inverses;
+    array<FunctionInverse> inverses;
     Pointer<FunctionStatus> status;
     Pointer<Integer> callCounter "Used during function evaluation to limit recursion.";
   end FUNCTION;
@@ -285,7 +285,7 @@ uniontype Function
     // Make sure builtin functions aren't added to the function tree.
     status := if isBuiltinAttr(attr) then FunctionStatus.COLLECTED else FunctionStatus.INITIAL;
     fn := FUNCTION(path, node, inputs, outputs, locals, {}, Type.UNKNOWN(),
-      attr, {}, {}, Pointer.create(status), Pointer.create(0));
+      attr, {}, listArray({}), Pointer.create(status), Pointer.create(0));
   end new;
 
   function lookupFunctionSimple
@@ -1435,9 +1435,7 @@ uniontype Function
     end for;
 
     // Type any inverses of the function.
-    if not listEmpty(fn.inverses) then
-      fn.inverses := list(FunctionInverse.typeInverse(i) for i in fn.inverses);
-    end if;
+    Array.mapNoCopy(fn.inverses, FunctionInverse.typeInverse);
 
     // If the function is pure, check that it doesn't contain any impure calls.
     if not isImpure(fn) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
@@ -55,9 +55,10 @@ public
   function instInverses
     input InstNode fnNode;
     input Function fn;
-    output list<FunctionInverse> invs = {};
+    output array<FunctionInverse> inverses;
   protected
     list<SCode.Mod> inv_mods;
+    list<FunctionInverse> invs = {};
   algorithm
     inv_mods := getInverseAnnotations(InstNode.definition(fnNode));
 
@@ -71,6 +72,8 @@ public
     for m in inv_mods loop
       invs := instInverseMod(m, fnNode, fn, invs);
     end for;
+
+    inverses := listArray(invs);
   end instInverses;
 
   function typeInverse

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -159,7 +159,7 @@ algorithm
   attr := DAE.FUNCTION_ATTRIBUTES_DEFAULT;
   status := Pointer.create(FunctionStatus.INITIAL);
   InstNode.cacheAddFunc(node, Function.FUNCTION(path, ctor_node, inputs,
-    {out_rec}, locals, {}, Type.UNKNOWN(), attr, {}, {}, status, Pointer.create(0)), false);
+    {out_rec}, locals, {}, Type.UNKNOWN(), attr, {}, listArray({}), status, Pointer.create(0)), false);
 end instDefaultConstructor;
 
 function checkLocalFieldOrder


### PR DESCRIPTION
- Change the list of function inverses to an array in order to make it
  mutable, to allow them to be updated correctly when there are mutual
  dependencies between function inverses.