### PR TITLE
Do not use variable length arrays. 

### DIFF
--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -769,7 +769,8 @@ extern const char* System_realpath(const char *path)
     MMC_THROW();
   }
 
-  WCHAR unicodeFullPath[bufLen];
+  // WCHAR unicodeFullPath[bufLen];
+  WCHAR* unicodeFullPath = (WCHAR*)omc_alloc_interface.malloc_atomic(sizeof(WCHAR) * bufLen);
   if (!GetFullPathNameW(unicodePath, bufLen, unicodeFullPath, NULL)) {
     MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodePath);
     fprintf(stderr, "GetFullPathNameW failed. %lu\n", GetLastError());
@@ -782,6 +783,8 @@ extern const char* System_realpath(const char *path)
   SystemImpl__toWindowsSeperators(buffer, bufferLength);
   char *res = omc_alloc_interface.malloc_strdup(buffer);
   MULTIBYTE_OR_WIDECHAR_VAR_FREE(buffer);
+
+  GC_free(unicodeFullPath);
   return res;
 #else
   char buf[PATH_MAX];

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -306,7 +306,8 @@ extern char* SystemImpl__pwd(void)
     return NULL;
   }
 
-  WCHAR unicodePath[bufLen];
+  // WCHAR unicodePath[bufLen];
+  WCHAR* unicodePath = (WCHAR*)omc_alloc_interface.malloc_atomic(bufLen * sizeof(WCHAR));
   if (!GetCurrentDirectoryW(bufLen, unicodePath)) {
     c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("GetCurrentDirectoryW failed."),NULL,0);
     return NULL;
@@ -316,6 +317,7 @@ extern char* SystemImpl__pwd(void)
   SystemImpl__toWindowsSeperators(buffer, bufferLength);
   char *res = omc_alloc_interface.malloc_strdup(buffer);
   MULTIBYTE_OR_WIDECHAR_VAR_FREE(buffer);
+  GC_free(unicodePath);
   return res;
 #else
   char buf[MAXPATHLEN];

--- a/OMCompiler/Compiler/runtime/zeromqimpl.c
+++ b/OMCompiler/Compiler/runtime/zeromqimpl.c
@@ -62,7 +62,8 @@ void* ZeroMQ_initialize(const char *zeroMQFileSuffix, int listenToAll, int port)
   }
   // get the port number
   const size_t endPointBufSize = 30;
-  char endPointBuf[endPointBufSize];
+  // char endPointBuf[endPointBufSize];
+  char* endPointBuf = (char*)omc_alloc_interface.malloc_atomic(sizeof(char) * endPointBufSize);
   zmq_getsockopt(zmqSocket, ZMQ_LAST_ENDPOINT, &endPointBuf, (size_t *)&endPointBufSize);
   // create the file path
   const char* tempPath = SettingsImpl__getTempDirectoryPath();
@@ -82,6 +83,8 @@ void* ZeroMQ_initialize(const char *zeroMQFileSuffix, int listenToAll, int port)
   printf("Created ZeroMQ Server.\nDumped server port in file: %s", zeroMQFilePath);fflush(NULL);
 
   mmcZmqSocket = mmc_mk_some(zmqSocket);
+
+  GC_free(endPointBuf);
   return mmcZmqSocket;
 }
 


### PR DESCRIPTION
[](https://github.com/mahge)@mahge
[Do not use variable length arrays.](https://github.com/OpenModelica/OpenModelica/pull/8748/commits/36aedde43a051731aa16ffeca1467e4785efa74a) 
[36aedde](https://github.com/OpenModelica/OpenModelica/pull/8748/commits/36aedde43a051731aa16ffeca1467e4785efa74a)[](https://github.com/mahge)
  - This is not valid C89. They are C99. They are however part of the
    default enabled extensions of gcc even for C89.

    It is better not use them if not absolutely necessary.
