### PR TITLE
chore: force version of sphinxcontrib-bibtex

### DIFF
--- a/doc/UsersGuide/source/requirements.txt
+++ b/doc/UsersGuide/source/requirements.txt
@@ -2,7 +2,7 @@ bibtexparser
 gitpython
 natsort
 sphinx
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0.0
 sphinxcontrib-inlinesyntaxhighlight
 sphinxcontrib-programoutput
 ompython


### PR DESCRIPTION
### Purpose

I try to build the user guid and get the error 

```
You must configure the bibtex_bibfiles setting
```  

### Approach
the idea is from  [here](https://github.com/executablebooks/jupyter-book/issues/1137) to force the version of `sphinxcontrib-bibtex`.
The alternative to define  `bibtex_bibfiles` I like more. But I don't know how to solve it.
