### PR TITLE
Don't overwrite inner/outer for derived types

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2079,7 +2079,7 @@ algorithm
     cty := ConnectorType.merge(cty, innerAttr.connectorType, node, isClass = true);
     var := Prefixes.variabilityMin(var, innerAttr.variability);
     dir := Prefixes.mergeDirection(dir, innerAttr.direction, node, allowSame = true);
-    attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl);
+    attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, innerAttr.innerOuter, fin, redecl, repl);
   end if;
 end mergeDerivedAttributes;
 

--- a/testsuite/flattening/modelica/scodeinst/InnerOuter10.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuter10.mo
@@ -1,0 +1,22 @@
+// name: InnerOuter10
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model InnerOuter10
+  connector R = Real;
+  inner R r;
+
+  model B
+    outer R r;
+  end B;
+
+  B b;
+end InnerOuter10;
+
+// Result:
+// class InnerOuter10
+//   Real r;
+// end InnerOuter10;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -725,6 +725,7 @@ InnerOuter6.mo \
 InnerOuter7.mo \
 InnerOuter8.mo \
 InnerOuter9.mo \
+InnerOuter10.mo \
 InnerOuterClass1.mo \
 InnerOuterDuplicate1.mo \
 InnerOuterInvalidMod1.mo \


### PR DESCRIPTION
- Don't overwrite the original inner/outer attribute when merging
  derived class attributes.

Fixes #8667