### PR TITLE
Classify Modelica as Modelica and Not Mokoto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mo linguist-language=Modelica


### PR DESCRIPTION
### Purpose
Due to changes on Github Modelica is incorrectly classified as Motoko:
![image](https://user-images.githubusercontent.com/8775827/146640929-5e69aac5-0e14-4ef6-a86b-402522ded07a.png)

### Approach
This PR adds a .gitattributes file s.t Modelica is classified as Modelica again