### PR TITLE
Improve 55f5d0dd

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -67,6 +67,7 @@ import Testsuite;
 import AbsynToSCode;
 import NFClassTree.ClassTree;
 import SCodeUtil;
+import System;
 
 public
 type MatchType = enumeration(FOUND, NOT_FOUND, PARTIAL);
@@ -1064,6 +1065,7 @@ algorithm
   try
     version := loadLibrary_work(name, scope);
     Error.addMessage(Error.NOTIFY_IMPLICIT_LOAD, {name, version});
+    System.loadModelCallBack(name);
     ErrorExt.delCheckpoint(getInstanceName());
   else
     ErrorExt.rollBack(getInstanceName());

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -354,9 +354,6 @@ algorithm
   (p, _) := loadModel(modelsToLoad, modelicaPath, p, false, notifyLoad, checkUses, requireExactVersion, false);
 end checkUsesAndUpdateProgram;
 
-protected type LoadModelFoldArg =
-  tuple<String /*modelicaPath*/, Boolean /*forceLoad*/, Boolean /*notifyLoad*/, Boolean /*checkUses*/, Boolean /*requireExactVersion*/, Boolean /*encrypted*/>;
-
 public function loadModel
   input list<tuple<Absyn.Path,String,list<String>,Boolean /* Only use the first entry on the MODELICAPATH */>> imodelsToLoad;
   input String modelicaPath;
@@ -367,33 +364,40 @@ public function loadModel
   input Boolean requireExactVersion;
   input Boolean encrypted = false;
   input String pathToFile = "";
-  output Absyn.Program pnew;
-  output Boolean success;
+  output Absyn.Program pnew = ip;
+  output Boolean success = true;
 protected
-  LoadModelFoldArg arg = (modelicaPath, forceLoad, notifyLoad, checkUses, requireExactVersion, encrypted);
+  Boolean b;
 algorithm
-  (pnew, success) := List.fold2(imodelsToLoad, loadModel1, arg, pathToFile, (ip, true));
-  System.loadModelCallBack();
+  for m in imodelsToLoad loop
+    (pnew, b) := loadModel1(m, modelicaPath, forceLoad, notifyLoad,
+      checkUses, requireExactVersion, encrypted, pathToFile, pnew);
+    success := b and success;
+  end for;
 end loadModel;
 
 protected function loadModel1
   input tuple<Absyn.Path,String,list<String>,Boolean> modelToLoad;
-  input LoadModelFoldArg inArg;
+  input String modelicaPath;
+  input Boolean forceLoad;
+  input Boolean notifyLoad;
+  input Boolean checkUses;
+  input Boolean requireExactVersion;
+  input Boolean encrypted;
   input String pathToFile;
-  input tuple<Absyn.Program, Boolean> inTpl;
-  output tuple<Absyn.Program, Boolean> outTpl;
+  input output Absyn.Program program;
+        output Boolean success = true;
 protected
   list<tuple<Absyn.Path,String,list<String>,Boolean>> modelsToLoad;
-  Boolean b, b1, success, forceLoad, notifyLoad, checkUses, requireExactVersion, onlyCheckFirstModelicaPath, encrypted;
+  Boolean onlyCheckFirstModelicaPath;
   Absyn.Path path;
   list<String> versionsLst;
-  String pathStr, versions, className, version, modelicaPath, thisModelicaPath, dir;
-  Absyn.Program p, pnew;
+  String pathStr, versions, version, thisModelicaPath, dir;
+  Absyn.Program pnew;
   ErrorTypes.MessageTokens msgTokens;
   Option<Absyn.Class> cl;
 algorithm
   (path, _, versionsLst, onlyCheckFirstModelicaPath) := modelToLoad;
-  (modelicaPath, forceLoad, notifyLoad, checkUses, requireExactVersion, encrypted) := inArg;
   if onlyCheckFirstModelicaPath then
     /* Using loadFile() */
     thisModelicaPath::_ := System.strtok(modelicaPath, Autoconf.groupDelimiter);
@@ -401,8 +405,7 @@ algorithm
     thisModelicaPath := modelicaPath;
   end if;
   try
-    (p, success) := inTpl;
-    if checkModelLoaded(modelToLoad, p, forceLoad, NONE()) then
+    if checkModelLoaded(modelToLoad, program, forceLoad, NONE()) then
       pnew := Absyn.PROGRAM({}, Absyn.TOP());
       version := "";
     else
@@ -417,30 +420,30 @@ algorithm
           pnew := Absyn.PROGRAM({}, Absyn.TOP());
         end if;
       end if;
-      version := getPackageVersion(path, pnew);
-      b := not notifyLoad or forceLoad;
-      msgTokens := {AbsynUtil.pathString(path), version};
-      Error.assertionOrAddSourceMessage(b, Error.NOTIFY_NOT_LOADED, msgTokens, AbsynUtil.dummyInfo);
-    end if;
-    p := InteractiveUtil.updateProgram(pnew, p);
 
-    b := true;
+      if notifyLoad and not forceLoad then
+        version := getPackageVersion(path, pnew);
+        msgTokens := {AbsynUtil.pathString(path), version};
+        Error.addMessage(Error.NOTIFY_LOAD_MODEL_DUE_TO_USES, msgTokens);
+        System.loadModelCallBack(AbsynUtil.pathFirstIdent(path));
+      end if;
+    end if;
+
+    program := InteractiveUtil.updateProgram(pnew, program);
+
     if checkUses then
       modelsToLoad := Interactive.getUsesAnnotationOrDefault(pnew, requireExactVersion);
-      (p, b) := loadModel(modelsToLoad, modelicaPath, p, false, notifyLoad, checkUses, requireExactVersion, false);
+      (program, success) := loadModel(modelsToLoad, modelicaPath, program, false, notifyLoad, checkUses, requireExactVersion, false);
     end if;
-    outTpl := (p, success and b);
   else
-    (p, _) := inTpl;
     pathStr := AbsynUtil.pathString(path);
     versions := stringDelimitList(versionsLst, ",");
     msgTokens := {pathStr, versions, thisModelicaPath};
     if forceLoad then
-      Error.addMessage(Error.LOAD_MODEL, msgTokens);
-      outTpl := (p, false);
+      Error.addMessage(Error.LOAD_MODEL_FAILED, msgTokens);
+      success := false;
     else
       Error.addMessage(Error.NOTIFY_LOAD_MODEL_FAILED, msgTokens);
-      outTpl := inTpl;
     end if;
   end try;
 end loadModel1;
@@ -609,7 +612,6 @@ algorithm
         paths := List.map(classes,AbsynUtil.className);
         paths := List.map1r(paths,AbsynUtil.joinWithinPath,within_);
         vals := List.map(paths,ValuesUtil.makeCodeTypeName);
-        System.loadModelCallBack();
       then
         ValuesUtil.makeArray(vals);
 
@@ -1354,7 +1356,6 @@ algorithm
         newp := InteractiveUtil.updateProgram(newp, SymbolTable.getAbsyn(), mergeAST);
         SymbolTable.setAbsyn(newp);
         outCache := FCore.emptyCache();
-        System.loadModelCallBack();
       then
         Values.BOOL(true);
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3254,7 +3254,8 @@ algorithm
   else
     str := AbsynUtil.pathFirstIdent(className);
     (p,b) := CevalScript.loadModel({(Absyn.IDENT(str),"the given model name to instantiate",{"default"},false)},Settings.getModelicaPath(Testsuite.isRunning()),p,true,true,true,false);
-    Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_NOT_LOADED,{str,"default"},AbsynUtil.dummyInfo);
+    Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_LOAD_MODEL_DUE_TO_USES,{str,"default"},AbsynUtil.dummyInfo);
+    System.loadModelCallBack(str);
     // print(stringDelimitList(list(AbsynUtil.pathString(path) for path in Interactive.getTopClassnames(p)), ",") + "\n");
     SymbolTable.setAbsyn(p);
   end try;

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -14824,7 +14824,6 @@ algorithm
   if updateProgram then
     SymbolTable.setAbsyn(InteractiveUtil.updateProgram(parsed, SymbolTable.getAbsyn()));
   end if;
-  System.loadModelCallBack();
 end parseFile;
 
 //he-mag begin

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -440,7 +440,7 @@ public constant ErrorTypes.Message EMPTY_ARRAY = ErrorTypes.MESSAGE(182, ErrorTy
   Gettext.gettext("Array constructor may not be empty."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS = ErrorTypes.MESSAGE(183, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("Requested package %s of version %s, but this package was already loaded with version %s. OpenModelica cannot reason about compatibility between the two packages since they are not semantic versions."));
-public constant ErrorTypes.Message LOAD_MODEL = ErrorTypes.MESSAGE(184, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
+public constant ErrorTypes.Message LOAD_MODEL_FAILED = ErrorTypes.MESSAGE(184, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("Failed to load package %s (%s) using MODELICAPATH %s."));
 public constant ErrorTypes.Message REPLACEABLE_BASE_CLASS_SIMPLE = ErrorTypes.MESSAGE(185, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Base class %s is replaceable."));
@@ -518,7 +518,7 @@ public constant ErrorTypes.Message CONNECT_IN_INITIAL_EQUATION = ErrorTypes.MESS
   Gettext.gettext("Connect equations are not allowed in initial equation sections."));
 public constant ErrorTypes.Message FINAL_COMPONENT_OVERRIDE = ErrorTypes.MESSAGE(222, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Trying to override final element %s with modifier '%s'."));
-public constant ErrorTypes.Message NOTIFY_NOT_LOADED = ErrorTypes.MESSAGE(223, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
+public constant ErrorTypes.Message NOTIFY_LOAD_MODEL_DUE_TO_USES = ErrorTypes.MESSAGE(223, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("Automatically loaded package %s %s due to uses annotation."));
 public constant ErrorTypes.Message REINIT_MUST_BE_REAL = ErrorTypes.MESSAGE(224, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The first argument to reinit must be a subtype of Real, but %s has type %s."));

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -372,7 +372,8 @@ public function loadModelCallBackDefined
 end loadModelCallBackDefined;
 
 public function loadModelCallBack
-  external "C" SystemImpl__loadModelCallBack(OpenModelica.threadData()) annotation(Library = "omcruntime");
+  input String modelName;
+  external "C" SystemImpl__loadModelCallBack(OpenModelica.threadData(), modelName) annotation(Library = "omcruntime");
 end loadModelCallBack;
 
 public function cd

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -898,11 +898,11 @@ int SystemImpl__loadModelCallBackDefined(threadData_t *threadData)
   return threadData->loadModelClassPointer && threadData->loadModelCB;
 }
 
-void SystemImpl__loadModelCallBack(threadData_t *threadData)
+void SystemImpl__loadModelCallBack(threadData_t *threadData, const char* modelname)
 {
   if (SystemImpl__loadModelCallBackDefined(threadData)) {
     LoadModelCallback cb = threadData->loadModelCB;
-    cb(threadData->loadModelClassPointer);
+    cb(threadData->loadModelClassPointer, modelname);
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/gc/omc_gc.h
+++ b/OMCompiler/SimulationRuntime/c/gc/omc_gc.h
@@ -91,7 +91,7 @@ typedef void (*PlotCallback)(void*, int externalWindow, const char* filename, co
     const char* curveWidth, const char* curveStyle, const char* legendPosition, const char* footer, const char* autoScale,
     const char* variables);
 
-typedef void (*LoadModelCallback)(void*);
+typedef void (*LoadModelCallback)(void*, const char* modelname);
 
 /* Thread-specific data passed around in most functions.
  * It is also possible to fetch it using pthread_getspecific (mostly for external functions that were not passed the pointer) */


### PR DESCRIPTION
- Only activate System.loadModelCallBack when loading dependencies due
  to uses-annotations or implicit usage.
- Add the name of the model that was loaded to the callback.
- Clean up CevalScript.loadModel.
- Rename some error messages so they make some sense:
  * LOAD_MODEL => LOAD_MODEL_FAILED
  * NOTIFY_NOT_LOADED => NOTIFY_LOAD_MODEL_DUE_TO_USES