### PR TITLE
Use textColor instead of depreciated lineColor from FilledShape

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -265,6 +265,27 @@ QStringList FilledShape::getShapeAnnotation()
 }
 
 /*!
+ * \brief FilledShape::getTextShapeAnnotation
+ * Returns the annotation values for Text shape.
+ * \return the annotation values as a list.
+ */
+QStringList FilledShape::getTextShapeAnnotation()
+{
+  QStringList annotationString;
+  /* get the text color */
+  if (mLineColor != Qt::black) {
+    QString lineColorString;
+    lineColorString.append("textColor={");
+    lineColorString.append(QString::number(mLineColor.red())).append(",");
+    lineColorString.append(QString::number(mLineColor.green())).append(",");
+    lineColorString.append(QString::number(mLineColor.blue()));
+    lineColorString.append("}");
+    annotationString.append(lineColorString);
+  }
+  return annotationString;
+}
+
+/*!
  * \class ShapeAnnotation
  * \brief The base class for all shapes LineAnnotation, PolygonAnnotation, RectangleAnnotation, EllipseAnnotation, TextAnnotation, BitmapAnnotation.
  */

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
@@ -90,6 +90,7 @@ public:
   void parseShapeAnnotation(QString annotation);
   QStringList getOMCShapeAnnotation();
   QStringList getShapeAnnotation();
+  QStringList getTextShapeAnnotation();
   void setLineColor(QColor color) {mLineColor = color;}
   QColor getLineColor() {return mLineColor;}
   void setFillColor(QColor color) {mFillColor = color;}

--- a/OMEdit/OMEditLIB/Annotations/ShapePropertiesDialog.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapePropertiesDialog.cpp
@@ -57,10 +57,10 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   mpTextAnnotation = dynamic_cast<TextAnnotation*>(mpShapeAnnotation);
   mpBitmapAnnotation = dynamic_cast<BitmapAnnotation*>(mpShapeAnnotation);
   QString title = getTitle();
-  setWindowTitle(QString(Helper::applicationName).append(" - ").append(title).append(" ").append(Helper::properties));
+  setWindowTitle(QString("%1 - %2 %3").arg(Helper::applicationName, title, Helper::properties));
   setAttribute(Qt::WA_DeleteOnClose);
   // heading label
-  mpShapePropertiesHeading = Utilities::getHeadingLabel(QString(title).append(" ").append(Helper::properties));
+  mpShapePropertiesHeading = Utilities::getHeadingLabel(QString("%1 %2").arg(title, Helper::properties));
   // set separator line
   mHorizontalLine = Utilities::getHeadingLine();
   // Transformations Group Box
@@ -138,8 +138,7 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   mpBorderPatternComboBox->addItem(StringHandler::getBorderPatternString(StringHandler::BorderRaised));
   mpBorderPatternComboBox->addItem(StringHandler::getBorderPatternString(StringHandler::BorderSunken));
   mpBorderPatternComboBox->addItem(StringHandler::getBorderPatternString(StringHandler::BorderEngraved));
-  int currentIndex = mpBorderPatternComboBox->findText(StringHandler::getBorderPatternString(
-                                                         mpShapeAnnotation->getBorderPattern()), Qt::MatchExactly);
+  int currentIndex = mpBorderPatternComboBox->findText(StringHandler::getBorderPatternString(mpShapeAnnotation->getBorderPattern()), Qt::MatchExactly);
   if (currentIndex > -1) {
     mpBorderPatternComboBox->setCurrentIndex(currentIndex);
   }
@@ -195,8 +194,7 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   mpAngleGroupBox->setLayout(pAngleGridLayout);
   // Text Group Box
   mpTextGroupBox = new QGroupBox(tr("Text"));
-  mpTextTextBox = new QLineEdit(mpShapeAnnotation->getTextString());
-  mpTextTextBox->setToolTip(tr("Use \\n for multi-line text"));
+  mpTextTextBox = new QPlainTextEdit(StringHandler::unparse(QString("\"%1\"").arg(mpShapeAnnotation->getTextString())));
   // set the Text Group Box layout
   QHBoxLayout *pTextGroupBoxLayout = new QHBoxLayout;
   pTextGroupBoxLayout->addWidget(mpTextTextBox);
@@ -265,6 +263,18 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   pFontAndTextStyleGroupBox->addWidget(mpTextHorizontalAlignmentLabel, 1, 4);
   pFontAndTextStyleGroupBox->addWidget(mpTextHorizontalAlignmentComboBox, 1, 5);
   mpFontAndTextStyleGroupBox->setLayout(pFontAndTextStyleGroupBox);
+  // Text color group box
+  mpTextColorGroupBox = new QGroupBox(tr("Color"));
+  // text color button
+  mpTextPickColorButton = new QPushButton(Helper::pickColor);
+  mpTextPickColorButton->setAutoDefault(false);
+  connect(mpTextPickColorButton, SIGNAL(clicked()), SLOT(textPickColor()));
+  setLineColor(mpShapeAnnotation->getLineColor());
+  setTextPickColorButtonIcon();
+  // set the text color group box layout
+  QHBoxLayout *pTextColorGroupBoxLayout = new QHBoxLayout;
+  pTextColorGroupBoxLayout->addWidget(mpTextPickColorButton);
+  mpTextColorGroupBox->setLayout(pTextColorGroupBoxLayout);
   // Line style Group Box
   mpLineStyleGroupBox = new QGroupBox(Helper::lineStyle);
   // Line Color
@@ -479,8 +489,7 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   mpApplyButton = new QPushButton(Helper::apply);
   mpApplyButton->setAutoDefault(false);
   connect(mpApplyButton, SIGNAL(clicked()), this, SLOT(applyShapeProperties()));
-  if (mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() ||
-      mpShapeAnnotation->isInheritedShape()) {
+  if (mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() || mpShapeAnnotation->isInheritedShape()) {
     mpOkButton->setDisabled(true);
     mpApplyButton->setDisabled(true);
   }
@@ -509,15 +518,16 @@ ShapePropertiesDialog::ShapePropertiesDialog(ShapeAnnotation *pShapeAnnotation, 
   if (mpTextAnnotation) {
     pMainLayout->addWidget(mpTextGroupBox, row++, 0, 1, colSpan);
     pMainLayout->addWidget(mpFontAndTextStyleGroupBox, row++, 0, 1, colSpan);
+    pMainLayout->addWidget(mpTextColorGroupBox, row++, 0, 1, colSpan);
   }
   if (mpBitmapAnnotation) {
     pMainLayout->addWidget(mpImageGroupBox, row++, 0, 1, colSpan);
-  } else {
+  } else if (!mpTextAnnotation) {
     pMainLayout->addWidget(mpLineStyleGroupBox, row, 0);
   }
   if (mpLineAnnotation) {
     pMainLayout->addWidget(mpArrowStyleGroupBox, row++, 1);
-  } else if (!mpBitmapAnnotation) {
+  } else if (!mpBitmapAnnotation && !mpTextAnnotation) {
     pMainLayout->addWidget(mpFillStyleGroupBox, row++, 1);
   }
   if (mpLineAnnotation || mpPolygonAnnotation) {
@@ -571,6 +581,13 @@ void ShapePropertiesDialog::setLinePickColorButtonIcon()
   mpLinePickColorButton->setIcon(pixmap);
 }
 
+void ShapePropertiesDialog::setTextPickColorButtonIcon()
+{
+  QPixmap pixmap(Helper::iconSize);
+  pixmap.fill(getLineColor());
+  mpTextPickColorButton->setIcon(pixmap);
+}
+
 void ShapePropertiesDialog::setFillColor(QColor color)
 {
   mFillColor = color;
@@ -586,6 +603,17 @@ void ShapePropertiesDialog::setFillPickColorButtonIcon()
   QPixmap pixmap(Helper::iconSize);
   pixmap.fill(getFillColor());
   mpFillPickColorButton->setIcon(pixmap);
+}
+
+void ShapePropertiesDialog::textPickColor()
+{
+  QColor color = QColorDialog::getColor(getLineColor());
+  // if user press ESC
+  if (!color.isValid()) {
+    return;
+  }
+  setLineColor(color);
+  setTextPickColorButtonIcon();
 }
 
 void ShapePropertiesDialog::linePickColor()
@@ -752,18 +780,16 @@ bool ShapePropertiesDialog::applyShapeProperties()
     bool Ok;
     pTableWidgetItem->text().toFloat(&Ok);
     if (!Ok || pTableWidgetItem->text().isEmpty()) {
-      QMessageBox::critical(MainWindow::instance(), QString(Helper::applicationName).append(" - ").append(Helper::error),
-                            GUIMessages::getMessage(GUIMessages::ENTER_VALID_NUMBER)
-                            .arg("points item ("+  QString::number(i+1) +",0)"), Helper::ok);
+      QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
+                            GUIMessages::getMessage(GUIMessages::ENTER_VALID_NUMBER).arg("points item ("+  QString::number(i+1) +",0)"), Helper::ok);
       mpPointsTableWidget->editItem(pTableWidgetItem);
       return false;
     }
     pTableWidgetItem = mpPointsTableWidget->item(i, 1); /* point Y value */
     pTableWidgetItem->text().toFloat(&Ok);
     if (!Ok || pTableWidgetItem->text().isEmpty()) {
-      QMessageBox::critical(MainWindow::instance(), QString(Helper::applicationName).append(" - ").append(Helper::error),
-                            GUIMessages::getMessage(GUIMessages::ENTER_VALID_NUMBER)
-                            .arg("points table ["+  QString::number(i+1) +",1]"), Helper::ok);
+      QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
+                            GUIMessages::getMessage(GUIMessages::ENTER_VALID_NUMBER).arg("points table ["+  QString::number(i+1) +",1]"), Helper::ok);
       mpPointsTableWidget->editItem(pTableWidgetItem);
       return false;
     }
@@ -772,14 +798,14 @@ bool ShapePropertiesDialog::applyShapeProperties()
   if (mpBitmapAnnotation) {
     if (mpStoreImageInModelCheckBox->isChecked() && mpShapeAnnotation->getImageSource().isEmpty()) {
       if (mpFileTextBox->text().isEmpty()) {
-        QMessageBox::critical(MainWindow::instance(), QString(Helper::applicationName).append(" - ").append(Helper::error),
+        QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
                               GUIMessages::getMessage(GUIMessages::ENTER_NAME).arg(Helper::fileLabel), Helper::ok);
         mpFileTextBox->setFocus();
         return false;
       }
     } else if (!mpStoreImageInModelCheckBox->isChecked()) {
       if (mpFileTextBox->text().isEmpty()) {
-        QMessageBox::critical(MainWindow::instance(), QString(Helper::applicationName).append(" - ").append(Helper::error),
+        QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
                               GUIMessages::getMessage(GUIMessages::ENTER_NAME).arg(Helper::fileLabel), Helper::ok);
         mpFileTextBox->setFocus();
         return false;
@@ -806,7 +832,7 @@ bool ShapePropertiesDialog::applyShapeProperties()
     mpShapeAnnotation->setClosure(StringHandler::getClosureType(mpClosureComboBox->currentText()));
   }
   if (mpTextAnnotation) {
-    mpShapeAnnotation->setTextString(StringHandler::escapeString(mpTextTextBox->text().trimmed()));
+    mpShapeAnnotation->setTextString(StringHandler::escapeString(mpTextTextBox->toPlainText().trimmed()));
     if (mpFontNameComboBox->currentText().compare("Default") != 0) {
       mpShapeAnnotation->setFontName(mpFontNameComboBox->currentText());
     }
@@ -907,12 +933,10 @@ bool ShapePropertiesDialog::applyShapeProperties()
   } else if (mpLineAnnotation && lineType == LineAnnotation::TransitionType) {
     // create a UpdateTransitionCommand object and push it to the undo stack.
     UpdateTransitionCommand *pUpdateTransitionCommand;
-    pUpdateTransitionCommand = new UpdateTransitionCommand(mpLineAnnotation, mpLineAnnotation->getCondition(), mpLineAnnotation->getImmediate(),
-                                                           mpLineAnnotation->getReset(), mpLineAnnotation->getSynchronize(),
-                                                           mpLineAnnotation->getPriority(), mOldAnnotation, mpLineAnnotation->getCondition(),
-                                                           mpLineAnnotation->getImmediate(), mpLineAnnotation->getReset(),
-                                                           mpLineAnnotation->getSynchronize(), mpLineAnnotation->getPriority(),
-                                                           mpShapeAnnotation->getOMCShapeAnnotation());
+    pUpdateTransitionCommand = new UpdateTransitionCommand(mpLineAnnotation, mpLineAnnotation->getCondition(), mpLineAnnotation->getImmediate(), mpLineAnnotation->getReset(),
+                                                           mpLineAnnotation->getSynchronize(), mpLineAnnotation->getPriority(), mOldAnnotation, mpLineAnnotation->getCondition(),
+                                                           mpLineAnnotation->getImmediate(), mpLineAnnotation->getReset(), mpLineAnnotation->getSynchronize(),
+                                                           mpLineAnnotation->getPriority(), mpShapeAnnotation->getOMCShapeAnnotation());
     mpShapeAnnotation->getGraphicsView()->getModelWidget()->getUndoStack()->push(pUpdateTransitionCommand);
     mpShapeAnnotation->getGraphicsView()->getModelWidget()->updateModelText();
   } else if (mpLineAnnotation && lineType == LineAnnotation::InitialStateType) {
@@ -934,8 +958,7 @@ bool ShapePropertiesDialog::applyShapeProperties()
 
 void ShapePropertiesDialog::browseImageFile()
 {
-  QString imageFileName = StringHandler::getOpenFileName(this, QString(Helper::applicationName).append(" - ").append(Helper::chooseFile),
-                                                         NULL, Helper::bitmapFileTypes, NULL);
+  QString imageFileName = StringHandler::getOpenFileName(this, QString("%1 - %2").arg(Helper::applicationName, Helper::chooseFile), NULL, Helper::bitmapFileTypes, NULL);
   if (imageFileName.isEmpty()) {
     return;
   }
@@ -954,9 +977,7 @@ void ShapePropertiesDialog::storeImageInModelToggled(bool checked)
     MainWindow *pMainWindow = MainWindow::instance();
     if (!mpBitmapAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->isFilePathValid()) {
       if (OptionsDialog::instance()->getNotificationsPage()->getSaveModelForBitmapInsertionCheckBox()->isChecked()) {
-        NotificationsDialog *pNotificationsDialog = new NotificationsDialog(NotificationsDialog::SaveModelForBitmapInsertion,
-                                                                            NotificationsDialog::InformationIcon,
-                                                                            pMainWindow);
+        NotificationsDialog *pNotificationsDialog = new NotificationsDialog(NotificationsDialog::SaveModelForBitmapInsertion, NotificationsDialog::InformationIcon, pMainWindow);
         pNotificationsDialog->exec();
       }
       mpStoreImageInModelCheckBox->blockSignals(true);

--- a/OMEdit/OMEditLIB/Annotations/ShapePropertiesDialog.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapePropertiesDialog.h
@@ -46,6 +46,7 @@
 #include <QTableWidget>
 #include <QDialogButtonBox>
 #include <QToolButton>
+#include <QPlainTextEdit>
 
 class ShapeAnnotation;
 class LineAnnotation;
@@ -66,6 +67,7 @@ public:
   void setLineColor(QColor color);
   QColor getLineColor();
   void setLinePickColorButtonIcon();
+  void setTextPickColorButtonIcon();
   void setFillColor(QColor color);
   QColor getFillColor();
   void setFillPickColorButtonIcon();
@@ -109,7 +111,7 @@ private:
   Label *mpClosureLabel;
   QComboBox *mpClosureComboBox;
   QGroupBox *mpTextGroupBox;
-  QLineEdit *mpTextTextBox;
+  QPlainTextEdit *mpTextTextBox;
   QGroupBox *mpFontAndTextStyleGroupBox;
   Label *mpFontNameLabel;
   QFontComboBox *mpFontNameComboBox;
@@ -121,6 +123,8 @@ private:
   QCheckBox *mpTextUnderlineCheckBox;
   Label *mpTextHorizontalAlignmentLabel;
   QComboBox *mpTextHorizontalAlignmentComboBox;
+  QGroupBox *mpTextColorGroupBox;
+  QPushButton *mpTextPickColorButton;
   QGroupBox *mpLineStyleGroupBox;
   Label *mpLineColorLabel;
   QPushButton *mpLinePickColorButton;
@@ -163,6 +167,7 @@ private:
   QPushButton *mpApplyButton;
   QDialogButtonBox *mpButtonBox;
 public slots:
+  void textPickColor();
   void linePickColor();
   void fillPickColor();
   void movePointUp();

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -432,7 +432,7 @@ QString TextAnnotation::getShapeAnnotation()
 {
   QStringList annotationString;
   annotationString.append(GraphicItem::getShapeAnnotation());
-  annotationString.append(FilledShape::getShapeAnnotation());
+  annotationString.append(FilledShape::getTextShapeAnnotation());
   // get the extents
   if (mExtents.size() > 1) {
     QString extentString;


### PR DESCRIPTION
### Related Issues

Fixes #8245

### Purpose

Use textColor instead of lineColor.

### Approach

Avoid using the depreciated FilledShape for text annotation.
