### PR TITLE
Don't change lambda when no homotpy should be used

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -1074,7 +1074,6 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
       if (!homotopyDeactivated && !omc_flag[FLAG_HOMOTOPY_ON_FIRST_TRY])
         infoStreamPrint(LOG_INIT_HOMOTOPY, 0, "Try to solve nonlinear initial system %d without homotopy first.", sysNumber);
 
-      data->simulationInfo->lambda = 1.0;
       /* SOLVE! */
       nonlinsys->solved = solveNLS(data, threadData, sysNumber);
     }

--- a/testsuite/simulation/libraries/msl32/Makefile
+++ b/testsuite/simulation/libraries/msl32/Makefile
@@ -276,12 +276,12 @@ Modelica.Mechanics.MultiBody.Examples.Elementary.UserDefinedGravityField.mos \
 Modelica.Media.Examples.SolveOneNonlinearEquation.Inverse_sine.mos \
 Modelica.Media.Examples.R134a.R134a1.mos \
 Modelica.Media.Examples.R134a.R134a2.mos \
-Modelica.Fluid.Examples.PumpingSystem.mos \
 Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SMEE_Generator_MultiPhase.mos \
 
 # Run make failingtest
 FAILINGTESTFILES = \
 Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench.mos \
+Modelica.Fluid.Examples.PumpingSystem.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.PumpingSystem.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.PumpingSystem.mos
@@ -1,6 +1,6 @@
 // name:     Modelica.Fluid.Examples.PumpingSystem
 // keywords: simulation MSL Examples
-// status: correct
+// status: erroneous
 // cflags: -d=-newInst
 //
 // Simulation Results

--- a/testsuite/simulation/modelica/initialization/Makefile
+++ b/testsuite/simulation/modelica/initialization/Makefile
@@ -39,6 +39,7 @@ homotopy3.mos \
 homotopy4.mos \
 homotopy4_solver.mos \
 homotopy5.mos \
+homotopy6.mos \
 initial_equation.mos \
 parameters.mos \
 parameterWithoutBinding.mos \

--- a/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
@@ -635,6 +635,111 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
+// |                 | |       | | | [6] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// 0
+// ""
+// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with equidistant step size started.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_equidistant_global_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = 0.57364 (pre: 0)
+// |                 | |       | | | [6] Real f(start=0, nominal=1) = -27.1705 (pre: 0)
+// |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
+// |                 | |       | | | [9] Real x2(start=0, nominal=1) = -2.16228 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -5.42636 (pre: 0)
+// |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
+// |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
+// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -2.16228 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 4.57364 (pre: 0)
+// |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
+// |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
+// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 4.67544 (pre: 0)
+// |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
+// LOG_INIT          | info    | ### END INITIALIZATION ###
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// true
+// 0
+// ""
+// "LOG_INIT          | info    | ### START INITIALIZATION ###
+// LOG_INIT          | info    | updating min-values
+// LOG_INIT          | info    | updating max-values
+// LOG_INIT          | info    | updating nominal-values
+// LOG_INIT          | info    | updating primary start-values
+// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
+// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with equidistant step size started.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_equidistant_global_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
+// LOG_INIT_V        | info    | parameter values
+// |                 | |       | | real parameters
+// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
+// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
+// |                 | |       | | other real variables
+// |                 | |       | | | [1] Real a(start=0, nominal=1) = 1 (pre: 0)
+// |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
+// |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
+// |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
 // |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
@@ -740,16 +845,16 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956366 (pre: 0)
 // |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95637 (pre: 0)
 // |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
 // |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04363 (pre: 0)
 // |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
 // |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
@@ -792,121 +897,16 @@ readFile("homotopy4_solver_system.log"); remove("homotopy4_solver_system.log");
 // |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
 // |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
 // |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
+// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956366 (pre: 0)
 // |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
 // |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
 // |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
+// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95637 (pre: 0)
 // |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
 // |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
 // |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with equidistant step size started.
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_equidistant_global_homotopy.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0 done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333 done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667 done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1 done
-// |                 | |       | ---------------------------
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
-// |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
-// |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
-// |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)
-// |                 | |       | | | [18] Real z3(start=0, nominal=1) = -1 (pre: 0)
-// LOG_INIT          | info    | ### END INITIALIZATION ###
-// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
-// LOG_SUCCESS       | info    | The simulation finished successfully.
-// "
-// true
-// 0
-// ""
-// "LOG_INIT          | info    | ### START INITIALIZATION ###
-// LOG_INIT          | info    | updating min-values
-// LOG_INIT          | info    | updating max-values
-// LOG_INIT          | info    | updating nominal-values
-// LOG_INIT          | info    | updating primary start-values
-// LOG_INIT          | info    | initialization method: symbolic        [solves the initialization problem symbolically - default]
-// LOG_INIT_HOMOTOPY | info    | Global homotopy with equidistant step size started.
-// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to initializationTests.homotopy4_solver_equidistant_global_homotopy.csv.
-// LOG_INIT_HOMOTOPY | info    | homotopy process
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0 done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333 done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667 done
-// |                 | |       | ---------------------------
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
-// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1 done
-// |                 | |       | ---------------------------
-// LOG_INIT_V        | info    | parameter values
-// |                 | |       | | real parameters
-// |                 | |       | | | [1] parameter Real p1(start=10, fixed=true) = 10
-// LOG_SOTI          | info    | ### SOLUTION OF THE INITIALIZATION ###
-// |                 | |       | | other real variables
-// |                 | |       | | | [1] Real a(start=0, nominal=1) = 1 (pre: 0)
-// |                 | |       | | | [2] Real b(start=0, nominal=1) = -0.412118 (pre: 0)
-// |                 | |       | | | [3] Real c(start=0, nominal=1) = 0.169842 (pre: 0)
-// |                 | |       | | | [4] Real d(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [5] Real e(start=0, nominal=1) = -0.956376 (pre: 0)
-// |                 | |       | | | [6] Real f(start=0, nominal=1) = -23.1114 (pre: 0)
-// |                 | |       | | | [7] Real x(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [8] Real x1(start=0, nominal=1) = -9 (pre: 0)
-// |                 | |       | | | [9] Real x2(start=0, nominal=1) = 3 (pre: 0)
-// |                 | |       | | | [10] Real x3(start=0, nominal=1) = -6.95638 (pre: 0)
-// |                 | |       | | | [11] Real y(start=0, nominal=1) = 5 (pre: 0)
-// |                 | |       | | | [12] Real y1(start=0, nominal=1) = 4.16984 (pre: 0)
-// |                 | |       | | | [13] Real y2(start=0, nominal=1) = -3 (pre: 0)
-// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04362 (pre: 0)
+// |                 | |       | | | [14] Real y3(start=0, nominal=1) = 3.04363 (pre: 0)
 // |                 | |       | | | [15] Real z(start=0, nominal=1) = -5 (pre: 0)
 // |                 | |       | | | [16] Real z1(start=0, nominal=1) = -4.16984 (pre: 0)
 // |                 | |       | | | [17] Real z2(start=0, nominal=1) = 9 (pre: 0)

--- a/testsuite/simulation/modelica/initialization/homotopy6.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy6.mos
@@ -1,0 +1,60 @@
+// name: homotopy6
+// keywords: initialization, homotopy
+// status: correct
+// cflags:
+// teardown_command: rm -rf initializationTests.homotopy5* _initializationTests.homotopy5* output.log
+// cflags: -d=-newInst
+//
+//  Check if equation system will get a different solution for each global lambda value.
+//
+
+loadString("model TestTornHomotopy2
+  Real x,y,z;
+equation
+  x = homotopy(y + 0.1*y^2 - 0.001*y^3, y);
+  y = 3*z;
+  z + 0.1*x = 1;
+end TestTornHomotopy2;
+"); getErrorString();
+
+simulate(TestTornHomotopy2, simflags="-lv=LOG_INIT_HOMOTOPY -s=dassl");
+getErrorString();
+
+readFile("TestTornHomotopy2_equidistant_global_homotopy.csv")
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "TestTornHomotopy2_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestTornHomotopy2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_HOMOTOPY -s=dassl'",
+//     messages = "LOG_INIT_HOMOTOPY | info    | Model contains homotopy operator: Use adaptive homotopy method to solve initialization problem. To disable initialization with homotopy operator use \"-noHomotopyOnFirstTry\".
+// LOG_INIT_HOMOTOPY | info    | Global homotopy with equidistant step size started.
+// LOG_INIT_HOMOTOPY | info    | The homotopy path will be exported to TestTornHomotopy2_equidistant_global_homotopy.csv.
+// LOG_INIT_HOMOTOPY | info    | homotopy process
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.333333 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 0.666667 done
+// |                 | |       | ---------------------------
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1
+// LOG_INIT_HOMOTOPY | info    | homotopy parameter lambda = 1 done
+// |                 | |       | ---------------------------
+// LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// "\"lambda\",\"x\",\"y\",\"z\"
+// 0,2.307692307692307,2.307692307692308,0.7692307692307693
+// 0.3333333333333333,2.436704982096462,2.268988505371062,0.7563295017903539
+// 0.6666666666666666,2.557625806717175,2.232712257984848,0.7442374193282825
+// 1,2.671349569180263,2.198595129245921,0.7328650430819735
+// "
+// endResult

--- a/testsuite/simulation/modelica/initialization/homotopy6.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy6.mos
@@ -5,7 +5,8 @@
 // teardown_command: rm -rf initializationTests.homotopy5* _initializationTests.homotopy5* output.log
 // cflags: -d=-newInst
 //
-//  Check if equation system will get a different solution for each global lambda value.
+// Check if equation system actually goes through all steps in the global homotopy path.
+// To prevent regressions like https://github.com/OpenModelica/OpenModelica/issues/8097
 //
 
 loadString("model TestTornHomotopy2

--- a/testsuite/simulation/modelica/initialization/homotopy6.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy6.mos
@@ -2,7 +2,7 @@
 // keywords: initialization, homotopy
 // status: correct
 // cflags:
-// teardown_command: rm -rf initializationTests.homotopy5* _initializationTests.homotopy5* output.log
+// teardown_command: rm -rf initializationTests.homotopy6* _initializationTests.homotopy6* output.log TestTornHomotopy2*
 // cflags: -d=-newInst
 //
 // Check if equation system actually goes through all steps in the global homotopy path.


### PR DESCRIPTION
### Related Issues

#8097 

### Purpose

Don't change the value of lambda if homotopy (for the non-linear loop) shouldn't be used.
Added a testcase from #8097 to testsuite.
