### PR TITLE
Flattening fixes

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -728,5 +728,26 @@ public
     end match;
   end source;
 
+  function makeTyped
+    input Expression exp;
+    input EachType eachType;
+    input Source source;
+    input SourceInfo info;
+    input EvalState state = EvalState.NOT_EVALUATED;
+    output Binding binding;
+  algorithm
+    binding := TYPED_BINDING(exp, Expression.typeOf(exp),
+      Expression.variability(exp), eachType, Mutable.create(state), false, source, info);
+  end makeTyped;
+
+  function makeFlat
+    input Expression exp;
+    input Variability var;
+    input Source source;
+    output Binding binding;
+  algorithm
+    binding := FLAT_BINDING(exp, var, source);
+  end makeFlat;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFBinding;

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -343,6 +343,7 @@ function evalCref
   input Expression defaultExp;
   input EvalTarget target;
   input Boolean evalSubscripts = true;
+  input Boolean liftExp = true;
   output Expression exp;
 protected
   InstNode c;
@@ -353,7 +354,7 @@ algorithm
     case ComponentRef.CREF(node = c as InstNode.COMPONENT_NODE())
       guard not ComponentRef.isIterator(cref) and
             ComponentRef.nodeVariability(cref) <= Variability.NON_STRUCTURAL_PARAMETER
-      then evalComponentBinding(c, cref, defaultExp, target, evalSubscripts);
+      then evalComponentBinding(c, cref, defaultExp, target, evalSubscripts, liftExp);
 
     else defaultExp;
   end match;
@@ -365,6 +366,7 @@ function evalComponentBinding
   input Expression defaultExp "The expression returned if the binding couldn't be evaluated";
   input EvalTarget target;
   input Boolean evalSubscripts = true;
+  input Boolean liftExp = false "Ensure that the result has the same dimensions as the cref";
   output Expression exp;
 protected
   InstContext.Type exp_context;
@@ -374,6 +376,8 @@ protected
   list<Subscript> subs;
   Variability var;
   Option<Expression> start_exp;
+  Type cref_ty, exp_ty;
+  Integer dim_diff;
 algorithm
   exp_context := if InstNode.isFunction(InstNode.explicitParent(node))
     then NFInstContext.FUNCTION else NFInstContext.CLASS;
@@ -463,6 +467,16 @@ algorithm
   // Apply subscripts from the cref to the binding expression as needed.
   if evaluated then
     exp := subscriptBinding(exp, cref, evalSubscripts);
+  end if;
+
+  if liftExp and not Expression.contains(exp, Expression.isSplitSubscriptedExp) then
+    exp_ty := Expression.typeOf(exp);
+    cref_ty := Expression.typeOf(defaultExp);
+    dim_diff := Type.dimensionDiff(cref_ty, exp_ty);
+
+    if dim_diff > 0 then
+      exp := Expression.liftArrayList(List.firstN(Type.arrayDims(cref_ty), dim_diff), exp);
+    end if;
   end if;
 end evalComponentBinding;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -487,8 +487,8 @@ public
       if InstNode.isRecord(cls_node) then
         try
           record_exp := Class.makeRecordExp(cls_node);
-          binding := Binding.FLAT_BINDING(record_exp,
-            Expression.variability(record_exp), NFBinding.Source.GENERATED);
+          binding := Binding.makeTyped(record_exp, NFBinding.EachType.NOT_EACH,
+            NFBinding.Source.GENERATED, info(component));
         else
         end try;
       end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -102,6 +102,14 @@ public
                 fail();
           end match;
 
+      case Expression.ARRAY()
+        guard Expression.arrayAllEqual(exp)
+        then fromExp(Expression.arrayFirstScalar(exp), var);
+
+      case Expression.SUBSCRIPTED_EXP(split = true)
+        guard Expression.isArray(exp.exp) and Expression.arrayAllEqual(exp.exp)
+        then fromExp(Expression.arrayFirstScalar(exp.exp), var);
+
       else EXP(exp, var);
     end match;
   end fromExp;
@@ -486,6 +494,19 @@ public
       else ();
     end match;
   end simplify;
+
+  function typeOf
+    input Dimension dim;
+    output Type ty;
+  algorithm
+    ty := match dim
+      case INTEGER() then Type.INTEGER();
+      case BOOLEAN() then Type.BOOLEAN();
+      case ENUM() then dim.enumType;
+      case EXP() then Expression.typeOf(dim.exp);
+      else Type.UNKNOWN();
+    end match;
+  end typeOf;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFDimension;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -609,7 +609,7 @@ public
     else
       field_exps := listReverseInPlace(field_exps);
       record_exp := Expression.makeRecord(InstNode.scopePath(InstNode.classScope(record_node)), record_ty, field_exps);
-      record_binding := Binding.FLAT_BINDING(record_exp, Component.variability(record_comp), NFBinding.Source.GENERATED);
+      record_binding := Binding.makeFlat(record_exp, Component.variability(record_comp), NFBinding.Source.GENERATED);
     end if;
 
     recordVar := Variable.VARIABLE(recordName, record_ty, record_binding, InstNode.visibility(record_node),

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -130,7 +130,7 @@ algorithm
           (ty_attr_names, ty_attr_iters) := scalarizeTypeAttributes(ty_attr);
           for cr in crefs loop
             (binding_iter, exp) := ExpressionIterator.next(binding_iter);
-            binding := Binding.FLAT_BINDING(exp, bind_var, bind_src);
+            binding := Binding.makeFlat(exp, bind_var, bind_src);
             ty_attr := nextTypeAttributes(ty_attr_names, ty_attr_iters);
             vars := Variable.VARIABLE(cr, elem_ty, binding, vis, attr, ty_attr, {}, cmt, info) :: vars;
           end for;
@@ -187,7 +187,7 @@ algorithm
     (iter, exp) := ExpressionIterator.next(iters[i]);
     arrayUpdate(iters, i, iter);
     i := i + 1;
-    attrs := (name, Binding.FLAT_BINDING(exp, Variability.PARAMETER, NFBinding.Source.BINDING)) :: attrs;
+    attrs := (name, Binding.makeFlat(exp, Variability.PARAMETER, NFBinding.Source.BINDING)) :: attrs;
   end for;
 end nextTypeAttributes;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -573,7 +573,7 @@ algorithm
           end if;
         end if;
 
-        dim := Dimension.fromExp(simplifyDimExp(exp), var);
+        dim := Dimension.fromExp(exp, var);
         arrayUpdate(dimensions, index, dim);
       then
         dim;
@@ -661,7 +661,7 @@ algorithm
               Structural.markExp(exp);
               exp := Ceval.evalExp(exp, Ceval.EvalTarget.DIMENSION(component, index, exp, info));
             then
-              Dimension.fromExp(simplifyDimExp(exp), dim.var);
+              Dimension.fromExp(exp, dim.var);
 
           case Dimension.UNKNOWN()
             algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
@@ -176,7 +176,7 @@ algorithm
       if Unit.isUnit(unit) then
         // Add the unit string to the variable's type attributes.
         unit_str := Unit.unitString(unit, htU2S);
-        binding := Binding.FLAT_BINDING(Expression.STRING(unit_str), Variability.CONSTANT, NFBinding.Source.GENERATED);
+        binding := Binding.makeFlat(Expression.STRING(unit_str), Variability.CONSTANT, NFBinding.Source.GENERATED);
         var.typeAttributes := ("unit", binding) :: var.typeAttributes;
       end if;
     else

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -134,7 +134,7 @@ public
         for cr in crefs loop
           v.name := cr;
           exp :: expl := expl;
-          v.binding := Binding.FLAT_BINDING(exp, bind_var, bind_src);
+          v.binding := Binding.makeFlat(exp, bind_var, bind_src);
           vars := v :: vars;
         end for;
       else


### PR DESCRIPTION
- Flatten types in statements.
- Flatten expressions after evaluating bindings in EvaluateConstants,
  since they come from the instance tree and not the flat model.
- Create typed bindings instead of flat bindings in some places where
  the generated binding might not actually be flat.
- Lift the result in evalComponentBinding if necessary to ensure it has
  the same dimensions as the cref being evaluated.
- Apply the array hack for dimensions in Dimension.fromExp instead of
  during typing to simplify problematic dimensions in more cases.
- Don't double delete components.