### PR TITLE
[CMake] do not build in each dir anymore. No need.

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -333,12 +333,7 @@ void buildOMC_CMake(cmake_args, cmake_exe='cmake') {
   else {
     sh "mkdir ./build_cmake"
     sh "${cmake_exe} -S ./ -B ./build_cmake ${cmake_args}"
-    sh "${cmake_exe} --build ./build_cmake/OMCompiler --parallel ${numPhysicalCPU()} --target install"
-    sh "${cmake_exe} --build ./build_cmake/OMParser --parallel ${numPhysicalCPU()} --target install"
-    sh "${cmake_exe} --build ./build_cmake/OMEdit --parallel ${numPhysicalCPU()} --target install"
-    sh "${cmake_exe} --build ./build_cmake/OMShell --parallel ${numPhysicalCPU()} --target install"
-    sh "${cmake_exe} --build ./build_cmake/OMNotebook --parallel ${numPhysicalCPU()} --target install"
-    sh "${cmake_exe} --build ./build_cmake/testsuite --parallel ${numPhysicalCPU()} --target install"
+    sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
     sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"
   }
 }


### PR DESCRIPTION
  - The CMake configuration setup has changed in #8485. 
    Which means almost all targets are enabled by default and all of them are part
    of the `all` make target.

    So there is no need to go into each dir and issue installation. The
    fact that they are part of `all` means all of them will be built and
    installed.

    The excpetion is the `testsuite-depends` target which includes the
    targets:
      - libs-for-testing: installation of Modelica libs for testing.
      - reference-files: extraction of reference files.
