### PR TITLE
Fixed gitattributes for sub projects

### DIFF
--- a/OMCompiler/.gitattributes
+++ b/OMCompiler/.gitattributes
@@ -13,3 +13,4 @@ Makefile* text eol=native
 *.tpl eol=lf
 *.po eol=lf
 *.g text eol=lf
+*.mo linguist-language=Modelica

--- a/OMNotebook/.gitattributes
+++ b/OMNotebook/.gitattributes
@@ -9,3 +9,4 @@ LICENSE text eol=lf
 configure.ac text eol=lf
 Makefile* text eol=lf
 *.pro text eol=lf
+*.mo linguist-language=Modelica

--- a/testsuite/.gitattributes
+++ b/testsuite/.gitattributes
@@ -4,3 +4,4 @@ Makefile* text eol=native
 *.c text eol=lf
 *.h text eol=lf
 *.pl text eol=lf
+*.mo linguist-language=Modelica


### PR DESCRIPTION
### Purpose

The previous PR only fixes the issue for the root directory.
However, sub repositories are reported differently. 

See: https://github.com/OpenModelica/OpenModelica/pull/8346

### Approach
Extend .gitattributes in the directories that contain Modelica code. 
