### PR TITLE
Add -DUNICODE to compilation of OMEDitLib.

### DIFF
--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -256,6 +256,12 @@ add_library(OMEditLib STATIC ${OMEDITLIB_SOURCES} ${OMEDITLIB_HEADERS})
 
 target_include_directories(OMEditLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+# qmake adds -DUNICODE by defult (As far as I can gather).
+# So add it for CMake as well to avoid having to modify the code.
+if(WIN32)
+  target_compile_definitions(OMEditLib PRIVATE -DUNICODE)
+endif()
+
 target_link_libraries(OMEditLib PUBLIC omedit::config)
 target_link_libraries(OMEditLib PUBLIC libOMSimulator)
 target_link_libraries(OMEditLib PUBLIC OMParser)


### PR DESCRIPTION
  - This is added by default by qmake as far as I can tell. So the code
    assumes it is set always. Set it for CMake as well.

    The relevant effect for us is that `PROCESSENTRY32` will be overridden
    to `PROCESSENTRY32W` if the define is present.
