### PR TITLE
Fix some uninitialized variable accesses

### DIFF
--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -662,7 +662,6 @@ PlainTextEdit::PlainTextEdit(BaseEditor *pBaseEditor)
   : QPlainTextEdit(pBaseEditor), mpBaseEditor(pBaseEditor)
 {
   setObjectName("BaseEditor");
-  setReadOnlyStyleSheet();
   QTextDocument *pTextDocument = document();
   pTextDocument->setDocumentMargin(2);
   BaseEditorDocumentLayout *pModelicaTextDocumentLayout = new BaseEditorDocumentLayout(pTextDocument);
@@ -698,6 +697,7 @@ PlainTextEdit::PlainTextEdit(BaseEditor *pBaseEditor)
   mpCompleter->setCompletionMode(QCompleter::PopupCompletion);
   connect(mpCompleter, SIGNAL(highlighted(QModelIndex)), this, SLOT(showCompletionItemToolTip(QModelIndex)));
   connect(mpCompleter, SIGNAL(activated(QModelIndex)), this, SLOT(insertCompletionItem(QModelIndex)));
+  setReadOnlyStyleSheet();
   updateLineNumberAreaWidth(0);
   updateHighlights();
   updateCursorPosition();

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -68,6 +68,7 @@ LibraryTreeItem::LibraryTreeItem()
   setName("");
   setNameStructure("");
   OMCInterface::getClassInformation_res classInformation;
+  setAccessAnnotations(false);
   setClassInformation(classInformation);
   setFileName("");
   mVersionDate = "";
@@ -83,7 +84,6 @@ LibraryTreeItem::LibraryTreeItem()
   setClassTextAfter("");
   setExpanded(false);
   setNonExisting(true);
-  setAccessAnnotations(false);
   setOMSElement(0);
   setSystemType(oms_system_none);
   setComponentType(oms_component_none);
@@ -115,6 +115,7 @@ LibraryTreeItem::LibraryTreeItem(LibraryType type, QString text, QString nameStr
   setDragPixmap(QPixmap());
   setName(text);
   setNameStructure(nameStructure);
+  setAccessAnnotations(false);
   if (type == LibraryTreeItem::Modelica) {
     setSaveContentsType(LibraryTreeItem::SaveInOneFile);
     setClassInformation(classInformation);
@@ -129,7 +130,6 @@ LibraryTreeItem::LibraryTreeItem(LibraryType type, QString text, QString nameStr
   setClassTextAfter("");
   setExpanded(false);
   setNonExisting(false);
-  setAccessAnnotations(false);
   setOMSElement(0);
   setSystemType(oms_system_none);
   setComponentType(oms_component_none);


### PR DESCRIPTION
- Make sure `mpCompleterToolTipWidget` is assigned in `PlainTestEdit`
  before calling `setReadOnlyStyleSheet()`, since it causes
  `eventFilter()` to be called which uses it.
- Make sure `mAccessAnnotations` is assigned in `LibraryTreeItem` before
  calling `setClassInformation()`, since it uses `getAccess()`.