### PR TITLE
[BE] fix ASSC pivoting

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4327,13 +4327,16 @@ uniontype LinearJacobian
           jump over all manipulations, nothing to do
         */
         (col_index, piv_value) := getPivot(linJac.rows[i]);
-        updatePivotRow(linJac.rows[i], piv_value);
+
+        //updatePivotRow(linJac.rows[i], piv_value);
+        // ToDo: updating the pivot row would also need an update for the rhs!
+
         for j in i+1:arrayLength(linJac.rows) loop
           row_value := getElementValue(linJac.rows[j], col_index);
           if not realEq(row_value, 0.0) then
             // set row to processed and perform pivot step
             linJac.eq_marks[j] := true;
-            solveRow(linJac.rows[i], linJac.rows[j], 1.0, row_value);
+            solveRow(linJac.rows[i], linJac.rows[j], piv_value, row_value);
             //perform multiplication inside? use simplification of multiplication afterwards?
             linJac.rhs[j] := DAE.BINARY(
                                   DAE.BINARY(linJac.rhs[j], DAE.MUL(DAE.T_REAL_DEFAULT), DAE.RCONST(piv_value)),       // row_rhs * piv_elem
@@ -4387,7 +4390,7 @@ uniontype LinearJacobian
 
   public function updatePivotRow
   "author: kabdelhak FHB 03-2021
-   updates the pivot row by deviding everything by its pivot value"
+   updates the pivot row by dividing everything by its pivot value"
     input LinearJacobianRow pivot_row;
     input Real piv_value;
   protected

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4362,6 +4362,7 @@ uniontype LinearJacobian
     Integer idx;
     Real val, diag_val;
   algorithm
+    // update all elements that are in the pivot row
     for idx in UnorderedMap.keyList(pivot_row) loop
       _ := match (UnorderedMap.get(idx, row), UnorderedMap.get(idx, pivot_row))
 
@@ -4385,6 +4386,17 @@ uniontype LinearJacobian
           Error.assertion(false, getInstanceName() + " key does not have an element in pivot row.", sourceInfo());
         then ();
        end match;
+    end for;
+
+    // update all row elements that are not in pivot row
+    for idx in UnorderedMap.keyList(row) loop
+      _ := match (UnorderedMap.get(idx, row), UnorderedMap.get(idx, pivot_row))
+        case (SOME(val), NONE()) algorithm
+          val := val * piv_value;
+          UnorderedMap.add(idx, val, row);
+        then ();
+        else ();
+      end match;
     end for;
   end solveRow;
 

--- a/testsuite/simulation/modelica/indexreduction/ASSC.mos
+++ b/testsuite/simulation/modelica/indexreduction/ASSC.mos
@@ -27,7 +27,7 @@ simulate(ASSC); getErrorString();
 //  LinearJacobian sparsity pattern: Solved (initial: false)
 // ######################################################
 // (scal_idx|arr_idx|changed) [var_index, value] || RHS_EXPRESSION
-// (3|3|false):    [2|1.0] [3|1.0]     || RHS: 10.0 - (x + c)
+// (3|3|false):    [2|2.0] [3|2.0]     || RHS: 10.0 - (x + c)
 // (5|5|true):    EMPTY ROW         || RHS: -10.0 + x + c - 2.0 * c
 //
 // [ASSC] The equation: a + b + c = 0.0


### PR DESCRIPTION
### Related Issues

 - fixes #8373 

### Purpose

it was wrong. fixed

### Approach

 - remove dividing pivot row by pivot element > it would need an update of rhs
 - also update row elements that do not have entries in the pivot row
