### PR TITLE
Always write a complete results file with Cpp runtime

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimController/SimManager.cpp
@@ -124,6 +124,7 @@ void SimManager::initialize()
     // Reset debug ID
     _dbgId = 0;
 
+    _solver->setStartTime(_tStart);
     try
     {
         // Build up system and update once
@@ -133,10 +134,13 @@ void SimManager::initialize()
     {
         LOGGER_WRITE("SimManager: Could not initialize system", LC_INIT, LL_ERROR);
         LOGGER_WRITE("SimManager: " + string(ex.what()), LC_INIT, LL_ERROR);
-        //ex << error_id(SIMMANAGER);
+        // Write current values as they might help to analyse the error
+        _solver->solve(ISolver::RECORDCALL);
         throw ModelicaSimulationError(SIMMANAGER, "Could not initialize system",
                                       string(ex.what()), LOGGER_IS_SET(LC_INIT, LL_ERROR));
     }
+    // Write initial values
+    _solver->solve(ISolver::RECORDCALL);
 
     if (_timeevent_system)
     {

--- a/OMCompiler/SimulationRuntime/cpp/Core/Solver/SolverDefaultImplementation.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Solver/SolverDefaultImplementation.h
@@ -113,6 +113,9 @@ protected:
   IWriteOutput::OUTPUT
     _outputCommand;           ///< Controls the output
 
+  IWriteOutput
+    *_writeoutput_system;
+
 private:
   /// Definition of signum function
   inline static int sgn (const double &c)


### PR DESCRIPTION
This simplifies the analysis of initialization errors
and it works around crashes of OMEdit,
see issue #8008 (OMEdit crashes if a simulation fails or is canceled).

- SimManager.cpp: write out values after initialization,
  also in case of failure for the analysis of intermediate results
- SolverDefaultImplementation: decouple writing of variable names
  from initialization of solver. Write them before first values instead.
