### PR TITLE
Avoid mutually dependent parent relationships during clock inference

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
@@ -696,11 +696,10 @@ algorithm
     if not intEq(part1,0) and not intEq(part2,0) then
       addPartAdjacencyEdge(part1,subClk1,part2,subClk2,partAdjacency);
     end if;
-    //to get the  parent relations, check only sub partition interfaces which don't interface clock-variables
-    //(commented out to get right order of subclocks derived from clock variables)
-    //if clockedVarsMask[var1] and clockedVarsMask[var2] then
-      partitionParents[part1]:= part2;
-    //end if;
+    //avoid mutually dependent parents that would result in stack overflow later on
+    if not intEq(partitionParents[part2], part1) then
+      partitionParents[part1] := part2;
+    end if;
   end for;
   /*
   for i in 1:numPartitions loop

--- a/testsuite/simulation/modelica/synchronous/Makefile
+++ b/testsuite/simulation/modelica/synchronous/Makefile
@@ -6,6 +6,7 @@ Bug3503.mos \
 EventClock.mos \
 EventClock_cpp.mos \
 EventClockAndClassic.mos \
+MutuallyDependentClocks.mos \
 SamplingWithClocks.mos \
 subSample.mos \
 SynchronousFeatures.ControlledMassBasic.mos \

--- a/testsuite/simulation/modelica/synchronous/MutuallyDependentClocks.mos
+++ b/testsuite/simulation/modelica/synchronous/MutuallyDependentClocks.mos
@@ -1,0 +1,158 @@
+// name: MutuallyDependentClocks
+// keywords: synchronous subSample superSampe
+// status: correct
+// cflags:
+//
+//
+
+setCommandLineOptions("+d=dumpSynchronous"); getErrorString();
+
+loadString("
+model MutuallyDependentClocks
+  Clock c = Clock(0.1);
+  Clock cs = subSample(c, 5); // c is parent of cs
+  Real x, y, z, w;
+equation
+  x = sample(time, c);
+  y = sample(time, cs);
+  z = superSample(y, 5); // cs becomes parent of c
+  w = x + z;
+end MutuallyDependentClocks;
+"); getErrorString();
+
+instantiateModel(MutuallyDependentClocks); getErrorString();
+translateModel(MutuallyDependentClocks); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "class MutuallyDependentClocks
+//   Clock c = Clock(0.1);
+//   Clock cs = subSample(c, 5);
+//   Real x;
+//   Real y;
+//   Real z;
+//   Real w;
+// equation
+//   x = sample(time, c);
+//   y = sample(time, cs);
+//   z = superSample(y, 5);
+//   w = x + z;
+// end MutuallyDependentClocks;
+// "
+// ""
+// synchronous features pre-phase: synchronousFeatures
+//
+//
+// ########################################
+// clock partitioning (2 partitions)
+// ########################################
+//
+//
+// clocked partition(1)
+// ========================================
+//
+// Variables (3)
+// ========================================
+// 1: w:VARIABLE()  type: Real
+// 2: z:VARIABLE()  type: Real
+// 3: x:VARIABLE()  type: Real
+//
+//
+// Equations (3, 3)
+// ========================================
+// 1/1 (1): x = $getPart(time)   [dynamic |0|0|0|0|]
+// 2/2 (1): z = $getPart(y)   [dynamic |0|0|0|0|]
+// 3/3 (1): w = x + z   [dynamic |0|0|0|0|]
+//
+//
+// no matching
+//
+//
+// clocked partition(2)
+// ========================================
+//
+// Variables (1)
+// ========================================
+// 1: y:VARIABLE()  type: Real
+//
+//
+// Equations (1, 1)
+// ========================================
+// 1/1 (1): y = $getPart(time)   [dynamic |0|0|0|0|]
+//
+//
+// no matching
+//
+//
+//
+// Base clocks (1)
+// ========================================
+// 1: Clock(0.1)[2]
+//
+//
+// Sub clocks (2)
+// ========================================
+// 1: factor(1/1) shift(0/1)  event(false)
+// 2: factor(5/1) shift(0/1)  event(false)
+//
+// synchronous features post-phase: synchronousFeatures
+//
+//
+// ########################################
+// clock partitioning (2 partitions)
+// ########################################
+//
+//
+// clocked partition(1)
+// ========================================
+//
+// Variables (3)
+// ========================================
+// 1: w:VARIABLE()  type: Real
+// 2: z:VARIABLE()  type: Real
+// 3: x:VARIABLE()  type: Real
+//
+//
+// Equations (3, 3)
+// ========================================
+// 1/1 (1): x = $getPart(time)   [dynamic |0|0|0|0|]
+// 2/2 (1): z = $getPart(y)   [dynamic |0|0|0|0|]
+// 3/3 (1): w = x + z   [dynamic |0|0|0|0|]
+//
+//
+// no matching
+//
+//
+// clocked partition(2)
+// ========================================
+//
+// Variables (1)
+// ========================================
+// 1: y:VARIABLE()  type: Real
+//
+//
+// Equations (1, 1)
+// ========================================
+// 1/1 (1): y = $getPart(time)   [dynamic |0|0|0|0|]
+//
+//
+// no matching
+//
+//
+//
+// Base clocks (1)
+// ========================================
+// 1: Clock(0.1)[2]
+//
+//
+// Sub clocks (2)
+// ========================================
+// 1: factor(1/1) shift(0/1)  event(false)
+// 2: factor(5/1) shift(0/1)  event(false)
+//
+// true
+// ""
+// endResult


### PR DESCRIPTION
See: Modelica.Clocked.Examples.CascadeControlledDrive.SubClocked

