### PR TITLE
Add test for numerical overflow to stopping criterion of C++ Newton

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
@@ -298,7 +298,7 @@ void Newton::solve( )
         // check for sufficient decrease
         // (also break for very small lambda and try a small step instead
         //  -- avoid "sufficient decrease" errors, still have iteration limit)
-        if (phiHelp <= (1.0 - alpha * lambda) * phi || lambda < alpha)
+        if (phiHelp <= (1.0 - alpha * lambda) * phi || (lambda < alpha && isfinite(phiHelp)))
           break;
       }
       // take iterate


### PR DESCRIPTION
This fixes a change introduced with commit e9f86ba1ce85f3717aac37619053a01e42997502
(Make Cpp Newton solver more robust).
