### PR TITLE
Improve conversion of imports

### DIFF
--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -42,6 +42,7 @@ requirements.log \
 scalable.log \
 device.log \
 ffi.log
+conversion.log
 
 SIMULATIONLOGS = \
 linearization.log \
@@ -619,6 +620,9 @@ flatmodelica.log: omc-diff
 	@echo $@ done
 ffi.log: omc-diff
 	$(MAKE) -C flattening/modelica/ffi -f Makefile test > $@
+	@echo $@ done
+conversion.log: omc-diff
+	$(MAKE) -C openmodelica/conversion -f Makefile test > $@
 	@echo $@ done
 
 failingtest: omc-diff

--- a/testsuite/openmodelica/conversion/ConvertClass4.mos
+++ b/testsuite/openmodelica/conversion/ConvertClass4.mos
@@ -64,7 +64,7 @@ list(ConvertClass4);
 //     end D;
 //
 //     model E
-//       import SI = Modelica.Units.SI;
+//       import Modelica.Units.SI;
 //       SI.Temperature x;
 //       function from_degC = Modelica.Units.Conversions.from_degC;
 //     equation

--- a/testsuite/openmodelica/conversion/ConvertClass5.mos
+++ b/testsuite/openmodelica/conversion/ConvertClass5.mos
@@ -23,7 +23,7 @@ list(ConvertClass5);
 // true
 // ""
 // "package ConvertClass5
-//   import SI = Modelica.Units.SI;
+//   import Modelica.Units.SI;
 //
 //   model A
 //     SI.Time t;

--- a/testsuite/openmodelica/conversion/ConvertClass7.mos
+++ b/testsuite/openmodelica/conversion/ConvertClass7.mos
@@ -1,0 +1,60 @@
+// name:   ConvertClass7
+// status: correct
+// cflags: -d=newInst
+// depends: scripts
+
+loadString("
+  package ConvertClass7
+    import SI = Modelica.SIunits;
+
+    model M1
+      SI.Conversions.NonSIunits.Angle_deg angle \"Shadowed by SI class below\";
+    end M1;
+
+    model SI
+      Real x;
+    end SI;
+
+    model M2
+      import SI = Modelica.SIunits;
+      SI.Conversions.NonSIunits.Angle_deg angle \"Not shadowed\";
+
+      model M3
+        Real SI;
+        SI.Conversions.NonSIunits.Angle_deg angle \"Shadowed by component SI\";
+      end M3;
+    end M2;
+
+  end ConvertClass7;
+");
+
+convertPackage(ConvertClass7, "scripts/ConvertClass4.mos");
+getErrorString();
+list(ConvertClass7);
+
+// Result:
+// true
+// true
+// ""
+// "package ConvertClass7
+//   import Modelica.Units.SI;
+//
+//   model M1
+//     SI.Conversions.NonSIunits.Angle_deg angle \"Shadowed by SI class below\";
+//   end M1;
+//
+//   model SI
+//     Real x;
+//   end SI;
+//
+//   model M2
+//     import Modelica.Units.SI;
+//     Modelica.Units.NonSI.Angle_deg angle \"Not shadowed\";
+//
+//     model M3
+//       Real SI;
+//       SI.Conversions.NonSIunits.Angle_deg angle \"Shadowed by component SI\";
+//     end M3;
+//   end M2;
+// end ConvertClass7;"
+// endResult

--- a/testsuite/openmodelica/conversion/ConvertClass8.mos
+++ b/testsuite/openmodelica/conversion/ConvertClass8.mos
@@ -1,0 +1,24 @@
+// name:   ConvertClass8
+// status: correct
+// cflags: -d=newInst
+// depends: scripts
+
+loadString("
+  package ConvertClass8
+    import SI = Modelica.SIunits;
+    import Modelica.SIunits;
+  end ConvertClass8;
+");
+
+convertPackage(ConvertClass8, "scripts/ConvertClass4.mos");
+getErrorString();
+list(ConvertClass8);
+
+// Result:
+// true
+// true
+// ""
+// "package ConvertClass8
+//   import Modelica.Units.SI;
+// end ConvertClass8;"
+// endResult

--- a/testsuite/openmodelica/conversion/Makefile
+++ b/testsuite/openmodelica/conversion/Makefile
@@ -8,6 +8,7 @@ ConvertClass4.mos \
 ConvertClass5.mos \
 ConvertClass6.mos \
 ConvertClass7.mos \
+ConvertClass8.mos \
 ConvertClassVectorize1.mos \
 ConvertClassVectorize2.mos \
 ConvertClassVectorize3.mos \


### PR DESCRIPTION
- Simplify imports like C = A.B.C to just A.B.C.
- Remove duplicate imports after conversion.
- Add missing tests and actually enable the conversion tests.