### PR TITLE
Only update the part of the documentation annotation

### DIFF
--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -1899,7 +1899,8 @@ void PlainTextEdit::focusInEvent(QFocusEvent *event)
 {
   MainWindow::instance()->getAutoSaveTimer()->stop();
   // Issue #8723. If we are editing the documentation then save and close the documentation editing when focus moves to text view.
-  if (mpBaseEditor->getModelWidget()->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::Modelica
+  if (dynamic_cast<ModelicaEditor*>(mpBaseEditor)
+      && mpBaseEditor->getModelWidget()->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::Modelica
       && MainWindow::instance()->getDocumentationDockWidget()->isVisible()
       && MainWindow::instance()->getDocumentationWidget()->isEditingDocumentation()) {
     MainWindow::instance()->getDocumentationWidget()->showDocumentation(mpBaseEditor->getModelWidget()->getLibraryTreeItem());

--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -803,56 +803,55 @@ void DocumentationWidget::saveDocumentation(LibraryTreeItem *pNextLibraryTreeIte
     if (pLibraryTreeItem && !pLibraryTreeItem->isNonExisting()) {
       QList<QString> documentation = MainWindow::instance()->getOMCProxy()->getDocumentationAnnotationInClass(pLibraryTreeItem);
       // old documentation annotation
-      QString oldDocAnnotationString = "annotate=Documentation(";
+      QList<QString> oldDocAnnotationList;
       if (!documentation.at(0).isEmpty()) {
-        oldDocAnnotationString.append("info=\"").append(StringHandler::escapeStringQuotes(documentation.at(0))).append("\"");
+        oldDocAnnotationList.append(QString("info=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(0))));
       }
       if (!documentation.at(1).isEmpty()) {
-        oldDocAnnotationString.append(", revisions=\"").append(StringHandler::escapeStringQuotes(documentation.at(1))).append("\"");
+        oldDocAnnotationList.append(QString("revisions=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(1))));
       }
       if (!documentation.at(2).isEmpty()) {
-        oldDocAnnotationString.append(", __OpenModelica_infoHeader=\"").append(StringHandler::escapeStringQuotes(documentation.at(2))).append("\"");
+        oldDocAnnotationList.append(QString("__OpenModelica_infoHeader=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(2))));
       }
-      oldDocAnnotationString.append(")");
+      QString oldDocAnnotationString = QString("annotate=Documentation(%1)").arg(oldDocAnnotationList.join(","));
       // new documentation annotation
-      QString newDocAnnotationString = "annotate=Documentation(";
+      QList<QString> newDocAnnotationList;
       if (mEditType == EditType::Info) { // if editing the info section
         if (!mpHTMLSourceEditor->getPlainTextEdit()->toPlainText().isEmpty()) {
-          newDocAnnotationString.append("info=\"").append(StringHandler::escapeStringQuotes(mpHTMLSourceEditor->getPlainTextEdit()->toPlainText())).append("\"");
+          newDocAnnotationList.append(QString("info=\"%1\"").arg(StringHandler::escapeStringQuotes(mpHTMLSourceEditor->getPlainTextEdit()->toPlainText())));
         }
         if (!documentation.at(1).isEmpty()) {
-          newDocAnnotationString.append(", revisions=\"").append(StringHandler::escapeStringQuotes(documentation.at(1))).append("\"");
+          newDocAnnotationList.append(QString("revisions=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(1))));
         }
         if (!documentation.at(2).isEmpty()) {
-          newDocAnnotationString.append(", __OpenModelica_infoHeader=\"").append(StringHandler::escapeStringQuotes(documentation.at(2))).append("\"");
+          newDocAnnotationList.append(QString("__OpenModelica_infoHeader=\"").arg(StringHandler::escapeStringQuotes(documentation.at(2))));
         }
       } else if (mEditType == EditType::Revisions) { // if editing the revisions section
         if (!documentation.at(0).isEmpty()) {
-          newDocAnnotationString.append("info=\"").append(StringHandler::escapeStringQuotes(documentation.at(0))).append("\"");
+          newDocAnnotationList.append(QString("info=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(0))));
         }
         if (!mpHTMLSourceEditor->getPlainTextEdit()->toPlainText().isEmpty()) {
-          newDocAnnotationString.append(", revisions=\"").append(StringHandler::escapeStringQuotes(mpHTMLSourceEditor->getPlainTextEdit()->toPlainText())).append("\"");
+          newDocAnnotationList.append(QString("revisions=\"%1\"").arg(StringHandler::escapeStringQuotes(mpHTMLSourceEditor->getPlainTextEdit()->toPlainText())));
         }
         if (!documentation.at(2).isEmpty()) {
-          newDocAnnotationString.append(", __OpenModelica_infoHeader=\"").append(StringHandler::escapeStringQuotes(documentation.at(2))).append("\"");
+          newDocAnnotationList.append(QString("__OpenModelica_infoHeader=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(2))));
         }
       } else if (mEditType == EditType::InfoHeader) { // if editing the __OpenModelica_infoHeader section
         if (!documentation.at(0).isEmpty()) {
-          newDocAnnotationString.append("info=\"").append(StringHandler::escapeStringQuotes(documentation.at(0))).append("\"");
+          newDocAnnotationList.append(QString("info=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(0))));
         }
         if (!documentation.at(1).isEmpty()) {
-          newDocAnnotationString.append(", revisions=\"").append(StringHandler::escapeStringQuotes(documentation.at(1))).append("\"");
+          newDocAnnotationList.append(QString("revisions=\"%1\"").arg(StringHandler::escapeStringQuotes(documentation.at(1))));
         }
         if (!mpHTMLSourceEditor->getPlainTextEdit()->toPlainText().isEmpty()) {
-          newDocAnnotationString.append(", __OpenModelica_infoHeader=\"").append(StringHandler::escapeStringQuotes(mpHTMLSourceEditor->getPlainTextEdit()->toPlainText())).append("\"");
+          newDocAnnotationList.append(QString("__OpenModelica_infoHeader=\"%1\"").arg(StringHandler::escapeStringQuotes(mpHTMLSourceEditor->getPlainTextEdit()->toPlainText())));
         }
       }
-      newDocAnnotationString.append(")");
+      QString newDocAnnotationString = QString("annotate=Documentation(%1)").arg(newDocAnnotationList.join(","));
       // if we have ModelWidget for class then put the change on undo stack.
       if (pLibraryTreeItem->getModelWidget()) {
         UpdateClassAnnotationCommand *pUpdateClassExperimentAnnotationCommand;
-        pUpdateClassExperimentAnnotationCommand = new UpdateClassAnnotationCommand(pLibraryTreeItem, oldDocAnnotationString,
-                                                                                   newDocAnnotationString);
+        pUpdateClassExperimentAnnotationCommand = new UpdateClassAnnotationCommand(pLibraryTreeItem, oldDocAnnotationString, newDocAnnotationString);
         pLibraryTreeItem->getModelWidget()->getUndoStack()->push(pUpdateClassExperimentAnnotationCommand);
         pLibraryTreeItem->getModelWidget()->updateModelText();
       } else {


### PR DESCRIPTION
### Related Issues

Fixes #8729

### Purpose

Avoid scripting error when only updating the part of documentation.

### Approach

Save only the updated part. Keep the rest of the documentation annotation as it is.
