### PR TITLE
Return EXIT(1) for invalid runtime flags

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -836,9 +836,9 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
     EXIT(1);
   }
 
-  if(omc_flag[FLAG_HELP]) {
+  if(omc_flag[FLAG_HELP])
+  {
     std::string option = omc_flagValue[FLAG_HELP];
-
     for(i=1; i<FLAG_MAX; ++i)
     {
       if(option == std::string(FLAG_NAME[i]))
@@ -917,7 +917,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
         }
         messageClose(LOG_STDOUT);
 
-        EXIT(1);
+        EXIT(0);
       }
     }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -833,7 +833,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
     }
 
     messageClose(LOG_STDOUT);
-    EXIT(0);
+    EXIT(1);
   }
 
   if(omc_flag[FLAG_HELP]) {
@@ -923,7 +923,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
 
     warningStreamPrint(LOG_STDOUT, 0, "invalid command line option: -help=%s", option.c_str());
     warningStreamPrint(LOG_STDOUT, 0, "use %s -help for a list of all command-line flags", argv[0]);
-    EXIT(0);
+    EXIT(1);
   }
 
   setGlobalVerboseLevel(argc, argv);

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -917,7 +917,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
         }
         messageClose(LOG_STDOUT);
 
-        EXIT(0);
+        EXIT(1);
       }
     }
 


### PR DESCRIPTION
### Related Issues

* #7719

### Purpose

Return a proper exit code if invalid runtime flags were specified. 
