### PR TITLE
Remove Cpp error ASUB_EASY_CASE -- apply regular case instead

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -1572,25 +1572,23 @@ template daeExpAsub(Exp inExp, Context context, Text &preExp, Text &varDecls, Si
     >>
    '<%res%>'
 
-  case ASUB(exp=RANGE(ty=t), sub={idx}) then
-    error(sourceInfo(),'ASUB_EASY_CASE <%ExpressionDumpTpl.dumpExp(exp,"\"")%>')
-
- case ASUB(exp=ecr as CREF(__), sub=subs) then
+  case ASUB(exp=ecr as CREF(__), sub=subs) then
     let arrName =  daeExpCrefRhs(buildCrefExpFromAsub(ecr, subs), context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     match context case FUNCTION_CONTEXT(__)  then
       arrName
     else
       '<%arrayScalarRhs(ecr.ty, subs, arrName, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
+
   case ASUB(exp=e, sub=indexes) then
-  let exp = daeExp(e, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-  // let typeShort = expTypeFromExpShort(e)
-  let expIndexes = (indexes |> index => '<%daeExpASubIndex(index, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>' ;separator=",")
-   //'<%typeShort%>_get<%match listLength(indexes) case 1 then "" case i then '_<%i%>D'%>(&<%exp%>, <%expIndexes%>)'
-  '(<%exp%>)(<%expIndexes%>)'
+    let exp = daeExp(e, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    // let typeShort = expTypeFromExpShort(e)
+    let expIndexes = (indexes |> index => '<%daeExpASubIndex(index, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>' ;separator=",")
+    //'<%typeShort%>_get<%match listLength(indexes) case 1 then "" case i then '_<%i%>D'%>(&<%exp%>, <%expIndexes%>)'
+    '(<%exp%>)(<%expIndexes%>)'
+
   case exp then
     error(sourceInfo(),'OTHER_ASUB <%ExpressionDumpTpl.dumpExp(exp,"\"")%>')
 end daeExpAsub;
-
 
 
 template daeExpASubIndex(Exp exp, Context context, Text &preExp, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl,

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -17,6 +17,7 @@ mathFunctionsTest.mos \
 mslDistributionsTest.mos \
 mslElectricalMachinesTest.mos \
 mslElectricalSensorsTest.mos \
+mslMathFFT1Test.mos \
 nameClashTest.mos \
 functionPointerTest.mos \
 recordTupleReturnTest.mos \

--- a/testsuite/openmodelica/cppruntime/mslMathFFT1Test.mos
+++ b/testsuite/openmodelica/cppruntime/mslMathFFT1Test.mos
@@ -8,7 +8,12 @@ setCommandLineOptions("+simCodeTarget=Cpp");
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 
+// simulate without echo to avoid a message with absolute path name
+echo(false);
 simulate(Modelica.Math.FastFourierTransform.Examples.RealFFT1);
+echo(true);
+
+// log some test results
 val(Ai[1], 6.0);
 val(Ai[11], 6.0);
 val(Ai[16], 6.0);
@@ -21,12 +26,7 @@ getErrorString();
 // true
 // true
 // ""
-// record SimulationResult
-//     resultFile = "Modelica.Math.FastFourierTransform.Examples.RealFFT1_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 6.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Math.FastFourierTransform.Examples.RealFFT1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "... FFT result computed at time = 4.975000 s stored on file: /home/rfranke/OpenModelica/testsuite/openmodelica/cppruntime/RealFFT1_resultFFT.mat
-// "
-// end SimulationResult;
+// true
 // 4.999999999999999
 // 2.97029702970297
 // 1.485148514851486

--- a/testsuite/openmodelica/cppruntime/mslMathFFT1Test.mos
+++ b/testsuite/openmodelica/cppruntime/mslMathFFT1Test.mos
@@ -1,0 +1,37 @@
+// name: mslMathFFT1Test
+// keywords: array slice asub
+// status: correct
+// teardown_command: rm -f *RealFFT1*
+// cflags: -d=newInst
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+
+simulate(Modelica.Math.FastFourierTransform.Examples.RealFFT1);
+val(Ai[1], 6.0);
+val(Ai[11], 6.0);
+val(Ai[16], 6.0);
+val(fi[1], 6.0);
+val(fi[11], 6.0);
+val(fi[16], 6.0);
+getErrorString();
+
+// Result:
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Modelica.Math.FastFourierTransform.Examples.RealFFT1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 6.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Math.FastFourierTransform.Examples.RealFFT1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "... FFT result computed at time = 4.975000 s stored on file: /home/rfranke/OpenModelica/testsuite/openmodelica/cppruntime/RealFFT1_resultFFT.mat
+// "
+// end SimulationResult;
+// 4.999999999999999
+// 2.97029702970297
+// 1.485148514851486
+// 0.0
+// 2.0
+// 3.0
+// ""
+// endResult


### PR DESCRIPTION
This fixes 4 MSL examples, see e.g. `Modelica.Math.FastFourierTransform.Examples.RealFFT1`
```
[CodegenCppCommonOld.tpl:1597:11-1597:11:writable] Error: Template error: ASUB_EASY_CASE 1:nfi.
```