### PR TITLE
Add cmake support for libffi

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -433,6 +433,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/DiffAlgorithm.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/DisjointSets.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/ExpandableArray.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/Util/FFI.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/FMI.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/FMIExt.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/GraphML.mo

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
 target_link_libraries(omcruntime PUBLIC omc::simrt::runtime)
+target_link_libraries(omcruntime PUBLIC omc::3rd::ffi)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -59,7 +59,8 @@ set(OMC_RUNTIIME_SOURCES
     om_unzip.c
     ptolemyio_omc.cpp
     SimulationResults_omc.c
-    systemimplmisc.cpp)
+    systemimplmisc.cpp
+    ffi_omc.c)
 
 
 # ######################################################################################################################

--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -35,6 +35,7 @@
 #include <assert.h>
 #include "omc_config.h"
 
+#define ADD_METARECORD_DEFINITIONS static
 #if defined(OMC_BOOTSTRAPPING)
   #include "../boot/tarball-include/OpenModelicaBootstrappingHeader.h"
 #else

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -198,6 +198,7 @@ goto rule ## func ## Ex; }}
 
   #if !defined(OMJULIA)
     #include "meta/meta_modelica.h"
+    #define ADD_METARECORD_DEFINITIONS static
     #if defined(OMC_BOOTSTRAPPING)
       #include "../Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h"
     #else


### PR DESCRIPTION

@mahge
[cmake] Initial update for libffi
ca9aa41

@mahge
[cmake] Add cmake support for libffi. …
9f26868
  - See corresponding 3rdParty commit for details.

  - Link the omcruntime library with libffi.
