### PR TITLE
Restructure and organize source code FMU handling

### DIFF
--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -359,7 +359,7 @@ RuntimeSources.mo: Makefile.common Makefile.objs RuntimeSources.mo.tpl
 	    -e "s#COMMON_FILES#`cat sources.tmp`#" \
 	    -e "s#DGESV_FILES#`echo $(DGESV_OBJS:%=\\\"./external_solvers/%.c\\\") | tr " " ,`#" \
 	    -e "s#NLS_FILES#`echo $(SOLVER_OBJS_NONLINEAR_SYSTEMS:%.o=\\\"./simulation/solver/%.c\\\") | tr " " ,`#" \
-	    -e "s#CMINPACK_FILES#$(CMINPACK_OBJS:%=,\\\"./external_solvers/%.c\\\")#" \
+	    -e "s#CMINPACK_FILES#`echo $(CMINPACK_OBJS:%=\\\"./external_solvers/%.c\\\") | tr " " ,`#" \
 	    -e "s#LS_FILES#`echo $(SOLVER_OBJS_LINEAR_SYSTEMS:%.o=\\\"./simulation/solver/%.c\\\") | tr " " ,`#" \
 	    -e "s#MIXED_FILES#`echo $(SOLVER_OBJS_MIXED_SYSTEMS:%.o=\\\"./simulation/solver/%.c\\\") | tr " " ,`#" \
 	    RuntimeSources.mo.tpl > $@.tmp

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.cmake
@@ -1,46 +1,48 @@
 encapsulated package RuntimeSources
   constant String fmu_sources_dir = "/@SOURCE_FMU_SOURCES_DIR@";
 
-  constant list<String> commonFiles={@SOURCE_FMU_COMMON_FILES@};
+  constant list<String> simrt_c_sources={@SOURCE_FMU_COMMON_FILES@};
 
-  constant list<String> commonHeaders={@SOURCE_FMU_COMMON_HEADERS@};
+  constant list<String> simrt_c_headers={@SOURCE_FMU_COMMON_HEADERS@};
 
   constant list<String> fmi1Files={"fmi-export/fmu1_model_interface.c.inc","fmi-export/fmu1_model_interface.h"};
   constant list<String> fmi2Files={"fmi-export/fmu2_model_interface.c.inc","fmi-export/fmu2_model_interface.h", "fmi-export/fmu_read_flags.c.inc", "fmi-export/fmu_read_flags.h"};
 
   constant list<String> defaultFileSuffixes={".c", "_functions.c", "_records.c", "_01exo.c", "_02nls.c", "_03lsy.c", "_04set.c", "_05evt.c", "_06inz.c", "_07dly.c", "_08bnd.c", "_09alg.c", "_10asr.c", "_11mix.c", "_12jac.c", "_13opt.c", "_14lnz.c", "_15syn.c", "_16dae.c", "_17inl.c", "_18spd.c", "_init_fmu.c", "_FMU.c"};
 
-  constant list<String> cvodeFiles={"sundials/cvode/cvode_ls.h",
-                                    "sundials/cvode/cvode_proj.h",
-                                    "sundials/cvode/cvode.h"};
 
-  constant list<String> sundialsFiles={"sundials/sundials/sundials_config.h",
-                                       "sundials/sundials/sundials_dense.h",
-                                       "sundials/sundials/sundials_direct.h",
-                                       "sundials/sundials/sundials_iterative.h",
-                                       "sundials/sundials/sundials_linearsolver.h",
-                                       "sundials/sundials/sundials_matrix.h",
-                                       "sundials/sundials/sundials_nonlinearsolver.h",
-                                       "sundials/sundials/sundials_types.h",
-                                       "sundials/sunlinsol/sunlinsol_dense.h",
-                                       "sundials/sunmatrix/sunmatrix_dense.h",
-                                       "sundials/sunnonlinsol/sunnonlinsol_fixedpoint.h"};
+  constant list<String> sundials_headers={"../../cvode/cvode_ls.h",
+                                         "../../cvode/cvode_proj.h",
+                                         "../../cvode/cvode.h",
+                                         "../../sundials/sundials_config.h",
+                                         "../../sundials/sundials_dense.h",
+                                         "../../sundials/sundials_direct.h",
+                                         "../../sundials/sundials_iterative.h",
+                                         "../../sundials/sundials_linearsolver.h",
+                                         "../../sundials/sundials_matrix.h",
+                                         "../../sundials/sundials_nonlinearsolver.h",
+                                         "../../sundials/sundials_types.h",
+                                         "../../sunlinsol/sunlinsol_dense.h",
+                                         "../../sunmatrix/sunmatrix_dense.h",
+                                         "../../sunnonlinsol/sunnonlinsol_fixedpoint.h",
+                                         "../../nvector/nvector_serial.h",
+                                         "../../sundials/sundials_nvector.h"};
 
-  constant list<String> nvectorFiles={"sundials/nvector/nvector_serial.h",
-                                      "sundials/sundials/sundials_nvector.h"};
+  constant list<String> simrt_c_sundials_sources={@SOURCE_FMU_CVODE_RUNTIME_FILES@};
 
-  constant list<String> external3rdPartyFiles=listAppend(listAppend(cvodeFiles,sundialsFiles), nvectorFiles);
+  constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
 
-  constant list<String> dgesvFiles={@SOURCE_FMU_DGESV_FILES@};
+  constant list<String> dgesv_sources={@SOURCE_FMU_DGESV_FILES@};
 
-  constant list<String> cvodeRuntimeFiles={"simulation/solver/cvode_solver.c",
-                                           "simulation/solver/sundials_error.c"};
+  constant list<String> cminpack_headers = {"./external_solvers/cminpack.h", "./external_solvers/minpack.h"};
 
-  constant list<String> lsFiles={@SOURCE_FMU_LS_FILES@};
+  constant list<String> cminpack_sources = {@SOURCE_FMU_CMINPACK_FILES@};
 
-  constant list<String> nlsFiles={@SOURCE_FMU_CMINPACK_FILES@, @SOURCE_FMU_NLS_FILES@};
+  constant list<String> simrt_linear_solver_sources={@SOURCE_FMU_LS_FILES@};
 
-  constant list<String> mixedFiles={@SOURCE_FMU_MIXED_FILES@};
+  constant list<String> simrt_non_linear_solver_sources={@SOURCE_FMU_NLS_FILES@};
+
+  constant list<String> simrt_mixed_solver_sources={@SOURCE_FMU_MIXED_FILES@};
 
 annotation(__OpenModelica_Interface="backend");
 end RuntimeSources;

--- a/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
+++ b/OMCompiler/SimulationRuntime/c/RuntimeSources.mo.tpl
@@ -1,33 +1,40 @@
 encapsulated package RuntimeSources
   constant String fmu_sources_dir = "/include/omc/c/";
-  constant list<String> commonFiles={COMMON_FILES};
-  constant list<String> commonHeaders={COMMON_HEADERS};
+  constant list<String> simrt_c_sources={COMMON_FILES};
+  constant list<String> simrt_c_headers={COMMON_HEADERS};
   constant list<String> fmi1Files={"fmi-export/fmu1_model_interface.c.inc","fmi-export/fmu1_model_interface.h"};
   constant list<String> fmi2Files={"fmi-export/fmu2_model_interface.c.inc","fmi-export/fmu2_model_interface.h", "fmi-export/fmu_read_flags.c.inc", "fmi-export/fmu_read_flags.h"};
   constant list<String> defaultFileSuffixes={".c", "_functions.c", "_records.c", "_01exo.c", "_02nls.c", "_03lsy.c", "_04set.c", "_05evt.c", "_06inz.c", "_07dly.c", "_08bnd.c", "_09alg.c", "_10asr.c", "_11mix.c", "_12jac.c", "_13opt.c", "_14lnz.c", "_15syn.c", "_16dae.c", "_17inl.c", "_18spd.c", "_init_fmu.c", "_FMU.c"};
-  constant list<String> cvodeFiles={"sundials/cvode/cvode_ls.h",
-                                    "sundials/cvode/cvode_proj.h",
-                                    "sundials/cvode/cvode.h"};
-  constant list<String> sundialsFiles={"sundials/sundials/sundials_config.h",
-                                       "sundials/sundials/sundials_dense.h",
-                                       "sundials/sundials/sundials_direct.h",
-                                       "sundials/sundials/sundials_iterative.h",
-                                       "sundials/sundials/sundials_linearsolver.h",
-                                       "sundials/sundials/sundials_matrix.h",
-                                       "sundials/sundials/sundials_nonlinearsolver.h",
-                                       "sundials/sundials/sundials_types.h",
-                                       "sundials/sunlinsol/sunlinsol_dense.h",
-                                       "sundials/sunmatrix/sunmatrix_dense.h",
-                                       "sundials/sunnonlinsol/sunnonlinsol_fixedpoint.h"};
-  constant list<String> nvectorFiles={"sundials/nvector/nvector_serial.h",
-                                      "sundials/sundials/sundials_nvector.h"};
-  constant list<String> external3rdPartyFiles=listAppend(listAppend(cvodeFiles,sundialsFiles), nvectorFiles);
-  constant list<String> dgesvFiles={DGESV_FILES, "./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
-  constant list<String> cvodeRuntimeFiles={"simulation/solver/cvode_solver.c",
+
+  constant list<String> sundials_headers={"sundials/cvode/cvode_ls.h",
+                                         "sundials/cvode/cvode_proj.h",
+                                         "sundials/cvode/cvode.h",
+                                         "sundials/sundials/sundials_config.h",
+                                         "sundials/sundials/sundials_dense.h",
+                                         "sundials/sundials/sundials_direct.h",
+                                         "sundials/sundials/sundials_iterative.h",
+                                         "sundials/sundials/sundials_linearsolver.h",
+                                         "sundials/sundials/sundials_matrix.h",
+                                         "sundials/sundials/sundials_nonlinearsolver.h",
+                                         "sundials/sundials/sundials_types.h",
+                                         "sundials/sunlinsol/sunlinsol_dense.h",
+                                         "sundials/sunmatrix/sunmatrix_dense.h",
+                                         "sundials/sunnonlinsol/sunnonlinsol_fixedpoint.h",
+                                         "sundials/nvector/nvector_serial.h",
+                                         "sundials/sundials/sundials_nvector.h"};
+
+  constant list<String> simrt_c_sundials_sources={"simulation/solver/cvode_solver.c",
                                            "simulation/solver/sundials_error.c"};
-  constant list<String> lsFiles={LS_FILES};
-  constant list<String> nlsFiles={NLS_FILESCMINPACK_FILES, "./external_solvers/cminpack.h", "./external_solvers/minpack.h"};
-  constant list<String> mixedFiles={MIXED_FILES};
+
+  constant list<String> dgesv_headers={"./external_solvers/blaswrap.h", "./external_solvers/clapack.h", "./external_solvers/f2c.h"};
+  constant list<String> dgesv_sources={DGESV_FILES};
+
+  constant list<String> cminpack_headers = {"./external_solvers/cminpack.h", "./external_solvers/minpack.h"};
+  constant list<String> cminpack_sources = {CMINPACK_FILES};
+
+  constant list<String> simrt_linear_solver_sources={LS_FILES};
+  constant list<String> simrt_non_linear_solver_sources={NLS_FILES};
+  constant list<String> simrt_mixed_solver_sources={MIXED_FILES};
 annotation(__OpenModelica_Interface="backend");
 end RuntimeSources;
 

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -31,8 +31,7 @@ set(SOURCE_FMU_COMMON_HEADERS \"./omc_inline.h\",\"./openmodelica_func.h\",\"./o
 
 ######################################################################################################################
 # Lapack files
-file(GLOB_RECURSE 3RD_DGESV_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/include/*.h
-                                    ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/blas/*.c
+file(GLOB_RECURSE 3RD_DGESV_FILES   ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/blas/*.c
                                     ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/lapack/*.c
                                     ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/libf2c/*.c)
 install(FILES ${3RD_DGESV_FILES}
@@ -67,9 +66,7 @@ set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/enorm_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/qform_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/dogleg_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1updt_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1mpyq_.c
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
-                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h)
+                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1mpyq_.c)
 
 install(FILES ${3RD_CMINPACK_FMU_FILES}
         DESTINATION ${SOURCE_FMU_SOURCES_DIR}/external_solvers
@@ -106,3 +103,15 @@ foreach(source_file ${SOURCE_FMU_MIXED_FILES_LIST})
 endforeach()
 string(REPLACE ";" "," SOURCE_FMU_MIXED_FILES "${SOURCE_FMU_MIXED_FILES_LIST_QUOTED}")
 
+
+
+######################################################################################################################
+## CVODE files
+set(SOURCE_FMU_CVODE_RUNTIME_FILES_LIST simulation/solver/cvode_solver.c simulation/solver/sundials_error.c)
+
+foreach(source_file ${SOURCE_FMU_CVODE_RUNTIME_FILES_LIST})
+  list(APPEND SOURCE_FMU_CVODE_RUNTIME_FILES_LIST_QUOTED \"${source_file}\")
+  get_filename_component(DEST_DIR ${source_file} DIRECTORY)
+  install(FILES ${source_file} DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR})
+endforeach()
+string(REPLACE ";" "," SOURCE_FMU_CVODE_RUNTIME_FILES "${SOURCE_FMU_CVODE_RUNTIME_FILES_LIST_QUOTED}")


### PR DESCRIPTION
@mahge
Restructure and organize source code FMU handling 
7b4da7a
  - It is better to rewrite this than to try and make sense of it.
    - Name variables properly.
    - Follow the same code structure and style.
    - Make intentions clear.
    - Add comments where needed.

  - I am still not sure what more is needed or what needs to be removed.
    We will see as we go.
    For now this simplification is a good starting place.

@mahge
[cmake] Update source FMU config. …
3d07197
  - The source FMU handling code has been updated for the normal build
    since it was easier to change change it than to try and follow it.

    This changes reflect that for the CMake config.