### PR TITLE
Fix initialization expressions for consts in Cpp runtime

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -2125,7 +2125,7 @@ template daeExpCall(Exp call, Context context, Text &preExp /*BUFP*/, Text &varD
 
     let argStr = (expLst |> exp => '<%daeExp(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>' ;separator=",")
     let funName = '<%underscorePath(path)%>'
-    let retType = '<%funName%>RetType /* undefined */'
+    let retType = '<%funName%>RetType'
     let retVar = tempDecl(retType, &varDecls)
     let &preExp += '<%contextFunName(funName, context)%>(<%argStr%><%if expLst then if retVar then "," %><%retVar%>);<%\n%>'
     '<%retVar%>'
@@ -2145,7 +2145,7 @@ template daeExpCall(Exp call, Context context, Text &preExp /*BUFP*/, Text &varD
     else
     /*end workaround*/
     let argStr = (explist |> exp => '<%daeExp(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>' ;separator=", ")
-    let retType = '<%funName%>RetType /* undefined */'
+    let retType = '<%funName%>RetType'
     let retVar = tempDecl(retType, &varDecls)
     let &preExp += match context case FUNCTION_CONTEXT(__) then'<%funName%>(<%argStr%><%if explist then if retVar then "," %><%if retVar then '<%retVar%>'%>);<%\n%>'
     else '<%contextFunName(funName, context)%>(<%argStr%><%if explist then if retVar then "," %> <%if retVar then '<%retVar%>'%>);<%\n%>'
@@ -2913,9 +2913,9 @@ template daeExpTsub(Exp inExp, Context context, Text &preExp,
   case TSUB(exp=CALL(path=p,attr=CALL_ATTR(ty=tys as T_TUPLE(__)))) then
     //let v = tempDecl(expTypeArrayIf(listGet(tys,ix)), &varDecls)
     //let additionalOutputs = List.restOrEmpty(tys) |> ty hasindex i1 fromindex 2 => if intEq(i1,ix) then ', &<%v%>' else ", NULL"
-     let retType = '<%underscorePath(p)%>RetType /* undefined */'
+    let retType = '<%underscorePath(p)%>RetType'
     let retVar = tempDecl(retType, &varDecls)
-     let res = daeExpCallTuple(exp,retVar, context, &preExp, &varDecls, simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    let res = daeExpCallTuple(exp, retVar, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let &preExp += '<%res%>;<%\n%>'
     'get<<%intAdd(-1,ix)%>>(<%retVar%>.data)'
 

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -8570,19 +8570,25 @@ template initConstValue(SimVar var, SimCode simCode, Text stateDerVectorName /*=
     case SIMVAR(numArrayElement=_::_) then ''
     case SIMVAR(type_=type,name=name) then
       match initialValue
-        case SOME(v) then '<%cref(name, useFlatArrayNotation)%> = <%initConstValue2(v, simCode, stateDerVectorName, useFlatArrayNotation)%>;'
+        case SOME(v) then
+          let &preExp = buffer ""
+          let &varDecls = buffer ""
+          let initValue = initConstValue2(v, &preExp, &varDecls, simCode, stateDerVectorName, useFlatArrayNotation)
+          <<
+          <%varDecls%>
+          <%preExp%>
+          <%cref(name, useFlatArrayNotation)%> = <%initValue%>;
+          >>
         else
           match type
             case T_STRING(__) then '<%cref(name, useFlatArrayNotation)%> = "";'
             else '<%cref(name, useFlatArrayNotation)%> = 0;'
 end initConstValue;
 
-template initConstValue2(Exp initialValue, SimCode simCode, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+template initConstValue2(Exp initialValue, Text &preExp, Text &varDecls, SimCode simCode, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
   match initialValue
     case v then
-      let &preExp = buffer "" //dummy ... the value is always a constant
-      let &varDecls = buffer ""
       let &extraFuncs = buffer ""
       let &extraFuncsDecl = buffer ""
       let &extraFuncsNamespace = buffer ""

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -15,6 +15,7 @@ clockedTest.mos \
 externalArrayInputTest.mos \
 mathFunctionsTest.mos \
 mslDistributionsTest.mos \
+mslElectricalMachinesTest.mos \
 mslElectricalSensorsTest.mos \
 nameClashTest.mos \
 functionPointerTest.mos \

--- a/testsuite/openmodelica/cppruntime/mslElectricalMachinesTest.mos
+++ b/testsuite/openmodelica/cppruntime/mslElectricalMachinesTest.mos
@@ -1,0 +1,30 @@
+// name: mslElectricalMachinesTest
+// keywords: init const string substring
+// status: correct
+// teardown_command: rm -f *AIMC_Transformer*
+// cflags: -d=newInst
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+
+simulate(Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer);
+val(currentQuasiRMSSensor.I, 2.5);
+val(aimc.wMechanical, 2.5);
+val(aimc.tauElectrical, 2.5);
+getErrorString();
+
+// Result:
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.5, numberOfIntervals = 25000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// 173.2163692829597
+// 150.8434362116317
+// 161.3997191190022
+// ""
+// endResult


### PR DESCRIPTION
This lets 8 examples from MSL fail to compile, e.g.
`Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer`

```
./OMCppModelica_3.2.3_cpp_Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer.cpp:3180:28:
error: use of undeclared identifier 'tmp37'
  _transformerData_P_C1_ = tmp37;
                           ^
```