### PR TITLE
Only add the prefix if the variable has a unit

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -52,9 +52,9 @@ Plot::Plot(PlotWindow *pParent)
   insertLegend(mpLegend, QwtPlot::TopLegend);
   // create an instance of grid
   mpPlotGrid = new PlotGrid(this);
-  mpXScaleDraw = new ScaleDraw(this);
+  mpXScaleDraw = new ScaleDraw(QwtPlot::xBottom, this);
   setAxisScaleDraw(QwtPlot::xBottom, mpXScaleDraw);
-  mpYScaleDraw = new ScaleDraw(this);
+  mpYScaleDraw = new ScaleDraw(QwtPlot::yLeft, this);
   setAxisScaleDraw(QwtPlot::yLeft, mpYScaleDraw);
   // create an instance of zoomer
   mpPlotZoomer = new PlotZoomer(QwtPlot::xBottom, QwtPlot::yLeft, canvas());
@@ -225,6 +225,8 @@ void Plot::setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, 
 // just overloaded this function to get colors for curves.
 void Plot::replot()
 {
+  bool canUseXPrefixUnits = true;
+  bool canUseYPrefixUnits = true;
   for (int i = 0 ; i < mPlotCurvesList.length() ; i++) {
     // if user has set the custom color for the curve then dont get automatic color for it
     if (!mPlotCurvesList[i]->hasCustomColor()) {
@@ -233,6 +235,22 @@ void Plot::replot()
       mPlotCurvesList[i]->setPen(pen);
     }
     mPlotCurvesList[i]->setTitleLocal();
+    if ((mpParentPlotWindow->getPlotType() == PlotWindow::PLOTPARAMETRIC || mpParentPlotWindow->getPlotType() == PlotWindow::PLOTARRAYPARAMETRIC)
+        && canUseXPrefixUnits && mPlotCurvesList[i]->getXDisplayUnit().isEmpty()) {
+      canUseXPrefixUnits = false;
+    }
+    if (canUseYPrefixUnits && mPlotCurvesList[i]->getYDisplayUnit().isEmpty()) {
+      canUseYPrefixUnits = false;
+    }
+  }
+
+  if (canUseXPrefixUnits != mpParentPlotWindow->canUseXPrefixUnits()) {
+    mpXScaleDraw->invalidateCache();
+    mpParentPlotWindow->setCanUseXPrefixUnits(canUseXPrefixUnits);
+  }
+  if (canUseYPrefixUnits != mpParentPlotWindow->canUseYPrefixUnits()) {
+    mpYScaleDraw->invalidateCache();
+    mpParentPlotWindow->setCanUseYPrefixUnits(canUseYPrefixUnits);
   }
 
   if (mpParentPlotWindow->getXCustomLabel().isEmpty()) {

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -129,6 +129,8 @@ void PlotWindow::initializePlot(QStringList arguments)
   }
   setTimeUnit("");
   setPrefixUnits(false);
+  setCanUseXPrefixUnits(false);
+  setCanUseYPrefixUnits(false);
   /* read variables */
   QStringList variablesToRead;
   for(int i = 18; i < arguments.length(); i++)
@@ -1603,6 +1605,26 @@ bool PlotWindow::getPrefixUnits() const
 void PlotWindow::setPrefixUnits(bool prefixUnits)
 {
   mPrefixUnits = prefixUnits;
+}
+
+bool PlotWindow::canUseXPrefixUnits() const
+{
+  return mCanUseXPrefixUnits;
+}
+
+void PlotWindow::setCanUseXPrefixUnits(bool canUseXPrefixUnits)
+{
+  mCanUseXPrefixUnits = canUseXPrefixUnits;
+}
+
+bool PlotWindow::canUseYPrefixUnits() const
+{
+  return mCanUseYPrefixUnits;
+}
+
+void PlotWindow::setCanUseYPrefixUnits(bool canUseYPrefixUnits)
+{
+  mCanUseYPrefixUnits = canUseYPrefixUnits;
 }
 
 void PlotWindow::checkForErrors(QStringList variables, QStringList variablesPlotted)

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.h
@@ -103,6 +103,8 @@ private:
   QwtSeriesData<QPointF>* mpInteractiveData;
   QString mInteractiveModelName;
   bool mPrefixUnits;
+  bool mCanUseXPrefixUnits;
+  bool mCanUseYPrefixUnits;
   QMdiSubWindow *mpSubWindow;
 public:
   PlotWindow(QStringList arguments = QStringList(), QWidget *parent = 0, bool isInteractiveSimulation = false);
@@ -175,6 +177,10 @@ public:
   QString getFooter();
   bool getPrefixUnits() const;
   void setPrefixUnits(bool prefixUnits);
+  bool canUseXPrefixUnits() const;
+  void setCanUseXPrefixUnits(bool canUseXPrefixUnits);
+  bool canUseYPrefixUnits() const;
+  void setCanUseYPrefixUnits(bool canUseYPrefixUnits);
   void checkForErrors(QStringList variables, QStringList variablesPlotted);
   Plot* getPlot();
   void receiveMessage(QStringList arguments);

--- a/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.cpp
@@ -37,9 +37,10 @@
 
 using namespace OMPlot;
 
-ScaleDraw::ScaleDraw(Plot *pParent)
+ScaleDraw::ScaleDraw(QwtPlot::Axis axis, Plot *pParent)
   : QwtScaleDraw()
 {
+  mAxis = axis;
   mpParentPlot = pParent;
   mUnitPrefix = "";
 }
@@ -60,7 +61,8 @@ QwtText ScaleDraw::label(double value) const
 {
   mUnitPrefix = "";
 
-  if (mpParentPlot->getParentPlotWindow()->getPrefixUnits()) {
+  if (mpParentPlot->getParentPlotWindow()->getPrefixUnits() && ((mAxis == QwtPlot::xBottom && mpParentPlot->getParentPlotWindow()->canUseXPrefixUnits())
+                                                                || (mAxis == QwtPlot::yLeft && mpParentPlot->getParentPlotWindow()->canUseYPrefixUnits()))) {
     int exponent = 0;
     // Use lowerBound if upperBound is zero
     /* Since log(1900) returns 3.278 so we need to round down for positive values to make it 3

--- a/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.h
+++ b/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.h
@@ -40,12 +40,13 @@ namespace OMPlot
 class ScaleDraw : public QwtScaleDraw
 {
 public:
-  ScaleDraw(Plot *pParent);
+  ScaleDraw(QwtPlot::Axis axis, Plot *pParent);
   QString getUnitPrefix() const {return mUnitPrefix;}
   void invalidateCache();
   virtual QwtText label(double value) const;
 
 private:
+  QwtPlot::Axis mAxis;
   Plot *mpParentPlot;
   mutable QString mUnitPrefix;
 };


### PR DESCRIPTION
### Related Issues

#5447

### Purpose

Adding the unit prefix to the variables without unit is confusing.

### Approach

When the variable has the unit then add the prefix and scale the axis accordingly.
