### PR TITLE
Speed up OMCProxy::getMessagesStringInternal

### DIFF
--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -543,9 +543,16 @@ bool OMCProxy::printMessagesStringInternal()
   */
 int OMCProxy::getMessagesStringInternal()
 {
-  sendCommand("errors:=getMessagesStringInternal()");
-  sendCommand("size(errors,1)");
-  return getResult().toInt();
+  // getMessagesStringInternal() is quite slow, check if there are any messages first.
+  sendCommand("countMessages()");
+
+  if (getResult() != "(0,0,0)") {
+    sendCommand("errors:=getMessagesStringInternal()");
+    sendCommand("size(errors,1)");
+    return getResult().toInt();
+  }
+
+  return 0;
 }
 
 /*!


### PR DESCRIPTION
### Related Issues

#6189

### Purpose

`OMCProxy::getMessagesStringInternal` calls
```Modelica
sendCommand("errors:=getMessagesStringInternal()");
sendCommand("size(errors,1)");
```
to fetch any messages that occurred after an operation, which takes 6-7 milliseconds on my machine. That might not sound like a lot of time, but when opening e.g. `CoolingCoilHumidifyingHeating_ClosedLoop` from `Buildings` it calls it ~600 times, which adds up to several seconds.

### Approach

Instead of always trying to fetch the messages this fix uses `countMessages()` to checks if there are actually any messages to fetch before trying to fetch them. Before the fix it took about 7.5s to open `CoolingCoilHumidifyingHeating_ClosedLoop` for me, with the fix it takes about 4.6s.
