### PR TITLE
Fix unary expression in FlatModelica::Expression

### DIFF
--- a/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/Expression.cpp
@@ -1280,7 +1280,7 @@ namespace FlatModelica
 
     if (tok.type == Token::SUB) {
       tokenizer.popToken();
-      auto e = parseExp(tokenizer);
+      auto e = parsePrimary(tokenizer);
 
       if (e.isNumber()) {
         return e.isInteger() ? Expression(-e.intValue()) : Expression(-e.realValue());
@@ -1289,7 +1289,7 @@ namespace FlatModelica
       }
     } else if (tok.type == Token::NOT) {
       tokenizer.popToken();
-      auto e = parseExp(tokenizer);
+      auto e = parsePrimary(tokenizer);
 
       if (e.isBoolean()) {
         return Expression(!e.boolValue());

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -150,6 +150,18 @@ void ExpressionTest::operators_data()
   QTest::addColumn<QString>("string");
   QTest::addColumn<QString>("result");
 
+  QTest::newRow("unary1")
+    << "-17"
+    << "-17";
+
+  QTest::newRow("unary2")
+    << "-3 + x"
+    << "-2";
+
+  QTest::newRow("unary3")
+    << "x + -5"
+    << "-4";
+
   QTest::newRow("logic1")
     << "x and y or z"
     << "true";


### PR DESCRIPTION
- Make unary expressions less greedy when parsing expression so that
  e.g. -x + y is parsed as -x + y and not -(x + y).