### PR TITLE
Remove check for `each` on scalars

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -46,7 +46,7 @@ protected
   import Error;
 
 public
-  constant Binding EMPTY_BINDING = UNBOUND(false, AbsynUtil.dummyInfo);
+  constant Binding EMPTY_BINDING = UNBOUND();
 
   type EachType = enumeration(
     NOT_EACH,
@@ -67,12 +67,6 @@ public
   );
 
   record UNBOUND
-    // NOTE: Use the EMPTY_BINDING constant above when a default unbound binding
-    //       is needed, to save memory. UNBOUND contains this information to be
-    //       able to check that 'each' is used correctly, so info is only needed
-    //       when isEach is true.
-    Boolean isEach;
-    SourceInfo info;
   end UNBOUND;
 
   record RAW_BINDING
@@ -144,7 +138,7 @@ public
         then
           RAW_BINDING(exp, scope, {}, each_ty, source, info);
 
-      else if eachPrefix then UNBOUND(true, info) else EMPTY_BINDING;
+      else EMPTY_BINDING;
     end match;
   end fromAbsyn;
 
@@ -381,7 +375,6 @@ public
     output SourceInfo info;
   algorithm
     info := match binding
-      case UNBOUND() then binding.info;
       case RAW_BINDING() then binding.info;
       case UNTYPED_BINDING() then binding.info;
       case TYPED_BINDING() then binding.info;
@@ -409,7 +402,6 @@ public
     output Boolean isEach;
   algorithm
     isEach := match binding
-      case UNBOUND() then binding.isEach;
       case RAW_BINDING() then binding.eachType == EachType.EACH;
       case UNTYPED_BINDING() then binding.eachType == EachType.EACH;
       case TYPED_BINDING() then binding.eachType == EachType.EACH;

--- a/testsuite/flattening/modelica/scodeinst/Each1.mo
+++ b/testsuite/flattening/modelica/scodeinst/Each1.mo
@@ -16,6 +16,4 @@ end Each1;
 // class Each1
 //   Real n.r = 1.0;
 // end Each1;
-// [flattening/modelica/scodeinst/Each1.mo:12:12-12:19:writable] Warning: 'each' used when modifying non-array element n.
-//
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Each3.mo
+++ b/testsuite/flattening/modelica/scodeinst/Each3.mo
@@ -14,7 +14,6 @@ end Each3;
 
 // Result:
 // Error processing file: Each3.mo
-// [flattening/modelica/scodeinst/Each3.mo:12:12-12:25:writable] Warning: 'each' used when modifying non-array element a.
 // [flattening/modelica/scodeinst/Each3.mo:12:14-12:24:writable] Notification: From here:
 // [flattening/modelica/scodeinst/Each3.mo:8:3-8:12:writable] Error: Non-array modification ‘true‘ for array component ‘fixed‘, possibly due to missing ‘each‘.
 //

--- a/testsuite/flattening/modelica/scodeinst/Each4.mo
+++ b/testsuite/flattening/modelica/scodeinst/Each4.mo
@@ -16,6 +16,4 @@ end Each4;
 // class Each4
 //   Real a.n(fixed = true);
 // end Each4;
-// [flattening/modelica/scodeinst/Each4.mo:12:14-12:24:writable] Warning: 'each' used when modifying non-array element n.
-//
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Each5.mo
+++ b/testsuite/flattening/modelica/scodeinst/Each5.mo
@@ -22,6 +22,4 @@ end Each5;
 //   Real b[2].a.x = 1.0;
 //   Real b[3].a.x = 1.0;
 // end Each5;
-// [flattening/modelica/scodeinst/Each5.mo:16:17-16:24:writable] Warning: 'each' used when modifying non-array element a.
-//
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/Each6.mo
+++ b/testsuite/flattening/modelica/scodeinst/Each6.mo
@@ -18,6 +18,4 @@ end Each6;
 //   Real a[2].x(start = 1.0);
 //   Real a[3].x(start = 1.0);
 // end Each6;
-// [flattening/modelica/scodeinst/Each6.mo:12:17-12:28:writable] Warning: 'each' used when modifying non-array element x.
-//
 // endResult

--- a/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
+++ b/testsuite/simulation/modelica/jacobian/reuseConstantPartsJac1.mos
@@ -51,11 +51,7 @@ getErrorString();
 // true
 // ""
 // {"Modelica.Fluid.Examples.DrumBoiler.DrumBoiler","Modelica.Fluid.Examples.DrumBoiler.DrumBoiler_init.xml"}
-// "[Modelica 3.2.3+maint.om/Fluid/Sources.mo:734:36-735:54:writable] Warning: 'each' used when modifying non-array element m_flow.
-// [Modelica 3.2.3+maint.om/Fluid/Sources.mo:732:36-733:54:writable] Warning: 'each' used when modifying non-array element m_flow.
-// [Modelica 3.2.3+maint.om/Fluid/Sources.mo:788:36-789:54:writable] Warning: 'each' used when modifying non-array element m_flow.
-// [Modelica 3.2.3+maint.om/Fluid/Sources.mo:786:36-787:54:writable] Warning: 'each' used when modifying non-array element m_flow.
-// Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // "
 // 0
 // ""


### PR DESCRIPTION
- Remove the check that `each` is not applied to scalars. The check is
  not correct since it only checks the immediate parent node, and
  checking it properly is not possible right now since submodifiers do
  not keep track of their parent modifiers. Since using `each` on a
  scalar isn't actually a problem it's better to remove the warning
  message for now instead of giving false warnings.

Fixes #7777