### PR TITLE
CMake CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ def common
 def shouldWeBuildOSX
 def shouldWeBuildMINGW
 def shouldWeBuildCENTOS7
+def shouldWeSkipCMakeBuild_value
 def shouldWeRunTests
 def isPR
 pipeline {
@@ -17,6 +18,7 @@ pipeline {
     booleanParam(name: 'BUILD_OSX', defaultValue: false, description: 'Build with OSX')
     booleanParam(name: 'BUILD_MINGW', defaultValue: false, description: 'Build with Win/MinGW')
     booleanParam(name: 'BUILD_CENTOS7', defaultValue: false, description: 'Build on CentOS7 with CMake 2.8')
+    booleanParam(name: 'SKIP_CMAKE_BUILD', defaultValue: false, description: 'Skip building omc with the CMake build system (CMake 3.17.2)')
   }
   // stages are ordered according to execution time; highest time first
   // nodes are selected based on a priority (in Jenkins config)
@@ -41,6 +43,8 @@ pipeline {
           print "shouldWeBuildMINGW: ${shouldWeBuildMINGW}"
           shouldWeBuildCENTOS7 = common.shouldWeBuildCENTOS7()
           print "shouldWeBuildCENTOS7: ${shouldWeBuildCENTOS7}"
+          shouldWeSkipCMakeBuild_value = common.shouldWeSkipCMakeBuild()
+          print "shouldWeSkipCMakeBuild: ${shouldWeSkipCMakeBuild_value}"
           shouldWeRunTests = common.shouldWeRunTests()
           print "shouldWeRunTests: ${shouldWeRunTests}"
         }
@@ -174,6 +178,39 @@ pipeline {
                 false)
             }
             //stash name: 'omc-centos7', includes: 'build/**, **/config.status'
+          }
+        }
+        stage('cmake-xenial-gcc') {
+          agent {
+            docker {
+              // image 'docker.openmodelica.org/build-deps:focal.nightly.amd64'
+              image 'docker.openmodelica.org/build-deps:v1.16-qt4-xenial'
+              label 'linux'
+              alwaysPull true
+              args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          when {
+            beforeAgent true
+            expression { !shouldWeSkipCMakeBuild_value }
+          }
+          environment {
+            CC = "gcc"
+            CXX = "g++"
+          }
+          steps {
+            script {
+              echo "Download and install CMake 3.17.2"
+              sh '''
+                wget "cmake.org/files/v3.17/cmake-3.17.2-Linux-x86_64.sh"
+                mkdir -p /tmp/cmake
+                sh cmake-3.17.2-Linux-x86_64.sh --prefix=/tmp/cmake --skip-license
+                /tmp/cmake/bin/cmake --version
+              '''
+              common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOMC_USE_CCACHE=OFF', '/tmp/cmake/bin/cmake')
+            }
+            // stash name: 'omc-cmake-gcc', includes: 'OMCompiler/build_cmake/install_cmake/bin/**'
           }
         }
         stage('checks') {

--- a/OMCompiler/Compiler/runtime/ffi_omc.c
+++ b/OMCompiler/Compiler/runtime/ffi_omc.c
@@ -30,11 +30,7 @@
  */
 
 
-#if defined(__APPLE__) /* MacOS doesn't like static libffi, use the system one */
-#include <ffi.h>
-#else /* sane systems */
-#include "../../3rdParty/libffi/install/include/ffi.h"
-#endif
+#include "ffi.h"
 
 #include <gc.h>
 


### PR DESCRIPTION
@mahge
Fix ffi.h inclusion. …
857eecd
  - Use the include directory (-I) already specified in the Makefiles.
 
@mahge
[cmake] Fix SuiteSparse folder name. …
268e7c6
  - SuiteSparse -> SuiteSparse-5.8.1
 
@mahge
[cmake] Add a CMake build CI job. …
0f1bef0
  - omc is built using CMake on xenial.

  - The job will download and install CMake 3.17.2 since the xenial
    docker image we use has older CMake version.
    We can use focal as well but right now the idea is to resemble the
    other jobs. Work where they work with minimal changes.

  - Control CI CMake build with a label.

    - By default the CMake job is on.

    - Add the label "CI/Skip CMake Build" to your PRs if you want to skip
      the cmake build.

      Use this as a last resort if you can not figure out how to fix the
      cmake build.
      Please also notify @mahge if you do so that the issue can be fixed.