### PR TITLE
Link to static versions of sundails for FMUs.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1278,7 +1278,7 @@ template fmuMakefile(String target, SimCode simCode, String FMUVersion, list<Str
     endif
     ifneq ($(NEED_SUNDIALS),)
     FMISUNDIALSFILES=<%sundialsObjectFiles ; separator = " "%>
-    LDFLAGS+=-lsundials_cvode -lsundials_nvecserial
+    LDFLAGS+=-Wl,-Bstatic -lsundials_cvode -lsundials_nvecserial -Wl,-Bdynamic
     endif
     >>
 


### PR DESCRIPTION
  - We build both static and shared versions of sundials libs.
    The shared versions are needed for the cpp runtime.

    If we are generating static FMUs with CVODE as a solver we
    link to `cvode` and `nvecserial`. Make sure we link to the static versions
    of this libraries.

