### PR TITLE
Show the display unit in the diagram layer with the parameter value

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1498,6 +1498,34 @@ QString Element::getParameterDisplayString(QString parameterName)
 }
 
 /*!
+ * \brief Element::getParameterModifierValue
+ * Reads the component parameter modifier value.
+ * \param parameterName
+ * \param modifier
+ * \return
+ */
+QString Element::getParameterModifierValue(const QString &parameterName, const QString &modifier)
+{
+  /* How to get the parameter modifier value,
+   * 1. Check if the value is available in component modifier.
+   */
+  OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
+  QString className = mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure();
+  QString parameterAndModiferName = QString("%1.%2").arg(parameterName).arg(modifier);
+  QString modifierValue = "";
+  /* case 1 */
+  QMap<QString, QString> modifiers = mpElementInfo->getModifiersMap(pOMCProxy, className, this);
+  QMap<QString, QString>::iterator modifiersIterator;
+  for (modifiersIterator = modifiers.begin(); modifiersIterator != modifiers.end(); ++modifiersIterator) {
+    if (parameterAndModiferName.compare(modifiersIterator.key()) == 0) {
+      modifierValue = modifiersIterator.value();
+      break;
+    }
+  }
+  return StringHandler::removeFirstLastQuotes(modifierValue);
+}
+
+/*!
  * \brief Element::getDerivedClassModifierValue
  * Used to fetch the values of unit and displayUnit.
  * \param modifierName

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -268,6 +268,7 @@ public:
   void emitDeleted();
   void componentParameterHasChanged();
   QString getParameterDisplayString(QString parameterName);
+  QString getParameterModifierValue(const QString &parameterName, const QString &modifier);
   QString getDerivedClassModifierValue(QString modifierName);
   QString getInheritedDerivedClassModifierValue(Element *pElement, QString modifierName);
   void shapeAdded();

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -364,7 +364,7 @@ VariablesTreeModel::VariablesTreeModel(VariablesTreeView *pVariablesTreeView)
   mpVariablesTreeView = pVariablesTreeView;
   QVector<QVariant> headers;
   headers << "" << "" << Helper::variables << Helper::variables << "" << tr("Value") << tr("Unit") << tr("Display Unit") <<
-             QStringList() << Helper::description << "" << false << QVariantList() << QVariantList() << QVariantList() << "dummy.json";
+             QStringList() << Helper::description << "" << false << QVariantList() << QVariantList() << QVariantList() << "dummy.json" << false;
   mpRootVariablesTreeItem = new VariablesTreeItem(headers, 0, true);
   mpActiveVariablesTreeItem = 0;
 }

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -1270,6 +1270,8 @@ QString Utilities::convertUnitToSymbol(const QString displayUnit)
 {
   if (displayUnit.compare(QStringLiteral("Ohm")) == 0) {
     return QChar(937);
+  } else if (displayUnit.compare(QStringLiteral("degC")) == 0) {
+    return QString("%1C").arg(QChar(176));
   } else {
     return displayUnit;
   }


### PR DESCRIPTION
### Related Issues

Fixes #7765

### Purpose

Defined display unit should be shown with the parameter value.

### Approach

Read the display unit from the component modifiers.
