### PR TITLE
Use _event_floor in _event_mod_real

### DIFF
--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -1189,6 +1189,9 @@ algorithm
       zc = createZeroCrossing(e_1, {eq_count});
       (eres, zeroCrossings, numMathFunctions) = zcIndex(e_1, zeroCrossings, numMathFunctions, zc);
 
+      // Add additional +1 to numMathFunctions because of internally used _event_floor
+      numMathFunctions = numMathFunctions + 1;
+
       if Flags.isSet(Flags.RELIDX) then
         print("collectZC result zc: " + ExpressionDump.printExpStr(eres) + "\n");
       end if;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1441,13 +1441,17 @@ modelica_integer _event_mod_integer(modelica_integer x1, modelica_integer x2, mo
  */
 modelica_real _event_mod_real(modelica_real x1, modelica_real x2, modelica_integer index, DATA *data, threadData_t *threadData)
 {
+  modelica_real value;
+
   if(data->simulationInfo->discreteCall && !data->simulationInfo->solveContinuous)
   {
     data->simulationInfo->mathEventsValuePre[index] = x1;
     data->simulationInfo->mathEventsValuePre[index+1] = x2;
   }
 
-  return x1 - floor(x1 / x2) * x2;
+  value = _event_floor(x1 / x2, index+2, data);
+
+  return x1 - value * x2;
 }
 
 /*! \fn _event_div_integer


### PR DESCRIPTION
### Related Issues

Fixes #8090 

### Purpose

Save correct pre-value at events

### Approach

Use `_event_floor()`  instead of `floor()` inside `_event_mod_real()`.
Adding an additional `+1` to numMathFunctions for case `mod` in the BackEnd.