### PR TITLE
Fix #7835

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -694,6 +694,7 @@ protected
   InstContext.Type exp_context;
   Binding binding;
   Component comp;
+  list<Subscript> subs;
 algorithm
   parent_cr := ComponentRef.rest(cref);
   parent := ComponentRef.node(parent_cr);
@@ -703,18 +704,20 @@ algorithm
   Typing.typeComponentBinding(parent, exp_context, typeChildren = false);
   comp := InstNode.component(parent);
   binding := Component.getBinding(comp);
+  subs := ComponentRef.getSubscripts(parent_cr);
 
   if Binding.hasExp(binding) then
     exp := Binding.getExp(binding);
-    exp := Expression.applySubscripts(ComponentRef.getSubscripts(parent_cr), exp);
+    exp := Expression.applySubscripts(subs, exp);
     exp := Expression.recordElement(ComponentRef.firstName(cref), exp);
     exp := evalExp(exp, target);
+
     exp := Expression.map(exp, function Expression.expandNonListedSplitIndices(
       indicesToKeep = ComponentRef.nodesIncludingSplitSubs(cref)));
   else
     // If the parent didn't have a binding, try the parent's parent.
     exp := makeRecordFieldBindingFromParent(parent_cr, target);
-    exp := Expression.applySubscripts(ComponentRef.getSubscripts(parent_cr), exp);
+    exp := Expression.applySubscripts(subs, exp);
     exp := Expression.recordElement(ComponentRef.firstName(cref), exp);
   end if;
 end makeRecordFieldBindingFromParent;

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -36,6 +36,7 @@ protected
   import Prefixes = NFPrefixes;
   import List;
   import SimplifyExp = NFSimplifyExp;
+  import Ceval = NFCeval;
 
 public
   import Absyn.{Exp, Path, Subscript};
@@ -46,6 +47,7 @@ public
   import ComponentRef = NFComponentRef;
   import NFPrefixes.Variability;
   import Inst = NFInst;
+  import NFCeval.EvalTarget;
 
   record RAW_DIM
     Absyn.Subscript dim;
@@ -480,6 +482,17 @@ public
       arg := foldExp(dim, func, arg);
     end for;
   end foldExpList;
+
+  function eval
+    input Dimension dim;
+    input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+    output Dimension outDim;
+  algorithm
+    outDim := match dim
+      case EXP() then fromExp(Ceval.evalExp(dim.exp, target), dim.var);
+      else dim;
+    end match;
+  end eval;
 
   function simplify
     input output Dimension dim;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4605,43 +4605,6 @@ public
     end match;
   end nthRecordElement;
 
-  function splitRecordCref
-    input Expression exp;
-    output Expression outExp;
-  algorithm
-    outExp := ExpandExp.expand(exp);
-
-    outExp := match outExp
-      local
-        InstNode cls;
-        array<InstNode> comps;
-        ComponentRef cr, field_cr;
-        Type ty;
-        list<Expression> fields;
-
-      case CREF(ty = Type.COMPLEX(cls = cls), cref = cr)
-        algorithm
-          comps := ClassTree.getComponents(Class.classTree(InstNode.getClass(cls)));
-          fields := {};
-
-          for i in arrayLength(comps):-1:1 loop
-            ty := InstNode.getType(comps[i]);
-            field_cr := ComponentRef.prefixCref(comps[i], ty, {}, cr);
-            fields := CREF(ty, field_cr) :: fields;
-          end for;
-        then
-          makeRecord(InstNode.scopePath(cls), outExp.ty, fields);
-
-      case ARRAY()
-        algorithm
-          outExp.elements := list(splitRecordCref(e) for e in outExp.elements);
-        then
-          outExp;
-
-      else exp;
-    end match;
-  end splitRecordCref;
-
   function retype
     input output Expression exp;
   algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -155,6 +155,10 @@ public
     input InstNode node;
     input Integer dimIndex;
     output Subscript subscript = SPLIT_INDEX(node, dimIndex);
+  algorithm
+    if dimIndex < 1 then
+      Error.assertion(false, getInstanceName() + " got invalid index " + String(dimIndex), sourceInfo());
+    end if;
   end makeSplitIndex;
 
   function isIndex

--- a/testsuite/flattening/modelica/scodeinst/CevalRecordArray9.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalRecordArray9.mo
@@ -1,0 +1,151 @@
+// name: CevalRecordArray9
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+connector HeatPort_a
+  Real T;
+  flow Real Q_flow;
+end HeatPort_a;
+
+record Material
+  parameter Real x;
+  parameter Integer nSta = max(1, integer(ceil(x)));
+end Material;
+
+model SingleLayer
+  HeatPort_a port_b;
+  Real[nSta + 1] Q_flow;
+  parameter Integer nSta;
+equation
+  port_b.Q_flow = -Q_flow[end];
+end SingleLayer;
+
+record Generic
+  parameter Integer nLay;
+  parameter Material[nLay] material;
+  parameter Integer[nLay] nSta = {i for i in material.nSta};
+end Generic;
+
+model Construction
+  parameter Generic layers;
+  parameter Integer nLay = size(layers.material, 1);
+  parameter Integer[nLay] nSta = {i for i in layers.material.nSta};
+  SingleLayer[nLay] lay(nSta = {i for i in layers.nSta});
+end Construction;
+
+model MixedAir
+  parameter Generic layers[2];
+  Construction[2] conBou(layers = layers);
+end MixedAir;
+
+model CevalRecordArray9
+  MixedAir roo(layers = {matFlo, matEWWal});
+  parameter Generic matFlo(nLay = 3, material = {Material(x = 5.28), Material(x = 0.01905), Material(x = 0.01905)});
+  parameter Generic matEWWal(nLay = 2, material = {Material(x = 0.133), Material(x = 0.015875)});
+end CevalRecordArray9;
+
+// Result:
+// class CevalRecordArray9
+//   final parameter Integer roo.layers[1].nLay = 3;
+//   parameter Real roo.layers[1].material[1].x = matFlo.material[1].x;
+//   parameter Integer roo.layers[1].material[1].nSta = 6;
+//   parameter Real roo.layers[1].material[2].x = matFlo.material[2].x;
+//   parameter Integer roo.layers[1].material[2].nSta = 1;
+//   parameter Real roo.layers[1].material[3].x = matFlo.material[3].x;
+//   parameter Integer roo.layers[1].material[3].nSta = 1;
+//   parameter Integer roo.layers[1].nSta[1] = matFlo.nSta[1];
+//   parameter Integer roo.layers[1].nSta[2] = matFlo.nSta[2];
+//   parameter Integer roo.layers[1].nSta[3] = matFlo.nSta[3];
+//   final parameter Integer roo.layers[2].nLay = 2;
+//   parameter Real roo.layers[2].material[1].x = matEWWal.material[1].x;
+//   parameter Integer roo.layers[2].material[1].nSta = 1;
+//   parameter Real roo.layers[2].material[2].x = matEWWal.material[2].x;
+//   parameter Integer roo.layers[2].material[2].nSta = 1;
+//   parameter Integer roo.layers[2].nSta[1] = matEWWal.nSta[1];
+//   parameter Integer roo.layers[2].nSta[2] = matEWWal.nSta[2];
+//   final parameter Integer roo.conBou[1].layers.nLay = 3;
+//   parameter Real roo.conBou[1].layers.material[1].x = roo.layers[1].material[1].x;
+//   final parameter Integer roo.conBou[1].layers.material[1].nSta = 6;
+//   parameter Real roo.conBou[1].layers.material[2].x = roo.layers[1].material[2].x;
+//   final parameter Integer roo.conBou[1].layers.material[2].nSta = 1;
+//   parameter Real roo.conBou[1].layers.material[3].x = roo.layers[1].material[3].x;
+//   final parameter Integer roo.conBou[1].layers.material[3].nSta = 1;
+//   final parameter Integer roo.conBou[1].layers.nSta[1] = 6;
+//   final parameter Integer roo.conBou[1].layers.nSta[2] = 1;
+//   final parameter Integer roo.conBou[1].layers.nSta[3] = 1;
+//   final parameter Integer roo.conBou[1].nLay = 3;
+//   parameter Integer roo.conBou[1].nSta[1] = 6;
+//   parameter Integer roo.conBou[1].nSta[2] = 1;
+//   parameter Integer roo.conBou[1].nSta[3] = 1;
+//   Real roo.conBou[1].lay[1].port_b.T;
+//   Real roo.conBou[1].lay[1].port_b.Q_flow;
+//   Real roo.conBou[1].lay[1].Q_flow[1];
+//   Real roo.conBou[1].lay[1].Q_flow[2];
+//   Real roo.conBou[1].lay[1].Q_flow[3];
+//   Real roo.conBou[1].lay[1].Q_flow[4];
+//   Real roo.conBou[1].lay[1].Q_flow[5];
+//   Real roo.conBou[1].lay[1].Q_flow[6];
+//   Real roo.conBou[1].lay[1].Q_flow[7];
+//   final parameter Integer roo.conBou[1].lay[1].nSta = 6;
+//   Real roo.conBou[1].lay[2].port_b.T;
+//   Real roo.conBou[1].lay[2].port_b.Q_flow;
+//   Real roo.conBou[1].lay[2].Q_flow[1];
+//   Real roo.conBou[1].lay[2].Q_flow[2];
+//   final parameter Integer roo.conBou[1].lay[2].nSta = 1;
+//   Real roo.conBou[1].lay[3].port_b.T;
+//   Real roo.conBou[1].lay[3].port_b.Q_flow;
+//   Real roo.conBou[1].lay[3].Q_flow[1];
+//   Real roo.conBou[1].lay[3].Q_flow[2];
+//   final parameter Integer roo.conBou[1].lay[3].nSta = 1;
+//   final parameter Integer roo.conBou[2].layers.nLay = 2;
+//   parameter Real roo.conBou[2].layers.material[1].x = roo.layers[2].material[1].x;
+//   final parameter Integer roo.conBou[2].layers.material[1].nSta = 1;
+//   parameter Real roo.conBou[2].layers.material[2].x = roo.layers[2].material[2].x;
+//   final parameter Integer roo.conBou[2].layers.material[2].nSta = 1;
+//   final parameter Integer roo.conBou[2].layers.nSta[1] = 1;
+//   final parameter Integer roo.conBou[2].layers.nSta[2] = 1;
+//   final parameter Integer roo.conBou[2].nLay = 2;
+//   parameter Integer roo.conBou[2].nSta[1] = 1;
+//   parameter Integer roo.conBou[2].nSta[2] = 1;
+//   Real roo.conBou[2].lay[1].port_b.T;
+//   Real roo.conBou[2].lay[1].port_b.Q_flow;
+//   Real roo.conBou[2].lay[1].Q_flow[1];
+//   Real roo.conBou[2].lay[1].Q_flow[2];
+//   final parameter Integer roo.conBou[2].lay[1].nSta = 1;
+//   Real roo.conBou[2].lay[2].port_b.T;
+//   Real roo.conBou[2].lay[2].port_b.Q_flow;
+//   Real roo.conBou[2].lay[2].Q_flow[1];
+//   Real roo.conBou[2].lay[2].Q_flow[2];
+//   final parameter Integer roo.conBou[2].lay[2].nSta = 1;
+//   final parameter Integer matFlo.nLay = 3;
+//   parameter Real matFlo.material[1].x = 5.28;
+//   final parameter Integer matFlo.material[1].nSta = 6;
+//   parameter Real matFlo.material[2].x = 0.01905;
+//   final parameter Integer matFlo.material[2].nSta = 1;
+//   parameter Real matFlo.material[3].x = 0.01905;
+//   final parameter Integer matFlo.material[3].nSta = 1;
+//   parameter Integer matFlo.nSta[1] = 6;
+//   parameter Integer matFlo.nSta[2] = 1;
+//   parameter Integer matFlo.nSta[3] = 1;
+//   final parameter Integer matEWWal.nLay = 2;
+//   parameter Real matEWWal.material[1].x = 0.133;
+//   final parameter Integer matEWWal.material[1].nSta = 1;
+//   parameter Real matEWWal.material[2].x = 0.015875;
+//   final parameter Integer matEWWal.material[2].nSta = 1;
+//   parameter Integer matEWWal.nSta[1] = 1;
+//   parameter Integer matEWWal.nSta[2] = 1;
+// equation
+//   roo.conBou[1].lay[1].port_b.Q_flow = 0.0;
+//   roo.conBou[1].lay[2].port_b.Q_flow = 0.0;
+//   roo.conBou[1].lay[3].port_b.Q_flow = 0.0;
+//   roo.conBou[2].lay[1].port_b.Q_flow = 0.0;
+//   roo.conBou[2].lay[2].port_b.Q_flow = 0.0;
+//   roo.conBou[1].lay[1].port_b.Q_flow = -roo.conBou[1].lay[1].Q_flow[7];
+//   roo.conBou[1].lay[2].port_b.Q_flow = -roo.conBou[1].lay[2].Q_flow[2];
+//   roo.conBou[1].lay[3].port_b.Q_flow = -roo.conBou[1].lay[3].Q_flow[2];
+//   roo.conBou[2].lay[1].port_b.Q_flow = -roo.conBou[2].lay[1].Q_flow[2];
+//   roo.conBou[2].lay[2].port_b.Q_flow = -roo.conBou[2].lay[2].Q_flow[2];
+// end CevalRecordArray9;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -177,6 +177,7 @@ CevalRecordArray5.mo \
 CevalRecordArray6.mo \
 CevalRecordArray7.mo \
 CevalRecordArray8.mo \
+CevalRecordArray9.mo \
 CevalRelation1.mo \
 CevalRem1.mo \
 CevalScalar1.mo \


### PR DESCRIPTION
- Subscript dimension expressions if they have too many dimensions after
  being evaluated.
- Improve the typing of split expressions to account for bindings that
  become ragged arrays after evaluation.
- Move splitRecordCref from Expression to Flatten and make sure crefs it
  creates are flattened.