### PR TITLE
Cmake improvements

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -78,7 +78,7 @@ write_compiler_detection_header(
 # Set the installation lib directory as an rpath for all installed
 # libs and executables.
 # Maybe there is a better way to do this but it should suffice for now.
-SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_LIBDIR})
 
 
 # Use ccache to speedup compilation!

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(omcruntime PUBLIC omc::config)
 target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
-target_link_libraries(omcruntime PUBLIC omc::simrt::runtime)
+target_link_libraries(omcruntime PUBLIC omc::simrt::memory)
 target_link_libraries(omcruntime PUBLIC omc::3rd::ffi)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
@@ -149,7 +149,7 @@ target_sources(omcbackendruntime PRIVATE ${OMC_BACKENDRUNTIIME_SOURCES})
 
 target_link_libraries(omcbackendruntime PUBLIC omc::config)
 target_link_libraries(omcbackendruntime PUBLIC ${Intl_LIBRARIES})
-target_link_libraries(omcbackendruntime PUBLIC omc::simrt::runtime)
+target_link_libraries(omcbackendruntime PUBLIC omc::simrt::memory)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib::static)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
@@ -164,26 +164,8 @@ add_library(omc::compiler::graphstream ALIAS omcgraphstream)
 set(OMC_GRAPH_STREAM_SOURCES GraphStreamExt_omc.cpp)
 target_sources(omcgraphstream PRIVATE ${OMC_GRAPH_STREAM_SOURCES})
 
-target_link_libraries(omcgraphstream PUBLIC omc::simrt::runtime)
+target_link_libraries(omcgraphstream PUBLIC omc::simrt::memory)
 target_link_libraries(omcgraphstream PUBLIC omc::3rd::netstream)
-
-# Remove the dependency of bootstrapping on graphstream lib and remove this. It is not needed for bootstrapping.
-# ######################################################################################################################
-# Library: omcgraphstream-boot
-add_library(omcgraphstream-boot STATIC)
-add_library(omc::compiler::graphstream-boot ALIAS omcgraphstream-boot)
-
-set(OMC_GRAPH_STREAM_SOURCES GraphStreamExt_omc.cpp)
-target_sources(omcgraphstream-boot PRIVATE ${OMC_GRAPH_STREAM_SOURCES})
-
-# Define OMC_BOOTSTRAPPING for the boot lib.
-target_compile_definitions(omcgraphstream-boot PRIVATE OMC_BOOTSTRAPPING)
-
-target_link_libraries(omcgraphstream-boot PUBLIC omc::simrt::runtime)
-target_link_libraries(omcgraphstream-boot PUBLIC omc::3rd::netstream)
-
-
-
 
 
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -16,6 +16,9 @@ file(GLOB_RECURSE OMC_SIMRT_SIMULATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/simul
 
 file(GLOB OMC_SIMRT_MATH_SUPPORT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/math-support/pivot.c)
 
+file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/optimization/*.c)
+file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/optimization/*.h)
+
 file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
 file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 
@@ -82,6 +85,21 @@ target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
 target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
 
 install(TARGETS SimulationRuntimeC)
+
+
+# ######################################################################################################################
+# Library: OptimizationRuntime
+## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
+add_library(OptimizationRuntime STATIC)
+add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
+
+target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
+
+target_link_libraries(OptimizationRuntime PUBLIC omc::config)
+target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::memory)
+target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
+
+install(TARGETS OptimizationRuntime)
 
 
 # ######################################################################################################################

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -9,6 +9,13 @@ file(GLOB OMC_SIMRT_META_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/meta/*.h)
 file(GLOB OMC_SIMRT_GC_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/gc/*.c)
 file(GLOB OMC_SIMRT_GC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/gc/*.h)
 
+file(GLOB_RECURSE OMC_SIMRT_SIMULATION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/simulation/*.c
+                                               ${CMAKE_CURRENT_SOURCE_DIR}/simulation/*.cpp)
+file(GLOB_RECURSE OMC_SIMRT_SIMULATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/simulation/*.h
+                                               ${CMAKE_CURRENT_SOURCE_DIR}/simulation/*.hpp)
+
+file(GLOB OMC_SIMRT_MATH_SUPPORT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/math-support/pivot.c)
+
 file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
 file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 
@@ -56,6 +63,28 @@ target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib::static)
 install(TARGETS OpenModelicaFMIRuntimeC)
 
 
+# ######################################################################################################################
+# Library: SimulationRuntimeC
+add_library(SimulationRuntimeC STATIC)
+add_library(omc::simrt::simruntime ALIAS SimulationRuntimeC)
+
+target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES} ${OMC_SIMRT_MATH_SUPPORT_SOURCES})
+
+target_link_libraries(SimulationRuntimeC PUBLIC omc::config)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::memory)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::cvode::static)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::config)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::klu)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::umfpack)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
+
+# Fix me. Make an interface (header only library) out of 3rdParty/dgesv
+target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
+
+install(TARGETS SimulationRuntimeC)
+
+
+# ######################################################################################################################
 # Quick and INCOMPLETE generation of RuntimeSources.mo
 set(DGESV_FILES \"\")
 set(LS_FILES \"\")

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(SimulationRuntimeC)
-
 file(GLOB OMC_SIMRT_UTIL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/util/*.c)
 file(GLOB OMC_SIMRT_UTIL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/util/*.h)
 
@@ -14,32 +12,46 @@ file(GLOB OMC_SIMRT_GC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/gc/*.h)
 file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
 file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 
+
+
+# ######################################################################################################################
+# Library: omcmemory
+## This tiny library provides the memory related functionality of OM (garbage collection and memory_pool).
+## The reason it is separated is because its functionality is clearly defined and should not be part of
+## a bunch of other libraries. For example there is no need to link to OpenModelicaRuntimeC just to get GC
+## functionality in Compiler/runtime.
+add_library(omcmemory STATIC)
+add_library(omc::simrt::memory ALIAS omcmemory)
+
+target_sources(omcmemory PRIVATE ${OMC_SIMRT_GC_SOURCES})
+target_link_libraries(omcmemory PUBLIC omc::3rd::omcgc)
+target_include_directories(omcmemory PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+
 # ######################################################################################################################
 # Library: OpenModelicaRuntimeC
 add_library(OpenModelicaRuntimeC STATIC)
 add_library(omc::simrt::runtime ALIAS OpenModelicaRuntimeC)
 
-target_sources(OpenModelicaRuntimeC PRIVATE ${OMC_SIMRT_UTIL_SOURCES} ${OMC_SIMRT_META_SOURCES} ${OMC_SIMRT_GC_SOURCES})
-target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
+target_sources(OpenModelicaRuntimeC PRIVATE ${OMC_SIMRT_UTIL_SOURCES} ${OMC_SIMRT_META_SOURCES})
+target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::simrt::memory)
 
 if(WIN32)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC dbghelp)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC regex)
 endif(WIN32)
 
-target_include_directories(OpenModelicaRuntimeC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 install(TARGETS OpenModelicaRuntimeC)
 
 # ######################################################################################################################
 # Library: OpenModelicaFMIRuntimeC
-add_library(OpenModelicaFMIRuntimeC STATIC ${OMC_SIMRT_FMI_SOURCES})
+add_library(OpenModelicaFMIRuntimeC STATIC)
 add_library(omc::simrt::fmiruntime ALIAS OpenModelicaFMIRuntimeC)
 
 target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES})
 
 target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib::static)
-target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::simrt::runtime)
 
 install(TARGETS OpenModelicaFMIRuntimeC)
 


### PR DESCRIPTION
@mahge
[cmake] Add a separate 'memory' library. …
bba4444
  - This used to be part of OpenModelicaRuntimeC library. the code provides
    memory related (garbage collection and memory_pool) functionality. Due
    to this OpenModelicaRuntimeC was being linked from other libraries
    just to get this functionality.

    the memory related functionality is now a separate lib. This lib can
    be used in places where we need the memory management related interface
    and functionality of omc.

   - Misc
     Remove unused library omcgraphstream-boot

@mahge
[cmake] Add lib SimulationRuntimeC …
721e7df
  - This library is the counter part of the libSimulationRuntimeC library
    built by the old Makefiles build system. However, this one only
    includes `simulation/*` and `math-support/pivot.c` source files. Other
    folders/source files are parts of the other libraries and they are
    not repeated here. e.g., `util/` is part of `libOpenModelicaRuntimeC`,
    `gc/` is part of a new lib `libomcmemory`, and `optimization/` will
    be part of a new library `libOptimizationRuntime` that will be added
    next.

@mahge
[cmake] Handle Ipopt's public headers. …
01e97c6
  - Just like FMIL, Ipopt assumes it will be always installed before use.
    So it does not organize its header files properly.

    We collect all public headers to a new include dir in the build directory
    of Ipopt. Then we provide this new directory as include dir for targets
    that depend on Ipopt.

@mahge
[cmake] Add a new libOptimizationRuntime library. …
0a6cbb2
  - This library is part of libSimulationRuntimeC in the normal Makefile
    build system used by OMC in default.

    In the new CMake build system it is now a separate library. This makes
    the structuring a bit clearer and also allows us to selectively build
    or skip it. Which means we can also skip Ipopt itself! Assuming nothing
    else goes wrong of course.