### PR TITLE
Use the hide result value from model_init.xml file

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -922,7 +922,8 @@ bool VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
       variableData << variantDefinedIn;
       variableData << infoFileName;
       bool variableExistsInResultFile = true;
-      if (readingVariablesFromInitFile && !variableListFromResultFile.contains(variableToFind)) {
+      QHash<QString, QString> variableHash = mScalarVariablesHash.value(variableToFind);
+      if (readingVariablesFromInitFile && (!variableListFromResultFile.contains(variableToFind) || variableHash.value("hideResult").compare(QStringLiteral("true")) == 0)) {
         variableExistsInResultFile = false;
       }
       variableData << variableExistsInResultFile;
@@ -1115,6 +1116,7 @@ QHash<QString, QString> VariablesTreeModel::parseScalarVariable(QXmlStreamReader
   scalarVariable["description"] = attributes.value("description").toString();
   scalarVariable["isValueChangeable"] = attributes.value("isValueChangeable").toString();
   scalarVariable["variability"] = attributes.value("variability").toString();
+  scalarVariable["hideResult"] = attributes.value("hideResult").toString();
   /* Read the next element i.e Real, Integer, Boolean etc. */
   xmlReader.readNext();
   while (!(xmlReader.tokenType() == QXmlStreamReader::EndElement && xmlReader.name() == "ScalarVariable")) {


### PR DESCRIPTION
### Related Issues

Fixes partially #4346

### Purpose

Hide the result of protected variables or variables with `HideResult` annotation.

### Approach

Read and use the hide result value from model_init.xml file.
