### PR TITLE
Give an error for invalid unit expressions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
@@ -39,6 +39,8 @@ encapsulated package NFUnit
 
 public
 import ComponentRef = NFComponentRef;
+import Absyn;
+import AbsynUtil;
 
 protected
 import Debug;
@@ -576,6 +578,7 @@ public function parseUnitString "author: lochel
   The second argument is optional."
   input String inUnitString;
   input HashTableStringToUnit.HashTable inKnownUnits = getKnownUnits();
+  input SourceInfo info = AbsynUtil.dummyInfo;
   output Unit outUnit;
 protected
   list<String> charList;
@@ -585,7 +588,14 @@ algorithm
   if listEmpty(charList) then
     fail();
   end if;
-  tokenList := lexer(charList);
+
+  try
+    tokenList := lexer(charList);
+  else
+    Error.addSourceMessage(Error.INVALID_UNIT, {inUnitString}, info);
+    fail();
+  end try;
+
   outUnit := parser3({true, true}, tokenList, UNIT(1e0, 0, 0, 0, 0, 0, 0, 0), inKnownUnits);
   if not isUnit(outUnit) then
     if Flags.isSet(Flags.FAILTRACE) then
@@ -879,9 +889,6 @@ algorithm
       tokenList = lexer(charList);
     then T_UNIT(unit)::tokenList;
 
-    else equation
-      Error.addInternalError("function lexer failed", sourceInfo());
-    then fail();
   end matchcontinue;
 end lexer;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
@@ -334,7 +334,7 @@ algorithm
         formal_args := listHead(out_units);
         formal_var := listHead(out_vars);
 
-        unit2 := if formal_args == "NONE" then Unit.MASTER({}) else Unit.parseUnitString(formal_args, htS2U);
+        unit2 := if formal_args == "NONE" then Unit.MASTER({}) else Unit.parseUnitString(formal_args, htS2U, Equation.info(eq));
 
         b := unitTypesEqual(unit1, unit2, htCr2U);
         if b then
@@ -1114,7 +1114,7 @@ algorithm
     case SOME(Expression.STRING(value = unit_string))
       guard not stringEmpty(unit_string)
       algorithm
-        (unit, htS2U, htU2S) := parse(unit_string, var.name, htS2U, htU2S);
+        (unit, htS2U, htU2S) := parse(unit_string, var.name, htS2U, htU2S, var.info);
         htCr2U := BaseHashTable.add((var.name, unit), htCr2U);
       then
         ();
@@ -1135,6 +1135,7 @@ protected function parse "author: lochel"
         output Unit.Unit unit;
   input output HashTableStringToUnit.HashTable htS2U;
   input output HashTableUnitToString.HashTable htU2S;
+  input SourceInfo info;
 algorithm
   if stringEmpty(unitString) then
     unit := Unit.MASTER({cref});
@@ -1144,7 +1145,7 @@ algorithm
     unit := BaseHashTable.get(unitString, htS2U);
   else
     try
-      unit := Unit.parseUnitString(unitString, htS2U);
+      unit := Unit.parseUnitString(unitString, htS2U, info);
     else
       unit := Unit.UNKNOWN(unitString);
     end try;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -897,6 +897,9 @@ public constant ErrorTypes.Message CONSISTENT_UNITS = ErrorTypes.MESSAGE(518, Er
   Gettext.gettext("The system of units is consistent."));
 public constant ErrorTypes.Message INCOMPLETE_UNITS = ErrorTypes.MESSAGE(519, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("The system of units is incomplete. Please provide unit information to the model by e.g. using types from the SIunits package."));
+public constant ErrorTypes.Message INVALID_UNIT = ErrorTypes.MESSAGE(520, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
+  Gettext.gettext("Invalid unit expression ‘%s‘."));
+
 public constant ErrorTypes.Message ASSIGN_RHS_ELABORATION = ErrorTypes.MESSAGE(521, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Failed to elaborate rhs of %s."));
 public constant ErrorTypes.Message FAILED_TO_EVALUATE_EXPRESSION = ErrorTypes.MESSAGE(522, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),

--- a/testsuite/simulation/modelica/unitcheck/Makefile
+++ b/testsuite/simulation/modelica/unitcheck/Makefile
@@ -20,6 +20,7 @@ UnitCheck16.mos \
 UnitCheck17.mos \
 UnitCheck18.mos \
 UnitCheck19.mos \
+UnitCheck20.mos \
 ticket3631.mos \
 
 

--- a/testsuite/simulation/modelica/unitcheck/UnitCheck20.mos
+++ b/testsuite/simulation/modelica/unitcheck/UnitCheck20.mos
@@ -1,0 +1,28 @@
+// name: UnitCheck20
+// keywords: initialization
+// status: correct
+// cflags: -d=-newInst
+
+loadString("
+package unitCheckTests
+  model UnitCheck20
+    Real A(unit = \"m^2\");
+  end UnitCheck20;
+end unitCheckTests;
+"); getErrorString();
+
+setCommandLineOptions("--unitChecking -d=newInst"); getErrorString();
+instantiateModel(unitCheckTests.UnitCheck20); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "class unitCheckTests.UnitCheck20
+//   Real A(unit = \"m^2\");
+// end unitCheckTests.UnitCheck20;
+// "
+// "[<interactive>:4:5-4:25:writable] Notification: Invalid unit expression ‘m^2‘.
+// "
+// endResult


### PR DESCRIPTION
- Give an error message if a unit expressions fails to parse instead of
  throwing an internal error.

Fixes #8509