### PR TITLE
Make subscripting functions for -f optional

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1779,28 +1779,32 @@ public
     String name;
     list<Subscript> subs;
   algorithm
-    subs := list(s for s guard not Subscript.isSplitIndex(s) in subscripts);
+    if Flags.getConfigBool(Flags.MODELICA_OUTPUT) then
+      subs := list(s for s guard not Subscript.isSplitIndex(s) in subscripts);
 
-    if listEmpty(subs) then
-      str := toFlatString(exp);
+      if listEmpty(subs) then
+        str := toFlatString(exp);
+      else
+        exp_ty := typeOf(exp);
+        dims := List.firstN(Type.arrayDims(exp_ty), listLength(subs));
+        sub_tyl := list(Dimension.subscriptType(d) for d in dims);
+        name := Type.subscriptedTypeName(exp_ty, sub_tyl);
+
+        strl := {")"};
+
+        for s in subs loop
+          strl := Subscript.toFlatString(s) :: strl;
+          strl := "," :: strl;
+        end for;
+
+        strl := toFlatString(exp) :: strl;
+        strl := "'(" :: strl;
+        strl := name :: strl;
+        strl := "'" :: strl;
+        str := stringAppendList(strl);
+      end if;
     else
-      exp_ty := typeOf(exp);
-      dims := List.firstN(Type.arrayDims(exp_ty), listLength(subs));
-      sub_tyl := list(Dimension.subscriptType(d) for d in dims);
-      name := Type.subscriptedTypeName(exp_ty, sub_tyl);
-
-      strl := {")"};
-
-      for s in subs loop
-        strl := Subscript.toFlatString(s) :: strl;
-        strl := "," :: strl;
-      end for;
-
-      strl := toFlatString(exp) :: strl;
-      strl := "'(" :: strl;
-      strl := name :: strl;
-      strl := "'" :: strl;
-      str := stringAppendList(strl);
+      str := toFlatString(exp) + Subscript.toFlatStringList(subscripts);
     end if;
   end toFlatSubscriptedString;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -511,6 +511,7 @@ public
   algorithm
     types := match exp
       case Expression.SUBSCRIPTED_EXP()
+        guard Flags.getConfigBool(Flags.MODELICA_OUTPUT)
         algorithm
           types := collectSubscriptedFlatType(exp.exp, exp.subscripts, exp.ty, types);
         then

--- a/testsuite/openmodelica/flatmodelica/DoublePendulum.mos
+++ b/testsuite/openmodelica/flatmodelica/DoublePendulum.mos
@@ -2,7 +2,7 @@
 // cflags: -d=-newInst
 
 loadModel(Modelica, {"3.2.3"});getErrorString();
-setCommandLineOptions("-d=newInst -f");
+setCommandLineOptions("-d=newInst -f -m");
 writeFile("DoublePendulum.mo", OpenModelica.Scripting.instantiateModel(Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum));getErrorString();
 clear();
 loadFile("DoublePendulum.mo");getErrorString();

--- a/testsuite/openmodelica/flatmodelica/Makefile
+++ b/testsuite/openmodelica/flatmodelica/Makefile
@@ -9,7 +9,8 @@ else
 endif
 
 TESTFILES = DoublePendulum.mos \
-  Tables.mos
+  Tables.mos \
+	SD.mo
 
 
 # test that currently fail. Move up when fixed.

--- a/testsuite/openmodelica/flatmodelica/SD.mo
+++ b/testsuite/openmodelica/flatmodelica/SD.mo
@@ -1,0 +1,73 @@
+// name: SD
+// keywords:
+// status: correct
+// cflags: -d=newInst,-nfScalarize,arrayConnect,combineSubscripts -f
+//
+
+connector C
+  Real e;
+  flow Real f;
+end C;
+
+model SF
+  parameter Real p = 6;
+  C c;
+equation
+  c.f = p;
+end SF;
+
+model CC
+  parameter Integer N = 3;
+  parameter Real p = 1;
+  Real[N] x;
+  C c;
+equation
+  x[1] = c.e;
+  x[N] = c.f;
+  for i in 2:N loop
+    x[i] = x[i - 1] + p;
+  end for;
+end CC;
+
+model SD
+  parameter Integer N = 3;
+  parameter Real[N] p = {1.0, 1.5, 2.0};
+  CC[N] c(p = p, N = {3, 4, 5});
+  SF s(p = 3);
+equation
+  connect(s.c, c[1].c);
+  for i in 1:N - 1 loop
+    connect(c[i + 1].c, c[i].c);
+  end for;
+end SD;
+
+// Result:
+// class 'SD'
+//   public parameter Integer 'N' = 3;
+//   public parameter Real[3] 'p' = {1.0, 1.5, 2.0};
+//   public Real[3] 'c.c.f';
+//   public Real[3] 'c.c.e';
+//   public Real[3, {3, 4, 5}] 'c.x';
+//   public parameter Real[3] 'c.p' = 'p'[:];
+//   public parameter Integer[3] 'c.N' = {3, 4, 5};
+//   public parameter Real 's.p' = 3.0;
+//   public Real 's.c.e';
+//   public Real 's.c.f';
+// public
+// equation
+//   'c.x'[:,1] = 'c.c.e'[:];
+//   'c.x'[:,'c.N'[:]] = 'c.c.f'[:];
+//
+//   for '$i1' in 1:3 loop
+//     for 'i' in 2:{3, 4, 5}['$i1'] loop
+//       'c.x'['$i1','i'] = 'c.x'['$i1','i' - 1] + 'c.p'['$i1'];
+//     end for;
+//   end for;
+//
+//   's.c.f' = 's.p';
+//   'c.c.e'[2] = 'c.c.e'[1];
+//   's.c.e' = 'c.c.e'[1];
+//   'c.c.e'[3] = 'c.c.e'[1];
+//   'c.c.f'[3] + 's.c.f' + 'c.c.f'[2] + 'c.c.f'[1] = 0.0;
+// end 'SD';
+// endResult

--- a/testsuite/openmodelica/flatmodelica/Tables.mos
+++ b/testsuite/openmodelica/flatmodelica/Tables.mos
@@ -3,7 +3,7 @@
 
 loadModel(ModelicaServices, {"3.2.3+maint.om"});getErrorString();
 loadModel(ModelicaTest, {"3.2.3"});getErrorString();
-setCommandLineOptions("-d=newInst -f");
+setCommandLineOptions("-d=newInst -f -m");
 writeFile("Tables.mo", OpenModelica.Scripting.instantiateModel(ModelicaTest.Tables.CombiTable1D.Test33));getErrorString();
 clear();
 loadFile("Tables.mo");getErrorString();


### PR DESCRIPTION
- Use the -m flag to enable the output of subscripting functions when -f
  is used, and otherwise output subscripted expressions.