### PR TITLE
Improve handling of graphical primitives with nfAPI

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -1927,6 +1927,20 @@ protected
       // If it had iterators then it will not reach here. The args would have been parsed to
       // Absyn.FOR_ITER_FARG and that is handled in instIteratorCall.
       case "array" then BuiltinCall.makeArrayExp(args, named_args, info);
+
+      case _ guard InstContext.inGraphicalExp(context)
+        algorithm
+          // If we're in a graphic annotation expression, first try to find the
+          // function in the top scope in case there's a user-defined function
+          // with the same name. If it's not found, check the normal scope.
+          try
+            fn_ref := Function.instFunction(functionName, InstNode.topScope(scope), context, info);
+          else
+            fn_ref := Function.instFunction(functionName, scope, context, info);
+          end try;
+        then
+          Expression.CALL(UNTYPED_CALL(fn_ref, args, named_args, scope));
+
       else
         algorithm
           fn_ref := Function.instFunction(functionName, scope, context, info);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
@@ -60,6 +60,7 @@ encapsulated package NFInstContext
   constant Type CONNECT         = intBitLShift(1, 21); // Part of connect argument.
   constant Type NOEVENT         = intBitLShift(1, 22); // Part of noEvent argument.
   constant Type ASSERT          = intBitLShift(1, 23); // Part of assert argument.
+  constant Type GRAPHICAL_EXP   = intBitLShift(1, 24); // Part of a graphical expression.
 
   // Combined flags:
   constant Type EQ_SUBEXPRESSION = intBitOr(EQUATION, SUBEXPRESSION);
@@ -212,6 +213,11 @@ encapsulated package NFInstContext
     input Type context;
     output Boolean res = intBitAnd(context, ASSERT) > 0;
   end inAssert;
+
+  function inGraphicalExp
+    input Type context;
+    output Boolean res = intBitAnd(context, GRAPHICAL_EXP) > 0;
+  end inGraphicalExp;
 
   function inValidTypenameScope
     input Type context;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -160,6 +160,7 @@ protected
   DAE.DAElist dae;
   Type ty;
   Variability var;
+  InstContext.Type context;
 algorithm
   stringLst := {};
 
@@ -224,7 +225,8 @@ algorithm
           if (stringEq(annName, "Icon") or stringEq(annName, "Diagram")) and not listEmpty(graphics_mod) then
             try
               {Absyn.MODIFICATION(modification = SOME(Absyn.CLASSMOD(eqMod = Absyn.EQMOD(exp = absynExp))))} := graphics_mod;
-              exp := NFInst.instExp(absynExp, inst_cls, NFInstContext.RELAXED, info);
+              context := InstContext.set(NFInstContext.RELAXED, NFInstContext.GRAPHICAL_EXP);
+              exp := NFInst.instExp(absynExp, inst_cls, context, info);
               (exp, ty, var) := Typing.typeExp(exp, NFInstContext.CLASS, info);
               save := exp;
               try


### PR DESCRIPTION
- When instantiating graphical expression, try to find function names in
  the top scope before checking the regular scope in case there's a
  user-defined function with the same name.