### PR TITLE
Handle fill in ExpandExp

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -2199,30 +2199,18 @@ public
 function evalBuiltinFill
   input list<Expression> args;
   output Expression result;
-algorithm
-  result := evalBuiltinFill2(listHead(args), listRest(args));
-end evalBuiltinFill;
-
-function evalBuiltinFill2
-  input Expression fillValue;
-  input list<Expression> dims;
-  output Expression result = fillValue;
 protected
-  Integer dim_size;
-  list<Expression> arr;
-  Type arr_ty = Expression.typeOf(result);
+  Expression fill_exp;
+  list<Expression> dims;
 algorithm
-  for d in listReverse(dims) loop
-    () := match d
-      case Expression.INTEGER(value = dim_size) then ();
-      else algorithm printWrongArgsError(getInstanceName(), {d}, sourceInfo()); then fail();
-    end match;
-
-    arr := list(result for e in 1:dim_size);
-    arr_ty := Type.liftArrayLeft(arr_ty, Dimension.fromInteger(dim_size));
-    result := Expression.makeArray(arr_ty, arr, Expression.isLiteral(fillValue));
-  end for;
-end evalBuiltinFill2;
+  try
+    fill_exp :: dims := args;
+    result := Expression.fillArgs(fill_exp, dims);
+  else
+    printWrongArgsError(getInstanceName(), args, sourceInfo());
+    fail();
+  end try;
+end evalBuiltinFill;
 
 protected
 function evalBuiltinFloor
@@ -2514,7 +2502,7 @@ function evalBuiltinOnes
   input list<Expression> args;
   output Expression result;
 algorithm
-  result := evalBuiltinFill2(Expression.INTEGER(1), args);
+  result := evalBuiltinFill(Expression.INTEGER(1) :: args);
 end evalBuiltinOnes;
 
 function evalBuiltinProduct
@@ -2874,7 +2862,7 @@ function evalBuiltinZeros
   input list<Expression> args;
   output Expression result;
 algorithm
-  result := evalBuiltinFill2(Expression.INTEGER(0), args);
+  result := evalBuiltinFill(Expression.INTEGER(0) :: args);
 end evalBuiltinZeros;
 
 function evalUriToFilename

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -280,12 +280,13 @@ public
     Absyn.Path fn_path = Function.nameConsiderBuiltin(fn);
   algorithm
     (outExp, expanded) := match AbsynUtil.pathFirstIdent(fn_path)
-      case "cat" then expandBuiltinCat(args, call);
-      case "der" then expandBuiltinGeneric(call);
-      case "diagonal" then expandBuiltinDiagonal(listHead(args));
-      case "pre" then expandBuiltinGeneric(call);
-      case "previous" then expandBuiltinGeneric(call);
-      case "promote" then expandBuiltinPromote(args);
+      case "cat"       then expandBuiltinCat(args, call);
+      case "der"       then expandBuiltinGeneric(call);
+      case "diagonal"  then expandBuiltinDiagonal(listHead(args));
+      case "fill"      then expandBuiltinFill(args);
+      case "pre"       then expandBuiltinGeneric(call);
+      case "previous"  then expandBuiltinGeneric(call);
+      case "promote"   then expandBuiltinPromote(args);
       case "transpose" then expandBuiltinTranspose(listHead(args));
     end match;
   end expandBuiltinCall;
@@ -335,6 +336,14 @@ public
       outExp := Ceval.evalBuiltinDiagonal(outExp);
     end if;
   end expandBuiltinDiagonal;
+
+  function expandBuiltinFill
+    input list<Expression> args;
+    output Expression outExp;
+    output Boolean expanded = true;
+  algorithm
+    outExp := Expression.fillArgs(listHead(args), listRest(args));
+  end expandBuiltinFill;
 
   function expandBuiltinTranspose
     input Expression arg;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -3826,6 +3826,27 @@ public
     end for;
   end fillType;
 
+  function fillArgs
+    "Creates an array from the given fill expression and list of dimensions,
+     similar to fill(fillExp, dims...). Fails if not all dimensions can be
+     converted to Integer values."
+    input Expression fillExp;
+    input list<Expression> dims;
+    output Expression result = fillExp;
+  protected
+    Integer dim_size;
+    list<Expression> arr;
+    Type arr_ty = typeOf(result);
+    Boolean is_literal = isLiteral(fillExp);
+  algorithm
+    for d in listReverse(dims) loop
+      dim_size := toInteger(d);
+      arr := list(result for e in 1:dim_size);
+      arr_ty := Type.liftArrayLeft(arr_ty, Dimension.fromInteger(dim_size));
+      result := Expression.makeArray(arr_ty, arr, is_literal);
+    end for;
+  end fillArgs;
+
   function liftArray
     "Creates an array with the given dimension, where each element is the given
      expression. Example: liftArray([3], 1) => {1, 1, 1}"

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -355,7 +355,7 @@ function simplifyFill
   output Expression exp;
 algorithm
   if List.all(dimArgs, Expression.isLiteral) then
-    exp := Ceval.evalBuiltinFill2(fillArg, dimArgs);
+    exp := Expression.fillArgs(fillArg, dimArgs);
   else
     exp := Expression.CALL(call);
   end if;


### PR DESCRIPTION
- Expand fill calls in ExpandExp.
- Move the implementation in Ceval.evalBuiltinFills to a more generic
  Expression.fillArgs function, since the functionality is used in
  several places in the compiler.