### PR TITLE
Minor cleanup for the CMake configuration.

### DIFF
--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -407,7 +407,7 @@ libzmq: $(builddir_lib_omc)/$(LIBZMQLIB)
 $(builddir_lib_omc)/$(LIBZMQLIB):
 	test -d 3rdParty/libzmq
 	mkdir -p 3rdParty/libzmq/build
-	(cd 3rdParty/libzmq/build && test -f Makefile || CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(CMAKE) -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_AR:String="$(AR)" -DCMAKE_INSTALL_PREFIX="`pwd`" -DCMAKE_COLOR_MAKEFILE:Bool=OFF -DWITH_PERF_TOOL:Bool=OFF -DZMQ_BUILD_TESTS:Bool=OFF -DENABLE_CPACK:Bool=OFF -DCMAKE_BUILD_TYPE=Release .. -G $(CMAKE_TARGET))
+	(cd 3rdParty/libzmq/build && test -f Makefile || CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(CMAKE) -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_AR:String="$(AR)" -DCMAKE_INSTALL_PREFIX="`pwd`" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_COLOR_MAKEFILE:Bool=OFF -DWITH_PERF_TOOL:Bool=OFF -DZMQ_BUILD_TESTS:Bool=OFF -DENABLE_CPACK:Bool=OFF -DCMAKE_BUILD_TYPE=Release .. -G $(CMAKE_TARGET))
 	test -f 3rdParty/libzmq/build/lib/$(LIBZMQLIB) || $(MAKE) -C 3rdParty/libzmq/build install
 	test ! `uname` = Darwin || install_name_tool -id @rpath/$(LIBZMQLIB) 3rdParty/libzmq/build/lib/$(LIBZMQLIB)
 	# copy dll/so to $(LIB_OMC) and $(builddir_bin) folders

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -30,14 +30,12 @@ add_subdirectory(FMU2)
 ## This little function will give us the filename of the CPP runtime
 ## library given its alias.
 function (omc_get_library_filename target_alias LIB_FILENAME)
-  message(STATUS ${target_alias})
   get_target_property(LIB_FILENAME_LOCAL ${target_alias} ALIASED_TARGET)
-  message(STATUS ${LIB_FILENAME_LOCAL})
   set(${LIB_FILENAME} ${CMAKE_SHARED_LIBRARY_PREFIX}${LIB_FILENAME_LOCAL}${CMAKE_SHARED_LIBRARY_SUFFIX} PARENT_SCOPE)
 endfunction(omc_get_library_filename)
 
 ## Get the actual output filenames of the CPP runtime shared libs
-## This are to be used in LibrariesConfig for the purpose of loading the
+## This are to be used in LibrariesConfig.h for the purpose of loading the
 ## libs at simulation time using their file name.
 omc_get_library_filename(omc::simrt::cpp::core::system SYSTEM_LIB)
 omc_get_library_filename(omc::simrt::cpp::core::dataexchange DATAEXCHANGE_LIB)

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -298,5 +298,3 @@ target_include_directories(OMEditLib PRIVATE
 
 target_link_options(OMEditLib PRIVATE -Wl,--no-undefined)
 
-install(TARGETS OMEditLib)
-

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -93,7 +93,7 @@ INCLUDEPATH += . ../ \
   $$OPENMODELICAHOME/include/omc/c/util \
   $$OPENMODELICAHOME/include/omc/fmil \
   $$OPENMODELICAHOME/../OMParser/ \
-  $$OPENMODELICAHOME/../OMParser/install/include/antlr4-runtime/
+  $$OPENMODELICAHOME/../OMParser/3rdParty/antlr4/runtime/Cpp/runtime/src
 
 # Don't show the warnings from included headers.
 # Don't add a space between for and open parenthesis below. Qt4 complains about it.

--- a/OMParser/3rdParty/antlr4/runtime/Cpp/CMakeLists.txt
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/CMakeLists.txt
@@ -25,6 +25,8 @@ option(WITH_STATIC_CRT "(Visual C++) Enable to statically link CRT, which avoids
 
 project(LIBANTLR4)
 
+include(GNUInstallDirs)
+
 if(CMAKE_VERSION VERSION_EQUAL "3.0.0" OR
    CMAKE_VERSION VERSION_GREATER "3.0.0")
   CMAKE_POLICY(SET CMP0026 NEW)
@@ -147,7 +149,6 @@ endif(WITH_DEMO)
 # Generate CMake Package Files only if install is active
 if (ANTLR4_INSTALL)
 
-  include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)
 
   if(NOT ANTLR4_CMAKE_DIR)

--- a/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
@@ -110,20 +110,21 @@ set_target_properties(antlr4_static
                                  ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 
-install(TARGETS antlr4_shared
-        DESTINATION lib
-        EXPORT antlr4-targets)
-install(TARGETS antlr4_static
-        DESTINATION lib
-        EXPORT antlr4-targets)
-
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"
-        DESTINATION "include/antlr4-runtime"
-        COMPONENT dev
-        FILES_MATCHING
-          PATTERN "*.h"
-          PATTERN "UTF8_LICENSE"
+install(TARGETS antlr4_shared antlr4_static
+        EXPORT antlr4-targets
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
+
+
+# install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"
+#         DESTINATION "include/antlr4-runtime"
+#         COMPONENT dev
+#         FILES_MATCHING
+#           PATTERN "*.h"
+#           PATTERN "UTF8_LICENSE"
+#         )
 
 
 

--- a/OMParser/Makefile
+++ b/OMParser/Makefile
@@ -14,7 +14,7 @@ else
 CMAKE_TARGET = "Unix Makefiles"
 endif
 
-override CXXFLAGS += -Iinstall/include/antlr4-runtime -std=c++11 -DANTLR4CPP_STATIC
+override CXXFLAGS += -I3rdParty/antlr4/runtime/Cpp/runtime/src -std=c++11 -DANTLR4CPP_STATIC
 
 CPP_FILES=modelicaBaseListener.cpp  modelicaBaseVisitor.cpp  modelicaLexer.cpp  modelicaListener.cpp  modelicaParser.cpp  modelicaVisitor.cpp
 H_FILES=$(patsubst %.cpp,%.h,$(CPP_FILES))
@@ -26,7 +26,7 @@ libOMParser.a: $(OBJS)
 	$(AR) -s -r $@ $(OBJS)
 	mkdir -p $(OMBUILDDIR)/lib/$(host_short)/omc/ $(OMBUILDDIR)/include/omc/
 	cp -pR $@ $(OMBUILDDIR)/lib/$(host_short)/omc/
-	cp -pR install/include/antlr4-runtime $(OMBUILDDIR)/include/omc/
+# 	cp -pR install/include/antlr4-runtime $(OMBUILDDIR)/include/omc/
 
 $(OBJS): $(CPP_FILES) install/lib/libantlr4-runtime.a
 

--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -258,5 +258,5 @@ target_compile_definitions(qwt PRIVATE QWT_MOC_INCLUDE)
 target_link_options(qwt PRIVATE -Wl,--no-undefined)
 
 
-install (FILES ${QWT_HEADERS} DESTINATION include/qwt)
+# install (FILES ${QWT_HEADERS} DESTINATION include/qwt)
 install (TARGETS qwt)

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -10,7 +10,7 @@ set(OMSHELLLIB_HEADERS commandcompletion.h
                        oms.h)
 
 
-add_library(OMShellLib SHARED ${OMSHELLLIB_SOURCES} ${OMSHELLLIB_HEADERS})
+add_library(OMShellLib STATIC ${OMSHELLLIB_SOURCES} ${OMSHELLLIB_HEADERS})
 target_compile_definitions(OMShellLib PRIVATE OMSHELLLIB_MOC_INCLUDE)
 
 target_link_libraries(OMShellLib PUBLIC Qt5::Xml)
@@ -25,7 +25,6 @@ target_link_options(OMShellLib PRIVATE -Wl,--no-undefined)
 add_executable(OMShell WIN32 MACOSX_BUNDLE main.cpp rc_omshell.rc)
 target_link_libraries(OMShell PRIVATE OMShellLib)
 
-install(TARGETS OMShellLib)
 install(TARGETS OMShell)
 
 install(FILES commands.xml


### PR DESCRIPTION
  - Remove unnecessary installs.
    Some of this files are not need to be in the final install. They are
    need at build time internally.

  - 3rdParty
    - Set status messages as STATUS
    - Fix installation lib dirs from just lib to ${CMAKE_INSTALL_LIBDIR}
    - Change pkgconfig to pkgconfig
