### PR TITLE
set start values attributes until initialization mode

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -801,7 +801,7 @@ case MODELINFO(vars=SIMVARS(__),varInfo=VARINFO(numAlgAliasVars=numAlgAliasVars,
   <<
   fmi2Status setReal(ModelInstance* comp, const fmi2ValueReference vr, const fmi2Real value) {
     // set start value attribute for all variable that has start value, till initialization mode
-    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
+    if (vr < <%ixFirstParam%> && (comp->state == modelInstantiated || comp->state == modelInitializationMode)) {
       comp->fmuData->modelData->realVarsData[vr].attribute.start = value;
     }
     if (vr < <%ixFirstParam%>) {
@@ -883,7 +883,7 @@ case MODELINFO(vars=SIMVARS(__),varInfo=VARINFO(numIntAliasVars=numAliasVars, nu
   <<
   fmi2Status setInteger(ModelInstance* comp, const fmi2ValueReference vr, const fmi2Integer value) {
     // set start value attribute for all variable that has start value, till initialization mode
-    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
+    if (vr < <%ixFirstParam%> && (comp->state == modelInstantiated || comp->state == modelInitializationMode)) {
       comp->fmuData->modelData->integerVarsData[vr].attribute.start = value;
     }
     if (vr < <%ixFirstParam%>) {
@@ -933,10 +933,6 @@ match modelInfo
 case MODELINFO(vars=SIMVARS(__)) then
   <<
   fmi2Status setBoolean(ModelInstance* comp, const fmi2ValueReference vr, const fmi2Boolean value) {
-    // set start value attribute for all variable that has start value, till initialization mode
-    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
-      comp->fmuData->modelData->booleanVarsData[vr].attribute.start = value;
-    }
     switch (vr) {
       <%vars.boolAlgVars |> var => SwitchVarsSet(simCode, var, "booleanVars") ;separator="\n"%>
       <%vars.boolParamVars |> var => SwitchParametersSet(simCode, var, "booleanParameter") ;separator="\n"%>
@@ -976,10 +972,6 @@ match modelInfo
 case MODELINFO(vars=SIMVARS(__)) then
   <<
   fmi2Status setString(ModelInstance* comp, const fmi2ValueReference vr, fmi2String value) {
-    // set start value attribute for all variable that has start value, till initialization mode
-    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
-      comp->fmuData->modelData->stringVarsData[vr].attribute.start = value;
-    }
     switch (vr) {
       <%vars.stringAlgVars |> var => SwitchVarsSet(simCode, var, "stringVars") ;separator="\n"%>
       <%vars.stringParamVars |> var => SwitchParametersSet(simCode, var, "stringParameter") ;separator="\n"%>

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -800,6 +800,10 @@ case MODELINFO(vars=SIMVARS(__),varInfo=VARINFO(numAlgAliasVars=numAlgAliasVars,
   let ixEnd = intAdd(numAlgAliasVars,intAdd(numParams, intAdd(intMul(2,numStateVars),intAdd(numAlgVars,numDiscreteReal))))
   <<
   fmi2Status setReal(ModelInstance* comp, const fmi2ValueReference vr, const fmi2Real value) {
+    // set start value attribute for all variable that has start value, till initialization mode
+    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
+      comp->fmuData->modelData->realVarsData[vr].attribute.start = value;
+    }
     if (vr < <%ixFirstParam%>) {
       comp->fmuData->localData[0]->realVars[vr] = value;
       return fmi2OK;
@@ -878,6 +882,10 @@ case MODELINFO(vars=SIMVARS(__),varInfo=VARINFO(numIntAliasVars=numAliasVars, nu
   let ixEnd = intAdd(numAliasVars,intAdd(numParams, numAlgVars))
   <<
   fmi2Status setInteger(ModelInstance* comp, const fmi2ValueReference vr, const fmi2Integer value) {
+    // set start value attribute for all variable that has start value, till initialization mode
+    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
+      comp->fmuData->modelData->integerVarsData[vr].attribute.start = value;
+    }
     if (vr < <%ixFirstParam%>) {
       comp->fmuData->localData[0]->integerVars[vr] = value;
       return fmi2OK;
@@ -925,6 +933,10 @@ match modelInfo
 case MODELINFO(vars=SIMVARS(__)) then
   <<
   fmi2Status setBoolean(ModelInstance* comp, const fmi2ValueReference vr, const fmi2Boolean value) {
+    // set start value attribute for all variable that has start value, till initialization mode
+    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
+      comp->fmuData->modelData->booleanVarsData[vr].attribute.start = value;
+    }
     switch (vr) {
       <%vars.boolAlgVars |> var => SwitchVarsSet(simCode, var, "booleanVars") ;separator="\n"%>
       <%vars.boolParamVars |> var => SwitchParametersSet(simCode, var, "booleanParameter") ;separator="\n"%>
@@ -964,6 +976,10 @@ match modelInfo
 case MODELINFO(vars=SIMVARS(__)) then
   <<
   fmi2Status setString(ModelInstance* comp, const fmi2ValueReference vr, fmi2String value) {
+    // set start value attribute for all variable that has start value, till initialization mode
+    if (comp->state == modelInstantiated  || comp->state == modelInitializationMode) {
+      comp->fmuData->modelData->stringVarsData[vr].attribute.start = value;
+    }
     switch (vr) {
       <%vars.stringAlgVars |> var => SwitchVarsSet(simCode, var, "stringVars") ;separator="\n"%>
       <%vars.stringParamVars |> var => SwitchParametersSet(simCode, var, "stringParameter") ;separator="\n"%>

--- a/testsuite/omsimulator/Issue_FMU_update_vars.mos
+++ b/testsuite/omsimulator/Issue_FMU_update_vars.mos
@@ -1,0 +1,84 @@
+// name:  Issue_FMU_update_vars
+// keywords: FMI 2.0 fmi2setReal OMSimulator
+// status: correct
+// teardown_command: rm -rf temp_Issue_FMU_update_vars/ Issue_FMU_update_vars.mat Issue_FMU_update_vars_info.json Issue_FMU_update_vars.lua Issue_FMU_update_vars_systemCall.log Issue_FMU_update_vars.fmu Issue_FMU_update_vars.log
+
+loadString("model Issue_FMU_update_vars
+  Real var;
+  parameter Real x = 1;
+equation
+  der(var) = 1.0;
+end Issue_FMU_update_vars;");
+getErrorString();
+
+// Build 2.0 FMU
+buildModelFMU(Issue_FMU_update_vars, version="2.0", fmuType="me_cs", platforms={"static"});
+getErrorString();
+
+// Simulate with OMSimulator
+writeFile("Issue_FMU_update_vars.lua", "
+oms_setCommandLineOption(\"--suppressPath=true\")
+oms_setTempDirectory(\"./temp_Issue_FMU_update_vars/\")
+
+oms_newModel(\"model\")
+
+oms_addSystem(\"model.root\", oms_system_sc)
+
+oms_addSubModel(\"model.root.fmuvar\", \"Issue_FMU_update_vars.fmu\")
+
+oms_setResultFile(\"model\", \"Issue_FMU_update_vars.mat\")
+
+print(\"info:    Virgin settings\")
+oms_setReal(\"model.root.fmuvar.var\", -4.0)
+oms_setReal(\"model.root.fmuvar.x\", -30.0)
+
+print(\"info:      model.root.fmuvar.var     : \" .. oms_getReal(\"model.root.fmuvar.var\"))
+print(\"info:      model.root.fmuvar.x       : \" .. oms_getReal(\"model.root.fmuvar.x\"))
+
+oms_instantiate(\"model\")
+oms_setReal(\"model.root.fmuvar.var\", -3.0)
+oms_setReal(\"model.root.fmuvar.x\", -40.0)
+
+print(\"info:    Instantiate settings\")
+print(\"info:      model.root.fmuvar.var     : \" .. oms_getReal(\"model.root.fmuvar.var\"))
+print(\"info:      model.root.fmuvar.x       : \" .. oms_getReal(\"model.root.fmuvar.x\"))
+
+oms_initialize(\"model\")
+
+print(\"info:    Initialize settings\")
+print(\"info:      model.root.fmuvar.var     : \" .. oms_getReal(\"model.root.fmuvar.var\"))
+print(\"info:      model.root.fmuvar.x       : \" .. oms_getReal(\"model.root.fmuvar.x\"))
+oms_simulate(\"model\")
+
+oms_terminate(\"model\")
+oms_delete(\"model\")
+"); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator Issue_FMU_update_vars.lua", "Issue_FMU_update_vars_systemCall.log");
+readFile("Issue_FMU_update_vars_systemCall.log");
+
+// Result:
+// true
+// ""
+// "Issue_FMU_update_vars.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// true
+// ""
+// 0
+// "info:    Virgin settings
+// info:      model.root.fmuvar.var     : -4.0
+// info:      model.root.fmuvar.x       : -30.0
+// info:    Instantiate settings
+// info:      model.root.fmuvar.var     : -3.0
+// info:      model.root.fmuvar.x       : -40.0
+// info:    maximum step size for 'model.root': 0.001000
+// info:    Result file: Issue_FMU_update_vars.mat (bufferSize=1)
+// info:    Initialize settings
+// info:      model.root.fmuvar.var     : -3.0
+// info:      model.root.fmuvar.x       : -40.0
+// info:    Final Statistics for 'model.root':
+//          NumSteps = 1001 NumRhsEvals  = 1002 NumLinSolvSetups = 51
+//          NumNonlinSolvIters = 1001 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
+// "
+// endResult

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -14,6 +14,7 @@ initialization_omc.mos \
 initialization.mos \
 initialization2_omc.mos \
 initialization2.mos \
+Issue_FMU_update_vars.mos \
 Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.mos \
 outputState_omc.mos \
 outputState.mos \


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1138

### Purpose

This  PR fixes the setReal() on variables that have start values during `instantiate` and `initialization` mode
