### PR TITLE
Fixes for FMU generation on Windows with CMake built omc

### DIFF
--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -133,13 +133,17 @@ target_sources(SimulationRuntimeFMI PRIVATE ${SOURCE_FMU_COMMON_FILES_LIST}
                                             ${SOURCE_FMU_MIXED_FILES_LIST}
                                             ${3RD_CMINPACK_FMU_FILES})
 
-target_compile_definitions(SimulationRuntimeFMI PRIVATE "-DOMC_MINIMAL_RUNTIME=1 -DOMC_FMI_RUNTIME=1")
+target_compile_definitions(SimulationRuntimeFMI PRIVATE -DOMC_MINIMAL_RUNTIME=1 -DOMC_FMI_RUNTIME=1 -DCMINPACK_NO_DLL)
 
 install(TARGETS SimulationRuntimeFMI)
 
 
 # ######################################################################################################################
-# Library: SimulationRuntimeFMI
+# Library: OpenModelicaFMIRuntimeC
+
+file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
+file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
+
 add_library(OpenModelicaFMIRuntimeC STATIC)
 add_library(omc::simrt::fmiruntime ALIAS OpenModelicaFMIRuntimeC)
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -26,9 +26,6 @@ file(GLOB_RECURSE OMC_SIMRT_DATA_RECONCILIATION_HEADERS ${CMAKE_CURRENT_SOURCE_D
 file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/optimization/*.c)
 file(GLOB_RECURSE OMC_SIMRT_OPTIMIZATION_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/optimization/*.h)
 
-file(GLOB OMC_SIMRT_FMI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.c)
-file(GLOB OMC_SIMRT_FMI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/fmi/*.h)
-
 
 # ######################################################################################################################
 # Library: OpenModelicaRuntimeC

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt
@@ -2,24 +2,27 @@
 
 ## This is not tested very well. Will be updated as we go.
 
-if(NOT WIN32)
-execute_process(COMMAND autoconf
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  RESULT_VARIABLE AUTOCONF_FOR_FMU_EXIT_STATUS
-  OUTPUT_VARIABLE AUTOCONF_FOR_FMU_OUTPUT
-  ERROR_VARIABLE AUTOCONF_FOR_FMU_ERROR
-  #   OUTPUT_QUIET
-)
-
-if(AUTOCONF_FOR_FMU_EXIT_STATUS AND NOT AUTOCONF_FOR_FMU_EXIT_STATUS EQUAL 0)
-    message(STATUS ${AUTOCONF_FOR_FMU_EXIT_STATUS})
-    message(STATUS ${AUTOCONF_FOR_FMU_OUTPUT})
-    message(STATUS ${AUTOCONF_FOR_FMU_ERROR})
-    message(FATAL_ERROR "autoconf failed configuring for FMUS.")
-endif()
-
-install(FILES configure
+if(WIN32)
+  install(FILES configure.ac
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
 )
+else()
+  execute_process(COMMAND autoconf
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    RESULT_VARIABLE AUTOCONF_FOR_FMU_EXIT_STATUS
+    OUTPUT_VARIABLE AUTOCONF_FOR_FMU_OUTPUT
+    ERROR_VARIABLE AUTOCONF_FOR_FMU_ERROR
+    #   OUTPUT_QUIET
+  )
 
+  if(AUTOCONF_FOR_FMU_EXIT_STATUS AND NOT AUTOCONF_FOR_FMU_EXIT_STATUS EQUAL 0)
+      message(STATUS ${AUTOCONF_FOR_FMU_EXIT_STATUS})
+      message(STATUS ${AUTOCONF_FOR_FMU_OUTPUT})
+      message(STATUS ${AUTOCONF_FOR_FMU_ERROR})
+      message(FATAL_ERROR "autoconf failed configuring for FMUS.")
+  endif()
+
+  install(FILES configure
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
+  )
 endif()


### PR DESCRIPTION
@mahge
[cmake] Define CMINPACK_NO_DLL for libSimulationRuntimeFMI. 
00f020e
  - It is a static library.

@mahge
Install fmi/export/buildproject/configure.ac on Win 
ce8b617
  - This is just following what the Makefiles do. I am not 100% sure
    why it is needed and how it is used.

    If it is not installed on Windows, the FMU creation complains about
    missing file and terminates.