### PR TITLE
Rotate ringBuffer when step size zero

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -506,6 +506,7 @@ int prefixedName_performSimulation(DATA* data, threadData_t *threadData, SOLVER_
         * skip that step and go further */
         if (solverInfo->currentStepSize < 1e-15 && syncEventStep){
           __currStepNo++;
+          rotateRingBuffer(data->simulationData, 1, (void**) data->localData);
           continue;
         }
 


### PR DESCRIPTION
### Related Issues

#7854 

### Purpose

When the step size becomes nearly zero we skip an integrator step, but the ringbuffer was rotated.
The integrators (euler, dassl, ida, ...) expect to have the last step they did in data->localData[1].

```C
  SIMULATION_DATA *sData = (SIMULATION_DATA*)data->localData[0];
  SIMULATION_DATA *sDataOld = (SIMULATION_DATA*)data->localData[1];
```

So we need to rotate the ring-buffer again.

That's the reason why we move backwards in time for some clocked systems, see e.g. the example in https://github.com/OpenModelica/OpenModelica/issues/7854#issuecomment-976792030

![image](https://user-images.githubusercontent.com/38031952/145404275-7ad3f7e2-cb05-4b2b-aa0c-4610b0a40adb.png)
