### PR TITLE
Install the configure script as executable.

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt
@@ -4,7 +4,8 @@
 
 if(WIN32)
   install(FILES configure.ac
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
+        ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject
 )
 else()
   execute_process(COMMAND autoconf
@@ -22,7 +23,16 @@ else()
       message(FATAL_ERROR "autoconf failed configuring for FMUS.")
   endif()
 
-  install(FILES configure
-          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
+  install(# INSTALL it as a program so it can be executed.
+          PROGRAMS configure
+          ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject
+  )
+  install(FILES configure.ac
+                ${OpenModelica_SOURCE_DIR}/common/config.sub
+                ${OpenModelica_SOURCE_DIR}/common/config.guess
+                ${OpenModelica_SOURCE_DIR}/common/install-sh
+          ## This should not be omc/runtime/c/fmi but rather omc/fmi. It is inconsistent
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omc/runtime/c/fmi/buildproject
   )
 endif()


### PR DESCRIPTION
  - It needs to be executed so install it as a program.

  - Install the additional autoconf related files as well. These are
    normally generated when OpenModelica is configured by autoconf.
    Since the CMake build does not do that we copy them from the common/
    folder instead. I hope this works find in all cases.
