### PR TITLE
Rename OMSimulator.mo to OMSimulatorExt.mo

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -449,7 +449,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableCrToCrEqLst.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableSimCodeEqCache.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/HashTableSM1.mo
-    ${CMAKE_CURRENT_SOURCE_DIR}/Util/OMSimulator.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/Util/OMSimulatorExt.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/PriorityQueue.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/SBAtomicSet.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/Util/SBFunctions.mo

--- a/OMCompiler/Compiler/Script/CevalScriptOMSimulator.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptOMSimulator.mo
@@ -40,7 +40,7 @@ encapsulated package CevalScriptOMSimulator
     Value: The evaluated value."
 
 import Values;
-import OMSimulator;
+import OMSimulatorExt;
 
 public function ceval
   input String inFunctionName;
@@ -56,457 +56,457 @@ algorithm
 
     case ("loadOMSimulator",{})
       equation
-        status = OMSimulator.loadOMSimulator();
+        status = OMSimulatorExt.loadOMSimulator();
       then
         Values.INTEGER(status);
 
     case ("unloadOMSimulator",{})
       equation
-        status = OMSimulator.unloadOMSimulator();
+        status = OMSimulatorExt.unloadOMSimulator();
       then
         Values.INTEGER(status);
 
     case("oms_addBus",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_addBus(cref);
+        status = OMSimulatorExt.oms_addBus(cref);
       then
         Values.INTEGER(status);
 
     case("oms_addConnection",{Values.STRING(crefA), Values.STRING(crefB)})
       equation
-        status = OMSimulator.oms_addConnection(crefA,crefB);
+        status = OMSimulatorExt.oms_addConnection(crefA,crefB);
       then
         Values.INTEGER(status);
 
     case("oms_addConnector",{Values.STRING(cref), Values.ENUM_LITERAL(index=causality), Values.ENUM_LITERAL(index=type_)})
       equation
-        status = OMSimulator.oms_addConnector(cref,causality-1,type_-1);
+        status = OMSimulatorExt.oms_addConnector(cref,causality-1,type_-1);
       then
         Values.INTEGER(status);
 
     case("oms_addConnectorToBus",{Values.STRING(busCref), Values.STRING(connectorCref)})
       equation
-        status = OMSimulator.oms_addConnectorToBus(busCref,connectorCref);
+        status = OMSimulatorExt.oms_addConnectorToBus(busCref,connectorCref);
       then
         Values.INTEGER(status);
 
     case("oms_addConnectorToTLMBus",{Values.STRING(busCref), Values.STRING(connectorCref), Values.STRING(stype_)})
       equation
-        status = OMSimulator.oms_addConnectorToTLMBus(busCref,connectorCref,stype_);
+        status = OMSimulatorExt.oms_addConnectorToTLMBus(busCref,connectorCref,stype_);
       then
         Values.INTEGER(status);
 
     case("oms_addDynamicValueIndicator",{Values.STRING(signal), Values.STRING(s_lower), Values.STRING(s_upper), Values.REAL(stepSize)})
       equation
-        status = OMSimulator.oms_addDynamicValueIndicator(signal,s_lower,s_upper,stepSize);
+        status = OMSimulatorExt.oms_addDynamicValueIndicator(signal,s_lower,s_upper,stepSize);
       then
         Values.INTEGER(status);
 
     case("oms_addEventIndicator",{Values.STRING(signal)})
       equation
-        status = OMSimulator.oms_addEventIndicator(signal);
+        status = OMSimulatorExt.oms_addEventIndicator(signal);
       then
         Values.INTEGER(status);
 
     case("oms_addExternalModel",{Values.STRING(cref), Values.STRING(path), Values.STRING(startscript)})
       equation
-        status = OMSimulator.oms_addExternalModel(cref,path,startscript);
+        status = OMSimulatorExt.oms_addExternalModel(cref,path,startscript);
       then
         Values.INTEGER(status);
 
     case("oms_addSignalsToResults",{Values.STRING(cref), Values.STRING(regex)})
       equation
-        status = OMSimulator.oms_addSignalsToResults(cref,regex);
+        status = OMSimulatorExt.oms_addSignalsToResults(cref,regex);
       then
         Values.INTEGER(status);
 
     case("oms_addStaticValueIndicator",{Values.STRING(signal), Values.REAL(lower), Values.REAL(upper), Values.REAL(stepSize)})
       equation
-        status = OMSimulator.oms_addStaticValueIndicator(signal,lower,upper,stepSize);
+        status = OMSimulatorExt.oms_addStaticValueIndicator(signal,lower,upper,stepSize);
       then
         Values.INTEGER(status);
 
     case("oms_addSubModel",{Values.STRING(cref), Values.STRING(fmuPath)})
       equation
-        status = OMSimulator.oms_addSubModel(cref,fmuPath);
+        status = OMSimulatorExt.oms_addSubModel(cref,fmuPath);
       then
         Values.INTEGER(status);
 
     case("oms_addSystem",{Values.STRING(cref), Values.ENUM_LITERAL(index=type_)})
       equation
-        status = OMSimulator.oms_addSystem(cref,type_-1);
+        status = OMSimulatorExt.oms_addSystem(cref,type_-1);
       then
         Values.INTEGER(status);
 
     case("oms_addTimeIndicator",{Values.STRING(signal)})
       equation
-        status = OMSimulator.oms_addTimeIndicator(signal);
+        status = OMSimulatorExt.oms_addTimeIndicator(signal);
       then
         Values.INTEGER(status);
 
     case("oms_addTLMBus",{Values.STRING(cref), Values.ENUM_LITERAL(index=domain), Values.INTEGER(dimensions),Values.ENUM_LITERAL(index=interpolation)})
       equation
-        status = OMSimulator.oms_addTLMBus(cref,(domain-1),dimensions,(interpolation-1));
+        status = OMSimulatorExt.oms_addTLMBus(cref,(domain-1),dimensions,(interpolation-1));
       then
         Values.INTEGER(status);
 
     case("oms_addTLMConnection",{Values.STRING(crefA), Values.STRING(crefB), Values.REAL(delay), Values.REAL(alpha), Values.REAL(linearimpedance), Values.REAL(angularimpedance)})
       equation
-        status = OMSimulator.oms_addTLMConnection(crefA,crefB,delay,alpha,linearimpedance,angularimpedance);
+        status = OMSimulatorExt.oms_addTLMConnection(crefA,crefB,delay,alpha,linearimpedance,angularimpedance);
       then
         Values.INTEGER(status);
 
     case("oms_compareSimulationResults",{Values.STRING(filenameA), Values.STRING(filenameB), Values.STRING(var), Values.REAL(relTol), Values.REAL(absTol)})
       equation
-        status = OMSimulator.oms_compareSimulationResults(filenameA,filenameB,var,relTol,absTol);
+        status = OMSimulatorExt.oms_compareSimulationResults(filenameA,filenameB,var,relTol,absTol);
       then
         Values.INTEGER(status);
 
     case("oms_copySystem",{Values.STRING(source), Values.STRING(target)})
       equation
-        status = OMSimulator.oms_copySystem(source,target);
+        status = OMSimulatorExt.oms_copySystem(source,target);
       then
         Values.INTEGER(status);
 
     case("oms_delete",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_delete(cref);
+        status = OMSimulatorExt.oms_delete(cref);
       then
         Values.INTEGER(status);
 
     case("oms_deleteConnection",{Values.STRING(crefA), Values.STRING(crefB)})
       equation
-        status = OMSimulator.oms_deleteConnection(crefA,crefB);
+        status = OMSimulatorExt.oms_deleteConnection(crefA,crefB);
       then
         Values.INTEGER(status);
 
     case("oms_deleteConnectorFromBus",{Values.STRING(busCref), Values.STRING(connectorCref)})
       equation
-        status = OMSimulator.oms_deleteConnectorFromBus(busCref,connectorCref);
+        status = OMSimulatorExt.oms_deleteConnectorFromBus(busCref,connectorCref);
       then
         Values.INTEGER(status);
 
     case("oms_deleteConnectorFromTLMBus",{Values.STRING(busCref), Values.STRING(connectorCref)})
       equation
-        status = OMSimulator.oms_deleteConnectorFromTLMBus(busCref,connectorCref);
+        status = OMSimulatorExt.oms_deleteConnectorFromTLMBus(busCref,connectorCref);
       then
         Values.INTEGER(status);
 
     case("oms_export",{Values.STRING(cref), Values.STRING(filename)})
       equation
-        status = OMSimulator.oms_export(cref,filename);
+        status = OMSimulatorExt.oms_export(cref,filename);
       then
         Values.INTEGER(status);
 
     case("oms_exportDependencyGraphs",{Values.STRING(cref), Values.STRING(initialization), Values.STRING(event), Values.STRING(simulation)})
       equation
-        status = OMSimulator.oms_exportDependencyGraphs(cref,initialization,event,simulation);
+        status = OMSimulatorExt.oms_exportDependencyGraphs(cref,initialization,event,simulation);
       then
         Values.INTEGER(status);
 
     case("oms_exportSnapshot",{Values.STRING(cref)})
       equation
-        (contents,status) = OMSimulator.oms_exportSnapshot(cref);
+        (contents,status) = OMSimulatorExt.oms_exportSnapshot(cref);
       then
         Values.TUPLE({Values.STRING(contents),Values.INTEGER(status)});
 
     case("oms_extractFMIKind",{Values.STRING(filename)})
       equation
-        (kind,status) = OMSimulator.oms_extractFMIKind(filename);
+        (kind,status) = OMSimulatorExt.oms_extractFMIKind(filename);
       then
         Values.TUPLE({Values.INTEGER(kind),Values.INTEGER(status)});
 
     case("oms_getBoolean",{Values.STRING(cref)})
       equation
-        (b,status) = OMSimulator.oms_getBoolean(cref);
+        (b,status) = OMSimulatorExt.oms_getBoolean(cref);
       then
         Values.TUPLE({Values.BOOL(b),Values.INTEGER(status)});
 
     case("oms_getFixedStepSize",{Values.STRING(cref)})
       equation
-        (rvalue,status) = OMSimulator.oms_getFixedStepSize(cref);
+        (rvalue,status) = OMSimulatorExt.oms_getFixedStepSize(cref);
       then
         Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getInteger",{Values.STRING(cref)})
       equation
-        (ivalue,status) = OMSimulator.oms_getInteger(cref);
+        (ivalue,status) = OMSimulatorExt.oms_getInteger(cref);
       then
         Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getModelState",{Values.STRING(cref)})
       equation
-        (ivalue,status) = OMSimulator.oms_getModelState(cref);
+        (ivalue,status) = OMSimulatorExt.oms_getModelState(cref);
       then
         Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getReal",{Values.STRING(cref)})
       equation
-        (rvalue,status) = OMSimulator.oms_getReal(cref);
+        (rvalue,status) = OMSimulatorExt.oms_getReal(cref);
       then
         Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getSolver",{Values.STRING(cref)})
       equation
-        (ivalue,status) = OMSimulator.oms_getSolver(cref);
+        (ivalue,status) = OMSimulatorExt.oms_getSolver(cref);
       then
         Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getStartTime",{Values.STRING(cref)})
       equation
-        (rvalue,status) = OMSimulator.oms_getStartTime(cref);
+        (rvalue,status) = OMSimulatorExt.oms_getStartTime(cref);
       then
         Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getStopTime",{Values.STRING(cref)})
       equation
-        (rvalue,status) = OMSimulator.oms_getStopTime(cref);
+        (rvalue,status) = OMSimulatorExt.oms_getStopTime(cref);
       then
         Values.TUPLE({Values.REAL(rvalue),Values.INTEGER(status)});
 
     case("oms_getSubModelPath",{Values.STRING(cref)})
       equation
-        (path,status) = OMSimulator.oms_getSubModelPath(cref);
+        (path,status) = OMSimulatorExt.oms_getSubModelPath(cref);
       then
         Values.TUPLE({Values.STRING(path),Values.INTEGER(status)});
 
     case("oms_getSystemType",{Values.STRING(cref)})
       equation
-        (ivalue,status) = OMSimulator.oms_getSystemType(cref);
+        (ivalue,status) = OMSimulatorExt.oms_getSystemType(cref);
       then
         Values.TUPLE({Values.INTEGER(ivalue),Values.INTEGER(status)});
 
     case("oms_getTolerance",{Values.STRING(cref)})
       equation
-        (absoluteTolerance,relativeTolerance,status) = OMSimulator.oms_getTolerance(cref);
+        (absoluteTolerance,relativeTolerance,status) = OMSimulatorExt.oms_getTolerance(cref);
       then
         Values.TUPLE({Values.REAL(absoluteTolerance),Values.REAL(relativeTolerance),Values.INTEGER(status)});
 
     case("oms_getVariableStepSize",{Values.STRING(cref)})
       equation
-        (initialStepSize,minimumStepSize,maximumStepSize,status) = OMSimulator.oms_getVariableStepSize(cref);
+        (initialStepSize,minimumStepSize,maximumStepSize,status) = OMSimulatorExt.oms_getVariableStepSize(cref);
       then
         Values.TUPLE({Values.REAL(initialStepSize),Values.REAL(minimumStepSize),Values.REAL(maximumStepSize),Values.INTEGER(status)});
 
     case("oms_faultInjection",{Values.STRING(signal), Values.ENUM_LITERAL(index=faultType), Values.REAL(faultValue)})
       equation
-        status = OMSimulator.oms_faultInjection(signal,faultType-1,faultValue);
+        status = OMSimulatorExt.oms_faultInjection(signal,faultType-1,faultValue);
       then
         Values.INTEGER(status);
 
     case("oms_importFile",{Values.STRING(filename)})
       equation
-        (cref,status) = OMSimulator.oms_importFile(filename);
+        (cref,status) = OMSimulatorExt.oms_importFile(filename);
       then
         Values.TUPLE({Values.STRING(cref),Values.INTEGER(status)});
 
     case("oms_importSnapshot",{Values.STRING(cref), Values.STRING(snapshot)})
       equation
-        status = OMSimulator.oms_importSnapshot(cref,snapshot);
+        status = OMSimulatorExt.oms_importSnapshot(cref,snapshot);
       then
         Values.INTEGER(status);
 
     case("oms_initialize",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_initialize(cref);
+        status = OMSimulatorExt.oms_initialize(cref);
       then
         Values.INTEGER(status);
 
     case("oms_instantiate",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_instantiate(cref);
+        status = OMSimulatorExt.oms_instantiate(cref);
       then
         Values.INTEGER(status);
 
     case("oms_list",{Values.STRING(cref)})
       equation
-        (contents,status) = OMSimulator.oms_list(cref);
+        (contents,status) = OMSimulatorExt.oms_list(cref);
       then
         Values.TUPLE({Values.STRING(contents),Values.INTEGER(status)});
 
     case("oms_listUnconnectedConnectors",{Values.STRING(cref)})
       equation
-        (contents,status) = OMSimulator.oms_listUnconnectedConnectors(cref);
+        (contents,status) = OMSimulatorExt.oms_listUnconnectedConnectors(cref);
       then
         Values.TUPLE({Values.STRING(contents),Values.INTEGER(status)});
 
     case("oms_loadSnapshot",{Values.STRING(cref), Values.STRING(snapshot)})
       equation
-        (newCref,status) = OMSimulator.oms_loadSnapshot(cref,snapshot);
+        (newCref,status) = OMSimulatorExt.oms_loadSnapshot(cref,snapshot);
       then
         Values.TUPLE({Values.STRING(newCref),Values.INTEGER(status)});
 
     case("oms_newModel",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_newModel(cref);
+        status = OMSimulatorExt.oms_newModel(cref);
       then
         Values.INTEGER(status);
 
     case("oms_removeSignalsFromResults",{Values.STRING(cref), Values.STRING(regex)})
       equation
-        status = OMSimulator.oms_removeSignalsFromResults(cref,regex);
+        status = OMSimulatorExt.oms_removeSignalsFromResults(cref,regex);
       then
         Values.INTEGER(status);
 
     case("oms_rename",{Values.STRING(cref), Values.STRING(newCref)})
       equation
-        status = OMSimulator.oms_rename(cref,newCref);
+        status = OMSimulatorExt.oms_rename(cref,newCref);
       then
         Values.INTEGER(status);
 
     case("oms_reset",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_reset(cref);
+        status = OMSimulatorExt.oms_reset(cref);
       then
         Values.INTEGER(status);
 
     case("oms_RunFile",{Values.STRING(filename)})
       equation
-        status = OMSimulator.oms_RunFile(filename);
+        status = OMSimulatorExt.oms_RunFile(filename);
       then
         Values.INTEGER(status);
 
     case("oms_setBoolean",{Values.STRING(cref),Values.BOOL(b)})
       equation
-        status = OMSimulator.oms_setBoolean(cref,b);
+        status = OMSimulatorExt.oms_setBoolean(cref,b);
       then
         Values.INTEGER(status);
 
     case("oms_setCommandLineOption",{Values.STRING(cmd)})
       equation
-        status = OMSimulator.oms_setCommandLineOption(cmd);
+        status = OMSimulatorExt.oms_setCommandLineOption(cmd);
       then
         Values.INTEGER(status);
 
     case("oms_setFixedStepSize",{Values.STRING(cref), Values.REAL(stepSize)})
       equation
-        status = OMSimulator.oms_setFixedStepSize(cref,stepSize);
+        status = OMSimulatorExt.oms_setFixedStepSize(cref,stepSize);
       then
         Values.INTEGER(status);
 
     case("oms_setInteger",{Values.STRING(cref), Values.INTEGER(ivalue)})
       equation
-        status = OMSimulator.oms_setInteger(cref,ivalue);
+        status = OMSimulatorExt.oms_setInteger(cref,ivalue);
       then
         Values.INTEGER(status);
 
     case("oms_setLogFile",{Values.STRING(filename)})
       equation
-        status = OMSimulator.oms_setLogFile(filename);
+        status = OMSimulatorExt.oms_setLogFile(filename);
       then
         Values.INTEGER(status);
 
     case("oms_setLoggingInterval",{Values.STRING(cref), Values.REAL(loggingInterval)})
       equation
-        status = OMSimulator.oms_setLoggingInterval(cref,loggingInterval);
+        status = OMSimulatorExt.oms_setLoggingInterval(cref,loggingInterval);
       then
         Values.INTEGER(status);
 
     case("oms_setLoggingLevel",{Values.INTEGER(logLevel)})
       equation
-        status = OMSimulator.oms_setLoggingLevel(logLevel);
+        status = OMSimulatorExt.oms_setLoggingLevel(logLevel);
       then
         Values.INTEGER(status);
 
     case("oms_setReal",{Values.STRING(cref), Values.REAL(rvalue)})
       equation
-        status = OMSimulator.oms_setReal(cref,rvalue);
+        status = OMSimulatorExt.oms_setReal(cref,rvalue);
       then
         Values.INTEGER(status);
 
     case("oms_setRealInputDerivative",{Values.STRING(cref), Values.REAL(rvalue)})
       equation
-        status = OMSimulator.oms_setRealInputDerivative(cref,rvalue);
+        status = OMSimulatorExt.oms_setRealInputDerivative(cref,rvalue);
       then
         Values.INTEGER(status);
 
     case("oms_setResultFile",{Values.STRING(cref), Values.STRING(filename), Values.INTEGER(bufferSize)})
       equation
-        status = OMSimulator.oms_setResultFile(cref,filename,bufferSize);
+        status = OMSimulatorExt.oms_setResultFile(cref,filename,bufferSize);
       then
         Values.INTEGER(status);
 
     case("oms_setSignalFilter",{Values.STRING(cref), Values.STRING(regex)})
       equation
-        status = OMSimulator.oms_setSignalFilter(cref,regex);
+        status = OMSimulatorExt.oms_setSignalFilter(cref,regex);
       then
         Values.INTEGER(status);
 
     case("oms_setSolver",{Values.STRING(cref), Values.ENUM_LITERAL(index=solver)})
       equation
-        status = OMSimulator.oms_setSolver(cref,solver-1);
+        status = OMSimulatorExt.oms_setSolver(cref,solver-1);
       then
         Values.INTEGER(status);
 
     case("oms_setStartTime",{Values.STRING(cref), Values.REAL(startTime)})
       equation
-        status = OMSimulator.oms_setStartTime(cref,startTime);
+        status = OMSimulatorExt.oms_setStartTime(cref,startTime);
       then
         Values.INTEGER(status);
 
     case("oms_setStopTime",{Values.STRING(cref), Values.REAL(stopTime)})
       equation
-        status = OMSimulator.oms_setStopTime(cref,stopTime);
+        status = OMSimulatorExt.oms_setStopTime(cref,stopTime);
       then
         Values.INTEGER(status);
 
     case("oms_setTempDirectory",{Values.STRING(newTempDir)})
       equation
-        status = OMSimulator.oms_setTempDirectory(newTempDir);
+        status = OMSimulatorExt.oms_setTempDirectory(newTempDir);
       then
         Values.INTEGER(status);
 
     case("oms_setTLMPositionAndOrientation",{Values.STRING(cref), Values.REAL(x1), Values.REAL(x2), Values.REAL(x3), Values.REAL(A11), Values.REAL(A12), Values.REAL(A13), Values.REAL(A21), Values.REAL(A22), Values.REAL(A23), Values.REAL(A31), Values.REAL(A32), Values.REAL(A33)})
       equation
-        status = OMSimulator.oms_setTLMPositionAndOrientation(cref,x1,x2,x3,A11,A12,A13,A21,A22,A23,A31,A32,A33);
+        status = OMSimulatorExt.oms_setTLMPositionAndOrientation(cref,x1,x2,x3,A11,A12,A13,A21,A22,A23,A31,A32,A33);
       then
         Values.INTEGER(status);
 
     case("oms_setTLMSocketData",{Values.STRING(cref), Values.STRING(address), Values.INTEGER(managerPort), Values.INTEGER(monitorPort)})
       equation
-        status = OMSimulator.oms_setTLMSocketData(cref,address,managerPort,monitorPort);
+        status = OMSimulatorExt.oms_setTLMSocketData(cref,address,managerPort,monitorPort);
       then
         Values.INTEGER(status);
 
     case("oms_setTolerance",{Values.STRING(cref), Values.REAL(absoluteTolerance), Values.REAL(relativeTolerance)})
       equation
-        status = OMSimulator.oms_setTolerance(cref,absoluteTolerance,relativeTolerance);
+        status = OMSimulatorExt.oms_setTolerance(cref,absoluteTolerance,relativeTolerance);
       then
         Values.INTEGER(status);
 
     case("oms_setVariableStepSize",{Values.STRING(cref), Values.REAL(initialStepSize), Values.REAL(minimumStepSize), Values.REAL(maximumStepSize)})
       equation
-        status = OMSimulator.oms_setVariableStepSize(cref,initialStepSize,minimumStepSize,maximumStepSize);
+        status = OMSimulatorExt.oms_setVariableStepSize(cref,initialStepSize,minimumStepSize,maximumStepSize);
       then
         Values.INTEGER(status);
 
     case("oms_setWorkingDirectory",{Values.STRING(newWorkingDir)})
       equation
-        status = OMSimulator.oms_setWorkingDirectory(newWorkingDir);
+        status = OMSimulatorExt.oms_setWorkingDirectory(newWorkingDir);
       then
         Values.INTEGER(status);
 
     case("oms_simulate",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_simulate(cref);
+        status = OMSimulatorExt.oms_simulate(cref);
       then
         Values.INTEGER(status);
 
     case("oms_stepUntil",{Values.STRING(cref), Values.REAL(stopTime)})
       equation
-        status = OMSimulator.oms_stepUntil(cref,stopTime);
+        status = OMSimulatorExt.oms_stepUntil(cref,stopTime);
       then
         Values.INTEGER(status);
 
     case("oms_terminate",{Values.STRING(cref)})
       equation
-        status = OMSimulator.oms_terminate(cref);
+        status = OMSimulatorExt.oms_terminate(cref);
       then
         Values.INTEGER(status);
 
     case ("oms_getVersion",{})
       equation
-        version = OMSimulator.oms_getVersion();
+        version = OMSimulatorExt.oms_getVersion();
       then
         Values.STRING(version);
   end matchcontinue;

--- a/OMCompiler/Compiler/Util/OMSimulatorExt.mo
+++ b/OMCompiler/Compiler/Util/OMSimulatorExt.mo
@@ -29,10 +29,10 @@
  *
  */
 
-encapsulated package OMSimulator
-" file:         OMSimulator.mo
-  package:     OMSimulator
-  description: This file contains OMSimulator wrapper functions which are implemented in  C and Linked through DLL.
+encapsulated package OMSimulatorExt
+" file:         OMSimulatorExt.mo
+  package:     OMSimulatorExt
+  description: This file contains OMSimulatorExt wrapper functions which are implemented in  C and Linked through DLL.
   "
 public function statusToString
   input Integer status;
@@ -606,4 +606,4 @@ function oms_terminate
 end oms_terminate;
 
 annotation(__OpenModelica_Interface="util");
-end OMSimulator;
+end OMSimulatorExt;

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -483,7 +483,7 @@ if true then /* Suppress output */
     "../Util/HashTableCrToCrEqLst.mo",
     "../Util/HashTableSimCodeEqCache.mo",
     "../Util/HashTableSM1.mo",
-    "../Util/OMSimulator.mo",
+    "../Util/OMSimulatorExt.mo",
     "../Util/PriorityQueue.mo",
     "../Util/SBAtomicSet.mo",
     "../Util/SBFunctions.mo",

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -273,18 +273,6 @@ target_link_libraries(OMEditLib PUBLIC OMPlotLib)
 target_link_libraries(OMEditLib PUBLIC OpenModelicaCompiler)
 target_link_libraries(OMEditLib PUBLIC ${OPENSCENEGRAPH_LIBRARIES})
 
-
-# OMEditLib needs OpenModelicaScriptingAPI.h which is generated in the build dir.
-# So we have the build dir as include through linking libOpenModelicaCompiler
-# There is also an OMSimulator.h generated in that dir from OMSimulator.mo
-# We also have an OMSimulator.h from OMSimulatorLib which we actually want to use.
-# Except we are using libOMSimulator as an imported lib now.
-# Headers from imported libs are treated as system libs and are added at the end of the include command line.
-# Which means the OMSimulator.h from OMSimulator.mo will be picked up first regardless of the order we specify for linking.
-# So for now we disable SYSTEM marking of imported libs for OMEditLib here.
-set_target_properties(OMEditLib PROPERTIES
-        NO_SYSTEM_FROM_IMPORTED ON)
-
 target_include_directories(OMEditLib PRIVATE
   ${OMCompiler_SOURCE_DIR}/Compiler/Script)
 


### PR DESCRIPTION
  - This is to avoid conflicting includes between the generated
    OMSimulator.h (from OMSimulator.mo) and the OMSimulator.h from
    OMSimulator itself (the public header of OMSimulator)

- Remove workaround added for the conflicting headers.