### PR TITLE
Enable/Disable GUI and CPP runtime at configure time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,17 @@ omc_add_to_report(CMAKE_Fortran_COMPILER_ID)
 omc_add_to_report(CMAKE_LIBRARY_ARCHITECTURE)
 
 
+## OPTIONS #################################################################################################
+omc_option(OM_ENABLE_GUI_CLIENTS "Enable, build, and install the qt based GUI clients." ON)
+## Use ccache to speedup compilation! It is important to use ccache if you can.
+## You get almost no op compilations (for unmodified files) at the cost of some memory.
+## This is usefull, for example, in cases where you change branches often or need to clean
+## for some reason. However, it is even more important with OMC because we generate C sources
+## from MetaModelica files whenever they change. This causes CMake to issue compilations of
+## dependent source files because headers are changed. ccache will essentially eliminate that cost.
+omc_option(OM_USE_CCACHE "Use ccache to speedup compilations." ON)
+
+
 ### Standards ###############################################################################################
 ## Set the C standard to use. Unfortunately, we can not enforce c90.
 ## Our sources contain a lot of c99 and gnu extension code.
@@ -50,15 +61,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 omc_add_to_report(CMAKE_BUILD_TYPE)
 
-## Use ccache to speedup compilation! It is important to use ccache if you can.
-## You get almost no op compilations (for unmodified files) at the cost of some memory.
-## This is usefull, for example, in cases where you change branches often or need to clean
-## for some reason. However, it is even more importatn with OMC because we generate C sources
-## from MetaModelica files whenever they change. This causes CMake to issue compilations of
-## dependent source files because headers are changed. This will pretty much nullify that.
-omc_option(OMC_USE_CCACHE "Use ccache to speedup compilations." ON)
-
-if(OMC_USE_CCACHE)
+if(OM_USE_CCACHE)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)
     message(STATUS "Found ccache. It will be used for compilation C/C++ sources")
@@ -67,7 +70,7 @@ if(OMC_USE_CCACHE)
     omc_add_to_report(CCACHE_PROGRAM)
   else()
     message(FATAL_ERROR "ccache program not found. It is highly recommended to use ccache for compilation of OpenModelica. Please install ccache and rerun configuration.
-            You can disable this check by specifying -DOMC_USE_CCACHE=OFF to CMake configuration command.")
+            You can disable this check by specifying -DOM_USE_CCACHE=OFF to CMake configuration command.")
   endif()
 endif()
 
@@ -122,15 +125,17 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 
 ## Subdirectories ##########################################################################################
 omc_add_subdirectory(OMCompiler)
-omc_add_subdirectory(OMParser EXCLUDE_FROM_ALL)
-omc_add_subdirectory(OMPlot EXCLUDE_FROM_ALL)
-omc_add_subdirectory(OMShell EXCLUDE_FROM_ALL)
-omc_add_subdirectory(OMNotebook EXCLUDE_FROM_ALL)
 
-include(omsimulator.cmake)
-omc_add_subdirectory(OMEdit EXCLUDE_FROM_ALL)
-omc_add_subdirectory(testsuite EXCLUDE_FROM_ALL)
-# omc_add_subdirectory(libraries)
+if(OM_ENABLE_GUI_CLIENTS)
+  omc_add_subdirectory(OMParser)
+  omc_add_subdirectory(OMPlot)
+  omc_add_subdirectory(OMShell)
+  omc_add_subdirectory(OMNotebook)
+  include(omsimulator.cmake)
+  omc_add_subdirectory(OMEdit)
+endif()
+
+omc_add_subdirectory(testsuite)
 
 
 ## Report some status info.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,7 +188,6 @@ pipeline {
               additionalBuildArgs '--pull'
               dir '.CI/cache-bionic-cmake-3.17.2'
               label 'linux'
-              args "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
                    "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
             }
@@ -199,7 +198,7 @@ pipeline {
           }
           steps {
             script {
-              common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOMC_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build', '/opt/cmake-3.17.2/bin/cmake')
+              common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOM_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build', '/opt/cmake-3.17.2/bin/cmake')
               sh "build/bin/omc --version"
             }
             // stash name: 'omc-cmake-gcc', includes: 'OMCompiler/build_cmake/install_cmake/bin/**'

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -1,6 +1,19 @@
 cmake_minimum_required(VERSION 3.14)
 project(OMCompiler C CXX Fortran)
 
+## OPTIONS #################################################################################################
+
+omc_option(OM_OMC_ENABLE_CPP_RUNTIME "Enable, build, and install the C++ simulation runtime libraries." ON)
+
+omc_option(WITH_IPOPT "Should we enable dynamic optimization support with Ipopt." ON)
+omc_option(OM_OMC_USE_CORBA "Should use corba." OFF)
+
+omc_option(OM_OMC_USE_LPSOLVE "Should we use lpsolve." OFF)
+omc_option(OM_OMC_BUILD_LPSOLVE "Should we build our own 3rdParty/lpsolve." OFF)
+
+omc_option(OM_OMC_USE_LAPACK "Should we use lapack." ON)
+
+
 # Remove -DNDEBUG from release build command lines. The reason is that -DNDEBUG completely
 # removes assert(...) statements. We have some assert statements with side effects. Of course,
 # these should be removed and the flag enabled so that we can benefit from removing asserts from
@@ -11,23 +24,13 @@ string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}
 string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
-## Set position independent code for OMCompiler wide. We will take some performance hit from this.
+## Set position independent code OMCompiler/ wide. We will take some performance hit from this.
 ## However it allows us to build all static libs and combine them later to single shared libs
 ## for easy configuration. Instead of having dozens of shared libs.
 ## This can of course be turned of if we do not care about memory and are happy to sacrifice a
 ## bunch of memory for some performance gain. If so disable this and change the few libraries
 ## we build as shared to static (see SimulationRuntime/c, which contains the only shared libs to come).
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# options
-omc_option(WITH_IPOPT "Should we enable dynamic optimization support with Ipopt." ON)
-omc_option(OMC_USE_CORBA "Should use corba." OFF)
-
-omc_option(OMC_USE_LPSOLVE "Should we use lpsolve." OFF)
-omc_option(OMC_BUILD_LPSOLVE "Should we build our own 3rdParty/lpsolve." OFF)
-
-omc_option(OMC_USE_LAPACK "Should we use lapack." ON)
-
 
 ## Add a config library for OMC. They will provide access to common config headres such as
 ## config.h, version.h ... These headers, right now for us, are in 'OMCompiler' directory. So
@@ -41,10 +44,10 @@ target_include_directories(omc_config INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 omc_add_subdirectory(3rdParty)
 
 
-# We want to make sure include directories are handled properly.
-# We have to disable implicit function declaration so that we can be consistent and correct with our inclusions.
+# We want to make sure include directories are handled properly by disabling implicit function
+# declaration so that we can be consistent and correct with our inclusions.
 # We do this after 3rdParty is added!! because some libs in FMILib use implicit function declaration
-# because of missing #defines due to bad configuration.
+# because of missing #defines due to bad configuration for now.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
 endif()

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(CURL REQUIRED)
 find_package(Intl REQUIRED)
 find_package(Iconv REQUIRED)
 
-if(OMC_USE_LAPACK)
+if(OM_OMC_USE_LAPACK)
   message(STATUS "Looking for LAPACK. This can be slow sometimes. Hang tight!")
   find_package(LAPACK REQUIRED)
 
@@ -79,13 +79,13 @@ target_link_libraries(omcruntime PUBLIC omc::3rd::ffi)
 target_link_libraries(omcruntime PUBLIC omc::3rd::libzmq)
 target_link_libraries(omcruntime PUBLIC omc::simrt::Modelica::zlib)
 
-if(OMC_USE_LPSOLVE)
+if(OM_OMC_USE_LPSOLVE)
   target_link_libraries(omcruntime PUBLIC omc::3rd::lpsolve55)
 else()
   target_compile_definitions(omcruntime PRIVATE NO_LPLIB)
 endif()
 
-if(OMC_USE_LAPACK)
+if(OM_OMC_USE_LAPACK)
   target_link_libraries(omcruntime PUBLIC ${LAPACK_LIBRARIES})
 endif()
 
@@ -99,7 +99,7 @@ if(NOT WIN32)
 endif()
 
 # Corba support
-if(OMC_USE_CORBA)
+if(OM_OMC_USE_CORBA)
   if(MINGW)
     # setup omniORB for MinGW OMDev
     include(.cmake/omdev_omniorb_setup.cmake)
@@ -126,7 +126,7 @@ if(OMC_USE_CORBA)
   endif()
 else() # No corba support requested. Use the stub file.
   target_sources(omcruntime PRIVATE corbaimpl_stub_omc.c)
-endif(OMC_USE_CORBA)
+endif(OM_OMC_USE_CORBA)
 
 # Install omcruntime. It is needed by bootstrapping tests.
 install(TARGETS omcruntime)

--- a/OMCompiler/SimulationRuntime/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/CMakeLists.txt
@@ -1,7 +1,10 @@
 
 omc_add_subdirectory(c)
 omc_add_subdirectory(fmi)
-omc_add_subdirectory(cpp)
+
+if(OM_OMC_ENABLE_CPP_RUNTIME)
+  omc_add_subdirectory(cpp)
+endif()
 
 # ModelicaExternalC
 omc_add_subdirectory(ModelicaExternalC)


### PR DESCRIPTION
  - They were always enabled but not built by default (i.e., not built by
    just `make`). You had to build them explicitly. This turns out to be
    a bit confusing for users.

    Now they are instead enabled or disabled at **configure** time.
    If they are enabled then they will be built by `make` or `make all`.

    If they are disabled at configure time they are not even available as
    build targets. Requires reconfigure to enable them.

    I think this is aligns better with expectations and is more intuitive.

  - Make names of CMake options a bit more descriptive
      - Options that are at the "OpenModelica" level start with `OM_` now.
      - Options at "OpenModelica/OMCompiler" level start with `OM_OMC_`
