### PR TITLE
Propagate overall simulation tolerance to C++ Newton solver and limit DASSL tolerance

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimController.cpp
@@ -172,6 +172,7 @@ void SimController::Start(SimSettings simsettings, string modelKey, string nls)
         global_settings->setStartTime(simsettings.start_time);
         global_settings->setEndTime(simsettings.end_time);
         global_settings->sethOutput(simsettings.step_size);
+        global_settings->setTolerance(simsettings.tolerance);
         global_settings->setResultsFileName(simsettings.outputfile_name);
         global_settings->setSelectedLinSolver(simsettings.linear_solver_name);
         global_settings->setSelectedNonLinSolver(nls);
@@ -273,6 +274,7 @@ void SimController::StartReduceDAE(SimSettings simsettings,string modelPath, str
         global_settings->setStartTime(simsettings.start_time);
         global_settings->setEndTime(simsettings.end_time);
         global_settings->sethOutput(simsettings.step_size);
+        global_settings->setTolerance(simsettings.tolerance);
         global_settings->setResultsFileName(simsettings.outputfile_name);
         global_settings->setSelectedLinSolver(simsettings.linear_solver_name);
         global_settings->setSelectedNonLinSolver(simsettings.nonlinear_solver_name);

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.cpp
@@ -12,6 +12,7 @@ GlobalSettings::GlobalSettings()
   : _startTime(0.0)
   , _endTime(1.0)
   , _hOutput(0.002)
+  , _tolerance(1e-6)
   , _emitResults(EMIT_ALL)
   , _variableFilter(".*")
   , _infoOutput(true)
@@ -62,6 +63,16 @@ double GlobalSettings::gethOutput()
 void GlobalSettings::sethOutput(double h)
 {
   _hOutput = h;
+}
+
+void GlobalSettings::setTolerance(double value)
+{
+  _tolerance = value;
+}
+
+double GlobalSettings::getTolerance()
+{
+  return _tolerance;
 }
 
 bool GlobalSettings::useEndlessSim()

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/GlobalSettings.h
@@ -21,6 +21,9 @@ public:
   ///< Output step size (default: 20 ms)
   virtual double gethOutput();
   virtual void sethOutput(double);
+  ///< Allowed tolerance
+  virtual void setTolerance(double);
+  virtual double getTolerance();
   ///< Write out results (default: EMIT_ALL)
   virtual EmitResults getEmitResults();
   virtual void setEmitResults(EmitResults);
@@ -70,7 +73,8 @@ private:
   double
       _startTime,   ///< Start time of integration (default: 0.0)
       _endTime,     ///< End time of integraiton (default: 1.0)
-      _hOutput;     ///< Output step size (default: 20 ms)
+      _hOutput,     ///< Output step size (default: 20 ms)
+      _tolerance;   ///< Global tolerance setting
   EmitResults
       _emitResults; ///< Write out results (default: EMIT_ALL)
   string

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/IGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/IGlobalSettings.h
@@ -64,6 +64,9 @@ public:
   ///< Output step size (default: 20 ms)
   virtual double gethOutput() = 0;
   virtual void sethOutput(double) = 0;
+  ///< Allowed tolerance
+  virtual void setTolerance(double) = 0;
+  virtual double getTolerance() = 0;
   ///< Write out results (default: EMIT_ALL)
   virtual EmitResults getEmitResults() = 0;
   virtual void setEmitResults(EmitResults) = 0;

--- a/OMCompiler/SimulationRuntime/cpp/Core/Solver/INonLinSolverSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Solver/INonLinSolverSettings.h
@@ -27,5 +27,17 @@ public:
   virtual void load(string) = 0;
   virtual void setContinueOnError(bool) = 0;
   virtual bool getContinueOnError() = 0;
+
+  /// Global simulation settings
+  virtual void setGlobalSettings(IGlobalSettings *settings)
+  {
+    _globalSettings = settings;
+  }
+  virtual IGlobalSettings* getGlobalSettings()
+  {
+    return _globalSettings;
+  }
+protected:
+  IGlobalSettings *_globalSettings = NULL;
 };
  /** @} */ // end of coreSolver

--- a/OMCompiler/SimulationRuntime/cpp/Core/System/AlgLoopSolverFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/System/AlgLoopSolverFactory.cpp
@@ -44,6 +44,7 @@ shared_ptr<INonLinearAlgLoopSolver> AlgLoopSolverFactory::createNonLinearAlgLoop
   {
     string nonlinsolver_name = _global_settings->getSelectedNonLinSolver();
     shared_ptr<INonLinSolverSettings> algsolversetting = createNonLinSolverSettings(nonlinsolver_name);
+    algsolversetting->setGlobalSettings(_global_settings);
     algsolversetting->setContinueOnError(_global_settings->getNonLinearSolverContinueOnError());
     _algsolversettings.push_back(algsolversetting);
 

--- a/OMCompiler/SimulationRuntime/cpp/FMU/FMUGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/FMU/FMUGlobalSettings.h
@@ -24,6 +24,9 @@ public:
     ///< Output step size (default: 20 ms)
     virtual double gethOutput() { return 20; }
     virtual void sethOutput(double) {}
+    ///< Allowed tolerance
+    virtual double getTolerance() { return 1e-6; }
+    virtual void setTolerance(double) {}
     ///< Write out results (EMIT_NONE)
     virtual EmitResults getEmitResults() { return EMIT_NONE; }
     virtual void setEmitResults(EmitResults) {}

--- a/OMCompiler/SimulationRuntime/cpp/FMU2/FMU2GlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/FMU2/FMU2GlobalSettings.h
@@ -56,6 +56,9 @@ class FMU2GlobalSettings : public IGlobalSettings
   ///< Output step size (default: 20 ms)
   virtual double          gethOutput() { return 20; }
   virtual void            sethOutput(double) {}
+  ///< Allowed tolerance
+  virtual double          getTolerance() { return 1e-6; }
+  virtual void            setTolerance(double) {}
   ///< Write out results (EMIT_NONE)
   virtual EmitResults     getEmitResults() { return EMIT_NONE; }
   virtual void            setEmitResults(EmitResults) {}

--- a/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.cpp
@@ -246,8 +246,8 @@ void DASSL::initialize()
   _atol[0] = _rtol[0] = 1.0; // in case of dummy state
   _continuous_system->getNominalStates(_atol);
   for (int i = 0; i < _dimSys; i++) {
-    _atol[i] *= _settings->getATol();
-    _rtol[i] = _settings->getRTol();
+    _atol[i] = max(_atol[i] * _settings->getATol(), 1e-10);
+    _rtol[i] = max(_settings->getRTol(), 1e-10);
   }
   LOGGER_WRITE_VECTOR("atol", _atol, _dimSys, LC_SOLVER, LL_DEBUG);
   LOGGER_WRITE_VECTOR("rtol", _rtol, _dimSys, LC_SOLVER, LL_DEBUG);

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Newton/NewtonSettings.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Newton/NewtonSettings.cpp
@@ -69,6 +69,13 @@ void NewtonSettings::load(string)
 {
 }
 
+void NewtonSettings::setGlobalSettings(IGlobalSettings *settings)
+{
+   _globalSettings = settings;
+   _dAtol = max(settings->getTolerance() * 1e-2, 1e-12);
+   _dRtol = _dAtol;
+}
+
 void NewtonSettings::setContinueOnError(bool value)
 {
   _continueOnError = value;

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Newton/NewtonSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Newton/NewtonSettings.h
@@ -26,6 +26,7 @@ class NewtonSettings :public INonLinSolverSettings
   virtual void        setDelta(double);
   virtual void load(string);
 
+  virtual void setGlobalSettings(IGlobalSettings *);
   virtual void setContinueOnError(bool);
   virtual bool getContinueOnError();
  private:

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed.mos
@@ -9,7 +9,7 @@
 
 runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
-modelTestingType := OpenModelicaModelTesting.Kind.SimpleSimulation;
+modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed);
 compareVars :=
 {
@@ -30,12 +30,13 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// OpenModelicaModelTesting.Kind.SimpleSimulation
+// OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed
 // {"opAmp.v_in","opAmp.q_fr1","opAmp.q_fr2","opAmp.q_fr3","opAmp.q_fp1","opAmp.v_source","opAmp.x"}
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 0.003, numberOfIntervals = 2500, tolerance = 2e-07, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed', options = '', outputFormat = 'mat', variableFilter = 'time|opAmp.v_in|opAmp.q_fr1|opAmp.q_fr2|opAmp.q_fr3|opAmp.q_fp1|opAmp.v_source|opAmp.x', cflags = '', simflags = ' -emit_protected'
 // Result file: Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed_res.mat
+// Files Equal!
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Analog.Examples.SimpleTriacCircuit.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Electrical.Analog.Examples.SimpleTriacCircuit.mos
@@ -9,7 +9,7 @@
 
 runScript("../common/ModelTestingDefaults.mos"); getErrorString();
 
-modelTestingType := OpenModelicaModelTesting.Kind.Compilation;
+modelTestingType := OpenModelicaModelTesting.Kind.VerifiedSimulation;
 modelName := $TypeName(Modelica.Electrical.Analog.Examples.SimpleTriacCircuit);
 compareVars :=
 {
@@ -26,11 +26,13 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// OpenModelicaModelTesting.Kind.Compilation
+// OpenModelicaModelTesting.Kind.VerifiedSimulation
 // Modelica.Electrical.Analog.Examples.SimpleTriacCircuit
 // {"L.i","simpleTriac.thyristor.vControl","simpleTriac.thyristor1.vControl"}
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
-// Compilation succeeded
+// Simulation options: startTime = 0.0, stopTime = 0.001, numberOfIntervals = 2000, tolerance = 1e-12, method = 'dassl', fileNamePrefix = 'Modelica.Electrical.Analog.Examples.SimpleTriacCircuit', options = '', outputFormat = 'mat', variableFilter = 'time|L.i|simpleTriac.thyristor.vControl|simpleTriac.thyristor1.vControl', cflags = '', simflags = ' -emit_protected'
+// Result file: Modelica.Electrical.Analog.Examples.SimpleTriacCircuit_res.mat
+// Files Equal!
 // "true
 // "
 // ""


### PR DESCRIPTION
First, propagate overall simulation tolerance to C++ global settings.

Then adapt tolerance of C++ Newton (see Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed).
Do this via the interface INonLinSolverSettings for now, to avoid a modification of all nonlinear solvers.
This could be changed to a constructor argument later on, cf. ISolverSettings.

Moreover, limit tolerance of DASSL to 1e-10 (see Modelica.Electrical.Analog.Examples.SimpleTriacCircuit).
