### PR TITLE
Remove bad simlification e1/tanh(e2) --> e1*cosh(e1)/sinh(e2)

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -4783,13 +4783,6 @@ algorithm
       equation
         true = Expression.expEqual(e1,e2);
       then Expression.makePureBuiltinCall("tanh",{e1},ty);
-    // e1/tanh(e2) => e1*cos(e2)/sin(e2)
-    case(_,op2 as DAE.DIV(ty),e1,DAE.CALL(path=Absyn.IDENT("tanh"),expLst={e2}),_,_)
-      equation
-        e3 = Expression.makePureBuiltinCall("sinh",{e2},ty);
-        e4 = Expression.makePureBuiltinCall("cosh",{e2},ty);
-        e = DAE.BINARY(e4,op2,e3);
-      then DAE.BINARY(e1,DAE.MUL(ty), e);
     // tanh(e2)/sinh(e2) => 1.0/cosh(e2)
     case(_,op2 as DAE.DIV(ty),DAE.CALL(path=Absyn.IDENT("tanh"),expLst={e1}),DAE.CALL(path=Absyn.IDENT("sinh"),expLst={e2}),_,_)
       equation

--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -4765,11 +4765,11 @@ algorithm
         e4 = Expression.makePureBuiltinCall("cos",{e2},ty);
         e = DAE.BINARY(e3,op2,e4);
       then e;
-    // cos(e2)/tan(e2) => sin(e2)
-    case(_,DAE.DIV(ty),DAE.CALL(path=Absyn.IDENT("cos"),expLst={e1}),DAE.CALL(path=Absyn.IDENT("tan"),expLst={e2}),_,_)
+    // sin(e2)/tan(e2) => cos(e2)
+    case(_,DAE.DIV(ty),DAE.CALL(path=Absyn.IDENT("sin"),expLst={e1}),DAE.CALL(path=Absyn.IDENT("tan"),expLst={e2}),_,_)
       equation
         true = Expression.expEqual(e1,e2);
-        e = Expression.makePureBuiltinCall("sin",{e2},ty);
+        e = Expression.makePureBuiltinCall("cos",{e2},ty);
       then e;
     // e1/tan(e2) => e1*cos(e2)/sin(e2)
     case(_,op2 as DAE.DIV(ty),e1,DAE.CALL(path=Absyn.IDENT("tan"),expLst={e2}),_,_)
@@ -4778,7 +4778,7 @@ algorithm
         e4 = Expression.makePureBuiltinCall("cos",{e2},ty);
         e = DAE.BINARY(e4,op2,e3);
       then DAE.BINARY(e1,DAE.MUL(ty), e);
-    // sinh(e)/cosh(e) => tan(e)
+    // sinh(e)/cosh(e) => tanh(e)
     case(_,DAE.DIV(ty),DAE.CALL(path=Absyn.IDENT("sinh"),expLst={e1}),DAE.CALL(path=Absyn.IDENT("cosh"),expLst={e2}),_,_)
       equation
         true = Expression.expEqual(e1,e2);
@@ -4791,11 +4791,11 @@ algorithm
         e4 = Expression.makePureBuiltinCall("cosh",{e2},ty);
         e = DAE.BINARY(e3,op2,e4);
       then e;
-    // cosh(e2)/tanh(e2) => sinh(e2)
-    case(_,DAE.DIV(ty),DAE.CALL(path=Absyn.IDENT("cosh"),expLst={e1}),DAE.CALL(path=Absyn.IDENT("tanh"),expLst={e2}),_,_)
+    // sinh(e2)/tanh(e2) => cosh(e2)
+    case(_,DAE.DIV(ty),DAE.CALL(path=Absyn.IDENT("sinh"),expLst={e1}),DAE.CALL(path=Absyn.IDENT("tanh"),expLst={e2}),_,_)
       equation
         true = Expression.expEqual(e1,e2);
-        e = Expression.makePureBuiltinCall("sinh",{e2},ty);
+        e = Expression.makePureBuiltinCall("cosh",{e2},ty);
       then e;
 
     // e1  -e2 => -e1  e2

--- a/testsuite/simulation/libraries/3rdParty/PowerSystems_cpp/PowerSystems.Examples.AC3ph.Inverters.InverterToLoad.mos
+++ b/testsuite/simulation/libraries/3rdParty/PowerSystems_cpp/PowerSystems.Examples.AC3ph.Inverters.InverterToLoad.mos
@@ -8,7 +8,7 @@
 
 runScript("../../common/ModelTestingDefaults.mos"); getErrorString();
 
-modelTestingType := OpenModelicaModelTesting.Kind.Compilation;
+modelTestingType := OpenModelicaModelTesting.Kind.SimpleSimulation;
 modelName := $TypeName(PowerSystems.Examples.AC3ph.Inverters.InverterToLoad);
 compareVars :=
 {
@@ -34,7 +34,7 @@ runScript(modelTesting);getErrorString();
 // "true
 // "
 // ""
-// OpenModelicaModelTesting.Kind.Compilation
+// OpenModelicaModelTesting.Kind.SimpleSimulation
 // PowerSystems.Examples.AC3ph.Inverters.InverterToLoad
 // {"meterDC.p","meterDC.v","meterDC.i","meterAC.p[1]","meterAC.p[2]","meterAC.p[3]","meterAC.v[1]","meterAC.v[2]","meterAC.v[3]","meterAC.i[1]","meterAC.i[2]","meterAC.i[3]"}
 // "PowerSystems
@@ -43,7 +43,8 @@ runScript(modelTesting);getErrorString();
 // \"PowerSystems\"
 // "
 // ""
-// Compilation succeeded
+// Simulation options: startTime = 0.0, stopTime = 0.2, numberOfIntervals = 1000, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'PowerSystems.Examples.AC3ph.Inverters.InverterToLoad', options = '', outputFormat = 'mat', variableFilter = 'time|meterDC.p|meterDC.v|meterDC.i|meterAC.p.1.|meterAC.p.2.|meterAC.p.3.|meterAC.v.1.|meterAC.v.2.|meterAC.v.3.|meterAC.i.1.|meterAC.i.2.|meterAC.i.3.', cflags = '', simflags = ' -emit_protected'
+// Result file: PowerSystems.Examples.AC3ph.Inverters.InverterToLoad_res.mat
 // "true
 // "
 // ""


### PR DESCRIPTION
This avoids two instead of one calls to builtin functions. It also
avoids potential numerical overflows for large values of e2 when sinh returns inf.
See: PowerSystems.Examples.AC3ph.Inverters.InverterToLoad
See also issue #8005.
