### PR TITLE
Expand calls with multiple iterators

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinReduction.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinReduction.mo
@@ -18,6 +18,7 @@ model FuncBuiltinReduction
   Real r7 = max(r*2.0 for r in 1:0);
   Real r8 = sum(r*2.0 for r in 1:0);
   Real r9 = product(r*2.0 for r in 1:0);
+  Real r10 = sum(r1*r2 for r1 in 1:integer(time), r2 in 1:4);
 
   Integer i1 = min(i-1 for i in {2, 4, 1});
   Integer i2 = max(i for i in {4, 2, 9});
@@ -50,6 +51,7 @@ end FuncBuiltinReduction;
 //   Real r7 = -8.777798510069901e+304;
 //   Real r8 = 0.0;
 //   Real r9 = 1.0;
+//   Real r10 = /*Real*/(sum(sum(r1 * r2 for r1 in 1:integer(time)) for r2 in 1:4));
 //   Integer i1 = min(i - 1 for i in {2, 4, 1});
 //   Integer i2 = max(i for i in {4, 2, 9});
 //   Integer i3 = 14;

--- a/testsuite/flattening/modelica/scodeinst/FuncVectorization2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncVectorization2.mo
@@ -62,6 +62,6 @@ end FuncVectorization2;
 //   Integer g[2,2];
 //   Integer g[2,3];
 // equation
-//   g = array(FuncVectorization2.F(b[$i1,$i2], 1) for $i2 in 1:3, $i1 in 1:2);
+//   g = array(array(FuncVectorization2.F(b[$i1,$i2], 1) for $i2 in 1:3) for $i1 in 1:2);
 // end FuncVectorization2;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncVectorization5.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncVectorization5.mo
@@ -31,7 +31,7 @@ end FuncVectorization5;
 //   input Real[:, :] y;
 //   output Real s = 0.0;
 // algorithm
-//   s := sum(array(FuncVectorization5.mySum(x[$i1,$i2], y[$i1,$i2]) for $i2 in 1:size(x, 2), $i1 in 1:size(x, 1)));
+//   s := sum(array(array(FuncVectorization5.mySum(x[$i1,$i2], y[$i1,$i2]) for $i2 in 1:size(x, 2)) for $i1 in 1:size(x, 1)));
 // end FuncVectorization5.f;
 //
 // function FuncVectorization5.mySum

--- a/testsuite/flattening/modelica/scodeinst/FuncVectorizationBuiltin.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncVectorizationBuiltin.mo
@@ -66,7 +66,7 @@ end FuncVectorizationBuiltin;
 //   Real b[2,3,3];
 //   Real b[2,3,4];
 // equation
-//   a = array(time for i in 1:4, j in 1:3, k in 1:2);
-//   b = array(sin(a[$i1,$i2,$i3]) for $i3 in 1:4, $i2 in 1:3, $i1 in 1:2);
+//   a = array(array(array(time for i in 1:4) for j in 1:3) for k in 1:2);
+//   b = array(array(array(sin(a[$i1,$i2,$i3]) for $i3 in 1:4) for $i2 in 1:3) for $i1 in 1:2);
 // end FuncVectorizationBuiltin;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncVectorizationMap1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncVectorizationMap1.mo
@@ -64,8 +64,8 @@ end FuncVectorizationMap1;
 //   Real g[2,2];
 //   Real g[2,3];
 // equation
-//   g = array(FuncVectorizationMap1.F(b[$i1,$i2], 1.0) for $i2 in 1:3, $i1 in 1:2);
+//   g = array(array(FuncVectorizationMap1.F(b[$i1,$i2], 1.0) for $i2 in 1:3) for $i1 in 1:2);
 //   g = array(array(FuncVectorizationMap1.F(b[i,$i1], 1.0) for $i1 in 1:3) for i in 1:2);
-//   g = array(FuncVectorizationMap1.F(b[i,j], 1.0) for j in 1:3, i in 1:2);
+//   g = array(array(FuncVectorizationMap1.F(b[i,j], 1.0) for j in 1:3) for i in 1:2);
 // end FuncVectorizationMap1;
 // endResult


### PR DESCRIPTION
- Expand reductions/array constructors with multiple iterators into
  nested calls when generating the DAE structure, since the code
  generation can't handle multiple iterators.