### PR TITLE
Implement DynamicSelect for more annotations

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -114,12 +114,7 @@ void BitmapAnnotation::parseShapeAnnotation(QString annotation)
     return;
   }
   // 4th item is the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(3))));
-  for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
-    QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
-    if (extentPoints.size() >= 2)
-      mExtents.replace(i, QPointF(extentPoints.at(0).toFloat(), extentPoints.at(1).toFloat()));
-  }
+  mExtents.parse(list.at(3));
   // 5th item is the fileName
   setFileName(StringHandler::removeFirstLastQuotes(stripDynamicSelect(list.at(4))));
   // 6th item is the imageSource
@@ -151,21 +146,17 @@ void BitmapAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible || !mDynamicVisible.isEmpty()) {
-    if (!mDynamicVisibleValue && ((mpGraphicsView && mpGraphicsView->isVisualizationView())
-                                  || (mpParentComponent && mpParentComponent->getGraphicsView()->isVisualizationView()))) {
-      return;
-    }
-    drawBitmapAnnotaion(painter);
+  if (mVisible) {
+    drawBitmapAnnotation(painter);
   }
 }
 
 /*!
- * \brief BitmapAnnotation::drawBitmapAnnotaion
+ * \brief BitmapAnnotation::drawBitmapAnnotation
  * Draws the bitmap.
  * \param painter
  */
-void BitmapAnnotation::drawBitmapAnnotaion(QPainter *painter)
+void BitmapAnnotation::drawBitmapAnnotation(QPainter *painter)
 {
   QRectF rect = getBoundingRect().normalized();
   QImage image = mImage.scaled(rect.width(), rect.height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);

--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.h
@@ -55,7 +55,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawBitmapAnnotaion(QPainter *painter);
+  void drawBitmapAnnotation(QPainter *painter);
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/BooleanAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BooleanAnnotation.cpp
@@ -1,0 +1,29 @@
+#include "BooleanAnnotation.h"
+
+BooleanAnnotation::BooleanAnnotation()
+  : mValue(true)
+{
+}
+
+BooleanAnnotation::BooleanAnnotation(const QString &str)
+  : DynamicAnnotation(str)
+{
+}
+
+void BooleanAnnotation::clear()
+{
+  mValue = true;
+}
+
+BooleanAnnotation& BooleanAnnotation::operator= (bool value)
+{
+  mValue = value;
+  return *this;
+}
+
+void BooleanAnnotation::fromExp(const FlatModelica::Expression &exp)
+{
+  if (exp.isBooleanish()) {
+    mValue = exp.boolValue();
+  }
+}

--- a/OMEdit/OMEditLIB/Annotations/BooleanAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/BooleanAnnotation.h
@@ -1,0 +1,24 @@
+#ifndef BOOLEANANNOTATION_H
+#define BOOLEANANNOTATION_H
+
+#include "DynamicAnnotation.h"
+
+class BooleanAnnotation : public DynamicAnnotation
+{
+  public:
+    BooleanAnnotation();
+    explicit BooleanAnnotation(const QString &str);
+
+    void clear() override;
+
+    operator bool() const { return mValue; }
+    BooleanAnnotation& operator= (bool value);
+
+  private:
+    void fromExp(const FlatModelica::Expression &exp) override;
+
+  private:
+    bool mValue;
+};
+
+#endif /* BOOLEANANNOTATION_H */

--- a/OMEdit/OMEditLIB/Annotations/ColorAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ColorAnnotation.cpp
@@ -1,0 +1,49 @@
+#include "ColorAnnotation.h"
+
+ColorAnnotation::ColorAnnotation()
+  : mValue(0, 0, 0)
+{
+}
+
+ColorAnnotation::ColorAnnotation(const QString &str)
+  : DynamicAnnotation(str)
+{
+}
+
+void ColorAnnotation::clear()
+{
+  mValue.setRgb(0, 0, 0);
+}
+
+ColorAnnotation& ColorAnnotation::operator= (const QColor &value)
+{
+  mValue = value;
+  return *this;
+}
+
+bool ColorAnnotation::operator== (const QColor &c) const
+{
+  return mValue == c;
+}
+
+bool ColorAnnotation::operator!= (const QColor &c) const
+{
+  return mValue != c;
+}
+
+void ColorAnnotation::fromExp(const FlatModelica::Expression &exp)
+{
+  if (exp.isArray()) {
+    auto &elems = exp.elements();
+
+    if (elems.size() == 3) {
+      int c[3];
+
+      for (int i = 0; i < 3; ++i) {
+        c[i] = elems[i].isNumber() ? elems[i].intValue() : 0;
+      }
+
+      mValue.setRgb(c[0], c[1], c[2]);
+    }
+  }
+}

--- a/OMEdit/OMEditLIB/Annotations/ColorAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ColorAnnotation.h
@@ -1,0 +1,32 @@
+#ifndef COLORANNOTATION_H
+#define COLORANNOTATION_H
+
+#include <QColor>
+#include "DynamicAnnotation.h"
+
+class ColorAnnotation : public DynamicAnnotation
+{
+  public:
+    ColorAnnotation();
+    explicit ColorAnnotation(const QString &str);
+
+    void clear() override;
+
+    operator const QColor&() const { return mValue; }
+    ColorAnnotation& operator= (const QColor &value);
+
+    int red()   const { return mValue.red(); }
+    int green() const { return mValue.green(); }
+    int blue()  const { return mValue.blue(); }
+
+    bool operator== (const QColor &c) const;
+    bool operator!= (const QColor &c) const;
+
+  private:
+    void fromExp(const FlatModelica::Expression &exp) override;
+
+  private:
+    QColor mValue;
+};
+
+#endif /* COLORANNOTATION_H */

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -1,0 +1,68 @@
+#include <QDebug>
+
+#include "Element/Element.h"
+#include "Plotting/VariablesWidget.h"
+
+DynamicAnnotation::DynamicAnnotation() = default;
+
+DynamicAnnotation::DynamicAnnotation(const QString &str)
+{
+  parse(str);
+}
+
+DynamicAnnotation::~DynamicAnnotation() = default;
+
+/*!
+ * \brief DynamicAnnotation::parse
+ * Parses an annotation expression string and stores the expression, then either
+ * calls reset or clear based on whether the parsing succeeded or not.
+ */
+void DynamicAnnotation::parse(const QString &str)
+{
+  try {
+    mExp = FlatModelica::Expression::parse(str);
+    mDynamic = mExp.isCall("DynamicSelect");
+    reset();
+  } catch (const std::exception &e) {
+    qDebug() << "Failed to parse annotation: " << str;
+    qDebug() << e.what();
+    clear();
+  }
+}
+
+/*!
+ * \brief DynamicAnnotation::update
+ * Evaluates the second argument for a given time point if the stored expression
+ * is a DynamicSelect call, then passes the evaluated expression to the derived
+ * class via fromExp. If the stored expression is not a DynamicSelect call then
+ * nothing is done.
+ * \return true if the expression was updated, otherwise false.
+ */
+bool DynamicAnnotation::update(double time, Element *parent)
+{
+  if (mDynamic) {
+    fromExp(mExp.arg(1).evaluate([&] (std::string name) {
+      auto vname = QString::fromStdString(name);
+
+      if (parent && parent->getComponentInfo()) {
+        vname = QString("%1.%2").arg(parent->getName(), vname);
+      }
+
+      return MainWindow::instance()->getVariablesWidget()->readVariableValue(vname, time);
+    }));
+    return true;
+  }
+
+  return false;
+}
+
+/*!
+ * \brief DynamicAnnotation::update
+ * Calls the derived class' fromExp method with the static part of the stored
+ * expression (either the expression itself, or the first argument if it's a
+ * DynamicSelect call).
+ */
+void DynamicAnnotation::reset()
+{
+  fromExp(mDynamic ? mExp.arg(0) : mExp);
+}

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
@@ -1,0 +1,46 @@
+#ifndef DYNAMICANNOTATION_H
+#define DYNAMICANNOTATION_H
+
+#include <QString>
+#include "FlatModelica/Expression.h"
+
+class Element;
+
+/*!
+ * \class DynamicAnnotation
+ * \brief Base class for DynamicSelect-aware types.
+ *
+ * This class implements the generic parts of handling annotations with
+ * DynamicSelect, like parsing and evaluating the annotation expression.
+ *
+ * Derived classes don't have to handle DynamicSelect directly, they just need
+ * to implement fromExp for the type they're representing and will then be given
+ * the static or dynamic expression for a certain time point when parse, update
+ * or reset is called.
+ *
+ * parse and reset will call fromExp with the static expression (the expression
+ * itself or the first argument if it's a DynamicSelect call), while update
+ * calls fromExp with the dynamic expression (second argument if it's a
+ * DynamicSelect call) evaluated for a given time point.
+ */
+class DynamicAnnotation
+{
+  public:
+    DynamicAnnotation();
+    DynamicAnnotation(const QString &str);
+    virtual ~DynamicAnnotation() = 0;
+
+    void parse(const QString &str);
+    bool update(double time, Element *parent);
+    void reset();
+    virtual void clear() = 0;
+
+  protected:
+    virtual void fromExp(const FlatModelica::Expression &exp) = 0;
+
+  protected:
+    FlatModelica::Expression mExp;
+    bool mDynamic = false;
+};
+
+#endif /* DYNAMICANNOTATION_H */

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
@@ -79,17 +79,11 @@ void EllipseAnnotation::parseShapeAnnotation(QString annotation)
     return;
   }
   // 9th item is the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(8))));
-  for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
-    QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
-    if (extentPoints.size() >= 2) {
-      mExtents.replace(i, QPointF(extentPoints.at(0).toFloat(), extentPoints.at(1).toFloat()));
-    }
-  }
+  mExtents.parse(list.at(8));
   // 10th item of the list contains the start angle.
-  mStartAngle = stripDynamicSelect(list.at(9)).toFloat();
+  mStartAngle.parse(list.at(9));
   // 11th item of the list contains the end angle.
-  mEndAngle = stripDynamicSelect(list.at(10)).toFloat();
+  mEndAngle.parse(list.at(10));
   // 12th item of the list contains the closure
   mClosure = StringHandler::getClosureType(stripDynamicSelect(list.at(11)));
 }
@@ -114,16 +108,12 @@ void EllipseAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem 
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible || !mDynamicVisible.isEmpty()) {
-    if (!mDynamicVisibleValue && ((mpGraphicsView && mpGraphicsView->isVisualizationView())
-                                  || (mpParentComponent && mpParentComponent->getGraphicsView()->isVisualizationView()))) {
-      return;
-    }
-    drawEllipseAnnotaion(painter);
+  if (mVisible) {
+    drawEllipseAnnotation(painter);
   }
 }
 
-void EllipseAnnotation::drawEllipseAnnotaion(QPainter *painter)
+void EllipseAnnotation::drawEllipseAnnotation(QPainter *painter)
 {
   // first we invert the painter since we have our coordinate system inverted.
   // inversion is required to draw the elliptic curves at correct angles.

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.h
@@ -53,7 +53,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawEllipseAnnotaion(QPainter *painter);
+  void drawEllipseAnnotation(QPainter *painter);
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/ExtentAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ExtentAnnotation.cpp
@@ -1,0 +1,42 @@
+#include <algorithm>
+#include <QDebug>
+
+#include "Element/Element.h"
+#include "Plotting/VariablesWidget.h"
+#include "ExtentAnnotation.h"
+
+ExtentAnnotation::ExtentAnnotation() = default;
+
+ExtentAnnotation::ExtentAnnotation(const QString &str)
+  : DynamicAnnotation(str)
+{
+}
+
+void ExtentAnnotation::clear()
+{
+  mValue.clear();
+}
+
+ExtentAnnotation& ExtentAnnotation::operator= (const QList<QPointF> &value)
+{
+  mValue = value;
+  return *this;
+}
+
+void ExtentAnnotation::fromExp(const FlatModelica::Expression &exp)
+{
+  if (exp.isArray()) {
+    auto &elems = exp.elements();
+
+    for (size_t i = 0u; i < std::min(elems.size(), decltype(elems.size()){2}); ++i) {
+      auto &point = elems[i].elements();
+
+      if (point.size() >= 2) {
+        mValue.replace(i, QPointF(
+          point[0].isNumber() ? point[0].realValue() : 0.0,
+          point[1].isNumber() ? point[1].realValue() : 0.0
+        ));
+      }
+    }
+  }
+}

--- a/OMEdit/OMEditLIB/Annotations/ExtentAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ExtentAnnotation.h
@@ -1,0 +1,36 @@
+#ifndef EXTENTANNOTATION_H
+#define EXTENTANNOTATION_H
+
+#include <QPointF>
+#include <QList>
+#include "DynamicAnnotation.h"
+
+class ExtentAnnotation : public DynamicAnnotation
+{
+  public:
+    ExtentAnnotation();
+    explicit ExtentAnnotation(const QString &str);
+
+    void clear() override;
+
+    operator const QList<QPointF>&() const { return mValue; }
+    ExtentAnnotation& operator= (const QList<QPointF> &value);
+
+    const QPointF& at(int i) const { return mValue.at(i); }
+    int size() const { return mValue.size(); }
+    void append(const QPointF &value) { mValue.append(value); }
+    void replace(int i, const QPointF &value) { mValue.replace(i, value); }
+
+    auto begin()       { return mValue.begin(); }
+    auto begin() const { return mValue.begin(); }
+    auto end()         { return mValue.end(); }
+    auto end() const   { return mValue.end(); }
+
+  private:
+    void fromExp(const FlatModelica::Expression &exp) override;
+
+  private:
+    QList<QPointF> mValue;
+};
+
+#endif /* EXTENTANNOTATION_H */

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -415,18 +415,11 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
     }
   }
   // 5th item of list contains the color.
-  QStringList colorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(4))));
-  if (colorList.size() >= 3) {
-    int red, green, blue = 0;
-    red = colorList.at(0).toInt();
-    green = colorList.at(1).toInt();
-    blue = colorList.at(2).toInt();
-    mLineColor = QColor (red, green, blue);
-  }
+  mLineColor.parse(list.at(4));
   // 6th item of list contains the Line Pattern.
   mLinePattern = StringHandler::getLinePatternType(stripDynamicSelect(list.at(5)));
   // 7th item of list contains the Line thickness.
-  mLineThickness = stripDynamicSelect(list.at(6)).toFloat();
+  mLineThickness.parse(list.at(6));
   // 8th item of list contains the Line Arrows.
   QStringList arrowList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(7))));
   if (arrowList.size() >= 2) {
@@ -434,7 +427,7 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
     mArrow.replace(1, StringHandler::getArrowType(arrowList.at(1)));
   }
   // 9th item of list contains the Line Arrow Size.
-  mArrowSize = stripDynamicSelect(list.at(8)).toFloat();
+  mArrowSize.parse(list.at(8));
   // 10th item of list contains the smooth.
   mSmooth = StringHandler::getSmoothType(stripDynamicSelect(list.at(9)));
 }
@@ -489,22 +482,19 @@ void LineAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible || !mDynamicVisible.isEmpty()) {
+  if (mVisible) {
     if (mLineType == LineAnnotation::TransitionType && mpGraphicsView->isVisualizationView()) {
       if (isActiveState()) {
         painter->setOpacity(1.0);
       } else {
         painter->setOpacity(0.2);
       }
-    } else if (!mDynamicVisibleValue && ((mpGraphicsView && mpGraphicsView->isVisualizationView())
-                                         || (mpParentComponent && mpParentComponent->getGraphicsView()->isVisualizationView()))) {
-      return;
     }
-    drawLineAnnotaion(painter);
+    drawLineAnnotation(painter);
   }
 }
 
-void LineAnnotation::drawLineAnnotaion(QPainter *painter)
+void LineAnnotation::drawLineAnnotation(QPainter *painter)
 {
   applyLinePattern(painter);
   // draw start arrow

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -83,7 +83,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawLineAnnotaion(QPainter *painter);
+  void drawLineAnnotation(QPainter *painter);
   void drawArrow(QPainter *painter, QPointF startPos, QPointF endPos, qreal size, int arrowType) const;
   QPolygonF perpendicularLine(QPointF startPos, QPointF endPos, qreal size) const;
   QString getOMCShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/PointAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PointAnnotation.cpp
@@ -1,0 +1,42 @@
+#include "PointAnnotation.h"
+
+PointAnnotation::PointAnnotation() = default;
+
+PointAnnotation::PointAnnotation(const QString &str)
+  : DynamicAnnotation(str)
+{
+}
+
+void PointAnnotation::clear()
+{
+  mValue = QPointF(0.0, 0.0);
+}
+
+PointAnnotation& PointAnnotation::operator= (const QPointF &value)
+{
+  mValue = value;
+  return *this;
+}
+
+bool PointAnnotation::operator== (const QPointF &c) const
+{
+  return mValue == c;
+}
+
+bool PointAnnotation::operator!= (const QPointF &c) const
+{
+  return mValue != c;
+}
+
+void PointAnnotation::fromExp(const FlatModelica::Expression &exp)
+{
+  if (exp.isArray()) {
+    auto &elems = exp.elements();
+
+    if (elems.size() >= 3) {
+      mValue.setX(elems[0].isNumber() ? elems[0].realValue() : 0.0);
+      mValue.setY(elems[1].isNumber() ? elems[1].realValue() : 0.0);
+    }
+  }
+}
+

--- a/OMEdit/OMEditLIB/Annotations/PointAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/PointAnnotation.h
@@ -1,0 +1,33 @@
+#ifndef POINTANNOTATION_H
+#define POINTANNOTATION_H
+
+#include <QPointF>
+#include "DynamicAnnotation.h"
+
+class Element;
+
+class PointAnnotation : public DynamicAnnotation
+{
+  public:
+    PointAnnotation();
+    explicit PointAnnotation(const QString &str);
+
+    void clear() override;
+
+    operator const QPointF&() const { return mValue; }
+    PointAnnotation& operator= (const QPointF &value);
+
+    qreal x() const { return mValue.x(); }
+    qreal y() const { return mValue.y(); }
+
+    bool operator== (const QPointF &c) const;
+    bool operator!= (const QPointF &c) const;
+
+  private:
+    void fromExp(const FlatModelica::Expression &exp) override;
+
+  private:
+    QPointF mValue;
+};
+
+#endif /* POINTANNOTATION_H */

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
@@ -176,16 +176,12 @@ void PolygonAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem 
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible || !mDynamicVisible.isEmpty()) {
-    if (!mDynamicVisibleValue && ((mpGraphicsView && mpGraphicsView->isVisualizationView())
-                                  || (mpParentComponent && mpParentComponent->getGraphicsView()->isVisualizationView()))) {
-      return;
-    }
-    drawPolygonAnnotaion(painter);
+  if (mVisible) {
+    drawPolygonAnnotation(painter);
   }
 }
 
-void PolygonAnnotation::drawPolygonAnnotaion(QPainter *painter)
+void PolygonAnnotation::drawPolygonAnnotation(QPainter *painter)
 {
   applyLinePattern(painter);
   applyFillPattern(painter);

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.h
@@ -55,7 +55,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawPolygonAnnotaion(QPainter *painter);
+  void drawPolygonAnnotation(QPainter *painter);
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/RealAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RealAnnotation.cpp
@@ -1,0 +1,29 @@
+#include "RealAnnotation.h"
+
+RealAnnotation::RealAnnotation()
+  : mValue(0.0)
+{
+}
+
+RealAnnotation::RealAnnotation(const QString &str)
+  : DynamicAnnotation(str)
+{
+}
+
+void RealAnnotation::clear()
+{
+  mValue = 0.0;
+}
+
+RealAnnotation& RealAnnotation::operator= (qreal value)
+{
+  mValue = value;
+  return *this;
+}
+
+void RealAnnotation::fromExp(const FlatModelica::Expression &exp)
+{
+  if (exp.isNumber()) {
+    mValue = exp.realValue();
+  }
+}

--- a/OMEdit/OMEditLIB/Annotations/RealAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/RealAnnotation.h
@@ -1,0 +1,24 @@
+#ifndef REALANNOTATION_H
+#define REALANNOTATION_H
+
+#include "DynamicAnnotation.h"
+
+class RealAnnotation : public DynamicAnnotation
+{
+  public:
+    RealAnnotation();
+    explicit RealAnnotation(const QString &str);
+
+    void clear() override;
+
+    operator qreal() const { return mValue; }
+    RealAnnotation& operator= (qreal value);
+
+  private:
+    void fromExp(const FlatModelica::Expression &exp) override;
+
+  private:
+    qreal mValue;
+};
+
+#endif /* REALANNOTATION_H */

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
@@ -126,15 +126,9 @@ void RectangleAnnotation::parseShapeAnnotation(QString annotation)
   // 9th item of the list contains the border pattern.
   mBorderPattern = StringHandler::getBorderPatternType(stripDynamicSelect(list.at(8)));
   // 10th item is the extent points
-  QStringList extentsList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(9))));
-  for (int i = 0 ; i < qMin(extentsList.size(), 2) ; i++) {
-    QStringList extentPoints = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(extentsList[i]));
-    if (extentPoints.size() >= 2) {
-      mExtents.replace(i, QPointF(extentPoints.at(0).toFloat(), extentPoints.at(1).toFloat()));
-    }
-  }
+  mExtents.parse(list.at(9));
   // 11th item of the list contains the corner radius.
-  mRadius = stripDynamicSelect(list.at(10)).toFloat();
+  mRadius.parse(list.at(10));
 }
 
 QRectF RectangleAnnotation::boundingRect() const
@@ -156,7 +150,7 @@ void RectangleAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsIte
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible || !mDynamicVisible.isEmpty()) {
+  if (mVisible) {
     // state machine visualization
     if (mpParentComponent && mpParentComponent->getLibraryTreeItem() && mpParentComponent->getLibraryTreeItem()->isState()
         && mpParentComponent->getGraphicsView()->isVisualizationView()) {
@@ -165,15 +159,12 @@ void RectangleAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsIte
       } else {
         painter->setOpacity(0.2);
       }
-    } else if (!mDynamicVisibleValue && ((mpGraphicsView && mpGraphicsView->isVisualizationView())
-                                         || (mpParentComponent && mpParentComponent->getGraphicsView()->isVisualizationView()))) {
-      return;
     }
-    drawRectangleAnnotaion(painter);
+    drawRectangleAnnotation(painter);
   }
 }
 
-void RectangleAnnotation::drawRectangleAnnotaion(QPainter *painter)
+void RectangleAnnotation::drawRectangleAnnotation(QPainter *painter)
 {
   applyLinePattern(painter);
   applyFillPattern(painter);

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.h
@@ -56,7 +56,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawRectangleAnnotaion(QPainter *painter);
+  void drawRectangleAnnotation(QPainter *painter);
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -57,14 +57,8 @@ QString stripDynamicSelect(const QString &str)
 void GraphicItem::setDefaults()
 {
   mVisible = true;
-  mDynamicVisible = "";
-  mDynamicVisibleValue = true;
   mOrigin = QPointF(0, 0);
-  mDynamicOrigin = "";
-  mDynamicOriginValue = QPointF(0, 0);
   mRotation = 0;
-  mDynamicRotation = "";
-  mDynamicRotationValue = 0;
 }
 
 /*!
@@ -75,14 +69,8 @@ void GraphicItem::setDefaults()
 void GraphicItem::setDefaults(ShapeAnnotation *pShapeAnnotation)
 {
   mVisible = pShapeAnnotation->mVisible;
-  mDynamicVisible = pShapeAnnotation->mDynamicVisible;
-  mDynamicVisibleValue = pShapeAnnotation->mDynamicVisibleValue;
   mOrigin = pShapeAnnotation->mOrigin;
-  mDynamicOrigin = pShapeAnnotation->mDynamicOrigin;
-  mDynamicOriginValue = pShapeAnnotation->mDynamicOriginValue;
   mRotation = pShapeAnnotation->mRotation;
-  mDynamicRotation = pShapeAnnotation->mDynamicRotation;
-  mDynamicRotationValue = pShapeAnnotation->mDynamicRotationValue;
 }
 
 /*!
@@ -96,36 +84,11 @@ void GraphicItem::parseShapeAnnotation(QString annotation)
   if (list.size() < 3)
     return;
   // if first item of list is true then the shape should be visible.
-  auto visible_str = stripDynamicSelect(list.at(0));
-  if (visible_str.startsWith("{")) { // DynamicSelect
-    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(visible_str));
-    if (args.count() > 0) {
-      mVisible = args.at(0).contains("true");
-    }
-    if (args.count() > 1) {
-      mDynamicVisible = args.at(1);  // variable name
-    }
-  } else {
-    mVisible = visible_str.contains("true");
-  }
+  mVisible.parse(list.at(0));
   // 2nd item is the origin
-  QStringList originList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(1))));
-  if (originList.size() >= 2) {
-    setOrigin(QPointF(originList.at(0).toFloat(), originList.at(1).toFloat()));
-  }
+  mOrigin.parse(list.at(1));
   // 3rd item is the rotation
-  auto rotation_str = stripDynamicSelect(list.at(2));
-  if (rotation_str.startsWith("{")) { // DynamicSelect
-    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(rotation_str));
-    if (args.count() > 0) {
-      mRotation = args.at(0).toFloat();
-    }
-    if (args.count() > 1) {
-      mDynamicRotation = args.at(1);  // variable name
-    }
-  } else {
-    mRotation = rotation_str.toFloat();
-  }
+  mRotation.parse(list.at(2));
 }
 
 /*!
@@ -214,29 +177,15 @@ void FilledShape::parseShapeAnnotation(QString annotation)
     return;
   }
   // 4th item of the list is the line color
-  QStringList colorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(3))));
-  if (colorList.size() >= 3) {
-    int red, green, blue = 0;
-    red = colorList.at(0).toInt();
-    green = colorList.at(1).toInt();
-    blue = colorList.at(2).toInt();
-    mLineColor = QColor (red, green, blue);
-  }
+  mLineColor.parse(list.at(3));
   // 5th item of list contains the fill color.
-  QStringList fillColorList = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(stripDynamicSelect(list.at(4))));
-  if (fillColorList.size() >= 3) {
-    int red, green, blue = 0;
-    red = fillColorList.at(0).toInt();
-    green = fillColorList.at(1).toInt();
-    blue = fillColorList.at(2).toInt();
-    mFillColor = QColor (red, green, blue);
-  }
+  mFillColor.parse(list.at(4));
   // 6th item of list contains the Line Pattern.
   mLinePattern = StringHandler::getLinePatternType(stripDynamicSelect(list.at(5)));
   // 7th item of list contains the Fill Pattern.
   mFillPattern = StringHandler::getFillPatternType(stripDynamicSelect(list.at(6)));
   // 8th item of list contains the thickness.
-  mLineThickness = stripDynamicSelect(list.at(7)).toFloat();
+  mLineThickness.parse(list.at(7));
 }
 
 /*!
@@ -548,7 +497,7 @@ void ShapeAnnotation::applyLinePattern(QPainter *painter)
     thickness = Utilities::convertMMToPixel(1.0);
   }
 
-  QPen pen(mLineColor, thickness, StringHandler::getLinePatternType(mLinePattern), Qt::SquareCap, Qt::MiterJoin);
+  QPen pen(QBrush(mLineColor), thickness, StringHandler::getLinePatternType(mLinePattern), Qt::SquareCap, Qt::MiterJoin);
   /* The specification doesn't say anything about it.
    * But just to keep this consist with Dymola we use Qt::BevelJoin for Line shapes.
    * All other shapes use Qt::MiterJoin
@@ -618,7 +567,7 @@ void ShapeAnnotation::applyFillPattern(QPainter *painter)
       break;
     default:
       painter->setBackgroundMode(Qt::OpaqueMode);
-      painter->setBackground(mFillColor);
+      painter->setBackground(QBrush(mFillColor));
       QBrush brush(mLineColor, StringHandler::getFillPatternType(mFillPattern));
       brush.setTransform(QTransform(1, 0, 0, 0, 1, 0, 0, 0, 0));
       painter->setBrush(brush);
@@ -964,7 +913,7 @@ void ShapeAnnotation::adjustPointsWithOrigin()
 void ShapeAnnotation::adjustExtentsWithOrigin()
 {
   QList<QPointF> extents;
-  foreach (QPointF extent, mExtents) {
+  for (auto &extent: mExtents) {
     extents.append(extent - mOrigin);
   }
   mExtents = extents;
@@ -1132,34 +1081,20 @@ void ShapeAnnotation::setShapeFlags(bool enable)
  */
 void ShapeAnnotation::updateDynamicSelect(double time)
 {
-  // visible
-  if (!mDynamicVisible.isEmpty()) {
-    if (mDynamicVisible.compare("true") == 0) {
-      mDynamicVisibleValue = true;
-    } else if (mDynamicVisible.compare("false") == 0) {
-      mDynamicVisibleValue = false;
-    } else if (mpParentComponent && mpParentComponent->getComponentInfo()) {
-      QString variableName = QString("%1.%2").arg(mpParentComponent->getName(), mDynamicVisible);
-      mDynamicVisibleValue = (bool)MainWindow::instance()->getVariablesWidget()->readVariableValue(variableName, time);
-    } else {
-      mDynamicVisibleValue = (bool)MainWindow::instance()->getVariablesWidget()->readVariableValue(mDynamicVisible, time);
-    }
-  }
-  // rotation
-  if (!mDynamicRotation.isEmpty()) {
-    bool ok = false;
-    float rotation = mDynamicRotation.toFloat(&ok);
-    if (ok) {
-      mDynamicRotationValue = rotation;
-    } else if (mpParentComponent && mpParentComponent->getComponentInfo()) {
-      QString variableName = QString("%1.%2").arg(mpParentComponent->getName(), mDynamicRotation);
-      mDynamicRotationValue = MainWindow::instance()->getVariablesWidget()->readVariableValue(variableName, time);
-    } else {
-      mDynamicRotationValue = MainWindow::instance()->getVariablesWidget()->readVariableValue(mDynamicRotation, time);
-    }
-    setRotation(mDynamicRotationValue);
-    update();
-  }
+  bool updated = false;
+
+  updated |= mVisible.update(time, mpParentComponent);
+  updated |= mOrigin.update(time, mpParentComponent);
+  updated |= mRotation.update(time, mpParentComponent);
+  updated |= mLineColor.update(time, mpParentComponent);
+  updated |= mFillColor.update(time, mpParentComponent);
+  updated |= mLineThickness.update(time, mpParentComponent);
+  updated |= mArrowSize.update(time, mpParentComponent);
+  updated |= mExtents.update(time, mpParentComponent);
+  updated |= mRadius.update(time, mpParentComponent);
+  updated |= mStartAngle.update(time, mpParentComponent);
+  updated |= mEndAngle.update(time, mpParentComponent);
+  updated |= mFontSize.update(time, mpParentComponent);
 
   // textString
   if (mTextExpression.isCall("DynamicSelect")) {
@@ -1173,6 +1108,10 @@ void ShapeAnnotation::updateDynamicSelect(double time)
       return MainWindow::instance()->getVariablesWidget()->readVariableValue(vname, time);
     }).toQString();
 
+    updated = true;
+  }
+
+  if (updated) {
     update();
   }
 }

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
@@ -38,6 +38,11 @@
 #include "Util/StringHandler.h"
 #include "Element/Transformation.h"
 #include "FlatModelica/Expression.h"
+#include "BooleanAnnotation.h"
+#include "ColorAnnotation.h"
+#include "ExtentAnnotation.h"
+#include "RealAnnotation.h"
+#include "PointAnnotation.h"
 
 #include <QGraphicsItem>
 #include <QSettings>
@@ -70,15 +75,9 @@ public:
   void setRotationAngle(qreal rotation) {mRotation = rotation;}
   qreal getRotation() {return mRotation;}
 protected:
-  bool mVisible;
-  QString mDynamicVisible; /* Dynamic variable for visible attribute */
-  bool mDynamicVisibleValue; /* Dynamic value for visible attribute */
-  QPointF mOrigin;
-  QString mDynamicOrigin; /* Dynamic variable for origin attribute */
-  QPointF mDynamicOriginValue; /* Dynamic value for origin attribute */
-  qreal mRotation;
-  QString mDynamicRotation; /* Dynamic variable for origin attribute */
-  qreal mDynamicRotationValue; /* Dynamic value for origin attribute */
+  BooleanAnnotation mVisible;
+  PointAnnotation mOrigin;
+  RealAnnotation mRotation;
 };
 
 class FilledShape
@@ -101,11 +100,11 @@ public:
   void setLineThickness(qreal thickness) {mLineThickness = thickness;}
   qreal getLineThickness() {return mLineThickness;}
 protected:
-  QColor mLineColor;
-  QColor mFillColor;
+  ColorAnnotation mLineColor;
+  ColorAnnotation mFillColor;
   StringHandler::LinePattern mLinePattern;
   StringHandler::FillPattern mFillPattern;
-  qreal mLineThickness;
+  RealAnnotation mLineThickness;
 };
 
 class ShapeAnnotation : public QObject, public QGraphicsItem, public GraphicItem, public FilledShape
@@ -267,17 +266,17 @@ protected:
   QList<QPointF> mPoints;
   QList<LineGeometryType> mGeometries;
   QList<StringHandler::Arrow> mArrow;
-  qreal mArrowSize;
+  RealAnnotation mArrowSize;
   StringHandler::Smooth mSmooth;
-  QList<QPointF> mExtents;
+  ExtentAnnotation mExtents;
   StringHandler::BorderPattern mBorderPattern;
-  qreal mRadius;
-  qreal mStartAngle;
-  qreal mEndAngle;
+  RealAnnotation mRadius;
+  RealAnnotation mStartAngle;
+  RealAnnotation mEndAngle;
   StringHandler::EllipseClosure mClosure;
   QString mOriginalTextString;
   QString mTextString;
-  qreal mFontSize;
+  RealAnnotation mFontSize;
   QString mFontName;
   QList<StringHandler::TextStyle> mTextStyles;
   StringHandler::TextAlignment mHorizontalAlignment;

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
@@ -59,7 +59,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawTextAnnotaion(QPainter *painter);
+  void drawTextAnnotation(QPainter *painter);
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
@@ -1658,6 +1658,17 @@ namespace FlatModelica
 
   /*!
    * \brief Expression::size
+   * Returns the number of elements in an array, or 0 if the expression is not
+   * an array.
+   * \return The size of the expression.
+   */
+  size_t Expression::size() const
+  {
+    return size(0);
+  }
+
+  /*!
+   * \brief Expression::size
    * Returns the size of the given dimension, or 0 if the Expression has no such
    * dimension.
    * \param dimension The index of the dimension.

--- a/OMEdit/OMEditLIB/FlatModelica/Expression.h
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.h
@@ -80,6 +80,7 @@ namespace FlatModelica
       bool isCall(const std::string &name) const;
 
       size_t ndims() const;
+      size_t size() const;
       size_t size(size_t dimension) const;
 
       int64_t intValue() const;

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -135,6 +135,12 @@ SOURCES += Util/Helper.cpp \
   Annotations/EllipseAnnotation.cpp \
   Annotations/TextAnnotation.cpp \
   Annotations/BitmapAnnotation.cpp \
+  Annotations/DynamicAnnotation.cpp \
+  Annotations/BooleanAnnotation.cpp \
+  Annotations/ColorAnnotation.cpp \
+  Annotations/ExtentAnnotation.cpp \
+  Annotations/PointAnnotation.cpp \
+  Annotations/RealAnnotation.cpp \
   Element/ElementProperties.cpp \
   Element/Transformation.cpp \
   Modeling/DocumentationWidget.cpp \
@@ -228,6 +234,12 @@ HEADERS  += Util/Helper.h \
   Annotations/EllipseAnnotation.h \
   Annotations/TextAnnotation.h \
   Annotations/BitmapAnnotation.h \
+  Annotations/DynamicAnnotation.h \
+  Annotations/BooleanAnnotation.h \
+  Annotations/ColorAnnotation.h \
+  Annotations/ExtentAnnotation.h \
+  Annotations/PointAnnotation.h \
+  Annotations/RealAnnotation.h \
   Element/ElementProperties.h \
   Element/Transformation.h \
   Modeling/DocumentationWidget.h \

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1850,10 +1850,14 @@ void VariablesWidget::initializeVisualization(SimulationOptions simulationOption
 double VariablesWidget::readVariableValue(QString variable, double time)
 {
   double value = 0.0;
+  bool found = false;
+
   if (mModelicaMatReader.file) {
     ModelicaMatVariable_t* var = omc_matlab4_find_var(&mModelicaMatReader, variable.toUtf8().constData());
     if (var) {
       omc_matlab4_val(&value, &mModelicaMatReader, var, time);
+      found = true;
+    } else {
     }
   } else if (mpCSVData) {
     double *timeDataSet = read_csv_dataset(mpCSVData, "time");
@@ -1863,6 +1867,7 @@ double VariablesWidget::readVariableValue(QString variable, double time)
           double *varDataSet = read_csv_dataset(mpCSVData, variable.toUtf8().constData());
           if (varDataSet) {
             value = varDataSet[i];
+            found = true;
             break;
           }
         }
@@ -1883,12 +1888,18 @@ double VariablesWidget::readVariableValue(QString variable, double time)
         QStringList values = currentLine.split(",");
         if (QString::number(time).compare(values[0]) == 0) {
           value = values[1].toDouble();
+          found = true;
           break;
         }
       }
     }
     textStream.seek(0);
   }
+
+  if (!found) {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, "No result for variable " + variable + " in result file.", Helper::simulationKind, Helper::warningLevel));
+  }
+
   return value;
 }
 


### PR DESCRIPTION
- Implement DynamicSelect-aware classes for the various types used in
  annotations and replace some of the the static variables with those.
- Add warning message when trying to read the value of a variable that's
  not in the result file.