### PR TITLE
Fix DynamicSelect for nfAPI

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -1907,7 +1907,6 @@ algorithm
     case "realClock" then evalRealClock(args);
     case "booleanClock" then evalBooleanClock(args);
     case "solverClock" then evalSolverClock(args);
-    case "DynamicSelect" then evalBuiltinDynamicSelect(fn, args, target);
     else
       algorithm
         Error.addInternalError(getInstanceName() + ": unimplemented case for " +
@@ -3050,23 +3049,6 @@ algorithm
     else algorithm printWrongArgsError(getInstanceName(), args, sourceInfo()); then fail();
   end match;
 end evalSolverClock;
-
-function evalBuiltinDynamicSelect
-  input Function fn;
-  input list<Expression> args;
-  input EvalTarget target;
-  output Expression result;
-protected
-  Expression s, d;
-algorithm
-  {s, d} := list(Expression.unbox(arg) for arg in args);
-  s := evalExp(s, target);
-  if Flags.isSet(Flags.NF_API_DYNAMIC_SELECT) then
-    result := Expression.CALL(Call.makeTypedCall(fn, {s, d}, Variability.CONTINUOUS, Purity.IMPURE, Expression.typeOf(s)));
-  else
-    result := s;
-  end if;
-end evalBuiltinDynamicSelect;
 
 function evalArrayConstructor
   input Expression callExp;

--- a/testsuite/openmodelica/interactive-API/Ticket6167.mos
+++ b/testsuite/openmodelica/interactive-API/Ticket6167.mos
@@ -1,7 +1,6 @@
 // name: Ticket6167.mos
 // keywords:
 // status: correct
-// cflags: -d=-newInst
 //
 // Tests if -nfAPI doesn't output DynamicSelect
 //
@@ -20,6 +19,6 @@ getIconAnnotation(Modelica.Fluid.Vessels.OpenTank); getErrorString();
 // ""
 // {-100.0,-100.0,100.0,100.0,true,-,-,, {Line(true, {0.0, 0.0}, 0.0, {{0.0, 50.0}, {0.0, 0.0}}, {0, 0, 0}, LinePattern.Solid, 0.25, {Arrow.None, Arrow.None}, 3.0, Smooth.None), Rectangle(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {0, 0, 0}, LinePattern.Solid, FillPattern.Solid, 0.25, BorderPattern.None, {{-20.0, 60.0}, {20.0, 50.0}}, 0.0), Polygon(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {255, 255, 255}, LinePattern.Solid, FillPattern.Solid, 0.25, {{-100.0, 50.0}, {100.0, -50.0}, {100.0, 50.0}, {0.0, 0.0}, {-100.0, -50.0}, {-100.0, 50.0}}, Smooth.None), Polygon(true, {0.0, 0.0}, 0.0, {255, 255, 255}, {0, 255, 0}, LinePattern.Solid, FillPattern.Solid, 0.25, {{-100.0, 0.0}, {100.0, 0.0}, {100.0, 0.0}, {0.0, 0.0}, {-100.0, 0.0}, {-100.0, 0.0}}, Smooth.None), Polygon(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {0, 0, 0}, LinePattern.Solid, FillPattern.None, 0.25, {{-100.0, 50.0}, {100.0, -50.0}, {100.0, 50.0}, {0.0, 0.0}, {-100.0, -50.0}, {-100.0, 50.0}}, Smooth.None)}}
 // ""
-// {-100.0,-100.0,100.0,100.0,true,0.2,-,, {Rectangle(true, {0.0, 0.0}, 0.0, {255, 255, 255}, {255, 255, 255}, LinePattern.Solid, FillPattern.VerticalCylinder, 0.25, BorderPattern.None, {{-100.0, 100.0}, {100.0, -100.0}}, 0.0), Rectangle(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {85, 170, 255}, LinePattern.Solid, FillPattern.VerticalCylinder, 0.25, BorderPattern.None, {{-100.0, -100.0}, {100.0, 10.0}}, 0.0), Line(true, {0.0, 0.0}, 0.0, {{-100.0, 100.0}, {-100.0, -100.0}, {100.0, -100.0}, {100.0, 100.0}}, {0, 0, 0}, LinePattern.Solid, 0.25, {Arrow.None, Arrow.None}, 3.0, Smooth.None), Text(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {0, 0, 0}, LinePattern.Solid, FillPattern.None, 0.25, {{-95.0, 60.0}, {95.0, 40.0}}, "level =", 0.0, {-1, -1, -1}, "", {}, TextAlignment.Center), Text(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {0, 0, 0}, LinePattern.Solid, FillPattern.None, 0.25, {{-95.0, -24.0}, {95.0, -44.0}}, "%level_start", 0.0, {-1, -1, -1}, "", {}, TextAlignment.Center)}}
+// {-100.0,-100.0,100.0,100.0,true,0.2,-,, {Rectangle(true, {0.0, 0.0}, 0.0, {255, 255, 255}, {255, 255, 255}, LinePattern.Solid, FillPattern.VerticalCylinder, 0.25, BorderPattern.None, {{-100.0, 100.0}, {100.0, -100.0}}, 0.0), Rectangle(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {85, 170, 255}, LinePattern.Solid, FillPattern.VerticalCylinder, 0.25, BorderPattern.None, {{-100.0, -100.0}, {100.0, 10.0}}, 0.0), Line(true, {0.0, 0.0}, 0.0, {{-100.0, 100.0}, {-100.0, -100.0}, {100.0, -100.0}, {100.0, 100.0}}, {0, 0, 0}, LinePattern.Solid, 0.25, {Arrow.None, Arrow.None}, 3.0, Smooth.None), Text(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {0, 0, 0}, LinePattern.Solid, FillPattern.None, 0.25, {{-95.0, 60.0}, {95.0, 40.0}}, "level =", 0.0, {-1, -1, -1}, "", {}, TextAlignment.Center), Text(true, {0.0, 0.0}, 0.0, {0, 0, 0}, {0, 0, 0}, LinePattern.Solid, FillPattern.None, 0.25, {{-95.0, -24.0}, {95.0, -44.0}}, {"%level_start", level, 2}, 0.0, {-1, -1, -1}, "", {}, TextAlignment.Center)}}
 // ""
 // endResult


### PR DESCRIPTION
- Remove constant evaluation of DynamicSelect, since DynamicSelect is
  impure anyway and should never be constant evaluated.
- Implement the same simplification rules for DynamicSelect that the OF
  uses:
    DynamicSelect("%y", String(y, significantDigits = 3)) => {"%y", y, 3}
    DynamicSelect(true, y) => {true, y}
    DynamicSelect(arg, ...) => arg

Fixes #5631