### PR TITLE
[BE] fix jacobian array differentiation

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1079,16 +1079,16 @@ algorithm
       BackendDAE.Var var;
       BackendDAE.VarKind kind;
 
-      list<BackendDAE.Var> vars;
+      list<BackendDAE.Var> vars, scalarLst;
       DAE.Type tp, arrayType;
       DAE.Exp e, e1, zero, one;
       DAE.Exp res, res1;
       DAE.ComponentRef cr, cr1;
-      list<DAE.Exp> expl, expl_1;
+      list<DAE.Exp> expl, expl_1, diffed_exps = {};
 
       list<DAE.Var> varLst;
       list<Boolean> b_lst;
-      list<DAE.ComponentRef> crefs, diffCref;
+      list<DAE.ComponentRef> crefs, diffCref, scalarCrefs;
 
       String s1, s2, serr, se1, matrixName;
 
@@ -1245,12 +1245,33 @@ algorithm
 
     // d(x)/d(x) => generate seed variables
     case ((DAE.CREF(componentRef = cr,ty = tp)), _, BackendDAE.DIFFINPUTDATA(independenentVars=SOME(timevars),matrixName=SOME(matrixName)), BackendDAE.GENERIC_GRADIENT(), _)
-      equation
+      algorithm
         //true = List.isMemberOnTrue(cr, diffCref, ComponentReference.crefEqual);
-        (_::_, _) = BackendVariable.getVar(cr, timevars);
-        cr = createSeedCrefName(cr, matrixName);
+        (scalarLst, _) := BackendVariable.getVar(cr, timevars);
+        // fix for ticket #7550
+        // if not all elements (but some of them) are iteration variables
+        // we scalarize the cref and treat them individually. afterwards
+        // thread them to an DAE.ARRAY()
+        arrayType := ComponentReference.crefTypeFull(cr);
+        if not listEmpty(scalarLst) and listLength(scalarLst) <> Types.getDimensionProduct(arrayType) then
+          if listLength(Types.getDimensionSizes(arrayType)) > 1 then
+            // ONLY WORKS FOR VECTORS! MATRICES NEED MORE TREATMENT
+            Error.addMessage(Error.INTERNAL_ERROR, {"differentiateCrefs failed because tensor has iteration and inner variables.)"});
+            fail();
+          end if;
+          scalarCrefs := ComponentReference.expandCref(cr, true);
+          outFunctionTree := inFunctionTree;
+          for cref in scalarCrefs loop
+            (res1, outFunctionTree) := differentiateCrefs(Expression.crefExp(cref), inDiffwrtCref, inInputData, inDiffType, outFunctionTree, maxIter);
+            diffed_exps := res1 :: diffed_exps;
+          end for;
+          res := DAE.ARRAY(arrayType, true, listReverse(diffed_exps));
+        else
+          cr := createSeedCrefName(cr, matrixName);
 
-        res = DAE.CREF(cr, tp);
+          res := DAE.CREF(cr, tp);
+        end if;
+
       then
         (res, inFunctionTree);
 

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1254,21 +1254,15 @@ algorithm
         // thread them to an DAE.ARRAY()
         arrayType := ComponentReference.crefTypeFull(cr);
         if not listEmpty(scalarLst) and listLength(scalarLst) <> Types.getDimensionProduct(arrayType) then
-          if listLength(Types.getDimensionSizes(arrayType)) > 1 then
-            // ONLY WORKS FOR VECTORS! MATRICES NEED MORE TREATMENT
-            Error.addMessage(Error.INTERNAL_ERROR, {"differentiateCrefs failed because tensor has iteration and inner variables.)"});
-            fail();
-          end if;
           scalarCrefs := ComponentReference.expandCref(cr, true);
           outFunctionTree := inFunctionTree;
           for cref in scalarCrefs loop
             (res1, outFunctionTree) := differentiateCrefs(Expression.crefExp(cref), inDiffwrtCref, inInputData, inDiffType, outFunctionTree, maxIter);
             diffed_exps := res1 :: diffed_exps;
           end for;
-          res := DAE.ARRAY(arrayType, true, listReverse(diffed_exps));
+          res := Expression.listToArray(listReverse(diffed_exps), Types.getDimensions(arrayType));
         else
           cr := createSeedCrefName(cr, matrixName);
-
           res := DAE.CREF(cr, tp);
         end if;
 

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1129,7 +1129,7 @@ public function crefEqualNoStringCompare
 "Returns true if two component references are equal!
   IMPORTANT! do not use this function if you have
   stringified components, meaning this function will
-  return false for: cref1: QUAL(x, IDENT(x)) != cref2: IDENT(x.y)"
+  return false for: cref1: QUAL(x, IDENT(y)) != cref2: IDENT(x.y)"
   input DAE.ComponentRef inCref1;
   input DAE.ComponentRef inCref2;
   output Boolean outEqual;


### PR DESCRIPTION
### Related Issues
 - fixes ticket #7550

### Purpose
 - problem: differentiation of arrays that have iteration as well as inner variables

### Approach
 - old behavior: if any of them is an iteration variable, the whole array cref is assumed to be
 - new behavior: if it contains both, it is scalarized and treated individually (just the cref!)
 - remaining issues: just works for vectors, higher dimension tensors will throw an error