### PR TITLE
[BE] follow up for PR #7853

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -4163,10 +4163,14 @@ protected function traverseStmts "Author: Frenkel TUD 2012-06
   end FuncExpType;
   replaceable type Type_a subtypeof Any;
   function removeSubscripts
+    "kabdelhak: remove left hand side subscripts
+     (Modelica Specification v3.5 : 11.1.2)
+     Fix: Do not do if it is a scalar variable with all constant subscripts.
+          It leads to a massive number of hash table accesses for big tensors."
     input output DAE.Exp exp;
   algorithm
     exp := match exp
-      case DAE.CREF() algorithm
+      case DAE.CREF() guard(not ComponentReference.crefIsScalarWithAllConstSubs(exp.componentRef)) algorithm
         exp.componentRef := ComponentReference.crefStripSubsExceptModelSubs(exp.componentRef);
       then exp;
       else exp;


### PR DESCRIPTION
### Related Issues
 - refers to ticket #7832
 - fixes FFT model regressions from previous PR #7853

### Purpose
 - Problem: removing all subscripts on LHS in algorithms lead to many hash table accesses for big tensors (n^2 where n is number of tensor elements)

### Approach
 - Solution: only do it for non constant subscripts
