### PR TITLE
Simplify typing of builtin functions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -118,12 +118,10 @@ public
       case "change" then typeChangeCall(call, next_context, info);
       case "Clock" guard Config.synchronousFeaturesAllowed() then typeClockCall(call, next_context, info);
       case "der" then typeDerCall(call, next_context, info);
-      case "diagonal" then typeDiagonalCall(call, next_context, info);
       case "DynamicSelect" then typeDynamicSelectCall("DynamicSelect", call, next_context, info);
       case "edge" then typeEdgeCall(call, next_context, info);
       case "fill" then typeFillCall(call, next_context, info);
       case "getInstanceName" then typeGetInstanceName(call);
-      //case "hold" guard Config.synchronousFeaturesAllowed() then typeHoldCall(call, next_context, info);
       //case "initialState" guard Config.synchronousFeaturesAllowed() then typeInitialStateCall(call, next_context, info);
       case "initial" then typeDiscreteCall(call, next_context, info);
       case "inStream" then typeActualInStreamCall("inStream", call, next_context, info);
@@ -132,12 +130,10 @@ public
       case "max" then typeMinMaxCall("max", call, next_context, info);
       case "min" then typeMinMaxCall("min", call, next_context, info);
       case "ndims" then typeNdimsCall(call, next_context, info);
-      //case "noClock" guard Config.synchronousFeaturesAllowed() then typeNoClockCall(call, next_context, info);
       case "noEvent" then typeNoEventCall(call, next_context, info);
       case "ones" then typeZerosOnesCall("ones", call, next_context, info);
       case "potentialRoot" then typePotentialRootCall(call, next_context, info);
       case "pre" then typePreCall(call, next_context, info);
-      case "previous" then typePreviousCall(call, next_context, info);
       case "product" then typeProductCall(call, next_context, info);
       case "promote" then typePromoteCall(call, next_context, info);
       case "pure" then typePureCall(call, next_context, info);
@@ -637,49 +633,6 @@ protected
     {fn} := Function.typeRefCache(fn_ref);
     callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, purity, ty));
   end typeDerCall;
-
-  function typeDiagonalCall
-    input Call call;
-    input InstContext.Type context;
-    input SourceInfo info;
-    output Expression callExp;
-    output Type ty;
-    output Variability variability;
-    output Purity purity;
-  protected
-    ComponentRef fn_ref;
-    list<Expression> args;
-    list<NamedArg> named_args;
-    Expression arg;
-    Dimension dim;
-    Function fn;
-  algorithm
-    Call.UNTYPED_CALL(ref = fn_ref, arguments = args, named_args = named_args) := call;
-    assertNoNamedParams("diagonal", named_args, info);
-
-    if listLength(args) <> 1 then
-      Error.addSourceMessageAndFail(Error.NO_MATCHING_FUNCTION_FOUND_NFINST,
-        {Call.toString(call), "diagonal(Any[n]) => Any[n, n]"}, info);
-    end if;
-
-    (arg, ty, variability, purity) := Typing.typeExp(listHead(args), context, info);
-
-    ty := match ty
-      case Type.ARRAY(dimensions = {dim})
-        then Type.ARRAY(ty.elementType, {dim, dim});
-
-      else
-        algorithm
-          Error.addSourceMessage(Error.ARG_TYPE_MISMATCH,
-            {"1", ComponentRef.toString(fn_ref), "", Expression.toString(arg),
-             Type.toString(ty), "Any[:]"}, info);
-        then
-          fail();
-    end match;
-
-    {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, purity, ty));
-  end typeDiagonalCall;
 
   function typeEdgeCall
     input Call call;
@@ -1434,39 +1387,12 @@ protected
       Error.addSourceMessageAndFail(Error.INVALID_CARDINALITY_CONTEXT, {}, info);
     end if;
 
-    Call.UNTYPED_CALL(ref = fn_ref, arguments = args, named_args = named_args) := call;
-    assertNoNamedParams("cardinality", named_args, info);
-
-    if listLength(args) <> 1 then
-      Error.addSourceMessageAndFail(Error.NO_MATCHING_FUNCTION_FOUND_NFINST,
-        {Call.toString(call), ComponentRef.toString(fn_ref) + "(Connector) => Integer"}, info);
-    end if;
-
     if InstContext.inFunction(context) then
       Error.addSourceMessageAndFail(Error.EXP_INVALID_IN_FUNCTION,
-        {ComponentRef.toString(fn_ref)}, info);
+        {AbsynUtil.pathString(Call.functionName(call))}, info);
     end if;
 
-    (arg, ty) := Typing.typeExp(listHead(args), context, info);
-
-    if not Expression.isCref(arg) then
-      Error.addSourceMessageAndFail(Error.ARGUMENT_MUST_BE_VARIABLE,
-        {"First", ComponentRef.toString(fn_ref), "<REMOVE ME>"}, info);
-    end if;
-
-    node := ComponentRef.node(Expression.toCref(arg));
-
-    if not (Type.isScalar(ty) and InstNode.isComponent(node) and Component.isConnector(InstNode.component(node))) then
-      Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH,
-        {"1", ComponentRef.toString(fn_ref), "",
-         Expression.toString(arg), Type.toString(ty), "connector"}, info);
-    end if;
-
-    {fn} := Function.typeRefCache(fn_ref);
-    ty := Type.INTEGER();
-    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, var, purity, ty));
-    // TODO: Check cardinality restrictions, 3.7.2.3.
-
+    (callExp, ty, _, _) := typeBuiltinCallExp(call, context, info, vectorize = false);
     System.setUsesCardinality(true);
   end typeCardinalityCall;
 
@@ -2244,7 +2170,7 @@ protected
       Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(counter);
     Structural.markExp(resolution);
-    callExp := Expression.CALL(Call.unboxArgs(ty_call));
+    callExp := Expression.CALL(ty_call);
   end typeBackSampleCall;
 
   function typeShiftSampleCall
@@ -2263,7 +2189,7 @@ protected
       Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(counter);
     Structural.markExp(resolution);
-    callExp := Expression.CALL(Call.unboxArgs(ty_call));
+    callExp := Expression.CALL(ty_call);
   end typeShiftSampleCall;
 
   function typeSubSampleCall
@@ -2281,7 +2207,7 @@ protected
     ty_call as Call.TYPED_CALL(arguments = {_, factor}, ty = ty, var = var) :=
       Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(factor);
-    callExp := Expression.CALL(Call.unboxArgs(ty_call));
+    callExp := Expression.CALL(ty_call);
   end typeSubSampleCall;
 
   function typeSuperSampleCall
@@ -2299,7 +2225,7 @@ protected
     ty_call as Call.TYPED_CALL(arguments = {_, factor}, ty = ty, var = var) :=
       Call.typeMatchNormalCall(call, context, info, vectorize = false);
     Structural.markExp(factor);
-    callExp := Expression.CALL(Call.unboxArgs(ty_call));
+    callExp := Expression.CALL(ty_call);
   end typeSuperSampleCall;
 
   function typePureCall
@@ -2334,47 +2260,27 @@ protected
     end match;
   end typePureCall;
 
-  function typePreviousCall
+  function typeBuiltinCallExp
     input Call call;
     input InstContext.Type context;
     input SourceInfo info;
-    output Expression callExp;
+    input Boolean vectorize = true;
+    output Expression outExp;
     output Type ty;
     output Variability var;
-    output Purity purity = Purity.PURE;
+    output Purity pur;
   protected
-    list<Expression> args;
-    Expression arg;
     Call c;
   algorithm
-    args := Call.arguments(call);
-
-    if listLength(args) == 1 then
-      arg := listHead(args);
-
-      () := match arg
-        case Expression.CREF()
-          guard ComponentRef.isCref(arg.cref) and
-                InstNode.isComponent(ComponentRef.node(arg.cref))
-          then ();
-
-        else
-          algorithm
-            Error.addSourceMessage(Error.FUNCTION_ARGUMENT_MUST_BE,
-              {"previous", Gettext.translateContent(Error.COMPONENT_EXPRESSION)}, info);
-          then
-            fail();
-      end match;
-    end if;
-
-    (c, ty, var, purity) := typeBuiltinCall(call, context, info);
-    callExp := Expression.CALL(c);
-  end typePreviousCall;
+    (c, ty, var, pur) := typeBuiltinCall(call, context, info, vectorize);
+    outExp := Expression.CALL(c);
+  end typeBuiltinCallExp;
 
   function typeBuiltinCall
     input Call call;
     input InstContext.Type context;
     input SourceInfo info;
+    input Boolean vectorize = true;
     output Call outCall;
     output Type ty;
     output Variability var;
@@ -2382,7 +2288,7 @@ protected
   protected
     Call c;
   algorithm
-    outCall := Call.typeMatchNormalCall(call, context, info);
+    outCall := Call.typeMatchNormalCall(call, context, info, vectorize);
     ty := Call.typeOf(outCall);
     var := Call.variability(outCall);
     pur := Call.purity(outCall);

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -372,11 +372,7 @@ public
     args := listReverseInPlace(args);
 
     ty := Function.returnType(func);
-
-    // Hack to fix return type of some builtin functions.
-    if Type.isPolymorphic(ty) then
-      ty := getSpecialReturnType(func, args);
-    end if;
+    ty := resolvePolymorphicReturnType(func, typed_args, ty);
 
     if var == Variability.PARAMETER and Function.isExternal(func) then
       // Mark external functions with parameter expressions as non-structural,
@@ -2662,46 +2658,49 @@ protected
     end match;
   end evaluateCallTypeDimExp;
 
-  function getSpecialReturnType
+  function resolvePolymorphicReturnType
+    "Resolves a polymorphic type to the actual type based on the inputs of a function."
     input Function fn;
-    input list<Expression> args;
-    output Type ty;
+    input list<TypedArg> args;
+    input Type ty;
+    output Type outType;
+  protected
+    String name;
+    Type input_ty;
+    TypedArg arg;
+    list<TypedArg> rest_args = args;
   algorithm
-    ty := match fn.path
-      case Absyn.IDENT("min")
-        then Type.arrayElementType(Expression.typeOf(Expression.unbox(listHead(args))));
-      case Absyn.IDENT("max")
-        then Type.arrayElementType(Expression.typeOf(Expression.unbox(listHead(args))));
-      case Absyn.IDENT("sum")
-        then Type.arrayElementType(Expression.typeOf(Expression.unbox(listHead(args))));
-      case Absyn.IDENT("product")
-        then Type.arrayElementType(Expression.typeOf(Expression.unbox(listHead(args))));
-      case Absyn.IDENT("previous")
-        then Type.arrayElementType(Expression.typeOf(listHead(args)));
-      case Absyn.IDENT("shiftSample")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("backSample")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("hold")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("superSample")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("subSample")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("noClock")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("DynamicSelect")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      case Absyn.IDENT("pure")
-        then Expression.typeOf(Expression.unbox(listHead(args)));
-      else
+    outType := match ty
+      case Type.POLYMORPHIC(name = name)
         algorithm
-          Error.assertion(false, getInstanceName() + ": unhandled case for " +
-            AbsynUtil.pathString(fn.path), sourceInfo());
+          // Go through the inputs until we find one with the same polymorphic
+          // type as the one we're looking for.
+          for i in fn.inputs loop
+            arg :: rest_args := rest_args;
+            input_ty := InstNode.getType(i);
+
+            if Type.isPolymorphicNamed(Type.arrayElementType(input_ty), name) then
+              // Replace the type with the corresponding argument type, but
+              // remove as many dimensions from it as the input has.
+              //   For example: T[:] and Real[2, 3] gives T = Real[3]
+              outType := Type.unliftArrayN(Type.dimensionCount(input_ty), arg.ty);
+              return;
+            end if;
+          end for;
         then
           fail();
+
+      case Type.ARRAY(elementType = Type.POLYMORPHIC())
+        algorithm
+          // For an array of polymorphic types, only resolve the polymorphic
+          // type itself and keep the dimensions.
+          ty.elementType := resolvePolymorphicReturnType(fn, args, ty.elementType);
+        then
+          ty;
+
+      else ty;
     end match;
-  end getSpecialReturnType;
+  end resolvePolymorphicReturnType;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFCall;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5017,5 +5017,39 @@ public
     end match;
   end isFunctionPointer;
 
+  function isConnector
+    "Returns true if the expression is a component reference that refers to a
+     connector, otherwise false."
+    input Expression exp;
+    output Boolean res;
+  protected
+    InstNode node;
+  algorithm
+    res := match exp
+      case Expression.CREF()
+        algorithm
+          node := ComponentRef.node(exp.cref);
+        then
+          InstNode.isComponent(node) and InstNode.isConnector(node);
+
+      else false;
+    end match;
+  end isConnector;
+
+  function isComponentExpression
+    "Returns true if the expression is a component reference that refers to an
+     actual component (and not e.g. a function), otherwise false"
+    input Expression exp;
+    output Boolean res;
+  algorithm
+    res := match exp
+      case Expression.CREF()
+        then ComponentRef.isCref(exp.cref) and
+             InstNode.isComponent(ComponentRef.node(exp.cref));
+
+      else false;
+    end match;
+  end isComponentExpression;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFExpression;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1619,7 +1619,6 @@ uniontype Function
           // argument should be a cref?
           case "change" then true;
           case "der" then true;
-          case "diagonal" then true;
           // Function should not be used in function context.
           case "edge" then true;
           // can have variable number of arguments
@@ -1649,7 +1648,6 @@ uniontype Function
           // Function should not be used in function context.
           // argument should be a cref?
           case "pre" then true;
-          case "previous" then true;
           // needs unboxing and return type fix.
           case "product" then true;
           case "promote" then true;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -404,7 +404,8 @@ end sum;
 
 function product<ArrayType, ScalarBasicType> "Product of all array elements"
   input ArrayType a;
-  output ScalarBasicType s;  external "builtin";
+  output ScalarBasicType s;
+  external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'product()'\">product()</a>
 </html>"));
@@ -425,8 +426,8 @@ function transpose<T> "Transpose a matrix"
 end transpose;
 
 function symmetric<T> "Returns a symmetric matrix"
-  input T[:,:] a;
-  output T[:,:] b;
+  input T[:, size(a, 1)] a;
+  output T[size(a, 1), size(a, 2)] b;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'symmetric()'\">symmetric()</a>
@@ -443,17 +444,17 @@ function smooth<RealArrayOrRecord> "Indicate smoothness of expression"
 </html>"));
 end smooth;
 
-function diagonal<T> "Returns a diagonal matrix"
-  input T v[:];
-  output T mat[size(v,1),size(v,1)];
+function diagonal<__Scalar> "Returns a diagonal matrix"
+  input __Scalar v[:];
+  output __Scalar mat[size(v,1),size(v,1)];
   external "builtin";
   annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'diagonal()'\">diagonal()</a>
 </html>"));
 end diagonal;
 
-function cardinality "Number of connectors in connection"
-  input Real c;
+function cardinality<__Connector> "Number of connectors in connection"
+  input __Connector c;
   parameter output Integer numOccurances;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
@@ -489,7 +490,9 @@ function fill "Returns an array with all elements equal"
 </html>"));
 end fill;
 
-function noEvent "Turn off event triggering"
+function noEvent<__Any> "Turn off event triggering"
+  input __Any x;
+  output __Any y;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'noEvent()'\">noEvent()</a>
@@ -553,24 +556,24 @@ package OMC_CLOCK
   end sample;
 end OMC_CLOCK;
 
-function shiftSample<T> "First activation of clock is shifted in time"
-  input T u;
+function shiftSample<__Any> "First activation of clock is shifted in time"
+  input __Any u;
   parameter input Integer shiftCounter(min = 0);
   parameter input Integer resolution(min = 1) = 1;
-  output T c;
+  output __Any c;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.3", Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'shiftSample()'\">shiftSample()</a>
 </html>"));
 end shiftSample;
 
-function backSample<T> "First activation of clock is shifted in time before activation of u"
-  input T u;
+function backSample<__Any> "First activation of clock is shifted in time before activation of u"
+  input __Any u;
   parameter input Integer backCounter(min = 0);
   parameter input Integer resolution(min = 1) = 1;
-  output T c;
+  output __Any c;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.3", Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'backSample()'\">backSample()</a>
 </html>"));
 end backSample;
@@ -612,12 +615,12 @@ function size "Returns dimensions of an array"
 </html>"));
 end size;
 
-function DynamicSelect<T> "select static or dynamic expressions in the annotations"
-  input T static;
-  input T dynamic;
-  output T selected;
+function DynamicSelect<__Any> "select static or dynamic expressions in the annotations"
+  input __Any static;
+  input __Any dynamic;
+  output __Any selected;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, __OpenModelica_Impure=true, Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, __OpenModelica_Impure=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Annotations.DynamicSelect\">DynamicSelect</a>
 </html>"));
 end DynamicSelect;
@@ -672,11 +675,11 @@ function inStream
 </html>"));
 end inStream;
 
-function pure<T>
-  input T x;
-  output T y;
+function pure<__Any>
+  input __Any x;
+  output __Any y;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.4");
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.4");
 end pure;
 
 /* Extension for uncertainty computations */
@@ -853,9 +856,9 @@ external "builtin";
 annotation(__OpenModelica_builtin=true, version="Modelica 3.3");
 end spatialDistribution;
 
-function previous<__Scalar> "Access previous value of a clocked variable"
-  input __Scalar u;
-  output __Scalar y;
+function previous<__ComponentExpression> "Access previous value of a clocked variable"
+  input __ComponentExpression u;
+  output __ComponentExpression y;
   external "builtin";
   annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'previous()'\">previous()</a>
@@ -918,30 +921,30 @@ end OMC_ARGS;
 
 function subSample = $overload(OpenModelica.Internal.subSampleExpression, OpenModelica.Internal.subSampleClock)
   "Conversion from faster clock to slower clock"
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.3", Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'subSample()'\">subSample()</a>
 </html>"));
 
 function superSample = $overload(OpenModelica.Internal.superSampleExpression, OpenModelica.Internal.superSampleClock)
   "Conversion from slower clock to faster clock"
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.3", Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'superSample()'\">superSample()</a>
 </html>"));
 
-function hold<T> "Conversion from clocked discrete-time to continuous time"
-  input T u;
-  output T y;
+function hold<__Any> "Conversion from clocked discrete-time to continuous time"
+  input __Any u;
+  output __Any y;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.3", Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'hold()'\">hold()</a>
 </html>"));
 end hold;
 
-function noClock<T> "Clock of y=Clock(u) is always inferred"
-  input T u;
-  output T y;
+function noClock<__Any> "Clock of y=Clock(u) is always inferred"
+  input __Any u;
+  output __Any y;
   external "builtin";
-  annotation(__OpenModelica_builtin=true, __OpenModelica_UnboxArguments=true, version="Modelica 3.3", Documentation(info="<html>
+  annotation(__OpenModelica_builtin=true, version="Modelica 3.3", Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'noClock()'\">noClock()</a>
 </html>"));
 end noClock;
@@ -1054,12 +1057,11 @@ package Internal "Contains internal implementations, e.g. overloaded builtin fun
     external "builtin";
   end solverClock;
 
-  impure function subSampleExpression<T>
-    input T u;
+  impure function subSampleExpression<__Any>
+    input __Any u;
     parameter input Integer factor(min=0)=0;
-    output T y;
+    output __Any y;
     external "builtin" y=subSample(u,factor);
-    annotation(__OpenModelica_UnboxArguments=true);
   end subSampleExpression;
 
   impure function subSampleClock
@@ -1069,12 +1071,11 @@ package Internal "Contains internal implementations, e.g. overloaded builtin fun
     external "builtin" y=subSample(u,factor);
   end subSampleClock;
 
-  impure function superSampleExpression<T>
-    input T u;
+  impure function superSampleExpression<__Any>
+    input __Any u;
     parameter input Integer factor(min=0)=0;
-    output T y;
+    output __Any y;
     external "builtin" y=superSample(u,factor);
-    annotation(__OpenModelica_UnboxArguments=true);
   end superSampleExpression;
 
   impure function superSampleClock

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -218,6 +218,10 @@ public
     input Integer N;
     input output Type ty;
   algorithm
+    if N == 0 then
+      return;
+    end if;
+
     ty := match ty
       local
         list<Dimension> dims;
@@ -596,6 +600,17 @@ public
       else false;
     end match;
   end isPolymorphic;
+
+  function isPolymorphicNamed
+    input Type ty;
+    input String name;
+    output Boolean res;
+  algorithm
+    res := match ty
+      case POLYMORPHIC() then name == ty.name;
+      else false;
+    end match;
+  end isPolymorphicNamed;
 
   function firstTupleType
     input Type ty;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2407,9 +2407,34 @@ function matchPolymorphic
         output MatchKind matchKind;
 algorithm
   (compatibleType, matchKind) := match polymorphicName
+    // Any type, used when we don't want the expression to be boxed.
+    case "__Any" then (actualType, MatchKind.GENERIC);
+
+    // Any scalar type.
     case "__Scalar"
       algorithm
-        matchKind := if Type.isScalar(actualType) then MatchKind.EXACT else MatchKind.NOT_COMPATIBLE;
+        matchKind := if Type.isScalar(actualType) then MatchKind.GENERIC else MatchKind.NOT_COMPATIBLE;
+      then
+        (actualType, matchKind);
+
+    // Any array type.
+    case "__Array"
+      algorithm
+        matchKind := if Type.isArray(actualType) then MatchKind.GENERIC else MatchKind.NOT_COMPATIBLE;
+      then
+        (actualType, matchKind);
+
+    case "__Connector"
+      algorithm
+        matchKind := if Type.isScalar(actualType) and Expression.isConnector(exp) then
+          MatchKind.GENERIC else MatchKind.NOT_COMPATIBLE;
+      then
+        (actualType, matchKind);
+
+    case "__ComponentExpression"
+      algorithm
+        matchKind := if Type.isScalar(actualType) and Expression.isComponentExpression(exp) then
+          MatchKind.GENERIC else MatchKind.NOT_COMPATIBLE;
       then
         (actualType, matchKind);
 

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -860,7 +860,6 @@ public constant ErrorTypes.Message CONVERSION_NO_COMPATIBLE_SCRIPT_FOUND = Error
   Gettext.gettext("No compatible conversion script for converting from %s %s to %s could be found."));
 
 public constant Gettext.TranslatableContent FUNCTION_CALL_EXPRESSION = Gettext.gettext("a function call expression");
-public constant Gettext.TranslatableContent COMPONENT_EXPRESSION = Gettext.gettext("a component expression");
 public constant ErrorTypes.Message FUNCTION_ARGUMENT_MUST_BE = ErrorTypes.MESSAGE(394, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("The argument to ‘%s‘ must be %s."));
 

--- a/testsuite/flattening/modelica/scodeinst/CardinalityInvalidArg2.mo
+++ b/testsuite/flattening/modelica/scodeinst/CardinalityInvalidArg2.mo
@@ -26,10 +26,10 @@ end CardinalityInvalidArg2;
 
 // Result:
 // Error processing file: CardinalityInvalidArg2.mo
-// [flattening/modelica/scodeinst/CardinalityInvalidArg2.mo:23:3-24:9:writable] Error: Type mismatch for positional argument 1 in cardinality(=a1.c). The argument has type:
+// [flattening/modelica/scodeinst/CardinalityInvalidArg2.mo:23:3-24:9:writable] Error: Type mismatch for positional argument 1 in cardinality(c=a1.c). The argument has type:
 //   C[2]
 // expected type:
-//   connector
+//   Connector
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinBackSample1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinBackSample1.mo
@@ -1,0 +1,17 @@
+// name: FuncBuiltinBackSample1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinBackSample1
+  Clock c1 = Clock(3, 10);
+  Clock c2 = backSample(c1, 2);
+end FuncBuiltinBackSample1;
+
+// Result:
+// class FuncBuiltinBackSample1
+//   Clock c1 = Clock(3, 10);
+//   Clock c2 = backSample(c1, 2, 1);
+// end FuncBuiltinBackSample1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinHold1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinHold1.mo
@@ -1,0 +1,20 @@
+// name: FuncBuiltinHold1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinHold1
+  Real x, y;
+equation
+  y = hold(x);
+end FuncBuiltinHold1;
+
+// Result:
+// class FuncBuiltinHold1
+//   Real x;
+//   Real y;
+// equation
+//   y = hold(x);
+// end FuncBuiltinHold1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinNoClock1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinNoClock1.mo
@@ -1,0 +1,26 @@
+// name: FuncBuiltinNoClock1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinNoClock1
+  Real x, y;
+  Clock c1 = Clock(0.1);
+equation
+  when c1 then
+    y = noClock(x);
+  end when;
+end FuncBuiltinNoClock1;
+
+// Result:
+// class FuncBuiltinNoClock1
+//   Real x;
+//   Real y;
+//   Clock c1 = Clock(0.1);
+// equation
+//   when c1 then
+//     y = noClock(x);
+//   end when;
+// end FuncBuiltinNoClock1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo
@@ -17,7 +17,10 @@ end FuncBuiltinPrevious4;
 
 // Result:
 // Error processing file: FuncBuiltinPrevious4.mo
-// [flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo:15:3-15:18:writable] Error: The argument to ‘previous‘ must be a component expression.
+// [flattening/modelica/scodeinst/FuncBuiltinPrevious4.mo:15:3-15:18:writable] Error: Type mismatch for positional argument 1 in previous(u=f). The argument has type:
+//   f<function>() => ()
+// expected type:
+//   ComponentExpression
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinShiftSample1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinShiftSample1.mo
@@ -1,0 +1,17 @@
+// name: FuncBuiltinShiftSample1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinShiftSample1
+  Clock c1 = Clock(3, 10);
+  Clock c2 = shiftSample(c1, 1, 3);
+end FuncBuiltinShiftSample1;
+
+// Result:
+// class FuncBuiltinShiftSample1
+//   Clock c1 = Clock(3, 10);
+//   Clock c2 = shiftSample(c1, 1, 3);
+// end FuncBuiltinShiftSample1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinSubSample1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinSubSample1.mo
@@ -1,0 +1,17 @@
+// name: FuncBuiltinSubSample1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinSubSample1
+  Boolean b1;
+  Boolean b2 = subSample(b1, 2);
+end FuncBuiltinSubSample1;
+
+// Result:
+// class FuncBuiltinSubSample1
+//   Boolean b1;
+//   Boolean b2 = subSample(b1, 2);
+// end FuncBuiltinSubSample1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinSubSample2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinSubSample2.mo
@@ -1,0 +1,17 @@
+// name: FuncBuiltinSubSample2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinSubSample2
+  Clock c1 = Clock(1);
+  Clock c2 = subSample(c1, 2);
+end FuncBuiltinSubSample2;
+
+// Result:
+// class FuncBuiltinSubSample2
+//   Clock c1 = Clock(1, 1);
+//   Clock c2 = subSample(c1, 2);
+// end FuncBuiltinSubSample2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinSuperSample1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinSuperSample1.mo
@@ -1,0 +1,17 @@
+// name: FuncBuiltinSuperSample1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinSuperSample1
+  Boolean b1;
+  Boolean b2 = superSample(b1, 2);
+end FuncBuiltinSuperSample1;
+
+// Result:
+// class FuncBuiltinSuperSample1
+//   Boolean b1;
+//   Boolean b2 = superSample(b1, 2);
+// end FuncBuiltinSuperSample1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinSuperSample2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinSuperSample2.mo
@@ -1,0 +1,17 @@
+// name: FuncBuiltinSuperSample2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model FuncBuiltinSuperSample2
+  Clock c1 = Clock(1);
+  Clock c2 = superSample(c1, 2);
+end FuncBuiltinSuperSample2;
+
+// Result:
+// class FuncBuiltinSuperSample2
+//   Clock c1 = Clock(1, 1);
+//   Clock c2 = superSample(c1, 2);
+// end FuncBuiltinSuperSample2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinSymmetric2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinSymmetric2.mo
@@ -1,0 +1,27 @@
+// name: FuncBuiltinSymmetric2
+// keywords: symmetric
+// status: incorrect
+// cflags: -d=newInst
+//
+// Tests the builtin symmetric operator.
+//
+
+model FuncBuiltinSymmetric2
+  Real x[:, :] = symmetric({{11, 12, 13},
+                            {21, 22, 23},
+                            {31, 32, 33},
+                            {41, 42, 43}});
+end FuncBuiltinSymmetric2;
+
+// Result:
+// Error processing file: FuncBuiltinSymmetric2.mo
+// [flattening/modelica/scodeinst/FuncBuiltinSymmetric2.mo:10:3-13:43:writable] Error: Type mismatch for positional argument 1 in symmetric(={{11, 12, 13}, {21, 22, 23}, {31, 32, 33}, {41, 42, 43}}). The argument has type:
+//   Integer[4, 3]
+// expected type:
+//   Any[n, n]
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -489,6 +489,7 @@ ForStatementPrefix.mo \
 func1.mo \
 func2.mo \
 FuncBuiltinAbs.mo \
+FuncBuiltinBackSample1.mo \
 FuncBuiltinCeil.mo \
 FuncBuiltinChange.mo \
 FuncBuiltinCross.mo \
@@ -504,6 +505,7 @@ FuncBuiltinFill2.mo \
 FuncBuiltinFill3.mo \
 FuncBuiltinFloor.mo \
 FuncBuiltinGetInstanceName.mo \
+FuncBuiltinHold1.mo \
 FuncBuiltinHomotopy.mo \
 FuncBuiltinIdentity.mo \
 FuncBuiltinInitial1.mo \
@@ -517,6 +519,7 @@ FuncBuiltinMax.mo \
 FuncBuiltinMin.mo \
 FuncBuiltinMod.mo \
 FuncBuiltinNdims.mo \
+FuncBuiltinNoClock1.mo \
 FuncBuiltinOnes.mo \
 FuncBuiltinOuterProduct.mo \
 FuncBuiltinPre.mo \
@@ -535,6 +538,7 @@ FuncBuiltinSample.mo \
 FuncBuiltinScalar.mo \
 FuncBuiltinScalar2.mo \
 FuncBuiltinSemiLinear.mo \
+FuncBuiltinShiftSample1.mo \
 FuncBuiltinSign.mo \
 FuncBuiltinSize.mo \
 FuncBuiltinSkew.mo \
@@ -545,8 +549,13 @@ FuncBuiltinSmoothWrongType1.mo \
 FuncBuiltinSmoothWrongType2.mo \
 FuncBuiltinSpatialDistribution.mo \
 FuncBuiltinSqrt.mo \
+FuncBuiltinSubSample1.mo \
+FuncBuiltinSubSample2.mo \
 FuncBuiltinSum.mo \
+FuncBuiltinSuperSample1.mo \
+FuncBuiltinSuperSample2.mo \
 FuncBuiltinSymmetric.mo \
+FuncBuiltinSymmetric2.mo \
 FuncBuiltinTerminal1.mo \
 FuncBuiltinTerminal2.mo \
 FuncBuiltinTranspose.mo \


### PR DESCRIPTION
- Implement some simple resolving of polymorphic return types when
  typing function calls, to replace the old hack of manually having to
  patch the return type of many builtin functions.
- Remove special handling of `diagonal` and `previous`, they can now be
  typed based on their definitions in ModelicaBuiltin.
- Simplify handling of `cardinality`, it can now be typed normally and
  only needs some checks that it's used in the correct context.
- Use a custom polymorphic type `__Any` to reduce the need for unboxing
  builtin functions.
- Add tests for some builtin functions that were lacking tests.