### PR TITLE
Allow partial calls in removed bindings

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -172,6 +172,7 @@ public
           if(BuiltinCall.needSpecialHandling(call)) then
             (outExp, ty, var, pur) := BuiltinCall.typeSpecial(call, context, info);
           else
+            checkNotPartial(cref, context, info);
             ty_call := typeMatchNormalCall(call, context, info);
             ty := typeOf(ty_call);
             var := variability(ty_call);
@@ -199,6 +200,7 @@ public
 
       case UNTYPED_REDUCTION()
         algorithm
+          checkNotPartial(call.ref, context, info);
           (ty_call, ty, var, pur) := typeReduction(call, context, info);
         then
           Expression.CALL(ty_call);
@@ -233,6 +235,18 @@ public
         then fail();
     end match;
   end typeCall;
+
+  function checkNotPartial
+    input ComponentRef fnRef;
+    input InstContext.Type context;
+    input SourceInfo info;
+  algorithm
+    if InstNode.isPartial(ComponentRef.node(fnRef)) and not InstContext.inRelaxed(context) then
+      Error.addSourceMessage(Error.PARTIAL_FUNCTION_CALL,
+        {ComponentRef.toString(fnRef)}, info);
+      fail();
+    end if;
+  end checkNotPartial;
 
   function typeNormalCall
     input output NFCall call;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -347,13 +347,6 @@ uniontype Function
   algorithm
     fn_ref := lookupFunction(functionName, scope, context, info);
     (fn_ref, fn_node, specialBuiltin) := instFunctionRef(fn_ref, context, info);
-
-    if (InstNode.isClass(ComponentRef.node(fn_ref)) and InstNode.isPartial(fn_node)) and
-       not InstContext.inRelaxed(context) then
-      Error.addSourceMessage(Error.PARTIAL_FUNCTION_CALL,
-        {InstNode.name(fn_node)}, info);
-      fail();
-    end if;
   end instFunction;
 
   function instFunctionRef

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -778,6 +778,7 @@ PartialApplicationInvalidArg1.mo \
 PartialApplicationInvalidArg2.mo \
 PartialClass1.mo \
 PartialFunction1.mo \
+PartialFunction2.mo \
 PartialLookup1.mo \
 PartialLookup2.mo \
 PartialType1.mo \

--- a/testsuite/flattening/modelica/scodeinst/PartialFunction2.mo
+++ b/testsuite/flattening/modelica/scodeinst/PartialFunction2.mo
@@ -1,0 +1,19 @@
+// name: PartialFunction2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+partial function f
+  input Real x;
+  output Real y;
+end f;
+
+class PartialFunction2
+  Real x = f(time) if false;
+end PartialFunction2;
+
+// Result:
+// class PartialFunction2
+// end PartialFunction2;
+// endResult


### PR DESCRIPTION
- Move the check for partial function calls from the instantiation to
  the typing, to allow such calls in bindings of removed conditional
  components.