### PR TITLE
Hide previous(v) in the result file

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -1716,6 +1716,9 @@ algorithm
   cr := ComponentReference.makeCrefQual(DAE.previousNamePrefix, DAE.T_REAL_DEFAULT, {}, inVar.varName);
   outVar := copyVarNewName(cr,inVar);
   outVar := setVarKind(outVar,BackendDAE.JAC_DIFF_VAR());
+
+  // HACK hide previous(v) in results because it's not calculated right
+  outVar := setHideResult(outVar, SOME(DAE.BCONST(true)));
 end createClockedState;
 
 public function createAliasDerVar

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -2712,6 +2712,10 @@ algorithm
           previousVar = BackendVariable.setBindExp(previousVar, NONE());
           previousVar = BackendVariable.setVarFixed(previousVar, true);
           previousVar = BackendVariable.setVarStartValueOption(previousVar, SOME(DAE.CREF(cr, ty)));
+
+          // HACK hide previous(v) in results because it's not calculated right
+          previousVar = BackendVariable.setHideResult(previousVar, SOME(DAE.BCONST(true)));
+
           previousExp = Expression.crefExp(previousCR);
           vars = BackendVariable.addVar(previousVar, vars);
           eqns = BackendEquation.add(BackendDAE.EQUATION(previousExp, crExp, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_INITIAL), eqns);

--- a/testsuite/openmodelica/cppruntime/testArrayEquations.mos
+++ b/testsuite/openmodelica/cppruntime/testArrayEquations.mos
@@ -208,10 +208,10 @@ val(y4, 1.0);
 // ========================================
 // algVars (104)
 // ----------------------
-// index: 0: $CLKPRE.x1 (no alias)  initial: x1	no arrCref index:(1) [10]
-// index: 1: $CLKPRE.x2 (no alias)  initial: x2	no arrCref index:(11) [10]
-// index: 2: $CLKPRE.x3 (no alias)  initial: x3	no arrCref index:(21) [10]
-// index: 3: $CLKPRE.x4 (no alias)  initial: x4	no arrCref index:(31) [10]
+// index: 0: $CLKPRE.x1 (no alias)  hideResult  initial: x1	no arrCref index:(1) [10]
+// index: 1: $CLKPRE.x2 (no alias)  hideResult  initial: x2	no arrCref index:(11) [10]
+// index: 2: $CLKPRE.x3 (no alias)  hideResult  initial: x3	no arrCref index:(21) [10]
+// index: 3: $CLKPRE.x4 (no alias)  hideResult  initial: x4	no arrCref index:(31) [10]
 // index: 4: $DER.x4 (no alias)  initial: 	no arrCref index:(41) [10]
 // index: 5: u (no alias)  initial: 1.0:10.0	no arrCref index:(51) [10]
 // index: 6: x1 (no alias)  initial: 	no arrCref index:(61) [10]


### PR DESCRIPTION
See Wittgenstein, Tractatus

### Related Issues

Addresses parts of #7854 

### Purpose

The values of `previous(v)` are not calculated correctly.
This may change in the future.

### Approach

Hide them in the result file, they are of no use there.