### PR TITLE
Pass on Fortran compiler and flags to CMake target

### DIFF
--- a/OMCompiler/Makefile.in
+++ b/OMCompiler/Makefile.in
@@ -12,22 +12,23 @@ datadir = @datadir@
 datarootdir = @datarootdir@
 docdir = @docdir@
 
+AR = @AR@
+host = @host@
+host_short = @host_short@
+FC = @FC@
+FCFLAGS = @FCFLAGS@
 CMAKE=@CMAKE@
 # Use the system's default cmake if nothing is passed to configure script, i.e., no CMAKE=<some_path> is specified
 ifeq ($(CMAKE),)
 	CMAKE=cmake
 endif
 
-CMAKE := CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="@LDFLAGS@" $(CMAKE) @CMAKE_EXTRA_DEFINES@
+CMAKE := CC="$(CC)" CXX="$(CXX)" FC="$(FC)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" FFLAGS="$(FCFLAGS)" LDFLAGS="@LDFLAGS@" $(CMAKE) @CMAKE_EXTRA_DEFINES@
 CMAKE_NO_CHECK_UNDEFINED := CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="@CMAKE_LDFLAGS_UNDEFINED_LOOKUP@ @LDFLAGS@" $(CMAKE) @CMAKE_EXTRA_DEFINES@
 CMAKE_RPATH := CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="@RPATH_QMAKE@ @CMAKE_LDFLAGS_UNDEFINED_LOOKUP@" $(CMAKE) @CMAKE_EXTRA_DEFINES@
 CMAKE_TARGET = "Unix Makefiles"
 OPENCL = @OPENCL@
-AR = @AR@
-host = @host@
-host_short = @host_short@
-FC = @FC@
-FCFLAGS = @FCFLAGS@
+
 ENABLE_PARMODAUTO = @ENABLE_PARMODAUTO@
 OMC_TBB_ROOT = @OMC_TBB_ROOT@
 


### PR DESCRIPTION
  - This was done for Windows in commit 0f7757d
    It was missing for Linux. It is only caught now because the nightly
    builds for some distributions are failing.

  - CC, CXX, CFLAGS, ... were passed on to the CMake compiled libraries.
     Fortran counterparts were missing.
