### PR TITLE
Always choose der(state) as tearing variable

### DIFF
--- a/testsuite/simulation/modelica/resolveLoops/Circuit3x.mos
+++ b/testsuite/simulation/modelica/resolveLoops/Circuit3x.mos
@@ -65,7 +65,7 @@ simulate(Circuit3x); getErrorString();
 //  * Torn equation systems: 2
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 2 {(1,100.0%) 4,(1,100.0%) 4}
+//  * Linear torn systems: 2 {(2,100.0%) 3,(1,100.0%) 4}
 //  * Non-linear torn systems: 0
 // "
 // endResult

--- a/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit1.mos
+++ b/testsuite/simulation/modelica/resolveLoops/ElectricalCircuit1.mos
@@ -75,7 +75,7 @@ res := OpenModelica.Scripting.compareSimulationResults("ElectricalCircuit1_res.m
 //  * Torn equation systems: 4
 //  * Mixed (continuous/discrete) equation systems: 0
 // Notification: Torn system details for strict tearing set:
-//  * Linear torn systems: 4 {(1,100.0%) 6,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
+//  * Linear torn systems: 4 {(2,100.0%) 5,(1,100.0%) 2,(1,100.0%) 2,(1,100.0%) 2}
 //  * Non-linear torn systems: 0
 // "
 // {"Files Equal!"}

--- a/testsuite/simulation/modelica/start_value_selection/asmaFlow.mos
+++ b/testsuite/simulation/modelica/start_value_selection/asmaFlow.mos
@@ -590,8 +590,10 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // $res_LSJac2_2.$pDERLSJac2.dummyVarLSJac2
 // $res_LSJac2_1.$pDERLSJac2.dummyVarLSJac2
 //
-// Unreplaceable Crefs: (5)
+// Unreplaceable Crefs: (7)
 // ========================================
+// $res_LSJac3_7.$pDERLSJac3.dummyVarLSJac3
+// $res_LSJac3_6.$pDERLSJac3.dummyVarLSJac3
 // $res_LSJac3_5.$pDERLSJac3.dummyVarLSJac3
 // $res_LSJac3_4.$pDERLSJac3.dummyVarLSJac3
 // $res_LSJac3_3.$pDERLSJac3.dummyVarLSJac3
@@ -1204,8 +1206,8 @@ val(aimc.inertiaRotor.flange_b.tau, 0);
 // {15:18}
 // {16:19}
 // {31:68}
-// {{{74:30}, {73:29}, {72:28}, {56:32}, {71:33}, {55:31}, {54:81}, {69:37}, {70:79}, {59:14}, {58:13}, {60:49}, {65:48}, {64:69}, {61:70}, {68:71}, {67:72}, {57:36}, {63:80}, {75:73}, {51:77}, {76:74}, {50:75}}
-// ,{62, 49, 53, 52, 66:78, 76, 15, 16, 47}} Size: 5 linear
+// {{{64:69}, {61:70}, {60:14}, {65:13}, {74:30}, {73:29}, {72:28}, {56:32}, {71:33}, {55:31}, {54:81}, {69:37}, {70:79}, {68:71}, {67:72}, {57:36}, {63:80}, {75:73}, {51:77}, {76:74}, {50:75}}
+// ,{58, 59, 62, 49, 53, 52, 66:78, 76, 15, 16, 47, 49, 48}} Size: 7 linear
 // For more information please use "-d=tearingdump".
 // {91:91}
 // {93:93}

--- a/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
@@ -36,7 +36,6 @@ val(i3,0.0); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
-// Warning: The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)


### PR DESCRIPTION

### Related Issues

#7704

### Purpose

Try to see if that helps with anything. @casella can you test this with your thermo-fluid models?

### Approach

During simulation state derivatives are always chosen as tearing variables, unless specified otherwise by the user.
