### PR TITLE
Fix editing of legend titles

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -2212,7 +2212,7 @@ bool SetupDialog::setupPlotCurve(VariablePageWidget *pVariablePageWidget)
   PlotCurve *pPlotCurve = pVariablePageWidget->getPlotCurve();
 
   /* set the legend title */
-  if (pPlotCurve->title().text().compare(pVariablePageWidget->getLegendTextBox()->text()) == 0) {
+  if (pPlotCurve->getCustomTitle().isEmpty() && pPlotCurve->title().text().compare(pVariablePageWidget->getLegendTextBox()->text()) == 0) {
     pPlotCurve->setCustomTitle("");
   } else {
     pPlotCurve->setCustomTitle(pVariablePageWidget->getLegendTextBox()->text());


### PR DESCRIPTION
### Related Issues

Fixes #7627

### Purpose

Update the legend titles.

### Approach

Do not reset the legend title if it is not modified.
