### PR TITLE
Fix #8131

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAEDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEDump.mo
@@ -1258,15 +1258,21 @@ algorithm
     case DAE.RECORD_CONSTRUCTOR(path = fpath,type_=t)
       equation
         false = Flags.isSet(Flags.DISABLE_RECORD_CONSTRUCTOR_OUTPUT);
-        Print.printBuf("function ");
-        fstr = AbsynUtil.pathStringNoQual(fpath);
-        Print.printBuf(fstr);
-        Print.printBuf(" \"Automatically generated record constructor for "+fstr+"\"\n");
-        Print.printBuf(printRecordConstructorInputsStr(t));
-        Print.printBuf("  output "+AbsynUtil.pathLastIdent(fpath)+ " res;\n");
-        Print.printBuf("end ");
-        Print.printBuf(fstr);
-        Print.printBuf(";\n\n");
+
+        if Flags.isSet(Flags.PRINT_RECORD_TYPES) then
+          Print.printBuf(Types.unparseType(t));
+          Print.printBuf("\n");
+        else
+          Print.printBuf("function ");
+          fstr = AbsynUtil.pathStringNoQual(fpath);
+          Print.printBuf(fstr);
+          Print.printBuf(" \"Automatically generated record constructor for "+fstr+"\"\n");
+          Print.printBuf(printRecordConstructorInputsStr(t));
+          Print.printBuf("  output "+AbsynUtil.pathLastIdent(fpath)+ " res;\n");
+          Print.printBuf("end ");
+          Print.printBuf(fstr);
+          Print.printBuf(";\n\n");
+        end if;
       then
         ();
 
@@ -3633,15 +3639,21 @@ algorithm
     case (DAE.RECORD_CONSTRUCTOR(path = fpath,type_=tp), str)
       equation
         false = Flags.isSet(Flags.DISABLE_RECORD_CONSTRUCTOR_OUTPUT);
-        fstr = AbsynUtil.pathStringNoQual(fpath);
-        str = IOStream.append(str, "function ");
-        str = IOStream.append(str, fstr);
-        str = IOStream.append(str, " \"Automatically generated record constructor for " + fstr + "\"\n");
-        str = IOStream.append(str, printRecordConstructorInputsStr(tp));
-        str = IOStream.append(str, "  output "+AbsynUtil.pathLastIdent(fpath) + " res;\n");
-        str = IOStream.append(str, "end ");
-        str = IOStream.append(str, fstr);
-        str = IOStream.append(str, ";\n\n");
+
+        if Flags.isSet(Flags.PRINT_RECORD_TYPES) then
+          str = IOStream.append(str, Types.unparseType(tp));
+          str = IOStream.append(str, "\n");
+        else
+          fstr = AbsynUtil.pathStringNoQual(fpath);
+          str = IOStream.append(str, "function ");
+          str = IOStream.append(str, fstr);
+          str = IOStream.append(str, " \"Automatically generated record constructor for " + fstr + "\"\n");
+          str = IOStream.append(str, printRecordConstructorInputsStr(tp));
+          str = IOStream.append(str, "  output "+AbsynUtil.pathLastIdent(fpath) + " res;\n");
+          str = IOStream.append(str, "end ");
+          str = IOStream.append(str, fstr);
+          str = IOStream.append(str, ";\n\n");
+        end if;
       then
         str;
 

--- a/OMCompiler/Compiler/Template/DAEDumpTV.mo
+++ b/OMCompiler/Compiler/Template/DAEDumpTV.mo
@@ -1471,11 +1471,19 @@ end System;
 
 package Flags
   uniontype ConfigFlag end ConfigFlag;
+  uniontype DebugFlag end DebugFlag;
   constant ConfigFlag MODELICA_OUTPUT;
+  constant DebugFlag PRINT_RECORD_TYPES;
+
   function getConfigBool
     input ConfigFlag inFlag;
     output Boolean outValue;
   end getConfigBool;
+
+  function isSet
+    input DebugFlag inFlag;
+    output Boolean outValue;
+  end isSet;
 end Flags;
 
 end DAEDumpTV;

--- a/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
@@ -79,6 +79,11 @@ template dumpFunction(DAE.Function function)
       end <%AbsynDumpTpl.dumpPathNoQual(path)%>;
       >>
     case RECORD_CONSTRUCTOR(__) then
+      if (Flags.isSet(Flags.PRINT_RECORD_TYPES)) then
+      <<
+      <%dumpRecordType(type_)%>
+      >>
+      else
       <<
       function <%AbsynDumpTpl.dumpPathNoQual(path)%> "Automatically generated record constructor for <%AbsynDumpTpl.dumpPathNoQual(path)%>"
         <%dumpRecordInputVarStr(type_)%>
@@ -382,6 +387,20 @@ match arg
     let binding_str = match defaultBinding case SOME(bexp) then ' := <%dumpExp(bexp)%>'
     '<%ty_str%> <%c_str%><%p_str%><%name%><%binding_str%>'
 end dumpFuncArg;
+
+template dumpRecordType(Type ty)
+::=
+match ty
+  case T_COMPLEX(__) then
+    let name = AbsynDumpTpl.dumpPath(ClassInf.getStateName(complexClassType))
+    let vars = dumpRecordVars(varLst)
+    <<
+    record <%name%>
+      <%vars%>
+    end <%name%>;
+    >>
+  case T_FUNCTION(__) then dumpRecordType(funcResultType)
+end dumpRecordType;
 
 template dumpConst(Const c)
 ::=

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -545,6 +545,8 @@ constant DebugFlag ZMQ_LISTEN_TO_ALL = DEBUG_FLAG(186, "zmqDangerousAcceptConnec
   Gettext.gettext("When opening a zmq connection, listen on all interfaces instead of only connections from 127.0.0.1."));
 constant DebugFlag DUMP_CONVERSION_RULES = DEBUG_FLAG(187, "dumpConversionRules", false,
   Gettext.gettext("Dumps the rules when converting a package using a conversion script."));
+constant DebugFlag PRINT_RECORD_TYPES = DEBUG_FLAG(188, "printRecordTypes", false,
+  Gettext.gettext("Prints out record types as part of the flat code."));
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -243,7 +243,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.ARRAY_CONNECT,
   Flags.COMBINE_SUBSCRIPTS,
   Flags.ZMQ_LISTEN_TO_ALL,
-  Flags.DUMP_CONVERSION_RULES
+  Flags.DUMP_CONVERSION_RULES,
+  Flags.PRINT_RECORD_TYPES
 };
 
 protected

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -809,6 +809,7 @@ PartialType3.mo \
 Prefix1.mo \
 Prefix2.mo \
 Prefix3.mo \
+PrintRecordTypes1.mo \
 PropagateExtends.mo \
 RangeInvalidStep1.mo \
 RangeInvalidStep2.mo \

--- a/testsuite/flattening/modelica/scodeinst/PrintRecordTypes1.mo
+++ b/testsuite/flattening/modelica/scodeinst/PrintRecordTypes1.mo
@@ -1,0 +1,52 @@
+// name: PrintRecordTypes1
+// keywords:
+// status: correct
+// cflags: -d=newInst,-nfScalarize,printRecordTypes
+//
+
+record R1
+  Real x;
+  Real y;
+end R1;
+
+record R2
+  R1 ra;
+  R1 rb;
+end R2;
+
+model B
+  R2 c[10];
+end B;
+
+model PrintRecordTypes1
+  B[100] b;
+equation
+  for i in 1:100 loop
+    b[i].c[10] = R2(R1(1, 0), R1(i,1));
+    b[i].c[1].rb = R1(i,0);
+  end for;
+end PrintRecordTypes1;
+
+// Result:
+// record R1
+//   input Real x;
+//   input Real y;
+// end R1;
+//
+// record R2
+//   input R1 ra;
+//   input R1 rb;
+// end R2;
+//
+// class PrintRecordTypes1
+//   Real[100, 10] b.c.ra.x;
+//   Real[100, 10] b.c.ra.y;
+//   Real[100, 10] b.c.rb.x;
+//   Real[100, 10] b.c.rb.y;
+// equation
+//   for i in 1:100 loop
+//     b[i].c[1].rb = R1(/*Real*/(i), 0.0);
+//     b[i].c[10] = R2(R1(1.0, 0.0), R1(/*Real*/(i), 1.0));
+//   end for;
+// end PrintRecordTypes1;
+// endResult


### PR DESCRIPTION
- Add flag `-d=printRecordTypes` to print out record types instead of
  record constructor functions in the flat code.