### PR TITLE
Omit listing of $cse and $TMP variables in OMEdit for Cpp runtime

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -572,7 +572,7 @@ void VariablesTreeModel::parseInitXml(QXmlStreamReader &xmlReader, QStringList* 
       /* If it's named ScalarVariable, we'll dig the information from there.*/
       if (xmlReader.name() == "ScalarVariable") {
         QHash<QString, QString> scalarVariable = parseScalarVariable(xmlReader);
-        if (!scalarVariable.value("name").startsWith("$")) {
+        if (!scalarVariable.value("name").startsWith("$") && !scalarVariable.value("name").startsWith("_D_")) {
           mScalarVariablesHash.insert(scalarVariable.value("name"),scalarVariable);
           if (addVariablesToList) {
             variablesList->append(scalarVariable.value("name"));


### PR DESCRIPTION
See Variables browser in Plot view.
The Cpp runtime follows the FMI convention of converting $ chars to _D_.
