### PR TITLE
Improve Flat Modelica output

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -52,6 +52,8 @@ protected
   import DAE.ElementSource;
   import MetaModelica.Dangerous.listReverseInPlace;
   import Util;
+  import Prefixes = NFPrefixes;
+  import NFPrefixes.Visibility;
 
   import FlatModel = NFFlatModel;
 
@@ -213,6 +215,7 @@ public
     input output IOStream.IOStream s;
   protected
     FlatModel flat_model = flatModel;
+    Visibility visibility = Visibility.PUBLIC;
   algorithm
     s := IOStream.append(s, "class '" + flat_model.name + "'\n");
 
@@ -231,11 +234,15 @@ public
     end for;
 
     for v in flat_model.variables loop
+      if visibility <> Variable.visibility(v) then
+        visibility := Variable.visibility(v);
+        s := IOStream.append(s, Prefixes.visibilityString(visibility));
+        s := IOStream.append(s, "\n");
+      end if;
+
       s := Variable.toFlatStream(v, "  ", printBindingTypes, s);
       s := IOStream.append(s, ";\n");
     end for;
-
-    s := IOStream.append(s, "public\n");
 
     if not listEmpty(flat_model.initialEquations) then
       s := IOStream.append(s, "initial equation\n");

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -162,6 +162,11 @@ public
     output Variability variability = variable.attributes.variability;
   end variability;
 
+  function visibility
+    input Variable variable;
+    output Visibility visibility = variable.visibility;
+  end visibility;
+
   function isEmptyArray
     input Variable variable;
     output Boolean isEmpty = Type.isEmptyArray(variable.ty);
@@ -315,12 +320,6 @@ public
     Integer var_dims, binding_dims;
   algorithm
     s := IOStream.append(s, indent);
-
-    if var.visibility == Visibility.PROTECTED then
-      s := IOStream.append(s, "protected ");
-    else
-      s := IOStream.append(s, "public ");
-    end if;
 
     s := Component.Attributes.toFlatStream(var.attributes, var.ty, s, ComponentRef.isSimple(var.name));
     s := IOStream.append(s, Type.toFlatString(var.ty));

--- a/testsuite/flattening/modelica/scodeinst/CombineSubscripts3.mo
+++ b/testsuite/flattening/modelica/scodeinst/CombineSubscripts3.mo
@@ -21,9 +21,8 @@ end CombineSubscripts3;
 
 // Result:
 // class 'CombineSubscripts3'
-//   public Real[3] 'b.p';
-//   public Real[3, 4] 'b.x';
-// public
+//   Real[3] 'b.p';
+//   Real[3, 4] 'b.x';
 // equation
 //   for 'i' in 1:3 loop
 //     for 'j' in 2:3 loop

--- a/testsuite/openmodelica/flatmodelica/SD.mo
+++ b/testsuite/openmodelica/flatmodelica/SD.mo
@@ -43,17 +43,16 @@ end SD;
 
 // Result:
 // class 'SD'
-//   public parameter Integer 'N' = 3;
-//   public parameter Real[3] 'p' = {1.0, 1.5, 2.0};
-//   public Real[3] 'c.c.f';
-//   public Real[3] 'c.c.e';
-//   public Real[3, {3, 4, 5}] 'c.x';
-//   public parameter Real[3] 'c.p' = 'p'[:];
-//   public parameter Integer[3] 'c.N' = {3, 4, 5};
-//   public parameter Real 's.p' = 3.0;
-//   public Real 's.c.e';
-//   public Real 's.c.f';
-// public
+//   parameter Integer 'N' = 3;
+//   parameter Real[3] 'p' = {1.0, 1.5, 2.0};
+//   Real[3] 'c.c.f';
+//   Real[3] 'c.c.e';
+//   Real[3, {3, 4, 5}] 'c.x';
+//   parameter Real[3] 'c.p' = 'p'[:];
+//   parameter Integer[3] 'c.N' = {3, 4, 5};
+//   parameter Real 's.p' = 3.0;
+//   Real 's.c.e';
+//   Real 's.c.f';
 // equation
 //   'c.x'[:,1] = 'c.c.e'[:];
 //   'c.x'[:,'c.N'[:]] = 'c.c.f'[:];


### PR DESCRIPTION
- Only print visibility for blocks of variables, not for every variable.
- Remove unnecessary public section at end of variable list.

Fixes #8227.