### PR TITLE
Fix behaviour of StringHandler::getStrings

### DIFF
--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -948,7 +948,11 @@ QStringList StringHandler::getStrings(QString value)
   }
 
   if (n > 0) {
+    // Append the rest of the string if there's anything left.
     res.append(value.mid(start).trimmed());
+  } else if (!value.isEmpty() && value[value.size()-1] == ',') {
+    // Append an empty string if the string ends with ,
+    res.append(QString());
   }
 
   return res;


### PR DESCRIPTION
- Preserve the old behaviour of StringHandler::getStrings by appending
  an empty string to the list if the string to split ends with a comma.