### PR TITLE
Remove the extra quotes from textString

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -171,9 +171,9 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
     mTextExpression = FlatModelica::Expression::parse(list.at(9));
 
     if (mTextExpression.isCall("DynamicSelect")) {
-      mOriginalTextString = mTextExpression.arg(0).toQString();
+      mOriginalTextString = StringHandler::removeFirstLastQuotes(mTextExpression.arg(0).toQString());
     } else {
-      mOriginalTextString = mTextExpression.toQString();
+      mOriginalTextString = StringHandler::removeFirstLastQuotes(mTextExpression.toQString());
     }
   } catch (const std::exception &e) {
     qDebug() << "Failed to parse annotation: " << list.at(9);
@@ -459,7 +459,7 @@ QString TextAnnotation::getShapeAnnotation()
     annotationString.append(extentString);
   }
   // get the text string
-  annotationString.append(QString("textString=\"").append(mOriginalTextString).append("\""));
+  annotationString.append(QString("textString=\"%1\"").arg(mOriginalTextString));
   // get the font size
   if (mFontSize != 0) {
     annotationString.append(QString("fontSize=").append(QString::number(mFontSize)));


### PR DESCRIPTION
### Purpose

Do not add extra quotes around text string.

### Approach

Expression print adds extra quotes. Remove the quotes when reading the expression as string.
