### PR TITLE
Fix Cpp error "size(X) not implemented"

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -1210,11 +1210,11 @@ template daeExpSize(Exp exp, Context context, Text &preExp, Text &varDecls, SimC
  "Generates code for a size expression."
 ::=
   match exp
-  case SIZE(exp=CREF(__), sz=SOME(dim)) then
+  case SIZE(sz=SOME(dim)) then
     let expPart = daeExp(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let dimPart = daeExp(dim, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     '<%expPart%>.getDim(<%dimPart%>)'
-  case SIZE(exp=CREF(__)) then
+  case SIZE(sz=NONE()) then
     let expPart = daeExp(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let tmp = tempDecl("vector<size_t>", &varDecls)
     let &preExp +=
@@ -1225,7 +1225,7 @@ template daeExpSize(Exp exp, Context context, Text &preExp, Text &varDecls, SimC
         <%tmp%>_size(<%tmp%>_i) = (int)<%tmp%>[<%tmp%>_i-1];<%\n%>
       >>
     '<%tmp%>_size'
-  else "size(X) not implemented"
+  else error(sourceInfo(), ExpressionDumpTpl.dumpExp(exp,"\"") + " not implemented")
 end daeExpSize;
 
 


### PR DESCRIPTION
This happened for two models from MSL and three models from ModelicaTest.
For example, the code generation for Modelica.Fluid.Examples.IncompressibleFluidNetwork
calls daeExpSize for a literal, unrolled array instead of a cref supported so far.
```
./OMCppModelica_3.2.3_cpp_Modelica.Fluid.Examples.IncompressibleFluidNetworkFunctions.cpp:7594:19: error: expected \')\'
    if (!(size(X) not implemented > 0))
```