### PR TITLE
Fixed handling of events in daeMode with no states

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.c
@@ -54,10 +54,6 @@ int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData
 {
   int retVal;
 
-  if (0 == data->simulationInfo->daeModeData->nResidualVars) {
-    return 0;
-  }
-
   data->simulationInfo->discreteCall = 1;
   retVal = data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_DISCRETE);
   data->simulationInfo->discreteCall = 0;


### PR DESCRIPTION
### Related Issues

Fixes #8617 

### Purpose

Algebraic and discrete variables need to be updated even there are no states present
