### PR TITLE
Use #C9C9C9 for plot grid lines

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/PlotGrid.h
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotGrid.h
@@ -43,7 +43,7 @@ class PlotGrid : public QwtPlotGrid
 public:
   PlotGrid(Plot *pParent);
   ~PlotGrid();
-  QPen getMajorPen() {return QPen(QColor(242, 242, 242));} // #F2F2F2 light gray color. More lighter than Qt::lightGray
+  QPen getMajorPen() {return QPen(QColor(201, 201, 201));} // #C9C9C9 light gray color. More lighter than Qt::lightGray
   QPen getMinorPen() {return QPen(Qt::lightGray, 0.0, Qt::DotLine);}
   void setGrid();
   void setDetailedGrid();


### PR DESCRIPTION
### Related Issues

Fixes #7711

### Purpose

Use a better lighter color for gridlines.

### Approach

Use #C9C9C9 instead of #F2F2F2
