### PR TITLE
Improve 55f5d0dd

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -67,6 +67,7 @@ import Testsuite;
 import AbsynToSCode;
 import NFClassTree.ClassTree;
 import SCodeUtil;
+import System;
 
 public
 type MatchType = enumeration(FOUND, NOT_FOUND, PARTIAL);
@@ -1064,6 +1065,7 @@ algorithm
   try
     version := loadLibrary_work(name, scope);
     Error.addMessage(Error.NOTIFY_IMPLICIT_LOAD, {name, version});
+    System.loadModelCallBack();
     ErrorExt.delCheckpoint(getInstanceName());
   else
     ErrorExt.rollBack(getInstanceName());

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3254,7 +3254,8 @@ algorithm
   else
     str := AbsynUtil.pathFirstIdent(className);
     (p,b) := CevalScript.loadModel({(Absyn.IDENT(str),"the given model name to instantiate",{"default"},false)},Settings.getModelicaPath(Testsuite.isRunning()),p,true,true,true,false);
-    Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_NOT_LOADED,{str,"default"},AbsynUtil.dummyInfo);
+    Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_LOAD_MODEL_DUE_TO_USES,{str,"default"},AbsynUtil.dummyInfo);
+    System.loadModelCallBack();
     // print(stringDelimitList(list(AbsynUtil.pathString(path) for path in Interactive.getTopClassnames(p)), ",") + "\n");
     SymbolTable.setAbsyn(p);
   end try;

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -14824,7 +14824,6 @@ algorithm
   if updateProgram then
     SymbolTable.setAbsyn(InteractiveUtil.updateProgram(parsed, SymbolTable.getAbsyn()));
   end if;
-  System.loadModelCallBack();
 end parseFile;
 
 //he-mag begin

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -440,7 +440,7 @@ public constant ErrorTypes.Message EMPTY_ARRAY = ErrorTypes.MESSAGE(182, ErrorTy
   Gettext.gettext("Array constructor may not be empty."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS = ErrorTypes.MESSAGE(183, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("Requested package %s of version %s, but this package was already loaded with version %s. OpenModelica cannot reason about compatibility between the two packages since they are not semantic versions."));
-public constant ErrorTypes.Message LOAD_MODEL = ErrorTypes.MESSAGE(184, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+public constant ErrorTypes.Message LOAD_MODEL_FAILED = ErrorTypes.MESSAGE(184, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("Failed to load package %s (%s) using MODELICAPATH %s."));
 public constant ErrorTypes.Message REPLACEABLE_BASE_CLASS_SIMPLE = ErrorTypes.MESSAGE(185, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Base class %s is replaceable."));
@@ -518,7 +518,7 @@ public constant ErrorTypes.Message CONNECT_IN_INITIAL_EQUATION = ErrorTypes.MESS
   Gettext.gettext("Connect equations are not allowed in initial equation sections."));
 public constant ErrorTypes.Message FINAL_COMPONENT_OVERRIDE = ErrorTypes.MESSAGE(222, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Trying to override final element %s with modifier '%s'."));
-public constant ErrorTypes.Message NOTIFY_NOT_LOADED = ErrorTypes.MESSAGE(223, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+public constant ErrorTypes.Message NOTIFY_LOAD_MODEL_DUE_TO_USES = ErrorTypes.MESSAGE(223, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("Automatically loaded package %s %s due to uses annotation."));
 public constant ErrorTypes.Message REINIT_MUST_BE_REAL = ErrorTypes.MESSAGE(224, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The first argument to reinit must be a subtype of Real, but %s has type %s."));


### PR DESCRIPTION
- Only activate System.loadModelCallBack when loading dependencies due
  to uses-annotations or implicit usage.
- Clean up CevalScript.loadModel.
- Rename some error messages so they make some sense:
  * LOAD_MODEL => LOAD_MODEL_FAILED
  * NOTIFY_NOT_LOADED => NOTIFY_LOAD_MODEL_DUE_TO_USES