### PR TITLE
Fix Cpp functions passing through function pointers

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -341,6 +341,8 @@ template daeExpCref(Boolean isLhs, Exp ecr, Context context, Text &preExp, Text 
  "Generates code for a component reference."
 ::=
 match ecr
+case component as CREF(componentRef=cr, ty=T_FUNCTION(path=name)) then
+  underscorePath(name)
 case component as CREF(componentRef=cr, ty=ty) then
   let box = daeExpCrefRhsArrayBox(cr, ty, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   if box then
@@ -664,6 +666,8 @@ template expTypeShort(DAE.Type type)
   case T_COMPLEX(__)     then '<%underscorePath(ClassInf.getStateName(complexClassType))%>Type'
   case T_METATYPE(__)
   case T_METABOXED(__)   then "metatype"
+  case T_FUNCTION(__)
+  case T_FUNCTION_REFERENCE_FUNC(__)
   case T_FUNCTION_REFERENCE_VAR(__) then "fnptr"
   else 'expTypeShort:ERROR <%unparseType(type)%> '
 end expTypeShort;
@@ -785,6 +789,8 @@ template expTypeShortSPS(DAE.Type type)
                       then "type not supported"
   case T_COMPLEX(__)     then '<%underscorePath(ClassInf.getStateName(complexClassType))%>Type'
   case T_METATYPE(__) case T_METABOXED(__)    then "type not supported"
+  case T_FUNCTION(__)
+  case T_FUNCTION_REFERENCE_FUNC(__)
   case T_FUNCTION_REFERENCE_VAR(__) then "type not supported"
   else "expTypeShort:ERROR"
 end expTypeShortSPS;
@@ -805,6 +811,8 @@ template expTypeShortMLPI(DAE.Type type)
                       then "type not supported"
   case T_COMPLEX(__)     then '<%underscorePath(ClassInf.getStateName(complexClassType))%>Type'
   case T_METATYPE(__) case T_METABOXED(__)    then "type not supported"
+  case T_FUNCTION(__)
+  case T_FUNCTION_REFERENCE_FUNC(__)
   case T_FUNCTION_REFERENCE_VAR(__) then "type not supported"
   else "expTypeShort:ERROR"
 end expTypeShortMLPI;

--- a/testsuite/openmodelica/cppruntime/functionPointerTest.mos
+++ b/testsuite/openmodelica/cppruntime/functionPointerTest.mos
@@ -14,21 +14,21 @@ package FunctionPointer
     output Real y;
   end pfunc;
 
-  function func0
+  function func
     input Real u;
     output Real y;
   algorithm
     y := 2*u;
-  end func0;
+  end func;
 
-  function func
+  function func2
     input Real u;
     input Real v;
     input Integer[:] w;
     output Real y;
   algorithm
     y := u + v + sum(w);
-  end func;
+  end func2;
 
   function feval
     input FunctionPointer.pfunc f;
@@ -43,15 +43,24 @@ package FunctionPointer
     input Real u;
     output Real y;
   algorithm
-    y := f(u) + feval(function func(v = u, w = {integer(u)}), u);
+    y := f(u) + feval(function func2(v = u, w = {integer(u)}), u);
   end feval2;
+
+  function feval3
+    input FunctionPointer.pfunc f;
+    input Real u;
+    output Real y;
+  algorithm
+    y := f(u) + feval(function f(), u);
+  end feval3;
 
   model Test
     input Real u = 0; // prevent presolving
-    Real x, y;
+    Real x, y, z;
   equation
-    x = feval2(function func0(), u + 4);
-    y = feval2(function func(v = 1, w = {2, 3}), u + 4);
+    x = feval2(function func(), u + 4);
+    y = feval2(function func2(v = 1, w = {2, 3}), u + 4);
+    z = feval3(function func(), u + 4);
     annotation(experiment(StopTime = 0));
   end Test;
 end FunctionPointer;
@@ -61,6 +70,7 @@ getErrorString();
 simulate(FunctionPointer.Test);
 val(x, 0);
 val(y, 0);
+val(z, 0);
 getErrorString();
 
 // Result:
@@ -69,11 +79,12 @@ getErrorString();
 // true
 // ""
 // record SimulationResult
-// resultFile = "FunctionPointer.Test_res.mat",
-// simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'FunctionPointer.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-// messages = ""
+//     resultFile = "FunctionPointer.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'FunctionPointer.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
 // end SimulationResult;
 // 20.0
 // 22.0
+// 16.0
 // ""
 // endResult


### PR DESCRIPTION
The trailing underscore must be omitted for function names as call args.
See Modelica.Math.Nonlinear.Examples.QuadratureLobatto3

```
./OMCppModelica_trunk_cpp_Modelica.Math.Nonlinear.Examples.QuadratureLobatto3Functions.cpp:357:58: error: use of undeclared identifier 'f_'
      Modelica_Math_Nonlinear_quadratureLobatto_quadStep(f_, a_, mll_, fa_, fmll_, is_,tmp14);
```