### PR TITLE
More array improvements

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -307,6 +307,7 @@ algorithm
 
   if Binding.isBound(binding) then
     bindingExp := Binding.getExp(binding);
+    bindingExp := Expression.map(bindingExp, Expression.clone);
   else
     bindingExp := buildBinding(node, map, mutableParams, buildArrayBinding);
   end if;

--- a/OMCompiler/Compiler/Util/Array.mo
+++ b/OMCompiler/Compiler/Util/Array.mo
@@ -1231,6 +1231,7 @@ algorithm
 end mapBoolAnd;
 
 function transpose<T>
+  "Transposes a two-dimensional array."
   input array<array<T>> arr;
   output array<array<T>> outArray;
 protected
@@ -1270,6 +1271,8 @@ algorithm
 end transpose;
 
 function threadMap<T1, T2, TO>
+  "Creates an array with the result from calling the given function on each pair
+   of elements in two arrays."
   input array<T1> arr1;
   input array<T2> arr2;
   input MapFunc func;
@@ -1307,11 +1310,38 @@ algorithm
 end threadMap;
 
 function fromScalar<T>
+  "Creates an array of length 1 containing the given value."
   input T e;
   output array<T> arr;
 algorithm
   arr := arrayCreate(1, e);
 end fromScalar;
+
+function generate<T>
+  "Generates an array of length n and fills it by calling the given generator
+   function for each array element."
+  input Integer n;
+  input Generator generator;
+  output array<T> arr;
+
+  partial function Generator
+    output T e;
+  end Generator;
+protected
+  T e;
+algorithm
+  if n <= 0 then
+    arr := listArray({});
+  else
+    e := generator();
+    arr := arrayCreateNoInit(n, e);
+    arrayUpdateNoBoundsChecking(arr, 1, e);
+
+    for i in 2:n loop
+      arrayUpdateNoBoundsChecking(arr, i, generator());
+    end for;
+  end if;
+end generate;
 
 annotation(__OpenModelica_Interface="util");
 end Array;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -864,7 +864,7 @@ public constant ErrorTypes.Message FUNCTION_ARGUMENT_MUST_BE = ErrorTypes.MESSAG
   Gettext.gettext("The argument to ‘%s‘ must be %s."));
 public constant ErrorTypes.Message UNEXPECTED_COMPONENT_IN_COMPOSITE_NAME = ErrorTypes.MESSAGE(395, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Found component ‘%s‘ in composite name ‘%s‘, expected class."));
-public constant ErrorTypes.Message NF_MODIFY_PROTECTED = ErrorTypes.MESSAGE(54, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+public constant ErrorTypes.Message NF_MODIFY_PROTECTED = ErrorTypes.MESSAGE(396, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Protected element ‘%s‘ may not be modified, got ‘%s‘."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),


### PR DESCRIPTION
- Clone bindings in EvalFunction to avoid writing to the actual
  bindings.
- Simplify the Expression.* functions that generate arrays and make sure
  they don't create arrays with shared elements.
- Get rid of some listArray calls by using arrays instead of lists.