### PR TITLE
fix #7354 Modelica Integer parsing, displaying and div on Windows 64bit

### DIFF
--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -554,7 +554,7 @@ protected
   Option<BackendDAE.InlineData> inlineData;
   list<BackendDAE.Equation> removedInitialEquationLst;
 algorithm
-  if Config.simulationCg() then
+  if Config.simulationCg() or Config.simulation() then
     info := BackendDAE.EXTRA_INFO(DAEUtil.daeDescription(dae), AbsynUtil.pathString(inClassName));
     dlow := BackendDAECreate.lower(dae, inCache, inEnv, info);
     (dlow, initDAE, initDAE_lambda0, inlineData, removedInitialEquationLst) := BackendDAEUtil.getSolvedSystem(dlow, "");
@@ -576,7 +576,7 @@ protected
   SimCode.SimulationSettings sim_settings;
   Integer intervals;
 algorithm
-  if Config.simulationCg() then
+  if Config.simulationCg() or Config.simulation() then
     Print.clearErrorBuf();
     Print.clearBuf();
     cname := AbsynUtil.pathString(inClassName);

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -6410,9 +6410,9 @@ let &sub = buffer ""
       if acceptMetaModelicaGrammar()
         then 'if (<%tvar%> == 0) {<%generateThrow()%>;}<%\n%>'
         else 'if (<%tvar%> == 0) {throwStreamPrint(threadData, "Division by zero %s", "<%Util.escapeModelicaStringToCString(cstr)%>");}<%\n%>'
-      /*ldiv not available in opencl c*/
+      /* ldiv not available in opencl c*/
     if isParallelFunctionContext(context) then '(modelica_integer)((<%var1%>) / <%tvar%>)'
-    else 'ldiv(<%var1%>,<%tvar%>).quot'
+    else 'modelica_div_integer(<%var1%>,<%tvar%>).quot'
 
   case CALL(path=IDENT(name="div"), expLst={e1,e2}) then
     let var1 = daeExp(e1, context, &preExp, &varDecls, &auxFunction)

--- a/OMCompiler/Compiler/Util/Config.mo
+++ b/OMCompiler/Compiler/Util/Config.mo
@@ -102,6 +102,12 @@ algorithm
   outBoolean := Flags.getConfigBool(Flags.SIMULATION_CG);
 end simulationCg;
 
+public function simulation
+  output Boolean outBoolean;
+algorithm
+  outBoolean := Flags.getConfigBool(Flags.SIMULATION);
+end simulation;
+
 public function simulationCodeTarget
 "@author: adrpo
  returns: 'gcc' or 'msvc'

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1409,6 +1409,10 @@ constant ConfigFlag DUMP_FLAT_MODEL = CONFIG_FLAG(149, "dumpFlatModel",
   })),
   Gettext.gettext("Dumps the flat model at the given stages of the frontend."));
 
+constant ConfigFlag SIMULATION = CONFIG_FLAG(150, "simulation",
+  SOME("u"), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Gettext.gettext("Simulates the last model in the given Modelica file."));
+
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."
   input Boolean initialize = true;

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -404,7 +404,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.EXPORT_CLOCKS_IN_MODELDESCRIPTION,
   Flags.LINK_TYPE,
   Flags.TEARING_ALWAYS_DERIVATIVES,
-  Flags.DUMP_FLAT_MODEL
+  Flags.DUMP_FLAT_MODEL,
+  Flags.SIMULATION
 };
 
 public function new

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -1556,7 +1556,11 @@ primary returns [void* ast]
 #endif
 
       errno = 0;
+#if defined(_WIN64) || defined(__MINGW64__)
+      l = strtoll(chars,&endptr,10);
+#else
       l = strtol(chars,&endptr,10);
+#endif
 
 #if !defined(OMJULIA)
       args[0] = chars;

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -92,6 +92,17 @@ typedef int mmc_sint_t;
 
 #endif
 
+/* helpers for mmc_sint_t: printing / div */
+#if defined(_WIN64) || defined(__MINGW64__)
+#define modelica_div_integer lldiv
+#define OMC_INT_FORMAT_LEFT_JUSTIFIED "%-*lld"
+#define OMC_INT_FORMAT "%*lld"
+#else
+#define modelica_div_integer ldiv
+#define OMC_INT_FORMAT_LEFT_JUSTIFIED "%-*ld"
+#define OMC_INT_FORMAT "%*ld"
+#endif
+
 typedef double            m_real;
 typedef mmc_sint_t        m_integer;
 typedef modelica_metatype m_string;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1482,8 +1482,8 @@ modelica_integer _event_div_integer(modelica_integer x1, modelica_integer x2, mo
   value1 = (modelica_integer)data->simulationInfo->mathEventsValuePre[index];
   value2 = (modelica_integer)data->simulationInfo->mathEventsValuePre[index+1];
 
-  assertStreamPrint(threadData, value2 != 0, "event_div_integer failt at time %f because x2 is zero!", data->localData[0]->timeValue);
-  return ldiv(value1, value2).quot;
+  assertStreamPrint(threadData, value2 != 0, "event_div_integer failed at time %f because x2 is zero!", data->localData[0]->timeValue);
+  return modelica_div_integer(value1, value2).quot;
 }
 
 /*! \fn _event_div_real

--- a/OMCompiler/SimulationRuntime/c/util/modelica_string.c
+++ b/OMCompiler/SimulationRuntime/c/util/modelica_string.c
@@ -200,19 +200,17 @@ modelica_string modelica_real_to_modelica_string_format(modelica_real r,modelica
 }
 
 /* Convert a modelica_string to a modelica_string, used in String(s) */
-
 modelica_string modelica_string_to_modelica_string(modelica_string s)
 {
   return s;
 }
 
 /* Convert a modelica_integer to a modelica_string, used in String(i) */
-
 modelica_string modelica_integer_to_modelica_string(modelica_integer i, modelica_integer minLen, modelica_boolean leftJustified)
 {
-  size_t sz = snprintf(NULL, 0, leftJustified ? "%-*ld" : "%*ld", (int) minLen, i);
+  size_t sz = snprintf(NULL, 0, leftJustified ? OMC_INT_FORMAT_LEFT_JUSTIFIED : OMC_INT_FORMAT, (int) minLen, i);
   void *res = alloc_modelica_string(sz);
-  sprintf(MMC_STRINGDATA(res), leftJustified ? "%-*ld" : "%*ld", (int) minLen, i);
+  sprintf(MMC_STRINGDATA(res), leftJustified ? OMC_INT_FORMAT_LEFT_JUSTIFIED : OMC_INT_FORMAT, (int) minLen, i);
   return res;
 }
 

--- a/testsuite/simulation/modelica/types/IntegerTest.mo
+++ b/testsuite/simulation/modelica/types/IntegerTest.mo
@@ -1,0 +1,16 @@
+
+model IntegerTest "test #7354"
+  Integer z;
+  Integer y;
+algorithm
+  z := 2147483647; // 2^31 - 1
+  print("z: 2147483647: " + String(z) + "\n");
+  z := z * 2;
+  print("z * 2: " + String(z) + "\n");
+  z := 2147483647; // 2^31 - 1
+  print("z: 2147483647: " + String(z) + "\n");
+  z := z + 10;
+  print("z + 10: " + String(z) + "\n");
+  y := div(z, 2);
+  print("div(z, 2): " + String(y) + "\n");
+end IntegerTest;

--- a/testsuite/simulation/modelica/types/IntegerTest.mos
+++ b/testsuite/simulation/modelica/types/IntegerTest.mos
@@ -1,0 +1,36 @@
+// name:     IntegerTest.mos [#7354]
+// keywords: Test that Integer works fine
+// status:   correct
+// teardown_command: rm -rf IntegerTest_* IntegerTest.exe IntegerTest.bat IntegerTest.cpp IntegerTest.makefile IntegerTest.libs IntegerTest.log output.log
+
+
+loadFile("IntegerTest.mo"); getErrorString();
+simulate(IntegerTest, stopTime=0); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "IntegerTest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'IntegerTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "z: 2147483647: 2147483647
+// z * 2: 4294967294
+// z: 2147483647: 2147483647
+// z + 10: 2147483657
+// div(z, 2): 1073741828
+// z: 2147483647: 2147483647
+// z * 2: 4294967294
+// z: 2147483647: 2147483647
+// z + 10: 2147483657
+// div(z, 2): 1073741828
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// z: 2147483647: 2147483647
+// z * 2: 4294967294
+// z: 2147483647: 2147483647
+// z + 10: 2147483657
+// div(z, 2): 1073741828
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/types/Makefile
+++ b/testsuite/simulation/modelica/types/Makefile
@@ -1,7 +1,8 @@
 TEST = ../../../rtest -v
 
 TESTFILES = \
-ComplexTypeEquationCount.mos 
+ComplexTypeEquationCount.mos \
+IntegerTest.mos
 
 
 # test that currently fail. Move up when fixed. 


### PR DESCRIPTION
- on Windows 64bit we use long long int for integers
- use strtoll in the parser
- use lld format to print
- use lldiv for integer division

