### PR TITLE
Fix expansion of unary minus and not

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -82,9 +82,9 @@ public
       case Expression.CALL()     then expandCall(exp.call, exp);
       case Expression.SIZE()     then expandSize(exp);
       case Expression.BINARY()   then expandBinary(exp, exp.operator);
-      case Expression.UNARY()    then expandUnary(exp.exp, exp.operator);
+      case Expression.UNARY()    then expandUnary(exp);
       case Expression.LBINARY()  then expandLogicalBinary(exp);
-      case Expression.LUNARY()   then expandLogicalUnary(exp.exp, exp.operator);
+      case Expression.LUNARY()   then expandLogicalUnary(exp);
       case Expression.RELATION() then (exp, true);
       case Expression.CAST()     then expandCast(exp.exp, exp.ty);
       else expandGeneric(exp);
@@ -870,18 +870,21 @@ public
 
   function expandUnary
     input Expression exp;
-    input Operator op;
     output Expression outExp;
     output Boolean expanded;
   protected
-    Operator scalar_op;
+    Expression operand;
+    Operator op, scalar_op;
   algorithm
-    (outExp, expanded) := expand(exp);
-    scalar_op := Operator.scalarize(op);
+    Expression.UNARY(op, operand) := exp;
+    (operand, expanded) := expand(operand);
 
     if expanded then
-      outExp := Expression.mapArrayElements(outExp,
+      scalar_op := Operator.scalarize(op);
+      outExp := Expression.mapArrayElements(operand,
         function SimplifyExp.simplifyUnaryOp(op = scalar_op));
+    else
+      outExp := exp;
     end if;
   end expandUnary;
 
@@ -928,17 +931,18 @@ public
 
   function expandLogicalUnary
     input Expression exp;
-    input Operator op;
     output Expression outExp;
     output Boolean expanded;
   protected
-    Operator scalar_op;
+    Expression operand;
+    Operator op, scalar_op;
   algorithm
-    (outExp, expanded) := expand(exp);
-    scalar_op := Operator.scalarize(op);
+    Expression.LUNARY(op, operand) := exp;
+    (operand, expanded) := expand(operand);
 
     if expanded then
-      outExp := Expression.mapArrayElements(outExp, function makeLogicalUnaryOp(op = scalar_op));
+      scalar_op := Operator.scalarize(op);
+      outExp := Expression.mapArrayElements(operand, function makeLogicalUnaryOp(op = scalar_op));
     else
       outExp := exp;
     end if;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -742,6 +742,7 @@ OperationDiv1.mo \
 OperationDivEW1.mo \
 OperationLogicalBinary1.mo \
 OperationLogicalUnary1.mo \
+OperationLogicalUnary2.mo \
 OperationMatrixProduct1.mo \
 OperationMatrixProduct2.mo \
 OperationMatrixProduct3.mo \
@@ -756,6 +757,7 @@ OperationSub1.mo \
 OperationSubEW1.mo \
 OperationSubEW2.mo \
 OperationUnary1.mo \
+OperationUnary2.mo \
 OperationVectorMatrixProduct1.mo \
 OperationVectorProduct1.mo \
 OperatorNonEncapsulated1.mo \

--- a/testsuite/flattening/modelica/scodeinst/OperationLogicalUnary2.mo
+++ b/testsuite/flattening/modelica/scodeinst/OperationLogicalUnary2.mo
@@ -1,0 +1,31 @@
+// name: OperationLogicalUnary2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+function f
+  input Boolean x[:, :];
+  output Boolean y[size(x, 2)];
+algorithm
+  y := not x[2, :];
+end f;
+
+model OperationLogicalUnary2
+  Boolean b[:] = f({{time > 0}});
+end OperationLogicalUnary2;
+
+// Result:
+// function f
+//   input Boolean[:, :] x;
+//   output Boolean[size(x, 2)] y;
+// algorithm
+//   y := not x[2,:];
+// end f;
+//
+// class OperationLogicalUnary2
+//   Boolean b[1];
+// equation
+//   b = f({{time > 0.0}});
+// end OperationLogicalUnary2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/OperationUnary2.mo
+++ b/testsuite/flattening/modelica/scodeinst/OperationUnary2.mo
@@ -1,0 +1,33 @@
+// name: OperationUnary2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+function f
+  input Real x[:, :];
+  output Real y[size(x, 2)];
+algorithm
+  y := -x[2, :];
+end f;
+
+model OperationUnary2
+  Real x[:] = f({{1, 2, 3}, {3, 4, time}});
+end OperationUnary2;
+
+// Result:
+// function f
+//   input Real[:, :] x;
+//   output Real[size(x, 2)] y;
+// algorithm
+//   y := -x[2,:];
+// end f;
+//
+// class OperationUnary2
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x = f({{1.0, 2.0, 3.0}, {3.0, 4.0, time}});
+// end OperationUnary2;
+// endResult


### PR DESCRIPTION
- Return the original unary expression if an expression couldn't be
  expanded, not just the operand.