### PR TITLE
Check for _WIN32 instead of WIN32.

### DIFF
--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -50,7 +50,7 @@
 #include <pwd.h>
 #endif
 
-#ifdef WIN32
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
@@ -338,7 +338,7 @@ extern const char* SettingsImpl__getTempDirectoryPath(void)
   if (tempDirectoryPath == NULL) {
   // On windows, set Temp directory path to Temp directory as returned by GetTempPath,
   // which is usually TMP or TEMP or windows catalogue.
-  #ifdef WIN32
+  #if defined(_WIN32)
     int numChars;
     char tempDirectory[1024];
       //extract the temp path

--- a/OMCompiler/SimulationRuntime/OMSICpp/omcWrapper/omcCAPI/include/OMCFunctions.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/omcWrapper/omcCAPI/include/OMCFunctions.h
@@ -10,7 +10,7 @@ extern "C" {
 int omc_Main_handleCommand(void* threadData, void* imsg, void** omsg);
 void* omc_Main_init(void* threadData, void* args);
 void omc_Main_readSettings(void* threadData, void* args);
-#ifdef WIN32
+#if defined(_WIN32)
 void omc_Main_setWindowsPaths(threadData_t *threadData, void* _inOMHome);
 #endif
 

--- a/OMEdit/OMEditLIB/Animation/ExtraShapes.cpp
+++ b/OMEdit/OMEditLIB/Animation/ExtraShapes.cpp
@@ -32,6 +32,11 @@
  * @author Volker Waurich <volker.waurich@tu-dresden.de>
  */
 
+#ifndef _USE_MATH_DEFINES
+  #define _USE_MATH_DEFINES
+#endif
+#include <cmath>
+
 #include "ExtraShapes.h"
 #include <iostream>
 

--- a/OMEdit/OMEditLIB/CrashReport/GDBBacktrace.cpp
+++ b/OMEdit/OMEditLIB/CrashReport/GDBBacktrace.cpp
@@ -32,7 +32,7 @@
  */
 
 #include "GDBBacktrace.h"
-#ifdef WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #else
 #include <unistd.h>
@@ -55,7 +55,7 @@ GDBBacktrace::GDBBacktrace(QObject *parent)
   : QObject(parent)
 {
   QString program = QLatin1String("gdb");
-#ifdef WIN32
+#if defined(_WIN32)
   program = Utilities::getGDBPath();
   const qint64 processId = GetCurrentProcessId();
 #else

--- a/OMEdit/OMEditLIB/CrashReport/backtrace.c
+++ b/OMEdit/OMEditLIB/CrashReport/backtrace.c
@@ -11,7 +11,7 @@
 /* adrpo commented this out as this is a C file compiled with gcc so it NEVER get QT_NO_DEBUG
  * #ifdef QT_NO_DEBUG
  */
-#ifdef WIN32
+#if defined(_WIN32)
 #include "backtrace.h"
 
 void
@@ -273,7 +273,7 @@ _backtrace(struct output_buffer *ob, struct bfd_set *set, int depth , LPCONTEXT 
     }
   }
 }
-#endif //#ifdef WIN32
+#endif //#if defined(_WIN32)
 
 /*
  * #endif // #ifdef QT_NO_DEBUG

--- a/OMEdit/OMEditLIB/CrashReport/backtrace.h
+++ b/OMEdit/OMEditLIB/CrashReport/backtrace.h
@@ -20,7 +20,7 @@
                      + __GNUC_MINOR__ * 100 \
 		     + __GNUC_PATCHLEVEL__)
 
-#ifdef WIN32
+#if defined(_WIN32)
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -76,7 +76,7 @@ void release_set(struct bfd_set *set);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
-#endif // #ifdef WIN32
+#endif // #if defined(_WIN32)
 
 /*
  * #endif // #ifdef QT_NO_DEBUG

--- a/OMEdit/OMEditLIB/Debugger/GDB/GDBAdapter.cpp
+++ b/OMEdit/OMEditLIB/Debugger/GDB/GDBAdapter.cpp
@@ -313,7 +313,7 @@ void GDBAdapter::launch(QString program, QString workingDirectory, QStringList a
   }
   mpGDBProcess = new QProcess;
   setGDBKilled(false);
-#ifdef WIN32
+#if defined(_WIN32)
   /* Set the environment for GDB process */
   QProcessEnvironment processEnvironment = StringHandler::simulationProcessEnvironment();
   if (!simulationOptions.getFileName().isEmpty()) {
@@ -363,7 +363,7 @@ void GDBAdapter::launch(QString processId, QString GDBPath)
   mAttachToProcessId = processId;
   mpGDBProcess = new QProcess;
   setGDBKilled(false);
-#ifdef WIN32
+#if defined(_WIN32)
   /* Set the environment for GDB process */
   mpGDBProcess->setProcessEnvironment(StringHandler::simulationProcessEnvironment());
 #endif

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -2527,7 +2527,7 @@ void Element::updateToolTip()
     OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
     comment = pOMCProxy->makeDocumentationUriToFileName(comment);
     // since tooltips can't handle file:// scheme so we have to remove it in order to display images and make links work.
-  #ifdef WIN32
+  #if defined(_WIN32)
     comment.replace("src=\"file:///", "src=\"");
   #else
     comment.replace("src=\"file://", "src=\"");

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -49,7 +49,7 @@ extern "C" {
 int omc_Main_handleCommand(void *threadData, void *imsg, void **omsg);
 void* omc_Main_init(void *threadData, void *args);
 void omc_System_initGarbageCollector(void *threadData);
-#ifdef WIN32
+#if defined(_WIN32)
 void omc_Main_setWindowsPaths(threadData_t *threadData, void* _inOMHome);
 #endif
 }
@@ -259,7 +259,7 @@ bool OMCProxy::initializeOMC(threadData_t *threadData)
   Helper::OpenModelicaVersion = getVersion();
   // set OpenModelicaHome variable
   Helper::OpenModelicaHome = mpOMCInterface->getInstallationDirectoryPath().replace("\\", "/");
-#ifdef WIN32
+#if defined(_WIN32)
   MMC_TRY_TOP_INTERNAL()
   omc_Main_setWindowsPaths(threadData, mmc_mk_scon(Helper::OpenModelicaHome.toUtf8().constData()));
   MMC_CATCH_TOP()
@@ -801,7 +801,7 @@ OMCInterface::getClassInformation_res OMCProxy::getClassInformation(QString clas
   QString comment = classInformation.comment.replace("\\\"", "\"");
   comment = makeDocumentationUriToFileName(comment);
   // since tooltips can't handle file:// scheme so we have to remove it in order to display images and make links work.
-#ifdef WIN32
+#if defined(_WIN32)
   comment.replace("src=\"file:///", "src=\"");
 #else
   comment.replace("src=\"file://", "src=\"");
@@ -2742,7 +2742,7 @@ QString OMCProxy::makeDocumentationUriToFileName(QString documentation)
     // ticket:4923 Modelica specification allows both modelica:// and Modelica://
     if (attribute.startsWith("modelica://") || attribute.startsWith("Modelica://")) {
       QString fileName = uriToFilename(attribute);
-#ifdef WIN32
+#if defined(_WIN32)
       documentation = documentation.replace(attribute, "file:///" + fileName);
 #else
       documentation = documentation.replace(attribute, "file://" + fileName);

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.cpp
@@ -300,7 +300,7 @@ OMSSimulationOutputWidget::OMSSimulationOutputWidget(const QString &cref, const 
     }
     // start the executable
     QString process;
-#ifdef WIN32
+#if defined(_WIN32)
     process = QString("python");
     QProcessEnvironment processEnvironment = QProcessEnvironment::systemEnvironment();
     QString OMHOME = QString(Helper::OpenModelicaHome);

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -4791,7 +4791,7 @@ DebuggerPage::DebuggerPage(OptionsDialog *pOptionsDialog)
   // GDB Path
   mpGDBPathLabel = new Label(tr("GDB Path:"));
   mpGDBPathTextBox = new QLineEdit;
-#ifdef WIN32
+#if defined(_WIN32)
   mpGDBPathTextBox->setPlaceholderText(Utilities::getGDBPath());
 #else
   mpGDBPathTextBox->setPlaceholderText("gdb");
@@ -4980,7 +4980,7 @@ FMIPage::FMIPage(OptionsDialog *pOptionsDialog)
     pCheckBox->setProperty(Helper::fmuPlatformNamePropertyId, dockerPlarform);
     pPlatformsLayout->addWidget(pCheckBox);
   }
-#ifdef WIN32
+#if defined(_WIN32)
   QStringList paths = QString(getenv("PATH")).split(";");
 #else
   QStringList paths = QString(getenv("PATH")).split(":");
@@ -5266,14 +5266,14 @@ void TLMPage::browseTLMPluginPath()
   path = path.replace('\\', '/');
   mpTLMPluginPathTextBox->setText(path);
   if (mpTLMManagerProcessTextBox->text().isEmpty()) {
-#ifdef WIN32
+#if defined(_WIN32)
     mpTLMManagerProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmanager.exe");
 #else
     mpTLMManagerProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmanager");
 #endif
   }
   if (mpTLMMonitorProcessTextBox->text().isEmpty()) {
-#ifdef WIN32
+#if defined(_WIN32)
     mpTLMMonitorProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmonitor.exe");
 #else
     mpTLMMonitorProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmonitor");

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1823,7 +1823,7 @@ void SimulationDialog::showAlgorithmicDebugger(SimulationOptions simulationOptio
     fileName = QString(simulationOptions.getWorkingDirectory()).append("/").append(fileName);
     fileName = fileName.replace("//", "/");
     // run the simulation executable to create the result file
-#ifdef WIN32
+#if defined(_WIN32)
     fileName = fileName.append(".exe");
 #endif
     // start the debugger

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -547,7 +547,7 @@ void SimulationOutputWidget::compileModel()
     numProcs = QString::number(mSimulationOptions.getNumberOfProcessors());
   }
   QStringList args;
-#ifdef WIN32
+#if defined(_WIN32)
   if (OptionsDialog::instance()->getSimulationPage()->getUseStaticLinkingCheckBox()->isChecked()) {
     linkType = "static";
   }
@@ -601,7 +601,7 @@ void SimulationOutputWidget::runSimulationExecutable()
   QString fileName = QString(mSimulationOptions.getWorkingDirectory()).append("/").append(mSimulationOptions.getOutputFileName());
   fileName = fileName.replace("//", "/");
   // run the simulation executable to create the result file
-#ifdef WIN32
+#if defined(_WIN32)
   fileName = fileName.append(".exe");
   QFileInfo fileInfo(mSimulationOptions.getFileName());
   QProcessEnvironment processEnvironment = StringHandler::simulationProcessEnvironment();
@@ -1058,7 +1058,7 @@ void SimulationOutputWidget::openTransformationBrowser(QUrl url)
   if (url.scheme().compare("omedittransformationsbrowser") == 0) {
     /* read the file name */
     QString fileName = url.path();
-#ifdef WIN32
+#if defined(_WIN32)
     if (fileName.startsWith("/")) fileName.remove(0, 1);
 #endif
     /* open the model_info.json file */

--- a/OMEdit/OMEditLIB/TLM/FetchInterfaceDataThread.cpp
+++ b/OMEdit/OMEditLIB/TLM/FetchInterfaceDataThread.cpp
@@ -64,7 +64,7 @@ void FetchInterfaceDataThread::run()
   args << fileInfo.absoluteFilePath();
   TLMPage *pTLMPage = OptionsDialog::instance()->getTLMPage();
   QProcessEnvironment environment;
-#ifdef WIN32
+#if defined(_WIN32)
   environment = StringHandler::simulationProcessEnvironment();
   environment.insert("PATH", pTLMPage->getOMTLMSimulatorPath() + ";" + environment.value("PATH"));
 #else
@@ -129,7 +129,7 @@ void FetchInterfaceDataThread::managerProcessFinished(int exitCode, QProcess::Ex
     emit sendManagerOutput(mpManagerProcess->errorString() + "\n" + exitCodeStr, StringHandler::Error);
   }
   emit sendManagerFinished(exitCode, exitStatus);
-#ifdef WIN32
+#if defined(_WIN32)
   Utilities::killProcessTreeWindows(mManagerProcessId);
 #else
   /*! @todo do similar stuff for Linux! */

--- a/OMEdit/OMEditLIB/TLM/TLMCoSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/TLM/TLMCoSimulationDialog.cpp
@@ -31,7 +31,7 @@
  * @author Adeel Asghar <adeel.asghar@liu.se>
  */
 
-#ifdef WIN32
+#if defined(_WIN32)
 #include <winsock2.h>
 #else
 #include <sys/socket.h>
@@ -308,7 +308,7 @@ TLMCoSimulationOptions TLMCoSimulationDialog::createTLMCoSimulationOptions()
 #define MAXHOSTNAME 1024
     char myname[MAXHOSTNAME+1];
     struct hostent *hp;
-#ifdef WIN32
+#if defined(_WIN32)
     WSADATA ws;
     int d;
     d = WSAStartup(0x0101,&ws);
@@ -340,14 +340,14 @@ void TLMCoSimulationDialog::browseTLMPluginPath()
 {
   mpTLMPluginPathTextBox->setText(StringHandler::getExistingDirectory(this, QString(Helper::applicationName).append(" - ").append(Helper::chooseDirectory), NULL));
   if (mpManagerProcessTextBox->text().isEmpty()) {
-#ifdef WIN32
+#if defined(_WIN32)
     mpManagerProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmanager.exe");
 #else
     mpManagerProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmanager");
 #endif
   }
   if (mpMonitorProcessTextBox->text().isEmpty()) {
-#ifdef WIN32
+#if defined(_WIN32)
     mpMonitorProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmonitor.exe");
 #else
     mpMonitorProcessTextBox->setText(mpTLMPluginPathTextBox->text() + "/tlmmonitor");

--- a/OMEdit/OMEditLIB/TLM/TLMCoSimulationThread.cpp
+++ b/OMEdit/OMEditLIB/TLM/TLMCoSimulationThread.cpp
@@ -99,7 +99,7 @@ void TLMCoSimulationThread::runManager()
   args << tlmCoSimulationOptions.getManagerArgs() << fileInfo.absoluteFilePath();
   QString fileName = tlmCoSimulationOptions.getManagerProcess();
   QProcessEnvironment environment;
-#ifdef WIN32
+#if defined(_WIN32)
   environment = StringHandler::simulationProcessEnvironment();
   environment.insert("PATH", tlmCoSimulationOptions.getTLMPluginPath() + ";" + environment.value("PATH"));
 #else
@@ -130,7 +130,7 @@ void TLMCoSimulationThread::runMonitor()
   QString fileName = tlmCoSimulationOptions.getMonitorProcess();
   // run the simulation executable to create the result file
   QProcessEnvironment environment;
-#ifdef WIN32
+#if defined(_WIN32)
   environment = StringHandler::simulationProcessEnvironment();
   environment.insert("PATH", tlmCoSimulationOptions.getTLMPluginPath() + ";" + environment.value("PATH"));
 #else
@@ -189,7 +189,7 @@ void TLMCoSimulationThread::managerProcessFinished(int exitCode, QProcess::ExitS
     emit sendManagerOutput(mpManagerProcess->errorString() + "\n" + exitCodeStr, StringHandler::Error);
   }
   emit sendManagerFinished(exitCode, exitStatus);
-#ifdef WIN32
+#if defined(_WIN32)
   Utilities::killProcessTreeWindows(mManagerProcessId);
 #else
   /*! @todo do similar stuff for Linux! */

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -59,7 +59,7 @@ QString Helper::matFileTypes = "MAT Files (*.mat)";
 QString Helper::csvFileTypes = "CSV Files (*.csv)";
 QString Helper::omResultFileTypes = "OpenModelica Result Files (*.mat *.plt *.csv)";
 QString Helper::omResultFileTypesRegExp = "\\b(mat|plt|csv)\\b";
-#ifdef WIN32
+#if defined(_WIN32)
 QString Helper::exeFileTypes = "EXE Files (*.exe)";
 #else
 QString Helper::exeFileTypes = "Executable files (*)";

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -1355,7 +1355,7 @@ QString StringHandler::getOpenFileName(QWidget* parent, const QString &caption, 
   }
 
   QString fileName = "";
-#ifdef WIN32
+#if defined(_WIN32)
   fileName = QFileDialog::getOpenFileName(parent, caption, dir_str, filter, selectedFilter);
 #else
   Q_UNUSED(selectedFilter)
@@ -1388,7 +1388,7 @@ QStringList StringHandler::getOpenFileNames(QWidget* parent, const QString &capt
   }
 
   QStringList fileNames;
-#ifdef WIN32
+#if defined(_WIN32)
   fileNames = QFileDialog::getOpenFileNames(parent, caption, dir_str, filter, selectedFilter);
 #else
   Q_UNUSED(selectedFilter);
@@ -1672,7 +1672,7 @@ bool StringHandler::naturalSortForResultVariables(const QString &s1, const QStri
   return StringHandler::naturalSort(s3, s4);
 }
 
-#ifdef WIN32
+#if defined(_WIN32)
 /*!
  * \brief StringHandler::simulationProcessEnvironment
  * Returns the environment for simulation process.

--- a/OMEdit/OMEditLIB/Util/StringHandler.h
+++ b/OMEdit/OMEditLIB/Util/StringHandler.h
@@ -153,7 +153,7 @@ public:
   static bool naturalSort(const QString &s1, const QString &s2);
   static QString cleanResultVariable(const QString &variable);
   static bool naturalSortForResultVariables(const QString &s1, const QString &s2);
-#ifdef WIN32
+#if defined(_WIN32)
   static QProcessEnvironment simulationProcessEnvironment();
 #endif
   static StringHandler::SimulationMessageType getSimulationMessageType(QString type);

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -597,7 +597,7 @@ QString& Utilities::tempDirectory()
   static QString tmpPath;
   if (!init) {
     init = 1;
-#ifdef WIN32
+#if defined(_WIN32)
     tmpPath = QDir::tempPath() + "/OpenModelica/OMEdit/";
 #else // UNIX environment
     char *user = getenv("USER");
@@ -867,7 +867,7 @@ qint64 Utilities::getProcessId(QProcess *pProcess)
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
   processId = pProcess->processId();
 #else /* Qt4 */
-#ifdef WIN32
+#if defined(_WIN32)
   _PROCESS_INFORMATION *procInfo = pProcess->pid();
   if (procInfo) {
     processId = procInfo->dwProcessId;
@@ -887,7 +887,7 @@ qint64 Utilities::getProcessId(QProcess *pProcess)
  */
 QString Utilities::formatExitCode(int code)
 {
-#ifdef WIN32
+#if defined(_WIN32)
   // Use 0xXXXXXXXX format on Windows.
   return QStringLiteral("0x%1").arg(code, 8, 16, QChar('0'));
 #else
@@ -896,7 +896,7 @@ QString Utilities::formatExitCode(int code)
 #endif
 }
 
-#ifdef WIN32
+#if defined(_WIN32)
 /* adrpo: found this on http://stackoverflow.com/questions/1173342/terminate-a-process-tree-c-for-windows
  * thanks go to: mjmarsh & Firas Assaad
  * adapted to recurse on children ids
@@ -1009,7 +1009,7 @@ QGenericMatrix<3,3, double> Utilities::getRotationMatrix(QGenericMatrix<3,1,doub
   return R;
 }
 
-#ifdef WIN32
+#if defined(_WIN32)
 QString Utilities::getGDBPath()
 {
 #if defined(__MINGW32__) && !defined(__MINGW64__)

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -60,7 +60,7 @@
 #include <QScrollBar>
 #include <QGenericMatrix>
 
-#ifdef WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #include <tlhelp32.h>
 #endif
@@ -479,7 +479,7 @@ namespace Utilities {
     CRLFLineEnding = 0,
     LFLineEnding = 1,
     NativeLineEnding =
-#ifdef WIN32
+#if defined(_WIN32)
     CRLFLineEnding,
 #else
     LFLineEnding
@@ -508,13 +508,13 @@ namespace Utilities {
   void highlightParentheses(QPlainTextEdit *pPlainTextEdit, QTextCharFormat parenthesesMatchFormat, QTextCharFormat parenthesesMisMatchFormat);
   qint64 getProcessId(QProcess *pProcess);
   QString formatExitCode(int code);
-#ifdef WIN32
+#if defined(_WIN32)
   void killProcessTreeWindows(DWORD myprocID);
 #endif
   bool isCFile(QString extension);
   bool isModelicaFile(QString extension);
   QGenericMatrix<3,3, double> getRotationMatrix(QGenericMatrix<3,1,double> rotation);
-#ifdef WIN32
+#if defined(_WIN32)
   QString getGDBPath();
 #endif
 


### PR DESCRIPTION
@mahge
Check for _WIN32 instead of WIN32. 
12badbb
  - WIN32 is not defined by the compilers. _WIN32 is.
    WIN32 is defined by MinGW in a convenience header that seems to be
    included by most system headers. However if you do the check before
    you include any file this will not work.

    We can manually define WIN32 in a config header if _WIN32 is defined.
    However, it is the same issue if we are not including the config header
    every time before we check for WIN32.

@mahge
Make sure C math constants are set before using them …
7ed91e8
  - cmath/math.h constants are sometimes not set if _USE_MATH_DEFINES is
    not set before including cmath/math.h.

  - Make sure the define comes at the top of the file so that the header
    is not included indirectly (by other headers) without the define.