### PR TITLE
Improve OF and NF checkModel

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -2140,6 +2140,9 @@ algorithm
       then
         nr;
 
+    case DAE.T_COMPLEX(complexClassType = ClassInf.EXTERNAL_OBJ())
+      then 0;
+
     // count the variables in record
     case DAE.T_COMPLEX(varLst = varLst)
       equation

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1323,7 +1323,8 @@ public
 
     function fold_comp_size
       input InstNode comp;
-      input output Integer sz = sz + sizeOf(InstNode.getType(comp));
+      input Integer sz;
+      output Integer outSize = sz + sizeOf(InstNode.getType(comp));
     end fold_comp_size;
   algorithm
     sz := match ty
@@ -1334,6 +1335,7 @@ public
       case CLOCK() then 1;
       case ENUMERATION() then 1;
       case ARRAY() then sizeOf(ty.elementType) * product(Dimension.size(d) for d in ty.dimensions);
+      case TUPLE() then List.fold(list(sizeOf(t) for t in ty.types), intAdd, 0);
       case COMPLEX()
         then ClassTree.foldComponents(Class.classTree(InstNode.getClass(ty.cls)), fold_comp_size, 0);
       else 0;

--- a/testsuite/flattening/modelica/external-objects/ExternalObjectSize1.mos
+++ b/testsuite/flattening/modelica/external-objects/ExternalObjectSize1.mos
@@ -1,0 +1,36 @@
+// name:     ExternalObjectSize1
+// keywords: external object
+// cflags:   -d=newInst
+// status:   correct
+//
+// description: External object in extended class
+
+loadString("
+  class EO
+    extends ExternalObject;
+
+    function constructor
+      output EO e;
+      external \"C\" e = init();
+    end constructor;
+
+    function destructor
+      input EO e;
+      external \"C\" deinit(e);
+    end destructor;
+  end EO;
+
+  model M
+    EO e1 = EO();
+    EO e2[1] = {e1};
+  end M;
+");
+
+checkModel(M);
+
+// Result:
+// true
+// "Check of M completed successfully.
+// Class M has 0 equation(s) and 0 variable(s).
+// 0 of these are trivial equation(s)."
+// endResult

--- a/testsuite/flattening/modelica/external-objects/Makefile
+++ b/testsuite/flattening/modelica/external-objects/Makefile
@@ -2,7 +2,8 @@
 TEST = ../../../rtest -v
 
 # Tests to run.
-TESTFILES = testExternalObject.mo
+TESTFILES = testExternalObject.mo \
+ ExternalObjectSize1.mos
 
 # test that currently fail. Move up when fixed.
 FAILINGTESTFILES= \


### PR DESCRIPTION
- Consider ExternalObject to have size 0 in both the OF and the NF
  checkModel implementations.
- Implement proper counting of tuples in the NF checkModel.
- Work around MetaModelica bug when counting size of complex types in
  the NF checkModel.