### PR TITLE
Divide the pixmap size with device pixel ratio for labels size

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -595,6 +595,7 @@ GroupBox::GroupBox(const QString &title, QWidget *parent)
   : QGroupBox(title, parent)
 {
   mpGroupImageLabel = new Label;
+  mpGroupImageLabel->setScaledContents(true);
   mpGridLayout = new QGridLayout;
   mpGridLayout->setObjectName(title);
   mpGridLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
@@ -613,6 +614,8 @@ void GroupBox::setGroupImage(QString groupImage)
 {
   if (QFile::exists(groupImage)) {
     QPixmap pixmap(groupImage);
+    mpGroupImageLabel->setMaximumWidth(pixmap.width() / qApp->devicePixelRatio());
+    mpGroupImageLabel->setMaximumHeight(pixmap.height() / qApp->devicePixelRatio());
     mpGroupImageLabel->setPixmap(pixmap);
   }
 }


### PR DESCRIPTION
### Related Issues

#7768

### Purpose

Handle big picture in parameters dialog.

### Approach

Calculate the layout size from the pixmap size and device pixel ratio.
Use QLabel::setScaledContents(true) to automatically scale the pixmap.
