### PR TITLE
Fix handling of function parameters of record type

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -557,7 +557,8 @@ algorithm
     is_con := Function.isDefaultRecordConstructor(func);
 
     func := Function.mapExp(func,
-      function evaluateFuncExp(fnNode = func.node, evaluateAll = is_con));
+      function evaluateFuncExp(fnNode = func.node, evaluateAll = is_con),
+      function evaluateFuncExp(fnNode = func.node, evaluateAll = true));
 
     if is_con then
       Record.checkLocalFieldOrder(func.locals, func.node, InstNode.info(func.node));

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1860,6 +1860,7 @@ uniontype Function
   function mapExp
     input output Function fn;
     input MapFunc mapFn;
+    input MapFunc mapFnFields = mapFn "Used for expressions in subcomponents, i.e. record fields";
     input Boolean mapParameters = true;
     input Boolean mapBody = true;
 
@@ -1878,7 +1879,8 @@ uniontype Function
 
     if mapParameters then
       ctree := Class.classTree(cls);
-      ClassTree.applyComponents(ctree, function mapExpParameter(mapFn = mapFn));
+      ClassTree.applyComponents(ctree,
+        function mapExpParameter(mapFn = mapFn, mapFnFields = mapFnFields));
       fn.returnType := makeReturnType(fn);
     end if;
 
@@ -1892,6 +1894,7 @@ uniontype Function
   function mapExpParameter
     input InstNode node;
     input MapFunc mapFn;
+    input MapFunc mapFnFields;
 
     partial function MapFunc
       input output Expression exp;
@@ -1924,7 +1927,7 @@ uniontype Function
 
           cls := InstNode.getClass(comp.classInst);
           ClassTree.applyComponents(Class.classTree(cls),
-            function mapExpParameter(mapFn = mapFn));
+            function mapExpParameter(mapFn = mapFnFields, mapFnFields = mapFnFields));
         then
           ();
 


### PR DESCRIPTION
- Treat function parameters of record type the same way as record
  constructors in EvalConstants, by always evaluating constant
  expressions in their fields. This fixes an issue where record types
  in functions sometimes contain references to functions that are not
  part of the flat model.