### PR TITLE
[cmake] Use Autoconf.mo.in for Windows as well.

### DIFF
--- a/OMCompiler/Compiler/Util/Autoconf.mo.in
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.in
@@ -1,21 +1,28 @@
 encapsulated package Autoconf
 
+  constant String configureCommandLine = "Configured @date@ using arguments: @CONFIGURE_ARGS@";
+
+  constant String os = "@CONFIG_OS@";
+
+  constant Boolean is64Bit = @OMC_TARGET_ARCH_IS_64@;
+  constant Boolean isWindows = os == "Windows_NT";
+  constant String platform = if isWindows and is64Bit then "WIN64" elseif isWindows then "WIN32" else "Unix";
+
+  constant String make = "@MAKE@";
+  constant String exeExt = if isWindows then ".exe" else "";
+  constant String dllExt = "@SHREXT@";
+
   constant Boolean haveBStatic = @BSTATIC@;
   constant String bstatic = if haveBStatic then "-Wl,-Bstatic" else "";
   constant String bdynamic = if haveBStatic then "-Wl,-Bdynamic" else "";
-  constant String configureCommandLine = "Configured @date@ using arguments: @CONFIGURE_ARGS@";
-  constant String os = "@CONFIG_OS@";
-  constant String make = "@MAKE@";
-  constant String exeExt = "";
-  constant String dllExt = "@SHREXT@";
+
+  constant String groupDelimiter = if isWindows then ";" else ":";
+  constant String pathDelimiter = "/";
+
   constant String ldflags_runtime = "@RT_LDFLAGS_GENERATED_CODE@";
   constant String ldflags_runtime_sim = "@RT_LDFLAGS_GENERATED_CODE_SIM@";
   constant String ldflags_runtime_fmu = "@RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU@";
   constant String ldflags_runtime_fmu_static = "@RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC@";
-
-  constant String platform = "Unix";
-  constant String pathDelimiter = "/";
-  constant String groupDelimiter = ":";
 
   constant String corbaLibs = "@CORBALIBS@";
   constant String hwloc = if @WITH_HWLOC@ == 1 then "-lhwloc" else "";

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -191,10 +191,10 @@ omc_add_to_report(OMC_TARGET_SYSTEM_NAME)
 set(OPENMODELICA_SPEC_PLATFORM ${CMAKE_SYSTEM_PROCESSOR}-${OMC_TARGET_SYSTEM_NAME})
 
 if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-  set(OMC_TARGET_ARCH_IS_64 TRUE)
+  set(OMC_TARGET_ARCH_IS_64 "true")
   set(MODELICA_SPEC_PLATFORM "${OMC_TARGET_SYSTEM_NAME}64")
 else()
-  set(OMC_TARGET_ARCH_IS_64 FALSE)
+  set(OMC_TARGET_ARCH_IS_64 "false")
   set(MODELICA_SPEC_PLATFORM "${OMC_TARGET_SYSTEM_NAME}32")
 endif()
 
@@ -248,39 +248,36 @@ configure_file(${OMCompiler_SOURCE_DIR}/omc_config.unix.h.in ${OMCompiler_SOURCE
 
 # Generate Autoconf.mo here since we have some of the variables already defined for omc_config.unix.h above.
 
+
+check_c_compiler_flag("-Wl,-Bstatic  -Wl,-Bdynamic" BSTATIC_INT)
+if(BSTATIC_INT)
+  set(BSTATIC "true")
+else()
+  set(BSTATIC "false")
+endif()
+
+set(MAKE ${CMAKE_MAKE_PROGRAM})
+
+string(REPLACE ";" " " LAPACK_LIBRARIES_SPACE "${LAPACK_LIBRARIES}")
+
 if(WIN32)
+  set(CONFIG_OS "Windows_NT")
 
-  if(OMC_TARGET_ARCH_IS_64)
-    set(ISMINGW64 "true")
-  else()
-    set(ISMINGW64 "false")
-  endif()
+  set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -lopenblas -lm -lpthread")
+  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lopenblas -lm -lpthread -lgfortran -lstdc++ -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -lopenblas -lm -lpthread -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -lopenblas -lm -lpthread -lgfortran -lstdc++ -Wl,--no-undefined")
 
-  if(${CMAKE_CXX_COMPILER_VERSION} STREQUAL "5.3.0")
-    set(IS_NEW_OMDEV "false")
-  else()
-    set(IS_NEW_OMDEV "true")
-  endif()
-
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.omdev.mingw ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo)
 
 else()
-  check_c_compiler_flag("-Wl,-Bstatic  -Wl,-Bdynamic" BSTATIC_INT)
-  if(BSTATIC_INT)
-    set(BSTATIC "true")
-  else()
-    set(BSTATIC "false")
-  endif()
-
   set(CONFIG_OS ${OMC_TARGET_SYSTEM_NAME})
-  set(MAKE ${CMAKE_MAKE_PROGRAM})
 
-  string(REPLACE ";" " " LAPACK_LIBRARIES_SPACE "${LAPACK_LIBRARIES}")
   set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -llapack -lblas -lm -lpthread -rdynamic")
   set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas -lm -lpthread -rdynamic -Wl,--no-undefined")
   set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
 
 
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.in ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo)
 endif()
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo.in ${CMAKE_CURRENT_SOURCE_DIR}/../Util/Autoconf.mo)

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -115,6 +115,16 @@ AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
+# Check for platform arch (32 vs 64 bit)
+# sets OMC_TARGET_ARCH_IS_64 to true if 64 bit.
+AC_SUBST(OMC_TARGET_ARCH_IS_64)
+AC_CHECK_SIZEOF([void *])
+if test "x$ac_cv_sizeof_void_p" = "x8" ; then
+   OMC_TARGET_ARCH_IS_64="true"
+else
+   OMC_TARGET_ARCH_IS_64="false"
+fi
+
 build_short=$build_cpu-$build_os
 host_short=$host_cpu-$host_os
 


### PR DESCRIPTION
  - Generate `Autoconf.mo` from `Autoconf.mo.in` on Windows. That is, instead
    of using the pre-written static `Autoconf.mo.omdev.mingw`.

  - On top of unifying the config and reducing a file, this also allows
    to control CMake config for Windows without affecting the makefile build
    system.