### PR TITLE
Fix some compiler warnings in OMPlot

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
@@ -81,8 +81,8 @@ public:
   Legend* getLegend();
   PlotPicker *getPlotPicker();
   PlotGrid* getPlotGrid();
-  LinearScaleEngine* getXLinearScaleEngine() const {mpXLinearScaleEngine;}
-  LinearScaleEngine* getYLinearScaleEngine() const {mpYLinearScaleEngine;}
+  LinearScaleEngine* getXLinearScaleEngine() const {return mpXLinearScaleEngine;}
+  LinearScaleEngine* getYLinearScaleEngine() const {return mpYLinearScaleEngine;}
   ScaleDraw *getXScaleDraw() const {return mpXScaleDraw;}
   ScaleDraw *getYScaleDraw() const {return mpYScaleDraw;}
   PlotZoomer* getPlotZoomer();

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -1736,7 +1736,7 @@ void PlotWindow::printPlot()
 
   printer.setDocName("OMPlot");
   printer.setCreator("Plot Window");
-  printer.setOrientation(QPrinter::Landscape);
+  printer.setPageOrientation(QPageLayout::Landscape);
 
   QPrintDialog dialog(&printer);
   if ( dialog.exec() )


### PR DESCRIPTION
- Add missing return in
  Plot::getXLinearScaleEngine/getYLinearScaleEngine.
- Replace deprecated QPrinter::setOrientation with
  QPrinter::setPageOrientation.