### PR TITLE
CMake improvements

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -211,8 +211,8 @@ target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::runtime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::backendruntime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::graphstream)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::simrt::runtime)
-target_link_libraries(OpenModelicaCompiler PUBLIC omc::3rd::modelica_external_c)
-target_link_libraries(OpenModelicaCompiler PUBLIC omc::3rd::modelica_io)
+target_link_libraries(OpenModelicaCompiler PUBLIC omc::3rd::Modelica::ExternalC)
+target_link_libraries(OpenModelicaCompiler PUBLIC omc::3rd::Modelica::IO)
 
 
 

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -30,8 +30,8 @@ target_include_directories(bomc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../Util)
 target_link_libraries(bomc PRIVATE omc::parser)
 target_link_libraries(bomc PRIVATE omc::compiler::runtime)
 target_link_libraries(bomc PRIVATE omc::compiler::graphstream)
-target_link_libraries(bomc PRIVATE omc::3rd::modelica_external_c)
-target_link_libraries(bomc PRIVATE omc::3rd::modelica_io)
+target_link_libraries(bomc PRIVATE omc::3rd::Modelica::ExternalC)
+target_link_libraries(bomc PRIVATE omc::3rd::Modelica::IO)
 
 
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -29,6 +29,8 @@ endif(WIN32)
 
 target_include_directories(OpenModelicaRuntimeC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+install(TARGETS OpenModelicaRuntimeC)
+
 # ######################################################################################################################
 # Library: OpenModelicaFMIRuntimeC
 add_library(OpenModelicaFMIRuntimeC STATIC ${OMC_SIMRT_FMI_SOURCES})
@@ -39,6 +41,7 @@ target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES})
 target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib::static)
 target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::simrt::runtime)
 
+install(TARGETS OpenModelicaFMIRuntimeC)
 
 
 # Quick and INCOMPLETE generation of RuntimeSources.mo


### PR DESCRIPTION
@mahge
[cmake] Install the built libraries.
b83bfd6

@mahge
[cmake] Improve ModelicaExternalC configuration. …
626a80b
   - Look for ZLIB and add the HAVE_ZLIB  define if found.
   - Do the same for HDF5 if needed. It is disabled now.

   - Add ModelicaStandardTables library. It was overlooked before.

   - Install the libraries. They were not installed before only built.

     I am not sure if we actually need to install all of them but let it
     be for now.