### PR TITLE
Remove previous from intervalCounter

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
@@ -2450,8 +2450,9 @@ algorithm
     then (DAE.REAL_CLOCK(e), eqs, vars, cnt);
 
     case DAE.INTEGER_CLOCK(e, i) equation
-      (e, eqs, vars, cnt) = substClockExp(e, inNewEqs, inNewVars, inCnt, inShared);
-    then (DAE.INTEGER_CLOCK(e, i), eqs, vars, cnt);
+      // Surpressing substClockExp to get rid of previous in intervalCounter
+      // (e, eqs, vars, cnt) = substClockExp(e, inNewEqs, inNewVars, inCnt, inShared);
+    then (DAE.INTEGER_CLOCK(e, i), inNewEqs, inNewVars, inCnt);
 
     else (inClk, inNewEqs, inNewVars, inCnt);
   end match;


### PR DESCRIPTION
### Related Issues

#7854 
Fixes #3771

### Purpose

This should solve clocked models with changing `intervalCounter`.

```modelica
model rationalClock
  Integer nextInterval(start = 2);
  Real y(start = 0);
equation
  when Clock(nextInterval, 10) then
    // interval clock that ticks at 0, 3/10, 7/10, ...
    nextInterval = previous(nextInterval) + 1;
    y = previous(y) + 1;
  end when;
end rationalClock;
```

### Approach

Problem is that we compute the `intervalCounter` with `previous(nextInterval )` and not `nextInterval`.
By removing `substClockExp` for `INTEGER_CLOCK` (the only type of clock where the interval can change) this should be solved.  I hope there are no side effects.
