### PR TITLE
Limit tolerance for zero crossings in Cpp runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/Math/Functions.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Math/Functions.cpp
@@ -29,10 +29,6 @@ namespace bindings = boost::numeric::bindings;
 /* #define get_pivot_matrix_elt(A,r,c) get_matrix_elt(A,colInd[c],rowInd[r],n_cols) */
 #define swap(a,b) { int _swap=a; a=b; b=_swap; }
 
-#ifndef min
-#define min(a,b) ((a > b) ? (b) : (a))
-#endif
-
 double  division (const double &a,const double &b, bool throwEx,const char* text)
 {
   if(b != 0)

--- a/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
@@ -280,8 +280,9 @@ void DASSL::initialize()
   _rwork[2] = _settings->gethInit();
 
   // Adapt tolerances for zero crossings and end time to output interval
-  _event_system->setZeroTol(1e-6 * _settings->getGlobalSettings()->gethOutput());
-  _settings->setEndTimeTol(1e-6 * _settings->getGlobalSettings()->gethOutput());
+  double tol = min(1e-6, max(1e-6 * _settings->getGlobalSettings()->gethOutput(), DBL_EPSILON));
+  _event_system->setZeroTol(tol);
+  _settings->setEndTimeTol(tol);
 
   LOGGER_WRITE_END(LC_SOLVER, LL_DEBUG);
 }


### PR DESCRIPTION
The upper limit 1e-6 is the old and current default value
(formerly fix in CodegenCpp.tpl, now defined in SystemDefaultImplementation.cpp).

The lower limit DBL_EPSILON was justified with two examples:

`Modelica.Electrical.Analog.Examples.NandGate` fails without limit if the
output step size gets reduced to 4e-11 in daily tests (from model setting 2e-10).

A larger lower limit, like 10*DBL_EPSILON, would give a spike in
`Modelica.Electrical.Spice3.Examples.Inverter` (mp.S.v at 1e-13s).

Additionally remove a misplaced min define in `Core/Math/Functions.cpp`.
See `Core/Modelica.h` and `Core/Math/Constants.h`:
```
#undef min
using std::min;
```