### PR TITLE
[BE, SimCode] backend part for guruTearing

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAE.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAE.mo
@@ -485,7 +485,7 @@ end ExternalObjectClass;
 public
 uniontype Matching
   record NO_MATCHING "matching has not yet been performed" end NO_MATCHING;
-  record MATCHING "not yet used"
+  record MATCHING
     array<Integer> ass1 "ass[varindx]=eqnindx";
     array<Integer> ass2 "ass[eqnindx]=varindx";
     StrongComponents comps;
@@ -603,6 +603,10 @@ uniontype InnerEquation
     list<Integer> vars;
     Constraints cons;
   end INNEREQUATIONCONSTRAINTS;
+
+  record INNERLOOP
+    TearingSet set;
+  end INNERLOOP;
 end InnerEquation;
 
 

--- a/OMCompiler/Compiler/BackEnd/BackendDAETransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAETransform.mo
@@ -100,7 +100,8 @@ algorithm
       ass1 := varAssignmentNonScalar(ass1, mapIncRowEqn);
 
       // Frenkel TUD: Do not hand over the scalar adjacency Matrix because following modules does not check if scalar or not
-      syst := BackendDAE.EQSYSTEM(syst.orderedVars, syst.orderedEqs, NONE(), NONE(), NONE(), BackendDAE.MATCHING(ass1, ass2, comps), syst.stateSets, syst.partitionKind, syst.removedEqs);
+      // Abdelhak FHB: I do not like discarding information, therefore i will keep it and check if scalar or not
+      syst := BackendDAE.EQSYSTEM(syst.orderedVars, syst.orderedEqs, syst.m, syst.mT, syst.mapping, BackendDAE.MATCHING(ass1, ass2, comps), syst.stateSets, syst.partitionKind, syst.removedEqs);
     then (syst, comps);
 
     else algorithm
@@ -525,7 +526,7 @@ algorithm
     local
       Integer v, e;
       list<Integer> elst, vlst, elst1, vlst1;
-      list<list<Integer>> vLstLst;
+      list<list<Integer>> eLstLst, vLstLst;
       BackendDAE.StrongComponent comp;
       BackendDAE.InnerEquations innerEquations;
 
@@ -551,7 +552,8 @@ algorithm
     then ({e}, vlst);
 
     case BackendDAE.TORNSYSTEM(BackendDAE.TEARINGSET(tearingvars=vlst, residualequations=elst, innerEquations=innerEquations)) equation
-      (elst1,vLstLst,_) = List.map_3(innerEquations, BackendDAEUtil.getEqnAndVarsFromInnerEquation);
+      (eLstLst,vLstLst,_) = BackendDAEUtil.getEqnAndVarsFromInnerEquationLst(innerEquations);
+      elst1 = List.flatten(eLstLst);
       vlst1 = List.flatten(vLstLst);
       elst = listAppend(elst1, elst);
       vlst = listAppend(vlst1, vlst);

--- a/OMCompiler/Compiler/BackEnd/BackendDump.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDump.mo
@@ -1426,8 +1426,8 @@ algorithm
   oString := match (inComp)
     local
       Integer i,v;
-      list<Integer> ilst,vlst,ilst2,vlst2,innerEqLst;
-      list<list<Integer>> innerVarLst;
+      list<Integer> ilst,vlst,ilst2,vlst2;
+      list<list<Integer>> innerEqLst, innerVarLst;
       list<String> ls;
       String s,s2,s3,s4;
       BackendDAE.JacobianType jacType;
@@ -1495,7 +1495,7 @@ algorithm
                    + "\nTearing Variables:\n-------------------------------------\n" + dumpMarkedVars(eSys,vlst) + "\n"
                    + "Residual Equations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,ilst)
                    + "Inner Variables:\n-------------------------------------\n" + dumpMarkedVarsLsts(eSys,innerVarLst) + "\n"
-                   + "InnerEquations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,innerEqLst);
+                   + "InnerEquations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,List.flatten(innerEqLst));
         else
           tmpStr = tmpStr + "For more information please use \"-d=tearingdump\".\n";
         end if;
@@ -1517,7 +1517,7 @@ algorithm
                    + "\nTearing Variables:\n-------------------------------------\n" + dumpMarkedVars(eSys,vlst) + "\n"
                    + "Residual Equations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,ilst)
                    + "Inner Variables:\n-------------------------------------\n" + dumpMarkedVarsLsts(eSys,innerVarLst) + "\n"
-                   + "InnerEquations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,innerEqLst);
+                   + "InnerEquations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,List.flatten(innerEqLst));
         else
           tmpStr = tmpStr + "For more information please use \"-d=tearingdump\".\n";
         end if;
@@ -1537,7 +1537,7 @@ algorithm
                    + "\nTearing Variables:\n-------------------------------------\n" + dumpMarkedVars(eSys,vlst2) + "\n"
                    + "Residual Equations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,ilst2)
                    + "Inner Variables:\n-------------------------------------\n" + dumpMarkedVarsLsts(eSys,innerVarLst) + "\n"
-                   + "InnerEquations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,innerEqLst);
+                   + "InnerEquations:\n-------------------------------------\n" + dumpMarkedEqns(eSys,List.flatten(innerEqLst));
         else
           tmpStr2 = tmpStr2 + "For more information please use \"-d=tearingdump\".\n";
         end if;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -872,6 +872,7 @@ constant ConfigFlag TEARING_METHOD = CONFIG_FLAG(44, "tearingMethod",
   SOME(STRING_DESC_OPTION({
     ("noTearing", Gettext.gettext("Skip tearing. This breaks models with mixed continuous-integer/boolean unknowns")),
     ("minimalTearing", Gettext.gettext("Minimal tearing method to only tear discrete variables.")),
+    ("guruTearing", Gettext.gettext("Tearing method only using predefined tearing variables and forces the rest to be inner variables.")),
     ("omcTearing", Gettext.gettext("Tearing method developed by TU Dresden: Frenkel, Schubert.")),
     ("cellier", Gettext.gettext("Tearing based on Celliers method, revised by FH Bielefeld: Täuber, Patrick"))})),
 


### PR DESCRIPTION
 - adresses issue #7628
 - implements a guru tearing where ONLY tearingSelect.always variables are used as iteration variables.
 - everything else is considered inner variables and equations even if that leads to nested loops

ToDo:
 - merge and clean all functions starting with getEqnAndVarsFromInner... and repair all calls
 - update the dumping functions to actually show nested loops
 - resolve double naming issues of residuals and stuff like that (simcode)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
