### PR TITLE
Fix DAEUtil.getStartAttr for the new frontend

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -900,26 +900,32 @@ algorithm
   end match;
 end setMinMax;
 
+public function getTypeDefaultStart
+
+end getTypeDefaultStart;
+
 public function getStartAttr "
   Return the start attribute."
-  input Option<DAE.VariableAttributes> inVariableAttributesOption;
+  input Option<DAE.VariableAttributes> inAttributes;
   input DAE.Type inType;
   output DAE.Exp start;
+protected
+  DAE.Exp e;
 algorithm
-  start := match inVariableAttributesOption
-    local
-      DAE.Exp r;
-    case SOME(DAE.VAR_ATTR_REAL(start = SOME(r))) then r;
-    case SOME(DAE.VAR_ATTR_REAL(start = NONE())) then DAE.RCONST(0.0);
-    case SOME(DAE.VAR_ATTR_INT(start = SOME(r))) then r;
-    case SOME(DAE.VAR_ATTR_INT(start = NONE())) then DAE.ICONST(0);
-    case SOME(DAE.VAR_ATTR_BOOL(start = SOME(r))) then r;
-    case SOME(DAE.VAR_ATTR_BOOL(start = NONE())) then DAE.BCONST(false);
-    case SOME(DAE.VAR_ATTR_STRING(start = SOME(r))) then r;
-    case SOME(DAE.VAR_ATTR_STRING(start = NONE())) then DAE.SCONST("");
-    case SOME(DAE.VAR_ATTR_ENUMERATION(start = SOME(r))) then r;
-    case SOME(DAE.VAR_ATTR_ENUMERATION(start = NONE())) then Types.getNthEnumLiteral(inType, 1);
-    else DAE.RCONST(0.0);
+  start := match inAttributes
+    case SOME(DAE.VAR_ATTR_REAL(start = SOME(e))) then e;
+    case SOME(DAE.VAR_ATTR_INT(start = SOME(e))) then e;
+    case SOME(DAE.VAR_ATTR_BOOL(start = SOME(e))) then e;
+    case SOME(DAE.VAR_ATTR_STRING(start = SOME(e))) then e;
+    case SOME(DAE.VAR_ATTR_ENUMERATION(start = SOME(e))) then e;
+    else
+      match Types.getBasicType(inType)
+        case DAE.Type.T_INTEGER() then DAE.ICONST(0);
+        case DAE.Type.T_STRING() then DAE.SCONST("");
+        case DAE.Type.T_BOOL() then DAE.BCONST(false);
+        case DAE.Type.T_ENUMERATION() then Types.getNthEnumLiteral(inType, 1);
+        else DAE.RCONST(0.0);
+      end match;
   end match;
 end getStartAttr;
 

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -8722,5 +8722,16 @@ algorithm
   end match;
 end isExpandableConnector;
 
+public function getBasicType
+  input DAE.Type ty;
+  output DAE.Type outType;
+algorithm
+  outType := match ty
+    case DAE.Type.T_ARRAY() then getBasicType(ty.ty);
+    case DAE.Type.T_SUBTYPE_BASIC() then getBasicType(ty.complexType);
+    else ty;
+  end match;
+end getBasicType;
+
 annotation(__OpenModelica_Interface="frontend");
 end Types;

--- a/testsuite/simulation/modelica/initialization/parameters.mos
+++ b/testsuite/simulation/modelica/initialization/parameters.mos
@@ -3,7 +3,6 @@
 // status: correct
 // cflags:
 // teardown_command: rm -rf initializationTests.parameters* _initializationTests.parameters* output.log
-// cflags: -d=-newInst
 
 loadString("
 within ;


### PR DESCRIPTION
- Use the type to get the default start attributes when no start
  attribute is given, since the new frontend doesn't create
  VariableAttributes records for variables with no attributes.

Fixes #8743