### PR TITLE
Update the connection when start and end belong to the same element

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1248,9 +1248,9 @@ void LineAnnotation::updateConnectionTransformation()
   /* If both start and end component are selected then this function is called twice.
    * we use the flag mStartAndEndComponentSelected to make sure that we only use this function once in such case.
    */
-  if (!mStartAndEndComponentsSelected
-      && mpStartComponent && mpStartComponent->getRootParentComponent()->isSelected()
-      && mpEndComponent && mpEndComponent->getRootParentComponent()->isSelected()) {
+  if (mpStartComponent && mpStartComponent->getRootParentComponent()->isSelected()
+      && mpEndComponent && mpEndComponent->getRootParentComponent()->isSelected()
+      && mpStartComponent->getRootParentComponent() != mpEndComponent->getRootParentComponent() && !mStartAndEndComponentsSelected) {
       mStartAndEndComponentsSelected = true;
       return;
   } else if (mStartAndEndComponentsSelected) {

--- a/OMEdit/OMEditLIB/Element/CornerItem.cpp
+++ b/OMEdit/OMEditLIB/Element/CornerItem.cpp
@@ -136,7 +136,7 @@ void CornerItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
  */
 void CornerItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
-  if (mpShapeAnnotation->isInheritedShape() && mpShapeAnnotation->getGraphicsView()->isVisualizationView()
+  if (mpShapeAnnotation->isInheritedShape() || mpShapeAnnotation->getGraphicsView()->isVisualizationView()
       || (mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::OMS
           && (mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getOMSConnector()
               || mpShapeAnnotation->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getOMSBusConnector()


### PR DESCRIPTION
### Purpose

Update the connection when the element is moved.

### Approach

Check if both the start and end of connection belong to the same element and update it.
