### PR TITLE
Fix typing of already typed binary expressions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -170,6 +170,23 @@ algorithm
       case Op.MUL_EW then checkBinaryOperationEW(exp1, type1, exp2, type2, Op.MUL, info);
       case Op.DIV_EW then checkBinaryOperationDiv(exp1, type1, exp2, type2, info, isElementWise = true);
       case Op.POW_EW then checkBinaryOperationPowEW(exp1, type1, exp2, type2, info);
+      // These operators should not occur in untyped expressions, but sometimes
+      // we want to retype already typed expressions due to changes in them.
+      case Op.ADD_SCALAR_ARRAY then checkBinaryOperationAdd(exp1, type1, exp2, type2, info);
+      case Op.ADD_ARRAY_SCALAR then checkBinaryOperationAdd(exp1, type1, exp2, type2, info);
+      case Op.SUB_SCALAR_ARRAY then checkBinaryOperationSub(exp1, type1, exp2, type2, info);
+      case Op.SUB_ARRAY_SCALAR then checkBinaryOperationSub(exp1, type1, exp2, type2, info);
+      case Op.MUL_SCALAR_ARRAY  then checkBinaryOperationMul(exp1, type1, exp2, type2, info);
+      case Op.MUL_ARRAY_SCALAR  then checkBinaryOperationMul(exp1, type1, exp2, type2, info);
+      case Op.MUL_VECTOR_MATRIX then checkBinaryOperationMul(exp1, type1, exp2, type2, info);
+      case Op.MUL_MATRIX_VECTOR then checkBinaryOperationMul(exp1, type1, exp2, type2, info);
+      case Op.SCALAR_PRODUCT    then checkBinaryOperationMul(exp1, type1, exp2, type2, info);
+      case Op.MATRIX_PRODUCT    then checkBinaryOperationMul(exp1, type1, exp2, type2, info);
+      case Op.DIV_SCALAR_ARRAY  then checkBinaryOperationDiv(exp1, type1, exp2, type2, info, isElementWise = false);
+      case Op.DIV_ARRAY_SCALAR  then checkBinaryOperationDiv(exp1, type1, exp2, type2, info, isElementWise = false);
+      case Op.POW_SCALAR_ARRAY  then checkBinaryOperationPowEW(exp1, type1, exp2, type2, info);
+      case Op.POW_ARRAY_SCALAR  then checkBinaryOperationPowEW(exp1, type1, exp2, type2, info);
+      case Op.POW_MATRIX        then checkBinaryOperationPow(exp1, type1, exp2, type2, info);
     end match;
   end if;
 end checkBinaryOperation;
@@ -1125,7 +1142,7 @@ protected
   Operator op;
 algorithm
   // Exponentiation always returns a Real value, so instead of checking if the types
-  // are compatible with ecah other we check if each type is compatible with Real.
+  // are compatible with each other we check if each type is compatible with Real.
   (e1, ty1, mk) := matchTypes(type1, Type.setArrayElementType(type1, Type.REAL()), exp1, true);
   valid := isCompatibleMatch(mk);
   (e2, ty2, mk) := matchTypes(type2, Type.setArrayElementType(type2, Type.REAL()), exp2, true);

--- a/testsuite/flattening/modelica/scodeinst/IfExpression12.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfExpression12.mo
@@ -1,0 +1,20 @@
+// name: IfExpression12
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model IfExpression12
+  parameter Integer n = 3;
+  Real x[:] = if n == 1 then {1} else 2 .* fill(n, 2);
+end IfExpression12;
+
+// Result:
+// class IfExpression12
+//   parameter Integer n = 3;
+//   Real x[1];
+//   Real x[2];
+// equation
+//   x = {6, 6};
+// end IfExpression12;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -647,6 +647,7 @@ IfExpression7.mo \
 IfExpression8.mo \
 IfExpression10.mo \
 IfExpression11.mo \
+IfExpression12.mo \
 IfEquationInvalidCond1.mo \
 ih1.mo \
 ih2.mo \


### PR DESCRIPTION
- Handle all operators when type checking binary expressions, even those
  that only occur in already typed expressions. This is needed since we
  might sometimes need to retype an expression when evaluating array
  dimensions.