### PR TITLE
Strip DynamicSelect where not yet supported

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -114,17 +114,17 @@ void BitmapAnnotation::parseShapeAnnotation(QString annotation)
     return;
   }
   // 4th item is the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(3)));
+  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(3))));
   for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
     QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
     if (extentPoints.size() >= 2)
       mExtents.replace(i, QPointF(extentPoints.at(0).toFloat(), extentPoints.at(1).toFloat()));
   }
   // 5th item is the fileName
-  setFileName(StringHandler::removeFirstLastQuotes(list.at(4)));
+  setFileName(StringHandler::removeFirstLastQuotes(stripDynamicSelect(list.at(4))));
   // 6th item is the imageSource
   if (list.size() >= 6) {
-    mImageSource = StringHandler::removeFirstLastQuotes(list.at(5));
+    mImageSource = StringHandler::removeFirstLastQuotes(stripDynamicSelect(list.at(5)));
   }
   if (!mImageSource.isEmpty()) {
     mImage.loadFromData(QByteArray::fromBase64(mImageSource.toLatin1()));

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
@@ -79,7 +79,7 @@ void EllipseAnnotation::parseShapeAnnotation(QString annotation)
     return;
   }
   // 9th item is the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(8)));
+  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(8))));
   for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
     QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
     if (extentPoints.size() >= 2) {
@@ -87,11 +87,11 @@ void EllipseAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 10th item of the list contains the start angle.
-  mStartAngle = list.at(9).toFloat();
+  mStartAngle = stripDynamicSelect(list.at(9)).toFloat();
   // 11th item of the list contains the end angle.
-  mEndAngle = list.at(10).toFloat();
+  mEndAngle = stripDynamicSelect(list.at(10)).toFloat();
   // 12th item of the list contains the closure
-  mClosure = StringHandler::getClosureType(list.at(11));
+  mClosure = StringHandler::getClosureType(stripDynamicSelect(list.at(11)));
 }
 
 QRectF EllipseAnnotation::boundingRect() const

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -407,7 +407,7 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
   }
   mPoints.clear();
   // 4th item of list contains the points.
-  QStringList pointsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(3)));
+  QStringList pointsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(3))));
   foreach (QString point, pointsList) {
     QStringList linePoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(point));
     if (linePoints.size() >= 2) {
@@ -415,7 +415,7 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 5th item of list contains the color.
-  QStringList colorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(4)));
+  QStringList colorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(4))));
   if (colorList.size() >= 3) {
     int red, green, blue = 0;
     red = colorList.at(0).toInt();
@@ -424,19 +424,19 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
     mLineColor = QColor (red, green, blue);
   }
   // 6th item of list contains the Line Pattern.
-  mLinePattern = StringHandler::getLinePatternType(list.at(5));
+  mLinePattern = StringHandler::getLinePatternType(stripDynamicSelect(list.at(5)));
   // 7th item of list contains the Line thickness.
-  mLineThickness = list.at(6).toFloat();
+  mLineThickness = stripDynamicSelect(list.at(6)).toFloat();
   // 8th item of list contains the Line Arrows.
-  QStringList arrowList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(7)));
+  QStringList arrowList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(7))));
   if (arrowList.size() >= 2) {
     mArrow.replace(0, StringHandler::getArrowType(arrowList.at(0)));
     mArrow.replace(1, StringHandler::getArrowType(arrowList.at(1)));
   }
   // 9th item of list contains the Line Arrow Size.
-  mArrowSize = list.at(8).toFloat();
+  mArrowSize = stripDynamicSelect(list.at(8)).toFloat();
   // 10th item of list contains the smooth.
-  mSmooth = StringHandler::getSmoothType(list.at(9));
+  mSmooth = StringHandler::getSmoothType(stripDynamicSelect(list.at(9)));
 }
 
 QPainterPath LineAnnotation::getShape() const

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
@@ -92,7 +92,7 @@ void PolygonAnnotation::parseShapeAnnotation(QString annotation)
   }
   mPoints.clear();
   // 9th item of list contains the points.
-  QStringList pointsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(8)));
+  QStringList pointsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(8))));
   foreach (QString point, pointsList) {
     QStringList polygonPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(point));
     if (polygonPoints.size() >= 2) {
@@ -112,7 +112,7 @@ void PolygonAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 10th item of the list is smooth.
-  mSmooth = StringHandler::getSmoothType(list.at(9));
+  mSmooth = StringHandler::getSmoothType(stripDynamicSelect(list.at(9)));
 }
 
 QPainterPath PolygonAnnotation::getShape() const

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
@@ -124,9 +124,9 @@ void RectangleAnnotation::parseShapeAnnotation(QString annotation)
     return;
   }
   // 9th item of the list contains the border pattern.
-  mBorderPattern = StringHandler::getBorderPatternType(list.at(8));
+  mBorderPattern = StringHandler::getBorderPatternType(stripDynamicSelect(list.at(8)));
   // 10th item is the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(9)));
+  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(9))));
   for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
     QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
     if (extentPoints.size() >= 2) {
@@ -134,7 +134,7 @@ void RectangleAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 11th item of the list contains the corner radius.
-  mRadius = list.at(10).toFloat();
+  mRadius = stripDynamicSelect(list.at(10)).toFloat();
 }
 
 QRectF RectangleAnnotation::boundingRect() const

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -43,6 +43,13 @@
 #include "Plotting/VariablesWidget.h"
 #include "Util/ResourceCache.h"
 
+
+QString stripDynamicSelect(const QString &str)
+{
+  return str.startsWith("DynamicSelect") ?
+    StringHandler::getStrings(str.mid(14)).at(0) : str;
+}
+
 /*!
  * \brief GraphicItem::setDefaults
  * Sets the default value.
@@ -89,8 +96,9 @@ void GraphicItem::parseShapeAnnotation(QString annotation)
   if (list.size() < 3)
     return;
   // if first item of list is true then the shape should be visible.
-  if (list.at(0).startsWith("{")) { // DynamicSelect
-    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(0)));
+  auto visible_str = stripDynamicSelect(list.at(0));
+  if (visible_str.startsWith("{")) { // DynamicSelect
+    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(visible_str));
     if (args.count() > 0) {
       mVisible = args.at(0).contains("true");
     }
@@ -98,16 +106,17 @@ void GraphicItem::parseShapeAnnotation(QString annotation)
       mDynamicVisible = args.at(1);  // variable name
     }
   } else {
-    mVisible = list.at(0).contains("true");
+    mVisible = visible_str.contains("true");
   }
   // 2nd item is the origin
-  QStringList originList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(1)));
+  QStringList originList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(1))));
   if (originList.size() >= 2) {
     setOrigin(QPointF(originList.at(0).toFloat(), originList.at(1).toFloat()));
   }
   // 3rd item is the rotation
-  if (list.at(2).startsWith("{")) { // DynamicSelect
-    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(2)));
+  auto rotation_str = stripDynamicSelect(list.at(2));
+  if (rotation_str.startsWith("{")) { // DynamicSelect
+    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(rotation_str));
     if (args.count() > 0) {
       mRotation = args.at(0).toFloat();
     }
@@ -115,7 +124,7 @@ void GraphicItem::parseShapeAnnotation(QString annotation)
       mDynamicRotation = args.at(1);  // variable name
     }
   } else {
-    mRotation = list.at(2).toFloat();
+    mRotation = rotation_str.toFloat();
   }
 }
 
@@ -205,7 +214,7 @@ void FilledShape::parseShapeAnnotation(QString annotation)
     return;
   }
   // 4th item of the list is the line color
-  QStringList colorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(3)));
+  QStringList colorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(3))));
   if (colorList.size() >= 3) {
     int red, green, blue = 0;
     red = colorList.at(0).toInt();
@@ -214,7 +223,7 @@ void FilledShape::parseShapeAnnotation(QString annotation)
     mLineColor = QColor (red, green, blue);
   }
   // 5th item of list contains the fill color.
-  QStringList fillColorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(4)));
+  QStringList fillColorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(4))));
   if (fillColorList.size() >= 3) {
     int red, green, blue = 0;
     red = fillColorList.at(0).toInt();
@@ -223,11 +232,11 @@ void FilledShape::parseShapeAnnotation(QString annotation)
     mFillColor = QColor (red, green, blue);
   }
   // 6th item of list contains the Line Pattern.
-  mLinePattern = StringHandler::getLinePatternType(list.at(5));
+  mLinePattern = StringHandler::getLinePatternType(stripDynamicSelect(list.at(5)));
   // 7th item of list contains the Fill Pattern.
-  mFillPattern = StringHandler::getFillPatternType(list.at(6));
+  mFillPattern = StringHandler::getFillPatternType(stripDynamicSelect(list.at(6)));
   // 8th item of list contains the thickness.
-  mLineThickness = list.at(7).toFloat();
+  mLineThickness = stripDynamicSelect(list.at(7)).toFloat();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
@@ -54,6 +54,8 @@ class CornerItem;
 class OriginItem;
 class ShapeAnnotation;
 
+QString stripDynamicSelect(const QString &str);
+
 class GraphicItem
 {
 public:

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -165,7 +165,7 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
     return;
   }
   // 9th item of the list contains the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(8)));
+  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(8))));
   for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
     QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
     if (extentPoints.size() >= 2)
@@ -173,11 +173,7 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
   }
   // 10th item of the list contains the textString.
   try {
-    if (list.at(9).contains("DynamicSelect")) {
-      mTextExpression = FlatModelica::Expression::parse(StringHandler::removeFirstLastQuotes(list.at(9)));
-    } else {
-      mTextExpression = FlatModelica::Expression::parse(list.at(9));
-    }
+    mTextExpression = FlatModelica::Expression::parse(list.at(9));
 
     if (mTextExpression.isCall("DynamicSelect")) {
       mOriginalTextString = mTextExpression.arg(0).toQString();
@@ -192,9 +188,9 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
   initUpdateTextString();
 
   // 11th item of the list contains the fontSize.
-  mFontSize = list.at(10).toFloat();
+  mFontSize = stripDynamicSelect(list.at(10)).toFloat();
   // 12th item of the list contains the optional textColor, {-1, -1, -1} if not set
-  QStringList textColorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(11)));
+  QStringList textColorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(11))));
   if (textColorList.size() >= 3) {
     int red, green, blue = 0;
     red = textColorList.at(0).toInt();
@@ -205,12 +201,12 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 13th item of the list contains the font name.
-  QString fontName = StringHandler::removeFirstLastQuotes(list.at(12));
+  QString fontName = StringHandler::removeFirstLastQuotes(stripDynamicSelect(list.at(12)));
   if (!fontName.isEmpty()) {
     mFontName = fontName;
   }
   // 14th item of the list contains the text styles.
-  QStringList textStyles = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(13)));
+  QStringList textStyles = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(13))));
   foreach (QString textStyle, textStyles) {
     if (textStyle == "TextStyle.Bold") {
       mTextStyles.append(StringHandler::TextStyleBold);
@@ -221,7 +217,7 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 15th item of the list contains the text alignment.
-  QString horizontalAlignment = StringHandler::removeFirstLastQuotes(list.at(14));
+  QString horizontalAlignment = StringHandler::removeFirstLastQuotes(stripDynamicSelect(list.at(14)));
   if (horizontalAlignment == "TextAlignment.Left") {
     mHorizontalAlignment = StringHandler::TextAlignmentLeft;
   } else if (horizontalAlignment == "TextAlignment.Center") {


### PR DESCRIPTION
- Use the first argument of DynamicSelect for annotations that don't
  support DynamicSelect yet.