### PR TITLE
CMake improvements

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -8,6 +8,10 @@ project(OMCompiler)
 # of simulationruntimemsvc by the Makefile.omdev.mingw makefiles.
 set(OPENMODELICA_NEW_CMAKE_BUILD ON)
 
+# Remove -DNDEBUG from release build command lines. The reason is that -DNDEBUG completely
+# removes assert(...) statements. We have some assert statements with side effects. Of course,
+# these should be removed and the flag enabled so that we can benefit from removing asserts from
+# libraries and standard headers.
 string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
@@ -16,9 +20,9 @@ string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/.cmake/")
-include(omc_utils)
-include(omc_check_exists)
+# include utility macros.
+include(.cmake/omc_utils.cmake)
+include(.cmake/omc_check_exists.cmake)
 
 # Add the compiler ids to the report for convenience.
 omc_add_to_report(CMAKE_CXX_COMPILER_ID)
@@ -39,9 +43,12 @@ endif(NOT CMAKE_BUILD_TYPE)
 omc_add_to_report(CMAKE_BUILD_TYPE)
 
 
+# Install following GNU conventions (i.e., bin, lib, include, share ...)
 include(GNUInstallDirs)
+
 # Precaution so that users do not install in system folders (e.g. /user/, /usr/local/)
-# unintentionally. If the user has not specified anything default to an install_cmake dir in the root folder.
+# unintentionally. If the user has not specified anything default to an install_cmake dir in the root
+# build directory.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX ${PROJECT_BINARY_DIR}/install_cmake CACHE PATH "Default installation directory" FORCE)
     message(WARNING "No installation directory specified. Defaulting to: ${CMAKE_INSTALL_PREFIX}")
@@ -53,7 +60,9 @@ omc_add_to_report(CMAKE_INSTALL_PREFIX)
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/omc/)
 
 
-
+# Write out a compiler detection header. checkout the file <build_dir>/omc_compiler_detection.h to
+# get an idea of what it means. We intend to use this for portability reasons in the future.
+# You know. things like is it ctime_s() or ctime_r(), MvFileEx() vs rename() and the like.
 include(WriteCompilerDetectionHeader)
 write_compiler_detection_header(
   FILE omc_compiler_detection.h
@@ -69,6 +78,7 @@ write_compiler_detection_header(
 SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_LIBDIR})
 
 
+# Use ccache to speedup compilation!
 omc_option(OMC_USE_CCACHE "Use ccache to speedup compilations." ON)
 
 if(OMC_USE_CCACHE)

--- a/OMCompiler/SimulationRuntime/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 omc_add_subdirectory(c)
+# omc_add_subdirectory(opc)
 # omc_add_subdirectory(ParModelica)
 #ADD_SUBDIRECTORY(cpp)
 #ADD_SUBDIRECTORY(fmi)

--- a/OMCompiler/SimulationRuntime/opc/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/opc/CMakeLists.txt
@@ -1,0 +1,1 @@
+omc_add_subdirectory(ua)

--- a/OMCompiler/SimulationRuntime/opc/ua/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/opc/ua/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.14)
+project(omopcua)
+
+
+add_library(omopcua STATIC)
+target_sources(omopcua PRIVATE omc_opc_ua.c)
+
+target_link_libraries(omopcua PRIVATE omc::3rd::opcua)
+
+install(TARGETS omopcua)


### PR DESCRIPTION
@mahge
[cmake] Some more documentation
f804634

@mahge
[cmake] Add omopcua to configuration. …
d6290cf
  - It is not enabled yet.

    We can enable it by just adding an include directory that contains
    simulation_data.h right now.
    However, we need to figure out how to handle common includes such as
    openmodelica.h and simulation_data.h in a proper way.

    The idea is to use CMake's INTERFACE library type.