### PR TITLE
Reorganize some NFExpression records

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBBackendUtil.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBBackendUtil.mo
@@ -522,7 +522,7 @@ public
         var := BVariable.getVar(exp.cref);
       then stringHashDjb2Mod(BackendExtension.BackendInfo.toString(var.backendinfo), mod);
       case Expression.TYPENAME() then 1; // ty !!
-      case Expression.ARRAY() algorithm // ty !!
+      case Expression.LIST() algorithm // ty !!
         for elem in exp.elements loop
           hash := hash + noNameHashExp(elem, mod);
         end for;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -351,12 +351,12 @@ public
     case Expression.CREF() then differentiateComponentRef(exp, diffArguments);
 
     // [a, b, c, ...]' = [a', b', c', ...]
-    case Expression.ARRAY() algorithm
+    case Expression.LIST() algorithm
       for element in exp.elements loop
         (element, diffArguments) := differentiateExpression(element, diffArguments);
         new_elements := element :: new_elements;
       end for;
-    then (Expression.ARRAY(exp.ty, listReverse(new_elements), exp.literal), diffArguments);
+    then (Expression.LIST(exp.ty, listReverse(new_elements), exp.literal), diffArguments);
 
     // |a, b, c|'   |a', b', c'|
     // |d, e, f|  = |d', e', f'|

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -2024,7 +2024,7 @@ protected
         then
           Expression.CALL(Call.makeTypedCall(fn, {arg}, var, Purity.IMPURE, arg.ty));
 
-      case Expression.ARRAY()
+      case Expression.LIST()
         algorithm
           arg.elements := list(typeActualInStreamCall2(name, fn, e, var, info) for e in arg.elements);
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -186,7 +186,7 @@ algorithm
     case Expression.TYPENAME()
       then evalTypename(exp.ty, exp, target);
 
-    case Expression.ARRAY()
+    case Expression.LIST()
       then if exp.literal then exp
            else
              Expression.makeArray(exp.ty,
@@ -1003,7 +1003,7 @@ algorithm
     case (Expression.STRING(), Expression.STRING())
       then Expression.STRING(exp1.value + exp2.value);
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       guard listLength(exp1.elements) == listLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
         list(evalBinaryAdd(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
@@ -1030,7 +1030,7 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value - exp2.value);
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       guard listLength(exp1.elements) == listLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
         list(evalBinarySub(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
@@ -1057,7 +1057,7 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value * exp2.value);
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       guard listLength(exp1.elements) == listLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
         list(evalBinaryMul(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
@@ -1094,7 +1094,7 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value / exp2.value);
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       guard listLength(exp1.elements) == listLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
         list(evalBinaryDiv(e1, e2, target) threaded for e1 in exp1.elements, e2 in exp2.elements),
@@ -1118,7 +1118,7 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value ^ exp2.value);
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       guard listLength(exp1.elements) == listLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
         list(evalBinaryPow(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
@@ -1146,7 +1146,7 @@ function evalBinaryScalarArray
   end FuncT;
 algorithm
   exp := match arrayExp
-    case Expression.ARRAY()
+    case Expression.LIST()
       then Expression.makeArray(arrayExp.ty,
         list(evalBinaryScalarArray(scalarExp, e, opFunc) for e in arrayExp.elements),
         literal = true);
@@ -1168,7 +1168,7 @@ function evalBinaryArrayScalar
   end FuncT;
 algorithm
   exp := match arrayExp
-    case Expression.ARRAY()
+    case Expression.LIST()
       then Expression.makeArray(arrayExp.ty,
         list(evalBinaryArrayScalar(e, scalarExp, opFunc) for e in arrayExp.elements),
         literal = true);
@@ -1187,7 +1187,7 @@ protected
   Type ty;
 algorithm
   exp := match Expression.transposeArray(matrixExp)
-    case Expression.ARRAY(Type.ARRAY(ty, {m, _}), expl)
+    case Expression.LIST(Type.ARRAY(ty, {m, _}), expl)
       algorithm
         expl := list(evalBinaryScalarProduct(vectorExp, e) for e in expl);
       then
@@ -1213,7 +1213,7 @@ protected
   Type ty;
 algorithm
   exp := match matrixExp
-    case Expression.ARRAY(Type.ARRAY(ty, {n, _}), expl)
+    case Expression.LIST(Type.ARRAY(ty, {n, _}), expl)
       algorithm
         expl := list(evalBinaryScalarProduct(e, vectorExp) for e in expl);
       then
@@ -1240,7 +1240,7 @@ algorithm
       Expression e2;
       list<Expression> rest_e2;
 
-    case (Expression.ARRAY(ty = Type.ARRAY(elem_ty)), Expression.ARRAY())
+    case (Expression.LIST(ty = Type.ARRAY(elem_ty)), Expression.LIST())
       guard listLength(exp1.elements) == listLength(exp2.elements)
       algorithm
         exp := Expression.makeZero(elem_ty);
@@ -1276,8 +1276,8 @@ algorithm
   e2 := Expression.transposeArray(exp2);
 
   exp := match (exp1, e2)
-    case (Expression.ARRAY(Type.ARRAY(elem_ty, {n, _}), expl1),
-          Expression.ARRAY(Type.ARRAY(_, {p, _}), expl2))
+    case (Expression.LIST(Type.ARRAY(elem_ty, {n, _}), expl1),
+          Expression.LIST(Type.ARRAY(_, {p, _}), expl2))
       algorithm
         mat_ty := Type.ARRAY(elem_ty, {n, p});
 
@@ -1310,7 +1310,7 @@ protected
   Integer n;
 algorithm
   exp := match (matrixExp, nExp)
-    case (Expression.ARRAY(), Expression.INTEGER(value = 0))
+    case (Expression.LIST(), Expression.INTEGER(value = 0))
       algorithm
         n := Dimension.size(listHead(Type.arrayDims(matrixExp.ty)));
       then
@@ -1382,7 +1382,7 @@ algorithm
   exp := match exp1
     case Expression.INTEGER() then Expression.INTEGER(-exp1.value);
     case Expression.REAL() then Expression.REAL(-exp1.value);
-    case Expression.ARRAY()
+    case Expression.LIST()
       algorithm
         exp1.elements := list(evalUnaryMinus(e) for e in exp1.elements);
       then
@@ -1452,9 +1452,9 @@ algorithm
     case Expression.BOOLEAN()
       then if exp1.value then evalExp(exp2, target) else exp1;
 
-    case Expression.ARRAY()
+    case Expression.LIST()
       algorithm
-        Expression.ARRAY(elements = expl) := evalExp(exp2, target);
+        Expression.LIST(elements = expl) := evalExp(exp2, target);
         expl := list(evalLogicBinaryAnd(e1, e2, target)
                      threaded for e1 in exp1.elements, e2 in expl);
       then
@@ -1482,9 +1482,9 @@ algorithm
     case Expression.BOOLEAN()
       then if exp1.value then exp1 else evalExp(exp2, target);
 
-    case Expression.ARRAY()
+    case Expression.LIST()
       algorithm
-        Expression.ARRAY(elements = expl) := evalExp(exp2, target);
+        Expression.LIST(elements = expl) := evalExp(exp2, target);
         expl := list(evalLogicBinaryOr(e1, e2, target)
                      threaded for e1 in exp1.elements, e2 in expl);
       then
@@ -1521,7 +1521,7 @@ function evalLogicUnaryNot
 algorithm
   exp := match exp1
     case Expression.BOOLEAN() then Expression.BOOLEAN(not exp1.value);
-    case Expression.ARRAY() then Expression.mapArrayElements(exp1, evalLogicUnaryNot);
+    case Expression.LIST() then Expression.mapArrayElements(exp1, evalLogicUnaryNot);
 
     else
       algorithm
@@ -2129,9 +2129,9 @@ protected
   Boolean e_lit, arg_lit = true;
 algorithm
   result := match arg
-    case Expression.ARRAY(elements = {}) then arg;
+    case Expression.LIST(elements = {}) then arg;
 
-    case Expression.ARRAY(elements = elems)
+    case Expression.LIST(elements = elems)
       algorithm
         n := listLength(elems);
 
@@ -2337,7 +2337,7 @@ algorithm
       Dimension dim1, dim2;
       Type ty;
 
-    case Expression.ARRAY(ty = ty)
+    case Expression.LIST(ty = ty)
       algorithm
         dim_count := Type.dimensionCount(ty);
 
@@ -2377,7 +2377,7 @@ function evalBuiltinMatrix2
   output Expression result;
 algorithm
   result := match arg
-    case Expression.ARRAY()
+    case Expression.LIST()
       then Expression.makeArray(ty,
                                 list(Expression.toScalar(e) for e in arg.elements),
                                 arg.literal);
@@ -2397,7 +2397,7 @@ protected
 algorithm
   result := match args
     case {e1, e2} then evalBuiltinMax2(e1, e2);
-    case {e1 as Expression.ARRAY(ty = ty)}
+    case {e1 as Expression.LIST(ty = ty)}
       algorithm
         result := Expression.fold(e1, evalBuiltinMax2, Expression.EMPTY(ty));
 
@@ -2426,7 +2426,7 @@ algorithm
       then if exp1.value < exp2.value then exp2 else exp1;
     case (Expression.ENUM_LITERAL(), Expression.ENUM_LITERAL())
       then if exp1.index < exp2.index then exp2 else exp1;
-    case (Expression.ARRAY(), _) then exp2;
+    case (Expression.LIST(), _) then exp2;
     case (_, Expression.EMPTY()) then exp1;
     else algorithm printWrongArgsError(getInstanceName(), {exp1, exp2}, sourceInfo()); then fail();
   end match;
@@ -2443,7 +2443,7 @@ protected
 algorithm
   result := match args
     case {e1, e2} then evalBuiltinMin2(e1, e2);
-    case {e1 as Expression.ARRAY(ty = ty)}
+    case {e1 as Expression.LIST(ty = ty)}
       algorithm
         result := Expression.fold(e1, evalBuiltinMin2, Expression.EMPTY(ty));
 
@@ -2472,7 +2472,7 @@ algorithm
       then if exp1.value > exp2.value then exp2 else exp1;
     case (Expression.ENUM_LITERAL(), Expression.ENUM_LITERAL())
       then if exp1.index > exp2.index then exp2 else exp1;
-    case (Expression.ARRAY(), _) then exp2;
+    case (Expression.LIST(), _) then exp2;
     case (_, Expression.EMPTY()) then exp1;
     else algorithm printWrongArgsError(getInstanceName(), {exp1, exp2}, sourceInfo()); then fail();
   end match;
@@ -2530,7 +2530,7 @@ function evalBuiltinProduct
   output Expression result;
 algorithm
   result := match arg
-    case Expression.ARRAY()
+    case Expression.LIST()
       then match Type.arrayElementType(Expression.typeOf(arg))
         case Type.INTEGER() then Expression.INTEGER(Expression.fold(arg, evalBuiltinProductInt, 1));
         case Type.REAL() then Expression.REAL(Expression.fold(arg, evalBuiltinProductReal, 1.0));
@@ -2547,7 +2547,7 @@ function evalBuiltinProductInt
 algorithm
   result := match exp
     case Expression.INTEGER() then result * exp.value;
-    case Expression.ARRAY() then result;
+    case Expression.LIST() then result;
     else fail();
   end match;
 end evalBuiltinProductInt;
@@ -2558,7 +2558,7 @@ function evalBuiltinProductReal
 algorithm
   result := match exp
     case Expression.REAL() then result * exp.value;
-    case Expression.ARRAY() then result;
+    case Expression.LIST() then result;
     else fail();
   end match;
 end evalBuiltinProductReal;
@@ -2625,7 +2625,7 @@ protected
   Expression exp = listHead(args);
 algorithm
   result := match exp
-    case Expression.ARRAY() then evalBuiltinScalar(exp.elements);
+    case Expression.LIST() then evalBuiltinScalar(exp.elements);
     else exp;
   end match;
 end evalBuiltinScalar;
@@ -2673,7 +2673,7 @@ protected
   Boolean literal;
 algorithm
   result := match arg
-    case Expression.ARRAY(ty = ty, elements = {x1, x2, x3}, literal = literal)
+    case Expression.LIST(ty = ty, elements = {x1, x2, x3}, literal = literal)
       algorithm
         zero := Expression.makeZero(Type.arrayElementType(ty));
         y1 := Expression.makeArray(ty, {zero, Expression.negate(x3), x2}, literal);
@@ -2752,7 +2752,7 @@ function evalBuiltinSum
   output Expression result;
 algorithm
   result := match arg
-    case Expression.ARRAY()
+    case Expression.LIST()
       then match Type.arrayElementType(Expression.typeOf(arg))
         case Type.INTEGER() then Expression.INTEGER(Expression.fold(arg, evalBuiltinSumInt, 0));
         case Type.REAL() then Expression.REAL(Expression.fold(arg, evalBuiltinSumReal, 0.0));
@@ -2769,7 +2769,7 @@ function evalBuiltinSumInt
 algorithm
   result := match exp
     case Expression.INTEGER() then result + exp.value;
-    case Expression.ARRAY() then result;
+    case Expression.LIST() then result;
     else fail();
   end match;
 end evalBuiltinSumInt;
@@ -2780,7 +2780,7 @@ function evalBuiltinSumReal
 algorithm
   result := match exp
     case Expression.REAL() then result + exp.value;
-    case Expression.ARRAY() then result;
+    case Expression.LIST() then result;
     else fail();
   end match;
 end evalBuiltinSumReal;
@@ -2795,7 +2795,7 @@ protected
   list<Expression> expl, accum = {};
 algorithm
   result := match arg
-    case Expression.ARRAY() guard Type.isMatrix(arg.ty)
+    case Expression.LIST() guard Type.isMatrix(arg.ty)
       algorithm
         mat := listArray(list(listArray(Expression.arrayElements(row))
                            for row in Expression.arrayElements(arg)));
@@ -2849,7 +2849,7 @@ protected
   Boolean literal;
 algorithm
   result := match arg
-    case Expression.ARRAY(ty = Type.ARRAY(elementType = ty,
+    case Expression.LIST(ty = Type.ARRAY(elementType = ty,
                                           dimensions = dim1 :: dim2 :: rest_dims),
                           elements = arr,
                           literal = literal)

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
@@ -100,7 +100,7 @@ public
   algorithm
     conns := match exp
       case Expression.CREF() then fromCref(exp.cref, exp.ty, source) :: conns;
-      case Expression.ARRAY()
+      case Expression.LIST()
         algorithm
           for e in listReverse(exp.elements) loop
             conns := fromExp(e, source, conns);

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -104,7 +104,7 @@ public
                 fail();
           end match;
 
-      case Expression.ARRAY()
+      case Expression.LIST()
         guard Expression.arrayAllEqual(exp)
         then fromExp(Expression.arrayFirstScalar(exp), var);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -774,7 +774,7 @@ protected
   list<Expression> subs, vals;
 algorithm
   result := match (arrayExp, subscripts)
-    case (Expression.ARRAY(), Subscript.INDEX(sub) :: rest_subs) guard Expression.isScalarLiteral(sub)
+    case (Expression.LIST(), Subscript.INDEX(sub) :: rest_subs) guard Expression.isScalarLiteral(sub)
       algorithm
         idx := Expression.toInteger(sub);
 
@@ -787,7 +787,7 @@ algorithm
       then
         arrayExp;
 
-    case (Expression.ARRAY(), Subscript.SLICE(sub) :: rest_subs)
+    case (Expression.LIST(), Subscript.SLICE(sub) :: rest_subs)
       algorithm
         subs := Expression.arrayElements(sub);
         vals := Expression.arrayElements(value);
@@ -809,7 +809,7 @@ algorithm
       then
         arrayExp;
 
-    case (Expression.ARRAY(), Subscript.WHOLE() :: rest_subs)
+    case (Expression.LIST(), Subscript.WHOLE() :: rest_subs)
       algorithm
         if listEmpty(rest_subs) then
           arrayExp.elements := Expression.arrayElements(value);

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunctionExt.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunctionExt.mo
@@ -568,7 +568,7 @@ protected
   list<Expression> expl;
   Type ty;
 algorithm
-  Expression.ARRAY(ty = ty, elements = expl) := Ceval.evalExp(arg);
+  Expression.LIST(ty = ty, elements = expl) := Ceval.evalExp(arg);
 
   // Some external functions don't make a difference between vectors and
   // matrices, so if the argument is a vector we convert it into a matrix.
@@ -595,7 +595,7 @@ algorithm
   exp := match (Expression.typeOf(variable), value)
     // Vector variable, matrix value => convert value to vector.
     case (Type.ARRAY(dimensions = {_}),
-          Expression.ARRAY(ty = Type.ARRAY(dimensions = {_, _})))
+          Expression.LIST(ty = Type.ARRAY(dimensions = {_, _})))
       then Expression.makeArray(Type.unliftArray(value.ty),
                                 list(Expression.arrayScalarElement(e) for e in value.elements),
                                 literal = true);

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -68,9 +68,9 @@ public
       case Expression.CREF(ty = Type.ARRAY()) then expandCref(exp);
 
       // One-dimensional arrays are already expanded.
-      case Expression.ARRAY(ty = Type.ARRAY(dimensions = {})) then (exp, true);
+      case Expression.LIST(ty = Type.ARRAY(dimensions = {})) then (exp, true);
 
-      case Expression.ARRAY()
+      case Expression.LIST()
         algorithm
           (expl, expanded) := expandList(exp.elements);
           exp.elements := expl;
@@ -391,9 +391,9 @@ public
       local
         list<Expression> expl;
 
-      case Expression.ARRAY(literal = true) then exp;
+      case Expression.LIST(literal = true) then exp;
 
-      case Expression.ARRAY()
+      case Expression.LIST()
         algorithm
           expl := list(expandBuiltinGeneric2(e, fn, ty, var, pur, attr) for e in exp.elements);
         then
@@ -612,7 +612,7 @@ public
     output Expression exp;
   algorithm
     exp := match exp2
-      case Expression.ARRAY() then exp2;
+      case Expression.LIST() then exp2;
       else SimplifyExp.simplifyBinaryOp(exp1, op, exp2);
     end match;
   end makeScalarArrayBinary_traverser;
@@ -654,7 +654,7 @@ public
     (exp2, expanded) := expand(exp2);
 
     if expanded then
-      Expression.ARRAY(Type.ARRAY(ty, {m, _}), expl) := Expression.transposeArray(exp2);
+      Expression.LIST(Type.ARRAY(ty, {m, _}), expl) := Expression.transposeArray(exp2);
       ty := Type.ARRAY(ty, {m});
 
       if listEmpty(expl) then
@@ -690,7 +690,7 @@ public
     (exp1, expanded) := expand(exp1);
 
     if expanded then
-      Expression.ARRAY(Type.ARRAY(ty, {n, _}), expl) := exp1;
+      Expression.LIST(Type.ARRAY(ty, {n, _}), expl) := exp1;
       ty := Type.ARRAY(ty, {n});
 
       if listEmpty(expl) then
@@ -742,8 +742,8 @@ public
     Type ty, elem_ty;
     Operator mul_op, add_op;
   algorithm
-    Expression.ARRAY(ty, expl1) := exp1;
-    Expression.ARRAY( _, expl2) := exp2;
+    Expression.LIST(ty, expl1) := exp1;
+    Expression.LIST( _, expl2) := exp2;
     elem_ty := Type.unliftArray(ty);
 
     if listEmpty(expl1) then
@@ -789,10 +789,10 @@ public
     Type ty, row_ty, mat_ty;
     Dimension n, p;
   algorithm
-    Expression.ARRAY(Type.ARRAY(ty, {n, _}), expl1) := exp1;
+    Expression.LIST(Type.ARRAY(ty, {n, _}), expl1) := exp1;
     // Transpose the second matrix. This makes it easier to do the multiplication,
     // since we can do row-row multiplications instead of row-column.
-    Expression.ARRAY(Type.ARRAY(dimensions = {p, _}), expl2) := Expression.transposeArray(exp2);
+    Expression.LIST(Type.ARRAY(dimensions = {p, _}), expl2) := Expression.transposeArray(exp2);
     mat_ty := Type.ARRAY(ty, {n, p});
 
     if listEmpty(expl2) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -72,9 +72,9 @@ public
         Expression e;
         Boolean expanded;
 
-      case Expression.ARRAY()
+      case Expression.LIST()
         algorithm
-          (Expression.ARRAY(elements = arr), expanded) := ExpandExp.expand(exp);
+          (Expression.LIST(elements = arr), expanded) := ExpandExp.expand(exp);
 
           if not expanded then
             Error.assertion(false, getInstanceName() + " got unexpandable expression `" +
@@ -90,7 +90,7 @@ public
           e := ExpandExp.expandCref(exp);
 
           iterator := match e
-            case Expression.ARRAY() then fromExp(e);
+            case Expression.LIST() then fromExp(e);
             else SCALAR_ITERATOR(e);
           end match;
         then
@@ -252,7 +252,7 @@ protected
       e := listHead(array);
 
       (array, slice) := match e
-        case Expression.ARRAY()
+        case Expression.LIST()
           algorithm
             (arr, slice) := nextArraySlice(e.elements);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -684,7 +684,7 @@ algorithm
       then
         Expression.makeRecord(InstNode.scopePath(cls), outExp.ty, fields);
 
-    case Expression.ARRAY()
+    case Expression.LIST()
       algorithm
         outExp.elements := list(splitRecordCref(e) for e in outExp.elements);
       then

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -1196,7 +1196,7 @@ algorithm
           algorithm
             res := match call.arguments
               // zero size array TODO! FIXME! check how zero size arrays are handled in the NF
-              case {Expression.ARRAY(elements = {})}
+              case {Expression.LIST(elements = {})}
                 equation
                  if Flags.isSet(Flags.CGRAPH) then
                     print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: " + Expression.toString(exp) + " = false\n");
@@ -1237,7 +1237,7 @@ algorithm
           algorithm
             res := match call.arguments
               // zero size array TODO! FIXME! check how zero size arrays are handled in the NF
-              case {Expression.ARRAY(elements = {})}
+              case {Expression.LIST(elements = {})}
                 equation
                   if Flags.isSet(Flags.CGRAPH) then
                     print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: " + Expression.toString(exp) + " = false\n");
@@ -1261,7 +1261,7 @@ algorithm
           algorithm
             res := match call.arguments
               // normal call
-              case {uroots as Expression.ARRAY(elements = lst),nodes,message}
+              case {uroots as Expression.LIST(elements = lst),nodes,message}
                 equation
                   if Flags.isSet(Flags.CGRAPH) then
                     print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: Connections.uniqueRootsIndicies(" +

--- a/OMCompiler/Compiler/NFFrontEnd/NFRangeIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRangeIterator.mo
@@ -93,7 +93,7 @@ public
         Absyn.Path path;
         list<Expression> values;
 
-      case Expression.ARRAY() then ARRAY_RANGE(exp.elements);
+      case Expression.LIST() then ARRAY_RANGE(exp.elements);
 
       case Expression.RANGE(start = Expression.INTEGER(istart),
                             step = SOME(Expression.INTEGER(istep)),

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -84,7 +84,7 @@ algorithm
       then
         exp;
 
-    case Expression.ARRAY()
+    case Expression.LIST()
       algorithm
         exp.elements := list(simplify(e) for e in exp.elements);
       then
@@ -331,7 +331,7 @@ algorithm
   e := if Expression.hasArrayCall(arg) then arg else ExpandExp.expand(arg);
 
   exp := match e
-    case Expression.ARRAY()
+    case Expression.LIST()
       guard List.all(e.elements, Expression.isArray)
       then Expression.transposeArray(e);
 
@@ -417,7 +417,7 @@ algorithm
           outExp := Expression.makeEmptyArray(ty);
         elseif dim_size == 1 then
           // Result is Array[1], return array with the single element.
-          (Expression.ARRAY(elements = {e}), _) := ExpandExp.expand(e);
+          (Expression.LIST(elements = {e}), _) := ExpandExp.expand(e);
           exp := Expression.replaceIterator(exp, iter, e);
           exp := Expression.makeArray(ty, {exp});
           outExp := simplify(exp);
@@ -470,7 +470,7 @@ algorithm
               SOME(outExp) := call.defaultExp;
             elseif dim_size == 1 then
               // Iteration range is one, return reduction expression with iterator value applied.
-              (Expression.ARRAY(elements = {e}), _) := ExpandExp.expand(e);
+              (Expression.LIST(elements = {e}), _) := ExpandExp.expand(e);
               outExp := Expression.replaceIterator(call.exp, iter, e);
               outExp := simplify(outExp);
             else
@@ -946,7 +946,7 @@ algorithm
     // e and true => e
     case (_, Expression.BOOLEAN(true))  then exp1;
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       algorithm
         o := Operator.unlift(op);
         expl := list(simplifyLogicBinaryAnd(e1, o, e2)
@@ -978,7 +978,7 @@ algorithm
     // e or false => e
     case (_, Expression.BOOLEAN(false)) then exp1;
 
-    case (Expression.ARRAY(), Expression.ARRAY())
+    case (Expression.LIST(), Expression.LIST())
       algorithm
         o := Operator.unlift(op);
         expl := list(simplifyLogicBinaryAnd(e1, o, e2)
@@ -1071,7 +1071,7 @@ algorithm
     case (Type.REAL(), Expression.INTEGER())
       then Expression.REAL(intReal(exp.value));
 
-    case (Type.ARRAY(elementType = Type.REAL()), Expression.ARRAY())
+    case (Type.ARRAY(elementType = Type.REAL()), Expression.LIST())
       algorithm
         ety := Type.unliftArray(ty);
         exp.elements := list(simplifyCast(e, ety) for e in exp.elements);
@@ -1316,7 +1316,7 @@ algorithm
       exp.cref := cref;
     then addArgument(result, exp, inverse);
 
-    case (_, Expression.ARRAY()) algorithm
+    case (_, Expression.LIST()) algorithm
       exp.elements := list(combineBinariesExp(element) for element in exp.elements);
     then addArgument(result, exp, inverse);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -438,7 +438,7 @@ algorithm
       Expression e, e2;
       list<Expression> expl, expl1, expl2;
 
-    case (Expression.ARRAY(elements = expl1), Expression.ARRAY(elements = expl2))
+    case (Expression.LIST(elements = expl1), Expression.LIST(elements = expl2))
       algorithm
         expl := {};
 
@@ -572,7 +572,7 @@ protected
   Type ty;
 algorithm
   (outExp, outType) := match exp2
-    case Expression.ARRAY(elements = {})
+    case Expression.LIST(elements = {})
       algorithm
         try
           ty := Type.unliftArray(type2);
@@ -586,7 +586,7 @@ algorithm
       then
         (Expression.makeArray(outType, {}), outType);
 
-    case Expression.ARRAY(elements = expl)
+    case Expression.LIST(elements = expl)
       algorithm
         ty := Type.unliftArray(type2);
         expl := list(checkOverloadedBinaryScalarArray2(exp1, type1, var1, op, e, ty, var2, candidates, info) for e in expl);
@@ -633,7 +633,7 @@ protected
   Type ty;
 algorithm
   (outExp, outType) := match exp1
-    case Expression.ARRAY(elements = {})
+    case Expression.LIST(elements = {})
       algorithm
         try
           ty := Type.unliftArray(type1);
@@ -647,7 +647,7 @@ algorithm
       then
         (Expression.makeArray(outType, {}), outType);
 
-    case Expression.ARRAY(elements = expl)
+    case Expression.LIST(elements = expl)
       algorithm
         ty := Type.unliftArray(type1);
         expl := list(checkOverloadedBinaryArrayScalar2(e, ty, var1, op, exp2, type2, var2, candidates, info) for e in expl);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -720,7 +720,7 @@ protected
   Expression exp;
 algorithm
   dimExp := match dimExp
-    case Expression.ARRAY()
+    case Expression.LIST()
       guard Expression.arrayAllEqual(dimExp)
       then Expression.arrayFirstScalar(dimExp);
 
@@ -1173,7 +1173,7 @@ algorithm
       then
         (exp, exp.ty, Variability.CONSTANT, Purity.PURE);
 
-    case Expression.ARRAY()  then typeArray(exp.elements, context, info);
+    case Expression.LIST()   then typeArray(exp.elements, context, info);
     case Expression.MATRIX() then typeMatrix(exp.elements, context, info);
     case Expression.RANGE()  then typeRange(exp, context, info);
     case Expression.TUPLE()  then typeTuple(exp.elements, context, info);
@@ -1471,7 +1471,7 @@ protected
   list<Expression> expl;
 algorithm
   (outExp, ty, variability, purity) := match exp
-    case Expression.ARRAY()
+    case Expression.LIST()
       guard not listEmpty(splitSubs) and not listEmpty(exp.elements)
       algorithm
         expl := {};
@@ -1520,7 +1520,7 @@ algorithm
     // the dimension we need, to avoid introducing unnecessary cycles.
     (dim, error) := match exp
       // An untyped array, use typeArrayDim to get the dimension.
-      case Expression.ARRAY(ty = Type.UNKNOWN())
+      case Expression.LIST(ty = Type.UNKNOWN())
         then typeArrayDim(exp, dimIndex);
 
       // A cref, use typeCrefDim to get the dimension.
@@ -1602,12 +1602,12 @@ function typeArrayDim2
         output TypingError error;
 algorithm
   (dim, error) := match (arrayExp, dimIndex)
-    case (Expression.ARRAY(), 1)
+    case (Expression.LIST(), 1)
       then (Dimension.fromExpList(arrayExp.elements), TypingError.NO_ERROR());
 
     // Modelica arrays are non-ragged and only the last dimension of an array
     // expression can be empty, so just traverse into the first element.
-    case (Expression.ARRAY(), _)
+    case (Expression.LIST(), _)
       then typeArrayDim2(listHead(arrayExp.elements), dimIndex - 1, dimCount + 1);
 
     else
@@ -3419,7 +3419,7 @@ function checkWhenInitial
   output Boolean invalid;
 algorithm
   invalid := match condition
-    case Expression.ARRAY()
+    case Expression.LIST()
       algorithm
         for e in condition.elements loop
           if checkWhenInitial(e) then

--- a/OMCompiler/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
+++ b/OMCompiler/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
@@ -230,20 +230,20 @@ extern struct record_description NFExpression_NFExpression_TYPENAME__desc;
 #define NFExpression__TYPENAME_3dBOX1 10
 #define NFExpression__TYPENAME(ty) (mmc_mk_box2(10,&NFExpression_NFExpression_TYPENAME__desc,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
-#ifndef NFExpression_NFExpression_ARRAY__desc_added
-#define NFExpression_NFExpression_ARRAY__desc_added
-ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_ARRAY__desc__fields[3] = {"ty","elements","literal"};
-ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_ARRAY__desc = {
-  "NFExpression_NFExpression_ARRAY",
-  "NFExpression.NFExpression.ARRAY",
-  NFExpression_NFExpression_ARRAY__desc__fields
+#ifndef NFExpression_NFExpression_LIST__desc_added
+#define NFExpression_NFExpression_LIST__desc_added
+ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_LIST__desc__fields[3] = {"ty","elements","literal"};
+ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_LIST__desc = {
+  "NFExpression_NFExpression_LIST",
+  "NFExpression.NFExpression.LIST",
+  NFExpression_NFExpression_LIST__desc__fields
 };
 #endif
 #else /* Only use the file as a header */
-extern struct record_description NFExpression_NFExpression_ARRAY__desc;
+extern struct record_description NFExpression_NFExpression_LIST__desc;
 #endif
-#define NFExpression__ARRAY_3dBOX3 11
-#define NFExpression__ARRAY(ty,elements,literal) (mmc_mk_box4(11,&NFExpression_NFExpression_ARRAY__desc,ty,elements,literal))
+#define NFExpression__LIST_3dBOX3 11
+#define NFExpression__LIST(ty,elements,literal) (mmc_mk_box4(11,&NFExpression_NFExpression_LIST__desc,ty,elements,literal))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_MATRIX__desc_added
 #define NFExpression_NFExpression_MATRIX__desc_added
@@ -426,6 +426,21 @@ extern struct record_description NFExpression_NFExpression_RELATION__desc;
 #define NFExpression__RELATION_3dBOX3 23
 #define NFExpression__RELATION(exp1,operator,exp2) (mmc_mk_box4(23,&NFExpression_NFExpression_RELATION__desc,exp1,operator,exp2))
 #ifdef ADD_METARECORD_DEFINITIONS
+#ifndef NFExpression_NFExpression_MULTARY__desc_added
+#define NFExpression_NFExpression_MULTARY__desc_added
+ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_MULTARY__desc__fields[3] = {"arguments","inv_arguments","operator"};
+ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_MULTARY__desc = {
+  "NFExpression_NFExpression_MULTARY",
+  "NFExpression.NFExpression.MULTARY",
+  NFExpression_NFExpression_MULTARY__desc__fields
+};
+#endif
+#else /* Only use the file as a header */
+extern struct record_description NFExpression_NFExpression_MULTARY__desc;
+#endif
+#define NFExpression__MULTARY_3dBOX3 24
+#define NFExpression__MULTARY(arguments,inv_arguments,operator) (mmc_mk_box4(24,&NFExpression_NFExpression_MULTARY__desc,arguments,inv_arguments,operator))
+#ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_IF__desc_added
 #define NFExpression_NFExpression_IF__desc_added
 ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_IF__desc__fields[4] = {"ty","condition","trueBranch","falseBranch"};
@@ -438,8 +453,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_I
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_IF__desc;
 #endif
-#define NFExpression__IF_3dBOX4 24
-#define NFExpression__IF(ty,condition,trueBranch,falseBranch) (mmc_mk_box5(24,&NFExpression_NFExpression_IF__desc,ty,condition,trueBranch,falseBranch))
+#define NFExpression__IF_3dBOX4 25
+#define NFExpression__IF(ty,condition,trueBranch,falseBranch) (mmc_mk_box5(25,&NFExpression_NFExpression_IF__desc,ty,condition,trueBranch,falseBranch))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_CAST__desc_added
 #define NFExpression_NFExpression_CAST__desc_added
@@ -453,8 +468,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_C
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_CAST__desc;
 #endif
-#define NFExpression__CAST_3dBOX2 25
-#define NFExpression__CAST(ty,exp) (mmc_mk_box3(25,&NFExpression_NFExpression_CAST__desc,ty,exp))
+#define NFExpression__CAST_3dBOX2 26
+#define NFExpression__CAST(ty,exp) (mmc_mk_box3(26,&NFExpression_NFExpression_CAST__desc,ty,exp))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_BOX__desc_added
 #define NFExpression_NFExpression_BOX__desc_added
@@ -468,8 +483,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_B
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_BOX__desc;
 #endif
-#define NFExpression__BOX_3dBOX1 26
-#define NFExpression__BOX(exp) (mmc_mk_box2(26,&NFExpression_NFExpression_BOX__desc,exp))
+#define NFExpression__BOX_3dBOX1 27
+#define NFExpression__BOX(exp) (mmc_mk_box2(27,&NFExpression_NFExpression_BOX__desc,exp))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_UNBOX__desc_added
 #define NFExpression_NFExpression_UNBOX__desc_added
@@ -483,12 +498,12 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_U
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_UNBOX__desc;
 #endif
-#define NFExpression__UNBOX_3dBOX2 27
-#define NFExpression__UNBOX(exp,ty) (mmc_mk_box3(27,&NFExpression_NFExpression_UNBOX__desc,exp,ty))
+#define NFExpression__UNBOX_3dBOX2 28
+#define NFExpression__UNBOX(exp,ty) (mmc_mk_box3(28,&NFExpression_NFExpression_UNBOX__desc,exp,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_SUBSCRIPTED__EXP__desc_added
 #define NFExpression_NFExpression_SUBSCRIPTED__EXP__desc_added
-ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_SUBSCRIPTED__EXP__desc__fields[3] = {"exp","subscripts","ty"};
+ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_SUBSCRIPTED__EXP__desc__fields[4] = {"exp","subscripts","ty","split"};
 ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_SUBSCRIPTED__EXP__desc = {
   "NFExpression_NFExpression_SUBSCRIPTED__EXP",
   "NFExpression.NFExpression.SUBSCRIPTED_EXP",
@@ -498,8 +513,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_S
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_SUBSCRIPTED__EXP__desc;
 #endif
-#define NFExpression__SUBSCRIPTED_5fEXP_3dBOX3 28
-#define NFExpression__SUBSCRIPTED_5fEXP(exp,subscripts,ty) (mmc_mk_box4(28,&NFExpression_NFExpression_SUBSCRIPTED__EXP__desc,exp,subscripts,ty))
+#define NFExpression__SUBSCRIPTED_5fEXP_3dBOX4 29
+#define NFExpression__SUBSCRIPTED_5fEXP(exp,subscripts,ty,split) (mmc_mk_box5(29,&NFExpression_NFExpression_SUBSCRIPTED__EXP__desc,exp,subscripts,ty,split))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_TUPLE__ELEMENT__desc_added
 #define NFExpression_NFExpression_TUPLE__ELEMENT__desc_added
@@ -513,8 +528,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_T
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_TUPLE__ELEMENT__desc;
 #endif
-#define NFExpression__TUPLE_5fELEMENT_3dBOX3 29
-#define NFExpression__TUPLE_5fELEMENT(tupleExp,index,ty) (mmc_mk_box4(29,&NFExpression_NFExpression_TUPLE__ELEMENT__desc,tupleExp,index,ty))
+#define NFExpression__TUPLE_5fELEMENT_3dBOX3 30
+#define NFExpression__TUPLE_5fELEMENT(tupleExp,index,ty) (mmc_mk_box4(30,&NFExpression_NFExpression_TUPLE__ELEMENT__desc,tupleExp,index,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_RECORD__ELEMENT__desc_added
 #define NFExpression_NFExpression_RECORD__ELEMENT__desc_added
@@ -528,8 +543,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_R
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_RECORD__ELEMENT__desc;
 #endif
-#define NFExpression__RECORD_5fELEMENT_3dBOX4 30
-#define NFExpression__RECORD_5fELEMENT(recordExp,index,fieldName,ty) (mmc_mk_box5(30,&NFExpression_NFExpression_RECORD__ELEMENT__desc,recordExp,index,fieldName,ty))
+#define NFExpression__RECORD_5fELEMENT_3dBOX4 31
+#define NFExpression__RECORD_5fELEMENT(recordExp,index,fieldName,ty) (mmc_mk_box5(31,&NFExpression_NFExpression_RECORD__ELEMENT__desc,recordExp,index,fieldName,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_MUTABLE__desc_added
 #define NFExpression_NFExpression_MUTABLE__desc_added
@@ -543,8 +558,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_M
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_MUTABLE__desc;
 #endif
-#define NFExpression__MUTABLE_3dBOX1 31
-#define NFExpression__MUTABLE(exp) (mmc_mk_box2(31,&NFExpression_NFExpression_MUTABLE__desc,exp))
+#define NFExpression__MUTABLE_3dBOX1 32
+#define NFExpression__MUTABLE(exp) (mmc_mk_box2(32,&NFExpression_NFExpression_MUTABLE__desc,exp))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_EMPTY__desc_added
 #define NFExpression_NFExpression_EMPTY__desc_added
@@ -558,8 +573,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_E
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_EMPTY__desc;
 #endif
-#define NFExpression__EMPTY_3dBOX1 32
-#define NFExpression__EMPTY(ty) (mmc_mk_box2(32,&NFExpression_NFExpression_EMPTY__desc,ty))
+#define NFExpression__EMPTY_3dBOX1 33
+#define NFExpression__EMPTY(ty) (mmc_mk_box2(33,&NFExpression_NFExpression_EMPTY__desc,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_PARTIAL__FUNCTION__APPLICATION__desc_added
 #define NFExpression_NFExpression_PARTIAL__FUNCTION__APPLICATION__desc_added
@@ -573,23 +588,8 @@ ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_P
 #else /* Only use the file as a header */
 extern struct record_description NFExpression_NFExpression_PARTIAL__FUNCTION__APPLICATION__desc;
 #endif
-#define NFExpression__PARTIAL_5fFUNCTION_5fAPPLICATION_3dBOX4 33
-#define NFExpression__PARTIAL_5fFUNCTION_5fAPPLICATION(fn,args,argNames,ty) (mmc_mk_box5(33,&NFExpression_NFExpression_PARTIAL__FUNCTION__APPLICATION__desc,fn,args,argNames,ty))
-#ifdef ADD_METARECORD_DEFINITIONS
-#ifndef NFExpression_NFExpression_BINDING__EXP__desc_added
-#define NFExpression_NFExpression_BINDING__EXP__desc_added
-ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_BINDING__EXP__desc__fields[5] = {"exp","expType","bindingType","parents","isEach"};
-ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_BINDING__EXP__desc = {
-  "NFExpression_NFExpression_BINDING__EXP",
-  "NFExpression.NFExpression.BINDING_EXP",
-  NFExpression_NFExpression_BINDING__EXP__desc__fields
-};
-#endif
-#else /* Only use the file as a header */
-extern struct record_description NFExpression_NFExpression_BINDING__EXP__desc;
-#endif
-#define NFExpression__BINDING_5fEXP_3dBOX5 34
-#define NFExpression__BINDING_5fEXP(exp,expType,bindingType,parents,isEach) (mmc_mk_box6(34,&NFExpression_NFExpression_BINDING__EXP__desc,exp,expType,bindingType,parents,isEach))
+#define NFExpression__PARTIAL_5fFUNCTION_5fAPPLICATION_3dBOX4 34
+#define NFExpression__PARTIAL_5fFUNCTION_5fAPPLICATION(fn,args,argNames,ty) (mmc_mk_box5(34,&NFExpression_NFExpression_PARTIAL__FUNCTION__APPLICATION__desc,fn,args,argNames,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFType_NFType_INTEGER__desc_added
 #define NFType_NFType_INTEGER__desc_added

--- a/OMCompiler/Compiler/runtime/ffi_omc.c
+++ b/OMCompiler/Compiler/runtime/ffi_omc.c
@@ -101,7 +101,7 @@ void* increment_ptr(void *ptr, size_t bytes)
 static int is_exp_pointer_type(void *exp)
 {
   switch (MMC_HDRCTOR(MMC_GETHDR(exp))) {
-    case NFExpression__ARRAY_3dBOX3: return 1;
+    case NFExpression__LIST_3dBOX3: return 1;
     case NFExpression__RECORD_3dBOX3: return 1;
   }
 
@@ -170,7 +170,7 @@ static ffi_type* exp_alignment_and_type(void *exp, struct Alignment *align, int 
       align->size = sizeof(char*);
       return &ffi_type_pointer;
 
-    case NFExpression__ARRAY_3dBOX3: {
+    case NFExpression__LIST_3dBOX3: {
       align->size = sizeof(void*);
       void *elems = MMC_STRUCTDATA(exp)[UNBOX_OFFSET+1];
 
@@ -255,7 +255,7 @@ static size_t size_of_exp(void *exp, struct Alignment *align)
     case NFExpression__STRING_3dBOX1:
       return sizeof(char*);
 
-    case NFExpression__ARRAY_3dBOX3:
+    case NFExpression__LIST_3dBOX3:
       return size_of_type(MMC_STRUCTDATA(exp)[UNBOX_OFFSET]);
 
     case NFExpression__RECORD_3dBOX3:
@@ -357,7 +357,7 @@ static void* mk_array_exp_2(void *arr, void *type, mk_exp_fn_t mkExpFn,
     }
   }
 
-  return NFExpression__ARRAY(type, elems, mmc_mk_icon(1));
+  return NFExpression__LIST(type, elems, mmc_mk_icon(1));
 }
 
 /* Constructs an array expression given a C array and the expected type of the array */
@@ -431,7 +431,7 @@ static void* mk_exp_from_arg(void *arg, void *value, struct Alignment *align)
     case NFExpression__ENUM_5fLITERAL_3dBOX3:
       return mk_enum_exp(value, MMC_STRUCTDATA(arg)[UNBOX_OFFSET]);
 
-    case NFExpression__ARRAY_3dBOX3:
+    case NFExpression__LIST_3dBOX3:
       return mk_array_exp(value, MMC_STRUCTDATA(arg)[UNBOX_OFFSET]);
 
     case NFExpression__RECORD_3dBOX3:
@@ -507,7 +507,7 @@ static void* write_exp_value(void *exp, void *ptr, struct Alignment *align)
       *(int*)ptr = MMC_UNTAGFIXNUM(MMC_STRUCTDATA(exp)[UNBOX_OFFSET+2]);
       return ((int*)ptr)+1;
 
-    case NFExpression__ARRAY_3dBOX3: {
+    case NFExpression__LIST_3dBOX3: {
       void *elems = MMC_STRUCTDATA(exp)[UNBOX_OFFSET+1];
 
       while (!listEmpty(elems)) {


### PR DESCRIPTION
- Rename NFExpression.ARRAY to NFExpression.LIST in order to prepare for
  adding an array expression based on actual arrays and not lists.
- Move NFExpression.MULTARY to where it should be.
- Update the bootstrapping header and ffi interface to reflect the
  NFExpression changes made.