### PR TITLE
Fix handling of default function arguments

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -135,7 +135,7 @@ constant InstNode INTEGER_DUMMY_NODE = NFInstNode.CLASS_NODE("Integer",
 
 constant Function INTEGER_FUNCTION = Function.FUNCTION(Path.IDENT("Integer"),
   INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, {
-    Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(ENUM_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
   }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}), Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("IntegerFunc",
@@ -154,48 +154,65 @@ constant InstNode STRING_DUMMY_NODE = NFInstNode.CLASS_NODE("String",
   DUMMY_ELEMENT, Visibility.PUBLIC, Pointer.createImmutable(Class.NOT_INSTANTIATED()),
   EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.NORMAL_CLASS());
 
+constant InstNode R_PARAM = InstNode.COMPONENT_NODE("r",
+  Visibility.PUBLIC, Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode I_PARAM = InstNode.COMPONENT_NODE("i",
+  Visibility.PUBLIC, Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode B_PARAM = InstNode.COMPONENT_NODE("b",
+  Visibility.PUBLIC, Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode E_PARAM = InstNode.COMPONENT_NODE("e",
+  Visibility.PUBLIC, Pointer.createImmutable(ENUM_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode SIGNIFICANT_DIGITS_PARAM = InstNode.COMPONENT_NODE("significantDigits",
+  Visibility.PUBLIC, Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode MINIMUM_LENGTH_PARAM = InstNode.COMPONENT_NODE("minimumLength",
+  Visibility.PUBLIC, Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode LEFT_JUSTIFIED_PARAM = InstNode.COMPONENT_NODE("leftJustified",
+  Visibility.PUBLIC, Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode FORMAT_PARAM = InstNode.COMPONENT_NODE("format",
+  Visibility.PUBLIC, Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+
 // String(r, significantDigits=d, minimumLength=0, leftJustified=true)
 constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {REAL_PARAM, INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
-    Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("significantDigits", SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 4, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(R_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(SIGNIFICANT_DIGITS_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 4, SlotEvalStatus.NOT_EVALUATED)
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(r, format="-0.6g")
 constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
-    Slot.SLOT("r", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("format", SlotType.NAMED, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(R_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(FORMAT_PARAM, SlotType.NAMED, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(i, minimumLength=0, leftJustified=true)
 constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {INT_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
-    Slot.SLOT("i", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(I_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(b, minimumLength=0, leftJustified=true)
 constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {BOOL_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
-    Slot.SLOT("b", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(B_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(e, minimumLength=0, leftJustified=true)
 constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {ENUM_PARAM, INT_PARAM, BOOL_PARAM}, {STRING_PARAM}, {}, {
-    Slot.SLOT("e", SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("minimumLength", SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("leftJustified", SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(E_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
   }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
@@ -313,34 +330,49 @@ constant Function CLOCK_INFERED = Function.FUNCTION(Path.IDENT("Clock"),
   DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
+constant InstNode INTERVAL_COUNTER_PARAM = InstNode.COMPONENT_NODE("intervalCounter",
+  Visibility.PUBLIC, Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode RESOLUTION_PARAM = InstNode.COMPONENT_NODE("resolution",
+  Visibility.PUBLIC, Pointer.createImmutable(INT_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode INTERVAL_PARAM = InstNode.COMPONENT_NODE("interval",
+  Visibility.PUBLIC, Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode CONDITION_PARAM = InstNode.COMPONENT_NODE("condition",
+  Visibility.PUBLIC, Pointer.createImmutable(BOOL_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode START_INTERVAL_PARAM = InstNode.COMPONENT_NODE("startInterval",
+  Visibility.PUBLIC, Pointer.createImmutable(REAL_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode C_PARAM = InstNode.COMPONENT_NODE("c",
+  Visibility.PUBLIC, Pointer.createImmutable(CLOCK_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+constant InstNode SOLVER_METHOD_PARAM = InstNode.COMPONENT_NODE("solverMethod",
+  Visibility.PUBLIC, Pointer.createImmutable(STRING_COMPONENT), InstNode.EMPTY_NODE(), InstNodeType.NORMAL_COMP());
+
 // Clock(intervalCounter, resolution = 1) - clock with Integer interval
 constant Function CLOCK_INT = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {INT_PARAM, INT_PARAM}, {CLOCK_PARAM}, {}, {
-    Slot.SLOT("intervalCounter", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("resolution", SlotType.GENERIC, SOME(Expression.INTEGER(1)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(INTERVAL_COUNTER_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(RESOLUTION_PARAM, SlotType.GENERIC, SOME(Expression.INTEGER(1)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(interval) - clock with Real interval
 constant Function CLOCK_REAL = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {REAL_PARAM}, {CLOCK_PARAM}, {}, {
-    Slot.SLOT("interval", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(INTERVAL_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(condition, startInterval = 0.0) - Boolean clock, triggered by zero-crossing events
 constant Function CLOCK_BOOL = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {BOOL_PARAM, REAL_PARAM}, {CLOCK_PARAM}, {}, {
-    Slot.SLOT("condition", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("startInterval", SlotType.GENERIC, SOME(Expression.REAL(0.0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(CONDITION_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(START_INTERVAL_PARAM, SlotType.GENERIC, SOME(Expression.REAL(0.0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(c, solverMethod) - Solver clock
 constant Function CLOCK_SOLVER = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {CLOCK_PARAM, STRING_PARAM}, {CLOCK_PARAM}, {}, {
-    Slot.SLOT("c", SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
-    Slot.SLOT("solverMethod", SlotType.GENERIC, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
+    Slot.SLOT(C_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
+    Slot.SLOT(SOLVER_METHOD_PARAM, SlotType.GENERIC, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
   }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 

--- a/testsuite/flattening/modelica/scodeinst/FuncDefaultArg6.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncDefaultArg6.mo
@@ -1,0 +1,31 @@
+// name: FuncDefaultArg6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Real x;
+  input Real r;
+  output Real o = x+r;
+end f;
+
+model FuncDefaultArg6
+  Real x = 2.0;
+  function g = f(r=x);
+  Real y = g(1.0);
+end FuncDefaultArg6;
+
+// Result:
+// function FuncDefaultArg6.g
+//   input Real x;
+//   input Real r = x;
+//   output Real o = x + r;
+// end FuncDefaultArg6.g;
+//
+// class FuncDefaultArg6
+//   Real x = 2.0;
+//   Real y = FuncDefaultArg6.g(1.0, x);
+// end FuncDefaultArg6;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncDefaultArg7.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncDefaultArg7.mo
@@ -1,0 +1,37 @@
+// name: FuncDefaultArg7
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Real x;
+  output Real y;
+algorithm
+  y := x + 2;
+end f;
+
+partial model Base
+  replaceable partial function func = f;
+end Base;
+
+model FuncDefaultArg7
+  extends Base(redeclare final function func = f(x = x));
+  parameter Real x = 5;
+  Real y = func();
+end FuncDefaultArg7;
+
+// Result:
+// function FuncDefaultArg7.func
+//   input Real x = 5.0;
+//   output Real y;
+// algorithm
+//   y := x + 2.0;
+// end FuncDefaultArg7.func;
+//
+// class FuncDefaultArg7
+//   parameter Real x = 5.0;
+//   Real y = FuncDefaultArg7.func(x);
+// end FuncDefaultArg7;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -551,6 +551,8 @@ FuncDefaultArg2.mo \
 FuncDefaultArg3.mo \
 FuncDefaultArg4.mo \
 FuncDefaultArg5.mo \
+FuncDefaultArg6.mo \
+FuncDefaultArg7.mo \
 FuncDuplicateParams1.mo \
 FuncExtends.mo \
 FuncInnerParam.mo \


### PR DESCRIPTION
- Use instance nodes instead of string names for function slots, to
  avoid mistaking references to components defined outside the function
  with references to function parameters when evaluating default
  arguments.

Fixes #2732