### PR TITLE
Give the error functions default values.

### DIFF
--- a/OMCompiler/Compiler/.cmake/omc_entry_point.c
+++ b/OMCompiler/Compiler/.cmake/omc_entry_point.c
@@ -14,11 +14,6 @@ omc_Main_main
 #endif
 (threadData_t*,modelica_metatype);
 
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
-
 #ifdef _OPENMP
 #include<omp.h>
 /* Hack to make gcc-4.8 link in the OpenMP runtime if -fopenmp is given */

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1228,13 +1228,13 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
         Set the error functions to be used for simulation.
         The default value for them is 'functions' version. Change it here to 'simulation' versions
       */
-      void (*omc_assert)(threadData_t*, FILE_INFO info, const char *msg, ...)  __attribute__ ((noreturn)) = omc_assert_simulation;
-      void (*omc_assert_withEquationIndexes)(threadData_t*, FILE_INFO info, const int *indexes, const char *msg, ...)  __attribute__ ((noreturn)) = omc_assert_simulation_withEquationIndexes;
+      omc_assert = omc_assert_simulation;
+      omc_assert_withEquationIndexes = omc_assert_simulation_withEquationIndexes;
 
-      void (*omc_assert_warning_withEquationIndexes)(FILE_INFO info, const int *indexes, const char *msg, ...) = omc_assert_warning_simulation_withEquationIndexes;
-      void (*omc_assert_warning)(FILE_INFO info, const char *msg, ...) = omc_assert_warning_simulation;
-      void (*omc_terminate)(FILE_INFO info, const char *msg, ...) = omc_terminate_simulation;
-      void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_simulation;
+      omc_assert_warning_withEquationIndexes = omc_assert_warning_simulation_withEquationIndexes;
+      omc_assert_warning = omc_assert_warning_simulation;
+      omc_terminate = omc_terminate_simulation;
+      omc_throw = omc_throw_simulation;
 
       int res;
       DATA data;

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -118,6 +118,7 @@ end translateModel;
     #include "simulation/simulation_runtime.h"
     #include "util/omc_error.h"
     #include "util/parallel_helper.h"
+    #include "simulation/simulation_omc_assert.h"
     #include "simulation/solver/model_help.h"
     #include "simulation/solver/delay.h"
     #include "simulation/solver/linearSystem.h"
@@ -1223,6 +1224,18 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
     /* call the simulation runtime main from our main! */
     int main(int argc, char**argv)
     {
+      /*
+        Set the error functions to be used for simulation.
+        The default value for them is 'functions' version. Change it here to 'simulation' versions
+      */
+      void (*omc_assert)(threadData_t*, FILE_INFO info, const char *msg, ...)  __attribute__ ((noreturn)) = omc_assert_simulation;
+      void (*omc_assert_withEquationIndexes)(threadData_t*, FILE_INFO info, const int *indexes, const char *msg, ...)  __attribute__ ((noreturn)) = omc_assert_simulation_withEquationIndexes;
+
+      void (*omc_assert_warning_withEquationIndexes)(FILE_INFO info, const int *indexes, const char *msg, ...) = omc_assert_warning_simulation_withEquationIndexes;
+      void (*omc_assert_warning)(FILE_INFO info, const char *msg, ...) = omc_assert_warning_simulation;
+      void (*omc_terminate)(FILE_INFO info, const char *msg, ...) = omc_terminate_simulation;
+      void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_simulation;
+
       int res;
       DATA data;
       MODEL_DATA modelData;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -48,11 +48,6 @@ extern void
 #endif
 (threadData_t*,modelica_metatype);
 
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
-
 #ifdef _OPENMP
 #include<omp.h>
 /* Hack to make gcc-4.8 link in the OpenMP runtime if -fopenmp is given */
@@ -1429,11 +1424,6 @@ template generateInFunc(Text fname, list<Variable> functionArguments, list<Varia
     fflush(NULL);
     return 1;
   }
-
-  void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-  void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-  void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-  void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
 
   int main(int argc, char **argv) {
     MMC_INIT(0);

--- a/OMCompiler/Compiler/boot/Makefile.common
+++ b/OMCompiler/Compiler/boot/Makefile.common
@@ -72,6 +72,7 @@ bootstrap-from-tarball2:
 	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory clean OMC="$(BOOTSTRAP_OMC)"
 	$(MAKE) -f $(defaultMakefileTarget) --no-print-directory runtime-depends OMBUILDDIR=$(OMBUILDDIR) OMC="$(BOOTSTRAP_OMC)"
 	OPENMODELICA_BACKEND_STUBS=1 $(MAKE) -f $(defaultMakefileTarget) generate-files-in-steps OMC="$(BOOTSTRAP_OMC)" OMC_EXTRA_FLAGS= TEMPLATES_TARGET=templates-bootstrap
+	cp bootstrap-sources/build/_main.c build/
 	# We have not compiled OpenModelicaScriptingAPI.mo yet
 	touch build/OpenModelicaScriptingAPI.h
 	$(MAKE) -f $(defaultMakefileTarget) install INCLUDESOURCES=1 OMC="$(BOOTSTRAP_OMC)" CPPFLAGS="$(CPPFLAGS) -DOMC_BOOTSTRAPPING_STAGE_2"

--- a/OMCompiler/Compiler/boot/bootstrap-sources/build/_main.c
+++ b/OMCompiler/Compiler/boot/bootstrap-sources/build/_main.c
@@ -19,10 +19,6 @@ extern void
 omc_Main_main
 #endif
 (threadData_t*,modelica_metatype);
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
 #ifdef _OPENMP
 #include<omp.h>
 int (*force_link_omp)(void) = omp_get_num_threads;

--- a/OMCompiler/SimulationRuntime/OMSICpp/omcWrapper/omcCAPI/include/OMCFunctions.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/omcWrapper/omcCAPI/include/OMCFunctions.h
@@ -7,10 +7,6 @@
 #include "scripting-API/OpenModelicaScriptingAPI.h"
 
 extern "C" {
-void (*omc_assert)(threadData_t*, FILE_INFO info, const char* msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info, const char* msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info, const char* msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__((noreturn)) = omc_throw_function;
 int omc_Main_handleCommand(void* threadData, void* imsg, void** omsg);
 void* omc_Main_init(void* threadData, void* args);
 void omc_Main_readSettings(void* threadData, void* args);

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -65,6 +65,7 @@ RUNTIMESIMULATION_HEADERS = ./simulation/modelinfo.h \
 ./simulation/options.h \
 ./simulation/simulation_info_json.h \
 ./simulation/simulation_input_xml.h \
+./simulation/simulation_omc_assert.h \
 ./simulation/simulation_runtime.h \
 ./simulation/omc_simulation_util.h
 

--- a/OMCompiler/SimulationRuntime/c/Makefile.objs
+++ b/OMCompiler/SimulationRuntime/c/Makefile.objs
@@ -259,6 +259,7 @@ SIM_HFILES = ../dataReconciliation/dataReconciliation.h \
              omc_simulation_util.h \
              simulation_info_json.h \
              simulation_input_xml.h \
+             simulation_omc_assert.h \
              simulation_runtime.h \
              socket.h \
              options.h

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_omc_assert.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_omc_assert.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF THE BSD NEW LICENSE OR THE
+ * GPL VERSION 3 LICENSE OR THE OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs: http://www.openmodelica.org or
+ * http://www.ida.liu.se/projects/OpenModelica, and in the OpenModelica
+ * distribution. GNU version 3 is obtained from:
+ * http://www.gnu.org/copyleft/gpl.html. The New BSD License is obtained from:
+ * http://www.opensource.org/licenses/BSD-3-Clause.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE, EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE
+ * CONDITIONS OF OSMC-PL.
+ *
+ */
+
+#ifndef OMC_SIMULATION_OMC_ASSERT_H
+#define OMC_SIMULATION_OMC_ASSERT_H
+
+#include "../util/omc_error.h"
+
+DLLExport extern void (*omc_assert_withEquationIndexes)(threadData_t*, FILE_INFO info, const int *indexes, const char *msg, ...)  __attribute__ ((noreturn));
+
+DLLExport extern void (*omc_assert_warning_withEquationIndexes)(FILE_INFO info, const int *indexes, const char *msg, ...);
+
+
+
+void omc_assert_simulation_withEquationIndexes(threadData_t *threadData, FILE_INFO info, const int *indexes, const char *msg, ...) __attribute__ ((noreturn));
+
+void omc_assert_warning_simulation_withEquationIndexes(FILE_INFO info, const int *indexes, const char *msg, ...);
+
+void omc_assert_simulation(threadData_t *threadData, FILE_INFO info, const char *msg, ...);
+void omc_terminate_simulation(FILE_INFO info, const char *msg, ...);
+void omc_throw_simulation(threadData_t* threadData);
+void omc_assert_warning_simulation(FILE_INFO info, const char *msg, ...);
+
+#endif // Header

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -34,6 +34,12 @@
 /* For MMC_THROW, so we can end this thing */
 #include "../meta/meta_modelica.h"
 
+void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
+void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
+void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
+void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
+
+
 const int firstOMCErrorStream = 1;
 
 const char *LOG_STREAM_NAME[SIM_LOG_MAX] = {

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.h
@@ -56,11 +56,13 @@ typedef struct _FILE_INFO
 #define omc_dummyFileInfo {"",0,0,0,0,0}
 
 DLLExport extern void printInfo(FILE *stream, FILE_INFO info);
+// Defined in omc_error.c
 DLLExport extern void (*omc_assert)(threadData_t*, FILE_INFO, const char*, ...) __attribute__ ((noreturn));
 DLLExport extern void (*omc_assert_warning)(FILE_INFO, const char*, ...);
 DLLExport extern void (*omc_terminate)(FILE_INFO, const char*, ...);
 DLLExport extern void (*omc_throw)(threadData_t*) __attribute__ ((noreturn));
 
+// Defined in simulation_omc_assert.c
 DLLExport extern void (*omc_assert_withEquationIndexes)(threadData_t*,FILE_INFO, const int*, const char*, ...) __attribute__ ((noreturn));
 DLLExport extern void (*omc_assert_warning_withEquationIndexes)(FILE_INFO, const int*, const char*, ...);
 

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -37,10 +37,6 @@ extern "C" {
 #include "omc_config.h"
 #include "gc.h"
 
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
 int omc_Main_handleCommand(void *threadData, void *imsg, void **omsg);
 void* omc_Main_init(void *threadData, void *args);
 void omc_System_initGarbageCollector(void *threadData);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/omcinteractiveenvironment.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/omcinteractiveenvironment.cpp
@@ -56,10 +56,6 @@
 #include "gc.h"
 
 extern "C" {
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
 int omc_Main_handleCommand(void *threadData, void *imsg, void **omsg);
 void* omc_Main_init(void *threadData, void *args);
 void omc_System_initGarbageCollector(void *threadData);

--- a/OMPlot/OMPlot/OMPlotGUI/main.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/main.cpp
@@ -45,9 +45,6 @@
 
 #include "util/omc_error.h"
 
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-
 using namespace OMPlot;
 
 #define CONSUME_BOOL_ARG(i,n,var) { \

--- a/OMShell/OMShell/OMShellGUI/omcinteractiveenvironment.cpp
+++ b/OMShell/OMShell/OMShellGUI/omcinteractiveenvironment.cpp
@@ -56,10 +56,6 @@
 #include "gc.h"
 
 extern "C" {
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
 int omc_Main_handleCommand(void *threadData, void *imsg, void **omsg);
 void* omc_Main_init(void *threadData, void *args);
 void omc_System_initGarbageCollector(void *threadData);

--- a/OMShell/mosh/src/omcinteractiveenvironment.cpp
+++ b/OMShell/mosh/src/omcinteractiveenvironment.cpp
@@ -42,10 +42,6 @@
 #include "gc.h"
 
 extern "C" {
-void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
-void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
-void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;
-void (*omc_throw)(threadData_t*) __attribute__ ((noreturn)) = omc_throw_function;
 int omc_Main_handleCommand(void *threadData, void *imsg, void **omsg);
 modelica_metatype omc_Main_init(void *threadData, modelica_metatype args);
 modelica_metatype omc_Main_readSettings(void *threadData, modelica_metatype args);

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
@@ -21,7 +21,6 @@ equation
   when time>1 then
       terminate(\"Simulation done by \" + s);
   end when;
-  annotation(experiment(StopTime=2));
 end test_ChangeParam;
 ");
 getErrorString();
@@ -42,7 +41,7 @@ val(y, 1);
 getErrorString();
 
 system("./test_ChangeParam_me_FMU -override a=-2,i=-10,b=false,s=\"bar\" -r test_ChangeParam.mat");
-readSimulationResult("test_ChangeParam.mat", {x,a,y}, 7);
+readSimulationResult("test_ChangeParam.mat", {x,a,y});
 getErrorString();
 
 
@@ -58,7 +57,7 @@ getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "test_ChangeParam_me_FMU_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 1, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'test_ChangeParam_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 1, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'test_ChangeParam_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -70,6 +69,6 @@ getErrorString();
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // 0
-// {{1.0,1.0,1.0,0.1353363211838032,0.1353363211838032,0.01831624751345867,0.01831624751345867},{-2.0,-2.0,-2.0,-2.0,-2.0,-2.0,-2.0},{-11.0,-11.0,-11.0,-10.1353363211838,-10.1353363211838,-10.01831624751346,-10.01831624751346}}
+// {{1.0,1.0,1.0,0.1353363211838032,0.1353363211838032},{-2.0,-2.0,-2.0,-2.0,-2.0},{-11.0,-11.0,-11.0,-10.1353363211838,-10.1353363211838}}
 // ""
 // endResult


### PR DESCRIPTION
- The default values given to the are the 'functions' versions, e.g.
  `omc_assert = omc_assert_function`

- This way we do not have to initialize them in every executable code
  that links to the OpenModelicaRuntimeC. If you do not specify anything
  you get the default value.

- For simulations set them to the 'simulation' versions in the simulation
  executables 'main' function, e.g,
  `omc_assert = omc_assert_simulation`

- Windows tests are now on track to start working without complaining
  about undefined references in 'function' mode.

### Related Issues

#8070