### PR TITLE
Flat Modelica fixes

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -356,6 +356,8 @@ public
 
       case Equation.FOR()
         algorithm
+          types := Util.applyOptionOrDefault(eq.range,
+            function collectExpFlatTypes(types = types), types);
           types := List.fold(eq.body, collectEquationFlatTypes, types);
         then
           ();

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -58,7 +58,12 @@ public
       print(stage);
       print("\n########################################\n\n");
 
-      FlatModel.printString(flat_model);
+      if Flags.getConfigBool(Flags.FLAT_MODELICA) then
+        FlatModel.printFlatString(flat_model, FunctionTree.listValues(functions));
+      else
+        FlatModel.printString(flat_model);
+      end if;
+
       print("\n");
     end if;
   end dumpFlatModelDebug;


### PR DESCRIPTION
- Use Flat Modelica for the dumpFlatModel output if the -f is used.
- Also check the for-range in FlatModel.collectEquationFlatTypes.