### PR TITLE
Clean up and fix C++ cat_array

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
@@ -31,53 +31,45 @@ Concatenates n real arrays along the k:th dimension.
 template <typename T>
 void cat_array(int k, const vector<const BaseArray<T>*>& x, BaseArray<T>& a)
 {
-    unsigned int new_k_dim_size = 0;
-    unsigned int n = x.size();
-    /* check dim sizes of all inputs */
-    if(n<1)
-      throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"No input arrays");
+  unsigned int new_k_dim_size = 0;
+  unsigned int n = x.size();
+  /* check dim sizes of all inputs */
+  if (n < 1)
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "No input arrays");
 
-    if(x[0]->getDims().size() < k)
-     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Wrong dimension for input array");
+  if (x[0]->getNumDims() < k)
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong dimension for input array");
 
-    new_k_dim_size = x[0]->getDims()[k-1];
-    for(int i = 1; i < n; i++)
-    {
-        //arrays must have same number of dimensions
-		if(x[0]->getDims().size() != x[i]->getDims().size())
-           throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Wrong dimension for input array");
-        //Size matching: Arrays must have identical array sizes with the exception of the size of dimension k
-		for(int j = 0; j < (k - 1); j++)
-        {
-            if (x[0]->getDims()[j] != x[i]->getDims()[j])
-                throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Wrong size for input array");
-        }
+  new_k_dim_size = x[0]->getDim(k);
+  for (int i = 1; i < n; i++)
+  {
+    //arrays must have same number of dimensions
+		if (x[0]->getNumDims() != x[i]->getNumDims())
+      throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong dimension for input array");
+    //Size matching: Arrays must have identical array sizes with the exception of the size of dimension k
+		for (int j = 1; j < k; j++)
+      if (x[0]->getDim(j) != x[i]->getDim(j))
+        throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong size for input array");
 		//calculate new size of dimension k
-        new_k_dim_size += x[i]->getDims()[k-1];
-         //Size matching: Arrays must have identical array sizes with the exception of the size of dimension k
-		for(int j = k; j < x[0]->getDims().size(); j++)
-        {
-          if (x[0]->getDims()[j] != x[i]->getDims()[j])
-            throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Wrong size for input array");
-        }
-    }
-    /* calculate size of sub and super structure in 1-dim data representation */
-    unsigned int n_sub = 1;
-    unsigned int n_super = 1;
-    for (int i = 0; i < (k - 1); i++)
-    {
-        n_super *= x[0]->getDims()[i];
-    }
-    for (int i = k; i < x[0]->getDims().size(); i++)
-    {
-        n_sub *= x[0]->getDims()[i];
-    }
-    /* allocate output array */
-    vector<size_t> ex = x[0]->getDims();
-    ex[k-1] = new_k_dim_size;
-    if(ex.size()<k)
-     throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION,"Error resizing concatenate array");
-    a.setDims( ex );
+    new_k_dim_size += x[i]->getDim(k);
+    //Size matching: Arrays must have identical array sizes with the exception of the size of dimension k
+		for (int j = k + 1; j <= x[0]->getNumDims(); j++)
+      if (x[0]->getDim(j) != x[i]->getDim(j))
+        throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Wrong size for input array");
+  }
+  /* calculate size of sub and super structure in 1-dim data representation */
+  unsigned int n_sub = 1;
+  unsigned int n_super = 1;
+  for (int i = 1; i < k; i++)
+    n_super *= x[0]->getDim(i);
+  for (int i = k + 1; i <= x[0]->getNumDims(); i++)
+    n_sub *= x[0]->getDim(i);
+  /* allocate output array */
+  vector<size_t> ex = x[0]->getDims();
+  ex[k-1] = new_k_dim_size;
+  if (ex.size() < k)
+    throw ModelicaSimulationError(MODEL_ARRAY_FUNCTION, "Error resizing concatenate array");
+  a.setDims(ex);
 
   /* concatenation along k-th dimension */
   T* a_data = a.getData();
@@ -86,7 +78,7 @@ void cat_array(int k, const vector<const BaseArray<T>*>& x, BaseArray<T>& a)
   {
     for (int c = 0; c < n; c++)
     {
-      int n_sub_k = n_sub * x[c]->getDims()[k-1];
+      int n_sub_k = n_sub * x[c]->getDim(k);
       const T* x_data = x[c]->getData();
       for (int r = 0; r < n_sub_k; r++)
       {

--- a/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
@@ -74,17 +74,14 @@ void cat_array(int k, const vector<const BaseArray<T>*>& x, BaseArray<T>& a)
   /* concatenation along k-th dimension */
   T* a_data = a.getData();
   int j = 0;
-  for (int i = 0; i < n_super; i++)
+  for (int i = 0; i < n_sub; i++)
   {
     for (int c = 0; c < n; c++)
     {
-      int n_sub_k = n_sub * x[c]->getDim(k);
-      const T* x_data = x[c]->getData();
-      for (int r = 0; r < n_sub_k; r++)
-      {
-        a_data[j] = x_data[r + (i * n_sub_k)];
-        j++;
-      }
+      int n_super_k = n_super * x[c]->getDim(k);
+      const T* x_data = x[c]->getData() + i * n_super_k;
+      std::copy(x_data, x_data + n_super_k, a_data + j);
+      j += n_super_k;
     }
   }
 }

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -6,6 +6,7 @@ WhenInitialTerminal.mos \
 WhenStatement1.mos \
 WhenTuple.mos \
 BouncingBall.mos \
+arrayCatTest.mos \
 arrayOperationsTest.mos \
 arraySliceTest.mos \
 clockedAlgloopTest.mos \

--- a/testsuite/openmodelica/cppruntime/arrayCatTest.mos
+++ b/testsuite/openmodelica/cppruntime/arrayCatTest.mos
@@ -1,0 +1,74 @@
+// name: arrayCatTest
+// keywords: array cat
+// status: correct
+// teardown_command: rm -f *ArrayCat.Test*
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadString("
+package ArrayCat
+model Test
+  Real[:,:] A = [11, 12; 21, 22];
+  Real[:,:] B = [31, 32];
+  Real[:,:] C = [13; 23];
+  Real[:,:] AB = cat1(A, B);
+  Real[:,:] AC = cat2(A, C);
+  annotation(experiment(StopTime = 0));
+end Test;
+function cat1
+  input Real[:,:] A;
+  input Real[:,:] B;
+  output Real[size(A,1) + size(B,1), size(A,2)] AB;
+algorithm
+  AB := cat(1, A, B);
+end cat1;
+function cat2
+  input Real[:,:] A;
+  input Real[:,:] C;
+  output Real[size(A,1), size(A,2) + size(C,2)] AC;
+algorithm
+  AC := cat(2, A, C);
+end cat2;
+end ArrayCat;
+");
+getErrorString();
+
+simulate(ArrayCat.Test);
+getErrorString();
+
+val(AB[1,1], 0);
+val(AB[1,2], 0);
+val(AB[2,1], 0);
+val(AB[2,2], 0);
+val(AB[3,1], 0);
+val(AB[3,2], 0);
+val(AC[1,1], 0);
+val(AC[1,2], 0);
+val(AC[1,3], 0);
+val(AC[2,1], 0);
+val(AC[2,2], 0);
+val(AC[2,3], 0);
+
+// Result:
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ArrayCat.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ArrayCat.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// ""
+// 11.0
+// 12.0
+// 21.0
+// 22.0
+// 31.0
+// 32.0
+// 11.0
+// 12.0
+// 13.0
+// 21.0
+// 22.0
+// 23.0
+// endResult


### PR DESCRIPTION
Spaces, avoid unnecessary temporary vectors created by BaseArray::getDims()
- replace getDims()[k-1] with getDim(k)
- replace getDims().size() with getNumDims()

The fix: it looks like the previous implementation had been made for row major storage order.

See ModelicaTest.Math.TestVectors
```
r = -nan
ERROR  : init  : SimManager: Could not initialize system
ERROR  : init  : SimManager: "Polynomials.roots()" failed
```