### PR TITLE
Improve flattening without scalarization

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect3.mo
@@ -56,16 +56,6 @@ end ArrayConnect3;
 //   Real[1000, 100] cells.l.f;
 //   Real[1000, 100] cells.l.e;
 // equation
-//   for $i1 in 1:999 loop
-//     for $i2 in 2:100 loop
-//       cells[$i1,$i2].l.e = cells[$i1,$i2 - 1].r.e;
-//     end for;
-//   end for;
-//   for $i1 in 1:999 loop
-//     for $i2 in 1:99 loop
-//       cells[$i1,$i2].r.f + cells[$i1,$i2 + 1].l.f = 0.0;
-//     end for;
-//   end for;
 //   for $i1 in 2:1000 loop
 //     for $i2 in 1:99 loop
 //       cells[$i1,$i2].u.e = cells[$i1 - 1,$i2].d.e;
@@ -76,6 +66,16 @@ end ArrayConnect3;
 //       cells[$i1,$i2].d.f + cells[$i1 + 1,$i2].u.f = 0.0;
 //     end for;
 //   end for;
+//   for $i1 in 1:999 loop
+//     for $i2 in 2:100 loop
+//       cells[$i1,$i2].l.e = cells[$i1,$i2 - 1].r.e;
+//     end for;
+//   end for;
+//   for $i1 in 1:999 loop
+//     for $i2 in 1:99 loop
+//       cells[$i1,$i2].r.f + cells[$i1,$i2 + 1].l.f = 0.0;
+//     end for;
+//   end for;
 //   for $i1 in 1:1000 loop
 //     cells[$i1,1].l.e = cells[$i1,100].r.e;
 //   end for;
@@ -83,13 +83,13 @@ end ArrayConnect3;
 //     cells[$i1,100].r.f + cells[$i1,1].l.f = 0.0;
 //   end for;
 //   for $i2 in 1:100 loop
-//     cells[1,$i2].u.e = S.p.e;
-//   end for;
-//   sum(cells[1,:].u.f) + S.p.f = 0.0;
-//   for $i2 in 1:100 loop
 //     cells[1000,$i2].d.e = S.n.e;
 //   end for;
 //   sum(cells[1000,:].d.f) + S.n.f = 0.0;
+//   for $i2 in 1:100 loop
+//     cells[1,$i2].u.e = S.p.e;
+//   end for;
+//   sum(cells[1,:].u.f) + S.p.f = 0.0;
 //   for $i1 in 1:999 loop
 //     cells[$i1,100].d.f = 0.0;
 //   end for;

--- a/testsuite/flattening/modelica/scodeinst/PrintRecordTypes1.mo
+++ b/testsuite/flattening/modelica/scodeinst/PrintRecordTypes1.mo
@@ -45,8 +45,8 @@ end PrintRecordTypes1;
 //   Real[100, 10] b.c.rb.y;
 // equation
 //   for i in 1:100 loop
-//     b[i].c[1].rb = R1(/*Real*/(i), 0.0);
 //     b[i].c[10] = R2(R1(1.0, 0.0), R1(/*Real*/(i), 1.0));
+//     b[i].c[1].rb = R1(/*Real*/(i), 0.0);
 //   end for;
 // end PrintRecordTypes1;
 // endResult


### PR DESCRIPTION
- Flatten equations and algorithms with an empty prefix when not doing
  scalarization, to get rid of any remaining split indices.