### PR TITLE
Vectorize bindings when using -d=-nfScalarize

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -175,7 +175,9 @@ algorithm
   flatModel := UnitCheck.checkUnits(flatModel);
 
   // Apply simplifications to the model.
-  flatModel := SimplifyModel.simplify(flatModel);
+  if not Flags.getConfigBool(Flags.NO_SIMPLIFY) then
+    flatModel := SimplifyModel.simplify(flatModel);
+  end if;
 
   // Collect package constants that couldn't be substituted with their values
   // (e.g. because they where used with non-constant subscripts), and add them
@@ -197,6 +199,7 @@ algorithm
   else
     // Remove empty arrays from variables
     flatModel.variables := List.filterOnFalse(flatModel.variables, Variable.isEmptyArray);
+    flatModel.variables := list(Flatten.vectorizeVariableBinding(v) for v in flatModel.variables);
   end if;
 
   flatModel := InstUtil.replaceEmptyArrays(flatModel);

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -756,6 +756,7 @@ NonConnectorFlow1.mo \
 NonexistentRedeclareModifier1.mo \
 NonexistentRedeclareModifier2.mo \
 NoScalarize1.mo \
+NoScalarize2.mo \
 OperationAdd1.mo \
 OperationAddEW1.mo \
 OperationDiv1.mo \

--- a/testsuite/flattening/modelica/scodeinst/NoScalarize2.mo
+++ b/testsuite/flattening/modelica/scodeinst/NoScalarize2.mo
@@ -1,0 +1,25 @@
+// name: NoScalarize2
+// keywords:
+// status: correct
+// cflags: -d=newInst,-nfScalarize --noSimplify
+//
+
+model NoScalarize2
+  model M
+    Real p;
+  end M;
+
+  model Q
+    M m[2];
+  end Q;
+
+  M m[2](each p = 2);
+  Q q[3](m(each p = 2));
+end NoScalarize2;
+
+// Result:
+// class NoScalarize2
+//   Real[2] m.p = fill(2.0, 2);
+//   Real[3, 2] q.m.p = fill(2.0, 3, 2);
+// end NoScalarize2;
+// endResult


### PR DESCRIPTION
- Vectorize bindings when scalarization is turned off by creating fill
  calls with the appropriate dimensions.
- Implement the old `--noSimplify` flag for the NF to allow turning of
  simplifications.