### PR TITLE
Do not use variable length arrays.

### DIFF
--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -769,7 +769,7 @@ extern const char* System_realpath(const char *path)
     MMC_THROW();
   }
 
-  WCHAR unicodeFullPath[bufLen];
+  WCHAR* unicodeFullPath = (WCHAR*)omc_alloc_interface.malloc_atomic(sizeof(WCHAR) * bufLen);
   if (!GetFullPathNameW(unicodePath, bufLen, unicodeFullPath, NULL)) {
     MULTIBYTE_OR_WIDECHAR_VAR_FREE(unicodePath);
     fprintf(stderr, "GetFullPathNameW failed. %lu\n", GetLastError());
@@ -782,6 +782,8 @@ extern const char* System_realpath(const char *path)
   SystemImpl__toWindowsSeperators(buffer, bufferLength);
   char *res = omc_alloc_interface.malloc_strdup(buffer);
   MULTIBYTE_OR_WIDECHAR_VAR_FREE(buffer);
+
+  GC_free(unicodeFullPath);
   return res;
 #else
   char buf[PATH_MAX];

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -306,7 +306,7 @@ extern char* SystemImpl__pwd(void)
     return NULL;
   }
 
-  WCHAR unicodePath[bufLen];
+  WCHAR* unicodePath = (WCHAR*)omc_alloc_interface.malloc_atomic(bufLen * sizeof(WCHAR));
   if (!GetCurrentDirectoryW(bufLen, unicodePath)) {
     c_add_message(NULL,-1,ErrorType_scripting,ErrorLevel_error,gettext("GetCurrentDirectoryW failed."),NULL,0);
     return NULL;
@@ -316,6 +316,7 @@ extern char* SystemImpl__pwd(void)
   SystemImpl__toWindowsSeperators(buffer, bufferLength);
   char *res = omc_alloc_interface.malloc_strdup(buffer);
   MULTIBYTE_OR_WIDECHAR_VAR_FREE(buffer);
+  GC_free(unicodePath);
   return res;
 #else
   char buf[MAXPATHLEN];

--- a/OMCompiler/Compiler/runtime/zeromqimpl.c
+++ b/OMCompiler/Compiler/runtime/zeromqimpl.c
@@ -61,9 +61,11 @@ void* ZeroMQ_initialize(const char *zeroMQFileSuffix, int listenToAll, int port)
     return mmcZmqSocket;
   }
   // get the port number
-  const size_t endPointBufSize = 30;
-  char endPointBuf[endPointBufSize];
-  zmq_getsockopt(zmqSocket, ZMQ_LAST_ENDPOINT, &endPointBuf, (size_t *)&endPointBufSize);
+  char endPointBuf[30];
+  size_t endPointBufSize = sizeof(endPointBuf);
+  zmq_getsockopt(zmqSocket, ZMQ_LAST_ENDPOINT, endPointBuf, &endPointBufSize);
+  assert(endPointBufSize > 0);
+
   // create the file path
   const char* tempPath = SettingsImpl__getTempDirectoryPath();
 #if defined(__MINGW32__) || defined(_MSC_VER)


### PR DESCRIPTION
[](https://github.com/mahge)@mahge
[Do not use variable length arrays.](https://github.com/OpenModelica/OpenModelica/pull/8755/commits/5be729893b2e90f76e111ce2ca3e916d68faa028) 
[5be7298](https://github.com/OpenModelica/OpenModelica/pull/8755/commits/5be729893b2e90f76e111ce2ca3e916d68faa028)
  - This is not valid C89. They are C99. They are however part of the
    default enabled extensions of gcc even for C89.
    It is better not use them if not absolutely necessary.

  - Fix a bug in zmq communication where we were sending an address of a
    C array instead of the array itself. Somehow it was working. OR Maybe
    that was the reason it was not working sometimes.
    Also check that zmq has actually written the information we asked to the
    buffer.