### PR TITLE
Fix class redeclaration issue

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -822,7 +822,7 @@ algorithm
         // Redeclare classes with redeclare modifiers. Redeclared components could
         // also be handled here, but since each component is only instantiated once
         // it's more efficient to apply the redeclare when instantiating them instead.
-        redeclareClasses(cls_tree, node);
+        redeclareClasses(cls_tree, par);
 
         // Instantiate the extends nodes.
         ClassTree.mapExtends(cls_tree,

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -847,6 +847,7 @@ RecursiveInst1.mo \
 RecursiveInst2.mo \
 RecursiveInst3.mo \
 RedeclareClass1.mo \
+RedeclareClass2.mo \
 RedeclareClassComponent.mo \
 RedeclareComponentClass.mo \
 RedeclareDim1.mo \

--- a/testsuite/flattening/modelica/scodeinst/RedeclareClass2.mo
+++ b/testsuite/flattening/modelica/scodeinst/RedeclareClass2.mo
@@ -1,0 +1,43 @@
+// name: RedeclareClass2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model LosslessPipe
+  extends PartialTwoPortInterface;
+end LosslessPipe;
+
+partial model PartialTwoPortInterface
+  parameter Real m_flow_nominal;
+end PartialTwoPortInterface;
+
+partial model PartialConnection2Pipe
+  replaceable model Model_pipCon = PartialTwoPortInterface(final m_flow_nominal = mCon_flow_nominal);
+  parameter Real mCon_flow_nominal;
+  Model_pipCon pipCon;
+end PartialConnection2Pipe;
+
+model Connection2PipeLossless
+  extends PartialConnection2Pipe(redeclare model Model_pipCon = LosslessPipe);
+end Connection2PipeLossless;
+
+partial model PartialDistribution2Pipe
+  parameter Integer nCon = 1;
+  parameter Real[nCon] mCon_flow_nominal;
+  replaceable PartialConnection2Pipe[nCon] con(final mCon_flow_nominal = mCon_flow_nominal);
+end PartialDistribution2Pipe;
+
+model RedeclareClass2
+  extends PartialDistribution2Pipe(redeclare Connection2PipeLossless[nCon] con);
+end RedeclareClass2;
+
+
+// Result:
+// class RedeclareClass2
+//   final parameter Integer nCon = 1;
+//   parameter Real mCon_flow_nominal[1];
+//   final parameter Real con[1].mCon_flow_nominal = mCon_flow_nominal[1];
+//   final parameter Real con[1].pipCon.m_flow_nominal = con[1].mCon_flow_nominal;
+// end RedeclareClass2;
+// endResult


### PR DESCRIPTION
- Use the component parent of a class when redeclaring classes in it
  rather than the class itself, to ensure references in it are prefixed
  with the component and not the class name.