### PR TITLE
Delay processing the loadModel callback using QTimer

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1904,10 +1904,12 @@ void MainWindow::loadSystemLibrary(const QString &library, QString version)
       version = QString("default");
     }
 
-    if ((library.compare("OpenModelica") == 0) || (mpOMCProxy->loadModel(library, version))) {
+    mpLibraryWidget->setLoadingLibraries(true);
+    if (mpOMCProxy->loadModel(library, version)) {
       pLibraryTreeModel->createLibraryTreeItem(library, pLibraryTreeModel->getRootLibraryTreeItem(), true, true, true);
       pLibraryTreeModel->checkIfAnyNonExistingClassLoaded();
     }
+    mpLibraryWidget->setLoadingLibraries(false);
     mpStatusBar->clearMessage();
     hideProgressBar();
   }

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -496,9 +496,11 @@ public:
   void saveTotalLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem);
   void openLibraryTreeItem(QString nameStructure);
   void loadAutoLoadedLibrary(const QString &modelName);
-
-  QTimer mAutoLoadedLibrariesTimer;
+  bool isLoadingLibraries() const {return mLoadingLibraries;}
+  void setLoadingLibraries(bool loadingLibraries) {mLoadingLibraries = loadingLibraries;}
 private:
+  bool mLoadingLibraries;
+  QTimer mAutoLoadedLibrariesTimer;
   QStringList mAutoLoadedLibrariesList;
   TreeSearchFilters *mpTreeSearchFilters;
   LibraryTreeModel *mpLibraryTreeModel;


### PR DESCRIPTION
### Purpose

Do not process the loadModel callback when it is called.

### Approach

Defer the handling of callback using the QTimer.
