### PR TITLE
Fix Cpp index of model variables for multidimensional arrays

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -7113,7 +7113,7 @@ end DefaultImplementationCode;
 */
 template getNominalStateValues(list<SimVar> stateVars,SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
-  let nominalVars = stateVars |> SIMVAR(__) hasindex i0 =>
+  let nominalVars = stateVars |> SIMVAR(index = i) =>
         match nominalValue
         case SOME(val)
         then
@@ -7121,13 +7121,13 @@ template getNominalStateValues(list<SimVar> stateVars,SimCode simCode, Text& ext
           let &varDecls = buffer "" /*BUFD*/
           let value = '<%daeExp(val, contextOther, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
           <<
-           <%varDecls%>
-           <%preExp%>
-           z[<%i0%>]=<%value%>;
+          <%varDecls%>
+          <%preExp%>
+          z[<%i%>] = <%value%>;
           >>
         else
           <<
-           z[<%i0%>] = 1.0;
+          z[<%i%>] = 1.0;
           >>
        ;separator="\n"
 <<

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -7252,7 +7252,7 @@ end DefaultImplementationCode;
 */
 template getNominalStateValues(list<SimVar> stateVars,SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
-  let nominalVars = stateVars |> SIMVAR(__) hasindex i0 =>
+  let nominalVars = stateVars |> SIMVAR(index = i) =>
         match nominalValue
         case SOME(val)
         then
@@ -7260,13 +7260,13 @@ template getNominalStateValues(list<SimVar> stateVars,SimCode simCode, Text& ext
           let &varDecls = buffer "" /*BUFD*/
           let value = '<%daeExp(val, contextOther, &preExp, &varDecls, simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace, stateDerVectorName, useFlatArrayNotation)%>'
           <<
-           <%varDecls%>
-           <%preExp%>
-           z[<%i0%>]=<%value%>;
+          <%varDecls%>
+          <%preExp%>
+          z[<%i%>] = <%value%>;
           >>
         else
           <<
-           z[<%i0%>] = 1.0;
+          z[<%i%>] = 1.0;
           >>
        ;separator="\n"
 <<

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -27,6 +27,7 @@ RefArrayDim2.mos \
 solveTest.mos \
 testArrayEquations.mos \
 testMatrixIO.mos \
+testMatrixState.mos \
 testVectorizedBlocks.mos \
 testVectorizedPowerSystem.mos \
 testVectorizedSolarSystem.mos \

--- a/testsuite/openmodelica/cppruntime/testMatrixState.mos
+++ b/testsuite/openmodelica/cppruntime/testMatrixState.mos
@@ -1,0 +1,60 @@
+// name: testMatrixState
+// keywords: array storage order
+// status: correct
+// teardown_command: rm -f *MatrixStateTest*
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadString("
+model MatrixStateTest
+  Real v(start = 1);
+  Real w(start = 2);
+  Real[2,2] x(start = [11, 12; 21, 22], nominal = [11, 12; 21, 22]);
+equation
+  der(v) = 1;
+  der(w) = 2;
+  der(x[1,1]) = 11;
+  der(x[1,2]) = 12;
+  der(x[2,1]) = 21;
+  der(x[2,2]) = 22;
+  annotation(experiment(StopTime = 1));
+end MatrixStateTest;
+");
+getErrorString();
+
+simulate(MatrixStateTest);
+val(v, 0);
+val(w, 0);
+val(x[1,1], 0);
+val(x[1,2], 0);
+val(x[2,1], 0);
+val(x[2,2], 0);
+val(v, 1);
+val(w, 1);
+val(x[1,1], 1);
+val(x[1,2], 1);
+val(x[2,1], 1);
+val(x[2,2], 1);
+
+// Result:
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "MatrixStateTest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'MatrixStateTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// 1.0
+// 2.0
+// 11.0
+// 12.0
+// 21.0
+// 22.0
+// 2.0
+// 4.0
+// 22.0
+// 24.0
+// 42.0
+// 44.0
+// endResult


### PR DESCRIPTION
This is important because states and derivatives are accessed through
lumped vectors z and zDot. Without this fix in particular the mapping
of results to variables for plotting or FMUs is wrong.
See e.g. discretized line models of PowerSystems library.

The fix is not needed for algebraic variables that are accessed through
their individual names -- but mind the recently introduced `__daeResidual`.
