### PR TITLE
Improve typing of sum(A) and product(A)

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -134,7 +134,6 @@ public
       case "ones" then typeZerosOnesCall("ones", call, next_context, info);
       case "potentialRoot" then typePotentialRootCall(call, next_context, info);
       case "pre" then typePreCall(call, next_context, info);
-      case "product" then typeProductCall(call, next_context, info);
       case "promote" then typePromoteCall(call, next_context, info);
       case "pure" then typePureCall(call, next_context, info);
       case "rooted" then typeRootedCall(call, next_context, info);
@@ -145,7 +144,6 @@ public
       case "smooth" then typeSmoothCall(call, next_context, info);
       case "String" then typeStringCall(call, next_context, info);
       case "subSample" then typeSubSampleCall(call, next_context, info);
-      case "sum" then typeSumCall(call, next_context, info);
       case "superSample" then typeSuperSampleCall(call, next_context, info);
       case "symmetric" then typeSymmetricCall(call, next_context, info);
       case "terminal" then typeDiscreteCall(call, next_context, info);
@@ -748,70 +746,6 @@ protected
     fn := listHead(Function.typeRefCache(fn_ref));
     callExp := Expression.CALL(Call.makeTypedCall(fn, args, var, purity, ty));
   end typeMinMaxCall;
-
-  function typeSumCall
-    input Call call;
-    input InstContext.Type context;
-    input SourceInfo info;
-    output Expression callExp;
-    output Type ty;
-    output Variability variability;
-    output Purity purity;
-  protected
-    ComponentRef fn_ref;
-    list<Expression> args;
-    list<NamedArg> named_args;
-    Expression arg;
-    Function fn;
-    Boolean expanded;
-    Operator op;
-  algorithm
-    Call.UNTYPED_CALL(ref = fn_ref, arguments = args, named_args = named_args) := call;
-    assertNoNamedParams("sum", named_args, info);
-
-    if listLength(args) <> 1 then
-      Error.addSourceMessageAndFail(Error.NO_MATCHING_FUNCTION_FOUND_NFINST,
-        {Call.toString(call), "sum(Any[:, ...]) => Any"}, info);
-    end if;
-
-    (arg, ty, variability, purity) := Typing.typeExp(listHead(args), context, info);
-    ty := Type.arrayElementType(ty);
-
-    {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, purity, ty));
-  end typeSumCall;
-
-  function typeProductCall
-    input Call call;
-    input InstContext.Type context;
-    input SourceInfo info;
-    output Expression callExp;
-    output Type ty;
-    output Variability variability;
-    output Purity purity;
-  protected
-    ComponentRef fn_ref;
-    list<Expression> args;
-    list<NamedArg> named_args;
-    Expression arg;
-    Function fn;
-    Boolean expanded;
-    Operator op;
-  algorithm
-    Call.UNTYPED_CALL(ref = fn_ref, arguments = args, named_args = named_args) := call;
-    assertNoNamedParams("product", named_args, info);
-
-    if listLength(args) <> 1 then
-      Error.addSourceMessageAndFail(Error.NO_MATCHING_FUNCTION_FOUND_NFINST,
-        {Call.toString(call), "product(Any[:, ...]) => Any"}, info);
-    end if;
-
-    (arg, ty, variability, purity) := Typing.typeExp(listHead(args), context, info);
-    ty := Type.arrayElementType(ty);
-
-    {fn} := Function.typeRefCache(fn_ref);
-    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg}, variability, purity, ty));
-  end typeProductCall;
 
   function typePromoteCall
     input Call call;

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2687,6 +2687,15 @@ protected
               return;
             end if;
           end for;
+
+          // If no input with the same type could be found and the result type
+          // is __Scalar, try to find some input with the type __Array and
+          // assume they have the same element type.
+          if name == "__Scalar" then
+            outType := resolvePolymorphicReturnType(fn, args, Type.POLYMORPHIC("__Array"));
+            outType := Type.arrayElementType(outType);
+            return;
+          end if;
         then
           fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1649,7 +1649,6 @@ uniontype Function
           // argument should be a cref?
           case "pre" then true;
           // needs unboxing and return type fix.
-          case "product" then true;
           case "promote" then true;
           case "pure" then true;
           case "root" then true;
@@ -1666,7 +1665,6 @@ uniontype Function
           case "smooth" then true;
           case "subSample" then true;
           // needs unboxing and return type fix.
-          case "sum" then true;
           case "superSample" then true;
           // unbox args and set return type.
           case "symmetric" then true;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -393,18 +393,18 @@ function max
 </html>"));
 end max;
 
-function sum<ArrayType, ScalarBasicType> "Sum of all array elements"
-  input ArrayType a;
-  output ScalarBasicType s;
+function sum<__Array, __Scalar> "Sum of all array elements"
+  input __Array a;
+  output __Scalar s;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'sum()'\">sum()</a>
 </html>"));
 end sum;
 
-function product<ArrayType, ScalarBasicType> "Product of all array elements"
-  input ArrayType a;
-  output ScalarBasicType s;
+function product<__Array, __Scalar> "Product of all array elements"
+  input __Array a;
+  output __Scalar s;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'product()'\">product()</a>

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinSum2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinSum2.mo
@@ -1,0 +1,24 @@
+// name: FuncBuiltinSum2
+// keywords: sum
+// status: incorrect
+// cflags: -d=newInst
+//
+// Tests the builtin sum operator.
+//
+
+model FuncBuiltinSum2
+  Real x = sum(0);
+end FuncBuiltinSum2;
+
+// Result:
+// Error processing file: FuncBuiltinSum2.mo
+// [flattening/modelica/scodeinst/FuncBuiltinSum2.mo:10:3-10:18:writable] Error: Type mismatch for positional argument 1 in sum(a=0). The argument has type:
+//   Integer
+// expected type:
+//   Array
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult


### PR DESCRIPTION
- Use custom polymorphic types to define sum/product and remove the
  custom type checking for them. This has the side-effect of giving a
  proper error for sum/product of a scalar instead of failing for
  various reasons later in the compiler.