### PR TITLE
Fix #8120

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1225,6 +1225,18 @@ public
     end match;
   end depth;
 
+  function isEmptyArray
+    "Returns whether any node in the cref has a dimension that's 0."
+    input ComponentRef cref;
+    output Boolean isEmpty;
+  algorithm
+    isEmpty := match cref
+      case CREF()
+        then Type.isEmptyArray(cref.ty) or isEmptyArray(cref.restCref);
+      else false;
+    end match;
+  end isEmptyArray;
+
   function isComplexArray
     input ComponentRef cref;
     output Boolean complexArray;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1137,6 +1137,11 @@ public
     Boolean literal;
     Expression first_e;
   algorithm
+    if isEmptyArray(exp) then
+      outExp := makeSubscriptedExp(subscript :: restSubscripts, exp);
+      return;
+    end if;
+
     sub := Subscript.expandSlice(subscript);
 
     outExp := match sub

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -311,13 +311,14 @@ algorithm
       algorithm
         dim := Type.nthDimension(Expression.typeOf(e), 1);
 
-        if Dimension.isOne(dim) then
-          // Unroll the loop if the iteration range consists of only one value.
-          e := Expression.applySubscript(Subscript.INDEX(Expression.INTEGER(1)), e);
-          body := Statement.replaceIteratorList(stmt.body, stmt.iterator, e);
-          body := simplifyStatements(body);
-          statements := listAppend(listReverse(body), statements);
-        elseif not Dimension.isZero(dim) then
+        //if Dimension.isOne(dim) then
+        //  // Unroll the loop if the iteration range consists of only one value.
+        //  e := Expression.applySubscript(Subscript.INDEX(Expression.INTEGER(1)), e);
+        //  body := Statement.replaceIteratorList(stmt.body, stmt.iterator, e);
+        //  body := simplifyStatements(body);
+        //  statements := listAppend(listReverse(body), statements);
+        //elseif not Dimension.isZero(dim) then
+        if not Dimension.isZero(dim) then
           // Otherwise just simplify if the iteration range is not empty.
           stmt.range := SOME(SimplifyExp.simplify(e));
           stmt.body := simplifyStatements(stmt.body);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2305,6 +2305,7 @@ protected
   TypingError ty_err;
   Option<Expression> oexp;
   InstContext.Type next_context = InstContext.set(context, NFInstContext.SUBEXPRESSION);
+  list<Expression> expl;
 algorithm
   (sizeExp, sizeType, variability, purity) := match sizeExp
     case Expression.SIZE(exp = exp, dimIndex = SOME(index))
@@ -2365,8 +2366,19 @@ algorithm
             fail();
           end if;
 
-          // Since we don't know which dimension to take the size of, return a size expression.
-          exp := Expression.SIZE(exp, SOME(index));
+          if Type.isEmptyArray(exp_ty) and not InstContext.inFunction(context) then
+            // If the expression has any dimensions that are 0 it might not be safe to generate
+            // a size expression with it, since it might be either a variable that's no longer
+            // present in the flat model or an array expression that doesn't have enough
+            // dimensions (e.g. Real[0, 2] => {}). In that case make an array with the dimension
+            // sizes of the expression and index that instead.
+            expl := list(Dimension.sizeExp(d) for d in Type.arrayDims(exp_ty));
+            exp := Expression.makeExpArray(expl, Type.INTEGER());
+            exp := Expression.makeSubscriptedExp({Subscript.makeIndex(index)}, exp);
+          else
+            // Since we don't know which dimension to take the size of, return a size expression.
+            exp := Expression.SIZE(exp, SOME(index));
+          end if;
         end if;
       then
         (exp, Type.INTEGER(), variability, purity);

--- a/testsuite/flattening/modelica/scodeinst/EmptyArray2.mo
+++ b/testsuite/flattening/modelica/scodeinst/EmptyArray2.mo
@@ -1,0 +1,26 @@
+// name: EmptyArray2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model EmptyArray2
+  Real x[0];
+  Real y = time;
+  Real z;
+algorithm
+  for m in 1:1 loop
+    z := if m == 1 then y else x[m - 1];
+  end for;
+end EmptyArray2;
+
+// Result:
+// class EmptyArray2
+//   Real y = time;
+//   Real z;
+// algorithm
+//   for m in 1:1 loop
+//     z := if m == 1 then y else {}[m - 1];
+//   end for;
+// end EmptyArray2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/EmptyArray3.mo
+++ b/testsuite/flattening/modelica/scodeinst/EmptyArray3.mo
@@ -1,0 +1,26 @@
+// name: EmptyArray3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model EmptyArray3
+  Real x[0, 2];
+  Real y = time;
+  Real z;
+algorithm
+  for m in 1:1 loop
+    z := if m == 1 then y else size(x, m - 1);
+  end for;
+end EmptyArray3;
+
+// Result:
+// class EmptyArray3
+//   Real y = time;
+//   Real z;
+// algorithm
+//   for m in 1:1 loop
+//     z := if m == 1 then y else {0.0, 2.0}[m - 1];
+//   end for;
+// end EmptyArray3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ForStatement3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ForStatement3.mo
@@ -21,6 +21,8 @@ end ForStatement3;
 //   Real x[4];
 //   Real x[5];
 // algorithm
-//   x[2] := time;
+//   for i in 2:2 loop
+//     x[i] := time;
+//   end for;
 // end ForStatement3;
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -350,6 +350,8 @@ Each4.mo \
 Each5.mo \
 Each6.mo \
 EmptyArray1.mo \
+EmptyArray2.mo \
+EmptyArray3.mo \
 Encapsulated1.mo \
 Encapsulated2.mo \
 EncapsulatingInst1.mo \


### PR DESCRIPTION
- Replace crefs that refer to variables with 0-dimensions with
  appropriately subscripted array expressions.
- Replace `size(exp, index)` of arrays with 0-dimensions with an array
  of the expression's dimensions subscripted with the index.
- Revert #8117 since it doesn't work with PNlib for unknown reasons.