### PR TITLE
Improve checking of protected modifications

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -1277,9 +1277,9 @@ algorithm
           for node_ptr in node_ptrs loop
             node := InstNode.resolveOuter(Mutable.access(node_ptr));
 
-            if InstNode.isProtected(node) and not InstNode.isExtends(parent) then
-              Error.addSourceMessage(Error.NF_MODIFY_PROTECTED,
-                {InstNode.name(node), Modifier.toString(mod)}, InstNode.info(node));
+            if InstNode.isProtected(node) and not (InstNode.isExtends(parent) or InstNode.isBaseClass(parent)) then
+              Error.addMultiSourceMessage(Error.NF_MODIFY_PROTECTED,
+                {InstNode.name(node), Modifier.toString(mod)}, {Modifier.info(mod), InstNode.info(node)});
               fail();
             end if;
 

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -873,10 +873,10 @@ PropagateExtends.mo \
 ProtectedMod1.mo \
 ProtectedMod2.mo \
 ProtectedMod3.mo \
-ProtectedMod4.mo \
 ProtectedMod5.mo \
 ProtectedMod6.mo \
 ProtectedMod7.mo \
+ProtectedMod8.mo \
 RangeInvalidStep1.mo \
 RangeInvalidStep2.mo \
 RangeInvalidStep3.mo \
@@ -1093,6 +1093,7 @@ sts.mos \
 # test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=\
+ProtectedMod4.mo \
 CevalFuncRecord3.mo \
 CevalFuncRecord4.mo \
 FinalParameter1.mo \

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod1.mo
@@ -15,6 +15,7 @@ end ProtectedMod1;
 
 // Result:
 // Error processing file: ProtectedMod1.mo
+// [flattening/modelica/scodeinst/ProtectedMod1.mo:13:7-13:14:writable] Notification: From here:
 // [flattening/modelica/scodeinst/ProtectedMod1.mo:9:13-9:25:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 2.0‘.
 //
 // # Error encountered! Exiting...

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod3.mo
@@ -19,6 +19,7 @@ end ProtectedMod3;
 
 // Result:
 // Error processing file: ProtectedMod3.mo
+// [flattening/modelica/scodeinst/ProtectedMod3.mo:17:15-17:22:writable] Notification: From here:
 // [flattening/modelica/scodeinst/ProtectedMod3.mo:9:13-9:25:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 2.0‘.
 //
 // # Error encountered! Exiting...

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod6.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod6.mo
@@ -20,6 +20,7 @@ end ProtectedMod6;
 
 // Result:
 // Error processing file: ProtectedMod6.mo
+// [flattening/modelica/scodeinst/ProtectedMod6.mo:18:7-18:14:writable] Notification: From here:
 // [flattening/modelica/scodeinst/ProtectedMod6.mo:9:3-9:15:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 2.0‘.
 //
 // # Error encountered! Exiting...

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod8.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod8.mo
@@ -1,0 +1,23 @@
+// name: ProtectedMod8
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+model A
+protected
+  Real x = 1.0;
+end A;
+
+model B = A(x = 2.0);
+
+model ProtectedMod8
+  B b;
+end ProtectedMod8;
+
+// Result:
+// class ProtectedMod8
+//   protected Real b.x = 2.0;
+// end ProtectedMod8;
+// endResult


### PR DESCRIPTION
- Add the source location of the modifier to the error message, to make
  it easier to see why the error occured.
- Allow modification of protected elements in base classes even in cases
  where it shouldn't be allowed, since we can't correctly detect those
  cases yet.