### PR TITLE
More Windows fixes.

### DIFF
--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -52,6 +52,14 @@ add_custom_command (
     COMMENT "Copying (NF/Meta/Modelica)Builtin.mo files for the bootstrapped omc.")
 
 
+if(WIN32)
+  add_custom_command (
+    TARGET bomc
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:omc::simrt::runtime> ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
+    COMMENT "Copying OpenModelicaRuntimeC.dll for the bootstrapped omc (to ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin).")
+endif()
+
 # add_custom_command(
 #     TARGET bomc
 #     POST_BUILD

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -86,7 +86,9 @@ endif(WIN32)
 
 if(WITH_IPOPT)
   target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})
-  target_compile_definitions(SimulationRuntimeC PRIVATE -DWITH_IPOPT)
+  ## disable for now to avoid duplicate definition warnings. The define is hardcoded in
+  ## omc_config.h. Until we remove that this just results in warnings.
+  # target_compile_definitions(SimulationRuntimeC PRIVATE -DWITH_IPOPT)
   target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::ipopt)
 endif()
 

--- a/OMCompiler/SimulationRuntime/c/util/rtclock.c
+++ b/OMCompiler/SimulationRuntime/c/util/rtclock.c
@@ -150,7 +150,7 @@ double rt_total(int ix) {
 static enum omc_rt_clock_t selectedClock = OMC_CLOCK_REALTIME;
 
 #if !defined(_MSC_VER)
-inline long long RDTSC() {
+static long long RDTSC() {
    register long long TSC asm("eax");
    asm volatile (".byte 15, 49" : : : "eax", "edx");
    return TSC;
@@ -159,7 +159,7 @@ inline long long RDTSC() {
 //    return (unsigned long long)lo | ((unsigned long long)hi << 32);
 }
 #else
-long long RDTSC() {
+static long RDTSC() {
 //  unsigned int ui;
 //  return __rdtscp(&ui);
    return __rdtsc();

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt
@@ -2,20 +2,24 @@
 
 ## This is not tested very well. Will be updated as we go.
 
+if(NOT WIN32)
 execute_process(COMMAND autoconf
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   RESULT_VARIABLE AUTOCONF_FOR_FMU_EXIT_STATUS
   OUTPUT_VARIABLE AUTOCONF_FOR_FMU_OUTPUT
-  ERROR_VARIABLE AUTOCONF_FOR_FMU_OUTPUT
+  ERROR_VARIABLE AUTOCONF_FOR_FMU_ERROR
   #   OUTPUT_QUIET
 )
 
-
-if(NOT ${AUTOCONF_FOR_FMU_EXIT_STATUS} EQUAL "0")
-    message(SEND_ERROR ${AUTOCONF_FOR_FMU_OUTPUT})
+if(AUTOCONF_FOR_FMU_EXIT_STATUS AND NOT AUTOCONF_FOR_FMU_EXIT_STATUS EQUAL 0)
+    message(STATUS ${AUTOCONF_FOR_FMU_EXIT_STATUS})
+    message(STATUS ${AUTOCONF_FOR_FMU_OUTPUT})
+    message(STATUS ${AUTOCONF_FOR_FMU_ERROR})
     message(FATAL_ERROR "autoconf failed configuring for FMUS.")
 endif()
 
 install(FILES configure
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
 )
+
+endif()


### PR DESCRIPTION
  - The bootstrapped compiler is run from its build directory since we
    need to use during build step (as opposed to after installation like
    everything else).

    On Windows we need the dlls it uses in the same dir since there is no
    RPATH. Luckily the only dll it needs right now is OpenModelicaRuntimeC.

  - Disable autoconf based config genration for source code FMUs on Windows
    This is temporary until I can find a good way.

    Small fix for checking source fmu autoconf config generation. Report
    any errors properly.

  - Do not declare function RDTSC() as inline. Instead it should be static
    (if it needs any qualifier at all)

  - Disable command line compile definition WITH_IPOPT for now. The define
    is already hard coded in omc_config.h. Which means this leads to warnings
    for every compilation unit. Until we remove the hard coded definition
    in omc_config.h disable this one.