### PR TITLE
Don't print inline type in the flat model

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAEDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEDump.mo
@@ -1200,12 +1200,11 @@ algorithm
       Absyn.Path fpath;
       list<DAE.Element> daeElts;
       DAE.Type t;
-      DAE.InlineType inlineType;
       Option<SCode.Comment> c;
       DAE.ExternalDecl ext_decl;
       Boolean isImpure;
 
-    case DAE.FUNCTION(path = fpath,inlineType=inlineType,functions = (DAE.FUNCTION_DEF(body = daeElts)::_),
+    case DAE.FUNCTION(path = fpath, functions = (DAE.FUNCTION_DEF(body = daeElts)::_),
                       type_ = t,isImpure = isImpure,comment = c)
       equation
         typeStr = Types.printTypeStr(t);
@@ -1217,8 +1216,6 @@ algorithm
         Print.printBuf("function ");
         fstr = AbsynUtil.pathStringNoQual(fpath);
         Print.printBuf(fstr);
-        inlineTypeStr = dumpInlineTypeStr(inlineType);
-        Print.printBuf(inlineTypeStr);
         Print.printBuf(dumpCommentStr(c));
         Print.printBuf("\n");
         dumpFunctionElements(daeElts);
@@ -1233,7 +1230,7 @@ algorithm
       then
         ();
 
-    case DAE.FUNCTION(path = fpath,inlineType=inlineType,functions = (DAE.FUNCTION_EXT(body = daeElts, externalDecl = ext_decl)::_),
+    case DAE.FUNCTION(path = fpath, functions = (DAE.FUNCTION_EXT(body = daeElts, externalDecl = ext_decl)::_),
                       isImpure = isImpure, comment = c)
       equation
         impureStr = if isImpure then "impure " else "";
@@ -1241,8 +1238,6 @@ algorithm
         Print.printBuf("function ");
         fstr = AbsynUtil.pathStringNoQual(fpath);
         Print.printBuf(fstr);
-        inlineTypeStr = dumpInlineTypeStr(inlineType);
-        Print.printBuf(inlineTypeStr);
         Print.printBuf(dumpCommentStr(c));
         Print.printBuf("\n");
         dumpFunctionElements(daeElts);
@@ -3588,13 +3583,12 @@ algorithm
       list<DAE.Element> daeElts;
       DAE.Type t;
       DAE.Type tp;
-      DAE.InlineType inlineType;
       IOStream.IOStream str;
       Option<SCode.Comment> c;
       DAE.ExternalDecl ext_decl;
       Boolean isImpure;
 
-    case (DAE.FUNCTION(path = fpath,inlineType=inlineType,functions = (DAE.FUNCTION_DEF(body = daeElts)::_),
+    case (DAE.FUNCTION(path = fpath, functions = (DAE.FUNCTION_DEF(body = daeElts)::_),
                        type_ = t, isImpure = isImpure, comment = c), str)
       equation
         str = IOStream.append(str, dumpParallelismStr(t));
@@ -3603,7 +3597,6 @@ algorithm
         str = IOStream.append(str, impureStr);
         str = IOStream.append(str, "function ");
         str = IOStream.append(str, fstr);
-        str = IOStream.append(str, dumpInlineTypeStr(inlineType));
         str = IOStream.append(str, dumpCommentStr(c));
         str = IOStream.append(str, "\n");
         str = dumpFunctionElementsStream(daeElts, str);
@@ -3618,7 +3611,7 @@ algorithm
       then
         str;
 
-      case (DAE.FUNCTION(path = fpath,inlineType=inlineType,functions = (DAE.FUNCTION_EXT(body = daeElts, externalDecl = ext_decl)::_),
+      case (DAE.FUNCTION(path = fpath, functions = (DAE.FUNCTION_EXT(body = daeElts, externalDecl = ext_decl)::_),
                          isImpure = isImpure, comment = c), str)
       equation
         fstr = AbsynUtil.pathStringNoQual(fpath);
@@ -3626,7 +3619,6 @@ algorithm
         str = IOStream.append(str, impureStr);
         str = IOStream.append(str, "function ");
         str = IOStream.append(str, fstr);
-        str = IOStream.append(str, dumpInlineTypeStr(inlineType));
         str = IOStream.append(str, dumpCommentStr(c));
         str = IOStream.append(str, "\n");
         str = dumpFunctionElementsStream(daeElts, str);

--- a/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
@@ -68,12 +68,11 @@ template dumpFunction(DAE.Function function)
 ::=
   match function
     case FUNCTION(__) then
-      let inline_str = dumpInlineType(inlineType)
       let cmt_str = dumpCommentOpt(comment)
       let ann_str = dumpClassAnnotation(comment)
       let impure_str = if isImpure then 'impure '
       <<
-      <%impure_str%>function <%AbsynDumpTpl.dumpPathNoQual(path)%><%inline_str%><%cmt_str%>
+      <%impure_str%>function <%AbsynDumpTpl.dumpPathNoQual(path)%><%cmt_str%>
       <%dumpFunctionDefinitions(functions)%>
       <%if ann_str then "  "%><%ann_str%>
       end <%AbsynDumpTpl.dumpPathNoQual(path)%>;
@@ -224,13 +223,6 @@ match algorithm_
       <%dumpStatements(statementLst)%>
     >>
 end dumpFunctionAlgorithm;
-
-template dumpInlineType(InlineType it)
-::=
-match it
-  case AFTER_INDEX_RED_INLINE() then ' "Inline after index reduction"'
-  case NORM_INLINE() then ' "Inline before index reduction"'
-end dumpInlineType;
 
 /*****************************************************************************
  *     SECTION: VARIABLE SECTION                                             *

--- a/testsuite/flattening/modelica/arrays/TypeTest.mos
+++ b/testsuite/flattening/modelica/arrays/TypeTest.mos
@@ -30,7 +30,7 @@ instantiateModel(TypeTestArrayBug); getErrorString();
 //   output Orientation res;
 // end Modelica.Mechanics.MultiBody.Frames.Orientation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.nullRotation \"Inline before index reduction\" \"Return orientation object that does not rotate a frame\"
+// function Modelica.Mechanics.MultiBody.Frames.nullRotation \"Return orientation object that does not rotate a frame\"
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object such that frame 1 and frame 2 are identical\";
 // algorithm
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}, {0.0, 0.0, 0.0});

--- a/testsuite/flattening/modelica/connectors/Bug3649.mos
+++ b/testsuite/flattening/modelica/connectors/Bug3649.mos
@@ -16,7 +16,7 @@ checkModel(Transformer.SC1); getErrorString();
 //   output Complex res;
 // end Complex;
 //
-// function Complex.'*'.multiply \"Inline before index reduction\" \"Multiply two complex numbers\"
+// function Complex.'*'.multiply \"Multiply two complex numbers\"
 //   input Complex c1 \"Complex number 1\";
 //   input Complex c2 \"Complex number 2\";
 //   output Complex c3 \"= c1*c2\";
@@ -24,7 +24,7 @@ checkModel(Transformer.SC1); getErrorString();
 //   c3 := Complex(c1.re * c2.re - c1.im * c2.im, c1.re * c2.im + c1.im * c2.re);
 // end Complex.'*'.multiply;
 //
-// function Complex.'*'.scalarProduct \"Inline before index reduction\" \"Scalar product c1*c2 of two complex vectors\"
+// function Complex.'*'.scalarProduct \"Scalar product c1*c2 of two complex vectors\"
 //   input Complex[:] c1 \"Vector of Complex numbers 1\";
 //   input Complex[size(c1, 1)] c2 \"Vector of Complex numbers 2\";
 //   output Complex c3 \"= c1*c2\";
@@ -35,7 +35,7 @@ checkModel(Transformer.SC1); getErrorString();
 //   end for;
 // end Complex.'*'.scalarProduct;
 //
-// function Complex.'+' \"Inline before index reduction\" \"Add two complex numbers\"
+// function Complex.'+' \"Add two complex numbers\"
 //   input Complex c1 \"Complex number 1\";
 //   input Complex c2 \"Complex number 2\";
 //   output Complex c3 \"= c1 + c2\";
@@ -43,14 +43,14 @@ checkModel(Transformer.SC1); getErrorString();
 //   c3 := Complex(c1.re + c2.re, c1.im + c2.im);
 // end Complex.'+';
 //
-// function Complex.'-'.negate \"Inline before index reduction\" \"Unary minus (multiply complex number by -1)\"
+// function Complex.'-'.negate \"Unary minus (multiply complex number by -1)\"
 //   input Complex c1 \"Complex number\";
 //   output Complex c2 \"= -c1\";
 // algorithm
 //   c2 := Complex(-c1.re, -c1.im);
 // end Complex.'-'.negate;
 //
-// function Complex.'-'.subtract \"Inline before index reduction\" \"Subtract two complex numbers\"
+// function Complex.'-'.subtract \"Subtract two complex numbers\"
 //   input Complex c1 \"Complex number 1\";
 //   input Complex c2 \"Complex number 2\";
 //   output Complex c3 \"= c1 - c2\";
@@ -58,7 +58,7 @@ checkModel(Transformer.SC1); getErrorString();
 //   c3 := Complex(c1.re - c2.re, c1.im - c2.im);
 // end Complex.'-'.subtract;
 //
-// function Complex.'constructor'.fromReal \"Inline before index reduction\" \"Construct Complex from Real\"
+// function Complex.'constructor'.fromReal \"Construct Complex from Real\"
 //   input Real re \"Real part of complex number\";
 //   input Real im = 0.0 \"Imaginary part of complex number\";
 //   output Complex result = Complex(re, im) \"Complex number\";
@@ -70,14 +70,14 @@ checkModel(Transformer.SC1); getErrorString();
 //   output ComplexOutput res;
 // end ComplexOutput;
 //
-// function Modelica.ComplexMath.'abs' \"Inline before index reduction\" \"Absolute value of complex number\"
+// function Modelica.ComplexMath.'abs' \"Absolute value of complex number\"
 //   input Complex c \"Complex number\";
 //   output Real result \"= abs(c)\";
 // algorithm
 //   result := (c.re ^ 2.0 + c.im ^ 2.0) ^ 0.5;
 // end Modelica.ComplexMath.'abs';
 //
-// function Modelica.ComplexMath.arg \"Inline before index reduction\" \"Phase angle of complex number\"
+// function Modelica.ComplexMath.arg \"Phase angle of complex number\"
 //   input Complex c \"Complex number\";
 //   input Real phi0(quantity = \"Angle\", unit = \"rad\", displayUnit = \"deg\") = 0.0 \"Phase angle phi shall be in the range: -pi < phi-phi0 < pi\";
 //   output Real phi(quantity = \"Angle\", unit = \"rad\", displayUnit = \"deg\") \"= phase angle of c\";
@@ -85,21 +85,21 @@ checkModel(Transformer.SC1); getErrorString();
 //   phi := Modelica.Math.atan3(c.im, c.re, phi0);
 // end Modelica.ComplexMath.arg;
 //
-// function Modelica.ComplexMath.conj \"Inline before index reduction\" \"Conjugate of complex number\"
+// function Modelica.ComplexMath.conj \"Conjugate of complex number\"
 //   input Complex c1 \"Complex number\";
 //   output Complex c2 \"= c1.re - j*c1.im\";
 // algorithm
 //   c2 := Complex(c1.re, -c1.im);
 // end Modelica.ComplexMath.conj;
 //
-// function Modelica.ComplexMath.imag \"Inline before index reduction\" \"Imaginary part of complex number\"
+// function Modelica.ComplexMath.imag \"Imaginary part of complex number\"
 //   input Complex c \"Complex number\";
 //   output Real r \"= c.im\";
 // algorithm
 //   r := c.im;
 // end Modelica.ComplexMath.imag;
 //
-// function Modelica.ComplexMath.real \"Inline before index reduction\" \"Real part of complex number\"
+// function Modelica.ComplexMath.real \"Real part of complex number\"
 //   input Complex c \"Complex number\";
 //   output Real r \"= c.re\";
 // algorithm

--- a/testsuite/flattening/modelica/connectors/CGraphBug.mo
+++ b/testsuite/flattening/modelica/connectors/CGraphBug.mo
@@ -32,14 +32,14 @@ end Test;
 // ./omc XXX.mo >> XXX.mo and then comment the inserted class.
 //
 // Result:
-// function Modelica.Math.Vectors.length "Inline before index reduction" "Return length of a vectorReturn length of a vector (better as norm(), if further symbolic processing is performed)"
+// function Modelica.Math.Vectors.length "Return length of a vectorReturn length of a vector (better as norm(), if further symbolic processing is performed)"
 //   input Real[:] v "Vector";
 //   output Real result "Length of vector v";
 // algorithm
 //   result := sqrt(v * v);
 // end Modelica.Math.Vectors.length;
 //
-// function Modelica.Math.Vectors.normalize "Inline before index reduction" "Return normalized vector such that length = 1Return normalized vector such that length = 1 and prevent zero-division for zero vector"
+// function Modelica.Math.Vectors.normalize "Return normalized vector such that length = 1Return normalized vector such that length = 1 and prevent zero-division for zero vector"
 //   input Real[:] v "Vector";
 //   input Real eps = 1e-13 "if |v| < eps then result = v/eps";
 //   output Real[size(v, 1)] result "Input vector v normalized to length=1";
@@ -76,7 +76,7 @@ end Test;
 //   external "C" y = sin(u);
 // end Modelica.Math.sin;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der "Inline before index reduction" "Derivative of function Frames.resolve1(..)"
+// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der "Derivative of function Frames.resolve1(..)"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v2 "Vector resolved in frame 2";
 //   input Real[3] v2_der "= der(v2)";
@@ -85,7 +85,7 @@ end Test;
 //   v1_der := Modelica.Mechanics.MultiBody.Frames.resolve1(R, {v2_der[1] + R.w[2] * v2[3] - R.w[3] * v2[2], v2_der[2] + R.w[3] * v2[1] - R.w[1] * v2[3], v2_der[3] + R.w[1] * v2[2] - R.w[2] * v2[1]});
 // end Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der "Inline before index reduction" "Derivative of function Frames.resolve2(..)"
+// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der "Derivative of function Frames.resolve2(..)"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v1 "Vector resolved in frame 1";
 //   input Real[3] v1_der "= der(v1)";
@@ -100,7 +100,7 @@ end Test;
 //   output Orientation res;
 // end Modelica.Mechanics.MultiBody.Frames.Orientation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint "Inline before index reduction" "Return the constraint residues to express that two frames have the same orientation"
+// function Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint "Return the constraint residues to express that two frames have the same orientation"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R1 "Orientation object to rotate frame 0 into frame 1";
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R2 "Orientation object to rotate frame 0 into frame 2";
 //   output Real[3] residue "The rotation angles around x-, y-, and z-axis of frame 1 to rotate frame 1 into frame 2 for a small rotation (should be zero)";
@@ -108,7 +108,7 @@ end Test;
 //   residue := {atan2((R1.T[1,2] * R1.T[2,3] - R1.T[1,3] * R1.T[2,2]) * R2.T[2,1] + (R1.T[1,3] * R1.T[2,1] - R1.T[1,1] * R1.T[2,3]) * R2.T[2,2] + (R1.T[1,1] * R1.T[2,2] - R1.T[1,2] * R1.T[2,1]) * R2.T[2,3], R1.T[1,1] * R2.T[1,1] + R1.T[1,2] * R2.T[1,2] + R1.T[1,3] * R2.T[1,3]), atan2((R1.T[1,3] * R1.T[2,2] - R1.T[1,2] * R1.T[2,3]) * R2.T[1,1] + (R1.T[1,1] * R1.T[2,3] - R1.T[1,3] * R1.T[2,1]) * R2.T[1,2] + (R1.T[1,2] * R1.T[2,1] - R1.T[1,1] * R1.T[2,2]) * R2.T[1,3], R1.T[2,1] * R2.T[2,1] + R1.T[2,2] * R2.T[2,2] + R1.T[2,3] * R2.T[2,3]), atan2(R1.T[2,1] * R2.T[1,1] + R1.T[2,2] * R2.T[1,2] + R1.T[2,3] * R2.T[1,3], R1.T[3,1] * R2.T[3,1] + R1.T[3,2] * R2.T[3,2] + R1.T[3,3] * R2.T[3,3])};
 // end Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.angularVelocity2 "Inline before index reduction" "Compute angular velocity resolved in frame 2 from quaternions orientation object and its derivative"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.angularVelocity2 "Compute angular velocity resolved in frame 2 from quaternions orientation object and its derivative"
 //   input Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 //   input Real[4] der_Q(unit = "1/s") "Derivative of Q";
 //   output Real[3] w(quantity = "AngularVelocity", unit = "rad/s") "Angular velocity of frame 2 with respect to frame 1 resolved in frame 2";
@@ -155,20 +155,20 @@ end Test;
 //   end if;
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation "Inline before index reduction" "Return quaternions orientation object that does not rotate a frame"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation "Return quaternions orientation object that does not rotate a frame"
 //   output Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 // algorithm
 //   Q := {0.0, 0.0, 0.0, 1.0};
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint "Inline before index reduction" "Return residues of orientation constraints (shall be zero)"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint "Return residues of orientation constraints (shall be zero)"
 //   input Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 //   output Real[1] residue "Residue constraint (shall be zero)";
 // algorithm
 //   residue := {Q[1] ^ 2.0 + Q[2] ^ 2.0 + Q[3] ^ 2.0 + Q[4] ^ 2.0 + -1.0};
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation "Inline before index reduction" "Return rotation object to rotate around one frame axis"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation "Return rotation object to rotate around one frame axis"
 //   input Integer axis(min = 1, max = 3) "Rotate around 'axis' of frame 1";
 //   input Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angle to rotate frame 1 into frame 2 along 'axis' of frame 1";
 //   output Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
@@ -176,7 +176,7 @@ end Test;
 //   T := if axis == 1 then {{1.0, 0.0, 0.0}, {0.0, cos(angle), sin(angle)}, {0.0, -sin(angle), cos(angle)}} else if axis == 2 then {{cos(angle), 0.0, -sin(angle)}, {0.0, 1.0, 0.0}, {sin(angle), 0.0, cos(angle)}} else {{cos(angle), sin(angle), 0.0}, {-sin(angle), cos(angle), 0.0}, {0.0, 0.0, 1.0}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation "Inline before index reduction" "Return orientation object of a planar rotation"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation "Return orientation object of a planar rotation"
 //   input Real[3] e(unit = "1") "Normalized axis of rotation (must have length=1)";
 //   input Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angle to rotate frame 1 into frame 2 along axis e";
 //   output Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
@@ -184,7 +184,7 @@ end Test;
 //   T := {{e[1] * e[1] + (1.0 - e[1] * e[1]) * cos(angle), e[1] * e[2] + (-e[1]) * e[2] * cos(angle) - (-e[3]) * sin(angle), e[1] * e[3] + (-e[1]) * e[3] * cos(angle) - e[2] * sin(angle)}, {e[2] * e[1] + (-e[2]) * e[1] * cos(angle) - e[3] * sin(angle), e[2] * e[2] + (1.0 - e[2] * e[2]) * cos(angle), e[2] * e[3] + (-e[2]) * e[3] * cos(angle) - (-e[1]) * sin(angle)}, {e[3] * e[1] + (-e[3]) * e[1] * cos(angle) - (-e[2]) * sin(angle), e[3] * e[2] + (-e[3]) * e[2] * cos(angle) - e[1] * sin(angle), e[3] * e[3] + (1.0 - e[3] * e[3]) * cos(angle)}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 "Inline before index reduction" "Transform vector from frame 2 to frame 1"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 "Transform vector from frame 2 to frame 1"
 //   input Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v2 "Vector in frame 2";
 //   output Real[3] v1 "Vector in frame 1";
@@ -192,7 +192,7 @@ end Test;
 //   v1 := {T[1,1] * v2[1] + T[2,1] * v2[2] + T[3,1] * v2[3], T[1,2] * v2[1] + T[2,2] * v2[2] + T[3,2] * v2[3], T[1,3] * v2[1] + T[2,3] * v2[2] + T[3,3] * v2[3]};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2 "Inline before index reduction" "Transform vector from frame 1 to frame 2"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2 "Transform vector from frame 1 to frame 2"
 //   input Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v1 "Vector in frame 1";
 //   output Real[3] v2 "Vector in frame 2";
@@ -200,14 +200,14 @@ end Test;
 //   v2 := {T[1,1] * v1[1] + T[1,2] * v1[2] + T[1,3] * v1[3], T[2,1] * v1[1] + T[2,2] * v1[2] + T[2,3] * v1[3], T[3,1] * v1[1] + T[3,2] * v1[2] + T[3,3] * v1[3]};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 "Inline before index reduction" "Return angular velocity resolved in frame 2 from orientation object"
+// function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 "Return angular velocity resolved in frame 2 from orientation object"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   output Real[3] w(quantity = "AngularVelocity", unit = "rad/s") "Angular velocity of frame 2 with respect to frame 1 resolved in frame 2";
 // algorithm
 //   w := {R.w[1], R.w[2], R.w[3]};
 // end Modelica.Mechanics.MultiBody.Frames.angularVelocity2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.axesRotations "Inline before index reduction" "Return fixed rotation object to rotate in sequence around fixed angles along 3 axes"
+// function Modelica.Mechanics.MultiBody.Frames.axesRotations "Return fixed rotation object to rotate in sequence around fixed angles along 3 axes"
 //   input Integer[3] sequence = {1, 2, 3} "Sequence of rotations from frame 1 to frame 2 along axis sequence[i]";
 //   input Real[3] angles(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angles around the axes defined in 'sequence'";
 //   input Real[3] der_angles(quantity = "AngularVelocity", unit = "rad/s") "= der(angles)";
@@ -250,14 +250,14 @@ end Test;
 //   angles[3] := Modelica.Mechanics.MultiBody.Frames.planarRotationAngle({e3_2[1], e3_2[2], e3_2[3]}, {e2_1a[1], e2_1a[2], e2_1a[3]}, Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2({{R.T[1,1], R.T[1,2], R.T[1,3]}, {R.T[2,1], R.T[2,2], R.T[2,3]}, {R.T[3,1], R.T[3,2], R.T[3,3]}}, Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1({{T_1a[1,1], T_1a[1,2], T_1a[1,3]}, {T_1a[2,1], T_1a[2,2], T_1a[2,3]}, {T_1a[3,1], T_1a[3,2], T_1a[3,3]}}, {e2_1a[1], e2_1a[2], e2_1a[3]})));
 // end Modelica.Mechanics.MultiBody.Frames.axesRotationsAngles;
 //
-// function Modelica.Mechanics.MultiBody.Frames.axis "Inline before index reduction" "Return unit vector for x-, y-, or z-axis"
+// function Modelica.Mechanics.MultiBody.Frames.axis "Return unit vector for x-, y-, or z-axis"
 //   input Integer axis(min = 1, max = 3) "Axis vector to be returned";
 //   output Real[3] e(unit = "1") "Unit axis vector";
 // algorithm
 //   e := if axis == 1 then {1.0, 0.0, 0.0} else if axis == 2 then {0.0, 1.0, 0.0} else {0.0, 0.0, 1.0};
 // end Modelica.Mechanics.MultiBody.Frames.axis;
 //
-// function Modelica.Mechanics.MultiBody.Frames.from_Q "Inline before index reduction" "Return orientation object R from quaternion orientation object Q"
+// function Modelica.Mechanics.MultiBody.Frames.from_Q "Return orientation object R from quaternion orientation object Q"
 //   input Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 //   input Real[3] w(quantity = "AngularVelocity", unit = "rad/s") "Angular velocity from frame 2 with respect to frame 1, resolved in frame 2";
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
@@ -265,13 +265,13 @@ end Test;
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{2.0 * (Q[1] ^ 2.0 + Q[4] ^ 2.0) + -1.0, 2.0 * (Q[1] * Q[2] + Q[3] * Q[4]), 2.0 * (Q[1] * Q[3] - Q[2] * Q[4])}, {2.0 * (Q[2] * Q[1] - Q[3] * Q[4]), 2.0 * (Q[2] ^ 2.0 + Q[4] ^ 2.0) + -1.0, 2.0 * (Q[2] * Q[3] + Q[1] * Q[4])}, {2.0 * (Q[3] * Q[1] + Q[2] * Q[4]), 2.0 * (Q[3] * Q[2] - Q[1] * Q[4]), 2.0 * (Q[3] ^ 2.0 + Q[4] ^ 2.0) + -1.0}}, {w[1], w[2], w[3]});
 // end Modelica.Mechanics.MultiBody.Frames.from_Q;
 //
-// function Modelica.Mechanics.MultiBody.Frames.nullRotation "Inline before index reduction" "Return orientation object that does not rotate a frame"
+// function Modelica.Mechanics.MultiBody.Frames.nullRotation "Return orientation object that does not rotate a frame"
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object such that frame 1 and frame 2 are identical";
 // algorithm
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}, {0.0, 0.0, 0.0});
 // end Modelica.Mechanics.MultiBody.Frames.nullRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.planarRotationAngle "Inline before index reduction" "Return angle of a planar rotation, given the rotation axis and the representations of a vector in frame 1 and frame 2"
+// function Modelica.Mechanics.MultiBody.Frames.planarRotationAngle "Return angle of a planar rotation, given the rotation axis and the representations of a vector in frame 1 and frame 2"
 //   input Real[3] e(unit = "1") "Normalized axis of rotation to rotate frame 1 around e into frame 2 (must have length=1)";
 //   input Real[3] v1 "A vector v resolved in frame 1 (shall not be parallel to e)";
 //   input Real[3] v2 "Vector v resolved in frame 2, i.e., v2 = resolve2(planarRotation(e,angle),v1)";
@@ -280,7 +280,7 @@ end Test;
 //   angle := atan2((e[3] * v1[2] - e[2] * v1[3]) * v2[1] + (e[1] * v1[3] - e[3] * v1[1]) * v2[2] + (e[2] * v1[1] - e[1] * v1[2]) * v2[3], v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3] - (e[1] * v1[1] + e[2] * v1[2] + e[3] * v1[3]) * (e[1] * v2[1] + e[2] * v2[2] + e[3] * v2[3]));
 // end Modelica.Mechanics.MultiBody.Frames.planarRotationAngle;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolve1 "Inline after index reduction" "Transform vector from frame 2 to frame 1"
+// function Modelica.Mechanics.MultiBody.Frames.resolve1 "Transform vector from frame 2 to frame 1"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v2 "Vector in frame 2";
 //   output Real[3] v1 "Vector in frame 1";
@@ -288,7 +288,7 @@ end Test;
 //   v1 := {R.T[1,1] * v2[1] + R.T[2,1] * v2[2] + R.T[3,1] * v2[3], R.T[1,2] * v2[1] + R.T[2,2] * v2[2] + R.T[3,2] * v2[3], R.T[1,3] * v2[1] + R.T[2,3] * v2[2] + R.T[3,3] * v2[3]};
 // end Modelica.Mechanics.MultiBody.Frames.resolve1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolve2 "Inline after index reduction" "Transform vector from frame 1 to frame 2"
+// function Modelica.Mechanics.MultiBody.Frames.resolve2 "Transform vector from frame 1 to frame 2"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v1 "Vector in frame 1";
 //   output Real[3] v2 "Vector in frame 2";
@@ -296,7 +296,7 @@ end Test;
 //   v2 := {R.T[1,1] * v1[1] + R.T[1,2] * v1[2] + R.T[1,3] * v1[3], R.T[2,1] * v1[1] + R.T[2,2] * v1[2] + R.T[2,3] * v1[3], R.T[3,1] * v1[1] + R.T[3,2] * v1[2] + R.T[3,3] * v1[3]};
 // end Modelica.Mechanics.MultiBody.Frames.resolve2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.to_Q "Inline before index reduction" "Return quaternion orientation object Q from orientation object R"
+// function Modelica.Mechanics.MultiBody.Frames.to_Q "Return quaternion orientation object Q from orientation object R"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[4] Q_guess = {0.0, 0.0, 0.0, 1.0} "Guess value for output Q (there are 2 solutions; the one closer to Q_guess is used";
 //   output Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";

--- a/testsuite/flattening/modelica/connectors/CGraphBug.mos
+++ b/testsuite/flattening/modelica/connectors/CGraphBug.mos
@@ -14,14 +14,14 @@ instantiateModel(Test); getErrorString();
 // ""
 // true
 // ""
-// "function Modelica.Math.Vectors.length \"Inline before index reduction\" \"Return length of a vector (better as norm(), if further symbolic processing is performed)\"
+// "function Modelica.Math.Vectors.length \"Return length of a vector (better as norm(), if further symbolic processing is performed)\"
 //   input Real[:] v \"Vector\";
 //   output Real result \"Length of vector v\";
 // algorithm
 //   result := sqrt(v * v);
 // end Modelica.Math.Vectors.length;
 //
-// function Modelica.Math.Vectors.normalizeWithAssert \"Inline before index reduction\" \"Return normalized vector such that length = 1 (trigger an assert for zero vector)\"
+// function Modelica.Math.Vectors.normalizeWithAssert \"Return normalized vector such that length = 1 (trigger an assert for zero vector)\"
 //   input Real[:] v \"Vector\";
 //   output Real[size(v, 1)] result \"Input vector v normalized to length=1\";
 // algorithm
@@ -30,7 +30,7 @@ instantiateModel(Test); getErrorString();
 //   result := v / Modelica.Math.Vectors.length(v);
 // end Modelica.Math.Vectors.normalizeWithAssert;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der \"Inline before index reduction\" \"Derivative of function Frames.resolve1(..)\"
+// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der \"Derivative of function Frames.resolve1(..)\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] v2 \"Vector resolved in frame 2\";
 //   input Real[3] v2_der \"= der(v2)\";
@@ -39,7 +39,7 @@ instantiateModel(Test); getErrorString();
 //   v1_der := Modelica.Mechanics.MultiBody.Frames.resolve1(R, {v2_der[1] + R.w[2] * v2[3] - R.w[3] * v2[2], v2_der[2] + R.w[3] * v2[1] - R.w[1] * v2[3], v2_der[3] + R.w[1] * v2[2] - R.w[2] * v2[1]});
 // end Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der \"Inline before index reduction\" \"Derivative of function Frames.resolve2(..)\"
+// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der \"Derivative of function Frames.resolve2(..)\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] v1 \"Vector resolved in frame 1\";
 //   input Real[3] v1_der \"= der(v1)\";
@@ -54,7 +54,7 @@ instantiateModel(Test); getErrorString();
 //   output Orientation res;
 // end Modelica.Mechanics.MultiBody.Frames.Orientation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint \"Inline before index reduction\" \"Return the constraint residues to express that two frames have the same orientation\"
+// function Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint \"Return the constraint residues to express that two frames have the same orientation\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R1 \"Orientation object to rotate frame 0 into frame 1\";
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R2 \"Orientation object to rotate frame 0 into frame 2\";
 //   output Real[3] residue \"The rotation angles around x-, y-, and z-axis of frame 1 to rotate frame 1 into frame 2 for a small rotation (should be zero)\";
@@ -62,7 +62,7 @@ instantiateModel(Test); getErrorString();
 //   residue := {atan2((R1.T[1,2] * R1.T[2,3] - R1.T[1,3] * R1.T[2,2]) * R2.T[2,1] + (R1.T[1,3] * R1.T[2,1] - R1.T[1,1] * R1.T[2,3]) * R2.T[2,2] + (R1.T[1,1] * R1.T[2,2] - R1.T[1,2] * R1.T[2,1]) * R2.T[2,3], R1.T[1,1] * R2.T[1,1] + R1.T[1,2] * R2.T[1,2] + R1.T[1,3] * R2.T[1,3]), atan2((R1.T[1,1] * R1.T[2,3] - R1.T[1,3] * R1.T[2,1]) * R2.T[1,2] - (R1.T[1,1] * R1.T[2,2] - R1.T[1,2] * R1.T[2,1]) * R2.T[1,3] - (R1.T[1,2] * R1.T[2,3] - R1.T[1,3] * R1.T[2,2]) * R2.T[1,1], R1.T[2,1] * R2.T[2,1] + R1.T[2,2] * R2.T[2,2] + R1.T[2,3] * R2.T[2,3]), atan2(R1.T[2,1] * R2.T[1,1] + R1.T[2,2] * R2.T[1,2] + R1.T[2,3] * R2.T[1,3], R1.T[3,1] * R2.T[3,1] + R1.T[3,2] * R2.T[3,2] + R1.T[3,3] * R2.T[3,3])};
 // end Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.angularVelocity2 \"Inline before index reduction\" \"Compute angular velocity resolved in frame 2 from quaternions orientation object and its derivative\"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.angularVelocity2 \"Compute angular velocity resolved in frame 2 from quaternions orientation object and its derivative\"
 //   input Real[4] Q \"Quaternions orientation object to rotate frame 1 into frame 2\";
 //   input Real[4] der_Q(unit = \"1/s\") \"Derivative of Q\";
 //   output Real[3] w(quantity = \"AngularVelocity\", unit = \"rad/s\") \"Angular velocity of frame 2 with respect to frame 1 resolved in frame 2\";
@@ -109,20 +109,20 @@ instantiateModel(Test); getErrorString();
 //   end if;
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation \"Inline before index reduction\" \"Return quaternion orientation object that does not rotate a frame\"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation \"Return quaternion orientation object that does not rotate a frame\"
 //   output Real[4] Q \"Quaternions orientation object to rotate frame 1 into frame 2\";
 // algorithm
 //   Q := {0.0, 0.0, 0.0, 1.0};
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint \"Inline before index reduction\" \"Return residues of orientation constraints (shall be zero)\"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint \"Return residues of orientation constraints (shall be zero)\"
 //   input Real[4] Q \"Quaternions orientation object to rotate frame 1 into frame 2\";
 //   output Real[1] residue \"Residue constraint (shall be zero)\";
 // algorithm
 //   residue := {-1.0 + Q[1] ^ 2.0 + Q[2] ^ 2.0 + Q[3] ^ 2.0 + Q[4] ^ 2.0};
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation \"Inline before index reduction\" \"Return rotation object to rotate around one frame axis\"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation \"Return rotation object to rotate around one frame axis\"
 //   input Integer axis(min = 1, max = 3) \"Rotate around 'axis' of frame 1\";
 //   input Real angle(quantity = \"Angle\", unit = \"rad\", displayUnit = \"deg\") \"Rotation angle to rotate frame 1 into frame 2 along 'axis' of frame 1\";
 //   output Real[3, 3] T \"Orientation object to rotate frame 1 into frame 2\";
@@ -130,7 +130,7 @@ instantiateModel(Test); getErrorString();
 //   T := if axis == 1 then {{1.0, 0.0, 0.0}, {0.0, cos(angle), sin(angle)}, {0.0, -sin(angle), cos(angle)}} else if axis == 2 then {{cos(angle), 0.0, -sin(angle)}, {0.0, 1.0, 0.0}, {sin(angle), 0.0, cos(angle)}} else {{cos(angle), sin(angle), 0.0}, {-sin(angle), cos(angle), 0.0}, {0.0, 0.0, 1.0}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation \"Inline before index reduction\" \"Return orientation object of a planar rotation\"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation \"Return orientation object of a planar rotation\"
 //   input Real[3] e(unit = \"1\") \"Normalized axis of rotation (must have length=1)\";
 //   input Real angle(quantity = \"Angle\", unit = \"rad\", displayUnit = \"deg\") \"Rotation angle to rotate frame 1 into frame 2 along axis e\";
 //   output Real[3, 3] T \"Orientation object to rotate frame 1 into frame 2\";
@@ -138,7 +138,7 @@ instantiateModel(Test); getErrorString();
 //   T := {{e[1] ^ 2.0 + (1.0 - e[1] ^ 2.0) * cos(angle), (e[1] - e[1] * cos(angle)) * e[2] + e[3] * sin(angle), (e[1] - e[1] * cos(angle)) * e[3] - e[2] * sin(angle)}, {(e[2] - e[2] * cos(angle)) * e[1] - e[3] * sin(angle), e[2] ^ 2.0 + (1.0 - e[2] ^ 2.0) * cos(angle), (e[2] - e[2] * cos(angle)) * e[3] + e[1] * sin(angle)}, {(e[3] - e[3] * cos(angle)) * e[1] + e[2] * sin(angle), (e[3] - e[3] * cos(angle)) * e[2] - e[1] * sin(angle), e[3] ^ 2.0 + (1.0 - e[3] ^ 2.0) * cos(angle)}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 \"Inline before index reduction\" \"Transform vector from frame 2 to frame 1\"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 \"Transform vector from frame 2 to frame 1\"
 //   input Real[3, 3] T \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] v2 \"Vector in frame 2\";
 //   output Real[3] v1 \"Vector in frame 1\";
@@ -146,7 +146,7 @@ instantiateModel(Test); getErrorString();
 //   v1 := {T[1,1] * v2[1] + T[2,1] * v2[2] + T[3,1] * v2[3], T[1,2] * v2[1] + T[2,2] * v2[2] + T[3,2] * v2[3], T[1,3] * v2[1] + T[2,3] * v2[2] + T[3,3] * v2[3]};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2 \"Inline before index reduction\" \"Transform vector from frame 1 to frame 2\"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2 \"Transform vector from frame 1 to frame 2\"
 //   input Real[3, 3] T \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] v1 \"Vector in frame 1\";
 //   output Real[3] v2 \"Vector in frame 2\";
@@ -154,14 +154,14 @@ instantiateModel(Test); getErrorString();
 //   v2 := {T[1,1] * v1[1] + T[1,2] * v1[2] + T[1,3] * v1[3], T[2,1] * v1[1] + T[2,2] * v1[2] + T[2,3] * v1[3], T[3,1] * v1[1] + T[3,2] * v1[2] + T[3,3] * v1[3]};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 \"Inline before index reduction\" \"Return angular velocity resolved in frame 2 from orientation object\"
+// function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 \"Return angular velocity resolved in frame 2 from orientation object\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
 //   output Real[3] w(quantity = \"AngularVelocity\", unit = \"rad/s\") \"Angular velocity of frame 2 with respect to frame 1 resolved in frame 2\";
 // algorithm
 //   w := {R.w[1], R.w[2], R.w[3]};
 // end Modelica.Mechanics.MultiBody.Frames.angularVelocity2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.axesRotations \"Inline before index reduction\" \"Return fixed rotation object to rotate in sequence around fixed angles along 3 axes\"
+// function Modelica.Mechanics.MultiBody.Frames.axesRotations \"Return fixed rotation object to rotate in sequence around fixed angles along 3 axes\"
 //   input Integer[3] sequence = {1, 2, 3} \"Sequence of rotations from frame 1 to frame 2 along axis sequence[i]\";
 //   input Real[3] angles(quantity = \"Angle\", unit = \"rad\", displayUnit = \"deg\") \"Rotation angles around the axes defined in 'sequence'\";
 //   input Real[3] der_angles(quantity = \"AngularVelocity\", unit = \"rad/s\") \"= der(angles)\";
@@ -204,14 +204,14 @@ instantiateModel(Test); getErrorString();
 //   angles[3] := Modelica.Mechanics.MultiBody.Frames.planarRotationAngle({e3_2[1], e3_2[2], e3_2[3]}, {e2_1a[1], e2_1a[2], e2_1a[3]}, Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2({{R.T[1,1], R.T[1,2], R.T[1,3]}, {R.T[2,1], R.T[2,2], R.T[2,3]}, {R.T[3,1], R.T[3,2], R.T[3,3]}}, Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1({{T_1a[1,1], T_1a[1,2], T_1a[1,3]}, {T_1a[2,1], T_1a[2,2], T_1a[2,3]}, {T_1a[3,1], T_1a[3,2], T_1a[3,3]}}, {e2_1a[1], e2_1a[2], e2_1a[3]})));
 // end Modelica.Mechanics.MultiBody.Frames.axesRotationsAngles;
 //
-// function Modelica.Mechanics.MultiBody.Frames.axis \"Inline before index reduction\" \"Return unit vector for x-, y-, or z-axis\"
+// function Modelica.Mechanics.MultiBody.Frames.axis \"Return unit vector for x-, y-, or z-axis\"
 //   input Integer axis(min = 1, max = 3) \"Axis vector to be returned\";
 //   output Real[3] e(unit = \"1\") \"Unit axis vector\";
 // algorithm
 //   e := if axis == 1 then {1.0, 0.0, 0.0} else if axis == 2 then {0.0, 1.0, 0.0} else {0.0, 0.0, 1.0};
 // end Modelica.Mechanics.MultiBody.Frames.axis;
 //
-// function Modelica.Mechanics.MultiBody.Frames.from_Q \"Inline before index reduction\" \"Return orientation object R from quaternion orientation object Q\"
+// function Modelica.Mechanics.MultiBody.Frames.from_Q \"Return orientation object R from quaternion orientation object Q\"
 //   input Real[4] Q \"Quaternions orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] w(quantity = \"AngularVelocity\", unit = \"rad/s\") \"Angular velocity from frame 2 with respect to frame 1, resolved in frame 2\";
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
@@ -219,13 +219,13 @@ instantiateModel(Test); getErrorString();
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{-1.0 + 2.0 * (Q[1] ^ 2.0 + Q[4] ^ 2.0), 2.0 * (Q[1] * Q[2] + Q[3] * Q[4]), 2.0 * (Q[1] * Q[3] - Q[2] * Q[4])}, {2.0 * (Q[2] * Q[1] - Q[3] * Q[4]), -1.0 + 2.0 * (Q[2] ^ 2.0 + Q[4] ^ 2.0), 2.0 * (Q[2] * Q[3] + Q[1] * Q[4])}, {2.0 * (Q[3] * Q[1] + Q[2] * Q[4]), 2.0 * (Q[3] * Q[2] - Q[1] * Q[4]), -1.0 + 2.0 * (Q[3] ^ 2.0 + Q[4] ^ 2.0)}}, {w[1], w[2], w[3]});
 // end Modelica.Mechanics.MultiBody.Frames.from_Q;
 //
-// function Modelica.Mechanics.MultiBody.Frames.nullRotation \"Inline before index reduction\" \"Return orientation object that does not rotate a frame\"
+// function Modelica.Mechanics.MultiBody.Frames.nullRotation \"Return orientation object that does not rotate a frame\"
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object such that frame 1 and frame 2 are identical\";
 // algorithm
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}, {0.0, 0.0, 0.0});
 // end Modelica.Mechanics.MultiBody.Frames.nullRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.planarRotationAngle \"Inline before index reduction\" \"Return angle of a planar rotation, given the rotation axis and the representations of a vector in frame 1 and frame 2\"
+// function Modelica.Mechanics.MultiBody.Frames.planarRotationAngle \"Return angle of a planar rotation, given the rotation axis and the representations of a vector in frame 1 and frame 2\"
 //   input Real[3] e(unit = \"1\") \"Normalized axis of rotation to rotate frame 1 around e into frame 2 (must have length=1)\";
 //   input Real[3] v1 \"A vector v resolved in frame 1 (shall not be parallel to e)\";
 //   input Real[3] v2 \"Vector v resolved in frame 2, i.e., v2 = resolve2(planarRotation(e,angle),v1)\";
@@ -234,7 +234,7 @@ instantiateModel(Test); getErrorString();
 //   angle := atan2((e[1] * v1[3] - e[3] * v1[1]) * v2[2] - (e[1] * v1[2] - e[2] * v1[1]) * v2[3] - (e[2] * v1[3] - e[3] * v1[2]) * v2[1], v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3] + ((-e[2]) * v1[2] - e[3] * v1[3] - e[1] * v1[1]) * (e[1] * v2[1] + e[2] * v2[2] + e[3] * v2[3]));
 // end Modelica.Mechanics.MultiBody.Frames.planarRotationAngle;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolve1 \"Inline after index reduction\" \"Transform vector from frame 2 to frame 1\"
+// function Modelica.Mechanics.MultiBody.Frames.resolve1 \"Transform vector from frame 2 to frame 1\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] v2 \"Vector in frame 2\";
 //   output Real[3] v1 \"Vector in frame 1\";
@@ -242,7 +242,7 @@ instantiateModel(Test); getErrorString();
 //   v1 := {R.T[1,1] * v2[1] + R.T[2,1] * v2[2] + R.T[3,1] * v2[3], R.T[1,2] * v2[1] + R.T[2,2] * v2[2] + R.T[3,2] * v2[3], R.T[1,3] * v2[1] + R.T[2,3] * v2[2] + R.T[3,3] * v2[3]};
 // end Modelica.Mechanics.MultiBody.Frames.resolve1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolve2 \"Inline after index reduction\" \"Transform vector from frame 1 to frame 2\"
+// function Modelica.Mechanics.MultiBody.Frames.resolve2 \"Transform vector from frame 1 to frame 2\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[3] v1 \"Vector in frame 1\";
 //   output Real[3] v2 \"Vector in frame 2\";
@@ -250,7 +250,7 @@ instantiateModel(Test); getErrorString();
 //   v2 := {R.T[1,1] * v1[1] + R.T[1,2] * v1[2] + R.T[1,3] * v1[3], R.T[2,1] * v1[1] + R.T[2,2] * v1[2] + R.T[2,3] * v1[3], R.T[3,1] * v1[1] + R.T[3,2] * v1[2] + R.T[3,3] * v1[3]};
 // end Modelica.Mechanics.MultiBody.Frames.resolve2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.to_Q \"Inline before index reduction\" \"Return quaternion orientation object Q from orientation object R\"
+// function Modelica.Mechanics.MultiBody.Frames.to_Q \"Return quaternion orientation object Q from orientation object R\"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R \"Orientation object to rotate frame 1 into frame 2\";
 //   input Real[4] Q_guess = {0.0, 0.0, 0.0, 1.0} \"Guess value for output Q (there are 2 solutions; the one closer to Q_guess is used\";
 //   output Real[4] Q \"Quaternions orientation object to rotate frame 1 into frame 2\";
@@ -258,7 +258,7 @@ instantiateModel(Test); getErrorString();
 //   Q := Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T({{R.T[1,1], R.T[1,2], R.T[1,3]}, {R.T[2,1], R.T[2,2], R.T[2,3]}, {R.T[3,1], R.T[3,2], R.T[3,3]}}, {Q_guess[1], Q_guess[2], Q_guess[3], Q_guess[4]});
 // end Modelica.Mechanics.MultiBody.Frames.to_Q;
 //
-// function Modelica.Mechanics.MultiBody.World$world.gravityAcceleration \"Inline before index reduction\" \"Standard gravity fields (no/parallel/point field)\"
+// function Modelica.Mechanics.MultiBody.World$world.gravityAcceleration \"Standard gravity fields (no/parallel/point field)\"
 //   input Real[3] r(quantity = \"Length\", unit = \"m\") \"Position vector from world frame to actual point, resolved in world frame\";
 //   output Real[3] gravity(quantity = \"Acceleration\", unit = \"m/s2\") \"Gravity acceleration at position r, resolved in world frame\";
 //   input enumeration(NoGravity, UniformGravity, PointGravity) gravityType = gravityType \"Type of gravity field\";

--- a/testsuite/flattening/modelica/equations/Ticket4157.mos
+++ b/testsuite/flattening/modelica/equations/Ticket4157.mos
@@ -23,7 +23,7 @@ instantiateModel(Ticket4157.if_complex_if_expression); getErrorString();
 //   output Complex res;
 // end Complex;
 //
-// function Complex.'+' \"Inline before index reduction\" \"Add two complex numbers\"
+// function Complex.'+' \"Add two complex numbers\"
 //   input Complex c1 \"Complex number 1\";
 //   input Complex c2 \"Complex number 2\";
 //   output Complex c3 \"= c1 + c2\";

--- a/testsuite/flattening/modelica/others/Sequence.mo
+++ b/testsuite/flattening/modelica/others/Sequence.mo
@@ -64,7 +64,7 @@ end Sequence;
 //   r := /*Real*/(sequence[1]) * angles[3] + /*Real*/(sequence[2]) * angles[2] + /*Real*/(sequence[3]) * angles[1];
 // end axesRot;
 //
-// function axesRotations "Inline before index reduction" "Return fixed rotation object to rotate in sequence around fixed angles along 3 axes"
+// function axesRotations "Return fixed rotation object to rotate in sequence around fixed angles along 3 axes"
 //   input Integer[3] sequence = {1, 2, 3} "Sequence of rotations from frame 1 to frame 2 along axis sequence[i]";
 //   input Real[3] angles "Rotation angles around the axes defined in 'sequence'";
 //   input Real[3] der_angles "= der(angles)";

--- a/testsuite/flattening/modelica/scodeinst/TestSampleNoClock.mos
+++ b/testsuite/flattening/modelica/scodeinst/TestSampleNoClock.mos
@@ -74,7 +74,7 @@ instantiateModel(Modelica.Blocks.Examples.BooleanNetwork1); getErrorString();
 //   end for;
 // end Modelica.Math.BooleanVectors.anyTrue;
 //
-// function Modelica.Math.BooleanVectors.countTrue \"Inline before index reduction\" \"Returns the number of true entries in a Boolean vector\"
+// function Modelica.Math.BooleanVectors.countTrue \"Returns the number of true entries in a Boolean vector\"
 //   input Boolean[:] b \"Boolean vector\";
 //   output Integer n \"Number of true entries\";
 // algorithm

--- a/testsuite/flattening/modelica/scoping/InnerOuterSamePrefix.mo
+++ b/testsuite/flattening/modelica/scoping/InnerOuterSamePrefix.mo
@@ -3586,14 +3586,14 @@ end InnerOuterSamePrefix;// Result:
 
 
 // Result:
-// function Modelica.Math.Vectors.length "Inline before index reduction" "Return length of a vector (better as norm(), if further symbolic processing is performed)"
+// function Modelica.Math.Vectors.length "Return length of a vector (better as norm(), if further symbolic processing is performed)"
 //   input Real[:] v "Vector";
 //   output Real result "Length of vector v";
 // algorithm
 //   result := sqrt(v * v);
 // end Modelica.Math.Vectors.length;
 //
-// function Modelica.Math.Vectors.normalize "Inline before index reduction" "Return normalized vector such that length = 1 and prevent zero-division for zero vector"
+// function Modelica.Math.Vectors.normalize "Return normalized vector such that length = 1 and prevent zero-division for zero vector"
 //   input Real[:] v "Vector";
 //   input Real eps(min = 0.0) = 1e-13 "if |v| < eps then result = v/eps";
 //   output Real[size(v, 1)] result "Input vector v normalized to length=1";
@@ -3601,7 +3601,7 @@ end InnerOuterSamePrefix;// Result:
 //   result := smooth(0, if noEvent(Modelica.Math.Vectors.length(v) >= eps) then v / Modelica.Math.Vectors.length(v) else v / eps);
 // end Modelica.Math.Vectors.normalize;
 //
-// function Modelica.Math.Vectors.normalizeWithAssert "Inline before index reduction" "Return normalized vector such that length = 1 (trigger an assert for zero vector)"
+// function Modelica.Math.Vectors.normalizeWithAssert "Return normalized vector such that length = 1 (trigger an assert for zero vector)"
 //   input Real[:] v "Vector";
 //   output Real[size(v, 1)] result "Input vector v normalized to length=1";
 // algorithm
@@ -3610,7 +3610,7 @@ end InnerOuterSamePrefix;// Result:
 //   result := v / Modelica.Math.Vectors.length(v);
 // end Modelica.Math.Vectors.normalizeWithAssert;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der "Inline before index reduction" "Derivative of function Frames.resolve1(..)"
+// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der "Derivative of function Frames.resolve1(..)"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v2 "Vector resolved in frame 2";
 //   input Real[3] v2_der "= der(v2)";
@@ -3619,7 +3619,7 @@ end InnerOuterSamePrefix;// Result:
 //   v1_der := Modelica.Mechanics.MultiBody.Frames.resolve1(R, {v2_der[1] + R.w[2] * v2[3] - R.w[3] * v2[2], v2_der[2] + R.w[3] * v2[1] - R.w[1] * v2[3], v2_der[3] + R.w[1] * v2[2] - R.w[2] * v2[1]});
 // end Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der "Inline before index reduction" "Derivative of function Frames.resolve2(..)"
+// function Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der "Derivative of function Frames.resolve2(..)"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v1 "Vector resolved in frame 1";
 //   input Real[3] v1_der "= der(v1)";
@@ -3634,7 +3634,7 @@ end InnerOuterSamePrefix;// Result:
 //   output Orientation res;
 // end Modelica.Mechanics.MultiBody.Frames.Orientation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint "Inline before index reduction" "Return the constraint residues to express that two frames have the same orientation"
+// function Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint "Return the constraint residues to express that two frames have the same orientation"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R1 "Orientation object to rotate frame 0 into frame 1";
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R2 "Orientation object to rotate frame 0 into frame 2";
 //   output Real[3] residue "The rotation angles around x-, y-, and z-axis of frame 1 to rotate frame 1 into frame 2 for a small rotation (should be zero)";
@@ -3642,7 +3642,7 @@ end InnerOuterSamePrefix;// Result:
 //   residue := {atan2((R1.T[1,2] * R1.T[2,3] - R1.T[1,3] * R1.T[2,2]) * R2.T[2,1] + (R1.T[1,3] * R1.T[2,1] - R1.T[1,1] * R1.T[2,3]) * R2.T[2,2] + (R1.T[1,1] * R1.T[2,2] - R1.T[1,2] * R1.T[2,1]) * R2.T[2,3], R1.T[1,1] * R2.T[1,1] + R1.T[1,2] * R2.T[1,2] + R1.T[1,3] * R2.T[1,3]), atan2((R1.T[1,1] * R1.T[2,3] - R1.T[1,3] * R1.T[2,1]) * R2.T[1,2] - (R1.T[1,1] * R1.T[2,2] - R1.T[1,2] * R1.T[2,1]) * R2.T[1,3] - (R1.T[1,2] * R1.T[2,3] - R1.T[1,3] * R1.T[2,2]) * R2.T[1,1], R1.T[2,1] * R2.T[2,1] + R1.T[2,2] * R2.T[2,2] + R1.T[2,3] * R2.T[2,3]), atan2(R1.T[2,1] * R2.T[1,1] + R1.T[2,2] * R2.T[1,2] + R1.T[2,3] * R2.T[1,3], R1.T[3,1] * R2.T[3,1] + R1.T[3,2] * R2.T[3,2] + R1.T[3,3] * R2.T[3,3])};
 // end Modelica.Mechanics.MultiBody.Frames.Orientation.equalityConstraint;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.angularVelocity2 "Inline before index reduction" "Compute angular velocity resolved in frame 2 from quaternions orientation object and its derivative"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.angularVelocity2 "Compute angular velocity resolved in frame 2 from quaternions orientation object and its derivative"
 //   input Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 //   input Real[4] der_Q(unit = "1/s") "Derivative of Q";
 //   output Real[3] w(quantity = "AngularVelocity", unit = "rad/s") "Angular velocity of frame 2 with respect to frame 1 resolved in frame 2";
@@ -3689,20 +3689,20 @@ end InnerOuterSamePrefix;// Result:
 //   end if;
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation "Inline before index reduction" "Return quaternion orientation object that does not rotate a frame"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation "Return quaternion orientation object that does not rotate a frame"
 //   output Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 // algorithm
 //   Q := {0.0, 0.0, 0.0, 1.0};
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.nullRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint "Inline before index reduction" "Return residues of orientation constraints (shall be zero)"
+// function Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint "Return residues of orientation constraints (shall be zero)"
 //   input Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 //   output Real[1] residue "Residue constraint (shall be zero)";
 // algorithm
 //   residue := {-1.0 + Q[1] ^ 2.0 + Q[2] ^ 2.0 + Q[3] ^ 2.0 + Q[4] ^ 2.0};
 // end Modelica.Mechanics.MultiBody.Frames.Quaternions.orientationConstraint;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotation "Inline before index reduction" "Return absolute orientation object from another absolute and a relative orientation object"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotation "Return absolute orientation object from another absolute and a relative orientation object"
 //   input Real[3, 3] T1 "Orientation object to rotate frame 0 into frame 1";
 //   input Real[3, 3] T_rel "Orientation object to rotate frame 1 into frame 2";
 //   output Real[3, 3] T2 "Orientation object to rotate frame 0 into frame 2";
@@ -3710,7 +3710,7 @@ end InnerOuterSamePrefix;// Result:
 //   T2 := {{T_rel[1,1] * T1[1,1] + T_rel[1,2] * T1[2,1] + T_rel[1,3] * T1[3,1], T_rel[1,1] * T1[1,2] + T_rel[1,2] * T1[2,2] + T_rel[1,3] * T1[3,2], T_rel[1,1] * T1[1,3] + T_rel[1,2] * T1[2,3] + T_rel[1,3] * T1[3,3]}, {T_rel[2,1] * T1[1,1] + T_rel[2,2] * T1[2,1] + T_rel[2,3] * T1[3,1], T_rel[2,1] * T1[1,2] + T_rel[2,2] * T1[2,2] + T_rel[2,3] * T1[3,2], T_rel[2,1] * T1[1,3] + T_rel[2,2] * T1[2,3] + T_rel[2,3] * T1[3,3]}, {T_rel[3,1] * T1[1,1] + T_rel[3,2] * T1[2,1] + T_rel[3,3] * T1[3,1], T_rel[3,1] * T1[1,2] + T_rel[3,2] * T1[2,2] + T_rel[3,3] * T1[3,2], T_rel[3,1] * T1[1,3] + T_rel[3,2] * T1[2,3] + T_rel[3,3] * T1[3,3]}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation "Inline before index reduction" "Return rotation object to rotate around one frame axis"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.axisRotation "Return rotation object to rotate around one frame axis"
 //   input Integer axis(min = 1, max = 3) "Rotate around 'axis' of frame 1";
 //   input Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angle to rotate frame 1 into frame 2 along 'axis' of frame 1";
 //   output Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
@@ -3732,7 +3732,7 @@ end InnerOuterSamePrefix;// Result:
 //   T := {{e_x[1], e_x[2], e_x[3]}, {e_z[2] * e_x[3] - e_z[3] * e_x[2], e_z[3] * e_x[1] - e_z[1] * e_x[3], e_z[1] * e_x[2] - e_z[2] * e_x[1]}, {e_z[1], e_z[2], e_z[3]}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.from_nxy;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation "Inline before index reduction" "Return orientation object of a planar rotation"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation "Return orientation object of a planar rotation"
 //   input Real[3] e(unit = "1") "Normalized axis of rotation (must have length=1)";
 //   input Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angle to rotate frame 1 into frame 2 along axis e";
 //   output Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
@@ -3740,7 +3740,7 @@ end InnerOuterSamePrefix;// Result:
 //   T := {{e[1] ^ 2.0 + (1.0 - e[1] ^ 2.0) * cos(angle), (e[1] - e[1] * cos(angle)) * e[2] + e[3] * sin(angle), (e[1] - e[1] * cos(angle)) * e[3] - e[2] * sin(angle)}, {(e[2] - e[2] * cos(angle)) * e[1] - e[3] * sin(angle), e[2] ^ 2.0 + (1.0 - e[2] ^ 2.0) * cos(angle), (e[2] - e[2] * cos(angle)) * e[3] + e[1] * sin(angle)}, {(e[3] - e[3] * cos(angle)) * e[1] + e[2] * sin(angle), (e[3] - e[3] * cos(angle)) * e[2] - e[1] * sin(angle), e[3] ^ 2.0 + (1.0 - e[3] ^ 2.0) * cos(angle)}};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.planarRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 "Inline before index reduction" "Transform vector from frame 2 to frame 1"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 "Transform vector from frame 2 to frame 1"
 //   input Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v2 "Vector in frame 2";
 //   output Real[3] v1 "Vector in frame 1";
@@ -3748,7 +3748,7 @@ end InnerOuterSamePrefix;// Result:
 //   v1 := {T[1,1] * v2[1] + T[2,1] * v2[2] + T[3,1] * v2[3], T[1,2] * v2[1] + T[2,2] * v2[2] + T[3,2] * v2[3], T[1,3] * v2[1] + T[2,3] * v2[2] + T[3,3] * v2[3]};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2 "Inline before index reduction" "Transform vector from frame 1 to frame 2"
+// function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2 "Transform vector from frame 1 to frame 2"
 //   input Real[3, 3] T "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v1 "Vector in frame 1";
 //   output Real[3] v2 "Vector in frame 2";
@@ -3756,7 +3756,7 @@ end InnerOuterSamePrefix;// Result:
 //   v2 := {T[1,1] * v1[1] + T[1,2] * v1[2] + T[1,3] * v1[3], T[2,1] * v1[1] + T[2,2] * v1[2] + T[2,3] * v1[3], T[3,1] * v1[1] + T[3,2] * v1[2] + T[3,3] * v1[3]};
 // end Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.absoluteRotation "Inline before index reduction" "Return absolute orientation object from another absolute and a relative orientation object"
+// function Modelica.Mechanics.MultiBody.Frames.absoluteRotation "Return absolute orientation object from another absolute and a relative orientation object"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R1 "Orientation object to rotate frame 0 into frame 1";
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R_rel "Orientation object to rotate frame 1 into frame 2";
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R2 "Orientation object to rotate frame 0 into frame 2";
@@ -3764,14 +3764,14 @@ end InnerOuterSamePrefix;// Result:
 //   R2 := Modelica.Mechanics.MultiBody.Frames.Orientation({{R_rel.T[1,1] * R1.T[1,1] + R_rel.T[1,2] * R1.T[2,1] + R_rel.T[1,3] * R1.T[3,1], R_rel.T[1,1] * R1.T[1,2] + R_rel.T[1,2] * R1.T[2,2] + R_rel.T[1,3] * R1.T[3,2], R_rel.T[1,1] * R1.T[1,3] + R_rel.T[1,2] * R1.T[2,3] + R_rel.T[1,3] * R1.T[3,3]}, {R_rel.T[2,1] * R1.T[1,1] + R_rel.T[2,2] * R1.T[2,1] + R_rel.T[2,3] * R1.T[3,1], R_rel.T[2,1] * R1.T[1,2] + R_rel.T[2,2] * R1.T[2,2] + R_rel.T[2,3] * R1.T[3,2], R_rel.T[2,1] * R1.T[1,3] + R_rel.T[2,2] * R1.T[2,3] + R_rel.T[2,3] * R1.T[3,3]}, {R_rel.T[3,1] * R1.T[1,1] + R_rel.T[3,2] * R1.T[2,1] + R_rel.T[3,3] * R1.T[3,1], R_rel.T[3,1] * R1.T[1,2] + R_rel.T[3,2] * R1.T[2,2] + R_rel.T[3,3] * R1.T[3,2], R_rel.T[3,1] * R1.T[1,3] + R_rel.T[3,2] * R1.T[2,3] + R_rel.T[3,3] * R1.T[3,3]}}, Modelica.Mechanics.MultiBody.Frames.resolve2(R_rel, {R1.w[1], R1.w[2], R1.w[3]}) + {R_rel.w[1], R_rel.w[2], R_rel.w[3]});
 // end Modelica.Mechanics.MultiBody.Frames.absoluteRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 "Inline before index reduction" "Return angular velocity resolved in frame 2 from orientation object"
+// function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 "Return angular velocity resolved in frame 2 from orientation object"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   output Real[3] w(quantity = "AngularVelocity", unit = "rad/s") "Angular velocity of frame 2 with respect to frame 1 resolved in frame 2";
 // algorithm
 //   w := {R.w[1], R.w[2], R.w[3]};
 // end Modelica.Mechanics.MultiBody.Frames.angularVelocity2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.axesRotations "Inline before index reduction" "Return fixed rotation object to rotate in sequence around fixed angles along 3 axes"
+// function Modelica.Mechanics.MultiBody.Frames.axesRotations "Return fixed rotation object to rotate in sequence around fixed angles along 3 axes"
 //   input Integer[3] sequence = {1, 2, 3} "Sequence of rotations from frame 1 to frame 2 along axis sequence[i]";
 //   input Real[3] angles(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angles around the axes defined in 'sequence'";
 //   input Real[3] der_angles(quantity = "AngularVelocity", unit = "rad/s") "= der(angles)";
@@ -3814,14 +3814,14 @@ end InnerOuterSamePrefix;// Result:
 //   angles[3] := Modelica.Mechanics.MultiBody.Frames.planarRotationAngle({e3_2[1], e3_2[2], e3_2[3]}, {e2_1a[1], e2_1a[2], e2_1a[3]}, Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve2({{R.T[1,1], R.T[1,2], R.T[1,3]}, {R.T[2,1], R.T[2,2], R.T[2,3]}, {R.T[3,1], R.T[3,2], R.T[3,3]}}, Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1({{T_1a[1,1], T_1a[1,2], T_1a[1,3]}, {T_1a[2,1], T_1a[2,2], T_1a[2,3]}, {T_1a[3,1], T_1a[3,2], T_1a[3,3]}}, {e2_1a[1], e2_1a[2], e2_1a[3]})));
 // end Modelica.Mechanics.MultiBody.Frames.axesRotationsAngles;
 //
-// function Modelica.Mechanics.MultiBody.Frames.axis "Inline before index reduction" "Return unit vector for x-, y-, or z-axis"
+// function Modelica.Mechanics.MultiBody.Frames.axis "Return unit vector for x-, y-, or z-axis"
 //   input Integer axis(min = 1, max = 3) "Axis vector to be returned";
 //   output Real[3] e(unit = "1") "Unit axis vector";
 // algorithm
 //   e := if axis == 1 then {1.0, 0.0, 0.0} else if axis == 2 then {0.0, 1.0, 0.0} else {0.0, 0.0, 1.0};
 // end Modelica.Mechanics.MultiBody.Frames.axis;
 //
-// function Modelica.Mechanics.MultiBody.Frames.from_Q "Inline before index reduction" "Return orientation object R from quaternion orientation object Q"
+// function Modelica.Mechanics.MultiBody.Frames.from_Q "Return orientation object R from quaternion orientation object Q"
 //   input Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
 //   input Real[3] w(quantity = "AngularVelocity", unit = "rad/s") "Angular velocity from frame 2 with respect to frame 1, resolved in frame 2";
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
@@ -3843,13 +3843,13 @@ end InnerOuterSamePrefix;// Result:
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{e_x[1], e_x[2], e_x[3]}, {e_z[2] * e_x[3] - e_z[3] * e_x[2], e_z[3] * e_x[1] - e_z[1] * e_x[3], e_z[1] * e_x[2] - e_z[2] * e_x[1]}, {e_z[1], e_z[2], e_z[3]}}, {0.0, 0.0, 0.0});
 // end Modelica.Mechanics.MultiBody.Frames.from_nxy;
 //
-// function Modelica.Mechanics.MultiBody.Frames.nullRotation "Inline before index reduction" "Return orientation object that does not rotate a frame"
+// function Modelica.Mechanics.MultiBody.Frames.nullRotation "Return orientation object that does not rotate a frame"
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object such that frame 1 and frame 2 are identical";
 // algorithm
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}, {0.0, 0.0, 0.0});
 // end Modelica.Mechanics.MultiBody.Frames.nullRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.planarRotation "Inline before index reduction" "Return orientation object of a planar rotation"
+// function Modelica.Mechanics.MultiBody.Frames.planarRotation "Return orientation object of a planar rotation"
 //   input Real[3] e(unit = "1") "Normalized axis of rotation (must have length=1)";
 //   input Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg") "Rotation angle to rotate frame 1 into frame 2 along axis e";
 //   input Real der_angle(quantity = "AngularVelocity", unit = "rad/s") "= der(angle)";
@@ -3858,7 +3858,7 @@ end InnerOuterSamePrefix;// Result:
 //   R := Modelica.Mechanics.MultiBody.Frames.Orientation({{e[1] ^ 2.0 + (1.0 - e[1] ^ 2.0) * cos(angle), (e[1] - e[1] * cos(angle)) * e[2] + e[3] * sin(angle), (e[1] - e[1] * cos(angle)) * e[3] - e[2] * sin(angle)}, {(e[2] - e[2] * cos(angle)) * e[1] - e[3] * sin(angle), e[2] ^ 2.0 + (1.0 - e[2] ^ 2.0) * cos(angle), (e[2] - e[2] * cos(angle)) * e[3] + e[1] * sin(angle)}, {(e[3] - e[3] * cos(angle)) * e[1] + e[2] * sin(angle), (e[3] - e[3] * cos(angle)) * e[2] - e[1] * sin(angle), e[3] ^ 2.0 + (1.0 - e[3] ^ 2.0) * cos(angle)}}, {e[1] * der_angle, e[2] * der_angle, e[3] * der_angle});
 // end Modelica.Mechanics.MultiBody.Frames.planarRotation;
 //
-// function Modelica.Mechanics.MultiBody.Frames.planarRotationAngle "Inline before index reduction" "Return angle of a planar rotation, given the rotation axis and the representations of a vector in frame 1 and frame 2"
+// function Modelica.Mechanics.MultiBody.Frames.planarRotationAngle "Return angle of a planar rotation, given the rotation axis and the representations of a vector in frame 1 and frame 2"
 //   input Real[3] e(unit = "1") "Normalized axis of rotation to rotate frame 1 around e into frame 2 (must have length=1)";
 //   input Real[3] v1 "A vector v resolved in frame 1 (shall not be parallel to e)";
 //   input Real[3] v2 "Vector v resolved in frame 2, i.e., v2 = resolve2(planarRotation(e,angle),v1)";
@@ -3867,7 +3867,7 @@ end InnerOuterSamePrefix;// Result:
 //   angle := atan2((e[1] * v1[3] - e[3] * v1[1]) * v2[2] - (e[1] * v1[2] - e[2] * v1[1]) * v2[3] - (e[2] * v1[3] - e[3] * v1[2]) * v2[1], v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3] + ((-e[2]) * v2[2] - e[3] * v2[3] - e[1] * v2[1]) * (e[1] * v1[1] + e[2] * v1[2] + e[3] * v1[3]));
 // end Modelica.Mechanics.MultiBody.Frames.planarRotationAngle;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolve1 "Inline after index reduction" "Transform vector from frame 2 to frame 1"
+// function Modelica.Mechanics.MultiBody.Frames.resolve1 "Transform vector from frame 2 to frame 1"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v2 "Vector in frame 2";
 //   output Real[3] v1 "Vector in frame 1";
@@ -3875,7 +3875,7 @@ end InnerOuterSamePrefix;// Result:
 //   v1 := {R.T[1,1] * v2[1] + R.T[2,1] * v2[2] + R.T[3,1] * v2[3], R.T[1,2] * v2[1] + R.T[2,2] * v2[2] + R.T[3,2] * v2[3], R.T[1,3] * v2[1] + R.T[2,3] * v2[2] + R.T[3,3] * v2[3]};
 // end Modelica.Mechanics.MultiBody.Frames.resolve1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolve2 "Inline after index reduction" "Transform vector from frame 1 to frame 2"
+// function Modelica.Mechanics.MultiBody.Frames.resolve2 "Transform vector from frame 1 to frame 2"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3] v1 "Vector in frame 1";
 //   output Real[3] v2 "Vector in frame 2";
@@ -3883,7 +3883,7 @@ end InnerOuterSamePrefix;// Result:
 //   v2 := {R.T[1,1] * v1[1] + R.T[1,2] * v1[2] + R.T[1,3] * v1[3], R.T[2,1] * v1[1] + R.T[2,2] * v1[2] + R.T[2,3] * v1[3], R.T[3,1] * v1[1] + R.T[3,2] * v1[2] + R.T[3,3] * v1[3]};
 // end Modelica.Mechanics.MultiBody.Frames.resolve2;
 //
-// function Modelica.Mechanics.MultiBody.Frames.resolveDyade1 "Inline before index reduction" "Transform second order tensor from frame 2 to frame 1"
+// function Modelica.Mechanics.MultiBody.Frames.resolveDyade1 "Transform second order tensor from frame 2 to frame 1"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[3, 3] D2 "Second order tensor resolved in frame 2";
 //   output Real[3, 3] D1 "Second order tensor resolved in frame 1";
@@ -3891,7 +3891,7 @@ end InnerOuterSamePrefix;// Result:
 //   D1 := {{(R.T[1,1] * D2[1,1] + R.T[2,1] * D2[2,1] + R.T[3,1] * D2[3,1]) * R.T[1,1] + (R.T[1,1] * D2[1,2] + R.T[2,1] * D2[2,2] + R.T[3,1] * D2[3,2]) * R.T[2,1] + (R.T[1,1] * D2[1,3] + R.T[2,1] * D2[2,3] + R.T[3,1] * D2[3,3]) * R.T[3,1], (R.T[1,1] * D2[1,1] + R.T[2,1] * D2[2,1] + R.T[3,1] * D2[3,1]) * R.T[1,2] + (R.T[1,1] * D2[1,2] + R.T[2,1] * D2[2,2] + R.T[3,1] * D2[3,2]) * R.T[2,2] + (R.T[1,1] * D2[1,3] + R.T[2,1] * D2[2,3] + R.T[3,1] * D2[3,3]) * R.T[3,2], (R.T[1,1] * D2[1,1] + R.T[2,1] * D2[2,1] + R.T[3,1] * D2[3,1]) * R.T[1,3] + (R.T[1,1] * D2[1,2] + R.T[2,1] * D2[2,2] + R.T[3,1] * D2[3,2]) * R.T[2,3] + (R.T[1,1] * D2[1,3] + R.T[2,1] * D2[2,3] + R.T[3,1] * D2[3,3]) * R.T[3,3]}, {(R.T[1,2] * D2[1,1] + R.T[2,2] * D2[2,1] + R.T[3,2] * D2[3,1]) * R.T[1,1] + (R.T[1,2] * D2[1,2] + R.T[2,2] * D2[2,2] + R.T[3,2] * D2[3,2]) * R.T[2,1] + (R.T[1,2] * D2[1,3] + R.T[2,2] * D2[2,3] + R.T[3,2] * D2[3,3]) * R.T[3,1], (R.T[1,2] * D2[1,1] + R.T[2,2] * D2[2,1] + R.T[3,2] * D2[3,1]) * R.T[1,2] + (R.T[1,2] * D2[1,2] + R.T[2,2] * D2[2,2] + R.T[3,2] * D2[3,2]) * R.T[2,2] + (R.T[1,2] * D2[1,3] + R.T[2,2] * D2[2,3] + R.T[3,2] * D2[3,3]) * R.T[3,2], (R.T[1,2] * D2[1,1] + R.T[2,2] * D2[2,1] + R.T[3,2] * D2[3,1]) * R.T[1,3] + (R.T[1,2] * D2[1,2] + R.T[2,2] * D2[2,2] + R.T[3,2] * D2[3,2]) * R.T[2,3] + (R.T[1,2] * D2[1,3] + R.T[2,2] * D2[2,3] + R.T[3,2] * D2[3,3]) * R.T[3,3]}, {(R.T[1,3] * D2[1,1] + R.T[2,3] * D2[2,1] + R.T[3,3] * D2[3,1]) * R.T[1,1] + (R.T[1,3] * D2[1,2] + R.T[2,3] * D2[2,2] + R.T[3,3] * D2[3,2]) * R.T[2,1] + (R.T[1,3] * D2[1,3] + R.T[2,3] * D2[2,3] + R.T[3,3] * D2[3,3]) * R.T[3,1], (R.T[1,3] * D2[1,1] + R.T[2,3] * D2[2,1] + R.T[3,3] * D2[3,1]) * R.T[1,2] + (R.T[1,3] * D2[1,2] + R.T[2,3] * D2[2,2] + R.T[3,3] * D2[3,2]) * R.T[2,2] + (R.T[1,3] * D2[1,3] + R.T[2,3] * D2[2,3] + R.T[3,3] * D2[3,3]) * R.T[3,2], (R.T[1,3] * D2[1,1] + R.T[2,3] * D2[2,1] + R.T[3,3] * D2[3,1]) * R.T[1,3] + (R.T[1,3] * D2[1,2] + R.T[2,3] * D2[2,2] + R.T[3,3] * D2[3,2]) * R.T[2,3] + (R.T[1,3] * D2[1,3] + R.T[2,3] * D2[2,3] + R.T[3,3] * D2[3,3]) * R.T[3,3]}};
 // end Modelica.Mechanics.MultiBody.Frames.resolveDyade1;
 //
-// function Modelica.Mechanics.MultiBody.Frames.to_Q "Inline before index reduction" "Return quaternion orientation object Q from orientation object R"
+// function Modelica.Mechanics.MultiBody.Frames.to_Q "Return quaternion orientation object Q from orientation object R"
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R "Orientation object to rotate frame 1 into frame 2";
 //   input Real[4] Q_guess = {0.0, 0.0, 0.0, 1.0} "Guess value for output Q (there are 2 solutions; the one closer to Q_guess is used";
 //   output Real[4] Q "Quaternions orientation object to rotate frame 1 into frame 2";
@@ -3899,7 +3899,7 @@ end InnerOuterSamePrefix;// Result:
 //   Q := Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T({{R.T[1,1], R.T[1,2], R.T[1,3]}, {R.T[2,1], R.T[2,2], R.T[2,3]}, {R.T[3,1], R.T[3,2], R.T[3,3]}}, {Q_guess[1], Q_guess[2], Q_guess[3], Q_guess[4]});
 // end Modelica.Mechanics.MultiBody.Frames.to_Q;
 //
-// function Modelica.Mechanics.MultiBody.World.gravityAcceleration "Inline before index reduction" "Gravity field acceleration depending on field type and position"
+// function Modelica.Mechanics.MultiBody.World.gravityAcceleration "Gravity field acceleration depending on field type and position"
 //   input Real[3] r(quantity = "Length", unit = "m") "Position vector from world frame to actual point, resolved in world frame";
 //   input enumeration(NoGravity, UniformGravity, PointGravity) gravityType = gravityType "Type of gravity field";
 //   input Real[3] g(quantity = "Acceleration", unit = "m/s2") = {0.0, -g, 0.0} "Constant gravity acceleration, resolved in world frame, if gravityType=1";
@@ -3909,7 +3909,7 @@ end InnerOuterSamePrefix;// Result:
 //   gravity := if gravityType == Modelica.Mechanics.MultiBody.Types.GravityTypes.UniformGravity then {g[1], g[2], g[3]} else if gravityType == Modelica.Mechanics.MultiBody.Types.GravityTypes.PointGravity then {(-r[1]) * mue / (r[1] ^ 2.0 + r[2] ^ 2.0 + r[3] ^ 2.0) / Modelica.Math.Vectors.length({r[1], r[2], r[3]}), (-r[2]) * mue / (r[1] ^ 2.0 + r[2] ^ 2.0 + r[3] ^ 2.0) / Modelica.Math.Vectors.length({r[1], r[2], r[3]}), (-r[3]) * mue / (r[1] ^ 2.0 + r[2] ^ 2.0 + r[3] ^ 2.0) / Modelica.Math.Vectors.length({r[1], r[2], r[3]})} else {0.0, 0.0, 0.0};
 // end Modelica.Mechanics.MultiBody.World.gravityAcceleration;
 //
-// function Modelica.SIunits.Conversions.to_unit1 "Inline before index reduction" "Change the unit of a Real number to unit=\"1\""
+// function Modelica.SIunits.Conversions.to_unit1 "Change the unit of a Real number to unit=\"1\""
 //   input Real r "Real number";
 //   output Real result(unit = "1") "Real number r with unit=\"1\"";
 // algorithm

--- a/testsuite/openmodelica/interactive-API/Bug2871.mos
+++ b/testsuite/openmodelica/interactive-API/Bug2871.mos
@@ -1651,21 +1651,21 @@ instantiateModel(Modelica.Fluid.Examples.Tanks.ThreeTanks); getErrorString();
 //   output FluidConstants$simpleWaterConstants res;
 // end Modelica.Media.Interfaces.Types.Basic.FluidConstants$simpleWaterConstants;
 //
-// function Modelica.SIunits.Conversions.from_degC \"Inline before index reduction\" \"Convert from degCelsius to Kelvin\"
+// function Modelica.SIunits.Conversions.from_degC \"Convert from degCelsius to Kelvin\"
 //   input Real Celsius(quantity = \"ThermodynamicTemperature\", unit = \"degC\") \"Celsius value\";
 //   output Real Kelvin(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Kelvin value\";
 // algorithm
 //   Kelvin := 273.15 + Celsius;
 // end Modelica.SIunits.Conversions.from_degC;
 //
-// function Modelica.SIunits.Conversions.to_bar \"Inline before index reduction\" \"Convert from Pascal to bar\"
+// function Modelica.SIunits.Conversions.to_bar \"Convert from Pascal to bar\"
 //   input Real Pa(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pascal value\";
 //   output Real bar(quantity = \"Pressure\", unit = \"bar\") \"bar value\";
 // algorithm
 //   bar := 1e-05 * Pa;
 // end Modelica.SIunits.Conversions.to_bar;
 //
-// function Modelica.SIunits.Conversions.to_degC \"Inline before index reduction\" \"Convert from Kelvin to degCelsius\"
+// function Modelica.SIunits.Conversions.to_degC \"Convert from Kelvin to degCelsius\"
 //   input Real Kelvin(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Kelvin value\";
 //   output Real Celsius(quantity = \"ThermodynamicTemperature\", unit = \"degC\") \"Celsius value\";
 // algorithm

--- a/testsuite/openmodelica/xml/XmlDumpComment.mos
+++ b/testsuite/openmodelica/xml/XmlDumpComment.mos
@@ -21542,7 +21542,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </equations>
 // <functions>
 // <function name=\"Modelica.Math.Vectors.length\">
-// <ModelicaImplementation>function(v :: array(Real)[:]) =&gt; RealModelica.Math.Vectors.lengthfunction Modelica.Math.Vectors.length &quot;Inline before index reduction&quot; &quot;Return length of a vector (better as norm(), if further symbolic processing is performed)&quot;
+// <ModelicaImplementation>function(v :: array(Real)[:]) =&gt; RealModelica.Math.Vectors.lengthfunction Modelica.Math.Vectors.length &quot;Return length of a vector (better as norm(), if further symbolic processing is performed)&quot;
 //   input Real[:] v &quot;Vector&quot;;
 //   output Real result &quot;Length of vector v&quot;;
 // algorithm
@@ -21553,7 +21553,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.world.gravityAcceleration\">
-// <ModelicaImplementation>function(r :: array(Real)[3] * gravityType :: Enumeration * g :: array(Real)[3] * mue :: Real) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.world.gravityAccelerationfunction Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.world.gravityAcceleration &quot;Inline before index reduction&quot;
+// <ModelicaImplementation>function(r :: array(Real)[3] * gravityType :: Enumeration * g :: array(Real)[3] * mue :: Real) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.world.gravityAccelerationfunction Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.world.gravityAcceleration
 //   input Real[3] r(quantity = &quot;Length&quot;, unit = &quot;m&quot;) &quot;Position vector from world frame to actual point, resolved in world frame&quot;;
 //   input enumeration(NoGravity, UniformGravity, PointGravity) gravityType = Modelica.Mechanics.MultiBody.Types.GravityTypes.UniformGravity &quot;Type of gravity field&quot;;
 //   input Real[3] g(quantity = &quot;Acceleration&quot;, unit = &quot;m/s2&quot;) = {0.0, -9.81, 0.0} &quot;Constant gravity acceleration, resolved in world frame, if gravityType=UniformGravity&quot;;
@@ -21577,7 +21577,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.absoluteRotation\">
-// <ModelicaImplementation>function(R1 :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * R_rel :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})) =&gt; composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})Modelica.Mechanics.MultiBody.Frames.absoluteRotationfunction Modelica.Mechanics.MultiBody.Frames.absoluteRotation &quot;Inline before index reduction&quot; &quot;Return absolute orientation object from another absolute and a relative orientation object&quot;
+// <ModelicaImplementation>function(R1 :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * R_rel :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})) =&gt; composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})Modelica.Mechanics.MultiBody.Frames.absoluteRotationfunction Modelica.Mechanics.MultiBody.Frames.absoluteRotation &quot;Return absolute orientation object from another absolute and a relative orientation object&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R1 &quot;Orientation object to rotate frame 0 into frame 1&quot;;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R_rel &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   output Modelica.Mechanics.MultiBody.Frames.Orientation R2 &quot;Orientation object to rotate frame 0 into frame 2&quot;;
@@ -21589,7 +21589,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.angularVelocity2\">
-// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.angularVelocity2function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 &quot;Inline before index reduction&quot; &quot;Return angular velocity resolved in frame 2 from orientation object&quot;
+// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.angularVelocity2function Modelica.Mechanics.MultiBody.Frames.angularVelocity2 &quot;Return angular velocity resolved in frame 2 from orientation object&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   output Real[3] w(quantity = &quot;AngularVelocity&quot;, unit = &quot;rad/s&quot;) &quot;Angular velocity of frame 2 with respect to frame 1 resolved in frame 2&quot;;
 // algorithm
@@ -21600,7 +21600,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.planarRotation\">
-// <ModelicaImplementation>function(e :: array(Real)[3] * angle :: Real * der_angle :: Real) =&gt; composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})Modelica.Mechanics.MultiBody.Frames.planarRotationfunction Modelica.Mechanics.MultiBody.Frames.planarRotation &quot;Inline before index reduction&quot; &quot;Return orientation object of a planar rotation&quot;
+// <ModelicaImplementation>function(e :: array(Real)[3] * angle :: Real * der_angle :: Real) =&gt; composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND})Modelica.Mechanics.MultiBody.Frames.planarRotationfunction Modelica.Mechanics.MultiBody.Frames.planarRotation &quot;Return orientation object of a planar rotation&quot;
 //   input Real[3] e(unit = &quot;1&quot;) &quot;Normalized axis of rotation (must have length=1)&quot;;
 //   input Real angle(quantity = &quot;Angle&quot;, unit = &quot;rad&quot;, displayUnit = &quot;deg&quot;) &quot;Rotation angle to rotate frame 1 into frame 2 along axis e&quot;;
 //   input Real der_angle(quantity = &quot;AngularVelocity&quot;, unit = &quot;rad/s&quot;) &quot;= der(angle)&quot;;
@@ -21613,7 +21613,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.resolve1\">
-// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v2 :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.resolve1function Modelica.Mechanics.MultiBody.Frames.resolve1 &quot;Inline after index reduction&quot; &quot;Transform vector from frame 2 to frame 1&quot;
+// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v2 :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.resolve1function Modelica.Mechanics.MultiBody.Frames.resolve1 &quot;Transform vector from frame 2 to frame 1&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   input Real[3] v2 &quot;Vector in frame 2&quot;;
 //   output Real[3] v1 &quot;Vector in frame 1&quot;;
@@ -21625,7 +21625,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.resolve2\">
-// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v1 :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.resolve2function Modelica.Mechanics.MultiBody.Frames.resolve2 &quot;Inline after index reduction&quot; &quot;Transform vector from frame 1 to frame 2&quot;
+// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v1 :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.resolve2function Modelica.Mechanics.MultiBody.Frames.resolve2 &quot;Transform vector from frame 1 to frame 2&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   input Real[3] v1 &quot;Vector in frame 1&quot;;
 //   output Real[3] v2 &quot;Vector in frame 2&quot;;
@@ -21637,7 +21637,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.to_Q\">
-// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * Q_guess :: array(Real)[4]) =&gt; array(Real)[4]Modelica.Mechanics.MultiBody.Frames.to_Qfunction Modelica.Mechanics.MultiBody.Frames.to_Q &quot;Inline before index reduction&quot; &quot;Return quaternion orientation object Q from orientation object R&quot;
+// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * Q_guess :: array(Real)[4]) =&gt; array(Real)[4]Modelica.Mechanics.MultiBody.Frames.to_Qfunction Modelica.Mechanics.MultiBody.Frames.to_Q &quot;Return quaternion orientation object Q from orientation object R&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   input Real[4] Q_guess = {0.0, 0.0, 0.0, 1.0} &quot;Guess value for output Q (there are 2 solutions; the one closer to Q_guess is used&quot;;
 //   output Real[4] Q &quot;Quaternions orientation object to rotate frame 1 into frame 2&quot;;
@@ -21649,7 +21649,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der\">
-// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v2 :: array(Real)[3] * v2_der :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_derfunction Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der &quot;Inline before index reduction&quot; &quot;Derivative of function Frames.resolve1(..)&quot;
+// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v2 :: array(Real)[3] * v2_der :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_derfunction Modelica.Mechanics.MultiBody.Frames.Internal.resolve1_der &quot;Derivative of function Frames.resolve1(..)&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   input Real[3] v2 &quot;Vector resolved in frame 2&quot;;
 //   input Real[3] v2_der &quot;= der(v2)&quot;;
@@ -21662,7 +21662,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der\">
-// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v1 :: array(Real)[3] * v1_der :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_derfunction Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der &quot;Inline before index reduction&quot; &quot;Derivative of function Frames.resolve2(..)&quot;
+// <ModelicaImplementation>function(R :: composite(record{array(Real)[3, 3] T VAR UNBOUND, array(Real)[3] w VAR UNBOUND}) * v1 :: array(Real)[3] * v1_der :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_derfunction Modelica.Mechanics.MultiBody.Frames.Internal.resolve2_der &quot;Derivative of function Frames.resolve2(..)&quot;
 //   input Modelica.Mechanics.MultiBody.Frames.Orientation R &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   input Real[3] v1 &quot;Vector resolved in frame 1&quot;;
 //   input Real[3] v1_der &quot;= der(v1)&quot;;
@@ -21675,7 +21675,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T\">
-// <ModelicaImplementation>function(T :: array(Real)[3, 3] * Q_guess :: array(Real)[4]) =&gt; array(Real)[4]Modelica.Mechanics.MultiBody.Frames.Quaternions.from_Tfunction Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T&quot;Inline if necessary&quot; &quot;Return quaternion orientation object Q from transformation matrix T&quot;
+// <ModelicaImplementation>function(T :: array(Real)[3, 3] * Q_guess :: array(Real)[4]) =&gt; array(Real)[4]Modelica.Mechanics.MultiBody.Frames.Quaternions.from_Tfunction Modelica.Mechanics.MultiBody.Frames.Quaternions.from_T &quot;Return quaternion orientation object Q from transformation matrix T&quot;
 //   input Real[3, 3] T &quot;Transformation matrix to transform vector from frame 1 to frame 2 (v2=T*v1)&quot;;
 //   input Real[4] Q_guess = {0.0, 0.0, 0.0, 1.0} &quot;Guess value for Q (there are 2 solutions; the one close to Q_guess is used&quot;;
 //   output Real[4] Q &quot;Quaternions orientation object to rotate frame 1 into frame 2 (Q and -Q have same transformation matrix)&quot;;
@@ -21718,7 +21718,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotation\">
-// <ModelicaImplementation>function(T1 :: array(Real)[3, 3] * T_rel :: array(Real)[3, 3]) =&gt; array(Real)[3, 3]Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotationfunction Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotation &quot;Inline before index reduction&quot; &quot;Return absolute orientation object from another absolute and a relative orientation object&quot;
+// <ModelicaImplementation>function(T1 :: array(Real)[3, 3] * T_rel :: array(Real)[3, 3]) =&gt; array(Real)[3, 3]Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotationfunction Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.absoluteRotation &quot;Return absolute orientation object from another absolute and a relative orientation object&quot;
 //   input Real[3, 3] T1 &quot;Orientation object to rotate frame 0 into frame 1&quot;;
 //   input Real[3, 3] T_rel &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   output Real[3, 3] T2 &quot;Orientation object to rotate frame 0 into frame 2&quot;;
@@ -21730,7 +21730,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.from_nxy\">
-// <ModelicaImplementation>function(n_x :: array(Real)[3] * n_y :: array(Real)[3]) =&gt; array(Real)[3, 3]Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.from_nxyfunction Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.from_nxy&quot;Inline if necessary&quot; &quot;Return orientation object from n_x and n_y vectors&quot;
+// <ModelicaImplementation>function(n_x :: array(Real)[3] * n_y :: array(Real)[3]) =&gt; array(Real)[3, 3]Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.from_nxyfunction Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.from_nxy &quot;Return orientation object from n_x and n_y vectors&quot;
 //   input Real[3] n_x(unit = &quot;1&quot;) &quot;Vector in direction of x-axis of frame 2, resolved in frame 1&quot;;
 //   input Real[3] n_y(unit = &quot;1&quot;) &quot;Vector in direction of y-axis of frame 2, resolved in frame 1&quot;;
 //   output Real[3, 3] T &quot;Orientation object to rotate frame 1 into frame 2&quot;;
@@ -21748,7 +21748,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1\">
-// <ModelicaImplementation>function(T :: array(Real)[3, 3] * v2 :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 &quot;Inline before index reduction&quot; &quot;Transform vector from frame 2 to frame 1&quot;
+// <ModelicaImplementation>function(T :: array(Real)[3, 3] * v2 :: array(Real)[3]) =&gt; array(Real)[3]Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1function Modelica.Mechanics.MultiBody.Frames.TransformationMatrices.resolve1 &quot;Transform vector from frame 2 to frame 1&quot;
 //   input Real[3, 3] T &quot;Orientation object to rotate frame 1 into frame 2&quot;;
 //   input Real[3] v2 &quot;Vector in frame 2&quot;;
 //   output Real[3] v1 &quot;Vector in frame 1&quot;;
@@ -21760,7 +21760,7 @@ readFile("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.xml");
 // </ModelicaImplementation>
 // </function>
 // <function name=\"Modelica.SIunits.Conversions.to_unit1\">
-// <ModelicaImplementation>function(r :: Real) =&gt; RealModelica.SIunits.Conversions.to_unit1function Modelica.SIunits.Conversions.to_unit1 &quot;Inline before index reduction&quot; &quot;Change the unit of a Real number to unit=\\&quot;1\\&quot;&quot;
+// <ModelicaImplementation>function(r :: Real) =&gt; RealModelica.SIunits.Conversions.to_unit1function Modelica.SIunits.Conversions.to_unit1 &quot;Change the unit of a Real number to unit=\\&quot;1\\&quot;&quot;
 //   input Real r &quot;Real number&quot;;
 //   output Real result(unit = &quot;1&quot;) &quot;Real number r with unit=\\&quot;1\\&quot;&quot;;
 // algorithm

--- a/testsuite/simulation/libraries/3rdParty/TestMedia/TestSteam.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMedia/TestSteam.mos
@@ -1271,7 +1271,7 @@ simulate(TestMedia.TestModels.TestSteam); getErrorString();
 //   h := 2087546.84511715 * (1.0 + x * (0.4880153718655694 + x * (0.2079670746250689 + x * (-6.084122698421623 + x * (25.08887602293532 + x * (-48.38215180269516 + x * (45.66489164833212 + (-16.98555442961553 + 0.0006616936460057692 * x) * x)))))));
 // end Modelica.Media.Water.IF97_Utilities.BaseIF97.Regions.hv_p_R4b;
 //
-// function Modelica.Media.Water.IF97_Utilities.BaseIF97.Regions.hvl_p \"Inline after index reduction\" \"Icon for a function\"
+// function Modelica.Media.Water.IF97_Utilities.BaseIF97.Regions.hvl_p \"Icon for a function\"
 //   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = -1000000000.0, max = 1000000000.0, start = 100000.0, nominal = 100000.0) \"pressure\";
 //   input Modelica.Media.Common.IF97PhaseBoundaryProperties bpro \"property record\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", nominal = 1000000.0) \"specific enthalpy\";
@@ -1426,7 +1426,7 @@ simulate(TestMedia.TestModels.TestSteam); getErrorString();
 //   end if;
 // end Modelica.Media.Water.IF97_Utilities.T_ph_der;
 //
-// function Modelica.Media.Water.IF97_Utilities.T_props_ph \"Inline after index reduction\" \"temperature as function of pressure and specific enthalpy\"
+// function Modelica.Media.Water.IF97_Utilities.T_props_ph \"temperature as function of pressure and specific enthalpy\"
 //   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = -1000000000.0, max = 1000000000.0, start = 100000.0, nominal = 100000.0) \"pressure\";
 //   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", nominal = 1000000.0) \"specific enthalpy\";
 //   input Modelica.Media.Common.IF97BaseTwoPhase properties \"auxiliary record\";
@@ -1476,7 +1476,7 @@ simulate(TestMedia.TestModels.TestSteam); getErrorString();
 //   end if;
 // end Modelica.Media.Water.IF97_Utilities.rho_ph_der;
 //
-// function Modelica.Media.Water.IF97_Utilities.rho_props_ph \"Inline after index reduction\" \"density as function of pressure and specific enthalpy\"
+// function Modelica.Media.Water.IF97_Utilities.rho_props_ph \"density as function of pressure and specific enthalpy\"
 //   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = -1000000000.0, max = 1000000000.0, start = 100000.0, nominal = 100000.0) \"pressure\";
 //   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", nominal = 1000000.0) \"specific enthalpy\";
 //   input Modelica.Media.Common.IF97BaseTwoPhase properties \"auxiliary record\";

--- a/testsuite/simulation/libraries/3rdParty/TestMedia/TestWater.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMedia/TestWater.mos
@@ -1271,7 +1271,7 @@ simulate(TestMedia.TestModels.TestWater); getErrorString();
 //   h := 2087546.84511715 * (1.0 + x * (0.4880153718655694 + x * (0.2079670746250689 + x * (-6.084122698421623 + x * (25.08887602293532 + x * (-48.38215180269516 + x * (45.66489164833212 + (-16.98555442961553 + 0.0006616936460057692 * x) * x)))))));
 // end Modelica.Media.Water.IF97_Utilities.BaseIF97.Regions.hv_p_R4b;
 //
-// function Modelica.Media.Water.IF97_Utilities.BaseIF97.Regions.hvl_p \"Inline after index reduction\" \"Icon for a function\"
+// function Modelica.Media.Water.IF97_Utilities.BaseIF97.Regions.hvl_p \"Icon for a function\"
 //   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = -1000000000.0, max = 1000000000.0, start = 100000.0, nominal = 100000.0) \"pressure\";
 //   input Modelica.Media.Common.IF97PhaseBoundaryProperties bpro \"property record\";
 //   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", nominal = 1000000.0) \"specific enthalpy\";
@@ -1426,7 +1426,7 @@ simulate(TestMedia.TestModels.TestWater); getErrorString();
 //   end if;
 // end Modelica.Media.Water.IF97_Utilities.T_ph_der;
 //
-// function Modelica.Media.Water.IF97_Utilities.T_props_ph \"Inline after index reduction\" \"temperature as function of pressure and specific enthalpy\"
+// function Modelica.Media.Water.IF97_Utilities.T_props_ph \"temperature as function of pressure and specific enthalpy\"
 //   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = -1000000000.0, max = 1000000000.0, start = 100000.0, nominal = 100000.0) \"pressure\";
 //   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", nominal = 1000000.0) \"specific enthalpy\";
 //   input Modelica.Media.Common.IF97BaseTwoPhase properties \"auxiliary record\";
@@ -1476,7 +1476,7 @@ simulate(TestMedia.TestModels.TestWater); getErrorString();
 //   end if;
 // end Modelica.Media.Water.IF97_Utilities.rho_ph_der;
 //
-// function Modelica.Media.Water.IF97_Utilities.rho_props_ph \"Inline after index reduction\" \"density as function of pressure and specific enthalpy\"
+// function Modelica.Media.Water.IF97_Utilities.rho_props_ph \"density as function of pressure and specific enthalpy\"
 //   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = -1000000000.0, max = 1000000000.0, start = 100000.0, nominal = 100000.0) \"pressure\";
 //   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", nominal = 1000000.0) \"specific enthalpy\";
 //   input Modelica.Media.Common.IF97BaseTwoPhase properties \"auxiliary record\";

--- a/testsuite/simulation/modelica/records/ATotal.mos
+++ b/testsuite/simulation/modelica/records/ATotal.mos
@@ -1016,7 +1016,7 @@ simulate(A); getErrorString();
 //   ret := false;
 // end Modelica.Electrical.Spice3.Internal.SpiceRoot.useInitialConditions;
 //
-// function Modelica.SIunits.Conversions.from_degC \"Inline before index reduction\" \"Convert from degCelsius to Kelvin\"
+// function Modelica.SIunits.Conversions.from_degC \"Convert from degCelsius to Kelvin\"
 //   input Real Celsius(quantity = \"ThermodynamicTemperature\", unit = \"degC\") \"Celsius value\";
 //   output Real Kelvin(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Kelvin value\";
 // algorithm


### PR DESCRIPTION
- Remove the printing of the inline type in the flat model, since it's
  using a syntax that's not compatible with Modelica and doesn't seem to
  be used for anything.

Fixes #8178