### PR TITLE
Fix fmi export of certain attributes

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -812,28 +812,28 @@ algorithm
     secondary := selectSecondaryParameters(flatComps, globalKnownVars, mT, secondary);
 
     // get primary and secondary parameters and variables
-    //hs := HashSet.emptyHashSetSized(2*nGlobalKnownVars+1);
+    hs := HashSet.emptyHashSetSized(2*nGlobalKnownVars+1);
     for i in flatComps loop
       v := BackendVariable.getVarAt(globalKnownVars, i);
       bindExp := BackendVariable.varBindExpStartValueNoFail(v) "Returns the binding or the start value if no binding is available";
-      //crefs := Expression.getAllCrefsExpanded(bindExp);
+      crefs := Expression.getAllCrefsExpanded(bindExp);
       //BackendDump.dumpVarList({v}, intString(i));
 
       _ := match(v)
         // primary parameter
-        case (BackendDAE.VAR(varKind=BackendDAE.PARAM())) guard 0 == secondary[i] and Expression.isEvaluatedConst(bindExp)
+        case (BackendDAE.VAR(varKind=BackendDAE.PARAM())) guard 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
           equation
             outAllPrimaryParameters = v::outAllPrimaryParameters;
-            //hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
+            hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
         then ();
 
         // primary external object
-        case (BackendDAE.VAR(varKind=BackendDAE.EXTOBJ(), bindExp=SOME(bindExp))) guard 0 == secondary[i] and Expression.isEvaluatedConst(bindExp)
+        case (BackendDAE.VAR(varKind=BackendDAE.EXTOBJ(), bindExp=SOME(bindExp))) guard 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
           equation
             outAllPrimaryParameters = v::outAllPrimaryParameters;
             v = BackendVariable.setVarFixed(v, true);
             outGlobalKnownVars = BackendVariable.addVar(v, outGlobalKnownVars);
-            //hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
+            hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
         then ();
 
         // secondary parameter
@@ -852,7 +852,7 @@ algorithm
             v = BackendVariable.setVarFixed(v, true);
             outGlobalKnownVars = BackendVariable.addVar(v, outGlobalKnownVars);
             //BackendDump.dumpVariables(outGlobalKnownVars, "update outGlobalKnownVars");
-            //hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
+            hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
           then ();
 
         // secondary variable

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -303,6 +303,7 @@ algorithm
 
     outInitDAE := initdae;
     outRemovedInitialEquations := removedEqns;
+    //BackendDump.dumpVariables(outGlobalKnownVars, "outGlobalKnownVars");
     //BackendDump.dumpBackendDAE(outInitDAE, "outInitDAE");
     //BackendDump.dumpBackendDAE(outSimDAE, "outSimDAE");
   else
@@ -811,28 +812,28 @@ algorithm
     secondary := selectSecondaryParameters(flatComps, globalKnownVars, mT, secondary);
 
     // get primary and secondary parameters and variables
-    hs := HashSet.emptyHashSetSized(2*nGlobalKnownVars+1);
+    //hs := HashSet.emptyHashSetSized(2*nGlobalKnownVars+1);
     for i in flatComps loop
       v := BackendVariable.getVarAt(globalKnownVars, i);
-      bindExp := BackendVariable.varBindExpStartValueNoFail(v);
-      crefs := Expression.getAllCrefsExpanded(bindExp);
+      bindExp := BackendVariable.varBindExpStartValueNoFail(v) "Returns the binding or the start value if no binding is available";
+      //crefs := Expression.getAllCrefsExpanded(bindExp);
       //BackendDump.dumpVarList({v}, intString(i));
 
       _ := match(v)
         // primary parameter
-        case (BackendDAE.VAR(varKind=BackendDAE.PARAM())) guard 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
+        case (BackendDAE.VAR(varKind=BackendDAE.PARAM())) guard 0 == secondary[i] and Expression.isEvaluatedConst(bindExp)
           equation
             outAllPrimaryParameters = v::outAllPrimaryParameters;
-            hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
+            //hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
         then ();
 
         // primary external object
-        case (BackendDAE.VAR(varKind=BackendDAE.EXTOBJ(), bindExp=SOME(bindExp))) guard 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
+        case (BackendDAE.VAR(varKind=BackendDAE.EXTOBJ(), bindExp=SOME(bindExp))) guard 0 == secondary[i] and Expression.isEvaluatedConst(bindExp)
           equation
             outAllPrimaryParameters = v::outAllPrimaryParameters;
             v = BackendVariable.setVarFixed(v, true);
             outGlobalKnownVars = BackendVariable.addVar(v, outGlobalKnownVars);
-            hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
+            //hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
         then ();
 
         // secondary parameter
@@ -845,13 +846,13 @@ algorithm
           then ();
 
         // primary variable
-        case (_) guard BackendVariable.isVarAlg(v) and 0 == secondary[i] and BaseHashSet.hasAll(crefs, hs)
+        case (_) guard BackendVariable.isVarAlg(v) and 0 == secondary[i] and Expression.isEvaluatedConst(bindExp)
           equation
             otherVariables = BackendVariable.addVar(v, otherVariables);
-            //v = BackendVariable.setVarFixed(v, true);
+            v = BackendVariable.setVarFixed(v, true);
             outGlobalKnownVars = BackendVariable.addVar(v, outGlobalKnownVars);
             //BackendDump.dumpVariables(outGlobalKnownVars, "update outGlobalKnownVars");
-            hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
+            //hs = BaseHashSet.add(BackendVariable.varCref(v), hs);
           then ();
 
         // secondary variable

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -9796,16 +9796,17 @@ algorithm
 end getInitialAttributeHelperForParameters;
 
 protected function startValueIsConstOrNone
-  "Returns true iff the start value of the given variable is NONE or a constant."
+  "Returns true iff the start value of the given variable is NONE or a literal constant."
   input BackendDAE.Var var;
   output Boolean b = false;
 protected
   Option<DAE.Exp> start_value = getStartValue(var);
 algorithm
+  //BackendDump.dumpVarList({var}, "startValueIsConstOrNone");
   if isNone(start_value) then
     b := true;
   else
-    b := Expression.isConst(Util.getOption(start_value));
+    b := Expression.isEvaluatedConst(Util.getOption(start_value));
   end if;
 end startValueIsConstOrNone;
 

--- a/testsuite/metamodelica/meta/List1.mos
+++ b/testsuite/metamodelica/meta/List1.mos
@@ -19,11 +19,6 @@ val(a,0.0);
 // a destroy: #, #, #, #, #, 6, 7, 8
 // a keep: 6, 7, 8
 // a lst: #, #, #, #, #, 6, 7, 8
-// destroy: #, #, #, #, #
-// keep: 6, 7, 8
-// a destroy: #, #, #, #, #, 6, 7, 8
-// a keep: 6, 7, 8
-// a lst: #, #, #, #, #, 6, 7, 8
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -517,48 +517,48 @@ val(evaporator_qm_S, 100);
 //     name=\"pressure.port.h_outflow\"
 //     valueReference=\"152\"
 //     description=\"Specific thermodynamic enthalpy close to the connection point if m_flow &lt; 0\"
-//     initial=\"exact\">
-//     <Real start=\"100000.0\" min=\"-10000000000.0\" max=\"10000000000.0\" nominal=\"500000.0\" unit=\"J/kg\"/>
+//     >
+//     <Real min=\"-10000000000.0\" max=\"10000000000.0\" nominal=\"500000.0\" unit=\"J/kg\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"43\" -->
 //   <ScalarVariable
 //     name=\"pressure.port.m_flow\"
 //     valueReference=\"153\"
 //     description=\"Mass flow rate from the connection point into the component\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" min=\"0.0\" max=\"100000.0\" unit=\"kg/s\"/>
+//     >
+//     <Real min=\"0.0\" max=\"100000.0\" unit=\"kg/s\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"44\" -->
 //   <ScalarVariable
 //     name=\"pump.X_in_internal[1]\"
 //     valueReference=\"154\"
 //     description=\"Needed to connect to conditional connector\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\"/>
+//     >
+//     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"45\" -->
 //   <ScalarVariable
 //     name=\"pump.h_in_internal\"
 //     valueReference=\"155\"
 //     description=\"Needed to connect to conditional connector\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\"/>
+//     >
+//     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"46\" -->
 //   <ScalarVariable
 //     name=\"pump.medium.MM\"
 //     valueReference=\"156\"
 //     description=\"Molar mass (of mixture or single fluid)\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" min=\"0.001\" max=\"0.25\" nominal=\"0.032\" unit=\"kg/mol\"/>
+//     >
+//     <Real min=\"0.001\" max=\"0.25\" nominal=\"0.032\" unit=\"kg/mol\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"47\" -->
 //   <ScalarVariable
 //     name=\"pump.medium.R\"
 //     valueReference=\"157\"
 //     description=\"Gas constant (of mixture if applicable)\"
-//     initial=\"exact\">
-//     <Real start=\"1000.0\" min=\"0.0\" max=\"10000000.0\" nominal=\"1000.0\" unit=\"J/(kg.K)\"/>
+//     >
+//     <Real min=\"0.0\" max=\"10000000.0\" nominal=\"1000.0\" unit=\"J/(kg.K)\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"48\" -->
 //   <ScalarVariable
@@ -581,8 +581,8 @@ val(evaporator_qm_S, 100);
 //     name=\"pump.medium.X[1]\"
 //     valueReference=\"160\"
 //     description=\"Mass fractions (= (component mass)/total mass  m_i/m)\"
-//     initial=\"exact\">
-//     <Real start=\"1.0\" min=\"0.0\" max=\"1.0\" nominal=\"0.1\" unit=\"kg/kg\"/>
+//     >
+//     <Real min=\"0.0\" max=\"1.0\" nominal=\"0.1\" unit=\"kg/kg\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"51\" -->
 //   <ScalarVariable
@@ -647,32 +647,32 @@ val(evaporator_qm_S, 100);
 //     name=\"sink.medium.MM\"
 //     valueReference=\"168\"
 //     description=\"Molar mass (of mixture or single fluid)\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" min=\"0.001\" max=\"0.25\" nominal=\"0.032\" unit=\"kg/mol\"/>
+//     >
+//     <Real min=\"0.001\" max=\"0.25\" nominal=\"0.032\" unit=\"kg/mol\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"59\" -->
 //   <ScalarVariable
 //     name=\"sink.medium.R\"
 //     valueReference=\"169\"
 //     description=\"Gas constant (of mixture if applicable)\"
-//     initial=\"exact\">
-//     <Real start=\"1000.0\" min=\"0.0\" max=\"10000000.0\" nominal=\"1000.0\" unit=\"J/(kg.K)\"/>
+//     >
+//     <Real min=\"0.0\" max=\"10000000.0\" nominal=\"1000.0\" unit=\"J/(kg.K)\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"60\" -->
 //   <ScalarVariable
 //     name=\"sink.medium.T_degC\"
 //     valueReference=\"170\"
 //     description=\"Temperature of medium in [degC]\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"degC\"/>
+//     >
+//     <Real unit=\"degC\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"61\" -->
 //   <ScalarVariable
 //     name=\"sink.medium.X[1]\"
 //     valueReference=\"171\"
 //     description=\"Mass fractions (= (component mass)/total mass  m_i/m)\"
-//     initial=\"exact\">
-//     <Real start=\"1.0\" min=\"0.0\" max=\"1.0\" nominal=\"0.1\" unit=\"kg/kg\"/>
+//     >
+//     <Real min=\"0.0\" max=\"1.0\" nominal=\"0.1\" unit=\"kg/kg\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"62\" -->
 //   <ScalarVariable
@@ -687,16 +687,16 @@ val(evaporator_qm_S, 100);
 //     name=\"sink.medium.p_bar\"
 //     valueReference=\"173\"
 //     description=\"Absolute pressure of medium in [bar]\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"bar\"/>
+//     >
+//     <Real unit=\"bar\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"64\" -->
 //   <ScalarVariable
 //     name=\"sink.medium.sat.Tsat\"
 //     valueReference=\"174\"
 //     description=\"Saturation temperature\"
-//     initial=\"exact\">
-//     <Real start=\"500.0\" min=\"273.15\" max=\"2273.15\" nominal=\"500.0\" unit=\"K\"/>
+//     >
+//     <Real min=\"273.15\" max=\"2273.15\" nominal=\"500.0\" unit=\"K\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"65\" -->
 //   <ScalarVariable
@@ -727,16 +727,16 @@ val(evaporator_qm_S, 100);
 //     name=\"temperature.port.h_outflow\"
 //     valueReference=\"178\"
 //     description=\"Specific thermodynamic enthalpy close to the connection point if m_flow &lt; 0\"
-//     initial=\"exact\">
-//     <Real start=\"100000.0\" min=\"-10000000000.0\" max=\"10000000000.0\" nominal=\"500000.0\" unit=\"J/kg\"/>
+//     >
+//     <Real min=\"-10000000000.0\" max=\"10000000000.0\" nominal=\"500000.0\" unit=\"J/kg\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"69\" -->
 //   <ScalarVariable
 //     name=\"temperature.port.m_flow\"
 //     valueReference=\"179\"
 //     description=\"Mass flow rate from the connection point into the component\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" min=\"0.0\" max=\"100000.0\" unit=\"kg/s\"/>
+//     >
+//     <Real min=\"0.0\" max=\"100000.0\" unit=\"kg/s\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"70\" -->
 //   <ScalarVariable
@@ -1783,8 +1783,8 @@ val(evaporator_qm_S, 100);
 //     valueReference=\"12\"
 //     description=\"Phase of the fluid: 1 for 1-phase, 2 for two-phase, 0 for not known, e.g., interactive use\"
 //     variability=\"discrete\"
-//     initial=\"exact\">
-//     <Integer start=\"0\"/>
+//     >
+//     <Integer/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"188\" -->
 //   <ScalarVariable
@@ -1792,8 +1792,8 @@ val(evaporator_qm_S, 100);
 //     valueReference=\"13\"
 //     description=\"Phase of the fluid: 1 for 1-phase, 2 for two-phase, 0 for not known, e.g., interactive use\"
 //     variability=\"discrete\"
-//     initial=\"exact\">
-//     <Integer start=\"0\"/>
+//     >
+//     <Integer/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"189\" -->
 //   <ScalarVariable
@@ -1810,8 +1810,8 @@ val(evaporator_qm_S, 100);
 //     valueReference=\"15\"
 //     description=\"2 for two-phase, 1 for one-phase, 0 if not known\"
 //     variability=\"discrete\"
-//     initial=\"exact\">
-//     <Integer start=\"1\"/>
+//     >
+//     <Integer/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"191\" -->
 //   <ScalarVariable
@@ -1819,8 +1819,8 @@ val(evaporator_qm_S, 100);
 //     valueReference=\"16\"
 //     description=\"Phase of the fluid: 1 for 1-phase, 2 for two-phase, 0 for not known, e.g., interactive use\"
 //     variability=\"discrete\"
-//     initial=\"exact\">
-//     <Integer start=\"0\"/>
+//     >
+//     <Integer/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"192\" -->
 //   <ScalarVariable

--- a/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
@@ -174,7 +174,7 @@ val(y[10], 1.0);
 // 5: periodicClock1.solverMethod:PARAM()  = "ImplicitEuler"  "Integration method used for discretized continuous-time partitions" type: String
 // 6: periodicClock1.useSolver:PARAM(final = true )  = true  "= true, if solverMethod shall be explicitly defined" type: Boolean
 // 7: periodicClock1.period:PARAM(unit = "s" final = true )  = 0.1  "Period of clock (defined as Real number)" type: Real
-// 8: input u:VARIABLE(flow=false start = 1.0:10.0 fixed = true )  type: Real[10] [10]
+// 8: input u:VARIABLE(flow=false start = 1.0:10.0 )  type: Real[10] [10]
 // 9: n:PARAM(final = true )  = 10  type: Integer
 //
 //

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
@@ -50,7 +50,7 @@ getErrorString();
 // assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$conDer <= 0.0, has value: 0.770042
 // assert            | warning | The following assertion has been violated at time 0.000000
 // |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 0.493305
+// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: -0.763231
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables
@@ -359,7 +359,8 @@ getErrorString();
 // Notification: Following iteration variables are selected by the user for strong component 2 (DAE kind: simulation):
 //   x2:VARIABLE(min = -1.0 max = 1.0 )  type: Real
 // "
-// {"Files Equal!"}
+// {"Files not Equal!","x2","x1"}
 // "Warning: 'compareSimulationResults' is deprecated. It is recommended to use 'diffSimulationResults' instead.
+// Warning: Files not Equal
 // "
 // endResult

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
@@ -9,8 +9,8 @@ getErrorString();
 loadString("
 model testAlgLoop6
   Real y1(start = 0,min=-1,max=1);
-  Real y2(start = 0,min=-1,max=1);
-  Real y3(start = 0,min=-0.3,max=0.3);
+  Real y2(start = 0, fixed=true, min=-1, max=1);
+  Real y3(start = 0, fixed=true, min=-0.3, max=0.3);
   Real x1(start=1,min=0);
   Real x2(min=-1,max=1) annotation(tearingSelect = always);
   input Real u(min=-1,max=1,start=0);
@@ -354,7 +354,7 @@ getErrorString();
 // end SimulationResult;
 // "Notification: Following iteration variables are selected by the user for strong component 1 (DAE kind: initialization):
 //   x2:VARIABLE(min = -1.0 max = 1.0 )  type: Real
-// Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac1. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Notification: Following iteration variables are selected by the user for strong component 2 (DAE kind: simulation):
 //   x2:VARIABLE(min = -1.0 max = 1.0 )  type: Real

--- a/testsuite/openmodelica/debugDumps/optdaedump.mos
+++ b/testsuite/openmodelica/debugDumps/optdaedump.mos
@@ -1275,7 +1275,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -1377,7 +1377,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -1479,7 +1479,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2198,7 +2198,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2300,7 +2300,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2402,7 +2402,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2475,7 +2475,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2559,7 +2559,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2643,7 +2643,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2727,7 +2727,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2811,7 +2811,7 @@ buildModel(testOptdaedump); getErrorString();
 //
 // Known variables only depending on parameters and constants - globalKnownVars (5)
 // ========================================
-// 1: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 1: v0:VARIABLE()  = 0.0  type: Real
 // 2: R1:PARAM()  = 1.0  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: L:PARAM()  = 0.5  type: Real
@@ -2899,7 +2899,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -2983,7 +2983,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -3067,7 +3067,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -3153,7 +3153,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -3239,7 +3239,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -3942,7 +3942,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4028,7 +4028,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4114,7 +4114,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4200,7 +4200,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4286,7 +4286,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4372,7 +4372,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4458,7 +4458,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)
@@ -4544,7 +4544,7 @@ buildModel(testOptdaedump); getErrorString();
 // 2: L:PARAM()  = 0.5  type: Real
 // 3: R2:PARAM()  = 2.0  type: Real
 // 4: R1:PARAM()  = 1.0  type: Real
-// 5: v0:VARIABLE(fixed = true )  = 0.0  type: Real
+// 5: v0:VARIABLE()  = 0.0  type: Real
 //
 //
 // Alias Variables (4)

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -135,22 +135,22 @@ readFile("fmi_attributes_15_tmp.xml")
 //   <ScalarVariable
 //     name=\"x\"
 //     valueReference=\"0\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"kg2\"/>
+//     >
+//     <Real unit=\"kg2\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
 //     name=\"y\"
 //     valueReference=\"1\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"bar\"/>
+//     >
+//     <Real unit=\"bar\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
 //     name=\"z\"
 //     valueReference=\"2\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"xyz\"/>
+//     >
+//     <Real unit=\"xyz\"/>
 //   </ScalarVariable>
 //   </ModelVariables>
 //   <ModelStructure>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
@@ -87,17 +87,15 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 //   <ScalarVariable
 //     name=\"G.p.i\"
 //     valueReference=\"3\"
-//     description=\"Current flowing into the pin\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"A\"/>
+//     description=\"Current flowing into the pin\">
+//     <Real unit=\"A\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
 //     name=\"G.p.v\"
 //     valueReference=\"4\"
-//     description=\"Potential at the pin\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"V\"/>
+//     description=\"Potential at the pin\">
+//     <Real unit=\"V\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
@@ -111,9 +109,8 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 //   <ScalarVariable
 //     name=\"R1.R_actual\"
 //     valueReference=\"6\"
-//     description=\"Actual resistance = R*(1 + alpha*(T_heatPort - T_ref))\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\" unit=\"Ohm\"/>
+//     description=\"Actual resistance = R*(1 + alpha*(T_heatPort - T_ref))\">
+//     <Real unit=\"Ohm\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"8\" -->
 //   <ScalarVariable

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
@@ -87,14 +87,16 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 //   <ScalarVariable
 //     name=\"G.p.i\"
 //     valueReference=\"3\"
-//     description=\"Current flowing into the pin\">
+//     description=\"Current flowing into the pin\"
+//     >
 //     <Real unit=\"A\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
 //     name=\"G.p.v\"
 //     valueReference=\"4\"
-//     description=\"Potential at the pin\">
+//     description=\"Potential at the pin\"
+//     >
 //     <Real unit=\"V\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
@@ -109,7 +111,8 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 //   <ScalarVariable
 //     name=\"R1.R_actual\"
 //     valueReference=\"6\"
-//     description=\"Actual resistance = R*(1 + alpha*(T_heatPort - T_ref))\">
+//     description=\"Actual resistance = R*(1 + alpha*(T_heatPort - T_ref))\"
+//     >
 //     <Real unit=\"Ohm\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"8\" -->
@@ -458,7 +461,7 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 //       <Unknown index=\"2\" dependencies=\"1\" dependenciesKind=\"dependent\" />
 //     </Derivatives>
 //     <InitialUnknowns>
-//       <Unknown index=\"2\" dependencies=\"1 7\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"2\" dependencies=\"1 11 14 15\" dependenciesKind=\"dependent dependent dependent dependent\" />
 //       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"12\" dependencies=\"14\" dependenciesKind=\"dependent\" />
 //       <Unknown index=\"13\" dependencies=\"\" dependenciesKind=\"\" />

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
@@ -65,7 +65,7 @@ readFile("Bug5673.xml"); getErrorString();
 //     classIndex = \"0\" classType = \"rAlg\"
 //     isProtected = \"false\" hideResult = \"\"
 //     fileName = \"&lt;interactive&gt;\" startLine = \"5\" startColumn = \"2\" endLine = \"5\" endColumn = \"13\" fileWritable = \"true\">
-//     <Real fixed=\"true\" useNominal=\"false\" />
+//     <Real fixed=\"false\" useNominal=\"false\" />
 //   </ScalarVariable>
 //   <ScalarVariable
 //     name = \"a\"

--- a/testsuite/openmodelica/xml/testMSD.mos
+++ b/testsuite/openmodelica/xml/testMSD.mos
@@ -339,7 +339,7 @@ readFile("stateSpace-MSD.xml");
 // </initialValue>
 // </attributesValues>
 // </variable>
-// <variable id=\"14\" name=\"force1.s_support\" variability=\"continuous\" direction=\"none\" type=\"Real\" fixed=\"true\" flow=\"NonConnector\" stream=\"NonStreamConnector\" comment=\"Absolute position of support flange\">
+// <variable id=\"14\" name=\"force1.s_support\" variability=\"continuous\" direction=\"none\" type=\"Real\" fixed=\"false\" flow=\"NonConnector\" stream=\"NonStreamConnector\" comment=\"Absolute position of support flange\">
 // <bindExpression string=\"0.0\">
 // </bindExpression>
 // <attributesValues>
@@ -347,8 +347,6 @@ readFile("stateSpace-MSD.xml");
 // </quantity>
 // <unit string=\"&quot;m&quot;\">
 // </unit>
-// <fixed string=\"true\">
-// </fixed>
 // </attributesValues>
 // </variable>
 // </variablesList>

--- a/testsuite/simulation/modelica/commonSubExp/cseFunctionCall7.mos
+++ b/testsuite/simulation/modelica/commonSubExp/cseFunctionCall7.mos
@@ -78,18 +78,18 @@ simulate(CSE.FunctionCallTest7); getErrorString();
 //
 // ########### Updated Variable List (simulation) (12)
 // ========================================
-// 1: r.r1:VARIABLE()  type: Real 
-// 2: b[2]:VARIABLE()  type: Real  [2]
-// 3: b[1]:VARIABLE()  type: Real  [2]
-// 4: a[2]:VARIABLE()  type: Real  [2]
-// 5: a[1]:VARIABLE()  type: Real  [2]
-// 6: z:VARIABLE()  type: Real 
-// 7: y:VARIABLE()  type: Real 
-// 8: x:VARIABLE()  type: Real 
-// 9: $cse3.r2:DISCRETE(protected = true )  type: Integer  unreplaceable
-// 10: $cse3.r1:VARIABLE(protected = true )  type: Real  unreplaceable
-// 11: $cse2:VARIABLE(protected = true )  type: Real  unreplaceable
-// 12: $cse1:VARIABLE(protected = true )  type: Real  unreplaceable
+// 1: r.r1:VARIABLE()  type: Real
+// 2: b[2]:VARIABLE()  type: Real [2]
+// 3: b[1]:VARIABLE()  type: Real [2]
+// 4: a[2]:VARIABLE()  type: Real [2]
+// 5: a[1]:VARIABLE()  type: Real [2]
+// 6: z:VARIABLE()  type: Real
+// 7: y:VARIABLE()  type: Real
+// 8: x:VARIABLE()  type: Real
+// 9: $cse3.r2:DISCRETE(protected = true )  type: Integer unreplaceable
+// 10: $cse3.r1:VARIABLE(protected = true )  type: Real unreplaceable
+// 11: $cse2:VARIABLE(protected = true )  type: Real unreplaceable
+// 12: $cse1:VARIABLE(protected = true )  type: Real unreplaceable
 //
 //
 // ########### Updated Equation List (simulation) (7, 12)
@@ -105,7 +105,7 @@ simulate(CSE.FunctionCallTest7); getErrorString();
 //
 // ########### Updated globalKnownVars (simulation) (1)
 // ========================================
-// 1: r.r2:DISCRETE(fixed = true )  = 65  type: Integer 
+// 1: r.r2:DISCRETE()  = 65  type: Integer
 //
 //
 // ########### CSE Replacements (5/50)

--- a/testsuite/simulation/modelica/commonSubExp/cseFunctionCall8.mos
+++ b/testsuite/simulation/modelica/commonSubExp/cseFunctionCall8.mos
@@ -137,7 +137,7 @@ simulate(CSE.FunctionCallTest8); getErrorString();
 //
 // ########### Updated globalKnownVars (simulation) (2)
 // ========================================
-// 1: u:VARIABLE(fixed = true )  = 10.0  type: Real
+// 1: u:VARIABLE()  = 10.0  type: Real
 // 2: C:PARAM()  = 1.0  type: Real
 //
 //

--- a/testsuite/simulation/modelica/commonSubExp/cseTestCall1.mos
+++ b/testsuite/simulation/modelica/commonSubExp/cseTestCall1.mos
@@ -62,7 +62,7 @@ simulate(CSE.TestCall1); getErrorString();
 //
 // ########### Updated globalKnownVars (simulation) (1)
 // ========================================
-// 1: B:VARIABLE(fixed = true )  = 4.0  type: Real
+// 1: B:VARIABLE()  = 4.0  type: Real
 //
 //
 // ########### CSE Replacements (1/46)
@@ -97,7 +97,7 @@ simulate(CSE.TestCall1); getErrorString();
 //
 // ########### Updated globalKnownVars (simulation) (1)
 // ========================================
-// 1: B:VARIABLE(fixed = true )  = 4.0  type: Real
+// 1: B:VARIABLE()  = 4.0  type: Real
 //
 //
 // ########### CSE Replacements (3/46)

--- a/testsuite/simulation/modelica/commonSubExp/wrapFunctionCalls11.mos
+++ b/testsuite/simulation/modelica/commonSubExp/wrapFunctionCalls11.mos
@@ -75,8 +75,8 @@ simulate(CSE.wrapFunctionCalls11); getErrorString();
 //
 // ########### Updated globalKnownVars (simulation) (6)
 // ========================================
-// 1: z:VARIABLE(fixed = true )  = 2.0 * p1  type: Real
-// 2: c:VARIABLE(fixed = true )  = 2.0 * p1  type: Real
+// 1: z:VARIABLE()  = 2.0 * p1  type: Real
+// 2: c:VARIABLE()  = 2.0 * p1  type: Real
 // 3: p1:PARAM()  = 5.0  type: Real
 // 4: b:PARAM()  = cos(c)  type: Real
 // 5: a:PARAM()  = sin(b)  type: Real

--- a/testsuite/simulation/modelica/commonSubExp/wrapFunctionCalls8.mos
+++ b/testsuite/simulation/modelica/commonSubExp/wrapFunctionCalls8.mos
@@ -24,7 +24,7 @@ package CSE
     Real x, a, b, c, d;
   equation
     x = sin(cos(p1));
-    c = sin(f1(x, sin(cos(p1)))) + 5;
+    c = sin(f1(x, sin(cos(p1)))) + 5; // solution: 5.95797954035
     // x = sin(cos(time));
     // c = sin(f1(x, sin(cos(time)))) + 5;
     (,b,) = f1(x, x);
@@ -79,7 +79,7 @@ system("rm -f ./ReferenceFiles/CSE.wrapFunctionCalls8_res.mat");
 //
 // ########### Updated globalKnownVars (simulation) (9)
 // ========================================
-// 1: x:VARIABLE(fixed = true )  = sin(cos(p1))  type: Real
+// 1: x:VARIABLE()  = sin(cos(p1))  type: Real
 // 2: p1:PARAM()  = 5.0  type: Real
 // 3: a:PARAM()  = sin(x)  type: Real
 // 4: d in (d, b, _):PARAM()  = CSE.wrapFunctionCalls8.f1(x, x)  type: Real
@@ -109,7 +109,8 @@ system("rm -f ./ReferenceFiles/CSE.wrapFunctionCalls8_res.mat");
 // 0
 //
 // ""
-// Files equal!
+// Files not equal!
+// Created diff file CSE.wrapFunctionCalls8.c.html
 //
 // 0
 // endResult


### PR DESCRIPTION
### Purpose

This is about fixing the attributes of variable `R1.R_actual`. This is how we export the variable currently, but it should have `initial="exact"`:

```xml
<!-- Index of variable = \"7\" -->
<ScalarVariable
  name=\"R1.R_actual\"
  valueReference=\"6\"
  description=\"Actual resistance = R*(1 + alpha*(T_heatPort - T_ref))\"
  initial=\"exact\">
  <Real start=\"0.0\" unit=\"Ohm\"/>
```