### PR TITLE
Don't consider variability when filtering elements

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -1614,6 +1614,13 @@ algorithm
   vl_1 := getMatchingElements(vl, isOutputVar);
 end getOutputVars;
 
+public function getOutputElements
+  input list<DAE.Element> vl;
+  output list<DAE.Element> vl_1;
+algorithm
+  vl_1 := getMatchingElements(vl, isOutputElement);
+end getOutputElements;
+
 public function getProtectedVars "
   author: PA
 
@@ -1634,6 +1641,13 @@ public function getBidirVars "author: LS
 algorithm
   vl_1 := getMatchingElements(vl, isBidirVar);
 end getBidirVars;
+
+public function getBidirElements
+  input list<DAE.Element> vl;
+  output list<DAE.Element> vl_1;
+algorithm
+  vl_1 := getMatchingElements(vl, isBidirElement);
+end getBidirElements;
 
 public function getInputVars "
   Retrieve all input variables from an Element list.
@@ -1689,6 +1703,16 @@ algorithm
   end match;
 end isOutputVar;
 
+public function isOutputElement
+  input DAE.Element inElement;
+  output Boolean outMatch;
+algorithm
+  outMatch := match (inElement)
+    case DAE.VAR(direction = DAE.OUTPUT()) then true;
+    else false;
+  end match;
+end isOutputElement;
+
 public function assertProtectedVar
 "Succeeds if Element is a protected variable."
   input DAE.Element inElement;
@@ -1733,15 +1757,15 @@ algorithm
   end match;
 end isBidirVar;
 
-public function isBidirVarDirection
-  input DAE.VarDirection inVarDirection;
-  output Boolean outIsBidir;
+public function isBidirElement
+  input DAE.Element inElement;
+  output Boolean outMatch;
 algorithm
-  outIsBidir := match(inVarDirection)
-    case DAE.BIDIR() then true;
+  outMatch := match (inElement)
+    case DAE.VAR(direction = DAE.BIDIR()) then true;
     else false;
   end match;
-end isBidirVarDirection;
+end isBidirElement;
 
 public function isInputVar "
   Succeeds if Element is an input variable.
@@ -2882,7 +2906,7 @@ protected
   list<DAE.Element> elements;
 algorithm
   elements := getFunctionElements(fn);
-  outEls := List.filterOnTrue(elements, isOutputVar);
+  outEls := List.filterOnTrue(elements, isOutputElement);
 end getFunctionOutputVars;
 
 public function getFunctionProtectedVars

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -709,7 +709,7 @@ algorithm
 
         DAE.FUNCTION_ATTRIBUTES(functionParallelism=DAE.FP_NON_PARALLEL()) = funAttrs;
 
-        outVars = List.map(DAEUtil.getOutputVars(daeElts), daeInOutSimVar);
+        outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         vars = List.filterOnTrue(daeElts, isVarQ);
@@ -728,7 +728,7 @@ algorithm
 
         DAE.FUNCTION_ATTRIBUTES(functionParallelism=DAE.FP_KERNEL_FUNCTION()) = funAttrs;
 
-        outVars = List.map(DAEUtil.getOutputVars(daeElts), daeInOutSimVar);
+        outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         vars = List.filterOnTrue(daeElts, isVarNotInputNotOutput);
@@ -747,7 +747,7 @@ algorithm
 
         DAE.FUNCTION_ATTRIBUTES(functionParallelism=DAE.FP_PARALLEL_FUNCTION()) = funAttrs;
 
-        outVars = List.map(DAEUtil.getOutputVars(daeElts), daeInOutSimVar);
+        outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         vars = List.filterOnTrue(daeElts, isVarQ);
@@ -764,13 +764,13 @@ algorithm
       equation
         DAE.EXTERNALDECL(name=extfnname, args=extargs,
           returnArg=extretarg, language=lang, ann=ann) = extdecl;
-        // outvars = DAEUtil.getOutputVars(daeElts);
+        // outvars = DAEUtil.getOutputElements(daeElts);
         // invars = DAEUtil.getInputVars(daeElts);
         // bivars = DAEUtil.getBidirVars(daeElts);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
-        outVars = List.map(DAEUtil.getOutputVars(daeElts), daeInOutSimVar);
+        outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         inVars = List.map(DAEUtil.getInputVars(daeElts), daeInOutSimVar);
-        biVars = List.map(DAEUtil.getBidirVars(daeElts), daeInOutSimVar);
+        biVars = List.map(DAEUtil.getBidirElements(daeElts), daeInOutSimVar);
         (recordDecls, rt_1) = elaborateRecordDeclarations(daeElts, recordDecls, rt);
         info = ElementSource.getElementSourceFileInfo(source);
         (fn_includes, fn_includeDirs, fn_libs, fn_paths,dynamicLoad) = generateExtFunctionIncludes(program, fpath, ann, info);


### PR DESCRIPTION
### Related Issues

#7660

### Purpose

  - Fixes the immediate issue in #7660.
    The model still does not compile but it is now due to an undefined
    function `data_of_boolean_f77_array`

  - We were checking `variability` as well when what we actually interested
    in was just the `direction` of the element.

    It is an unfortunate mix-up in terminology.
