### PR TITLE
Fix some compilation warnings

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
@@ -112,7 +112,7 @@ namespace IAEX
 
     //TextCell interface.
     virtual QString text() = 0;
-    virtual QString textHtml(){return QString::null;}  // Added 2005-10-27 AF
+    virtual QString textHtml(){return QString();}  // Added 2005-10-27 AF
     virtual QTextCursor textCursor();          // Added 2005-10-27 AF
     virtual QTextEdit* textEdit(){return 0;}      // Added 2005-10-27 AF
     virtual void viewExpression(const bool){};

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
@@ -228,7 +228,7 @@ namespace IAEX
         else
         {
           cout << "File not found: " << fileToOpen.toStdString() << endl;
-          open(QString::null);
+          open(QString());
         }
       }
       else
@@ -269,7 +269,7 @@ namespace IAEX
             {
               cout << "Unable to find (3): " << drmodelica.toStdString() << endl;
               cout << "Unable to find (4): DrModelica/DrModelica.nb" << endl;
-              open(QString::null);
+              open(QString());
             }
           }
         }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcursor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcursor.h
@@ -75,7 +75,7 @@ namespace IAEX
     void moveAfter(Cell *current);
 
     virtual void accept(Visitor &v);
-    virtual QString text(){return QString::null;}
+    virtual QString text(){return QString();}
 
     //Flag
     bool isEditable();                // Added 2005-10-28 AF

--- a/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
@@ -160,7 +160,7 @@ namespace IAEX
     // 2005-12-01 AF, Added try-catch
     try
     {
-      if(filename_ != QString::null)
+      if(!filename_.isNull())
         open( filename_, readmode );
     }
     catch( exception &e )
@@ -666,7 +666,7 @@ namespace IAEX
 
     // save the image temporary to the harddrive
     QImageWriter writer( name, "png" );
-    writer.setDescription( tr("Temporary OMNotebook image") );
+    writer.setText("Description", tr("Temporary OMNotebook image") );
     writer.setQuality( 100 );
     writer.write( *image );
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellfactory.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellfactory.cpp
@@ -330,7 +330,7 @@ namespace IAEX
 
       // set correct cell style
       QString style_ = style;
-      if(style_ == QString::null)
+      if(style_.isNull())
         style_ = QString("Text");
 
       text->setStyle( style_ );

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.h
@@ -86,7 +86,7 @@ namespace IAEX{
 
     int height();
     CellStyle *style();                // Changed 2005-10-28
-    virtual QString text(){return QString::null;}
+    virtual QString text(){return QString();}
 
     void closeChildCells();              // Added 2005-11-30 AF
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/commandcompletion.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/commandcompletion.cpp
@@ -274,7 +274,7 @@ namespace IAEX
       }
     }
 
-    return QString::null;
+    return QString();
   }
 
   /*

--- a/OMNotebook/OMNotebook/OMNotebookGUI/commandunit.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/commandunit.h
@@ -81,7 +81,7 @@ namespace IAEX
       if( datafields_.contains( fieldID ))
         return datafields_[fieldID];
       else
-        return QString::null;
+        return QString();
     }
     void addDataField( QString fieldID, QString data )
     {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
@@ -1233,7 +1233,7 @@ namespace IAEX {
   QString GraphCell::ChapterCounter()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toPlainText();
   }
@@ -1248,7 +1248,7 @@ namespace IAEX {
   QString GraphCell::ChapterCounterHtml()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toHtml();
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
@@ -824,7 +824,7 @@ namespace IAEX
   QString InputCell::ChapterCounter()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toPlainText();
   }
@@ -839,7 +839,7 @@ namespace IAEX
   QString InputCell::ChapterCounterHtml()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toHtml();
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
@@ -655,7 +655,7 @@ namespace IAEX {
   QString LatexCell::ChapterCounter()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toPlainText();
   }
@@ -667,7 +667,7 @@ namespace IAEX {
   QString LatexCell::ChapterCounterHtml()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toHtml();
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
@@ -112,10 +112,10 @@ namespace IAEX
 
 
 // 2006-03-01 AF, Open, Save, Image and Link dir
-QString NotebookWindow::openDir_ = QString::null;
-QString NotebookWindow::saveDir_ = QString::null;
-QString NotebookWindow::imageDir_ = QString::null;
-QString NotebookWindow::linkDir_ = QString::null;
+QString NotebookWindow::openDir_ = QString();
+QString NotebookWindow::saveDir_ = QString();
+QString NotebookWindow::imageDir_ = QString();
+QString NotebookWindow::linkDir_ = QString();
 
 
 /*!
@@ -136,7 +136,7 @@ NotebookWindow::NotebookWindow(Document *subject,
     app_( subject->application() ), //AF
     findForm_( 0 )          //AF
 {
-  if( filename_ != QString::null )
+  if( !filename_.isNull() )
     qDebug( filename_.toStdString().c_str() );
 
   //    subject_->attach(this);
@@ -2396,7 +2396,7 @@ void NotebookWindow::newFile()
   if( subject_->isOpen() )
   {
     // a file is open, open a new window with the new file //AF
-    application()->commandCenter()->executeCommand(new OpenFileCommand(QString::null));
+    application()->commandCenter()->executeCommand(new OpenFileCommand(QString()));
   }
   else
   {
@@ -2413,7 +2413,7 @@ void NotebookWindow::newFile()
         return;
     }
 
-    subject_ = new CellDocument(app_, QString::null);
+    subject_ = new CellDocument(app_, QString());
     dynamic_cast<CellDocument*>(subject_)->autoIndent = autoIndentAction->isChecked();
     subject_->executeCommand(new NewFileCommand());
     subject_->attach(this);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebookcommands.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebookcommands.h
@@ -360,7 +360,7 @@ namespace IAEX
       {
         /*
         Document *doc = document();
-        doc = new CellDocument( application(), QString::null );
+        doc = new CellDocument( application(), QString() );
         */
       }
       catch(exception &e)

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcell.cpp
@@ -637,7 +637,7 @@ namespace IAEX
   QString TextCell::ChapterCounter()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toPlainText();
   }
@@ -652,7 +652,7 @@ namespace IAEX
   QString TextCell::ChapterCounterHtml()
   {
     if( chaptercounter_->toPlainText().isEmpty() )
-      return QString::null;
+      return QString();
 
     return chaptercounter_->toHtml();
   }

--- a/OMShell/OMShell/OMShellGUI/commandcompletion.cpp
+++ b/OMShell/OMShell/OMShellGUI/commandcompletion.cpp
@@ -260,7 +260,7 @@ namespace IAEX
       }
     }
 
-    return QString::null;
+    return QString();
   }
 
   /*

--- a/OMShell/OMShell/OMShellGUI/commandunit.h
+++ b/OMShell/OMShell/OMShellGUI/commandunit.h
@@ -81,7 +81,7 @@ namespace IAEX
       if( datafields_.contains( fieldID ))
         return datafields_[fieldID];
       else
-        return QString::null;
+        return QString();
     }
     void addDataField( QString fieldID, QString data )
     {

--- a/OMShell/OMShell/OMShellGUI/oms.cpp
+++ b/OMShell/OMShell/OMShellGUI/oms.cpp
@@ -493,7 +493,7 @@ void OMS::returnPressed()
   currentCommand_ = -1;
 
   // remove any newline
-  commandText.simplified();
+  commandText = commandText.simplified();
 
   // if 'quit()' exit OMShell
   if( commandText == "quit()" )
@@ -715,7 +715,7 @@ void OMS::loadModel()
   QString filename = QFileDialog::getOpenFileName(
     this,
     "OMShell - Load Model",
-    QString::null,
+    QString(),
     "Modelica files (*.mo)" );
 
   if( !filename.isNull() )


### PR DESCRIPTION
- `QString::null` is obsolete, use `QString()` instead.
- `QImageWriter::setDescription()` is obsolete, use
  `QImageWriter::setText()` instead.
- Don't ignore the return value of `QString::simplified()`,
  it doesn't change the string but returns a new string.