### PR TITLE
Fix importing of OMSimulatorLib for Windows.

### DIFF
--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -286,9 +286,7 @@ set_target_properties(OMEditLib PROPERTIES
         NO_SYSTEM_FROM_IMPORTED ON)
 
 target_include_directories(OMEditLib PRIVATE
-  ${OMCompiler_SOURCE_DIR}/Compiler/Script
-  ${OMParser_BINARY_DIR}/
-  ${OMParser_SOURCE_DIR}/3rdParty/antlr4/runtime/Cpp/runtime/src/)
+  ${OMCompiler_SOURCE_DIR}/Compiler/Script)
 
 target_link_options(OMEditLib PRIVATE -Wl,--no-undefined)
 

--- a/OMParser/CMakeLists.txt
+++ b/OMParser/CMakeLists.txt
@@ -42,13 +42,10 @@ target_sources(OMParser PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/modelicaBaseListener
                                 ${CMAKE_CURRENT_BINARY_DIR}/modelicaLexer.cpp
                                 ${CMAKE_CURRENT_BINARY_DIR}/modelicaListener.cpp
                                 ${CMAKE_CURRENT_BINARY_DIR}/modelicaParser.cpp
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaVisitor.cpp
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaBaseListener.h
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaBaseVisitor.h
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaLexer.h
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaListener.h
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaParser.h
-                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaVisitor.h)
+                                ${CMAKE_CURRENT_BINARY_DIR}/modelicaVisitor.cpp)
 
 target_link_libraries(OMParser PUBLIC antlr4_static)
+# The generated parser header files (e.g modelicaLexer.h) are put in the binary dir of OMParser.
+# So add it as a PUBLIC (can be INTERFACE as well) include directory so that they are made available
+# to libraries that link to OMParser.
 target_include_directories(OMParser PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/omsimulator.cmake
+++ b/omsimulator.cmake
@@ -40,12 +40,28 @@ set_target_properties(OMSimulator_external PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 
 add_library(libOMSimulator SHARED IMPORTED)
+add_dependencies(libOMSimulator OMSimulator_external)
+
+# The location where the lib is located and whether it comes with an import lib, depends on the OS/Env.
+if(MINGW)
+  set_target_properties(libOMSimulator PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/bin/libOMSimulator.dll
+    # The dll.a import lib. It is located in the same dir as the dll right now.
+    IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/bin/libOMSimulator.dll.a
+  )
+elseif(MSVC)
+  # For now print error and bail out. It should be the same as Mingw except we need to check where the .lib file is located.
+  message(FATAL_ERROR "Importing of OMSimulator is not implemented correctly for MSVC. Adjust the MINGW implementation to where the dll and lib files are expected.")
+else()
+  set_target_properties(libOMSimulator PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/lib/x86_64-linux-gnu/omc/libOMSimulator.so
+  )
+endif()
+
 set_target_properties(libOMSimulator PROPERTIES
-  IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/lib/x86_64-linux-gnu/omc/libOMSimulator.so
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/OMSimulator/src/OMSimulatorLib
 )
 
-add_dependencies(libOMSimulator OMSimulator_external)
 
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/


### PR DESCRIPTION
  - It was written assuming just linux. Down to the .so extension.

  - It is now improved for MinGW. Including importing the corresponding
    dll import lib.

  - For MSVC an error is issued and configuration terminated for now.

  - Some minor cleanup for OMParser related uses.
