### PR TITLE
Add fallback nonlinear solver to Cpp runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -152,7 +152,7 @@ void SimController::Start(SimSettings simsettings, string modelKey)
         global_settings->sethOutput(simsettings.step_size);
         global_settings->setResultsFileName(simsettings.outputfile_name);
         global_settings->setSelectedLinSolver(simsettings.linear_solver_name);
-        global_settings->setSelectedNonLinSolver(simsettings.nonlinear_solver_name);
+        global_settings->setNonLinSolvers(simsettings.nonlinear_solver_names);
         global_settings->setSelectedSolver(simsettings.solver_name);
         global_settings->setLogSettings(simsettings.logSettings);
         global_settings->setAlarmTime(simsettings.timeOut);
@@ -460,7 +460,7 @@ void SimController::initialize(SimSettings simsettings, string modelKey, double 
         global_settings->sethOutput(simsettings.step_size);
         global_settings->setResultsFileName(simsettings.outputfile_name);
         global_settings->setSelectedLinSolver(simsettings.linear_solver_name);
-        global_settings->setSelectedNonLinSolver(simsettings.nonlinear_solver_name);
+        global_settings->setNonLinSolvers(simsettings.nonlinear_solver_names);
         global_settings->setSelectedSolver(simsettings.solver_name);
         global_settings->setLogSettings(simsettings.logSettings);
        // global_settings->setAlarmTime(simsettings.timeOut);

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
@@ -117,7 +117,7 @@ void SimManager::initialize()
     _tStart = global_settings->getStartTime();
     _tEnd = global_settings->getEndTime();
 
-    LOGGER_WRITE("SimManager: Start initialization", LC_INIT, LL_INFO);
+    LOGGER_WRITE("SimManager: Start initialization", LC_SOLVER, LL_INFO);
     LOGGER_STATUS_STARTING(_tStart, _tEnd);
 
     // Reset debug ID
@@ -138,7 +138,7 @@ void SimManager::initialize()
         try
         {
             string nls = global_settings->getNonLinSolvers()[1];
-            LOGGER_WRITE("SimManager: Applying fallback nonlinear solver " + nls, LC_INIT, LL_INFO);
+            LOGGER_WRITE("SimManager: Applying fallback nonlinear solver " + nls, LC_SOLVER, LL_INFO);
             global_settings->setSelectedNonLinSolver(nls);
             _initialization->initializeSystem();
         }

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -10,13 +10,14 @@
 
 GlobalSettings::GlobalSettings()
   : _startTime(0.0)
-  , _endTime(5.0)
-  , _hOutput(0.001)
+  , _endTime(1.0)
+  , _hOutput(0.002)
   , _emitResults(EMIT_ALL)
   , _infoOutput(true)
-  , _selected_solver("Euler")
-  , _selected_lin_solver("linearSolver")
-  , _selected_nonlin_solver("Newton")
+  , _nonlin_solvers({"newton", "kinsol"})
+  , _selected_solver("euler")
+  , _selected_lin_solver("dgesvSolver")
+  , _selected_nonlin_solver("newton")
   , _resultsfile_name("results.csv")
   , _endless_sim(false)
   , _nonLinSolverContinueOnError(false)
@@ -145,6 +146,17 @@ void GlobalSettings::setInputPath(string path)
   _input_path = path;
 }
 
+const string* GlobalSettings::getNonLinSolvers()
+{
+  return _nonlin_solvers;
+}
+
+void GlobalSettings::setNonLinSolvers(const string* solvers)
+{
+  _nonlin_solvers[0] = solvers[0];
+  _nonlin_solvers[1] = solvers[1];
+}
+
 string GlobalSettings::getSelectedSolver()
 {
   return _selected_solver;
@@ -155,7 +167,7 @@ void GlobalSettings::setSelectedSolver(string solver)
   _selected_solver = solver;
 }
 
-string   GlobalSettings::getSelectedLinSolver()
+string GlobalSettings::getSelectedLinSolver()
 {
   return _selected_lin_solver;
 }

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -14,7 +14,7 @@ GlobalSettings::GlobalSettings()
   , _hOutput(0.002)
   , _emitResults(EMIT_ALL)
   , _infoOutput(true)
-  , _nonlin_solvers({"newton", "kinsol"})
+  , _nonlin_solvers{"newton", "kinsol"}
   , _selected_solver("euler")
   , _selected_lin_solver("dgesvSolver")
   , _selected_nonlin_solver("newton")

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
@@ -8,7 +8,7 @@ struct SimSettings
 {
   string solver_name;
   string linear_solver_name;
-  string nonlinear_solver_name;
+  string nonlinear_solver_names[2];
   double start_time;
   double end_time;
   double step_size;

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
@@ -44,6 +44,8 @@ public:
   //solver used for simulation
   virtual string getSelectedSolver();
   virtual void setSelectedSolver(string);
+  virtual const string* getNonLinSolvers();
+  virtual void setNonLinSolvers(const string*);
   virtual string getSelectedNonLinSolver();
   virtual void setSelectedNonLinSolver(string);
   virtual string getSelectedLinSolver();
@@ -75,6 +77,8 @@ private:
       _infoOutput,  ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
       _endless_sim,
       _nonLinSolverContinueOnError;
+  string
+      _nonlin_solvers[2];
   string
       _input_path,
       _output_path,

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
@@ -86,6 +86,8 @@ public:
   virtual string getSelectedSolver() = 0;
   virtual void setSelectedSolver(string) = 0;
   virtual string getSelectedLinSolver() = 0;
+  virtual void setNonLinSolvers(const string*) = 0;
+  virtual const string* getNonLinSolvers() = 0;
   virtual void setSelectedLinSolver(string) = 0;
   virtual string getSelectedNonLinSolver() = 0;
   virtual void setSelectedNonLinSolver(string) = 0;

--- a/OMCompiler/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
@@ -40,6 +40,8 @@ public:
     virtual void setOutputPointType(OutputPointType) {};
     virtual void setOutputPath(string) {}
     virtual void setInputPath(string) {}
+    virtual const string* getNonLinSolvers() { return NULL; }
+    virtual void setNonLinSolvers(const string*) {}
     virtual string    getSelectedSolver() { return "euler"; }
     virtual void setSelectedSolver(string) {}
     virtual string    getSelectedLinSolver() { return "dgesvSolver"; }

--- a/OMCompiler/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
@@ -72,6 +72,8 @@ class FMU2GlobalSettings : public IGlobalSettings
   virtual void            setOutputPointType(OutputPointType) {};
   virtual void            setOutputPath(string) {}
   virtual void            setInputPath(string) {}
+  virtual const string*   getNonLinSolvers() { return NULL; }
+  virtual void            setNonLinSolvers(const string*) {}
   virtual string          getSelectedSolver() { return "euler"; }
   virtual void            setSelectedSolver(string) {}
   virtual string          getSelectedLinSolver() { return "dgesvSolver"; }

--- a/OMCompiler/SimulationRuntime/cpp/Include/SimCoreFactory/OMCFactory/OMCFactory.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/SimCoreFactory/OMCFactory/OMCFactory.h
@@ -80,7 +80,7 @@ protected:
   //shared_ptr<ISimController> _simController;
   map<string,shared_library> _modules;
   string _defaultLinSolver;
-  string _defaultNonLinSolver;
+  string _defaultNonLinSolvers[2];
   PATH _library_path;
   PATH _modelicasystem_path;
   unordered_set<string> _argumentsToIgnore; //a set of arguments that should be ignored

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -102,7 +102,7 @@ OMCFactory::OMCFactory(PATH library_path, PATH modelicasystem_path)
   : _library_path(library_path)
   , _modelicasystem_path(modelicasystem_path)
   , _defaultLinSolver("dgesvSolver")
-	, _defaultNonLinSolvers({"newton", "kinsol"})
+	, _defaultNonLinSolvers{"newton", "kinsol"}
 {
   fillArgumentsToIgnore();
   fillArgumentsToReplace();
@@ -112,7 +112,7 @@ OMCFactory::OMCFactory()
   : _library_path("")
   , _modelicasystem_path("")
   , _defaultLinSolver("dgesvSolver")
-  , _defaultNonLinSolvers({"newton", "kinsol"})
+  , _defaultNonLinSolvers{"newton", "kinsol"}
 {
   fillArgumentsToIgnore();
   fillArgumentsToReplace();


### PR DESCRIPTION
If the selected solver (default: newton) fails during initialization,
it will be changed to kinsol (or newton if kinsol was selected) for a second attempt.

This is according to discussions in #7672.