### PR TITLE
fix --fmiFilter=blackBox and protected

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4015,7 +4015,7 @@ algorithm
   for platform in platforms loop
     configureLogFile := System.realpath(fmutmp)+"/resources/"+System.stringReplace(listGet(Util.stringSplitAtChar(platform," "),1),"/","-")+".log";
     configureFMU(platform, fmutmp, configureLogFile, isWindows, needs3rdPartyLibs);
-    if Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX then
+    if Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX or Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_PROTECTED then
       System.removeFile(configureLogFile);
     end if;
     ExecStat.execStat("buildModelFMU: Generate platform " + platform);

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -747,8 +747,8 @@ algorithm
             fail();
           end if;
         else
-          // check for _info.json file in resource directory  when --fmiFilter=blackBox is not set
-          if Flags.getConfigEnum(Flags.FMI_FILTER) <> Flags.FMI_BLACKBOX then
+          // check for _info.json file in resource directory  when --fmiFilter=blackBox and --fmiFilter=protected is not set
+          if Flags.getConfigEnum(Flags.FMI_FILTER) <> Flags.FMI_BLACKBOX and Flags.getConfigEnum(Flags.FMI_FILTER) <> Flags.FMI_PROTECTED then
             if 0 <> System.systemCall("mv '" + simCode.fileNamePrefix + "_info.json"+"' '" + fmutmp+"/resources/" + "'") then
               Error.addInternalError("Failed to move " + simCode.fileNamePrefix + "_info.json file", sourceInfo());
             end if;

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -38,7 +38,7 @@
 #include "../util/omc_mmap.h"
 #include "../util/omc_numbers.h"
 #include "solver/model_help.h"
-#include <sys/stat.h>
+#include "../util/omc_file.h"
 
 static inline const char* skipSpace(const char* str)
 {

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -38,6 +38,7 @@
 #include "../util/omc_mmap.h"
 #include "../util/omc_numbers.h"
 #include "solver/model_help.h"
+#include <sys/stat.h>
 
 static inline const char* skipSpace(const char* str)
 {
@@ -373,6 +374,27 @@ static void readInfoJson(const char *str,MODEL_DATA_XML *xml)
 
 void modelInfoInit(MODEL_DATA_XML* xml)
 {
+#if defined(__MINGW32__) || defined(_MSC_VER)
+  struct _stat buf;
+#else
+  struct stat buf = {0};
+#endif
+  // check for file exists, as --fmiFilter=blackBox or protected will not export the _info.json file
+  int fileStatus;
+  if (omc_flag[FLAG_INPUT_PATH])
+  {
+    const char *jsonFile;
+    GC_asprintf(&jsonFile, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], xml->fileName);
+    fileStatus = omc_stat(jsonFile, &buf);
+  }
+  else
+  {
+    fileStatus = omc_stat(xml->fileName, &buf);
+  }
+
+  if (fileStatus != 0)
+    return;
+
 #if !defined(OMC_NO_FILESYSTEM)
   omc_mmap_read mmap_reader = {0};
 #endif

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -8,6 +8,8 @@ enumeration.mos \
 enumeration2.mos \
 enumeration3.mos \
 fmi_interpolate_cs.mos \
+fmiBlackBox.mos \
+fmiProtected.mos \
 initialization_omc.mos \
 initialization.mos \
 initialization2_omc.mos \

--- a/testsuite/omsimulator/fmiBlackBox.mos
+++ b/testsuite/omsimulator/fmiBlackBox.mos
@@ -1,0 +1,61 @@
+// keywords: fmu export
+// status: correct
+// teardown_command: rm -rf fmiblackbox.lua fmiblackbox_res.mat fmi_attributes_11.fmu fmiblackbox_fmi_attributes_11.log fmi_attributes_11_info.json fmiblackbox_systemCall.log temp-fmiblackbox/
+
+loadString("
+model fmi_attributes_11
+  input Real u;
+  Real x;
+  output Real y;
+  Real a, b;
+  parameter Real z=30;
+initial equation
+  x = 0.0;
+equation
+  a = 2.0*u;
+  b = 0.5*a;
+  der(x) = b+z;
+  y = x;
+end fmi_attributes_11;
+"); getErrorString();
+
+setCommandLineOptions("--fmiFilter=blackBox"); getErrorString();
+buildModelFMU(fmi_attributes_11, version="2.0", fmuType="me_cs", platforms={"static"}); getErrorString();
+
+writeFile("fmiblackbox.lua", "
+oms_setTempDirectory(\"./temp-fmiblackbox/\")
+
+oms_newModel(\"fmiblackbox\")
+oms_addSystem(\"fmiblackbox.root\", oms_system_sc)
+oms_addSubModel(\"fmiblackbox.root.fmi_attributes_11\", \"fmi_attributes_11.fmu\")
+
+oms_instantiate(\"fmiblackbox\")
+
+oms_initialize(\"fmiblackbox\")
+
+oms_simulate(\"fmiblackbox\")
+
+oms_terminate(\"fmiblackbox\")
+oms_delete(\"fmiblackbox\")
+"); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator fmiblackbox.lua", "fmiblackbox_systemCall.log");
+readFile("fmiblackbox_systemCall.log");
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi_attributes_11.fmu"
+// ""
+// true
+// ""
+// 0
+// "info:    maximum step size for 'fmiblackbox.root': 0.001000
+// info:    Result file: fmiblackbox_res.mat (bufferSize=10)
+// info:    Final Statistics for 'fmiblackbox.root':
+//          NumSteps = 1001 NumRhsEvals  = 1002 NumLinSolvSetups = 51
+//          NumNonlinSolvIters = 1001 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// "
+// endResult

--- a/testsuite/omsimulator/fmiProtected.mos
+++ b/testsuite/omsimulator/fmiProtected.mos
@@ -1,0 +1,65 @@
+// keywords: fmu export
+// status: correct
+// teardown_command: rm -rf fmiprotected.lua fmiprotected_res.mat fmi_attributes_12.fmu fmiprotected_fmi_attributes_12.log fmi_attributes_12_info fmiprotected_systemCall.log temp-fmiprotected/
+
+loadString("
+model fmi_attributes_12
+  input Real u;
+  Real x;
+  output Real y;
+  Real a, b;
+  parameter Real z=30;
+protected
+  Real m, n;
+initial equation
+  x = 0.0;
+equation
+  a = 2.0*u;
+  b = 0.5*a;
+  der(x) = b+z;
+  y = x;
+  m = z;
+  n = a;
+end fmi_attributes_12;
+"); getErrorString();
+
+setCommandLineOptions("--fmiFilter=protected"); getErrorString();
+buildModelFMU(fmi_attributes_12, version="2.0", fmuType="me_cs", platforms={"static"}); getErrorString();
+
+writeFile("fmiprotected.lua", "
+oms_setTempDirectory(\"./temp-fmiprotected/\")
+
+oms_newModel(\"fmiprotected\")
+oms_addSystem(\"fmiprotected.root\", oms_system_sc)
+oms_addSubModel(\"fmiprotected.root.fmi_attributes_12\", \"fmi_attributes_12.fmu\")
+
+oms_instantiate(\"fmiprotected\")
+
+oms_initialize(\"fmiprotected\")
+
+oms_simulate(\"fmiprotected\")
+
+oms_terminate(\"fmiprotected\")
+oms_delete(\"fmiprotected\")
+"); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator fmiprotected.lua", "fmiprotected_systemCall.log");
+readFile("fmiprotected_systemCall.log");
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmi_attributes_12.fmu"
+// ""
+// true
+// ""
+// 0
+// "info:    maximum step size for 'fmiprotected.root': 0.001000
+// info:    Result file: fmiprotected_res.mat (bufferSize=10)
+// info:    Final Statistics for 'fmiprotected.root':
+//          NumSteps = 1001 NumRhsEvals  = 1002 NumLinSolvSetups = 51
+//          NumNonlinSolvIters = 1001 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// "
+// endResult


### PR DESCRIPTION
### Related Issues
#8411 and #8158

### Purpose
This PR fixes the issue when exporting `fmu's` with ` --fmiFilter=blackBox and --fmiFilter=protected`, by checking `_info.json` file exists in the directory 

