### PR TITLE
Three things

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/Array.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/Array.h
@@ -5,13 +5,6 @@
  */
 
 /**
-* forward declaration
-*/
-template <class T> class DynArrayDim1;
-template <class T> class DynArrayDim2;
-template <class T> class DynArrayDim3;
-
-/**
 * Operator class to assign simvar memory to a reference array
 */
 template<typename T>
@@ -106,42 +99,62 @@ public:
   virtual T& operator()(size_t i)
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
 
   virtual const T& operator()(size_t i) const
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
 
   virtual T& operator()(size_t i, size_t j)
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
 
   virtual const T& operator()(size_t i, size_t j) const
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
 
   virtual T& operator()(size_t i, size_t j, size_t k)
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
 
   virtual const T& operator()(size_t i, size_t j, size_t k) const
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
 
   virtual T& operator()(size_t i, size_t j, size_t k, size_t l)
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
+
+  virtual const T& operator()(size_t i, size_t j, size_t k, size_t l) const
+  {
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
+  }
 
   virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m)
   {
     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
-  };
+  }
+
+  virtual const T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m) const
+  {
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
+  }
+
+  virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n)
+  {
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
+  }
+
+  virtual const T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) const
+  {
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong virtual Array operator call");
+  }
 
   bool isStatic() const
   {
@@ -1544,6 +1557,603 @@ class StatArrayDim3 : public StatArray<T, size1*size2*size3, external>
 };
 
 /**
+ * Three dimensional static array, implements BaseArray interface methods
+ * @param  T type of the array
+ * @param size1  size of dimension one
+ * @param size2  size of dimension two
+ * @param size3  size of dimension three
+ * @param size4  size of dimension four
+ * @param external indicates if the memory is provided externally
+ */
+template<typename T, std::size_t size1, std::size_t size2, std::size_t size3, std::size_t size4, bool external = false>
+class StatArrayDim4 : public StatArray<T, size1*size2*size3*size4, external>
+{
+ public:
+  /**
+   * Constuctor for one dimensional array
+   * if reference array it uses data from simvars memory
+   * else it copies data  in array memory
+   */
+  StatArrayDim4(T* data)
+    :StatArray<T, size1*size2*size3*size4, external>(data) {}
+
+  /**
+   * Constuctor for three dimensional array
+   * copies data from otherarray in array memory
+   * or holds a pointer to otherarray's data
+   */
+  StatArrayDim4(const StatArrayDim4<T, size1, size2, size3, size4, true>& otherarray)
+    :StatArray<T, size1*size2*size3*size4, external>(otherarray)
+  {
+  }
+
+  /**
+   * Constuctor for three dimensional array
+   * copies data from otherarray in array memory
+   * or holds a pointer to otherarray's data
+   */
+  StatArrayDim4(const StatArrayDim4<T, size1, size2, size3, size4, false>& otherarray)
+    :StatArray<T, size1*size2*size3*size4, external>(otherarray)
+  {
+  }
+
+  /**
+   * Constuctor for one dimensional array that
+   * lets otherarray copy data into array memory
+   */
+  StatArrayDim4(const BaseArray<T>& otherarray)
+    :StatArray<T, size1*size2*size3*size4, external>(otherarray)
+  {
+  }
+
+  /**
+   * Default constuctor for three dimensional array
+   */
+  StatArrayDim4()
+    :StatArray<T, size1*size2*size3*size4, external>() {}
+
+  virtual ~StatArrayDim4() {}
+
+  /**
+   * Assign static array with external storage to static array.
+   * a = b
+   * @param b any array of type StatArrayDim4
+   */
+  StatArrayDim4<T, size1, size2, size3, size4, external>&
+  operator=(const StatArrayDim4<T, size1, size2, size3, size4, true>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Assign static array with internal storage to static array.
+   * a = b
+   * @param b any array of type StatArrayDim4
+   */
+  StatArrayDim4<T, size1, size2, size3, size4, external>&
+  operator=(const StatArrayDim4<T, size1, size2, size3, size4, false>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Assign array of type base array to three dim static array
+   * a = b
+   * @param b any array of type BaseArray
+   */
+  StatArrayDim4<T, size1, size2, size3, size4, external>&
+  operator=(const BaseArray<T>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Copies two dimensional array to row i
+   * @param b array of type StatArrayDim3
+   * @param i row number
+   * @param n optional number of rows not needed for static arrays
+   */
+  template<bool anybool>
+  void append(size_t i, const StatArrayDim3<T, size2, size3, anybool>& b, size_t n = 0)
+  {
+    const T* data = b.getData();
+    T *array_data = StatArray<T, size1*size2*size3*size4, external>::getData() + i-1;
+    for (size_t l = 1; l <= size4; l++) {
+      for (size_t k = 1; k <= size3; k++) {
+        for (size_t j = 1; j <= size2; j++) {
+          //(*this)(i, j, k, l) = b(j, k, l);
+          *array_data = *data++;
+          array_data += size1;
+        }
+      }
+    }
+  }
+
+  /**
+   * Return sizes of dimensions
+   */
+  virtual std::vector<size_t> getDims() const
+  {
+    std::vector<size_t> v;
+    v.push_back(size1);
+    v.push_back(size2);
+    v.push_back(size3);
+    v.push_back(size4);
+    return v;
+  }
+
+  /**
+   * Return sizes of one dimension
+   */
+  virtual int getDim(size_t dim) const
+  {
+    switch (dim) {
+    case 1:
+      return (int)size1;
+    case 2:
+      return (int)size2;
+    case 3:
+      return (int)size3;
+    case 4:
+      return (int)size4;
+    default:
+      throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong getDim");
+    }
+  }
+
+  /**
+   * Index operator to read array element
+   * @param idx  vector of indices
+   */
+  virtual const T& operator()(const vector<size_t>& idx) const
+  {
+    return StatArray<T, size1*size2*size3*size4, external>::
+      _data[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1 + size3*(idx[3]-1)))];
+  }
+
+  /**
+   * Index operator to write array element
+   * @param idx  vector of indices
+   */
+  virtual T& operator()(const vector<size_t>& idx)
+  {
+    return StatArray<T, size1*size2*size3*size4, external>::
+      _data[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1 + size3*(idx[3]-1)))];
+  }
+
+  /**
+   * Index operator to access array element
+   * @param i  index 1
+   * @param j  index 2
+   * @param k  index 3
+   * @param l  index 4
+   */
+  inline virtual T& operator()(size_t i, size_t j, size_t k, size_t l)
+  {
+    return StatArray<T, size1*size2*size3*size4, external>::
+      _data[i-1 + size1*(j-1 + size2*(k-1 + size3*(l-1)))];
+  }
+
+  /**
+   * Return sizes of dimensions
+   */
+  virtual size_t getNumDims() const
+  {
+    return 4;
+  }
+
+  void setDims(size_t i, size_t j, size_t k, size_t l) {}
+};
+
+/**
+ * Three dimensional static array, implements BaseArray interface methods
+ * @param  T type of the array
+ * @param size1  size of dimension one
+ * @param size2  size of dimension two
+ * @param size3  size of dimension three
+ * @param size4  size of dimension four
+ * @param size5  size of dimension five
+ * @param external indicates if the memory is provided externally
+ */
+template<typename T, std::size_t size1, std::size_t size2, std::size_t size3, std::size_t size4, std::size_t size5, bool external = false>
+class StatArrayDim5 : public StatArray<T, size1*size2*size3*size4*size5, external>
+{
+ public:
+  /**
+   * Constuctor for one dimensional array
+   * if reference array it uses data from simvars memory
+   * else it copies data  in array memory
+   */
+  StatArrayDim5(T* data)
+    :StatArray<T, size1*size2*size3*size4*size5, external>(data) {}
+
+  /**
+   * Constuctor for three dimensional array
+   * copies data from otherarray in array memory
+   * or holds a pointer to otherarray's data
+   */
+  StatArrayDim5(const StatArrayDim5<T, size1, size2, size3, size4, size5, true>& otherarray)
+    :StatArray<T, size1*size2*size3*size4*size5, external>(otherarray)
+  {
+  }
+
+  /**
+   * Constuctor for three dimensional array
+   * copies data from otherarray in array memory
+   * or holds a pointer to otherarray's data
+   */
+  StatArrayDim5(const StatArrayDim5<T, size1, size2, size3, size4, size5, false>& otherarray)
+    :StatArray<T, size1*size2*size3*size4*size5, external>(otherarray)
+  {
+  }
+
+  /**
+   * Constuctor for one dimensional array that
+   * lets otherarray copy data into array memory
+   */
+  StatArrayDim5(const BaseArray<T>& otherarray)
+    :StatArray<T, size1*size2*size3*size4*size5, external>(otherarray)
+  {
+  }
+
+  /**
+   * Default constuctor for three dimensional array
+   */
+  StatArrayDim5()
+    :StatArray<T, size1*size2*size3*size4*size5, external>() {}
+
+  virtual ~StatArrayDim5() {}
+
+  /**
+   * Assign static array with external storage to static array.
+   * a = b
+   * @param b any array of type StatArrayDim5
+   */
+  StatArrayDim5<T, size1, size2, size3, size4, size5, external>&
+  operator=(const StatArrayDim5<T, size1, size2, size3, size4, size5, true>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Assign static array with internal storage to static array.
+   * a = b
+   * @param b any array of type StatArrayDim5
+   */
+  StatArrayDim5<T, size1, size2, size3, size4, size5, external>&
+  operator=(const StatArrayDim5<T, size1, size2, size3, size4, size5, false>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Assign array of type base array to three dim static array
+   * a = b
+   * @param b any array of type BaseArray
+   */
+  StatArrayDim5<T, size1, size2, size3, size4, size5, external>&
+  operator=(const BaseArray<T>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Copies two dimensional array to row i
+   * @param b array of type StatArrayDim3
+   * @param i row number
+   * @param n optional number of rows not needed for static arrays
+   */
+  template<bool anybool>
+  void append(size_t i, const StatArrayDim4<T, size2, size3, size4, anybool>& b, size_t n = 0)
+  {
+    const T* data = b.getData();
+    T *array_data = StatArray<T, size1*size2*size3*size4*size5, external>::getData() + i-1;
+    for (size_t m = 1; m <= size5; m++) {
+      for (size_t l = 1; l <= size4; l++) {
+        for (size_t k = 1; k <= size3; k++) {
+          for (size_t j = 1; j <= size2; j++) {
+            //(*this)(i, j, k, l, m) = b(j, k, l, m);
+            *array_data = *data++;
+            array_data += size1;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Return sizes of dimensions
+   */
+  virtual std::vector<size_t> getDims() const
+  {
+    std::vector<size_t> v;
+    v.push_back(size1);
+    v.push_back(size2);
+    v.push_back(size3);
+    v.push_back(size4);
+    v.push_back(size5);
+    return v;
+  }
+
+  /**
+   * Return sizes of one dimension
+   */
+  virtual int getDim(size_t dim) const
+  {
+    switch (dim) {
+    case 1:
+      return (int)size1;
+    case 2:
+      return (int)size2;
+    case 3:
+      return (int)size3;
+    case 4:
+      return (int)size4;
+    case 5:
+      return (int)size5;
+    default:
+      throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong getDim");
+    }
+  }
+
+  /**
+   * Index operator to read array element
+   * @param idx  vector of indices
+   */
+  virtual const T& operator()(const vector<size_t>& idx) const
+  {
+    return StatArray<T, size1*size2*size3*size4*size5, external>::
+      _data[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1 + size3*(idx[3]-1 + size4*(idx[4]-1))))];
+  }
+
+  /**
+   * Index operator to write array element
+   * @param idx  vector of indices
+   */
+  virtual T& operator()(const vector<size_t>& idx)
+  {
+    return StatArray<T, size1*size2*size3*size4*size5, external>::
+      _data[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1 + size3*(idx[3]-1 + size4*(idx[4]-1))))];
+  }
+
+  /**
+   * Index operator to access array element
+   * @param i  index 1
+   * @param j  index 2
+   * @param k  index 3
+   * @param l  index 4
+   * @param m  index 5
+   */
+  inline virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m)
+  {
+    return StatArray<T, size1*size2*size3*size4*size5, external>::
+      _data[i-1 + size1*(j-1 + size2*(k-1 + size3*(l-1 + size4*(m-1))))];
+  }
+
+  /**
+   * Return sizes of dimensions
+   */
+  virtual size_t getNumDims() const
+  {
+    return 5;
+  }
+
+  void setDims(size_t i, size_t j, size_t k, size_t l, size_t m) {}
+};
+
+/**
+ * Three dimensional static array, implements BaseArray interface methods
+ * @param  T type of the array
+ * @param size1  size of dimension one
+ * @param size2  size of dimension two
+ * @param size3  size of dimension three
+ * @param size4  size of dimension four
+ * @param size5  size of dimension five
+ * @param size6  size of dimension six
+ * @param external indicates if the memory is provided externally
+ */
+template<typename T, std::size_t size1, std::size_t size2, std::size_t size3, std::size_t size4, std::size_t size5, std::size_t size6, bool external = false>
+class StatArrayDim6 : public StatArray<T, size1*size2*size3*size4*size5*size6, external>
+{
+ public:
+  /**
+   * Constuctor for one dimensional array
+   * if reference array it uses data from simvars memory
+   * else it copies data  in array memory
+   */
+  StatArrayDim6(T* data)
+    :StatArray<T, size1*size2*size3*size4*size5*size6, external>(data) {}
+
+  /**
+   * Constuctor for three dimensional array
+   * copies data from otherarray in array memory
+   * or holds a pointer to otherarray's data
+   */
+  StatArrayDim6(const StatArrayDim6<T, size1, size2, size3, size4, size5, size6, true>& otherarray)
+    :StatArray<T, size1*size2*size3*size4*size5*size6, external>(otherarray)
+  {
+  }
+
+  /**
+   * Constuctor for three dimensional array
+   * copies data from otherarray in array memory
+   * or holds a pointer to otherarray's data
+   */
+  StatArrayDim6(const StatArrayDim6<T, size1, size2, size3, size4, size5, size6, false>& otherarray)
+    :StatArray<T, size1*size2*size3*size4*size5*size6, external>(otherarray)
+  {
+  }
+
+  /**
+   * Constuctor for one dimensional array that
+   * lets otherarray copy data into array memory
+   */
+  StatArrayDim6(const BaseArray<T>& otherarray)
+    :StatArray<T, size1*size2*size3*size4*size5*size6, external>(otherarray)
+  {
+  }
+
+  /**
+   * Default constuctor for three dimensional array
+   */
+  StatArrayDim6()
+    :StatArray<T, size1*size2*size3*size4*size5*size6, external>() {}
+
+  virtual ~StatArrayDim6() {}
+
+  /**
+   * Assign static array with external storage to static array.
+   * a = b
+   * @param b any array of type StatArrayDim6
+   */
+  StatArrayDim6<T, size1, size2, size3, size4, size5, size6, external>&
+  operator=(const StatArrayDim6<T, size1, size2, size3, size4, size5, size6, true>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Assign static array with internal storage to static array.
+   * a = b
+   * @param b any array of type StatArrayDim6
+   */
+  StatArrayDim6<T, size1, size2, size3, size4, size5, size6, external>&
+  operator=(const StatArrayDim6<T, size1, size2, size3, size4, size5, size6, false>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Assign array of type base array to three dim static array
+   * a = b
+   * @param b any array of type BaseArray
+   */
+  StatArrayDim6<T, size1, size2, size3, size4, size5, size6, external>&
+  operator=(const BaseArray<T>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  /**
+   * Copies two dimensional array to row i
+   * @param b array of type StatArrayDim3
+   * @param i row number
+   * @param n optional number of rows not needed for static arrays
+   */
+  template<bool anybool>
+  void append(size_t i, const StatArrayDim5<T, size2, size3, size4, size5, anybool>& b, size_t n = 0)
+  {
+    const T* data = b.getData();
+    T *array_data = StatArray<T, size1*size2*size3*size4*size5*size6, external>::getData() + i-1;
+    for (size_t n = 1; n <= size6; n++) {
+      for (size_t m = 1; m <= size5; m++) {
+        for (size_t l = 1; l <= size4; l++) {
+          for (size_t k = 1; k <= size3; k++) {
+            for (size_t j = 1; j <= size2; j++) {
+              //(*this)(i, j, k, l, m, n) = b(j, k, l, m, n);
+              *array_data = *data++;
+              array_data += size1;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Return sizes of dimensions
+   */
+  virtual std::vector<size_t> getDims() const
+  {
+    std::vector<size_t> v;
+    v.push_back(size1);
+    v.push_back(size2);
+    v.push_back(size3);
+    v.push_back(size4);
+    v.push_back(size5);
+    v.push_back(size6);
+    return v;
+  }
+
+  /**
+   * Return sizes of one dimension
+   */
+  virtual int getDim(size_t dim) const
+  {
+    switch (dim) {
+    case 1:
+      return (int)size1;
+    case 2:
+      return (int)size2;
+    case 3:
+      return (int)size3;
+    case 4:
+      return (int)size4;
+    case 5:
+      return (int)size5;
+    case 6:
+      return (int)size6;
+    default:
+      throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong getDim");
+    }
+  }
+
+  /**
+   * Index operator to read array element
+   * @param idx  vector of indices
+   */
+  virtual const T& operator()(const vector<size_t>& idx) const
+  {
+    return StatArray<T, size1*size2*size3*size4*size5*size6, external>::
+      _data[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1 + size3*(idx[3]-1 + size4*(idx[4]-1 + size5*(idx[5]-1)))))];
+  }
+
+  /**
+   * Index operator to write array element
+   * @param idx  vector of indices
+   */
+  virtual T& operator()(const vector<size_t>& idx)
+  {
+    return StatArray<T, size1*size2*size3*size4*size5*size6, external>::
+      _data[idx[0]-1 + size1*(idx[1]-1 + size2*(idx[2]-1 + size3*(idx[3]-1 + size4*(idx[4]-1 + size5*(idx[5]-1)))))];
+  }
+
+  /**
+   * Index operator to access array element
+   * @param i  index 1
+   * @param j  index 2
+   * @param k  index 3
+   * @param l  index 4
+   * @param m  index 5
+   * @param n  index 6
+   */
+  inline virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n)
+  {
+    return StatArray<T, size1*size2*size3*size4*size5*size6, external>::
+      _data[i-1 + size1*(j-1 + size2*(k-1 + size3*(l-1 + size4*(m-1 + size5*(n-1)))))];
+  }
+
+  /**
+   * Return sizes of dimensions
+   */
+  virtual size_t getNumDims() const
+  {
+    return 6;
+  }
+
+  void setDims(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) {}
+};
+
+/**
  * Dynamically allocated array, implements BaseArray interface methods
  * @param T type of the array
  * @param ndims number of dimensions of array
@@ -1697,7 +2307,6 @@ class DynArray : public BaseArray<T>
 template<typename T>
 class DynArrayDim1 : public DynArray<T, 1>
 {
-  friend class DynArrayDim2<T>;
  public:
   DynArrayDim1()
     :DynArray<T, 1>()
@@ -1976,4 +2585,251 @@ public:
     return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1))];
   }
 };
+
+/**
+ * Dynamically allocated three dimensional array, specializes DynArray
+ * @param T type of the array
+ */
+template<typename T>
+class DynArrayDim4 : public DynArray<T, 4>
+{
+public:
+  DynArrayDim4()
+    :DynArray<T, 4>()
+  {
+  }
+
+  DynArrayDim4(const BaseArray<T>& b)
+    :DynArray<T, 4>(b)
+  {
+  }
+
+  DynArrayDim4(size_t size1, size_t size2, size_t size3, size_t size4)
+    :DynArray<T, 4>()
+  {
+    std::vector<size_t> dims;
+    dims.push_back(size1);
+    dims.push_back(size2);
+    dims.push_back(size3);
+    dims.push_back(size4);
+    this->resize(dims);
+  }
+
+  virtual ~DynArrayDim4() {}
+
+  DynArrayDim4<T>& operator=(const DynArrayDim4<T>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  void setDims(size_t size1, size_t size2, size_t size3, size_t size4)
+  {
+    std::vector<size_t> dims;
+    dims.push_back(size1);
+    dims.push_back(size2);
+    dims.push_back(size3);
+    dims.push_back(size4);
+    this->resize(dims);
+  }
+  virtual void setDims(const std::vector<size_t>& dims)
+  {
+      this->resize(dims);
+  }
+
+  virtual const T& operator()(const vector<size_t>& idx) const
+  {
+    //return _multi_array[idx[0]-1][idx[1]-1][idx[2]-1][idx[3]-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[idx[0]-1 + shape[0]*(idx[1]-1 + shape[1]*(idx[2]-1 + shape[2]*(idx[3]-1)))];
+  }
+
+  virtual T& operator()(const vector<size_t>& idx)
+  {
+    //return _multi_array[idx[0]-1][idx[1]-1][idx[2]-1][idx[3]-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[idx[0]-1 + shape[0]*(idx[1]-1 + shape[1]*(idx[2]-1 + shape[2]*(idx[3]-1)))];
+  }
+
+  inline virtual T& operator()(size_t i, size_t j, size_t k, size_t l)
+  {
+    //return _multi_array[i-1][j-1][k-1][l-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1 + shape[2]*(l-1)))];
+  }
+
+  inline virtual const T& operator()(size_t i, size_t j, size_t k, size_t l) const
+  {
+    //return _multi_array[i-1][j-1][k-1][l-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1 + shape[2]*(l-1)))];
+  }
+};
+
+/**
+ * Dynamically allocated three dimensional array, specializes DynArray
+ * @param T type of the array
+ */
+template<typename T>
+class DynArrayDim5 : public DynArray<T, 5>
+{
+public:
+  DynArrayDim5()
+    :DynArray<T, 5>()
+  {
+  }
+
+  DynArrayDim5(const BaseArray<T>& b)
+    :DynArray<T, 5>(b)
+  {
+  }
+
+  DynArrayDim5(size_t size1, size_t size2, size_t size3, size_t size4, size_t size5)
+    :DynArray<T, 5>()
+  {
+    std::vector<size_t> dims;
+    dims.push_back(size1);
+    dims.push_back(size2);
+    dims.push_back(size3);
+    dims.push_back(size4);
+    dims.push_back(size5);
+    this->resize(dims);
+  }
+
+  virtual ~DynArrayDim5() {}
+
+  DynArrayDim5<T>& operator=(const DynArrayDim5<T>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  void setDims(size_t size1, size_t size2, size_t size3, size_t size4, size_t size5)
+  {
+    std::vector<size_t> dims;
+    dims.push_back(size1);
+    dims.push_back(size2);
+    dims.push_back(size3);
+    dims.push_back(size4);
+    dims.push_back(size5);
+    this->resize(dims);
+  }
+  virtual void setDims(const std::vector<size_t>& dims)
+  {
+      this->resize(dims);
+  }
+
+  virtual const T& operator()(const vector<size_t>& idx) const
+  {
+    //return _multi_array[idx[0]-1][idx[1]-1][idx[2]-1][idx[3]-1][idx[4]-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[idx[0]-1 + shape[0]*(idx[1]-1 + shape[1]*(idx[2]-1 + shape[2]*(idx[3]-1 + shape[3]*(idx[4]-1))))];
+  }
+
+  virtual T& operator()(const vector<size_t>& idx)
+  {
+    //return _multi_array[idx[0]-1][idx[1]-1][idx[2]-1][idx[3]-1][idx[4]-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[idx[0]-1 + shape[0]*(idx[1]-1 + shape[1]*(idx[2]-1 + shape[2]*(idx[3]-1 + shape[3]*(idx[4]-1))))];
+  }
+
+  inline virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m)
+  {
+    //return _multi_array[i-1][j-1][k-1][l-1][m-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1 + shape[2]*(l-1 + shape[3]*(m-1))))];
+  }
+
+  inline virtual const T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m) const
+  {
+    //return _multi_array[i-1][j-1][k-1][l-1][m-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1 + shape[2]*(l-1 + shape[3]*(m-1))))];
+  }
+};
+
+/**
+ * Dynamically allocated three dimensional array, specializes DynArray
+ * @param T type of the array
+ */
+template<typename T>
+class DynArrayDim6 : public DynArray<T, 6>
+{
+public:
+  DynArrayDim6()
+    :DynArray<T, 6>()
+  {
+  }
+
+  DynArrayDim6(const BaseArray<T>& b)
+    :DynArray<T, 6>(b)
+  {
+  }
+
+  DynArrayDim6(size_t size1, size_t size2, size_t size3, size_t size4, size_t size5, size_t size6)
+    :DynArray<T, 6>()
+  {
+    std::vector<size_t> dims;
+    dims.push_back(size1);
+    dims.push_back(size2);
+    dims.push_back(size3);
+    dims.push_back(size4);
+    dims.push_back(size5);
+    dims.push_back(size6);
+    this->resize(dims);
+  }
+
+  virtual ~DynArrayDim6() {}
+
+  DynArrayDim6<T>& operator=(const DynArrayDim6<T>& b)
+  {
+    this->assign(b);
+    return *this;
+  }
+
+  void setDims(size_t size1, size_t size2, size_t size3, size_t size4, size_t size5, size_t size6)
+  {
+    std::vector<size_t> dims;
+    dims.push_back(size1);
+    dims.push_back(size2);
+    dims.push_back(size3);
+    dims.push_back(size4);
+    dims.push_back(size5);
+    dims.push_back(size6);
+    this->resize(dims);
+  }
+  virtual void setDims(const std::vector<size_t>& dims)
+  {
+      this->resize(dims);
+  }
+
+  virtual const T& operator()(const vector<size_t>& idx) const
+  {
+    //return _multi_array[idx[0]-1][idx[1]-1][idx[2]-1][idx[3]-1][idx[4]-1][idx[5]-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[idx[0]-1 + shape[0]*(idx[1]-1 + shape[1]*(idx[2]-1 + shape[2]*(idx[3]-1 + shape[3]*(idx[4]-1 + shape[4]*(idx[5]-1)))))];
+  }
+
+  virtual T& operator()(const vector<size_t>& idx)
+  {
+    //return _multi_array[idx[0]-1][idx[1]-1][idx[2]-1][idx[3]-1][idx[4]-1][idx[5]-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[idx[0]-1 + shape[0]*(idx[1]-1 + shape[1]*(idx[2]-1 + shape[2]*(idx[3]-1 + shape[3]*(idx[4]-1 + shape[4]*(idx[5]-1)))))];
+  }
+
+  inline virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n)
+  {
+    //return _multi_array[i-1][j-1][k-1][l-1][m-1][n-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1 + shape[2]*(l-1 + shape[3]*(m-1 + shape[4]*(n-1)))))];
+  }
+
+  inline virtual const T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) const
+  {
+    //return _multi_array[i-1][j-1][k-1][l-1][m-1][n-1];
+    const std::vector<size_t>& shape = this->_dims;
+    return this->_array_data[i-1 + shape[0]*(j-1 + shape[1]*(k-1 + shape[2]*(l-1 + shape[3]*(m-1 + shape[4]*(n-1)))))];
+  }
+};
+
 /** @} */ // end of math

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/ArraySlice.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/Math/ArraySlice.h
@@ -278,6 +278,11 @@ class ArraySliceConst: public BaseArray<T> {
     return _baseArray(baseIdx(5, idx));
   }
 
+  virtual const T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) const {
+    size_t idx[] = {i, j, k, l, m, n};
+    return _baseArray(baseIdx(6, idx));
+  }
+
  protected:
   const BaseArray<T> &_baseArray;  // underlying array
   vector<const BaseArray<int>*> _isets; // given index sets per dimension
@@ -406,6 +411,11 @@ class ArraySlice: public ArraySliceConst<T> {
   virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m) {
     size_t idx[] = {i, j, k, l, m};
     return _baseArray(ArraySliceConst<T>::baseIdx(5, idx));
+  }
+
+  virtual T& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) {
+    size_t idx[] = {i, j, k, l, m, n};
+    return _baseArray(ArraySliceConst<T>::baseIdx(6, idx));
   }
 
  protected:

--- a/OMCompiler/SimulationRuntime/cpp/Include/SimCoreFactory/OMCFactory/OMCFactory.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/SimCoreFactory/OMCFactory/OMCFactory.h
@@ -56,15 +56,6 @@ protected:
   std::vector<const char *> handleComplexCRuntimeArguments(int argc, const char* argv[], std::map<std::string, std::string> &opts);
 
   /**
-   * Replace all argument names that are part of the arguments-to-replace-map.
-   * @param argc Number of arguments in the argv-array.
-   * @param argv The command line arguments as c-string array.
-   * @param opts Already parsed command line arguments (as key-value-pairs)
-   * @return All arguments including the replaced strings.
-   */
-  std::vector<const char *> handleArgumentsToReplace(int argc, const char* argv[], std::map<std::string, std::string> &opts);
-
-  /**
    * Evaluate all given command line arguments and store their values into the SimSettings structure.
    * @param argc Number of arguments in the argv-array.
    * @param argv The command line arguments as c-string array.
@@ -75,13 +66,11 @@ protected:
 
   /**
    * This helper-function is invoked by the boost program option library and will handle options in the c-runtime
-   * format and options that should be ignored.
-   * It parses a long option that starts with one dash, like '-port=12345' and put it into the 'unrecognized' category.
-   * If an option is detected which is part of the arguments to ignore list, it is put into the 'ignored' category.
+   * format, replacing them with correcponding cpp options.
    * @param The argument that should be handled.
    * @return The pair of category and value that should be used for the given argument.
    */
-  pair<string, string> parseIngoredAndWrongFormatOption(const string &s);
+  pair<string, string> replaceCRuntimeArguments(const string &arg);
 
   void fillArgumentsToIgnore();
   void fillArgumentsToReplace();

--- a/OMCompiler/SimulationRuntime/cpp/Include/Solver/Newton/Newton.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Solver/Newton/Newton.h
@@ -97,6 +97,7 @@ class Newton : public INonLinearAlgLoopSolver,  public AlgLoopSolverDefaultImple
     *_fTest,                    ///< Temp        - Auxillary variables
     *_jac;                      ///< Temp        - Jacobian
   long int *_iHelp;
+  long int *_jHelp;
   LogCategory _lc;              ///< LC_NLS or LC_LS
 
 };/** @} */ // end of solverNewton

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Dgesv/DgesvSolver.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Dgesv/DgesvSolver.cpp
@@ -218,10 +218,12 @@ void DgesvSolver::solve()
     dgetc2_(&_dimSys, _A, &_dimSys, _iHelp, _jHelp, &info2);
     dgesc2_(&_dimSys, _A, &_dimSys, _b, _iHelp, _jHelp, &scale);
     _hasDgetc2Factors = true;
-    LOGGER_WRITE("DgesvSolver: using total pivoting (dgesv info: " + to_string(info) + ", dgesc2 scale: " + to_string(scale) + ")", LC_LS, LL_DEBUG);
+    LOGGER_WRITE("total pivoting: dgesv/dgetc2 infos: " + to_string(info) + "/" + to_string(info2) +
+                 ", dgesc2 scale: " + to_string(scale) + ")", LC_LS, LL_DEBUG);
   }
   else if (info < 0) {
     _iterationStatus = SOLVERERROR;
+    LOGGER_WRITE_END(LC_LS, LL_DEBUG);
     if (_algLoop->isLinearTearing())
       throw ModelicaSimulationError(ALGLOOP_SOLVER, "error solving linear tearing system (dgesv info: " + to_string(info) + ")");
     else

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
@@ -30,6 +30,7 @@ Newton::Newton(INonLinSolverSettings* settings,shared_ptr<INonLinearAlgLoop> alg
   , _fHelp            (NULL)
   , _fTest            (NULL)
   , _iHelp            (NULL)
+  , _jHelp            (NULL)
   , _jac              (NULL)
   , _firstCall        (true)
   , _iterationStatus  (CONTINUE)
@@ -59,6 +60,7 @@ Newton::~Newton()
   if (_fHelp)    delete []    _fHelp;
   if (_fTest)    delete []    _fTest;
   if (_iHelp)    delete []    _iHelp;
+  if (_jHelp)    delete []    _jHelp;
   if (_jac)      delete []    _jac;
 }
 
@@ -89,6 +91,7 @@ void Newton::initialize()
       if (_fHelp)    delete []    _fHelp;
       if (_fTest)    delete []    _fTest;
       if (_iHelp)    delete []    _iHelp;
+      if (_jHelp)    delete []    _jHelp;
       if (_jac)      delete []    _jac;
 
       _yNames       = new const char* [_dimSys];
@@ -103,6 +106,7 @@ void Newton::initialize()
       _fHelp        = new double[_dimSys];
       _fTest        = new double[_dimSys];
       _iHelp        = new long int[_dimSys];
+      _jHelp        = new long int[_dimSys];
       _jac          = new double[_dimSys*_dimSys];
 
       _algLoop->getNamesReal(_yNames);
@@ -176,10 +180,20 @@ void Newton::solve( )
       // Solve linear system
       dgesv_(&_dimSys, &dimRHS, _jac, &_dimSys, _iHelp, _f, &_dimSys, &info);
 
-      if (info != 0)
+      if (info > 0) {
+        long int info2 = 0;
+        double scale = 0.0;
+        dgetc2_(&_dimSys, _jac, &_dimSys, _iHelp, _jHelp, &info2);
+        dgesc2_(&_dimSys, _jac, &_dimSys, _f, _iHelp, _jHelp, &scale);
+        LOGGER_WRITE("total pivoting: dgesv/dgetc2 infos: " + to_string(info) + "/" + to_string(info2) +
+                     ", dgesc2 scale: " + to_string(scale), _lc, LL_DEBUG);
+      }
+      else if (info < 0) {
+        LOGGER_WRITE_END(_lc, LL_DEBUG);
         throw ModelicaSimulationError(ALGLOOP_SOLVER,
           "error solving nonlinear system (iteration: " + to_string(totSteps)
           + ", dgesv info: " + to_string(info) + ")");
+      }
 
       // Increase counter
       ++ totSteps;
@@ -248,9 +262,11 @@ void Newton::solve( )
                         0.0, lambdaTest*lambdaTest, lambda*lambda};
           dgesv_(&n, &dimRHS, A, &n, ipiv, bx, &n, &info);
           lambda = std::max(0.1*lambda, -0.5*bx[1]/bx[2]);
-          if (!(lambda >= 1e-10))
+          if (!(lambda >= 1e-10)) {
+            LOGGER_WRITE_END(_lc, LL_DEBUG);
             throw ModelicaSimulationError(ALGLOOP_SOLVER,
               "Can't get sufficient decrease of solution");
+          }
           if (lambda >= lambdaTest) {
             // upper bound 0.5*lambda
             lambda = lambdaTest;

--- a/testsuite/openmodelica/cppruntime/libraries/msl32/Modelica.Electrical.Analog.Examples.ShowSaturatingInductor.mos
+++ b/testsuite/openmodelica/cppruntime/libraries/msl32/Modelica.Electrical.Analog.Examples.ShowSaturatingInductor.mos
@@ -10,7 +10,7 @@
 
 loadModel(Modelica,{"3.2.1"});
 
-simulate(Modelica.Electrical.Analog.Examples.ShowSaturatingInductor, outputFormat="mat", simflags="-nls=kinsol");
+simulate(Modelica.Electrical.Analog.Examples.ShowSaturatingInductor, outputFormat="mat");
 getErrorString();
 
 res := OpenModelica.Scripting.compareSimulationResults("Modelica.Electrical.Analog.Examples.ShowSaturatingInductor_res.mat",
@@ -23,7 +23,7 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Electrical.Anal
 // true
 // record SimulationResult
 //     resultFile = "Modelica.Electrical.Analog.Examples.ShowSaturatingInductor_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 6.2832, numberOfIntervals = 628, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Analog.Examples.ShowSaturatingInductor', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nls=kinsol'",
+//     simulationOptions = "startTime = 0.0, stopTime = 6.2832, numberOfIntervals = 628, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Analog.Examples.ShowSaturatingInductor', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
 // ""

--- a/testsuite/openmodelica/cppruntime/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa.mos
+++ b/testsuite/openmodelica/cppruntime/libraries/msl32/Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa.mos
@@ -13,7 +13,7 @@ loadModel(Modelica,{"3.2.1"});
 setMatchingAlgorithm("PFPlusExt"); getErrorString();
 setIndexReductionMethod("dynamicStateSelection"); getErrorString();
 
-simulate(Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa, outputFormat="mat", simflags="-nls=kinsol");
+simulate(Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa, outputFormat="mat");
 getErrorString();
 
 res := OpenModelica.Scripting.compareSimulationResults("Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa_res.mat",
@@ -30,7 +30,7 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Media.Examples.
 // ""
 // record SimulationResult
 //     resultFile = "Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nls=kinsol'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.Tests.MediaTestModels.Air.DryAirNasa', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.


### PR DESCRIPTION
Extend StatArray, DynArray and ArraySlice for up to 6 dimensions
- see Buildings

Simplify and fix Cpp command line parsing
- see daily library tests warning about unrecognized --emit-results all
- translate linear solver names `default`, `lapack` and `klu` from C to Cpp `dgesvSolver` and `linearSolver`

Extend Newton solver with total pivoting as fallback and fix XML logging
- total pivoting prevents some "error solving nonlinear system"
- so far the solver logs did not appear in OMEdit in the most important case of solver errors