### PR TITLE
CMake build support for OMShell and OMNotebook 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 omc_add_subdirectory(OMCompiler)
 omc_add_subdirectory(OMParser EXCLUDE_FROM_ALL)
 omc_add_subdirectory(OMPlot EXCLUDE_FROM_ALL)
+omc_add_subdirectory(OMShell EXCLUDE_FROM_ALL)
+omc_add_subdirectory(OMNotebook EXCLUDE_FROM_ALL)
 # omc_add_subdirectory(libraries)
 include(omsimulator.cmake)
 

--- a/OMNotebook/CMakeLists.txt
+++ b/OMNotebook/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required (VERSION 3.14)
+
+project(OMNotebook)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+
+find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml REQUIRED)
+
+omc_add_subdirectory(OMNotebook/OMNotebookGUI)
+
+
+# Move this to DrModelica directory once we add CMake support for it.
+install(DIRECTORY
+	DrModelica/
+	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omnotebook/drmodelica/
+    FILES_MATCHING PATTERN "*.onb")

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -1,0 +1,114 @@
+
+
+set(OMNOTEBOOKLIB_SOURCES  qtapp.cpp
+                           cellapplication.cpp
+                           cellparserfactory.cpp
+                           stylesheet.cpp
+                           cellcommandcenter.cpp
+                           chaptercountervisitor.cpp
+                           omcinteractiveenvironment.cpp
+                           textcell.cpp
+                           cellcommands.cpp
+                           commandcompletion.cpp
+                           ModelicaTextHighlighter.cpp
+                           textcursorcommands.cpp
+                           cell.cpp
+                           printervisitor.cpp
+                           treeview.cpp
+                           cellcursor.cpp
+                           puretextvisitor.cpp
+                           updategroupcellvisitor.cpp
+                           celldocument.cpp
+                           inputcell.cpp
+                           qcombobox_search.cpp
+                           updatelinkvisitor.cpp
+                           cellfactory.cpp
+                           notebook.cpp
+                           xmlparser.cpp
+                           searchform.cpp
+                           cellgroup.cpp
+                           serializingvisitor.cpp
+                           graphcell.cpp
+                           latexcell.cpp
+                           indent.cpp
+                           res_qt.qrc)
+
+set(OMNOTEBOOKLIB_HEADERS application.h
+                          command.h
+                          serializingvisitor.h
+                          cellapplication.h
+                          commandunit.h
+                          stripstring.h
+                          cellcommandcenter.h
+                          cursorcommands.h
+                          omcinteractiveenvironment.h
+                          stylesheet.h
+                          cellcommands.h
+                          cursorposvisitor.h
+                          ModelicaTextHighlighter.h
+                          cellcursor.h
+                          document.h
+                          otherdlg.h
+                          textcell.h
+                          celldocument.h
+                          documentview.h
+                          parserfactory.h
+                          textcursorcommands.h
+                          celldocumentview.h
+                          factory.h
+                          printervisitor.h
+                          treeview.h
+                          cellfactory.h
+                          puretextvisitor.h
+                          updategroupcellvisitor.h
+                          cellgroup.h
+                          imagesizedlg.h
+                          qcombobox_search.h
+                          updatelinkvisitor.h
+                          cell.h
+                          inputcelldelegate.h
+                          removehighlightervisitor.h
+                          visitor.h
+                          cellstyle.h
+                          inputcell.h
+                          replaceallvisitor.h
+                          xmlnodename.h
+                          chaptercountervisitor.h
+                          nbparser.h
+                          resource1.h
+                          xmlparser.h
+                          commandcenter.h
+                          notebookcommands.h
+                          rule.h
+                          commandcompletion.h
+                          notebook.h
+                          searchform.h
+                          graphcell.h
+                          latexcell.h
+                          indent.h)
+
+
+add_executable(OMNotebook ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS})
+target_compile_definitions(OMNotebook PRIVATE OMNOTEBOOKLIB_MOC_INCLUDE)
+
+target_include_directories(OMNotebook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(OMNotebook PUBLIC Qt5::Xml)
+target_link_libraries(OMNotebook PUBLIC Qt5::Widgets)
+target_link_libraries(OMNotebook PUBLIC Qt5::PrintSupport)
+target_link_libraries(OMNotebook PUBLIC Qt5::WebKitWidgets)
+target_link_libraries(OMNotebook PUBLIC OMPlotLib)
+target_link_libraries(OMNotebook PUBLIC OpenModelicaCompiler)
+
+# target_link_options(OMNotebook PRIVATE -Wl,--no-undefined)
+
+
+# add_executable(OMNotebook qtapp.cpp)
+# target_link_libraries(OMNotebook PRIVATE OMNotebookLib)
+
+# install(TARGETS OMNotebookLib)
+install(TARGETS OMNotebook)
+
+install(FILES stylesheet.xml
+              commands.xml
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omnotebook/)

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OMPLOTLIB_SOURCES Plot.cpp
                       PlotApplication.cpp
                       PlotWindowContainer.cpp
                       PlotMainWindow.cpp
-                      ScaleDraw.cpp)
-
+                      ScaleDraw.cpp
+                      resource_omplot.qrc)
 
 set(OMPLOTLIB_HEADERS OMPlot.h
                       PlotZoomer.h
@@ -30,6 +30,8 @@ set(OMPLOTLIB_HEADERS OMPlot.h
 add_library(OMPlotLib SHARED ${OMPLOTLIB_SOURCES} ${OMPLOTLIB_HEADERS})
 target_compile_definitions(OMPlotLib PRIVATE OMPLOTLIB_MOC_INCLUDE)
 
+target_include_directories(OMPlotLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 target_link_libraries(OMPlotLib PUBLIC Qt5::Widgets)
 target_link_libraries(OMPlotLib PUBLIC Qt5::PrintSupport)
 target_link_libraries(OMPlotLib PUBLIC qwt)
@@ -40,3 +42,6 @@ target_link_options(OMPlotLib PRIVATE -Wl,--no-undefined)
 
 add_executable(OMPlot main.cpp)
 target_link_libraries(OMPlot PRIVATE OMPlotLib)
+
+install(TARGETS OMPlotLib)
+install(TARGETS OMPlot)

--- a/OMShell/CMakeLists.txt
+++ b/OMShell/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required (VERSION 3.14)
+
+project(OMShell)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+
+find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml REQUIRED)
+
+omc_add_subdirectory(OMShell/OMShellGUI)

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -1,0 +1,32 @@
+
+
+set(OMSHELLLIB_SOURCES commandcompletion.cpp
+                       omcinteractiveenvironment.cpp
+                       oms.cpp
+                       oms.qrc)
+
+set(OMSHELLLIB_HEADERS commandcompletion.h
+                       omcinteractiveenvironment.h
+                       oms.h)
+
+
+add_library(OMShellLib SHARED ${OMSHELLLIB_SOURCES} ${OMSHELLLIB_HEADERS})
+target_compile_definitions(OMShellLib PRIVATE OMSHELLLIB_MOC_INCLUDE)
+
+target_link_libraries(OMShellLib PUBLIC Qt5::Xml)
+target_link_libraries(OMShellLib PUBLIC Qt5::Widgets)
+target_link_libraries(OMShellLib PUBLIC Qt5::PrintSupport)
+target_link_libraries(OMShellLib PUBLIC Qt5::WebKitWidgets)
+target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
+
+target_link_options(OMShellLib PRIVATE -Wl,--no-undefined)
+
+
+add_executable(OMShell main.cpp)
+target_link_libraries(OMShell PRIVATE OMShellLib)
+
+install(TARGETS OMShellLib)
+install(TARGETS OMShell)
+
+install(FILES commands.xml
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omshell)


### PR DESCRIPTION
@mahge
[cmake] Add CMake build support for OMShell 
fd31827
  - This works but right now it is missing some extra things.

  - Fix OMPlot config a bit. Install the targets and add an include
      directory for linking targets.


@mahge
[cmake] Add CMake build support for OMNotebook 
437dfb0
  - This is a very basic support.

  - OMSketch is not added yet.