### PR TITLE
Fix #7767

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -639,25 +639,21 @@ function makeComponentBinding
   input EvalTarget target;
   output Binding binding;
 protected
-  ClassTree tree;
-  array<InstNode> comps;
-  list<Expression> fields;
-  Type ty, exp_ty;
+  Type ty;
   InstNode rec_node;
   Expression exp;
-  ComponentRef rest_cr;
 algorithm
-  binding := matchcontinue (component, cref)
+  binding := matchcontinue component
     // A record field without an explicit binding, evaluate the parent's binding
     // if it has one and fetch the binding from it instead.
-    case (_, _)
+    case _
       algorithm
         exp := makeRecordFieldBindingFromParent(cref, target);
       then
         Binding.CEVAL_BINDING(exp);
 
     // A record component without an explicit binding, create one from its children.
-    case (Component.TYPED_COMPONENT(ty = Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node))), _)
+    case Component.TYPED_COMPONENT(ty = Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node)))
       algorithm
         exp := makeRecordBindingExp(component.classInst, rec_node, component.ty, cref);
         binding := Binding.CEVAL_BINDING(exp);
@@ -669,11 +665,13 @@ algorithm
         binding;
 
     // A record array component without an explicit binding, create one from its children.
-    case (Component.TYPED_COMPONENT(ty = ty as Type.ARRAY(elementType =
-            Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node)))), _)
+    case Component.TYPED_COMPONENT(ty = Type.ARRAY(elementType = ty as
+        Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node))))
       algorithm
-        exp := makeRecordBindingExp(component.classInst, rec_node, component.ty, cref);
-        exp := splitRecordArrayExp(exp);
+        exp := Expression.mapCrefScalars(Expression.fromCref(cref),
+          function makeRecordBindingExp(typeNode = component.classInst,
+            recordNode = rec_node, recordType = ty));
+
         binding := Binding.CEVAL_BINDING(exp);
 
         if not ComponentRef.hasSubscripts(cref) then
@@ -696,7 +694,6 @@ protected
   InstContext.Type exp_context;
   Binding binding;
   Component comp;
-  list<Subscript> subs;
 algorithm
   parent_cr := ComponentRef.rest(cref);
   parent := ComponentRef.node(parent_cr);
@@ -732,7 +729,6 @@ protected
   ClassTree tree;
   array<InstNode> comps;
   list<Expression> args;
-  list<Record.Field> fields;
   Type ty;
   InstNode c;
   ComponentRef cr;
@@ -757,18 +753,6 @@ algorithm
 
   exp := Expression.makeRecord(InstNode.scopePath(recordNode, includeRoot = true), recordType, args);
 end makeRecordBindingExp;
-
-function splitRecordArrayExp
-  input output Expression exp;
-protected
-  Absyn.Path path;
-  Type ty;
-  list<Expression> expl;
-algorithm
-  Expression.RECORD(path, ty, expl) := exp;
-  exp := Expression.makeRecord(path, Type.arrayElementType(ty), expl);
-  exp := Expression.fillType(ty, exp);
-end splitRecordArrayExp;
 
 function evalTypename
   input Type ty;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -280,6 +280,7 @@ public
     classInst := match component
       case UNTYPED_COMPONENT() then component.classInst;
       case TYPED_COMPONENT() then component.classInst;
+      case ITERATOR(ty = Type.COMPLEX(cls = classInst)) then classInst;
     end match;
   end classInstance;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -407,7 +407,7 @@ public
   algorithm
     for i in iterators loop
       (node, range) := i;
-      iter := Mutable.create(Expression.INTEGER(0));
+      iter := Mutable.create(Expression.EMPTY(InstNode.getType(node)));
       e := Expression.replaceIterator(e, node, Expression.MUTABLE(iter));
       iters := iter :: iters;
       (range, true) := expand(range);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -96,6 +96,7 @@ algorithm
     case Expression.UNBOX() then Expression.UNBOX(simplify(exp.exp), exp.ty);
     case Expression.SUBSCRIPTED_EXP() then simplifySubscriptedExp(exp);
     case Expression.TUPLE_ELEMENT() then simplifyTupleElement(exp);
+    case Expression.RECORD_ELEMENT() then simplifyRecordElement(exp);
     case Expression.BOX() then Expression.BOX(simplify(exp.exp));
     case Expression.MUTABLE() then simplify(Mutable.access(exp.exp));
     else exp;
@@ -919,6 +920,21 @@ algorithm
   e := simplify(e);
   tupleExp := Expression.tupleElement(e, ty, index);
 end simplifyTupleElement;
+
+function simplifyRecordElement
+  input output Expression exp;
+protected
+  Expression e, e2;
+  Integer idx;
+  Type ty;
+algorithm
+  Expression.RECORD_ELEMENT(e, idx, _, ty) := exp;
+  e2 := simplify(e);
+
+  if not referenceEq(e, e2) then
+    exp := Expression.nthRecordElement(idx, e2);
+  end if;
+end simplifyRecordElement;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFSimplifyExp;

--- a/testsuite/flattening/modelica/scodeinst/ArrayConstructorRecord1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConstructorRecord1.mo
@@ -1,0 +1,27 @@
+// name: ArrayConstructorRecord1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record R
+  Real x;
+end R;
+
+model ArrayConstructorRecord1
+  parameter R r[3](x = {1, 2, 3});
+  Real x[:] = {i.x for i in r};
+end ArrayConstructorRecord1;
+
+// Result:
+// class ArrayConstructorRecord1
+//   parameter Real r[1].x = 1.0;
+//   parameter Real r[2].x = 2.0;
+//   parameter Real r[3].x = 3.0;
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x = {1.0, 2.0, 3.0};
+// end ArrayConstructorRecord1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ArrayConstructorRecord2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConstructorRecord2.mo
@@ -1,0 +1,27 @@
+// name: ArrayConstructorRecord2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record R
+  Real x = 1;
+end R;
+
+model ArrayConstructorRecord2
+  parameter R r[3];
+  Real x[:] = {i.x for i in r};
+end ArrayConstructorRecord2;
+
+// Result:
+// class ArrayConstructorRecord2
+//   parameter Real r[1].x = 1.0;
+//   parameter Real r[2].x = 1.0;
+//   parameter Real r[3].x = 1.0;
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x = {1.0, 1.0, 1.0};
+// end ArrayConstructorRecord2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -19,6 +19,8 @@ ArrayConnect1.mo \
 ArrayConnect2.mo \
 ArrayConnect3.mo \
 ArrayConstructorComplex1.mo \
+ArrayConstructorRecord1.mo \
+ArrayConstructorRecord2.mo \
 arrfunc.mo \
 Assert1.mo \
 Assert2.mo \


### PR DESCRIPTION
- Fix lookup so that it works also on iterators of complex type.
- Improve Expression.replaceIterator so it handles qualified iterator
  names.
- Improve construction of record array bindings in Ceval, evaluate each
  element instead of evaluating only one and filling an array.
- Add simplification of record element expressions, to make sure mutable
  expressions are simplified away properly.