### PR TITLE
Fix issue #7848

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -3551,6 +3551,7 @@ algorithm
       tuple<BackendDAE.Variables,AvlSetInt.Tree, Boolean> tpl;
       Boolean isInitial;
 
+    // inner variable
     case (DAE.CREF(componentRef = cr),(vars,pa,isInitial))
       equation
         cr = ComponentReference.makeCrefQual(BackendDAE.partialDerivativeNamePrefix, DAE.T_REAL_DEFAULT, {}, cr);
@@ -3558,6 +3559,7 @@ algorithm
         res = adjacencyRowExp1withInput(varslst,p,pa,0);
       then (inExp,false,(vars,res,isInitial));
 
+    // iteration var with start value
     case (DAE.CREF(componentRef=cr), (vars, pa, isInitial))
       equation
         (varslst, p) = BackendVariable.getVar(cr, vars);
@@ -3567,18 +3569,21 @@ algorithm
         res = adjacencyRowExp1withInput(varslst, p, res, 0);
       then (inExp, true, (vars, res, isInitial));
 
+    // iteration var without start value
     case (DAE.CREF(componentRef = cr),(vars,pa,isInitial))
       equation
         (varslst,p) = BackendVariable.getVar(cr, vars);
         res = adjacencyRowExp1withInput(varslst,p,pa,0);
       then (inExp, true, (vars, res, isInitial));
 
+    // state derivative (in backend)
     case (DAE.CALL(path = Absyn.IDENT(name = "der"),expLst = {DAE.CREF(componentRef = cr)}),(vars,pa,isInitial))
       equation
         (varslst,p) = BackendVariable.getVar(cr, vars);
         res = adjacencyRowExp1withInput(varslst,p,pa,1);
       then (inExp,false,(vars,res,isInitial));
 
+    // state derivative (in simcode)
     case (DAE.CALL(path = Absyn.IDENT(name = "der"),expLst = {DAE.CREF(componentRef = cr)}),(vars,pa,isInitial))
       equation
         cr = ComponentReference.crefPrefixDer(cr);
@@ -3586,6 +3591,7 @@ algorithm
         res = adjacencyRowExp1withInput(varslst,p,pa,1);
       then (inExp,false,(vars,res,isInitial));
 
+    // CLOCKED state
     case (DAE.CALL(path = Absyn.IDENT(name = "previous"),expLst = {DAE.CREF(componentRef = cr)}),(vars,pa,isInitial))
       equation
         cr = ComponentReference.makeCrefQual(DAE.previousNamePrefix, DAE.T_REAL_DEFAULT, {}, cr);

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -1384,7 +1384,7 @@ protected function dumpSparsePatternStatistics
 protected
   Integer maxDegree;
 algorithm
-  (_, maxDegree) := List.mapFold(sparsepatternT, findDegrees, 1);
+  (_, maxDegree) := List.mapFold(sparsepatternT, findDegrees, 0);
   print("analytical Jacobians[SPARSE] -> got sparse pattern nonZeroElements: "+ String(nonZeroElements) + " maxNodeDegree: " + String(maxDegree) + " time : " + String(clock()) + "\n");
 end dumpSparsePatternStatistics;
 

--- a/testsuite/openmodelica/cruntime/simoptions/nlssMinSize.mos
+++ b/testsuite/openmodelica/cruntime/simoptions/nlssMinSize.mos
@@ -20,6 +20,14 @@ simulate(M, simflags="-nlssMinSize=1"); getErrorString();
 //     resultFile = "M_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'M', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-nlssMinSize=1'",
 //     messages = "stdout            | info    | Minimum system size for using non-linear sparse solver changed to 1
+// stdout            | info    | Using sparse solver kinsol for nonlinear system 0,
+// |                 | |       | because density of 1.00 remains under threshold of 0.20 or size of 1 exceeds threshold of 1.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
+// stdout            | info    | Using sparse solver kinsol for nonlinear system 1,
+// |                 | |       | because density of 1.00 remains under threshold of 0.20 or size of 1 exceeds threshold of 1.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/libraries/msl32/Makefile
+++ b/testsuite/simulation/libraries/msl32/Makefile
@@ -93,7 +93,6 @@ Modelica.Electrical.MultiPhase.Examples.Rectifier.mos \
 Modelica.Electrical.MultiPhase.Examples.TestSensors.mos \
 Modelica.Electrical.MultiPhase.Examples.TransformerYD.mos \
 Modelica.Electrical.MultiPhase.Examples.TransformerYY.mos \
-Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench.mos \
 Modelica.Electrical.QuasiStationary.MultiPhase.Examples.BalancingDelta.mos \
 Modelica.Electrical.QuasiStationary.MultiPhase.Examples.BalancingStar.mos \
 Modelica.Electrical.QuasiStationary.SinglePhase.Examples.ParallelResonance.mos \
@@ -282,6 +281,7 @@ Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SMEE_Generator_MultiPha
 
 # Run make failingtest
 FAILINGTESTFILES = \
+Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/simulation/modelica/daemode/testDAEScaling.mos
+++ b/testsuite/simulation/modelica/daemode/testDAEScaling.mos
@@ -53,7 +53,11 @@ simulate(Test3, stopTime = 2, simflags="-noEquidistantTimeGrid");getErrorString(
 // record SimulationResult
 //     resultFile = "Test3_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'ida', fileNamePrefix = 'Test3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-noEquidistantTimeGrid'",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver kinsol for nonlinear system 0,
+// |                 | |       | because density of 0.01 remains under threshold of 0.20 or size of 199 exceeds threshold of 10001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/nonlinear_system/problem6_symjac.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/problem6_symjac.mos
@@ -29,7 +29,15 @@ val(x[100],{0.0});
 // record SimulationResult
 //     resultFile = "nonlinear_system.problem6_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'nonlinear_system.problem6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver kinsol for nonlinear system 0,
+// |                 | |       | because density of 0.03 remains under threshold of 0.20 or size of 98 exceeds threshold of 10001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
+// stdout            | info    | Using sparse solver kinsol for nonlinear system 1,
+// |                 | |       | because density of 0.03 remains under threshold of 0.20 or size of 98 exceeds threshold of 10001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/solver/problem1-symSolverImp.mos
+++ b/testsuite/simulation/modelica/solver/problem1-symSolverImp.mos
@@ -52,7 +52,11 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "testSolver.problem1_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 2e-06, numberOfIntervals = 1000, tolerance = 1e-06, method = 'symSolver', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver kinsol for nonlinear system 0,
+// |                 | |       | because density of 0.04 remains under threshold of 0.20 or size of 75 exceeds threshold of 10001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/solver/problem1-symSolverImpSsc.mos
+++ b/testsuite/simulation/modelica/solver/problem1-symSolverImpSsc.mos
@@ -52,7 +52,11 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "testSolver.problem1_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 2e-06, numberOfIntervals = 1000, tolerance = 1e-06, method = 'symSolverSsc', fileNamePrefix = 'testSolver.problem1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "stdout            | info    | Using sparse solver kinsol for nonlinear system 0,
+// |                 | |       | because density of 0.04 remains under threshold of 0.20 or size of 75 exceeds threshold of 10001.
+// |                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
+// |                 | |       | using the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
I don't even understand how this worked before.

The data about the nonlinear system was initialized after checking
for the sparse pattern, but at that time the sparse pattern was not
initialized yet so that case should have never occured. I swapped
the order of that so now it reports correctly to use a sparse solver.

Also the solver is now chosen after all systems have been looked at.
This avoids some segmentation faults that haven't been found before
by accident I guess.

This helps a handfull of models in the testsuite but also breaks one,
namely Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed
This fails for some other reason. TODO find and fix that other reason!