### PR TITLE
Fix segmentation fault when using KINSOL with LAPACK as linear solver.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -165,7 +165,7 @@ static void resetKinsolMemory(NLS_KINSOL_DATA *kinsolData,
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINInit");
 
   /* Create matrix object */
-  if (kinsolData->linearSolverMethod == NLS_LS_DEFAULT) {
+  if (kinsolData->linearSolverMethod == NLS_LS_DEFAULT || kinsolData->linearSolverMethod == NLS_LS_LAPACK) {
     kinsolData->J = SUNDenseMatrix(size, size);
   } else if (kinsolData->linearSolverMethod == NLS_LS_KLU) {
     kinsolData->nnz = nlsData->sparsePattern->numberOfNoneZeros;


### PR DESCRIPTION
Allocate memory for dense Jacobian when LAPACK is selected.

### Related Issues

#7848 

### Purpose

@phannebohm found a segmentation fault.

### Approach

Don't work on un-allocated memory....
