### PR TITLE
Fix Cpp reduction for record and add test

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppCommon.tpl
@@ -1064,9 +1064,6 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
       '<%res%> = mmc_mk_cons(<%reductionBodyExpr%>,<%res%>);'
     case IDENT(name="array") then
       match typeof(r.expr)
-        case T_COMPLEX(complexClassType = record_state) then
-          let rec_name = '<%underscorePath(ClassInf.getStateName(record_state))%>'
-          '<%rec_name%>_array_get(<%res%>, 1, <%arrIndex%>++) = <%reductionBodyExpr%>;'
         case T_ARRAY(__) then
           let tmp_slice = tempDecl("vector<Slice>", &varDecls)
           <<
@@ -1140,9 +1137,6 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
        <<
        <%arrIndex%> = 1;
        <% match typeof(r.expr)
-        case T_COMPLEX(complexClassType = record_state) then
-          let rec_name = '<%underscorePath(ClassInf.getStateName(record_state))%>'
-          'alloc_generic_array(&<%res%>,sizeof(<%rec_name%>),1,<%length%>);'
         case T_ARRAY(__) then
           let dim_vec = tempDecl("std::vector<size_t>",&tmpVarDecls)
           let dimSizes = dims |> dim => match dim

--- a/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
@@ -11,20 +11,6 @@
 
 using namespace std;
 
-//void boost::assertion_failed(char const * expr, char const * function,
-//                             char const * file, long line)
-//{
-//  fprintf(stdout, "Range check failed for Array please check indices \n" );
-//}
-
-size_t getNextIndex(const vector<size_t> idx, size_t k)
-{
-  if((idx.size()-1)<k)
-    return idx.back();
-  else
-    return idx[k];
-}
-
 /**
 Concatenates n real arrays along the k:th dimension.
 */

--- a/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.h
@@ -18,20 +18,11 @@ Auxillary Array operations for OpenModelica.
 Copyright (c) 2010, OSMC
 *****************************************************************************/
 
-/*index type for multi array, first shape, second indeces*/
-typedef std::vector<std::vector<size_t> > idx_type;
-typedef std::pair<vector<size_t>,idx_type >  spec_type;
-
-
-size_t getNextIndex(const vector<size_t> idx, size_t k);
-
-
 /**
 Concatenates n real arrays along the k:th dimension.
 */
 template <typename T>
 void cat_array(int k, const vector<const BaseArray<T>*>& x, BaseArray<T>& a);
-
 
 template <typename T>
 void transpose_array(const BaseArray<T>& x, BaseArray<T>& a);

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -29,6 +29,7 @@ solveTest.mos \
 testArrayEquations.mos \
 testMatrixIO.mos \
 testMatrixState.mos \
+testReduction.mos \
 testVectorizedBlocks.mos \
 testVectorizedPowerSystem.mos \
 testVectorizedSolarSystem.mos \

--- a/testsuite/openmodelica/cppruntime/testReduction.mos
+++ b/testsuite/openmodelica/cppruntime/testReduction.mos
@@ -1,0 +1,72 @@
+// name: testReduction
+// keywords: reduction array record
+// status: correct
+// teardown_command: rm -f *ReductionTest*
+// cflags:
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadModel(Modelica, {"3.2.3"});
+loadString("
+model ReductionTest
+  input Real u(start = 1); // prevent presolving during translation
+  parameter Integer n = 2;
+  Real[:] b = f(n, u);
+  Real[:, :] A = g(n, u);
+  Complex[:] C = h(n, u);
+equation
+  annotation(experiment(StopTime = 0));
+end ReductionTest;
+function f
+  input Integer n;
+  input Real u;
+  output Real[n] b = {u * i for i in 1:n};
+end f;
+function g
+  input Integer n;
+  input Real u;
+  output Real[n,n] A = {{10 * i + u * j for j in 1:n} for i in 1:n};
+end g;
+function h
+  input Integer n;
+  input Real u;
+  output Complex[n] C = {Complex(i, 0.1 * i) for i in 1:n};
+end h;
+");
+getErrorString();
+
+simulate(ReductionTest);
+val(b[1], 0);
+val(b[2], 0);
+val(A[1,1], 0);
+val(A[1,2], 0);
+val(A[2,1], 0);
+val(A[2,2], 0);
+val(C[1].re, 0);
+val(C[1].im, 0);
+val(C[2].re, 0);
+val(C[2].im, 0);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ReductionTest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ReductionTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// 1.0
+// 2.0
+// 11.0
+// 12.0
+// 21.0
+// 22.0
+// 1.0
+// 0.1
+// 2.0
+// 0.2
+// ""
+// endResult


### PR DESCRIPTION
Remove special treatment to treat array of record as regular array.

Also remove idx_type, spec_type and getNextIndex from ArrayOperations
that are not used anymore since removal of create/fill_array_from_shape.
