### PR TITLE
Improve conditional array type handling

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -695,6 +695,7 @@ public
       case ARRAY() then ty.dimensions;
       case FUNCTION() then arrayDims(Function.returnType(ty.fn));
       case METABOXED() then arrayDims(ty.ty);
+      case CONDITIONAL_ARRAY() then List.fill(Dimension.UNKNOWN(), dimensionCount(ty.trueType));
       else {};
     end match;
   end arrayDims;

--- a/testsuite/flattening/modelica/scodeinst/IfExpression14.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfExpression14.mo
@@ -1,0 +1,29 @@
+// name: IfExpression14
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model IfExpression14
+  parameter Boolean cond = false;
+  Real[3] a = if cond then {1.0} else {1.0, 2.0, 3.0};
+  Real x[:] = cat(1, a, a);
+end IfExpression14;
+
+// Result:
+// class IfExpression14
+//   parameter Boolean cond = false;
+//   Real a[1];
+//   Real a[2];
+//   Real a[3];
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+//   Real x[4];
+//   Real x[5];
+//   Real x[6];
+// equation
+//   a = {1.0, 2.0, 3.0};
+//   x = {a[1], a[2], a[3], a[1], a[2], a[3]};
+// end IfExpression14;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -673,6 +673,7 @@ IfExpression10.mo \
 IfExpression11.mo \
 IfExpression12.mo \
 IfExpression13.mo \
+IfExpression14.mo \
 IfEquationInvalidCond1.mo \
 ih1.mo \
 ih2.mo \


### PR DESCRIPTION
- Return unknown dimensions for conditional array types in
  Type.arrayDims instead of an empty array, so at least the number of
  dimensions is correct (needed by `cat`).
- Handle type checking when both the expected and the actual type is a
  conditonal array type.