### PR TITLE
Always choose der(state) as tearing variable

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -548,7 +548,7 @@ algorithm
   columark := arrayCreate(size,-1);
 
   // Collect variables with annotation attribute 'tearingSelect=always', 'tearingSelect=prefer', 'tearingSelect=avoid' and 'tearingSelect=never'
-  (tSel_always,tSel_prefer,tSel_avoid,tSel_never) := tearingSelect(var_lst, {}, DAEtypeStr);
+  (tSel_always,tSel_prefer,tSel_avoid,tSel_never,_) := tearingSelect(var_lst, {}, DAEtypeStr);
 
   // determine tvars and do cheap matching until a maximum matching is there
   // if cheap matching stucks select additional tearing variable and continue
@@ -1996,7 +1996,7 @@ protected
   Integer size, tornsize;
   array<Integer> ass1, ass2, mapIncRowEqn, eqnNonlinPoints;
   array<list<Integer>> mapEqnIncRow;
-  list<Integer> OutTVars, residual, residual_coll, order, unsolvables, discreteVars, tSel_always, tSel_prefer, tSel_avoid,tSel_never;
+  list<Integer> OutTVars, residual, residual_coll, order, unsolvables, discreteVars, tSel_always, tSel_alwaysByUser, tSel_prefer, tSel_avoid, tSel_never;
   BackendDAE.InnerEquations innerEquations;
   BackendDAE.EqSystem subsyst;
   BackendDAE.Variables vars;
@@ -2099,9 +2099,9 @@ algorithm
   end if;
 
   // Collect variables with annotation attribute 'tearingSelect=always', 'tearingSelect=prefer', 'tearingSelect=avoid' and 'tearingSelect=never'
-  (tSel_always,tSel_prefer,tSel_avoid,tSel_never) := tearingSelect(var_lst, tearingSelect_always, DAEtypeStr);
-  if not listEmpty(tSel_always) then
-    Error.addMessage(Error.USER_TEARING_VARS, {intString(strongComponentIndex), BackendDump.printBackendDAEType2String(DAEtype), BackendDump.dumpMarkedVarList(var_lst, tSel_always)});
+  (tSel_always, tSel_prefer, tSel_avoid, tSel_never, tSel_alwaysByUser) := tearingSelect(var_lst, tearingSelect_always, DAEtypeStr);
+  if not listEmpty(tSel_alwaysByUser) then
+    Error.addMessage(Error.USER_TEARING_VARS, {intString(strongComponentIndex), BackendDump.printBackendDAEType2String(DAEtype), BackendDump.dumpMarkedVarList(var_lst, tSel_alwaysByUser)});
   end if;
   if debug then execStat("Tearing.CellierTearing -> 3"); end if;
 
@@ -2291,34 +2291,48 @@ protected function tearingSelect
   output list<Integer> prefer = {};
   output list<Integer> avoid = {};
   output list<Integer> never = {};
+  output list<Integer> alwaysByUser = always "distinguish betwween user choice and compiler choice";
 protected
   BackendDAE.Var var;
   Integer index = 1;
   Option<BackendDAE.TearingSelect> ts;
   Boolean preferTVarsWithStartValue;
+  Boolean inSimulation = DAEtypeStr == "simulation";
+  Boolean decided;
 algorithm
-  preferTVarsWithStartValue := Flags.getConfigBool(Flags.PREFER_TVARS_WITH_START_VALUE) and stringEq(DAEtypeStr, "initialization");
+  preferTVarsWithStartValue := Flags.getConfigBool(Flags.PREFER_TVARS_WITH_START_VALUE) and (DAEtypeStr == "initialization");
   for var in var_lstIn loop
-      // Get the value of the variable's tearingSelect attribute.
+    // Get the value of the variable's tearingSelect attribute.
     BackendDAE.VAR(tearingSelectOption = ts) := var;
 
-      // Add the variable's index to the appropriate list.
-      _ := match(ts)
-        case SOME(BackendDAE.ALWAYS()) guard not listMember(index, always) algorithm always := index :: always; then ();
-        case SOME(BackendDAE.PREFER()) algorithm prefer := index :: prefer; then ();
-        case SOME(BackendDAE.AVOID()) algorithm avoid  := index :: avoid;  then ();
-        case SOME(BackendDAE.NEVER()) algorithm never  := index :: never;  then ();
-        else ();
-      end match;
+    // Add the variable's index to the appropriate list.
+    decided := match(ts)
+      case NONE() then false;
+      case SOME(BackendDAE.ALWAYS()) algorithm
+        if not listMember(index, always) then
+          always := index :: always;
+          alwaysByUser := index :: alwaysByUser;
+        end if;
+      then true;
+      case SOME(BackendDAE.PREFER()) algorithm prefer := index :: prefer; then true;
+      case SOME(BackendDAE.DEFAULT()) then true;
+      case SOME(BackendDAE.AVOID()) algorithm avoid := index :: avoid; then true;
+      case SOME(BackendDAE.NEVER()) algorithm never := index :: never; then true;
+    end match;
+
+    if not decided then
+      // During simulation, always select states
+      // see https://github.com/OpenModelica/OpenModelica/issues/7704
+      if Flags.getConfigBool(Flags.TEARING_ALWAYS_DERIVATIVES) and
+         inSimulation and BackendVariable.isStateVar(var) and not listMember(index, always) then
+        always := index :: always;
 
       // Also prefer variables with start value
-      if preferTVarsWithStartValue then
-        if BackendVariable.varHasStartValue(var) then
-          prefer := index :: prefer;
-        end if;
+      elseif preferTVarsWithStartValue and BackendVariable.varHasStartValue(var) then
+        prefer := index :: prefer;
       end if;
-
-      index := index + 1;
+    end if;
+    index := index + 1;
   end for;
 
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1374,6 +1374,10 @@ constant ConfigFlag LINK_TYPE = CONFIG_FLAG(145, "linkType",
                "dynamic: libraries are dynamically linked; the executable is built very fast but is not portable because of DLL dependencies.\n"+
                "static: libraries are statically linked; the executable is built more slowly but it is portable and dependency-free.\n"));
 
+constant ConfigFlag TEARING_ALWAYS_DERIVATIVES = CONFIG_FLAG(140, "tearingAlwaysDer",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Gettext.gettext("Always choose state derivatives as iteration variables in strong components."));
+
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."
   input Boolean initialize = true;

--- a/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
@@ -36,7 +36,6 @@ val(i3,0.0); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
-// Warning: The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)


### PR DESCRIPTION
During simulation state derivatives are always chosen as
tearing variables, unless specified otherwise by the user.
(See issue #7704)

### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

<!--- Describe the problem or feature. -->

### Approach

<!--- How does this address the problem? -->
