### PR TITLE
Simplify min/max reductions more

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -698,7 +698,7 @@ public
       case UNARY()           then Operator.typeOf(exp.operator);
       case LBINARY()         then Operator.typeOf(exp.operator);
       case LUNARY()          then Operator.typeOf(exp.operator);
-      case RELATION()        then Operator.typeOf(exp.operator);
+      case RELATION()        then Type.copyDims(Operator.typeOf(exp.operator), Type.BOOLEAN());
       case IF()              then exp.ty;
       case CAST()            then exp.ty;
       case BOX()             then Type.METABOXED(typeOf(exp.exp));

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -471,6 +471,10 @@ algorithm
             outExp;
 
         case _
+          guard call.var <= Variability.STRUCTURAL_PARAMETER
+          then Ceval.tryEvalExp(Expression.CALL(call));
+
+        case _
           then simplifyReduction2(AbsynUtil.pathString(Function.name(call.fn)), call.exp, iters);
 
         else

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinReduction.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinReduction.mo
@@ -42,8 +42,8 @@ end FuncBuiltinReduction;
 
 // Result:
 // class FuncBuiltinReduction
-//   Real r1 = min(r * 2.0 for r in {1.0, 2.0, 3.0, 4.0});
-//   Real r2 = max(r * r for r in {-4.0, -2.0, 3.0, 5.0});
+//   Real r1 = 2.0;
+//   Real r2 = 25.0;
 //   Real r3 = 110.0;
 //   Real r4 = 14400.0;
 //   Real r5 = 420.0;
@@ -52,20 +52,20 @@ end FuncBuiltinReduction;
 //   Real r8 = 0.0;
 //   Real r9 = 1.0;
 //   Real r10 = /*Real*/(sum(sum(r1 * r2 for r1 in 1:integer(time)) for r2 in 1:4));
-//   Integer i1 = min(i - 1 for i in {2, 4, 1});
-//   Integer i2 = max(i for i in {4, 2, 9});
+//   Integer i1 = 0;
+//   Integer i2 = 9;
 //   Integer i3 = 14;
 //   Integer i4 = 60480;
 //   Integer i5 = 4611686018427387903;
 //   Integer i6 = -4611686018427387903;
 //   Integer i7 = 0;
 //   Integer i8 = 1;
-//   Boolean b1 = min(not b for b in {false, true});
-//   Boolean b2 = max(i == 2 for i in 1:4);
+//   Boolean b1 = false;
+//   Boolean b2 = true;
 //   Boolean b3 = true;
 //   Boolean b4 = false;
-//   enumeration(one, two, three) e1 = min(e for e in E.one:E.three);
-//   enumeration(one, two, three) e2 = max(e for e in {E.one, E.two, E.three});
+//   enumeration(one, two, three) e1 = E.one;
+//   enumeration(one, two, three) e2 = E.three;
 //   enumeration(one, two, three) e3 = E.three;
 //   enumeration(one, two, three) e4 = E.one;
 // end FuncBuiltinReduction;


### PR DESCRIPTION
- Evaluate min/max reductions if possible.
- Fix Expression.typeOf for relations, to avoid using the wrong default
  value when evaluating reductions.