### PR TITLE
copy also version specific library

### DIFF
--- a/OMCompiler/Makefile.in
+++ b/OMCompiler/Makefile.in
@@ -126,7 +126,7 @@ lis: lis-configure
 	@echo Building Lis from sources
 	$(MAKE) -C 3rdParty/lis-1.4.12/src
 	# Copy the library; not headers (as they are not used by the runtime system)
-	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis@SHREXT@* $(OMBUILDDIR)/$(LIB_OMC)/
+	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis*@SHREXT@* $(OMBUILDDIR)/$(LIB_OMC)/
 	@# FreeBSD lis does not create the symlinks...
 	! test -f build/lib/omc/liblis.so.0.0 -a ! -f $(OMBUILDDIR)/lib/omc/liblis.so.0 || ln -s liblis.so.0.0 $(OMBUILDDIR)/lib/omc/liblis.so.0
 	! test -f build/lib/omc/liblis.so.0.0 -a ! -f $(OMBUILDDIR)/lib/omc/liblis.so || ln -s liblis.so.0.0 $(OMBUILDDIR)/lib/omc/liblis.so


### PR DESCRIPTION
### Purpose

On macOS liblis.0.dylib is not copied, but only the soft link of liblis.dylib pointing to that file.
