### PR TITLE
For now install kinsol_impl.h until #7959 is fixed

### DIFF
--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -624,7 +624,6 @@ $(builddir_lib_omc)/libsundials_ida.a: 3rdParty/sundials-5.4.0/CMakeLists.txt
 	#-$(MAKE) -C 3rdParty/sundials-5.4.0/build test test_install || echo "WARNING: SUNDIALS test failing, continuing any way"
 	mkdir -p $(builddir_inc)/sundials
 	(cp -pfr 3rdParty/sundials-5.4.0/build/include/* $(builddir_inc)/sundials)
-	cp 3rdParty/sundials-5.4.0/src/kinsol/kinsol_impl.h $(builddir_inc)/sundials/kinsol/
 
 	# copy the libs to the build/lib/omc directory
 	find 3rdParty/sundials-5.4.0/build/lib* -not -type d -exec cp -apf {} $(builddir_lib_omc) ";"


### PR DESCRIPTION
  - We should not be using internal headers of Kinsol. There is an interface
    specifically for specifying the linear solver for Kinsol. We should
    use that instead.

### Related Issues
#7959

