### PR TITLE
Fallback to ASUB if applying subs gets complicated

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -1022,19 +1022,16 @@ algorithm
     case(_, {}) then inExp;
 
     case(DAE.CREF(cref, ty), _)
-      equation
-        cref = ComponentReference.subscriptCref(cref, inSubs);
-        ty = ComponentReference.crefTypeFull(cref);
+      algorithm
+        try
+          cref := ComponentReference.subscriptCref(cref, inSubs);
+          ty := ComponentReference.crefTypeFull(cref);
+          exp := DAE.CREF(cref, ty);
+        else
+          exp := applyExpSubscriptsFoldCheckSimplify(inExp, inSubs);
+        end try;
       then
-        DAE.CREF(cref, ty);
-
-    /*
-    case(DAE.ARRAY(_, _, explst), sub::restsubs)
-      equation
-        exp = listGet(explst, subscriptInt(sub));
-      then
-        applyExpSubscripts2(exp, restsubs);
-    */
+        exp;
 
     // This is the default operation for exps not handled explicitly. It is unfortunate
     // we have to build ASUBs. But we can improve this step by step to exclude more exps.


### PR DESCRIPTION
 Sometimes we try to apply subscripts to sliced crefs internally.
    Something that looks like this is created internally due to inlining:

      Real a[3];
    algorithm
      a[1:2][1];
 

  - We will need to fix the function ComponentReference.subscriptCref to
    avoid creating ASUBs for things like this. That function has more
    issues for now. It will need more work than just fixing that function
    as changing it leads to failing models in the testsuite.
