### PR TITLE
Add initial testcases for automatic parallelization.

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -614,6 +614,7 @@ algorithm
 
         if Flags.getConfigBool(Flags.PARMODAUTO) then
           codegenFuncs := (function runToStr(func=function SerializeTaskSystemInfo.serializeParMod(code=simCode, withOperations=Flags.isSet(Flags.INFO_XML_OPERATIONS)))) :: codegenFuncs;
+          generatedObjects := AvlSetString.add(generatedObjects, simCode.fileNamePrefix + "_ode.json\n");
         end if;
 
         if Autoconf.os == "Windows_NT" then

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -561,6 +561,9 @@ parallel.log: omc-diff
 parameters.log: omc-diff
 	$(MAKE) -C simulation/modelica/parameters -f Makefile test > $@
 	@echo $@ done
+parmodauto.log: omc-diff
+	$(MAKE) -C simulation/modelica/parmodauto -f Makefile test > $@
+	@echo $@ done
 taskGraph.log: omc-diff
 	$(MAKE) -C simulation/modelica/hpcom -f Makefile test > $@
 	@echo $@ done

--- a/testsuite/simulation/modelica/parmodauto/Makefile
+++ b/testsuite/simulation/modelica/parmodauto/Makefile
@@ -1,0 +1,51 @@
+TEST = ../../../rtest -v
+
+TESTFILES = \
+Modelica.Electrical.Analog.Examples.CauerLowPassSC.mos \
+Modelica.Fluid.Examples.BranchingDynamicPipes.mos
+
+# test that currently fail. Move up when fixed.
+# Run make testfailing
+FAILINGTESTFILES= \
+
+# Dependency files that are not .mo .mos or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.mo \
+*.mos \
+Makefile
+
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps
+
+test:
+	@echo
+	@echo Running tests...
+	@echo
+	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
+	@$(TEST) $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean :
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@rm -f $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+# do it after cleaning and updating the folder
+# then you can get a list of file names (which must be dependencies
+# since you got them from repository + your own new files)
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
+
+failingtest :
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/testsuite/simulation/modelica/parmodauto/Modelica.Electrical.Analog.Examples.CauerLowPassSC.mos
+++ b/testsuite/simulation/modelica/parmodauto/Modelica.Electrical.Analog.Examples.CauerLowPassSC.mos
@@ -1,0 +1,45 @@
+// name:      Modelica.Electrical.Analog.Examples.CauerLowPassSC
+// keywords:  parmodauto
+// status:    correct
+// cflags:
+//
+// Tests automatic parallelization with parmodauto
+//
+
+setCommandLineOptions("--parmodauto");
+getErrorString();
+
+loadModel(Modelica, {"3.2.1"});
+getErrorString();
+
+echo(false);
+res := simulate(Modelica.Electrical.Analog.Examples.CauerLowPassSC);
+echo(true);
+getErrorString();
+
+
+echo(false);
+expectedRes := getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Electrical.Analog.Examples.CauerLowPassSC.mat";
+outDiffFile := "Modelica.Electrical.Analog.Examples.CauerLowPassSC_diff";
+
+varsToCompare := {"C1.v","C2.v","C3.v","C4.v","C7.v","R4.Capacitor1.v","R5.Capacitor1.v","R8.Capacitor1.v","R9.Capacitor1.v","R1.Capacitor1.v","R2.Capacitor1.v","R3.Capacitor1.v","Rp1.Capacitor1.v"};
+echo(true);
+
+
+OpenModelica.Scripting.diffSimulationResults(actualFile = "Modelica.Electrical.Analog.Examples.CauerLowPassSC_res.mat",
+                                             expectedFile = expectedRes,
+                                             diffPrefix = outDiffFile,
+                                             vars = varsToCompare);
+getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// (true,{})
+// ""
+// endResult

--- a/testsuite/simulation/modelica/parmodauto/Modelica.Fluid.Examples.BranchingDynamicPipes.mos
+++ b/testsuite/simulation/modelica/parmodauto/Modelica.Fluid.Examples.BranchingDynamicPipes.mos
@@ -1,0 +1,71 @@
+// name:      Modelica.Fluid.Examples.BranchingDynamicPipes
+// keywords:  parmodauto
+// status:    correct
+// cflags:
+//
+// Tests automatic parallelization with parmodauto
+//
+
+setCommandLineOptions("--parmodauto");
+getErrorString();
+
+loadModel(Modelica);
+getErrorString();
+
+echo(false);
+res := simulate(Modelica.Fluid.Examples.BranchingDynamicPipes, simflags="-noHomotopyOnFirstTry");
+echo(true);
+getErrorString();
+
+
+echo(false);
+expectedRes := getEnvironmentVar("REFERENCEFILES")+"/msl32/Modelica.Fluid.Examples.BranchingDynamicPipes.mat";
+outDiffFile := "Modelica.Fluid.Examples.BranchingDynamicPipes_diff";
+
+varsToCompare :=   {"pipe1.mediums[1].p", "pipe1.mediums[1].Xi[1]", "pipe1.mediums[1].T",
+                    "pipe1.mediums[2].p", "pipe1.mediums[2].Xi[1]", "pipe1.mediums[2].T",
+                    "pipe1.mediums[3].p", "pipe1.mediums[3].Xi[1]", "pipe1.mediums[3].T",
+                    "pipe1.mediums[4].p", "pipe1.mediums[4].Xi[1]", "pipe1.mediums[4].T",
+                    "pipe1.mediums[5].p", "pipe1.mediums[5].Xi[1]", "pipe1.mediums[5].T",
+                    "pipe1.flowModel.m_flows[1]", "pipe1.flowModel.m_flows[2]", "pipe1.flowModel.m_flows[3]",
+                    "pipe1.flowModel.m_flows[4]", "pipe1.flowModel.m_flows[5]", "pipe2.mediums[1].p",
+                    "pipe2.mediums[1].Xi[1]", "pipe2.mediums[1].T", "pipe2.mediums[2].p",
+                    "pipe2.mediums[2].Xi[1]", "pipe2.mediums[2].T", "pipe2.mediums[3].p",
+                    "pipe2.mediums[3].Xi[1]", "pipe2.mediums[3].T", "pipe2.mediums[4].p",
+                    "pipe2.mediums[4].Xi[1]", "pipe2.mediums[4].T", "pipe2.mediums[5].Xi[1]",
+                    "pipe2.mediums[5].T", "pipe2.flowModel.m_flows[1]", "pipe2.flowModel.m_flows[2]",
+                    "pipe2.flowModel.m_flows[3]", "pipe2.flowModel.m_flows[4]", "pipe3.mediums[1].p",
+                    "pipe3.mediums[1].Xi[1]", "pipe3.mediums[1].T", "pipe3.mediums[2].p",
+                    "pipe3.mediums[2].Xi[1]", "pipe3.mediums[2].T", "pipe3.mediums[3].p",
+                    "pipe3.mediums[3].Xi[1]", "pipe3.mediums[3].T", "pipe3.mediums[4].p",
+                    "pipe3.mediums[4].Xi[1]", "pipe3.mediums[4].T", "pipe3.mediums[5].Xi[1]",
+                    "pipe3.mediums[5].T", "pipe3.flowModel.m_flows[1]", "pipe3.flowModel.m_flows[2]",
+                    "pipe3.flowModel.m_flows[3]", "pipe3.flowModel.m_flows[4]", "pipe3.flowModel.m_flows[5]",
+                    "pipe4.mediums[1].p", "pipe4.mediums[1].Xi[1]", "pipe4.mediums[1].T",
+                    "pipe4.mediums[2].p", "pipe4.mediums[2].Xi[1]", "pipe4.mediums[2].T",
+                    "pipe4.mediums[3].p", "pipe4.mediums[3].Xi[1]", "pipe4.mediums[3].T",
+                    "pipe4.mediums[4].p", "pipe4.mediums[4].Xi[1]", "pipe4.mediums[4].T",
+                    "pipe4.mediums[5].p", "pipe4.mediums[5].Xi[1]", "pipe4.mediums[5].T",
+                    "pipe4.flowModel.m_flows[1]", "pipe4.flowModel.m_flows[2]", "pipe4.flowModel.m_flows[3]",
+                    "pipe4.flowModel.m_flows[4]", "pipe4.flowModel.m_flows[5]"};
+echo(true);
+
+
+OpenModelica.Scripting.diffSimulationResults(actualFile = "Modelica.Fluid.Examples.BranchingDynamicPipes_res.mat",
+                                             expectedFile = expectedRes,
+                                             diffPrefix = outDiffFile,
+                                             vars = varsToCompare);
+getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
+// "
+// true
+// (true,{})
+// ""
+// endResult


### PR DESCRIPTION
  - These testcases are not here to test parallelization performance or
    speedup. Their purpose is to make sure that compilation and simulation
    with automatic parallelization enabled (--parmoduato) does not break
    due to changes.