### PR TITLE
Improve handling of MSL

### DIFF
--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -213,7 +213,7 @@ char* SettingsImpl__getModelicaPath(int runningTestsuite) {
     const char *path = runningTestsuite ? NULL : getenv("OPENMODELICALIBRARY");
     if (path != NULL)
     {
-        omc_modelicaPath = strdup(path);
+      omc_modelicaPath = strdup(path);
     }
     else
     {
@@ -234,7 +234,7 @@ char* SettingsImpl__getModelicaPath(int runningTestsuite) {
       } else {
         int lenHome = strlen(homePath);
         omc_modelicaPath = (char*)omc_alloc_interface.malloc_atomic(lenOmhome+lenHome+41);
-        snprintf(omc_modelicaPath, lenOmhome+lenHome+41,"%s/lib/omlibrary%s%s/.openmodelica/libraries/", omhome, OMC_GROUP_DELIMITER, homePath);
+        snprintf(omc_modelicaPath, lenHome+lenOmhome+41,"%s/.openmodelica/libraries/%s%s/lib/omlibrary", homePath, OMC_GROUP_DELIMITER, omhome);
       }
     }
 

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -358,13 +358,6 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpCentralStackedWidget->addWidget(mpPlotWindowContainer);
   //Set the centralwidget
   setCentralWidget(mpCentralStackedWidget);
-  //! @todo Remove the following MSL verison block once we have fixed the MSL handling.
-  // set MSL version
-  QSettings *pSettings = Utilities::getApplicationSettings();
-  if (!isTestsuiteRunning() && (!pSettings->contains("MSLVersion") || !pSettings->value("MSLVersion").toBool())) {
-    MSLVersionDialog *pMSLVersionDialog = new MSLVersionDialog;
-    pMSLVersionDialog->exec();
-  }
   // Load and add user defined Modelica libraries into the Library Widget.
   mpLibraryWidget->getLibraryTreeModel()->addModelicaLibraries();
   // set command line options
@@ -374,6 +367,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   OptionsDialog::instance()->saveSimulationSettings();
   OptionsDialog::instance()->saveNFAPISettings();
   // restore OMEdit widgets state
+  QSettings *pSettings = Utilities::getApplicationSettings();
   if (OptionsDialog::instance()->getGeneralSettingsPage()->getPreserveUserCustomizations()) {
     restoreGeometry(pSettings->value("application/geometry").toByteArray());
     bool restoreMessagesWidget = !MessagesWidget::instance()->getAllMessageWidget()->getMessagesTextBrowser()->toPlainText().isEmpty();
@@ -2512,10 +2506,10 @@ void MainWindow::exportModelToOMNotebook()
  * \brief MainWindow::openInstallLibraryDialog
  * Opens the install library dialog.
  */
-void MainWindow::openInstallLibraryDialog()
+bool MainWindow::openInstallLibraryDialog()
 {
   InstallLibraryDialog *pInstallLibraryDialog = new InstallLibraryDialog;
-  pInstallLibraryDialog->exec();
+  return pInstallLibraryDialog->exec();
 }
 
 /*!
@@ -4739,130 +4733,4 @@ void AboutOMEditDialog::showReportIssue()
   // show the CrashReportDialog
   CrashReportDialog *pCrashReportDialog = new CrashReportDialog("", true);
   pCrashReportDialog->exec();
-}
-
-/*!
- * \brief MSLVersionDialog::MSLVersionDialog
- * \param parent
- */
-MSLVersionDialog::MSLVersionDialog(QWidget *parent)
-  : QDialog(parent)
-{
-  QString title = tr("Setup of Modelica Standard Library version");
-  setAttribute(Qt::WA_DeleteOnClose);
-  setWindowFlags(windowFlags() & ~Qt::WindowCloseButtonHint);
-  setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, title));
-  // heading
-  Label *pHeadingLabel = Utilities::getHeadingLabel(title);
-  // horizontal line
-  QFrame *pHorizontalLine = Utilities::getHeadingLine();
-  // Information
-  const QString info = QString("OpenModelica 1.17.x supports both Modelica Standard Library (MSL) v3.2.3 and v4.0.0. Please note that synchronous components in Modelica.Clocked are still not fully reliable, while most other models work fine in both versions.<br /><br />"
-                               "MSL v3.2.3 and v4.0.0 are mutually incompatible, because of changes of class names and paths; for example, Modelica.SIunits became Modelica.Units.SI in v4.0.0 (​<a href=\"https://github.com/modelica/ModelicaStandardLibrary/releases/tag/v4.0.0\">further information</a>). Please note that conversion scripts are not yet available in OpenModelica 1.17.x, so you need to use other Modelica tools to upgrade existing libraries to use MSL v4.0.0. Conversion script support is planned in OpenModelica 1.18.0.<br /><br />"
-                               "On Windows, both versions of the MSL are installed automatically by the installer. On Linux, you need to install them manually, by following the instructions on the <a href=\"https://openmodelica.org/download/download-linux\">OpenModelica download page</a>. We suggest you do it immediately, otherwise OMEdit won't work correctly.<br /><br />"
-                               "You have three startup options:"
-                               "<ol>"
-                               "<li>Automatically load MSL v3.2.3. You can then load other models or packages that use MSL v3.2.3, or start new ones that will use it. If you then open a model or package that uses MSL v4.0.0, errors will occur. This option is recommended if you are not interested in MSL v4.0.0 and you would like to get the same behaviour as in OpenModelica 1.16.x.</li>"
-                               "<li>Automatically load MSL v4.0.0. You can then load other models or packages that use MSL v4.0.0, or start new ones that will use it. If you then open a model or package that uses MSL v3.2.3, errors will occur. This option is recommended if you exclusively use new libraries depending on MSL v4.0.0.</li>"
-                               "<li>Do not load MSL. When you open a model or library, the appropriate version of MSL will be loaded automatically, based on the uses() annotation of library being opened. This option is recommended if you work with different projects, some using MSL v3.2.3 and some others using MSL v4.0.0. It is also recommended if you are a developer of the Modelica Standard Library, so you want to load your own modified version instead of the pre-installed version customized for OpenModelica.</li>"
-                               "</ol>"
-                               "Please choose one startup option:");
-  Label *pInfoLabel = new Label(info);
-  pInfoLabel->setWordWrap(true);
-  pInfoLabel->setTextFormat(Qt::RichText);
-  pInfoLabel->setTextInteractionFlags(pInfoLabel->textInteractionFlags() | Qt::LinksAccessibleByMouse | Qt::LinksAccessibleByKeyboard);
-  pInfoLabel->setOpenExternalLinks(true);
-  pInfoLabel->setToolTip("");
-  // options
-  mpMSL3RadioButton = new QRadioButton("Load MSL v3.2.3");
-  mpMSL4RadioButton = new QRadioButton("Load MSL v4.0.0");
-  mpNoMSLRadioButton = new QRadioButton("Do not load MSL");
-  QButtonGroup *pButtonGroup = new QButtonGroup;
-  pButtonGroup->addButton(mpMSL3RadioButton);
-  pButtonGroup->addButton(mpMSL4RadioButton);
-  pButtonGroup->addButton(mpNoMSLRadioButton);
-  // radio buttons layout
-  QVBoxLayout *pRadioButtonsLayout = new QVBoxLayout;
-  pRadioButtonsLayout->setAlignment(Qt::AlignTop);
-  pRadioButtonsLayout->setSpacing(0);
-  pRadioButtonsLayout->addWidget(mpMSL3RadioButton);
-  pRadioButtonsLayout->addWidget(mpMSL4RadioButton);
-  pRadioButtonsLayout->addWidget(mpNoMSLRadioButton);
-  // more info
-  Label *pPostInfoLabel = new Label(QString("You can later change this setting by going to Tools | Options | Libraries, where you can add or remove the Modelica library from the list of automatically loaded system libraries, as well as specify which version of the library you want to load. Version tag \"default\" will load the latest installed version (i.e. v4.0.0 for MSL)"));
-  pPostInfoLabel->setWordWrap(true);
-  pPostInfoLabel->setToolTip("");
-  // Create the buttons
-  QPushButton *pOkButton = new QPushButton(Helper::ok);
-  connect(pOkButton, SIGNAL(clicked()), SLOT(setMSLVersion()));
-  // layout
-  QGridLayout *pMainGridLayout = new QGridLayout;
-  pMainGridLayout->setAlignment(Qt::AlignTop);
-  pMainGridLayout->addWidget(pHeadingLabel, 0, 0);
-  pMainGridLayout->addWidget(pHorizontalLine, 1, 0);
-  pMainGridLayout->addWidget(pInfoLabel, 2, 0);
-  pMainGridLayout->addLayout(pRadioButtonsLayout, 3, 0);
-  pMainGridLayout->addWidget(pPostInfoLabel, 4, 0);
-  pMainGridLayout->addWidget(pOkButton, 5, 0, Qt::AlignRight);
-  mpWidget = new QWidget;
-  mpWidget->setLayout(pMainGridLayout);
-  QScrollArea *pScrollArea = new QScrollArea;
-  pScrollArea->setWidgetResizable(true);
-  pScrollArea->setWidget(mpWidget);
-  QVBoxLayout *pMainLayout = new QVBoxLayout;
-  pMainLayout->addWidget(pScrollArea);
-  setLayout(pMainLayout);
-}
-
-/*!
- * \brief MSLVersionDialog::setMSLVersion
- */
-void MSLVersionDialog::setMSLVersion()
-{
-  // if no option is selected
-  if (!mpMSL3RadioButton->isChecked() && !mpMSL4RadioButton->isChecked() && !mpNoMSLRadioButton->isChecked()) {
-    QMessageBox::information(this, QString("%1 - %2").arg(Helper::applicationName, Helper::information), "Please select an option.", Helper::ok);
-    return;
-  }
-  QSettings *pSettings = Utilities::getApplicationSettings();
-  // First clear any Modelica and ModelicaReference setting
-  pSettings->beginGroup("libraries");
-  QStringList libraries = pSettings->childKeys();
-  foreach (QString lib, libraries) {
-    if (lib.compare("Modelica") == 0 || lib.compare("ModelicaReference") == 0) {
-      pSettings->remove(lib);
-    }
-  }
-  pSettings->endGroup();
-  // set the Modelica version based on user setting.
-  if (mpMSL3RadioButton->isChecked()) {
-    pSettings->setValue("libraries/Modelica", "3.2.3");
-  } else if (mpMSL4RadioButton->isChecked()) {
-    pSettings->setValue("libraries/Modelica", "4.0.0");
-  } else { // mpNoMSLRadioButton->isChecked()
-    pSettings->setValue("forceModelicaLoad", false);
-  }
-  pSettings->setValue("MSLVersion", true);
-  accept();
-}
-
-/*!
- * \brief MSLVersionDialog::reject
- * Override QDialog::reject() so we can't close the dialog.
- */
-void MSLVersionDialog::reject()
-{
-  // do nothing here.
-}
-
-/*!
- * \brief MSLVersionDialog::sizeHint
- * \return
- */
-QSize MSLVersionDialog::sizeHint() const
-{
-  QSize size = QWidget::sizeHint();
-  size.rwidth() = mpWidget->width();
-  size.rheight() = mpWidget->height() + 50; // add 50 for dialog frame and title bar
-  return size;
 }

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -528,7 +528,7 @@ public slots:
 #endif
   void runOMSensPlugin();
   void exportModelToOMNotebook();
-  void openInstallLibraryDialog();
+  bool openInstallLibraryDialog();
   void upgradeInstalledLibraries();
   void importModelfromOMNotebook();
   void importNgspiceNetlist();
@@ -603,28 +603,6 @@ public slots:
   void showReportIssue();
 private slots:
   void readOMContributors(QNetworkReply *pNetworkReply);
-};
-
-class MSLVersionDialog : public QDialog
-{
-  Q_OBJECT
-public:
-  MSLVersionDialog(QWidget *parent = 0);
-private:
-  QRadioButton *mpMSL3RadioButton;
-  QRadioButton *mpMSL4RadioButton;
-  QRadioButton *mpNoMSLRadioButton;
-  QWidget *mpWidget;
-private slots:
-  void setMSLVersion();
-
-  // QDialog interface
-public slots:
-  virtual void reject() override;
-
-  // QWidget interface
-public:
-  virtual QSize sizeHint() const override;
 };
 
 #endif // MAINWINDOW_H

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -1417,13 +1417,13 @@ void LibraryTreeModel::addModelicaLibraries()
   OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
   pOMCProxy->loadSystemLibraries();
   QStringList systemLibs = pOMCProxy->getClassNames();
-  if (OptionsDialog::instance()->getLibrariesPage()->getLoadOpenModelicaLibraryCheckBox()->isChecked()) {
-    systemLibs.prepend("OpenModelica");
-  }
-  foreach (QString lib, systemLibs) {
-    SplashScreen::instance()->showMessage(QString(Helper::loading).append(" ").append(lib), Qt::AlignRight, Qt::white);
-    createLibraryTreeItem(lib, mpRootLibraryTreeItem, true, true, true);
-    checkIfAnyNonExistingClassLoaded();
+  foreach (QString systemLib, systemLibs) {
+    LibraryTreeItem *pLibraryTreeItem = findLibraryTreeItem(systemLib);
+    if (!pLibraryTreeItem) {
+      SplashScreen::instance()->showMessage(QString("%1 %2").arg(Helper::loading, systemLib), Qt::AlignRight, Qt::white);
+      createLibraryTreeItem(systemLib, mpRootLibraryTreeItem, true, true, true);
+      checkIfAnyNonExistingClassLoaded();
+    }
   }
   // load Modelica User Libraries.
   pOMCProxy->loadUserLibraries();
@@ -4707,9 +4707,7 @@ void LibraryWidget::saveTotalLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem)
 void LibraryWidget::openLibraryTreeItem(QString nameStructure)
 {
   LibraryTreeItem *pLibraryTreeItem = mpLibraryTreeModel->findLibraryTreeItem(nameStructure);
-  if (!pLibraryTreeItem) {
-    return;
-  } else {
+  if (pLibraryTreeItem) {
     mpLibraryTreeModel->showModelWidget(pLibraryTreeItem);
   }
 }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -268,8 +268,7 @@ bool OMCProxy::initializeOMC(threadData_t *threadData)
 #endif
   /* set the tmp directory as the working directory */
   changeDirectory(tmpPath);
-  // set the OpenModelicaLibrary variable.
-  Helper::OpenModelicaLibrary = getModelicaPath();
+  // set the user home directory variable.
   Helper::userHomeDirectory = getHomeDirectoryPath();
   return true;
 }
@@ -722,27 +721,10 @@ void OMCProxy::loadSystemLibraries()
     loadModel("Modelica", "default");
     loadModel("ModelicaReference", "default");
   } else {
-    bool forceModelicaLoad = true;
     QSettings *pSettings = Utilities::getApplicationSettings();
-    if (pSettings->contains("forceModelicaLoad")) {
-      forceModelicaLoad = pSettings->value("forceModelicaLoad").toBool();
-    }
     pSettings->beginGroup("libraries");
     QStringList libraries = pSettings->childKeys();
     pSettings->endGroup();
-    /* Only force loading of Modelica & ModelicaReference if user is using OMEdit for the first time.
-     * Later user must use the libraries options dialog.
-     */
-    if (forceModelicaLoad) {
-      if (!pSettings->contains("libraries/Modelica")) {
-        pSettings->setValue("libraries/Modelica","default");
-        libraries.prepend("Modelica");
-      }
-      if (!pSettings->contains("libraries/ModelicaReference")) {
-        pSettings->setValue("libraries/ModelicaReference","default");
-        libraries.prepend("ModelicaReference");
-      }
-    }
     foreach (QString lib, libraries) {
       QString version = pSettings->value("libraries/" + lib).toString();
       loadModel(lib, version);
@@ -2771,6 +2753,18 @@ QString OMCProxy::uriToFilename(QString uri)
   } else {
     return "";
   }
+}
+
+/*!
+ * \brief OMCProxy::setModelicaPath
+ * Sets the Modelica library path.
+ * \param path
+ */
+bool OMCProxy::setModelicaPath(const QString &path)
+{
+  bool result = mpOMCInterface->setModelicaPath(path);
+  printMessagesStringInternal();
+  return result;
 }
 
 /*!

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -230,6 +230,7 @@ public:
   bool disableNewInstantiation();
   QString makeDocumentationUriToFileName(QString documentation);
   QString uriToFilename(QString uri);
+  bool setModelicaPath(const QString &path);
   QString getModelicaPath();
   QString getHomeDirectoryPath();
   QStringList getAvailableLibraries();

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -307,28 +307,26 @@ class LibrariesPage : public QWidget
   Q_OBJECT
 public:
   LibrariesPage(OptionsDialog *pOptionsDialog);
+  QLineEdit *getModelicaPathTextBox() const {return mpModelicaPathTextBox;}
   QTreeWidget* getSystemLibrariesTree() {return mpSystemLibrariesTree;}
-  QCheckBox* getForceModelicaLoadCheckBox() {return mpForceModelicaLoadCheckBox;}
-  QCheckBox* getLoadOpenModelicaLibraryCheckBox() {return mpLoadOpenModelicaOnStartupCheckBox;}
   QTreeWidget* getUserLibrariesTree() {return mpUserLibrariesTree;}
   OptionsDialog *mpOptionsDialog;
 private:
   QGroupBox *mpSystemLibrariesGroupBox;
+  Label *mpModelicaPathLabel;
+  QLineEdit *mpModelicaPathTextBox;
   Label *mpSystemLibrariesNoteLabel;
   QTreeWidget *mpSystemLibrariesTree;
   QPushButton *mpAddSystemLibraryButton;
   QPushButton *mpRemoveSystemLibraryButton;
   QPushButton *mpEditSystemLibraryButton;
   QDialogButtonBox *mpSystemLibrariesButtonBox;
-  QCheckBox *mpForceModelicaLoadCheckBox;
-  QCheckBox *mpLoadOpenModelicaOnStartupCheckBox;
   QGroupBox *mpUserLibrariesGroupBox;
   QTreeWidget *mpUserLibrariesTree;
   QPushButton *mpAddUserLibraryButton;
   QPushButton *mpRemoveUserLibraryButton;
   QPushButton *mpEditUserLibraryButton;
   QDialogButtonBox *mpUserLibrariesButtonBox;
-  Label *mpModelicaPathLabel;
 private slots:
   void openAddSystemLibrary();
   void removeSystemLibrary();
@@ -342,20 +340,27 @@ class AddSystemLibraryDialog : public QDialog
 {
   Q_OBJECT
 public:
-  AddSystemLibraryDialog(LibrariesPage *pLibrariesPage);
+  AddSystemLibraryDialog(LibrariesPage *pLibrariesPage, bool editFlag = false);
   bool nameExists(QTreeWidgetItem *pItem = 0);
-
+  QComboBox *getNameComboBox() const {return mpNameComboBox;}
+  QComboBox *getVersionsComboBox() const {return mpVersionsComboBox;}
+private:
   LibrariesPage *mpLibrariesPage;
   Label *mpNameLabel;
   QComboBox *mpNameComboBox;
   Label *mpValueLabel;
-  QLineEdit *mpVersionTextBox;
+  QComboBox *mpVersionsComboBox;
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
+  QPushButton *mpInstallLibraryButton;
   QDialogButtonBox *mpButtonBox;
   bool mEditFlag;
+
+  void getSystemLibraries();
 private slots:
+  void getLibraryVersions(const QString &library);
   void addSystemLibrary();
+  void openInstallLibraryDialog();
 };
 
 class AddUserLibraryDialog : public QDialog

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -43,7 +43,6 @@ QString Helper::application = "omedit"; /* case-sensitive string. Don't change i
 // Following four variables are set once we are connected to OMC......in OMCProxy::initializeOMC().
 QString Helper::OpenModelicaVersion = "";
 QString Helper::OpenModelicaHome = "";
-QString Helper::OpenModelicaLibrary = "";
 QString Helper::userHomeDirectory = "";
 QString Helper::OMCServerName = "OMEdit";
 QString Helper::omFileTypes = "All Files (*.mo *.mol *.ssp);;Modelica Files (*.mo);;Encrypted Modelica Libraries (*.mol);;System Structure and Parameterization Files (*.ssp)";

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -57,7 +57,6 @@ public:
   static QString application;
   static QString OpenModelicaVersion;
   static QString OpenModelicaHome;
-  static QString OpenModelicaLibrary;
   static QString userHomeDirectory;
   static QString OMCServerName;
   static QString omFileTypes;


### PR DESCRIPTION
Change the order of priority of MODELICAPATH, so it looks in the APPDATA directory first, and then in the omlibrary as a fallback option.
Remove initial splash screen with obsolete library explanation.
Do not load any library by default.
Do not load OpenModelica. We have a nice online documentation for the scripting API.
Improved the libraries settings dialog to add system libraries to load startup.
Allow changing the ModelicaPath.