### PR TITLE
Fix string escaping issues

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1613,7 +1613,7 @@ public
     str := match exp
       case INTEGER() then intString(exp.value);
       case REAL() then realString(exp.value);
-      case STRING() then "\"" + exp.value + "\"";
+      case STRING() then "\"" + System.escapedString(exp.value, false) + "\"";
       case BOOLEAN() then boolString(exp.value);
 
       case ENUM_LITERAL(ty = t as Type.ENUMERATION())

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -911,6 +911,8 @@ QStringList StringHandler::getStrings(QString value)
     } else if (str_char) {
       if (c == str_char) {
         str_char = 0;
+      } else if (c == '\\') {
+        escaped = true;
       }
       continue;
     }


### PR DESCRIPTION
- Escape strings in Expression.toString in OMC.
- Handle escaped characters inside strings in StringHandler::getStrings
  in OMEdit.