### PR TITLE
Fix initial environment when changing frontend

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Builtin.mo
+++ b/OMCompiler/Compiler/FrontEnd/Builtin.mo
@@ -218,5 +218,10 @@ algorithm
   end matchcontinue;
 end getSetInitialGraph;
 
+public function clearInitialGraph
+algorithm
+  setGlobalRoot(Global.builtinGraphIndex, {});
+end clearInitialGraph;
+
 annotation(__OpenModelica_Interface="frontend");
 end Builtin;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -251,7 +251,7 @@ algorithm
   topNode := InstNode.newClass(cls_elem, InstNode.EMPTY_NODE(), node_ty);
 
   // Create a new class from the elements, and update the inst node with it.
-  cls := Class.fromSCode(NFBuiltin.Elements.CLOCK :: topClasses, false, topNode, NFClass.DEFAULT_PREFIXES);
+  cls := Class.fromSCode(topClasses, false, topNode, NFClass.DEFAULT_PREFIXES);
   // The class needs to be expanded to allow lookup in it. The top scope will
   // only contain classes, so we can do this instead of the whole expandClass.
   cls := Class.initExpandedClass(cls);

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -43,9 +43,9 @@ type Uncertainty = enumeration(
   refine
 ) annotation(__OpenModelica_builtin = true);
 
-//partial class Clock
-//  annotation(__OpenModelica_builtin=true);
-//end Clock;
+partial class Clock
+  annotation(__OpenModelica_builtin=true);
+end Clock;
 
 partial class ExternalObject
   annotation(__OpenModelica_builtin=true);

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -65,6 +65,7 @@ import Values;
 protected
 import Autoconf;
 import BaseHashSet;
+import Builtin;
 import CevalFunction;
 import CevalScriptBackend;
 import ClassInf;
@@ -868,9 +869,14 @@ algorithm
 
     case ("setCommandLineOptions",{Values.STRING(str)})
       algorithm
+        b := Flags.isSet(Flags.SCODE_INST);
         strs := System.strtok(str, " ");
         {} := FlagsUtil.readArgs(strs);
         outCache := FCore.emptyCache();
+
+        if b <> Flags.isSet(Flags.SCODE_INST) then
+          Builtin.clearInitialGraph();
+        end if;
       then
         Values.BOOL(true);
 
@@ -895,7 +901,11 @@ algorithm
 
     case ("enableNewInstantiation",_)
       algorithm
-        FlagsUtil.enableDebug(Flags.SCODE_INST);
+        if not Flags.isSet(Flags.SCODE_INST) then
+          Builtin.clearInitialGraph();
+          FlagsUtil.enableDebug(Flags.SCODE_INST);
+          outCache := FCore.emptyCache();
+        end if;
       then
         Values.BOOL(true);
 
@@ -904,7 +914,11 @@ algorithm
 
     case ("disableNewInstantiation",_)
       algorithm
-        FlagsUtil.disableDebug(Flags.SCODE_INST);
+        if Flags.isSet(Flags.SCODE_INST) then
+          FlagsUtil.disableDebug(Flags.SCODE_INST);
+          outCache := FCore.emptyCache();
+          Builtin.clearInitialGraph();
+        end if;
       then
         Values.BOOL(true);
 

--- a/testsuite/flattening/modelica/scodeinst/Clock2.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock2.mo
@@ -14,7 +14,7 @@ end Clock2;
 
 // Result:
 // Error processing file: Clock2.mo
-// Notification: From here:
+// [lib/omc/NFModelicaBuiltin.mo:46:1-48:10:writable] Notification: From here:
 // [flattening/modelica/scodeinst/Clock2.mo:7:1-9:10:writable] Error: An element with name Clock is already declared in this scope.
 //
 // # Error encountered! Exiting...


### PR DESCRIPTION
- Clear the cached initial environment when changing frontend via the
  scripting API to make sure the correct one is used.
- Revert #8261.