### PR TITLE
Fix #8141

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1209,6 +1209,12 @@ protected
       end if;
     end for;
 
+    // The array might be empty even if one dimension is larger than 1,
+    // in that case the result will also be an empty array.
+    if Type.isEmptyArray(ty) then
+      vector_dim := Dimension.fromInteger(0);
+    end if;
+
     ty := Type.ARRAY(Type.arrayElementType(ty), {vector_dim});
     {fn} := Function.typeRefCache(fn_ref);
     callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, purity, ty));

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinVector.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinVector.mo
@@ -10,6 +10,7 @@ model FuncBuiltinVector
   Real x[1] = vector(1);
   Real y[3] = vector({{1}, {2}, {3}});
   Real z[3] = vector({1, 2, 3});
+  Real w[0] = vector(zeros(0, 1));
 end FuncBuiltinVector;
 
 // Result:


### PR DESCRIPTION
- Fix the typing of `vector()` when the argument has 0-dimensions.