### PR TITLE
Added a flag hintReadAllVars to filterSimulationResults API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -581,6 +581,7 @@ pipeline {
             skipDefaultCheckout true
           }
           steps {
+            echo "${env.NODE_NAME}"
             sh 'rm -rf testsuite/'
             unstash 'cross-fmu'
             unstash 'cross-fmu-extras'
@@ -607,6 +608,7 @@ pipeline {
             skipDefaultCheckout true
           }
           steps {
+            echo "${env.NODE_NAME}"
             sh 'rm -rf testsuite/'
             unstash 'cross-fmu'
             unstash 'cross-fmu-extras'
@@ -632,6 +634,7 @@ pipeline {
             skipDefaultCheckout true
           }
           steps {
+            echo "${env.NODE_NAME}"
             sh 'rm -rf testsuite/'
             unstash 'cross-fmu'
             unstash 'cross-fmu-extras'
@@ -667,6 +670,7 @@ pipeline {
             unstash 'cross-fmu-results-linux-wine'
             unstash 'cross-fmu-results-osx'
             unstash 'cross-fmu-results-armhf'
+            echo "${env.NODE_NAME}"
             sh 'cd testsuite/special/FmuExportCrossCompile && ../../../build/bin/omc check-files.mos'
             sh 'cd testsuite/special/FmuExportCrossCompile && tar -czf ../../../Test_FMUs.tar.gz Test_FMUs'
             archiveArtifacts 'Test_FMUs.tar.gz'
@@ -687,6 +691,7 @@ pipeline {
           steps {
             unstash 'compliance'
             unstash 'compliance-newinst'
+            echo "${env.NODE_NAME}"
             sshPublisher(publishers: [sshPublisherDesc(configName: 'ModelicaComplianceReports', transfers: [sshTransfer(sourceFiles: 'compliance-*html')])])
           }
         }
@@ -704,6 +709,7 @@ pipeline {
           }
           steps {
             unstash 'usersguide'
+            echo "${env.NODE_NAME}"
             sh "tar xJf OpenModelicaUsersGuide-${common.tagName()}.html.tar.xz"
             sh "mv OpenModelicaUsersGuide ${common.tagName()}"
             sshPublisher(publishers: [sshPublisherDesc(configName: 'OpenModelicaUsersGuide', transfers: [sshTransfer(sourceFiles: "OpenModelicaUsersGuide-${common.tagName()}*,${common.tagName()}/**")])])

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2934,12 +2934,14 @@ public function filterSimulationResults
   input String[:] vars;
   input Integer numberOfIntervals = 0 "0=Do not resample";
   input Boolean removeDescription = false;
+  input Boolean hintReadAllVars = true;
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
 <p>Takes one simulation result and filters out the selected variables only, producing the output file.</p>
 <p>If numberOfIntervals<>0, re-sample to that number of intervals, ignoring event points (might be changed in the future).</p>
 <p>if removeDescription=true, the description matrix will contain 0-length strings, making the file smaller.</p>
+<p>if hintReadAllVars=true, the whole mat-file will be read at once (this is faster but uses more memory if you only use few variables from the file). May cause a crash if there is not enough virtual memory.</p>
 </html>",revisions="<html>
 <table>
 <tr><th>Revision</th><th>Author</th><th>Comment</th></tr>

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3157,12 +3157,14 @@ public function filterSimulationResults
   input String[:] vars;
   input Integer numberOfIntervals = 0 "0=Do not resample";
   input Boolean removeDescription = false;
+  input Boolean hintReadAllVars = true;
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
 <p>Takes one simulation result and filters out the selected variables only, producing the output file.</p>
 <p>If numberOfIntervals<>0, re-sample to that number of intervals, ignoring event points (might be changed in the future).</p>
 <p>if removeDescription=true, the description matrix will contain 0-length strings, making the file smaller.</p>
+<p>if hintReadAllVars=true, the whole mat-file will be read at once (this is faster but uses more memory if you only use few variables from the file). May cause a crash if there is not enough virtual memory.</p>
 </html>",revisions="<html>
 <table>
 <tr><th>Revision</th><th>Author</th><th>Comment</th></tr>

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1887,7 +1887,7 @@ algorithm
       list<String> vars_1,args,strings,strs,strs1,strs2,visvars,postOptModStrings,postOptModStringsOrg,mps,files,dirs,modifiernamelst;
       Real timeTotal,timeSimulation,timeStamp,val,x1,x2,y1,y2,r,r1,r2,linearizeTime,curveWidth,offset,offset1,offset2,scaleFactor,scaleFactor1,scaleFactor2;
       GlobalScript.Statements istmts;
-      Boolean have_corba, bval, anyCode, b, b1, b2, b3, b4, b5, externalWindow, logX, logY, autoScale, forceOMPlot, gcc_res, omcfound, rm_res, touch_res, uname_res,  ifcpp, ifmsvc,sort, builtin, showProtected, inputConnectors, outputConnectors, sanityCheckFailed, keepRedeclares;
+      Boolean have_corba, bval, anyCode, b, b1, b2, b3, b4, b5, externalWindow, logX, logY, autoScale, forceOMPlot, gcc_res, omcfound, rm_res, touch_res, uname_res,  ifcpp, ifmsvc,sort, builtin, showProtected, inputConnectors, outputConnectors, sanityCheckFailed, keepRedeclares, hintReadAllVars;
       FCore.Cache cache;
       Absyn.ComponentRef  crefCName;
       list<tuple<String,Values.Value>> resultValues;
@@ -2437,10 +2437,10 @@ algorithm
     case (cache,_,"compareSimulationResults",_,_)
       then (cache,Values.STRING("Error in compareSimulationResults"));
 
-    case (cache,_,"filterSimulationResults",{Values.STRING(filename),Values.STRING(filename_1),Values.ARRAY(valueLst=cvars),Values.INTEGER(numberOfIntervals),Values.BOOL(b)},_)
+    case (cache,_,"filterSimulationResults",{Values.STRING(filename),Values.STRING(filename_1),Values.ARRAY(valueLst=cvars),Values.INTEGER(numberOfIntervals),Values.BOOL(b),Values.BOOL(hintReadAllVars)},_)
       equation
         vars_1 = List.map(cvars, ValuesUtil.extractValueString);
-        b = SimulationResults.filterSimulationResults(filename,filename_1,vars_1,numberOfIntervals,b);
+        b = SimulationResults.filterSimulationResults(filename,filename_1,vars_1,numberOfIntervals,b,hintReadAllVars=hintReadAllVars);
       then
         (cache,Values.BOOL(b));
 

--- a/OMCompiler/Compiler/Util/SimulationResults.mo
+++ b/OMCompiler/Compiler/Util/SimulationResults.mo
@@ -148,10 +148,11 @@ public function filterSimulationResults
   input String inFile;
   input String outFile;
   input list<String> vars;
-  input Integer numberOfIntervals=0;
+  input Integer numberOfIntervals;
   input Boolean removeDescription;
+  input Boolean hintReadAllVars "Read a whole mat-file into memory. May crash OMC if you have too little virtual memory.";
   output Boolean result;
-  external "C" result=SimulationResults_filterSimulationResults(inFile,outFile,vars,numberOfIntervals,removeDescription) annotation(Library = "omcruntime");
+  external "C" result=SimulationResults_filterSimulationResults(inFile,outFile,vars,numberOfIntervals,removeDescription,hintReadAllVars) annotation(Library = "omcruntime");
 end filterSimulationResults;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/runtime/SimulationResults.c
+++ b/OMCompiler/Compiler/runtime/SimulationResults.c
@@ -419,7 +419,7 @@ static int endsWith(const char *s, const char *suffix)
     return 0;
   }
 }
-int SimulationResults_filterSimulationResults(const char *inFile, const char *outFile, void *vars, int numberOfIntervals, int removeDescription)
+int SimulationResults_filterSimulationResults(const char *inFile, const char *outFile, void *vars, int numberOfIntervals, int removeDescription, int readAllVars)
 {
   const char *msg[5] = {"","","","",""};
   void *tmp;
@@ -446,7 +446,9 @@ int SimulationResults_filterSimulationResults(const char *inFile, const char *ou
     double stop = omc_matlab4_stopTime(&simresglob.matReader);
     double start_stop[2] = {start, stop};
     parameter_indexes[0] = 1; /* time */
-    omc_matlab4_read_all_vals(&simresglob.matReader);
+    if (readAllVars) {
+      omc_matlab4_read_all_vals(&simresglob.matReader);
+    }
     if (endsWith(outFile,".csv")) {
       double **vals = omc_alloc_interface.malloc(sizeof(double*)*numToFilter);
       FILE *fout = NULL;

--- a/OMCompiler/Compiler/runtime/SimulationResultsCmp.c
+++ b/OMCompiler/Compiler/runtime/SimulationResultsCmp.c
@@ -608,15 +608,21 @@ void* SimulationResultsCmp_compareResults(int isResultCmp, int runningTestsuite,
   /* open files */
   /*  fprintf(stderr, "Open File %s\n", filename); */
   if (UNKNOWN_PLOT == SimulationResultsImpl__openFile(filename,&simresglob_c)) {
-    *success = 0;
     c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("Error opening file: %s"),&filename,1);
-    return mmc_mk_nil();
+    if (success) {
+      *success = 0;
+      return mmc_mk_nil();
+    }
+    MMC_THROW();
   }
   /* fprintf(stderr, "Open File %s\n", reffilename); */
   if (UNKNOWN_PLOT == SimulationResultsImpl__openFile(reffilename,&simresglob_ref)) {
-    *success = 0;
     c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("Error opening reference file: %s"),&reffilename,1);
-    return mmc_mk_nil();
+    if (success) {
+      *success = 0;
+      return mmc_mk_nil();
+    }
+    MMC_THROW();
   }
 
   size = SimulationResultsImpl__readSimulationResultSize(filename,&simresglob_c);
@@ -633,9 +639,12 @@ void* SimulationResultsCmp_compareResults(int isResultCmp, int runningTestsuite,
     suggestReadAll = 1;
     cmpvars = getVars(allvarsref,&ncmpvars);
     if (ncmpvars==0) {
-      *success = 0;
       c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("Error getting variables"),NULL,0);
-      return mmc_mk_nil();
+      if (success) {
+        *success = 0;
+        return mmc_mk_nil();
+      }
+      MMC_THROW();
     }
   }
 #ifdef DEBUGOUTPUT
@@ -649,16 +658,22 @@ void* SimulationResultsCmp_compareResults(int isResultCmp, int runningTestsuite,
   timeVarNameRef = getTimeVarName(allvarsref);
   time = getData(timeVarName,filename,size,suggestReadAll,&simresglob_c,runningTestsuite);
   if (time.n==0) {
-    *success = 0;
     c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("Error getting time"),NULL,0);
-    return mmc_mk_nil();
+    if (success) {
+      *success = 0;
+      return mmc_mk_nil();
+    }
+    MMC_THROW();
   }
   /* fprintf(stderr, "get reftime\n"); */
   timeref = getData(timeVarNameRef,reffilename,size_ref,suggestReadAll,&simresglob_ref,runningTestsuite);
   if (timeref.n==0) {
-    *success = 0;
     c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("Error getting time from reference file"),NULL,0);
-    return mmc_mk_nil();
+    if (success) {
+      *success = 0;
+      return mmc_mk_nil();
+    }
+    MMC_THROW();
   }
   cmpdiffvars = (char**)omc_alloc_interface.malloc(sizeof(char*)*(ncmpvars));
   /* check if time is larger or less reftime */

--- a/testsuite/special/FmuExportCrossCompile/check-files.mos
+++ b/testsuite/special/FmuExportCrossCompile/check-files.mos
@@ -1,10 +1,10 @@
 for m in {"FmuExportCrossCompile","RoomHeating_OM_RH","WaterTank_Control","WaterTank_TestSingleWaterTank","BouncingBall"} loop
-for os in {"linux32","linux64","win32","win64","darwin64","arm-linux-gnueabi"} loop // "darwin32"
+for os in {"linux32","linux64","win32","win64","darwin64","arm-linux-gnueabihf"} loop // "darwin32"
 for t in {"me","cs"} loop
 
 target := os+"-"+t;
 (success,vars) := diffSimulationResults(m + "-" + target + ".csv", m + "_res.csv", target+"-diff", vars={"h"});
-writeFile(target+"-diff.html", diffSimulationResultsHtml("h", target + ".csv", "FmuExportCrossCompile_res.csv"));
+writeFile(target+"-diff.html", diffSimulationResultsHtml("h", m + "-" + target + ".csv", "FmuExportCrossCompile_res.csv"));
 if not success then
   print("Failed for "+m+"-"+target+": "+sum(v + ", " for v in vars)+"\n");
   print(getErrorString()+"\n");

--- a/testsuite/special/FmuExportCrossCompile/check-files.mos
+++ b/testsuite/special/FmuExportCrossCompile/check-files.mos
@@ -11,6 +11,7 @@ if not success then
   exit(1);
 else
   print(m + "-" + target+" OK\n");
+  print(getErrorString()+"\n");
 end if;
 
 end for;

--- a/testsuite/special/FmuExportCrossCompile/check-files.mos
+++ b/testsuite/special/FmuExportCrossCompile/check-files.mos
@@ -7,6 +7,7 @@ target := os+"-"+t;
 writeFile(target+"-diff.html", diffSimulationResultsHtml("h", target + ".csv", "FmuExportCrossCompile_res.csv"));
 if not success then
   print("Failed for "+m+"-"+target+": "+sum(v + ", " for v in vars)+"\n");
+  print(getErrorString()+"\n");
   exit(1);
 else
   print(m + "-" + target+" OK\n");


### PR DESCRIPTION
We can now disable reading all variables in cases where this will use up
all available virtual memory (and crash OMC).

There were also some changes to the C-code to not return errors in the
strings where failed variables show up.