### PR TITLE
clean up enum handling

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -8085,11 +8085,7 @@ protected
   BackendDAE.Equation eqn;
 algorithm
   lhs := BackendVariable.varExp(var);
-  try
-    rhs := BackendVariable.varBindExpStartValue(var);
-  else
-    rhs := DAE.RCONST(0.0);
-  end try;
+  rhs := BackendVariable.varBindExpStartValueNoFail(var);
   eqn := BackendDAE.EQUATION(lhs, rhs, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_BINDING);
   parameterEqns := BackendEquation.add(eqn, parameterEqns);
 end createGlobalKnownVarsEquations;

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -4573,7 +4573,7 @@ public function varExp
   input BackendDAE.Var inVar;
   output DAE.Exp outExp;
 algorithm
-  outExp := Expression.crefExp(inVar.varName);
+  outExp := Expression.crefToExp(inVar.varName);
 end varExp;
 
 public function varExp2 "same as varExp but adds a der()-call for state derivatives"

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -265,30 +265,12 @@ public function varStartValueType "author: Frenkel TUD 2012-11
   Returns the DAE.StartValue of a variable. If nothing is set the type specific one is used"
   input BackendDAE.Var v;
   output DAE.Exp sv;
+protected
+  Option<DAE.VariableAttributes> attr;
+  DAE.Type ty;
 algorithm
-  sv := matchcontinue(v)
-    local
-      Option<DAE.VariableAttributes> attr;
-      DAE.Type ty;
-
-    case (BackendDAE.VAR(values=attr)) equation
-      sv = DAEUtil.getStartAttrFail(attr);
-    then sv;
-
-    case BackendDAE.VAR(varType=ty) equation
-      true = Types.isIntegerOrSubTypeInteger(ty);
-    then DAE.ICONST(0);
-
-    case BackendDAE.VAR(varType=ty) equation
-      true = Types.isBooleanOrSubTypeBoolean(ty);
-    then DAE.BCONST(false);
-
-    case BackendDAE.VAR(varType=ty) equation
-      true = Types.isStringOrSubTypeString(ty);
-    then DAE.SCONST("");
-
-    else DAE.RCONST(0.0);
-  end matchcontinue;
+  BackendDAE.VAR(values=attr, varType=ty) := v;
+  sv := DAEUtil.getStartAttr(attr, ty);
 end varStartValueType;
 
 public function varStartValueOption "author: Frenkel TUD
@@ -622,7 +604,6 @@ public function getVariableAttributefromType
 algorithm
   attr := match(inType)
     case DAE.T_REAL() then DAE.VAR_ATTR_REAL(NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE());
-    case DAE.T_INTEGER() then DAE.VAR_ATTR_INT(NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE());
     case DAE.T_INTEGER() then DAE.VAR_ATTR_INT(NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE());
     case DAE.T_BOOL() then DAE.VAR_ATTR_BOOL(NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE());
     case DAE.T_STRING() then DAE.VAR_ATTR_STRING(NONE(),NONE(),NONE(),NONE(),NONE(),NONE(),NONE());
@@ -4176,6 +4157,9 @@ algorithm
     case(NONE(),_) guard Types.isStringOrSubTypeString(iTy)
       then
         DAE.SCONST("");
+    case(NONE(),_) guard Types.isEnumerationOrSubTypeEnumeration(iTy)
+      then
+        Types.getNthEnumLiteral(iTy, 1);
     else
       DAE.RCONST(0.0);
   end match;

--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -917,11 +917,7 @@ algorithm
     Error.addSourceMessage(Error.UNBOUND_PARAMETER_WITH_START_VALUE_WARNING, {s, str}, info);
   end if;
 
-  try
-    rhs := BackendVariable.varBindExpStartValue(var);
-  else
-    rhs := DAE.RCONST(0.0);
-  end try;
+  rhs := BackendVariable.varBindExpStartValueNoFail(var);
   eqn := BackendDAE.EQUATION(lhs, rhs, DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_BINDING);
   parameterEqns := BackendEquation.add(eqn, parameterEqns);
 end createGlobalKnownVarsEquations;

--- a/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ConnectUtil.mo
@@ -2910,7 +2910,7 @@ algorithm
     case DAE.T_REAL() then 1;
     case DAE.T_STRING() then 1;
     case DAE.T_BOOL() then 1;
-    case DAE.T_ENUMERATION(index = NONE()) then 1;
+    case DAE.T_ENUMERATION() then 1;
     // The size of an array is its dimension multiplied with the size of its type.
     case DAE.T_ARRAY()
       then intMul(Expression.dimensionSize(dim) for dim in ty.dims) * sizeOfType(ty.ty);

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -906,21 +906,19 @@ public function getStartAttr "
   input DAE.Type inType;
   output DAE.Exp start;
 algorithm
-  start := match(inVariableAttributesOption, inType)
+  start := match inVariableAttributesOption
     local
       DAE.Exp r;
-      Absyn.Path path;
-      list<String> names;
-    case (SOME(DAE.VAR_ATTR_REAL(start = SOME(r))), _) then r;
-    case (SOME(DAE.VAR_ATTR_REAL(start = NONE())), _) then DAE.RCONST(0.0);
-    case (SOME(DAE.VAR_ATTR_INT(start = SOME(r))), _) then r;
-    case (SOME(DAE.VAR_ATTR_INT(start = NONE())), _) then DAE.ICONST(0);
-    case (SOME(DAE.VAR_ATTR_BOOL(start = SOME(r))), _) then r;
-    case (SOME(DAE.VAR_ATTR_BOOL(start = NONE())), _) then DAE.BCONST(false);
-    case (SOME(DAE.VAR_ATTR_STRING(start = SOME(r))), _) then r;
-    case (SOME(DAE.VAR_ATTR_STRING(start = NONE())), _) then DAE.SCONST("");
-    case (SOME(DAE.VAR_ATTR_ENUMERATION(start = SOME(r))), _) then r;
-    case (SOME(DAE.VAR_ATTR_ENUMERATION(start = NONE())), DAE.T_ENUMERATION(path = path, names = names)) then DAE.ENUM_LITERAL(AbsynUtil.joinPaths(path, Absyn.IDENT(listHead(names))), 1);
+    case SOME(DAE.VAR_ATTR_REAL(start = SOME(r))) then r;
+    case SOME(DAE.VAR_ATTR_REAL(start = NONE())) then DAE.RCONST(0.0);
+    case SOME(DAE.VAR_ATTR_INT(start = SOME(r))) then r;
+    case SOME(DAE.VAR_ATTR_INT(start = NONE())) then DAE.ICONST(0);
+    case SOME(DAE.VAR_ATTR_BOOL(start = SOME(r))) then r;
+    case SOME(DAE.VAR_ATTR_BOOL(start = NONE())) then DAE.BCONST(false);
+    case SOME(DAE.VAR_ATTR_STRING(start = SOME(r))) then r;
+    case SOME(DAE.VAR_ATTR_STRING(start = NONE())) then DAE.SCONST("");
+    case SOME(DAE.VAR_ATTR_ENUMERATION(start = SOME(r))) then r;
+    case SOME(DAE.VAR_ATTR_ENUMERATION(start = NONE())) then Types.getNthEnumLiteral(inType, 1);
     else DAE.RCONST(0.0);
   end match;
 end getStartAttr;

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -13346,6 +13346,7 @@ algorithm
     case DAE.RCONST() then true;
     case DAE.SCONST() then true;
     case DAE.BCONST() then true;
+    case DAE.ENUM_LITERAL() then true;
     case DAE.BINARY() then true;
     case DAE.UNARY() then true;
     case DAE.LBINARY() then true;

--- a/OMCompiler/Compiler/FrontEnd/StateMachineFlatten.mo
+++ b/OMCompiler/Compiler/FrontEnd/StateMachineFlatten.mo
@@ -789,6 +789,10 @@ algorithm
         algorithm
           Error.addCompilerWarning("Variable "+ComponentReference.crefStr(inLHSCref)+" lacks start value. Defaulting to start=\"\".\n");
         then DAE.SCONST("");
+      case DAE.T_ENUMERATION()
+        algorithm
+          Error.addCompilerWarning("Variable "+ComponentReference.crefStr(inLHSCref)+" lacks start value. Defaulting to start=\"\".\n");
+        then Types.getNthEnumLiteral(inLHSty, 1);
       else
         algorithm
           Error.addCompilerError("Variable "+ComponentReference.crefStr(inLHSCref)+" lacks start value.\n");
@@ -891,6 +895,10 @@ algorithm
         algorithm
           Error.addCompilerWarning("Variable "+ComponentReference.crefStr(inLHSCref)+" lacks start value. Defaulting to start=\"\".\n");
         then DAE.SCONST("");
+      case DAE.T_ENUMERATION()
+        algorithm
+          Error.addCompilerWarning("Variable "+ComponentReference.crefStr(inLHSCref)+" lacks start value. Defaulting to start=\"\".\n");
+        then Types.getNthEnumLiteral(inLHSty, 1);
       else
         algorithm
           Error.addCompilerError("Variable "+ComponentReference.crefStr(inLHSCref)+" lacks start value.\n");

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8400,7 +8400,7 @@ algorithm
         addSimVar(simVar, SimVarsIndex.const, simVars);
       end if;
     // Integer vars
-    elseif Types.isInteger(dlowVar.varType) or  Types.isEnumeration(dlowVar.varType) then
+    elseif Types.isInteger(dlowVar.varType) or Types.isEnumeration(dlowVar.varType) then
       if isAlg then
         addSimVar(simVar, SimVarsIndex.intAlg, simVars);
       elseif isParam then
@@ -10108,6 +10108,7 @@ algorithm
     local
       Option<DAE.VariableAttributes> dae_var_attr;
       DAE.Exp e;
+      DAE.Type tp;
 
     case (BackendDAE.VAR(varKind = BackendDAE.VARIABLE(), values = dae_var_attr)) equation
       e = DAEUtil.getStartAttrFail(dae_var_attr);
@@ -10138,8 +10139,8 @@ algorithm
     then SOME(e);
 
     /* Parameters without binding. Investigate if it has start value */
-    case (BackendDAE.VAR(varKind = BackendDAE.PARAM(), values = dae_var_attr)) equation
-      e = DAEUtil.getStartAttrFail(dae_var_attr);
+    case (BackendDAE.VAR(varKind = BackendDAE.PARAM(), values = dae_var_attr, varType = tp)) equation
+      e = DAEUtil.getStartAttr(dae_var_attr, tp);
     then SOME(e);
 
     case (BackendDAE.VAR(varKind = BackendDAE.EXTOBJ(_), bindExp = SOME(e)))

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -9945,7 +9945,7 @@ algorithm
     case (DAE.T_REAL()) then SOME(DAE.RCONST(0.0));
     case (DAE.T_BOOL()) then SOME(DAE.BCONST(false));
     case (DAE.T_STRING()) then SOME(DAE.SCONST(""));
-    case (DAE.T_ENUMERATION()) then SOME(DAE.ICONST(0));
+    case (DAE.T_ENUMERATION()) then SOME(Types.getNthEnumLiteral(type_, 1));
     else NONE();
   end match;
 end setDefaultStartValue;

--- a/testsuite/openmodelica/cruntime/xmlFiles/testxmlInitForChangeableparameter.mos
+++ b/testsuite/openmodelica/cruntime/xmlFiles/testxmlInitForChangeableparameter.mos
@@ -128,7 +128,7 @@ readFile("testParameters_init.tmp.xml");
 //     classIndex = \"1\" classType = \"rPar\"
 //     isProtected = \"false\" hideResult = \"\"
 //     fileName = \"&lt;interactive&gt;\" startLine = \"3\" startColumn = \"3\" endLine = \"3\" endColumn = \"20\" fileWritable = \"true\">
-//     <Real fixed=\"true\" useNominal=\"false\" />
+//     <Real start=\"0.0\" fixed=\"true\" useNominal=\"false\" />
 //   </ScalarVariable>
 //   <ScalarVariable
 //     name = \"b\"
@@ -161,7 +161,7 @@ readFile("testParameters_init.tmp.xml");
 //     classIndex = \"4\" classType = \"rPar\"
 //     isProtected = \"false\" hideResult = \"\"
 //     fileName = \"&lt;interactive&gt;\" startLine = \"7\" startColumn = \"3\" endLine = \"7\" endColumn = \"32\" fileWritable = \"true\">
-//     <Real fixed=\"false\" useNominal=\"false\" />
+//     <Real start=\"0.0\" fixed=\"false\" useNominal=\"false\" />
 //   </ScalarVariable>
 //
 //

--- a/testsuite/simulation/modelica/initialization/parameters.mos
+++ b/testsuite/simulation/modelica/initialization/parameters.mos
@@ -41,9 +41,6 @@ simulate(initializationTests.parameters, simflags="-lv=LOG_INIT_V"); getErrorStr
 //     resultFile = "initializationTests.parameters_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'initializationTests.parameters', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V'",
 //     messages = "LOG_INIT          | info    | ### START INITIALIZATION ###
-// assert | warning | The following assertion has been violated at time 0.000000
-// | | |       | e1 >= initializationTests.E.E1 and e1 <= initializationTests.E.En
-// assert | warning | Variable violating min/max constraint: initializationTests.E.E1 <= e1 <= initializationTests.E.En, has value: 0
 // LOG_INIT          | info    | updating min-values
 // LOG_INIT          | info    | updating max-values
 // LOG_INIT          | info    | updating nominal-values
@@ -56,7 +53,7 @@ simulate(initializationTests.parameters, simflags="-lv=LOG_INIT_V"); getErrorStr
 // |                 | |       | | | [2] parameter Real r2(start=2, fixed=false) = 2
 // |                 | |       | | | [3] parameter Real r3(start=3, fixed=true) = 3
 // |                 | |       | | integer parameters
-// |                 | |       | | | [1] parameter Integer e1(start=0, fixed=true) = 0
+// |                 | |       | | | [1] parameter Integer e1(start=1, fixed=true) = 1
 // |                 | |       | | | [2] parameter Integer e2(start=2, fixed=false) = 2
 // |                 | |       | | | [3] parameter Integer e3(start=3, fixed=true) = 3
 // |                 | |       | | | [4] parameter Integer i1(start=0, fixed=true) = 0


### PR DESCRIPTION
### Purpose

Trying to find a reason for false assert failure
```
LOG_INIT          | info    | ### START INITIALIZATION ###
assert            | warning | The following assertion has been violated at time 0.000000
|                 | |       | e1 >= initializationTests.E.E1 and e1 <= initializationTests.E.En
assert            | warning | Variable violating min/max constraint: initializationTests.E.E1 <= e1 <= initializationTests.E.En, has value: 0
```
in `simulation/modelica/initialization/parameters.mo`

Variable `e1` is using default value (`initializationTests.E.E1`) and should not produce an assert failure.
