### PR TITLE
Fix preprocessor guards.

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -223,8 +223,6 @@ target_link_libraries(OpenModelicaCompiler PUBLIC omc::parser)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::backendruntime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::runtime)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::compiler::graphstream)
-target_link_libraries(OpenModelicaCompiler PUBLIC omc::simrt::Modelica::ExternalC)
-target_link_libraries(OpenModelicaCompiler PUBLIC omc::simrt::Modelica::IO)
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::simrt::runtime)
 
 # On Windows we need explicitly tell the dll to export all symbols. It is not so good

--- a/OMCompiler/Compiler/runtime/HpcOmSchedulerExt_omc.cpp
+++ b/OMCompiler/Compiler/runtime/HpcOmSchedulerExt_omc.cpp
@@ -68,11 +68,14 @@ extern void* HpcOmSchedulerExt_scheduleMetis(modelica_metatype xadjIn, modelica_
   }
 
   return HpcOmSchedulerExtImpl__scheduleMetis(xadj, adjncy, vwgt, adjwgt, xadjNelts, adjncyNelts, nparts);
+#endif
 }
 
 extern void* HpcOmSchedulerExt_schedulehMetis(modelica_metatype xadjIn, modelica_metatype adjncyIn, modelica_metatype vwgtIn, modelica_metatype adjwgtIn, int npartsIn)
 {
-
+#if defined(_MSC_VER)
+  HPC_OM_VS();
+#else
   int vwgtsNelts = (int)MMC_HDRSLOTS(MMC_GETHDR(xadjIn)); //number of elements in xadj-array
   int eptrNelts = (int)MMC_HDRSLOTS(MMC_GETHDR(adjncyIn)); //number of elements in adjncy-array
   int eintNelts = (int)MMC_HDRSLOTS(MMC_GETHDR(vwgtIn)); //number of elements in vwgt-array


### PR DESCRIPTION
[](https://github.com/mahge)@mahge
[Remove old ModelicaExternalC linking to omc.](https://github.com/OpenModelica/OpenModelica/pull/8746/commits/c5905941c4ae5952c6e77a8f0519c24437c31fcc) 
[c590594](https://github.com/OpenModelica/OpenModelica/pull/8746/commits/c5905941c4ae5952c6e77a8f0519c24437c31fcc)[](https://github.com/mahge)
  - This has not been needed for a while. It was fixed for the autoconf
    build system but was overlooked for CMake.

@mahge
[Add missing preprocessor guards for MSVC.](https://github.com/OpenModelica/OpenModelica/pull/8746/commits/742ec248c4b3d86383c7bed3bf67aad1953c024b) 
[742ec24](https://github.com/OpenModelica/OpenModelica/pull/8746/commits/742ec248c4b3d86383c7bed3bf67aad1953c024b)
  - There was a `if defined` that spanned functions but did not cover them
    properly. Make it cover each function separately and properly.