### PR TITLE
implement fmi2SetRealInputDerivatives

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -324,6 +324,7 @@ uniontype VarInfo "Number of variables of various types in a Modelica model."
     Integer numSensitivityParameters;
     Integer numSetcVars;
     Integer numDataReconVars;
+    Integer numRealInputVars "for fmi cs to interpolate inputs";
   end VARINFO;
 end VarInfo;
 

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -363,11 +363,13 @@ let numberOfReals = intAdd(intMul(varInfo.numStateVars,2),intAdd(varInfo.numDisc
 let numberOfIntegers = intAdd(varInfo.numIntAlgVars,intAdd(varInfo.numIntParams,varInfo.numIntAliasVars))
 let numberOfStrings = intAdd(varInfo.numStringAlgVars,intAdd(varInfo.numStringParamVars,varInfo.numStringAliasVars))
 let numberOfBooleans = intAdd(varInfo.numBoolAlgVars,intAdd(varInfo.numBoolParams,varInfo.numBoolAliasVars))
+let numberOfRealInputs = varInfo.numRealInputVars
   <<
   // define model size
   #define NUMBER_OF_STATES <%if intEq(varInfo.numStateVars,1) then statesnumwithDummy(listStates) else  varInfo.numStateVars%>
   #define NUMBER_OF_EVENT_INDICATORS <%varInfo.numZeroCrossings%>
   #define NUMBER_OF_REALS <%numberOfReals%>
+  #define NUMBER_OF_REAL_INPUTS <%numberOfRealInputs%>
   #define NUMBER_OF_INTEGERS <%numberOfIntegers%>
   #define NUMBER_OF_STRINGS <%numberOfStrings%>
   #define NUMBER_OF_BOOLEANS <%numberOfBooleans%>

--- a/OMCompiler/Compiler/Template/CodegenFMU2.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU2.tpl
@@ -140,7 +140,7 @@ case SIMCODE(__) then
     modelIdentifier="<%Util.escapeModelicaStringToXmlString(modelIdentifier)%>"
     needsExecutionTool="false"
     canHandleVariableCommunicationStepSize="true"
-    canInterpolateInputs="false"
+    canInterpolateInputs="true"
     maxOutputDerivativeOrder="1"
     canRunAsynchronuously = "false"
     canBeInstantiatedOnlyOncePerProcess="false"

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -797,7 +797,8 @@ package SimCode
       Integer numSensitivityParameters;
       Integer numSetcVars;
       Integer numDataReconVars;
-      end VARINFO;
+      Integer numRealInputVars "for fmi cs to interpolate inputs";
+    end VARINFO;
   end VarInfo;
 
   uniontype DaeModeConfig

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -1492,6 +1492,7 @@ fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference
 
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: nvr = %d", nvr)
 
+#if NUMBER_OF_REAL_INPUTS > 0
   for (i = 0; i < nvr; i++) {
     if (order[i] > 1) // currently first order derivative is supported
       return fmi2Error;
@@ -1500,11 +1501,10 @@ fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference
     // TODO check valueReference is a valid Real input
 
     comp->input_real_derivative[i]= value[i]; // store the values in an external array
-
-    // should we use setReal here to set the values to inputs directly ?
-    // if (setReal(comp, vr[i], value[i]) != fmi2OK) // to be implemented by the includer of this file
-    //   return fmi2Error;
+    FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: #r%u# = %.16g", vr[i], value[i])
   }
+#endif
+
   comp->_need_update = 1;
   return fmi2OK;
 }

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -1482,6 +1482,7 @@ fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference
 {
   /* Variables */
   int i;
+  int mappedIndex;
   ModelInstance *comp = (ModelInstance*)c;
 
   /* Check for valid call sequence */
@@ -1502,9 +1503,10 @@ fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference
     if (vrOutOfRange(comp, "fmi2SetRealInputDerivatives", vr[i], NUMBER_OF_REALS))
       return fmi2Error;
     // check valueReference is an input of type Real
-    if (mapInputReference2InputNumber(vr[i]) == -1)
+    mappedIndex = mapInputReference2InputNumber(vr[i]);
+    if (mappedIndex == -1)
       return fmi2Error;
-    comp->input_real_derivative[i]= value[i]; // store the values in an external array
+    comp->input_real_derivative[mappedIndex] = value[i]; // store the values in an external array
     FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: #r%u# = %.16g", vr[i], value[i])
   }
 #endif

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -582,6 +582,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
   comp->states_der = (fmi2Real*)functions->allocateMemory(NUMBER_OF_STATES, sizeof(fmi2Real));
   comp->event_indicators = (fmi2Real*)functions->allocateMemory(NUMBER_OF_EVENT_INDICATORS, sizeof(fmi2Real));
   comp->event_indicators_prev = (fmi2Real*)functions->allocateMemory(NUMBER_OF_EVENT_INDICATORS, sizeof(fmi2Real));
+  comp->input_real_derivative = (fmi2Real*)functions->allocateMemory(NUMBER_OF_REAL_INPUTS, sizeof(fmi2Real));
 
   comp->_need_update = 1;
 
@@ -647,6 +648,7 @@ void fmi2FreeInstance(fmi2Component c)
   freeMemory(comp->states_der); comp->states_der = NULL;
   freeMemory(comp->event_indicators); comp->event_indicators = NULL;
   freeMemory(comp->event_indicators_prev); comp->event_indicators_prev = NULL;
+  freeMemory(comp->input_real_derivative); comp->input_real_derivative = NULL;
 
   freeMemory(comp->fmuData->modelData->resourcesDir);
   if (comp->solverInfo) {
@@ -1493,13 +1495,15 @@ fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: nvr = %d", nvr)
 
 #if NUMBER_OF_REAL_INPUTS > 0
-  for (i = 0; i < nvr; i++) {
+  for (i = 0; i < nvr; i++)
+  {
     if (order[i] > 1) // currently first order derivative is supported
       return fmi2Error;
     if (vrOutOfRange(comp, "fmi2SetRealInputDerivatives", vr[i], NUMBER_OF_REALS))
       return fmi2Error;
-    // TODO check valueReference is a valid Real input
-
+    // check valueReference is an input of type Real
+    if (mapInputReference2InputNumber(vr[i]) == -1)
+      return fmi2Error;
     comp->input_real_derivative[i]= value[i]; // store the values in an external array
     FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: #r%u# = %.16g", vr[i], value[i])
   }

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -1478,8 +1478,35 @@ Functions for FMI2 for Co-Simulation
 ****************************************************/
 fmi2Status fmi2SetRealInputDerivatives(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer order[], const fmi2Real value[])
 {
-  // TODO Write code here
-  return unsupportedFunction(c, "fmi2SetRealInputDerivatives", ~0);
+  /* Variables */
+  int i;
+  ModelInstance *comp = (ModelInstance*)c;
+
+  /* Check for valid call sequence */
+  if (invalidState(comp, "fmi2SetRealInputDerivatives", modelInitializationMode|modelEventMode|modelContinuousTimeMode|modelTerminated|modelError, ~0))
+    return fmi2Error;
+  if (nvr > 0 && nullPointer(comp, "fmi2SetRealInputDerivatives", "vr[]", vr))
+    return fmi2Error;
+  if (nvr > 0 && nullPointer(comp, "fmi2SetRealInputDerivatives", "value[]", value))
+    return fmi2Error;
+
+  FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2SetRealInputDerivatives: nvr = %d", nvr)
+
+  for (i = 0; i < nvr; i++) {
+    if (order[i] > 1) // currently first order derivative is supported
+      return fmi2Error;
+    if (vrOutOfRange(comp, "fmi2SetRealInputDerivatives", vr[i], NUMBER_OF_REALS))
+      return fmi2Error;
+    // TODO check valueReference is a valid Real input
+
+    comp->input_real_derivative[i]= value[i]; // store the values in an external array
+
+    // should we use setReal here to set the values to inputs directly ?
+    // if (setReal(comp, vr[i], value[i]) != fmi2OK) // to be implemented by the includer of this file
+    //   return fmi2Error;
+  }
+  comp->_need_update = 1;
+  return fmi2OK;
 }
 
 fmi2Status fmi2GetRealOutputDerivatives(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer order[], fmi2Real value[])

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
@@ -97,6 +97,7 @@ typedef struct {
   fmi2Real* states_der;
   fmi2Real* event_indicators;
   fmi2Real* event_indicators_prev;
+  fmi2Real* input_real_derivative;
 } ModelInstance;
 
 /* reset alignment policy to the one set before reading this file */


### PR DESCRIPTION
### Purpose

This PR implements `fmi2SetRealInputDerivatives` and set `canInterpolateInputs = true` in `modeldescription.xml`

