### PR TITLE
Install some missing headers needed for source code FMUs

### DIFF
--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -60,7 +60,9 @@ string(REPLACE ";" "," SOURCE_FMU_NLS_FILES "${SOURCE_FMU_NLS_FILES_LIST_QUOTED}
 
 
 # CMinPack files for NLS
-set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/enorm_.c
+set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
+                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h
+                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/enorm_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/hybrj_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/dpmpar_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/qrfac_.c
@@ -69,7 +71,11 @@ set(3RD_CMINPACK_FMU_FILES ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/enorm_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1updt_.c
                             ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/r1mpyq_.c)
 
-install(FILES ${3RD_CMINPACK_FMU_FILES}
+set(3RD_CMINPACK_HEADERS  ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
+                            ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/minpack.h)
+
+install(FILES ${3RD_CMINPACK_HEADERS}
+              ${3RD_CMINPACK_FMU_FILES}
         DESTINATION ${SOURCE_FMU_SOURCES_DIR}/external_solvers
 )
 

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -31,11 +31,14 @@ set(SOURCE_FMU_COMMON_HEADERS \"./omc_inline.h\",\"./openmodelica_func.h\",\"./o
 
 ######################################################################################################################
 # Lapack files
-file(GLOB_RECURSE 3RD_DGESV_FILES   ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/include/*.h
-                                    ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/blas/*.c
+file(GLOB_RECURSE 3RD_DGESV_FILES   ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/blas/*.c
                                     ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/lapack/*.c
                                     ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/libf2c/*.c)
-install(FILES ${3RD_DGESV_FILES}
+
+file(GLOB_RECURSE 3RD_DGESV_HEADERS ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/include/*.h)
+
+install(FILES ${3RD_DGESV_HEADERS}
+              ${3RD_DGESV_FILES}
         DESTINATION ${SOURCE_FMU_SOURCES_DIR}/external_solvers
 )
 


### PR DESCRIPTION
@mahge
Install the CMinpack headers to the FMU sources dir 
dc05586
  - Temporary solution since modifying FMU setup to copy these
    files from the include dir - the correct fix - will require
    modifications to the autoconf build system as well. I think?

@mahge
Install the dgesv headers to the FMU sources dir. 
be04523
  - This was listing them in the sources list by mistake.

    They should be installed but they should not be added to the sources
    list.
