### PR TITLE
Use winsock2.h instead of winsock.h

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/socket.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/socket.h
@@ -18,7 +18,7 @@
 #define SOCKET_H_
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
-  #include <winsock.h>
+  #include <winsock2.h>
 #else
   #include <sys/socket.h>
   #include <sys/types.h>

--- a/OMCompiler/SimulationRuntime/c/simulation/socket_win.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/socket_win.inc
@@ -15,7 +15,7 @@
  */
 
 #include <cstdlib>
-#include <winsock.h>
+#include <winsock2.h>
 #include <io.h>
 #include <iostream>
 #include <stdio.h>


### PR DESCRIPTION
  - The two can not used be simultaneously. The rest of our code (e.g. our
    parsers) use winsock2.h.

    winsock2.h is backwards compatible with winsock.h. Use it as we are
    not possibly targeting anything that does not have winsock2 support.
