### PR TITLE
Only try to read the profiling json file when profiling is on

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1291,11 +1291,11 @@ void MainWindow::createOMNotebookCodeCell(LibraryTreeItem *pLibraryTreeItem, QDo
  * \param fileName
  * \return
  */
-TransformationsWidget *MainWindow::showTransformationsWidget(QString fileName)
+TransformationsWidget *MainWindow::showTransformationsWidget(QString fileName, bool profiling)
 {
   TransformationsWidget *pTransformationsWidget = mTransformationsWidgetHash.value(fileName, 0);
   if (!pTransformationsWidget) {
-    pTransformationsWidget = new TransformationsWidget(fileName);
+    pTransformationsWidget = new TransformationsWidget(fileName, profiling);
     mTransformationsWidgetHash.insert(fileName, pTransformationsWidget);
   } else {
     pTransformationsWidget->reloadTransformations();
@@ -1719,7 +1719,7 @@ void MainWindow::showOpenTransformationFileDialog()
   }
   mpProgressBar->setRange(0, 0);
   mpStatusBar->showMessage(QString("%1: %2").arg(Helper::loading, fileName));
-  showTransformationsWidget(fileName);
+  showTransformationsWidget(fileName, false);
   mpStatusBar->clearMessage();
   hideProgressBar();
 }

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -244,7 +244,7 @@ public:
   void createOMNotebookTitleCell(LibraryTreeItem *pLibraryTreeItem, QDomDocument xmlDocument, QDomElement domElement);
   void createOMNotebookImageCell(LibraryTreeItem *pLibraryTreeItem, QDomDocument xmlDocument, QDomElement domElement, QString filePath);
   void createOMNotebookCodeCell(LibraryTreeItem *pLibraryTreeItem, QDomDocument xmlDocument, QDomElement domElement);
-  TransformationsWidget* showTransformationsWidget(QString fileName);
+  TransformationsWidget* showTransformationsWidget(QString fileName, bool profiling);
   void findFileAndGoToLine(QString fileName, QString lineNumber);
   void printStandardOutAndErrorFilesMessages();
   static void PlotCallbackFunction(void *p, int externalWindow, const char* filename, const char* title, const char* grid, const char* plotType, const char* logX,

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1246,7 +1246,7 @@ void VariablesTreeModel::openTransformationsBrowser()
     QString fileName = list[0].toString();
     int equationIndex = list[1].toInt();
     if (QFileInfo(fileName).exists()) {
-      TransformationsWidget *pTransformationsWidget = MainWindow::instance()->showTransformationsWidget(fileName);
+      TransformationsWidget *pTransformationsWidget = MainWindow::instance()->showTransformationsWidget(fileName, false);
       QTreeWidgetItem *pTreeWidgetItem = pTransformationsWidget->findEquationTreeItem(equationIndex);
       if (pTreeWidgetItem) {
         pTransformationsWidget->getEquationsTreeWidget()->clearSelection();

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -2055,9 +2055,10 @@ void SimulationDialog::simulationProcessFinished(SimulationOptions simulationOpt
     }
     pVariablesWidget->insertVariablesItemsToTree(simulationOptions.getFullResultFileName(), workingDirectory, QStringList(), simulationOptions);
   }
+  bool profiling = simulationOptions.getProfiling().compare(QStringLiteral("none")) != 0;
   if (OptionsDialog::instance()->getDebuggerPage()->getAlwaysShowTransformationsCheckBox()->isChecked() ||
-      simulationOptions.getLaunchTransformationalDebugger() || simulationOptions.getProfiling() != "none") {
-    MainWindow::instance()->showTransformationsWidget(simulationOptions.getWorkingDirectory() + "/" + simulationOptions.getOutputFileName() + "_info.json");
+      simulationOptions.getLaunchTransformationalDebugger() || profiling) {
+    MainWindow::instance()->showTransformationsWidget(simulationOptions.getWorkingDirectory() + "/" + simulationOptions.getOutputFileName() + "_info.json", profiling);
   }
   // Show the data reconciliation report
   if (simulationOptions.getEnableDataReconciliation()) {

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -635,10 +635,11 @@ void SimulationOutputWidget::compilationProcessFinishedHelper(int exitCode, QPro
   mpProgressBar->setValue(1);
   mpCancelButton->setEnabled(false);
   if (exitStatus == QProcess::NormalExit && exitCode == 0) {
+    bool profiling = mSimulationOptions.getProfiling().compare(QStringLiteral("none")) != 0;
     if (mSimulationOptions.getBuildOnly() &&
         (OptionsDialog::instance()->getDebuggerPage()->getAlwaysShowTransformationsCheckBox()->isChecked() ||
-         mSimulationOptions.getLaunchTransformationalDebugger() || mSimulationOptions.getProfiling() != "none")) {
-      MainWindow::instance()->showTransformationsWidget(mSimulationOptions.getWorkingDirectory() + "/" + mSimulationOptions.getOutputFileName() + "_info.json");
+         mSimulationOptions.getLaunchTransformationalDebugger() || profiling)) {
+      MainWindow::instance()->showTransformationsWidget(mSimulationOptions.getWorkingDirectory() + "/" + mSimulationOptions.getOutputFileName() + "_info.json", profiling);
     }
     MainWindow::instance()->getSimulationDialog()->showAlgorithmicDebugger(mSimulationOptions);
   }
@@ -805,10 +806,9 @@ void SimulationOutputWidget::openTransformationalDebugger()
   QString fileName = QString("%1/%2_info.json").arg(mSimulationOptions.getWorkingDirectory(), mSimulationOptions.getOutputFileName());
   /* open the model_info.json file */
   if (QFileInfo(fileName).exists()) {
-    MainWindow::instance()->showTransformationsWidget(fileName);
+    MainWindow::instance()->showTransformationsWidget(fileName, mSimulationOptions.getProfiling().compare(QStringLiteral("none")) != 0);
   } else {
-    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                          GUIMessages::getMessage(GUIMessages::FILE_NOT_FOUND).arg(fileName), Helper::ok);
+    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::FILE_NOT_FOUND).arg(fileName), Helper::ok);
   }
 }
 
@@ -1063,7 +1063,7 @@ void SimulationOutputWidget::openTransformationBrowser(QUrl url)
 #endif
     /* open the model_info.json file */
     if (QFileInfo(fileName).exists()) {
-      TransformationsWidget *pTransformationsWidget = MainWindow::instance()->showTransformationsWidget(fileName);
+      TransformationsWidget *pTransformationsWidget = MainWindow::instance()->showTransformationsWidget(fileName, mSimulationOptions.getProfiling().compare(QStringLiteral("none")) != 0);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
       QUrlQuery query(url);
       int equationIndex = query.queryItemValue("index").toInt();

--- a/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
@@ -536,10 +536,10 @@ EquationTreeWidget::EquationTreeWidget(TransformationsWidget *pTransformationWid
   connect(this, SIGNAL(itemDoubleClicked(QTreeWidgetItem*,int)), mpTransformationWidget, SLOT(fetchEquationData(QTreeWidgetItem*,int)));
 }
 
-TransformationsWidget::TransformationsWidget(QString infoJSONFullFileName, QWidget *pParent)
+TransformationsWidget::TransformationsWidget(QString infoJSONFullFileName, bool profiling, QWidget *pParent)
   : QWidget(pParent), mInfoJSONFullFileName(infoJSONFullFileName)
 {
-  if (!mInfoJSONFullFileName.endsWith("_info.json")) {
+  if (!mInfoJSONFullFileName.endsWith("_info.json") || !profiling) {
     mProfJSONFullFileName = "";
     mProfilingDataRealFileName = "";
   } else {

--- a/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.h
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.h
@@ -162,7 +162,7 @@ class TransformationsWidget : public QWidget
 {
   Q_OBJECT
 public:
-  TransformationsWidget(QString infoJSONFullFileName, QWidget *pParent = 0);
+  TransformationsWidget(QString infoJSONFullFileName, bool profiling, QWidget *pParent = 0);
   MyHandler* getInfoXMLFileHandler() {return mpInfoXMLFileHandler;}
   QTreeWidget* getEquationsTreeWidget() {return mpEquationsTreeWidget;}
   InfoBar* getTSourceEditorInfoBar() {return mpTSourceEditorInfoBar;}


### PR DESCRIPTION
### Related Issues

Fixes #8316

### Purpose

Avoid crashing of transformational debugger.

### Approach

Read the profiling json file when profiling is set.
