### PR TITLE
Apply Cramer's rule to 1x1 and 2x2 systems in C++ runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Solver/Dgesv/DgesvSolver.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Dgesv/DgesvSolver.cpp
@@ -198,7 +198,18 @@ void DgesvSolver::solve()
   for (int i = 0; i < _dimSys; i++)
     _b[i] /= _fNominal[i];
 
-  if (!_hasDgesvFactors && !_hasDgetc2Factors) {
+  double det;
+  if (_dimSys == 1 && (det = _A[0]) != 0.0) {
+    _b[0] /= det;
+    info = 0;
+  }
+  else if (_dimSys == 2 && (det = _A[0]*_A[3] - _A[1]*_A[2]) != 0.0) {
+    double b0 = (_b[0]*_A[3] - _b[1]*_A[2]) / det;
+    _b[1] = (_A[0]*_b[1] - _A[1]*_b[0]) / det;
+    _b[0] = b0;
+    info = 0;
+  }
+  else if (!_hasDgesvFactors && !_hasDgetc2Factors) {
     dgesv_(&_dimSys, &dimRHS, _A, &_dimSys, _iHelp, _b, &_dimSys, &info);
     _hasDgesvFactors = true;
   }

--- a/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/Newton/Newton.cpp
@@ -179,8 +179,23 @@ void Newton::solve( )
         phi += _f[i] * _f[i];
       }
 
-      // Solve linear system
-      dgesv_(&_dimSys, &dimRHS, _jac, &_dimSys, _iHelp, _f, &_dimSys, &info);
+      double det;
+      if (_dimSys == 1 && abs(det = _jac[0]) > 1e-10) {
+        det = _jac[0];
+        _f[0] /= det;
+        info = 0;
+      }
+      else if (_dimSys == 2 && abs(det = _jac[0]*_jac[3] - _jac[1]*_jac[2]) > 1e-10) {
+        det = _jac[0]*_jac[3] - _jac[1]*_jac[2];
+        double f0 = (_f[0]*_jac[3] - _f[1]*_jac[2]) / det;
+        _f[1] = (_jac[0]*_f[1] - _jac[1]*_f[0]) / det;
+        _f[0] = f0;
+        info = 0;
+      }
+      else {
+        // Solve linear system
+        dgesv_(&_dimSys, &dimRHS, _jac, &_dimSys, _iHelp, _f, &_dimSys, &info);
+      }
 
       if (info > 0) {
         long int info2 = 0;


### PR DESCRIPTION
Unfortunately OpenModelica generates many of those.
See e.g. issue #7815 (omc emits trivial algebraic loops).
