### PR TITLE
Automatically load used libraries

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/BackendInterface.mo
+++ b/OMCompiler/Compiler/FrontEnd/BackendInterface.mo
@@ -43,6 +43,7 @@ protected
 import CevalScript;
 import RewriteRules;
 import StaticScript;
+import SymbolTable;
 
 public function cevalInteractiveFunctions
   input FCore.Cache inCache;
@@ -100,6 +101,18 @@ function rewriteFrontEnd
 algorithm
   (outExp,isChanged) := RewriteRules.rewriteFrontEnd(inExp);
 end rewriteFrontEnd;
+
+function appendLibrary
+  input Absyn.Path modelName;
+  input String modelicaPath;
+  output Absyn.Program program;
+  output Boolean success;
+algorithm
+  program := SymbolTable.getAbsyn();
+  (program, success) := CevalScript.loadModel({(modelName, "", {"default"}, false)},
+    modelicaPath, program, true, true, true, false);
+  SymbolTable.setAbsyn(program);
+end appendLibrary;
 
 annotation(__OpenModelica_Interface="backendInterface");
 end BackendInterface;

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -1354,6 +1354,56 @@ public
       end match;
     end isEmptyTree;
 
+    function appendClasses
+      input list<InstNode> clsNodes;
+      input output ClassTree tree;
+    protected
+      array<InstNode> classes;
+      LookupTree.Tree ltree;
+    algorithm
+      () := match tree
+        case PARTIAL_TREE()
+          algorithm
+            (ltree, classes) := appendClasses2(clsNodes, tree.tree, tree.classes);
+            tree.tree := ltree;
+            tree.classes := classes;
+          then
+            ();
+
+        case EXPANDED_TREE()
+          algorithm
+            (ltree, classes) := appendClasses2(clsNodes, tree.tree, tree.classes);
+            tree.tree := ltree;
+            tree.classes := classes;
+          then
+            ();
+
+        case FLAT_TREE()
+          algorithm
+            (ltree, classes) := appendClasses2(clsNodes, tree.tree, tree.classes);
+            tree.tree := ltree;
+            tree.classes := classes;
+          then
+            ();
+      end match;
+    end appendClasses;
+
+    function appendClasses2
+      input list<InstNode> clsNodes;
+      input output LookupTree.Tree tree;
+      input output array<InstNode> classes;
+    protected
+      Integer index;
+    algorithm
+      index := arrayLength(classes);
+      classes := Array.appendList(classes, clsNodes);
+
+      for c in clsNodes loop
+        index := index + 1;
+        tree := LookupTree.add(tree, InstNode.name(c), LookupTree.Entry.CLASS(index));
+      end for;
+    end appendClasses2;
+
   protected
 
     function instExtendsComps

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -59,8 +59,15 @@ import Subscript = NFSubscript;
 import ComplexType = NFComplexType;
 import Config;
 import Error;
+import ErrorExt;
 import UnorderedMap;
 import Modifier = NFModifier;
+import BackendInterface;
+import Settings;
+import Testsuite;
+import AbsynToSCode;
+import NFClassTree.ClassTree;
+import SCodeUtil;
 
 public
 type MatchType = enumeration(FOUND, NOT_FOUND, PARTIAL);
@@ -419,6 +426,7 @@ function lookupSimpleName
 protected
   InstNode cur_scope = scope;
   Boolean require_builtin = false;
+  Boolean loaded = false;
 algorithm
   // Look for the name in each enclosing scope, until it's either found or we
   // run out of scopes.
@@ -443,8 +451,15 @@ algorithm
         node := cur_scope;
         return;
       else
-        // Otherwise, continue in the enclosing scope.
-        cur_scope := InstNode.parentScope(cur_scope);
+        if InstNode.isTopScope(cur_scope) and not loaded then
+          // If the name couldn't be found in any scope, try to load a library
+          // with that name and then try the look it up in the top scope again.
+          loaded := true;
+          loadLibrary(name, cur_scope);
+        else
+          // Otherwise, continue in the enclosing scope.
+          cur_scope := InstNode.parentScope(cur_scope);
+        end if;
       end if;
     end try;
   end for;
@@ -724,6 +739,7 @@ function lookupSimpleCref
   output LookupState state;
 protected
   Boolean is_import, require_builtin = false;
+  Boolean loaded = false;
 algorithm
   try
     (node, cref, state) := lookupSimpleBuiltinCref(name, subs);
@@ -767,8 +783,15 @@ algorithm
           foundScope := InstNode.topScope(InstNode.parentScope(foundScope));
           require_builtin := true;
         else
-          // Look in the next enclosing scope.
-          foundScope := InstNode.parentScope(foundScope);
+          if InstNode.isTopScope(foundScope) and not loaded then
+            // If the name couldn't be found in any scope, try to load a library
+            // with that name and then try the look it up in the top scope again.
+            loaded := true;
+            loadLibrary(name, foundScope);
+          else
+            // Look in the next enclosing scope.
+            foundScope := InstNode.parentScope(foundScope);
+          end if;
         end if;
       end try;
     end for;
@@ -1015,6 +1038,68 @@ algorithm
           fail();
   end match;
 end makeInnerNode;
+
+function loadLibrary
+  "Tries to load the default version of a library and add it to the top scope."
+  input String name;
+  input InstNode scope;
+protected
+  String version;
+algorithm
+  ErrorExt.setCheckpoint(getInstanceName());
+
+  try
+    version := loadLibrary_work(name, scope);
+    Error.addMessage(Error.NOTIFY_IMPLICIT_LOAD, {name, version});
+    ErrorExt.delCheckpoint(getInstanceName());
+  else
+    ErrorExt.rollBack(getInstanceName());
+  end try;
+end loadLibrary;
+
+function loadLibrary_work
+  input String name;
+  input InstNode scope;
+  output String version;
+protected
+  String modelica_path, cls_name;
+  Absyn.Program aprog;
+  SCode.Element scls;
+  Class cls;
+  InstNode lib_node;
+  list<InstNode> new_libs = {};
+algorithm
+  // Try to load the library.
+  modelica_path := Settings.getModelicaPath(Testsuite.isRunning());
+  (aprog, true) := BackendInterface.appendLibrary(Absyn.Path.IDENT(name), modelica_path);
+
+  // Multiple libraries might have been loaded due to uses-annotations.
+  // Create nodes for the ones not yet defined in the top scope.
+  for c in aprog.classes loop
+    try
+      lookupLocalSimpleName(AbsynUtil.getClassName(c), scope);
+    else
+      scls := AbsynToSCode.translateClass(c);
+      lib_node := InstNode.new(scls, scope);
+      new_libs := lib_node :: new_libs;
+
+      // If this is the library we were looking for, try to find out which
+      // version it is so we can tell the user.
+      if name == SCodeUtil.getElementName(scls) then
+        try
+          Absyn.Exp.STRING(value = version) :=
+            SCodeUtil.getElementNamedAnnotation(scls, "version");
+        else
+        end try;
+      end if;
+    end try;
+  end for;
+
+  // Append the new libraries to the scope.
+  cls := InstNode.getClass(scope);
+  cls := Class.classTreeApply(cls, function ClassTree.appendClasses(clsNodes = new_libs));
+  InstNode.updateClass(cls, scope);
+end loadLibrary_work;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFLookup;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -852,6 +852,8 @@ public constant ErrorTypes.Message UNSUPPORTED_RECORD_REORDERING = ErrorTypes.ME
   Gettext.gettext("The record constructor for ‘%s‘ requires reordering of local fields to initialize them in the correct order, which is not yet supported."));
 public constant ErrorTypes.Message FUNCTION_INVALID_OUTPUTS_FOR_INVERSE = ErrorTypes.MESSAGE(390, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Invalid inverse annotation for ‘%s‘, only functions with exactly one output may have an inverse."));
+public constant ErrorTypes.Message NOTIFY_IMPLICIT_LOAD = ErrorTypes.MESSAGE(391, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("Automatically loaded package %s %s due to usage."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/flattening/modelica/scodeinst/LookupLibrary1.mo
+++ b/testsuite/flattening/modelica/scodeinst/LookupLibrary1.mo
@@ -1,0 +1,21 @@
+// name: LookupLibrary1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Tests that libraries can be looked up even when not explicitly loaded.
+//
+
+class LookupLibrary1
+  Modelica.Units.SI.Angle angle;
+end LookupLibrary1;
+
+// Result:
+// class LookupLibrary1
+//   Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg");
+// end LookupLibrary1;
+// Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation.
+// Notification: Automatically loaded package Modelica 4.0.0 due to usage.
+//
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -710,6 +710,7 @@ lookup1.mo \
 lookup2.mo \
 lookup3.mo \
 lookup4.mo \
+LookupLibrary1.mo \
 loop1.mo \
 loop2.mo \
 loop3.mo \


### PR DESCRIPTION
- If a top-level name can't be found during name lookup, try to load a
  library with that name.