### PR TITLE
Add dumping of name map for mergeComponents

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -145,7 +145,7 @@ algorithm
   // Look up the class to instantiate and mark it as the root class.
   cls := Lookup.lookupClassName(classPath, top, NFInstContext.RELAXED,
            AbsynUtil.dummyInfo, checkAccessViolations = false);
-  cls := InstUtil.mergeScalars(cls);
+  cls := InstUtil.mergeScalars(cls, classPath);
   checkInstanceRestriction(cls, classPath, context);
   cls := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), cls);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -304,6 +304,7 @@ public
      can be merged if they have e.g. the same type, same prefixes, same
      modifiers, etc."
     input output InstNode node;
+    input Absyn.Path classPath;
   protected
     SCode.Element elem;
   algorithm
@@ -312,7 +313,7 @@ public
     end if;
 
     elem := InstNode.definition(node);
-    elem := mergeScalars2(elem);
+    elem := mergeScalars2(elem, classPath);
     node := InstNode.setDefinition(elem, node);
     execStat(getInstanceName());
   end mergeScalars;
@@ -320,6 +321,7 @@ public
   function mergeScalars2
     "Helper function to mergeScalars, does the actual merging."
     input output SCode.Element cls;
+    input Absyn.Path classPath;
   protected
     SCode.ClassDef cdef;
     list<SCode.Element> elems;
@@ -337,6 +339,9 @@ public
           cdef.normalAlgorithmLst := mergeScalarsAlgs(cdef.normalAlgorithmLst, name_map);
           cdef.initialAlgorithmLst := mergeScalarsAlgs(cdef.initialAlgorithmLst, name_map);
           cls.classDef := cdef;
+
+          System.writeFile(AbsynUtil.pathString(classPath) + "_merged_table.json",
+            UnorderedMap.toJSON(name_map, Util.id, Dump.printComponentRefStr));
         then
           ();
 

--- a/OMCompiler/Compiler/Script/Obfuscate.mo
+++ b/OMCompiler/Compiler/Script/Obfuscate.mo
@@ -34,8 +34,6 @@ encapsulated package Obfuscate
   import AbsynUtil;
   import Dump;
   import FBuiltin;
-  import IOStream;
-  import List;
   import SCode;
   import SCodeUtil;
   import System;
@@ -94,7 +92,7 @@ encapsulated package Obfuscate
 
     // Convert the mapping table to a JSON structure that can be used to look up
     // which name is mapped to what.
-    mapStr := mappingToString(env.mapping);
+    mapStr := UnorderedMap.toJSON(env.mapping, Util.id, Util.id);
   end obfuscateProgram;
 
   function makeBuiltins
@@ -1015,54 +1013,6 @@ encapsulated package Obfuscate
     ety := UnorderedMap.getOrDefault(name, env.builtins, ElementType.OTHER);
     res := ety == ElementType.FUNCTION or ety == ElementType.TYPE_AND_FUNCTION;
   end isBuiltinCall;
-
-  function mappingToString
-    "Converts a mapping to a string in JSON format."
-    input Mapping mapping;
-    output String str;
-  protected
-    list<tuple<String, String>> map;
-    String key, value;
-    IOStream.IOStream io;
-
-    function key_value_comp
-      input tuple<String, String> p1;
-      input tuple<String, String> p2;
-      output Boolean res;
-    protected
-      String key1, key2;
-    algorithm
-      (key1, _) := p1;
-      (key2, _) := p2;
-      res := key1 > key2;
-    end key_value_comp;
-  algorithm
-    map := UnorderedMap.toList(mapping);
-    map := List.sort(map, key_value_comp);
-    io := IOStream.create("ObfuscateMapping", IOStream.IOStreamType.LIST());
-    io := IOStream.append(io, "{\n");
-
-    if not listEmpty(map) then
-      (key, value) :: map := map;
-      io := IOStream.append(io, "  \"");
-      io := IOStream.append(io, key);
-      io := IOStream.append(io, "\": \"");
-      io := IOStream.append(io, value);
-      io := IOStream.append(io, "\"");
-
-      for p in map loop
-        (key, value) := p;
-        io := IOStream.append(io, ",\n  \"");
-        io := IOStream.append(io, key);
-        io := IOStream.append(io, "\": \"");
-        io := IOStream.append(io, value);
-        io := IOStream.append(io, "\"");
-      end for;
-    end if;
-
-    io := IOStream.append(io, "\n}");
-    str := IOStream.string(io);
-  end mappingToString;
 
   annotation(__OpenModelica_Interface="backend");
 end Obfuscate;

--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -41,6 +41,7 @@ protected
   import List;
   import MetaModelica.Dangerous.*;
   import Util;
+  import IOStream;
 
 public
   partial function Hash
@@ -636,6 +637,50 @@ public
 
     str := stringDelimitList(strl, delimiter);
   end toString;
+
+  function toJSON
+    input UnorderedMap<K, V> map;
+    input KeyStringFn keyStringFn;
+    input ValueStringFn valueStringFn;
+    output String str;
+
+    partial function KeyStringFn
+      input K key;
+      output String str;
+    end KeyStringFn;
+
+    partial function ValueStringFn
+      input V value;
+      output String str;
+    end ValueStringFn;
+  protected
+    IOStream.IOStream io;
+    Vector<K> keys = map.keys;
+    Vector<V> values = map.values;
+    Integer sz = Vector.size(keys);
+  algorithm
+    io := IOStream.create("UnorderedMap.toJSON", IOStream.IOStreamType.LIST());
+    io := IOStream.append(io, "{\n");
+
+    if sz > 0 then
+      io := IOStream.append(io, "  \"");
+      io := IOStream.append(io, keyStringFn(Vector.getNoBounds(keys, 1)));
+      io := IOStream.append(io, "\": \"");
+      io := IOStream.append(io, valueStringFn(Vector.getNoBounds(values, 1)));
+      io := IOStream.append(io, "\"");
+
+      for i in 2:sz loop
+        io := IOStream.append(io, ",\n  \"");
+        io := IOStream.append(io, keyStringFn(Vector.getNoBounds(keys, i)));
+        io := IOStream.append(io, "\": \"");
+        io := IOStream.append(io, valueStringFn(Vector.getNoBounds(values, i)));
+        io := IOStream.append(io, "\"");
+      end for;
+    end if;
+
+    io := IOStream.append(io, "\n}");
+    str := IOStream.string(io);
+  end toJSON;
 
 protected
   function find


### PR DESCRIPTION
- Generalize the JSON dump function used by `Obfuscate` and move it to
  `UnorderedMap.toJSON`.
- Use the new `UnorderedMap.toJSON` to dump the name map generated by
  the `-d=mergeComponents` flag.