### PR TITLE
[wip] Check if nonlinear system is too sparse

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -396,6 +396,11 @@ int initializeNonlinearSystems(DATA *data, threadData_t *threadData)
 
       if(nnz/(double)(size*size)<=nonlinearSparseSolverMaxDensity || size >= nonlinearSparseSolverMinSize)
       {
+        if(nnz < size)
+        {
+          infoStreamPrint(LOG_STDOUT, 0, "nonlinear system %d has too low density, only %d nnz with size %d", i, nnz, size);
+          assertStreamPrint(threadData, nnz >= size, "system singular?");
+        }
         data->simulationInfo->nlsMethod = NLS_KINSOL;
         infoStreamPrint(LOG_STDOUT, 0, "Using sparse solver kinsol for nonlinear system %d,\nbecause density of %.2f remains under threshold of %.2f or size of %d exceeds threshold of %d.\nThe maximum density and the minimal system size for using sparse solvers can be specified\nusing the runtime flags '<-nlsMaxDensity=value>' and '<-nlsMinSize=value>'.", i, nnz/(double)(size*size), nonlinearSparseSolverMaxDensity, size, nonlinearSparseSolverMinSize);
       }


### PR DESCRIPTION
If the density of a strong component is too low (i.e. nnz < size)
then the system can only be singular since there is at leas one
row with only zeros. Either the sparse pattern has errors or the
system doens't make sense.

### Purpose

I saw this in [one of the most recent regression reports](https://libraries.openmodelica.org/branches/master/ScalableTestSuite_noopt/files/ScalableTestSuite_noopt_ScalableTestSuite.Electrical.DistributionSystemAC.ScaledExperiments.DistributionSystemLinear_N_40_M_40.sim):
```
startTime=0
stopTime=1
tolerance=1e-06
numberOfIntervals=1000
stepSize=0.001
Regular simulation: ./ScalableTestSuite_noopt_ScalableTestSuite.Electrical.DistributionSystemAC.ScaledExperiments.DistributionSystemLinear_N_40_M_40 -abortSlowSimulation -alarm=300   -emit_protected -lv LOG_STATS
stdout            | info    | Using sparse solver for linear system 0,
|                 | |       | because density of 0.000 remains under threshold of 0.200 or size of 12957 exceeds threshold of 201.
|                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
|                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
stdout            | info    | Using sparse solver for linear system 1,
|                 | |       | because density of 0.000 remains under threshold of 0.200 or size of 12957 exceeds threshold of 201.
|                 | |       | The maximum density and the minimal system size for using sparse solvers can be specified
|                 | |       | using the runtime flags '<-lssMaxDensity=value>' and '<-lssMinSize=value>'.
LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
```
The density seems to be zero, i.e. no nonzero elements in the Jacobian. That seems dubious.