### PR TITLE
Only apply the prefix if unit is one of prefixable unit

### DIFF
--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -4481,6 +4481,7 @@ PlottingPage::PlottingPage(OptionsDialog *pOptionsDialog)
   mpAutoScaleCheckBox->setToolTip(tr("Auto scale the plot to fit in view when variable is plotted."));
   // prefix units
   mpPrefixUnitsCheckbox = new QCheckBox(tr("Prefix Units"));
+  mpPrefixUnitsCheckbox->setChecked(true);
   mpPrefixUnitsCheckbox->setToolTip(tr("Automatically pick the right prefix for units."));
   // set general groupbox layout
   QGridLayout *pGeneralGroupBoxLayout = new QGridLayout;

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -1684,7 +1684,11 @@ void VariablesWidget::updateVariablesTreeHelper(QMdiSubWindow *pSubWindow)
           mpVariablesTreeModel->setData(mpVariablesTreeModel->variablesTreeItemIndex(pVariablesTreeItem), Qt::Checked, Qt::CheckStateRole);
         }
         // if a simulation was left running, make a replot
-        pPlotWindow->getPlot()->replot();
+        if (pPlotWindow->getAutoScaleButton()->isChecked()) {
+          pPlotWindow->fitInView();
+        } else {
+          pPlotWindow->updatePlot();
+        }
       }
     }
     mpVariablesTreeModel->blockSignals(state);
@@ -2024,11 +2028,9 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
               pPlotCurve->updateYAxisValue(i, Utilities::convertUnit(pPlotCurve->mYAxisVector.at(i), convertUnit.offset, convertUnit.scaleFactor));
             }
             pPlotCurve->setData(pPlotCurve->getXAxisVector(), pPlotCurve->getYAxisVector(), pPlotCurve->getSize());
-            pPlotWindow->getPlot()->replot();
           } else {
-            pPlotCurve->setYDisplayUnit(pVariablesTreeItem->getUnit());
+            pPlotCurve->setYDisplayUnit(Utilities::convertUnitToSymbol(pVariablesTreeItem->getUnit()));
           }
-          pPlotCurve->setTitleLocal();
         }
         // update the time values if time unit is different then s
         if (pPlotWindow->getTimeUnit().compare("s") != 0) {
@@ -2038,7 +2040,6 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
               pPlotCurve->updateXAxisValue(i, Utilities::convertUnit(pPlotCurve->mXAxisVector.at(i), convertUnit.offset, convertUnit.scaleFactor));
             }
             pPlotCurve->setData(pPlotCurve->getXAxisVector(), pPlotCurve->getYAxisVector(), pPlotCurve->getSize());
-            pPlotWindow->getPlot()->replot();
           }
         }
         if (pPlotWindow->getAutoScaleButton()->isChecked()) {
@@ -2309,11 +2310,14 @@ void VariablesWidget::unitChanged(const QModelIndex &index)
             pPlotCurve->updateYAxisValue(i, Utilities::convertUnit(pPlotCurve->mYAxisVector.at(i), convertUnit.offset, convertUnit.scaleFactor));
           }
           pPlotCurve->setData(pPlotCurve->getXAxisVector(), pPlotCurve->getYAxisVector(), pPlotCurve->getSize());
-          pPlotCurve->setYDisplayUnit(pVariablesTreeItem->getDisplayUnit());
-          pPlotCurve->setTitleLocal();
-          pPlotWindow->getPlot()->replot();
+          pPlotCurve->setYDisplayUnit(Utilities::convertUnitToSymbol(pVariablesTreeItem->getDisplayUnit()));
           break;
         }
+      }
+      if (pPlotWindow->getAutoScaleButton()->isChecked()) {
+        pPlotWindow->fitInView();
+      } else {
+        pPlotWindow->updatePlot();
       }
     }
   } catch (PlotException &e) {
@@ -2568,7 +2572,11 @@ void VariablesWidget::timeUnitChanged(QString unit)
           }
           pPlotCurve->setData(pPlotCurve->getXAxisVector(), pPlotCurve->getYAxisVector(), pPlotCurve->getSize());
         }
-        pPlotWindow->getPlot()->replot();
+        if (pPlotWindow->getAutoScaleButton()->isChecked()) {
+          pPlotWindow->fitInView();
+        } else {
+          pPlotWindow->updatePlot();
+        }
       }
     }
   } catch (PlotException &e) {

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
@@ -89,6 +89,7 @@ public:
   QColor getUniqueColor(int index, int total);
   void setFontSizes(double titleFontSize, double verticalAxisTitleFontSize, double verticalAxisNumbersFontSize, double horizontalAxisTitleFontSize,
                     double horizontalAxisNumbersFontSize, double footerFontSize, double legendFontSize);
+  static bool prefixableUnit(const QString &unit);
 public slots:
   virtual void replot();
 };

--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -238,6 +238,7 @@ bool Plot::prefixableUnit(const QString &unit)
                   << "rad"
                   << "rad/s"
                   << "rad/s2"
+                  << "rpm"
                   << "Hz"
                   << "N"
                   << "N.m"

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -128,7 +128,7 @@ void PlotWindow::initializePlot(QStringList arguments)
     throw PlotException("Invalid input" + arguments[17]);
   }
   setTimeUnit("");
-  setPrefixUnits(false);
+  setPrefixUnits(true);
   setCanUseXPrefixUnits(false);
   setCanUseYPrefixUnits(false);
   /* read variables */


### PR DESCRIPTION
### Related Issues

Fixes #8584, fixes #8488

### Purpose

Avoid using wrong unit prefix.

### Approach

Only add the prefix to the list of prefixable units.
