### PR TITLE
Fixed OPC UA server crash related to Boolean vars

### DIFF
--- a/OMCompiler/SimulationRuntime/opc/ua/omc_opc_ua.c
+++ b/OMCompiler/SimulationRuntime/opc/ua/omc_opc_ua.c
@@ -322,7 +322,7 @@ static inline omc_opc_ua_state* addVars(omc_opc_ua_state *state, var_kind_t varK
     case VARKIND_BOOL:
     {
       STATIC_BOOLEAN_DATA *booleanVarsData = modelData->booleanVarsData;
-      state->boolVals[state->latestValues][*varIndex] = ((int*)vars)[i];
+      state->boolVals[state->latestValues][*varIndex] = ((signed char*)vars)[i];
       inputIndex = booleanVarsData[i].info.inputIndex;
       state->boolValsInputIndex[*varIndex] = inputIndex;
       nameStr = (char*) booleanVarsData[i].info.name;
@@ -656,7 +656,7 @@ int omc_embedded_server_update(void *state_vp, double t)
   for (i = 0; i < modelData->nVariablesReal; i++, realIndex++) {
     state->realVals[latestValues][realIndex] = (data->localData[0])->realVars[i];
   }
-  for (i = 0; i < modelData->nVariablesReal; i++, boolIndex++) {
+  for (i = 0; i < modelData->nVariablesBoolean; i++, boolIndex++) {
     state->boolVals[latestValues][boolIndex] = (data->localData[0])->booleanVars[i];
   }
 


### PR DESCRIPTION
### Related Issues

<!-- Link to the issues that are solved with this PR. -->
Fix  #7467

### Purpose

<!--- Describe the problem or feature. -->
Fix the OPC UA server crash at the end of the simulation due to free operation on invalid pointers

### Approach

<!--- How does this address the problem? -->
Referencing the correct count of Boolean variables and correct type-casting has worked for the model in #7467 and few other models that we made.