### PR TITLE
Handle paths with more than one trailing slashes.

### DIFF
--- a/OMCompiler/Compiler/runtime/TaskGraphResultsCmp.h
+++ b/OMCompiler/Compiler/runtime/TaskGraphResultsCmp.h
@@ -38,7 +38,7 @@
 #include <vector>
 #include <iostream>
 #include <set>
-#include <cstring>
+#include <string.h>
 #include <sys/types.h>
 #include "regex.h"
 #include "expat.h"

--- a/OMCompiler/Compiler/runtime/TaskGraphResults_omc.cpp
+++ b/OMCompiler/Compiler/runtime/TaskGraphResults_omc.cpp
@@ -13,7 +13,7 @@ extern "C" {
 
 #include "TaskGraphResultsCmp.cpp"
 #else
-#include "meta_modelica.h"
+#include "meta/meta_modelica.h"
 #include "errorext.h"
 #define TASKGRAPH_VS() c_add_message(NULL, -1, ErrorType_scripting, ErrorLevel_error, "TaskGraphResults not supported on Visual Studio.", NULL, 0);MMC_THROW();
 #endif

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -919,7 +919,11 @@ extern int SystemImpl__directoryExists(const char *str)
   char* path = strdup(str);
   int last = strlen(path)-1;
   /* adrpo: RTFM! the path cannot end in a slash??!! https://msdn.microsoft.com/en-us/library/windows/desktop/aa364418(v=vs.85).aspx */
-  if (last > 0 && (path[last] == '\\' || path[last] == '/')) path[last] = '\0';
+  while (last > 0 && (path[last] == '\\' || path[last] == '/'))
+      last--;
+
+  path[last + 1] = '\0';
+
   sh = FindFirstFile(path, &FileData);
   free(path);
   if (sh == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
  - The str given as input to `SystemImpl__directoryExists` can be as string
    with multiple `\` or `/` at the end of it. Not just one of them.

    FindFirstFile does not allow inputs with trailing slashes.

  - Do not include C++ std headers in C headers. Include the C versions.

  - Qualify our header inclusions meta_modelica.h -> meta/meta_modelica.h
