### PR TITLE
Check for negative dimensions later

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -676,8 +676,6 @@ algorithm
     // Other kinds of dimensions are already typed.
     else dimension;
   end match;
-
-  verifyDimension(dimension, component, info);
 end typeDimension;
 
 function subscriptDimExp
@@ -737,27 +735,6 @@ algorithm
     else dimExp;
   end match;
 end simplifyDimExp;
-
-function verifyDimension
-  input Dimension dimension;
-  input InstNode component;
-  input SourceInfo info;
-algorithm
-  () := match dimension
-    case Dimension.INTEGER()
-      algorithm
-        // Check that integer dimensions are not negative.
-        if dimension.size < 0 then
-          Error.addSourceMessage(Error.NEGATIVE_DIMENSION_INDEX,
-            {String(dimension.size), InstNode.name(component)}, info);
-          fail();
-        end if;
-      then
-        ();
-
-    else ();
-  end match;
-end verifyDimension;
 
 function makeDimension
   input Expression dimExp;

--- a/testsuite/flattening/modelica/scodeinst/DimNegative2.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimNegative2.mo
@@ -1,0 +1,14 @@
+// name: DimNegative1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model DimNegative2
+  Real x[-1] if false;
+end DimNegative2;
+
+// Result:
+// class DimNegative2
+// end DimNegative2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -318,6 +318,7 @@ DimInvalidExp3.mo \
 DimInvalidType1.mo \
 DimInvalidType2.mo \
 DimNegative1.mo \
+DimNegative2.mo \
 DimRagged1.mo \
 DimRagged2.mo \
 DimSize1.mo \


### PR DESCRIPTION
- Move the check for negative dimensions from typing to flattening, so
  it's done after deleted conditional components have been removed.

Fixes #8374