### PR TITLE
Fix initialization of reductions in Cpp runtime

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -7052,7 +7052,6 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
   case r as REDUCTION(reductionInfo=ri as REDUCTIONINFO(iterType=COMBINE()),iterators=iterators as {_}) then
   (
   let &tmpVarDecls = buffer ""
-  let &tmpExpPre = buffer ""
   let &bodyExpPre = buffer ""
   let &rangeExpPre = buffer ""
   let arrayTypeResult = expTypeFromExpArray(r)
@@ -7098,11 +7097,12 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           '<%arrayTypeResult%>_get1(<%res%>, 1, <%arrIndex%>++) = <%reductionBodyExpr%>;'
     else match ri.foldExp case SOME(fExp) then
       let &foldExpPre = buffer ""
-      let fExpStr = daeExp(fExp, context, &bodyExpPre, &tmpVarDecls, &auxFunction)
+      let fExpStr = daeExp(fExp, context, &foldExpPre, &tmpVarDecls, &auxFunction)
       if foundFirst then
       <<
-      if(<%foundFirst%>)
+      if (<%foundFirst%>)
       {
+        <%foldExpPre%>
         <%res%> = <%fExpStr%>;
       }
       else

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -7097,12 +7097,11 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           '<%arrayTypeResult%>_get1(<%res%>, 1, <%arrIndex%>++) = <%reductionBodyExpr%>;'
     else match ri.foldExp case SOME(fExp) then
       let &foldExpPre = buffer ""
-      let fExpStr = daeExp(fExp, context, &foldExpPre, &tmpVarDecls, &auxFunction)
+      let fExpStr = daeExp(fExp, context, &bodyExpPre, &tmpVarDecls, &auxFunction)
       if foundFirst then
       <<
       if (<%foundFirst%>)
       {
-        <%foldExpPre%>
         <%res%> = <%fExpStr%>;
       }
       else

--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -1022,7 +1022,6 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
   case r as REDUCTION(reductionInfo=ri as REDUCTIONINFO(iterType=COMBINE()),iterators=iterators as {_}) then
   (
   let &tmpVarDecls = buffer ""
-  let &tmpExpPre = buffer ""
   let &bodyExpPre = buffer ""
   let &rangeExpPre = buffer ""
   let arrayTypeResult = expTypeFromExpArray(r)
@@ -1087,11 +1086,12 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           '<%res%>(<%arrIndex%>++) = <%reductionBodyExpr%>;'
     else match ri.foldExp case SOME(fExp) then
       let &foldExpPre = buffer ""
-      let fExpStr = daeExp(fExp, context, &bodyExpPre, &tmpVarDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+      let fExpStr = daeExp(fExp, context, &foldExpPre, &tmpVarDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
       if foundFirst then
       <<
-      if(<%foundFirst%>)
+      if (<%foundFirst%>)
       {
+        <%foldExpPre%>
         <%res%> = <%fExpStr%>;
       }
       else
@@ -1167,10 +1167,8 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
           <%dimSizes%>;
           <%res%>.setDims(<%dim_vec%>);
           >>
-
         else
           '<%res%>.setDims(<%length%>);'%>
-
        >>
      else
         (if foundFirst then
@@ -1182,7 +1180,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
         <%&preDefault%>
         <%res%> = <%defaultValue%>; /* defaultValue */
         >>)
-      )
+    )
   let loop =
     <<
     while(1) {


### PR DESCRIPTION
`foldExpPre` had been declared but not used. This resulted in Cpp errors.

See e.g. ModelicaTest.Fluid.TestComponents.Machines.TestWaterPumpCharacteristics
or PowerSystems.Examples.AC3ph.Precalculation.Z_matrixTrDat3
```
ERROR  : init  : SimManager: Right and left array must have the same size for element wise addition
```
