### PR TITLE
CMake improvements

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -5,6 +5,9 @@ endmacro()
 
 set(SCOREP_INCLUDE_ ".")
 set(Boost_INCLUDE_ ".")
+set(Boost_LIBS_ ".")
+set(LAPACK_LIBS_ ".")
+set(LAPACK_LIBRARIES_ "-llapack -lblas")
 set(SYSTEM_CFLAGS ${SYSTEM_CFLAGS} "-DOMC_BUILD -fPIC")
 
 configure_file(Modelica/ModelicaLibraryConfig_gcc.inc.in ${CMAKE_CURRENT_BINARY_DIR}/ModelicaLibraryConfig_gcc.inc)
@@ -177,7 +180,7 @@ set(OMC_SIMRT_CPP_CORE_SIMCONTROLLER_SOURCES SimController/Configuration.cpp
                                              SimController/SimObjects.cpp)
 
 add_library(OMCppSimController SHARED)
-add_library(omc::simrt::cpp::core::system ALIAS OMCppSimController)
+add_library(omc::simrt::cpp::core::simcontroller ALIAS OMCppSimController)
 
 target_sources(OMCppSimController PRIVATE ${OMC_SIMRT_CPP_CORE_SIMCONTROLLER_SOURCES})
 

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -8,7 +8,7 @@ set(Boost_INCLUDE_ ".")
 set(Boost_LIBS_ ".")
 set(LAPACK_LIBS_ ".")
 set(LAPACK_LIBRARIES_ "-llapack -lblas")
-set(SYSTEM_CFLAGS ${SYSTEM_CFLAGS} "-DOMC_BUILD -fPIC")
+set(SYSTEM_CFLAGS ${SYSTEM_CFLAGS} "-DOMC_BUILD -fPIC -DUSE_THREAD")
 
 configure_file(Modelica/ModelicaLibraryConfig_gcc.inc.in ${CMAKE_CURRENT_BINARY_DIR}/ModelicaLibraryConfig_gcc.inc)
 configure_file(Modelica/ModelicaConfig_gcc.inc.in ${CMAKE_CURRENT_BINARY_DIR}/ModelicaConfig_gcc.inc)

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -86,6 +86,19 @@ target_link_options(OMCppMath PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppMath)
 
+# OMCppMath_static
+add_library(OMCppMath_static STATIC)
+add_library(omc::simrt::cpp::core::math::static ALIAS OMCppMath_static)
+
+target_sources(OMCppMath_static PRIVATE ${OMC_SIMRT_CPP_CORE_MATH_SOURCES})
+
+target_compile_definitions(OMCppMath_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppMath_static PUBLIC omc::simrt::cpp::config)
+
+install(TARGETS OMCppMath_static)
+##
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         TYPE INCLUDE
         FILES_MATCHING
@@ -114,6 +127,19 @@ target_link_options(OMCppSolver PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppSolver)
 
+# OMCppSolver_static
+add_library(OMCppSolver_static STATIC)
+add_library(omc::simrt::cpp::core::solver::static ALIAS OMCppSolver_static)
+
+target_sources(OMCppSolver_static PRIVATE ${OMC_SIMRT_CPP_CORE_SOLVER_SOURCES})
+
+target_compile_definitions(OMCppSolver_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppSolver_static PUBLIC omc::simrt::cpp::config)
+
+install(TARGETS OMCppSolver_static)
+##
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         TYPE INCLUDE
         FILES_MATCHING
@@ -140,6 +166,19 @@ target_link_options(OMCppExtensionUtilities PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppExtensionUtilities)
 
+# OMCppExtensionUtilities_static
+add_library(OMCppExtensionUtilities_static STATIC)
+add_library(omc::simrt::cpp::core::utils::extension::static ALIAS OMCppExtensionUtilities_static)
+
+target_sources(OMCppExtensionUtilities_static PRIVATE ${OMC_SIMRT_CPP_CORE_UTILS_EXTENSIONS_SOURCES})
+
+target_compile_definitions(OMCppExtensionUtilities_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppExtensionUtilities_static PUBLIC omc::simrt::cpp::config)
+
+install(TARGETS OMCppExtensionUtilities_static)
+##
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         TYPE INCLUDE
         FILES_MATCHING
@@ -163,6 +202,19 @@ target_link_libraries(OMCppModelicaUtilities PUBLIC omc::simrt::cpp::config)
 target_link_options(OMCppModelicaUtilities PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppModelicaUtilities)
+
+# OMCppModelicaUtilities_static
+add_library(OMCppModelicaUtilities_static STATIC)
+add_library(omc::simrt::cpp::core::utils::modelica::static ALIAS OMCppModelicaUtilities_static)
+
+target_sources(OMCppModelicaUtilities_static PRIVATE ${OMC_SIMRT_CPP_CORE_UTILS_MODELICA_SOURCES})
+
+target_compile_definitions(OMCppModelicaUtilities_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppModelicaUtilities_static PUBLIC omc::simrt::cpp::config)
+
+install(TARGETS OMCppModelicaUtilities_static)
+##
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         TYPE INCLUDE
@@ -254,8 +306,23 @@ target_link_options(OMCppSystem PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppSystem)
 
+# OMCppSystem_static
+add_library(OMCppSystem_static STATIC)
+add_library(omc::simrt::cpp::core::system::static ALIAS OMCppSystem_static)
+
+target_sources(OMCppSystem_static PRIVATE ${OMC_SIMRT_CPP_CORE_SYSTEM_SOURCES})
+
+target_compile_definitions(OMCppSystem_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppSystem_static PUBLIC omc::simrt::cpp::config)
+
+install(TARGETS OMCppSystem_static)
+##
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         TYPE INCLUDE
         FILES_MATCHING
         PATTERN System/*.h
 )
+
+

--- a/OMCompiler/SimulationRuntime/cpp/FMU/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/FMU/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(OPENMODELICA_NEW_CMAKE_BUILD)
+  include(cmake_3.14.cmake)
+else(OPENMODELICA_NEW_CMAKE_BUILD)
+
 cmake_minimum_required(VERSION 2.8.9)
 
 project(${FMUName})
@@ -24,3 +28,5 @@ install(FILES
   ${CMAKE_SOURCE_DIR}/FMU/IFMUInterface.h
   ${CMAKE_SOURCE_DIR}/FMU/FactoryExport.h
   DESTINATION include/omc/cpp/FMU)
+
+  endif(OPENMODELICA_NEW_CMAKE_BUILD)

--- a/OMCompiler/SimulationRuntime/cpp/FMU/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/FMU/cmake_3.14.cmake
@@ -1,0 +1,35 @@
+#####################################################################################################
+# OMCppFMU
+set(OMC_SIMRT_CPP_FMU_SOURCES FMULogger.cpp)
+
+add_library(OMCppFMU SHARED)
+add_library(omc::simrt::cpp::fmu ALIAS OMCppFMU)
+
+target_sources(OMCppFMU PRIVATE ${OMC_SIMRT_CPP_FMU_SOURCES})
+
+target_link_libraries(OMCppFMU PUBLIC omc::simrt::cpp::config)
+target_link_libraries(OMCppFMU PUBLIC omc::simrt::cpp::core::utils::extension)
+
+target_link_options(OMCppFMU PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppFMU)
+
+# OMCppFMU_static
+add_library(OMCppFMU_static STATIC)
+add_library(omc::simrt::cpp::fmu::static ALIAS OMCppFMU_static)
+
+target_sources(OMCppFMU_static PRIVATE ${OMC_SIMRT_CPP_FMU_SOURCES})
+
+target_compile_definitions(OMCppFMU_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppFMU_static PUBLIC omc::simrt::cpp::config)
+
+install(TARGETS OMCppFMU_static)
+##
+
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN *.h
+)

--- a/OMCompiler/SimulationRuntime/cpp/FMU2/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/FMU2/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        TYPE INCLUDE
+        FILES_MATCHING
+        PATTERN *.h
+        PATTERN *.cpp
+)

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
@@ -42,24 +42,36 @@ install(TARGETS OMCppDASSL)
 
 
 #####################################################################################################
-# OMCppDgesv
+# OMCppDgesvSolver
 set(OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES Dgesv/DgesvSolver.cpp
                                        Dgesv/DgesvSolverSettings.cpp
                                        Dgesv/FactoryExport.cpp)
 
-add_library(OMCppDgesv SHARED)
-add_library(omc::simrt::cpp::solver::dgesvsolver ALIAS OMCppDgesv)
+add_library(OMCppDgesvSolver SHARED)
+add_library(omc::simrt::cpp::solver::dgesvsolver ALIAS OMCppDgesvSolver)
 
-target_sources(OMCppDgesv PRIVATE ${OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES})
+target_sources(OMCppDgesvSolver PRIVATE ${OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES})
 
-target_link_libraries(OMCppDgesv PRIVATE omc::simrt::cpp::core::modelica)
-target_link_libraries(OMCppDgesv PRIVATE omc::simrt::cpp::core::solver)
-target_link_libraries(OMCppDgesv PRIVATE ${LAPACK_LIBRARIES})
-# target_link_libraries(OMCppDgesv PRIVATE omc::3rd::cdaskr)
+target_link_libraries(OMCppDgesvSolver PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppDgesvSolver PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppDgesvSolver PRIVATE ${LAPACK_LIBRARIES})
 
-target_link_options(OMCppDgesv PRIVATE  -Wl,--no-undefined)
+target_link_options(OMCppDgesvSolver PRIVATE  -Wl,--no-undefined)
 
-install(TARGETS OMCppDgesv)
+install(TARGETS OMCppDgesvSolver)
+
+# OMCppDgesvSolver_static
+add_library(OMCppDgesvSolver_static STATIC)
+add_library(omc::simrt::cpp::solver::dgesvsolver::static ALIAS OMCppDgesvSolver_static)
+
+target_sources(OMCppDgesvSolver_static PRIVATE ${OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES})
+
+target_compile_definitions(OMCppDgesvSolver_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppDgesvSolver_static PUBLIC omc::simrt::cpp::core::modelica)
+
+install(TARGETS OMCppDgesvSolver_static)
+##
 
 
 #####################################################################################################
@@ -119,7 +131,19 @@ target_link_libraries(OMCppNewton PRIVATE omc::simrt::cpp::core::modelica)
 target_link_libraries(OMCppNewton PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppNewton PRIVATE ${LAPACK_LIBRARIES})
 
-
 target_link_options(OMCppNewton PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppNewton)
+
+# OMCppNewton_static
+add_library(OMCppNewton_static STATIC)
+add_library(omc::simrt::cpp::solver::newton::static ALIAS OMCppNewton_static)
+
+target_sources(OMCppNewton_static PRIVATE ${OMC_SIMRT_CPP_SOLVER_NEWTON_SOURCES})
+
+target_compile_definitions(OMCppNewton_static PRIVATE -DRUNTIME_STATIC_LINKING)
+
+target_link_libraries(OMCppNewton_static PUBLIC omc::simrt::cpp::core::modelica)
+
+install(TARGETS OMCppNewton_static)
+##

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
@@ -22,6 +22,47 @@ install(TARGETS OMCppCVode)
 
 
 #####################################################################################################
+# OMCppDASSL
+set(OMC_SIMRT_CPP_SOLVER_DASSL_SOURCES DASSL/DASSL.cpp
+                                       DASSL/DASSLSettings.cpp
+                                       DASSL/FactoryExport.cpp)
+
+add_library(OMCppDASSL SHARED)
+add_library(omc::simrt::cpp::solver::dassl ALIAS OMCppDASSL)
+
+target_sources(OMCppDASSL PRIVATE ${OMC_SIMRT_CPP_SOLVER_DASSL_SOURCES})
+
+target_link_libraries(OMCppDASSL PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppDASSL PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppDASSL PRIVATE omc::3rd::cdaskr)
+
+target_link_options(OMCppDASSL PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppDASSL)
+
+
+#####################################################################################################
+# OMCppDgesv
+set(OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES Dgesv/DgesvSolver.cpp
+                                       Dgesv/DgesvSolverSettings.cpp
+                                       Dgesv/FactoryExport.cpp)
+
+add_library(OMCppDgesv SHARED)
+add_library(omc::simrt::cpp::solver::dgesvsolver ALIAS OMCppDgesv)
+
+target_sources(OMCppDgesv PRIVATE ${OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES})
+
+target_link_libraries(OMCppDgesv PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppDgesv PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppDgesv PRIVATE ${LAPACK_LIBRARIES})
+# target_link_libraries(OMCppDgesv PRIVATE omc::3rd::cdaskr)
+
+target_link_options(OMCppDgesv PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppDgesv)
+
+
+#####################################################################################################
 # OMCppKinsol
 set(OMC_SIMRT_CPP_SOLVER_KINSOL_SOURCES Kinsol/Kinsol.cpp
                                         Kinsol/KinsolLapack.cpp
@@ -61,3 +102,24 @@ target_link_libraries(OMCppLinearSolver PRIVATE ${LAPACK_LIBRARIES})
 target_link_options(OMCppLinearSolver PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppLinearSolver)
+
+
+#####################################################################################################
+# OMCppNewton
+set(OMC_SIMRT_CPP_SOLVER_NEWTON_SOURCES Newton/Newton.cpp
+                                       Newton/NewtonSettings.cpp
+                                       Newton/FactoryExport.cpp)
+
+add_library(OMCppNewton SHARED)
+add_library(omc::simrt::cpp::solver::newton ALIAS OMCppNewton)
+
+target_sources(OMCppNewton PRIVATE ${OMC_SIMRT_CPP_SOLVER_NEWTON_SOURCES})
+
+target_link_libraries(OMCppNewton PRIVATE omc::simrt::cpp::core::modelica)
+target_link_libraries(OMCppNewton PRIVATE omc::simrt::cpp::core::solver)
+target_link_libraries(OMCppNewton PRIVATE ${LAPACK_LIBRARIES})
+
+
+target_link_options(OMCppNewton PRIVATE  -Wl,--no-undefined)
+
+install(TARGETS OMCppNewton)

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -9,11 +9,6 @@ set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/cpp)
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/omc/cpp)
 
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LibrariesConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h
-        TYPE INCLUDE)
-
 
 # An interface library for providing common include directories for all the CPP libs.
 add_library(OMCppConfig INTERFACE)
@@ -28,7 +23,40 @@ target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Inc
 add_subdirectory(SimCoreFactory)
 add_subdirectory(Core)
 add_subdirectory(Solver)
+add_subdirectory(FMU)
 
+
+## This little function will give us the filename of the CPP runtime
+## library given its alias.
+function (omc_get_library_filename target_alias LIB_FILENAME)
+  message(STATUS ${target_alias})
+  get_target_property(LIB_FILENAME_LOCAL ${target_alias} ALIASED_TARGET)
+  message(STATUS ${LIB_FILENAME_LOCAL})
+  set(${LIB_FILENAME} ${CMAKE_SHARED_LIBRARY_PREFIX}${LIB_FILENAME_LOCAL}${CMAKE_SHARED_LIBRARY_SUFFIX} PARENT_SCOPE)
+endfunction(omc_get_library_filename)
+
+## Get the actual output filenames of the CPP runtime shared libs
+## This are to be used in LibrariesConfig for the purpose of loading the
+## libs at simulation time using their file name.
+omc_get_library_filename(omc::simrt::cpp::core::system SYSTEM_LIB)
+omc_get_library_filename(omc::simrt::cpp::core::dataexchange DATAEXCHANGE_LIB)
+omc_get_library_filename(omc::simrt::cpp::core::math MATH_LIB)
+omc_get_library_filename(omc::simrt::cpp::core::simsettings SETTINGSFACTORY_LIB)
+omc_get_library_filename(omc::simrt::cpp::core::solver SOLVER_LIB)
+
+omc_get_library_filename(omc::simrt::cpp::solver::cvode CVODE_LIB)
+omc_get_library_filename(omc::simrt::cpp::solver::dassl DASSL_LIB)
+omc_get_library_filename(omc::simrt::cpp::solver::dgesvsolver DGESVSOLVER_LIB)
+omc_get_library_filename(omc::simrt::cpp::solver::kinsol KINSOL_LIB)
+omc_get_library_filename(omc::simrt::cpp::solver::newton NEWTON_LIB)
+# omc_get_library_filename(omc::simrt::cpp::core::utils::extension EXTENSIONUTILITIES_LIB)
+omc_get_library_filename(omc::simrt::cpp::core::simcontroller SIMCONTROLLER_LIB)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LibrariesConfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h)
+
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LibrariesConfig.h
+        TYPE INCLUDE)
 
 # This folder contains only one file right now. Something should be done about it.
 install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Include/

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -24,6 +24,7 @@ add_subdirectory(SimCoreFactory)
 add_subdirectory(Core)
 add_subdirectory(Solver)
 add_subdirectory(FMU)
+add_subdirectory(FMU2)
 
 
 ## This little function will give us the filename of the CPP runtime


### PR DESCRIPTION
@mahge
[cmake] Improve CMake config for CPP runtime. 
a07c0d7
  - Add libraries
    - libOMCppDASSL
    - libOMCppDgesv
    - libOMCppNewton

  - Improve generation of config file LibrariesConfig.h

  - All tests that use the shared build of CPP runtime are passing now.

@mahge
[cmake] Add static versions of CPP runtime libs. 
d6799c3
  - Add the required static libraries based on tests in the testsuite.
    If more of them are needed to be built as static then they will be
    added later. Right now this is purely test guided and trying to make
    sure the tests in the testsuite are passing.

@mahge
[cmake] Add OMCppFMU library.
65dd679

@mahge
[cmake] Install CPP runtime FMU2 files. 
bf1f17d
  - Just a nitpick, the folders should be restructured a bit. A cpp/FMU
    folder should contain folder FMU1 and FMU2, i.e,

      - cpp
        - FMU
          - FMU1
          - FMU2

    Then the FMU folder's cmake file can take care of both folders.

@mahge
[cmake] Assume we always have C++11 threads. …
531bb00
  - Threads support is needed for HPCOM CPP runtime tests.
  - It is a fair assumption for now. If it needs to be checked and enabled
    we will do that later.