### PR TITLE
Partition the partest tests into 3 jobs during CI

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -67,7 +67,7 @@ def numLogicalCPU() {
   return env.JENKINS_NUM_LOGICAL_CPU
 }
 
-void partest(cache=true, extraArgs='') {
+void partest(partition=1,partitionmodulo=1,cache=true, extraArgs='') {
   if (isWindows()) {
 
   bat ("""
@@ -105,7 +105,7 @@ void partest(cache=true, extraArgs='') {
   ulimit -v 6291456 # Max 6GB per process
 
   cd testsuite/partest
-  ./runtests.pl -j${numPhysicalCPU()} -nocolour -with-xml ${extraArgs}
+  ./runtests.pl -j${numPhysicalCPU()} -partition=${partition}/${partitionmodulo} -nocolour -with-xml ${extraArgs}
   CODE=\$?
   test \$CODE = 0 -o \$CODE = 7 || exit 1
   """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,7 +242,7 @@ pipeline {
     }
     stage('tests') {
       parallel {
-        stage('testsuite-clang') {
+        stage('testsuite-clang 1/3') {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
@@ -272,12 +272,80 @@ pipeline {
               common.standardSetup()
               unstash 'omc-clang'
               common.makeLibsAndCache()
-              common.partest()
+              common.partest(1,3)
+            }
+          }
+        }
+        stage('testsuite-clang 2/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache'
+              /* The cache Dockerfile makes /cache/runtest, etc world writable
+               * This is necessary because we run the docker image as a user and need to
+               * be able to have a global caching of the omlibrary parts and the runtest database.
+               * Note that the database is stored in a volume on a per-node basis, so the first time
+               * the tests run on a particular node, they might execute slightly slower
+               */
+              label 'linux'
+              args "--mount type=volume,source=runtest-clang-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeRunTests }
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-clang'
+              common.makeLibsAndCache()
+              common.partest(2,3)
+            }
+          }
+        }
+        stage('testsuite-clang 3/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache'
+              /* The cache Dockerfile makes /cache/runtest, etc world writable
+               * This is necessary because we run the docker image as a user and need to
+               * be able to have a global caching of the omlibrary parts and the runtest database.
+               * Note that the database is stored in a volume on a per-node basis, so the first time
+               * the tests run on a particular node, they might execute slightly slower
+               */
+              label 'linux'
+              args "--mount type=volume,source=runtest-clang-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeRunTests }
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-clang'
+              common.makeLibsAndCache()
+              common.partest(3,3)
             }
           }
         }
 
-        stage('testsuite-gcc') {
+        stage('testsuite-gcc 1/3') {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
@@ -301,7 +369,63 @@ pipeline {
               common.standardSetup()
               unstash 'omc-gcc'
               common.makeLibsAndCache()
-              common.partest()
+              common.partest(1,3)
+            }
+          }
+        }
+        stage('testsuite-gcc 2/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-xenial'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeRunTests }
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-gcc'
+              common.makeLibsAndCache()
+              common.partest(2,3)
+            }
+          }
+        }
+        stage('testsuite-gcc 3/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-xenial'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeRunTests }
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-gcc'
+              common.makeLibsAndCache()
+              common.partest(3,3)
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -599,7 +599,7 @@ pipeline {
             script {
               common.standardSetup()
               unstash 'omc-clang'
-              common.partest(false, '-j1 -parmodexp')
+              common.partest(1, 1, false, '-j1 -parmodexp')
             }
           }
         }


### PR DESCRIPTION
This will make the throughput faster if we get slow machines doing clang
or gcc tests (currently takes upwards of 40 minutes).
The overhead from copying 3 OMC installations should be OK.