### PR TITLE
Change selection logic of sparse solvers (#7695)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1001,7 +1001,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
   }
   if(omc_flag[FLAG_LSS_MIN_SIZE]) {
     linearSparseSolverMinSize = atoi(omc_flagValue[FLAG_LSS_MIN_SIZE]);
-    infoStreamPrint(LOG_STDOUT, 0, "Maximum system size for using linear sparse solver changed to %d", linearSparseSolverMinSize);
+    infoStreamPrint(LOG_STDOUT, 0, "Minimum system size for using linear sparse solver changed to %d", linearSparseSolverMinSize);
   }
   if(omc_flag[FLAG_NLS_MAX_DENSITY]) {
     nonlinearSparseSolverMaxDensity = atof(omc_flagValue[FLAG_NLS_MAX_DENSITY]);
@@ -1009,7 +1009,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
   }
   if(omc_flag[FLAG_NLS_MIN_SIZE]) {
     nonlinearSparseSolverMinSize = atoi(omc_flagValue[FLAG_NLS_MIN_SIZE]);
-    infoStreamPrint(LOG_STDOUT, 0, "Maximum system size for using non-linear sparse solver changed to %d", nonlinearSparseSolverMinSize);
+    infoStreamPrint(LOG_STDOUT, 0, "Minimum system size for using non-linear sparse solver changed to %d", nonlinearSparseSolverMinSize);
   }
   if(omc_flag[FLAG_NEWTON_XTOL]) {
     newtonXTol = atof(omc_flagValue[FLAG_NEWTON_XTOL]);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -139,10 +139,10 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
 #endif
     }
 
-    if(nnz/(double)(size*size)<=linearSparseSolverMaxDensity && size>=linearSparseSolverMinSize)
+    if(nnz/(double)(size*size)<=linearSparseSolverMaxDensity || size>=linearSparseSolverMinSize)
     {
       linsys[i].useSparseSolver = 1;
-      infoStreamPrint(LOG_STDOUT, 0, "Using sparse solver for linear system %d,\nbecause density of %.3f remains under threshold of %.3f and size of %d exceeds threshold of %d.\nThe maximum density and the minimal system size for using sparse solvers can be specified\nusing the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.", i, nnz/(double)(size*size), linearSparseSolverMaxDensity, size, linearSparseSolverMinSize);
+      infoStreamPrint(LOG_STDOUT, 0, "Using sparse solver for linear system %d,\nbecause density of %.3f remains under threshold of %.3f or size of %d exceeds threshold of %d.\nThe maximum density and the minimal system size for using sparse solvers can be specified\nusing the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.", i, nnz/(double)(size*size), linearSparseSolverMaxDensity, size, linearSparseSolverMinSize);
     }
 
     /* allocate more system data */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -394,10 +394,10 @@ int initializeNonlinearSystems(DATA *data, threadData_t *threadData)
     {
       nnz = nonlinsys[i].sparsePattern->numberOfNoneZeros;
 
-      if(nnz/(double)(size*size)<=nonlinearSparseSolverMaxDensity && size >= nonlinearSparseSolverMinSize)
+      if(nnz/(double)(size*size)<=nonlinearSparseSolverMaxDensity || size >= nonlinearSparseSolverMinSize)
       {
         data->simulationInfo->nlsMethod = NLS_KINSOL;
-        infoStreamPrint(LOG_STDOUT, 0, "Using sparse solver kinsol for nonlinear system %d,\nbecause density of %.2f remains under threshold of %.2f and size of %d exceeds threshold of %d.\nThe maximum density and the minimal system size for using sparse solvers can be specified\nusing the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.", i, nnz/(double)(size*size), nonlinearSparseSolverMaxDensity, size, nonlinearSparseSolverMinSize);
+        infoStreamPrint(LOG_STDOUT, 0, "Using sparse solver kinsol for nonlinear system %d,\nbecause density of %.2f remains under threshold of %.2f or size of %d exceeds threshold of %d.\nThe maximum density and the minimal system size for using sparse solvers can be specified\nusing the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.", i, nnz/(double)(size*size), nonlinearSparseSolverMaxDensity, size, nonlinearSparseSolverMinSize);
       }
     }
 #endif

--- a/testsuite/openmodelica/cruntime/simoptions/nlssMinSize.mos
+++ b/testsuite/openmodelica/cruntime/simoptions/nlssMinSize.mos
@@ -19,7 +19,7 @@ simulate(M, simflags="-nlssMinSize=1"); getErrorString();
 // record SimulationResult
 //     resultFile = "M_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nlssMinSize=1'",
-//     messages = "stdout            | info    | Maximum system size for using non-linear sparse solver changed to 1
+//     messages = "stdout            | info    | Minimum system size for using non-linear sparse solver changed to 1
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder.mos
@@ -80,7 +80,39 @@ runScript(modelTesting);getErrorString();
 // {"X1.X1.X1.X1.Q1.vbe","X1.X1.X1.X1.Q2.vbc","X1.X1.X1.X1.Q2.vbe","X1.X1.X1.X1.Q3.vbc","X1.X1.X1.X1.Q3.vbe","X1.X1.X1.X1.Q4.vbc","X1.X1.X1.X1.Q4.vbe","X1.X1.X1.X1.Q5.vbc","X1.X1.X1.X1.Q5.vbe","X1.X1.X1.X2.Q1.vbc","X1.X1.X1.X2.Q1.vbe","X1.X1.X1.X2.Q2.vbe","X1.X1.X1.X2.Q3.vbc","X1.X1.X1.X2.Q3.vbe","X1.X1.X1.X2.Q4.vbc","X1.X1.X1.X2.Q4.vbe","X1.X1.X1.X2.Q5.vbc","X1.X1.X1.X2.Q5.vbe","X1.X1.X2.X3.Q1.vbc","X1.X1.X2.X3.Q1.vbe","X1.X1.X2.X3.Q2.vbe","X1.X1.X2.X3.Q3.vbc","X1.X1.X2.X3.Q3.vbe","X1.X1.X2.X3.Q4.vbc","X1.X1.X2.X3.Q4.vbe","X1.X1.X2.X3.Q5.vbe","X1.X1.X2.X4.Q1.vbc","X1.X1.X2.X4.Q1.vbe","X1.X1.X2.X4.Q2.vbc","X1.X1.X2.X4.Q2.vbe","X1.X1.X2.X4.Q3.vbc","X1.X1.X2.X4.Q3.vbe","X1.X1.X2.X4.Q4.vbc","X1.X1.X2.X4.Q4.vbe","X1.X1.X2.X4.Q5.vbc","X1.X1.X2.X4.Q5.vbe","X1.X2.X2.X9.Q1.vbc","X1.X2.X2.X9.Q1.vbe","X1.X2.X2.X9.Q2.vbc","X1.X2.X2.X9.Q2.vbe","X1.X2.X2.X9.Q3.vbc","X1.X2.X2.X9.Q3.vbe","X1.X2.X2.X9.Q4.vbc","X1.X2.X2.X9.Q4.vbe","X1.X2.X2.X9.Q5.vbc","X1.X2.X2.X9.Q5.vbe"}
 // Simulation options: startTime = 0.0, stopTime = 1e-09, numberOfIntervals = 999, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder', options = '', outputFormat = 'mat', variableFilter = 'time|X1.X1.X1.X1.Q1.vbe|X1.X1.X1.X1.Q2.vbc|X1.X1.X1.X1.Q2.vbe|X1.X1.X1.X1.Q3.vbc|X1.X1.X1.X1.Q3.vbe|X1.X1.X1.X1.Q4.vbc|X1.X1.X1.X1.Q4.vbe|X1.X1.X1.X1.Q5.vbc|X1.X1.X1.X1.Q5.vbe|X1.X1.X1.X2.Q1.vbc|X1.X1.X1.X2.Q1.vbe|X1.X1.X1.X2.Q2.vbe|X1.X1.X1.X2.Q3.vbc|X1.X1.X1.X2.Q3.vbe|X1.X1.X1.X2.Q4.vbc|X1.X1.X1.X2.Q4.vbe|X1.X1.X1.X2.Q5.vbc|X1.X1.X1.X2.Q5.vbe|X1.X1.X2.X3.Q1.vbc|X1.X1.X2.X3.Q1.vbe|X1.X1.X2.X3.Q2.vbe|X1.X1.X2.X3.Q3.vbc|X1.X1.X2.X3.Q3.vbe|X1.X1.X2.X3.Q4.vbc|X1.X1.X2.X3.Q4.vbe|X1.X1.X2.X3.Q5.vbe|X1.X1.X2.X4.Q1.vbc|X1.X1.X2.X4.Q1.vbe|X1.X1.X2.X4.Q2.vbc|X1.X1.X2.X4.Q2.vbe|X1.X1.X2.X4.Q3.vbc|X1.X1.X2.X4.Q3.vbe|X1.X1.X2.X4.Q4.vbc|X1.X1.X2.X4.Q4.vbe|X1.X1.X2.X4.Q5.vbc|X1.X1.X2.X4.Q5.vbe|X1.X2.X2.X9.Q1.vbc|X1.X2.X2.X9.Q1.vbe|X1.X2.X2.X9.Q2.vbc|X1.X2.X2.X9.Q2.vbe|X1.X2.X2.X9.Q3.vbc|X1.X2.X2.X9.Q3.vbe|X1.X2.X2.X9.Q4.vbc|X1.X2.X2.X9.Q4.vbe|X1.X2.X2.X9.Q5.vbc|X1.X2.X2.X9.Q5.vbe', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Electrical.Spice3.Examples.Spice3BenchmarkFourBitBinaryAdder_res.mat
-// Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// Messages: stdout            | info    | Using sparse solver for linear system 12,
+// |                 | |       | because density of 0.175 remains under threshold of 0.200 or size of 24 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 25,
+// |                 | |       | because density of 0.179 remains under threshold of 0.200 or size of 26 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 38,
+// |                 | |       | because density of 0.179 remains under threshold of 0.200 or size of 26 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 51,
+// |                 | |       | because density of 0.186 remains under threshold of 0.200 or size of 26 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 75,
+// |                 | |       | because density of 0.182 remains under threshold of 0.200 or size of 30 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 87,
+// |                 | |       | because density of 0.162 remains under threshold of 0.200 or size of 30 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 97,
+// |                 | |       | because density of 0.173 remains under threshold of 0.200 or size of 30 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 102,
+// |                 | |       | because density of 0.168 remains under threshold of 0.200 or size of 28 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6.mos
@@ -33,7 +33,15 @@ runScript(modelTesting);getErrorString();
 // {"load.phi","load.w","filter.x[1]","filter.x[2]"}
 // Simulation options: startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6', options = '', outputFormat = 'mat', variableFilter = 'time|load.phi|load.w|filter.x.1.|filter.x.2.', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_res.mat
-// Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// Messages: stdout            | info    | Using sparse solver for linear system 6,
+// |                 | |       | because density of 0.176 remains under threshold of 0.200 or size of 27 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 13,
+// |                 | |       | because density of 0.155 remains under threshold of 0.200 or size of 25 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/modelica/linear_system/EngineV6_partlintorn.mos
+++ b/testsuite/simulation/modelica/linear_system/EngineV6_partlintorn.mos
@@ -23,7 +23,15 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Mechanics.Multi
 // record SimulationResult
 //     resultFile = "Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver for linear system 6,
+// |                 | |       | because density of 0.176 remains under threshold of 0.200 or size of 27 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 7,
+// |                 | |       | because density of 0.155 remains under threshold of 0.200 or size of 25 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/linear_system/NPendulum.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum.mos
@@ -136,28 +136,60 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 // {"NPendulum.pendulum","NPendulum.pendulum_init.xml"}
 // ""
 // 0
-// "stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
+// "stdout            | info    | Minimum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.012 remains under threshold of 0.200 or size of 278 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.013 remains under threshold of 0.200 or size of 275 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
 // {"Files Equal!"}
 // 0
-// "stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
+// "stdout            | info    | Minimum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.012 remains under threshold of 0.200 or size of 278 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.013 remains under threshold of 0.200 or size of 275 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
 // {"Files Equal!"}
 // 0
-// "stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
+// "stdout            | info    | Minimum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.012 remains under threshold of 0.200 or size of 278 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.013 remains under threshold of 0.200 or size of 275 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // true
 // {"Files Equal!"}
 // 0
-// "stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
+// "stdout            | info    | Minimum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.012 remains under threshold of 0.200 or size of 278 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.013 remains under threshold of 0.200 or size of 275 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/linear_system/NPendulum40.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum40.mos
@@ -31,12 +31,36 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res
 // true
 // {"NPendulum.pendulum40","NPendulum.pendulum40_init.xml"}
 // ""
-// stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Minimum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.003 remains under threshold of 0.200 or size of 1178 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.003 remains under threshold of 0.200 or size of 1175 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 2,
+// |                 | |       | because density of 0.003 remains under threshold of 0.200 or size of 1175 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // 0
 // {"Files Equal!"}
-// stdout            | info    | Maximum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Minimum system size for using linear sparse solver changed to 4001
+// stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.003 remains under threshold of 0.200 or size of 1178 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.003 remains under threshold of 0.200 or size of 1175 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 2,
+// |                 | |       | because density of 0.003 remains under threshold of 0.200 or size of 1175 exceeds threshold of 4001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // 0

--- a/testsuite/simulation/modelica/others/EngineV6_output.mos
+++ b/testsuite/simulation/modelica/others/EngineV6_output.mos
@@ -23,11 +23,19 @@ val(crankshaftSpeed,1.0); getErrorString();
 // record SimulationResult
 //     resultFile = "EngineV6_output_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'EngineV6_output', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver for linear system 6,
+// |                 | |       | because density of 0.176 remains under threshold of 0.200 or size of 27 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 13,
+// |                 | |       | because density of 0.155 remains under threshold of 0.200 or size of 25 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
 // ""
-// 561.4775584669958
+// 561.4775584670217
 // ""
 // endResult

--- a/testsuite/simulation/modelica/tearing/Tearing12-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-minimal.mos
@@ -28,11 +28,11 @@ simulate(Tearing12); getErrorString();
 //     resultFile = "Tearing12_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing12', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "stdout            | info    | Using sparse solver for linear system 0,
-// |                 | |       | because density of 0.004 remains under threshold of 0.200 and size of 908 exceeds threshold of 201.
+// |                 | |       | because density of 0.004 remains under threshold of 0.200 or size of 908 exceeds threshold of 201.
 // |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
 // |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // stdout            | info    | Using sparse solver for linear system 1,
-// |                 | |       | because density of 0.004 remains under threshold of 0.200 and size of 905 exceeds threshold of 201.
+// |                 | |       | because density of 0.004 remains under threshold of 0.200 or size of 905 exceeds threshold of 201.
 // |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
 // |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.

--- a/testsuite/simulation/modelica/tearing/Tearing7-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing7-minimal.mos
@@ -29,7 +29,15 @@ val(R1.v,0.2); getErrorString();
 // record SimulationResult
 //     resultFile = "Tearing7_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing7', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.136 remains under threshold of 0.200 or size of 18 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.136 remains under threshold of 0.200 or size of 18 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/tearing/Tearing8-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing8-minimal.mos
@@ -27,7 +27,15 @@ val(R1.v,0.2); getErrorString();
 // record SimulationResult
 //     resultFile = "Tearing8_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver for linear system 0,
+// |                 | |       | because density of 0.087 remains under threshold of 0.200 or size of 29 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// stdout            | info    | Using sparse solver for linear system 1,
+// |                 | |       | because density of 0.087 remains under threshold of 0.200 or size of 29 exceeds threshold of 201.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
* Change selection logic of sparse solvers

Now sparse solvers are selected if size OR density criterion applies.
Before, the system had to be sparse AND large simultaneously.

See the discussion in:
https://trac.openmodelica.org/OpenModelica/ticket/6342#comment:9

* Update testsuite

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
