### PR TITLE
fix #7534 add --linkType=dynamic|static

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -228,7 +228,7 @@ public function compileModel "Compiles a model given a file-prefix, helper funct
 protected
   String omhome = Settings.getInstallationDirectoryPath(),omhome_1 = System.stringReplace(omhome, "\"", "");
   String pd = Autoconf.pathDelimiter;
-  String cdWorkingDir,setMakeVars,libsfilename,libs_str,s_call,filename,winCompileMode,workDir = (if stringEq(workingDir, "") then "" else workingDir + pd);
+  String cdWorkingDir,setMakeVars,libsfilename,libs_str,s_call,filename,winCompileMode,workDir = (if stringEq(workingDir, "") then "" else workingDir + pd), linkType = "dynamic";
   String fileDLL = workDir + fileprefix + Autoconf.dllExt,
          fileEXE = workDir + fileprefix + Autoconf.exeExt,
          fileLOG = workDir + fileprefix + ".log";
@@ -252,7 +252,13 @@ algorithm
     setMakeVars := sum("set "+var+"&& " for var in makeVarsNoBinding);
     cdWorkingDir := if stringEmpty(workingDir) then "" else ("cd \"" + workingDir + "\"&& ");
     winCompileMode := if Testsuite.isRunning() then "serial" else "parallel";
-    s_call := stringAppendList({omhome,cdWorkingDir,setMakeVars,"\"",omhome_1,pd,"share",pd,"omc",pd,"scripts",pd,"Compile","\""," ",fileprefix," ",Config.simulationCodeTarget()," ", System.openModelicaPlatform(), " ", winCompileMode});
+    if Flags.getConfigEnum(Flags.LINK_TYPE) == 1 then
+      linkType := "static";
+    elseif Flags.getConfigEnum(Flags.LINK_TYPE) == 2 then
+      linkType := "dynamic";
+    end if;
+    linkType := if Testsuite.isRunning() then "dynamic" else linkType;
+    s_call := stringAppendList({omhome,cdWorkingDir,setMakeVars,"\"",omhome_1,pd,"share",pd,"omc",pd,"scripts",pd,"Compile","\""," ",fileprefix," ",Config.simulationCodeTarget()," ", System.openModelicaPlatform(), " ", winCompileMode, " ", linkType});
   else
     numParallel := if Testsuite.isRunning() then 1 else Config.noProc();
     cdWorkingDir := if stringEmpty(workingDir) then "" else (" -C \"" + workingDir + "\"");

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1367,6 +1367,13 @@ constant ConfigFlag EXPORT_CLOCKS_IN_MODELDESCRIPTION = CONFIG_FLAG(144, "export
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("exports clocks in modeldescription.xml for fmus, The default is false."));
 
+constant ConfigFlag LINK_TYPE = CONFIG_FLAG(145, "linkType",
+  NONE(), EXTERNAL(), ENUM_FLAG(1, {("dynamic",1), ("static",2)}),
+  SOME(STRING_OPTION({"dynamic", "static"})),
+  Gettext.gettext("Sets the link type for the simulation executable.\n"+
+               "dynamic: Will link dynamically to build the executable very fast. This is the default."+
+               "static: Will link statically to avoid dynamic libraries dependencies. Static linking is quite slow.\n"));
+
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."
   input Boolean initialize = true;

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -394,7 +394,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.PARMODAUTO,
   Flags.INTERACTIVE_PORT,
   Flags.ALLOW_NON_STANDARD_MODELICA,
-  Flags.EXPORT_CLOCKS_IN_MODELDESCRIPTION
+  Flags.EXPORT_CLOCKS_IN_MODELDESCRIPTION,
+  Flags.LINK_TYPE
 };
 
 public function new

--- a/OMCompiler/Compiler/scripts/Compile.bat
+++ b/OMCompiler/Compiler/scripts/Compile.bat
@@ -4,10 +4,12 @@ REM 1 fileprefix
 REM 2 target (gcc|msvc)
 REM 3 platform (mingw64|mingw32)
 REM 4 serial/parallel
-REM 5 number of processors
-REM 6 LOGGING 0/1
-if not "%5"=="" (set NUM_PROCS=%5) else (set NUM_PROCS=%NUMBER_OF_PROCESSORS%)
-if not "%6"=="" (set LOGGING=%6) else (set LOGGING=1)
+REM 5 linkType (dynamic|static)
+REM 6 number of processors
+REM 7 LOGGING 0/1
+if not "%5"=="" (set LINK_TYPE=%5) else (set LINK_TYPE=dynamic)
+if not "%6"=="" (set NUM_PROCS=%6) else (set NUM_PROCS=%NUMBER_OF_PROCESSORS%)
+if not "%7"=="" (set LOGGING=%7) else (set LOGGING=1)
 set OM_PLATFORM=%3
 REM Clear all environment variables that may interfere during compile and link phases.
 set GCC_EXEC_PREFIX=
@@ -107,7 +109,7 @@ goto :Final
 :MINGW
 REM echo "MINGW"
 if "%4"=="parallel" set ADDITIONAL_ARGS=-j%NUM_PROCS%
-if %LOGGING%==1 ("%MinGW%\bin\mingw32-make" -w -f %1.makefile %ADDITIONAL_ARGS%  >> %1.log 2>&1) else ("%MinGW%\bin\mingw32-make" -w -f %1.makefile %ADDITIONAL_ARGS%)
+if %LOGGING%==1 ("%MinGW%\bin\mingw32-make" -w -f %1.makefile OMC_LDFLAGS_LINK_TYPE=%LINK_TYPE% %ADDITIONAL_ARGS%  >> %1.log 2>&1) else ("%MinGW%\bin\mingw32-make" -w -f %1.makefile OMC_LDFLAGS_LINK_TYPE=%LINK_TYPE% %ADDITIONAL_ARGS%)
 set RESULT=%ERRORLEVEL%
 if %LOGGING%==1 echo RESULT: %RESULT% >> %1.log 2>&1
 goto :Final

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -629,6 +629,11 @@ void OptionsDialog::readSimulationSettings()
   if (mpSettings->contains("simulation/cxxCompiler")) {
     mpSimulationPage->getCXXCompilerComboBox()->lineEdit()->setText(mpSettings->value("simulation/cxxCompiler").toString());
   }
+#ifdef Q_OS_WIN
+  if (mpSettings->contains("simulation/useStaticLinking")) {
+    mpSimulationPage->getUseStaticLinkingCheckBox()->setChecked(mpSettings->value("simulation/useStaticLinking").toBool());
+  }
+#endif
   if (mpSettings->contains("simulation/ignoreCommandLineOptionsAnnotation")) {
     mpSimulationPage->getIgnoreCommandLineOptionsAnnotationCheckBox()->setChecked(mpSettings->value("simulation/ignoreCommandLineOptionsAnnotation").toBool());
   }
@@ -1397,6 +1402,10 @@ void OptionsDialog::saveGlobalSimulationSettings()
     cxxCompiler = mpSimulationPage->getCXXCompilerComboBox()->lineEdit()->placeholderText();
   }
   MainWindow::instance()->getOMCProxy()->setCXXCompiler(cxxCompiler);
+#ifdef Q_OS_WIN
+  // static linking
+  mpSettings->setValue("simulation/useStaticLinking", mpSimulationPage->getUseStaticLinkingCheckBox()->isChecked());
+#endif
   // save ignore command line options
   mpSettings->setValue("simulation/ignoreCommandLineOptionsAnnotation", mpSimulationPage->getIgnoreCommandLineOptionsAnnotationCheckBox()->isChecked());
   if (mpSimulationPage->getIgnoreCommandLineOptionsAnnotationCheckBox()->isChecked()) {
@@ -3879,6 +3888,10 @@ SimulationPage::SimulationPage(OptionsDialog *pOptionsDialog)
   mpCXXCompilerComboBox->addItem("clang++");
 #endif
   mpCXXCompilerComboBox->lineEdit()->setPlaceholderText(MainWindow::instance()->getOMCProxy()->getCXXCompiler());
+#ifdef Q_OS_WIN
+  mpUseStaticLinkingCheckBox = new QCheckBox(tr("Use static Linking"));
+  mpUseStaticLinkingCheckBox->setToolTip(tr("Enables static linking for the simulation executable. Default is dynamic linking."));
+#endif
   // ignore command line options annotation checkbox
   mpIgnoreCommandLineOptionsAnnotationCheckBox = new QCheckBox(tr("Ignore __OpenModelica_commandLineOptions annotation"));
   // ignore simulation flags annotation checkbox
@@ -3944,6 +3957,9 @@ SimulationPage::SimulationPage(OptionsDialog *pOptionsDialog)
   pSimulationLayout->addWidget(mpCompilerComboBox, row++, 1);
   pSimulationLayout->addWidget(mpCXXCompilerLabel, row, 0);
   pSimulationLayout->addWidget(mpCXXCompilerComboBox, row++, 1);
+#ifdef Q_OS_WIN
+  pSimulationLayout->addWidget(mpUseStaticLinkingCheckBox, row++, 0, 1, 2);
+#endif
   pSimulationLayout->addWidget(mpIgnoreCommandLineOptionsAnnotationCheckBox, row++, 0, 1, 2);
   pSimulationLayout->addWidget(mpIgnoreSimulationFlagsAnnotationCheckBox, row++, 0, 1, 2);
   pSimulationLayout->addWidget(mpSaveClassBeforeSimulationCheckBox, row++, 0, 1, 2);

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -614,6 +614,9 @@ public:
   QComboBox* getTargetBuildComboBox() {return mpTargetBuildComboBox;}
   QComboBox* getCompilerComboBox() {return mpCompilerComboBox;}
   QComboBox* getCXXCompilerComboBox() {return mpCXXCompilerComboBox;}
+#ifdef Q_OS_WIN
+  QCheckBox* getUseStaticLinkingCheckBox() {return mpUseStaticLinkingCheckBox;}
+#endif
   QCheckBox* getIgnoreCommandLineOptionsAnnotationCheckBox() {return mpIgnoreCommandLineOptionsAnnotationCheckBox;}
   QCheckBox* getIgnoreSimulationFlagsAnnotationCheckBox() {return mpIgnoreSimulationFlagsAnnotationCheckBox;}
   QCheckBox* getSaveClassBeforeSimulationCheckBox() {return mpSaveClassBeforeSimulationCheckBox;}
@@ -637,6 +640,9 @@ private:
   QComboBox *mpCompilerComboBox;
   Label *mpCXXCompilerLabel;
   QComboBox *mpCXXCompilerComboBox;
+#ifdef Q_OS_WIN
+  QCheckBox *mpUseStaticLinkingCheckBox;
+#endif
   QCheckBox *mpIgnoreCommandLineOptionsAnnotationCheckBox;
   QCheckBox *mpIgnoreSimulationFlagsAnnotationCheckBox;
   QCheckBox *mpSaveClassBeforeSimulationCheckBox;

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -548,6 +548,9 @@ void SimulationOutputWidget::compileModel()
   }
   QStringList args;
 #ifdef WIN32
+  if (OptionsDialog::instance()->getSimulationPage()->getUseStaticLinkingCheckBox()->isChecked()) {
+    linkType = "static";
+  }
 #if defined(__MINGW32__) && defined(__MINGW64__) /* on 64 bit */
   const char* omPlatform = "mingw64";
 #else

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -540,7 +540,7 @@ void SimulationOutputWidget::compileModel()
   connect(mpCompilationProcess, SIGNAL(error(QProcess::ProcessError)), SLOT(compilationProcessError(QProcess::ProcessError)));
 #endif
   connect(mpCompilationProcess, SIGNAL(finished(int,QProcess::ExitStatus)), SLOT(compilationProcessFinished(int,QProcess::ExitStatus)));
-  QString numProcs;
+  QString numProcs, linkType("dynamic");
   if (mSimulationOptions.getNumberOfProcessors() == 0) {
     numProcs = QString::number(mSimulationOptions.getNumberOfProcessors());
   } else {
@@ -556,7 +556,7 @@ void SimulationOutputWidget::compileModel()
   SimulationPage *pSimulationPage = OptionsDialog::instance()->getSimulationPage();
   args << mSimulationOptions.getOutputFileName()
        << pSimulationPage->getTargetBuildComboBox()->itemData(pSimulationPage->getTargetBuildComboBox()->currentIndex()).toString()
-       << omPlatform << "parallel" << numProcs << "0";
+       << omPlatform << "parallel" << linkType << numProcs << "0";
   QString compilationProcessPath = QString(Helper::OpenModelicaHome) + "/share/omc/scripts/Compile.bat";
   writeCompilationOutput(QString("%1 %2\n").arg(compilationProcessPath).arg(args.join(" ")), Qt::blue);
   mpCompilationProcess->start(compilationProcessPath, args);

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1335,6 +1335,9 @@ Simulation
 
   -  *CXX Compiler* – sets the CXX compiler for compiling the generated code.
 
+  -  *Use static linking* – if true then static linking is used for simulation executable.
+     The default is dynamic linking. This option is only available on Windows.
+
   -  *Ignore __OpenModelica_commandLineOptions annotation* – if true then ignores the __OpenModelica_commandLineOptions
      annotation while running the simulation.
 


### PR DESCRIPTION
- add a new argument to Compile.bat linkType
- fix the code in omc when calling Compile.bat
- fix the code in OMEdit when calling Compile.bat
  new dialog needed, maybe a checkbox or dropdown
  with dynamic|static

