### PR TITLE
Add $cpuTime variable to the variables list if cpu time flag is set

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -736,6 +736,13 @@ bool VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
   std::sort(variablesList.begin(), variablesList.end(), StringHandler::naturalSortForResultVariables);
   // remove time from variables list
   variablesList.removeOne("time");
+  /* Fixes issue #7551
+   * Add the $cpuTime variable to the list if cpu time flag is set.
+   * We read the variables from model_init.xml file that doesn't contain $cpuTime variable but is present in model_res.mat file.
+   */
+  if (simulationOptions.isValid() && simulationOptions.getCPUTime()) {
+    variablesList.append("$cpuTime");
+  }
   QStringList variables;
   foreach (QString plotVariable, variablesList) {
     QString parentVariable = "";


### PR DESCRIPTION
### Related Issues

Fixes #7551

### Purpose

Show the $cpuTime variable in the Variables Browser when cpu time flag is set.

### Approach

Add the variable to the list when the cpu time flag is on.
