### PR TITLE
Limit steps of Cpp Newton solver in case of singular Jacobians

### DIFF
--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip.mos
@@ -33,12 +33,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip', options = '', outputFormat = 'mat', variableFilter = 'time|revolute1.phi|revolute1.w|revolute2.phi|revolute2.w', cflags = '', simflags = ' -emit_protected'
 // Result file: Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulumInitTip_res.mat
-// Messages: ERROR  : init  : SimManager: Could not initialize system
-// ERROR  : init  : SimManager: Nonlinear solver 623 stopped at time 0 with error in algloop solver: 
-// error solving nonlinear system (iteration limit: 50)
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
-// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
-//
 // "true
 // "
 // ""

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1.mos
@@ -31,12 +31,6 @@ runScript(modelTesting);getErrorString();
 // OpenModelicaModelTesting.SimulationRuntime.Cpp
 // Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1', options = '', outputFormat = 'mat', variableFilter = 'time|j1.phi|j1.w', cflags = '', simflags = ' -emit_protected'
 // Result file: Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1_res.mat
-// Messages: ERROR  : init  : SimManager: Could not initialize system
-// ERROR  : init  : SimManager: Nonlinear solver 885 stopped at time 0 with error in algloop solver: 
-// error solving nonlinear system (iteration limit: 50)
-// ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
-// ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
-//
 // Files Equal!
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions("-d=initialization").
 //

--- a/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.Rotational.Examples.LossyGearDemo2.mos
+++ b/testsuite/simulation/libraries/msl32_cpp/Modelica.Mechanics.Rotational.Examples.LossyGearDemo2.mos
@@ -40,7 +40,7 @@ runScript(modelTesting);getErrorString();
 // Result file: Modelica.Mechanics.Rotational.Examples.LossyGearDemo2_res.mat
 // Messages: ERROR  : init  : SimManager: Could not initialize system
 // ERROR  : init  : SimManager: Nonlinear solver 62 stopped at time 0 with error in algloop solver: 
-// Can't get sufficient decrease of solution
+// error solving nonlinear system (iteration limit: 50)
 // ERROR  : solver: SimController: Simulation failed using nonlinear solver newton
 // ERROR  : solver: SimController: Recovering with nonlinear solver kinsol
 //


### PR DESCRIPTION
This should also avoid endless iterations.
See Modelica.Electrical.Analog.*Lightning* examples of MSL 4.
