### PR TITLE
CMake build the needed runtime libs as shared libs.

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -41,6 +41,14 @@ set(CXX_STANDARD_REQUIRED ON)
 ## Make sure we do not start relying on extensions down the road.
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+## Set position independent code project wide. We will take some performance hit from this.
+## However it allows us to build all static libs and combine them later to single shared libs
+## for easy configuration. Instead of having dozens of shared libs.
+## This can of course be turned of if we do not care about memory and are happy to sacrifice a
+## bunch of memory for some performance gain. If so disable this and change the few libraries
+## we build as shared to static (see SimulationRuntime/c, which contains the only shared libs to come).
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 #########################################################################################################
 ## Enable verbose Makefiles if you want to debug. (you can also instead use 'make VERBOSE=1')
 # set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -72,9 +72,14 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 omc_add_to_report(CMAKE_INSTALL_PREFIX)
 
-
 # We prefer to install libs to "<library architecture>/omc" dir inside lib directory (e.g lib/x86_64-linux-gnu/omc/).
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/omc/)
+
+## Set the adjusted installation lib directory as an rpath for all installed binaries.
+## This is useful for those binaries that end up in bin/ directory but not for
+## others as it is a relative path to the lib dir from <build_dir>/<some_dir>.
+## Maybe there is a better way to do this but it should suffice for now.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
 
 
 # Write out a compiler detection header. checkout the file <build_dir>/omc_compiler_detection.h to
@@ -87,13 +92,6 @@ write_compiler_detection_header(
   COMPILERS GNU Clang MSVC
   FEATURES cxx_static_assert
 )
-
-
-# Set the installation lib directory as an rpath for all installed
-# libs and executables.
-# Maybe there is a better way to do this but it should suffice for now.
-set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_LIBDIR})
-
 
 # Use ccache to speedup compilation!
 omc_option(OMC_USE_CCACHE "Use ccache to speedup compilations." ON)

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -270,9 +270,9 @@ else()
   set(MAKE ${CMAKE_MAKE_PROGRAM})
 
   string(REPLACE ";" " " LAPACK_LIBRARIES_SPACE "${LAPACK_LIBRARIES}")
-  set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC  -llapack -lblas   -lm -lomcgc -lpthread -rdynamic")
-  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC  -llapack -lblas   -lm -lomcgc -lpthread -rdynamic -Wl,--no-undefined")
-  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas   -lm -lpthread -rdynamic -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC  -llapack -lblas -lm -lomcgc -lpthread -rdynamic")
+  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOptimizationRuntime -lOpenModelicaRuntimeC -lomcmemory -llapack -lblas -lm -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -lOpenModelicaFMIRuntimeC -llapack -lblas -lm -lpthread -rdynamic -Wl,--no-undefined")
 
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.in ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo)
 endif()

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -29,7 +29,10 @@ file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/opt
 file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
 file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 
-
+## This should be set. The reason it is not now is because there is a cyclic dependency between
+## gc/ and meta/ sources which are part of two different libraries at the moment. Either fix the
+## code to remove the cyclic dependency or move meta/ sources out of libOpenModelicaRuntimeC and into libomcmemory
+# set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 
 # ######################################################################################################################
 # Library: omcmemory
@@ -37,7 +40,7 @@ file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 ## The reason it is separated is because its functionality is clearly defined and should not be part of
 ## a bunch of other libraries. For example there is no need to link to OpenModelicaRuntimeC just to get GC
 ## functionality in Compiler/runtime.
-add_library(omcmemory STATIC)
+add_library(omcmemory SHARED)
 add_library(omc::simrt::memory ALIAS omcmemory)
 
 target_sources(omcmemory PRIVATE ${OMC_SIMRT_GC_SOURCES})
@@ -48,7 +51,7 @@ install(TARGETS omcmemory)
 
 # ######################################################################################################################
 # Library: OpenModelicaRuntimeC
-add_library(OpenModelicaRuntimeC STATIC)
+add_library(OpenModelicaRuntimeC SHARED)
 add_library(omc::simrt::runtime ALIAS OpenModelicaRuntimeC)
 
 target_sources(OpenModelicaRuntimeC PRIVATE ${OMC_SIMRT_UTIL_SOURCES} ${OMC_SIMRT_META_SOURCES})
@@ -64,10 +67,15 @@ install(TARGETS OpenModelicaRuntimeC)
 
 # ######################################################################################################################
 # Library: OpenModelicaFMIRuntimeC
+## This library is built as a static library and contains everything needed to run an OpenModelica FMU.
+## Therefore it has to include the functionality from the other libraries.
+## It is not complete yet. I have to see what needs to go in here.
 add_library(OpenModelicaFMIRuntimeC STATIC)
 add_library(omc::simrt::fmiruntime ALIAS OpenModelicaFMIRuntimeC)
 
-target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES})
+target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES}
+                                               $<TARGET_OBJECTS:OpenModelicaRuntimeC>
+                                               $<TARGET_OBJECTS:omcmemory>)
 
 target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib)
 
@@ -75,25 +83,8 @@ install(TARGETS OpenModelicaFMIRuntimeC)
 
 
 # ######################################################################################################################
-# Library: OptimizationRuntime
-## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
-## However having it as a separate lib will allow us to remove it based on an option. This means we can
-## also remove the need for ipopt and mumps if this is disabled.
-add_library(OptimizationRuntime STATIC)
-add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
-
-target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
-
-target_link_libraries(OptimizationRuntime PUBLIC omc::config)
-target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::memory)
-target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
-
-install(TARGETS OptimizationRuntime)
-
-
-# ######################################################################################################################
 # Library: SimulationRuntimeC
-add_library(SimulationRuntimeC STATIC)
+add_library(SimulationRuntimeC SHARED)
 add_library(omc::simrt::simruntime ALIAS SimulationRuntimeC)
 
 target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES}
@@ -103,6 +94,7 @@ target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES}
 
 target_link_libraries(SimulationRuntimeC PUBLIC omc::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::memory)
+target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::runtime)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::FMIL::expat)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::cvode)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::idas)
@@ -123,6 +115,39 @@ target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
 target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
 
 install(TARGETS SimulationRuntimeC)
+
+
+# ######################################################################################################################
+# Library: OptimizationRuntime
+## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
+## However having it as a separate lib will allow us to remove it based on an option. This means we can
+## also remove the need for ipopt and mumps if this is disabled.
+add_library(OptimizationRuntime SHARED)
+add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
+
+target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
+
+target_link_libraries(OptimizationRuntime PUBLIC omc::config)
+target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::memory)
+target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::simruntime)
+target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
+
+
+install(TARGETS OptimizationRuntime)
+
+
+# ######################################################################################################################
+# Library: OpenModelicaSimulation
+## This is a shared library containing everything needed for simulation. This is not intended to be used by the
+## simulation executables. If something is needed for simulation executables add it here.
+# add_library(OpenModelicaSimulation SHARED $<TARGET_OBJECTS:SimulationRuntimeC>
+#                                           $<TARGET_OBJECTS:OpenModelicaRuntimeC>)
+# add_library(omc::simrt::simulation ALIAS OpenModelicaSimulation)
+
+# target_link_libraries(OpenModelicaSimulation PUBLIC
+#                       $<TARGET_PROPERTY:SimulationRuntimeC,INTERFACE_LINK_LIBRARIES>)
+
+# install(TARGETS OpenModelicaSimulation)
 
 
 # ######################################################################################################################


### PR DESCRIPTION
@mahge
[cmake] Set RPATH for <install_dir>/<some_dir> in mind. …
4214b44
  - This will set RPATH using $ORIGIN. As it is now the setting will work
    for any binary that ends up <install_dir>/<another_dir>. Binaries that
    are installed in different dir structure than this will not be able
    to find the omc installed libs.
    As it stands now this is not a problem for us since binaries will end
    up in either `<install_dir>/bin` (for exe and dll) or in
    `<install_dir>/lib/<arch_triple>/omc` (for .lib, .a or .so). Those
    in the lib dir will of course be able to find each other since they
    are in the same dir.

  - This should work just fine as it has been the approach we have been
    using with the autoconf build.

@mahge
[cmake] Set PIC project wide. The time has come. …
06860f1
  - Set position independent code project wide.

    We will take some performance hit from this. However it allows us to
    build all 3rdParty libs as static libs and combine them later into single
    shared libs for easy management. Probably better than having dozens of
    shared libs lying around.

  - This can of course be turned of if we do not care about memory and
    are happy to sacrifice a bunch of memory for some performance gain.
    If so disable this and change the few libraries we build as shared to
    static.

  - Right now the plan is to have 5 or maybe 6 shared libs. See the next
    commits for more info.

@mahge
[cmake] Build the needed runtime libs as shared. …
f621802
  - The shared libs that exist right now are:

  - `libomcmemory`: A lib for garbage collection and memory_pool related
    functionality. This is used by both OMC itself and simulation
    executables.

    There are two reasons why this is a separate shared lib.
    It is SEPARATE lib because it is has a clear purpose and its functionality
    is used all over the OpenModelica code. So it is nice to have a small
    library that can be linked everywhere.

    It is made a SHARED lib because we really do not want to link to static
    GC lib  functionality from two different DLLs as this will create two
    instances of the garbage collector. This will not work in anything
    multi-threaded if you are even a little unlucky since Boehm GC depends
    a lot on global variables.

    We really want to have only one instance of Boehm GC at all times
    if we can achieve that.

    The best debugging strategy is just initial paranoia and refusal to give
    any room for complications :)

  - `libOpenModelicaRuntime`: A lib for common runtime functionality
    (e.g the functionality in c/util or c/meta goes here). This (like
    `libomcmemory`) is used by both OMC itself and simulation executables.

  - `libSimulationRuntimeC`: Contains everything solver related including
    linearization and data reconciliation support. This the library needed
    for normal simulation executables generated by OMC.
    **Depends on**: `libOpenModelicaRuntimeC` and `libomcmemory`.

  - `libOpenModelicaOptimization`: A lib for optimization enabled simulation.
    will incorporate our optimization code as well as `ipopt` and `coinmumps.`
    **Depends on**: libSimulationRuntimeC.