### PR TITLE
Don't treat Clock as a reserved name

### DIFF
--- a/OMCompiler/Compiler/FFrontEnd/FBuiltin.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FBuiltin.mo
@@ -309,7 +309,7 @@ protected constant SCode.Element objectiveVarComp =
             SCode.noComment, NONE(), AbsynUtil.dummyInfo);
 
 protected constant list<SCode.Element> basicTypes = {clockType, rlType, intType, strType, boolType, enumType, ExternalObjectType, realType, integerType, stringType, booleanType, uncertaintyType};
-protected constant list<SCode.Element> basicTypesNF = {clockType, rlType, intType, strType, boolType, enumType, realType, integerType, stringType, booleanType};
+protected constant list<SCode.Element> basicTypesNF = {rlType, intType, strType, boolType, enumType, realType, integerType, stringType, booleanType};
 
 public function getBasicTypes
   output list<SCode.Element> tys;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -386,7 +386,19 @@ constant InstNode CLOCK_NODE = InstNode.CLASS_NODE("Clock",
   Pointer.createImmutable(
     Class.PARTIAL_BUILTIN(Type.CLOCK(), CLOCK_CLASS_TREE, Modifier.NOMOD(),
       NFClass.DEFAULT_PREFIXES, Restriction.CLOCK())),
-  EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
+  listArrayLiteral({
+    NFInstNode.CachedData.FUNCTION({
+        NFBuiltinFuncs.CLOCK_INFERED,
+        NFBuiltinFuncs.CLOCK_INT,
+        NFBuiltinFuncs.CLOCK_REAL,
+        NFBuiltinFuncs.CLOCK_BOOL,
+        NFBuiltinFuncs.CLOCK_SOLVER
+        },
+      true, true),
+    NFInstNode.CachedData.NO_CACHE(),
+    NFInstNode.CachedData.NO_CACHE()}
+  ),
+  InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 
 constant ComponentRef CLOCK_CREF =
   ComponentRef.CREF(CLOCK_NODE, {}, Type.CLOCK(), Origin.CREF, ComponentRef.EMPTY());

--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -1404,6 +1404,19 @@ public
       end for;
     end appendClasses2;
 
+    function replaceClass
+      "Replaces the node for a class with another node. Assumes the class
+       already exists in the tree, and that the tree isn't instantiated."
+      input InstNode node;
+      input output ClassTree tree;
+    protected
+      Integer index;
+    algorithm
+      LookupTree.Entry.CLASS(index = index) :=
+        LookupTree.get(lookupTree(tree), InstNode.name(node));
+      arrayUpdate(getClasses(tree), index, node);
+    end replaceClass;
+
   protected
 
     function instExtendsComps

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -261,8 +261,13 @@ algorithm
   // should have this annotation anyway.
   elems := Class.classTree(cls);
   ClassTree.mapClasses(elems, markBuiltinTypeNodes);
-  cls := Class.setClassTree(elems, cls);
 
+  // ModelicaBuiltin has a dummy declaration of Clock to make sure no one can
+  // declare another Clock class in the top scope, here we replace it with the
+  // actual Clock node (which can't be defined in regular Modelica).
+  ClassTree.replaceClass(NFBuiltin.CLOCK_NODE, elems);
+
+  cls := Class.setClassTree(elems, cls);
   topNode := InstNode.updateClass(cls, topNode);
 end makeTopNode;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1749,6 +1749,17 @@ uniontype InstNode
       else 0;
     end match;
   end dimensionCount;
+
+  function isClockType
+    input InstNode node;
+    output Boolean clock;
+  algorithm
+    clock := match node
+      case CLASS_NODE(name = "Clock", nodeType = InstNodeType.BUILTIN_CLASS()) then true;
+      else false;
+    end match;
+  end isClockType;
+
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -57,7 +57,6 @@ import NFInstNode.CachedData;
 import Component = NFComponent;
 import Subscript = NFSubscript;
 import ComplexType = NFComplexType;
-import Config;
 import Error;
 import ErrorExt;
 import UnorderedMap;
@@ -697,7 +696,6 @@ algorithm
     case "Integer" then NFBuiltin.INTEGER_NODE;
     case "Boolean" then NFBuiltin.BOOLEAN_NODE;
     case "String" then NFBuiltin.STRING_NODE;
-    case "Clock" then NFBuiltin.CLOCK_NODE;
     case "polymorphic" then NFBuiltin.POLYMORPHIC_NODE;
   end match;
 end lookupSimpleBuiltinName;
@@ -709,7 +707,6 @@ function lookupSimpleBuiltinCref
   output ComponentRef cref;
   output LookupState state;
 algorithm
-
   (node, cref, state) := match name
     case "time"
       then (NFBuiltin.TIME, NFBuiltin.TIME_CREF, LookupState.PREDEF_COMP());
@@ -719,8 +716,6 @@ algorithm
       then (NFBuiltinFuncs.INTEGER_NODE, NFBuiltinFuncs.INTEGER_CREF, LookupState.FUNC());
     case "String"
       then (NFBuiltinFuncs.STRING_NODE, NFBuiltinFuncs.STRING_CREF, LookupState.FUNC());
-    case "Clock" guard Config.synchronousFeaturesAllowed()
-      then (NFBuiltinFuncs.CLOCK_NODE, NFBuiltinFuncs.CLOCK_CREF, LookupState.FUNC());
   end match;
 
   if not listEmpty(subs) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
@@ -154,7 +154,7 @@ uniontype LookupState
   protected
     SCode.Element def = InstNode.definition(node);
   algorithm
-    callable := SCodeUtil.isRecord(def) or SCodeUtil.isOperator(def);
+    callable := SCodeUtil.isRecord(def) or SCodeUtil.isOperator(def) or InstNode.isClockType(node);
   end isCallableType;
 
   function isCallableComponent

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -43,6 +43,10 @@ type Uncertainty = enumeration(
   refine
 ) annotation(__OpenModelica_builtin = true);
 
+partial class Clock
+  annotation(__OpenModelica_builtin=true);
+end Clock;
+
 partial class ExternalObject
   annotation(__OpenModelica_builtin=true);
 end ExternalObject;

--- a/testsuite/flattening/modelica/scodeinst/Clock1.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock1.mo
@@ -1,0 +1,19 @@
+// name: Clock1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model Clock1
+  model Clock
+    Real t;
+  end Clock;
+
+  Clock c;
+end Clock1;
+
+// Result:
+// class Clock1
+//   Real c.t;
+// end Clock1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Clock2.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock2.mo
@@ -1,0 +1,24 @@
+// name: Clock2
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model Clock
+  Real t;
+end Clock;
+
+model Clock2
+  Clock c;
+end Clock2;
+
+// Result:
+// Error processing file: Clock2.mo
+// [lib/omc/NFModelicaBuiltin.mo:46:1-48:10:writable] Notification: From here:
+// [flattening/modelica/scodeinst/Clock2.mo:7:1-9:10:writable] Error: An element with name Clock is already declared in this scope.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Clock3.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock3.mo
@@ -1,0 +1,23 @@
+// name: Clock3
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model Clock3
+  model Clock
+    Real t;
+  end Clock;
+
+  Clock c = Clock();
+end Clock3;
+
+// Result:
+// Error processing file: Clock3.mo
+// [flattening/modelica/scodeinst/Clock3.mo:12:3-12:20:writable] Error: Expected Clock to be a function, but found class instead.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Clock4.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock4.mo
@@ -1,0 +1,19 @@
+// name: Clock4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model Clock4
+  model Clock
+    Real t;
+  end Clock;
+
+  .Clock c = .Clock();
+end Clock4;
+
+// Result:
+// class Clock4
+//   Clock c = Clock();
+// end Clock4;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Clock5.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock5.mo
@@ -1,0 +1,19 @@
+// name: Clock5
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model Clock5
+  record Clock
+    Real t;
+  end Clock;
+
+  Clock c = Clock(1);
+end Clock5;
+
+// Result:
+// class Clock5
+//   Real c.t = 1.0;
+// end Clock5;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Clock6.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock6.mo
@@ -1,0 +1,25 @@
+// name: Clock6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+package P
+  record Clock
+    Real t;
+  end Clock;
+end P;
+
+model Clock6
+  P.Clock Clock = P.Clock(1);
+equation
+  Clock.t = der(time);
+end Clock6;
+
+// Result:
+// class Clock6
+//   Real Clock.t = 1.0;
+// equation
+//   Clock.t = der(time);
+// end Clock6;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -224,6 +224,12 @@ ClassMod3.mo \
 ClassMod4.mo \
 ClassMod5.mo \
 ClassMod6.mo \
+Clock1.mo \
+Clock2.mo \
+Clock3.mo \
+Clock4.mo \
+Clock5.mo \
+Clock6.mo \
 ClockConstructor1.mo \
 CombineSubscripts1.mo \
 CombineSubscripts2.mo \


### PR DESCRIPTION
- Remove Clock from the lookup of predefined types, and instead add it
  to the top scope since it shouldn't be treated as a reserved name.

Fixes #3273