### PR TITLE
Add CMake support libs-for-testing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ omc_add_subdirectory(OMNotebook EXCLUDE_FROM_ALL)
 
 include(omsimulator.cmake)
 omc_add_subdirectory(OMEdit EXCLUDE_FROM_ALL)
+omc_add_subdirectory(testsuite EXCLUDE_FROM_ALL)
 # omc_add_subdirectory(libraries)
 
 

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -273,6 +273,6 @@ install(DIRECTORY scripts
 # or 'cmake --build <b_dir> --target install_omc' in the general case.
 add_custom_target(install_omc
                   DEPENDS omc
-                  COMMAND ${CMAKE_COMMAND} cmake -DCOMPONENT=compiler -P cmake_install.cmake
+                  COMMAND ${CMAKE_COMMAND} -DCOMPONENT=compiler -P cmake_install.cmake
                   COMMENT "Installing omc."
                   )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -1,1 +1,2 @@
-ADD_SUBDIRECTORY(mofiles)
+
+omc_add_subdirectory(libraries-for-testing)

--- a/testsuite/libraries-for-testing/CMakeLists.txt
+++ b/testsuite/libraries-for-testing/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+
+set(STAMP 20200610130629.stamp)
+
+# Note that omc needs to be built and INSTALLED before you can add the libs for testing.
+# The reason being omc needs to be ina folder **/bin to work. Otherwise it will refuse to run
+# Plus it needs to know where find the shared libs it needs. That is structured to work for install.
+add_custom_target(libs-for-testing
+            COMMAND ${CMAKE_COMMAND} -E remove_directory .openmodelica/libraries
+            COMMAND ${CMAKE_COMMAND} -E make_directory .openmodelica/libraries
+            COMMAND ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/omc -d=showStatement index.mos
+
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )


### PR DESCRIPTION
  - Note that, since the package manager depends on `omc` itself, you would
    have to build and INSTALL `omc` before you can install the libraries.
