### PR TITLE
Prevent addition of duplicate expanded variables.

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8245,6 +8245,13 @@ protected
 algorithm
   // if it is an array parameter split it up. Do not do it for Cpp runtime, they can handle array parameters
   if Types.isArray(dlowVar.varType) and not (Config.simCodeTarget() == "Cpp" ) then
+    // Make sure the array does not get expanded again. The check for existence is made by the caller
+    // of this function, extractVarsFromList. Which checks for the whole unxpanded array, which is never
+    // actually added by itslef. So add it here manually.
+    // We can do a check in extractVarFromVar2 for each expanded var as well.
+    // However that means we do the exapnsion of the array for nothing. So add it here so that it does
+    // not get expanded again (and every entry checked again).
+    Mutable.update(hs, BaseHashSet.add(dlowVar.varName, Mutable.access(hs)));
     scalar_crefs := ComponentReference.expandCref(dlowVar.varName, false);
     for cref in scalar_crefs loop
       // extract the sim var


### PR DESCRIPTION
  - The initialization DAE creates some duplicate variables (from the normal DAE)
    for its own purposes. These variables were getting added twice due to
    the fact that they were unexpanded arrays that are expanded when
    simcode is being created. The creation uses the name of the variables
    for identification. However, since the variables arrive as non-expanded
    arrays and then get added after expansion (subscripted names) the check
    did not catch that the array was expanded and added already.

    Add the name of the whole array to the hashtable so that it can be detected
    and skipped.

  - Fixes #8418.
