### PR TITLE
If the library required is already loaded with some other version

### DIFF
--- a/.openmodelica.aspell
+++ b/.openmodelica.aspell
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 75 UTF-8
+personal_ws-1.1 en 79 UTF-8
 subscripted
 UTF
 RML
@@ -76,3 +76,4 @@ URI
 SHA
 differentiable
 evaluable
+convertPackageToLibrary

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -813,7 +813,7 @@ public constant ErrorTypes.Message DER_OF_NONDIFFERENTIABLE_EXP = ErrorTypes.MES
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_WITHOUT_CONVERSION = ErrorTypes.MESSAGE(370, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("%1 requested package %2 of version %3. %2 %4 is used instead which states that it is fully compatible without conversion script needed."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_WITH_CONVERSION = ErrorTypes.MESSAGE(371, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
-  Gettext.gettext("%1 requested package %2 of version %3. %2 %4 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result."));
+  Gettext.gettext("%1 requested package %2 of version %3. %2 %4 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(%1, %2, \"%4\") to run the conversion script or proceed with potential issues as a result."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_OLDER = ErrorTypes.MESSAGE(372, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("Requested package %1 of version %2, but this package was already loaded with version %3. There are no conversion annotations and %2 is older than %3, so the libraries are probably incompatible."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_NEWER = ErrorTypes.MESSAGE(373, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -812,6 +812,7 @@ public constant ErrorTypes.Message DER_OF_NONDIFFERENTIABLE_EXP = ErrorTypes.MES
   Gettext.gettext("Argument ‘%s‘ of der is not differentiable."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_WITHOUT_CONVERSION = ErrorTypes.MESSAGE(370, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("%1 requested package %2 of version %3. %2 %4 is used instead which states that it is fully compatible without conversion script needed."));
+// The following errors (371, 372, 373) are used by OMEdit. Do not change them.
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_WITH_CONVERSION = ErrorTypes.MESSAGE(371, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("%1 requested package %2 of version %3. %2 %4 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(%1, %2, \"%4\") to run the conversion script or proceed with potential issues as a result."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_OLDER = ErrorTypes.MESSAGE(372, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1503,7 +1503,7 @@ void MainWindow::addSystemLibraries()
     if (versions.isEmpty()) {
       QAction *pAction = new QAction(library, this);
       pAction->setData(QStringList() << library << "");
-      connect(pAction, SIGNAL(triggered()), SLOT(loadSystemLibrary()));
+      connect(pAction, SIGNAL(triggered()), mpLibraryWidget, SLOT(loadSystemLibrary()));
       mpLibrariesMenu->addAction(pAction);
     } else {
       QMenu *pLibraryMenu = new QMenu(library);
@@ -1513,7 +1513,7 @@ void MainWindow::addSystemLibraries()
         if ((library.compare(QStringLiteral("Modelica")) == 0) && (version.compare(QStringLiteral("4.0.0")) == 0)) {
           pAction->setShortcut(QKeySequence("Ctrl+m"));
         }
-        connect(pAction, SIGNAL(triggered()), SLOT(loadSystemLibrary()));
+        connect(pAction, SIGNAL(triggered()), mpLibraryWidget, SLOT(loadSystemLibrary()));
         pLibraryMenu->addAction(pAction);
       }
       mpLibrariesMenu->addMenu(pLibraryMenu);
@@ -1857,69 +1857,13 @@ void MainWindow::openDirectory()
 }
 
 /*!
- * \brief MainWindow::loadSystemLibrary
- * Loads a system library.
- */
-void MainWindow::loadSystemLibrary()
-{
-  QAction *pAction = qobject_cast<QAction*>(sender());
-  if (pAction) {
-    QStringList actionData = pAction->data().toStringList();
-    if (actionData.size() > 1) {
-      loadSystemLibrary(actionData.at(0), actionData.at(1));
-    }
-  }
-}
-
-/*!
- * \brief MainWindow::loadSystemLibrary
- * Loads a system library.
- * \param library
- * \param version
- */
-void MainWindow::loadSystemLibrary(const QString &library, QString version)
-{
-  /* check if library is already loaded. */
-  LibraryTreeModel *pLibraryTreeModel = mpLibraryWidget->getLibraryTreeModel();
-  if (pLibraryTreeModel->findLibraryTreeItemOneLevel(library)) {
-    QMessageBox *pMessageBox = new QMessageBox(this);
-    pMessageBox->setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::information));
-    pMessageBox->setIcon(QMessageBox::Information);
-    pMessageBox->setAttribute(Qt::WA_DeleteOnClose);
-    pMessageBox->setText(QString(GUIMessages::getMessage(GUIMessages::UNABLE_TO_LOAD_FILE).arg(library)));
-    pMessageBox->setInformativeText(QString(GUIMessages::getMessage(GUIMessages::REDEFINING_EXISTING_CLASSES)).arg(library).append("\n")
-                                    .append(GUIMessages::getMessage(GUIMessages::DELETE_AND_LOAD).arg(library)));
-    pMessageBox->setStandardButtons(QMessageBox::Ok);
-    pMessageBox->exec();
-  } else {  /* if library is not loaded then load it. */
-    mpProgressBar->setRange(0, 0);
-    showProgressBar();
-    mpStatusBar->showMessage(QString(Helper::loading).append(": ").append(library));
-
-    if (version.isEmpty()) {
-      version = QString("default");
-    }
-
-    mpLibraryWidget->setLoadingLibraries(true);
-    if (mpOMCProxy->loadModel(library, version)) {
-      pLibraryTreeModel->createLibraryTreeItem(library, pLibraryTreeModel->getRootLibraryTreeItem(), true, true, true);
-      pLibraryTreeModel->checkIfAnyNonExistingClassLoaded();
-    }
-    mpLibraryWidget->setLoadingLibraries(false);
-    mpStatusBar->clearMessage();
-    hideProgressBar();
-  }
-}
-
-/*!
  * \brief MainWindow::writeOutputFileData
  * Writes the output data from stdout file and adds it to MessagesWidget.
  * \param data
  */
 void MainWindow::writeOutputFileData(QString data)
 {
-  MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, data,
-                                                        Helper::scriptingKind, Helper::notificationLevel));
+  MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, data, Helper::scriptingKind, Helper::notificationLevel));
 }
 
 /*!

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -486,8 +486,6 @@ public slots:
   void openCompositeModelFile();
   void loadExternalModels();
   void openDirectory();
-  void loadSystemLibrary();
-  void loadSystemLibrary(const QString &library, QString version = QString("default"));
   void writeOutputFileData(QString data);
   void writeErrorFileData(QString data);
   void openRecentFile();

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -4196,60 +4196,12 @@ void LibraryWidget::openModelicaFile(QString fileName, QString encoding, bool sh
       pMessageBox->exec();
     } else { // if no conflicting model found then just load the file simply
       setLoadingLibraries(true);
+      QStringList classes = MainWindow::instance()->getOMCProxy()->getClassNames();
       // load the file in OMC
-      QStringList loadedClassesList1, loadedClassesList2;
-      LibraryTreeItem *pLibraryTreeItem = 0;
-      loadedClassesList1 = MainWindow::instance()->getOMCProxy()->getClassNames();
       if (MainWindow::instance()->getOMCProxy()->loadFile(fileName, encoding)) {
-        /* Issue #8183
-         * If the library required is already loaded with some other version.
-         * Then allow the user to cancel the operation or unload everything and reload the class again.
-         */
         if (MainWindow::instance()->getOMCProxy()->isLoadModelError()) {
-          // clear loadModelCallback classes
-          mAutoLoadedLibrariesList.clear();
-
-          QMessageBox *pMessageBox = new QMessageBox;
-          pMessageBox->setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::error));
-          pMessageBox->setIcon(QMessageBox::Critical);
-          pMessageBox->setAttribute(Qt::WA_DeleteOnClose);
-          pMessageBox->setText(tr("The loaded class(es) <b>%1</b> uses versions of already loaded libraries which are not compatible with the required ones.<br /><br />"
-                                  "Cancel the operation i.e., do not load anything.<br />"
-                                  "Unload everything and reload %1 from the start (the correct dependent libraries will be loaded due to uses annotations). "
-                                  "Makesure to save your work.")
-                               .arg(classesList.join(",")));
-          pMessageBox->addButton(tr("Cancel Operation"), QMessageBox::ActionRole);
-          pMessageBox->addButton(tr("Unload all && Reload %1").arg(classesList.join(",")), QMessageBox::ActionRole);
-          int answer = pMessageBox->exec();
-          switch (answer) {
-            case 0: // cancel operation
-            default:
-              loadedClassesList2 = MainWindow::instance()->getOMCProxy()->getClassNames();
-              if (loadedClassesList2.size() > loadedClassesList1.size()) {
-                foreach (QString loadedClass, loadedClassesList2) {
-                  if (!loadedClassesList1.contains(loadedClass)) {
-                    pLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItemOneLevel(loadedClass);
-                    if (pLibraryTreeItem) {
-                      MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->unloadClass(pLibraryTreeItem, false, true);
-                    } else {
-                      MainWindow::instance()->getOMCProxy()->deleteClass(loadedClass);
-                    }
-                  }
-                }
-              }
-              break;
-            case 1: // unload all and reload
-              loadedClassesList2 = MainWindow::instance()->getOMCProxy()->getClassNames();
-              foreach (QString loadedClass, loadedClassesList2) {
-                pLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItemOneLevel(loadedClass);
-                if (pLibraryTreeItem) {
-                  MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->unloadClass(pLibraryTreeItem, false, true);
-                } else {
-                  MainWindow::instance()->getOMCProxy()->deleteClass(loadedClass);
-                }
-              }
-              openModelicaFile(fileName, encoding, showProgress);
-              break;
+          if (resolveConflictWithLoadedLibraries(classesList.join(","), classes)) {
+            openModelicaFile(fileName, encoding, showProgress);
           }
         } else {
           // create library tree nodes for loaded models
@@ -5294,6 +5246,67 @@ void LibraryWidget::saveTotalLibraryTreeItemHelper(LibraryTreeItem *pLibraryTree
 }
 
 /*!
+ * \brief LibraryWidget::resolveConflictWithLoadedLibraries
+ * Check if the library loaded is compatiable with the already loaded libraries.
+ * \param library
+ * \param classes
+ * \return
+ */
+bool LibraryWidget::resolveConflictWithLoadedLibraries(const QString &library, const QStringList classes)
+{
+  /* Issue #8183
+   * If the library required is already loaded with some other version.
+   * Then allow the user to cancel the operation or unload everything and reload the class again.
+   */
+  QStringList classes1;
+  LibraryTreeItem *pLibraryTreeItem = 0;
+  // clear loadModelCallback classes
+  mAutoLoadedLibrariesList.clear();
+
+  QMessageBox *pMessageBox = new QMessageBox;
+  pMessageBox->setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::error));
+  pMessageBox->setIcon(QMessageBox::Critical);
+  pMessageBox->setAttribute(Qt::WA_DeleteOnClose);
+  pMessageBox->setText(tr("The loaded class(es) <b>%1</b> uses versions of already loaded libraries which are not compatible with the required ones.<br /><br />"
+                          "<b>Cancel Operation</b> does not load class <b>%1</b> and its dependencies.<br />"
+                          "<b>Unload All & Reload %1</b> unloads all previously loaded classes and loads <b>%1</b> starting from a clean environment. "
+                          "Make sure to save your work.").arg(library));
+  pMessageBox->addButton(tr("Cancel Operation"), QMessageBox::ActionRole);
+  pMessageBox->addButton(tr("Unload all && Reload %1").arg(library), QMessageBox::ActionRole);
+  int answer = pMessageBox->exec();
+  switch (answer) {
+    case 0: // cancel operation
+    default:
+      classes1 = MainWindow::instance()->getOMCProxy()->getClassNames();
+      if (classes1.size() > classes.size()) {
+        foreach (QString loadedClass, classes1) {
+          if (!classes.contains(loadedClass)) {
+            pLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItemOneLevel(loadedClass);
+            if (pLibraryTreeItem) {
+              MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->unloadClass(pLibraryTreeItem, false, true);
+            } else {
+              MainWindow::instance()->getOMCProxy()->deleteClass(loadedClass);
+            }
+          }
+        }
+      }
+      return false;
+    case 1: // unload all and reload
+      classes1 = MainWindow::instance()->getOMCProxy()->getClassNames();
+      foreach (QString loadedClass, classes1) {
+        pLibraryTreeItem = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItemOneLevel(loadedClass);
+        if (pLibraryTreeItem) {
+          MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->unloadClass(pLibraryTreeItem, false, true);
+        } else {
+          MainWindow::instance()->getOMCProxy()->deleteClass(loadedClass);
+        }
+      }
+      // Just return true and the calling function will load the library.
+      return true;
+  }
+}
+
+/*!
  * \brief LibraryWidget::handleAutoLoadedLibrary
  * Slot activated when auto load library timer is timeout.
  */
@@ -5304,6 +5317,67 @@ void LibraryWidget::handleAutoLoadedLibrary()
   } else {
     mpLibraryTreeModel->loadDependentLibraries(mAutoLoadedLibrariesList);
     mAutoLoadedLibrariesList.clear();
+  }
+}
+
+/*!
+ * \brief LibraryWidget::loadSystemLibrary
+ * Loads a system library.
+ */
+void LibraryWidget::loadSystemLibrary()
+{
+  QAction *pAction = qobject_cast<QAction*>(sender());
+  if (pAction) {
+    QStringList actionData = pAction->data().toStringList();
+    if (actionData.size() > 1) {
+      loadSystemLibrary(actionData.at(0), actionData.at(1));
+    }
+  }
+}
+
+/*!
+ * \brief LibraryWidget::loadSystemLibrary
+ * Loads a system library.
+ * \param library
+ * \param version
+ */
+void LibraryWidget::loadSystemLibrary(const QString &library, QString version)
+{
+  /* check if library is already loaded. */
+  if (mpLibraryTreeModel->findLibraryTreeItemOneLevel(library)) {
+    QMessageBox *pMessageBox = new QMessageBox(this);
+    pMessageBox->setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::information));
+    pMessageBox->setIcon(QMessageBox::Information);
+    pMessageBox->setAttribute(Qt::WA_DeleteOnClose);
+    pMessageBox->setText(QString(GUIMessages::getMessage(GUIMessages::UNABLE_TO_LOAD_FILE).arg(library)));
+    pMessageBox->setInformativeText(QString(GUIMessages::getMessage(GUIMessages::REDEFINING_EXISTING_CLASSES)).arg(library).append("\n")
+                                    .append(GUIMessages::getMessage(GUIMessages::DELETE_AND_LOAD).arg(library)));
+    pMessageBox->setStandardButtons(QMessageBox::Ok);
+    pMessageBox->exec();
+  } else {  /* if library is not loaded then load it. */
+    MainWindow::instance()->getProgressBar()->setRange(0, 0);
+    MainWindow::instance()->showProgressBar();
+    MainWindow::instance()->getStatusBar()->showMessage(QString(Helper::loading).append(": ").append(library));
+
+    if (version.isEmpty()) {
+      version = QString("default");
+    }
+
+    setLoadingLibraries(true);
+    QStringList classes = MainWindow::instance()->getOMCProxy()->getClassNames();
+    if (MainWindow::instance()->getOMCProxy()->loadModel(library, version)) {
+      if (MainWindow::instance()->getOMCProxy()->isLoadModelError()) {
+        if (resolveConflictWithLoadedLibraries(library, classes)) {
+          loadSystemLibrary(library, version);
+        }
+      } else {
+        mpLibraryTreeModel->createLibraryTreeItem(library, mpLibraryTreeModel->getRootLibraryTreeItem(), true, true, true);
+        mpLibraryTreeModel->checkIfAnyNonExistingClassLoaded();
+      }
+    }
+    setLoadingLibraries(false);
+    MainWindow::instance()->getStatusBar()->clearMessage();
+    MainWindow::instance()->hideProgressBar();
   }
 }
 

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -521,9 +521,12 @@ private:
   bool saveAsOMSLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem);
   bool saveCompositeModelLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, QString fileName);
   void saveTotalLibraryTreeItemHelper(LibraryTreeItem *pLibraryTreeItem);
+  bool resolveConflictWithLoadedLibraries(const QString &library, const QStringList classes);
 private slots:
   void handleAutoLoadedLibrary();
 public slots:
+  void loadSystemLibrary();
+  void loadSystemLibrary(const QString &library, QString version = QString("default"));
   void scrollToActiveLibraryTreeItem();
   void searchClasses();
 };

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -133,6 +133,7 @@ OMCProxy::OMCProxy(threadData_t* threadData, QWidget *pParent)
   mLibrariesBrowserDeletionCommandsList << "deleteClass"
                                       << "clear"
                                       << "clearProgram";
+  mLoadModelError = false;
   //start the server
   if(!initializeOMC(threadData)) {  // if we are unable to start OMC. Exit the application.
     MainWindow::instance()->setExitApplicationStatus(true);
@@ -573,9 +574,14 @@ bool OMCProxy::printMessagesStringInternal()
   /* Loop in reverse order since getMessagesStringInternal returns error messages in reverse order. */
   for (int i = errorsSize; i > 0 ; i--) {
     setCurrentError(i);
-    MessageItem messageItem(MessageItem::Modelica, getErrorFileName(), getErrorReadOnly(), getErrorLineStart(), getErrorColumnStart(), getErrorLineEnd(),
-                            getErrorColumnEnd(), getErrorMessage(), getErrorKind(), getErrorLevel());
-    MessagesWidget::instance()->addGUIMessage(messageItem);
+    const int errorId = getErrorId();
+    if (errorId == 371 || errorId == 372 || errorId == 373) {
+      mLoadModelError = true;
+    } else {
+      MessageItem messageItem(MessageItem::Modelica, getErrorFileName(), getErrorReadOnly(), getErrorLineStart(), getErrorColumnStart(), getErrorLineEnd(),
+                              getErrorColumnEnd(), getErrorMessage(), getErrorKind(), getErrorLevel());
+      MessagesWidget::instance()->addGUIMessage(messageItem);
+    }
   }
   return returnValue;
 }
@@ -699,6 +705,17 @@ QString OMCProxy::getErrorLevel()
 {
   sendCommand("currentError.level");
   return getResult();
+}
+
+/*!
+ * \brief OMCProxy::getErrorId
+ * Gets the current error id.
+ * \return
+ */
+int OMCProxy::getErrorId()
+{
+  sendCommand("currentError.id");
+  return getResult().toInt();
 }
 
 /*!
@@ -1584,6 +1601,7 @@ QString OMCProxy::changeDirectory(QString directory)
   */
 bool OMCProxy::loadModel(QString className, QString priorityVersion, bool notify, QString languageStandard, bool requireExactVersion)
 {
+  mLoadModelError = false;
   bool result = false;
   QList<QString> priorityVersionList;
   priorityVersionList << priorityVersion;
@@ -1599,6 +1617,7 @@ bool OMCProxy::loadModel(QString className, QString priorityVersion, bool notify
   */
 bool OMCProxy::loadFile(QString fileName, QString encoding, bool uses, bool notify, bool requireExactVersion)
 {
+  mLoadModelError = false;
   bool result = false;
   fileName = fileName.replace('\\', '/');
   result = mpOMCInterface->loadFile(fileName, encoding, uses, notify, requireExactVersion);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -82,6 +82,7 @@ private:
   bool mIsLoggingEnabled;
   QStringList mLibrariesBrowserAdditionCommandsList;
   QStringList mLibrariesBrowserDeletionCommandsList;
+  bool mLoadModelError;
 public:
   OMCProxy(threadData_t *threadData, QWidget *pParent = 0);
   ~OMCProxy();
@@ -97,6 +98,7 @@ public:
   void removeObjectRefFile();
   void setLoggingEnabled(bool enable) {mIsLoggingEnabled = enable;}
   bool isLoggingEnabled() {return mIsLoggingEnabled;}
+  bool isLoadModelError() const {return mLoadModelError;}
   QString getErrorString(bool warningsAsErrors = false);
   bool printMessagesStringInternal();
   int getMessagesStringInternal();
@@ -110,6 +112,7 @@ public:
   QString getErrorMessage();
   QString getErrorKind();
   QString getErrorLevel();
+  int getErrorId();
   QString getVersion(QString className = QString("OpenModelica"));
   void loadSystemLibraries();
   void loadUserLibraries();

--- a/testsuite/flattening/libraries/biochem/BiochemModels.mos
+++ b/testsuite/flattening/libraries/biochem/BiochemModels.mos
@@ -595,7 +595,7 @@ checkModel(BioChem.Examples.MultiCompartments.Utilities.SmallCompartment); getEr
 // "
 // true
 // true
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // "
 // "class BioChem_Examples_centralMetabolism_extra_cellular
 //   Real V(quantity = \"Volume\", unit = \"l\", start = 2.0, stateSelect = StateSelect.prefer) \"Compartment volume\";
@@ -1318,16 +1318,16 @@ checkModel(BioChem.Examples.MultiCompartments.Utilities.SmallCompartment); getEr
 //   cytosol.node_LAC.c = vef.s1.c;
 // end BioChem_Examples_centralMetabolism_extra_cellular;
 // "
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // "
 // "Check of BioChem_Examples_centralMetabolism_extra_cellular completed successfully.
 // Class BioChem_Examples_centralMetabolism_extra_cellular has 353 equation(s) and 353 variable(s).
 // 249 of these are trivial equation(s)."
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // "
 // true
 // true
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // "
 // "class BioChem_Examples_CircadianOscillator_Container
 //   Real V(quantity = \"Volume\", unit = \"l\", start = 1.0, stateSelect = StateSelect.prefer) \"Compartment volume\";
@@ -1850,7 +1850,7 @@ checkModel(BioChem.Examples.MultiCompartments.Utilities.SmallCompartment); getEr
 //   cytoplasm.y3_node.c = nucleus.y3_node.c;
 // end BioChem_Examples_CircadianOscillator_Container;
 // "
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // [flattening/libraries/biochem/ContainerTotal.mo:867:9-867:145:writable] Warning: Connecting two signal sources while connecting cytoplasm.y5_node.V to nucleus.y5_node.V.
 // [flattening/libraries/biochem/ContainerTotal.mo:868:9-868:144:writable] Warning: Connecting two signal sources while connecting nucleus.y6_node.V to cytoplasm.y6_node.V.
 // [flattening/libraries/biochem/ContainerTotal.mo:869:9-869:144:writable] Warning: Connecting two signal sources while connecting cytoplasm.y2_node.V to nucleus.y2_node.V.
@@ -1859,7 +1859,7 @@ checkModel(BioChem.Examples.MultiCompartments.Utilities.SmallCompartment); getEr
 // "Check of BioChem_Examples_CircadianOscillator_Container completed successfully.
 // Class BioChem_Examples_CircadianOscillator_Container has 252 equation(s) and 252 variable(s).
 // 180 of these are trivial equation(s)."
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // [flattening/libraries/biochem/ContainerTotal.mo:867:9-867:145:writable] Warning: Connecting two signal sources while connecting cytoplasm.y5_node.V to nucleus.y5_node.V.
 // [flattening/libraries/biochem/ContainerTotal.mo:868:9-868:144:writable] Warning: Connecting two signal sources while connecting nucleus.y6_node.V to cytoplasm.y6_node.V.
 // [flattening/libraries/biochem/ContainerTotal.mo:869:9-869:144:writable] Warning: Connecting two signal sources while connecting cytoplasm.y2_node.V to nucleus.y2_node.V.
@@ -1867,7 +1867,7 @@ checkModel(BioChem.Examples.MultiCompartments.Utilities.SmallCompartment); getEr
 // "
 // true
 // true
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // "
 // "class BioChem_Examples_CaOscillations_Cytosol
 //   Real V(quantity = \"Volume\", unit = \"l\", start = 1.0, stateSelect = StateSelect.prefer) \"Compartment volume\";
@@ -1991,13 +1991,13 @@ checkModel(BioChem.Examples.MultiCompartments.Utilities.SmallCompartment); getEr
 //   Endoplasmic_Reticulum.CaER_node.c = Jpump.p1.c;
 // end BioChem_Examples_CaOscillations_Cytosol;
 // "
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // [flattening/libraries/biochem/CytosolTotal.mo:862:9-862:228:writable] Warning: Connecting two signal sources while connecting Ca_Cyt.n1.V to Endoplasmic_Reticulum.Ca_Cyt_node.V.
 // "
 // "Check of BioChem_Examples_CaOscillations_Cytosol completed successfully.
 // Class BioChem_Examples_CaOscillations_Cytosol has 60 equation(s) and 60 variable(s).
 // 44 of these are trivial equation(s)."
-// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: BioChem requested package Modelica of version 2.2.1. Modelica 3.1 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary(BioChem, Modelica, \"3.1\") to run the conversion script or proceed with potential issues as a result.
 // [flattening/libraries/biochem/CytosolTotal.mo:862:9-862:228:writable] Warning: Connecting two signal sources while connecting Ca_Cyt.n1.V to Endoplasmic_Reticulum.Ca_Cyt_node.V.
 // "
 // true

--- a/testsuite/openmodelica/interactive-API/UsesAnnotation2.mos
+++ b/testsuite/openmodelica/interactive-API/UsesAnnotation2.mos
@@ -51,7 +51,7 @@ instantiateModel('0.8.1');getErrorString();
 // "class '2.2.2'
 // end '2.2.2';
 // "
-// "Warning: '2.2.2' requested package Modelica of version 2.2.2. Modelica 3.2.3 is used instead which states that it is only compatible with a conversion script. OpenModelica currently does not support conversion scripts and will proceed with potential issues as a result.
+// "Warning: '2.2.2' requested package Modelica of version 2.2.2. Modelica 3.2.3 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary('2.2.2', Modelica, \"3.2.3\") to run the conversion script or proceed with potential issues as a result.
 // "
 // true
 // true


### PR DESCRIPTION
### Related Issues

Fixes #8183

### Purpose

Allow the user to select what to do when wrong version of the required library is loaded.

### Approach

Allow the user to cancel the operation or unload everything and reload the class again.

### Todo

 - [x] Handle loadFile
 - [x] Handle LoadModel