### PR TITLE
Improve library loading for conversion

### DIFF
--- a/OMCompiler/Compiler/Util/Config.mo
+++ b/OMCompiler/Compiler/Util/Config.mo
@@ -490,11 +490,12 @@ end languageStandardString;
 
 public function setLanguageStandardFromMSL
   input String inLibraryName;
+  input Boolean force = false "Set the standard even if it was already set";
 protected
   LanguageStandard current_std;
 algorithm
   current_std := getLanguageStandard();
-  if current_std <> LanguageStandard.latest then
+  if not force and current_std <> LanguageStandard.latest then
     // If we selected an MSL version manually, we respect that choice.
     return;
   end if;


### PR DESCRIPTION
- Only load the library to convert to if it isn't already loaded.
- Try to set the language standard to the version needed to load the
  library to convert to, in case another version was already loaded with
  a different language standard.