### PR TITLE
Handle linking of binutil's libbfd with OMEdit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@
 cmake_minimum_required(VERSION 3.14)
 project(OpenModelica C CXX Fortran)
 
+# Any custom Find* modules should be placed here.
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
+
 #########################################################################################################
 ## Enable verbose Makefiles if you want to debug. (you can also instead use 'make VERBOSE=1')
 # set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -8,8 +8,8 @@ project(OMCompiler C CXX Fortran)
 string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
 
-string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
-string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
 ## Set position independent code for OMCompiler wide. We will take some performance hit from this.
 ## However it allows us to build all static libs and combine them later to single shared libs

--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -48,7 +48,7 @@ extern "C" {
 #include <QMessageBox>
 
 #ifdef QT_NO_DEBUG
-#ifdef WIN32
+#if defined(_WIN32)
 #include "CrashReport/backtrace.h"
 
 static char *g_output = NULL;
@@ -126,7 +126,7 @@ void signalHandler(int signalNumber)
   pCrashReportDialog->exec();
   exit(signalNumber);
 }
-#endif // #ifdef WIN32
+#endif // #if defined(_WIN32)
 #endif // #ifdef QT_NO_DEBUG
 
 void printOMEditUsage()
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
   MMC_TRY_TOP()
   /* Do not use the signal handler OR exception filter if user is building a debug version. Perhaps the user wants to use gdb. */
 #ifdef QT_NO_DEBUG
-#ifdef WIN32
+#if defined(_WIN32)
   SetUnhandledExceptionFilter(exceptionFilter);
 #else
   /* Abnormal termination (abort) */

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -3,6 +3,15 @@
 # file(GLOB_RECURSE OMEDITLIB_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 # set(OMEDITLIB_SOURCES resource_omedit.qrc ${OMEDITLIB_SOURCES})
 
+
+# This small module (OpenModelica/cmake/modules/Findbinutils.cmake) finds and sets up
+# libbfd which is need for providing bactrace support for OMEdit.
+# It is required always on MinGW for now. Can be made optional with some changes.
+if(MINGW)
+  find_package(binutils REQUIRED)
+endif()
+
+
 omc_add_subdirectory(Debugger/Parser)
 
 set(CMAKE_AUTOMOC ON)
@@ -278,6 +287,10 @@ target_link_libraries(OMEditLib PUBLIC omc::3rd::opcua)
 target_link_libraries(OMEditLib PUBLIC OMPlotLib)
 target_link_libraries(OMEditLib PUBLIC OpenModelicaCompiler)
 target_link_libraries(OMEditLib PUBLIC ${OPENSCENEGRAPH_LIBRARIES})
+
+if(MINGW)
+  target_link_libraries(OMEditLib PUBLIC binutils::bfd)
+endif()
 
 target_include_directories(OMEditLib PRIVATE
   ${OMCompiler_SOURCE_DIR}/Compiler/Script)

--- a/cmake/modules/Findbinutils.cmake
+++ b/cmake/modules/Findbinutils.cmake
@@ -1,0 +1,39 @@
+# This small module finds and sets up
+# libbfd from binutils which is need for providing bactrace support for OMEdit.
+# The library is not installed in the standard location on MinGW. It is in
+# lib/binutils. This modules makes sure that it can be found.
+# It exports an imported target 'binutils::bfd' for the library
+# which brings in the dependency 'libiberty' (binutils::iberty) library with it.
+
+if(binutils_FOUND)
+  return()
+endif()
+
+find_library(LIBBFD_LIBRARY
+              NAMES libbfd.a
+              PATH_SUFFIXES binutils)
+
+find_library(LIBIBERTY_LIBRARY
+              NAMES libiberty.a
+              PATH_SUFFIXES binutils)
+
+
+include (FindPackageHandleStandardArgs)
+
+
+# handle the QUIETLY and REQUIRED arguments and set binutils_FOUND to TRUE if all listed variables are TRUE
+find_package_handle_standard_args(binutils DEFAULT_MSG
+  LIBBFD_LIBRARY
+  LIBIBERTY_LIBRARY)
+
+mark_as_advanced(LIBBFD_LIBRARY LIBIBERTY_LIBRARY)
+
+if(binutils_FOUND)
+  add_library(binutils::iberty STATIC IMPORTED)
+  set_target_properties(binutils::iberty PROPERTIES IMPORTED_LOCATION ${LIBIBERTY_LIBRARY})
+
+  add_library(binutils::bfd STATIC IMPORTED)
+  set_target_properties(binutils::bfd PROPERTIES IMPORTED_LOCATION ${LIBBFD_LIBRARY})
+
+  target_link_libraries(binutils::bfd INTERFACE binutils::iberty)
+endif()


### PR DESCRIPTION
@mahge
Modify the C flags not the CXX flags. Typo. 
baa3009
  - It was modifying the CXX flags instead of the C flags.

@mahge
Handle linking of binutil's libbfd with OMEdit. …
cbd0a3c
  - The binutils libraries (bfd ...) are not available in the standard
    locations on MinGW. They are instead in lib/binutils/ folder.

    A small cmake find module (Findbinutils.cmake) is added to handle
    this. It looks for the library and imports it as target under
    binutil:: namespace.

    The libibery lib, which is a dependency of libbfd is also searched
    for and added as a dependency.