### PR TITLE
Update build section in READMEs to use contrib

### DIFF
--- a/OMCompiler/README-OMDev-MINGW.md
+++ b/OMCompiler/README-OMDev-MINGW.md
@@ -6,11 +6,11 @@
     ```bash
       git config --global core.eol lf
       git config --global core.autocrlf input
-	```
+    ```
   - get OMDev from git
      ```bash
-	  git clone https://openmodelica.org/git/OMDev.git
-	 ```
+    git clone https://openmodelica.org/git/OMDev.git
+     ```
   - this package contains all prerequisites to compile OMC on Windows using msys2+mingw32+mingw64
   - if you get issues with OpenModelica compilation maybe you should update OMDev (git pull)
   - please make sure you have OMDEV environment variable defined and that you have restarted or logout/login to make it available
@@ -22,16 +22,15 @@
 - get OpenModelica from git
   - do not create an OpenModelica directory in which you clone OpenModelica repository, it will be created when you clone it
   - start `$OMDEV\tools\msys\mingw64.exe` or `$OMDEV\tools\msys\mingw32.exe` and type:
-
-		```bash
-		# change the directory to where you want the OpenModelica repository on your hard drive
-		cd /path/to/where/you/want/to/clone/the/repository
-		# export the path to your tools: git, svn, java/javac
-		# note: if you have a space in your path to your tool you need to escape it, i.e.: /c/Program\ Files
-		export PATH=$PATH:/c/path/to/git/bin:/c/path/to/svn/tools/bin:/c/path/to/jdk/bin
-		# git clone OpenModelica recursively using the installed git for windows
-		git clone https://github.com/OpenModelica/OpenModelica.git --recursive
-		```
+    ```bash
+    # change the directory to where you want the OpenModelica repository on your hard drive
+    cd /path/to/where/you/want/to/clone/the/repository
+    # export the path to your tools: git, svn, java/javac
+    # note: if you have a space in your path to your tool you need to escape it, i.e.: /c/Program\ Files
+    export PATH=$PATH:/c/path/to/git/bin:/c/path/to/svn/tools/bin:/c/path/to/jdk/bin
+    # git clone OpenModelica recursively using the installed git for windows
+    git clone https://github.com/OpenModelica/OpenModelica.git --recursive
+    ```
   - you should have an OpenModelica directory you got from OpenModelica GIT repository https://github.com/OpenModelica/OpenModelica
   - you can also follow the instructions at the bottom of the page on how to get OpenModelica sources
 - You could use msys2+mingw32 or msys2+mingw64 or Eclipse to build OMC. Follow the instructions in **Compiling OMC using MSYS** or **Compiling OMC using Eclipse**.

--- a/OMCompiler/README-Windows-WSL.md
+++ b/OMCompiler/README-Windows-WSL.md
@@ -11,14 +11,20 @@ Follow the instructions from Microsoft to install a Linux distribution.
 ## Install build dependencies
 See the Dependencies for Linux in [Linux instructions](README.Linux.md) or use
 ```bash
-echo deb http://build.openmodelica.org/apt bionic nightly | sudo tee -a /etc/apt/sources.list
-echo deb-src http://build.openmodelica.org/apt bionic nightly | sudo tee -a /etc/apt/sources.list
+echo deb http://build.openmodelica.org/apt `lsb_release --short --codename` nightly | sudo tee -a /etc/apt/sources.list.d/openmodelica.list
+echo deb-src http://build.openmodelica.org/apt nightly contrib | sudo tee -a /etc/apt/sources.list.d/openmodelica.list
 
-# Get key for OpenModelica
+# You'll also need to import the GPG key used to sign the releases:
 wget -q http://build.openmodelica.org/apt/openmodelica.asc -O- | sudo apt-key add -
+# To verify that your key is installed correctly
+apt-key fingerprint
+# Gives output:
+# pub   2048R/64970947 2010-06-22
+#      Key fingerprint = D229 AF1C E5AE D74E 5F59  DF30 3A59 B536 6497 0947
+# uid                  OpenModelica Build System
 
-sudo apt update
-sudo apt build-dep openmodelica
+sudo apt-get update
+sudo apt-get build-dep openmodelica
 ```
 ## Install additional dependencies
 If you want to build documentation and run all tests successfully you need some additional programs. There are two options:
@@ -44,8 +50,8 @@ git clone --recursive https://openmodelica.org/git-readonly/OpenModelica.git Ope
 ```bash
 cd OpenModelica
 autoconf
-./configure CC=clang CXX=clang++ -without-omc -with-cppruntime
-make -j4    # Or 4 with the number of cores you have
+./configure CC=clang CXX=clang++ --without-omc --with-cppruntime
+make -j4    # Or replace 4 with the number of cores you have
 ```
 
 ## Test your build

--- a/OMCompiler/README.Linux.md
+++ b/OMCompiler/README.Linux.md
@@ -14,14 +14,22 @@ If your distribution is not supported, it might still work if you use an appropr
 
 ```bash
 echo Linux name: `lsb_release --short --codename`
-echo deb http://build.openmodelica.org/apt `lsb_release --short --codename` nightly | sudo tee -a /etc/apt/sources.list
-echo deb-src http://build.openmodelica.org/apt `lsb_release --short --codename` nightly | sudo tee -a /etc/apt/sources.list
+echo deb http://build.openmodelica.org/apt `lsb_release --short --codename` nightly | sudo tee -a /etc/apt/sources.list.d/openmodelica.list
+echo deb-src http://build.openmodelica.org/apt nightly contrib | sudo tee -a /etc/apt/sources.list.d/openmodelica.list
+# You'll also need to import the GPG key used to sign the releases:
+wget -q http://build.openmodelica.org/apt/openmodelica.asc -O- | sudo apt-key add -
+# To verify that your key is installed correctly
+apt-key fingerprint
+# Gives output:
+# pub   2048R/64970947 2010-06-22
+#      Key fingerprint = D229 AF1C E5AE D74E 5F59  DF30 3A59 B536 6497 0947
+# uid                  OpenModelica Build System
 sudo apt-get update
 sudo apt-get build-dep openmodelica
 git clone --recursive https://openmodelica.org/git-readonly/OpenModelica.git OpenModelica
 cd OpenModelica
 autoconf
-./configure --with-cppruntime
+./configure --with-cppruntime --without-omc
 make -j4
 ```
 


### PR DESCRIPTION
### Issues

Current build section on dependencies is not working at the moment. Using `contrib` for deb-src solves that problem.

