### PR TITLE
Show a help message to select mingw when msvc compilation fails

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1821,10 +1821,8 @@ void SimulationDialog::performSimulation()
     SimulationPage *pSimulationPage = OptionsDialog::instance()->getSimulationPage();
     QString targetBuild = pSimulationPage->getTargetBuildComboBox()->itemData(pSimulationPage->getTargetBuildComboBox()->currentIndex()).toString();
     if ((targetBuild.compare("vxworks69") == 0) || (targetBuild.compare("debugrt") == 0)) {
-      QString msg = tr("Generated code for the target build <b>%1</b> at %2.").arg(targetBuild)
-                    .arg(simulationOptions.getWorkingDirectory());
-      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind,
-                                                            Helper::notificationLevel));
+      QString msg = tr("Generated code for the target build <b>%1</b> at %2.").arg(targetBuild).arg(simulationOptions.getWorkingDirectory());
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::notificationLevel));
       return;
     }
     QString targetLanguage = pSimulationPage->getTargetLanguageComboBox()->currentText();
@@ -1832,10 +1830,8 @@ void SimulationDialog::performSimulation()
     if ((targetLanguage.compare("C") == 0) || (targetLanguage.compare("Cpp") == 0)) {
       createAndShowSimulationOutputWidget(simulationOptions);
     } else {
-      QString msg = tr("Generated code for the target language <b>%1</b> at %2.").arg(targetLanguage)
-          .arg(simulationOptions.getWorkingDirectory());
-      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind,
-                                                            Helper::notificationLevel));
+      QString msg = tr("Generated code for the target language <b>%1</b> at %2.").arg(targetLanguage).arg(simulationOptions.getWorkingDirectory());
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::notificationLevel));
       return;
     }
   }

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -937,6 +937,14 @@ void SimulationOutputWidget::compilationProcessFinished(int exitCode, QProcess::
 {
   mIsCompilationProcessRunning = false;
   QString exitCodeStr = tr("Compilation process failed. Exited with code %1.").arg(Utilities::formatExitCode(exitCode));
+  /* Issue #7862
+   * Show instructions to select default MinGW compiler if compilation with MSVC compiler fails.
+   */
+  SimulationPage *pSimulationPage = OptionsDialog::instance()->getSimulationPage();
+  QString targetBuild = pSimulationPage->getTargetBuildComboBox()->itemData(pSimulationPage->getTargetBuildComboBox()->currentIndex()).toString();
+  if (targetBuild.startsWith("msvc")) {
+    exitCodeStr.append("\nTry compiling with the default MinGW compiler. Select \"MinGW\" in \"Tools->Options->Simulation->Target Build\".");
+  }
   if (exitStatus == QProcess::NormalExit && exitCode == 0) {
     writeCompilationOutput(tr("Compilation process finished successfully."), Qt::blue);
     compilationProcessFinishedHelper(exitCode, exitStatus);


### PR DESCRIPTION
### Related Issues

#7862 

### Purpose

Give some hint to the user when the compilation with alternate compiler fails.

### Approach

Show a message to the user about how to switch to the default shipped compiler.
