### PR TITLE
Don't type outer components

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -366,6 +366,10 @@ protected
   Expression cond;
   Boolean is_deleted;
 algorithm
+  if InstNode.isOnlyOuter(component) then
+    return;
+  end if;
+
   ty := match c
     // An untyped component, type it.
     case Component.UNTYPED_COMPONENT()
@@ -860,6 +864,10 @@ protected
   Type ty;
 algorithm
   c := InstNode.component(node);
+
+  if InstNode.isOnlyOuter(component) then
+    return;
+  end if;
 
   () := match c
     case Component.TYPED_COMPONENT()
@@ -2763,7 +2771,7 @@ protected
 algorithm
   comp := InstNode.component(component);
 
-  if Component.isDeleted(comp) then
+  if Component.isDeleted(comp) or InstNode.isOnlyOuter(component) then
     return;
   end if;
 

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterPartialOuter1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterPartialOuter1.mo
@@ -1,0 +1,28 @@
+// name: InnerOuterPartialOuter1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+partial model A
+end A;
+
+model B
+  extends A;
+  Real x;
+end B;
+
+model C
+  outer A a;
+end C;
+
+model InnerOuterPartialOuter1
+  C c;
+  inner B a;
+end InnerOuterPartialOuter1;
+
+// Result:
+// class InnerOuterPartialOuter1
+//   Real a.x;
+// end InnerOuterPartialOuter1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterPartialOuter2.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterPartialOuter2.mo
@@ -1,0 +1,30 @@
+// name: InnerOuterPartialOuter2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+partial record BaseR
+  constant Integer n;
+  parameter Real x[n];
+end BaseR;
+
+record R
+  extends BaseR(n = 1);
+end R;
+
+model A
+  outer BaseR r;
+end A;
+
+model InnerOuterPartialOuter2
+  A a;
+  inner R r;
+end InnerOuterPartialOuter2;
+
+// Result:
+// class InnerOuterPartialOuter2
+//   constant Integer r.n = 1;
+//   parameter Real r.x[1];
+// end InnerOuterPartialOuter2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -737,6 +737,8 @@ InnerOuterMissing6.mo \
 InnerOuterMissing7.mo \
 InnerOuterMissing8.mo \
 InnerOuterNotInner1.mo \
+InnerOuterPartialOuter1.mo \
+InnerOuterPartialOuter2.mo \
 InnerOuterReplaceable1.mo \
 InStreamArray.mo \
 InStreamFlowThreshold.mo \


### PR DESCRIPTION
- Outer components may be partial and/or contain e.g. structural
  parameters without bindings, so it might not be possible to type them.
  It's also not necessary to type them since they're removed from the
  flat model anyway.

Fixes #4908