### PR TITLE
Fixed reinit in DAE

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1470,6 +1470,9 @@ algorithm
       markedEqns := markStateEquationsWork(indicesAlgebraic, adjMatrix, assigndVar, markedEqns);
       eqns := setMarkedEqnsEvalStage(eqns, markedEqns, BackendEquation.setEvalStageAlgebraic);
 
+      markedEqns := arrayCreate(BackendEquation.getNumberOfEquations(eqSystem.removedEqs), 1);
+      eqSystem.removedEqs := setMarkedEqnsEvalStage(eqSystem.removedEqs, markedEqns, BackendEquation.setEvalStageDiscrete);
+
       /* For now avoid this and evaluate all the event update breaks right now
          quite a lot models.
       */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -735,6 +735,10 @@ int ida_event_update(DATA* data, threadData_t *threadData)
   if (measure_time_flag) rt_tick(SIM_TIMER_SOLVER);
 
   infoStreamPrint(LOG_SOLVER, 0, "##IDA## do event update at %.15g", data->localData[0]->timeValue);
+  memcpy(idaData->states, data->localData[0]->realVars, sizeof(double)*data->modelData->nStates);
+  memcpy(idaData->statesDer, data->localData[0]->realVars + data->modelData->nStates, sizeof(double)*data->modelData->nStates);
+  idaData->y = N_VMake_Serial(idaData->N, idaData->states);
+  idaData->yp = N_VMake_Serial(idaData->N, idaData->statesDer);
   flag = IDAReInit(idaData->ida_mem,
                     data->localData[0]->timeValue,
                     idaData->y,


### PR DESCRIPTION
### Purpose
Activate no return equations in DAE mode
Especially, reinit operator did not work

### Approach

- Marked reinit equations as discrete
- Set states in ida for correct restart at events

