### PR TITLE
Disable running tests on no PR events.

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -546,7 +546,7 @@ def shouldWeRunTests() {
     }
     return runTest
   }
-  return true
+  return false
 }
 
 def isPR() {


### PR DESCRIPTION
  - The main aim is to disable running tests on merges to master.

  - Merges to master are already tested on the PRs.

    Since we can not directly push to master there is no point in running
    the tests again as it just wastes time and resources. It also usually
    end up being cancelled by subsequent merges.

  - If there is a flow where some branches need to run tests even after
    merge we can change this to explicitly check for 'master'.

  - We can also remove the build on master completely if needed.
