### PR TITLE
Fix empty array slices in Cpp runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/ArraySlice.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/ArraySlice.h
@@ -141,7 +141,7 @@ class ArraySliceConst: public BaseArray<T> {
             dit->push_back(start + i * step);
         }
       }
-      if (size == 1 && sit->step == 0)
+      if (sit->iset == NULL && size == 1 && sit->step == 0)
         // preset constant _baseIdx in case of reduction
         _baseIdx[dim - 1] = sit->iset != NULL? (*_isets[dim - 1])(1): (*dit)[0];
       else {

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/ArraySlice.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/ArraySlice.h
@@ -258,6 +258,21 @@ class ArraySliceConst: public BaseArray<T> {
     return _baseArray(baseIdx(2, idx));
   }
 
+  virtual const T& operator()(size_t i, size_t j, size_t k) const {
+    size_t idx[] = {i, j, k};
+    return _baseArray(baseIdx(3, idx));
+  }
+
+  virtual const T& operator()(size_t i, size_t j, size_t k, size_t l) const {
+    size_t idx[] = {i, j, k, l};
+    return _baseArray(baseIdx(4, idx));
+  }
+
+  virtual const T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m) const {
+    size_t idx[] = {i, j, k, l, m};
+    return _baseArray(baseIdx(5, idx));
+  }
+
  protected:
   const BaseArray<T> &_baseArray;  // underlying array
   vector<const BaseArray<int>*> _isets; // given index sets per dimension

--- a/testsuite/openmodelica/cppruntime/arraySliceTest.mos
+++ b/testsuite/openmodelica/cppruntime/arraySliceTest.mos
@@ -2,7 +2,6 @@
 // keywords: slice array
 // status: correct
 // teardown_command: rm -f *ArraySlice.Test*
-// cflags: -d=-newInst
 
 setCommandLineOptions("+simCodeTarget=Cpp");
 
@@ -11,6 +10,7 @@ package ArraySlice
 model Test
   Real[:,:] m = [1; 2; 3; 4; 5];
   Real[:] w = reverse(m);
+  Real y = catEmpty(w);
   annotation(experiment(StopTime = 0));
 end Test;
 function reverse
@@ -22,6 +22,14 @@ protected
 algorithm
   w := v[size(w, 1):-1:1]; // test slice with negative step
 end reverse;
+function catEmpty
+  input Real[:] v;
+  output Real y;
+protected
+  parameter Integer n = size(v, 1);
+algorithm
+  y := sum(v + cat(1, v[1:n], v[2:n-size(v, 1)])); // empty slice
+end catEmpty;
 end ArraySlice;
 ");
 getErrorString();
@@ -31,6 +39,7 @@ getErrorString();
 
 val(w[1], 0);
 val(w[4], 0);
+val(y, 0);
 
 // Result:
 // true
@@ -44,4 +53,5 @@ val(w[4], 0);
 // ""
 // 4.0
 // 1.0
+// 20.0
 // endResult

--- a/testsuite/openmodelica/cppruntime/arraySliceTest.mos
+++ b/testsuite/openmodelica/cppruntime/arraySliceTest.mos
@@ -11,6 +11,7 @@ model Test
   Real[:,:] m = [1; 2; 3; 4; 5];
   Real[:] w = reverse(m);
   Real y = catEmpty(w);
+  Real z = reduction(w);
   annotation(experiment(StopTime = 0));
 end Test;
 function reverse
@@ -30,6 +31,15 @@ protected
 algorithm
   y := sum(v + cat(1, v[1:n], v[2:n-size(v, 1)])); // empty slice
 end catEmpty;
+function reduction
+  input Real[:] v;
+  output Real y;
+protected
+  parameter Integer n = size(v, 1);
+  Integer[:] idx = {1};
+algorithm
+  y := product(sum(v[i*idx] for i in 1:n)); // index set with one element
+end reduction;
 end ArraySlice;
 ");
 getErrorString();
@@ -40,6 +50,7 @@ getErrorString();
 val(w[1], 0);
 val(w[4], 0);
 val(y, 0);
+val(z, 0);
 
 // Result:
 // true
@@ -54,4 +65,5 @@ val(y, 0);
 // 4.0
 // 1.0
 // 20.0
+// 10.0
 // endResult


### PR DESCRIPTION
`stop=0` in `start:step:stop` was used to mark `end` so far.
It is needed for empty slices though.

See e.g. ModelicaTest.Math.TestMatrices2b (MSL 4.0.0) raising
```
ERROR  : init  : SimManager: Wrong slice exceeding array size
```
