### PR TITLE
Remove DAE.STMT_FOR index and DAE.CREF_ITER

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1932,7 +1932,6 @@ algorithm
       DAE.Type tp;
       Boolean b1;
       String id1;
-      Integer index;
 
       list<DAE.ComponentRef> conditions;
       Boolean initialCall;
@@ -1971,11 +1970,11 @@ algorithm
         xs = removeDiscreteAssignments(rest,vars);
       then DAE.STMT_IF(e,stmts,algElse,source)::xs;
 
-    case (((DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,index=index,range=e,statementLst=stmts, source = source))::rest),vars)
+    case (((DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source))::rest),vars)
       equation
         stmts = removeDiscreteAssignments(stmts,vars);
         xs = removeDiscreteAssignments(rest,vars);
-      then DAE.STMT_FOR(tp,b1,id1,index,e,stmts,source)::xs;
+      then DAE.STMT_FOR(tp,b1,id1,e,stmts,source)::xs;
 
     case (((DAE.STMT_WHILE(exp=e,statementLst=stmts, source = source))::rest),vars)
       equation

--- a/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVarTransform.mo
@@ -2036,7 +2036,6 @@ protected
   DAE.Ident ident;
   list<DAE.ComponentRef> conditions;
   Boolean initialCall;
-  Integer index;
   Boolean b,b1,b2,b3;
   list<tuple<DAE.ComponentRef,SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
 algorithm
@@ -2089,7 +2088,7 @@ algorithm
         then
           replaceSTMT_IF(e1_2,statementLst,else_,source,repl,inFuncTypeExpExpToBooleanOption,outStatementLst,replacementPerformed or b1);
 
-      case DAE.STMT_FOR(type_=type_,iterIsArray=iterIsArray,iter=ident,index=index,range=e1,statementLst=statementLst,source=source)
+      case DAE.STMT_FOR(type_=type_,iterIsArray=iterIsArray,iter=ident,range=e1,statementLst=statementLst,source=source)
         equation
           repl = addIterationVar(repl,ident);
           (statementLst_1,b1) = replaceStatementLst(statementLst, repl,inFuncTypeExpExpToBooleanOption,{},false);
@@ -2100,9 +2099,9 @@ algorithm
           source = ElementSource.addSymbolicTransformationSimplify(b1,source,DAE.PARTIAL_EQUATION(e1_1),DAE.PARTIAL_EQUATION(e1_2));
           repl = removeIterationVar(repl,ident);
         then
-          (DAE.STMT_FOR(type_,iterIsArray,ident,index,e1_2,statementLst_1,source) :: outStatementLst, true);
+          (DAE.STMT_FOR(type_,iterIsArray,ident,e1_2,statementLst_1,source) :: outStatementLst, true);
 
-      case DAE.STMT_PARFOR(type_=type_,iterIsArray=iterIsArray,iter=ident,index=index,range=e1,statementLst=statementLst,loopPrlVars=loopPrlVars,source=source)
+      case DAE.STMT_PARFOR(type_=type_,iterIsArray=iterIsArray,iter=ident,range=e1,statementLst=statementLst,loopPrlVars=loopPrlVars,source=source)
         equation
           (statementLst_1,b1) = replaceStatementLst(statementLst, repl,inFuncTypeExpExpToBooleanOption,{},false);
           (e1_1,b2) = replaceExp(e1, repl,inFuncTypeExpExpToBooleanOption);
@@ -2111,7 +2110,7 @@ algorithm
           (e1_2,b1) = ExpressionSimplify.condsimplify(b2,e1_1);
           source = ElementSource.addSymbolicTransformationSimplify(b1,source,DAE.PARTIAL_EQUATION(e1_1),DAE.PARTIAL_EQUATION(e1_2));
         then
-          (DAE.STMT_PARFOR(type_,iterIsArray,ident,index,e1_2,statementLst_1,loopPrlVars,source) :: outStatementLst, true);
+          (DAE.STMT_PARFOR(type_,iterIsArray,ident,e1_2,statementLst_1,loopPrlVars,source) :: outStatementLst, true);
 
       case DAE.STMT_WHILE(exp=e1,statementLst=statementLst,source=source)
         equation

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -3381,7 +3381,6 @@ algorithm
       then
         (if referenceEq(subs_1,subs) then inCref else DAE.CREF_IDENT(name, ty, subs_1), b);
 
-    case (DAE.CREF_ITER(), _) then (inCref, iPerformed);
     case (DAE.OPTIMICA_ATTR_INST_CREF(), _) then (inCref, iPerformed);
     case (DAE.WILD(), _) then (inCref, iPerformed);
 

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -831,7 +831,6 @@ algorithm
       DAE.Exp elseif_exp;
       DAE.Else elseif_else_;
       list<DAE.Exp> expLst, dexpLst, expLstRHS;
-      Integer index;
       list<tuple<DAE.Exp, DAE.Exp>> exptl;
       list<DAE.Statement> statementLst, restStatements, derivedStatements1, derivedStatements2, else_statementLst, elseif_statementLst;
       String s1,s2;
@@ -888,14 +887,14 @@ algorithm
         (derivedStatements2, functions) = differentiateStatements(restStatements, inDiffwrtCref, inInputData, inDiffType, derivedStatements2, functions, maxIter);
       then (derivedStatements2, functions);
 
-    case DAE.STMT_FOR(type_=type_, iterIsArray=iterIsArray, iter=ident, index=index, range=exp, statementLst=statementLst, source=source)::restStatements
+    case DAE.STMT_FOR(type_=type_, iterIsArray=iterIsArray, iter=ident, range=exp, statementLst=statementLst, source=source)::restStatements
       equation
         cref = ComponentReference.makeCrefIdent(ident, DAE.T_INTEGER_DEFAULT, {});
         controlVar = BackendDAE.VAR(cref, BackendDAE.DISCRETE(), DAE.BIDIR(), DAE.NON_PARALLEL(), DAE.T_REAL_DEFAULT, NONE(), NONE(), {}, DAE.emptyElementSource, NONE(), NONE(), NONE(), NONE(), DAE.NON_CONNECTOR(), DAE.NOT_INNER_OUTER(), false);
         inputData = addGlobalVars({controlVar}, inInputData);
         (derivedStatements1, functions) = differentiateStatements(statementLst, inDiffwrtCref, inputData, inDiffType, {}, inFunctionTree, maxIter);
 
-        derivedStatements1 = {DAE.STMT_FOR(type_, iterIsArray, ident, index, exp, derivedStatements1, source)};
+        derivedStatements1 = {DAE.STMT_FOR(type_, iterIsArray, ident, exp, derivedStatements1, source)};
 
         derivedStatements2 = listAppend(derivedStatements1, inStmtsAccum);
         (derivedStatements2, functions) = differentiateStatements(restStatements, inDiffwrtCref, inInputData, inDiffType, derivedStatements2, functions, maxIter);

--- a/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
+++ b/OMCompiler/Compiler/BackEnd/FindZeroCrossings.mo
@@ -1742,7 +1742,6 @@ protected function traverseStmtsExps "Handles the traversing of list<DAE.Stateme
   output ForArgType extraArg = inExtraArg;
 protected
   DAE.Exp e_1, e_2, e, e2, iteratorExp;
-  Integer ix;
   list<DAE.Exp> expl1, expl2, iteratorexps;
   DAE.ComponentRef cr_1, cr;
   list<DAE.Statement> stmts, stmts2;
@@ -1787,19 +1786,19 @@ algorithm
         (e_1, extraArg) = Expression.traverseExpTopDown(e, collectZCAlgsFor, extraArg);
       then (DAE.STMT_IF(e_1, stmts2, algElse, source), extraArg);
 
-      case (DAE.STMT_FOR(type_=tp, iterIsArray=b1, iter=id1, index=ix, range=e, statementLst=stmts, source=source)) equation
+      case (DAE.STMT_FOR(type_=tp, iterIsArray=b1, iter=id1, range=e, statementLst=stmts, source=source)) equation
         cr = ComponentReference.makeCrefIdent(id1, tp, {});
         iteratorExp = Expression.crefExp(cr);
         iteratorexps = BackendDAEUtil.extendRange(e, inKnvars);
         (stmts2, extraArg) = traverseStmtsForExps(iteratorExp, iteratorexps, e, stmts, inKnvars, extraArg);
-      then (DAE.STMT_FOR(tp, b1, id1, ix, e, stmts2, source), extraArg);
+      then (DAE.STMT_FOR(tp, b1, id1, e, stmts2, source), extraArg);
 
-      case (DAE.STMT_PARFOR(type_=tp, iterIsArray=b1, iter=id1, index=ix, range=e, statementLst=stmts, loopPrlVars= loopPrlVars, source=source)) equation
+      case (DAE.STMT_PARFOR(type_=tp, iterIsArray=b1, iter=id1, range=e, statementLst=stmts, loopPrlVars= loopPrlVars, source=source)) equation
         cr = ComponentReference.makeCrefIdent(id1, tp, {});
         iteratorExp = Expression.crefExp(cr);
         iteratorexps = BackendDAEUtil.extendRange(e, inKnvars);
         (stmts2, extraArg) = traverseStmtsForExps(iteratorExp, iteratorexps, e, stmts, inKnvars, extraArg);
-      then (DAE.STMT_PARFOR(tp, b1, id1, ix, e, stmts2, loopPrlVars, source), extraArg);
+      then (DAE.STMT_PARFOR(tp, b1, id1, e, stmts2, loopPrlVars, source), extraArg);
 
       case (DAE.STMT_WHILE(exp=e, statementLst=stmts, source=source)) equation
         (stmts2, extraArg) = traverseStmtsExps(stmts, extraArg, inKnvars);

--- a/OMCompiler/Compiler/BackEnd/HpcOmMemory.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmMemory.mo
@@ -3433,8 +3433,6 @@ import Util;
         then DAE.CREF_QUAL(ident,identType,subscriptLst,componentRef);
       case(DAE.CREF_IDENT(ident,identType,subscriptLst))
         then DAE.CREF_IDENT(ident,identType,{});
-      case(DAE.CREF_ITER(ident,index,identType,subscriptLst))
-        then DAE.CREF_ITER(ident,index,identType,{});
       else iCref;
     end match;
   end removeSubscripts;

--- a/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
+++ b/OMCompiler/Compiler/BackEnd/RemoveSimpleEquations.mo
@@ -4533,7 +4533,6 @@ algorithm
       unReplaceable = if b then BaseHashSet.add(pcr, iUnreplaceable) else iUnreplaceable;
     then unReplaceable;
 
-    case (DAE.CREF_ITER(), _) then iUnreplaceable;
     case (DAE.OPTIMICA_ATTR_INST_CREF(), _) then iUnreplaceable;
     case (DAE.WILD(), _) then iUnreplaceable;
   end match;

--- a/OMCompiler/Compiler/FrontEnd/Algorithm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Algorithm.mo
@@ -685,17 +685,17 @@ algorithm
     case (i, e, DAE.PROP(type_ = DAE.T_ARRAY(ty = t, dims = dims)), stmts, _)
       equation
         isArray = Types.isNonscalarArray(t, dims);
-      then DAE.STMT_FOR(t, isArray, i, -1, e, stmts, source);
+      then DAE.STMT_FOR(t, isArray, i, e, stmts, source);
 
     case (i, e, DAE.PROP(type_ = DAE.T_METALIST(ty = t)), stmts, _)
       equation
         t = Types.simplifyType(t);
-      then DAE.STMT_FOR(t, false, i, -1, e, stmts, source);
+      then DAE.STMT_FOR(t, false, i, e, stmts, source);
 
     case (i, e, DAE.PROP(type_ = DAE.T_METAARRAY(ty = t)), stmts, _)
       equation
         t = Types.simplifyType(t);
-      then DAE.STMT_FOR(t, false, i, -1, e, stmts, source);
+      then DAE.STMT_FOR(t, false, i, e, stmts, source);
 
     case (_, e, DAE.PROP(type_ = t), _, _)
       equation
@@ -732,7 +732,7 @@ algorithm
         isArray = Types.isNonscalarArray(t, dims);
         _ = Types.simplifyType(t);
       then
-        DAE.STMT_PARFOR(t, isArray, i, -1, e, stmts, inLoopPrlVars, source);
+        DAE.STMT_PARFOR(t, isArray, i, e, stmts, inLoopPrlVars, source);
 
     case (_, e, DAE.PROP(type_ = t), _, _, _)
       equation

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -100,8 +100,6 @@ hash := match(cr)
     //print("QUAL, "+id+" hashed to "+intString(stringHashDjb2(id))+", subs hashed to "+intString(hashSubscripts(tp,subs))+"\n");
   then stringHashDjb2(id)+hashSubscripts(tp,subs)+hashComponentRef(cr1);
 
-  case(DAE.CREF_ITER(id,_,tp,subs))
-  then stringHashDjb2(id)+ hashSubscripts(tp,subs);
   else 0;
 end match;
 end hashComponentRef;
@@ -314,13 +312,6 @@ algorithm
       Absyn.ComponentRef cr_1;
       DAE.ComponentRef cr;
 
-    // iterators
-    case (DAE.CREF_ITER(ident = id, subscriptLst = subs))
-      equation
-        subs_1 = unelabSubscripts(subs);
-      then
-        Absyn.CREF_IDENT(id ,subs_1);
-
     // identifiers
     case (DAE.CREF_IDENT(ident = id, subscriptLst = subs))
       equation
@@ -509,17 +500,6 @@ algorithm
         str = printComponentRef2Str(s, subs);
       then
         str;
-
-    // Optimize -- a function call less
-    case (DAE.CREF_ITER(ident = s,index=ix,subscriptLst = {}))
-      then s + "/* iter index " + intString(ix) + " */";
-
-    // idents with subscripts
-    case DAE.CREF_ITER(ident = s,index=ix,subscriptLst = subs)
-      equation
-        str = printComponentRef2Str(s, subs);
-      then
-        str + "/* iter index " + intString(ix) + " */";
 
     // Qualified - Modelica output - does not handle names with underscores
     // Qualified - non Modelica output
@@ -2298,12 +2278,6 @@ algorithm
       then
         DAE.CREF_IDENT(id, ty, subs);
 
-    case (_, DAE.CREF_ITER(id, idx, ty, subs))
-      equation
-        id = stringAppend(id, inString);
-      then
-        DAE.CREF_ITER(id, idx, ty, subs);
-
   end match;
 end appendStringFirstIdent;
 
@@ -2331,12 +2305,6 @@ algorithm
         id = stringAppend(id, inString);
       then
         DAE.CREF_IDENT(id, ty, subs);
-
-    case (_, DAE.CREF_ITER(id, idx, ty, subs))
-      equation
-        id = stringAppend(id, inString);
-      then
-        DAE.CREF_ITER(id, idx, ty, subs);
 
   end match;
 end appendStringLastIdent;
@@ -2578,9 +2546,6 @@ algorithm
         child = crefSetLastType(child,newType);
       then
         makeCrefQual(id,ty,subs,child);
-
-    case DAE.CREF_ITER(id, idx, _, subs)
-      then DAE.CREF_ITER(id, idx, newType, subs);
 
   end match;
 end crefSetLastType;
@@ -3523,9 +3488,6 @@ algorithm
       then
         cr;
 
-    case DAE.CREF_ITER()
-      then
-        inCref;
     case DAE.WILD()
       then
         inCref;
@@ -3806,12 +3768,6 @@ algorithm
       then
         ();
 
-    case (DAE.CREF_ITER(identType = ty, subscriptLst = subs), _, _)
-      equation
-        checkCrefSubscriptsBounds3(ty, subs, inWholeCref, inInfo);
-      then
-        ();
-
   end match;
 end checkCrefSubscriptsBounds2;
 
@@ -4041,11 +3997,6 @@ algorithm
           szIdents := szIdents + System.getSizeOfData(cr.ident);
           szTypes := szTypes + System.getSizeOfData(cr.identType);
           szSubs := szSubs + System.getSizeOfData(cr.subscriptLst);
-        then (false,cr);
-      case DAE.CREF_ITER()
-        algorithm
-          szIdents := szIdents + System.getSizeOfData(cr.ident);
-          szTypes := szTypes + System.getSizeOfData(cr.identType);
         then (false,cr);
       case DAE.CREF_QUAL()
         algorithm

--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -716,7 +716,6 @@ uniontype Statement "There are four kinds of statements:
     Type type_ "this is the type of the iterator";
     Boolean iterIsArray "True if the iterator has an array type, otherwise false.";
     Ident iter "the iterator variable";
-    Integer index "the index of the iterator variable, to make it unique; used by the new inst";
     Exp range "range for the loop";
     list<Statement> statementLst;
     ElementSource source "the origin of the component/equation/algorithm" ;
@@ -726,7 +725,6 @@ uniontype Statement "There are four kinds of statements:
     Type type_ "this is the type of the iterator";
     Boolean iterIsArray "True if the iterator has an array type, otherwise false.";
     Ident iter "the iterator variable";
-    Integer index "the index of the iterator variable, to make it unique; used by the new inst";
     Exp range "range for the loop";
     list<Statement> statementLst;
     list<tuple<ComponentRef,SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
@@ -1833,13 +1831,6 @@ uniontype ComponentRef "- Component references
     Type identType "type of the identifier, without considering the subscripts";
     list<Subscript> subscriptLst;
   end CREF_IDENT;
-
-  record CREF_ITER "An iterator index; used in local scopes in for-loops and reductions"
-    Ident ident;
-    Integer index;
-    Type identType "type of the identifier, without considering the subscripts";
-    list<Subscript> subscriptLst;
-  end CREF_ITER;
 
   record OPTIMICA_ATTR_INST_CREF "An Optimica component reference with the time instant in it. e.g x2(finalTime)"
     ComponentRef componentRef;

--- a/OMCompiler/Compiler/FrontEnd/DAEDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEDump.mo
@@ -1394,7 +1394,7 @@ algorithm
     local
       DAE.ComponentRef c;
       DAE.Exp e,cond,msg,e1,e2;
-      Integer i,i_1,index;
+      Integer i,i_1;
       String s1,s2,s3,str,id,name;
       list<String> es;
       list<DAE.Exp> expl;
@@ -1452,14 +1452,11 @@ algorithm
       then
         ();
 
-    case (DAE.STMT_FOR(iter = id,index = index,range = e,statementLst = stmts),i)
+    case (DAE.STMT_FOR(iter = id,range = e,statementLst = stmts),i)
       equation
         indent(i);
         Print.printBuf("for ");
         Print.printBuf(id);
-        if index <> -1 then
-          Print.printBuf(" /* iter index " + intString(index) + " */");
-        end if;
         Print.printBuf(" in ");
         ExpressionDump.printExp(e);
         Print.printBuf(" loop\n");
@@ -1470,14 +1467,11 @@ algorithm
       then
         ();
 
-    case (DAE.STMT_PARFOR(iter = id,index=index,range = e,statementLst = stmts),i)
+    case (DAE.STMT_PARFOR(iter = id,range = e,statementLst = stmts),i)
       equation
         indent(i);
         Print.printBuf("parfor ");
         Print.printBuf(id);
-        if index <> -1 then
-          Print.printBuf(" /* iter index " + intString(index) + " */");
-        end if;
         Print.printBuf(" in ");
         ExpressionDump.printExp(e);
         Print.printBuf(" loop\n");
@@ -1641,7 +1635,7 @@ algorithm
       String s1,s2,s3,s4,s5,s6,str,s7,s8,s9,s10,s11,id,cond_str,msg_str,e1_str,e2_str;
       DAE.ComponentRef c;
       DAE.Exp e,cond,msg,e1,e2;
-      Integer i,i_1,index;
+      Integer i,i_1;
       list<String> es;
       list<DAE.Exp> expl;
       list<DAE.Statement> then_,stmts;
@@ -1695,27 +1689,25 @@ algorithm
       then
         str;
 
-    case (DAE.STMT_FOR(iter = id,index = index,range = e,statementLst = stmts),i)
+    case (DAE.STMT_FOR(iter = id,range = e,statementLst = stmts),i)
       equation
         s1 = indentStr(i);
-        s2 = if index == -1 then "" else ("/* iter index " + intString(index) + " */");
         s3 = ExpressionDump.printExpStr(e);
         i_1 = i + 2;
         s4 = ppStmtListStr(stmts, i_1);
         s5 = indentStr(i);
-        str = stringAppendList({s1,"for ",id,s2," in ",s3," loop\n",s4,s5,"end for;\n"});
+        str = stringAppendList({s1,"for ",id," in ",s3," loop\n",s4,s5,"end for;\n"});
       then
         str;
 
-    case (DAE.STMT_PARFOR(iter = id,index = index,range = e,statementLst = stmts),i)
+    case (DAE.STMT_PARFOR(iter = id,range = e,statementLst = stmts),i)
       equation
         s1 = indentStr(i);
-        s2 = if index == -1 then "" else ("/* iter index " + intString(index) + " */");
         s3 = ExpressionDump.printExpStr(e);
         i_1 = i + 2;
         s4 = ppStmtListStr(stmts, i_1);
         s5 = indentStr(i);
-        str = stringAppendList({s1,"parfor ",id,s2," in ",s3," loop\n",s4,s5,"end for;\n"});
+        str = stringAppendList({s1,"parfor ",id," in ",s3," loop\n",s4,s5,"end for;\n"});
       then
         str;
 

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -4538,7 +4538,6 @@ algorithm
       DAE.Statement x,ew,ew_1;
       Boolean b1;
       String id1,str;
-      Integer ix;
       DAE.ElementSource source;
       DAE.Else algElse,algElse1;
       Type_a extraArg;
@@ -4593,18 +4592,18 @@ algorithm
         stmts1 = if not b and referenceEq(e,e_1) and referenceEq(stmts,stmts2) and referenceEq(algElse,algElse1) then (inStmt::{}) else stmts1;
       then (stmts1,extraArg);
 
-    case (DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,index=ix,range=e,statementLst=stmts, source = source),_,_,extraArg)
+    case (DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source),_,_,extraArg)
       equation
         (stmts2, extraArg) = traverseDAEEquationsStmtsList(stmts,func,opt,extraArg);
         (e_1, extraArg) = func(e, extraArg);
-        x = if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then inStmt else DAE.STMT_FOR(tp,b1,id1,ix,e_1,stmts2,source);
+        x = if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then inStmt else DAE.STMT_FOR(tp,b1,id1,e_1,stmts2,source);
       then (x::{},extraArg);
 
-    case (DAE.STMT_PARFOR(type_=tp,iterIsArray=b1,iter=id1,index=ix,range=e,statementLst=stmts, loopPrlVars=loopPrlVars, source = source),_,_,extraArg)
+    case (DAE.STMT_PARFOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, loopPrlVars=loopPrlVars, source = source),_,_,extraArg)
       equation
         (stmts2, extraArg) = traverseDAEEquationsStmtsList(stmts,func,opt,extraArg);
         (e_1, extraArg) = func(e, extraArg);
-        x = if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then inStmt else DAE.STMT_PARFOR(tp,b1,id1,ix,e_1,stmts2,loopPrlVars,source);
+        x = if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then inStmt else DAE.STMT_PARFOR(tp,b1,id1,e_1,stmts2,loopPrlVars,source);
       then (x::{},extraArg);
 
     case (DAE.STMT_WHILE(exp = e,statementLst=stmts, source = source),_,_,extraArg)
@@ -4748,7 +4747,6 @@ protected
   DAE.Statement ew,ew_1;
   Boolean b1;
   String id1,str;
-  Integer ix;
   DAE.ElementSource source;
   DAE.Else algElse;
   list<tuple<DAE.ComponentRef,SourceInfo>> loopPrlVars "list of parallel variables used/referenced in the parfor loop";
@@ -4792,19 +4790,19 @@ algorithm
         then
           List.append_reverse(stmts1, outStmts);
 
-      case DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,index=ix,range=e,statementLst=stmts, source = source)
+      case DAE.STMT_FOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, source = source)
         equation
           (stmts2, extraArg) = traverseDAEStmts(stmts,func,extraArg);
           (e_1, extraArg) = func(e, stmt, extraArg);
         then
-          if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then stmt :: outStmts else DAE.STMT_FOR(tp,b1,id1,ix,e_1,stmts2,source)::outStmts;
+          if referenceEq(e,e_1) and referenceEq(stmts,stmts2) then stmt :: outStmts else DAE.STMT_FOR(tp,b1,id1,e_1,stmts2,source)::outStmts;
 
-      case DAE.STMT_PARFOR(type_=tp,iterIsArray=b1,iter=id1,index=ix,range=e,statementLst=stmts, loopPrlVars=loopPrlVars, source = source)
+      case DAE.STMT_PARFOR(type_=tp,iterIsArray=b1,iter=id1,range=e,statementLst=stmts, loopPrlVars=loopPrlVars, source = source)
         equation
           (stmts2, extraArg) = traverseDAEStmts(stmts,func,extraArg);
           (e_1, extraArg) = func(e, stmt, extraArg);
         then
-          DAE.STMT_PARFOR(tp,b1,id1,ix,e_1,stmts2,loopPrlVars,source)::outStmts;
+          DAE.STMT_PARFOR(tp,b1,id1,e_1,stmts2,loopPrlVars,source)::outStmts;
 
       case DAE.STMT_WHILE(exp = e,statementLst=stmts, source = source)
         equation

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -6051,14 +6051,6 @@ algorithm
       then
         (cr, arg);
 
-    case DAE.CREF_ITER(id, idx, ty, subs)
-      equation
-        (new_ty, arg) = traverseExpTypeDims(ty, inFunc, inArg);
-        cr = if referenceEq(new_ty, ty)
-          then inCref else DAE.CREF_ITER(id, idx, new_ty, subs);
-      then
-        (cr, arg);
-
     else (inCref, inArg);
   end match;
 end traverseExpCrefDims;
@@ -7397,13 +7389,6 @@ algorithm
       equation
         (subs_1, arg) = traverseExpSubs(subs, rel, arg);
         cr = if referenceEq(subs,subs_1) then inCref else DAE.CREF_IDENT(name, ty, subs_1);
-      then
-        (cr, arg);
-
-    case (DAE.CREF_ITER(ident = name, index = ix, identType = ty, subscriptLst = subs), _, arg)
-      equation
-        (subs_1, arg) = traverseExpSubs(subs, rel, arg);
-        cr = if referenceEq(subs,subs_1) then inCref else DAE.CREF_ITER(name, ix, ty, subs_1);
       then
         (cr, arg);
 

--- a/OMCompiler/Compiler/FrontEnd/Inline.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inline.mo
@@ -482,7 +482,6 @@ algorithm
       list<DAE.Statement> stmts,stmts_1;
       Boolean b,b1,b2,b3;
       String i;
-      Integer ix;
       DAE.ElementSource source;
       list<DAE.ComponentRef> conditions;
       Boolean initialCall;
@@ -516,13 +515,13 @@ algorithm
         true = b1 or b2 or b3;
       then
         (DAE.STMT_IF(e_1,stmts_1,a_else_1,source),true);
-    case(DAE.STMT_FOR(t,b,i,ix,e,stmts,source),fns)
+    case(DAE.STMT_FOR(t,b,i,e,stmts,source),fns)
       equation
         (e_1,source,b1,_) = inlineExp(e,fns,source);
         (stmts_1,b2) = inlineStatements(stmts,fns,{},false);
         true = b1 or b2;
       then
-        (DAE.STMT_FOR(t,b,i,ix,e_1,stmts_1,source),true);
+        (DAE.STMT_FOR(t,b,i,e_1,stmts_1,source),true);
     case(DAE.STMT_WHILE(e,stmts,source),fns)
       equation
         (e_1,source,b1,_) = inlineExp(e,fns,source);

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -7863,14 +7863,14 @@ algorithm
     case (DAE.STMT_FOR(iter=iter,range=exp,statementLst=stmts,source=source),_,(_,_,unbound))
       equation
         info = ElementSource.getElementSourceFileInfo(source);
-        unbound = List.filter1OnTrue(unbound,Util.stringNotEqual,iter) "TODO: This is not needed if all references are tagged CREF_ITER";
+        unbound = List.filter1OnTrue(unbound,Util.stringNotEqual,iter);
         (_,(unbound,_)) = Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
         ((_,b,unbound)) = List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound));
       then ((b,b,unbound));
     case (DAE.STMT_PARFOR(iter=iter,range=exp,statementLst=stmts,source=source),_,(_,_,unbound))
       equation
         info = ElementSource.getElementSourceFileInfo(source);
-        unbound = List.filter1OnTrue(unbound,Util.stringNotEqual,iter) "TODO: This is not needed if all references are tagged CREF_ITER";
+        unbound = List.filter1OnTrue(unbound,Util.stringNotEqual,iter);
         (_,(unbound,_)) = Expression.traverseExpTopDown(exp,findUnboundVariableUse,(unbound,info));
         ((_,b,unbound)) = List.fold1(stmts, checkFunctionDefUseStmt, true, (false,false,unbound));
       then ((b,b,unbound));

--- a/OMCompiler/Compiler/FrontEnd/Patternm.mo
+++ b/OMCompiler/Compiler/FrontEnd/Patternm.mo
@@ -2921,7 +2921,6 @@ algorithm
       SourceInfo info;
       Boolean b;
       String id;
-      Integer index;
       DAE.ElementSource source;
 
     case DAE.STMT_ASSIGN(type_=ty,exp1=lhs,exp=exp,source=source as DAE.SOURCE(info=info))
@@ -2953,7 +2952,7 @@ algorithm
         useTree = AvlSetString.join(useTree,elseTree);
       then (DAE.STMT_IF(exp,body,else_,source),useTree);
 
-    case DAE.STMT_FOR(ty,b,id,index,exp,body,source)
+    case DAE.STMT_FOR(ty,b,id,exp,body,source)
       equation
         // Loops repeat, so check for usage in the whole loop before removing any dead stores.
         ErrorExt.setCheckpoint(getInstanceName());
@@ -2963,7 +2962,7 @@ algorithm
         (_,useTree) = Expression.traverseExpBottomUp(exp, useLocalCref, useTree);
         // TODO: We should remove ident from the use-tree in case of shadowing... But our avlTree cannot delete
         useTree = AvlSetString.join(useTree,inUseTree);
-      then (DAE.STMT_FOR(ty,b,id,index,exp,body,source),useTree);
+      then (DAE.STMT_FOR(ty,b,id,exp,body,source),useTree);
 
     case DAE.STMT_WHILE(exp=exp,statementLst=body,source=source)
       equation

--- a/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
@@ -1109,7 +1109,6 @@ algorithm
       DAE.ComponentRef cRef;
       Boolean bool;
       DAE.Else elseBranch;
-      Integer ix;
       case DAE.STMT_ASSIGN(t,e1,e,source)
         equation
           (outCache,e1) = prefixExpWork(outCache,env,inIH,e1,p);
@@ -1134,11 +1133,11 @@ algorithm
           outStmts = elem::outStmts;
         then ();
 
-      case DAE.STMT_FOR(t,bool,id,ix,e,sList,source)
+      case DAE.STMT_FOR(t,bool,id,e,sList,source)
         equation
           (outCache,e) = prefixExpWork(outCache,env,inIH,e,p);
           (outCache,sList) = prefixStatements(outCache,env,inIH,sList,p);
-          elem = DAE.STMT_FOR(t,bool,id,ix,e,sList,source);
+          elem = DAE.STMT_FOR(t,bool,id,e,sList,source);
           outStmts = elem::outStmts;
         then ();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -931,14 +931,14 @@ algorithm
   forDAE := match for_type
     case Statement.ForType.NORMAL()
       then DAE.Statement.STMT_FOR(Type.toDAE(ty), Type.isArray(ty),
-        InstNode.name(iterator), 0, Expression.toDAE(range), dbody, source);
+        InstNode.name(iterator), Expression.toDAE(range), dbody, source);
 
     case Statement.ForType.PARALLEL()
       algorithm
         loop_vars := list(convertForStatementParallelVar(v) for v in for_type.vars);
       then
         DAE.Statement.STMT_PARFOR(Type.toDAE(ty), Type.isArray(ty),
-          InstNode.name(iterator), 0, Expression.toDAE(range), dbody, loop_vars, source);
+          InstNode.name(iterator), Expression.toDAE(range), dbody, loop_vars, source);
   end match;
 end convertForStatement;
 

--- a/OMCompiler/Compiler/SimCode/ReduceDAE.mo
+++ b/OMCompiler/Compiler/SimCode/ReduceDAE.mo
@@ -514,7 +514,6 @@ protected function addLabelToAlgorithms
       Boolean iterIsArray;
       DAE.Ident iter;
       list<Integer> helpVarIndices;
-    Integer index;
     list<DAE.ComponentRef> conditions;
     Boolean initialCall;
     case({},vars,idx,_,_)
@@ -552,7 +551,7 @@ protected function addLabelToAlgorithms
       then
         (DAE.STMT_IF(e,stmtLst2,else_,source)::rest2,vars_2,idx3,labels3);
 
-    case(DAE.STMT_FOR(ty,iterIsArray,iter,index,e,stmtLst,source)::rest,vars,idx,_,_)
+    case(DAE.STMT_FOR(ty,iterIsArray,iter,e,stmtLst,source)::rest,vars,idx,_,_)
       equation
 
         if(Flags.isSet(Flags.REDUCE_DAE)) then
@@ -562,7 +561,7 @@ protected function addLabelToAlgorithms
         (rest2,vars_2,idx3,labels2) = addLabelToAlgorithms(rest,vars_1,idx2,reduceList,inVarRepl);
         labels3=listAppend(labels,labels2);
       then
-        (DAE.STMT_FOR(ty,iterIsArray,iter,index,e,stmtLst2,source)::rest2,vars_2,idx3,labels3);
+        (DAE.STMT_FOR(ty,iterIsArray,iter,e,stmtLst2,source)::rest2,vars_2,idx3,labels3);
 
     case(DAE.STMT_WHILE(e,stmtLst,source)::rest,vars,idx,_,_)
       equation

--- a/OMCompiler/Compiler/Template/ExpressionDumpTV.mo
+++ b/OMCompiler/Compiler/Template/ExpressionDumpTV.mo
@@ -163,13 +163,6 @@ package DAE
       list<Subscript> subscriptLst;
     end CREF_IDENT;
 
-    record CREF_ITER
-      Ident ident;
-      Integer index;
-      Type identType;
-      list<Subscript> subscriptLst;
-    end CREF_ITER;
-
     record OPTIMICA_ATTR_INST_CREF
       ComponentRef componentRef;
       String instant;

--- a/OMCompiler/Compiler/Template/ExpressionDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/ExpressionDumpTpl.tpl
@@ -211,9 +211,6 @@ match cref
   case CREF_IDENT(__) then
     let sub_str = dumpSubscripts(subscriptLst)
     '<%ident%><%sub_str%>'
-  case CREF_ITER(__) then
-    let sub_str = dumpSubscripts(subscriptLst)
-    '<%ident%><%sub_str%> /* iter index <%index%> */'
   case CREF_QUAL(__) then
     let sub_str = dumpSubscripts(subscriptLst)
     let cref_str = dumpCref(componentRef)

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -2185,12 +2185,6 @@ package DAE
       Type identType;
       list<Subscript> subscriptLst;
     end CREF_IDENT;
-    record CREF_ITER "An iterator index; used in local scopes in for-loops and reductions"
-      Ident ident;
-      Integer index;
-      Type identType "type of the identifier, without considering the subscripts";
-      list<Subscript> subscriptLst;
-    end CREF_ITER;
     record OPTIMICA_ATTR_INST_CREF
       ComponentRef componentRef;
       String instant;

--- a/OMCompiler/Compiler/Template/VisualXMLTplTV.mo
+++ b/OMCompiler/Compiler/Template/VisualXMLTplTV.mo
@@ -508,13 +508,6 @@ interface package VisualXMLTplTV
         list<Subscript> subscriptLst;
       end CREF_IDENT;
 
-      record CREF_ITER "An iterator index; used in local scopes in for-loops and reductions"
-        Ident ident;
-        Integer index;
-        Type identType "type of the identifier, without considering the subscripts";
-        list<Subscript> subscriptLst;
-      end CREF_ITER;
-
       record OPTIMICA_ATTR_INST_CREF "An Optimica component reference with the time instant in it. e.g x2(finalTime)"
         ComponentRef componentRef;
         String instant;

--- a/OMCompiler/Compiler/Util/VarTransform.mo
+++ b/OMCompiler/Compiler/Util/VarTransform.mo
@@ -530,7 +530,6 @@ algorithm
       list<DAE.ComponentRef> conditions;
       Boolean initialCall,iterIsArray;
       DAE.Else el,el_1;
-      Integer ix;
 
     case ({},_,_) then ({},false);
     case ((DAE.STMT_ASSIGN(type_ = tp,exp1 = e2,exp = e,source = source) :: xs),_,_)
@@ -577,7 +576,7 @@ algorithm
         (xs_1,_) = replaceEquationsStmts(xs, repl,condExpFunc);
       then
         (DAE.STMT_IF(e_1,stmts2,el_1,source) :: xs_1,true);
-    case (((DAE.STMT_FOR(type_=tp,iterIsArray=iterIsArray,iter=id1,index=ix,range=e,statementLst=stmts,source = source)) :: xs),_,_)
+    case (((DAE.STMT_FOR(type_=tp,iterIsArray=iterIsArray,iter=id1,range=e,statementLst=stmts,source = source)) :: xs),_,_)
       equation
         (stmts2,b1) = replaceEquationsStmts(stmts,repl,condExpFunc);
         (e_1,b2) = replaceExp(e, repl, condExpFunc);
@@ -585,7 +584,7 @@ algorithm
         /* TODO: Add operation to source; do simplify? */
         (xs_1,_) = replaceEquationsStmts(xs, repl,condExpFunc);
       then
-        (DAE.STMT_FOR(tp,iterIsArray,id1,ix,e_1,stmts2,source) :: xs_1,true);
+        (DAE.STMT_FOR(tp,iterIsArray,id1,e_1,stmts2,source) :: xs_1,true);
     case (((DAE.STMT_WHILE(exp = e,statementLst=stmts,source = source)) :: xs),_,_)
       equation
         (stmts2,b1) = replaceEquationsStmts(stmts,repl,condExpFunc);


### PR DESCRIPTION
- The index in DAE.STMT_FOR and the DAE.CREF_ITER cref type are not
  generated anywhere in the compiler. They were used by a previous
  attempt at a new frontend which was scrapped a long time ago, and
  keeping them is unnecessary and confusing.