### PR TITLE
Document Expression and fix some design issues

### DIFF
--- a/OMEdit/OMEditLIB/FlatModelica/Expression.h
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.h
@@ -12,6 +12,31 @@ namespace FlatModelica
 {
   class ExpressionBase;
 
+  /*!
+   * \class FlatModelica::Expression
+   * \brief Represents a flat Modelica expression.
+   *
+   * This class can be used to parse and evaluate flat Modelica expressions.
+   * It supports most of Modelica's builtin operators and functions, though the
+   * operators are only implemented for literal values so expressions should be
+   * evaluated before using them.
+   *
+   * Using the default constructor will create an Expression that contains no
+   * value, the only methods allowed on such Expressions are the isXXX methods
+   * (like isNull()) and assignment operators.
+   *
+   * Since Flat Modelica expression contain no type information and the result
+   * files only store double values all variables are evaluated to Real
+   * expression. This class is therefore more permissive than regular Modelica
+   * when type casting, and evaluating an expression might result in a Real when
+   * e.g. a Boolean was expected (so e.g.  isNumber or isBooleanish should
+   * usually be used rather than isInteger or isBoolean when checking the type
+   * of an evaluated Expression).
+   *
+   * Also since there's no type information methods like isInteger will only
+   * return true for an actual Integer expression, not for an expression whose
+   * type is Integer (like an Integer variable).
+   */
   class Expression
   {
     public:
@@ -47,6 +72,7 @@ namespace FlatModelica
       bool isReal() const;
       bool isNumber() const;
       bool isBoolean() const;
+      bool isBooleanish() const;
       bool isString() const;
       bool isArray() const;
       bool isCall() const;
@@ -55,11 +81,14 @@ namespace FlatModelica
       size_t ndims() const;
       size_t size(size_t dimension) const;
 
-      int64_t toInteger() const;
-      double toReal() const;
-      bool toBoolean() const;
+      int64_t intValue() const;
+      double realValue() const;
+      bool boolValue() const;
+      std::string stringValue() const;
+
       std::string toString() const;
       QString toQString() const;
+
       const std::vector<Expression>& elements() const;
       const std::vector<Expression>& args() const;
       const Expression& arg(size_t index) const;

--- a/OMEdit/OMEditLIB/FlatModelica/ExpressionFuncs.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/ExpressionFuncs.cpp
@@ -10,21 +10,21 @@ namespace FlatModelica
   Expression evalAbs(const Expression &x)
   {
     if (x.isInteger()) {
-      return Expression(std::abs(x.toInteger()));
+      return Expression(std::abs(x.intValue()));
     } else {
-      return Expression(std::abs(x.toReal()));
+      return Expression(std::abs(x.realValue()));
     }
   }
 
   Expression evalSign(const Expression &x)
   {
-    auto v = x.toReal();
+    auto v = x.realValue();
     return Expression(int64_t{v > 0 ? 1 : (v < 0 ? -1 : 0)});
   }
 
   Expression evalSqrt(const Expression &x)
   {
-    auto v = x.toReal();
+    auto v = x.realValue();
 
     if (v < 0) {
       throw std::runtime_error("Invalid argument " + x.toString() + " to sqrt()");
@@ -51,18 +51,18 @@ namespace FlatModelica
   {
     switch (args.size()) {
       case 2: // String(r, format)
-        return Expression(format_string("%" + args[1].toString(), args[0].toReal()));
+        return Expression(format_string("%" + args[1].stringValue(), args[0].realValue()));
 
       case 3: // String(i, minimumLength, leftJustified)
         return Expression(format_string(
-            (args[2].toBoolean() ? "%-" : "%") + args[1].toString() + "d",
-            args[0].toInteger()
+            (args[2].boolValue() ? "%-" : "%") + args[1].toString() + "d",
+            args[0].intValue()
           ));
 
       case 4: // String(r, significantDigits, mininumLength, leftJustified)
         return Expression(format_string(
-          (args[3].toBoolean() ? "%-" : "%") + args[2].toString() + "." + args[1].toString() + "g",
-          args[0].toReal()
+          (args[3].boolValue() ? "%-" : "%") + args[2].toString() + "." + args[1].toString() + "g",
+          args[0].realValue()
         ));
     }
 
@@ -72,17 +72,17 @@ namespace FlatModelica
   Expression evalDiv(const Expression &x, const Expression &y)
   {
     if (x.isInteger() && y.isInteger()) {
-      return Expression(x.toInteger() / y.toInteger());
+      return Expression(x.intValue() / y.intValue());
     } else {
-      return Expression(x.toReal() / y.toReal());
+      return Expression(x.realValue() / y.realValue());
     }
   }
 
   Expression evalMod(const Expression &x, const Expression &y)
   {
     if (x.isInteger() && y.isInteger()) {
-      auto ix = x.toInteger();
-      auto iy = y.toInteger();
+      auto ix = x.intValue();
+      auto iy = y.intValue();
       auto res = ix % iy;
 
       if ((iy > 0 && res < 0) || (iy < 0 && res > 0)) {
@@ -91,8 +91,8 @@ namespace FlatModelica
 
       return Expression(res);
     } else {
-      auto rx = x.toReal();
-      auto ry = y.toReal();
+      auto rx = x.realValue();
+      auto ry = y.realValue();
       return Expression(rx - std::floor(rx / ry) * ry);
     }
   }
@@ -100,94 +100,94 @@ namespace FlatModelica
   Expression evalRem(const Expression &x, const Expression &y)
   {
     if (x.isInteger() && y.isInteger()) {
-      auto ix = x.toInteger();
-      auto iy = y.toInteger();
+      auto ix = x.intValue();
+      auto iy = y.intValue();
       return Expression(ix - ix / iy * iy);
     } else {
-      auto rx = x.toReal();
-      auto ry = y.toReal();
+      auto rx = x.realValue();
+      auto ry = y.realValue();
       return Expression(rx - rx / ry * ry);
     }
   }
 
   Expression evalCeil(const Expression &x)
   {
-    return Expression(std::ceil(x.toReal()));
+    return Expression(std::ceil(x.realValue()));
   }
 
   Expression evalFloor(const Expression &x)
   {
-    return Expression(std::floor(x.toReal()));
+    return Expression(std::floor(x.realValue()));
   }
 
   Expression evalInteger(const Expression &x)
   {
-    return Expression(static_cast<int64_t>(std::floor(x.toReal())));
+    return Expression(static_cast<int64_t>(std::floor(x.realValue())));
   }
 
   Expression evalSin(const Expression &x)
   {
-    return Expression(std::sin(x.toReal()));
+    return Expression(std::sin(x.realValue()));
   }
 
   Expression evalCos(const Expression &x)
   {
-    return Expression(std::cos(x.toReal()));
+    return Expression(std::cos(x.realValue()));
   }
 
   Expression evalTan(const Expression &x)
   {
-    return Expression(std::tan(x.toReal()));
+    return Expression(std::tan(x.realValue()));
   }
 
   Expression evalAsin(const Expression &x)
   {
-    return Expression(std::asin(x.toReal()));
+    return Expression(std::asin(x.realValue()));
   }
 
   Expression evalAcos(const Expression &x)
   {
-    return Expression(std::acos(x.toReal()));
+    return Expression(std::acos(x.realValue()));
   }
 
   Expression evalAtan(const Expression &x)
   {
-    return Expression(std::atan(x.toReal()));
+    return Expression(std::atan(x.realValue()));
   }
 
   Expression evalAtan2(const Expression &x, const Expression &y)
   {
-    return Expression(std::atan2(x.toReal(), y.toReal()));
+    return Expression(std::atan2(x.realValue(), y.realValue()));
   }
 
   Expression evalSinh(const Expression &x)
   {
-    return Expression(std::sinh(x.toReal()));
+    return Expression(std::sinh(x.realValue()));
   }
 
   Expression evalCosh(const Expression &x)
   {
-    return Expression(std::cosh(x.toReal()));
+    return Expression(std::cosh(x.realValue()));
   }
 
   Expression evalTanh(const Expression &x)
   {
-    return Expression(std::tanh(x.toReal()));
+    return Expression(std::tanh(x.realValue()));
   }
 
   Expression evalExp(const Expression &x)
   {
-    return Expression(std::exp(x.toReal()));
+    return Expression(std::exp(x.realValue()));
   }
 
   Expression evalLog(const Expression &x)
   {
-    return Expression(std::log(x.toReal()));
+    return Expression(std::log(x.realValue()));
   }
 
   Expression evalLog10(const Expression &x)
   {
-    return Expression(std::log10(x.toReal()));
+    return Expression(std::log10(x.realValue()));
   }
 
   Expression evalNdim(const Expression &A)
@@ -216,7 +216,7 @@ namespace FlatModelica
 
   Expression evalSize(const Expression &A, const Expression &i)
   {
-    return Expression(static_cast<int64_t>(A.size(i.toInteger())));
+    return Expression(static_cast<int64_t>(A.size(i.intValue()-1)));
   }
 
   Expression evalScalar(const Expression &A)
@@ -261,7 +261,7 @@ namespace FlatModelica
       throw std::runtime_error("Invalid argument " + n.toString() + " to identity()");
     }
 
-    auto in = n.toInteger();
+    auto in = n.intValue();
 
     std::vector<Expression> rows;
     rows.reserve(in);
@@ -310,7 +310,7 @@ namespace FlatModelica
     Expression res = value;
 
     for (auto it = first; it != last; ++it) {
-      res = Expression(std::vector<Expression>(it->toInteger(), res));
+      res = Expression(std::vector<Expression>(it->intValue(), res));
     }
 
     return res;


### PR DESCRIPTION
- Document the public interface of the Expression class.
- Implement Expression::isBooleanish that can be used to check if an
  Expression is convertible to bool.
- Split toString into two methods: stringValue that returns the string
  contained in a String expression and toString that returns the
  expression printed as a string. toString previously had different
  behaviour depending on whether the Expression was a string or not,
  which was potentially confusing.
- Rename toInteger -> intValue, toReal -> realValue, and
  toBoolean -> boolValue to reflect the design change with toString.
- Change Expression::size to use a 0-based index instead of 1-based.