### PR TITLE
Fix Expression.recordElement

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5049,6 +5049,7 @@ public
           cls := InstNode.getClass(node);
           index := Class.lookupComponentIndex(elementName, cls);
           ty := InstNode.getType(Class.nthComponent(index, cls));
+          ty := Type.liftArrayLeftList(ty, Type.arrayDims(recordExp.ty));
         then
           makeEmptyArray(ty);
 


### PR DESCRIPTION
- Set the correct type in the case that handles empty arrays of record
  instances.