### PR TITLE
Fix dgesv files copying for source code FMUs

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -247,6 +247,9 @@ install(FILES FrontEnd/ModelicaBuiltin.mo
 install(FILES FrontEnd/MetaModelicaBuiltin.mo
             DESTINATION lib/omc
             COMPONENT compiler)
+install(FILES FrontEnd/PDEModelicaBuiltin.mo
+            DESTINATION lib/omc
+            COMPONENT compiler)
 
 
 # This is a convenience target to install omc. We are used to issuing 'make install' to install

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -772,7 +772,7 @@ algorithm
           // The dgesv headers are in the RuntimeSources.fmu_sources_dir for now since they are not properly installed in the include folder
           copyFiles(RuntimeSources.dgesv_headers, source=install_fmu_sources_dir, destination=fmu_tmp_sources_dir);
           copyFiles(RuntimeSources.dgesv_sources, source=install_fmu_sources_dir, destination=fmu_tmp_sources_dir);
-          dgesv_sources := RuntimeSources.sundials_headers;
+          dgesv_sources := RuntimeSources.dgesv_sources;
         else
           dgesv_sources := {};
         end if;

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -31,7 +31,8 @@ set(SOURCE_FMU_COMMON_HEADERS \"./omc_inline.h\",\"./openmodelica_func.h\",\"./o
 
 ######################################################################################################################
 # Lapack files
-file(GLOB_RECURSE 3RD_DGESV_FILES   ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/blas/*.c
+file(GLOB_RECURSE 3RD_DGESV_FILES   ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/include/*.h
+                                    ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/blas/*.c
                                     ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/lapack/*.c
                                     ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/libf2c/*.c)
 install(FILES ${3RD_DGESV_FILES}


### PR DESCRIPTION
@mahge
Fix wrong list of dgesv sources. …
be7dd6d
  - [cmake] Install the dgesv headers to fmu sources dir for now.

    I will add lapack to 3rdParty soon. Since we need to build it ourselves
    for multiple reasons. When that is done the proper headers will be
    installed in omc include directory like every other 3rdParty lib.
    Until then this suffices.

@mahge
[cmake] Install PDEModelicaBuiltin.mo …
7d369ce
  - It was overlooked before.