### PR TITLE
Add support for omc-diff and reference files.

### DIFF
--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -214,7 +214,7 @@ if (QWT_WITH_WIDGETS)
     qwt_wheel.cpp)
 endif ()
 
-add_library(qwt ${QWT_HEADERS} ${QWT_SOURCES})
+add_library(qwt SHARED ${QWT_HEADERS} ${QWT_SOURCES})
 
 target_compile_definitions(qwt
 	PUBLIC

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -1,2 +1,5 @@
 
+
+omc_add_subdirectory(difftool)
+omc_add_subdirectory(ReferenceFiles)
 omc_add_subdirectory(libraries-for-testing)

--- a/testsuite/ReferenceFiles/CMakeLists.txt
+++ b/testsuite/ReferenceFiles/CMakeLists.txt
@@ -1,0 +1,26 @@
+
+
+file(GLOB_RECURSE COMPRESSED_REF_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.mat.xz)
+
+foreach(compressed_file_path ${COMPRESSED_REF_FILES})
+  get_filename_component(compressed_file_dir ${compressed_file_path} DIRECTORY)
+  # Remove only the last extension. The file names have a lot of dots.
+  get_filename_component(compressed_file_name_no_xz_ext ${compressed_file_path} NAME_WLE)
+  set(output_file_path ${compressed_file_dir}/${compressed_file_name_no_xz_ext})
+
+  add_custom_command(
+    DEPENDS ${compressed_file_path}
+    COMMAND xz --keep --decompress --force ${compressed_file_path}
+    OUTPUT ${output_file_path}
+    COMMENT "Extracting: ${compressed_file_path}"
+  )
+
+  set(OMC_EXTRACTED_REFERENCE_FILES ${OMC_EXTRACTED_REFERENCE_FILES} ${output_file_path})
+endforeach()
+
+# A custom target the depends on the extracted files. Makeing sure they get generated when it is
+# invoked.
+add_custom_target(reference-files
+            DEPENDS ${OMC_EXTRACTED_REFERENCE_FILES}
+            COMMENT "Extracted reference files to ${CMAKE_CURRENT_SOURCE_DIR}"
+        )

--- a/testsuite/difftool/CMakeLists.txt
+++ b/testsuite/difftool/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+
+find_package(FLEX)
+
+if(NOT FLEX_FOUND)
+  message(WARNING "GNU Flex not found. You will not be able to use omc-diff to verify test results against expected results.")
+else()
+  FLEX_TARGET(omc_diff_lexer omc-diff.l ${CMAKE_CURRENT_BINARY_DIR}/lex.yy.c)
+  add_executable(omc-diff ${FLEX_omc_diff_lexer_OUTPUTS})
+
+  install(TARGETS omc-diff)
+endif()

--- a/testsuite/libraries-for-testing/Makefile
+++ b/testsuite/libraries-for-testing/Makefile
@@ -11,4 +11,4 @@ clean:
 	$(MAKE) clean
 	mkdir -p .openmodelica/libraries
 	ls -l .openmodelica/libraries
-	../../build/bin/omc -d=showStatement index.mos
+	../../build/bin/omc index.mos


### PR DESCRIPTION
  - The target `reference-files` can be used to extract the reference files.

  - Explicitly set qwt as SHARED lib. This was overlooked.

  - Do not show statements when installing libraries. This was fixed for
    the CMake version but was forgotten for the makefiles.
