### PR TITLE
Fix #8130

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -226,9 +226,9 @@ public
       input output Expression exp;
     end MapFn;
   algorithm
-    var.binding := Binding.mapExp(var.binding, fn);
+    var.binding := Binding.mapExpShallow(var.binding, fn);
     var.typeAttributes := list(
-      (Util.tuple21(a), Binding.mapExp(Util.tuple22(a), fn)) for a in var.typeAttributes);
+      (Util.tuple21(a), Binding.mapExpShallow(Util.tuple22(a), fn)) for a in var.typeAttributes);
     var.children := list(mapExp(v, fn) for v in var.children);
   end mapExp;
 

--- a/testsuite/flattening/modelica/scodeinst/CombineSubscripts3.mo
+++ b/testsuite/flattening/modelica/scodeinst/CombineSubscripts3.mo
@@ -1,0 +1,34 @@
+// name: CombineSubscripts3
+// keywords:
+// status: correct
+// cflags: -d=newInst,-nfScalarize,combineSubscripts -f
+//
+
+record A
+  Real[4] x;
+  Real p;
+end A;
+
+model CombineSubscripts3
+  A[3] b;
+equation
+  for i in 1:3 loop
+    for j in 2:3 loop
+      b[i].x[j] = b[i].x[j - 1] + b[i].p;
+    end for;
+  end for;
+end CombineSubscripts3;
+
+// Result:
+// class 'CombineSubscripts3'
+//   public Real[3] 'b.p';
+//   public Real[3, 4] 'b.x';
+// public
+// equation
+//   for i in 1:3 loop
+//     for j in 2:3 loop
+//       'b.x'['i','j'] = 'b.x'['i','j' - 1] + 'b.p'['i'];
+//     end for;
+//   end for;
+// end 'CombineSubscripts3';
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -226,6 +226,7 @@ ClassMod6.mo \
 ClockConstructor1.mo \
 CombineSubscripts1.mo \
 CombineSubscripts2.mo \
+CombineSubscripts3.mo \
 Comment1.mo \
 CompAsFunc.mo \
 ComponentAsTypeError.mo \


### PR DESCRIPTION
- Honor `-d=combineSubscripts` also when using `-f`.
- Change Inst.combineSubscripts to traverse expression, since
  FlatModel.mapExp is a shallow traversal.