### PR TITLE
Evaluate subscripts in actualStream/inStream

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/ActualStreamVariability2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ActualStreamVariability2.mo
@@ -1,0 +1,33 @@
+// name: ActualStreamVariability2
+// keywords: stream actualStream connector
+// status: correct
+// cflags: -d=newInst
+//
+
+connector C
+  Real r;
+  flow Real f;
+  stream Real s;
+end C;
+
+model ActualStreamVariability2
+  C c[2];
+  parameter Integer n = 1;
+  Real as = actualStream(c[n].s);
+end ActualStreamVariability2;
+
+// Result:
+// class ActualStreamVariability2
+//   Real c[1].r;
+//   Real c[1].f;
+//   Real c[1].s;
+//   Real c[2].r;
+//   Real c[2].f;
+//   Real c[2].s;
+//   final parameter Integer n = 1;
+//   Real as = c[1].s;
+// equation
+//   c[1].f = 0.0;
+//   c[2].f = 0.0;
+// end ActualStreamVariability2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -6,6 +6,7 @@ ActualStream.mo \
 ActualStreamNonCref1.mo \
 ActualStreamNoStream1.mo \
 ActualStreamVariability1.mo \
+ActualStreamVariability2.mo \
 Algorithm1.mo \
 Algorithm2.mo \
 Algorithm3.mo \


### PR DESCRIPTION
- Evaluate the subscripts in the connector reference used as argument to
  actualStream/inStream, to ensure we can look up e.g. the matching
  stream variable for a flow correctly. We already check that the
  subscripts can be evaluated, with this change we also actually
  evaluate them as intended.