### PR TITLE
Remove no longer needed linkage of ModelicaExternalC libs.

### DIFF
--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -62,6 +62,6 @@ CONFIG(release, debug|release) { # release
 }
 LIBS += -L$$(OMBUILDDIR)/../OMEdit/OMEditLIB/Debugger/Parser -lGDBMIParser \
   -L$$(OMBUILDDIR)/lib/omc -L$$(OMBUILDDIR)/../OMParser/install/lib -Wl,-Bstatic -lOMParser -lantlr4-runtime -Wl,-Bdynamic -lomantlr3 -lOMPlot -lomqwt -lomopcua -lzmq \
-  -lOpenModelicaCompiler -lomcruntime -lOpenModelicaRuntimeC -lfmilib -lzlib -lModelicaExternalC -lomcgc -lpthread -lshlwapi \
+  -lOpenModelicaCompiler -lomcruntime -lOpenModelicaRuntimeC -lfmilib -lzlib -lomcgc -lpthread -lshlwapi \
   -lws2_32 \
   -L$$(OMBUILDDIR)/bin -lOMSimulator

--- a/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebook.config.in
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebook.config.in
@@ -4,7 +4,7 @@ QMAKE_LINK = @CXX@
 
 PLOTLIBS = -L@OPENMODELICAHOME@/lib/@host_short@/omc -lOMPlot -lomqwt @RPATH_QMAKE@
 PLOTINC = @OPENMODELICAHOME@/include/omplot/qwt @OPENMODELICAHOME@/include/omplot
-OMCLIBS = -L@OPENMODELICAHOME@/lib/@host_short@/omc -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lomcruntime -lfmilib_shared -lModelicaExternalC -lomcgc -lomantlr3
+OMCLIBS = -L@OPENMODELICAHOME@/lib/@host_short@/omc -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lomcruntime -lfmilib_shared -lomcgc -lomantlr3
 OMCINC = @OPENMODELICAHOME@/include/omc/c
 
 QMAKE_CFLAGS = @CFLAGS@ @CPPFLAGS@

--- a/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
@@ -165,7 +165,7 @@ win32 {
   PLOTLIBS = -L$$(OMBUILDDIR)/build/lib/omc -lOMPlot -lomqwt
   PLOTINC = $$(OMBUILDDIR)/include/omplot \
             $$(OMBUILDDIR)/include/omplot/qwt
-  OMCLIBS = -L$$(OMBUILDDIR)/lib/omc -lOpenModelicaCompiler -lomcruntime -lOpenModelicaRuntimeC -lfmilib -lModelicaExternalC -lomcgc -lpthread
+  OMCLIBS = -L$$(OMBUILDDIR)/lib/omc -lOpenModelicaCompiler -lomcruntime -lOpenModelicaRuntimeC -lfmilib -lomcgc -lpthread
   OMCINC = $$(OMBUILDDIR)/include/omc/c
 } else {
   include(OMNotebook.config)

--- a/OMShell/OMShell/OMShellGUI/OMShell.config.in
+++ b/OMShell/OMShell/OMShellGUI/OMShell.config.in
@@ -1,7 +1,7 @@
 QMAKE_CC  = @CC@
 QMAKE_CXX = @CXX@
 QMAKE_LINK = @CXX@
-OMCLIBS = -L@OPENMODELICAHOME@/lib/@host_short@/omc @RPATH_QMAKE@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib_shared -lModelicaExternalC -lomcgc -lomantlr3
+OMCLIBS = -L@OPENMODELICAHOME@/lib/@host_short@/omc @RPATH_QMAKE@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib_shared -lomcgc -lomantlr3
 OMCINC = @OMBUILDDIR@/include/omc/c
 INCLUDEPATH += $$system(echo @CFLAGS@ | sed "s/\ //g" | grep ^-I | sed s/^-I//)
 QMAKE_CFLAGS = -g @CFLAGS@ @CPPFLAGS@

--- a/OMShell/OMShell/OMShellGUI/OMShellGUI.pro
+++ b/OMShell/OMShell/OMShellGUI/OMShellGUI.pro
@@ -36,7 +36,7 @@ win32 {
   } else { # 64-bit
     QMAKE_LFLAGS += -Wl,--stack,33554432,--enable-auto-import
   }
-  OMCLIBS = -L$$(OMBUILDDIR)/lib/omc -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib -lModelicaExternalC -lomcgc -lpthread
+  OMCLIBS = -L$$(OMBUILDDIR)/lib/omc -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib -lomcgc -lpthread
   OMCINC = $$(OMBUILDDIR)/include/omc/c
 } else {
   include(OMShell.config)

--- a/OMShell/mosh/src/Makefile.in
+++ b/OMShell/mosh/src/Makefile.in
@@ -10,7 +10,7 @@ CPPFLAGS = @CPPFLAGS@
 CXXFLAGS = $(CFLAGS)
 LDFLAGS = @LDFLAGS@ $(LIBS)
 
-LIBS = @LIBREADLINE@ -lncurses -lm -lpthread -L@OMBUILDDIR@/lib/@host_short@/omc @RPATH@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib_shared -lModelicaExternalC -lomcgc -lomantlr3
+LIBS = @LIBREADLINE@ -lncurses -lm -lpthread -L@OMBUILDDIR@/lib/@host_short@/omc @RPATH@ -lOpenModelicaCompiler -lOpenModelicaRuntimeC -lfmilib_shared -lomcgc -lomantlr3
 
 
 OBJS += mosh.o omcinteractiveenvironment.o options.o


### PR DESCRIPTION
  - This libs are not needed to be linked in for a while since
    `libOpenModelicaCompiler` stopped depending on them.
