### PR TITLE
libfmi shared and static. libOpenModelicaFMIRuntime static.

### DIFF
--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -359,9 +359,7 @@ $(OMBUILDDIR)/$(LIB_OMC)/$(LIBFMILIB): 3rdParty/FMIL/build/Makefile
 	test -d 3rdParty/FMIL/install || $(MAKE) -C 3rdParty/FMIL/build install
 	test "(" ! `uname` = Darwin ")" -o "(" ! -f 3rdParty/FMIL/install/$(LIB_OMC)/libfmilib_shared$(SHREXT) ")" || install_name_tool -id @rpath/libfmilib_shared$(SHREXT) 3rdParty/FMIL/install/$(LIB_OMC)/libfmilib_shared$(SHREXT)
 	cp -pPR 3rdParty/FMIL/install/$(LIB_OMC)/$(LIBFMILIB) $(builddir_lib_omc)
-	@if [ "$(FMILIB_SHARED)" = "ON" ]; then\
-	    cp -v -pPR 3rdParty/FMIL/install/$(LIB_OMC)/libfmilib_shared$(SHREXT) $(builddir_lib_omc);\
-	fi
+	cp -v -pPR 3rdParty/FMIL/install/$(LIB_OMC)/libfmilib* $(builddir_lib_omc);\
 	test ! -f $(OMBUILDDIR)/$(LIB_OMC)/libfmilib_shared$(SHREXT) || ln -sf libfmilib_shared$(SHREXT) $(OMBUILDDIR)/$(LIB_OMC)/libfmilib$(SHREXT)
 	#TODO: Only copy required headers, add them in omc/fmi subfolder, and do not copy c/txt-files
 	mkdir -p $(builddir_inc)/fmil/
@@ -370,7 +368,7 @@ $(OMBUILDDIR)/$(LIB_OMC)/$(LIBFMILIB): 3rdParty/FMIL/build/Makefile
 3rdParty/FMIL/build/Makefile: 3rdParty/FMIL/CMakeLists.txt $(LIBMODELICAZLIB)
 	test -d 3rdParty/FMIL
 	mkdir -p 3rdParty/FMIL/build
-	(cd 3rdParty/FMIL/build && test -f Makefile || CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(CMAKE) -D CMAKE_AR:String="$(AR)" $(MINGW_FMIL_FLAGS) -D FMILIB_BUILD_SHARED_LIB:Bool=$(FMILIB_SHARED) -D FMILIB_BUILD_TESTS:Bool=OFF -D FMILIB_GENERATE_DOXYGEN_DOC:Bool=OFF -DCMAKE_INSTALL_PREFIX:String=../install -DCMAKE_INSTALL_LIBDIR="$(LIB_OMC)" -DCMAKE_INSTALL_INCLUDEDIR=include -DOMC_ZLIB_LIBRARY=$(LIBMODELICAZLIB) -DOMC_ZLIB_INCLUDE_DIR=$(builddir_inc) .. -G $(CMAKE_TARGET))
+	(cd 3rdParty/FMIL/build && test -f Makefile || CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(CMAKE) -D CMAKE_AR:String="$(AR)" $(MINGW_FMIL_FLAGS) -D FMILIB_BUILD_SHARED_LIB:Bool=ON -D FMILIB_BUILD_TESTS:Bool=OFF -D FMILIB_GENERATE_DOXYGEN_DOC:Bool=OFF -DCMAKE_INSTALL_PREFIX:String=../install -DCMAKE_INSTALL_LIBDIR="$(LIB_OMC)" -DCMAKE_INSTALL_INCLUDEDIR=include -DOMC_ZLIB_LIBRARY=$(LIBMODELICAZLIB) -DOMC_ZLIB_INCLUDE_DIR=$(builddir_inc) .. -G $(CMAKE_TARGET))
 
 # Install expat
 expat: fmil

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -120,8 +120,6 @@ main.PHONY: simulationruntimecmsvc runtimeCPPinstall runtimeCPPmsvcinstall OMSIC
 include Makefile.common
 include Makefile.omsi.common
 
-# For Windows build static FMI lib!
-FMILIB_SHARED = ON
 # For Windows build static CMinpack lib!
 CMINPACKLIB_SHARED = OFF
 

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -70,7 +70,6 @@ AC_SUBST(LIBFMIRUNTIME)
 AC_SUBST(LIBFMILIB)
 AC_SUBST(WITH_FMIL)
 AC_SUBST(NO_FMIL)
-AC_SUBST(FMILIB_SHARED)
 AC_SUBST(LIBCMINPACKLIB)
 AC_SUBST(LIBZMQLIB)
 AC_SUBST(CMINPACKLIB_SHARED)
@@ -755,7 +754,6 @@ if test "$DARWIN" = "1"; then
   LIBRUNTIME=libOpenModelicaRuntimeC.dylib
   LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.dylib
   LIBFMILIB=libfmilib_shared.dylib
-  FMILIB_SHARED=ON
   LIBCMINPACKLIB=libcminpack.dylib
   LIBZMQLIB=libzmq.dylib
   CMINPACKLIB_SHARED=ON
@@ -791,7 +789,6 @@ elif echo "$host" | grep -iq "mingw"; then
   LIBRUNTIME=libOpenModelicaRuntimeC.a
   LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.a
   LIBFMILIB=libfmilib.a
-  FMILIB_SHARED=OFF
   LIBCMINPACKLIB=libcminpack.a
   LIBZMQLIB=libzmq.a
   CMINPACKLIB_SHARED=OFF
@@ -824,9 +821,8 @@ else
   LIBGC="$OMBUILDDIR/lib/$host_short/omc/libomcgc.so"
   LIBSIMULATION=libSimulationRuntimeC.so
   LIBRUNTIME=libOpenModelicaRuntimeC.so
-  LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.so
+  LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.a
   LIBFMILIB=libfmilib_shared.so
-  FMILIB_SHARED=ON
   LIBCMINPACKLIB=libcminpack.so
   LIBZMQLIB=libzmq.so
   CMINPACKLIB_SHARED=ON


### PR DESCRIPTION
  - Make library types consistent across Linux and Windows.

  - Install both static and shared versions of `libfmi`. Only the shared version
    was being installed on Linux even though both are built anyway.
    They also have different names so nothing should confuse them.

    Technically the shared version might not even be needed at all. I am
    just not sure what would miss it if I remove it. Leave it as it is for
    now.

  - Build only static versions of `libOpenModelicaFMIRuntime` on Linux as
    well as Windows. It was shared on Linux and static on Windows.
