### PR TITLE
[cmake] Add the testsuite-depends target.

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -339,6 +339,7 @@ void buildOMC_CMake(cmake_args, cmake_exe='cmake') {
     sh "${cmake_exe} --build ./build_cmake/OMShell --parallel ${numPhysicalCPU()} --target install"
     sh "${cmake_exe} --build ./build_cmake/OMNotebook --parallel ${numPhysicalCPU()} --target install"
     sh "${cmake_exe} --build ./build_cmake/testsuite --parallel ${numPhysicalCPU()} --target install"
+    sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
   }
 }
 

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -3,3 +3,9 @@
 omc_add_subdirectory(difftool)
 omc_add_subdirectory(ReferenceFiles)
 omc_add_subdirectory(libraries-for-testing)
+
+
+add_custom_target(testsuite-depends
+                    DEPENDS omc-diff
+                    DEPENDS libs-for-testing
+                    DEPENDS reference-files)


### PR DESCRIPTION
  - This corresponds to the same target of the autoconf build. It is
    missing some functionality but it is fine for most use cases.

