### PR TITLE
Fix passing of C array to a function.

### DIFF
--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -597,19 +597,14 @@ extern void* System_regex(const char* str, const char* re, int maxn, int extende
 {
   void *res;
   int i = 0;
-#if !defined(_MSC_VER)
-  void *matches[maxn];
-#else
   void **matches = omc_alloc_interface.malloc(sizeof(void*)*maxn);
-#endif
-  *nmatch = OpenModelica_regexImpl(str,re,maxn,extended,sensitive,mmc_mk_scon,(void**)&matches);
+  *nmatch = OpenModelica_regexImpl(str,re,maxn,extended,sensitive,mmc_mk_scon,(void**)matches);
   res = mmc_mk_nil();
   for (i=maxn-1; i>=0; i--) {
     res = mmc_mk_cons(matches[i],res);
   }
-#if defined(_MSC_VER)
+
   GC_free(matches);
-#endif
   return res;
 }
 


### PR DESCRIPTION
  - We seem to have a few of these around. Passing an address of a C array
    when we should pass the array (since it decays to a pointer on pass).

    I am not completely _sure_ what should happen if you pass the address
    of the array but it is not what we intend to do.

    This time, the C array is removed completely since it was a variable
    length array anyway (replaced by dynamic allocation) and the passing
    is fixed.
