### PR TITLE
Windows build fixes

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -20,6 +20,7 @@ string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # options
+omc_option(WITH_IPOPT "Should we enable dynamic optimization support with Ipopt." ON)
 omc_option(OMC_USE_CORBA "Should use corba." OFF)
 
 omc_option(OMC_USE_LPSOLVE "Should we use lpsolve." OFF)

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -6350,6 +6350,7 @@ case SIMCODE(modelInfo=MODELINFO(varInfo=varInfo as VARINFO(__)), delayedExps=DE
   let libsPos2 = if dirExtra then libsStr // else ""
   let ParModelicaExpLibs = if acceptParModelicaGrammar() then '-lParModelicaExpl -lOpenCL' // else ""
   let ExtraStack = if boolOr(stringEq(makefileParams.platform, "win32"),stringEq(makefileParams.platform, "win64")) then '--stack,16777216,'
+  let linkBinDirWindows = if boolOr(stringEq(makefileParams.platform, "win32"),stringEq(makefileParams.platform, "win64")) then '-L"<%makefileParams.omhome%>/bin"'
   let extraCflags = match sopt case SOME(s as SIMULATION_SETTINGS(__)) then
     match s.method case "dassljac" then "-D_OMC_JACOBIAN "
 
@@ -6375,7 +6376,7 @@ case SIMCODE(modelInfo=MODELINFO(varInfo=varInfo as VARINFO(__)), delayedExps=DE
   RUNTIME_LIBS=<%makefileParams.runtimelibs%>
   LDFLAGS=<%
   if stringEq(Config.simCodeTarget(),"JavaScript") then <<-L'<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc/emcc' -lblas -llapack -lexpat -lSimulationRuntimeC -s TOTAL_MEMORY=805306368 -s OUTLINING_LIMIT=20000 --pre-js $(OMC_EMCC_PRE_JS)>>
-  else <<-L"<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc" -L"<%makefileParams.omhome%>/lib" -Wl,<%ExtraStack%>-rpath,"<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc" -Wl,-rpath,"<%makefileParams.omhome%>/lib" <%ParModelicaExpLibs%> <%makefileParams.ldflags%> $(RUNTIME_LIBS) >>
+  else <<-L"<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc" -L"<%makefileParams.omhome%>/lib" -Wl,<%ExtraStack%>-rpath,"<%makefileParams.omhome%>/lib/<%Autoconf.triple%>/omc" <%linkBinDirWindows%> -Wl,-rpath,"<%makefileParams.omhome%>/lib" <%ParModelicaExpLibs%> <%makefileParams.ldflags%> $(RUNTIME_LIBS) >>
   %>
   DIREXTRA=<%stringReplace(dirExtra,"#","\\#") /* make strips everything after # */%>
   MAINFILE=<%fileNamePrefix%>.c

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(omcruntime PUBLIC omc::config)
 target_link_libraries(omcruntime PUBLIC CURL::libcurl)
 target_link_libraries(omcruntime PUBLIC ${Intl_LIBRARIES})
 target_link_libraries(omcruntime PUBLIC Iconv::Iconv)
-target_link_libraries(omcruntime PUBLIC omc::simrt::memory)
+target_link_libraries(omcruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcruntime PUBLIC omc::3rd::ffi)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::3rd::FMIL::minizip) # We use the minizip lib from 3rdParty/FMIL
@@ -152,7 +152,7 @@ target_sources(omcbackendruntime PRIVATE ${OMC_BACKENDRUNTIIME_SOURCES})
 
 target_link_libraries(omcbackendruntime PUBLIC omc::config)
 target_link_libraries(omcbackendruntime PUBLIC ${Intl_LIBRARIES})
-target_link_libraries(omcbackendruntime PUBLIC omc::simrt::memory)
+target_link_libraries(omcbackendruntime PUBLIC omc::simrt::runtime)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::fmilib)
 target_link_libraries(omcbackendruntime PUBLIC omc::3rd::metis)
 
@@ -167,7 +167,7 @@ add_library(omc::compiler::graphstream ALIAS omcgraphstream)
 set(OMC_GRAPH_STREAM_SOURCES GraphStreamExt_omc.cpp)
 target_sources(omcgraphstream PRIVATE ${OMC_GRAPH_STREAM_SOURCES})
 
-target_link_libraries(omcgraphstream PUBLIC omc::simrt::memory)
+target_link_libraries(omcgraphstream PUBLIC omc::simrt::runtime)
 target_link_libraries(omcgraphstream PUBLIC omc::3rd::netstream)
 
 
@@ -276,8 +276,8 @@ else()
   set(MAKE ${CMAKE_MAKE_PROGRAM})
 
   string(REPLACE ";" " " LAPACK_LIBRARIES_SPACE "${LAPACK_LIBRARIES}")
-  set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -lomcmemory -llapack -lblas -lm -lpthread -rdynamic")
-  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOptimizationRuntime -lOpenModelicaRuntimeC -lomcmemory -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -llapack -lblas -lm -lpthread -rdynamic")
+  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lOptimizationRuntime -lOpenModelicaRuntimeC -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas -lm -lpthread -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -277,7 +277,7 @@ else()
 
   string(REPLACE ";" " " LAPACK_LIBRARIES_SPACE "${LAPACK_LIBRARIES}")
   set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -llapack -lblas -lm -lpthread -rdynamic")
-  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lOptimizationRuntime -lOpenModelicaRuntimeC -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas -lm -lpthread -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -84,6 +84,11 @@ if(WIN32)
   target_link_options(SimulationRuntimeC PRIVATE  -Wl,--export-all-symbols)
 endif(WIN32)
 
+if(WITH_IPOPT)
+  target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
+  target_compile_definitions(SimulationRuntimeC PRIVATE -DWITH_IPOPT)
+  target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::ipopt)
+endif()
 
 # Fix me. Make an interface (header only library) out of 3rdParty/dgesv
 target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
@@ -91,25 +96,6 @@ target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3
 # target_link_options(SimulationRuntimeC PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS SimulationRuntimeC)
-
-
-# ######################################################################################################################
-# Library: OptimizationRuntime
-## This is now separated from SimulationRuntimeC. Just for clarity. It can be put back in there if needed.
-## However having it as a separate lib will allow us to remove it based on an option. This means we can
-## also remove the need for ipopt and mumps if this is disabled.
-add_library(OptimizationRuntime SHARED)
-add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
-
-target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
-
-target_link_libraries(OptimizationRuntime PUBLIC omc::config)
-target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::runtime)
-target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::simruntime)
-target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
-
-
-install(TARGETS OptimizationRuntime)
 
 
 # ######################################################################################################################

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -29,37 +29,23 @@ file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/opt
 file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
 file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
 
-## This should be set. The reason it is not now is because there is a cyclic dependency between
-## gc/ and meta/ sources which are part of two different libraries at the moment. Either fix the
-## code to remove the cyclic dependency or move meta/ sources out of libOpenModelicaRuntimeC and into libomcmemory
-# set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-
-# ######################################################################################################################
-# Library: omcmemory
-## This tiny library provides the memory related functionality of OM (garbage collection and memory_pool).
-## The reason it is separated is because its functionality is clearly defined and should not be part of
-## a bunch of other libraries. For example there is no need to link to OpenModelicaRuntimeC just to get GC
-## functionality in Compiler/runtime.
-add_library(omcmemory SHARED)
-add_library(omc::simrt::memory ALIAS omcmemory)
-
-target_sources(omcmemory PRIVATE ${OMC_SIMRT_GC_SOURCES})
-target_link_libraries(omcmemory PUBLIC omc::3rd::omcgc)
-target_include_directories(omcmemory PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-install(TARGETS omcmemory)
 
 # ######################################################################################################################
 # Library: OpenModelicaRuntimeC
 add_library(OpenModelicaRuntimeC SHARED)
 add_library(omc::simrt::runtime ALIAS OpenModelicaRuntimeC)
 
-target_sources(OpenModelicaRuntimeC PRIVATE ${OMC_SIMRT_UTIL_SOURCES} ${OMC_SIMRT_META_SOURCES})
-target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::simrt::memory)
+target_sources(OpenModelicaRuntimeC PRIVATE ${OMC_SIMRT_GC_SOURCES} ${OMC_SIMRT_UTIL_SOURCES} ${OMC_SIMRT_META_SOURCES})
+target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
+
+target_include_directories(OpenModelicaRuntimeC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 
 if(WIN32)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC dbghelp)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC regex)
+  target_link_libraries(OpenModelicaRuntimeC PUBLIC wsock32)
+  target_link_options(OpenModelicaRuntimeC PRIVATE  -Wl,--export-all-symbols)
 endif(WIN32)
 
 
@@ -77,7 +63,6 @@ target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_SIMULATION_SOURCES}
                                           ${OMC_SIMRT_DATA_RECONCILIATION_SOURCES})
 
 target_link_libraries(SimulationRuntimeC PUBLIC omc::config)
-target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::memory)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::simrt::runtime)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::FMIL::expat)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::sundials::cvode)
@@ -96,8 +81,9 @@ target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cdaskr)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
 
 if(WIN32)
-  target_link_libraries(OpenModelicaRuntimeC PUBLIC wsock32)
+  target_link_options(SimulationRuntimeC PRIVATE  -Wl,--export-all-symbols)
 endif(WIN32)
+
 
 # Fix me. Make an interface (header only library) out of 3rdParty/dgesv
 target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
@@ -118,7 +104,7 @@ add_library(omc::simrt::optimize ALIAS OptimizationRuntime)
 target_sources(OptimizationRuntime PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
 
 target_link_libraries(OptimizationRuntime PUBLIC omc::config)
-target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::memory)
+target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::runtime)
 target_link_libraries(OptimizationRuntime PUBLIC omc::simrt::simruntime)
 target_link_libraries(OptimizationRuntime PUBLIC omc::3rd::ipopt)
 


### PR DESCRIPTION
@mahge
Add the bin dir to link dirs on Windows. 
6c66bb9
  - DLLs are installed in the bin dir. Add it to the list of link directories
    specified for generated code on Windows.

@mahge
[cmake] Remove the omcmemory library. 
7190356
  - This (short lived) library was an attempt to provide a small memory
    manager library for omc libraries. It was supposed to provide just
    the GC and memory pool interfaces.

    Unfortunately, there are cyclic dependencies between itself and
    OpenModelicaRuntimeC. While this is acceptable on linux and can be
    overlooked, it is porblematic with Windows DLLs. We need to start
    adapting import libs and def files if we need to continue in this path.

    This is not something to do right now. It is better to fix the cyclic
    dependencies properly later.

    So for now it is removed and the functionality will be part of the
    OpenModelicaRuntimeC library instead (just like the makefile build
    system does).

@mahge
[cmake] Remove the Optimization library. …
04fc028
  - this is also to reduce the amount of DLLs. It is actually better to
    just disable ipopt and dynamic optimization with a flag.

    It is enabled with the option WITH_IPOPT to match the makefile build
    system.

    NOTE: Disabling the option in CMake DOES NOT actually result in a
    functional compilation right now. The reason is that the flag WITH_IPOPT
    is actually hard coded in to omc_config* headers.

    I will fix that later.