### PR TITLE
Handle the inheritance when animating using DynamicSelect annotation

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -83,6 +83,18 @@ void DynamicAnnotation::reset()
 }
 
 /*!
+ * \brief DynamicAnnotation::resetDynamicToStatic
+ * Resets from dynamic to static.
+ */
+void DynamicAnnotation::resetDynamicToStatic()
+{
+  if (mState == State::Dynamic) {
+    mState = State::Static;
+    reset();
+  }
+}
+
+/*!
  * \brief DynamicAnnotation::isDynamicSelectExpression
  * Returns true if state is not none. DynamicSelect doesn't have state none.
  * \return

--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.h
@@ -43,6 +43,7 @@ class DynamicAnnotation
     void parse(const QString &str);
     bool update(double time, Element *parent);
     void reset();
+    void resetDynamicToStatic();
     virtual void clear() = 0;
     virtual FlatModelica::Expression toExp() const = 0;
     bool isDynamicSelectExpression() const;

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1000,12 +1000,12 @@ void LineAnnotation::setShapeFlags(bool enable)
   if ((mLineType == LineAnnotation::ConnectionType || mLineType == LineAnnotation::TransitionType
        || mLineType == LineAnnotation::InitialStateType || mLineType == LineAnnotation::ShapeType)
       && mpGraphicsView) {
-    /*
-      Only set the ItemIsMovable & ItemSendsGeometryChanges flags on Line if the class is not a system library class
-      AND Line is not an inherited Line AND Line type is not ConnectionType.
-      */
+    /* Only set the ItemIsMovable & ItemSendsGeometryChanges flags on Line if the class is not a system library class
+     * AND not a visualization view
+     * AND Line is not an inherited Line AND Line type is not ConnectionType.
+     */
     bool isSystemLibrary = mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary();
-    if (!isSystemLibrary && !isInheritedShape() && mLineType != LineAnnotation::ConnectionType &&
+    if (!isSystemLibrary && !mpGraphicsView->isVisualizationView() && !isInheritedShape() && mLineType != LineAnnotation::ConnectionType &&
         mLineType != LineAnnotation::TransitionType && mLineType != LineAnnotation::InitialStateType) {
       setFlag(QGraphicsItem::ItemIsMovable, enable);
       setFlag(QGraphicsItem::ItemSendsGeometryChanges, enable);
@@ -2164,7 +2164,7 @@ CreateOrEditTransitionDialog::CreateOrEditTransitionDialog(GraphicsView *pGraphi
   // Create the buttons
   mpOkButton = new QPushButton(Helper::ok);
   mpOkButton->setAutoDefault(true);
-  if (mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary() || mpGraphicsView->isVisualizationView()) {
+  if (mpGraphicsView->getModelWidget()->getLibraryTreeItem()->isSystemLibrary()) {
     mpOkButton->setDisabled(true);
   }
   connect(mpOkButton, SIGNAL(clicked()), SLOT(createOrEditTransition()));

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
@@ -261,6 +261,7 @@ public slots:
   void referenceShapeChanged();
   void referenceShapeDeleted();
   void updateDynamicSelect(double time);
+  void resetDynamicSelect();
 protected:
   GraphicsView *mpGraphicsView;
   Element *mpParentComponent;

--- a/OMEdit/OMEditLIB/Element/CornerItem.cpp
+++ b/OMEdit/OMEditLIB/Element/CornerItem.cpp
@@ -119,7 +119,7 @@ void CornerItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
  */
 void CornerItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-  if (event->button() == Qt::LeftButton) {
+  if (event->button() == Qt::LeftButton && !mpShapeAnnotation->getGraphicsView()->isVisualizationView()) {
     if (!signalsBlocked()) {
       emit cornerItemPress(mConnectedPointIndex);
     }
@@ -136,7 +136,7 @@ void CornerItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
  */
 void CornerItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
-  if (mpShapeAnnotation->isInheritedShape()
+  if (mpShapeAnnotation->isInheritedShape() && mpShapeAnnotation->getGraphicsView()->isVisualizationView()
       || (mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::OMS
           && (mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getOMSConnector()
               || mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getOMSBusConnector()
@@ -179,7 +179,7 @@ void CornerItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 void CornerItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
   QGraphicsItem::mouseReleaseEvent(event);
-  if (event->button() == Qt::LeftButton) {
+  if (event->button() == Qt::LeftButton && !mpShapeAnnotation->getGraphicsView()->isVisualizationView()) {
     if (!signalsBlocked()) {
       emit cornerItemRelease(mOldScenePosition != scenePos());
     }
@@ -300,7 +300,7 @@ bool ResizerItem::isPressed()
   */
 void ResizerItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-  if (event->button() == Qt::LeftButton) {
+  if (event->button() == Qt::LeftButton && !mpComponent->getGraphicsView()->isVisualizationView()) {
     emit resizerItemPressed(this);
     mIsPressed = true;
     mResizerItemOldPosition = event->scenePos();
@@ -331,7 +331,7 @@ void ResizerItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 void ResizerItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
   QGraphicsItem::mouseReleaseEvent(event);
-  if (event->button() == Qt::LeftButton) {
+  if (event->button() == Qt::LeftButton && !mpComponent->getGraphicsView()->isVisualizationView()) {
     mIsPressed = false;
     emit resizerItemReleased();
     if (mResizerItemOldPosition != mpComponent->getGraphicsView()->snapPointToGrid(event->scenePos())) {

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -415,6 +415,7 @@ public slots:
   void showSubModelAttributes();
   void showElementPropertiesDialog();
   void updateDynamicSelect(double time);
+  void resetDynamicSelect();
 protected:
   virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 };

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -2029,8 +2029,9 @@ void MainWindow::resetZoom()
       }
     }
   } else if (isPlottingPerspectiveActive()) {
-    if (mpPlotWindowContainer->currentSubWindow() && mpPlotWindowContainer->isDiagramWindow(mpPlotWindowContainer->currentSubWindow()->widget())) {
-      mpPlotWindowContainer->getDiagramWindow()->getGraphicsView()->resetZoom();
+    if (mpPlotWindowContainer->currentSubWindow() && mpPlotWindowContainer->isDiagramWindow(mpPlotWindowContainer->currentSubWindow()->widget())
+        && mpPlotWindowContainer->getDiagramWindow() && mpPlotWindowContainer->getDiagramWindow()->getModelWidget()) {
+      mpPlotWindowContainer->getDiagramWindow()->getModelWidget()->getDiagramGraphicsView()->resetZoom();
     }
   }
 }
@@ -2055,8 +2056,9 @@ void MainWindow::zoomIn()
       }
     }
   } else if (isPlottingPerspectiveActive()) {
-    if (mpPlotWindowContainer->currentSubWindow() && mpPlotWindowContainer->isDiagramWindow(mpPlotWindowContainer->currentSubWindow()->widget())) {
-      mpPlotWindowContainer->getDiagramWindow()->getGraphicsView()->zoomIn();
+    if (mpPlotWindowContainer->currentSubWindow() && mpPlotWindowContainer->isDiagramWindow(mpPlotWindowContainer->currentSubWindow()->widget())
+        && mpPlotWindowContainer->getDiagramWindow() && mpPlotWindowContainer->getDiagramWindow()->getModelWidget()) {
+      mpPlotWindowContainer->getDiagramWindow()->getModelWidget()->getDiagramGraphicsView()->zoomIn();
     }
   }
 }
@@ -2081,8 +2083,9 @@ void MainWindow::zoomOut()
       }
     }
   } else if (isPlottingPerspectiveActive()) {
-    if (mpPlotWindowContainer->currentSubWindow() && mpPlotWindowContainer->isDiagramWindow(mpPlotWindowContainer->currentSubWindow()->widget())) {
-      mpPlotWindowContainer->getDiagramWindow()->getGraphicsView()->zoomOut();
+    if (mpPlotWindowContainer->currentSubWindow() && mpPlotWindowContainer->isDiagramWindow(mpPlotWindowContainer->currentSubWindow()->widget())
+        && mpPlotWindowContainer->getDiagramWindow() && mpPlotWindowContainer->getDiagramWindow()->getModelWidget()) {
+      mpPlotWindowContainer->getDiagramWindow()->getModelWidget()->getDiagramGraphicsView()->zoomOut();
     }
   }
 }
@@ -4165,6 +4168,19 @@ void MainWindow::switchToWelcomePerspective()
   mpOMSimulatorToobar->setVisible(false);
 }
 
+#define ADD_SHOW_DIAGRAMVIEW() \
+  if (mpPlotWindowContainer->getDiagramWindow() && mpPlotWindowContainer->getDiagramWindow()->getModelWidget()) { \
+    ModelWidget *pModelWidget = mpPlotWindowContainer->getDiagramWindow()->getModelWidget(); \
+    pModelWidget->getDiagramGraphicsView()->setIsVisualizationView(false); \
+    if ((pModelWidget->getIconGraphicsView() && pModelWidget->getIconGraphicsView()->isVisible()) \
+        || (pModelWidget->getEditor() && pModelWidget->getEditor()->isVisible())) { \
+      pModelWidget->getDiagramGraphicsView()->hide(); \
+    } \
+    mpPlotWindowContainer->getDiagramWindow()->removeVisualizationDiagram(); \
+    pModelWidget->getDiagramGraphicsView()->emitResetDynamicSelect(); \
+    pModelWidget->getMainLayout()->addWidget(pModelWidget->getDiagramGraphicsView(), 1); \
+  }
+
 /*!
  * \brief MainWindow::switchToModelingPerspective
  * Switches to Modeling perspective.
@@ -4176,6 +4192,7 @@ void MainWindow::switchToModelingPerspective()
   if (OptionsDialog::instance()->getGeneralSettingsPage()->getHideVariablesBrowserCheckBox()->isChecked()) {
     mpVariablesDockWidget->hide();
   }
+  ADD_SHOW_DIAGRAMVIEW()
   // show/hide toolbars
   mpEditToolBar->setVisible(true);
   mpViewToolBar->setVisible(true);
@@ -4217,9 +4234,9 @@ void MainWindow::switchToPlottingPerspective()
   if (mpPlotWindowContainer->subWindowList().size() == 0) {
     mpPlotWindowContainer->addPlotWindow(true);
   }
-  // if we have DiagramWindow then draw items on it based on the current ModelWidget
-  if (pModelWidget && mpPlotWindowContainer->getDiagramSubWindowFromMdi()) {
-    mpPlotWindowContainer->getDiagramWindow()->drawDiagram(pModelWidget);
+  QMdiSubWindow *pDiagramSubWindow = mpPlotWindowContainer->getDiagramSubWindowFromMdi();
+  if (pModelWidget && pDiagramSubWindow) {
+    mpPlotWindowContainer->getDiagramWindow()->showVisualizationDiagram(pModelWidget);
   }
   mpVariablesDockWidget->show();
   // show/hide toolbars
@@ -4260,6 +4277,7 @@ void MainWindow::switchToAlgorithmicDebuggingPerspective()
   if (OptionsDialog::instance()->getGeneralSettingsPage()->getHideVariablesBrowserCheckBox()->isChecked()) {
     mpVariablesDockWidget->hide();
   }
+  ADD_SHOW_DIAGRAMVIEW()
   // show/hide toolbars
   mpEditToolBar->setVisible(true);
   mpViewToolBar->setVisible(true);

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -2818,7 +2818,7 @@ void LibraryTreeModel::unloadClassHelper(LibraryTreeItem *pLibraryTreeItem, Libr
     }
     // if ModelWidget is used by DiagramWindow
     if (MainWindow::instance()->getPlotWindowContainer()->getDiagramSubWindowFromMdi()) {
-      MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->removeDiagram(pLibraryTreeItem->getModelWidget());
+      MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->removeVisualizationDiagram();
     }
     pLibraryTreeItem->getModelWidget()->deleteLater();
     pLibraryTreeItem->setModelWidget(0);
@@ -3263,29 +3263,7 @@ void LibraryTreeView::libraryTreeItemDoubleClicked(const QModelIndex &index)
       if (!MainWindow::instance()->getModelWidgetContainer()->validateText()) {
         return;
       }
-      /* Check if we are in the plotting perspective
-       * If yes then we first load the model and switch to Modeling perspective like normal
-       * and then switches back to plotting perspective and show the DiagramWindow
-       * If we don't do that then the window title is messed up.
-       */
-      bool isPlottingPerspectiveActive = MainWindow::instance()->isPlottingPerspectiveActive();
       mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
-      // Issue #7772. If control is not clicked then switch to plotting perspective.
-      bool controlModifier = QApplication::keyboardModifiers().testFlag(Qt::ControlModifier);
-      if (!controlModifier) {
-        // if we are in the plotting perspective then open the Diagram Window
-        if (isPlottingPerspectiveActive) {
-          MainWindow::instance()->switchToPlottingPerspectiveSlot();
-          if (MainWindow::instance()->getPlotWindowContainer()->getDiagramSubWindowFromMdi()) {
-            if (pLibraryTreeItem->getModelWidget()) {
-              pLibraryTreeItem->getModelWidget()->loadDiagramView();
-              pLibraryTreeItem->getModelWidget()->loadConnections();
-            }
-            MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->drawDiagram(pLibraryTreeItem->getModelWidget());
-          }
-          MainWindow::instance()->getPlotWindowContainer()->addDiagramWindow(pLibraryTreeItem->getModelWidget());
-        }
-      }
     }
   }
 }

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -156,12 +156,13 @@ private:
   // scene->items().contains(...) involves sorting on each items() call, avoid it
   QSet<QGraphicsItem*> mAllItems;
 public:
-  GraphicsView(StringHandler::ViewType viewType, ModelWidget *pModelWidget, bool visualizationView = false);
+  GraphicsView(StringHandler::ViewType viewType, ModelWidget *pModelWidget);
   bool mSkipBackground; /* Do not draw the background rectangle */
   QPointF mContextMenuStartPosition;
   bool mContextMenuStartPositionValid;
   StringHandler::ViewType getViewType() {return mViewType;}
   ModelWidget* getModelWidget() {return mpModelWidget;}
+  void setIsVisualizationView(bool visualizationView);
   bool isVisualizationView() {return mVisualizationView;}
   void setExtentRectangle(const QRectF rectangle);
   void setIsCustomScale(bool enable) {mIsCustomScale = enable;}
@@ -302,6 +303,7 @@ public:
   void addItem(QGraphicsItem *pGraphicsItem);
   void removeItem(QGraphicsItem *pGraphicsItem);
   void fitInViewInternal();
+  void emitResetDynamicSelect();
 private:
   void createActions();
   bool isClassDroppedOnItself(LibraryTreeItem *pLibraryTreeItem);
@@ -363,6 +365,8 @@ signals:
   void keyPressShiftRight();
   void keyPressCtrlRight();
   void keyPressDuplicate();
+  void updateDynamicSelect(double time);
+  void resetDynamicSelect();
 public slots:
   void addConnection(Element *pComponent);
   void removeCurrentConnection();
@@ -528,6 +532,7 @@ public:
   BaseEditor* getEditor() {return mpEditor;}
   void setModelClassPathLabel(QString path) {mpModelClassPathLabel->setText(path);}
   void setModelFilePathLabel(QString path) {mpModelFilePathLabel->setText(path);}
+  QVBoxLayout* getMainLayout() {return mpMainLayout;}
   bool isLoadedWidgetComponents() {return mCreateModelWidgetComponents;}
   void addInheritedClass(LibraryTreeItem *pLibraryTreeItem) {mInheritedClassesList.append(pLibraryTreeItem);}
   void removeInheritedClass(LibraryTreeItem *pLibraryTreeItem) {mInheritedClassesList.removeOne(pLibraryTreeItem);}
@@ -604,6 +609,7 @@ private:
   bool mDiagramViewLoaded;
   bool mConnectionsLoaded;
   bool mCreateModelWidgetComponents;
+  QVBoxLayout *mpMainLayout;
   QString mIconAnnotationString;
   QString mDiagramAnnotationString;
   bool mExtendsModifiersLoaded;

--- a/OMEdit/OMEditLIB/Plotting/DiagramWindow.h
+++ b/OMEdit/OMEditLIB/Plotting/DiagramWindow.h
@@ -38,23 +38,18 @@
 #include <QGraphicsView>
 #include <QVBoxLayout>
 
-class GraphicsScene;
-class GraphicsView;
 class ModelWidget;
 class DiagramWindow : public QWidget
 {
   Q_OBJECT
 public:
   explicit DiagramWindow(QWidget *parent = 0);
-  GraphicsView* getGraphicsView() {return mpGraphicsView;}
-  void drawDiagram(ModelWidget *pModelWidget);
-  void removeDiagram(ModelWidget *pModelWidget);
+  ModelWidget* getModelWidget() {return mpModelWidget;}
+  void showVisualizationDiagram(ModelWidget *pModelWidget);
+  void removeVisualizationDiagram();
 private:
-  GraphicsScene *mpGraphicsScene;
-  GraphicsView *mpGraphicsView;
+  ModelWidget *mpModelWidget;
   QVBoxLayout *mpMainLayout;
-
-  void deleteGraphicsViewAndScene();
 protected:
   virtual void closeEvent(QCloseEvent *event) override;
 };

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -475,8 +475,8 @@ void PlotWindowContainer::addDiagramWindow(ModelWidget *pModelWidget, bool maxim
 {
   if (!mpDiagramWindow) {
     mpDiagramWindow = new DiagramWindow(this);
-    mpDiagramWindow->drawDiagram(pModelWidget ? pModelWidget : MainWindow::instance()->getModelWidgetContainer()->getCurrentModelWidget());
   }
+  mpDiagramWindow->showVisualizationDiagram(pModelWidget ? pModelWidget : MainWindow::instance()->getModelWidgetContainer()->getCurrentModelWidget());
   QMdiSubWindow *pSubWindow = getDiagramSubWindowFromMdi();
   if (!pSubWindow) {
     pSubWindow = addSubWindow(mpDiagramWindow);

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -2485,8 +2485,8 @@ void VariablesWidget::updateVisualization()
   // Update the DiagramWindow
   emit updateDynamicSelect(mpTimeManager->getVisTime());
   if (MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()
-      && MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->getGraphicsView()) {
-    MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->getGraphicsView()->scene()->update();
+      && MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->getModelWidget()) {
+    MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->getModelWidget()->getDiagramGraphicsView()->scene()->update();
   }
   mpTimeManager->updateTick();  //for real-time measurement
   visTime = mpTimeManager->getRealTime() - visTime;


### PR DESCRIPTION
### Related Issues

Fixes #8607

### Purpose

Use the DynamicSelect for inherited elements.

### Approach

Unify the modeling and plotting diagram view.
