### PR TITLE
Add the mingw directories to the FFI search paths.

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1227,7 +1227,13 @@ algorithm
       // Search for both dir/lib and e.g. dir/linux64/lib.
       paths := (dir + "/" + lib) :: paths;
       paths := (dir + "/" + System.modelicaPlatform() + "/" + lib) :: paths;
+
+      if Autoconf.os == "Windows_NT" then
+        paths := (dir + "/" + System.openModelicaPlatform() + "/" + lib) :: paths;
+      end if;
+
     end for;
+
     paths := installLibDir + "/" + lib :: paths;
   end for;
 


### PR DESCRIPTION
  - We can also do the same and cover linux triplets like x86_64-linux.
     For now this is what is needed to handle libraries in Resources/Library/mingw(32/64).

  - See discussions in #8596