### PR TITLE
CMake improvements

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -295,6 +295,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFCallParameterTree.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFCardinalityTable.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFCeval.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFCheckModel.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFClass.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFClassTree.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFClockKind.mo
@@ -320,6 +321,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFFlatModel.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFFlatten.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFFunctionDerivative.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFFunctionInverse.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFFunction.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFHashTable3.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFHashTableCG.mo
@@ -377,6 +379,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Script/MMToJuliaUtil.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Script/MMToJuliaKeywords.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Script/NFApi.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/Script/Conversion.mo
 
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/HpcOmSimCodeMain.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SerializeInitXML.mo

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -56,12 +56,16 @@ add_custom_command (
 #     TARGET bomc
 #     POST_BUILD
 
-#     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/Absyn.mo 
-#             ${CMAKE_CURRENT_SOURCE_DIR}/../Script/GlobalScript.mo 
-#             ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/Values.mo 
-#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Error.mo 
-#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Util.mo 
-#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/FMI.mo 
+#     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/Absyn.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../Script/GlobalScript.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../FrontEnd/Values.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/ErrorTypes.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Config.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Gettext.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../Util/FMI.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../NFFrontEnd/NFType.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../NFFrontEnd/NFExpression.mo
+#             ${CMAKE_CURRENT_SOURCE_DIR}/../NFFrontEnd/NFDimension.mo
 #             ${CMAKE_CURRENT_SOURCE_DIR}/../GenerateOMCHeader.mos
 
 #     # The GenerateOMCHeader.mos script expects us to be in OMCompiler/Compiler folder.
@@ -69,10 +73,10 @@ add_custom_command (
 
 
 #     COMMAND $<TARGET_FILE:bomc> -g=MetaModelica ${CMAKE_CURRENT_SOURCE_DIR}/../GenerateOMCHeader.mos
-#     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h.new 
+#     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h.new
 #                                      ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h
 
-#     BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h
+#     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h
 #     BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h.new
 #     COMMENT "Generating ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h"
 # )

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -3,7 +3,7 @@ project(bomc)
 
 # OpenModelicaBootstrappingHeader.h should probably be added to source control and
 # updated just like the bootstrap-source c files.
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tarball-include/OpenModelicaBootstrappingHeader.h 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tarball-include/OpenModelicaBootstrappingHeader.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h)
 
 file(GLOB BOOTSTRAP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap-sources/build/*.c)

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -192,7 +192,7 @@ target_link_libraries(omcgraphstream-boot PUBLIC omc::3rd::netstream)
 ################################################################################
 # This is a lazy approach to generating runtime/config.unix.h and Compiler/Util/Autoconf.mo
 # Needs to be refactored quite a bit. The variable names should be updated to be more
-# unique and descriptive. 
+# unique and descriptive.
 # However, If I do that I need to update the .in files which means the normal compilation is
 # also affected. As a result I would have to change a few things since many things depend on
 # the generated output files. For now just mimic the old compilation.
@@ -257,7 +257,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/revision.h.in ${CMAKE_CURRENT_SOURCE_
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.unix.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.unix.h)
 
 
-# Generate Autoconf.mo here since we have some of the variables already defined for config.unix.h above. 
+# Generate Autoconf.mo here since we have some of the variables already defined for config.unix.h above.
 
 if(WIN32)
 
@@ -290,6 +290,6 @@ else()
   set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC  -llapack -lblas   -lm -lomcgc -lpthread -rdynamic")
   set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC  -llapack -lblas   -lm -lomcgc -lpthread -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas   -lm -lpthread -rdynamic -Wl,--no-undefined")
- 
+
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.in ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo)
 endif()

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Intl REQUIRED)
 find_package(Iconv REQUIRED)
 
 if(OMC_USE_LAPACK)
+  message(STATUS "Looking for LAPACK. This can be slow sometimes. Hang tight!")
   find_package(LAPACK REQUIRED)
 
   # Check if our lapack version have the deprecated functions.


### PR DESCRIPTION
### Purpose

Improve and update CMake compilation support.

### Approach

@mahge
[cmake] Notify about slow LAPACK existence check.
cf8fb52

@mahge
[cmake] Remove trailing whitespace
7271dc5

@mahge
[cmake] Update commented out content. For later. …
9318ffb
  - This is about generating OpenModelicaBootstrappingHeader.h
 
@mahge
[cmake] Add new MM files to cmake compilation.
3a785e9