### PR TITLE
[NB] switch back to numeric jacobian default

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimJacobian.mo
@@ -244,7 +244,7 @@ public
             name                = jacobian.name,
             jacobianIndex       = indices.jacobianIndex,
             partitionIndex      = 0,
-            numberOfResultVars  = listLength(columnVars),   // needs to be changed once tearing is implmented
+            numberOfResultVars  = listLength(columnVars),
             columnEqns          = listReverse(columnEqns),
             constantEqns        = {},
             columnVars          = columnVars,

--- a/testsuite/simulation/modelica/NBackend/array_handling/simple_der_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/simple_der_for.mos
@@ -15,7 +15,7 @@ end simple_der_for;
 
 "); getErrorString();
 
-setCommandLineOptions("--newBackend -d=symjacdump");
+setCommandLineOptions("--newBackend --generateSymbolicJacobian -d=symjacdump");
 
 simulate(simple_der_for); getErrorString();
 

--- a/testsuite/simulation/modelica/NBackend/functions/builtin_functions.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/builtin_functions.mos
@@ -26,7 +26,7 @@ end builtin_functions;
 
 "); getErrorString();
 
-setCommandLineOptions("--newBackend -d=symjacdump"); getErrorString();
+setCommandLineOptions("--newBackend --generateSymbolicJacobian -d=symjacdump"); getErrorString();
 simulate(builtin_functions); getErrorString();
 // Result:
 // true

--- a/testsuite/simulation/modelica/NBackend/functions/function_annotation_der.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_annotation_der.mos
@@ -48,8 +48,9 @@ algorithm
 end df;
 "); getErrorString();
 
-setCommandLineOptions("--newBackend -d=debugDifferentiation"); getErrorString();
+setCommandLineOptions("--newBackend --generateSymbolicJacobian -d=debugDifferentiation"); getErrorString();
 simulate(function_annotation_der); getErrorString();
+
 // Result:
 // true
 // ""

--- a/testsuite/simulation/modelica/NBackend/functions/function_diff.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_diff.mos
@@ -26,8 +26,9 @@ algorithm
 end f;
 "); getErrorString();
 
-setCommandLineOptions("--newBackend -d=debugDifferentiation"); getErrorString();
+setCommandLineOptions("--newBackend --generateSymbolicJacobian -d=debugDifferentiation"); getErrorString();
 simulate(function_diff); getErrorString();
+
 // Result:
 // true
 // ""


### PR DESCRIPTION
 - tests have shown that the symbolic jacobian is slower for big systems even with proper coloring
 - reactivates numeric jacobian as default (with coloring) just as the old backend
 - symbolic jacobian can be activated with --generateSymbolicJacobian (also just as OB)