### PR TITLE
getModelInstances fixes

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -532,6 +532,21 @@ public
     end match;
   end hasSplitSubscripts;
 
+  function expandSplitSubscripts
+    input output ComponentRef cref;
+  algorithm
+    () := match cref
+      case CREF(origin = Origin.CREF)
+        algorithm
+          cref.subscripts := Subscript.expandSplitIndices(cref.subscripts, {});
+          cref.restCref := expandSplitSubscripts(cref.restCref);
+        then
+          ();
+
+      else ();
+    end match;
+  end expandSplitSubscripts;
+
   function getSubscripts
     input ComponentRef cref;
     output list<Subscript> subscripts;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5507,6 +5507,12 @@ public
       case SUBSCRIPTED_EXP()
         then applySubscripts(Subscript.expandSplitIndices(exp.subscripts, {}), exp.exp);
 
+      case CREF()
+        algorithm
+          exp.cref := ComponentRef.expandSplitSubscripts(exp.cref);
+        then
+          exp;
+
       else exp;
     end match;
   end expandSplitIndices;

--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -31,7 +31,6 @@
 
 encapsulated uniontype JSON
 
-import BaseAvlTree;
 import LexerJSON;
 import LexerJSON.{Token,TokenId,tokenContent,printToken,tokenSourceInfo};
 import IOStream;
@@ -44,29 +43,6 @@ import Error;
 import MetaModelica.Dangerous.listReverseInPlace;
 
 public
-
-encapsulated package AvlTree "AvlTree for String to String"
-  import BaseAvlTree;
-  import JSON;
-  extends BaseAvlTree;
-  redeclare type Key = String;
-  redeclare type Value = JSON;
-  redeclare function extends keyStr
-  algorithm
-    outString := inKey;
-  end keyStr;
-  redeclare function extends valueStr
-  algorithm
-    outString := JSON.toString(inValue);
-  end valueStr;
-  redeclare function extends keyCompare
-  algorithm
-    outResult := stringCompare(inKey1, inKey2);
-  end keyCompare;
-annotation(__OpenModelica_Interface="util");
-end AvlTree;
-
-type Dict = JSON.AvlTree.Tree;
 
 record OBJECT
   UnorderedMap<String, JSON> values;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -984,7 +984,7 @@ protected
   SCode.Comment cmt;
   SCode.Annotation ann;
 algorithm
-  comp := InstNode.component(compNode);
+  comp := InstNode.component(InstNode.resolveOuter(compNode));
   json := JSON.emptyObject();
 
   () := match comp


### PR DESCRIPTION
- Expand split subscripts in crefs.
- Resolve inner/outer components to the outer one.
- Remove some unused code in the JSON parser.