### PR TITLE
Fix typing of assignments

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2961,7 +2961,7 @@ algorithm
   st := match st
     local
       Expression cond, e1, e2, e3;
-      Type ty1, ty2, ty3;
+      Type ty1, ty2;
       list<Statement> sts1, body;
       list<tuple<Expression, list<Statement>>> tybrs;
       InstNode iterator;
@@ -2977,7 +2977,7 @@ algorithm
         (e2, ty2) := typeExp(st.rhs, InstContext.set(context, NFInstContext.RHS), info);
 
         // TODO: Should probably only be allowUnknown = true if in a function.
-        (e2, ty3, mk) := TypeCheck.matchTypes(ty2, ty1, e2, allowUnknown = true);
+        (e2, _, mk) := TypeCheck.matchTypes(ty2, ty1, e2, allowUnknown = true);
 
         if TypeCheck.isIncompatibleMatch(mk) then
           Error.addSourceMessage(Error.ASSIGN_TYPE_MISMATCH_ERROR,
@@ -2988,7 +2988,7 @@ algorithm
 
         checkAssignment(e1, e2, var, context, info);
       then
-        Statement.ASSIGNMENT(e1, e2, ty3, st.source);
+        Statement.ASSIGNMENT(e1, e2, ty1, st.source);
 
     case Statement.FOR()
       algorithm

--- a/testsuite/flattening/modelica/scodeinst/IfExpression11.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfExpression11.mo
@@ -1,0 +1,34 @@
+// name: IfExpression11
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+function f
+  input Integer n;
+  output Real x[2];
+algorithm
+  x := if n <> 2 then {1.0, 2.0, 3.0} else {1.0, 2.0};
+end f;
+
+model IfExpression11
+  Integer n;
+  Real x[2] = f(n);
+end IfExpression11;
+
+// Result:
+// function f
+//   input Integer n;
+//   output Real[2] x;
+// algorithm
+//   x := if n <> 2 then {1.0, 2.0, 3.0} else {1.0, 2.0};
+// end f;
+//
+// class IfExpression11
+//   Integer n;
+//   Real x[1];
+//   Real x[2];
+// equation
+//   x = f(n);
+// end IfExpression11;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -620,6 +620,7 @@ IfExpression5.mo \
 IfExpression7.mo \
 IfExpression8.mo \
 IfExpression10.mo \
+IfExpression11.mo \
 IfEquationInvalidCond1.mo \
 ih1.mo \
 ih2.mo \


### PR DESCRIPTION
- Use the lhs type as the type of an assignment instead of the
  compatible type of both sides, since the lhs is never type cast.