### PR TITLE
Do not show a checkbox to plot a protected array

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
@@ -78,6 +78,7 @@ public:
   void setVariability(QString variability) {mVariability = variability;}
   bool isParameter() const {return mVariability.compare("parameter") == 0;}
   bool isMainArray() const {return mIsMainArray;}
+  bool isMainArrayProtected() const;
   SimulationOptions getSimulationOptions() {return mSimulationOptions;}
   void setSimulationOptions(SimulationOptions simulationOptions) {mSimulationOptions = simulationOptions;}
   bool isActive() const {return mActive;}


### PR DESCRIPTION
### Related Issues

Fixes #7880

### Purpose

User should not be able to plot protected array variable.

### Approach

Hide the checkbox next to the protected array variable.
