### PR TITLE
Fix some compilation warnings

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -74,7 +74,7 @@
 #include <math.h>
 #include <string.h>
 
-extern int init_lambda_steps = 3;
+int init_lambda_steps = 3;
 
 /*! \fn void dumpInitializationStatus(DATA *data)
  *

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -923,7 +923,7 @@ static int rungekutta_step_ssc(DATA* data, threadData_t *threadData, SOLVER_INFO
   modelica_real* stateDerOld = sDataOld->realVars + nx;
   double t = sDataOld->timeValue;
   const double targetTime = t + solverInfo->currentStepSize;
-  const short isMaxStepSizeSet = (short) omc_flagValue[FLAG_MAX_STEP_SIZE];
+  const short isMaxStepSizeSet = omc_flagValue[FLAG_MAX_STEP_SIZE] != NULL;
   const double maxStepSize = isMaxStepSizeSet ? atof(omc_flagValue[FLAG_MAX_STEP_SIZE]) : -1;
 #if defined(_MSC_VER)
   /* handle stupid compilers */

--- a/OMCompiler/SimulationRuntime/cpp/Core/Solver/AlgLoopSolverDefaultImplementation.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Solver/AlgLoopSolverDefaultImplementation.cpp
@@ -9,62 +9,60 @@
 
 
 AlgLoopSolverDefaultImplementation::AlgLoopSolverDefaultImplementation()
-:_dimZeroFunc(-1)
-, _dimSys(-1)
-,_algloopVars(NULL)
-,_conditions0(NULL)
-,_conditions1(NULL)
+  :_dimZeroFunc(-1)
+  , _dimSys(-1)
+  ,_algloopVars(NULL)
+  ,_conditions0(NULL)
+  ,_conditions1(NULL)
 {
 
 }
 
 AlgLoopSolverDefaultImplementation::~AlgLoopSolverDefaultImplementation()
 {
- if(_algloopVars)
-       delete [] _algloopVars;
-     if(_conditions0)
-       delete [] _conditions0;
-     if(_conditions1)
-       delete [] _conditions1;
+  if(_algloopVars)
+    delete [] _algloopVars;
+  if(_conditions0)
+    delete [] _conditions0;
+  if(_conditions1)
+    delete [] _conditions1;
 }
 bool* AlgLoopSolverDefaultImplementation::getConditionsWorkArray()
 {
-	if(_conditions0)
-	  return _conditions0;
-    else
-		ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
-
+  if(_conditions0)
+    return _conditions0;
+  else
+    throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
 }
 bool* AlgLoopSolverDefaultImplementation::getConditions2WorkArray()
 {
-	if(_conditions1)
-	  return _conditions1;
-    else
-	  ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
- }
+  if(_conditions1)
+    return _conditions1;
+  else
+    throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
+}
 
 
- double* AlgLoopSolverDefaultImplementation::getVariableWorkArray()
- {
-	if(_algloopVars)
-	  return _algloopVars;
-    else
-		ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
-
- }
+double* AlgLoopSolverDefaultImplementation::getVariableWorkArray()
+{
+  if(_algloopVars)
+    return _algloopVars;
+  else
+    throw ModelicaSimulationError(ALGLOOP_SOLVER, "algloop working arrays are not initialized");
+}
 
 void AlgLoopSolverDefaultImplementation::initialize(int dimZeroFunc,int dimSys)
 {
   _dimZeroFunc = dimZeroFunc;
   if(_conditions0)
-     delete [] _conditions0;
+    delete [] _conditions0;
   if(_conditions1)
     delete [] _conditions1;
-    _conditions0 = new bool[_dimZeroFunc];
-    _conditions1 = new bool[_dimZeroFunc];
-    _dimSys=dimSys;
+  _conditions0 = new bool[_dimZeroFunc];
+  _conditions1 = new bool[_dimZeroFunc];
+  _dimSys=dimSys;
   if(_algloopVars)
-      delete [] _algloopVars;
+    delete [] _algloopVars;
   _algloopVars = new double[_dimSys];
   memset(_algloopVars, 0, _dimSys*sizeof(double));
 }


### PR DESCRIPTION
- Remove `extern` from `init_lambda_steps` definition, only the header
  declaration should have it.
- Don't convert pointer to integer in `rungekutta_step_ssc` solver just
  to check if it's not NULL, do an actual NULL check instead.
- Add missing `throw` keywords in `AlgLoopSolverDefaultImplementation`
  (and also fix the messed up indentation).