### PR TITLE
Fix cleaning of pristine repository clone.

### DIFF
--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -170,7 +170,7 @@ ipopt:
 	$(CMAKE) --build $(OMC_IPOPT_ROOT)/build/ --target install
 
 ipopt-clean:
-	$(CMAKE) --build $(OMC_IPOPT_ROOT)/build/ --target clean
+	if test -f $(OMC_IPOPT_ROOT)/build/Makefile; then $(MAKE) -C $(OMC_IPOPT_ROOT)/build/ clean; fi
 	rm -rf $(OMC_IPOPT_ROOT)/build
 
 suitesparse:
@@ -690,7 +690,7 @@ libffi: $(LIBFFI)
 	$(MAKE) -C "$(LIBFFI)" install
 
 libffi-clean:
-	-$(MAKE) -C "$(LIBFFI)" clean
+	if test -f $(LIBFFI)/Makefile; then $(MAKE) -C "$(LIBFFI)" clean; fi
 
 sanity-check: omc
 	$(OMBUILDDIR)/bin/omc Examples/SanityCheck.mos


### PR DESCRIPTION
  - Check if the Makefile exists before issuing make clean for Ipopt.

  - Change cleaning of libffi to not even issue an error instead of
    issuing and ignoring. It makes it easier to understand and easier
    to locate other errors in the build logs.