### PR TITLE
Use size_t to avoid overflow for large int values

### DIFF
--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -68,7 +68,7 @@ static void pool_init(void)
   memory_pools->next = NULL;
 }
 
-static unsigned long upper_power_of_two(unsigned long v)
+static size_t upper_power_of_two(size_t v)
 {
   v--;
   v |= v >> 1;
@@ -158,7 +158,18 @@ static void nofree(void* ptr)
 }
 
 static void* malloc_zero(size_t sz) {
-  return calloc(1, sz);
+  // Our runtime system sometimes asks for 0 size allocation.
+  // Maybe we should forbid that to avoid masking issues like
+  // zero caused by overflow. See #7611.
+  if(sz == 0)
+    return NULL;
+
+  void* addr = calloc(1, sz);
+
+  if(!addr)
+    throwStreamPrint(NULL, "memory_pool.c: Error: Failed to allocate memory (calloc returned NULL.)");
+
+  return addr;
 }
 
 omc_alloc_interface_t omc_alloc_interface_pooled = {

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -37,6 +37,7 @@
 #if !defined(OMC_NO_THREADS)
 #include <pthread.h>
 #endif
+#include "../util/omc_error.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -297,4 +298,3 @@ void* generic_alloc(int n, size_t sze)
 #if defined(__cplusplus)
 } /* end extern "C" */
 #endif
-


### PR DESCRIPTION
  - Fix for #7611. Fixes the immediate issue.

  - Seems like `long` is not enough to contain the sizes of memory we
    are trying to allocate, 4 bytes on x64 MinGW gcc/clang

  - Use size_t as it is fixed size and 8 bytes long.

  - Check if calloc returns NULL, i.e., failed to allocate memory.
