### PR TITLE
Fix Clock for the old frontend

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -251,7 +251,7 @@ algorithm
   topNode := InstNode.newClass(cls_elem, InstNode.EMPTY_NODE(), node_ty);
 
   // Create a new class from the elements, and update the inst node with it.
-  cls := Class.fromSCode(topClasses, false, topNode, NFClass.DEFAULT_PREFIXES);
+  cls := Class.fromSCode(NFBuiltin.Elements.CLOCK :: topClasses, false, topNode, NFClass.DEFAULT_PREFIXES);
   // The class needs to be expanded to allow lookup in it. The top scope will
   // only contain classes, so we can do this instead of the whole expandClass.
   cls := Class.initExpandedClass(cls);

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -43,9 +43,9 @@ type Uncertainty = enumeration(
   refine
 ) annotation(__OpenModelica_builtin = true);
 
-partial class Clock
-  annotation(__OpenModelica_builtin=true);
-end Clock;
+//partial class Clock
+//  annotation(__OpenModelica_builtin=true);
+//end Clock;
 
 partial class ExternalObject
   annotation(__OpenModelica_builtin=true);

--- a/testsuite/flattening/modelica/scodeinst/Clock2.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock2.mo
@@ -14,7 +14,7 @@ end Clock2;
 
 // Result:
 // Error processing file: Clock2.mo
-// [lib/omc/NFModelicaBuiltin.mo:46:1-48:10:writable] Notification: From here:
+// Notification: From here:
 // [flattening/modelica/scodeinst/Clock2.mo:7:1-9:10:writable] Error: An element with name Clock is already declared in this scope.
 //
 // # Error encountered! Exiting...


### PR DESCRIPTION
- Disable the dummy declaration for Clock in NFModelicaBuiltin and add
  it when building the top scope instead, since the old frontend
  incorrectly uses NFModelicaBuiltin in some cases.