### PR TITLE
Make the installation dir of OMSimulator consistent

### DIFF
--- a/omsimulator.cmake
+++ b/omsimulator.cmake
@@ -49,6 +49,15 @@ if(MINGW)
     # The dll.a import lib. It is located in the same dir as the dll right now.
     IMPORTED_IMPLIB ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/bin/libOMSimulator.dll.a
   )
+
+
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/
+          DESTINATION ${CMAKE_INSTALL_PREFIX}
+          USE_SOURCE_PERMISSIONS
+          # Exclude the directories created by CMake's ExternalProject
+          PATTERN src EXCLUDE
+          PATTERN tmp EXCLUDE)
+
 elseif(MSVC)
   # For now print error and bail out. It should be the same as Mingw except we need to check where the .lib file is located.
   message(FATAL_ERROR "Importing of OMSimulator is not implemented correctly for MSVC. Adjust the MINGW implementation to where the dll and lib files are expected.")
@@ -65,17 +74,32 @@ else()
   set_target_properties(libOMSimulator PROPERTIES
     IMPORTED_LOCATION ${OMSIMULATORLIB_LOCATION}/libOMSimulator.so
   )
+
+
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/
+          DESTINATION ${CMAKE_INSTALL_PREFIX}
+          USE_SOURCE_PERMISSIONS
+          # Exclude the lib dir. We handle it differently below.
+          PATTERN lib EXCLUDE
+          # Exclude the directories created by CMake's ExternalProject
+          PATTERN src EXCLUDE
+          PATTERN tmp EXCLUDE)
+
+  # Copy the libs from the location (based on existence of CMAKE_LIBRARY_ARCHITECTURE)
+  # to the correct installation lib dir (i.e., either lib/<arch>/omc or lib/omc. Instead of them
+  # ending up in just lib/ when arch is empty)
+  install(DIRECTORY ${OMSIMULATORLIB_LOCATION}
+          DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  # There is another folder called OMSimulator inside the lib folder that
+  # contains some python files as well some duplicate .so libs.
+  # I am guessing they are expected to be in <actual_lib_dir>/OMSimulator.
+  # So copy them as they are for now.
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/lib/OMSimulator/
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/OMSimulator
+         )
 endif()
 
 set_target_properties(libOMSimulator PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/OMSimulator/src/OMSimulatorLib
 )
-
-
-
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/OMSimulator/
-        DESTINATION ${CMAKE_INSTALL_PREFIX}
-        USE_SOURCE_PERMISSIONS
-        # Exclude the directories created by CMake's ExternalProject
-        PATTERN src EXCLUDE
-        PATTERN tmp EXCLUDE)


### PR DESCRIPTION
  - OMSimulator's installation is done by building it and then copying
    the build dir it produces. Depending on library arch this output dir
    is just `lib/` or `lib/arch/omc`.

    Copying it as it is now can be inconsistent with the rest of OpenModelica's
    installation.

  - Always install the libs to to `lib/omc` or `lib/<arch>/omc`. Never to
    just `lib`.

    This is done by individually installing each subfolder instead of
    installing the whole folder at once.
