### PR TITLE
Move selection of nonlinear solvers up from init to whole simulation

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -142,6 +142,7 @@ void SimController::Start(SimSettings simsettings, string modelKey)
             if (i > 0)
                 LOGGER_WRITE("SimController: Trying nonlinear solver " + nls, LC_SOLVER, LL_WARNING);
             Start(simsettings, modelKey, nls);
+            break;
         }
         catch(ModelicaSimulationError & ex)
         {

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
@@ -123,32 +123,18 @@ void SimManager::initialize()
     // Reset debug ID
     _dbgId = 0;
 
-    string nls = global_settings->getNonLinSolvers()[0];
     try
     {
         // Build up system and update once
-        global_settings->setSelectedNonLinSolver(nls);
         _initialization->initializeSystem();
     }
     catch (std::exception& ex)
     {
-        LOGGER_WRITE("SimManager: Could not initialize system with " + nls, LC_INIT, LL_WARNING);
-        LOGGER_WRITE("SimManager: " + string(ex.what()), LC_INIT, LL_WARNING);
+        LOGGER_WRITE("SimManager: Could not initialize system", LC_INIT, LL_ERROR);
+        LOGGER_WRITE("SimManager: " + string(ex.what()), LC_INIT, LL_ERROR);
         //ex << error_id(SIMMANAGER);
-        try
-        {
-            string nls = global_settings->getNonLinSolvers()[1];
-            LOGGER_WRITE("SimManager: Applying fallback nonlinear solver " + nls, LC_SOLVER, LL_INFO);
-            global_settings->setSelectedNonLinSolver(nls);
-            _initialization->initializeSystem();
-        }
-        catch (std::exception& ex)
-        {
-            LOGGER_WRITE("SimManager: Could not initialize system", LC_INIT, LL_ERROR);
-            LOGGER_WRITE("SimManager: " + string(ex.what()), LC_INIT, LL_ERROR);
-            throw ModelicaSimulationError(SIMMANAGER, "Could not initialize system",
-                                          string(ex.what()), LOGGER_IS_SET(LC_INIT, LL_ERROR));
-        }
+        throw ModelicaSimulationError(SIMMANAGER, "Could not initialize system",
+                                      string(ex.what()), LOGGER_IS_SET(LC_INIT, LL_ERROR));
     }
 
     if (_timeevent_system)

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimObjects.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimObjects.cpp
@@ -73,8 +73,8 @@ shared_ptr<ISimData> SimObjects::getSimData(string modelname)
     }
     else
     {
-        string error = string("Simulation data was not found for model: ") + modelname;
-        throw ModelicaSimulationError(SIMMANAGER,error);
+        string error = string("Simulation data not found for model ") + modelname;
+        throw ModelicaSimulationError(SIMMANAGER, error);
     }
 }
 
@@ -87,8 +87,8 @@ shared_ptr<ISimVars> SimObjects::getSimVars(string modelname)
     }
     else
     {
-        string error = string("Simulation data was not found for model: ") + modelname;
-        throw ModelicaSimulationError(SIMMANAGER,error);
+        string error = string("Simulation vars not found for model ") + modelname;
+        throw ModelicaSimulationError(SIMMANAGER, error);
     }
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -14,7 +14,6 @@ GlobalSettings::GlobalSettings()
   , _hOutput(0.002)
   , _emitResults(EMIT_ALL)
   , _infoOutput(true)
-  , _nonlin_solvers{"kinsol", "newton"}
   , _selected_solver("euler")
   , _selected_lin_solver("dgesvSolver")
   , _selected_nonlin_solver("kinsol")
@@ -144,19 +143,6 @@ string GlobalSettings::getInputPath()
 void GlobalSettings::setInputPath(string path)
 {
   _input_path = path;
-}
-
-const std::vector<string>& GlobalSettings::getNonLinSolvers()
-{
-  return _nonlin_solvers;
-}
-
-void GlobalSettings::setNonLinSolvers(const std::vector<string>& solvers)
-{
-  _nonlin_solvers.clear();
-  for (size_t i = 0; i < solvers.size(); i++) {
-    _nonlin_solvers.push_back(solvers[i]);
-  }
 }
 
 string GlobalSettings::getSelectedSolver()

--- a/OMCompiler/SimulationRuntime/cpp/Core/System/ContinuousEvents.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/System/ContinuousEvents.cpp
@@ -114,9 +114,9 @@ bool ContinuousEvents::startEventIteration(bool& state_vars_reinitialized)
   }
   catch (std::exception& ex)
   {
-
-	 // if  evaluateConditions throws and error during event iteration the event iteration will restarted
-	  assert = true;
+    LOGGER_WRITE(string("Failed evaluating event conditions: ") + ex.what(), LC_EVENTS, LL_DEBUG);
+    // if  evaluateConditions throws and error during event iteration the event iteration will restarted
+    assert = true;
   }
   return(drestart || crestart || assert); //returns true if new events occurred
 }

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimController/SimController.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimController/SimController.h
@@ -18,6 +18,7 @@ public:
       /// Stops the simulation
     virtual void Stop();
     virtual void Start(SimSettings simsettings, string modelKey);
+    virtual void Start(SimSettings simsettings, string modelKey, string nls);
     virtual shared_ptr<IMixedSystem> getSystem(string modelname);
     virtual shared_ptr<ISimObjects> getSimObjects();
     virtual void StartReduceDAE(SimSettings simsettings,string modelPath, string modelKey,bool loadMSL, bool loadPackage);
@@ -25,7 +26,6 @@ public:
      virtual void runReducedSimulation();
 private:
     void initialize(PATH library_path, PATH modelicasystem_path);
-    bool _initialized;
     shared_ptr<Configuration> _config;
     std::map<string, shared_ptr<IMixedSystem> > _systems;
 
@@ -39,5 +39,7 @@ private:
     std::vector<MeasureTimeData*> *measureTimeFunctionsArray;
     MeasureTimeValues *measuredFunctionStartValues, *measuredFunctionEndValues;
     #endif
+    string _modelLib;
+    string _modelKey;
 };
 /** @} */ // end of coreSimcontroller

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
@@ -44,8 +44,6 @@ public:
   //solver used for simulation
   virtual string getSelectedSolver();
   virtual void setSelectedSolver(string);
-  virtual const std::vector<string>& getNonLinSolvers();
-  virtual void setNonLinSolvers(const std::vector<string>&);
   virtual string getSelectedNonLinSolver();
   virtual void setSelectedNonLinSolver(string);
   virtual string getSelectedLinSolver();
@@ -77,7 +75,6 @@ private:
       _infoOutput,  ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
       _endless_sim,
       _nonLinSolverContinueOnError;
-  std::vector<string> _nonlin_solvers;
   string
       _input_path,
       _output_path,

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
@@ -86,8 +86,6 @@ public:
   virtual string getSelectedSolver() = 0;
   virtual void setSelectedSolver(string) = 0;
   virtual string getSelectedLinSolver() = 0;
-  virtual void setNonLinSolvers(const std::vector<string>&) = 0;
-  virtual const std::vector<string>& getNonLinSolvers() = 0;
   virtual void setSelectedLinSolver(string) = 0;
   virtual string getSelectedNonLinSolver() = 0;
   virtual void setSelectedNonLinSolver(string) = 0;

--- a/OMCompiler/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
@@ -40,8 +40,6 @@ public:
     virtual void setOutputPointType(OutputPointType) {};
     virtual void setOutputPath(string) {}
     virtual void setInputPath(string) {}
-    virtual const std::vector<string>& getNonLinSolvers() { return _nonlin_solvers; }
-    virtual void setNonLinSolvers(const std::vector<string>&) {}
     virtual string    getSelectedSolver() { return "euler"; }
     virtual void setSelectedSolver(string) {}
     virtual string    getSelectedLinSolver() { return "dgesvSolver"; }
@@ -61,6 +59,4 @@ public:
     virtual int getSolverThreads() { return 1; };
     virtual OutputFormat getOutputFormat() {return EMPTY;};
     virtual void setOutputFormat(OutputFormat) {};
-protected:
-    vector<string> _nonlin_solvers = { DEFAULT_NLS };
 };

--- a/OMCompiler/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
@@ -72,8 +72,6 @@ class FMU2GlobalSettings : public IGlobalSettings
   virtual void            setOutputPointType(OutputPointType) {};
   virtual void            setOutputPath(string) {}
   virtual void            setInputPath(string) {}
-  virtual const std::vector<string>& getNonLinSolvers() { return _nonlin_solvers; }
-  virtual void            setNonLinSolvers(const std::vector<string>&) {}
   virtual string          getSelectedSolver() { return "euler"; }
   virtual void            setSelectedSolver(string) {}
   virtual string          getSelectedLinSolver() { return "dgesvSolver"; }
@@ -93,7 +91,5 @@ class FMU2GlobalSettings : public IGlobalSettings
   virtual int getSolverThreads() { return 1; };
   virtual OutputFormat getOutputFormat() {return EMPTY;};
   virtual void setOutputFormat(OutputFormat) {};
-protected:
-  vector<string> _nonlin_solvers = { DEFAULT_NLS };
 };
 /** @} */ // end of fmu2

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CVode/CVode.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CVode/CVode.cpp
@@ -992,6 +992,10 @@ int Cvode::reportErrorMessage(ostream& messageStream)
 
 void Cvode::writeSimulationInfo()
 {
+	// don't write before memory has been initialized
+	if (_cvodeMem == NULL)
+		return;
+
 	long int nst, nfe, nsetups, nni, ncfn, netf;
 	long int nfQe, netfQ;
 	long int nfSe, nfeS, nsetupsS, nniS, ncfnS;


### PR DESCRIPTION
The treatment by SimController instead of SimManager covers cases that fail after initialization during regular simulation.
The whole system is recreated from scratch as re-init of all existing objects would require diverse extensions.

This also enables to remove solver options from IGlobalSettings and dependents again.
