### PR TITLE
ParModelica fixes for the new frontend

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3243,7 +3243,16 @@ algorithm
         next_origin := InstContext.set(context, NFInstContext.FOR);
         stmtl := instStatements(scodeStmt.forBody, for_scope, next_origin);
       then
-        Statement.FOR(iter, oexp, stmtl, makeSource(scodeStmt.comment, info));
+        Statement.FOR(iter, oexp, stmtl, Statement.ForType.NORMAL(), makeSource(scodeStmt.comment, info));
+
+    case SCode.Statement.ALG_PARFOR(info = info)
+      algorithm
+        oexp := instExpOpt(scodeStmt.range, scope, context, info);
+        (for_scope, iter) := addIteratorToScope(scodeStmt.index, scope, info);
+        next_origin := InstContext.set(context, NFInstContext.FOR);
+        stmtl := instStatements(scodeStmt.parforBody, for_scope, next_origin);
+      then
+        Statement.FOR(iter, oexp, stmtl, Statement.ForType.PARALLEL({}), makeSource(scodeStmt.comment, info));
 
     case SCode.Statement.ALG_IF(info = info)
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -360,7 +360,7 @@ function scalarizeStatement
 algorithm
   statements := match stmt
     case Statement.FOR()
-      then Statement.FOR(stmt.iterator, stmt.range, scalarizeStatements(stmt.body), stmt.source) :: statements;
+      then Statement.FOR(stmt.iterator, stmt.range, scalarizeStatements(stmt.body), stmt.forType, stmt.source) :: statements;
 
     case Statement.IF()
       then scalarizeIfStatement(stmt.branches, stmt.source, statements);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -3107,7 +3107,7 @@ algorithm
         next_context := InstContext.set(context, NFInstContext.FOR);
         body := typeStatements(st.body, next_context);
       then
-        Statement.FOR(st.iterator, SOME(e1), body, st.source);
+        Statement.FOR(st.iterator, SOME(e1), body, st.forType, st.source);
 
     case Statement.IF()
       algorithm

--- a/OMCompiler/Compiler/Template/DAEDumpTV.mo
+++ b/OMCompiler/Compiler/Template/DAEDumpTV.mo
@@ -527,6 +527,14 @@ package DAE
       ElementSource source;
     end STMT_FOR;
 
+    record STMT_PARFOR
+      Boolean iterIsArray;
+      Ident iter;
+      Exp range;
+      list<Statement> statementLst;
+      ElementSource source;
+    end STMT_PARFOR;
+
     record STMT_WHILE
       Exp exp;
       list<Statement> statementLst;

--- a/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
@@ -866,6 +866,7 @@ match stmt
   case STMT_ASSIGN_ARR(__)   then dumpArrayAssignStatement(stmt)
   case STMT_IF(__) then dumpIfStatement(stmt)
   case STMT_FOR(__) then dumpForStatement(stmt)
+  case STMT_PARFOR(__) then dumpParForStatement(stmt)
   case STMT_WHILE(__) then dumpWhileStatement(stmt)
   case STMT_WHEN(__) then dumpWhenStatement(stmt)
   case STMT_ASSERT(__) then dumpAssert(cond, msg, level, source)
@@ -963,6 +964,20 @@ match stmt
     end for<%src_str%>;
     >>
 end dumpForStatement;
+
+template dumpParForStatement(DAE.Statement stmt)
+::=
+match stmt
+  case STMT_PARFOR(__) then
+    let range_str = dumpExp(range)
+    let alg_str = (statementLst |> e => dumpStatement(e) ;separator="\n")
+    let src_str = dumpSource(source)
+    <<
+    parfor <%iter%> in <%range_str%> loop
+      <%alg_str%>
+    end for<%src_str%>;
+    >>
+end dumpParForStatement;
 
 template dumpWhileStatement(DAE.Statement stmt)
 ::=

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/ParModelicaBuiltin.mo
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/ParModelicaBuiltin.mo
@@ -38,91 +38,91 @@
 
 // package ParModelica
 
-parallel function oclGetWorkDim
+impure parallel function oclGetWorkDim
   output Integer dim;
   external "builtin";
 end oclGetWorkDim;
 
-parallel function oclGetGlobalSize
+impure parallel function oclGetGlobalSize
   input Integer dim;
   output Integer size;
   external "builtin";
 end oclGetGlobalSize;
 
-parallel function oclGetGlobalId
+impure parallel function oclGetGlobalId
   input Integer dim;
   output Integer id;
   external "builtin";
 end oclGetGlobalId;
 
-parallel function oclGetLocalSize
+impure parallel function oclGetLocalSize
   input Integer dim;
   output Integer size;
   external "builtin";
 end oclGetLocalSize;
 
-parallel function oclGetLocalId
+impure parallel function oclGetLocalId
   input Integer dim;
   output Integer id;
   external "builtin";
 end oclGetLocalId;
 
-parallel function oclGetNumGroups
+impure parallel function oclGetNumGroups
   input Integer dim;
   output Integer num;
   external "builtin";
 end oclGetNumGroups;
 
-parallel function oclGetGroupId
+impure parallel function oclGetGroupId
   input Integer dim;
   output Integer id;
   external "builtin";
 end oclGetGroupId;
 
-parallel function oclGlobalBarrier
+impure parallel function oclGlobalBarrier
   external "builtin";
 end oclGlobalBarrier;
 
-parallel function oclLocalBarrier
+impure parallel function oclLocalBarrier
   external "builtin";
 end oclLocalBarrier;
 
-function oclSetNumThreadsOnlyGlobal
+impure function oclSetNumThreadsOnlyGlobal
   input Integer num_threads;
   external "builtin";
 end oclSetNumThreadsOnlyGlobal;
 
-function oclSetNumThreadsGlobalLocal
+impure function oclSetNumThreadsGlobalLocal
   input Integer global_num_threads;
   input Integer local_num_threads;
   external "builtin";
 end oclSetNumThreadsGlobalLocal;
 
-function oclSetNumThreadsGlobalLocal1D
+impure function oclSetNumThreadsGlobalLocal1D
   input Integer[1] global_num_threads;
   input Integer[1] local_num_threads;
   external "builtin";
 end oclSetNumThreadsGlobalLocal1D;
 
-function oclSetNumThreadsGlobalLocal2D
+impure function oclSetNumThreadsGlobalLocal2D
   input Integer[2] global_num_threads;
   input Integer[2] local_num_threads;
   external "builtin";
 end oclSetNumThreadsGlobalLocal2D;
 
-function oclSetNumThreadsGlobalLocal3D
+impure function oclSetNumThreadsGlobalLocal3D
   input Integer[3] global_num_threads;
   input Integer[3] local_num_threads;
   external "builtin";
 end oclSetNumThreadsGlobalLocal3D;
 
-function oclSetNumThreadsGlobalLocalError
+impure function oclSetNumThreadsGlobalLocalError
   input Integer[:] global_num_threads;
   input Integer[:] local_num_threads;
   external "builtin";
 end oclSetNumThreadsGlobalLocalError;
 
-function oclSetNumThreads = $overload(
+impure function oclSetNumThreads = $overload(
   oclSetNumThreadsOnlyGlobal,
   oclSetNumThreadsGlobalLocal,
   oclSetNumThreadsGlobalLocal1D,
@@ -135,14 +135,14 @@ function oclSetNumThreads = $overload(
 
 encapsulated package OpenCL
 
-  function matrixMult
+  impure function matrixMult
     parglobal input Integer A[:,:];
     parglobal input Integer B[:,:];
     parglobal output Integer C[:,:];
     external "builtin";
   end matrixMult;
 
-  function matrixTranspose
+  impure function matrixTranspose
     parglobal input Integer A[:,:];
     parglobal output Integer B[:,:];
     external "builtin";


### PR DESCRIPTION
- Handle parfor statements.
- Add dumping of parfor statements in DAEDumpTpl.
- Declare builtin ParModelica functions as impure so the NF doesn't try
  to evaluate them.