### PR TITLE
Fix scope when mixing replaceable and inner/outer

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -633,7 +633,7 @@ algorithm
   if ComponentRef.isPackageConstant(cref) then
     res := false;
   elseif ComponentRef.nodeVariability(cref) <= Variability.PARAMETER and ComponentRef.isCref(cref) then
-    node := InstNode.derivedParent(ComponentRef.node(ComponentRef.last(cref)));
+    node := InstNode.instanceParent(ComponentRef.node(ComponentRef.last(cref)));
 
     if InstNode.isClass(node) then
       fnl := Function.getCachedFuncs(node);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -566,17 +566,20 @@ uniontype InstNode
     CLASS_NODE(parentScope = parent) := node;
   end classParent;
 
-  function derivedParent
+  function instanceParent
+    "Returns the parent of the node in the instance tree."
     input InstNode node;
     output InstNode parent;
   algorithm
     parent := match node
       case CLASS_NODE() then getDerivedNode(node.parentScope);
+      case COMPONENT_NODE(nodeType = InstNodeType.REDECLARED_COMP(parent = parent))
+        then getDerivedNode(parent);
       case COMPONENT_NODE() then getDerivedNode(node.parent);
       case IMPLICIT_SCOPE() then getDerivedNode(node.parentScope);
       else EMPTY_NODE();
     end match;
-  end derivedParent;
+  end instanceParent;
 
   function rootParent
     input InstNode node;
@@ -1728,7 +1731,7 @@ uniontype InstNode
   algorithm
     hasBinding := match node
       case COMPONENT_NODE()
-        then Component.hasBinding(Pointer.access(node.component)) or hasBinding(derivedParent(node));
+        then Component.hasBinding(Pointer.access(node.component)) or hasBinding(instanceParent(node));
       else false;
     end match;
   end hasBinding;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -398,7 +398,7 @@ algorithm
     else
       // Continue looking in the instance parent's scope.
       prev_scope := cur_scope;
-      cur_scope := InstNode.derivedParent(cur_scope);
+      cur_scope := InstNode.instanceParent(cur_scope);
     end try;
   end while;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -698,7 +698,7 @@ algorithm
   // If the expression has too many dimensions, add split subscripts based on
   // the component's parent's dimensions until we get a scalar expression.
   subs := {};
-  parent := InstNode.derivedParent(component);
+  parent := InstNode.instanceParent(component);
 
   while exp_dims > 0 and not InstNode.isEmpty(parent) loop
     parent_dims := InstNode.dimensionCount(parent);
@@ -712,7 +712,7 @@ algorithm
       end if;
     end for;
 
-    parent := InstNode.derivedParent(parent);
+    parent := InstNode.instanceParent(parent);
   end while;
 
   dimExp := Expression.applySubscripts(subs, dimExp);
@@ -767,7 +767,7 @@ protected
   Expression exp;
   Binding parent_binding;
 algorithm
-  parent := InstNode.derivedParent(component);
+  parent := InstNode.instanceParent(component);
 
   if InstNode.isComponent(parent) then
     // Get the binding of the component's parent.
@@ -1038,7 +1038,7 @@ protected
   InstNode parent;
 algorithm
   if Binding.isEach(binding) then
-    parent := InstNode.derivedParent(component);
+    parent := InstNode.instanceParent(component);
 
     if not Type.isArray(InstNode.getType(parent)) then
       Error.addStrictMessage(Error.EACH_ON_NON_ARRAY,

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterReplaceable1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterReplaceable1.mo
@@ -1,0 +1,38 @@
+// name: InnerOuterReplaceable1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model A
+  outer Real x;
+  Real y;
+equation
+  x = y;
+end A;
+
+model B
+  outer Real x;
+  Real y;
+equation
+  x = 2 * y;
+end B;
+
+model C
+  replaceable A a;
+  inner Real x;
+end C;
+
+model InnerOuterReplaceable1
+  C c(redeclare B a);
+end InnerOuterReplaceable1;
+
+
+// Result:
+// class InnerOuterReplaceable1
+//   Real c.a.y;
+//   Real c.x;
+// equation
+//   c.x = 2.0 * c.a.y;
+// end InnerOuterReplaceable1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -736,6 +736,7 @@ InnerOuterMissing6.mo \
 InnerOuterMissing7.mo \
 InnerOuterMissing8.mo \
 InnerOuterNotInner1.mo \
+InnerOuterReplaceable1.mo \
 InStreamArray.mo \
 InStreamFlowThreshold.mo \
 InStreamInsideOutside.mo \


### PR DESCRIPTION
- When looking for the corresponding inner for an outer instance, use
  the scope of the original element if it has been redeclared.

Fixes #8389