### PR TITLE
Use the simple grid as default instead of detailed

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2814,7 +2814,7 @@ function plot "Launches a plot window using OMPlot."
   input Boolean externalWindow = false "Opens the plot in a new plot window";
   input String fileName = "<default>" "The filename containing the variables. <default> will read the last simulation result";
   input String title = "" "This text will be used as the diagram title.";
-  input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
+  input String grid = "simple" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
   input String xLabel = "time" "This text will be used as the horizontal label in the diagram.";
@@ -2852,7 +2852,7 @@ function plotAll "Works in the same way as plot(), but does not accept any
   input Boolean externalWindow = false "Opens the plot in a new plot window";
   input String fileName = "<default>" "The filename containing the variables. <default> will read the last simulation result";
   input String title = "" "This text will be used as the diagram title.";
-  input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
+  input String grid = "simple" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
   input String xLabel = "time" "This text will be used as the horizontal label in the diagram.";
@@ -2881,7 +2881,7 @@ function plotParametric "Launches a plotParametric window using OMPlot. Returns 
   input Boolean externalWindow = false "Opens the plot in a new plot window";
   input String fileName = "<default>" "The filename containing the variables. <default> will read the last simulation result";
   input String title = "" "This text will be used as the diagram title.";
-  input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
+  input String grid = "simple" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
   input String xLabel = "" "This text will be used as the horizontal label in the diagram.";

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3037,7 +3037,7 @@ function plot "Launches a plot window using OMPlot."
   input Boolean externalWindow = false "Opens the plot in a new plot window";
   input String fileName = "<default>" "The filename containing the variables. <default> will read the last simulation result";
   input String title = "" "This text will be used as the diagram title.";
-  input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
+  input String grid = "simple" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
   input String xLabel = "time" "This text will be used as the horizontal label in the diagram.";
@@ -3075,7 +3075,7 @@ function plotAll "Works in the same way as plot(), but does not accept any
   input Boolean externalWindow = false "Opens the plot in a new plot window";
   input String fileName = "<default>" "The filename containing the variables. <default> will read the last simulation result";
   input String title = "" "This text will be used as the diagram title.";
-  input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
+  input String grid = "simple" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
   input String xLabel = "time" "This text will be used as the horizontal label in the diagram.";
@@ -3104,7 +3104,7 @@ function plotParametric "Launches a plotParametric window using OMPlot. Returns 
   input Boolean externalWindow = false "Opens the plot in a new plot window";
   input String fileName = "<default>" "The filename containing the variables. <default> will read the last simulation result";
   input String title = "" "This text will be used as the diagram title.";
-  input String grid = "detailed" "Sets the grid for the plot i.e simple, detailed, none.";
+  input String grid = "simple" "Sets the grid for the plot i.e simple, detailed, none.";
   input Boolean logX = false "Determines whether or not the horizontal axis is logarithmically scaled.";
   input Boolean logY = false "Determines whether or not the vertical axis is logarithmically scaled.";
   input String xLabel = "" "This text will be used as the horizontal label in the diagram.";

--- a/OMPlot/OMPlot/OMPlotGUI/PlotApplication.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotApplication.cpp
@@ -40,6 +40,8 @@ using namespace OMPlot;
 PlotApplication::PlotApplication(int &argc, char *argv[], const QString uniqueKey)
     : QApplication(argc, argv)
 {
+    setAttribute(Qt::AA_DontShowIconsInMenus, false);
+    setAttribute(Qt::AA_UseHighDpiPixmaps);
     mSharedMemory.setKey(uniqueKey);
 
     if (mSharedMemory.attach())

--- a/OMPlot/OMPlot/OMPlotGUI/PlotGrid.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotGrid.h
@@ -43,7 +43,7 @@ class PlotGrid : public QwtPlotGrid
 public:
   PlotGrid(Plot *pParent);
   ~PlotGrid();
-  QPen getMajorPen() {return QPen(Qt::gray);}
+  QPen getMajorPen() {return QPen(QColor(242, 242, 242));} // #F2F2F2 light gray color. More lighter than Qt::lightGray
   QPen getMinorPen() {return QPen(Qt::lightGray, 0.0, Qt::DotLine);}
   void setGrid();
   void setDetailedGrid();

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -81,7 +81,7 @@ void PlotWindow::setUpWidget()
   // set the plot title
   setTitle(tr("Plot by OpenModelica"));
   // set the plot grid
-  setDetailedGrid(true);
+  setGrid(true);
 }
 
 void PlotWindow::initializePlot(QStringList arguments)
@@ -1421,17 +1421,12 @@ void PlotWindow::updatePlot()
 
 void PlotWindow::setGrid(QString grid)
 {
-  if (grid.toLower().compare("simple") == 0)
-  {
-    setGrid(true);
-  }
-  else if (grid.toLower().compare("none") == 0)
-  {
-    setNoGrid(true);
-  }
-  else
-  {
+  if (grid.toLower().compare("detailed") == 0) {
     setDetailedGrid(true);
+  } else if (grid.toLower().compare("none") == 0) {
+    setNoGrid(true);
+  } else {
+    setGrid(true);
   }
 }
 

--- a/OMPlot/OMPlot/OMPlotGUI/main.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/main.cpp
@@ -237,6 +237,9 @@ int main(int argc, char *argv[])
     arguments.append(autoScale ? "true" : "false");
     arguments.append(vars);
     // create the plot application object that is used to check that only one instance of application is running
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
     PlotApplication app(argc, argv, "OMPlot");
     // create the plot main window
     PlotMainWindow w;


### PR DESCRIPTION
### Related Issues

Fixes #7711

### Purpose

Improve OMEdit plot grids

### Approach

Changed the default grid to simple from detailed. Updated the grid lines to very light gray color.