### PR TITLE
Remove AbsynUtil.printComponentRefStr

### DIFF
--- a/OMCompiler/Compiler/FFrontEnd/FGraphBuild.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphBuild.mo
@@ -65,6 +65,7 @@ type Graph = FCore.Graph;
 type Scope = FCore.Scope;
 
 protected
+import Dump;
 import List;
 import AbsynToSCode;
 import SCodeDump;
@@ -770,7 +771,7 @@ algorithm
 
     case (_, _, _, g)
       equation
-        name = AbsynUtil.printComponentRefStr(inCref);
+        name = Dump.printComponentRefStr(inCref);
         (g, n) = FGraph.node(g, name, {inParentRef}, FCore.CR(inCref));
         nr = FNode.toRef(n);
         FNode.addChildRef(inParentRef, name, nr);

--- a/OMCompiler/Compiler/FFrontEnd/FGraphBuildEnv.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphBuildEnv.mo
@@ -68,6 +68,7 @@ type Graph = FCore.Graph;
 type Scope = FCore.Scope;
 
 protected
+import Dump;
 import List;
 import AbsynToSCode;
 import SCodeDump;
@@ -756,7 +757,7 @@ algorithm
 
     case (_, _, _, g)
       equation
-        name = AbsynUtil.printComponentRefStr(inCref);
+        name = Dump.printComponentRefStr(inCref);
         (g, n) = FGraph.node(g, name, {inParentRef}, FCore.CR(inCref));
         nr = FNode.toRef(n);
         FNode.addChildRef(inParentRef, name, nr);

--- a/OMCompiler/Compiler/FFrontEnd/FGraphDump.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphDump.mo
@@ -72,7 +72,6 @@ protected
 import Flags;
 import Dump;
 import Absyn;
-import AbsynUtil;
 import SCodeUtil;
 import Util;
 
@@ -415,7 +414,7 @@ algorithm
     // component references
     case (FCore.N(_, _, _, _, nd as FCore.CR(r = r)), _)
       equation
-        s = FNode.dataStr(nd) + ":" + AbsynUtil.printComponentRefStr(r);
+        s = FNode.dataStr(nd) + ":" + Dump.printComponentRefStr(r);
       then
         (GraphML.COLOR_PURPLE, GraphML.OCTAGON(), s);
 

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1381,37 +1381,6 @@ algorithm
 annotation(__OpenModelica_EarlyInline = true);
 end crefExp;
 
-public function expComponentRefStr
-  input Absyn.Exp aexp;
-  output String outString;
-algorithm
-  outString := printComponentRefStr(expCref(aexp));
-end expComponentRefStr;
-
-public function printComponentRefStr
-  input Absyn.ComponentRef cr;
-  output String ostring;
-algorithm
-  ostring := match(cr)
-    local
-      String s1,s2;
-      Absyn.ComponentRef child;
-    case(Absyn.CREF_IDENT(s1,_)) then s1;
-    case(Absyn.CREF_QUAL(s1,_,child))
-      equation
-        s2 = printComponentRefStr(child);
-        s1 = s1 + "." + s2;
-      then s1;
-    case(Absyn.CREF_FULLYQUALIFIED(child))
-      equation
-        s2 = printComponentRefStr(child);
-        s1 = "." + s2;
-      then s1;
-    case (Absyn.ALLWILD()) then "__";
-    case (Absyn.WILD()) then "_";
-  end match;
-end printComponentRefStr;
-
 public function pathEqual "Returns true if two paths are equal."
   input Absyn.Path inPath1;
   input Absyn.Path inPath2;

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -3914,7 +3914,7 @@ algorithm
         cmod2 = List.fold2r(cmod::ltmod,Mod.merge,name,true,DAE.NOMOD());
         SCode.PREFIXES(finalPrefix = fprefix) = SCodeUtil.elementPrefixes(comp);
 
-        //print("("+intString(listLength(ltmod))+")UpdateCompeltsMods_(" + stringDelimitList(List.map(crefs,AbsynUtil.printComponentRefStr),",") + ") subs: " + stringDelimitList(List.map(crefs,Absyn.printComponentRefStr),",")+ "\n");
+        //print("("+intString(listLength(ltmod))+")UpdateCompeltsMods_(" + stringDelimitList(List.map(crefs,Dump.printComponentRefStr),",") + ") subs: " + stringDelimitList(List.map(crefs,Dump.printComponentRefStr),",")+ "\n");
         //print("REDECL     acquired mods: " + Mod.printModStr(cmod2) + "\n");
         (cache,env2,ih) = updateComponentsInEnv(cache, env, ih, pre, cmod2, crefs, ci_state, impl);
         (cache,env2,ih) = updateComponentsInEnv(cache, env2, ih, pre,
@@ -3954,7 +3954,7 @@ algorithm
         cmod2 = List.fold2r(ltmod,Mod.merge,name,true,DAE.NOMOD());
         SCode.PREFIXES(finalPrefix = fprefix) = SCodeUtil.elementPrefixes(comp);
 
-        //print("("+intString(listLength(ltmod))+")UpdateCompeltsMods_(" + stringDelimitList(List.map(crefs,AbsynUtil.printComponentRefStr),",") + ") subs: " + stringDelimitList(List.map(crefs,Absyn.printComponentRefStr),",")+ "\n");
+        //print("("+intString(listLength(ltmod))+")UpdateCompeltsMods_(" + stringDelimitList(List.map(crefs,Dump.printComponentRefStr),",") + ") subs: " + stringDelimitList(List.map(crefs,Dump.printComponentRefStr),",")+ "\n");
         //print("     acquired mods: " + Mod.printModStr(cmod2) + "\n");
 
         (cache,env2,ih) = updateComponentsInEnv(cache, env, ih, pre, cmod2, crefs, ci_state, impl);

--- a/OMCompiler/Compiler/FrontEnd/InstExtends.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstExtends.mo
@@ -1578,7 +1578,7 @@ algorithm
         cref = AbsynUtil.crefReplaceFirstIdent(cref,FGraph.getGraphName(denv));
         // cref = if_(isOutside, cref, FGraph.crefStripGraphScopePrefix(cref, env, false));
         cref = FGraph.crefStripGraphScopePrefix(cref, env, false);
-        //fprintln(Flags.DEBUG, "Cref VAR fixed: " + AbsynUtil.printComponentRefStr(cref));
+        //fprintln(Flags.DEBUG, "Cref VAR fixed: " + Dump.printComponentRefStr(cref));
         cref = if AbsynUtil.crefEqual(cref, inCref) then inCref else cref;
       then cref;
 
@@ -1595,7 +1595,7 @@ algorithm
         cref = AbsynUtil.crefReplaceFirstIdent(cref,FGraph.getGraphName(denv));
         // cref = if_(isOutside, cref, FGraph.crefStripGraphScopePrefix(cref, env, false));
         cref = FGraph.crefStripGraphScopePrefix(cref, env, false);
-        //print("Cref CLASS fixed: " + AbsynUtil.printComponentRefStr(cref) + "\n");
+        //print("Cref CLASS fixed: " + Dump.printComponentRefStr(cref) + "\n");
         cref = if AbsynUtil.crefEqual(cref, inCref) then inCref else cref;
       then cref;
 

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -3343,8 +3343,8 @@ algorithm
         (cache,NONE()) = Static.elabCref(cache, env, c1, impl, false, pre, info);
         // adrpo: TODO! FIXME! add this as an Error not as a print!
         print("Error: The marked virtual expandable component reference in connect([" +
-         PrefixUtil.printPrefixStrIgnoreNoPre(pre) + "." + AbsynUtil.printComponentRefStr(c1) + "], " +
-         PrefixUtil.printPrefixStrIgnoreNoPre(pre) + "." + AbsynUtil.printComponentRefStr(c2) + "); should be qualified, i.e. expandableConnectorName.virtualName!\n");
+         PrefixUtil.printPrefixStrIgnoreNoPre(pre) + "." + Dump.printComponentRefStr(c1) + "], " +
+         PrefixUtil.printPrefixStrIgnoreNoPre(pre) + "." + Dump.printComponentRefStr(c2) + "); should be qualified, i.e. expandableConnectorName.virtualName!\n");
       then
         fail();
 

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -1376,7 +1376,7 @@ algorithm
       then getModsForDep(dep,elems);
     case(dep,((SCode.COMPONENT(name=name1),cmod))::_)
       equation
-        name2 = AbsynUtil.printComponentRefStr(dep);
+        name2 = Dump.printComponentRefStr(dep);
         true = stringEq(name2,name1);
         cmod = DAE.MOD(SCode.NOT_FINAL(),SCode.NOT_EACH(),{DAE.NAMEMOD(name2,cmod)},NONE(), AbsynUtil.dummyInfo);
       then
@@ -4215,7 +4215,7 @@ algorithm
     ty_str := Types.unparseTypeNoAttr(inType);
     exp_str := ExpressionDump.printExpStr(inExp);
     name_str := PrefixUtil.printPrefixStrIgnoreNoPre(inPrefix) +
-      AbsynUtil.printComponentRefStr(inCref);
+      Dump.printComponentRefStr(inCref);
     Error.addSourceMessageAndFail(Error.MODIFIER_DECLARATION_TYPE_MISMATCH_ERROR,
       {name_str, ad_str, exp_str, ty_str}, inInfo);
   end try;
@@ -4502,7 +4502,7 @@ algorithm
 
     case(SCode.NAMEMOD("noDerivative",(SCode.MOD(binding = SOME(Absyn.CREF(acr)))))::subs,_,_,_,_,_,_)
     equation
-      name = AbsynUtil.printComponentRefStr(acr);
+      name = Dump.printComponentRefStr(acr);
         outconds = getDeriveCondition(subs,elemDecl,inCache,inEnv,inIH,inPrefix,info);
       varPos = setFunctionInputIndex(elemDecl,name,1);
     then
@@ -4510,7 +4510,7 @@ algorithm
 
     case(SCode.NAMEMOD("zeroDerivative",(SCode.MOD(binding =  SOME(Absyn.CREF(acr)))))::subs,_,_,_,_,_,_)
     equation
-      name = AbsynUtil.printComponentRefStr(acr);
+      name = Dump.printComponentRefStr(acr);
         outconds = getDeriveCondition(subs,elemDecl,inCache,inEnv,inIH,inPrefix,info);
       varPos = setFunctionInputIndex(elemDecl,name,1);
     then
@@ -6998,7 +6998,7 @@ algorithm
     else
       equation
         /* Doesn't work anyway right away
-        crefStr = AbsynUtil.printComponentRefStr(cref);
+        crefStr = Dump.printComponentRefStr(cref);
         varStr = SCodeDump.variabilityString(variability);
         Error.addMessage(Error.CIRCULAR_PARAM,{crefStr,varStr});*/
       then fail();

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -6686,7 +6686,7 @@ algorithm
       return;
     else
       true := numErrorMessages == Error.getNumErrorMessages();
-      name := AbsynUtil.printComponentRefStr(fn);
+      name := Dump.printComponentRefStr(fn);
       s1 := stringDelimitList(List.map(args, Dump.printExpStr), ", ");
       s2 := stringDelimitList(List.map(nargs, Dump.printNamedArgStr), ", ");
       s := if s2 == "" then s1 else s1 + ", " + s2;
@@ -10270,9 +10270,9 @@ algorithm
         (cache,DAE.TYPES_VAR(name, attributes, visibility, ty, binding, constOfForIteratorRange),
                SOME((cl as SCode.COMPONENT(n, pref, SCode.ATTR(arrayDims = ad), Absyn.TPATH(tpath, _),m,comment,cond,info),cmod)),instStatus,_)
           = Lookup.lookupIdent(cache, env, id);
-        print("Static: cref:" + AbsynUtil.printComponentRefStr(c) + " component first ident:\n" + SCodeDump.unparseElementStr(cl) + "\n");
+        print("Static: cref:" + Dump.printComponentRefStr(c) + " component first ident:\n" + SCodeDump.unparseElementStr(cl) + "\n");
         (cache, cl, env) = Lookup.lookupClass(cache, env, tpath);
-        print("Static: cref:" + AbsynUtil.printComponentRefStr(c) + " class component first ident:\n" + SCodeDump.unparseElementStr(cl) + "\n");
+        print("Static: cref:" + Dump.printComponentRefStr(c) + " class component first ident:\n" + SCodeDump.unparseElementStr(cl) + "\n");
       then
         (cache,NONE());*/
 
@@ -12453,7 +12453,7 @@ algorithm
       equation
         true = Flags.isSet(Flags.FAILTRACE);
         Debug.traceln("- Static.elabArrayDim failed on: " +
-          AbsynUtil.printComponentRefStr(inCref) +
+          Dump.printComponentRefStr(inCref) +
           Dump.printArraydimStr({inDimension}));
       then
         fail();

--- a/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
@@ -1850,7 +1850,7 @@ algorithm
 
     case (Values.CODE(A = Absyn.C_VARIABLENAME(cr)))
       equation
-        Print.printBuf(AbsynUtil.printComponentRefStr(cr));
+        Print.printBuf(Dump.printComponentRefStr(cr));
       then
         ();
 

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -7660,7 +7660,7 @@ algorithm
         cls = getPathedClassInProgram(path, p);
         Absyn.EXTERNAL(Absyn.EXTERNALDECL(funcName, lang, output_, args, ann1), ann2) = AbsynUtil.getExternalDecl(cls);
         strLanguage  = "\"" + Util.getOptionOrDefault(lang, "") + "\"";
-        strOutput  = "\"" + AbsynUtil.printComponentRefStr(
+        strOutput  = "\"" + Dump.printComponentRefStr(
                                 Util.getOptionOrDefault(
                                   output_,
                                   Absyn.CREF_IDENT("", {}))) + "\"";

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -5879,7 +5879,7 @@ algorithm
         cls = getPathedClassInProgram(path, p);
         Absyn.EXTERNAL(Absyn.EXTERNALDECL(funcName, lang, output_, args, ann1), ann2) = AbsynUtil.getExternalDecl(cls);
         strLanguage  = "\"" + Util.getOptionOrDefault(lang, "") + "\"";
-        strOutput  = "\"" + AbsynUtil.printComponentRefStr(
+        strOutput  = "\"" + Dump.printComponentRefStr(
                                 Util.getOptionOrDefault(
                                   output_,
                                   Absyn.CREF_IDENT("", {}))) + "\"";


### PR DESCRIPTION
- Remove AbsynUtil.printComponentRefStr and replace any uses of it with
  Dump.printComponentRefStr. They are not the same since the AbsynUtil
  one ignores subscripts, but it's hard to know whether it's used
  intentionally or if the user just mistook it for the Dump one.
- Also remove the unused function AbsynUtil.expComponentRefStr.