### PR TITLE
Fixing memory leak in ida_solver.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -737,8 +737,8 @@ int ida_event_update(DATA* data, threadData_t *threadData)
   infoStreamPrint(LOG_SOLVER, 0, "##IDA## do event update at %.15g", data->localData[0]->timeValue);
   memcpy(idaData->states, data->localData[0]->realVars, sizeof(double)*data->modelData->nStates);
   memcpy(idaData->statesDer, data->localData[0]->realVars + data->modelData->nStates, sizeof(double)*data->modelData->nStates);
-  idaData->y = N_VMake_Serial(idaData->N, idaData->states);
-  idaData->yp = N_VMake_Serial(idaData->N, idaData->statesDer);
+  memcpy(NV_DATA_S(idaData->y), idaData->states, idaData->N);
+  memcpy(NV_DATA_S(idaData->yp), idaData->statesDer, idaData->N);
   flag = IDAReInit(idaData->ida_mem,
                     data->localData[0]->timeValue,
                     idaData->y,


### PR DESCRIPTION


### Related Issues

#8664

### Purpose

Fixing memory leak introduced in ed09380d8a0202e6ff508b95f8cd8f136a3aab13.
`N_VMake_Serial` is allocating new memory but the data should only be updated.

### Approach

`NV_DATA_S`
