### PR TITLE
fix #7594

### DIFF
--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -91,7 +91,9 @@ Ticket6287and6288.mos \
 Ticket6300.mos \
 Ticket6307.mos \
 Ticket6406.mos \
-ReadOnlyPkg.mos
+ReadOnlyPkg.mos \
+getComponentsTestNF.mos \
+getComponentsTestOF.mos
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/openmodelica/interactive-API/getComponentsTestNF.mos
+++ b/testsuite/openmodelica/interactive-API/getComponentsTestNF.mos
@@ -1,0 +1,93 @@
+// name: getComponentsTestNF.mos
+// keywords:
+// status: correct
+// cflags: -d=nfAPI
+//
+
+loadModel(Modelica, {"4.0.0"}); getErrorString();
+y := getComponentsTest(Modelica.Thermal.HeatTransfer.Examples.TwoMasses); getErrorString();
+
+// Result:
+// true
+// ""
+// {record OpenModelica.Scripting.getComponentsTest.Component
+//     className = "Modelica.Units.SI.Temperature",
+//     name = "T_final_K",
+//     comment = "Projected final temperature",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "parameter",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = "Modelica.Thermal.HeatTransfer.Components.HeatCapacitor",
+//     name = "mass1",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = "Modelica.Thermal.HeatTransfer.Components.HeatCapacitor",
+//     name = "mass2",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = "Modelica.Thermal.HeatTransfer.Components.ThermalConductor",
+//     name = "conduction",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = "Modelica.Thermal.HeatTransfer.Celsius.TemperatureSensor",
+//     name = "Tsensor1",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = "Modelica.Thermal.HeatTransfer.Celsius.TemperatureSensor",
+//     name = "Tsensor2",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;}
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/getComponentsTestOF.mos
+++ b/testsuite/openmodelica/interactive-API/getComponentsTestOF.mos
@@ -1,0 +1,93 @@
+// name: getComponentsTestOF.mos
+// keywords:
+// status: correct
+// cflags: -d=-newInst
+//
+
+loadModel(Modelica, {"4.0.0"}); getErrorString();
+y := getComponentsTest(Modelica.Thermal.HeatTransfer.Examples.TwoMasses); getErrorString();
+
+// Result:
+// true
+// ""
+// {record OpenModelica.Scripting.getComponentsTest.Component
+//     className = ".Modelica.Units.SI.Temperature",
+//     name = "T_final_K",
+//     comment = "Projected final temperature",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "parameter",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = ".Modelica.Thermal.HeatTransfer.Components.HeatCapacitor",
+//     name = "mass1",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = ".Modelica.Thermal.HeatTransfer.Components.HeatCapacitor",
+//     name = "mass2",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = ".Modelica.Thermal.HeatTransfer.Components.ThermalConductor",
+//     name = "conduction",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = ".Modelica.Thermal.HeatTransfer.Celsius.TemperatureSensor",
+//     name = "Tsensor1",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;,record OpenModelica.Scripting.getComponentsTest.Component
+//     className = ".Modelica.Thermal.HeatTransfer.Celsius.TemperatureSensor",
+//     name = "Tsensor2",
+//     comment = "",
+//     isProtected = false,
+//     isFinal = false,
+//     isFlow = false,
+//     isStream = false,
+//     isReplaceable = false,
+//     variability = "",
+//     innerOuter = "",
+//     inputOutput = "",
+//     dimensions = {}
+// end OpenModelica.Scripting.getComponentsTest.Component;}
+// ""
+// endResult


### PR DESCRIPTION
- make getComponentsTest work with new instantiation and -d=nfAPI
- make getComponentsTest work with old instantiation via -d=-newInst

### Purpose

Fix getComponentsTest API

### Approach

Implement it for the new frontend, fix an issue for the old frontend.


