### PR TITLE
Fix #7667 and simplify Codegen.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -2610,7 +2610,7 @@ template extArg(SimExtArg extArg, Text &preExp, Text &varDecls, Text &auxFunctio
     let &varDecls += 'void *<%name%>_c89;<%\n%>'
     //let arg_name = match shortTypeStr case "integer" then '<%name%>_packed' else name
     let arg_name = if isInput then (match shortTypeStr case "integer" then '<%name%>_packed' else name) else name
-    let &preExp += '<%name%>_c89 = (void*) data_of_<%shortTypeStr%>_c89_array(&(<%arg_name%>));<%\n%>'
+    let &preExp += '<%name%>_c89 = (void*) data_of_<%shortTypeStr%>_c89_array(<%arg_name%>);<%\n%>'
     '(<%extType(t,isInput,true,false)%>) <%name%>_c89'
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=0, type_=t) then
     let cr = match t case T_STRING(__) then contextCrefNoPrevExp(c,contextFunction,&auxFunction) else extVarName(c)
@@ -2631,7 +2631,7 @@ template extArgF77(SimExtArg extArg, Text &preExp, Text &varDecls, Text &auxFunc
   match extArg
   case SIMEXTARG(cref=c, isArray=true, type_=t) then
     // Arrays are converted to fortran format that are stored in _ext-variables.
-    'data_of_<%expTypeShort(t)%>_f77_array(&(<%extVarName(c)%>))'
+    'data_of_<%expTypeShort(t)%>_f77_array(<%extVarName(c)%>)'
   case SIMEXTARG(cref=c, outputIndex=oi, type_=T_INTEGER(__)) then
     // Always prefix fortran arguments with &.
     let suffix = if oi then "_ext"
@@ -4971,7 +4971,7 @@ template daeExternalCExp(Exp exp, Context context, Text &preExp, Text &varDecls,
   match typeof(exp)
     case T_ARRAY(__) then  // Array-expressions
       let shortTypeStr = expTypeShort(typeof(exp))
-      '(<%extType(typeof(exp),true,true,false)%>) data_of_<%shortTypeStr%>_array(&<%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>)'
+      '(<%extType(typeof(exp),true,true,false)%>) data_of_<%shortTypeStr%>_array(<%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>)'
     case T_STRING(__) then
       let mstr = daeExp(exp, context, &preExp, &varDecls, &auxFunction)
       'MMC_STRINGDATA(<%mstr%>)'
@@ -4984,7 +4984,7 @@ template daeExternalF77Exp(Exp exp, Context context, Text &preExp, Text &varDecl
   match typeof(exp)
     case T_ARRAY(__) then  // Array-expressions
       let shortTypeStr = expTypeShort(typeof(exp))
-      '(<%extType(typeof(exp),true,true,false)%>) data_of_<%shortTypeStr%>_array(&<%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>)'
+      '(<%extType(typeof(exp),true,true,false)%>) data_of_<%shortTypeStr%>_array(<%daeExp(exp, context, &preExp, &varDecls, &auxFunction)%>)'
     case T_STRING(__) then
       let texp = daeExp(exp, contextFunction, &preExp, &varDecls, &auxFunction)
       let tvar = tempDecl(expTypeFromExpFlag(exp,8),&varDecls)

--- a/OMCompiler/Compiler/boot/bootstrap-sources/build/ModelicaExternalC.c
+++ b/OMCompiler/Compiler/boot/bootstrap-sources/build/ModelicaExternalC.c
@@ -18,7 +18,7 @@ alloc_real_array(&(_matrix), 2, _nrow, _ncol); // _matrix has no default value.
 _nrow_ext = (int)_nrow;
 _ncol_ext = (int)_ncol;
 _verboseRead_ext = (int)_verboseRead;
-_matrix_c89 = (void*) data_of_real_c89_array(&(_matrix));
+_matrix_c89 = (void*) data_of_real_c89_array(_matrix);
 ModelicaIO_readRealMatrix(MMC_STRINGDATA(_fileName), MMC_STRINGDATA(_matrixName), (double*) _matrix_c89, _nrow_ext, _ncol_ext, _verboseRead_ext);
 return _matrix;
 }
@@ -41,7 +41,7 @@ integer_array omc_ModelicaExternalC_ModelicaIO__readMatrixSizes(threadData_t *th
 void *_dim_c89;
 integer_array _dim;
 alloc_integer_array(&(_dim), 1, 2); // _dim has no default value.
-_dim_c89 = (void*) data_of_integer_c89_array(&(_dim));
+_dim_c89 = (void*) data_of_integer_c89_array(_dim);
 ModelicaIO_readMatrixSizes(MMC_STRINGDATA(_fileName), MMC_STRINGDATA(_matrixName), (int*) _dim_c89);
 unpack_integer_array(&_dim);
 return _dim;

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.h
@@ -169,10 +169,6 @@ extern void promote_alloc_boolean_array(const boolean_array_t* a, int n,
 
 static inline int ndims_boolean_array(const boolean_array_t* a)
 { return ndims_base_array(a); }
-static inline modelica_boolean *data_of_boolean_array(const boolean_array_t*a)
-{ return (modelica_boolean *) a->data; }
-static inline modelica_boolean *data_of_boolean_c89_array(const boolean_array_t*a)
-{ return (modelica_boolean *) a->data; }
 
 extern void size_boolean_array(const boolean_array_t* a, integer_array_t* dest);
 extern m_boolean scalar_boolean_array(const boolean_array_t* a);

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.h
@@ -83,4 +83,26 @@ void* generic_array_get2(const base_array_t* source, size_t sze, int dim1, int d
 
 void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t sze, ...);
 
+
+
+
+/// Get data functions. They return the raw data without the dim and size specifications.
+
+// #define data_of_real_array(arr)                     (modelica_real*) ((arr).data)
+#define data_of_real_f77_array(arr)                 (modelica_real*) ((arr).data)
+// #define data_of_real_c89_array(arr)                 (modelica_real*) ((arr).data)
+
+/* Note: data_of_integer_array converts from integer_array to int*, for external functions only */
+// #define data_of_integer_array(arr)                  (int*) ((arr).data)
+// Integer arrays are packed to int when converted to fortran arrays
+#define data_of_integer_f77_array(arr)              (int*) ((arr).data)
+// #define data_of_integer_c89_array(arr)              (int*) ((arr).data)
+
+// #define data_of_boolean_array(arr)                  (modelica_boolean*) ((arr).data)
+#define data_of_boolean_f77_array(arr)              (modelica_boolean*) ((arr).data)
+// #define data_of_boolean_c89_array(arr)              (modelica_boolean*) ((arr).data)
+
+
+
+
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.h
@@ -88,19 +88,22 @@ void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t s
 
 /// Get data functions. They return the raw data without the dim and size specifications.
 
-// #define data_of_real_array(arr)                     (modelica_real*) ((arr).data)
+#define data_of_real_array(arr)                     (modelica_real*) ((arr).data)
 #define data_of_real_f77_array(arr)                 (modelica_real*) ((arr).data)
-// #define data_of_real_c89_array(arr)                 (modelica_real*) ((arr).data)
+#define data_of_real_c89_array(arr)                 (modelica_real*) ((arr).data)
 
-/* Note: data_of_integer_array converts from integer_array to int*, for external functions only */
-// #define data_of_integer_array(arr)                  (int*) ((arr).data)
-// Integer arrays are packed to int when converted to fortran arrays
+#define data_of_integer_array(arr)                  (int*) ((arr).data)
+/// Integer arrays are packed to int when converted to fortran arrays
 #define data_of_integer_f77_array(arr)              (int*) ((arr).data)
-// #define data_of_integer_c89_array(arr)              (int*) ((arr).data)
+#define data_of_integer_c89_array(arr)              (int*) ((arr).data)
 
-// #define data_of_boolean_array(arr)                  (modelica_boolean*) ((arr).data)
+#define data_of_boolean_array(arr)                  (modelica_boolean*) ((arr).data)
 #define data_of_boolean_f77_array(arr)              (modelica_boolean*) ((arr).data)
-// #define data_of_boolean_c89_array(arr)              (modelica_boolean*) ((arr).data)
+#define data_of_boolean_c89_array(arr)              (modelica_boolean*) ((arr).data)
+
+#define data_of_string_array(arr)                  (modelica_string*) ((arr).data)
+// This one needs some manual processing. It is implemented in string_array.c/h
+// const char** data_of_string_c89_array(const string_array_t *a);
 
 
 

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.h
@@ -273,14 +273,4 @@ void unpack_integer_array(integer_array_t *a);
 void pack_alloc_integer_array(integer_array_t *a, integer_array_t *dest);
 void unpack_copy_integer_array(const integer_array_t *a, integer_array_t *dest);
 
-/* Note: data_of_integer_array converts from integer_array to int*, for external functions only */
-static inline int* data_of_integer_array(const integer_array_t *a)
-{ return (int *) a->data; }
-
-static inline int* data_of_integer_f77_array(const integer_array_t *a)
-{ return (int *) a->data; }
-
-static inline int* data_of_integer_c89_array(const integer_array_t *a)
-{ return (int *) a->data; }
-
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/real_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.h
@@ -212,12 +212,6 @@ extern void promote_alloc_real_array(const real_array_t * a, int n, real_array_t
 
 static inline int ndims_real_array(const real_array_t * a)
 { return ndims_base_array(a); }
-static inline modelica_real *data_of_real_array(const real_array_t *a)
-{ return (modelica_real *) a->data; }
-static inline modelica_real *data_of_real_c89_array(const real_array_t *a)
-{ return (modelica_real *) a->data; }
-static inline modelica_real *data_of_real_f77_array(const real_array_t *a)
-{ return (modelica_real *) a->data; }
 
 extern void size_real_array(const real_array_t * a,integer_array_t* dest);
 extern modelica_real scalar_real_array(const real_array_t * a);

--- a/OMCompiler/SimulationRuntime/c/util/string_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.c
@@ -825,13 +825,13 @@ void fill_alloc_string_array(string_array_t* dest, modelica_string value, int nd
   }
 }
 
-const char** data_of_string_c89_array(const string_array_t *a)
+const char** data_of_string_c89_array(const string_array_t a)
 {
   long i;
-  size_t sz = base_array_nr_of_elements(*a);
+  size_t sz = base_array_nr_of_elements(a);
   const char **res = (const char**) omc_alloc_interface.malloc(sz*sizeof(const char*));
   for (i=0; i<sz; i++) {
-    res[i] = MMC_STRINGDATA(((void**)a->data)[i]);
+    res[i] = MMC_STRINGDATA(((void**)a.data)[i]);
   }
   return res;
 }

--- a/OMCompiler/SimulationRuntime/c/util/string_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.h
@@ -164,7 +164,7 @@ extern void promote_alloc_string_array(const string_array_t * a, int n,
 static inline int ndims_string_array(const string_array_t * a)
 { return ndims_base_array(a); }
 
-extern const char** data_of_string_c89_array(const string_array_t *a);
+extern const char** data_of_string_c89_array(const string_array_t a);
 
 extern void size_string_array(const string_array_t * a, integer_array_t* dest);
 extern modelica_string scalar_string_array(const string_array_t * a);

--- a/OMCompiler/SimulationRuntime/c/util/string_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.h
@@ -163,8 +163,7 @@ extern void promote_alloc_string_array(const string_array_t * a, int n,
 
 static inline int ndims_string_array(const string_array_t * a)
 { return ndims_base_array(a); }
-static inline modelica_string *data_of_string_array(const string_array_t *a)
-{ return (modelica_string *) a->data; }
+
 extern const char** data_of_string_c89_array(const string_array_t *a);
 
 extern void size_string_array(const string_array_t * a, integer_array_t* dest);


### PR DESCRIPTION
### Related Issues

#7667

### Approach
@mahge
Fix #7667 and simplify codegen. …
270e671
  - Remove unnecessary small functions and replace them with #defines in
    generic_array.h

  - Add data_of_boolean* defines.
  

@mahge
Enable more data_of_* & Update bootstrap source …
7ba7a71
  - Enable data_of_real_c89_array(), data_of_integer_c89_array()

  - Change data_of_string_array to macro version.
    data_of_string_c89_array() is left in string_array.h since it actually
    does some modifications.

  - Remove overlooked boolean versions of the functions.

  - Update bootstrap sources that use this function because now it is a
    macro and there is no need to pass by pointer.


@mahge
Fix parameter type for string version. …
9ab1213
  - We need to pass by value now since the macros are written that way.
    We will have to improve this later and use a macro that handles it.
