### PR TITLE
Improve `-d=mergeComponents`

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -546,6 +546,10 @@ public
           has_submods := not listEmpty(mod.subModLst);
 
           if has_binding then
+            if stringEmpty(name) then
+              strl := Dump.printExpStr(Util.getOption(mod.binding)) :: strl;
+            end if;
+
             strl := "=" :: strl;
           end if;
 

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -782,6 +782,7 @@ MergeComponents4.mo \
 MergeComponents5.mo \
 MergeComponents6.mo \
 MergeComponents7.mo \
+MergeComponents8.mo \
 MissingRedeclare1.mo \
 mod1.mo \
 mod10.mo \

--- a/testsuite/flattening/modelica/scodeinst/MergeComponents8.mo
+++ b/testsuite/flattening/modelica/scodeinst/MergeComponents8.mo
@@ -1,0 +1,40 @@
+// name: MergeComponents8
+// keywords:
+// status: correct
+// cflags: -d=newInst,mergeComponents,-nfScalarize
+//
+
+model A
+  parameter Real p = 1;
+  input Real u;
+  Real y;
+  Real x;
+equation
+  der(x) = -p*x+u;
+  y = 2*p*x;
+end A;
+
+model MergeComponents8
+  parameter Real n1 = 1.0;
+  parameter Real n2 = 2.0;
+  A a1(p = n1);
+  A a2(p = n2);
+end MergeComponents8;
+
+// Result:
+// class MergeComponents8
+//   parameter Real n1 = 1.0;
+//   parameter Real n2 = 2.0;
+//   Real[2] $A1.x;
+//   Real[2] $A1.y;
+//   Real[2] $A1.u;
+//   parameter Real[2] $A1.p = {n1, n2};
+// equation
+//   for $i1 in 1:2 loop
+//     der($A1[$i1].x) = (-$A1[$i1].p * $A1[$i1].x) + $A1[$i1].u;
+//   end for;
+//   for $i1 in 1:2 loop
+//     $A1[$i1].y = 2.0 * $A1[$i1].p * $A1[$i1].x;
+//   end for;
+// end MergeComponents8;
+// endResult


### PR DESCRIPTION
- Include the binding equation in the modifier signature, to avoid
  trying (and failing) to merge components with different binding
  equations.