### PR TITLE
Generate a batch script on Windows (launches exe)

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -616,6 +616,10 @@ algorithm
           codegenFuncs := (function runToStr(func=function SerializeTaskSystemInfo.serializeParMod(code=simCode, withOperations=Flags.isSet(Flags.INFO_XML_OPERATIONS)))) :: codegenFuncs;
         end if;
 
+        if Autoconf.os == "Windows_NT" then
+          codegenFuncs := (function runToStr(func=function SimCodeUtil.generateRunnerBatScript(code=simCode))) :: codegenFuncs;
+        end if;
+
         // Test the parallel code generator in the test suite. Should give decent results given that the task is disk-intensive.
         numThreads := max(1, if Testsuite.isRunning() then min(2, System.numProcessors()) else Config.noProc());
         if (not Flags.isSet(Flags.PARALLEL_CODEGEN)) or numThreads==1 then

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15160,7 +15160,11 @@ algorithm
         locations := getDirectoriesForDLLsFromLinkLibs(code.makefileParams.libs);
         str := "@echo off\n"
                 + "set PATH=" + locations + ";%PATH%;\n"
-                + "\"%CD%/" + code.fileNamePrefix + ".exe\"\n";
+                + "set ERRORLEVEL=\n"
+                + "call \"%CD%/" + code.fileNamePrefix + ".exe\"\n"
+                + "set RESULT=%ERRORLEVEL%\n"
+                + "\n"
+                + "exit /b %RESULT%\n";
         File.write(file, str);
       then (fileName);
     else

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15138,5 +15138,65 @@ algorithm
   end match;
 end isArrayVar;
 
+public function generateRunnerBatScript
+  "Always succeeds in order to clean-up external objects.
+
+   This function will generate a .bat file that can be used to launch the simulation
+   executable on Windows. The bat file will set the necessary PATHs and then launches
+   the executable."
+  input SimCode.SimCode code;
+  output String fileName;
+protected
+  File.File file = File.File();
+algorithm
+  (fileName) := matchcontinue code
+    local
+      String str, locations;
+    case SimCode.SIMCODE()
+      algorithm
+        fileName := code.fileNamePrefix + ".bat";
+        File.open(file,fileName,File.Mode.Write);
+
+        locations := getDirectoriesForDLLsFromLinkLibs(code.makefileParams.libs);
+        str := "@echo off\n"
+                + "set PATH=" + locations + ";%PATH%;\n"
+                + "\"%CD%/" + code.fileNamePrefix + ".exe\"\n";
+        File.write(file, str);
+      then (fileName);
+    else
+      algorithm
+        Error.addInternalError("SimCodeMain.generateRunnerBatScript failed", sourceInfo());
+      then ("");
+  end matchcontinue;
+end generateRunnerBatScript;
+
+protected function getDirectoriesForDLLsFromLinkLibs
+  " Parse the makefileParams.libs and extract the necessary directories
+   to be added to the PATH for finding dependenncy libraries (DLLs on Windows).
+   NOTE: this function expects the 'link command' as the second argument. This will
+   look something like
+       {\"-LC:/Users/username/AppData/Roaming/.openmodelica/libraries/Buildings/Resources/Library/win64\",
+        \"-LC:/Users/username/AppData/Roaming/.openmodelica/libraries/Buildings/Resources/Library\",
+         ...}
+   The function will check for strings that start with \"-L and then trims it to get the
+   corrseponding directory.
+
+   If you want something more general write another function and generalize this.
+   We can also fix the creation of MakefileParams to separately list out these directories
+   (We do have MakefileParams.libDirs which seems to be empty).
+  "
+  input list<String> libsAndLinkDirs;
+  output String outLocations;
+algorithm
+
+  outLocations := "";
+  for str in libsAndLinkDirs loop
+    if Util.stringStartsWith("\"-L", str) then
+      outLocations := outLocations + System.trim(str, "\"-L") + ";";
+    end if;
+  end for;
+
+end getDirectoriesForDLLsFromLinkLibs;
+
 annotation(__OpenModelica_Interface="backend");
 end SimCodeUtil;

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -574,6 +574,37 @@ void SimulationOutputWidget::compileModel()
 #endif
 }
 
+
+/*!
+ * \brief getPathsFromBatFile
+ * Parses the fileName.bat file to get the necessary paths.
+ * Returns "" if it fails to parse the file as expected.
+ */
+QString SimulationOutputWidget::getPathsFromBatFile(QString fileName) {
+
+  QFile batFile(fileName);
+  batFile.open(QIODevice::ReadOnly | QIODevice::Text);
+
+  QString line;
+  // first line is supposed to be '@echo off'
+  line = batFile.readLine();
+  // Second line is where the PATH is set. We want that.
+  line = batFile.readLine();
+
+  if (!line.startsWith("set PATH=")) {
+    QString warnMessage = "Failed to read the neccesary PATH values from '" + fileName + "'\n"
+                          + "If simulation fails please check that you have the bat file and it is formatted correctly\n";
+    writeSimulationOutput(warnMessage, StringHandler::Error, true);
+    line = "";
+  } else {
+    // Strip the 'set PATH='
+    line.remove(0, 9);
+  }
+  batFile.close();
+
+  return line;
+}
+
 /*!
  * \brief SimulationOutputWidget::runSimulationExecutable
  * Runs the simulation executable.
@@ -602,10 +633,15 @@ void SimulationOutputWidget::runSimulationExecutable()
   fileName = fileName.replace("//", "/");
   // run the simulation executable to create the result file
 #if defined(_WIN32)
+  QProcessEnvironment processEnvironment = StringHandler::simulationProcessEnvironment();
+
+  QString paths = getPathsFromBatFile(fileName + ".bat");
+
   fileName = fileName.append(".exe");
   QFileInfo fileInfo(mSimulationOptions.getFileName());
-  QProcessEnvironment processEnvironment = StringHandler::simulationProcessEnvironment();
-  processEnvironment.insert("PATH", fileInfo.absoluteDir().absolutePath() + ";" + processEnvironment.value("PATH"));
+  paths = fileInfo.absoluteDir().absolutePath() + ";" + paths;
+
+  processEnvironment.insert("PATH", paths + ";" + processEnvironment.value("PATH"));
   mpSimulationProcess->setProcessEnvironment(processEnvironment);
 #endif
   // make the output tab enabled and current

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
@@ -139,6 +139,7 @@ private:
   void deleteIntermediateCompilationFiles();
   void writeSimulationOutput(QString output, StringHandler::SimulationMessageType type, bool textFormat);
   void simulationProcessFinishedHelper();
+  QString getPathsFromBatFile(QString fileName);
 private slots:
   void cancelCompilationOrSimulation();
   void openTransformationalDebugger();


### PR DESCRIPTION
  - We now generate a <ModelName>.bat file along with other generated files.

    The script updates the PATH with the directories extracted from the model
    and then launches the executable.

  - The APIs `simulate`, `optimize` and `linearize` now launch executables
    using this bat file.

  - OMEdit manually parses the bat file, extracts the additional paths
    needed and updates the PATH itself before launching the executable.
    If it fails to find or parse the bat file a warning message will be printed
    but simulation will be attempted anyway.

  - OMNotebook and OMShell are supposed to use the API functions and
    should be correct as well.
