### PR TITLE
check epsilon greater than 0 for dataReconciliation

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -2533,7 +2533,7 @@ void DataReconciliationDialog::calculateDataReconciliation()
       mpDataReconciliationMeasurementInputFileTextBox->setFocus(Qt::ActiveWindowFocusReason);
       return;
     }
-    if (mpDataReconciliationEpsilonTextBox->text().toDouble() == 0 && !mpDataReconciliationEpsilonTextBox->text().isEmpty()) {
+    if (mpDataReconciliationEpsilonTextBox->text().toDouble() <= 0 && !mpDataReconciliationEpsilonTextBox->text().isEmpty()) {
       QMessageBox::critical(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::error),
                           "Epsilon value must be greater than 0", Helper::ok);
       mpDataReconciliationEpsilonTextBox->setFocus(Qt::ActiveWindowFocusReason);


### PR DESCRIPTION
### Purpose

This PR checks epsilon always greater than `0` for computing `data Reconciliation`
