### PR TITLE
Fix simplification of `array or array`

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -981,7 +981,7 @@ algorithm
     case (Expression.LIST(), Expression.LIST())
       algorithm
         o := Operator.unlift(op);
-        expl := list(simplifyLogicBinaryAnd(e1, o, e2)
+        expl := list(simplifyLogicBinaryOr(e1, o, e2)
                      threaded for e1 in exp1.elements, e2 in exp2.elements);
       then
         Expression.makeArray(Operator.typeOf(op), expl);

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -812,6 +812,7 @@ OperationAddEW1.mo \
 OperationDiv1.mo \
 OperationDivEW1.mo \
 OperationLogicalBinary1.mo \
+OperationLogicalBinary2.mo \
 OperationLogicalUnary1.mo \
 OperationLogicalUnary2.mo \
 OperationMatrixProduct1.mo \

--- a/testsuite/flattening/modelica/scodeinst/OperationLogicalBinary2.mo
+++ b/testsuite/flattening/modelica/scodeinst/OperationLogicalBinary2.mo
@@ -1,0 +1,26 @@
+// name: OperationLogicalBinary2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model OperationLogicalBinary2
+  Boolean b1[:] = {false, false, true, true} or {true, false, true, false};
+  Boolean b2[:] = {false, false, true, true} and {true, false, true, false};
+end OperationLogicalBinary2;
+
+// Result:
+// class OperationLogicalBinary2
+//   Boolean b1[1];
+//   Boolean b1[2];
+//   Boolean b1[3];
+//   Boolean b1[4];
+//   Boolean b2[1];
+//   Boolean b2[2];
+//   Boolean b2[3];
+//   Boolean b2[4];
+// equation
+//   b1 = {true, false, true, true};
+//   b2 = {false, false, true, false};
+// end OperationLogicalBinary2;
+// endResult


### PR DESCRIPTION
- Fix simplification of `array or array`, which was calling the wrong
  function and doing `and` instead of `or`.