### PR TITLE
Declare equationIndexes to null if missing the info needed.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -4655,6 +4655,8 @@ template functionZeroCrossing(list<ZeroCrossing> zeroCrossings, list<SimEqSystem
   int <%symbolName(modelNamePrefix,"function_ZeroCrossings")%>(DATA *data, threadData_t *threadData, double *gout)
   {
     TRACE_PUSH
+    const int *equationIndexes = NULL;
+
     <%varDecls2%>
 
   #if !defined(OMC_MINIMAL_RUNTIME)
@@ -4796,6 +4798,8 @@ template functionRelations(list<ZeroCrossing> relations, String modelNamePrefix)
   int <%symbolName(modelNamePrefix,"function_updateRelations")%>(DATA *data, threadData_t *threadData, int evalforZeroCross)
   {
     TRACE_PUSH
+    const int *equationIndexes = NULL;
+
     <%varDecls%>
 
     if(evalforZeroCross) {


### PR DESCRIPTION
  - Fixes #8578.

  - There are functions that seem to be intended to provide these indices,
    e.g., `zeroCrossingDescription` and `relationDescription`.

    However, there is no way to actually use them now since the generation
    of expressions are handled by the generic `daeExp` function instead of
    with dedicated generators. `daeExp` will just generate `equationIndexes`
    for everything. So at least declare the variable for now even though
    it does not provide an additional info.
