### PR TITLE
Find value of NEED_CMINPACK in configure

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/configure.ac
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/configure.ac
@@ -247,6 +247,10 @@ if test "$OPENMODELICADYNAMIC" = "no"; then
   NEED_RUNTIME=1
 fi
 
+if test -f "external_solvers/hybrj_.c"; then
+  NEED_CMINPACK=1
+fi
+
 if echo "$host_os" | grep -q darwin; then
   DLLEXT=".dylib"
   if echo "$host_cpu" | grep -q i@<:@3456@:>@86; then

--- a/testsuite/omsimulator/recompileFMU.mos
+++ b/testsuite/omsimulator/recompileFMU.mos
@@ -29,7 +29,7 @@ buildModelFMU(simpleLoop, version="2.0", fmuType="me"); getErrorString();
 // Re-build FMU
 system("unzip -o -qq simpleLoop.fmu -d simpleLoop_FMU/");
 remove("simpleLoop.fmu");
-system("cd simpleLoop_FMU/sources && ./configure CPPFLAGS=\"-I" + getInstallationDirectoryPath() + "/include/omc/c/fmi\" NEED_CMINPACK=1 && make -s", "build_simpleLoop.log"); getErrorString();
+system("cd simpleLoop_FMU/sources && ./configure CPPFLAGS=\"-I" + getInstallationDirectoryPath() + "/include/omc/c/fmi\" && make -s", "build_simpleLoop.log"); getErrorString();
 
 system(getInstallationDirectoryPath() + "/bin/OMSimulator simpleLoop.fmu", "simpleLoop_me_systemCall.log");
 readFile("simpleLoop_me_systemCall.log");


### PR DESCRIPTION
  Needed for source-code FMUs that have non-linear loops.


### Purpose

User's don't need to know if the FMU needs CMinpack to re-compile.

