### PR TITLE
Cmake improvements

### DIFF
--- a/OMCompiler/.cmake/omc_utils.cmake
+++ b/OMCompiler/.cmake/omc_utils.cmake
@@ -3,7 +3,10 @@ include(CMakePrintHelpers)
 
 macro(omc_add_to_report var)
   cmake_print_variables(${var})
-  add_feature_info(${var} ${var} ${${var}})
+  # quote to change variables with empty values to "" (empty string).
+  # Otherwise they will valuate to nothing and that will cause a
+  # syntax error since add_feature_info expects 3 arguments.
+  add_feature_info(${var} ${var} "${${var}}")
 endmacro(omc_add_to_report)
 
 set(CMAKE_MESSAGE_CONTEXT_SHOW ON)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(OMCompiler)
+project(OMCompiler C CXX Fortran)
 
 # Variable for signifying that we are using the new CMake configuration.
 # We use this to selectively include some cmake source files
@@ -25,8 +25,9 @@ include(.cmake/omc_target_info.cmake)
 include(.cmake/omc_check_exists.cmake)
 
 # Add the compiler ids to the report for convenience.
-omc_add_to_report(CMAKE_CXX_COMPILER_ID)
 omc_add_to_report(CMAKE_C_COMPILER_ID)
+omc_add_to_report(CMAKE_CXX_COMPILER_ID)
+omc_add_to_report(CMAKE_Fortran_COMPILER_ID)
 omc_add_to_report(CMAKE_LIBRARY_ARCHITECTURE)
 
 #########################################################################################################

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -73,7 +73,7 @@ endif()
 omc_add_to_report(CMAKE_INSTALL_PREFIX)
 
 
-# We prefer to install libs to "library architecture" dir inside lib directory (e.g lib/x86_64-linux-gnu/omc/).
+# We prefer to install libs to "<library architecture>/omc" dir inside lib directory (e.g lib/x86_64-linux-gnu/omc/).
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/omc/)
 
 

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -18,7 +18,6 @@ string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}
 string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
-# set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # include utility macros.
 include(.cmake/omc_utils.cmake)
@@ -30,6 +29,20 @@ omc_add_to_report(CMAKE_CXX_COMPILER_ID)
 omc_add_to_report(CMAKE_C_COMPILER_ID)
 omc_add_to_report(CMAKE_LIBRARY_ARCHITECTURE)
 
+#########################################################################################################
+## Set the C standard to use. Unfortunately, we can not enforce c90.
+## Our sources contain a lot of c99 and gnu extension code.
+# set(CMAKE_C_STANDARD 90)
+
+## Set the C++ standard to use.
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_STANDARD_REQUIRED ON)
+## Make sure we do not start relying on extensions down the road.
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+#########################################################################################################
+## Enable verbose Makefiles if you want to debug. (you can also instead use 'make VERBOSE=1')
+# set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # Export compile commands (compile_commands.json) for each source file. This helps editors (e.g. vscode, emacs) have
 # a more accurate code navigation and intellisense. E.g. includes can be pinpointed instead of

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -150,7 +150,6 @@ add_custom_target(INTERFACE_CHECK
 # Add a small dependency scanner program. This reads a list of list of dependencies and generates
 # a list of dependents for each entry.
 add_executable(dep_scanner ${CMAKE_CURRENT_SOURCE_DIR}/.cmake/dep_scanner.cpp)
-target_compile_features(dep_scanner PRIVATE cxx_std_11)
 
 # Write out a new line separated list of all MM source files to a list so that it can be easily
 # parsed by the small MetaModelica dependency scanner we have now. (c++ code)

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -149,7 +149,7 @@ target_sources(omcbackendruntime PRIVATE ${OMC_BACKENDRUNTIIME_SOURCES})
 target_link_libraries(omcbackendruntime PUBLIC omc::config)
 target_link_libraries(omcbackendruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcbackendruntime PUBLIC omc::simrt::memory)
-target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib::static)
+target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
 target_include_directories(omcbackendruntime PUBLIC ${Intl_INCLUDE_DIRS})

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -69,7 +69,6 @@ add_library(omcruntime STATIC)
 add_library(omc::compiler::runtime ALIAS omcruntime)
 
 target_sources(omcruntime PRIVATE ${OMC_RUNTIIME_SOURCES})
-target_compile_features(omcruntime PRIVATE cxx_std_11)
 
 target_link_libraries(omcruntime PUBLIC omc::config)
 target_link_libraries(omcruntime PUBLIC CURL::libcurl)

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -44,6 +44,7 @@ target_sources(omcmemory PRIVATE ${OMC_SIMRT_GC_SOURCES})
 target_link_libraries(omcmemory PUBLIC omc::3rd::omcgc)
 target_include_directories(omcmemory PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+install(TARGETS omcmemory)
 
 # ######################################################################################################################
 # Library: OpenModelicaRuntimeC

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -75,6 +75,23 @@ install(TARGETS OpenModelicaFMIRuntimeC)
 
 
 # ######################################################################################################################
+# Library: OptimizationRuntime
+## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
+## However having it as a separate lib will allow us to remove it based on an option. This means we can
+## also remove the need for ipopt and mumps if this is disabled.
+add_library(OptimizationRuntime STATIC)
+add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
+
+target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
+
+target_link_libraries(OptimizationRuntime PUBLIC omc::config)
+target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::memory)
+target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
+
+install(TARGETS OptimizationRuntime)
+
+
+# ######################################################################################################################
 # Library: SimulationRuntimeC
 add_library(SimulationRuntimeC STATIC)
 add_library(omc::simrt::simruntime ALIAS SimulationRuntimeC)
@@ -92,12 +109,12 @@ target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::idas)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::kinsol)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::sunlinsolklu)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::sunlinsollapackdense)
-target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::klu)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::amd)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::btf)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::colamd)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::umfpack)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cminpack)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cdaskr)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
@@ -109,22 +126,6 @@ install(TARGETS SimulationRuntimeC)
 
 
 # ######################################################################################################################
-# Library: OptimizationRuntime
-## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
-## However having it as a separate lib will allow us to remove it based on an option. This means we can
-## also remove the need for ipopt and mumps if this is disabled.
-add_library(OptimizationRuntime STATIC)
-add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
-
-target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
-
-target_link_libraries(OptimizationRuntime PUBLIC omc::config)
-target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::memory)
-target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
-
-install(TARGETS OptimizationRuntime)
-
-
 ## Install the header files. This installs the whole directory structure of c/ folder
 ## which means all headers will be installed keeping the directory structure intact.
 ## It might install some unneeded headers but it suffices for now.

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -125,6 +125,20 @@ target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
 install(TARGETS OptimizationRuntime)
 
 
+## Install the header files. This installs the whole directory structure of c/ folder
+## which means all headers will be installed keeping the directory structure intact.
+## It might install some unneeded headers but it suffices for now.
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/omc
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.c.inc"
+        PATTERN "build" EXCLUDE # To skip the build dir created by the normal Makefiles build system.
+)
+
+
+
+
 # ######################################################################################################################
 # Quick and INCOMPLETE generation of RuntimeSources.mo
 set(DGESV_FILES \"\")

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -69,7 +69,7 @@ add_library(omc::simrt::fmiruntime ALIAS OpenModelicaFMIRuntimeC)
 
 target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES})
 
-target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib::static)
+target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib)
 
 install(TARGETS OpenModelicaFMIRuntimeC)
 
@@ -86,10 +86,20 @@ target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES}
 
 target_link_libraries(SimulationRuntimeC PUBLIC omc::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::memory)
-target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::cvode::static)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::FMIL::expat)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::cvode)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::idas)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::kinsol)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::sunlinsolklu)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::sunlinsollapackdense)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::klu)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::amd)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::btf)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::colamd)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::umfpack)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cminpack)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cdaskr)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
 
 # Fix me. Make an interface (header only library) out of 3rdParty/dgesv

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -16,6 +16,13 @@ file(GLOB_RECURSE OMC_SIMRT_SIMULATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/simul
 
 file(GLOB OMC_SIMRT_MATH_SUPPORT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/math-support/pivot.c)
 
+file(GLOB OMC_SIMRT_LINEARIZATION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/linearization/linearize.cpp)
+file(GLOB OMC_SIMRT_LINEARIZATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/linearization/linearize.h)
+
+file(GLOB_RECURSE OMC_SIMRT_DATA_RECONCILIATION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/dataReconciliation/*.cpp)
+file(GLOB_RECURSE OMC_SIMRT_DATA_RECONCILIATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/dataReconciliation/*.h)
+
+
 file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/optimization/*.c)
 file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/optimization/*.h)
 
@@ -71,7 +78,10 @@ install(TARGETS OpenModelicaFMIRuntimeC)
 add_library(SimulationRuntimeC STATIC)
 add_library(omc::simrt::simruntime ALIAS SimulationRuntimeC)
 
-target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES} ${OMC_SIMRT_MATH_SUPPORT_SOURCES})
+target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES}
+                                          ${OMC_SIMRT_MATH_SUPPORT_SOURCES}
+                                          ${OMC_SIMRT_LINEARIZATION_SOURCES}
+                                          ${OMC_SIMRT_DATA_RECONCILIATION_SOURCES})
 
 target_link_libraries(SimulationRuntimeC PUBLIC omc::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::memory)
@@ -90,6 +100,8 @@ install(TARGETS SimulationRuntimeC)
 # ######################################################################################################################
 # Library: OptimizationRuntime
 ## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
+## However having it as a separate lib will allow us to remove it based on an option. This means we can
+## also remove the need for ipopt and mumps if this is disabled.
 add_library(OptimizationRuntime STATIC)
 add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
 


### PR DESCRIPTION
@mahge
[cmake] Require and enforce C++11 project wide. 
342656e
  - Instead of allowing C++11 on a target by target basis when needed,
    enable it globally. We would not be able to have a working omc or
    simulation as it is now without a compiler with C++11 support. So
    require it globally.

  - Unfortunately, we can not enforce c89/90 standards on our code at the
    moment as we rely heavily on C99 features and GNU extensions.

@mahge
[cmake] Add more sources to libSimulationRuntimeC 
817eb34
  - Added `linearization/` and `dataReconciliation/` sources.
    The reason we are not making a separate library for these is that
    they do not bring in any new dependency. This can be slef contained
    with in libSimulationRuntimeC.

@mahge
[cmake] General improvements to CMake config. 
743eaad
  - Allow calling omc_add_to_report with a variable that is not set. Some
    variables can be set or not depending on configuration. This used to
    cause errors when the variable was unset and also added to report.

  - Explicitly tell cmake our project needs C CXX and Fortran.
        Just to get the initial reports of compiler info at the beginning
        of configuration.

  - Add CXX and Fortran compiler IDs to the printed report.

  - Install `libomcmemory`. It was overlooked before.
 
@mahge
[cmake] Complete libSimulationRuntimeC linkage. 
9a7a711
  - Complete the link dependencies of libSimulationRuntimeC.

  - Remove ::static suffixes

    - Remove the ::static suffix from libraries since our default build
      target type is static libraries by default. We do not build anything
      as shared library now (at least not intentionally.)

      There will be few shared libs later. For collecting the static libs
      and providing all the functionality in one library. But that is special
      and our intention is not to build any individual libs as shared libs.

  - Add alias for expat

    - Expat is needed for libSimulationRuntimeC.
      We use the expat from FMIL (since it is available and built there)

  - Add aliases for more Sundials libs.

    - Also factorize the include directory providing a little bit. See the
      comments in the code.

@mahge
[cmake] Install SimulationRuntime/c headers. 
b203df1
  - We install all headers with in the directory and all its subdirectories
    recursively.

  - This might mean that some header files will be installed even though
    they are not needed.
    For now this is enough. We can manually specify which headers to
    install later.

    Even better we can put all our public headers in a separate include/
    directory.

@mahge
[cmake] Link SS config after other SS libs 
9cdf54d
  - Link SuiteSparse config after other SuiteSparse libs.
    This makes a difference when our Simulation libs as shared libs.

  - Minor refactor: Move code for libOptimizationRuntime a little up.