### PR TITLE
Fix template errors for unrolled array return value for Cpp (see #7743)

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -9660,7 +9660,7 @@ template equationString(SimEqSystem eq, Context context, Text &varDecls, SimCode
   }
   >>
   else
-    error(sourceInfo(),"NOT IMPLEMENTED EQUATION 2")
+    error(sourceInfo(), 'NOT IMPLEMENTED EQUATION 2: <%dumpEqs(fill(eq,1))%>')
 end equationString;
 
 template equation_function_call(SimEqSystem eq, Context context, Text &varDecls, SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace,Text method)
@@ -9695,6 +9695,7 @@ template equation_function_create_single_func(SimEqSystem eq, Context context, S
      then
      equationIfEquation(e, context, &varDeclsLocal, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
    case e as SES_ALGORITHM(__)
+   case e as SES_INVERSE_ALGORITHM(__)
       then
       equationAlgorithm(e, context, &varDeclsLocal,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
    case e as SES_WHEN(__)
@@ -9716,7 +9717,7 @@ template equation_function_create_single_func(SimEqSystem eq, Context context, S
       then
         equationForLoop(e, context, &varDeclsLocal,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation, assignToStartValues)
     else
-      error(sourceInfo(),"NOT IMPLEMENTED EQUATION")
+      error(sourceInfo(), 'NOT IMPLEMENTED EQUATION: <%dumpEqs(fill(eq,1))%>')
   end match
   let &measureTimeStartVar += if createMeasureTime then generateMeasureTimeStartCode("measuredProfileBlockStartValues", 'evaluate<%ix_str%>', "MEASURETIME_PROFILEBLOCKS") else ""
   let &measureTimeEndVar += if createMeasureTime then generateMeasureTimeEndCode("measuredProfileBlockStartValues", "measuredProfileBlockEndValues", '(*measureTimeProfileBlocksArray)[<%ix_str_array%>]', 'evaluate<%ix_str%>', "MEASURETIME_PROFILEBLOCKS") else ""
@@ -13073,7 +13074,7 @@ template algStmtAssign(DAE.Statement stmt, Context context, Text &varDecls, SimC
   case STMT_ASSIGN(exp1=CREF(ty = T_FUNCTION_REFERENCE_VAR(__)))
   case STMT_ASSIGN(exp1=CREF(ty = T_FUNCTION_REFERENCE_FUNC(__))) then
     let &preExp = buffer "" /*BUFD*/
-    let varPart = scalarLhsCref(exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    let varPart = daeExpCref(true, exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let expPart = daeExp(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     <<
 
@@ -13112,7 +13113,7 @@ template algStmtAssign(DAE.Statement stmt, Context context, Text &varDecls, SimC
     >>
   case STMT_ASSIGN(exp1=CREF(__)) then
     let &preExp = buffer "" /*BUFD*/
-    let varPart = scalarLhsCref(exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    let varPart = daeExpCref(true, exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let expPart = daeExp(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     <<
 

--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -2805,7 +2805,7 @@ match exp
 case ecr as CREF(componentRef=WILD(__)) then
   ''
 case ecr as CREF(componentRef=cr, ty=ty as DAE.T_ARRAY()) then
-  let lhsStr = scalarLhsCref(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let lhsStr = daeExpCref(true, exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   match cref2simvar(cr, simCode)
   case SIMVAR(varKind=varKind) then
     match varKind
@@ -2822,7 +2822,7 @@ case ecr as CREF(componentRef=cr, ty=ty as DAE.T_ARRAY()) then
     end match
   end match
 case UNARY(exp = e as CREF(ty=t as DAE.T_ARRAY(__))) then
-  let lhsStr = scalarLhsCref(e, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let lhsStr = daeExpCref(true, e, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   match context
   case SIMULATION_CONTEXT(__) then
     <<
@@ -2834,7 +2834,7 @@ case UNARY(exp = e as CREF(ty=t as DAE.T_ARRAY(__))) then
 case CREF(componentRef = cr, ty=DAE.T_COMPLEX(varLst = varLst, complexClassType=RECORD(__))) then
   match context
   case FUNCTION_CONTEXT(__) then
-    let lhsStr = scalarLhsCref(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    let lhsStr = daeExpCref(true, exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     <<
     <%lhsStr%> = <%rhsStr%>;
     >>
@@ -2848,12 +2848,12 @@ case CREF(componentRef = cr, ty=DAE.T_COMPLEX(varLst = varLst, complexClassType=
     >>
   end match
 case CREF(__) then
-  let lhsStr = scalarLhsCref(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let lhsStr = daeExpCref(true, exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   <<
   <%lhsStr%> = <%rhsStr%>;
   >>
 case UNARY(exp = e as CREF(__)) then
-  let lhsStr = scalarLhsCref(e, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+  let lhsStr = daeExpCref(true, e, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
   <<
   <%lhsStr%> = -<%rhsStr%>;
   >>
@@ -2862,12 +2862,13 @@ case ARRAY(array = {}) then
 
   >>
 case ARRAY(ty=T_ARRAY(ty=ty, dims=dims), array=expl) then
-  let typeShort = expTypeFromExpShort(exp)
-  let fcallsuf = match listLength(dims) case 1 then "" case i then '_<%i%>D'
+  //let typeShort = expTypeFromExpShort(exp)
+  //let fcallsuf = match listLength(dims) case 1 then "" case i then '_<%i%>D'
   let body = (List.zip(expl,dimsToAllIndexes(dims)) |>  (lhs,indxs) =>
-                 let lhsstr = scalarLhsCref(lhs, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-                 let indxstr = (indxs |> i => '<%i%>' ;separator=",")
-                 '<%lhsstr%> = <%typeShort%>_get<%fcallsuf%>(&<%rhsStr%>, <%indxstr%>);'
+                 let lhsStr = daeExpCref(true, lhs, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+                 let indexStr = (indxs |> i => '<%i%>' ;separator=",")
+                 //'<%lhsStr%> = <%typeShort%>_get<%fcallsuf%>(&<%rhsStr%>, <%indexStr%>);'
+                 '<%lhsStr%> = (<%rhsStr%>)(<%indexStr%>);'
               ;separator="\n")
   <<
   <%body%>
@@ -2879,7 +2880,7 @@ case RECORD(exps=exps, comp=comp) then
   /*
   // assign fields of rhs record to lhs exps, one by one
   let body = (List.zip(exps, comp) |> (exp, compn) =>
-                let lhsStr = scalarLhsCref(exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+                let lhsStr = daeExpCref(true, exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
                 let compnStr = crefStr(makeUntypedCrefIdent(compn))
                 '<%lhsStr%> = <%rhsStr%>.<%compnStr%>;'
               ;separator="\n")
@@ -2893,66 +2894,6 @@ else
   error(sourceInfo(), 'writeLhsCref UNHANDLED: <%ExpressionDumpTpl.dumpExp(exp,"\"")%> = <%rhsStr%>')
 
 end writeLhsCref;
-
-template scalarLhsCref(Exp ecr, Context context, Text &preExp, Text &varDecls, SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
-  "Generates a single lhs cref of an assignment"
-::=
-match ecr
-case ecr as CREF(componentRef=CREF_IDENT(subscriptLst=subs)) then
-  if crefNoSub(ecr.componentRef) then
-    contextCref(ecr.componentRef, context, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-  else
-    daeExpCref(true, ecr, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-case ecr as CREF(componentRef=cr as CREF_QUAL(__)) then
-  if crefIsScalar(cr, context) then
-    contextCref(ecr.componentRef, context, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-  else
-    let arrName = contextCref(crefStripSubs(cr), context, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-    <<
-    <%arrName%>(<%threadDimSubList(crefDims(cr), crefSubs(cr), context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>)
-    >>
-case ecr as CREF(componentRef=CREF_QUAL(__)) then
-  contextCref(ecr.componentRef, context, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-else
-  error(sourceInfo(), 'scalarLhsCref UNSUPPORTED: <%ExpressionDumpTpl.dumpExp(ecr,"\"")%>')
-end scalarLhsCref;
-
-
-template threadDimSubList(list<Dimension> dims, list<Subscript> subs, Context context, Text &preExp, Text &varDecls,SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
-  "Do direct indexing since sizes are known during compile-time"
-::=
-  match subs
-  case {} then error(sourceInfo(),"Empty dimensions in indexing cref?")
-
-  case {sub as INDEX(__)} then
-    match dims
-    case {dim} then
-       let estr = daeExp(sub.exp, context, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-      '<%estr%>'
-    else error(sourceInfo(),"Less subscripts that dimensions in indexing cref? That's odd!")
-
-  case (sub as INDEX(__))::subrest then
-    match dims
-      case _::dimrest
-      then
-
-        let estr = daeExp(sub.exp, context, &preExp, &varDecls, simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
-        '<%estr%><%match subrest case {} then "" else ',<%threadDimSubList(dimrest, subrest, context, &preExp, &varDecls, simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'%>'
-        /*'((<%estr%><%
-          dimrest |> dim =>
-          match dim
-          case DIM_INTEGER(__) then ')*<%integer%>'
-          case DIM_BOOLEAN(__) then '*2'
-          case DIM_ENUM(__) then '*<%size%>'
-          else error(sourceInfo(),"Non-constant dimension in simulation context")
-        %>)<%match subrest case {} then "" else ',<%threadDimSubList(dimrest, subrest, context, &preExp, &varDecls, simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, useFlatArrayNotation)%>'%>'
-        */
-      else error(sourceInfo(),"Less subscripts that dimensions in indexing cref? That's odd!")
-  else error(sourceInfo(),"Non-index subscript in indexing cref? That's odd!")
-end threadDimSubList;
-
-
-
 
 template daeExpTsub(Exp inExp, Context context, Text &preExp,
                     Text &varDecls,SimCode simCode, Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -9851,7 +9851,7 @@ template equationString(SimEqSystem eq, Context context, Text &varDecls, SimCode
     IF EQUATIONS ARE NOT IMPLEMENTED
     >>
   else
-    error(sourceInfo(),"NOT IMPLEMENTED EQUATION 2")
+    error(sourceInfo(), 'NOT IMPLEMENTED EQUATION 2: <%dumpEqs(fill(eq,1))%>')
 end equationString;
 
 template equation_function_call(SimEqSystem eq, Context context, Text &varDecls, SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace,Text method)
@@ -9886,6 +9886,7 @@ template equation_function_create_single_func(SimEqSystem eq, Context context, S
      then
      equationIfEquation(e, context, &varDeclsLocal, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
    case e as SES_ALGORITHM(__)
+   case e as SES_INVERSE_ALGORITHM(__)
       then
       equationAlgorithm(e, context, &varDeclsLocal,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
    case e as SES_WHEN(__)
@@ -9907,7 +9908,7 @@ template equation_function_create_single_func(SimEqSystem eq, Context context, S
       then
         equationForLoop(e, context, &varDeclsLocal,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation, assignToStartValues)
     else
-      error(sourceInfo(),"NOT IMPLEMENTED EQUATION")
+      error(sourceInfo(), 'NOT IMPLEMENTED EQUATION: <%dumpEqs(fill(eq,1))%>')
   end match
   let &measureTimeStartVar += if createMeasureTime then generateMeasureTimeStartCode("measuredProfileBlockStartValues", 'evaluate<%ix_str%>', "MEASURETIME_PROFILEBLOCKS") else ""
   let &measureTimeEndVar += if createMeasureTime then generateMeasureTimeEndCode("measuredProfileBlockStartValues", "measuredProfileBlockEndValues", '(*measureTimeProfileBlocksArray)[<%ix_str_array%>]', 'evaluate<%ix_str%>', "MEASURETIME_PROFILEBLOCKS") else ""
@@ -13278,7 +13279,7 @@ template algStmtAssign(DAE.Statement stmt, Context context, Text &varDecls, SimC
   case STMT_ASSIGN(exp1=CREF(ty = T_FUNCTION_REFERENCE_VAR(__)))
   case STMT_ASSIGN(exp1=CREF(ty = T_FUNCTION_REFERENCE_FUNC(__))) then
     let &preExp = buffer "" /*BUFD*/
-    let varPart = scalarLhsCref(exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    let varPart = daeExpCref(true, exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let expPart = daeExp(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     <<
 
@@ -13317,7 +13318,7 @@ template algStmtAssign(DAE.Statement stmt, Context context, Text &varDecls, SimC
     >>
   case STMT_ASSIGN(exp1=CREF(__)) then
     let &preExp = buffer "" /*BUFD*/
-    let varPart = scalarLhsCref(exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
+    let varPart = daeExpCref(true, exp1, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     let expPart = daeExp(exp, context, &preExp /*BUFC*/, &varDecls /*BUFD*/,simCode , &extraFuncs , &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)
     <<
 

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.InverseParameterization.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.InverseParameterization.mos
@@ -9,7 +9,7 @@
 
 runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
-modelTestingType := OpenModelicaModelTesting.Kind.Compilation;
+modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Fluid.Examples.InverseParameterization);
 compareVars :=
 {
@@ -35,11 +35,13 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// OpenModelicaModelTesting.Kind.Compilation
+// OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Fluid.Examples.InverseParameterization
 // {"source.ports[1].m_flow","source.ports[1].p","source.ports[1].h_outflow","sink.ports[1].m_flow","sink.ports[1].p","sink.ports[1].h_outflow","sink1.ports[1].m_flow","sink1.ports[1].p","sink1.ports[1].h_outflow","sink2.ports[1].m_flow","sink2.ports[1].p","sink2.ports[1].h_outflow"}
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
-// Compilation failed
+// Simulation options: startTime = 0.0, stopTime = 10.0, numberOfIntervals = 10000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.InverseParameterization', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
+// Result file: Modelica.Fluid.Examples.InverseParameterization_res.mat
+// Files Equal!
 // [Modelica 3.2.1+maint.om/Fluid/Interfaces.mo:734:9-739:39:writable] Notification: From here:
 // [Modelica 3.2.1+maint.om/Fluid/Interfaces.mo:327:3-329:69:writable] Warning: Inherited elements are not identical: bug: https://trac.modelica.org/Modelica/ticket/627
 // 	first:  Medium.MassFlowRate m_flow(min = if allowFlowReversal then -Modelica.Constants.inf else 0, start = m_flow_start, stateSelect = if momentumDynamics == Modelica.Fluid.Types.Dynamics.SteadyState then StateSelect.default else StateSelect.prefer) "mass flow rates between states"
@@ -50,20 +52,7 @@ runScript(modelTesting);getErrorString();
 // ========================================
 // 1: pump.medium.p
 // Please use -d=bltdump for more information.
-// Error: Error building simulator. Build log: g++  -fopenmp  -Winvalid-pch -O0 -g -DNDEBUG -fPIC   -std=c++11 -DBOOST_ALL_DYN_LINK   -DUSE_DGESV -DUSE_LOGGER -DOMC_BUILD -DUSE_PUGI_XML -DUSE_THREAD -DSUNDIALS_MAJOR_VERSION=5 -DSUNDIALS_MINOR_VERSION=4 -DPMC_USE_SUNDIALS -I"." -I"/home/rfranke/OpenModelica/build/bin/../include/omc/cpp/" -I.  -I"." -I"." -I"/home/rfranke/OpenModelica/build/include/omc/c/sundials"     -DMEASURETIME_PROFILEBLOCKS -DUSE_LOGGER  -c -o OMCppModelica.Fluid.Examples.InverseParameterizationCalcHelperMain.o OMCppModelica.Fluid.Examples.InverseParameterizationCalcHelperMain.cpp
-// In file included from OMCppModelica.Fluid.Examples.InverseParameterizationAlgLoopMain.cpp:15,
-//                  from OMCppModelica.Fluid.Examples.InverseParameterizationCalcHelperMain.cpp:25:
-// OMCppModelica.Fluid.Examples.InverseParameterizationAlgloop631.cpp: In member function 'virtual void InverseParameterizationAlgloop631::evaluate()':
-// OMCppModelica.Fluid.Examples.InverseParameterizationAlgloop631.cpp:127:46: error: '_homotopyLambda' was not declared in this scope
-//   127 |   _system->__omcQ_24DER_P_pump_P_V_flow_ = ((_homotopyLambda * division(((_system->__omcQ_24DER_P_pump_P_m_flow_ * _system->_pump_P_rho_) - (_system->_pump_P_m_flow_ * _system->__omcQ_24DER_P_pump_P_rho_)),std::pow(_system->_pump_P_rho_, 2.0),!_system->_initial,"pump.rho ^ 2.0")) + ((1.0 - _homotopyLambda) * division(_system->__omcQ_24DER_P_pump_P_m_flow_,_system->_pump_P_rho_nominal_,!_system->_initial,"pump.rho_nominal")));
-//       |                                              ^~~~~~~~~~~~~~~
-// In file included from OMCppModelica.Fluid.Examples.InverseParameterizationAlgLoopMain.cpp:21,
-//                  from OMCppModelica.Fluid.Examples.InverseParameterizationCalcHelperMain.cpp:25:
-// OMCppModelica.Fluid.Examples.InverseParameterizationAlgloop195.cpp: In member function 'virtual void InverseParameterizationAlgloop195::evaluate()':
-// OMCppModelica.Fluid.Examples.InverseParameterizationAlgloop195.cpp:130:46: error: '_homotopyLambda' was not declared in this scope
-//   130 |   _system->__omcQ_24DER_P_pump_P_V_flow_ = ((_homotopyLambda * division(((_system->__omcQ_24DER_P_pump_P_m_flow_ * _system->_pump_P_rho_) - (_system->_pump_P_m_flow_ * _system->__omcQ_24DER_P_pump_P_rho_)),std::pow(_system->_pump_P_rho_, 2.0),!_system->_initial,"pump.rho ^ 2.0")) + ((1.0 - _homotopyLambda) * division(_system->__omcQ_24DER_P_pump_P_m_flow_,_system->_pump_P_rho_nominal_,!_system->_initial,"pump.rho_nominal")));
-//       |                                              ^~~~~~~~~~~~~~~
-// make: *** [<builtin>: OMCppModelica.Fluid.Examples.InverseParameterizationCalcHelperMain.o] Error 1
+//
 // "true
 // "
 // ""


### PR DESCRIPTION
- remove template scalarLhsCref and call daeExpCref(isLhs=true, ...) instead
  to cover slice y[:] in
    (y[:], t) := runSimulation(delta, dt, 1, counter);
- fix assignment of array return value to unrolled array
- add missing case SES_INVERSE_ALGORITHM
