### PR TITLE
Improve handling of previous() operator

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1649,6 +1649,7 @@ uniontype Function
           // Function should not be used in function context.
           // argument should be a cref?
           case "pre" then true;
+          case "previous" then true;
           // needs unboxing and return type fix.
           case "product" then true;
           case "promote" then true;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -860,6 +860,7 @@ public constant ErrorTypes.Message CONVERSION_NO_COMPATIBLE_SCRIPT_FOUND = Error
   Gettext.gettext("No compatible conversion script for converting from %s %s to %s could be found."));
 
 public constant Gettext.TranslatableContent FUNCTION_CALL_EXPRESSION = Gettext.gettext("a function call expression");
+public constant Gettext.TranslatableContent COMPONENT_EXPRESSION = Gettext.gettext("a component expression");
 public constant ErrorTypes.Message FUNCTION_ARGUMENT_MUST_BE = ErrorTypes.MESSAGE(394, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("The argument to ‘%s‘ must be %s."));
 

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious1.mo
@@ -1,0 +1,21 @@
+// name: FuncBuiltinPrevious1
+// keywords: pre
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the builtin previous operator.
+//
+
+model FuncBuiltinPrevious1
+  Real x;
+equation
+  x = previous(x);
+end FuncBuiltinPrevious1;
+
+// Result:
+// class FuncBuiltinPrevious1
+//   Real x;
+// equation
+//   x = previous(x);
+// end FuncBuiltinPrevious1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious2.mo
@@ -1,0 +1,25 @@
+// name: FuncBuiltinPrevious2
+// keywords: pre
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the builtin previous operator.
+//
+
+model FuncBuiltinPrevious2
+  Real x[3];
+equation
+  x = previous(x);
+end FuncBuiltinPrevious2;
+
+// Result:
+// class FuncBuiltinPrevious2
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x[1] = previous(x[1]);
+//   x[2] = previous(x[2]);
+//   x[3] = previous(x[3]);
+// end FuncBuiltinPrevious2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious3.mo
@@ -1,0 +1,33 @@
+// name: FuncBuiltinPrevious3
+// keywords: pre
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the builtin previous operator.
+//
+
+function f
+  input Real x[3];
+  output Real y[3] = x;
+end f;
+
+model FuncBuiltinPrevious3
+  Real x[3];
+equation
+  x = f(previous(x));
+end FuncBuiltinPrevious3;
+
+// Result:
+// function f
+//   input Real[3] x;
+//   output Real[3] y = x;
+// end f;
+//
+// class FuncBuiltinPrevious3
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+// equation
+//   x = f({previous(x[1]), previous(x[2]), previous(x[3])});
+// end FuncBuiltinPrevious3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo
@@ -1,0 +1,26 @@
+// name: FuncBuiltinPrevious4
+// keywords: pre
+// status: incorrect
+// cflags: -d=newInst
+//
+// Tests the builtin previous operator.
+//
+
+function f
+end f;
+
+model FuncBuiltinPrevious4
+  Real x;
+equation
+  x = previous(f);
+end FuncBuiltinPrevious4;
+
+// Result:
+// Error processing file: FuncBuiltinPrevious4.mo
+// [flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo:15:3-15:18:writable] Error: The argument to ‘previous‘ must be a component expression.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -519,6 +519,10 @@ FuncBuiltinNdims.mo \
 FuncBuiltinOnes.mo \
 FuncBuiltinOuterProduct.mo \
 FuncBuiltinPre.mo \
+FuncBuiltinPrevious1.mo \
+FuncBuiltinPrevious2.mo \
+FuncBuiltinPrevious3.mo \
+FuncBuiltinPrevious4.mo \
 FuncBuiltinProduct.mo \
 FuncBuiltinPromote.mo \
 FuncBuiltinPromoteInvalid1.mo \


### PR DESCRIPTION
- Add check that the argument of previous is a component expression.
- Expand previous since the backend can't yet handle previous of arrays.