### PR TITLE
Implement array expression using arrays

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBBackendUtil.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBBackendUtil.mo
@@ -522,7 +522,7 @@ public
         var := BVariable.getVar(exp.cref);
       then stringHashDjb2Mod(BackendExtension.BackendInfo.toString(var.backendinfo), mod);
       case Expression.TYPENAME() then 1; // ty !!
-      case Expression.LIST() algorithm // ty !!
+      case Expression.ARRAY() algorithm // ty !!
         for elem in exp.elements loop
           hash := hash + noNameHashExp(elem, mod);
         end for;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -61,6 +61,7 @@ public
   import BVariable = NBVariable;
 
   // Util imports
+  import Array;
   import Error;
   import UnorderedMap;
 
@@ -339,6 +340,7 @@ public
       Expression elem1, elem2;
       list<Expression> new_elements = {};
       list<list<Expression>> new_matrix_elements = {};
+      array<Expression> arr;
 
     // differentiation of constant expressions results in zero
     case Expression.INTEGER()   then (Expression.INTEGER(0), diffArguments);
@@ -351,12 +353,10 @@ public
     case Expression.CREF() then differentiateComponentRef(exp, diffArguments);
 
     // [a, b, c, ...]' = [a', b', c', ...]
-    case Expression.LIST() algorithm
-      for element in exp.elements loop
-        (element, diffArguments) := differentiateExpression(element, diffArguments);
-        new_elements := element :: new_elements;
-      end for;
-    then (Expression.LIST(exp.ty, listReverse(new_elements), exp.literal), diffArguments);
+    case Expression.ARRAY() algorithm
+      (arr, diffArguments) := Array.mapFold(exp.elements, differentiateExpression, diffArguments);
+      exp.elements := arr;
+    then (exp, diffArguments);
 
     // |a, b, c|'   |a', b', c'|
     // |d, e, f|  = |d', e', f'|

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -66,6 +66,7 @@ protected
   import NFPrefixes.ConnectorType;
   import ClockKind = NFClockKind;
   import Structural = NFStructural;
+  import Array;
 
 public
   function needSpecialHandling
@@ -208,7 +209,7 @@ public
       fail();
     end if;
 
-    arrayExp := Expression.makeArray(Type.UNKNOWN(), posArgs);
+    arrayExp := Expression.makeArray(Type.UNKNOWN(), listArray(posArgs));
   end makeArrayExp;
 
   function makeCatExp
@@ -2024,9 +2025,10 @@ protected
         then
           Expression.CALL(Call.makeTypedCall(fn, {arg}, var, Purity.IMPURE, arg.ty));
 
-      case Expression.LIST()
+      case Expression.ARRAY()
         algorithm
-          arg.elements := list(typeActualInStreamCall2(name, fn, e, var, info) for e in arg.elements);
+          arg.elements := Array.map(arg.elements, function
+            typeActualInStreamCall2(name = name, fn = fn, var = var, info = info));
         then
           arg;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -1138,7 +1138,7 @@ public
 
       case UNTYPED_CALL()
         algorithm
-          res := Expression.listContainsShallow(call.arguments, func);
+          res := List.exist(call.arguments, func);
 
           if not res then
             for arg in call.named_args loop
@@ -1171,7 +1171,7 @@ public
         then
           false;
 
-      case TYPED_CALL() then Expression.listContainsShallow(call.arguments, func);
+      case TYPED_CALL() then List.exist(call.arguments, func);
       case UNTYPED_ARRAY_CONSTRUCTOR() then func(call.exp);
       case TYPED_ARRAY_CONSTRUCTOR() then func(call.exp);
       case UNTYPED_REDUCTION() then func(call.exp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -68,6 +68,8 @@ import Flags;
 import Prefixes = NFPrefixes;
 import UnorderedMap;
 import ErrorExt;
+import Array;
+import Vector;
 
 public
 uniontype EvalTarget
@@ -173,7 +175,6 @@ algorithm
       InstNode c;
       Binding binding;
       Expression exp1, exp2, exp3;
-      list<Expression> expl = {};
       Call call;
       Component comp;
       Option<Expression> oexp;
@@ -186,11 +187,11 @@ algorithm
     case Expression.TYPENAME()
       then evalTypename(exp.ty, exp, target);
 
-    case Expression.LIST()
+    case Expression.ARRAY()
       then if exp.literal then exp
            else
              Expression.makeArray(exp.ty,
-               list(evalExp(e, target) for e in exp.elements),
+               Array.map(exp.elements, function evalExp(target = target)),
                literal = true);
 
     case Expression.RANGE() then evalRange(exp, target);
@@ -890,7 +891,7 @@ algorithm
   end if;
 
   exp := Expression.makeArray(Type.ARRAY(ty, {Dimension.fromInteger(listLength(expl))}),
-                              expl, literal = true);
+                              listArray(expl), literal = true);
 end evalRangeExp;
 
 function evalRangeReal
@@ -1003,10 +1004,10 @@ algorithm
     case (Expression.STRING(), Expression.STRING())
       then Expression.STRING(exp1.value + exp2.value);
 
-    case (Expression.LIST(), Expression.LIST())
-      guard listLength(exp1.elements) == listLength(exp2.elements)
+    case (Expression.ARRAY(), Expression.ARRAY())
+      guard arrayLength(exp1.elements) == arrayLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
-        list(evalBinaryAdd(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
+        Array.threadMap(exp1.elements, exp2.elements, evalBinaryAdd),
         literal = true);
 
     else
@@ -1030,10 +1031,10 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value - exp2.value);
 
-    case (Expression.LIST(), Expression.LIST())
-      guard listLength(exp1.elements) == listLength(exp2.elements)
+    case (Expression.ARRAY(), Expression.ARRAY())
+      guard arrayLength(exp1.elements) == arrayLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
-        list(evalBinarySub(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
+        Array.threadMap(exp1.elements, exp2.elements, evalBinarySub),
         literal = true);
 
     else
@@ -1057,10 +1058,10 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value * exp2.value);
 
-    case (Expression.LIST(), Expression.LIST())
-      guard listLength(exp1.elements) == listLength(exp2.elements)
+    case (Expression.ARRAY(), Expression.ARRAY())
+      guard arrayLength(exp1.elements) == arrayLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
-        list(evalBinaryMul(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
+        Array.threadMap(exp1.elements, exp2.elements, evalBinaryMul),
         literal = true);
 
     else
@@ -1094,10 +1095,10 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value / exp2.value);
 
-    case (Expression.LIST(), Expression.LIST())
-      guard listLength(exp1.elements) == listLength(exp2.elements)
+    case (Expression.ARRAY(), Expression.ARRAY())
+      guard arrayLength(exp1.elements) == arrayLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
-        list(evalBinaryDiv(e1, e2, target) threaded for e1 in exp1.elements, e2 in exp2.elements),
+        Array.threadMap(exp1.elements, exp2.elements, function evalBinaryDiv(target = target)),
         literal = true);
 
     else
@@ -1118,10 +1119,10 @@ algorithm
     case (Expression.REAL(), Expression.REAL())
       then Expression.REAL(exp1.value ^ exp2.value);
 
-    case (Expression.LIST(), Expression.LIST())
-      guard listLength(exp1.elements) == listLength(exp2.elements)
+    case (Expression.ARRAY(), Expression.ARRAY())
+      guard arrayLength(exp1.elements) == arrayLength(exp2.elements)
       then Expression.makeArray(exp1.ty,
-        list(evalBinaryPow(e1, e2) threaded for e1 in exp1.elements, e2 in exp2.elements),
+        Array.threadMap(exp1.elements, exp2.elements, evalBinaryPow),
         literal = true);
 
     else
@@ -1146,9 +1147,9 @@ function evalBinaryScalarArray
   end FuncT;
 algorithm
   exp := match arrayExp
-    case Expression.LIST()
+    case Expression.ARRAY()
       then Expression.makeArray(arrayExp.ty,
-        list(evalBinaryScalarArray(scalarExp, e, opFunc) for e in arrayExp.elements),
+        Array.map(arrayExp.elements, function evalBinaryScalarArray(scalarExp = scalarExp, opFunc = opFunc)),
         literal = true);
 
     else opFunc(scalarExp, arrayExp);
@@ -1168,9 +1169,9 @@ function evalBinaryArrayScalar
   end FuncT;
 algorithm
   exp := match arrayExp
-    case Expression.LIST()
+    case Expression.ARRAY()
       then Expression.makeArray(arrayExp.ty,
-        list(evalBinaryArrayScalar(e, scalarExp, opFunc) for e in arrayExp.elements),
+        Array.map(arrayExp.elements, function evalBinaryArrayScalar(scalarExp = scalarExp, opFunc = opFunc)),
         literal = true);
 
     else opFunc(arrayExp, scalarExp);
@@ -1182,16 +1183,16 @@ function evalBinaryMulVectorMatrix
   input Expression matrixExp;
   output Expression exp;
 protected
-  list<Expression> expl;
   Dimension m;
   Type ty;
+  array<Expression> arr;
 algorithm
   exp := match Expression.transposeArray(matrixExp)
-    case Expression.LIST(Type.ARRAY(ty, {m, _}), expl)
+    case Expression.ARRAY(Type.ARRAY(ty, {m, _}), arr)
       algorithm
-        expl := list(evalBinaryScalarProduct(vectorExp, e) for e in expl);
+        arr := Array.map(arr, function evalBinaryScalarProduct(exp1 = vectorExp));
       then
-        Expression.makeArray(Type.ARRAY(ty, {m}), expl, literal = true);
+        Expression.makeArray(Type.ARRAY(ty, {m}), arr, literal = true);
 
     else
       algorithm
@@ -1208,16 +1209,16 @@ function evalBinaryMulMatrixVector
   input Expression vectorExp;
   output Expression exp;
 protected
-  list<Expression> expl;
   Dimension n;
   Type ty;
+  array<Expression> arr;
 algorithm
   exp := match matrixExp
-    case Expression.LIST(Type.ARRAY(ty, {n, _}), expl)
+    case Expression.ARRAY(Type.ARRAY(ty, {n, _}), arr)
       algorithm
-        expl := list(evalBinaryScalarProduct(e, vectorExp) for e in expl);
+        arr := Array.map(arr, function evalBinaryScalarProduct(exp2 = vectorExp));
       then
-        Expression.makeArray(Type.ARRAY(ty, {n}), expl, literal = true);
+        Expression.makeArray(Type.ARRAY(ty, {n}), arr, literal = true);
 
     else
       algorithm
@@ -1240,15 +1241,15 @@ algorithm
       Expression e2;
       list<Expression> rest_e2;
 
-    case (Expression.LIST(ty = Type.ARRAY(elem_ty)), Expression.LIST())
-      guard listLength(exp1.elements) == listLength(exp2.elements)
+    case (Expression.ARRAY(ty = Type.ARRAY(elem_ty)), Expression.ARRAY())
+      guard arrayLength(exp1.elements) == arrayLength(exp2.elements)
       algorithm
         exp := Expression.makeZero(elem_ty);
-        rest_e2 := exp2.elements;
 
-        for e1 in exp1.elements loop
-          e2 :: rest_e2 := rest_e2;
-          exp := evalBinaryAdd(exp, evalBinaryMul(e1, e2));
+        for i in 1:arrayLength(exp1.elements) loop
+          exp := evalBinaryAdd(exp,
+            evalBinaryMul(arrayGetNoBoundsChecking(exp1.elements, i),
+                          arrayGetNoBoundsChecking(exp2.elements, i)));
         end for;
       then
         exp;
@@ -1272,22 +1273,30 @@ protected
   list<Expression> expl1, expl2;
   Type elem_ty, row_ty, mat_ty;
   Dimension n, p;
+  array<Expression> arr1, arr2, arr;
 algorithm
   e2 := Expression.transposeArray(exp2);
 
   exp := match (exp1, e2)
-    case (Expression.LIST(Type.ARRAY(elem_ty, {n, _}), expl1),
-          Expression.LIST(Type.ARRAY(_, {p, _}), expl2))
+    case (Expression.ARRAY(Type.ARRAY(elem_ty, {n, _}), arr1),
+          Expression.ARRAY(Type.ARRAY(_, {p, _}), arr2))
       algorithm
         mat_ty := Type.ARRAY(elem_ty, {n, p});
 
-        if listEmpty(expl2) then
+        if arrayEmpty(arr2) then
           exp := Expression.makeZero(mat_ty);
         else
           row_ty := Type.ARRAY(elem_ty, {p});
-          expl1 := list(Expression.makeArray(row_ty,
-            list(evalBinaryScalarProduct(r, c) for c in expl2), literal = true) for r in expl1);
-          exp := Expression.makeArray(mat_ty, expl1, literal = true);
+          arr := arrayCreateNoInit(arrayLength(arr1), exp1);
+
+          for i in 1:arrayLength(arr1) loop
+            arrayUpdateNoBoundsChecking(arr, i,
+                Expression.makeArray(row_ty,
+                  Array.map(arr2, function evalBinaryScalarProduct(exp1 = arrayGetNoBoundsChecking(arr1, i))),
+                  literal = true));
+          end for;
+
+          exp := Expression.makeArray(mat_ty, arr, literal = true);
         end if;
       then
         exp;
@@ -1309,14 +1318,14 @@ function evalBinaryPowMatrix
 protected
   Integer n;
 algorithm
-  exp := match (matrixExp, nExp)
-    case (Expression.LIST(), Expression.INTEGER(value = 0))
+  exp := match nExp
+    case Expression.INTEGER(value = 0)
       algorithm
-        n := Dimension.size(listHead(Type.arrayDims(matrixExp.ty)));
+        n := Dimension.size(listHead(Type.arrayDims(Expression.typeOf(matrixExp))));
       then
         Expression.makeIdentityMatrix(n, Type.REAL());
 
-    case (_, Expression.INTEGER(value = n))
+    case Expression.INTEGER(value = n)
       then evalBinaryPowMatrix2(matrixExp, n);
 
     else
@@ -1382,9 +1391,10 @@ algorithm
   exp := match exp1
     case Expression.INTEGER() then Expression.INTEGER(-exp1.value);
     case Expression.REAL() then Expression.REAL(-exp1.value);
-    case Expression.LIST()
+
+    case Expression.ARRAY()
       algorithm
-        exp1.elements := list(evalUnaryMinus(e) for e in exp1.elements);
+        exp1.elements := Array.map(exp1.elements, evalUnaryMinus);
       then
         exp1;
 
@@ -1447,18 +1457,17 @@ function evalLogicBinaryAnd
 algorithm
   exp := matchcontinue exp1
     local
-      list<Expression> expl;
+      array<Expression> arr;
 
     case Expression.BOOLEAN()
       then if exp1.value then evalExp(exp2, target) else exp1;
 
-    case Expression.LIST()
+    case Expression.ARRAY()
       algorithm
-        Expression.LIST(elements = expl) := evalExp(exp2, target);
-        expl := list(evalLogicBinaryAnd(e1, e2, target)
-                     threaded for e1 in exp1.elements, e2 in expl);
+        Expression.ARRAY(elements = arr) := evalExp(exp2, target);
+        arr := Array.threadMap(exp1.elements, arr, function evalLogicBinaryAnd(target = target));
       then
-        Expression.makeArray(Type.setArrayElementType(exp1.ty, Type.BOOLEAN()), expl, literal = true);
+        Expression.makeArray(Type.setArrayElementType(exp1.ty, Type.BOOLEAN()), arr, literal = true);
 
     else
       algorithm
@@ -1477,18 +1486,17 @@ function evalLogicBinaryOr
 algorithm
   exp := match exp1
     local
-      list<Expression> expl;
+      array<Expression> arr;
 
     case Expression.BOOLEAN()
       then if exp1.value then exp1 else evalExp(exp2, target);
 
-    case Expression.LIST()
+    case Expression.ARRAY()
       algorithm
-        Expression.LIST(elements = expl) := evalExp(exp2, target);
-        expl := list(evalLogicBinaryOr(e1, e2, target)
-                     threaded for e1 in exp1.elements, e2 in expl);
+        Expression.ARRAY(elements = arr) := evalExp(exp2, target);
+        arr := Array.threadMap(exp1.elements, arr, function evalLogicBinaryOr(target = target));
       then
-        Expression.makeArray(Type.setArrayElementType(exp1.ty, Type.BOOLEAN()), expl, literal = true);
+        Expression.makeArray(Type.setArrayElementType(exp1.ty, Type.BOOLEAN()), arr, literal = true);
 
     else
       algorithm
@@ -1521,7 +1529,7 @@ function evalLogicUnaryNot
 algorithm
   exp := match exp1
     case Expression.BOOLEAN() then Expression.BOOLEAN(not exp1.value);
-    case Expression.LIST() then Expression.mapArrayElements(exp1, evalLogicUnaryNot);
+    case Expression.ARRAY() then Expression.mapArrayElements(exp1, evalLogicUnaryNot);
 
     else
       algorithm
@@ -1895,7 +1903,7 @@ algorithm
     case "product" then evalBuiltinProduct(listHead(args));
     case "promote" then evalBuiltinPromote(listGet(args,1),listGet(args,2));
     case "rem" then evalBuiltinRem(args, target);
-    case "scalar" then evalBuiltinScalar(args);
+    case "scalar" then evalBuiltinScalar(listHead(args));
     case "sign" then evalBuiltinSign(listHead(args));
     case "sinh" then evalBuiltinSinh(listHead(args));
     case "sin" then evalBuiltinSin(listHead(args));
@@ -1994,7 +2002,7 @@ protected
 algorithm
   ty := Expression.typeOf(listHead(args));
   ty := Type.liftArrayLeft(ty, Dimension.fromInteger(listLength(args)));
-  result := Expression.makeArray(ty, args, literal = true);
+  result := Expression.makeArray(ty, listArray(args), literal = true);
 end evalBuiltinArray;
 
 function evalBuiltinAsin
@@ -2076,7 +2084,7 @@ algorithm
   elseif sz == 1 then
     result := listHead(es);
   else
-    (es,dims) := ExpressionSimplify.evalCat(n, es, getArrayContents=Expression.arrayElements, toString=Expression.toString);
+    (es,dims) := ExpressionSimplify.evalCat(n, es, getArrayContents=Expression.arrayElementList, toString=Expression.toString);
     result := Expression.arrayFromList(es, Expression.typeOf(listHead(es)), list(Dimension.fromInteger(d) for d in dims));
   end if;
 end evalBuiltinCat;
@@ -2123,42 +2131,35 @@ function evalBuiltinDiagonal
   output Expression result;
 protected
   Type elem_ty, row_ty;
-  Expression zero;
+  Expression zero, exp;
   list<Expression> elems, row, rows = {};
   Integer n, i = 1;
   Boolean e_lit, arg_lit = true;
+  array<Expression> arr_zero, arr_row, arr_rows;
 algorithm
   result := match arg
-    case Expression.LIST(elements = {}) then arg;
+    case Expression.ARRAY() guard arrayEmpty(arg.elements) then arg;
 
-    case Expression.LIST(elements = elems)
+    case Expression.ARRAY()
       algorithm
-        n := listLength(elems);
-
-        elem_ty := Expression.typeOf(listHead(elems));
+        n := arrayLength(arg.elements);
+        elem_ty := Type.unliftArray(arg.ty);
         row_ty := Type.liftArrayLeft(elem_ty, Dimension.fromInteger(n));
         zero := Expression.makeZero(elem_ty);
+        arr_zero := arrayCreate(n, zero);
+        arr_rows := arrayCreateNoInit(n, zero);
 
-        for e in listReverse(elems) loop
-          row := {};
-
-          for j in 2:i loop
-            row := zero :: row;
-          end for;
-
-          row := e :: row;
-          e_lit := Expression.isLiteral(e);
+        for i in 1:n loop
+          arr_row := arrayCopy(arr_zero);
+          exp := arrayGetNoBoundsChecking(arg.elements, i);
+          e_lit := Expression.isLiteral(exp);
           arg_lit := arg_lit and e_lit;
-
-          for j in i:n-1 loop
-            row := zero :: row;
-          end for;
-
-          i := i + 1;
-          rows := Expression.makeArray(row_ty, row, e_lit) :: rows;
+          arrayUpdateNoBoundsChecking(arr_row, i, exp);
+          exp := Expression.makeArray(row_ty, arr_row, e_lit);
+          arrayUpdateNoBoundsChecking(arr_rows, i, exp);
         end for;
       then
-        Expression.makeArray(Type.liftArrayLeft(row_ty, Dimension.fromInteger(n)), rows, arg_lit);
+        Expression.makeArray(Type.liftArrayLeft(row_ty, Dimension.fromInteger(n)), arr_rows, arg_lit);
 
     else algorithm printWrongArgsError(getInstanceName(), {arg}, sourceInfo()); then fail();
   end match;
@@ -2333,11 +2334,11 @@ algorithm
   result := match arg
     local
       Integer dim_count;
-      list<Expression> expl;
       Dimension dim1, dim2;
       Type ty;
+      array<Expression> arr;
 
-    case Expression.LIST(ty = ty)
+    case Expression.ARRAY(ty = ty)
       algorithm
         dim_count := Type.dimensionCount(ty);
 
@@ -2348,9 +2349,9 @@ algorithm
         else
           dim1 :: dim2 :: _ := Type.arrayDims(ty);
           ty := Type.liftArrayLeft(Type.arrayElementType(ty), dim2);
-          expl := list(evalBuiltinMatrix2(e, ty) for e in arg.elements);
+          arr := Array.map(arg.elements, function evalBuiltinMatrix2(ty = ty));
           ty := Type.liftArrayLeft(ty, dim1);
-          result := Expression.makeArray(ty, expl);
+          result := Expression.makeArray(ty, arr);
         end if;
       then
         result;
@@ -2377,9 +2378,9 @@ function evalBuiltinMatrix2
   output Expression result;
 algorithm
   result := match arg
-    case Expression.LIST()
+    case Expression.ARRAY()
       then Expression.makeArray(ty,
-                                list(Expression.toScalar(e) for e in arg.elements),
+                                Array.map(arg.elements, Expression.toScalar),
                                 arg.literal);
 
     else algorithm printWrongArgsError(getInstanceName(), {arg}, sourceInfo()); then fail();
@@ -2392,13 +2393,15 @@ function evalBuiltinMax
   output Expression result;
 protected
   Expression e1, e2;
-  list<Expression> expl;
   Type ty;
 algorithm
   result := match args
     case {e1, e2} then evalBuiltinMax2(e1, e2);
-    case {e1 as Expression.LIST(ty = ty)}
+
+    case {e1}
+      guard Expression.isArray(e1)
       algorithm
+        ty := Expression.typeOf(e1);
         result := Expression.fold(e1, evalBuiltinMax2, Expression.EMPTY(ty));
 
         if Expression.isEmpty(result) then
@@ -2426,7 +2429,7 @@ algorithm
       then if exp1.value < exp2.value then exp2 else exp1;
     case (Expression.ENUM_LITERAL(), Expression.ENUM_LITERAL())
       then if exp1.index < exp2.index then exp2 else exp1;
-    case (Expression.LIST(), _) then exp2;
+    case (Expression.ARRAY(), _) then exp2;
     case (_, Expression.EMPTY()) then exp1;
     else algorithm printWrongArgsError(getInstanceName(), {exp1, exp2}, sourceInfo()); then fail();
   end match;
@@ -2438,13 +2441,15 @@ function evalBuiltinMin
   output Expression result;
 protected
   Expression e1, e2;
-  list<Expression> expl;
   Type ty;
 algorithm
   result := match args
     case {e1, e2} then evalBuiltinMin2(e1, e2);
-    case {e1 as Expression.LIST(ty = ty)}
+
+    case {e1}
+      guard Expression.isArray(e1)
       algorithm
+        ty := Expression.typeOf(e1);
         result := Expression.fold(e1, evalBuiltinMin2, Expression.EMPTY(ty));
 
         if Expression.isEmpty(result) then
@@ -2472,7 +2477,7 @@ algorithm
       then if exp1.value > exp2.value then exp2 else exp1;
     case (Expression.ENUM_LITERAL(), Expression.ENUM_LITERAL())
       then if exp1.index > exp2.index then exp2 else exp1;
-    case (Expression.LIST(), _) then exp2;
+    case (Expression.ARRAY(), _) then exp2;
     case (_, Expression.EMPTY()) then exp1;
     else algorithm printWrongArgsError(getInstanceName(), {exp1, exp2}, sourceInfo()); then fail();
   end match;
@@ -2530,7 +2535,8 @@ function evalBuiltinProduct
   output Expression result;
 algorithm
   result := match arg
-    case Expression.LIST()
+    case _
+      guard Expression.isArray(arg)
       then match Type.arrayElementType(Expression.typeOf(arg))
         case Type.INTEGER() then Expression.INTEGER(Expression.fold(arg, evalBuiltinProductInt, 1));
         case Type.REAL() then Expression.REAL(Expression.fold(arg, evalBuiltinProductReal, 1.0));
@@ -2547,7 +2553,7 @@ function evalBuiltinProductInt
 algorithm
   result := match exp
     case Expression.INTEGER() then result * exp.value;
-    case Expression.LIST() then result;
+    case Expression.ARRAY() then result;
     else fail();
   end match;
 end evalBuiltinProductInt;
@@ -2558,7 +2564,7 @@ function evalBuiltinProductReal
 algorithm
   result := match exp
     case Expression.REAL() then result * exp.value;
-    case Expression.LIST() then result;
+    case Expression.ARRAY() then result;
     else fail();
   end match;
 end evalBuiltinProductReal;
@@ -2619,15 +2625,12 @@ algorithm
 end evalBuiltinRem;
 
 function evalBuiltinScalar
-  input list<Expression> args;
-  output Expression result;
-protected
-  Expression exp = listHead(args);
+  input Expression arg;
+  output Expression result = arg;
 algorithm
-  result := match exp
-    case Expression.LIST() then evalBuiltinScalar(exp.elements);
-    else exp;
-  end match;
+  while Expression.isArray(result) loop
+    result := Expression.arrayScalarElement(result);
+  end while;
 end evalBuiltinScalar;
 
 function evalBuiltinSign
@@ -2673,15 +2676,18 @@ protected
   Boolean literal;
 algorithm
   result := match arg
-    case Expression.LIST(ty = ty, elements = {x1, x2, x3}, literal = literal)
+    case Expression.ARRAY(ty = ty, literal = literal)
       algorithm
+        x1 := arrayGet(arg.elements, 1);
+        x2 := arrayGet(arg.elements, 2);
+        x3 := arrayGet(arg.elements, 3);
         zero := Expression.makeZero(Type.arrayElementType(ty));
-        y1 := Expression.makeArray(ty, {zero, Expression.negate(x3), x2}, literal);
-        y2 := Expression.makeArray(ty, {x3, zero, Expression.negate(x1)}, literal);
-        y3 := Expression.makeArray(ty, {Expression.negate(x2), x1, zero}, literal);
+        y1 := Expression.makeArray(ty, listArray({zero, Expression.negate(x3), x2}), literal);
+        y2 := Expression.makeArray(ty, listArray({x3, zero, Expression.negate(x1)}), literal);
+        y3 := Expression.makeArray(ty, listArray({Expression.negate(x2), x1, zero}), literal);
         ty := Type.liftArrayLeft(ty, Dimension.fromInteger(3));
       then
-        Expression.makeArray(ty, {y1, y2, y3}, literal);
+        Expression.makeArray(ty, listArray({y1, y2, y3}), literal);
 
     else algorithm printWrongArgsError(getInstanceName(), {arg}, sourceInfo()); then fail();
   end match;
@@ -2752,7 +2758,7 @@ function evalBuiltinSum
   output Expression result;
 algorithm
   result := match arg
-    case Expression.LIST()
+    case _ guard Expression.isArray(arg)
       then match Type.arrayElementType(Expression.typeOf(arg))
         case Type.INTEGER() then Expression.INTEGER(Expression.fold(arg, evalBuiltinSumInt, 0));
         case Type.REAL() then Expression.REAL(Expression.fold(arg, evalBuiltinSumReal, 0.0));
@@ -2769,7 +2775,7 @@ function evalBuiltinSumInt
 algorithm
   result := match exp
     case Expression.INTEGER() then result + exp.value;
-    case Expression.LIST() then result;
+    case Expression.ARRAY() then result;
     else fail();
   end match;
 end evalBuiltinSumInt;
@@ -2780,7 +2786,7 @@ function evalBuiltinSumReal
 algorithm
   result := match exp
     case Expression.REAL() then result + exp.value;
-    case Expression.LIST() then result;
+    case Expression.ARRAY() then result;
     else fail();
   end match;
 end evalBuiltinSumReal;
@@ -2791,30 +2797,34 @@ function evalBuiltinSymmetric
 protected
   array<array<Expression>> mat;
   Integer n;
-  Type row_ty;
-  list<Expression> expl, accum = {};
+  Type ty, row_ty;
+  array<Expression> arr, accum;
 algorithm
-  result := match arg
-    case Expression.LIST() guard Type.isMatrix(arg.ty)
-      algorithm
-        mat := listArray(list(listArray(Expression.arrayElements(row))
-                           for row in Expression.arrayElements(arg)));
-        n := arrayLength(mat);
-        row_ty := Type.unliftArray(arg.ty);
+  ty := Expression.typeOf(arg);
 
-        for i in n:-1:1 loop
-          expl := {};
-          for j in n:-1:1 loop
-            expl := (if i > j then arrayGet(mat[j], i) else arrayGet(mat[i], j)) :: expl;
-          end for;
+  if Expression.isArray(arg) and Type.isSquareMatrix(ty) then
+    mat := Array.map(Expression.arrayElements(arg), Expression.arrayElements);
+    n := arrayLength(mat);
+    row_ty := Type.unliftArray(Expression.typeOf(arg));
+    accum := arrayCreateNoInit(n, arg);
 
-          accum := Expression.makeArray(row_ty, expl, literal = true) :: accum;
-        end for;
-      then
-        Expression.makeArray(arg.ty, accum, literal = true);
+    for i in 1:n loop
+      arr := arrayCreateNoInit(n, arg);
 
-    else algorithm printWrongArgsError(getInstanceName(), {arg}, sourceInfo()); then fail();
-  end match;
+      for j in 1:n loop
+        arrayUpdateNoBoundsChecking(arr, j,
+          if i > j then arrayGet(mat[j], i) else arrayGet(mat[i], j));
+      end for;
+
+      arrayUpdateNoBoundsChecking(accum, i,
+        Expression.makeArray(row_ty, arr, literal = true));
+    end for;
+
+    result := Expression.makeArray(ty, accum, literal = true);
+  else
+    printWrongArgsError(getInstanceName(), {arg}, sourceInfo());
+    fail();
+  end if;
 end evalBuiltinSymmetric;
 
 function evalBuiltinTanh
@@ -2848,22 +2858,14 @@ protected
   list<list<Expression>> arrl;
   Boolean literal;
 algorithm
-  result := match arg
-    case Expression.LIST(ty = Type.ARRAY(elementType = ty,
-                                          dimensions = dim1 :: dim2 :: rest_dims),
-                          elements = arr,
-                          literal = literal)
-      algorithm
-        arrl := list(Expression.arrayElements(e) for e in arr);
-        arrl := List.transposeList(arrl);
-        ty := Type.liftArrayLeft(ty, dim1);
-        arr := list(Expression.makeArray(ty, expl, literal) for expl in arrl);
-        ty := Type.liftArrayLeft(ty, dim2);
-      then
-        Expression.makeArray(ty, arr, literal);
+  ty := Expression.typeOf(arg);
 
-    else algorithm printWrongArgsError(getInstanceName(), {arg}, sourceInfo()); then fail();
-  end match;
+  if Expression.isArray(arg) and Type.dimensionCount(ty) >= 2 then
+    result := Expression.transposeArray(arg);
+  else
+    printWrongArgsError(getInstanceName(), {arg}, sourceInfo());
+    fail();
+  end if;
 end evalBuiltinTranspose;
 
 function evalBuiltinVector
@@ -2874,7 +2876,7 @@ protected
   Type ty;
 algorithm
   expl := Expression.arrayScalarElements(arg);
-  result := Expression.makeExpArray(expl,
+  result := Expression.makeExpArray(listArray(expl),
     Type.arrayElementType(Expression.typeOf(arg)), isLiteral = true);
 end evalBuiltinVector;
 
@@ -3126,7 +3128,7 @@ algorithm
       expl := evalArrayConstructor3(exp, ranges_rest, iters_rest, rest_ty) :: expl;
     end while;
 
-    result := Expression.makeArray(ty, listReverseInPlace(expl), literal = true);
+    result := Expression.makeArray(ty, listArray(listReverseInPlace(expl)), literal = true);
   end if;
 end evalArrayConstructor3;
 
@@ -3185,8 +3187,8 @@ protected
   TypingError ty_err;
   Dimension dim;
   Type ty;
-  list<Expression> expl;
   SourceInfo info;
+  array<Expression> arr;
 algorithm
   info := EvalTarget.getInfo(target);
 
@@ -3203,9 +3205,9 @@ algorithm
     outExp := Dimension.sizeExp(dim);
   else
     (outExp, ty) := Typing.typeExp(exp, NFInstContext.CLASS, info);
-    expl := list(Dimension.sizeExp(d) for d in Type.arrayDims(ty));
-    dim := Dimension.fromInteger(listLength(expl), Variability.PARAMETER);
-    outExp := Expression.makeArray(Type.ARRAY(Type.INTEGER(), {dim}), expl);
+    arr := Array.mapList(Type.arrayDims(ty), Dimension.sizeExp);
+    dim := Dimension.fromInteger(arrayLength(arr), Variability.PARAMETER);
+    outExp := Expression.makeArray(Type.ARRAY(Type.INTEGER(), {dim}), arr);
   end if;
 end evalSize;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
@@ -50,6 +50,7 @@ protected
   import Restriction = NFRestriction;
   import ComplexType = NFComplexType;
   import Dimension = NFDimension;
+  import MetaModelica.Dangerous.arrayGetNoBoundsChecking;
 
 public
   type Face = enumeration(INSIDE, OUTSIDE);
@@ -100,10 +101,11 @@ public
   algorithm
     conns := match exp
       case Expression.CREF() then fromCref(exp.cref, exp.ty, source) :: conns;
-      case Expression.LIST()
+
+      case Expression.ARRAY()
         algorithm
-          for e in listReverse(exp.elements) loop
-            conns := fromExp(e, source, conns);
+          for i in arrayLength(exp.elements):-1:1 loop
+            conns := fromExp(arrayGetNoBoundsChecking(exp.elements, i), source, conns);
           end for;
         then
           conns;

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -104,7 +104,7 @@ public
                 fail();
           end match;
 
-      case Expression.LIST()
+      case Expression.ARRAY()
         guard Expression.arrayAllEqual(exp)
         then fromExp(Expression.arrayFirstScalar(exp), var);
 
@@ -144,6 +144,11 @@ public
     input Variability var = Variability.CONSTANT;
     output Dimension dim = INTEGER(n, var);
   end fromInteger;
+
+  function fromExpArray
+    input array<Expression> expl;
+    output Dimension dim = INTEGER(arrayLength(expl), Variability.CONSTANT);
+  end fromExpArray;
 
   function fromExpList
     input list<Expression> expl;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -771,51 +771,57 @@ protected
   Expression sub, val;
   list<Subscript> rest_subs;
   Integer idx;
-  list<Expression> subs, vals;
+  array<Expression> subs, vals;
 algorithm
   result := match (arrayExp, subscripts)
-    case (Expression.LIST(), Subscript.INDEX(sub) :: rest_subs) guard Expression.isScalarLiteral(sub)
+    case (Expression.ARRAY(), Subscript.INDEX(sub) :: rest_subs) guard Expression.isScalarLiteral(sub)
       algorithm
         idx := Expression.toInteger(sub);
 
         if listEmpty(rest_subs) then
-          arrayExp.elements := List.set(arrayExp.elements, idx, value);
+          arrayUpdate(arrayExp.elements, idx, value);
         else
-          arrayExp.elements := List.set(arrayExp.elements, idx,
-            assignArrayElement(listGet(arrayExp.elements, idx), rest_subs, value));
+          arrayUpdate(arrayExp.elements, idx,
+            assignArrayElement(arrayGet(arrayExp.elements, idx), rest_subs, value));
         end if;
       then
         arrayExp;
 
-    case (Expression.LIST(), Subscript.SLICE(sub) :: rest_subs)
+    case (Expression.ARRAY(), Subscript.SLICE(sub) :: rest_subs)
       algorithm
         subs := Expression.arrayElements(sub);
         vals := Expression.arrayElements(value);
 
+        if arrayLength(subs) > arrayLength(vals) then
+          fail();
+        end if;
+
         if listEmpty(rest_subs) then
-          for s in subs loop
-            val :: vals := vals;
-            idx := Expression.toInteger(s);
-            arrayExp.elements := List.set(arrayExp.elements, idx, val);
+          for i in 1:arrayLength(subs) loop
+            sub := arrayGetNoBoundsChecking(subs, i);
+            val := arrayGetNoBoundsChecking(vals, i);
+            idx := Expression.toInteger(sub);
+            arrayUpdate(arrayExp.elements, idx, val);
           end for;
         else
-          for s in subs loop
-            val :: vals := vals;
-            idx := Expression.toInteger(s);
-            arrayExp.elements := List.set(arrayExp.elements, idx,
-              assignArrayElement(listGet(arrayExp.elements, idx), rest_subs, val));
+          for i in 1:arrayLength(subs) loop
+            sub := arrayGetNoBoundsChecking(subs, i);
+            val := arrayGetNoBoundsChecking(vals, i);
+            idx := Expression.toInteger(sub);
+            arrayUpdate(arrayExp.elements, idx,
+              assignArrayElement(arrayGet(arrayExp.elements, idx), rest_subs, val));
           end for;
         end if;
       then
         arrayExp;
 
-    case (Expression.LIST(), Subscript.WHOLE() :: rest_subs)
+    case (Expression.ARRAY(), Subscript.WHOLE() :: rest_subs)
       algorithm
         if listEmpty(rest_subs) then
-          arrayExp.elements := Expression.arrayElements(value);
+          arrayExp.elements := arrayCopy(Expression.arrayElements(value));
         else
-          arrayExp.elements := list(assignArrayElement(e, rest_subs, v) threaded for
-            e in arrayExp.elements, v in Expression.arrayElements(value));
+          arrayExp.elements := listArray(list(assignArrayElement(e, rest_subs, v) threaded for
+            e in arrayExp.elements, v in Expression.arrayElements(value)));
         end if;
       then
         arrayExp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunctionExt.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunctionExt.mo
@@ -547,7 +547,7 @@ function evaluateExtIntArrayArg
 protected
   list<Expression> expl;
 algorithm
-  expl := Expression.arrayElements(Ceval.evalExp(arg));
+  expl := Expression.arrayElementList(Ceval.evalExp(arg));
   value := list(getExtIntValue(e) for e in expl);
 end evaluateExtIntArrayArg;
 
@@ -557,7 +557,7 @@ function evaluateExtRealArrayArg
 protected
   list<Expression> expl;
 algorithm
-  expl := Expression.arrayElements(Ceval.evalExp(arg));
+  expl := Expression.arrayElementList(Ceval.evalExp(arg));
   value := list(getExtRealValue(e) for e in expl);
 end evaluateExtRealArrayArg;
 
@@ -565,10 +565,10 @@ function evaluateExtRealMatrixArg
   input Expression arg;
   output list<list<Real>> value;
 protected
-  list<Expression> expl;
+  array<Expression> expl;
   Type ty;
 algorithm
-  Expression.LIST(ty = ty, elements = expl) := Ceval.evalExp(arg);
+  Expression.ARRAY(ty = ty, elements = expl) := Ceval.evalExp(arg);
 
   // Some external functions don't make a difference between vectors and
   // matrices, so if the argument is a vector we convert it into a matrix.
@@ -595,9 +595,9 @@ algorithm
   exp := match (Expression.typeOf(variable), value)
     // Vector variable, matrix value => convert value to vector.
     case (Type.ARRAY(dimensions = {_}),
-          Expression.LIST(ty = Type.ARRAY(dimensions = {_, _})))
+          Expression.ARRAY(ty = Type.ARRAY(dimensions = {_, _})))
       then Expression.makeArray(Type.unliftArray(value.ty),
-                                list(Expression.arrayScalarElement(e) for e in value.elements),
+                                listArray(list(Expression.arrayScalarElement(e) for e in value.elements)),
                                 literal = true);
 
     else value;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -49,6 +49,7 @@ protected
   import NFPrefixes.{Variability, Purity};
   import MetaModelica.Dangerous.*;
   import EvalTarget = NFCeval.EvalTarget;
+  import Array;
 
 public
   function expand
@@ -57,7 +58,7 @@ public
   algorithm
     (exp, expanded) := match exp
       local
-        list<Expression> expl;
+        array<Expression> arr;
 
       case Expression.INTEGER()      then (exp, true);
       case Expression.REAL()         then (exp, true);
@@ -68,12 +69,12 @@ public
       case Expression.CREF(ty = Type.ARRAY()) then expandCref(exp);
 
       // One-dimensional arrays are already expanded.
-      case Expression.LIST(ty = Type.ARRAY(dimensions = {})) then (exp, true);
+      case Expression.ARRAY() guard Type.isVector(exp.ty) then (exp, true);
 
-      case Expression.LIST()
+      case Expression.ARRAY()
         algorithm
-          (expl, expanded) := expandList(exp.elements);
-          exp.elements := expl;
+          (arr, expanded) := expandArray(exp.elements);
+          exp.elements := arr;
         then
           (exp, expanded);
 
@@ -90,6 +91,29 @@ public
       else expandGeneric(exp);
     end match;
   end expand;
+
+  function expandArray
+    "Expands an array of Expressions."
+    input array<Expression> arr;
+    output array<Expression> outArray;
+    output Boolean expanded = true;
+  protected
+    Boolean res;
+    Expression e;
+  algorithm
+    outArray := arrayCopy(arr);
+
+    for i in 1:arrayLength(outArray) loop
+      (e, res) := expand(arrayGetNoBoundsChecking(outArray, i));
+
+      if not res then
+        expanded := false;
+        return;
+      end if;
+
+      arrayUpdateNoBoundsChecking(outArray, i, e);
+    end for;
+  end expandArray;
 
   function expandList
     "Expands a list of Expressions. If abortOnFailure is true the function will
@@ -193,17 +217,26 @@ public
     input Type crefType;
     output Expression arrayExp;
   protected
-    list<Expression> expl = {};
+    array<Expression> expl;
     Type arr_ty;
     list<Subscript> slice, rest;
+    Integer i;
   algorithm
     arrayExp := match subs
       case {} then expandCref3(restSubs, cref, crefType, listReverse(comb) :: accum);
 
       case Subscript.EXPANDED_SLICE(indices = slice) :: rest
         algorithm
-          expl := list(expandCref4(rest, idx :: comb, accum, restSubs, cref, crefType) for idx in slice);
-          arr_ty := Type.liftArrayLeft(Expression.typeOf(listHead(expl)), Dimension.fromExpList(expl));
+          expl := arrayCreateNoInit(listLength(slice), Expression.INTEGER(0));
+          i := 1;
+
+          for idx in slice loop
+            arrayUpdateNoBoundsChecking(expl, i,
+              expandCref4(rest, idx :: comb, accum, restSubs, cref, crefType));
+            i := i + 1;
+          end for;
+
+          arr_ty := Type.liftArrayLeft(Expression.typeOf(arrayGet(expl, 1)), Dimension.fromExpArray(expl));
         then
           Expression.makeArray(arr_ty, expl);
 
@@ -220,13 +253,13 @@ public
         list<Expression> lits;
 
       case Type.ARRAY(elementType = Type.BOOLEAN())
-        then Expression.makeArray(ty, {Expression.BOOLEAN(false), Expression.BOOLEAN(true)}, true);
+        then Expression.makeArray(ty, listArray({Expression.BOOLEAN(false), Expression.BOOLEAN(true)}), true);
 
       case Type.ARRAY(elementType = Type.ENUMERATION())
         algorithm
           lits := Expression.makeEnumLiterals(ty.elementType);
         then
-          Expression.makeArray(ty, lits, true);
+          Expression.makeArray(ty, listArray(lits), true);
 
       else
         algorithm
@@ -370,7 +403,7 @@ public
     Purity pur;
     NFCallAttributes attr;
     Expression arg;
-    list<Expression> args, expl;
+    list<Expression> args;
   algorithm
     Call.TYPED_CALL(fn, ty, var, pur, {arg}, attr) := call;
     ty := Type.arrayElementType(ty);
@@ -389,15 +422,16 @@ public
   algorithm
     exp := match exp
       local
-        list<Expression> expl;
+        array<Expression> arr;
 
-      case Expression.LIST(literal = true) then exp;
+      case Expression.ARRAY(literal = true) then exp;
 
-      case Expression.LIST()
+      case Expression.ARRAY()
         algorithm
-          expl := list(expandBuiltinGeneric2(e, fn, ty, var, pur, attr) for e in exp.elements);
+          arr := Array.map(exp.elements,
+            function expandBuiltinGeneric2(fn = fn, ty = ty, var = var, pur = pur, attr = attr));
         then
-          Expression.makeArray(Type.setArrayElementType(exp.ty, ty), expl);
+          Expression.makeArray(Type.setArrayElementType(exp.ty, ty), arr);
 
       else Expression.CALL(Call.TYPED_CALL(fn, ty, var, pur, {exp}, attr));
     end match;
@@ -412,7 +446,7 @@ public
   protected
     Expression e = exp, range;
     InstNode node;
-    list<Expression> ranges = {}, expl;
+    list<Expression> ranges = {};
     Mutable<Expression> iter;
     list<Mutable<Expression>> iters = {};
   algorithm
@@ -462,7 +496,7 @@ public
         expl := expandArrayConstructor2(exp, el_ty, ranges_rest, iters_rest) :: expl;
       end while;
 
-      result := Expression.makeArray(ty, listReverseInPlace(expl));
+      result := Expression.makeArray(ty, listArray(listReverseInPlace(expl)));
     end if;
   end expandArrayConstructor2;
 
@@ -484,7 +518,7 @@ public
           dims := Type.dimensionCount(ty);
           expl := list(Expression.SIZE(e, SOME(Expression.INTEGER(i))) for i in 1:dims);
         then
-          Expression.makeArray(Type.ARRAY(ty, {Dimension.fromInteger(dims)}), expl);
+          Expression.makeArray(Type.ARRAY(ty, {Dimension.fromInteger(dims)}), listArray(expl));
 
       // Size with an index is scalar, and thus already maximally expanded.
       else exp;
@@ -565,7 +599,7 @@ public
       output Expression exp;
     end MakeFn;
   protected
-    list<Expression> expl1, expl2, expl;
+    array<Expression> expl1, expl2, expl;
     Type ty;
     Operator eop;
   algorithm
@@ -575,9 +609,10 @@ public
     eop := Operator.setType(Type.unliftArray(ty), op);
 
     if Type.dimensionCount(ty) > 1 then
-      expl := list(expandBinaryElementWise2(e1, eop, e2, func) threaded for e1 in expl1, e2 in expl2);
+      expl := Array.threadMap(expl1, expl2, function expandBinaryElementWise2(op = eop, func = func));
     else
-      expl := list(func(e1, eop, e2) threaded for e1 in expl1, e2 in expl2);
+      expl := Array.threadMap(expl1, expl2, function func(op = eop));
+      //expl := list(func(e1, eop, e2) threaded for e1 in expl1, e2 in expl2);
     end if;
 
     exp := Expression.makeArray(ty, expl);
@@ -590,7 +625,6 @@ public
     output Boolean expanded;
   protected
     Expression exp1, exp2;
-    list<Expression> expl;
     Operator op;
   algorithm
     Expression.BINARY(exp1 = exp1, operator = op, exp2 = exp2) := exp;
@@ -612,7 +646,7 @@ public
     output Expression exp;
   algorithm
     exp := match exp2
-      case Expression.LIST() then exp2;
+      case Expression.ARRAY() then exp2;
       else SimplifyExp.simplifyBinaryOp(exp1, op, exp2);
     end match;
   end makeScalarArrayBinary_traverser;
@@ -624,7 +658,6 @@ public
     output Boolean expanded;
   protected
     Expression exp1, exp2;
-    list<Expression> expl;
     Operator op;
   algorithm
     Expression.BINARY(exp1 = exp1, operator = op, exp2 = exp2) := exp;
@@ -646,7 +679,7 @@ public
     output Boolean expanded;
   protected
     Expression exp1, exp2;
-    list<Expression> expl;
+    array<Expression> arr;
     Type ty;
     Dimension m;
   algorithm
@@ -654,18 +687,18 @@ public
     (exp2, expanded) := expand(exp2);
 
     if expanded then
-      Expression.LIST(Type.ARRAY(ty, {m, _}), expl) := Expression.transposeArray(exp2);
+      Expression.ARRAY(Type.ARRAY(ty, {m, _}), arr) := Expression.transposeArray(exp2);
       ty := Type.ARRAY(ty, {m});
 
-      if listEmpty(expl) then
+      if arrayEmpty(arr) then
         outExp := Expression.makeZero(ty);
       else
         (exp1, expanded) := expand(exp1);
 
         if expanded then
           // c[i] = a * b[:, i] for i in 1:m
-          expl := list(makeScalarProduct(exp1, e2) for e2 in expl);
-          outExp := Expression.makeArray(ty, expl);
+          arr := Array.map(arr, function makeScalarProduct(exp1 = exp1));
+          outExp := Expression.makeArray(ty, arr);
         else
           outExp := exp;
         end if;
@@ -682,7 +715,7 @@ public
     output Boolean expanded;
   protected
     Expression exp1, exp2;
-    list<Expression> expl;
+    array<Expression> arr;
     Type ty;
     Dimension n;
   algorithm
@@ -690,18 +723,18 @@ public
     (exp1, expanded) := expand(exp1);
 
     if expanded then
-      Expression.LIST(Type.ARRAY(ty, {n, _}), expl) := exp1;
+      Expression.ARRAY(Type.ARRAY(ty, {n, _}), arr) := exp1;
       ty := Type.ARRAY(ty, {n});
 
-      if listEmpty(expl) then
+      if arrayEmpty(arr) then
         outExp := Expression.makeZero(ty);
       else
         (exp2, expanded) := expand(exp2);
 
         if expanded then
           // c[i] = a[i, :] * b for i in 1:n
-          expl := list(makeScalarProduct(e1, exp2) for e1 in expl);
-          outExp := Expression.makeArray(ty, expl);
+          arr := Array.map(arr, function makeScalarProduct(exp2 = exp2));
+          outExp := Expression.makeArray(ty, arr);
         else
           outExp := exp;
         end if;
@@ -738,23 +771,23 @@ public
     input Expression exp2;
     output Expression exp;
   protected
-    list<Expression> expl1, expl2;
+    array<Expression> arr1, arr2;
     Type ty, elem_ty;
     Operator mul_op, add_op;
   algorithm
-    Expression.LIST(ty, expl1) := exp1;
-    Expression.LIST( _, expl2) := exp2;
+    Expression.ARRAY(ty, arr1) := exp1;
+    Expression.ARRAY( _, arr2) := exp2;
     elem_ty := Type.unliftArray(ty);
 
-    if listEmpty(expl1) then
+    if arrayEmpty(arr1) then
       // Scalar product of two empty arrays. The result is defined in the spec
       // by sum, so we return 0 since that's the default value of sum.
       exp := Expression.makeZero(elem_ty);
     else
       mul_op := Operator.makeMul(elem_ty);
       add_op := Operator.makeAdd(elem_ty);
-      expl1 := list(SimplifyExp.simplifyBinaryOp(e1, mul_op, e2) threaded for e1 in expl1, e2 in expl2);
-      exp := List.reduce(expl1, function SimplifyExp.simplifyBinaryOp(op = add_op));
+      arr1 := Array.threadMap(arr1, arr2, function SimplifyExp.simplifyBinaryOp(op = mul_op));
+      exp := Array.reduce(arr1, function SimplifyExp.simplifyBinaryOp(op = add_op));
     end if;
   end makeScalarProduct;
 
@@ -785,35 +818,45 @@ public
     input Expression exp2;
     output Expression exp;
   protected
-    list<Expression> expl1, expl2;
+    array<Expression> arr1, arr2, arr;
     Type ty, row_ty, mat_ty;
     Dimension n, p;
+    Integer len;
+    Expression e;
   algorithm
-    Expression.LIST(Type.ARRAY(ty, {n, _}), expl1) := exp1;
+    Expression.ARRAY(Type.ARRAY(ty, {n, _}), arr1) := exp1;
     // Transpose the second matrix. This makes it easier to do the multiplication,
     // since we can do row-row multiplications instead of row-column.
-    Expression.LIST(Type.ARRAY(dimensions = {p, _}), expl2) := Expression.transposeArray(exp2);
+    Expression.ARRAY(Type.ARRAY(dimensions = {p, _}), arr2) := Expression.transposeArray(exp2);
     mat_ty := Type.ARRAY(ty, {n, p});
 
-    if listEmpty(expl2) then
+    if arrayEmpty(arr2) then
       // If any of the matrices' dimensions are zero, the result will be a matrix
-      // of zeroes (the default value of sum). Only expl2 needs to be checked here,
-      // the normal case can handle expl1 being empty.
+      // of zeroes (the default value of sum). Only arr2 needs to be checked here,
+      // the normal case can handle arr1 being empty.
       exp := Expression.makeZero(mat_ty);
     else
       // c[i, j] = a[i, :] * b[:, j] for i in 1:n, j in 1:p.
       row_ty := Type.ARRAY(ty, {p});
-      expl1 := list(Expression.makeArray(row_ty, makeBinaryMatrixProduct2(e, expl2)) for e in expl1);
-      exp := Expression.makeArray(mat_ty, expl1);
+      len := arrayLength(arr1);
+      arr := arrayCreateNoInit(len, exp1);
+
+      for i in 1:len loop
+        e := arrayGetNoBoundsChecking(arr1, i);
+        arrayUpdateNoBoundsChecking(arr, i,
+          Expression.makeArray(row_ty, makeBinaryMatrixProduct2(e, arr2)));
+      end for;
+
+      exp := Expression.makeArray(mat_ty, arr);
     end if;
   end makeBinaryMatrixProduct;
 
   function makeBinaryMatrixProduct2
     input Expression row;
-    input list<Expression> matrix;
-    output list<Expression> outRow;
+    input array<Expression> matrix;
+    output array<Expression> outRow;
   algorithm
-    outRow := list(makeScalarProduct(row, e) for e in matrix);
+    outRow := Array.map(matrix, function makeScalarProduct(exp1 = row));
   end makeBinaryMatrixProduct2;
 
   function expandBinaryPowMatrix
@@ -1016,14 +1059,22 @@ public
   protected
     Type t;
     list<Subscript> sub;
-    list<Expression> expl;
+    array<Expression> expl;
     list<list<Subscript>> rest_subs;
+    Integer i;
   algorithm
     outExp := match subs
       case sub :: rest_subs
         algorithm
           t := Type.unliftArray(ty);
-          expl := list(expandGeneric2(rest_subs, exp, t, s :: accum) for s in sub);
+          expl := arrayCreateNoInit(listLength(sub), exp);
+          i := 1;
+
+          for s in sub loop
+            arrayUpdateNoBoundsChecking(expl, i,
+              expandGeneric2(rest_subs, exp, t, s :: accum));
+            i := i + 1;
+          end for;
         then
           Expression.makeArray(ty, expl);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -36,14 +36,16 @@ protected
   import NFInstNode.InstNode;
   import ExpandExp = NFExpandExp;
   import SimplifyExp = NFSimplifyExp;
+  import MetaModelica.Dangerous.listReverseInPlace;
 
 public
   import Expression = NFExpression;
   import Binding = NFBinding;
 
   record ARRAY_ITERATOR
-    list<Expression> array;
-    list<Expression> slice;
+    array<Expression> arr;
+    Integer index;
+    list<array<Expression>> arrays;
   end ARRAY_ITERATOR;
 
   record SCALAR_ITERATOR
@@ -72,25 +74,23 @@ public
         Expression e;
         Boolean expanded;
 
-      case Expression.LIST()
+      case Expression.ARRAY()
         algorithm
-          (Expression.LIST(elements = arr), expanded) := ExpandExp.expand(exp);
+          (e, expanded) := ExpandExp.expand(exp);
 
           if not expanded then
             Error.assertion(false, getInstanceName() + " got unexpandable expression `" +
               Expression.toString(exp) + "`", sourceInfo());
           end if;
-
-          (arr, slice) := nextArraySlice(arr);
         then
-          ARRAY_ITERATOR(arr, slice);
+          makeArrayIterator(e);
 
       case Expression.CREF()
         algorithm
           e := ExpandExp.expandCref(exp);
 
           iterator := match e
-            case Expression.LIST() then fromExp(e);
+            case Expression.ARRAY() then fromExp(e);
             else SCALAR_ITERATOR(e);
           end match;
         then
@@ -142,7 +142,7 @@ public
     output Boolean hasNext;
   algorithm
     hasNext := match iterator
-      case ARRAY_ITERATOR() then not listEmpty(iterator.slice);
+      case ARRAY_ITERATOR() then iterator.index <= arrayLength(iterator.arr);
       case SCALAR_ITERATOR() then true;
       case EACH_ITERATOR() then true;
       case NONE_ITERATOR() then false;
@@ -158,16 +158,25 @@ public
       local
         list<Expression> rest, arr;
         Expression next;
+        list<array<Expression>> arrs;
 
       case ARRAY_ITERATOR()
         algorithm
-          next :: rest := iterator.slice;
+          next := arrayGet(iterator.arr, iterator.index);
 
-          if listEmpty(rest) then
-            (arr, rest) := nextArraySlice(iterator.array);
-            iterator := ARRAY_ITERATOR(arr, rest);
+          if iterator.index >= arrayLength(iterator.arr) then
+            arrs := iterator.arrays;
+            while not listEmpty(arrs) and arrayEmpty(listHead(arrs)) loop
+              arrs := listRest(arrs);
+            end while;
+
+            if listEmpty(arrs) then
+              iterator := ARRAY_ITERATOR(listArray({}), 1, {});
+            else
+              iterator := ARRAY_ITERATOR(listHead(arrs), 1, listRest(arrs));
+            end if;
           else
-            iterator.slice := rest;
+            iterator.index := iterator.index + 1;
           end if;
         then
           (iterator, next);
@@ -228,47 +237,68 @@ public
     input ExpressionIterator iterator;
     input Boolean trySimplify = true;
     output Boolean b;
+  protected
+    function is_sub_call
+      input Expression exp;
+      input Boolean trySimplify;
+      output Boolean res;
+    protected
+      Expression call;
+    algorithm
+      res := match exp
+        case Expression.SUBSCRIPTED_EXP(exp = Expression.CALL())
+          then not trySimplify or Expression.isCall(SimplifyExp.simplify(exp.exp));
+        else false;
+      end match;
+    end is_sub_call;
   algorithm
     b := match iterator
-      local
-        Expression call;
-      case ARRAY_ITERATOR(slice = Expression.SUBSCRIPTED_EXP(exp = call as Expression.CALL())::_)
-        then (not trySimplify) or Expression.isCall(SimplifyExp.simplify(call));
+      case ARRAY_ITERATOR() then is_sub_call(arrayGet(iterator.arr, 1), trySimplify);
       else false;
     end match;
   end isSubscriptedArrayCall;
 
 protected
-  function nextArraySlice
-    input output list<Expression> array;
-          output list<Expression> slice;
+  function makeArrayIterator
+    input Expression exp;
+    output ExpressionIterator iterator;
   protected
-    Expression e;
-    list<Expression> arr;
+    array<Expression> arr;
+    list<array<Expression>> arrays;
   algorithm
-    if listEmpty(array) then
-      slice := {};
+    arrays := flattenArray(exp, {});
+
+    if listEmpty(arrays) then
+      iterator := ARRAY_ITERATOR(listArray({}), 1, arrays);
     else
-      e := listHead(array);
-
-      (array, slice) := match e
-        case Expression.LIST()
-          algorithm
-            (arr, slice) := nextArraySlice(e.elements);
-
-            if listEmpty(arr) then
-              array := listRest(array);
-            else
-              e.elements := arr;
-              array := e :: listRest(array);
-            end if;
-          then
-            (array, slice);
-
-        else ({}, array);
-      end match;
+      iterator := ARRAY_ITERATOR(listHead(arrays), 1, listRest(arrays));
     end if;
-  end nextArraySlice;
+  end makeArrayIterator;
+
+  function flattenArray
+    input Expression exp;
+    input output list<array<Expression>> arrays;
+  algorithm
+    arrays := flattenArray_impl(exp, {});
+    arrays := listReverseInPlace(arrays);
+
+    while not listEmpty(arrays) and arrayEmpty(listHead(arrays)) loop
+      arrays := listRest(arrays);
+    end while;
+  end flattenArray;
+
+  function flattenArray_impl
+    input Expression exp;
+    input output list<array<Expression>> arrays;
+  algorithm
+    if Expression.isVector(exp) then
+      arrays := Expression.arrayElements(exp) :: arrays;
+    else
+      for e in Expression.arrayElements(exp) loop
+        arrays := flattenArray_impl(e, arrays);
+      end for;
+    end if;
+  end flattenArray_impl;
 
 annotation(__OpenModelica_Interface = "frontend");
 end NFExpressionIterator;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -684,9 +684,9 @@ algorithm
       then
         Expression.makeRecord(InstNode.scopePath(cls), outExp.ty, fields);
 
-    case Expression.LIST()
+    case Expression.ARRAY()
       algorithm
-        outExp.elements := list(splitRecordCref(e) for e in outExp.elements);
+        outExp.elements := Array.map(outExp.elements, splitRecordCref);
       then
         outExp;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2658,6 +2658,7 @@ algorithm
       Operator op;
       list<Expression> expl;
       list<list<Expression>> expll;
+      array<Expression> arr;
 
     case Absyn.Exp.INTEGER() then Expression.INTEGER(absynExp.value);
     case Absyn.Exp.REAL() then Expression.REAL(stringReal(absynExp.value));
@@ -2669,9 +2670,10 @@ algorithm
 
     case Absyn.Exp.ARRAY()
       algorithm
-        expl := list(instExp(e, scope, context, info) for e in absynExp.arrayExp);
+        arr := Array.mapList(absynExp.arrayExp,
+          function instExp(scope = scope, context = context, info = info));
       then
-        Expression.makeArray(Type.UNKNOWN(), expl);
+        Expression.makeArray(Type.UNKNOWN(), arr);
 
     case Absyn.Exp.MATRIX()
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -1196,7 +1196,7 @@ algorithm
           algorithm
             res := match call.arguments
               // zero size array TODO! FIXME! check how zero size arrays are handled in the NF
-              case {Expression.LIST(elements = {})}
+              case _ guard Expression.isEmptyArray(listHead(call.arguments))
                 equation
                  if Flags.isSet(Flags.CGRAPH) then
                     print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: " + Expression.toString(exp) + " = false\n");
@@ -1237,7 +1237,7 @@ algorithm
           algorithm
             res := match call.arguments
               // zero size array TODO! FIXME! check how zero size arrays are handled in the NF
-              case {Expression.LIST(elements = {})}
+              case _ guard Expression.isEmptyArray(listHead(call.arguments))
                 equation
                   if Flags.isSet(Flags.CGRAPH) then
                     print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: " + Expression.toString(exp) + " = false\n");
@@ -1261,7 +1261,7 @@ algorithm
           algorithm
             res := match call.arguments
               // normal call
-              case {uroots as Expression.LIST(elements = lst),nodes,message}
+              case {uroots,nodes,message}
                 equation
                   if Flags.isSet(Flags.CGRAPH) then
                     print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: Connections.uniqueRootsIndicies(" +
@@ -1269,9 +1269,10 @@ algorithm
                       Expression.toString(nodes) + "," +
                       Expression.toString(message) + ")\n");
                   end if;
+                  lst = Expression.arrayElementList(uroots);
                   lst = List.fill(Expression.INTEGER(1), listLength(lst)); // TODO! FIXME! actually implement this correctly
                 then
-                  Expression.makeArray(Type.INTEGER(), lst);
+                  Expression.makeArray(Type.INTEGER(), listArray(lst));
             end match;
           then
             res;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRangeIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRangeIterator.mo
@@ -58,7 +58,8 @@ public
   end REAL_RANGE;
 
   record ARRAY_RANGE
-    list<Expression> values;
+    array<Expression> values;
+    Integer index;
   end ARRAY_RANGE;
 
   record INVALID_RANGE
@@ -93,7 +94,7 @@ public
         Absyn.Path path;
         list<Expression> values;
 
-      case Expression.LIST() then ARRAY_RANGE(exp.elements);
+      case Expression.ARRAY() then ARRAY_RANGE(exp.elements, 1);
 
       case Expression.RANGE(start = Expression.INTEGER(istart),
                             step = SOME(Expression.INTEGER(istep)),
@@ -117,7 +118,7 @@ public
 
       case Expression.RANGE(start = Expression.BOOLEAN(bstart),
                             stop = Expression.BOOLEAN(bstop))
-        then ARRAY_RANGE(list(Expression.BOOLEAN(b) for b in bstart:bstop));
+        then ARRAY_RANGE(listArray(list(Expression.BOOLEAN(b) for b in bstart:bstop)), 1);
 
       case Expression.RANGE(start = Expression.ENUM_LITERAL(ty = ty, index = istart),
                             step = NONE(),
@@ -139,7 +140,7 @@ public
             values := listReverse(values);
           end if;
         then
-          ARRAY_RANGE(values);
+          ARRAY_RANGE(listArray(values), 1);
 
       // enumeration type based range
       case Expression.TYPENAME(ty = Type.ARRAY(elementType = ty as Type.ENUMERATION(literals = literals)))
@@ -152,7 +153,7 @@ public
             values := Expression.ENUM_LITERAL(ty, l, istep) :: values;
           end for;
         then
-          ARRAY_RANGE(values);
+          ARRAY_RANGE(listArray(values), 1);
 
       else INVALID_RANGE(exp);
 
@@ -171,10 +172,10 @@ public
       case Dimension.INTEGER() then INT_RANGE(1, dim.size);
 
       case Dimension.BOOLEAN()
-        then ARRAY_RANGE({Expression.BOOLEAN(false), Expression.BOOLEAN(true)});
+        then ARRAY_RANGE(listArray({Expression.BOOLEAN(false), Expression.BOOLEAN(true)}), 1);
 
       case Dimension.ENUM(enumType = ty as Type.ENUMERATION())
-        then ARRAY_RANGE(Expression.makeEnumLiterals(ty));
+        then ARRAY_RANGE(listArray(Expression.makeEnumLiterals(ty)), 1);
 
       case Dimension.EXP() then fromExp(dim.exp);
 
@@ -215,8 +216,8 @@ public
 
       case ARRAY_RANGE()
         algorithm
-          nextExp := listHead(iterator.values);
-          iterator.values := listRest(iterator.values);
+          nextExp := arrayGet(iterator.values, iterator.index);
+          iterator.index := iterator.index + 1;
         then
           nextExp;
 
@@ -238,7 +239,7 @@ public
       case INT_STEP_RANGE() then if iterator.stepsize > 0 then iterator.current <= iterator.last
                                                           else iterator.current >= iterator.last;
       case REAL_RANGE() then iterator.current < iterator.steps;
-      case ARRAY_RANGE() then not listEmpty(iterator.values);
+      case ARRAY_RANGE() then iterator.index <= arrayLength(iterator.values);
       case INVALID_RANGE()
         algorithm
           Error.assertion(false, getInstanceName() + " got invalid range " +

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -79,6 +79,7 @@ import Util;
 import Component = NFComponent;
 import InstContext = NFInstContext;
 import NFInstNode.InstNodeType;
+import Array;
 
 public
 type MatchKind = enumeration(
@@ -435,17 +436,16 @@ algorithm
   (outExp, outType) := match (exp1, exp2)
     local
       Type ty, ty1, ty2;
-      Expression e, e2;
-      list<Expression> expl, expl1, expl2;
+      Expression e, e1, e2;
+      array<Expression> arr, arr1, arr2;
 
-    case (Expression.LIST(elements = expl1), Expression.LIST(elements = expl2))
+    case (Expression.ARRAY(elements = arr1), Expression.ARRAY(elements = arr2))
       algorithm
-        expl := {};
-
-        if listEmpty(expl1) then
+        if arrayEmpty(arr1) then
           // If the arrays are empty, match against the element types to get the expected return type.
           ty1 := Type.arrayElementType(type1);
           ty2 := Type.arrayElementType(type2);
+          arr := listArray({});
 
           try
             (_, ty) := matchOverloadedBinaryOperator(
@@ -456,18 +456,18 @@ algorithm
         else
           ty1 := Type.unliftArray(type1);
           ty2 := Type.unliftArray(type2);
+          arr := arrayCreateNoInit(arrayLength(arr1), arr1[1]);
 
-          for e1 in expl1 loop
-            e2 :: expl2 := expl2;
+          for i in 1:arrayLength(arr1) loop
+            e1 := arrayGetNoBoundsChecking(arr1, i);
+            e2 := arrayGetNoBoundsChecking(arr2, i);
             (e, ty) := checkOverloadedBinaryArrayAddSub2(e1, ty1, var1, op, e2, ty2, var2, candidates, info);
-            expl := e :: expl;
+            arrayUpdateNoBoundsChecking(arr, i, e);
           end for;
-
-          expl := listReverseInPlace(expl);
         end if;
 
         outType := Type.setArrayElementType(type1, ty);
-        outExp := Expression.makeArray(outType, expl);
+        outExp := Expression.makeArray(outType, arr);
       then
         (outExp, outType);
 
@@ -570,9 +570,12 @@ function checkOverloadedBinaryScalarArray2
 protected
   list<Expression> expl;
   Type ty;
+  array<Expression> arr;
+  Expression e2;
 algorithm
   (outExp, outType) := match exp2
-    case Expression.LIST(elements = {})
+    case Expression.ARRAY()
+      guard arrayEmpty(exp2.elements)
       algorithm
         try
           ty := Type.unliftArray(type2);
@@ -584,15 +587,22 @@ algorithm
 
         outType := Type.setArrayElementType(exp2.ty, outType);
       then
-        (Expression.makeArray(outType, {}), outType);
+        (Expression.makeEmptyArray(outType), outType);
 
-    case Expression.LIST(elements = expl)
+    case Expression.ARRAY()
       algorithm
         ty := Type.unliftArray(type2);
-        expl := list(checkOverloadedBinaryScalarArray2(exp1, type1, var1, op, e, ty, var2, candidates, info) for e in expl);
-        outType := Type.setArrayElementType(exp2.ty, Expression.typeOf(listHead(expl)));
+        arr := arrayCreateNoInit(arrayLength(exp2.elements), exp2);
+
+        for i in 1:arrayLength(arr) loop
+          e2 := arrayGetNoBoundsChecking(exp2.elements, i);
+          arrayUpdateNoBoundsChecking(arr, i,
+            checkOverloadedBinaryScalarArray2(exp1, type1, var1, op, e2, ty, var2, candidates, info));
+        end for;
+
+        outType := Type.setArrayElementType(exp2.ty, Expression.typeOf(arr[1]));
       then
-        (Expression.makeArray(outType, expl), outType);
+        (Expression.makeArray(outType, arr), outType);
 
     else matchOverloadedBinaryOperator(exp1, type1, var1, op, exp2, type2, var2, candidates, info);
   end match;
@@ -631,9 +641,11 @@ protected
   Expression e1;
   list<Expression> expl;
   Type ty;
+  array<Expression> arr;
 algorithm
   (outExp, outType) := match exp1
-    case Expression.LIST(elements = {})
+    case Expression.ARRAY()
+      guard arrayEmpty(exp1.elements)
       algorithm
         try
           ty := Type.unliftArray(type1);
@@ -645,15 +657,22 @@ algorithm
 
         outType := Type.setArrayElementType(exp1.ty, outType);
       then
-        (Expression.makeArray(outType, {}), outType);
+        (Expression.makeEmptyArray(outType), outType);
 
-    case Expression.LIST(elements = expl)
+    case Expression.ARRAY()
       algorithm
         ty := Type.unliftArray(type1);
-        expl := list(checkOverloadedBinaryArrayScalar2(e, ty, var1, op, exp2, type2, var2, candidates, info) for e in expl);
-        outType := Type.setArrayElementType(exp1.ty, Expression.typeOf(listHead(expl)));
+        arr := arrayCreateNoInit(arrayLength(exp1.elements), exp1);
+
+        for i in 1:arrayLength(arr) loop
+          e1 := arrayGetNoBoundsChecking(exp1.elements, i);
+          arrayUpdateNoBoundsChecking(arr, i,
+            checkOverloadedBinaryArrayScalar2(e1, ty, var1, op, exp2, type2, var2, candidates, info));
+        end for;
+
+        outType := Type.setArrayElementType(exp1.ty, Expression.typeOf(arr[1]));
       then
-        (Expression.makeArray(outType, expl), outType);
+        (Expression.makeArray(outType, arr), outType);
 
     else matchOverloadedBinaryOperator(exp1, type1, var1, op, exp2, type2, var2, candidates, info);
   end match;
@@ -694,7 +713,6 @@ function checkOverloadedBinaryArrayEW
 protected
   Expression e1, e2;
   MatchKind mk;
-  list<Expression> expl1, expl2;
   Type ty;
 algorithm
   if Type.isArray(type1) and Type.isArray(type2) then
@@ -728,8 +746,9 @@ function checkOverloadedBinaryArrayEW2
   output Expression outExp;
   output Type outType;
 protected
-  Expression e2;
-  list<Expression> expl, expl1, expl2;
+  Expression e1, e2;
+  list<Expression> expl;
+  array<Expression> expl1, expl2;
   Type ty, ty1, ty2;
   Boolean is_array1, is_array2;
 algorithm
@@ -756,10 +775,15 @@ algorithm
       expl1 := Expression.arrayElements(exp1);
       expl2 := Expression.arrayElements(exp2);
 
-      for e in expl1 loop
-        e2 :: expl2 := expl2;
-        (e, ty) := checkOverloadedBinaryArrayEW2(e, ty1, var1, op, e2, ty2, var2, candidates, info);
-        expl := e :: expl;
+      if arrayLength(expl1) > arrayLength(expl2) then
+        fail();
+      end if;
+
+      for i in 1:arrayLength(expl1) loop
+        e1 := arrayGetNoBoundsChecking(expl1, i);
+        e2 := arrayGetNoBoundsChecking(expl2, i);
+        (e1, ty) := checkOverloadedBinaryArrayEW2(e1, ty1, var1, op, e2, ty2, var2, candidates, info);
+        expl := e1 :: expl;
       end for;
     elseif is_array1 then
       ty1 := Type.unliftArray(type1);
@@ -780,7 +804,7 @@ algorithm
     end if;
 
     outType := Type.setArrayElementType(type1, ty);
-    outExp := Expression.makeArray(outType, listReverseInPlace(expl));
+    outExp := Expression.makeArray(outType, listArray(listReverseInPlace(expl)));
   else
     (outExp, outType) := matchOverloadedBinaryOperator(
       exp1, type1, var1, op,

--- a/OMCompiler/Compiler/NFFrontEnd/NFVerifyModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVerifyModel.mo
@@ -235,7 +235,7 @@ protected
     output list<ComponentRef> outCrefs = {};
   protected
     Expression exp;
-    list<Expression> expl;
+    array<Expression> expl;
   algorithm
     for cref in crefs loop
       exp := Expression.fromCref(cref);

--- a/OMCompiler/Compiler/Util/Array.mo
+++ b/OMCompiler/Compiler/Util/Array.mo
@@ -1142,5 +1142,176 @@ algorithm
   end for;
 end maxElement;
 
+function compare<T1, T2>
+  "Returns -1 if arr1 is shorter than arr2 or 1 if arr1 is longer than arr2.
+   If both arrays are of equal length it applies the given compare function to
+   each pair of array elements and returns the first nonzero value, or 0 if no
+   nonzero value is received."
+  input array<T1> arr1;
+  input array<T2> arr2;
+  input CompFunc compFn;
+  output Integer res;
+
+  partial function CompFunc
+    input T1 e1;
+    input T2 e2;
+    output Integer res;
+  end CompFunc;
+protected
+  Integer l1, l2;
+algorithm
+  l1 := arrayLength(arr1);
+  l2 := arrayLength(arr2);
+  res := if l1 == l2 then 0 elseif l1 > l2 then 1 else -1;
+
+  if res <> 0 then
+    return;
+  end if;
+
+  for i in 1:l1 loop
+    res := compFn(arrayGetNoBoundsChecking(arr1, i),
+                  arrayGetNoBoundsChecking(arr2, i));
+
+    if res <> 0 then
+      return;
+    end if;
+  end for;
+end compare;
+
+function mapFold<TI, TO, ArgT>
+  input array<TI> arr;
+  input FuncType func;
+  input ArgT arg;
+  output array<TO> outArray;
+  output ArgT outArg = arg;
+
+  partial function FuncType
+    input TI e;
+    input ArgT arg;
+    output TO result;
+    output ArgT outArg;
+  end FuncType;
+protected
+  Integer len = arrayLength(arr);
+  TO res;
+algorithm
+  if len == 0 then
+    outArray := listArray({});
+  else
+    (res, outArg) := func(arrayGetNoBoundsChecking(arr, 1), outArg);
+    outArray := arrayCreateNoInit(len, res);
+    arrayUpdateNoBoundsChecking(outArray, 1, res);
+
+    for i in 2:len loop
+      (res, outArg) := func(arrayGetNoBoundsChecking(arr, i), outArg);
+      arrayUpdateNoBoundsChecking(outArray, i, res);
+    end for;
+  end if;
+end mapFold;
+
+function mapBoolAnd<T>
+  "Maps each element of a inList to Boolean type with inFunc.
+   Stops mapping at first occurrence of false return value."
+  input array<T> arr;
+  input MapFunc func;
+  output Boolean res = false;
+
+  partial function MapFunc
+    input T e;
+    output Boolean res;
+  end MapFunc;
+algorithm
+  for e in arr loop
+    if not func(e) then
+      return;
+    end if;
+  end for;
+
+  res := true;
+end mapBoolAnd;
+
+function transpose<T>
+  input array<array<T>> arr;
+  output array<array<T>> outArray;
+protected
+  Integer c_len, r_len;
+  T val;
+  array<T> row;
+algorithm
+  if arrayEmpty(arr) then
+    outArray := arr;
+    return;
+  end if;
+
+  row := arrayGetNoBoundsChecking(arr, 1);
+
+  if arrayEmpty(row) then
+    outArray := arr;
+    return;
+  end if;
+
+  val := arrayGetNoBoundsChecking(row, 1);
+
+  c_len := arrayLength(arr);
+  r_len := arrayLength(row);
+  outArray := arrayCreateNoInit(r_len, row);
+
+  for i in 1:r_len loop
+    arrayUpdateNoBoundsChecking(outArray, i, arrayCreateNoInit(c_len, val));
+  end for;
+
+  for r in 1:r_len loop
+    for c in 1:c_len loop
+      // outArray[r, c] := arr[c, r]
+      val := arrayGetNoBoundsChecking(arrayGetNoBoundsChecking(arr, c), r);
+      arrayUpdateNoBoundsChecking(arrayGetNoBoundsChecking(outArray, r), c, val);
+    end for;
+  end for;
+end transpose;
+
+function threadMap<T1, T2, TO>
+  input array<T1> arr1;
+  input array<T2> arr2;
+  input MapFunc func;
+  output array<TO> outArray;
+
+  partial function MapFunc
+    input T1 e1;
+    input T2 e2;
+    output TO res;
+  end MapFunc;
+protected
+  TO res;
+  Integer len1, len2;
+algorithm
+  if arrayEmpty(arr1) then
+    outArray := listArray({});
+    return;
+  end if;
+
+  len1 := arrayLength(arr1);
+  len2 := arrayLength(arr2);
+
+  if len1 <> len2 then
+    fail();
+  end if;
+
+  res := func(arrayGetNoBoundsChecking(arr1, 1), arrayGetNoBoundsChecking(arr2, 1));
+  outArray := arrayCreateNoInit(len1, res);
+  arrayUpdateNoBoundsChecking(outArray, 1, res);
+
+  for i in 2:len1 loop
+    arrayUpdateNoBoundsChecking(outArray, i,
+      func(arrayGetNoBoundsChecking(arr1, i), arrayGetNoBoundsChecking(arr2, i)));
+  end for;
+end threadMap;
+
+function fromScalar<T>
+  input T e;
+  output array<T> arr;
+algorithm
+  arr := arrayCreate(1, e);
+end fromScalar;
+
 annotation(__OpenModelica_Interface="util");
 end Array;

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -3310,7 +3310,7 @@ algorithm
 end mapBoolOr;
 
 public function mapBoolAnd<TI>
-  "Maps each element of a inList to Boolean type with inFunc. Stops mapping at first occurrence of true return value."
+  "Maps each element of a inList to Boolean type with inFunc. Stops mapping at first occurrence of false return value."
   input list<TI> inList;
   input MapFunc inFunc;
   output Boolean res = false;
@@ -3329,7 +3329,7 @@ algorithm
 end mapBoolAnd;
 
 public function mapMapBoolAnd<TI,TI2>
-  "Maps each element of a inList to Boolean type with inFunc. Stops mapping at first occurrence of true return value."
+  "Maps each element of a inList to Boolean type with inFunc. Stops mapping at first occurrence of false return value."
   input list<TI> inList;
   input MapFunc inFunc;
   input MapBFunc inBFunc;

--- a/OMCompiler/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
+++ b/OMCompiler/Compiler/boot/tarball-include/OpenModelicaBootstrappingHeader.h
@@ -230,20 +230,20 @@ extern struct record_description NFExpression_NFExpression_TYPENAME__desc;
 #define NFExpression__TYPENAME_3dBOX1 10
 #define NFExpression__TYPENAME(ty) (mmc_mk_box2(10,&NFExpression_NFExpression_TYPENAME__desc,ty))
 #ifdef ADD_METARECORD_DEFINITIONS
-#ifndef NFExpression_NFExpression_LIST__desc_added
-#define NFExpression_NFExpression_LIST__desc_added
-ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_LIST__desc__fields[3] = {"ty","elements","literal"};
-ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_LIST__desc = {
-  "NFExpression_NFExpression_LIST",
-  "NFExpression.NFExpression.LIST",
-  NFExpression_NFExpression_LIST__desc__fields
+#ifndef NFExpression_NFExpression_ARRAY__desc_added
+#define NFExpression_NFExpression_ARRAY__desc_added
+ADD_METARECORD_DEFINITIONS const char* NFExpression_NFExpression_ARRAY__desc__fields[3] = {"ty","elements","literal"};
+ADD_METARECORD_DEFINITIONS struct record_description NFExpression_NFExpression_ARRAY__desc = {
+  "NFExpression_NFExpression_ARRAY",
+  "NFExpression.NFExpression.ARRAY",
+  NFExpression_NFExpression_ARRAY__desc__fields
 };
 #endif
 #else /* Only use the file as a header */
-extern struct record_description NFExpression_NFExpression_LIST__desc;
+extern struct record_description NFExpression_NFExpression_ARRAY__desc;
 #endif
-#define NFExpression__LIST_3dBOX3 11
-#define NFExpression__LIST(ty,elements,literal) (mmc_mk_box4(11,&NFExpression_NFExpression_LIST__desc,ty,elements,literal))
+#define NFExpression__ARRAY_3dBOX3 11
+#define NFExpression__ARRAY(ty,elements,literal) (mmc_mk_box4(11,&NFExpression_NFExpression_ARRAY__desc,ty,elements,literal))
 #ifdef ADD_METARECORD_DEFINITIONS
 #ifndef NFExpression_NFExpression_MATRIX__desc_added
 #define NFExpression_NFExpression_MATRIX__desc_added


### PR DESCRIPTION
- Implement `Expression.ARRAY` using arrays.
- Remove `Expression.LIST` since it's no longer used.
- Remove `Expression.listContainsShallow`, since `List.exist` does the
  same thing and is more general.
- Update bootstrapping header and ffi interface to reflect the changes
  in Expression.