### PR TITLE
Fix some issues with Connections.uniqueRootIndices

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1681,7 +1681,20 @@ protected
     arg1 :: arg2 :: args := args;
 
     (arg1, ty1) := typeConnectionsArg(arg1, context, info, fn_ref, 1);
+
+    if not Type.isArray(ty1) then
+      Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH,
+        {"1", ComponentRef.toString(fn_ref), "", Expression.toString(arg1),
+         Type.toString(ty1), "Connector[:]"}, info);
+    end if;
+
     (arg2, ty2) := typeConnectionsArg(arg2, context, info, fn_ref, 2);
+
+    if not Type.isArray(ty2) then
+      Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH,
+        {"2", ComponentRef.toString(fn_ref), "", Expression.toString(arg2),
+         Type.toString(ty2), "Connector[:]"}, info);
+    end if;
 
     if args_len == 3 then
       arg3 := listHead(args);
@@ -1693,13 +1706,13 @@ protected
            Type.toString(ty3), "String"}, info);
       end if;
     else
-      arg2 := Expression.STRING("");
+      arg3 := Expression.STRING("");
     end if;
 
     {fn} := Function.typeRefCache(fn_ref);
     assert(listLength(Type.arrayDims(ty1)) == listLength(Type.arrayDims(ty2)), "the first two parameters need to have the same size");
     ty := Type.ARRAY(Type.Type.INTEGER(), Type.arrayDims(ty1));
-    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2}, var, purity, ty));
+    callExp := Expression.CALL(Call.makeTypedCall(fn, {arg1, arg2, arg3}, var, purity, ty));
 
   end typeUniqueRootIndicesCall;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -1188,6 +1188,7 @@ algorithm
       list<Expression> lst;
       Call call;
       String str;
+      Dimension dim;
 
     case Expression.CALL(call = call as Call.TYPED_CALL())
       then match identifyConnectionsOperator(Function.name(call.fn))
@@ -1262,17 +1263,23 @@ algorithm
             res := match call.arguments
               // normal call
               case {uroots,nodes,message}
-                equation
+                algorithm
                   if Flags.isSet(Flags.CGRAPH) then
-                    print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: Connections.uniqueRootsIndicies(" +
+                    print("- NFOCConnectionGraph.evalConnectionsOperatorsHelper: Connections.uniqueRootsIndices(" +
                       Expression.toString(uroots) + "," +
                       Expression.toString(nodes) + "," +
                       Expression.toString(message) + ")\n");
                   end if;
-                  lst = Expression.arrayElementList(uroots);
-                  lst = List.fill(Expression.INTEGER(1), listLength(lst)); // TODO! FIXME! actually implement this correctly
+
+                  dim := Type.nthDimension(Expression.typeOf(uroots), 1);
+
+                  if not Dimension.isKnown(dim) then
+                    Error.addSourceMessage(Error.DIMENSION_NOT_KNOWN,
+                      {Expression.toString(exp)}, info);
+                    fail();
+                  end if;
                 then
-                  Expression.makeArray(Type.INTEGER(), listArray(lst));
+                  Expression.fillArray(Dimension.size(dim), Expression.INTEGER(1)); // TODO! FIXME! actually implement this correctly
             end match;
           then
             res;


### PR DESCRIPTION
- Check that the first two arguments are actually arrays.
- Actually append the default value for the third argument when the
  argument is omitted.
- Fix the evaluation of the operators so that it doesn't assume the
  arguments have been expanded and fails without error otherwise.