### PR TITLE
Make Cpp Newton solver more robust and fix crash of IDA

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Solver/IDA/IDA.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/IDA/IDA.cpp
@@ -332,6 +332,7 @@ void Ida::initialize()
       throw std::invalid_argument(/*_idid,_tCurrent,*/"IDA::initialize()");
 
     // Initialize dense linear solver
+    _ida_ySolver = N_VNew_Serial(_dimSys);
     _ida_J = SUNDenseMatrix(_dimSys, _dimSys);
     _ida_linSol = SUNLinSol_Dense(_ida_ySolver, _ida_J);
     _idid = IDASetLinearSolver(_idaMem, _ida_linSol, _ida_J);


### PR DESCRIPTION
Try another Newton iteration instead of raising
"Can't get sufficient decrease of solution" from line search.

