### PR TITLE
Pass all flags from the bat file to the executable.

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15300,7 +15300,7 @@ algorithm
         str := "@echo off\n"
                 + "set PATH=" + locations + ";%PATH%;\n"
                 + "set ERRORLEVEL=\n"
-                + "call \"%CD%/" + code.fileNamePrefix + ".exe\"\n"
+                + "call \"%CD%/" + code.fileNamePrefix + ".exe\" %*\n"
                 + "set RESULT=%ERRORLEVEL%\n"
                 + "\n"
                 + "exit /b %RESULT%\n";


### PR DESCRIPTION
  - On Windows we use a bat file. Some operations, e.g. linearize API, want
    to launch the model with specific flags straight from omc.

    Simply pass all flags passed to the bat file directly to the executable.

  - Fixes #8717.
