### PR TITLE
Fix type table bug in Conversion

### DIFF
--- a/OMCompiler/Compiler/Script/Conversion.mo
+++ b/OMCompiler/Compiler/Script/Conversion.mo
@@ -2754,6 +2754,8 @@ protected
     input list<Absyn.ClassPart> parts;
     input TypeTable components;
   algorithm
+    UnorderedMap.clear(components);
+
     for part in parts loop
       () := match part
         case Absyn.ClassPart.PUBLIC()

--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -262,6 +262,15 @@ public
     Vector.apply(map.buckets, function update_indices(removedIndex = index));
   end remove;
 
+  function clear
+    input UnorderedMap<K, V> map;
+  algorithm
+    Vector.clear(map.buckets);
+    Vector.push(map.buckets, {});
+    Vector.clear(map.keys);
+    Vector.clear(map.values);
+  end clear;
+
   function get
     "Returns SOME(value) if the given key has an associated value in the map,
      otherwise NONE()."


### PR DESCRIPTION
- Clear the type table when going into a new class, to avoid
  accumulating every variable in the whole library.