### PR TITLE
Improve Expression class in OMEdit

### DIFF
--- a/OMEdit/OMEditLIB/FlatModelica/Expression.h
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <ostream>
 #include <functional>
+#include <vector>
 
 #include <QString>
 

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -201,6 +201,22 @@ void ExpressionTest::operators_data()
   QTest::newRow("- array")
     << "-{1, 2, 3}"
     << "{-1,-2,-3}";
+
+  QTest::newRow("relation 1")
+    << "x == y"
+    << "true";
+
+  QTest::newRow("relation 2")
+    << "x > y"
+    << "false";
+
+  QTest::newRow("relation 3")
+    << "x >= y"
+    << "true";
+
+  QTest::newRow("relation 4")
+    << "not x == y"
+    << "false";
 }
 
 void ExpressionTest::functions()


### PR DESCRIPTION
- Fix parsing of >= and == that didn't consume the last =.
- Fix binaryOpFromToken for ==, <> and <, which was wrong due to a
  copy/paste error.
- Simplify unary operators when the operand is a literal so that e.g. -5
  becomes -5 instead of -(5).