### PR TITLE
No states da emode fix

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -753,6 +753,7 @@ static int callSolver(DATA* simData, threadData_t *threadData, string init_initM
     if (compiledInDAEMode)
     {
       simData->callback->functionDAE = evaluateDAEResiduals_wrapperEventUpdate;
+      simData->callback->function_ZeroCrossingsEquations = evaluateDAEResiduals_wrapperZeroCrossingsEquations;
     }
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.c
@@ -54,10 +54,6 @@ int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData
 {
   int retVal;
 
-  if (0 == data->simulationInfo->daeModeData->nResidualVars) {
-    return 0;
-  }
-
   data->simulationInfo->discreteCall = 1;
   retVal = data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_DISCRETE);
   data->simulationInfo->discreteCall = 0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.c
@@ -61,6 +61,18 @@ int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData
   return retVal;
 }
 
+/*! \fn void evaluateDAEResiduals_wrapperZeroCrossingsEquations
+ *
+ * wrapper function of the ZeroCrossing function for DAE mode
+ */
+int evaluateDAEResiduals_wrapperZeroCrossingsEquations(DATA* data, threadData_t* threadData)
+{
+  int retVal;
+  retVal = data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_ZEROCROSS);
+
+  return retVal;
+}
+
 /*! \fn void getAlgebraicDAEVarNominals
  *
  *  collects DAE mode algebraic nominal values from modelData

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dae_mode.h
@@ -49,6 +49,7 @@ extern "C" {
 #endif
 
 int evaluateDAEResiduals_wrapperEventUpdate(DATA* data, threadData_t* threadData);
+int evaluateDAEResiduals_wrapperZeroCrossingsEquations(DATA* data, threadData_t* threadData);
 
 void getAlgebraicDAEVarNominals(DATA*, double*);
 void getAlgebraicDAEVars(DATA*, double*);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -72,9 +72,7 @@ static void prefixedName_updateContinuousSystem(DATA *data, threadData_t *thread
 
   if (compiledInDAEMode) /* dae mode */
   {
-    if (data->simulationInfo->daeModeData->nResidualVars > 0) {
-      data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_ALGEBRAIC);
-    }
+    data->simulationInfo->daeModeData->evaluateDAEResiduals(data, threadData, EVAL_ALGEBRAIC);
   }
   else /* ode mode */
   {
@@ -473,7 +471,7 @@ int prefixedName_performSimulation(DATA* data, threadData_t *threadData, SOLVER_
         printAllVars(data, 0, LOG_SOLVER_V);
 
         clear_rt_step(data);
-        if (!compiledInDAEMode) { /* do not use ringbuffer for daeMode */
+        if (!compiledInDAEMode || data->modelData->nStates == 0) { /* do not use ringbuffer for daeMode */
           rotateRingBuffer(data->simulationData, 1, (void**) data->localData);
         }
 


### PR DESCRIPTION
### Related Issues

#8617 

### Purpose

<!--- Describe the problem or feature. -->

### Approach

Without states the model is simulated in ODE mode and the RingBuffer has to be activated
