### PR TITLE
Change Cpp nonlinear solver order to newton, kinsol

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -102,7 +102,7 @@ OMCFactory::OMCFactory(PATH library_path, PATH modelicasystem_path)
   : _library_path(library_path)
   , _modelicasystem_path(modelicasystem_path)
   , _defaultLinSolver("dgesvSolver")
-	, _defaultNonLinSolvers{"kinsol", "newton"}
+	, _defaultNonLinSolvers({"newton", "kinsol"})
 {
   fillArgumentsToIgnore();
   fillArgumentsToReplace();
@@ -112,7 +112,7 @@ OMCFactory::OMCFactory()
   : _library_path("")
   , _modelicasystem_path("")
   , _defaultLinSolver("dgesvSolver")
-  , _defaultNonLinSolvers{"kinsol", "newton"}
+  , _defaultNonLinSolvers({"newton", "kinsol"})
 {
   fillArgumentsToIgnore();
   fillArgumentsToReplace();
@@ -445,11 +445,11 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      else
          outputPath = modelica_lib_path;
 
-     string resultsfilename;
+     string resultsFileName;
      if (vm.count("results-file"))
      {
          //cout << "results file: " << vm["results-file"].as<string>() << endl;
-         resultsfilename = vm["results-file"].as<vector<string> >().front();
+         resultsFileName = vm["results-file"].as<vector<string> >().front();
      }
      else
          throw ModelicaSimulationError(MODEL_FACTORY,"results-filename is not set");
@@ -476,6 +476,12 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
        else
          throw ModelicaSimulationError(MODEL_FACTORY,
            "Unknown output-format " + outputFormat_str);
+
+       // adapt resultsFileName to match selected format
+       // (this is needed if outputFormat differs from value at compilation time)
+       size_t idx = resultsFileName.find_last_of('.');
+       if (idx > 0 && outputFormatMap.find(resultsFileName.substr(idx + 1)) != outputFormatMap.end())
+         resultsFileName = resultsFileName.substr(0, idx + 1) + outputFormat_str;
      }
      else
        throw ModelicaSimulationError(MODEL_FACTORY, "output-format is not set");
@@ -497,7 +503,7 @@ SimSettings OMCFactory::readSimulationParameter(int argc, const char* argv[])
      libraries_path.make_preferred();
      modelica_path.make_preferred();
 
-     SimSettings settings = {solver, linSolver, nonLinSolvers, starttime, stoptime, stepsize, 1e-24, 0.01, tolerance, resultsfilename, timeOut, outputPointType, logSettings, nlsContinueOnError, solverThreads, outputFormat, emitResults, inputPath, outputPath};
+     SimSettings settings = {solver, linSolver, nonLinSolvers, starttime, stoptime, stepsize, 1e-24, 0.01, tolerance, resultsFileName, timeOut, outputPointType, logSettings, nlsContinueOnError, solverThreads, outputFormat, emitResults, inputPath, outputPath};
 
      _library_path = libraries_path.string();
      _modelicasystem_path = modelica_path.string();

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.SMEE_LoadDump.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.SMEE_LoadDump.mos
@@ -37,6 +37,12 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 10.0, numberOfIntervals = 10000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.SMEE_LoadDump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Electrical.Machines.Examples.SynchronousInductionMachines.SMEE_LoadDump_res.mat
+// Messages: ERROR  : solver: DASSL: failed step at t = 0.000282: Number of event iteration steps exceeded at time: 0.000282
+// ERROR  : solver: SimManager: Simulation stopped with errors before t = 10.000000
+// ERROR  : solver: SimManager: DASSL: solve failed with idid = 5
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // Files Equal!
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Spice3.Examples.Inverter.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Spice3.Examples.Inverter.mos
@@ -33,13 +33,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 9.999999999999999e-12, numberOfIntervals = 1999, tolerance = 1e-07, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Spice3.Examples.Inverter', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Electrical.Spice3.Examples.Inverter_res.mat
-// Messages: ERROR  : solver: DASSL: failed step at t = 0.000000: Nonlinear solver 82 stopped at time 4e-12 with error in algloop solver: 
-// Nonlinear solver failed!
-// ERROR  : solver: SimManager: Simulation stopped with errors before t = 0.000000
-// ERROR  : solver: SimManager: DASSL: solve failed with idid = 3
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.AST_BatchPlant.Test.TankWithEmptyingPipe2.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.AST_BatchPlant.Test.TankWithEmptyingPipe2.mos
@@ -31,14 +31,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 120.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.AST_BatchPlant.Test.TankWithEmptyingPipe2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.AST_BatchPlant.Test.TankWithEmptyingPipe2_res.mat
-// Messages: DASKR--  R IS ILL-DEFINED.  ZERO VALUES WERE FOUND AT TWO                       
-//          VERY CLOSE T VALUES, AT T = R1                                         
-//       In above message,  R1 =   1.1382017794797E+02
-// ERROR  : solver: SimManager: Simulation stopped with errors before t = 120.000000
-// ERROR  : solver: SimManager: DASSL: solve failed with idid = -33
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // Files Equal!
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.AST_BatchPlant.Test.TanksWithEmptyingPipe2.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.AST_BatchPlant.Test.TanksWithEmptyingPipe2.mos
@@ -35,11 +35,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 120.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.AST_BatchPlant.Test.TanksWithEmptyingPipe2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.AST_BatchPlant.Test.TanksWithEmptyingPipe2_res.mat
-// Messages: ERROR  : solver: SimManager: Simulation stopped with errors before t = 120.000000
-// ERROR  : solver: SimManager: Number of event iteration steps exceeded at time: 0.000000
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // Files Equal!
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.BranchingDynamicPipes.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.BranchingDynamicPipes.mos
@@ -9,7 +9,7 @@
 
 runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
-modelTestingType := OpenModelicaModelTesting.Kind.SuppressedVerifiedSimulation;
+modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Fluid.Examples.BranchingDynamicPipes);
 compareVars :=
 {
@@ -100,7 +100,7 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// OpenModelicaModelTesting.Kind.SuppressedVerifiedSimulation
+// OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Fluid.Examples.BranchingDynamicPipes
 // {"pipe1.mediums[1].p","pipe1.mediums[1].Xi[1]","pipe1.mediums[1].T","pipe1.mediums[2].p","pipe1.mediums[2].Xi[1]","pipe1.mediums[2].T","pipe1.mediums[3].p","pipe1.mediums[3].Xi[1]","pipe1.mediums[3].T","pipe1.mediums[4].p","pipe1.mediums[4].Xi[1]","pipe1.mediums[4].T","pipe1.mediums[5].p","pipe1.mediums[5].Xi[1]","pipe1.mediums[5].T","pipe1.flowModel.m_flows[1]","pipe1.flowModel.m_flows[2]","pipe1.flowModel.m_flows[3]","pipe1.flowModel.m_flows[4]","pipe1.flowModel.m_flows[5]","pipe2.mediums[1].p","pipe2.mediums[1].Xi[1]","pipe2.mediums[1].T","pipe2.mediums[2].p","pipe2.mediums[2].Xi[1]","pipe2.mediums[2].T","pipe2.mediums[3].p","pipe2.mediums[3].Xi[1]","pipe2.mediums[3].T","pipe2.mediums[4].p","pipe2.mediums[4].Xi[1]","pipe2.mediums[4].T","pipe2.mediums[5].Xi[1]","pipe2.mediums[5].T","pipe2.flowModel.m_flows[1]","pipe2.flowModel.m_flows[2]","pipe2.flowModel.m_flows[3]","pipe2.flowModel.m_flows[4]","pipe3.mediums[1].p","pipe3.mediums[1].Xi[1]","pipe3.mediums[1].T","pipe3.mediums[2].p","pipe3.mediums[2].Xi[1]","pipe3.mediums[2].T","pipe3.mediums[3].p","pipe3.mediums[3].Xi[1]","pipe3.mediums[3].T","pipe3.mediums[4].p","pipe3.mediums[4].Xi[1]","pipe3.mediums[4].T","pipe3.mediums[5].Xi[1]","pipe3.mediums[5].T","pipe3.flowModel.m_flows[1]","pipe3.flowModel.m_flows[2]","pipe3.flowModel.m_flows[3]","pipe3.flowModel.m_flows[4]","pipe3.flowModel.m_flows[5]","pipe4.mediums[1].p","pipe4.mediums[1].Xi[1]","pipe4.mediums[1].T","pipe4.mediums[2].p","pipe4.mediums[2].Xi[1]","pipe4.mediums[2].T","pipe4.mediums[3].p","pipe4.mediums[3].Xi[1]","pipe4.mediums[3].T","pipe4.mediums[4].p","pipe4.mediums[4].Xi[1]","pipe4.mediums[4].T","pipe4.mediums[5].p","pipe4.mediums[5].Xi[1]","pipe4.mediums[5].T","pipe4.flowModel.m_flows[1]","pipe4.flowModel.m_flows[2]","pipe4.flowModel.m_flows[3]","pipe4.flowModel.m_flows[4]","pipe4.flowModel.m_flows[5]"}
 // OpenModelicaModelTesting.SimulationRuntime.Cpp

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.Explanatory.MeasuringTemperature.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.Explanatory.MeasuringTemperature.mos
@@ -41,11 +41,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 1.1, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.Explanatory.MeasuringTemperature', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.Explanatory.MeasuringTemperature_res.mat
-// Messages: ERROR  : solver: SimManager: Simulation stopped with errors before t = 1.100000
-// ERROR  : solver: SimManager: Number of event iteration steps exceeded at time: 0.000000
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // Files Equal!
 // Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 //

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.Explanatory.MomentumBalanceFittings.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.Explanatory.MomentumBalanceFittings.mos
@@ -41,12 +41,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 1.1, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.Explanatory.MomentumBalanceFittings', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.Explanatory.MomentumBalanceFittings_res.mat
-// Messages: ERROR  : init  : SimManager: Could not initialize system
-// ERROR  : init  : SimManager: Nonlinear solver 55 stopped at time 0 with error in algloop solver: 
-// Nonlinear solver failed!
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // [Modelica 3.2.1+maint.om/Fluid/Interfaces.mo:734:9-739:39:writable] Notification: From here:
 // [Modelica 3.2.1+maint.om/Fluid/Interfaces.mo:327:3-329:69:writable] Warning: Inherited elements are not identical: bug: https://trac.modelica.org/Modelica/ticket/627
 // 	first:  Medium.MassFlowRate m_flow(min = if allowFlowReversal then -Modelica.Constants.inf else 0, start = m_flow_start, stateSelect = if momentumDynamics == Modelica.Fluid.Types.Dynamics.SteadyState then StateSelect.default else StateSelect.prefer) "mass flow rates between states"

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation.mos
@@ -89,13 +89,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 200.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.HeatExchanger.HeatExchangerSimulation_res.mat
-// Messages: ERROR  : solver: DASSL: failed step at t = 54.987305: Nonlinear solver 4268 stopped at time 54.9873 with error in algloop solver: 
-// Nonlinear solver failed!
-// ERROR  : solver: SimManager: Simulation stopped with errors before t = 200.000000
-// ERROR  : solver: SimManager: DASSL: solve failed with idid = 1
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // Files Equal!
 // Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 //

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.Tanks.TanksWithOverflow.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.Tanks.TanksWithOverflow.mos
@@ -33,6 +33,12 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 25000.0, numberOfIntervals = 5000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.Tanks.TanksWithOverflow', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.Tanks.TanksWithOverflow_res.mat
+// Messages: ERROR  : init  : SimManager: Could not initialize system
+// ERROR  : init  : SimManager: Nonlinear solver 126 stopped at time 0 with error in algloop solver: 
+// error solving nonlinear system (iteration limit: 50)
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.TraceSubstances.RoomCO2WithControls.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Fluid.Examples.TraceSubstances.RoomCO2WithControls.mos
@@ -47,12 +47,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 86400.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.TraceSubstances.RoomCO2WithControls', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Fluid.Examples.TraceSubstances.RoomCO2WithControls_res.mat
-// Messages: ERROR  : init  : SimManager: Could not initialize system
-// ERROR  : init  : SimManager: Nonlinear solver 413 stopped at time 0 with error in algloop solver: 
-// Nonlinear solver failed!
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // [Modelica 3.2.1+maint.om/Fluid/Examples/TraceSubstances.mo:112:17-112:29:writable] Warning: Non-array modification '0.01' for array component, possibly due to missing 'each'.
 // [Modelica 3.2.1+maint.om/Fluid/Examples/TraceSubstances.mo:122:23-122:37:writable] Warning: Non-array modification '0.01' for array component, possibly due to missing 'each'.
 // [Modelica 3.2.1+maint.om/Fluid/Examples/TraceSubstances.mo:168:23-168:37:writable] Warning: Non-array modification '0.01' for array component, possibly due to missing 'each'.

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip.mos
@@ -33,6 +33,12 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip_res.mat
+// Messages: ERROR  : init  : SimManager: Could not initialize system
+// ERROR  : init  : SimManager: Nonlinear solver 623 stopped at time 0 with error in algloop solver: 
+// error solving nonlinear system (iteration limit: 50)
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings.mos
@@ -38,6 +38,12 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings_res.mat
+// Messages: ERROR  : init  : SimManager: Could not initialize system
+// ERROR  : init  : SimManager: Nonlinear solver 717 stopped at time 0 with error in algloop solver: 
+// error solving nonlinear system (iteration limit: 50)
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // Files Equal!
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1.mos
@@ -31,6 +31,12 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1_res.mat
+// Messages: ERROR  : init  : SimManager: Could not initialize system
+// ERROR  : init  : SimManager: Nonlinear solver 885 stopped at time 0 with error in algloop solver: 
+// error solving nonlinear system (iteration limit: 50)
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // Files Equal!
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions("-d=initialization").
 //

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.Rotational.Examples.HeatLosses.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.Rotational.Examples.HeatLosses.mos
@@ -43,6 +43,13 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 1.0, numberOfIntervals = 10000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.Rotational.Examples.HeatLosses', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Mechanics.Rotational.Examples.HeatLosses_res.mat
+// Messages: ERROR  : solver: DASSL: failed step at t = 0.034294: Nonlinear solver 293 stopped at time 0.0342939 with error in algloop solver: 
+// error solving nonlinear system (iteration limit: 50)
+// ERROR  : solver: SimManager: Simulation stopped with errors before t = 1.000000
+// ERROR  : solver: SimManager: DASSL: solve failed with idid = 5
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.Rotational.Examples.LossyGearDemo2.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.Rotational.Examples.LossyGearDemo2.mos
@@ -38,6 +38,12 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 0.5, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.Rotational.Examples.LossyGearDemo2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Mechanics.Rotational.Examples.LossyGearDemo2_res.mat
+// Messages: ERROR  : init  : SimManager: Could not initialize system
+// ERROR  : init  : SimManager: Nonlinear solver 62 stopped at time 0 with error in algloop solver: 
+// error solving nonlinear system (iteration limit: 50)
+// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
+// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
+//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Media.Examples.Tests.MediaTestModels.Air.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Media.Examples.Tests.MediaTestModels.Air.MoistAir.mos
@@ -32,13 +32,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.Tests.MediaTestModels.Air.MoistAir', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Media.Examples.Tests.MediaTestModels.Air.MoistAir_res.mat
-// Messages: ERROR  : solver: DASSL: failed step at t = 0.000000: Nonlinear solver 147 stopped at time 9.0072e-15 with error in algloop solver: 
-// Algloop could not be evaluated! Evaluation failed at the first call.
-// ERROR  : solver: SimManager: Simulation stopped with errors before t = 1.010000
-// ERROR  : solver: SimManager: DASSL: solve failed with idid = 1
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // Files Equal!
 // "true
 // "

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Media.Examples.Tests.MediaTestModels.Water.WaterIF97_pT.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Media.Examples.Tests.MediaTestModels.Water.WaterIF97_pT.mos
@@ -31,15 +31,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.Tests.MediaTestModels.Water.WaterIF97_pT', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''
 // Result file: Modelica.Media.Examples.Tests.MediaTestModels.Water.WaterIF97_pT_res.mat
-// Messages: DASKR--  AT T (=R1) AND STEPSIZE H (=R2) THE                                    
-//       In above,  R1 =   1.4073748835533E-16   R2 =   3.5184372088832E-17
-// DASKR--  NONLINEAR SYSTEM SOLVER COULD NOT CONVERGE                             
-// DASKR--  BECAUSE IRES WAS EQUAL TO MINUS ONE                                    
-// ERROR  : solver: SimManager: Simulation stopped with errors before t = 1.010000
-// ERROR  : solver: SimManager: DASSL: solve failed with idid = -10
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver kinsol
-// ERROR  : solver: SimController: Recovering with nonlinear solver newton
-//
 // Files Equal!
 // Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 //


### PR DESCRIPTION
Default kinsol failed 10 times for testsuite/simulation/libraries/msl32_cpp.
Default newton fails 7 times. Moreover, experience with
newton is more valuable as this is the solver exported with FMUs.

Additionally adapt name of results file to format selected at runtime.
