### PR TITLE
Try expanding non param variables as well.

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8177,7 +8177,7 @@ protected
   BackendDAE.Var scalarVar;
 algorithm
   // if it is an array parameter split it up. Do not do it for Cpp runtime, they can handle array parameters
-  if BackendVariable.isParam(dlowVar) and Types.isArray(dlowVar.varType) and not (Config.simCodeTarget() == "Cpp" ) then
+  if Types.isArray(dlowVar.varType) and not (Config.simCodeTarget() == "Cpp" ) then
     scalar_crefs := ComponentReference.expandCref(dlowVar.varName, false);
     for cref in scalar_crefs loop
       // extract the sim var

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -2246,9 +2246,11 @@ algorithm
       Boolean b;
 
     // array equation that may result from -d=-nfScalarize and is assumed solved
-    case BackendDAE.ARRAY_EQUATION(left = DAE.CREF(componentRef = cr), right = e2, source = source, attr = eqAttr)
+    case BackendDAE.ARRAY_EQUATION(left = DAE.CREF(componentRef = cr), right = e2, source = source, attr = eqAttr) algorithm
+        varexp := Expression.crefExp(cr);
+        simEqSys := SimCode.SES_ARRAY_CALL_ASSIGN(iuniqueEqIndex, varexp, e2, source, eqAttr);
       then
-        ({SimCode.SES_SIMPLE_ASSIGN(iuniqueEqIndex, cr, e2, source, eqAttr)}, iuniqueEqIndex + 1, itempvars);
+        ({simEqSys}, iuniqueEqIndex + 1, itempvars);
 
     // for equation that may result from -d=-nfScalarize
     case BackendDAE.FOR_EQUATION(iter = varexp, start = start, stop = cond, source = source, attr = eqAttr)


### PR DESCRIPTION
This an attempt to fix #7999. 

`parameter` arrays with `function call` bindings are not expanded by the NF anymore since #7271.  Instead they are expanded while SimCode is being created.

Unfortunately (as far as I can understand) the initialization system takes these `parameter` arrays and treats them as `variable` arrays. This seems to cause creation of SimCode to fail. 

This commit seems to fix the SimCode issue but the models now fail at C compilation time due to mismatched types directly as a result of the expansion.

The assignments get created as SIMPLE_ASSIGN while they should probably be ARRAY_CALL_ASSIGN.

We need to investigate more.