### PR TITLE
Define LINK_SUNDIALS_STATIC when compiling FMU sources

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3693,7 +3693,7 @@ algorithm
   end if;
   if needs3rdPartyLibs then
     SUNDIALS :=  "1";
-    CPPFLAGS := CPPFLAGS + " -DWITH_SUNDIALS=1" + " -Isundials";
+    CPPFLAGS := CPPFLAGS + " -DWITH_SUNDIALS=1 -DLINK_SUNDIALS_STATIC" + " -Isundials";
   else
     SUNDIALS :=  "";
   end if;


### PR DESCRIPTION
  - If we ask sundials to build shared libs it adds dll export related
    function attributes to the headers.

    If we build both static and shared versions of sundials and we want
    to use the static libs later, we need to define LINK_SUNDIALS_STATIC
    so that the corresponding dll attributes are disabled in the headers
    (i.e, the function declarations do not get the attributes).

- Fixes #8449.