### PR TITLE
Avoid declaration of StatArray with unknown dimension

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -610,7 +610,12 @@ end dimension;
 
 template checkDimension(Dimensions dims)
 ::=
-  dimensionsList(dims) |> dim as Integer   =>  '<%dim%>';separator=","
+  let dimstr = dimensionsList(dims) |> dim as Integer   =>  '<%dim%>';separator=","
+  // check for unknown dimension that is treated as -1
+  if intEq(-1, stringFind(dimstr, "-")) then
+    dimstr
+  else
+    ""
 end checkDimension;
 
 template checkExpDimension(list<DAE.Exp> dims)


### PR DESCRIPTION
See `PowerSystems.Examples.AC3ph.Precalculation.Z_matrixEqCirc0`

```
./OMCppPowerSystems_cpp_PowerSystems.Examples.AC3ph.Precalculation.Z_matrixEqCirc0Initialize.cpp:198:31:
 note: in instantiation of template class 'StatArrayDim1<double, 18446744073709551615, false>' requested here
     StatArrayDim1<double, -1> tmp3;
```