### PR TITLE
Fix import location of libOMSimulator.

### DIFF
--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -44,7 +44,7 @@ set(OMC_RUNTIIME_SOURCES
     Dynload_omc.cpp
     Print_omc.c
     ErrorMessage.cpp
-    System_omc
+    System_omc.c
     Lapack_omc.cpp
     Settings_omc.cpp
     UnitParserExt_omc.cpp

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -253,7 +253,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 
 
 #####################################################################################################
-find_package(Boost COMPONENTS filesystem)
+find_package(Boost COMPONENTS filesystem REQUIRED)
 
 # OMCppSimulationSettings
 set(OMC_SIMRT_CPP_CORE_SIM_SETTINGS_SOURCES SimulationSettings/GlobalSettings.cpp

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
@@ -2,8 +2,8 @@
 
 #####################################################################################################
 # OMCppOMCFactory
-find_package(Boost COMPONENTS program_options filesystem)
-find_package(Threads)
+find_package(Boost COMPONENTS program_options filesystem REQUIRED)
+find_package(Threads REQUIRED)
 
 
 set(OMC_SIMRT_CPP_SIMCOREFACTORY_OMCFACTORY_SOURCES OMCFactory/OMCFactory.cpp)

--- a/omsimulator.cmake
+++ b/omsimulator.cmake
@@ -53,8 +53,17 @@ elseif(MSVC)
   # For now print error and bail out. It should be the same as Mingw except we need to check where the .lib file is located.
   message(FATAL_ERROR "Importing of OMSimulator is not implemented correctly for MSVC. Adjust the MINGW implementation to where the dll and lib files are expected.")
 else()
+
+  # if host_short (= CMAKE_LIBRARY_ARCHITECTURE) is empty, OMSimulator does not
+  # add the omc/ part to the library location. (See OMSimulator/Makefile:88-93)
+  if(CMAKE_LIBRARY_ARCHITECTURE)
+    set(OMSIMULATORLIB_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/lib/${CMAKE_LIBRARY_ARCHITECTURE}/omc/)
+  else()
+    set(OMSIMULATORLIB_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/lib/)
+  endif()
+
   set_target_properties(libOMSimulator PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/lib/x86_64-linux-gnu/omc/libOMSimulator.so
+    IMPORTED_LOCATION ${OMSIMULATORLIB_LOCATION}/libOMSimulator.so
   )
 endif()
 


### PR DESCRIPTION
  - On platforms that do not have multi-arch lib dirs CMAKE_LIBRARY_ARCHITECTURE
    is empty.

    If it is empty (which means empty `host_short` is passed to OMSimulator)
    then OMSimulator will not add and omc folder to the install path.

    That is, it is either `lib/x86_64-linux-gnu/omc` or just `lib/` depending
    on host_short. It is never `lib//omc/`.

  - Make boost required for CPP runtime. It is not optional.
