### PR TITLE
Add cmake support for OMParser. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 
 ## Subdirectories ##########################################################################################
 omc_add_subdirectory(OMCompiler)
+omc_add_subdirectory(OMParser EXCLUDE_FROM_ALL)
 # omc_add_subdirectory(libraries)
 include(omsimulator.cmake)
 

--- a/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
@@ -26,6 +26,14 @@ file(GLOB libantlrcpp_SRC
 add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
 add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 
+# This are needed for transitive include dirs. Ideally all include dirs should be specified
+# like this. For now, luckily, this folder provides all the 'public' headers needed when linking to this libs.
+target_include_directories(antlr4_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(antlr4_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# Anything that links to the static lib should use the ANTLR4CPP_STATIC define as well.
+target_compile_definitions(antlr4_static INTERFACE -DANTLR4CPP_STATIC)
+
 set(LIB_OUTPUT_DIR "${CMAKE_HOME_DIRECTORY}/dist") # put generated libraries here.
 message(STATUS "Output libraries to ${LIB_OUTPUT_DIR}")
 

--- a/OMParser/CMakeLists.txt
+++ b/OMParser/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.14)
+project(OMParser CXX)
+
+find_package(Java REQUIRED Runtime)
+
+option(WITH_LIBCXX OFF)
+omc_add_subdirectory(3rdParty/antlr4/runtime/Cpp)
+set(OMAntlr4_ANTLRJAR ${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/antlr4/tool/antlr-4.8-complete.jar CACHE PATH "Path to antlr jar.")
+
+
+add_custom_command(
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/modelica.g4
+    SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/modelica.g4
+    COMMAND ${Java_JAVA_EXECUTABLE}
+    ARGS -cp ${OMAntlr4_ANTLRJAR}
+          org.antlr.v4.Tool -Dlanguage=Cpp -package openmodelica -listener -visitor
+          -o ${CMAKE_CURRENT_BINARY_DIR}
+          ${CMAKE_CURRENT_SOURCE_DIR}/modelica.g4
+    COMMENT "Generating ${output_file_path_no_ext}.c/h for ANTLR file modelica.g4."
+    OUTPUT modelicaBaseListener.cpp
+           modelicaBaseVisitor.cpp
+           modelicaLexer.cpp
+           modelicaListener.cpp
+           modelicaParser.cpp
+           modelicaVisitor.cpp
+           modelica.interp
+           modelica.tokens
+           modelicaBaseListener.h
+           modelicaBaseVisitor.h
+           modelicaLexer.h
+           modelicaLexer.interp
+           modelicaLexer.tokens
+           modelicaListener.h
+           modelicaParser.h
+           modelicaVisitor.h
+  )
+
+
+add_library(omcparserantlr4 STATIC)
+target_sources(omcparserantlr4 PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/modelicaBaseListener.cpp
+                                       ${CMAKE_CURRENT_BINARY_DIR}/modelicaBaseVisitor.cpp
+                                       ${CMAKE_CURRENT_BINARY_DIR}/modelicaLexer.cpp
+                                       ${CMAKE_CURRENT_BINARY_DIR}/modelicaListener.cpp
+                                       ${CMAKE_CURRENT_BINARY_DIR}/modelicaParser.cpp
+                                       ${CMAKE_CURRENT_BINARY_DIR}/modelicaVisitor.cpp)
+
+target_link_libraries(omcparserantlr4 PUBLIC antlr4_static)

--- a/cmake/omc_utils.cmake
+++ b/cmake/omc_utils.cmake
@@ -12,7 +12,7 @@ endmacro(omc_add_to_report)
 set(CMAKE_MESSAGE_CONTEXT_SHOW ON)
 macro(omc_add_subdirectory var)
   list(APPEND CMAKE_MESSAGE_CONTEXT ${var})
-  add_subdirectory(${var})
+  add_subdirectory(${ARGV0} ${ARGV1} ${ARGV2})
   list(POP_BACK CMAKE_MESSAGE_CONTEXT)
 endmacro(omc_add_subdirectory)
 


### PR DESCRIPTION
@mahge
Generalize omc_add_subdirectory for multiple args. 
856c29a
  - the `cmake add_subdirectory()` function can take up to three arguments.
    Pass them through `omc_add_subdirectory()` as well.

@mahge
Add cmake support for OMParser. 
d619316
  - OMParser can now be compiled with CMake. It is not build by default (it
   is `EXCLUDED_FROM_ALL`).
   It can be built by navigating to its build directory or you can just
   ask cmake to build the only target it adds, `omcparserantlr4`