### PR TITLE
Fix #5991

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -1647,20 +1647,23 @@ public
       case UNTYPED_ARRAY_CONSTRUCTOR()
         algorithm
           (e, foldArg) := Expression.mapFold(call.exp, func, foldArg);
+          (iters, foldArg) := mapFoldIteratorsExp(call.iters, func, foldArg);
         then
-          UNTYPED_ARRAY_CONSTRUCTOR(e, call.iters);
+          UNTYPED_ARRAY_CONSTRUCTOR(e, iters);
 
       case TYPED_ARRAY_CONSTRUCTOR()
         algorithm
           (e, foldArg) := Expression.mapFold(call.exp, func, foldArg);
+          (iters, foldArg) := mapFoldIteratorsExp(call.iters, func, foldArg);
         then
-          TYPED_ARRAY_CONSTRUCTOR(call.ty, call.var, call.purity, e, call.iters);
+          TYPED_ARRAY_CONSTRUCTOR(call.ty, call.var, call.purity, e, iters);
 
       case UNTYPED_REDUCTION()
         algorithm
           (e, foldArg) := Expression.mapFold(call.exp, func, foldArg);
+          (iters, foldArg) := mapFoldIteratorsExp(call.iters, func, foldArg);
         then
-          UNTYPED_REDUCTION(call.ref, e, call.iters);
+          UNTYPED_REDUCTION(call.ref, e, iters);
 
       case TYPED_REDUCTION()
         algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -473,9 +473,6 @@ function subscriptBinding
 protected
   list<Subscript> subs;
 algorithm
-  exp := Expression.mapFold(exp,
-    function subscriptBinding2(cref = cref, evalSubscripts = evalSubscripts), NONE());
-
   subs := ComponentRef.getSubscripts(cref);
 
   if evalSubscripts then
@@ -483,6 +480,8 @@ algorithm
   end if;
 
   exp := Expression.applySubscripts(subs, exp);
+  exp := Expression.mapFold(exp,
+    function subscriptBinding2(cref = cref, evalSubscripts = evalSubscripts), NONE());
 end subscriptBinding;
 
 function subscriptBinding2
@@ -683,6 +682,7 @@ protected
   InstContext.Type exp_context;
   Binding binding;
   Component comp;
+  list<Subscript> subs;
 algorithm
   parent_cr := ComponentRef.rest(cref);
   parent := ComponentRef.node(parent_cr);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -773,6 +773,7 @@ public
   function simplifyList
     input list<Subscript> subscripts;
     input list<Dimension> dimensions;
+    input Boolean trim = false;
     output list<Subscript> outSubscripts = {};
   protected
     Dimension d;
@@ -790,7 +791,9 @@ public
         outSubscripts := simplify(s, d) :: outSubscripts;
       end for;
 
-      if not List.all(outSubscripts, isWhole) then
+      if trim then
+        outSubscripts := listReverseInPlace(List.trim(outSubscripts, isWhole));
+      else
         outSubscripts := listReverseInPlace(outSubscripts);
       end if;
     end if;
@@ -1136,16 +1139,16 @@ public
     end match;
   end hash;
 
-  function splitIndexDimSize
+  function splitIndexDimExp
     input Subscript sub;
-    output Integer size;
+    output Expression exp;
   protected
     InstNode node;
     Integer index;
   algorithm
     SPLIT_INDEX(node = node, dimIndex = index) := sub;
-    size := Dimension.size(Type.nthDimension(InstNode.getType(node), index));
-  end splitIndexDimSize;
+    exp := Dimension.sizeExp(Type.nthDimension(InstNode.getType(node), index));
+  end splitIndexDimExp;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFSubscript;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1099,7 +1099,7 @@ public
             fail();
           end if;
         then
-          ty;
+          Type.UNKNOWN();
 
     end match;
   end subscript;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1421,11 +1421,16 @@ algorithm
     expanded_subs := List.trim(expanded_subs, Subscript.isWhole);
     if not listEmpty(expanded_subs) then
       expanded_subs := listReverseInPlace(expanded_subs);
-      // Subscripting the type might not be possible if the type is wrong, but
-      // we ignore that here and handle it during type checking instead when we
-      // can give better error messages.
+      // Subscripting the expression might not be possible if the type is wrong,
+      // but we ignore it here so we can handle it during type checking instead
+      // when we can give better error messages.
       ty := Type.subscript(ty, expanded_subs, failOnError = false);
-      exp := Expression.SUBSCRIPTED_EXP(exp, expanded_subs, ty, true);
+
+      if Type.isUnknown(ty) then
+        exp := Expression.SUBSCRIPTED_EXP(exp, expanded_subs, ty, true);
+      else
+        exp := Expression.applySubscripts(expanded_subs, exp);
+      end if;
 
       // Take the purity and variability of the subscripts into consideration.
       if purity == Purity.PURE then

--- a/testsuite/flattening/modelica/scodeinst/CevalRecordArray6.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalRecordArray6.mo
@@ -1,0 +1,61 @@
+// name: CevalRecordArray6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model MultiLayer
+  parameter Generic layers;
+  SingleLayer[3] lay(nSta = {layers.nSta[i] for i in 1:3});
+end MultiLayer;
+
+model SingleLayer
+  Real[nSta] u;
+  parameter Integer nSta;
+end SingleLayer;
+
+record Generic
+  parameter Integer[3] nSta = {1 for i in 1:3};
+end Generic;
+
+model Construction
+  parameter Generic layers;
+  MultiLayer opa(layers = layers);
+end Construction;
+
+record ParameterConstruction
+  parameter Generic layers;
+end ParameterConstruction;
+
+model RoomHeatMassBalance
+  parameter ParameterConstruction[1] datConExtWin;
+  Construction[1] conExtWin(layers = datConExtWin.layers);
+end RoomHeatMassBalance;
+
+model CevalRecordArray6
+  final parameter Generic conExtWal;
+  RoomHeatMassBalance roo(datConExtWin(layers = {conExtWal}));
+end CevalRecordArray6;
+
+// Result:
+// class CevalRecordArray6
+//   final parameter Integer conExtWal.nSta[1] = 1;
+//   final parameter Integer conExtWal.nSta[2] = 1;
+//   final parameter Integer conExtWal.nSta[3] = 1;
+//   parameter Integer roo.datConExtWin[1].layers.nSta[1] = conExtWal.nSta[1];
+//   parameter Integer roo.datConExtWin[1].layers.nSta[2] = conExtWal.nSta[2];
+//   parameter Integer roo.datConExtWin[1].layers.nSta[3] = conExtWal.nSta[3];
+//   parameter Integer roo.conExtWin[1].layers.nSta[1] = roo.datConExtWin[1].layers.nSta[1];
+//   parameter Integer roo.conExtWin[1].layers.nSta[2] = roo.datConExtWin[1].layers.nSta[2];
+//   parameter Integer roo.conExtWin[1].layers.nSta[3] = roo.datConExtWin[1].layers.nSta[3];
+//   final parameter Integer roo.conExtWin[1].opa.layers.nSta[1] = 1;
+//   final parameter Integer roo.conExtWin[1].opa.layers.nSta[2] = 1;
+//   final parameter Integer roo.conExtWin[1].opa.layers.nSta[3] = 1;
+//   Real roo.conExtWin[1].opa.lay[1].u[1];
+//   final parameter Integer roo.conExtWin[1].opa.lay[1].nSta = 1;
+//   Real roo.conExtWin[1].opa.lay[2].u[1];
+//   final parameter Integer roo.conExtWin[1].opa.lay[2].nSta = 1;
+//   Real roo.conExtWin[1].opa.lay[3].u[1];
+//   final parameter Integer roo.conExtWin[1].opa.lay[3].nSta = 1;
+// end CevalRecordArray6;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -170,6 +170,7 @@ CevalRecordArray1.mo \
 CevalRecordArray2.mo \
 CevalRecordArray4.mo \
 CevalRecordArray5.mo \
+CevalRecordArray6.mo \
 CevalRelation1.mo \
 CevalRem1.mo \
 CevalScalar1.mo \


### PR DESCRIPTION
- Handle split subscripts after applying the cref subscripts in
  Ceval.subscriptBinding instead of before.
- Handle split subscripts in Expression.applySubscriptRange.
- Fix type in Expression.recordElement.
- Fix order of subscripts in Expression.mapSplitExpressions.
- Handle jagged subscripted arrays in Expression.mapSplitExpressions.
- Handle split subscripts in crefs during flattening.
- Use Expression.applySubscripts instead of creating a subscripted
  expression directly in Typing.typeSubscriptedExp.
- Map over iterator expressions too in Call.mapFoldExp.