### PR TITLE
Remove "using namespace std" in OMEdit header

### DIFF
--- a/OMEdit/OMEditLIB/Debugger/GDB/GDBAdapter.cpp
+++ b/OMEdit/OMEditLIB/Debugger/GDB/GDBAdapter.cpp
@@ -1011,17 +1011,13 @@ void GDBAdapter::processGDBMIResponse(QString response)
     }
     delete pGDBMIResponse;
   } else {
-    list<string> parserErrorsList = getParserErrorsList();
-    list<string>::iterator parserErrorsListIterator;
-    for (parserErrorsListIterator = parserErrorsList.begin(); parserErrorsListIterator != parserErrorsList.end(); ++parserErrorsListIterator) {
-      qCritical() << (*parserErrorsListIterator).c_str();
+    for (auto &e: getParserErrorsList()) {
+      qCritical() << e.c_str();
     }
     clearParserErrorsList();
   }
-  list<string> lexerErrorsList = getLexerErrorsList();
-  list<string>::iterator lexerErrorsListIterator;
-  for (lexerErrorsListIterator = lexerErrorsList.begin(); lexerErrorsListIterator != lexerErrorsList.end(); ++lexerErrorsListIterator) {
-    qCritical() << (*lexerErrorsListIterator).c_str();
+  for (auto &e: getLexerErrorsList()) {
+    qCritical() << e.c_str();
   }
   clearLexerErrorsList();
 }
@@ -1051,7 +1047,7 @@ void GDBAdapter::processGDBMIResultRecord(GDBMIResultRecord *pGDBMIResultRecord)
   if (pGDBMIResultRecord->token == -1) {
     /* handle stopped response */
     if (pGDBMIResultRecord->cls.compare("stopped") == 0) {
-      string reason = "";
+      std::string reason;
       GDBMIResultList::iterator it;
       for (it = pGDBMIResultRecord->miResultsList.begin(); it != pGDBMIResultRecord->miResultsList.end(); ++it) {
         GDBMIResult *pGDBMIResult = *it;
@@ -1205,7 +1201,7 @@ bool GDBAdapter::skipSteppedInFrames(GDBMIResultRecord *pGDBMIResultRecord)
  * \param reason
  * \param pGDBMIResultRecord
  */
-void GDBAdapter::handleStoppedEvent(string reason, GDBMIResultRecord *pGDBMIResultRecord)
+void GDBAdapter::handleStoppedEvent(std::string reason, GDBMIResultRecord *pGDBMIResultRecord)
 {
   // call changeStdStreamBuffer no matter for what reason we have stopped
   if (!isChangeStdStreamBuffer() && !(reason.compare("\"exited-normally\"") == 0 || reason.compare("\"exited\""))) {

--- a/OMEdit/OMEditLIB/Debugger/GDB/GDBAdapter.h
+++ b/OMEdit/OMEditLIB/Debugger/GDB/GDBAdapter.h
@@ -209,7 +209,7 @@ private:
   void handleGDBMIConsoleStream(GDBMIStreamRecord *pGDBMIStreamRecord);
   void handleGDBMILogStream(GDBMIStreamRecord *pGDBMIStreamRecord);
   bool skipSteppedInFrames(GDBMIResultRecord *pGDBMIResultRecord);
-  void handleStoppedEvent(string reason, GDBMIResultRecord *pGDBMIResultRecord);
+  void handleStoppedEvent(std::string reason, GDBMIResultRecord *pGDBMIResultRecord);
   void handleBreakpointHit(GDBMIResultRecord *pGDBMIResultRecord);
   void handleSteppingRange(GDBMIResultRecord *pGDBMIResultRecord);
   void handleFunctionFinished(GDBMIResultRecord *pGDBMIResultRecord);

--- a/OMEdit/OMEditLIB/Debugger/Parser/GDBMIOutput.g
+++ b/OMEdit/OMEditLIB/Debugger/Parser/GDBMIOutput.g
@@ -112,18 +112,18 @@ async_output returns [GDBMIResultRecord* miResultRecord]
     (COMMA result {miResultRecord->miResultsList.push_back($result.miResult);})* NL?
   ;
 
-var returns [string txt]
+var returns [std::string txt]
   @init {
-    string txt;
+    std::string txt;
   }
   : STRING {
       txt = (char*)$STRING.text->chars;
     }
   ;
 
-constant returns [string txt]
+constant returns [std::string txt]
   @init {
-    string txt;
+    std::string txt;
   }
   : C_STRING {
       txt = (char*)$C_STRING.text->chars;

--- a/OMEdit/OMEditLIB/Debugger/Parser/GDBMIParser.cpp
+++ b/OMEdit/OMEditLIB/Debugger/Parser/GDBMIParser.cpp
@@ -144,7 +144,7 @@ GDBMIResponse::~GDBMIResponse()
   if (miResultRecord) delete miResultRecord;
 }
 
-static list<string> lexerErrorsList;
+static std::list<std::string> lexerErrorsList;
 static void handleLexerError(pANTLR3_BASE_RECOGNIZER recognizer, pANTLR3_UINT8 * tokenNames)
 {
   pANTLR3_LEXER lexer;
@@ -183,7 +183,7 @@ static void handleLexerError(pANTLR3_BASE_RECOGNIZER recognizer, pANTLR3_UINT8 *
   }
 }
 
-static list<string> parserErrorsList;
+static std::list<std::string> parserErrorsList;
 /* Error handling based on antlr3baserecognizer.c */
 static void handleParseError(pANTLR3_BASE_RECOGNIZER recognizer, pANTLR3_UINT8 * tokenNames)
 {
@@ -398,7 +398,7 @@ void printGDBMIList(GDBMIList *miList)
   }
 }
 
-list<string> getLexerErrorsList()
+std::list<std::string> getLexerErrorsList()
 {
   return lexerErrorsList;
 }
@@ -408,7 +408,7 @@ void clearLexerErrorsList()
   lexerErrorsList.clear();
 }
 
-list<string> getParserErrorsList()
+std::list<std::string> getParserErrorsList()
 {
   return parserErrorsList;
 }
@@ -436,7 +436,7 @@ GDBMIResponse* parseGDBOutput(const char* output) {
   /* if the parser fails */
   if (parser->pParser->rec->state->failed)
   {
-    parserErrorsList.push_back(string(output));
+    parserErrorsList.emplace_back(output);
     delete retval;
     retval = NULL;
   }

--- a/OMEdit/OMEditLIB/Debugger/Parser/GDBMIParser.h
+++ b/OMEdit/OMEditLIB/Debugger/Parser/GDBMIParser.h
@@ -40,8 +40,6 @@
 #include <sstream>
 #include <list>
 
-using namespace std;
-
 namespace GDBMIParser {
 
 class GDBMITuple;
@@ -56,7 +54,7 @@ public:
     ListValue       /* Used for list values. */
   };
   ValueType type;
-  string value;
+  std::string value;
   GDBMITuple *miTuple;
   GDBMIList *miList;
 
@@ -65,7 +63,7 @@ public:
 };
 
 class GDBMIResult;
-typedef list<GDBMIResult*>GDBMIResultList;
+typedef std::list<GDBMIResult*>GDBMIResultList;
 class GDBMITuple
 {
 public:
@@ -74,7 +72,7 @@ public:
   ~GDBMITuple();
 };
 
-typedef list<GDBMIValue*>GDBMIValueList;
+typedef std::list<GDBMIValue*>GDBMIValueList;
 class GDBMIList
 {
 public:
@@ -94,7 +92,7 @@ public:
 class GDBMIResult
 {
 public:
-  string variable;
+  std::string variable;
   GDBMIValue *miValue;
 
   GDBMIResult();
@@ -105,10 +103,10 @@ class GDBMIResultRecord
 {
 public:
   int token;
-  string cls;
+  std::string cls;
   GDBMIResultList miResultsList;
-  string consoleStreamOutput;
-  string logStreamOutput;
+  std::string consoleStreamOutput;
+  std::string logStreamOutput;
 
   GDBMIResultRecord();
   ~GDBMIResultRecord();
@@ -123,7 +121,7 @@ public:
     LogStream       /* Used for log stream output. */
   };
   StreamType type;
-  string value;
+  std::string value;
 };
 
 class GDBMIOutOfBandRecord
@@ -142,7 +140,7 @@ public:
   ~GDBMIOutOfBandRecord();
 };
 
-typedef list<GDBMIOutOfBandRecord*>GDBMIOutOfBandRecordList;
+typedef std::list<GDBMIOutOfBandRecord*>GDBMIOutOfBandRecordList;
 class GDBMIResponse
 {
 public:
@@ -170,9 +168,9 @@ void printGDBMIValue(GDBMIValue *miValue);
 void printGDBMITuple(GDBMITuple *miTuple);
 void printGDBMIList(GDBMIList *miList);
 
-list<string> getLexerErrorsList();
+std::list<std::string> getLexerErrorsList();
 void clearLexerErrorsList();
-list<string> getParserErrorsList();
+std::list<std::string> getParserErrorsList();
 void clearParserErrorsList();
 GDBMIResponse* parseGDBOutput(const char* data);
 


### PR DESCRIPTION
- Remove "using namespace std" in GDBMIParser.h to avoid name conflicts.