### PR TITLE
Add omc_fread() to wrap fread()

### DIFF
--- a/OMCompiler/Compiler/runtime/SimulationResultsCmpTubes.c
+++ b/OMCompiler/Compiler/runtime/SimulationResultsCmpTubes.c
@@ -825,7 +825,7 @@ fprintf(fout, "{title: '%s',\n"
         perror("Error on fseek set!");
       }
       html = (char*)malloc((html_size + 1) * sizeof(char));
-      omc_fread(html, sizeof(char), html_size, fout);
+      omc_fread(html, sizeof(char), html_size, fout, 0);
 
       html[html_size] = '\0';
       fclose(fout);

--- a/OMCompiler/Compiler/runtime/SimulationResultsCmpTubes.c
+++ b/OMCompiler/Compiler/runtime/SimulationResultsCmpTubes.c
@@ -815,7 +815,6 @@ fprintf(fout, "{title: '%s',\n"
 
     if (isHtml) {
 #if !(_XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L)
-      size_t r;
       if (fseek(fout, 0, SEEK_END))
       {
         perror("Error on fseek end!");
@@ -826,11 +825,8 @@ fprintf(fout, "{title: '%s',\n"
         perror("Error on fseek set!");
       }
       html = (char*)malloc((html_size + 1) * sizeof(char));
-      r = fread(html, sizeof(char), html_size, fout);
-      if (r != html_size)
-      {
-        perror("Error on fread!");
-      }
+      omc_fread(html, sizeof(char), html_size, fout);
+
       html[html_size] = '\0';
       fclose(fout);
       unlink(fname);

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -425,7 +425,7 @@ static char* SystemImpl__readFile(const char* filename)
   }
   buf = (char*) omc_alloc_interface.malloc_atomic(statstr.st_size+1);
 
-  if( (res = omc_fread(buf, sizeof(char), statstr.st_size, file)) != statstr.st_size) {
+  if( (res = omc_fread(buf, sizeof(char), statstr.st_size, file, 0)) != statstr.st_size) {
     const char *c_tokens[2]={strerror(errno),filename};
     c_add_message(NULL,85, /* ERROR_OPENING_FILE */
       ErrorType_scripting,
@@ -974,7 +974,7 @@ extern int SystemImpl__copyFile(const char *str_1, const char *str_2)
     return 0;
   }
 
-  while (( n = omc_fread(buf, 1, 8192, source) )) {
+  while (( n = omc_fread(buf, 1, 8192, source, 1) )) {
     if (n != fwrite(buf, 1, n, target)) {
       rv = 0;
       break;
@@ -1246,7 +1246,7 @@ extern const char* SystemImpl__readFileNoNumeric(const char* filename)
   file = omc_fopen(filename,"rb");
   buf = (char*) omc_alloc_interface.malloc_atomic(statstr.st_size+1);
   bufRes = (char*) omc_alloc_interface.malloc_atomic((statstr.st_size+70)*sizeof(char));
-  if( (res = omc_fread(buf, sizeof(char), statstr.st_size, file)) != statstr.st_size) {
+  if( (res = omc_fread(buf, sizeof(char), statstr.st_size, file, 0)) != statstr.st_size) {
     fclose(file);
     return "Failed while reading file";
   }
@@ -2930,8 +2930,8 @@ int SystemImpl__fileContentsEqual(const char *file1, const char *file2)
     return 0;
   }
   do {
-    i1 = omc_fread(buf1,1,8192,f1);
-    i2 = omc_fread(buf2,1,8192,f2);
+    i1 = omc_fread(buf1,1,8192,f1, 1);
+    i2 = omc_fread(buf2,1,8192,f2, 1);
     if (i1 != i2 || strncmp(buf1,buf2,i1)) {
       error = 1;
     }
@@ -3068,7 +3068,7 @@ int SystemImpl__covertTextFileToCLiteral(const char *textFile, const char *outFi
     fputc('{', fout);
     fputc('\n', fout);
     do {
-      n = omc_fread(buffer,1,511,fin);
+      n = omc_fread(buffer,1,511,fin, 1);
       j = 0;
       /* adrpo: encode each char */
       for (i=0; i<n; i++) {
@@ -3111,7 +3111,7 @@ int SystemImpl__covertTextFileToCLiteral(const char *textFile, const char *outFi
   {
     fputc('\"', fout);
     do {
-      n = omc_fread(buffer,1,511,fin);
+      n = omc_fread(buffer,1,511,fin, 1);
       j = 0;
       for (i=0; i<n; i++) {
         switch (buffer[i]) {

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -425,7 +425,7 @@ static char* SystemImpl__readFile(const char* filename)
   }
   buf = (char*) omc_alloc_interface.malloc_atomic(statstr.st_size+1);
 
-  if( (res = fread(buf, sizeof(char), statstr.st_size, file)) != statstr.st_size) {
+  if( (res = omc_fread(buf, sizeof(char), statstr.st_size, file)) != statstr.st_size) {
     const char *c_tokens[2]={strerror(errno),filename};
     c_add_message(NULL,85, /* ERROR_OPENING_FILE */
       ErrorType_scripting,
@@ -974,7 +974,7 @@ extern int SystemImpl__copyFile(const char *str_1, const char *str_2)
     return 0;
   }
 
-  while (( n = fread(buf, 1, 8192, source) )) {
+  while (( n = omc_fread(buf, 1, 8192, source) )) {
     if (n != fwrite(buf, 1, n, target)) {
       rv = 0;
       break;
@@ -1246,7 +1246,7 @@ extern const char* SystemImpl__readFileNoNumeric(const char* filename)
   file = omc_fopen(filename,"rb");
   buf = (char*) omc_alloc_interface.malloc_atomic(statstr.st_size+1);
   bufRes = (char*) omc_alloc_interface.malloc_atomic((statstr.st_size+70)*sizeof(char));
-  if( (res = fread(buf, sizeof(char), statstr.st_size, file)) != statstr.st_size) {
+  if( (res = omc_fread(buf, sizeof(char), statstr.st_size, file)) != statstr.st_size) {
     fclose(file);
     return "Failed while reading file";
   }
@@ -2930,8 +2930,8 @@ int SystemImpl__fileContentsEqual(const char *file1, const char *file2)
     return 0;
   }
   do {
-    i1 = fread(buf1,1,8192,f1);
-    i2 = fread(buf2,1,8192,f2);
+    i1 = omc_fread(buf1,1,8192,f1);
+    i2 = omc_fread(buf2,1,8192,f2);
     if (i1 != i2 || strncmp(buf1,buf2,i1)) {
       error = 1;
     }
@@ -3068,7 +3068,7 @@ int SystemImpl__covertTextFileToCLiteral(const char *textFile, const char *outFi
     fputc('{', fout);
     fputc('\n', fout);
     do {
-      n = fread(buffer,1,511,fin);
+      n = omc_fread(buffer,1,511,fin);
       j = 0;
       /* adrpo: encode each char */
       for (i=0; i<n; i++) {
@@ -3111,7 +3111,7 @@ int SystemImpl__covertTextFileToCLiteral(const char *textFile, const char *outFi
   {
     fputc('\"', fout);
     do {
-      n = fread(buffer,1,511,fin);
+      n = omc_fread(buffer,1,511,fin);
       j = 0;
       for (i=0; i<n; i++) {
         switch (buffer[i]) {

--- a/OMCompiler/SimulationRuntime/OMSI/base/src/omsi_initialization.c
+++ b/OMCompiler/SimulationRuntime/OMSI/base/src/omsi_initialization.c
@@ -353,7 +353,7 @@ omsi_string omsi_get_model_name(omsi_string fmuResourceLocation) {
 
     /* read XML */
     do {
-        omsi_unsigned_int len = omc_fread(buf, 1, sizeof(buf), file);
+        omsi_unsigned_int len = fread(buf, 1, sizeof(buf), file);
         done = len < sizeof(buf);
         if(XML_STATUS_ERROR == XML_Parse(parser, buf, len, done)) {
             filtered_base_logger(global_logCategories, log_statuserror, omsi_error,

--- a/OMCompiler/SimulationRuntime/OMSI/base/src/omsi_initialization.c
+++ b/OMCompiler/SimulationRuntime/OMSI/base/src/omsi_initialization.c
@@ -353,7 +353,7 @@ omsi_string omsi_get_model_name(omsi_string fmuResourceLocation) {
 
     /* read XML */
     do {
-        omsi_unsigned_int len = fread(buf, 1, sizeof(buf), file);
+        omsi_unsigned_int len = omc_fread(buf, 1, sizeof(buf), file);
         done = len < sizeof(buf);
         if(XML_STATUS_ERROR == XML_Parse(parser, buf, len, done)) {
             filtered_base_logger(global_logCategories, log_statuserror, omsi_error,

--- a/OMCompiler/SimulationRuntime/c/simulation/results/MatVer4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/MatVer4.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "MatVer4.h"
+#include "util/omc_file.h"
 
 #include <assert.h>
 #include <stddef.h>
@@ -95,7 +96,7 @@ void updateHeader_matVer4(FILE* file, long position, const char* name, size_t ro
 
   long eof = ftell(file);
   fseek(file, position, SEEK_SET);
-  fread(&header, sizeof(MatVer4Header), 1, file);
+  omc_fread(&header, sizeof(MatVer4Header), 1, file);
 
   assert(header.type == (isBigEndian() ? 1000 : 0) + type);
   assert(header.mrows == rows);
@@ -122,7 +123,7 @@ MatVer4Matrix* readMatVer4Matrix(FILE* file)
   if (!matrix)
     return NULL;
 
-  fread(&matrix->header, sizeof(MatVer4Header), 1, file);
+  omc_fread(&matrix->header, sizeof(MatVer4Header), 1, file);
 
   // skip name
   fseek(file, matrix->header.namelen, SEEK_CUR);
@@ -130,7 +131,7 @@ MatVer4Matrix* readMatVer4Matrix(FILE* file)
   MatVer4Type_t type = (MatVer4Type_t) (matrix->header.type % 100);
   size_t size = sizeofMatVer4Type(type);
   matrix->data = malloc(matrix->header.mrows * matrix->header.ncols * size);
-  fread(matrix->data, size, matrix->header.mrows*matrix->header.ncols, file);
+  omc_fread(matrix->data, size, matrix->header.mrows*matrix->header.ncols, file);
 
   return matrix;
 }
@@ -149,7 +150,7 @@ void freeMatrix_matVer4(MatVer4Matrix** matrix)
 void skipMatrix_matVer4(FILE* file)
 {
   MatVer4Header header;
-  fread(&header, sizeof(MatVer4Header), 1, file);
+  omc_fread(&header, sizeof(MatVer4Header), 1, file);
 
   // skip name
   fseek(file, header.namelen, SEEK_CUR);

--- a/OMCompiler/SimulationRuntime/c/simulation/results/MatVer4.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/results/MatVer4.cpp
@@ -96,7 +96,7 @@ void updateHeader_matVer4(FILE* file, long position, const char* name, size_t ro
 
   long eof = ftell(file);
   fseek(file, position, SEEK_SET);
-  omc_fread(&header, sizeof(MatVer4Header), 1, file);
+  omc_fread(&header, sizeof(MatVer4Header), 1, file, 0);
 
   assert(header.type == (isBigEndian() ? 1000 : 0) + type);
   assert(header.mrows == rows);
@@ -123,7 +123,7 @@ MatVer4Matrix* readMatVer4Matrix(FILE* file)
   if (!matrix)
     return NULL;
 
-  omc_fread(&matrix->header, sizeof(MatVer4Header), 1, file);
+  omc_fread(&matrix->header, sizeof(MatVer4Header), 1, file, 0);
 
   // skip name
   fseek(file, matrix->header.namelen, SEEK_CUR);
@@ -131,7 +131,7 @@ MatVer4Matrix* readMatVer4Matrix(FILE* file)
   MatVer4Type_t type = (MatVer4Type_t) (matrix->header.type % 100);
   size_t size = sizeofMatVer4Type(type);
   matrix->data = malloc(matrix->header.mrows * matrix->header.ncols * size);
-  omc_fread(matrix->data, size, matrix->header.mrows*matrix->header.ncols, file);
+  omc_fread(matrix->data, size, matrix->header.mrows*matrix->header.ncols, file, 0);
 
   return matrix;
 }
@@ -150,7 +150,7 @@ void freeMatrix_matVer4(MatVer4Matrix** matrix)
 void skipMatrix_matVer4(FILE* file)
 {
   MatVer4Header header;
-  omc_fread(&header, sizeof(MatVer4Header), 1, file);
+  omc_fread(&header, sizeof(MatVer4Header), 1, file, 0);
 
   // skip name
   fseek(file, header.namelen, SEEK_CUR);

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -479,7 +479,7 @@ void read_input_xml(MODEL_DATA* modelData,
     char buf[BUFSIZ] = {0};
     do
     {
-      size_t len = omc_fread(buf, 1, sizeof(buf), file);
+      size_t len = omc_fread(buf, 1, sizeof(buf), file, 1);
       done = len < sizeof(buf);
       if(XML_STATUS_ERROR == XML_Parse(parser, buf, len, done))
       {
@@ -961,7 +961,7 @@ void doOverride(omc_ModelInput *mi, MODEL_DATA *modelData, const char *override,
     line[0] = '\0';
     fseek(infile, 0L, SEEK_SET);
     errno = 0;
-    if (1 != omc_fread(line, n, 1, infile)) {
+    if (1 != omc_fread(line, n, 1, infile, 0)) {
       free(line);
       throwStreamPrint(NULL, "simulation_input_xml.c: could not read overrideFile %s: %s", overrideFile, strerror(errno));
     }

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -479,7 +479,7 @@ void read_input_xml(MODEL_DATA* modelData,
     char buf[BUFSIZ] = {0};
     do
     {
-      size_t len = fread(buf, 1, sizeof(buf), file);
+      size_t len = omc_fread(buf, 1, sizeof(buf), file);
       done = len < sizeof(buf);
       if(XML_STATUS_ERROR == XML_Parse(parser, buf, len, done))
       {
@@ -961,7 +961,7 @@ void doOverride(omc_ModelInput *mi, MODEL_DATA *modelData, const char *override,
     line[0] = '\0';
     fseek(infile, 0L, SEEK_SET);
     errno = 0;
-    if (1 != fread(line, n, 1, infile)) {
+    if (1 != omc_fread(line, n, 1, infile)) {
       free(line);
       throwStreamPrint(NULL, "simulation_input_xml.c: could not read overrideFile %s: %s", overrideFile, strerror(errno));
     }

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -34,6 +34,7 @@ extern "C" {
 #endif
 
 #include "omc_file.h"
+#include "omc_error.h"
 
 FILE* omc_fopen(const char *filename, const char *mode)
 {
@@ -53,6 +54,23 @@ FILE* omc_fopen(const char *filename, const char *mode)
 #endif
   return f;
 }
+
+size_t omc_fread(void *buffer, size_t size, size_t count, FILE *stream) {
+  size_t read_len = fread(buffer, size, count, stream);
+  if(read_len != count)  {
+    if (feof(stream)) {
+      printf("Error reading stream: unexpected end of file\n");
+    }
+    else if (ferror(stream)) {
+      perror("Error reading csv file.");
+    }
+    throwStreamPrint(NULL, "Error: omc_fread() failed to read file\n");
+  }
+
+  return read_len;
+}
+
+
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
 int omc_stat(const char *filename, struct _stat *statbuf)

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.h
@@ -89,7 +89,11 @@ extern "C" {
 
 FILE* omc_fopen(const char *filename, const char *mode);
 
-size_t omc_fread(void *buffer, size_t size, size_t count, FILE *stream);
+/// The last argument allow_early_eof specifies wheather the call is okay or not with reaching
+/// EOF before reading the specified amount. Set it to 1 if you do not exactly know how much to read
+/// and would not mind if the file ends before 'count' elements are read from it.
+/// If you are not sure what to do start by passing 0.
+size_t omc_fread(void *buffer, size_t size, size_t count, FILE *stream, int allow_early_eof);
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
 int omc_stat(const char *filename, struct _stat *statbuf);

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.h
@@ -88,11 +88,15 @@ extern "C" {
 #endif /* mingw and msvc */
 
 FILE* omc_fopen(const char *filename, const char *mode);
+
+size_t omc_fread(void *buffer, size_t size, size_t count, FILE *stream);
+
 #if defined(__MINGW32__) || defined(_MSC_VER)
 int omc_stat(const char *filename, struct _stat *statbuf);
 #else
 int omc_stat(const char *filename, struct stat *statbuf);
 #endif
+
 int omc_unlink(const char *filename);
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/util/omc_mmap.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_mmap.c
@@ -120,7 +120,7 @@ static FILE* omc_mmap_common(const char *fileName, const char *mode, size_t *siz
     *data = (char*) malloc(*size);
   }
 
-  omc_fread(*data, (*size > fileSize ? fileSize : *size), 1, file);
+  omc_fread(*data, (*size > fileSize ? fileSize : *size), 1, file, 0);
 
   return file;
 }

--- a/OMCompiler/SimulationRuntime/c/util/omc_mmap.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_mmap.c
@@ -119,9 +119,9 @@ static FILE* omc_mmap_common(const char *fileName, const char *mode, size_t *siz
   } else {
     *data = (char*) malloc(*size);
   }
-  if (1 != fread(*data, (*size > fileSize ? fileSize : *size), 1, file)) {
-    throwStreamPrint(NULL, "Failed to read file data: %s\n", fileName);
-  }
+
+  omc_fread(*data, (*size > fileSize ? fileSize : *size), 1, file);
+
   return file;
 }
 

--- a/OMCompiler/SimulationRuntime/c/util/read_csv.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_csv.c
@@ -106,10 +106,10 @@ int read_csv_dataset_size(const char* filename)
   }
 
   /* determine delim */
-  fread(buf, 1, 5, f);
+  omc_fread(buf, 1, 5, f);
   if (0 == strcmp(buf, "\"sep="))
   {
-    fread(&delim, 1, 1, f);
+    omc_fread(&delim, 1, 1, f);
     offset = 8;
   }
   fseek(f, offset, SEEK_SET);
@@ -118,7 +118,7 @@ int read_csv_dataset_size(const char* filename)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = fread(buf, 1, buf_size, f);
+    size_t len = omc_fread(buf, 1, buf_size, f);
     if (len != buf_size && !feof(f)) {
       csv_free(&p);
       fclose(f);
@@ -143,7 +143,7 @@ char** read_csv_variables(FILE *fin, int *length, unsigned char delim)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = fread(buf, 1, buf_size, fin);
+    size_t len = omc_fread(buf, 1, buf_size, fin);
     if (len != buf_size && !feof(fin)) {
       csv_free(&p);
       return NULL;
@@ -212,10 +212,10 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   }
 
   /* determine delim */
-  fread(buf, 1, 5, fin);
+  omc_fread(buf, 1, 5, fin);
   if (0 == strcmp(buf, "\"sep="))
   {
-    fread(&delim, 1, 1, fin);
+    omc_fread(&delim, 1, 1, fin);
     offset = 8;
   }
   fseek(fin, offset, SEEK_SET);
@@ -224,7 +224,7 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = fread(buf, 1, buf_size, fin);
+    size_t len = omc_fread(buf, 1, buf_size, fin);
     if (len != buf_size && !feof(fin)) {
       csv_free(&p);
       fclose(fin);
@@ -258,10 +258,10 @@ struct csv_data* read_csv(const char *filename)
   }
 
   /* determine delim */
-  fread(buf, 1, 5, fin);
+  omc_fread(buf, 1, 5, fin);
   if (0 == strcmp(buf, "\"sep="))
   {
-    fread(&delim, 1, 1, fin);
+    omc_fread(&delim, 1, 1, fin);
     offset = 8;
   }
   fseek(fin, offset, SEEK_SET);
@@ -277,7 +277,7 @@ struct csv_data* read_csv(const char *filename)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = fread(buf, 1, buf_size, fin);
+    size_t len = omc_fread(buf, 1, buf_size, fin);
     if (len != buf_size && !feof(fin)) {
       csv_free(&p);
       fclose(fin);

--- a/OMCompiler/SimulationRuntime/c/util/read_csv.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_csv.c
@@ -106,10 +106,10 @@ int read_csv_dataset_size(const char* filename)
   }
 
   /* determine delim */
-  omc_fread(buf, 1, 5, f);
+  omc_fread(buf, 1, 5, f, 0);
   if (0 == strcmp(buf, "\"sep="))
   {
-    omc_fread(&delim, 1, 1, f);
+    omc_fread(&delim, 1, 1, f, 0);
     offset = 8;
   }
   fseek(f, offset, SEEK_SET);
@@ -118,7 +118,7 @@ int read_csv_dataset_size(const char* filename)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = omc_fread(buf, 1, buf_size, f);
+    size_t len = omc_fread(buf, 1, buf_size, f, 1);
     if (len != buf_size && !feof(f)) {
       csv_free(&p);
       fclose(f);
@@ -143,7 +143,7 @@ char** read_csv_variables(FILE *fin, int *length, unsigned char delim)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = omc_fread(buf, 1, buf_size, fin);
+    size_t len = omc_fread(buf, 1, buf_size, fin, 1);
     if (len != buf_size && !feof(fin)) {
       csv_free(&p);
       return NULL;
@@ -212,10 +212,10 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   }
 
   /* determine delim */
-  omc_fread(buf, 1, 5, fin);
+  omc_fread(buf, 1, 5, fin, 0);
   if (0 == strcmp(buf, "\"sep="))
   {
-    omc_fread(&delim, 1, 1, fin);
+    omc_fread(&delim, 1, 1, fin, 0);
     offset = 8;
   }
   fseek(fin, offset, SEEK_SET);
@@ -224,7 +224,7 @@ double* read_csv_dataset_var(const char *filename, const char *var, int dimsize)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = omc_fread(buf, 1, buf_size, fin);
+    size_t len = omc_fread(buf, 1, buf_size, fin, 1);
     if (len != buf_size && !feof(fin)) {
       csv_free(&p);
       fclose(fin);
@@ -258,10 +258,10 @@ struct csv_data* read_csv(const char *filename)
   }
 
   /* determine delim */
-  omc_fread(buf, 1, 5, fin);
+  omc_fread(buf, 1, 5, fin, 0);
   if (0 == strcmp(buf, "\"sep="))
   {
-    omc_fread(&delim, 1, 1, fin);
+    omc_fread(&delim, 1, 1, fin, 0);
     offset = 8;
   }
   fseek(fin, offset, SEEK_SET);
@@ -277,7 +277,7 @@ struct csv_data* read_csv(const char *filename)
   csv_set_realloc_func(&p, realloc);
   csv_set_free_func(&p, free);
   do {
-    size_t len = omc_fread(buf, 1, buf_size, fin);
+    size_t len = omc_fread(buf, 1, buf_size, fin, 1);
     if (len != buf_size && !feof(fin)) {
       csv_free(&p);
       fclose(fin);

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -162,14 +162,14 @@ static int read_chars(int type, size_t n, FILE *file, char *str)
     double d=0.0;
     int k;
     for (k=0; k<n; k++) {
-      if (fread(&d, sizeof(double), 1, file) != 1) {
+      if (omc_fread(&d, sizeof(double), 1, file) != 1) {
         return 1;
       }
       str[k] = (char) d;
     }
     return 0;
   } else if (p == 5) { /* Byte */
-    return fread(str,n,1,file) != 1;
+    return omc_fread(str,n,1,file) != 1;
   }
   return 1;
 }
@@ -181,14 +181,14 @@ static int read_int32(int type, size_t n, FILE *file, int32_t *val)
     double d=0.0;
     int k;
     for (k=0; k<n; k++) {
-      if (fread(&d, sizeof(double), 1, file) != 1) {
+      if (omc_fread(&d, sizeof(double), 1, file) != 1) {
         return 1;
       }
       val[k] = (int32_t) d;
     }
     return 0;
   } else if (p == 2) { /* int32 */
-    return fread(val,n*sizeof(int32_t),1,file) != 1;
+    return omc_fread(val,n*sizeof(int32_t),1,file) != 1;
   }
   return 1;
 }
@@ -200,12 +200,12 @@ static int read_double(int type, size_t n, FILE *file, double *val)
     return 0;
   }
   if (p == 0) { /* Double */
-    return fread(val,n*sizeof(double),1,file) != 1;
+    return omc_fread(val,n*sizeof(double),1,file) != 1;
   } else if (p == 1) { /* float */
     float f=0.0;
     int k;
     for (k=0; k<n; k++) {
-      if (fread(&f, sizeof(float), 1, file) != 1) {
+      if (omc_fread(&f, sizeof(float), 1, file) != 1) {
         return 1;
       }
       val[k] = (double) f;
@@ -233,7 +233,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
   reader->stopTime = NAN;
   for(i=0; i<nMatrix;i++) {
     MHeader_t hdr;
-    int nr = fread(&hdr,sizeof(MHeader_t),1,reader->file);
+    int nr = omc_fread(&hdr,sizeof(MHeader_t),1,reader->file);
     size_t matrix_length,element_length;
     char *name;
     if(nr != 1) return "Corrupt header (1)";
@@ -241,7 +241,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
     if(hdr.imagf > 1) return "Matrix uses imaginary numbers";
     if((element_length = mat_element_length(hdr.type)) == -1) return "Could not determine size of matrix elements";
     name = (char*) malloc(hdr.namelen);
-    nr = fread(name,hdr.namelen,1,reader->file);
+    nr = omc_fread(name,hdr.namelen,1,reader->file);
     if(nr != 1) {
       free(name);
       return "Corrupt header (2)";
@@ -576,7 +576,7 @@ double* omc_matlab4_read_vals(ModelicaMatReader *reader, int varIndex)
     {
       for(i=0; i<reader->nrows; i++) {
         fseek(reader->file,reader->var_offset + sizeof(double)*(i*reader->nvar + absVarIndex-1), SEEK_SET);
-        if(1 != fread(&tmp[i], sizeof(double), 1, reader->file)) {
+        if(1 != omc_fread(&tmp[i], sizeof(double), 1, reader->file)) {
           /* fprintf(stderr, "Corrupt file at %d of %d? nvar %d\n", i, reader->nrows, reader->nvar); */
           free(tmp);
           tmp=NULL;
@@ -591,7 +591,7 @@ double* omc_matlab4_read_vals(ModelicaMatReader *reader, int varIndex)
       float *buffer = (float*) malloc(reader->nrows*sizeof(float));
       for(i=0; i<reader->nrows; i++) {
         fseek(reader->file,reader->var_offset + sizeof(float)*(i*reader->nvar + absVarIndex-1), SEEK_SET);
-        if(1 != fread(&buffer[i], sizeof(float), 1, reader->file)) {
+        if(1 != omc_fread(&buffer[i], sizeof(float), 1, reader->file)) {
           /* fprintf(stderr, "Corrupt file at %d of %d? nvar %d\n", i, reader->nrows, reader->nvar); */
           free(buffer);
           free(tmp);
@@ -684,7 +684,7 @@ int omc_matlab4_read_all_vals(ModelicaMatReader *reader)
     return 1;
   }
   fseek(reader->file, reader->var_offset, SEEK_SET);
-  if (nvar*reader->nrows != fread(tmp, reader->doublePrecision==1 ? sizeof(double) : sizeof(float), nvar*nrows, reader->file)) {
+  if (nvar*reader->nrows != omc_fread(tmp, reader->doublePrecision==1 ? sizeof(double) : sizeof(float), nvar*nrows, reader->file)) {
     free(tmp);
     return 1;
   }
@@ -721,14 +721,14 @@ double omc_matlab4_read_single_val(double *res, ModelicaMatReader *reader, int v
   }
   if(reader->doublePrecision==1) {
     fseek(reader->file,reader->var_offset + sizeof(double)*(timeIndex*reader->nvar + absVarIndex-1), SEEK_SET);
-    if(1 != fread(res, sizeof(double), 1, reader->file)) {
+    if(1 != omc_fread(res, sizeof(double), 1, reader->file)) {
       *res = 0;
       return 1;
     }
   } else {
     float tmpres;
     fseek(reader->file,reader->var_offset + sizeof(float)*(timeIndex*reader->nvar + absVarIndex-1), SEEK_SET);
-    if(1 != fread(&tmpres, sizeof(float), 1, reader->file)) {
+    if(1 != omc_fread(&tmpres, sizeof(float), 1, reader->file)) {
       *res = 0;
       return 1;
     }

--- a/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_matlab4.c
@@ -162,14 +162,14 @@ static int read_chars(int type, size_t n, FILE *file, char *str)
     double d=0.0;
     int k;
     for (k=0; k<n; k++) {
-      if (omc_fread(&d, sizeof(double), 1, file) != 1) {
+      if (omc_fread(&d, sizeof(double), 1, file, 0) != 1) {
         return 1;
       }
       str[k] = (char) d;
     }
     return 0;
   } else if (p == 5) { /* Byte */
-    return omc_fread(str,n,1,file) != 1;
+    return omc_fread(str,n,1,file, 0) != 1;
   }
   return 1;
 }
@@ -181,14 +181,14 @@ static int read_int32(int type, size_t n, FILE *file, int32_t *val)
     double d=0.0;
     int k;
     for (k=0; k<n; k++) {
-      if (omc_fread(&d, sizeof(double), 1, file) != 1) {
+      if (omc_fread(&d, sizeof(double), 1, file, 0) != 1) {
         return 1;
       }
       val[k] = (int32_t) d;
     }
     return 0;
   } else if (p == 2) { /* int32 */
-    return omc_fread(val,n*sizeof(int32_t),1,file) != 1;
+    return omc_fread(val,n*sizeof(int32_t),1,file, 0) != 1;
   }
   return 1;
 }
@@ -200,12 +200,12 @@ static int read_double(int type, size_t n, FILE *file, double *val)
     return 0;
   }
   if (p == 0) { /* Double */
-    return omc_fread(val,n*sizeof(double),1,file) != 1;
+    return omc_fread(val,n*sizeof(double),1,file, 0) != 1;
   } else if (p == 1) { /* float */
     float f=0.0;
     int k;
     for (k=0; k<n; k++) {
-      if (omc_fread(&f, sizeof(float), 1, file) != 1) {
+      if (omc_fread(&f, sizeof(float), 1, file, 0) != 1) {
         return 1;
       }
       val[k] = (double) f;
@@ -233,7 +233,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
   reader->stopTime = NAN;
   for(i=0; i<nMatrix;i++) {
     MHeader_t hdr;
-    int nr = omc_fread(&hdr,sizeof(MHeader_t),1,reader->file);
+    int nr = omc_fread(&hdr,sizeof(MHeader_t),1,reader->file, 0);
     size_t matrix_length,element_length;
     char *name;
     if(nr != 1) return "Corrupt header (1)";
@@ -241,7 +241,7 @@ const char* omc_new_matlab4_reader(const char *filename, ModelicaMatReader *read
     if(hdr.imagf > 1) return "Matrix uses imaginary numbers";
     if((element_length = mat_element_length(hdr.type)) == -1) return "Could not determine size of matrix elements";
     name = (char*) malloc(hdr.namelen);
-    nr = omc_fread(name,hdr.namelen,1,reader->file);
+    nr = omc_fread(name,hdr.namelen,1,reader->file, 0);
     if(nr != 1) {
       free(name);
       return "Corrupt header (2)";
@@ -576,7 +576,7 @@ double* omc_matlab4_read_vals(ModelicaMatReader *reader, int varIndex)
     {
       for(i=0; i<reader->nrows; i++) {
         fseek(reader->file,reader->var_offset + sizeof(double)*(i*reader->nvar + absVarIndex-1), SEEK_SET);
-        if(1 != omc_fread(&tmp[i], sizeof(double), 1, reader->file)) {
+        if(1 != omc_fread(&tmp[i], sizeof(double), 1, reader->file, 0)) {
           /* fprintf(stderr, "Corrupt file at %d of %d? nvar %d\n", i, reader->nrows, reader->nvar); */
           free(tmp);
           tmp=NULL;
@@ -591,7 +591,7 @@ double* omc_matlab4_read_vals(ModelicaMatReader *reader, int varIndex)
       float *buffer = (float*) malloc(reader->nrows*sizeof(float));
       for(i=0; i<reader->nrows; i++) {
         fseek(reader->file,reader->var_offset + sizeof(float)*(i*reader->nvar + absVarIndex-1), SEEK_SET);
-        if(1 != omc_fread(&buffer[i], sizeof(float), 1, reader->file)) {
+        if(1 != omc_fread(&buffer[i], sizeof(float), 1, reader->file, 0)) {
           /* fprintf(stderr, "Corrupt file at %d of %d? nvar %d\n", i, reader->nrows, reader->nvar); */
           free(buffer);
           free(tmp);
@@ -684,7 +684,7 @@ int omc_matlab4_read_all_vals(ModelicaMatReader *reader)
     return 1;
   }
   fseek(reader->file, reader->var_offset, SEEK_SET);
-  if (nvar*reader->nrows != omc_fread(tmp, reader->doublePrecision==1 ? sizeof(double) : sizeof(float), nvar*nrows, reader->file)) {
+  if (nvar*reader->nrows != omc_fread(tmp, reader->doublePrecision==1 ? sizeof(double) : sizeof(float), nvar*nrows, reader->file, 0)) {
     free(tmp);
     return 1;
   }
@@ -721,14 +721,14 @@ double omc_matlab4_read_single_val(double *res, ModelicaMatReader *reader, int v
   }
   if(reader->doublePrecision==1) {
     fseek(reader->file,reader->var_offset + sizeof(double)*(timeIndex*reader->nvar + absVarIndex-1), SEEK_SET);
-    if(1 != omc_fread(res, sizeof(double), 1, reader->file)) {
+    if(1 != omc_fread(res, sizeof(double), 1, reader->file, 0)) {
       *res = 0;
       return 1;
     }
   } else {
     float tmpres;
     fseek(reader->file,reader->var_offset + sizeof(float)*(timeIndex*reader->nvar + absVarIndex-1), SEEK_SET);
-    if(1 != omc_fread(&tmpres, sizeof(float), 1, reader->file)) {
+    if(1 != omc_fread(&tmpres, sizeof(float), 1, reader->file, 0)) {
       *res = 0;
       return 1;
     }


### PR DESCRIPTION
@mahge
Add omc_fread() to wrap fread() …
8cc7be3
  - We tend to ignore the return value from `fread()` which leads to warnings.

  - It is also good to make sure errors are always checked and reported.

  - It is also good to wrap the common functions to reduce the amount of
    error check code scattered around.