### PR TITLE
Add variable filter option to Cpp runtime

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -2218,6 +2218,7 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   let home      = makefileParams.omhome
   let &includeMeasure = buffer "" /*BUFD*/
   let outputtype = settings.outputFormat
+  let variableFilter = settings.variableFilter
   <<
   #include <Core/ModelicaDefine.h>
   #include <Core/Modelica.h>
@@ -2293,6 +2294,7 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
       opts["-R"] = "<%simulationLibDir(simulationCodeTarget(), simCode, &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)%>";
       opts["-M"] = "<%moLib%>";
       opts["-F"] = "<%simulationResults(Testsuite.isRunning(), simCode, &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)%>";
+      opts["-B"] = "<%variableFilter%>";
       opts["--solver-threads"] = "<%if(intGt(getConfigInt(NUM_PROC), 0)) then getConfigInt(NUM_PROC) else 1%>";
       <%if (stringEq(settings.outputFormat, "empty")) then 'opts["-O"] = "none";' else ""%>
       <%
@@ -2393,10 +2395,10 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
             Logger::finalize();
             return 0;
       }
-      catch(ModelicaSimulationError& ex)
+      catch (ModelicaSimulationError& ex)
       {
-          if(!ex.isSuppressed())
-              std::cerr << "Simulation stopped with error in " << error_id_string(ex.getErrorID()) << ": "  << ex.what();
+          if (!ex.isSuppressed())
+              std::cerr << "Simulation stopped with error in " << error_id_string(ex.getErrorID()) << ": "  << ex.what() << std::endl;
           Logger::finalize();
           return 1;
       }

--- a/OMCompiler/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/DataExchange/XmlPropertyReader.cpp
@@ -8,6 +8,7 @@
 #include <boost/lexical_cast.hpp>
 #include <fstream>
 #include <iostream>
+#include <regex>
 
 XmlPropertyReader::XmlPropertyReader(IGlobalSettings *globalSettings, std::string propertyFile)
   : IPropertyReader()
@@ -34,6 +35,7 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
     double *derVars= sim_vars-> getDerStateVector();
     int refIdx = -1;
     boost::optional<int> refIdxOpt;
+    std::regex filterRegex(_globalSettings->getVariableFilter());
     try
     {
       ptree tree;
@@ -68,7 +70,7 @@ void XmlPropertyReader::readInitialValues(IContinuous& system, shared_ptr<ISimVa
           bool isAlias = aliasInfo.compare("alias") == 0;
           bool isNegatedAlias = aliasInfo.compare("negatedAlias") == 0;
 
-          bool emitResult = true;
+          bool emitResult = std::regex_match(name, filterRegex);
           if (_globalSettings->getEmitResults() == EMIT_NONE)
             emitResult = false;
           else if (_globalSettings->getEmitResults() != EMIT_ALL)

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -186,6 +186,7 @@ void SimController::Start(SimSettings simsettings, string modelKey, string nls)
         global_settings->setOutputPointType(simsettings.outputPointType);
         global_settings->setOutputFormat(simsettings.outputFormat);
         global_settings->setEmitResults(simsettings.emitResults);
+        global_settings->setVariableFilter(simsettings.variableFilter);
         global_settings->setNonLinearSolverContinueOnError(simsettings.nonLinearSolverContinueOnError);
         global_settings->setSolverThreads(simsettings.solverThreads);
         global_settings->setInputPath(simsettings.inputPath);
@@ -287,6 +288,7 @@ void SimController::StartReduceDAE(SimSettings simsettings,string modelPath, str
         global_settings->setOutputPointType(simsettings.outputPointType);
         global_settings->setOutputFormat(simsettings.outputFormat);
         global_settings->setEmitResults(simsettings.emitResults);
+        global_settings->setVariableFilter(simsettings.variableFilter);
         global_settings->setNonLinearSolverContinueOnError(simsettings.nonLinearSolverContinueOnError);
         global_settings->setSolverThreads(simsettings.solverThreads);
         /*shared_ptr<SimManager>*/ _simMgr = shared_ptr<SimManager>(new SimManager(mixedsystem, _config.get()));
@@ -496,6 +498,7 @@ void SimController::initialize(SimSettings simsettings, string modelKey, double 
         global_settings->setOutputPointType(simsettings.outputPointType);
         global_settings->setOutputFormat(simsettings.outputFormat);
         global_settings->setEmitResults(simsettings.emitResults);
+        global_settings->setVariableFilter(simsettings.variableFilter);
         global_settings->setNonLinearSolverContinueOnError(simsettings.nonLinearSolverContinueOnError);
         global_settings->setSolverThreads(simsettings.solverThreads);
         /*shared_ptr<SimManager>*/ _simMgr = shared_ptr<SimManager>(new SimManager(mixedsystem, _config.get()));

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -13,6 +13,7 @@ GlobalSettings::GlobalSettings()
   , _endTime(1.0)
   , _hOutput(0.002)
   , _emitResults(EMIT_ALL)
+  , _variableFilter(".*")
   , _infoOutput(true)
   , _selected_solver("euler")
   , _selected_lin_solver("dgesvSolver")
@@ -102,6 +103,16 @@ EmitResults GlobalSettings::getEmitResults()
 void GlobalSettings::setEmitResults(EmitResults emitResults)
 {
   _emitResults = emitResults;
+}
+
+const string& GlobalSettings::getVariableFilter()
+{
+  return _variableFilter;
+}
+
+void GlobalSettings::setVariableFilter(const string& variableFilter)
+{
+  _variableFilter = variableFilter;
 }
 
 void GlobalSettings::setResultsFileName(string name)

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimController/ISimController.h
@@ -23,6 +23,7 @@ struct SimSettings
   int solverThreads;
   OutputFormat outputFormat;
   EmitResults emitResults;
+  string variableFilter;
   string inputPath;
   string outputPath;
 };

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/GlobalSettings.h
@@ -24,6 +24,8 @@ public:
   ///< Write out results (default: EMIT_ALL)
   virtual EmitResults getEmitResults();
   virtual void setEmitResults(EmitResults);
+  virtual const string& getVariableFilter();
+  virtual void setVariableFilter(const string&);
   ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false, true]; default: true)
   virtual bool getInfoOutput();
   virtual void setInfoOutput(bool);
@@ -71,6 +73,8 @@ private:
       _hOutput;     ///< Output step size (default: 20 ms)
   EmitResults
       _emitResults; ///< Write out results (default: EMIT_ALL)
+  string
+      _variableFilter;
   bool
       _infoOutput,  ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)
       _endless_sim,

--- a/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/Core/SimulationSettings/IGlobalSettings.h
@@ -67,6 +67,9 @@ public:
   ///< Write out results (default: EMIT_ALL)
   virtual EmitResults getEmitResults() = 0;
   virtual void setEmitResults(EmitResults) = 0;
+  ///< Write variables that match a name filter (default: .*)
+  virtual const string& getVariableFilter() = 0;
+  virtual void setVariableFilter(const string&) = 0;
   virtual OutputPointType getOutputPointType() = 0;
   virtual void setOutputPointType(OutputPointType) = 0;
   virtual LogSettings getLogSettings() = 0;

--- a/OMCompiler/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/FMU/FMUGlobalSettings.h
@@ -27,6 +27,8 @@ public:
     ///< Write out results (EMIT_NONE)
     virtual EmitResults getEmitResults() { return EMIT_NONE; }
     virtual void setEmitResults(EmitResults) {}
+    virtual const string& getVariableFilter() { return "";}
+    virtual void setVariableFilter(const string&) {}
     virtual bool useEndlessSim() {return true; }
     virtual void useEndlessSim(bool) {}
     ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)

--- a/OMCompiler/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Include/FMU2/FMU2GlobalSettings.h
@@ -59,6 +59,8 @@ class FMU2GlobalSettings : public IGlobalSettings
   ///< Write out results (EMIT_NONE)
   virtual EmitResults     getEmitResults() { return EMIT_NONE; }
   virtual void            setEmitResults(EmitResults) {}
+  virtual const string&   getVariableFilter() { return "";}
+  virtual void            setVariableFilter(const string&) {}
   virtual bool            useEndlessSim() {return true; }
   virtual void            useEndlessSim(bool) {}
   ///< Write out statistical simulation infos, e.g. number of steps (at the end of simulation); [false,true]; default: true)


### PR DESCRIPTION
This is particularly useful to reduce results file sizes for automated tests.
It will hopefully also solve issues with file size limits, see:
  https://github.com/OpenModelica/OpenModelicaLibraryTesting/issues/5

