### PR TITLE
Fix handling of REAL_CLOCK

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
@@ -2302,9 +2302,8 @@ algorithm
     then (DAE.REAL_CLOCK(e), eqs, vars, cnt);
 
     case DAE.RATIONAL_CLOCK(e, i) equation
-      // AHeu: Surpressing substClockExp to get rid of previous in intervalCounter
-      //(e, eqs, vars, cnt) = substClockExp(e, inNewEqs, inNewVars, inCnt, inShared);
-    then (DAE.RATIONAL_CLOCK(e, i), inNewEqs, inNewVars, inCnt);
+      (e, eqs, vars, cnt) = substClockExp(e, inNewEqs, inNewVars, inCnt, inShared);
+    then (DAE.RATIONAL_CLOCK(e, i), eqs, vars, cnt);
 
     else (inClk, inNewEqs, inNewVars, inCnt);
   end match;
@@ -2362,10 +2361,6 @@ algorithm
     outCnt := inCnt;
   else
     ({outExp}, outNewEqs, outNewVars, outCnt) := substExp({inExp}, inNewEqs, inNewVars, inCnt);
-    outExp := match outExp
-      case DAE.CREF(_, ty) then Expression.makePureBuiltinCall("previous", {outExp}, ty);
-      else outExp;
-    end match;
   end if;
 end substClockExp;
 

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -357,6 +357,11 @@ template baseClockInit(ClockKind baseClock, Integer baseClockIdx, list<SubPartit
     else
       '0'
   let interval = match baseClock
+    case REAL_CLOCK() then
+      if isConst(interval) then
+        daeExp(interval, contextOther, &preExp, &varDecls, &auxFunction)
+      else
+        '-1 /* Interval set in _updateSynchronous */'
     case INFERRED_CLOCK() then
       '1'
     else
@@ -471,11 +476,16 @@ template updatePartition(Integer i, DAE.ClockKind baseClock, Text &varDecls, Tex
         data->simulationInfo->baseClocks[base_idx].interval = DIVISION((modelica_real)data->simulationInfo->baseClocks[base_idx].intervalCounter, (modelica_real)data->simulationInfo->baseClocks[base_idx].resolution, "intervalCounter/resolution");
         >>
     case REAL_CLOCK() then
-      let interval = daeExp(getClockInterval(baseClock), contextOther, &preExp, &varDecls, &auxFunction)
-      <<
-      <%preExp%>
-      data->simulationInfo->baseClocks[base_idx].interval = <%interval%>;
-      >>
+      if isConst(interval) then
+        <<
+        /* Nothing to do */
+        >>
+      else
+        let interval_ = daeExp(interval, contextOther, &preExp, &varDecls, &auxFunction)
+        <<
+        <%preExp%>
+        data->simulationInfo->baseClocks[base_idx].interval = <%interval_%>;
+        >>
     case INFERRED_CLOCK()
     case SOLVER_CLOCK()
     case EVENT_CLOCK() then


### PR DESCRIPTION
### Related Issues

Partially fixes #8387

### Purpose

- Do not put Clock constructor arguments inside previous call, but still generate local var if necessary.
- No need to update constant interval.
