### PR TITLE
CMake improvements

### DIFF
--- a/OMCompiler/SimulationRuntime/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 omc_add_subdirectory(c)
 omc_add_subdirectory(fmi)
+omc_add_subdirectory(cpp)
 # omc_add_subdirectory(opc)
 # omc_add_subdirectory(ParModelica)
 #ADD_SUBDIRECTORY(cpp)

--- a/OMCompiler/SimulationRuntime/cpp/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/CMakeLists.txt
@@ -34,6 +34,10 @@
 #
 # The used defines are stored in the SYSTEM_CFLAGS variable, which is passed to the ModelicaConfig.inc and written in the PrecompiledHeader.cmake
 
+if(OPENMODELICA_NEW_CMAKE_BUILD)
+  include(cmake_3.14.cmake)
+else(OPENMODELICA_NEW_CMAKE_BUILD)
+
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.9)
 
 IF(UNIX)
@@ -520,7 +524,7 @@ MESSAGE(STATUS ${LAPACK_LIBRARIES})
 
 MESSAGE(STATUS "use reduce dae method: ${REDUCE_DAE} - "  )
 IF(REDUCE_DAE)
- MESSAGE(STATUS "using reduce dae method") 
+ MESSAGE(STATUS "using reduce dae method")
  ADD_DEFINITIONS("-DUSE_REDUCE_DAE")
  SET(OMCCAPI_INLCUDE_HOME  omcCAPI/include/)
  SET(OMCCAPI_LIBRARY_RELEASE_HOME   Build_CAPI/)
@@ -1126,3 +1130,6 @@ if(UNIX AND Boost_INCLUDE_DIR STREQUAL "/usr/include")
   # symlink boost includes outside platform specific /usr/include
   install(CODE "execute_process(COMMAND ln -sf /usr/include/boost \"${CMAKE_INSTALL_PREFIX}/include/omc/cpp/\")")
 endif(UNIX AND Boost_INCLUDE_DIR STREQUAL "/usr/include")
+
+
+endif(OPENMODELICA_NEW_CMAKE_BUILD)

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -1,4 +1,45 @@
 
+macro(target_public_headers TARGET)
+    set_target_properties(${TARGET} PROPERTIES PUBLIC_HEADER "${ARGN}")
+endmacro()
+
+set(SCOREP_INCLUDE_ ".")
+set(Boost_INCLUDE_ ".")
+set(SYSTEM_CFLAGS ${SYSTEM_CFLAGS} "-DOMC_BUILD -fPIC")
+
+configure_file(Modelica/ModelicaLibraryConfig_gcc.inc.in ${CMAKE_CURRENT_BINARY_DIR}/ModelicaLibraryConfig_gcc.inc)
+configure_file(Modelica/ModelicaConfig_gcc.inc.in ${CMAKE_CURRENT_BINARY_DIR}/ModelicaConfig_gcc.inc)
+
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/ModelicaLibraryConfig_gcc.inc
+               ${CMAKE_CURRENT_BINARY_DIR}/ModelicaConfig_gcc.inc
+         TYPE INCLUDE)
+
+
+
+
+#####################################################################################################
+# OMCppDataExchange
+set(OMC_SIMRT_CPP_CORE_DATAEXCHANGE_SOURCES DataExchange/SimData.cpp
+                                            DataExchange/FactoryExport.cpp
+                                            DataExchange/XmlPropertyReader.cpp)
+
+add_library(OMCppDataExchange SHARED)
+add_library(omc::simrt::cpp::core::dataexchange ALIAS OMCppDataExchange)
+
+target_sources(OMCppDataExchange PRIVATE ${OMC_SIMRT_CPP_CORE_DATAEXCHANGE_SOURCES})
+
+target_link_libraries(OMCppDataExchange PUBLIC omc::simrt::cpp::config)
+
+target_link_options(OMCppDataExchange PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppDataExchange)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN DataExchange/*.h
+)
+
 
 #####################################################################################################
 # OMCppModelica
@@ -15,6 +56,15 @@ target_link_options(OMCppModelica PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppModelica)
 
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN Modelica.h
+        PATTERN ModelicaDefine.h
+        PATTERN DataExchange/Policies/TextfileWriter.h
+        PATTERN DataExchange/Policies/MatfileWriter.h
+        PATTERN DataExchange/Policies/BufferReaderWriter.h
+)
 
 #####################################################################################################
 # OMCppMath
@@ -32,6 +82,12 @@ target_link_libraries(OMCppMath PUBLIC omc::simrt::cpp::config)
 target_link_options(OMCppMath PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppMath)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN Math/*.h
+)
 
 
 #####################################################################################################
@@ -54,3 +110,149 @@ target_link_libraries(OMCppSolver PUBLIC omc::simrt::cpp::core::math)
 target_link_options(OMCppSolver PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppSolver)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN Solver/*.h
+)
+
+
+#####################################################################################################
+# OMCppExtensionUtilities
+set(OMC_SIMRT_CPP_CORE_UTILS_EXTENSIONS_SOURCES Utils/extension/measure_time.cpp
+                                     Utils/extension/measure_time_statistic.cpp
+                                     Utils/extension/measure_time_rdtsc.cpp
+                                     Utils/extension/measure_time_scorep.cpp
+                                     Utils/extension/logger.cpp)
+
+add_library(OMCppExtensionUtilities SHARED)
+add_library(omc::simrt::cpp::core::utils::extension ALIAS OMCppExtensionUtilities)
+
+target_sources(OMCppExtensionUtilities PRIVATE ${OMC_SIMRT_CPP_CORE_UTILS_EXTENSIONS_SOURCES})
+
+target_link_libraries(OMCppExtensionUtilities PUBLIC omc::simrt::cpp::config)
+
+target_link_options(OMCppExtensionUtilities PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppExtensionUtilities)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN Utils/extension/*.hpp
+        PATTERN Utils/extension/impl/*.hpp
+)
+
+
+#####################################################################################################
+# OMCppModelicaUtilities
+set(OMC_SIMRT_CPP_CORE_UTILS_MODELICA_SOURCES Utils/Modelica/ModelicaUtilities.cpp
+                                              Utils/Modelica/ModelicaSimulationError.cpp)
+
+add_library(OMCppModelicaUtilities SHARED)
+add_library(omc::simrt::cpp::core::utils::modelica ALIAS OMCppModelicaUtilities)
+
+target_sources(OMCppModelicaUtilities PRIVATE ${OMC_SIMRT_CPP_CORE_UTILS_MODELICA_SOURCES})
+
+target_link_libraries(OMCppModelicaUtilities PUBLIC omc::simrt::cpp::config)
+
+target_link_options(OMCppModelicaUtilities PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppModelicaUtilities)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN Utils/Modelica/ModelicaSimulationError.h
+)
+
+#####################################################################################################
+# OMCppSimController
+set(OMC_SIMRT_CPP_CORE_SIMCONTROLLER_SOURCES SimController/Configuration.cpp
+                                             SimController/FactoryExport.cpp
+                                             SimController/Initialization.cpp
+                                             SimController/SimController.cpp
+                                             SimController/SimManager.cpp
+                                             SimController/SimObjects.cpp)
+
+add_library(OMCppSimController SHARED)
+add_library(omc::simrt::cpp::core::system ALIAS OMCppSimController)
+
+target_sources(OMCppSimController PRIVATE ${OMC_SIMRT_CPP_CORE_SIMCONTROLLER_SOURCES})
+
+target_link_libraries(OMCppSimController PUBLIC omc::simrt::cpp::config)
+target_link_libraries(OMCppSimController PUBLIC omc::simrt::cpp::simcorefactory::omcfactory)
+target_link_libraries(OMCppSimController PUBLIC omc::simrt::cpp::core::utils::modelica)
+target_link_libraries(OMCppSimController PUBLIC Boost::filesystem)
+
+target_link_options(OMCppSimController PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppSimController)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN SimController/*.h
+)
+
+
+#####################################################################################################
+find_package(Boost COMPONENTS filesystem)
+
+# OMCppSimulationSettings
+set(OMC_SIMRT_CPP_CORE_SIM_SETTINGS_SOURCES SimulationSettings/GlobalSettings.cpp
+                                            SimulationSettings/Factory.cpp
+                                            SimulationSettings/FactoryExport.cpp)
+
+add_library(OMCppSimulationSettings SHARED)
+add_library(omc::simrt::cpp::core::simsettings ALIAS OMCppSimulationSettings)
+
+target_sources(OMCppSimulationSettings PRIVATE ${OMC_SIMRT_CPP_CORE_SIM_SETTINGS_SOURCES})
+
+target_link_libraries(OMCppSimulationSettings PUBLIC omc::simrt::cpp::config)
+target_link_libraries(OMCppSimulationSettings PUBLIC omc::simrt::cpp::simcorefactory::omcfactory)
+target_link_libraries(OMCppSimulationSettings PUBLIC Boost::filesystem)
+
+target_link_options(OMCppSimulationSettings PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppSimulationSettings)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN SimulationSettings/IGlobalSettings.h
+        PATTERN SimulationSettings/ISettingsFactory.h
+)
+
+
+#####################################################################################################
+# OMCppSystem
+set(OMC_SIMRT_CPP_CORE_SYSTEM_SOURCES System/LinearAlgLoopDefaultImplementation.cpp
+                                      System/NonLinearAlgLoopDefaultImplementation.cpp
+                                      System/AlgLoopSolverFactory.cpp
+                                      System/EventHandling.cpp
+                                      System/DiscreteEvents.cpp
+                                      System/ContinuousEvents.cpp
+                                      System/SystemDefaultImplementation.cpp
+                                      System/SimVars.cpp
+                                      System/FactoryExport.cpp)
+
+add_library(OMCppSystem SHARED)
+add_library(omc::simrt::cpp::core::system ALIAS OMCppSystem)
+
+target_sources(OMCppSystem PRIVATE ${OMC_SIMRT_CPP_CORE_SYSTEM_SOURCES})
+
+target_link_libraries(OMCppSystem PUBLIC omc::simrt::cpp::config)
+target_link_libraries(OMCppSystem PUBLIC omc::simrt::cpp::simcorefactory::omcfactory)
+target_link_libraries(OMCppSystem PUBLIC Boost::filesystem)
+
+target_link_options(OMCppSystem PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppSystem)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN System/*.h
+)

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -1,0 +1,56 @@
+
+
+#####################################################################################################
+# OMCppModelica
+set(OMC_SIMRT_CPP_CORE_MODELICA_SOURCES Modelica/Modelica.cpp)
+
+add_library(OMCppModelica SHARED)
+add_library(omc::simrt::cpp::core::modelica ALIAS OMCppModelica)
+
+target_sources(OMCppModelica PRIVATE ${OMC_SIMRT_CPP_CORE_MODELICA_SOURCES})
+
+target_link_libraries(OMCppModelica PUBLIC omc::simrt::cpp::config)
+
+target_link_options(OMCppModelica PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppModelica)
+
+
+#####################################################################################################
+# OMCppMath
+set(OMC_SIMRT_CPP_CORE_MATH_SOURCES Math/ArrayOperations.cpp
+                                    Math/Functions.cpp
+                                    Math/FactoryExport.cpp)
+
+add_library(OMCppMath SHARED)
+add_library(omc::simrt::cpp::core::math ALIAS OMCppMath)
+
+target_sources(OMCppMath PRIVATE ${OMC_SIMRT_CPP_CORE_MATH_SOURCES})
+
+target_link_libraries(OMCppMath PUBLIC omc::simrt::cpp::config)
+
+target_link_options(OMCppMath PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppMath)
+
+
+#####################################################################################################
+# OMCppSolver
+set(OMC_SIMRT_CPP_CORE_SOLVER_SOURCES Solver/SolverDefaultImplementation.cpp
+                                      Solver/AlgLoopSolverDefaultImplementation.cpp
+                                      Solver/SolverSettings.cpp
+                                      Solver/SystemStateSelection.cpp
+                                      Solver/FactoryExport.cpp
+                                      Solver/SimulationMonitor.cpp)
+
+add_library(OMCppSolver SHARED)
+add_library(omc::simrt::cpp::core::solver ALIAS OMCppSolver)
+
+target_sources(OMCppSolver PRIVATE ${OMC_SIMRT_CPP_CORE_SOLVER_SOURCES})
+
+target_link_libraries(OMCppSolver PUBLIC omc::simrt::cpp::config)
+target_link_libraries(OMCppSolver PUBLIC omc::simrt::cpp::core::math)
+
+target_link_options(OMCppSolver PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppSolver)

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
@@ -1,0 +1,33 @@
+
+
+#####################################################################################################
+# OMCppOMCFactory
+find_package(Boost COMPONENTS program_options filesystem)
+find_package(Threads)
+
+
+set(OMC_SIMRT_CPP_SIMCOREFACTORY_OMCFACTORY_SOURCES OMCFactory/OMCFactory.cpp)
+
+add_library(OMCppOMCFactory SHARED)
+add_library(omc::simrt::cpp::simcorefactory::omcfactory ALIAS OMCppOMCFactory)
+
+target_sources(OMCppOMCFactory PRIVATE ${OMC_SIMRT_CPP_SIMCOREFACTORY_OMCFACTORY_SOURCES})
+
+target_link_libraries(OMCppOMCFactory PUBLIC omc::simrt::cpp::config)
+target_link_libraries(OMCppOMCFactory PUBLIC omc::simrt::cpp::core::utils::extension)
+target_link_libraries(OMCppOMCFactory PUBLIC Boost::program_options)
+target_link_libraries(OMCppOMCFactory PUBLIC Boost::filesystem)
+target_link_libraries(OMCppOMCFactory PUBLIC Threads::Threads)
+target_link_libraries(OMCppOMCFactory PUBLIC ${CMAKE_DL_LIBS})
+
+target_link_options(OMCppOMCFactory PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppOMCFactory)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN Policies/FactoryConfig.h
+        PATTERN OMCFactory/OMCFactory.h
+)
+

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
@@ -1,0 +1,63 @@
+
+
+
+#####################################################################################################
+# OMCppCVode
+set(OMC_SIMRT_CPP_SOLVER_CVODE_SOURCES CVode/CVode.cpp
+                                       CVode/CVodeSettings.cpp
+                                       CVode/FactoryExport.cpp)
+
+add_library(OMCppCVode SHARED)
+add_library(omc::simrt::cpp::solver::cvode ALIAS OMCppCVode)
+
+target_sources(OMCppCVode PRIVATE ${OMC_SIMRT_CPP_SOLVER_CVODE_SOURCES})
+
+target_link_libraries(OMCppCVode PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppCVode PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppCVode PRIVATE omc::3rd::sundials::cvode)
+
+target_link_options(OMCppCVode PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppCVode)
+
+
+#####################################################################################################
+# OMCppKinsol
+set(OMC_SIMRT_CPP_SOLVER_KINSOL_SOURCES Kinsol/Kinsol.cpp
+                                        Kinsol/KinsolLapack.cpp
+                                        Kinsol/KinsolSettings.cpp
+                                        Kinsol/FactoryExport.cpp)
+
+add_library(OMCppKinsol SHARED)
+add_library(omc::simrt::cpp::solver::kinsol ALIAS OMCppKinsol)
+
+target_sources(OMCppKinsol PRIVATE ${OMC_SIMRT_CPP_SOLVER_KINSOL_SOURCES})
+
+target_link_libraries(OMCppKinsol PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppKinsol PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppKinsol PRIVATE omc::3rd::sundials::kinsol)
+target_link_libraries(OMCppKinsol PRIVATE ${LAPACK_LIBRARIES})
+
+target_link_options(OMCppKinsol PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppKinsol)
+
+
+#####################################################################################################
+# OMCppLinearSolver
+set(OMC_SIMRT_CPP_SOLVER_LINEAR_SOLVER_SOURCES LinearSolver/LinearSolver.cpp
+                                               LinearSolver/LinearSolverSettings.cpp
+                                               LinearSolver/FactoryExport.cpp)
+
+add_library(OMCppLinearSolver SHARED)
+add_library(omc::simrt::cpp::solver::linsolver ALIAS OMCppLinearSolver)
+
+target_sources(OMCppLinearSolver PRIVATE ${OMC_SIMRT_CPP_SOLVER_LINEAR_SOLVER_SOURCES})
+
+target_link_libraries(OMCppLinearSolver PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppLinearSolver PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppLinearSolver PRIVATE ${LAPACK_LIBRARIES})
+
+target_link_options(OMCppLinearSolver PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppLinearSolver)

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -3,8 +3,19 @@ project(SimRT_CPP)
 
 add_definitions(-DOMC_BUILD)
 
-configure_file (${CMAKE_CURRENT_SOURCE_DIR}/LibrariesConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h )
+# CPP libs should be installed to in lib/<arch>/omc/cpp/ for now.
+set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/cpp)
+# CPP headers are installed in include/omc/cpp for now.
+set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/omc/cpp)
 
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LibrariesConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h
+        TYPE INCLUDE)
+
+
+# An interface library for providing common include directories for all the CPP libs.
 add_library(OMCppConfig INTERFACE)
 add_library(omc::simrt::cpp::config ALIAS OMCppConfig)
 
@@ -12,5 +23,14 @@ target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
 
+
+# Subdirectories
+add_subdirectory(SimCoreFactory)
 add_subdirectory(Core)
 add_subdirectory(Solver)
+
+
+# This folder contains only one file right now. Something should be done about it.
+install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Include/
+         TYPE INCLUDE)
+

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -1,0 +1,16 @@
+
+project(SimRT_CPP)
+
+add_definitions(-DOMC_BUILD)
+
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/LibrariesConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h )
+
+add_library(OMCppConfig INTERFACE)
+add_library(omc::simrt::cpp::config ALIAS OMCppConfig)
+
+target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
+
+add_subdirectory(Core)
+add_subdirectory(Solver)


### PR DESCRIPTION
@mahge
[cmake] Initial config support for CPP runtime. 
f9f3d13
  - Libraries handled so far
      - libOMCppModelica
      - libOMCppMath
      - libOMCppSolver
      - libOMCppCVode
      - libOMCppKinsol
      - libOMCppLinearSolver

@mahge
[cmake] Improve config support for CPP runtime. 
c143ed1
  - Added libraries
    - libOMCppDataExchange.so
    - libOMCppExtensionUtilities.so
    - libOMCppModelicaUtilities.so
    - libOMCppOMCFactory.so
    - libOMCppSimController.so
    - libOMCppSimulationSettings.so
    - libOMCppSystem.so

  - Improve installation of headers.

  - Fix some config variables.
    - There are many more to fix. They will be added based on test
      failures as I can not be sure what they all means right now.