### PR TITLE
[NB] proper adjacency matrix types + janitor

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
@@ -279,37 +279,5 @@ public
     end if;
   end createParameterEquations;
 
-  function sortInitEqns
-    "sorts initial equations to be at the start of the array"
-    input output EquationPointers equations;
-  protected
-    DoubleEnded.MutableList<Pointer<Equation>> eqns = DoubleEnded.empty(Pointer.create(Equation.DUMMY_EQUATION()));
-  algorithm
-    for eqn in EquationPointers.toList(equations) loop
-      if Equation.isInitial(eqn) then
-        DoubleEnded.push_front(eqns, eqn);
-      else
-        DoubleEnded.push_back(eqns, eqn);
-      end if;
-    end for;
-    equations := EquationPointers.fromList(DoubleEnded.toListAndClear(eqns));
-  end sortInitEqns;
-
-  function sortInitVars
-    "sorts initial variables such that states are at the end of the array"
-    input output VariablePointers variables;
-  protected
-    DoubleEnded.MutableList<Pointer<Variable>> vars = DoubleEnded.empty(Pointer.create(NBVariable.DUMMY_VARIABLE));
-  algorithm
-    for var in VariablePointers.toList(variables) loop
-      if BVariable.isState(var) then
-        DoubleEnded.push_back(vars, var);
-      else
-        DoubleEnded.push_front(vars, var);
-      end if;
-    end for;
-    variables := VariablePointers.fromList(DoubleEnded.toListAndClear(vars));
-  end sortInitVars;
-
   annotation(__OpenModelica_Interface="backend");
 end NBInitialization;

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
@@ -57,9 +57,10 @@ protected
   import Adjacency = NBAdjacency;
   import NBEquation.{Equation, EqData, EquationPointer, EquationPointers};
   import Module = NBModule;
+  import ResolveSingularities = NBResolveSingularities;
+  import System = NBSystem;
   import BVariable = NBVariable;
   import NBVariable.{VarData, VariablePointer, VariablePointers};
-  import ResolveSingularities = NBResolveSingularities;
 
   // OB import
   import BackendDAEEXT;
@@ -156,6 +157,7 @@ public
     input output FunctionTree funcTree;
     input output VarData varData;
     input output EqData eqData;
+    input System.SystemType systemType;
     input Boolean transposed = false        "transpose matching if true";
     input Boolean partially = false         "do not resolve singular systems and return partial matching if true";
     input Boolean clear = true              "start from scratch if true";
@@ -170,8 +172,8 @@ public
     (matching, marked_eqns, mapping, matrixType, matrixStrictness) := continue_(matching, adj, transposed, clear);
 
     // 2. Resolve singular systems if necessary
-    changed := match matrixStrictness
-      case NBAdjacency.MatrixStrictness.INIT algorithm
+    changed := match systemType
+      case NBSystem.SystemType.INI algorithm
         // ####### BALANCE INITIALIZATION #######
         (vars, eqns, varData, eqData, funcTree, changed) := ResolveSingularities.balanceInitialization(vars, eqns, varData, eqData, funcTree, mapping, matrixType, matching);
       then changed;
@@ -186,7 +188,7 @@ public
     if changed then
       // ToDo: keep more of old information by only updating changed stuff
       adj := Adjacency.Matrix.create(vars, eqns, matrixType, matrixStrictness);
-      (matching, adj, vars, eqns, funcTree, varData, eqData) := singular(EMPTY_MATCHING(), adj, vars, eqns, funcTree, varData, eqData, false, true);
+      (matching, adj, vars, eqns, funcTree, varData, eqData) := singular(EMPTY_MATCHING(), adj, vars, eqns, funcTree, varData, eqData, systemType, false, true);
     end if;
   end singular;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBPartitioning.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBPartitioning.mo
@@ -339,9 +339,9 @@ protected
     clone_eqns := EquationPointers.clone(equations);
     systems := {System.SYSTEM(
       systemType        = systemType,
-      unknowns          = if isInit then Initialization.sortInitVars(clone_vars) else clone_vars,
+      unknowns          = clone_vars,
       daeUnknowns       = NONE(),
-      equations         = if isInit then Initialization.sortInitEqns(clone_eqns) else clone_eqns,
+      equations         = clone_eqns,
       adjacencyMatrix   = NONE(),
       matching          = NONE(),
       strongComponents  = NONE(),

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBResolveSingularities.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBResolveSingularities.mo
@@ -168,7 +168,7 @@ public
       constraint_ptrs := EquationPointers.fromList(sliced_constraints);
 
       // create adjacency matrix and match with transposed matrix to respect variable priority
-      set_adj := Adjacency.Matrix.create(candidate_ptrs, constraint_ptrs, matrixType, NBAdjacency.MatrixStrictness.STATE_SELECT);
+      set_adj := Adjacency.Matrix.create(candidate_ptrs, constraint_ptrs, matrixType, NBAdjacency.MatrixStrictness.LINEAR);
       set_matching := Matching.regular(Matching.EMPTY_MATCHING(), set_adj, true, true);
 
       if debug then

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -710,12 +710,12 @@ protected
         IfEquationBody ifBody;
 
       case Equation.WHEN_EQUATION() algorithm
-        (whenBody, bucket) := collectEventsWhenBody(eqn.body, bucket , eqn_ptr);
+        (whenBody, bucket) := collectEventsWhenBody(eqn.body, bucket, eqn_ptr);
         eqn.body := whenBody;
       then bucket;
 
       case Equation.IF_EQUATION() algorithm
-        (ifBody, bucket) := collectEventsIfBody(eqn.body, bucket , eqn_ptr);
+        (ifBody, bucket) := collectEventsIfBody(eqn.body, bucket, eqn_ptr);
         eqn.body := ifBody;
       then bucket;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/NBModule.mo
@@ -120,7 +120,6 @@ public
     input output VarData varData;
     input output EqData eqData;
     input output FunctionTree funcTree;
-    input Adjacency.MatrixStrictness matrixStrictness;
   end causalizeInterface;
 
   partial function resolveSingularitiesInterface


### PR DESCRIPTION
 - change adjacency matrix types to:
   1. LINEAR - only allows linear occurences (e.g. state selection)
   2. SOLVABLE - only allows solvable occurences (e.g. matching)
   3. FULL - allows all occurences (e.g. sorting)
 - [janitor] remove unused ordering stuff because matching is always done
   in multiple steps if something has to be prefered in the matching process