### PR TITLE
Downgrade OMEditLIB to c++14

### DIFF
--- a/OMEdit/OMEdit.pro
+++ b/OMEdit/OMEdit.pro
@@ -28,8 +28,6 @@
  #
  #/
 
-CONFIG += c++17
-
 TEMPLATE = subdirs
 
 SUBDIRS = OMEditLIB \

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -33,7 +33,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
   QT += printsupport widgets webkitwidgets concurrent
 }
 
-CONFIG += c++17
+CONFIG += c++14
 
 TARGET = OMEdit
 TEMPLATE = lib


### PR DESCRIPTION
- Downgrade to c++14 in OMEditLIB for better compatibility with older
  distributions.
- Remove CONFIG from OMEdit.pro since it doesn't seem to have any
  effect.