### PR TITLE
Ignore asserts while calling simulationUpdate()

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4376,6 +4376,7 @@ template assertCommon(Exp condition, list<Exp> messages, Exp level, Context cont
             else '_withEquationIndexes'
   let infoTextContext = '"The following assertion has been violated %sat time %f\n<%Util.escapeModelicaStringToCString(ExpressionDumpTpl.dumpExp(condition,"\""))%>", initial() ? "during initialization " : "", data->localData[0]->timeValue'
   let omcAssertFunc = match level case ENUM_LITERAL(index=1) then 'omc_assert_warning<%AddionalFuncName%>(' else 'omc_assert<%AddionalFuncName%>(threadData, '
+  let rethrow = match level case ENUM_LITERAL(index=1) then '' else '<%\n%>data->simulationInfo->needToReThrow = 1;'
   let assertCode = match context case FUNCTION_CONTEXT(__) then
     <<
     FILE_INFO info = {<%infoArgs(info)%>};
@@ -4384,8 +4385,8 @@ template assertCommon(Exp condition, list<Exp> messages, Exp level, Context cont
     else
     <<
     if (data->simulationInfo->noThrowAsserts) {
-      infoStreamPrintWithEquationIndexes(LOG_STDOUT, 0, equationIndexes, <%infoTextContext%>);
-      data->simulationInfo->needToReThrow = 1;
+      infoStreamPrintWithEquationIndexes(LOG_ASSERT, 0, equationIndexes, <%infoTextContext%>);
+      infoStreamPrint(LOG_ASSERT, 0, <%msgVar%>);<%rethrow%>
     } else {
       FILE_INFO info = {<%infoArgs(info)%>};
       omc_assert_warning(info, <%infoTextContext%>);
@@ -4448,7 +4449,7 @@ template assertCommonVar(Text condVar, Text msgVar, Context context, Text &varDe
     if(!(<%condVar%>))
     {
       if (data->simulationInfo->noThrowAsserts) {
-        infoStreamPrintWithEquationIndexes(LOG_STDOUT, 0, equationIndexes, "The following assertion has been violated %sat time %f", initial() ? "during initialization " : "", data->localData[0]->timeValue);
+        infoStreamPrintWithEquationIndexes(LOG_ASSERT, 0, equationIndexes, "The following assertion has been violated %sat time %f", initial() ? "during initialization " : "", data->localData[0]->timeValue);
         data->simulationInfo->needToReThrow = 1;
       } else {
         FILE_INFO info = {<%infoArgs(info)%>};

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1098,6 +1098,8 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
   /*  switches used to evaluate the system */
   data->simulationInfo->solveContinuous = 0;
   data->simulationInfo->noThrowDivZero = 0;
+  data->simulationInfo->noThrowAsserts = 0;
+  data->simulationInfo->needToReThrow = 0;
   data->simulationInfo->discreteCall = 0;
 
   /* initialize model error code */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -93,6 +93,9 @@ static void prefixedName_updateContinuousSystem(DATA *data, threadData_t *thread
 static int simulationUpdate(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
 {
   int foundEvent = 0;
+  data->simulationInfo->noThrowAsserts = 1 /* true */;
+  data->simulationInfo->needToReThrow = 0 /* false */;
+
   prefixedName_updateContinuousSystem(data, threadData);
 
   if (solverInfo->solverMethod == S_SYM_SOLVER_SSC) {
@@ -160,6 +163,16 @@ static int simulationUpdate(DATA* data, threadData_t *threadData, SOLVER_INFO* s
   if (foundEvent==1) {
     data->callback->function_storeSpatialDistribution(data, threadData);
   }
+
+  /* Check if ignored assert throw was actually a valid throw */
+  data->simulationInfo->noThrowAsserts = 0 /* false */;
+  if (data->simulationInfo->needToReThrow && !foundEvent) {
+    throwStreamPrint(threadData, "No event found, but assert was triggered. Throwing now!");
+    omc_throw(threadData);
+  } else if (data->simulationInfo->needToReThrow) {
+    infoStreamPrint(LOG_STDOUT, 0, "Found event, previous asserts are ignored.");
+  }
+
   return syncRet;
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -167,10 +167,10 @@ static int simulationUpdate(DATA* data, threadData_t *threadData, SOLVER_INFO* s
   /* Check if ignored assert throw was actually a valid throw */
   data->simulationInfo->noThrowAsserts = 0 /* false */;
   if (data->simulationInfo->needToReThrow && !foundEvent) {
-    throwStreamPrint(threadData, "No event found, but assert was triggered. Throwing now!");
+    errorStreamPrint(LOG_ASSERT, 0, "No event found, but assert was triggered. Throwing now!");
     omc_throw(threadData);
   } else if (data->simulationInfo->needToReThrow) {
-    infoStreamPrint(LOG_STDOUT, 0, "Found event, previous asserts are ignored.");
+    infoStreamPrint(LOG_ASSERT, 0, "Found event, previous asserts are ignored.");
   }
 
   return syncRet;

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -653,6 +653,8 @@ typedef struct SIMULATION_INFO
   modelica_boolean sampleActivated;    /* true if a sample expresion is going to be actived */
   modelica_boolean solveContinuous;    /* true during continuous integration to avoid zero-crossings jumps */
   modelica_boolean noThrowDivZero;     /* true if solving nonlinear system to avoid THROW for division by zero */
+  modelica_boolean noThrowAsserts;     /* true if asserts can be ignored, e.g. when searching for an event location */
+  modelica_boolean needToReThrow;      /* true if an ignored asserts was found, and may need to be rethrown */
 
   double solverSteps;                  /* Number of integration steps so far for writing to the result file */ // FIXME why is this not an integer?
 

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runExReduceDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runExReduceDrumBoiler.mos
@@ -31,12 +31,12 @@ getErrorString();
 // |                 | |       | der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0
 // assert            | warning | Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 849.600000
+// assert            | info    | The following assertion has been violated at time 849.600000
 // |                 | |       | conSigma.con >= conSigma.MinValue and conSigma.con <= conSigma.MaxValue
-// assert            | warning | Variable violating min/max constraint: conSigma.MinValue <= conSigma.con <= conSigma.MaxValue, has value: -150.308
-// assert            | warning | The following assertion has been violated at time 1252.800000
+// assert            | info    | Variable violating min/max constraint: conSigma.MinValue <= conSigma.con <= conSigma.MaxValue, has value: -150.308
+// assert            | info    | The following assertion has been violated at time 1252.800000
 // |                 | |       | der_V_v >= -0.02 and der_V_v <= 0.025
-// assert            | warning | Variable violating min/max constraint: -0.02 <= der_V_v <= 0.025, has value: 0.0252797
+// assert            | info    | Variable violating min/max constraint: -0.02 <= der_V_v <= 0.025, has value: 0.0252797
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -97,14 +97,14 @@ getErrorString();
 // LOG_IPOPT_ERROR   | info    | max violation is 61.2224 for the constraint $EqCon$der_evaporator_p(time = 1296)
 // LOG_IPOPT_ERROR   | info    | max violation is 15.3174 for the constraint $EqCon$der_evaporator_p(time = 1296)
 // LOG_IPOPT_ERROR   | info    | max violation is 3.83252 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.958956 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.240156 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.0600273 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.0149906 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.00373544 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.000920151 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 0.000217648 for the constraint $EqCon$der_evaporator_p(time = 1296)
-// LOG_IPOPT_ERROR   | info    | max violation is 4.56618e-05 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.95895 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.240162 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.0600248 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.0149926 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.00373615 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.000920756 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 0.00021756 for the constraint $EqCon$der_evaporator_p(time = 1296)
+// LOG_IPOPT_ERROR   | info    | max violation is 4.08627e-05 for the constraint $EqCon$der_evaporator_p(time = 1296)
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump.mos
+++ b/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump.mos
@@ -31,9 +31,9 @@ getEnvironmentVar("REFERENCEFILES")+"/ThermoSysPro/ThermoSysPro.Examples.SimpleE
 //     resultFile = "ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1000.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 200.000000
+// assert            | info    | The following assertion has been violated at time 200.000000
 // |                 | |       | StaticCentrifugalPump1.hn >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= StaticCentrifugalPump1.hn, has value: -1.7295e-29
+// assert            | info    | Variable violating min constraint: 0.0 <= StaticCentrifugalPump1.hn, has value: -1.7295e-29
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution.mos
+++ b/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution.mos
@@ -31,9 +31,9 @@ getEnvironmentVar("REFERENCEFILES")+"/ThermoSysPro/ThermoSysPro.Examples.SimpleE
 //     resultFile = "ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1000.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 200.000000
+// assert            | info    | The following assertion has been violated at time 200.000000
 // |                 | |       | staticCentrifugalPumpWaterLiBr.deltaP >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= staticCentrifugalPumpWaterLiBr.deltaP, has value: -86.9556
+// assert            | info    | Variable violating min constraint: 0.0 <= staticCentrifugalPumpWaterLiBr.deltaP, has value: -86.9556
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.MoistAir.mos
@@ -19,9 +19,9 @@ simulate(Modelica.Media.Examples.MoistAir);
 //     resultFile = "Modelica.Media.Examples.MoistAir_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.MoistAir', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.952000
+// assert            | info    | The following assertion has been violated at time 0.952000
 // |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00448
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00448
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
+++ b/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
@@ -22,15 +22,15 @@ simulate(Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates);
 // |                 | |       | medium.p >= 2000.0 and medium.p <= 100000000.0
 // assert            | warning | Variable violating min/max constraint: 2000.0 <= medium.p <= 100000000.0, has value: 700
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 20.080589
+// assert            | info    | The following assertion has been violated at time 20.080589
 // |                 | |       | medium.x >= 0.0 and medium.x <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1
-// assert            | warning | The following assertion has been violated at time 21.964800
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1
+// assert            | info    | The following assertion has been violated at time 21.964800
 // |                 | |       | medium.cp_d >= 0.0 and medium.cp_d <= 1000000.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.cp_d <= 1000000.0, has value: 1.08101e+06
-// assert            | warning | The following assertion has been violated at time 21.991200
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.cp_d <= 1000000.0, has value: 1.08101e+06
+// assert            | info    | The following assertion has been violated at time 21.991200
 // |                 | |       | medium.cp_b >= 0.0 and medium.cp_b <= 1000000.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.cp_b <= 1000000.0, has value: 1.01516e+06
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.cp_b <= 1000000.0, has value: 1.01516e+06
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.Tanks.EmptyTanks.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.Tanks.EmptyTanks.mos
@@ -43,12 +43,12 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 50.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.Tanks.EmptyTanks', options = '', outputFormat = 'mat', variableFilter = 'time|tank1.level|tank1.medium.T|tank2.level|tank2.medium.T|tank2.traceDynamics|tank2.substanceDynamics|tank2.massDynamics|tank2.energyDynamics|tank1.traceDynamics|tank1.substanceDynamics|tank1.massDynamics|tank1.energyDynamics|system.traceDynamics|system.substanceDynamics|system.massDynamics|system.energyDynamics', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Fluid.Examples.Tanks.EmptyTanks_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
-// assert            | warning | The following assertion has been violated at time 35.406941
+// assert            | info    | The following assertion has been violated at time 35.406941
 // |                 | |       | tank1.m >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= tank1.m, has value: -9.95587e-08
-// assert            | warning | The following assertion has been violated at time 35.406941
+// assert            | info    | Variable violating min constraint: 0.0 <= tank1.m, has value: -9.95589e-08
+// assert            | info    | The following assertion has been violated at time 35.406941
 // |                 | |       | tank1.level >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= tank1.level, has value: -1e-10
+// assert            | info    | Variable violating min constraint: 0.0 <= tank1.level, has value: -1e-10
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.MoistAir.mos
@@ -29,9 +29,9 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.MoistAir', options = '', outputFormat = 'mat', variableFilter = 'time|medium.p|medium.T', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.MoistAir_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.954000
+// assert            | info    | The following assertion has been violated at time 0.954000
 // |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00869
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00869
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir.mos
@@ -31,12 +31,12 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.ReferenceAir.MoistAir', options = '', outputFormat = 'mat', variableFilter = 'time|medium.p|medium.T|der_p|der_T', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.ReferenceAir.MoistAir_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.448000
+// assert            | info    | The following assertion has been violated at time 0.448000
 // |                 | |       | medium.X_liquid >= 0.0 and medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869
-// assert            | warning | The following assertion has been violated at time 0.954000
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869
+// assert            | info    | The following assertion has been violated at time 0.954000
 // |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
@@ -29,9 +29,9 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 22.0, numberOfIntervals = 2200, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates', options = '', outputFormat = 'mat', variableFilter = 'time|medium.p|medium.h', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 20.080014
+// assert            | info    | The following assertion has been violated at time 20.080014
 // |                 | |       | medium.x >= 0.0 and medium.x <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/modelica/asserts/AssertTest4.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest4.mos
@@ -26,23 +26,10 @@ getErrorString();
 // Value of x(=0.666667)
 // Value of x(=0.555556)
 // Value of x(=0.444444)
-// assert            | warning | The following assertion has been violated at time 0.555556
+// assert            | info    | The following assertion has been violated at time 0.555556
 // |                 | |       | assertTest.x >= 0.5
-// assert            | error   | Variable x(=0.444444) out of limit
-// Value of x(=0.555556)
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// Value of x(=0.5)
-// Value of x(=0.333333)
-// assert            | warning | The following assertion has been violated at time 0.666667
-// |                 | |       | assertTest.x >= 0.5
-// assert            | error   | Variable x(=0.333333) out of limit
-// Value of x(=0.5)
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// Value of x(=0.416667)
-// assert            | warning | The following assertion has been violated at time 0.583333
-// |                 | |       | assertTest.x >= 0.5
-// assert            | error   | Variable x(=0.416667) out of limit
-// stdout            | info    | model terminate | Simulation terminated by an assert at time: 0.583333
+// assert            | info    | Variable x(=0.444444) out of limit
+// assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;
 // ""

--- a/testsuite/simulation/modelica/asserts/AssertTest5.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest5.mos
@@ -26,23 +26,10 @@ getErrorString();
 // Value of x(=0.666667)
 // Value of x(=0.555556)
 // Value of x(=0.444444)
-// assert            | warning | The following assertion has been violated at time 0.555556
+// assert            | info    | The following assertion has been violated at time 0.555556
 // |                 | |       | assertTest.x >= 0.5
-// assert            | error   | Variable x(=0.444444) out of limit
-// Value of x(=0.555556)
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// Value of x(=0.5)
-// Value of x(=0.333333)
-// assert            | warning | The following assertion has been violated at time 0.666667
-// |                 | |       | assertTest.x >= 0.5
-// assert            | error   | Variable x(=0.333333) out of limit
-// Value of x(=0.5)
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// Value of x(=0.416667)
-// assert            | warning | The following assertion has been violated at time 0.583333
-// |                 | |       | assertTest.x >= 0.5
-// assert            | error   | Variable x(=0.416667) out of limit
-// stdout            | info    | model terminate | Simulation terminated by an assert at time: 0.583333
+// assert            | info    | Variable x(=0.444444) out of limit
+// assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;
 // ""

--- a/testsuite/simulation/modelica/asserts/TestAssert.mos
+++ b/testsuite/simulation/modelica/asserts/TestAssert.mos
@@ -91,9 +91,9 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     resultFile = "TestAssert.TestWarningVariable_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestWarningVariable', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.834000
+// assert            | info    | The following assertion has been violated at time 0.834000
 // |                 | |       | m3.x < 5.0
-// assert            | warning | Variable x is probably too big
+// assert            | info    | Variable x is probably too big
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -102,9 +102,9 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     resultFile = "TestAssert.TestWarningRecurring_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestWarningRecurring', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.158000
+// assert            | info    | The following assertion has been violated at time 0.158000
 // |                 | |       | m3.x < 5.0
-// assert            | warning | Variable x is probably too big
+// assert            | info    | Variable x is probably too big
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -125,21 +125,13 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestErrorVariable', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: TestAssert.TestErrorVariable
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.250000
+// assert            | info    | The following assertion has been violated at time 0.250000
 // |                 | |       | m2.x < 5.0
-// assert            | warning | Variable x is probably too big
-// assert            | warning | The following assertion has been violated at time 0.500000
+// assert            | info    | Variable x is probably too big
+// assert            | info    | The following assertion has been violated at time 0.500000
 // |                 | |       | m2.x < 10.0
-// assert            | error   | Variable x is too big
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// assert            | warning | The following assertion has been violated at time 0.502000
-// |                 | |       | m2.x < 10.0
-// assert            | error   | Variable x is too big
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// assert            | warning | The following assertion has been violated at time 0.500500
-// |                 | |       | m2.x < 10.0
-// assert            | error   | Variable x is too big
-// stdout            | info    | model terminate | Simulation terminated by an assert at time: 0.5005
+// assert            | info    | Variable x is too big
+// assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;
 // ""

--- a/testsuite/simulation/modelica/events/whenTest2.mos
+++ b/testsuite/simulation/modelica/events/whenTest2.mos
@@ -57,12 +57,12 @@ val(x, 0.9);
 // x : 1.28938
 // Time : 0.5
 // x : 1.22416
-// assert            | warning | The following assertion has been violated at time 0.573517
+// assert            | info    | The following assertion has been violated at time 0.573517
 // |                 | |       | time < 0.5
-// assert            | warning | Assert does trigger.
-// assert            | warning | The following assertion has been violated at time 0.591693
+// assert            | info    | Assert does trigger.
+// assert            | info    | The following assertion has been violated at time 0.591693
 // |                 | |       | time < 0.55
-// assert            | warning | Assert does triggered again .
+// assert            | info    | Assert does triggered again .
 // Time : 0.6
 // x : 1.24662
 // Time : 0.7

--- a/testsuite/simulation/modelica/functions_eval/MoistAir.mos
+++ b/testsuite/simulation/modelica/functions_eval/MoistAir.mos
@@ -20,12 +20,12 @@ getErrorString();
 //     resultFile = "Modelica.Media.Examples.ReferenceAir.MoistAir_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.ReferenceAir.MoistAir', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.448000
+// assert            | info    | The following assertion has been violated at time 0.448000
 // |                 | |       | medium.X_liquid >= 0.0 and medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869
-// assert            | warning | The following assertion has been violated at time 0.954000
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869
+// assert            | info    | The following assertion has been violated at time 0.954000
 // |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089
+// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/others/StringTest.mos
+++ b/testsuite/simulation/modelica/others/StringTest.mos
@@ -17,14 +17,10 @@ simulate(STest1, tolerance=1e-5, numberOfIntervals=100);
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 100, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'STest1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: STest1
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | warning | The following assertion has been violated at time 0.110000
+// assert            | info    | The following assertion has been violated at time 0.110000
 // |                 | |       | x < 0.1
-// assert            | error   | x reached 0.11 at time 0.11 b =true i =     66
-// stdout            | warning | Integrator attempt to handle a problem with a called assert.
-// assert            | warning | The following assertion has been violated at time 0.105000
-// |                 | |       | x < 0.1
-// assert            | error   | x reached 0.1 at time 0.105 b =true i =     66
-// stdout            | info    | model terminate | Simulation terminated by an assert at time: 0.105
+// assert            | info    | x reached 0.11 at time 0.11 b =true i =     66
+// assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;
 // endResult


### PR DESCRIPTION
* While searching for an event asserts can be ignored
* If no event was found but an assert triggered, throw an error at end of
  simulationUpdate()
* Output info message when assert was triggered, but ignored

### Related Issues

Fixes #6195 

### Purpose

Ignore asserts while searching for an event.

### Approach

Added new variables `noThrowAsserts` and `needToReThrow` to `SIMULATION_INFO`. Store information if asserts can be ignored and if an assert was encountered.
