### PR TITLE
Preserve the DynamicSelect when the graphical primitives are updated

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -176,14 +176,7 @@ QString BitmapAnnotation::getOMCShapeAnnotation()
   QStringList annotationString;
   annotationString.append(GraphicItem::getOMCShapeAnnotation());
   // get the extents
-  QString extentString;
-  extentString.append("{");
-  extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-  extentString.append(QString::number(mExtents.at(0).y())).append("},");
-  extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-  extentString.append(QString::number(mExtents.at(1).y())).append("}");
-  extentString.append("}");
-  annotationString.append(extentString);
+  annotationString.append(mExtents.toQString());
   // get the file name
   annotationString.append(QString("\"").append(mOriginalFileName).append("\""));
   // get the image source
@@ -211,15 +204,8 @@ QString BitmapAnnotation::getShapeAnnotation()
   QStringList annotationString;
   annotationString.append(GraphicItem::getShapeAnnotation());
   // get the extents
-  if (mExtents.size() > 1) {
-    QString extentString;
-    extentString.append("extent={");
-    extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-    extentString.append(QString::number(mExtents.at(0).y())).append("},");
-    extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-    extentString.append(QString::number(mExtents.at(1).y())).append("}");
-    extentString.append("}");
-    annotationString.append(extentString);
+  if (mExtents.isDynamicSelectExpression() || mExtents.size() > 1) {
+    annotationString.append(QString("extent=%1").arg(mExtents.toQString()));
   }
   // get the file name
   if (!mOriginalFileName.isEmpty()) {

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -82,6 +82,30 @@ void DynamicAnnotation::reset()
   }
 }
 
+/*!
+ * \brief DynamicAnnotation::isDynamicSelectExpression
+ * Returns true is expression is DynamicSelect call.
+ * \return
+ */
+bool DynamicAnnotation::isDynamicSelectExpression() const
+{
+  return mExp.isCall("DynamicSelect");
+}
+
+/*!
+ * \brief DynamicAnnotation::toExpressionString
+ * Creates the actual expression string.
+ * \return
+ */
+QString DynamicAnnotation::toExpressionString() const
+{
+  if (mExp.isCall("DynamicSelect")) {
+    return QString("DynamicSelect(%1, %2)").arg(mExp.arg(0).toQString(), mExp.arg(1).toQString());
+  } else {
+    return mExp.toQString();
+  }
+}
+
 void DynamicAnnotation::setExp()
 {
   if (mState == State::None) {

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -84,26 +84,22 @@ void DynamicAnnotation::reset()
 
 /*!
  * \brief DynamicAnnotation::isDynamicSelectExpression
- * Returns true is expression is DynamicSelect call.
+ * Returns true if state is not none. DynamicSelect doesn't have state none.
  * \return
  */
 bool DynamicAnnotation::isDynamicSelectExpression() const
 {
-  return mExp.isCall("DynamicSelect");
+  return mState != State::None;
 }
 
 /*!
- * \brief DynamicAnnotation::toExpressionString
- * Creates the actual expression string.
+ * \brief DynamicAnnotation::toQString
+ * Unparses the Annotation into a string.
  * \return
  */
-QString DynamicAnnotation::toExpressionString() const
+QString DynamicAnnotation::toQString() const
 {
-  if (mExp.isCall("DynamicSelect")) {
-    return QString("DynamicSelect(%1, %2)").arg(mExp.arg(0).toQString(), mExp.arg(1).toQString());
-  } else {
-    return mExp.toQString();
-  }
+  return mExp.toQString();
 }
 
 void DynamicAnnotation::setExp()

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
@@ -45,6 +45,8 @@ class DynamicAnnotation
     void reset();
     virtual void clear() = 0;
     virtual FlatModelica::Expression toExp() const = 0;
+    bool isDynamicSelectExpression() const;
+    QString toExpressionString() const;
 
   protected:
     virtual void fromExp(const FlatModelica::Expression &exp) = 0;

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
@@ -46,7 +46,7 @@ class DynamicAnnotation
     virtual void clear() = 0;
     virtual FlatModelica::Expression toExp() const = 0;
     bool isDynamicSelectExpression() const;
-    QString toExpressionString() const;
+    QString toQString() const;
 
   protected:
     virtual void fromExp(const FlatModelica::Expression &exp) = 0;

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
@@ -144,18 +144,11 @@ QString EllipseAnnotation::getOMCShapeAnnotation()
   annotationString.append(GraphicItem::getOMCShapeAnnotation());
   annotationString.append(FilledShape::getOMCShapeAnnotation());
   // get the extents
-  QString extentString;
-  extentString.append("{");
-  extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-  extentString.append(QString::number(mExtents.at(0).y())).append("},");
-  extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-  extentString.append(QString::number(mExtents.at(1).y())).append("}");
-  extentString.append("}");
-  annotationString.append(extentString);
+  annotationString.append(mExtents.toQString());
   // get the start angle
-  annotationString.append(QString::number(mStartAngle));
+  annotationString.append(mStartAngle.toQString());
   // get the end angle
-  annotationString.append(QString::number(mEndAngle));
+  annotationString.append(mEndAngle.toQString());
   // get the closure
   annotationString.append(StringHandler::getClosureString(mClosure));
   return annotationString.join(",");
@@ -182,23 +175,16 @@ QString EllipseAnnotation::getShapeAnnotation()
   annotationString.append(GraphicItem::getShapeAnnotation());
   annotationString.append(FilledShape::getShapeAnnotation());
   // get the extents
-  if (mExtents.size() > 1) {
-    QString extentString;
-    extentString.append("extent={");
-    extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-    extentString.append(QString::number(mExtents.at(0).y())).append("},");
-    extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-    extentString.append(QString::number(mExtents.at(1).y())).append("}");
-    extentString.append("}");
-    annotationString.append(extentString);
+  if (mExtents.isDynamicSelectExpression() || mExtents.size() > 1) {
+    annotationString.append(QString("extent=%1").arg(mExtents.toQString()));
   }
   // get the start angle
-  if (mStartAngle != 0) {
-    annotationString.append(QString("startAngle=").append(QString::number(mStartAngle)));
+  if (mStartAngle.isDynamicSelectExpression() || mStartAngle != 0) {
+    annotationString.append(QString("startAngle=%1").arg(mStartAngle.toQString()));
   }
   // get the end angle
-  if (mEndAngle != 360) {
-    annotationString.append(QString("endAngle=").append(QString::number(mEndAngle)));
+  if (mEndAngle.isDynamicSelectExpression() || mEndAngle != 360) {
+    annotationString.append(QString("endAngle=%1").arg(mEndAngle.toQString()));
   }
   // get the closure
   if (!((mStartAngle == 0 && mEndAngle == 360 && mClosure == StringHandler::ClosureChord)

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -718,24 +718,18 @@ QString LineAnnotation::getOMCShapeAnnotation()
     annotationString.append(pointsString);
   }
   // get the line color
-  QString colorString;
-  colorString.append("{");
-  colorString.append(QString::number(mLineColor.red())).append(",");
-  colorString.append(QString::number(mLineColor.green())).append(",");
-  colorString.append(QString::number(mLineColor.blue()));
-  colorString.append("}");
-  annotationString.append(colorString);
+  annotationString.append(mLineColor.toQString());
   // get the line pattern
   annotationString.append(StringHandler::getLinePatternString(mLinePattern));
   // get the thickness
-  annotationString.append(QString::number(mLineThickness));
+  annotationString.append(mLineThickness.toQString());
   // get the start and end arrow
   QString arrowString;
   arrowString.append("{").append(StringHandler::getArrowString(mArrow.at(0))).append(",");
   arrowString.append(StringHandler::getArrowString(mArrow.at(1))).append("}");
   annotationString.append(arrowString);
   // get the arrow size
-  annotationString.append(QString::number(mArrowSize));
+  annotationString.append(mArrowSize.toQString());
   // get the smooth
   annotationString.append(StringHandler::getSmoothString(mSmooth));
   return annotationString.join(",");
@@ -777,22 +771,16 @@ QString LineAnnotation::getShapeAnnotation()
     annotationString.append(pointsString);
   }
   // get the line color
-  if (mLineColor != Qt::black) {
-    QString colorString;
-    colorString.append("color={");
-    colorString.append(QString::number(mLineColor.red())).append(",");
-    colorString.append(QString::number(mLineColor.green())).append(",");
-    colorString.append(QString::number(mLineColor.blue()));
-    colorString.append("}");
-    annotationString.append(colorString);
+  if (mLineColor.isDynamicSelectExpression() || mLineColor != Qt::black) {
+    annotationString.append(QString("color=%1").arg(mLineColor.toQString()));
   }
   // get the line pattern
   if (mLinePattern != StringHandler::LineSolid) {
     annotationString.append(QString("pattern=").append(StringHandler::getLinePatternString(mLinePattern)));
   }
   // get the thickness
-  if (mLineThickness != 0.25) {
-    annotationString.append(QString("thickness=").append(QString::number(mLineThickness)));
+  if (mLineThickness.isDynamicSelectExpression() || mLineThickness != 0.25) {
+    annotationString.append(QString("thickness=%1").arg(mLineThickness.toQString()));
   }
   // get the start and end arrow
   if ((mArrow.at(0) != StringHandler::ArrowNone) || (mArrow.at(1) != StringHandler::ArrowNone)) {
@@ -803,8 +791,8 @@ QString LineAnnotation::getShapeAnnotation()
     annotationString.append(arrowString);
   }
   // get the arrow size
-  if (mArrowSize != 3) {
-    annotationString.append(QString("arrowSize=").append(QString::number(mArrowSize)));
+  if (mArrowSize.isDynamicSelectExpression() || mArrowSize != 3) {
+    annotationString.append(QString("arrowSize=%1").arg(mArrowSize.toQString()));
   }
   // get the smooth
   if (mSmooth != StringHandler::SmoothNone) {

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
@@ -184,18 +184,9 @@ QString RectangleAnnotation::getOMCShapeAnnotation()
   // get the border pattern
   annotationString.append(StringHandler::getBorderPatternString(mBorderPattern));
   // get the extents
-  if (mExtents.size() > 1) {
-    QString extentString;
-    extentString.append("{");
-    extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-    extentString.append(QString::number(mExtents.at(0).y())).append("},");
-    extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-    extentString.append(QString::number(mExtents.at(1).y())).append("}");
-    extentString.append("}");
-    annotationString.append(extentString);
-  }
+  annotationString.append(mExtents.toQString());
   // get the radius
-  annotationString.append(QString::number(mRadius));
+  annotationString.append(mRadius.toQString());
   return annotationString.join(",");
 }
 
@@ -224,19 +215,12 @@ QString RectangleAnnotation::getShapeAnnotation()
     annotationString.append(QString("borderPattern=").append(StringHandler::getBorderPatternString(mBorderPattern)));
   }
   // get the extents
-  if (mExtents.size() > 1) {
-    QString extentString;
-    extentString.append("extent={");
-    extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-    extentString.append(QString::number(mExtents.at(0).y())).append("},");
-    extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-    extentString.append(QString::number(mExtents.at(1).y())).append("}");
-    extentString.append("}");
-    annotationString.append(extentString);
+  if (mExtents.isDynamicSelectExpression() || mExtents.size() > 1) {
+    annotationString.append(QString("extent=%1").arg(mExtents.toQString()));
   }
   // get the radius
-  if (mRadius != 0) {
-    annotationString.append(QString("radius=").append(QString::number(mRadius)));
+  if (mRadius.isDynamicSelectExpression() || mRadius != 0) {
+    annotationString.append(QString("radius=%1").arg(mRadius.toQString()));
   }
   return QString("Rectangle(").append(annotationString.join(",")).append(")");
 }

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -100,7 +100,7 @@ QStringList GraphicItem::getOMCShapeAnnotation()
 {
   QStringList annotationString;
   /* get visible */
-  annotationString.append(mVisible ? "true" : "false");
+  annotationString.append(mVisible.toExpressionString());
   /* get origin */
   QString originString;
   originString.append("{").append(QString::number(mOrigin.x())).append(",");
@@ -120,8 +120,8 @@ QStringList GraphicItem::getShapeAnnotation()
 {
   QStringList annotationString;
   /* get visible */
-  if (!mVisible) {
-    annotationString.append("visible=false");
+  if (mVisible.isDynamicSelectExpression() || !mVisible) {
+    annotationString.append(QString("visible=%1").arg(mVisible.toExpressionString()));
   }
   /* get origin */
   if (mOrigin != QPointF(0, 0)) {
@@ -211,7 +211,7 @@ QStringList FilledShape::getOMCShapeAnnotation()
   fillColorString.append(QString::number(mFillColor.green())).append(",");
   fillColorString.append(QString::number(mFillColor.blue()));
   fillColorString.append("}");
-  annotationString.append(fillColorString);
+  annotationString.append(mFillColor.toExpressionString());
   /* get the line pattern */
   annotationString.append(StringHandler::getLinePatternString(mLinePattern));
   /* get the fill pattern */
@@ -240,14 +240,8 @@ QStringList FilledShape::getShapeAnnotation()
     annotationString.append(lineColorString);
   }
   /* get the fill color */
-  if (mFillColor != Qt::black) {
-    QString fillColorString;
-    fillColorString.append("fillColor={");
-    fillColorString.append(QString::number(mFillColor.red())).append(",");
-    fillColorString.append(QString::number(mFillColor.green())).append(",");
-    fillColorString.append(QString::number(mFillColor.blue()));
-    fillColorString.append("}");
-    annotationString.append(fillColorString);
+  if (mFillColor.isDynamicSelectExpression() || mFillColor != Qt::black) {
+    annotationString.append(QString("fillColor=%1").arg(mFillColor.toExpressionString()));
   }
   /* get the line pattern */
   if (mLinePattern != StringHandler::LineSolid) {

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -100,14 +100,11 @@ QStringList GraphicItem::getOMCShapeAnnotation()
 {
   QStringList annotationString;
   /* get visible */
-  annotationString.append(mVisible.toExpressionString());
+  annotationString.append(mVisible.toQString());
   /* get origin */
-  QString originString;
-  originString.append("{").append(QString::number(mOrigin.x())).append(",");
-  originString.append(QString::number(mOrigin.y())).append("}");
-  annotationString.append(originString);
+  annotationString.append(mOrigin.toQString());
   /* get rotation */
-  annotationString.append(QString::number(mRotation));
+  annotationString.append(mRotation.toQString());
   return annotationString;
 }
 
@@ -121,19 +118,15 @@ QStringList GraphicItem::getShapeAnnotation()
   QStringList annotationString;
   /* get visible */
   if (mVisible.isDynamicSelectExpression() || !mVisible) {
-    annotationString.append(QString("visible=%1").arg(mVisible.toExpressionString()));
+    annotationString.append(QString("visible=%1").arg(mVisible.toQString()));
   }
   /* get origin */
-  if (mOrigin != QPointF(0, 0)) {
-    QString originString;
-    originString.append("origin=");
-    originString.append("{").append(QString::number(mOrigin.x())).append(",");
-    originString.append(QString::number(mOrigin.y())).append("}");
-    annotationString.append(originString);
+  if (mOrigin.isDynamicSelectExpression() || mOrigin != QPointF(0, 0)) {
+    annotationString.append(QString("origin=%1").arg(mOrigin.toQString()));
   }
   /* get rotation */
-  if (mRotation != 0) {
-    annotationString.append(QString("rotation=").append(QString::number(mRotation)));
+  if (mRotation.isDynamicSelectExpression() || mRotation != 0) {
+    annotationString.append(QString("rotation=%1").arg(mRotation.toQString()));
   }
   return annotationString;
 }
@@ -197,27 +190,15 @@ QStringList FilledShape::getOMCShapeAnnotation()
 {
   QStringList annotationString;
   /* get the line color */
-  QString lineColorString;
-  lineColorString.append("{");
-  lineColorString.append(QString::number(mLineColor.red())).append(",");
-  lineColorString.append(QString::number(mLineColor.green())).append(",");
-  lineColorString.append(QString::number(mLineColor.blue()));
-  lineColorString.append("}");
-  annotationString.append(lineColorString);
+  annotationString.append(mLineColor.toQString());
   /* get the fill color */
-  QString fillColorString;
-  fillColorString.append("{");
-  fillColorString.append(QString::number(mFillColor.red())).append(",");
-  fillColorString.append(QString::number(mFillColor.green())).append(",");
-  fillColorString.append(QString::number(mFillColor.blue()));
-  fillColorString.append("}");
-  annotationString.append(mFillColor.toExpressionString());
+  annotationString.append(mFillColor.toQString());
   /* get the line pattern */
   annotationString.append(StringHandler::getLinePatternString(mLinePattern));
   /* get the fill pattern */
   annotationString.append(StringHandler::getFillPatternString(mFillPattern));
   // get the thickness
-  annotationString.append(QString::number(mLineThickness));
+  annotationString.append(mLineThickness.toQString());
   return annotationString;
 }
 
@@ -230,18 +211,12 @@ QStringList FilledShape::getShapeAnnotation()
 {
   QStringList annotationString;
   /* get the line color */
-  if (mLineColor != Qt::black) {
-    QString lineColorString;
-    lineColorString.append("lineColor={");
-    lineColorString.append(QString::number(mLineColor.red())).append(",");
-    lineColorString.append(QString::number(mLineColor.green())).append(",");
-    lineColorString.append(QString::number(mLineColor.blue()));
-    lineColorString.append("}");
-    annotationString.append(lineColorString);
+  if (mLineColor.isDynamicSelectExpression() || mLineColor != Qt::black) {
+    annotationString.append(QString("lineColor=%1").arg(mLineColor.toQString()));
   }
   /* get the fill color */
   if (mFillColor.isDynamicSelectExpression() || mFillColor != Qt::black) {
-    annotationString.append(QString("fillColor=%1").arg(mFillColor.toExpressionString()));
+    annotationString.append(QString("fillColor=%1").arg(mFillColor.toQString()));
   }
   /* get the line pattern */
   if (mLinePattern != StringHandler::LineSolid) {
@@ -252,8 +227,8 @@ QStringList FilledShape::getShapeAnnotation()
     annotationString.append(QString("fillPattern=").append(StringHandler::getFillPatternString(mFillPattern)));
   }
   // get the thickness
-  if (mLineThickness != 0.25) {
-    annotationString.append(QString("lineThickness=").append(QString::number(mLineThickness)));
+  if (mLineThickness.isDynamicSelectExpression() || mLineThickness != 0.25) {
+    annotationString.append(QString("lineThickness=%1").arg(mLineThickness.toQString()));
   }
   return annotationString;
 }
@@ -267,14 +242,8 @@ QStringList FilledShape::getTextShapeAnnotation()
 {
   QStringList annotationString;
   /* get the text color */
-  if (mLineColor != Qt::black) {
-    QString lineColorString;
-    lineColorString.append("textColor={");
-    lineColorString.append(QString::number(mLineColor.red())).append(",");
-    lineColorString.append(QString::number(mLineColor.green())).append(",");
-    lineColorString.append(QString::number(mLineColor.blue()));
-    lineColorString.append("}");
-    annotationString.append(lineColorString);
+  if (mLineColor.isDynamicSelectExpression() || mLineColor != Qt::black) {
+    annotationString.append(QString("lineColor=%1").arg(mLineColor.toQString()));
   }
   return annotationString;
 }

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -374,26 +374,13 @@ QString TextAnnotation::getOMCShapeAnnotation()
   annotationString.append(GraphicItem::getOMCShapeAnnotation());
   annotationString.append(FilledShape::getOMCShapeAnnotation());
   // get the extents
-  QString extentString;
-  extentString.append("{");
-  extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-  extentString.append(QString::number(mExtents.at(0).y())).append("},");
-  extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-  extentString.append(QString::number(mExtents.at(1).y())).append("}");
-  extentString.append("}");
-  annotationString.append(extentString);
+  annotationString.append(mExtents.toQString());
   // get the text string
-  annotationString.append(QString("\"").append(mTextString).append("\""));
+  annotationString.append(mTextString.toQString());
   // get the font size
-  annotationString.append(QString::number(mFontSize));
+  annotationString.append(mFontSize.toQString());
   // get the text color
-  QString textColorString;
-  textColorString.append("{");
-  textColorString.append(QString::number(mLineColor.red())).append(",");
-  textColorString.append(QString::number(mLineColor.green())).append(",");
-  textColorString.append(QString::number(mLineColor.blue()));
-  textColorString.append("}");
-  annotationString.append(textColorString);
+  annotationString.append(mLineColor.toQString());
   // get the font name
   if (!mFontName.isEmpty() && mFontName.compare(Helper::systemFontInfo.family()) != 0) {
     annotationString.append(QString("\"").append(mFontName).append("\""));
@@ -434,21 +421,14 @@ QString TextAnnotation::getShapeAnnotation()
   annotationString.append(GraphicItem::getShapeAnnotation());
   annotationString.append(FilledShape::getTextShapeAnnotation());
   // get the extents
-  if (mExtents.size() > 1) {
-    QString extentString;
-    extentString.append("extent={");
-    extentString.append("{").append(QString::number(mExtents.at(0).x())).append(",");
-    extentString.append(QString::number(mExtents.at(0).y())).append("},");
-    extentString.append("{").append(QString::number(mExtents.at(1).x())).append(",");
-    extentString.append(QString::number(mExtents.at(1).y())).append("}");
-    extentString.append("}");
-    annotationString.append(extentString);
+  if (mExtents.isDynamicSelectExpression() || mExtents.size() > 1) {
+    annotationString.append(QString("extent=%1").arg(mExtents.toQString()));
   }
   // get the text string
-  annotationString.append(QString("textString=\"").append(mTextString).append("\""));
+  annotationString.append(QString("textString=%1").arg(mTextString.toQString()));
   // get the font size
-  if (mFontSize != 0) {
-    annotationString.append(QString("fontSize=").append(QString::number(mFontSize)));
+  if (mFontSize.isDynamicSelectExpression() || mFontSize != 0) {
+    annotationString.append(QString("fontSize=%1").arg(mFontSize.toQString()));
   }
   // get the font name
   /* Ticket:4204


### PR DESCRIPTION
### Related Issues

Fixes #8593

### Purpose

Do not discard the actual DynamicSelect annotation during reparsing.

### Approach

Preserve the DynamicSelect annotation. Just update the static part of the expression.
