### PR TITLE
[NF] add expanding of fill expression

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -280,13 +280,14 @@ public
     Absyn.Path fn_path = Function.nameConsiderBuiltin(fn);
   algorithm
     (outExp, expanded) := match AbsynUtil.pathFirstIdent(fn_path)
-      case "cat" then expandBuiltinCat(args, call);
-      case "der" then expandBuiltinGeneric(call);
-      case "diagonal" then expandBuiltinDiagonal(listHead(args));
-      case "pre" then expandBuiltinGeneric(call);
-      case "previous" then expandBuiltinGeneric(call);
-      case "promote" then expandBuiltinPromote(args);
-      case "transpose" then expandBuiltinTranspose(listHead(args));
+      case "cat"        then expandBuiltinCat(args, call);
+      case "der"        then expandBuiltinGeneric(call);
+      case "diagonal"   then expandBuiltinDiagonal(listHead(args));
+      case "pre"        then expandBuiltinGeneric(call);
+      case "previous"   then expandBuiltinGeneric(call);
+      case "promote"    then expandBuiltinPromote(args);
+      case "transpose"  then expandBuiltinTranspose(listHead(args));
+      case "fill"       then expandBuiltinFill(args);
     end match;
   end expandBuiltinCall;
 
@@ -347,6 +348,22 @@ public
       outExp := Expression.transposeArray(outExp);
     end if;
   end expandBuiltinTranspose;
+
+  function expandBuiltinFill
+    input list<Expression> args;
+    output Expression outExp;
+    output Boolean expanded = true;
+  protected
+    Expression content;
+    Integer size;
+  algorithm
+    {content, Expression.INTEGER(value = size)} := args;
+    outExp := Expression.ARRAY(
+      ty        = Type.liftArrayLeft(Expression.typeOf(content), Dimension.INTEGER(size, NFPrefixes.Variability.CONSTANT)),
+      elements  = List.fill(content, size),
+      literal   = true
+    );
+  end expandBuiltinFill;
 
   function expandBuiltinGeneric
     input Call call;


### PR DESCRIPTION

### Purpose
Also expand fill expressions in ExpandExp.mo
Fill expressions were implemented as default for repeated array bindings in #8329. For scalarizing this, the expand expression module needs to be able to scalarize it.