### PR TITLE
Fix constant evaluation in annotations

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -230,7 +230,7 @@ algorithm
               try
                 exp := NFCeval.evalExp(save);
               else
-                exp := save;
+                exp := EvalConstants.evaluateExp(save, info);
               end try;
               exp := SimplifyExp.simplify(exp);
               str := str + ", " + Expression.toString(exp);


### PR DESCRIPTION
- Use EvalConstants if Ceval fails, to make sure structural parameters
  are always evaluated.