### PR TITLE
Improve handling of conditional components

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -216,10 +216,6 @@ public
     Modifier modifier;
   end TYPE_ATTRIBUTE;
 
-  record DELETED_COMPONENT
-    Component component;
-  end DELETED_COMPONENT;
-
   function new
     input SCode.Element definition;
     output Component component;
@@ -273,7 +269,6 @@ public
       case TYPED_COMPONENT() then component.info;
       case ITERATOR() then component.info;
       case TYPE_ATTRIBUTE() then Modifier.info(component.modifier);
-      case DELETED_COMPONENT() then info(component.component);
       // Fail for enumeration literals, InstNode.info handles that case instead.
     end match;
   end info;
@@ -362,7 +357,6 @@ public
       case UNTYPED_COMPONENT() then InstNode.getType(component.classInst);
       case ITERATOR() then component.ty;
       case TYPE_ATTRIBUTE() then component.ty;
-      case DELETED_COMPONENT() then getType(component.component);
       else Type.UNKNOWN();
     end match;
   end getType;
@@ -757,7 +751,6 @@ public
     cty := match component
       case UNTYPED_COMPONENT(attributes = Attributes.ATTRIBUTES(connectorType = cty)) then cty;
       case TYPED_COMPONENT(attributes = Attributes.ATTRIBUTES(connectorType = cty)) then cty;
-      case DELETED_COMPONENT() then connectorType(component.component);
       else ConnectorType.NON_CONNECTOR;
     end match;
   end connectorType;
@@ -985,7 +978,6 @@ public
     count := match component
       case UNTYPED_COMPONENT() then arrayLength(component.dimensions);
       case TYPED_COMPONENT() then listLength(Type.arrayDims(component.ty));
-      case DELETED_COMPONENT() then dimensionCount(component.component);
       else 0;
     end match;
   end dimensionCount;
@@ -1075,7 +1067,6 @@ public
       case TYPED_COMPONENT(condition = condition)
         then Binding.isBound(condition) and Expression.isFalse(Binding.getTypedExp(condition));
 
-      case DELETED_COMPONENT() then true;
       else false;
     end match;
   end isDeleted;

--- a/testsuite/flattening/modelica/scodeinst/Condition7.mo
+++ b/testsuite/flattening/modelica/scodeinst/Condition7.mo
@@ -1,0 +1,24 @@
+// name: Condition7
+// keywords:
+// status: correct
+// cflags:   -d=newInst
+//
+//
+
+model A
+  parameter Boolean b;
+  Real x if b;
+end A;
+
+model Condition7
+  A a[3](b = {false, true, false});
+end Condition7;
+
+// Result:
+// class Condition7
+//   final parameter Boolean a[1].b = false;
+//   final parameter Boolean a[2].b = true;
+//   Real a[2].x;
+//   final parameter Boolean a[3].b = false;
+// end Condition7;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -232,6 +232,7 @@ Condition3.mo \
 Condition4.mo \
 Condition5.mo \
 Condition6.mo \
+Condition7.mo \
 ConditionInvalid1.mo \
 ConditionInvalidBinding1.mo \
 ConditionInvalidBinding2.mo \


### PR DESCRIPTION
- Use the condition directly instead of replacing components when
  determining if a component is deleted, to allow deleting components in
  only some elements of an array.