### PR TITLE
Handle array constructors in Call.unboxArgs

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -305,6 +305,8 @@ public
 
   function unboxArgs
     input output NFCall call;
+  protected
+    Call c;
   algorithm
     () := match call
       case TYPED_CALL()
@@ -312,6 +314,14 @@ public
           call.arguments := list(Expression.unbox(arg) for arg in call.arguments);
         then
           ();
+
+      case TYPED_ARRAY_CONSTRUCTOR(exp = Expression.CALL(call = c))
+        algorithm
+          call.exp := Expression.CALL(unboxArgs(c));
+        then
+          ();
+
+      else ();
     end match;
   end unboxArgs;
 

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinEdge2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinEdge2.mo
@@ -1,0 +1,25 @@
+// name: FuncBuiltinEdge2
+// keywords: edge
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the builtin edge operator.
+//
+
+model FuncBuiltinEdge2
+  Boolean b[3];
+  Boolean x[:] = edge(b);
+end FuncBuiltinEdge2;
+
+// Result:
+// class FuncBuiltinEdge2
+//   Boolean b[1];
+//   Boolean b[2];
+//   Boolean b[3];
+//   Boolean x[1];
+//   Boolean x[2];
+//   Boolean x[3];
+// equation
+//   x = array(edge(b[$i1]) for $i1 in 1:3);
+// end FuncBuiltinEdge2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -498,6 +498,7 @@ FuncBuiltinDerInvalid1.mo \
 FuncBuiltinDiagonal.mo \
 FuncBuiltinDiv.mo \
 FuncBuiltinEdge.mo \
+FuncBuiltinEdge2.mo \
 FuncBuiltinFill.mo \
 FuncBuiltinFill2.mo \
 FuncBuiltinFill3.mo \


### PR DESCRIPTION
- Handle vectorized calls in the form of array constructors in
  Call.unboxArgs, and ignore other calls instead of failing.

Fixes #8305