### PR TITLE
Refactor typing of builtin Connections.* functions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -202,6 +202,25 @@ public
     end if;
   end makeConnectors;
 
+  function toString
+    input Connections conns;
+    output String str;
+  protected
+    list<String> strl = {};
+  algorithm
+    strl := "FLOWS:" :: strl;
+    for f in conns.flows loop
+      strl := Connector.toString(f) :: strl;
+    end for;
+
+    strl := "\nCONNECTIONS:" :: strl;
+    for c in conns.connections loop
+      strl := Connection.toString(c) :: strl;
+    end for;
+
+    strl := listReverseInPlace(strl);
+    str := stringDelimitList(strl, "\n");
+  end toString;
 
   annotation(__OpenModelica_Interface="frontend");
 end NFConnections;


### PR DESCRIPTION
- Add functions to type and check arguments of the builtin Connections.*
  functions, to reduce code repetition.
- Add toString debug function to NFConnections.