### PR TITLE
CMake improvements

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -107,6 +107,11 @@ omc_option(OMC_BUILD_LPSOLVE "Should we build our own 3rdParty/lpsolve." OFF)
 omc_option(OMC_USE_LAPACK "Should we use lapack." ON)
 
 
+add_library(omc_config INTERFACE)
+add_library(omc::config ALIAS omc_config)
+target_include_directories(omc_config INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+
 
 omc_add_subdirectory(3rdParty)
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(omc::compiler::runtime ALIAS omcruntime)
 target_sources(omcruntime PRIVATE ${OMC_RUNTIIME_SOURCES})
 target_compile_features(omcruntime PRIVATE cxx_std_11)
 
+target_link_libraries(omcruntime PUBLIC omc::config)
 target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
@@ -91,7 +92,6 @@ endif()
 
 target_include_directories(omcruntime PUBLIC ${Intl_INCLUDE_DIRS})
 target_include_directories(omcruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(omcruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
 
 # uuid is one of the default libs that cmake adds to any target on Win32. On non-Win systems we look for the library and
 # explicitly use it.
@@ -147,6 +147,7 @@ set(OMC_BACKENDRUNTIIME_SOURCES
 
 target_sources(omcbackendruntime PRIVATE ${OMC_BACKENDRUNTIIME_SOURCES})
 
+target_link_libraries(omcbackendruntime PUBLIC omc::config)
 target_link_libraries(omcbackendruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcbackendruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib::static)
@@ -154,7 +155,6 @@ target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
 target_include_directories(omcbackendruntime PUBLIC ${Intl_INCLUDE_DIRS})
 target_include_directories(omcbackendruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(omcbackendruntime PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h
 
 # ######################################################################################################################
 # Library: omcgraphstream

--- a/OMCompiler/Parser/CMakeLists.txt
+++ b/OMCompiler/Parser/CMakeLists.txt
@@ -39,5 +39,3 @@ target_link_libraries(omparse PUBLIC omc::3rd::omantlr3)
 # To find the generated antlr headers. SYSTEM to disable warnings on the generated code.
 target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_include_directories(omparse PRIVATE ${OMCompiler_SOURCE_DIR}) # for revision.h :/


### PR DESCRIPTION
@mahge
Add Ipopt to CMake configuration and compilation.
ff5dddb

@mahge
Add a new "interface" library for OMC config …
d41be10
  - This is essentially a header only library. It can be linked-to to get
    access to the OpenModelica configure headers, e.g., omc_config.h

    You can link to it from any library to get access to the headers in
    it.

  - This gives us a good and clean way to incorporate, add-to and modify
    our configuration settlings and options.