### PR TITLE
Fix type computation for subscripting

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1740,6 +1740,39 @@ algorithm
   DAE.CREF_QUAL(componentRef = outCref) := inCref;
 end crefRest;
 
+protected function crefTypeFullComputeDims
+  input list<DAE.Dimension> inDims;
+  input list<DAE.Subscript> inSubs;
+  output list<DAE.Dimension> outDims;
+protected
+  list<DAE.Dimension> dims;
+  DAE.Dimension dim, slice_dim;
+algorithm
+  dims := inDims;
+  outDims := {};
+  for sub in inSubs loop
+    dim::dims := dims;
+
+    _ := match sub
+      case DAE.INDEX() then ();
+
+      case DAE.SLICE() algorithm
+        slice_dim::_ := Types.getDimensions(Expression.typeof(sub.exp));
+        outDims := slice_dim::outDims;
+      then ();
+
+      case DAE.WHOLEDIM() algorithm
+        outDims := dim::outDims;
+      then ();
+
+    end match;
+
+  end for;
+
+  outDims := listAppend(outDims, dims) annotation(__OpenModelica_DisableListAppendWarning=true);
+
+end crefTypeFullComputeDims;
+
 public function crefTypeFull2
   "Helper function to crefTypeFull."
   input DAE.ComponentRef inCref;
@@ -1757,7 +1790,7 @@ algorithm
     case DAE.CREF_IDENT(identType = ty, subscriptLst = subs)
       equation
         (ty,dims) = Types.flattenArrayType(ty);
-        dims = List.stripN(dims, listLength(subs));
+        dims = crefTypeFullComputeDims(dims, subs);
 
         if not listEmpty(accumDims) then
           dims = listReverse(List.append_reverse(dims, accumDims));
@@ -1767,7 +1800,7 @@ algorithm
     case DAE.CREF_QUAL(identType = ty, subscriptLst = subs, componentRef = cr)
       equation
         (ty,dims) = Types.flattenArrayType(ty);
-        dims = List.stripN(dims,listLength(subs));
+        dims = crefTypeFullComputeDims(dims, subs);
 
         (basety, dims) = crefTypeFull2(cr, List.append_reverse(dims, accumDims));
       then (basety, dims);

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -1024,6 +1024,7 @@ algorithm
     case(DAE.CREF(cref, ty), _)
       equation
         cref = ComponentReference.subscriptCref(cref, inSubs);
+        ty = ComponentReference.crefTypeFull(cref);
       then
         DAE.CREF(cref, ty);
 

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -932,19 +932,30 @@ algorithm
   end match;
 end prependSubscriptExp;
 
-public function applyExpSubscripts "
-author: PA
-Takes an arbitrary expression and applies subscripts to it. This is done by creating asub
-expressions given the original expression and then simplify them.
-Note: The subscripts must be INDEX
+public function applyExpSubscripts
+"@mahge
+  Takes an expression and a list of subscripts and subscripts
+  the given expression.
+  If a component reference is given the subs are applied to it.
+  If an array(DAE.ARRAY) is given the element at the specified
+  subscripts is returned. Otherwise and ASUB is built and returned.
+  e.g. subscriptExp on ({{1,2},{3,4}}) with sub [2,1] gives 3
+       subscriptExp on (a) with sub [2,1] gives a[2,1]
 
-alternative names: subsriptExp (but already taken), subscriptToAsub"
+"
   input output DAE.Exp exp;
   input list<DAE.Subscript> inSubs;
 protected
-  DAE.Exp s;
+  String str;
 algorithm
-  exp := applyExpSubscriptsFoldCheckSimplify(exp, inSubs);
+  try
+    exp := applyExpSubscripts2(exp, inSubs);
+  else
+    str := "Expression.applyExpSubscripts failed applying subs: [" + ExpressionDump.printSubscriptLstStr(inSubs)
+    + "] on expression:" + ExpressionDump.printExpStr(exp) + "\n";
+    Error.addMessage(Error.INTERNAL_ERROR, {str});
+  end try;
+
 end applyExpSubscripts;
 
 
@@ -958,7 +969,11 @@ alternative names: subsriptExp (but already taken), subscriptToAsub
 
 This version of the function also returns a boolean stating if simplify
 improved anything (can be used as a heuristic if you want to apply
-the subscript when scalarizing)"
+the subscript when scalarizing)
+
+Note: mahge. Uses of this function should be replaced by applyExpSubscripts. I have not
+replaced them because I could not make sense of the usage in Backend/RemoveSimpleEquations.
+It uses the checkSimplify arg and I am not sure what it expects or is supposed to do with the result."
   input output DAE.Exp exp;
   input list<DAE.Subscript> inSubs;
   input output Boolean checkSimplify = false;
@@ -979,17 +994,13 @@ algorithm
   end for;
 end applyExpSubscriptsFoldCheckSimplify;
 
-public function subscriptExp
+public function applyExpSubscripts2
 "@mahge
-  This function does the same job as 'applyExpSubscripts' function.
-  However this one doesn't use ExpressionSimplify.simplify.
-
-
   Takes an expression and a list of subscripts and subscripts
   the given expression.
   If a component reference is given the subs are applied to it.
   If an array(DAE.ARRAY) is given the element at the specified
-  subscripts is returned.
+  subscripts is returned. Otherwise and ASUB is built and returned.
   e.g. subscriptExp on ({{1,2},{3,4}}) with sub [2,1] gives 3
        subscriptExp on (a) with sub [2,1] gives a[2,1]
 
@@ -1002,11 +1013,10 @@ algorithm
     local
       DAE.ComponentRef cref;
       DAE.Type ty;
-      DAE.Exp exp,exp1,exp2;
+      DAE.Exp exp;
       list<DAE.Exp> explst;
       DAE.Subscript sub;
       list<DAE.Subscript> restsubs;
-      DAE.Operator op;
       String str;
 
     case(_, {}) then inExp;
@@ -1017,36 +1027,25 @@ algorithm
       then
         DAE.CREF(cref, ty);
 
+    /*
     case(DAE.ARRAY(_, _, explst), sub::restsubs)
       equation
         exp = listGet(explst, subscriptInt(sub));
       then
-        subscriptExp(exp, restsubs);
+        applyExpSubscripts2(exp, restsubs);
+    */
 
-    case (DAE.BINARY(exp1, op, exp2), _)
-      equation
-        exp1 = subscriptExp(exp1, inSubs);
-        exp2 = subscriptExp(exp2, inSubs);
-      then
-        DAE.BINARY(exp1, op, exp2);
-
-    case (DAE.CAST(ty,exp1), _)
-      equation
-        exp1 = subscriptExp(exp1, inSubs);
-        ty = Types.arrayElementType(ty);
-        exp1 = DAE.CAST(ty,exp1);
-      then
-        exp1;
-
-    else
-      equation
-        str = "Expression.subscriptExp failed on " + ExpressionDump.printExpStr(inExp) + "\n";
-        Error.addMessage(Error.INTERNAL_ERROR, {str});
-      then
-        fail();
+    // This is the default operation for exps not handled explicitly. It is unfortunate
+    // we have to build ASUBs. But we can improve this step by step to exclude more exps.
+    // Note getSubscriptExp does not work on WHOLE_DIM subs. So this will fail if one of the
+    // subs is WHOLE_DIM. DAE.ASUB should have been able to have list<DAE.Subscript> instead
+    // of just list<DAE.Exp> represneting subs.
+    else algorithm
+      exp := applyExpSubscriptsFoldCheckSimplify(inExp, inSubs);
+    then exp;
 
   end match;
-end subscriptExp;
+end applyExpSubscripts2;
 
 
 public function unliftArray

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -3296,7 +3296,7 @@ algorithm
 
         // print("CREF EB: " + ComponentReference.printComponentRefStr(inCref) + "\nTyParent: " + Types.printTypeStr(inParentType) + "\nParent:\n" + Types.printBindingStr(inParentBinding) + "\nChild:\n" + Types.printBindingStr(inChildBinding) + "\n");
 
-        DAE.RECORD(_, exps, comp, _) = Expression.subscriptExp(e, ss);
+        DAE.RECORD(_, exps, comp, _) = Expression.applyExpSubscripts(e, ss);
 
         e = listGet(exps, List.position(cId, comp));
         b = DAE.EQBOUND(e, NONE(), c, s);
@@ -3323,7 +3323,7 @@ algorithm
         true = Types.isRecord(tyElement);
         // print("CREF VB: " + ComponentReference.printComponentRefStr(inCref) + "\nTyParent: " + Types.printTypeStr(inParentType) + "\nParent:\n" + Types.printBindingStr(inParentBinding) + "\nChild:\n" + Types.printBindingStr(inChildBinding) + "\n");
         e = ValuesUtil.valueExp(v);
-        DAE.RECORD(_, exps, comp, _) = Expression.subscriptExp(e, ss);
+        DAE.RECORD(_, exps, comp, _) = Expression.applyExpSubscripts(e, ss);
 
         e = listGet(exps, List.position(cId, comp));
 

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -6984,7 +6984,7 @@ template daeExpAsub(Exp inExp, Context context, Text &preExp,
     error(sourceInfo(),'ASUB_EASY_CASE type:<%unparseType(t)%> range:<%ExpressionDumpTpl.dumpExp(exp,"\"")%> index:<%ExpressionDumpTpl.dumpExp(idx,"\"")%>')
 
   case ASUB(exp=ecr as CREF(__), sub=subs) then
-    daeExpCrefRhs(buildCrefExpFromAsub(ecr, subs), context, &preExp, &varDecls, &auxFunction)
+    daeExpCrefLhs(buildCrefExpFromAsub(ecr, subs), context, &preExp, &varDecls, &auxFunction, false)
 
   case ASUB(exp=e, sub=indexes) then
     let exp = daeExp(e, context, &preExp, &varDecls, &auxFunction)

--- a/testsuite/simulation/modelica/inlineFunction/testBug6205.mos
+++ b/testsuite/simulation/modelica/inlineFunction/testBug6205.mos
@@ -1,0 +1,53 @@
+// name: ticket6205
+// status: correct
+
+// test inlining of function which has crefs with slices
+
+
+loadString("
+function f
+  input Integer sz;
+  input Real x[sz];
+  input Real y[sz];
+  input Integer i;
+  output Real z;
+algorithm
+  z := x[1:i] * y[1:i] + 1;
+  annotation(Inline = true);
+end f;
+
+model M
+  Real x[3] = {time, time, time};
+  Real y[3] = {time, time, time};
+  Real z;
+  Integer i = integer(time + 1);
+algorithm
+  when time > 0 then
+    z := f(3, x, y, i);
+  end when;
+end M;
+");
+getErrorString();
+
+simulate(M);
+getErrorString();
+
+val(z, {0.0,1.0});
+getErrorString();
+
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "M_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// {0.0,1.0}
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

#6205

### Purpose

- Improves the way types of slice arrays are computed in the Frontend and Backend. 
- Improve code generation of ASUB expressions.   

### Approach

<!--- How does this address the problem? -->

@mahge
Compute proper dimensions for subscripting. …
88d8756
    - Handle subscripting with slices and whole_dims when computing the
      type of a cref.

@mahge
Use the LHS cref generation functions. …
03259fb
  - This was using the RHS generation function by mistake.

@mahge
Use the updated subscripting function. …
235ab73
  - Change applyExpSubscripts to use the updated `applyExpSubscripts2`
    instead of `applyExpSubscriptsFoldCheckSimplify`. The latter builds
    ASUBs for everything.

  - I have not removed the `applyExpSubscriptsFoldCheckSimplify` function
    because it is used in the backend and it is not easy to figure out
    what it is supposed to return for some fold arguments.

@mahge
Compute the type after applying the subscripts.
86be9b3

@mahge
Add the example model from #6205 as test. …
9b9bb80
  - The model has been modified a bit to avoid zero size arrays and to
    give different results at different times.
