### PR TITLE
Compile the resource files with the GUI executables

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -88,7 +88,7 @@ set(OMNOTEBOOKLIB_HEADERS application.h
                           indent.h)
 
 
-add_executable(OMNotebook ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS})
+add_executable(OMNotebook ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc)
 target_compile_definitions(OMNotebook PRIVATE OMNOTEBOOKLIB_MOC_INCLUDE)
 
 target_include_directories(OMNotebook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(OMPlotLib PUBLIC omc::simrt::runtime)
 target_link_options(OMPlotLib PRIVATE -Wl,--no-undefined)
 
 
-add_executable(OMPlot main.cpp)
+add_executable(OMPlot main.cpp rc_omplot.rc)
 target_link_libraries(OMPlot PRIVATE OMPlotLib)
 
 install(TARGETS OMPlotLib)

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
 target_link_options(OMShellLib PRIVATE -Wl,--no-undefined)
 
 
-add_executable(OMShell main.cpp)
+add_executable(OMShell main.cpp rc_omshell.rc)
 target_link_libraries(OMShell PRIVATE OMShellLib)
 
 install(TARGETS OMShellLib)


### PR DESCRIPTION
  - The .rc files need to be compiled as part of the exe generation.
    To get, among other things, the icons.
