### PR TITLE
Improve linking of GUI executables

### DIFF
--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-add_executable(OMEdit main.cpp rc_omedit.rc)
+add_executable(OMEdit WIN32 MACOSX_BUNDLE main.cpp rc_omedit.rc)
 
 target_link_libraries(OMEdit PRIVATE OMEditLib)
 

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -290,6 +290,7 @@ target_link_libraries(OMEditLib PUBLIC ${OPENSCENEGRAPH_LIBRARIES})
 
 if(MINGW)
   target_link_libraries(OMEditLib PUBLIC binutils::bfd)
+  target_link_libraries(OMEditLib PUBLIC zlib)
 endif()
 
 target_include_directories(OMEditLib PRIVATE

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -88,7 +88,7 @@ set(OMNOTEBOOKLIB_HEADERS application.h
                           indent.h)
 
 
-add_executable(OMNotebook ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc)
+add_executable(OMNotebook WIN32 MACOSX_BUNDLE ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc)
 target_compile_definitions(OMNotebook PRIVATE OMNOTEBOOKLIB_MOC_INCLUDE)
 
 target_include_directories(OMNotebook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
 target_link_options(OMShellLib PRIVATE -Wl,--no-undefined)
 
 
-add_executable(OMShell main.cpp rc_omshell.rc)
+add_executable(OMShell WIN32 MACOSX_BUNDLE main.cpp rc_omshell.rc)
 target_link_libraries(OMShell PRIVATE OMShellLib)
 
 install(TARGETS OMShellLib)

--- a/cmake/modules/Findbinutils.cmake
+++ b/cmake/modules/Findbinutils.cmake
@@ -22,13 +22,16 @@ include (FindPackageHandleStandardArgs)
 
 
 # handle the QUIETLY and REQUIRED arguments and set binutils_FOUND to TRUE if all listed variables are TRUE
-find_package_handle_standard_args(binutils DEFAULT_MSG
-  LIBBFD_LIBRARY
-  LIBIBERTY_LIBRARY)
+find_package_handle_standard_args(binutils
+                                  REQUIRED_VARS LIBBFD_LIBRARY LIBIBERTY_LIBRARY
+                                  HANDLE_COMPONENTS)
 
 mark_as_advanced(LIBBFD_LIBRARY LIBIBERTY_LIBRARY)
 
 if(binutils_FOUND)
+
+  find_package(Intl REQUIRED)
+
   add_library(binutils::iberty STATIC IMPORTED)
   set_target_properties(binutils::iberty PROPERTIES IMPORTED_LOCATION ${LIBIBERTY_LIBRARY})
 
@@ -36,4 +39,5 @@ if(binutils_FOUND)
   set_target_properties(binutils::bfd PROPERTIES IMPORTED_LOCATION ${LIBBFD_LIBRARY})
 
   target_link_libraries(binutils::bfd INTERFACE binutils::iberty)
+  target_link_libraries(binutils::bfd INTERFACE ${Intl_LIBRARIES})
 endif()


### PR DESCRIPTION
@mahge
libbfd needs libintl and zlib. 
5296372
  - Look for libintl if bdf is found.

  - We use our own zlib so link to that where needed.

@mahge
Mark the qt clients as GUI executables. 
8039e80
  - So that, for example, they do not open a consol when they
    are launched.