### PR TITLE
Rename GC.mo to GCExt.mo.

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -151,7 +151,7 @@ set(OMC_MM_ALWAYS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/ExecStat.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/Flags.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/FlagsUtil.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Util/GC.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/Util/GCExt.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/Gettext.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/Graph.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/GraphStream.mo

--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -75,7 +75,7 @@ import ExpressionSolve;
 import ExpressionSimplify;
 import Error;
 import Flags;
-import GC;
+import GCExt;
 import HashTableExpToIndex;
 import HpcOmTaskGraph;
 import List;
@@ -1700,9 +1700,9 @@ algorithm
         systs = if b then SynchronousFeatures.partitionIndependentBlocksSplitBlocks(i, syst, eqPartMap, rixs, mT, rmT, throwNoError, funcs, isInitial) else {syst};
         // print("Number of partitioned systems: " + intString(listLength(systs)) + "\n");
         // List.map1_0(systs, BackendDump.dumpEqSystem, "System");
-        GC.free(eqPartMap);
-        GC.free(varPartMap);
-        GC.free(rixs);
+        GCExt.free(eqPartMap);
+        GCExt.free(varPartMap);
+        GCExt.free(rixs);
       then (systs,shared);
     else
       equation
@@ -4244,8 +4244,8 @@ algorithm
             BackendDump.dumpAdjacencyMatrixT(mT);
           end if;
 
-          GC.free(w_vars);
-          GC.free(w_eqns);
+          GCExt.free(w_vars);
+          GCExt.free(w_eqns);
         then BackendDAEUtil.clearEqSyst(syst1);
     end match;
     new_systlst := syst :: new_systlst;

--- a/OMCompiler/Compiler/BackEnd/BackendDAETransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAETransform.mo
@@ -58,7 +58,7 @@ protected
   import Expression;
   import ExpressionDump;
   import Flags;
-  import GC;
+  import GCExt;
   import List;
   import MetaModelica.Dangerous;
   import Sorting;
@@ -96,7 +96,7 @@ algorithm
 
       markarray := arrayCreate(BackendEquation.getNumberOfEquations(inSystem.orderedEqs), -1);
       comps := analyseStrongComponentsScalar(comps_m, inSystem, inShared, ass1, ass2, mapEqnIncRow, mapIncRowEqn, 1, markarray);
-      GC.free(markarray);
+      GCExt.free(markarray);
       ass1 := varAssignmentNonScalar(ass1, mapIncRowEqn);
 
       // Frenkel TUD: Do not hand over the scalar adjacency Matrix because following modules does not check if scalar or not

--- a/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
+++ b/OMCompiler/Compiler/BackEnd/CommonSubExpression.mo
@@ -56,7 +56,7 @@ import Expression;
 import ExpressionDump;
 import ExpressionSolve;
 import ExpressionSimplify;
-import GC;
+import GCExt;
 import Global;
 import HashSet;
 import HashTableExpToExp;
@@ -2015,8 +2015,8 @@ algorithm
       cseLst := commonSubExpressionFind(m, mT, vars, eqs, isInitial);
           //if not listEmpty(cseLst) then print("update "+stringDelimitList(List.map(cseLst, printCSE), "\n")+"\n");end if;
       syst := commonSubExpressionUpdate(cseLst, m, mT, sysIn);
-      GC.free(m);
-      GC.free(mT);
+      GCExt.free(m);
+      GCExt.free(mT);
       syst.orderedEqs := eqs;
           //print("done this eqSystem\n");
           //BackendDump.dumpEqSystem(syst, "eqSystem");
@@ -2171,8 +2171,8 @@ algorithm
            cses := SHORTCUT_CSE(adjEqs,varIdx)::cses;
          end if;
        end for; //end the variables
-       GC.free(m);
-       GC.free(mT);
+       GCExt.free(m);
+       GCExt.free(mT);
      end for;  //end all partitions
       //print("the SHORTPATH cses : \n"+stringDelimitList(List.map(cses, printCSE), "\n")+"\n");
     end if;
@@ -2300,8 +2300,8 @@ algorithm
             varIdcs2 := listAppend(varIdcs1, varIdcs2);
             varIdcs2 := list(arrayGet(varMapArr, i) for i in varIdcs2);
             eqIdcs := list(arrayGet(eqMapArr,i) for i in loop1);
-            GC.free(eqMapArr);
-            GC.free(varMapArr);
+            GCExt.free(eqMapArr);
+            GCExt.free(varMapArr);
             cseLst := ASSIGNMENT_CSE(eqIdcs, sharedVarIdcs, varIdcs2)::cseLst;
           end if;
       end for;

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -64,7 +64,7 @@ import Expression;
 import ExpressionDump;
 import ExpressionSimplify;
 import Flags;
-import GC;
+import GCExt;
 import IndexReduction;
 import List;
 import Matching;
@@ -864,7 +864,7 @@ algorithm
       end match;
     end for;
 
-    GC.free(secondary);
+    GCExt.free(secondary);
     outAllPrimaryParameters := listReverse(outAllPrimaryParameters);
     dae := BackendDAEUtil.setDAEGlobalKnownVars(dae, otherVariables);
 
@@ -2227,7 +2227,7 @@ algorithm
           if Flags.getConfigBool(Flags.INITIAL_STATE_SELECTION) then
             (vars, eqns) := collectInitialStateSets(eq.stateSets, stateSetFixCounts, vars, eqns);
           end if;
-          GC.free(stateSetFixCounts);
+          GCExt.free(stateSetFixCounts);
         then
           ();
     end match;

--- a/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -70,7 +70,7 @@ import ExpressionDump;
 import ExpressionSimplify;
 import ExpressionSolve;
 import Flags;
-import GC;
+import GCExt;
 import HashSet;
 import HashTableCrToCrEqLst;
 import HashTableCrToExp;
@@ -581,7 +581,7 @@ algorithm
 
     outSystem := updateSystem(globalFoundSimple, eqnslst, vars, repl, outSystem);
     outTpl := ((repl, globalFoundSimple, unReplaceable, maxTraversals, warnAliasConflicts));
-    GC.free(mT);
+    GCExt.free(mT);
   else
     //Error.addCompilerWarning("The module removeSimpleEquations failed for a subsystem. The relevant subsystem get skipped and the transformation is proceeded.");
     outSystem := inSystem;

--- a/OMCompiler/Compiler/BackEnd/Sorting.mo
+++ b/OMCompiler/Compiler/BackEnd/Sorting.mo
@@ -40,7 +40,7 @@ import BackendDAE;
 
 protected
 import BackendDump;
-import GC;
+import GCExt;
 import Matching;
 
 public function Tarjan "author: lochel
@@ -70,9 +70,9 @@ algorithm
       (stack, index, outComponents) := StrongConnect(m, ass1, eqn, stack, index, number, lowlink, onStack, outComponents);
     end if;
   end for;
-  GC.free(number);
-  GC.free(lowlink);
-  GC.free(onStack);
+  GCExt.free(number);
+  GCExt.free(lowlink);
+  GCExt.free(onStack);
 
   outComponents := listReverse(outComponents);
 end Tarjan;

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -67,7 +67,7 @@ import ExpressionSimplify;
 import Error;
 import Flags;
 import FlagsUtil;
-import GC;
+import GCExt;
 import Global;
 import Graph;
 import HashSet;
@@ -624,8 +624,8 @@ algorithm
 
   (bVarsOut,bEqsOut) := createBVecVars(sysIdxIn,compIdxIn,n,DAE.T_REAL_DEFAULT,beqs);
   sysEqsOut := createSysEquations(A,b,n,order,var_lst,bVarsOut);
-  GC.free(A);
-  GC.free(b);
+  GCExt.free(A);
+  GCExt.free(b);
   sysIdxOut := sysIdxIn+1;
   orderOut := order;
 end solveConstJacLinearSystem;
@@ -1358,15 +1358,15 @@ algorithm
       Graph.partialDistance2colorInt(sparseGraphT, forbiddenColor, nodesList, arraysparseGraph, colored);
     end if;
     if debug then execStat("generateSparsePattern -> coloring end "); end if;
-    GC.free(forbiddenColor);
-    GC.free(arraysparseGraph);
+    GCExt.free(forbiddenColor);
+    GCExt.free(arraysparseGraph);
     // get max color used
     maxColor := Array.fold(colored, intMax, 0);
 
     // map index of that array into colors
     coloredArray := arrayCreate(maxColor, {});
     mapIndexColors(colored, sizeVars, coloredArray);
-    GC.free(colored);
+    GCExt.free(colored);
 
     if Flags.isSet(Flags.DUMP_SPARSE_VERBOSE) then
       print("Print Coloring Cols: \n");

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -60,7 +60,7 @@ import ExpressionDump;
 import ExpressionSimplify;
 import ExpressionSolve;
 import Flags;
-import GC;
+import GCExt;
 import Global;
 import List;
 import Matching;
@@ -4165,7 +4165,7 @@ algorithm
       end if;
     end for;
   end for;
-  GC.free(eqn_size_arr);
+  GCExt.free(eqn_size_arr);
 end getVarsOfEqnsWithMostVars;
 
 

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -130,7 +130,7 @@ import Flags;
 import FGraph;
 import FGraphBuildEnv;
 import FNode;
-import GC;
+import GCExt;
 import Global;
 import HashTable;
 import HashTable5;
@@ -206,7 +206,7 @@ algorithm
         source = ElementSource.addElementSourcePartOfOpt(DAE.emptyElementSource, FGraph.getScopePath(env));
 
         if Flags.isSet(Flags.GC_PROF) then
-          print(GC.profStatsStr(GC.getProfStats(), head="GC stats after pre-frontend work (building graphs):") + "\n");
+          print(GCExt.profStatsStr(GCExt.getProfStats(), head="GC stats after pre-frontend work (building graphs):") + "\n");
         end if;
         ExecStat.execStat("FrontEnd - mkProgramGraph");
 
@@ -252,7 +252,7 @@ algorithm
         //System.startTimer();
         //print("\nInstClass");
         if Flags.isSet(Flags.GC_PROF) then
-          print(GC.profStatsStr(GC.getProfStats(), head="GC stats after pre-frontend work (building graphs):") + "\n");
+          print(GCExt.profStatsStr(GCExt.getProfStats(), head="GC stats after pre-frontend work (building graphs):") + "\n");
         end if;
         ExecStat.execStat("FrontEnd - mkProgramGraph");
 
@@ -3177,8 +3177,8 @@ algorithm
 
     outVars := listAppend(lst for lst in var_arr);
     outDae := DAE.DAE(listAppend(lst for lst in dae_arr));
-    GC.free(var_arr);
-    GC.free(dae_arr);
+    GCExt.free(var_arr);
+    GCExt.free(dae_arr);
   else
     // For functions, use the sorted elements instead, otherwise things break.
     for e in el loop

--- a/OMCompiler/Compiler/FrontEnd/Parser.mo
+++ b/OMCompiler/Compiler/FrontEnd/Parser.mo
@@ -239,9 +239,9 @@ algorithm
   if Testsuite.isRunning() or Config.noProc()==1 or numThreads == 1 or listLength(filenames)<2 or isSome(lveInstance) then
     partialResults := list(loadFileThread(t) for t in workList);
   else
-    // GC.disable(); // Seems to sometimes break building nightly omc
+    // GCExt.disable(); // Seems to sometimes break building nightly omc
     partialResults := System.launchParallelTasks(min(8, numThreads) /* Boehm GC does not scale to infinity */, workList, loadFileThread);
-    // GC.enable();
+    // GCExt.enable();
   end if;
 end parallelParseFilesWork;
 

--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -67,7 +67,7 @@ import FGraph;
 import FGraphStream;
 import Flags;
 import FlagsUtil;
-import GC;
+import GCExt;
 import Global;
 import GlobalScript;
 import Interactive;
@@ -783,9 +783,9 @@ algorithm
   // 150M for Windows, 300M for others makes the GC try to unmap less and so it crashes less.
   // Disabling unmap is another alternative that seems to work well (but could cause the memory consumption to not be released, and requires manually calling collect and unmap
   if true then
-    GC.setForceUnmapOnGcollect(Autoconf.os == "Windows_NT");
+    GCExt.setForceUnmapOnGcollect(Autoconf.os == "Windows_NT");
   else
-    GC.expandHeap(if Autoconf.os == "Windows_NT"
+    GCExt.expandHeap(if Autoconf.os == "Windows_NT"
                       then 1024*1024*150
                       else 1024*1024*300);
   end if;
@@ -805,7 +805,7 @@ public function main
   input list<String> args;
 protected
   list<String> args_1;
-  GC.ProfStats stats;
+  GCExt.ProfStats stats;
   Integer seconds;
 algorithm
   execStatReset();
@@ -813,7 +813,7 @@ algorithm
     try
       args_1 := init(args);
       if Flags.isSet(Flags.GC_PROF) then
-        print(GC.profStatsStr(GC.getProfStats(), head="GC stats after initialization:") + "\n");
+        print(GCExt.profStatsStr(GCExt.getProfStats(), head="GC stats after initialization:") + "\n");
       end if;
       seconds := Flags.getConfigInt(Flags.ALARM);
       if seconds > 0 then
@@ -827,7 +827,7 @@ algorithm
       fail();
     end try;
     if Flags.isSet(Flags.GC_PROF) then
-      print(GC.profStatsStr(GC.getProfStats(), head="GC stats at end of program:") + "\n");
+      print(GCExt.profStatsStr(GCExt.getProfStats(), head="GC stats at end of program:") + "\n");
     end if;
   else
     print("Stack overflow detected and was not caught.\n" +

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -88,7 +88,7 @@ import FGraph;
 import Flags;
 import FlagsUtil;
 import FNode;
-import GC;
+import GCExt;
 import GenerateAPIFunctionsTpl;
 import Global;
 import Graph;
@@ -600,7 +600,7 @@ algorithm
       list<SCode.Element> elts;
       list<ErrorTypes.TotalMessage> messages;
       list<tuple<String,list<String>>> interfaceTypeAssoc;
-      GC.ProfStats gcStats;
+      GCExt.ProfStats gcStats;
 
     case ("parseString",{Values.STRING(str1),Values.STRING(str2)})
       algorithm
@@ -678,22 +678,22 @@ algorithm
 
     case ("GC_gcollect_and_unmap",{})
       algorithm
-        GC.gcollectAndUnmap();
+        GCExt.gcollectAndUnmap();
       then
         Values.BOOL(true);
 
     case ("GC_expand_hp",{Values.INTEGER(i)})
-      then Values.BOOL(GC.expandHeap(i));
+      then Values.BOOL(GCExt.expandHeap(i));
 
     case ("GC_set_max_heap_size",{Values.INTEGER(i)})
       algorithm
-        GC.setMaxHeapSize(i);
+        GCExt.setMaxHeapSize(i);
       then
         Values.BOOL(true);
 
     case ("GC_get_prof_stats",{})
       algorithm
-        gcStats := GC.getProfStats();
+        gcStats := GCExt.getProfStats();
       then
         Values.RECORD(Absyn.IDENT("GC_PROFSTATS"),
          {

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -94,7 +94,7 @@ import Flags;
 import FlagsUtil;
 import FMI;
 import FMIExt;
-import GC;
+import GCExt;
 import Graph;
 import HashSetString;
 import InnerOuter;
@@ -3319,12 +3319,12 @@ algorithm
     b := runFrontEndLoadProgram(className);
     true := b;
     if Flags.isSet(Flags.GC_PROF) then
-      print(GC.profStatsStr(GC.getProfStats(), head="GC stats before front-end:") + "\n");
+      print(GCExt.profStatsStr(GCExt.getProfStats(), head="GC stats before front-end:") + "\n");
     end if;
     ExecStat.execStat("FrontEnd - loaded program");
     (cache,env,dae,flatString) := runFrontEndWork(cache,env,className,relaxedFrontEnd,dumpFlat);
     if Flags.isSet(Flags.GC_PROF) then
-      print(GC.profStatsStr(GC.getProfStats(), head="GC stats after front-end:") + "\n");
+      print(GCExt.profStatsStr(GCExt.getProfStats(), head="GC stats after front-end:") + "\n");
     end if;
     ExecStat.execStat("FrontEnd - DAE generated");
 

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -78,7 +78,7 @@ import ExpressionSimplify;
 import FGraph;
 import Flags;
 import FlagsUtil;
-import GC;
+import GCExt;
 import GlobalScriptDump;
 import InnerOuter;
 import Inst;
@@ -358,7 +358,7 @@ algorithm
   else
     str := "";
     str_1 := "";
-    GC.gcollect();
+    GCExt.gcollect();
     str := StackOverflow.getReadableMessage();
     if Testsuite.isRunning() then
       /* It's useful to print the name of the component we failed on.

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -80,7 +80,7 @@ import ErrorExt;
 import ExecStat;
 import Flags;
 import FMI;
-import GC;
+import GCExt;
 import HashTable;
 import HashTableCrefSimVar;
 import HashTableCrIListArray;
@@ -1004,8 +1004,8 @@ algorithm
         serializeNotify((dae,dae1), "FrontEnd DAE before+after transformations");
         ExecStat.execStat("Serialize DAE (2)");
       end if;
-      GC.free(dae1);
-      GC.free(odae);
+      GCExt.free(dae1);
+      GCExt.free(odae);
       odae := NONE();
       dae1 := DAE.emptyDae;
 
@@ -1019,7 +1019,7 @@ algorithm
       description := DAEUtil.daeDescription(dae);
       dlow := BackendDAECreate.lower(dae, cache, graph, BackendDAE.EXTRA_INFO(description,filenameprefix));
 
-      GC.free(dae);
+      GCExt.free(dae);
       dae := DAE.emptyDae;
 
       if Flags.isSet(Flags.SERIALIZED_SIZE) then
@@ -1190,7 +1190,7 @@ algorithm
       description := DAEUtil.daeDescription(dae);
       dlow := BackendDAECreate.lower(dae, outCache, graph, BackendDAE.EXTRA_INFO(description,filenameprefix));
 
-      GC.free(dae);
+      GCExt.free(dae);
 
       if Flags.isSet(Flags.SERIALIZED_SIZE) then
         serializeNotify(dlow, "dlow");

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -91,7 +91,7 @@ import ExpressionSolve;
 import Flags;
 import FlagsUtil;
 import FMI;
-import GC;
+import GCExt;
 import Global;
 import Graph;
 import HashSet;
@@ -877,8 +877,8 @@ algorithm
                                  sccOffset, oeqSccMapping, oeqBackendSimCodeMapping, oBackendMapping, true);
     sccOffset := listLength(comps) + sccOffset;
     //otempvars := listAppend(clockedVars, otempvars);
-    GC.free(stateeqnsmark);
-    GC.free(zceqnsmarks);
+    GCExt.free(stateeqnsmark);
+    GCExt.free(zceqnsmarks);
 
     (ouniqueEqIndex, removedEquations) := BackendEquation.traverseEquationArray(syst.removedEqs, traversedlowEqToSimEqSystem, (ouniqueEqIndex, {}));
 
@@ -905,7 +905,7 @@ algorithm
         ouniqueEqIndex := ouniqueEqIndex + 1;
       end if;
     end for;
-    GC.free(isPrevVar);
+    GCExt.free(isPrevVar);
 
     //otempvars := listAppend(clockedVars, otempvars);
     simSubPartition := SimCode.SUBPARTITION(prevClockedVars,  equations, removedEquations, subPartition.clock, subPartition.holdEvents);
@@ -915,7 +915,7 @@ algorithm
 
   end for;
   outPartitions := createClockedSimPartitions(inShared.partitionsInfo.basePartitions, simSubPartitions);
-  GC.free(simSubPartitions);
+  GCExt.free(simSubPartitions);
 end translateClockedEquations;
 
 protected function createClockedSimPartitions
@@ -1544,8 +1544,8 @@ algorithm
             createEquationsForSystem(
                 stateeqnsmark, zceqnsmarks, syst, shared, comps, uniqueEqIndex, tempvars,
                 sccOffset, eqSccMapping, eqBackendSimCodeMapping, backendMapping, createAlgebraicEquations);
-        GC.free(stateeqnsmark);
-        GC.free(zceqnsmarks);
+        GCExt.free(stateeqnsmark);
+        GCExt.free(zceqnsmarks);
 
         odeEquations = List.consOnTrue(not listEmpty(odeEquations1), odeEquations1, odeEquations);
         algebraicEquations = List.consOnTrue(not listEmpty(algebraicEquations1), algebraicEquations1, algebraicEquations);
@@ -8110,7 +8110,7 @@ algorithm
     Dangerous.arrayGetNoBoundsChecking(simVars, Integer(SimVarsIndex.setcvars)),
     Dangerous.arrayGetNoBoundsChecking(simVars, Integer(SimVarsIndex.datareconinputvars))
   );
-  GC.free(simVars);
+  GCExt.free(simVars);
 end createVars;
 
 protected function extractVarsFromList
@@ -14341,8 +14341,8 @@ algorithm
     getHighestDerivationVisit(i, ders, depth);
   end for;
   highestDerivation := max(i for i in depth);
-  GC.free(ders);
-  GC.free(depth);
+  GCExt.free(ders);
+  GCExt.free(depth);
 end getHighestDerivation;
 
 protected function getHighestDerivationVisit "Uses stack depth of at most max depth"

--- a/OMCompiler/Compiler/Util/DoubleEnded.mo
+++ b/OMCompiler/Compiler/Util/DoubleEnded.mo
@@ -42,7 +42,7 @@ uniontype MutableList<T>
 end MutableList;
 
 protected
-import GC;
+import GCExt;
 import MetaModelica.Dangerous;
 
 public impure function new<T>
@@ -249,7 +249,7 @@ algorithm
   Mutable.update(delst.front, {});
   Mutable.update(delst.length, 0);
   for l in lst loop
-    GC.free(l);
+    GCExt.free(l);
   end for;
 end clear;
 

--- a/OMCompiler/Compiler/Util/ExecStat.mo
+++ b/OMCompiler/Compiler/Util/ExecStat.mo
@@ -4,7 +4,7 @@ protected
 
 import ClockIndexes;
 import Error;
-import GC;
+import GCExt;
 import Global;
 import Flags;
 import System;
@@ -16,7 +16,7 @@ function execStatReset
 algorithm
   System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
   System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
-  setGlobalRoot(Global.gcProfilingIndex, GC.getProfStats());
+  setGlobalRoot(Global.gcProfilingIndex, GCExt.getProfStats());
 end execStatReset;
 
 function execStat
@@ -31,24 +31,24 @@ protected
   Real t, total;
   String timeStr, totalTimeStr, gcStr;
   Integer memory, oldMemory, heapsize_full, free_bytes_full, since, before;
-  GC.ProfStats stats, oldStats;
+  GCExt.ProfStats stats, oldStats;
 algorithm
   if Flags.isSet(Flags.EXEC_STAT) then
     for i in if Flags.isSet(Flags.EXEC_STAT_EXTRA_GC) then {1,2} else {1} loop
       if i==2 then
-        GC.gcollect();
+        GCExt.gcollect();
       end if;
-      (stats as GC.PROFSTATS(bytes_allocd_since_gc=since, allocd_bytes_before_gc=before, heapsize_full=heapsize_full, free_bytes_full=free_bytes_full)) := GC.getProfStats();
+      (stats as GCExt.PROFSTATS(bytes_allocd_since_gc=since, allocd_bytes_before_gc=before, heapsize_full=heapsize_full, free_bytes_full=free_bytes_full)) := GCExt.getProfStats();
       memory := since+before;
       oldStats := getGlobalRoot(Global.gcProfilingIndex);
-      GC.PROFSTATS(bytes_allocd_since_gc=since, allocd_bytes_before_gc=before) := oldStats;
+      GCExt.PROFSTATS(bytes_allocd_since_gc=since, allocd_bytes_before_gc=before) := oldStats;
       oldMemory := since+before;
       t := System.realtimeTock(ClockIndexes.RT_CLOCK_EXECSTAT);
       total := System.realtimeTock(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
       timeStr := System.snprintff("%.4g", 20, t);
       totalTimeStr := System.snprintff("%.4g", 20, total);
       if Flags.isSet(Flags.GC_PROF) then
-        gcStr := GC.profStatsStr(stats, head="", delimiter=" / ");
+        gcStr := GCExt.profStatsStr(stats, head="", delimiter=" / ");
         Error.addMessage(Error.EXEC_STAT_GC, {name + (if i==2 then " GC" else ""), timeStr, totalTimeStr, gcStr});
       else
         Error.addMessage(Error.EXEC_STAT, {name + (if i==2 then " GC" else ""), timeStr, totalTimeStr,

--- a/OMCompiler/Compiler/Util/GCExt.mo
+++ b/OMCompiler/Compiler/Util/GCExt.mo
@@ -29,7 +29,7 @@
  *
  */
 
-encapsulated package GC
+encapsulated package GCExt
 
 function gcollect
 external "C" GC_gcollect() annotation(Library = {"omcgc"});
@@ -60,7 +60,7 @@ void omc_GC_free_ext(void *data)
 <p>GC_free requires \"a pointer to the base of an object\".</p>
 <p>So the object passed to free must not be allocated by any of the list
 routines that allocate multiple elements with a single malloc call.</p>
-<p>Calling GC.free is very dangerous. You might be better off trying to
+<p>Calling GCExt.free is very dangerous. You might be better off trying to
 set variables to a constant value if you want to GC them. Use this if
 you are concerned about temporary variables, etc remaining on the stack
 and not cleared for a long time.</p>
@@ -95,7 +95,7 @@ function setMaxHeapSize
 external "C" GC_set_max_heap_size_dbl(sz) annotation(Include="#define GC_set_max_heap_size_dbl(sz) omc_GC_set_max_heap_size((size_t)sz)",Library = {"omcgc"});
 end setMaxHeapSize;
 
-uniontype ProfStats "TODO: Support regular records in the bootstrapped compiler to avoid allocation to return the stats in the GC..."
+uniontype ProfStats "TODO: Support regular records in the bootstrapped compiler to avoid allocation to return the stats in the GCExt..."
   record PROFSTATS
     Integer heapsize_full, free_bytes_full, unmapped_bytes, bytes_allocd_since_gc, allocd_bytes_before_gc, non_gc_bytes, gc_no, markers_m1, bytes_reclaimed_since_gc, reclaimed_bytes_before_gc;
   end PROFSTATS;
@@ -177,4 +177,4 @@ annotation(Documentation(info="<html>
 end getProfStats;
 
 annotation(__OpenModelica_Interface="util");
-end GC;
+end GCExt;

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -100,7 +100,7 @@ import Array;
 import MetaModelica.Dangerous.{listReverseInPlace, arrayGetNoBoundsChecking, arrayUpdateNoBoundsChecking, arrayCreateNoInit};
 import MetaModelica.Dangerous;
 import DoubleEnded;
-import GC;
+import GCExt;
 
 public function create<T>
   "Creates a list from an element."
@@ -1093,7 +1093,7 @@ algorithm
       outSorted := v :: outSorted;
     end for;
   end for;
-  GC.free(a1);
+  GCExt.free(a1);
 end countingSort;
 
 public function unique<T>
@@ -1128,7 +1128,7 @@ algorithm
 
     arrayUpdate(arr, i, false);
   end for;
-  GC.free(arr);
+  GCExt.free(arr);
 end uniqueIntN;
 
 public function uniqueIntNArr
@@ -1707,7 +1707,7 @@ algorithm
     a := addPos(inList1, a, 1);
     a := addPos(inList2, a, 1);
     outResult := intersectionIntVec(a, inList1);
-    GC.free(a);
+    GCExt.free(a);
   else
     outResult := {};
   end if;
@@ -1827,7 +1827,7 @@ algorithm
         outDifference := i :: outDifference;
       end if;
     end for;
-    GC.free(a);
+    GCExt.free(a);
   end if;
 end setDifferenceIntN;
 
@@ -1895,7 +1895,7 @@ algorithm
         outUnion := i :: outUnion;
       end if;
     end for;
-    GC.free(a);
+    GCExt.free(a);
   end if;
 end unionIntN;
 

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -157,7 +157,7 @@ if true then /* Suppress output */
     "../Util/ExecStat.mo",
     "../Util/Flags.mo",
     "../Util/FlagsUtil.mo",
-    "../Util/GC.mo",
+    "../Util/GCExt.mo",
     "../Util/Gettext.mo",
     "../Util/Graph.mo",
     "../Util/GraphStream.mo",


### PR DESCRIPTION
  - Done to avoid conflicting names between the generated GC.h (from the
    .mo) file and the gc.h from 3rdParty/gc.

    Affects case insensitive OSs (GC.h vs gc.h) like most Windows setups.
    It was working fine on linux.