### PR TITLE
Fix ConvertDAE.makeTypeRecordVar

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -50,6 +50,7 @@ import ElementSource;
 import ExecStat.execStat;
 import Expression = NFExpression;
 import Flags;
+import Flatten = NFFlatten;
 import Function = NFFunction.Function;
 import MetaModelica.Dangerous.listReverseInPlace;
 import Class = NFClass;
@@ -1240,7 +1241,7 @@ algorithm
 
   binding := Component.getBinding(comp);
   binding := Binding.mapExp(binding, stripScopePrefixExp);
-  binding := Binding.mapExpShallow(binding, Expression.expandSplitIndices);
+  binding := Flatten.flattenBinding(binding, ComponentRef.EMPTY());
   bind_from_outside := Binding.source(binding) == NFBinding.Source.MODIFIER;
 
   ty := Component.getType(comp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -907,7 +907,7 @@ algorithm
   end if;
 end subscriptBindingOpt;
 
-function flattenBinding
+public function flattenBinding
   input output Binding binding;
   input ComponentRef prefix;
   input Boolean isTypeAttribute = false;


### PR DESCRIPTION
- Flatten the binding when taking the binding from a component to get
  rid of any split subscripts in it.