### PR TITLE
Improve package manager GUI

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1522,6 +1522,16 @@ void MainWindow::addSystemLibraries()
 }
 
 /*!
+ * \brief MainWindow::getLibraryIndexFilePath
+ * Returns the library index file path.
+ * \return
+ */
+QString MainWindow::getLibraryIndexFilePath() const
+{
+  return QString("%1/.openmodelica/libraries/index.json").arg(Helper::userHomeDirectory);
+}
+
+/*!
  * \brief MainWindow::showMessagesBrowser
  * Slot activated when MessagesWidget::MessageAdded signal is raised.\n
  * Shows the Messages Browser.
@@ -2506,18 +2516,67 @@ void MainWindow::exportModelToOMNotebook()
  */
 bool MainWindow::openInstallLibraryDialog()
 {
-  InstallLibraryDialog *pInstallLibraryDialog = new InstallLibraryDialog;
-  return pInstallLibraryDialog->exec();
+  updateLibraryIndex(false);
+  bool returnValue = false;
+  QString indexFilePath = getLibraryIndexFilePath();
+  if (QFile::exists(indexFilePath)) {
+    InstallLibraryDialog *pInstallLibraryDialog = new InstallLibraryDialog;
+    returnValue = pInstallLibraryDialog->exec();
+  } else {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, GUIMessages::getMessage(GUIMessages::LIBRARY_INDEX_FILE_NOT_FOUND).arg(indexFilePath),
+                                                          Helper::scriptingKind, Helper::errorLevel));
+  }
+  return returnValue;
 }
 
 /*!
  * \brief MainWindow::updateInstalledLibraries
- * Opens the update installed libraries dialog.
+ * Opens the upgrade installed libraries dialog.
  */
-void MainWindow::updateInstalledLibraries()
+void MainWindow::upgradeInstalledLibraries()
 {
-  UpdateInstalledLibrariesDialog *pUpdateInstalledLibrariesDialog = new UpdateInstalledLibrariesDialog;
-  pUpdateInstalledLibrariesDialog->exec();
+  updateLibraryIndex(false);
+  QString indexFilePath = getLibraryIndexFilePath();
+  if (QFile::exists(indexFilePath)) {
+    UpgradeInstalledLibrariesDialog *pUpdateInstalledLibrariesDialog = new UpgradeInstalledLibrariesDialog;
+    pUpdateInstalledLibrariesDialog->exec();
+  } else {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, GUIMessages::getMessage(GUIMessages::LIBRARY_INDEX_FILE_NOT_FOUND).arg(indexFilePath),
+                                                          Helper::scriptingKind, Helper::errorLevel));
+  }
+}
+
+/*!
+ * \brief MainWindow::updateLibraryIndex
+ * Slot activated when Update Library Index menu item is triggered.
+ */
+void MainWindow::updateLibraryIndex()
+{
+  updateLibraryIndex(true);
+}
+
+/*!
+ * \brief MainWindow::updateLibraryIndex
+ * Calls OMCProxy::updatePackageIndex() once per OMEdit session.
+ * \param forceUpdate
+ */
+void MainWindow::updateLibraryIndex(bool forceUpdate)
+{
+  static int init = 0;
+  if (forceUpdate || !init) {
+    init = 1;
+    // show the progressbar and set the message in status bar
+    mpStatusBar->showMessage(tr("Updating library index"));
+    mpProgressBar->setRange(0, 0);
+    showProgressBar();
+    if (!MainWindow::instance()->getOMCProxy()->updatePackageIndex()) {
+      MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Failed to update the library index. This could be because of bad internet connection."),
+                                                            Helper::scriptingKind, Helper::errorLevel));
+    }
+    // hide the progressbar and clear the message in status bar
+    mpStatusBar->clearMessage();
+    hideProgressBar();
+  }
 }
 
 //! Imports the models from OMNotebook.
@@ -3463,10 +3522,14 @@ void MainWindow::createActions()
   mpInstallLibraryAction = new QAction(Helper::installLibrary, this);
   mpInstallLibraryAction->setStatusTip(tr("Opens the install library window"));
   connect(mpInstallLibraryAction, SIGNAL(triggered()), SLOT(openInstallLibraryDialog()));
-  // updated installed libraries action
-  mpUpdateInstalledLibrariesAction = new QAction(Helper::updateInstalledLibraries, this);
-  mpUpdateInstalledLibrariesAction->setStatusTip(tr("Updates the installed libraries"));
-  connect(mpUpdateInstalledLibrariesAction, SIGNAL(triggered()), SLOT(updateInstalledLibraries()));
+  // upgrade installed libraries action
+  mpUpgradeInstalledLibrariesAction = new QAction(Helper::upgradeInstalledLibraries, this);
+  mpUpgradeInstalledLibrariesAction->setStatusTip(tr("Upgrades the installed libraries"));
+  connect(mpUpgradeInstalledLibrariesAction, SIGNAL(triggered()), SLOT(upgradeInstalledLibraries()));
+  // update library index action
+  mpUpdateLibraryIndexAction = new QAction(Helper::updateLibraryIndex, this);
+  mpUpdateLibraryIndexAction->setStatusTip(tr("Updates the library index"));
+  connect(mpUpdateLibraryIndexAction, SIGNAL(triggered()), SLOT(updateLibraryIndex()));
   // clear recent files action
   mpClearRecentFilesAction = new QAction(Helper::clearRecentFiles, this);
   mpClearRecentFilesAction->setStatusTip(tr("Clears the recent files list"));
@@ -3919,12 +3982,19 @@ void MainWindow::createMenus()
   mpFileMenu->addSeparator();
   // System libraries menu
   mpLibrariesMenu = new QMenu(menuBar());
-  mpLibrariesMenu->setObjectName("LibrariesMenu");
+  mpLibrariesMenu->setObjectName("SystemLibrariesMenu");
   mpLibrariesMenu->setTitle(tr("&System Libraries"));
   addSystemLibraries();
   mpFileMenu->addMenu(mpLibrariesMenu);
-  mpFileMenu->addAction(mpInstallLibraryAction);
-  mpFileMenu->addAction(mpUpdateInstalledLibrariesAction);
+  // manage libraries menu
+  QMenu *pManageLibrariesMenu = new QMenu(menuBar());
+  pManageLibrariesMenu->setObjectName("ManageLibrariesMenu");
+  pManageLibrariesMenu->setTitle(tr("&Manage Libraries"));
+  // add actions to manage libraries
+  pManageLibrariesMenu->addAction(mpInstallLibraryAction);
+  pManageLibrariesMenu->addAction(mpUpgradeInstalledLibrariesAction);
+  pManageLibrariesMenu->addAction(mpUpdateLibraryIndexAction);
+  mpFileMenu->addMenu(pManageLibrariesMenu);
   mpFileMenu->addSeparator();
   mpRecentFilesMenu = new QMenu(menuBar());
   mpRecentFilesMenu->setObjectName("RecentFilesMenu");

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -253,6 +253,7 @@ public:
                                    const char* curveStyle, const char* legendPosition, const char* footer, const char* autoScale, const char* variables);
   static void LoadModelCallbackFunction(void *p, const char* modelName);
   void addSystemLibraries();
+  QString getLibraryIndexFilePath() const;
 
   QList<QString> mFMUDirectoriesList;
   QList<QString> mMOLDirectoriesList;
@@ -336,7 +337,8 @@ private:
   QAction *mpExportFigaroAction;
   QAction *mpExportToOMNotebookAction;
   QAction *mpInstallLibraryAction;
-  QAction *mpUpdateInstalledLibrariesAction;
+  QAction *mpUpgradeInstalledLibrariesAction;
+  QAction *mpUpdateLibraryIndexAction;
   QAction *mpClearRecentFilesAction;
   QAction *mpPrintModelAction;
   QAction *mpQuitAction;
@@ -529,7 +531,9 @@ public slots:
   void runOMSensPlugin();
   void exportModelToOMNotebook();
   bool openInstallLibraryDialog();
-  void updateInstalledLibraries();
+  void upgradeInstalledLibraries();
+  void updateLibraryIndex();
+  void updateLibraryIndex(bool forceUpdate);
   void importModelfromOMNotebook();
   void importNgspiceNetlist();
   void exportModelAsImage(bool copyToClipboard = false);

--- a/OMEdit/OMEditLIB/Modeling/InstallLibraryDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/InstallLibraryDialog.cpp
@@ -82,9 +82,7 @@ InstallLibraryDialog::InstallLibraryDialog(QDialog *parent)
   // version combobox
   mpVersionComboBox = new QComboBox;
   // fetch libraries
-  QString indexFilePath = QString("%1/.openmodelica/libraries/index.json").arg(Helper::userHomeDirectory);
-  // update the package index
-  MainWindow::instance()->getOMCProxy()->updatePackageIndex();
+  QString indexFilePath = MainWindow::instance()->getLibraryIndexFilePath();
   if (QFile::exists(indexFilePath)) {
     if (mIndexJsonDocument.parse(indexFilePath)) {
       QVariantMap result = mIndexJsonDocument.result.toMap();
@@ -96,7 +94,8 @@ InstallLibraryDialog::InstallLibraryDialog(QDialog *parent)
       }
     }
   } else {
-    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), tr("Package index file <b>%1</b> doesn't exist.").arg(indexFilePath), Helper::ok);
+    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
+                          GUIMessages::getMessage(GUIMessages::LIBRARY_INDEX_FILE_NOT_FOUND).arg(indexFilePath), Helper::ok);
   }
   // exact match checkbox
   mpExactMatchCheckBox = new QCheckBox(tr("Exact Match (Install only the specified version of dependencies)"));
@@ -234,7 +233,6 @@ void InstallLibraryDialog::installLibrary()
   bool exactMatch = mpExactMatchCheckBox->isChecked();
 
   if (MainWindow::instance()->getOMCProxy()->installPackage(library, version, exactMatch)) {
-    MainWindow::instance()->getOMCProxy()->updatePackageIndex();
     MainWindow::instance()->addSystemLibraries();
     accept();
   } else {
@@ -246,35 +244,34 @@ void InstallLibraryDialog::installLibrary()
 }
 
 /*!
- * \brief UpdateInstalledLibrariesDialog::UpdateInstalledLibrariesDialog
+ * \brief UpgradeInstalledLibrariesDialog::UpgradeInstalledLibrariesDialog
  * \param parent
  */
-UpdateInstalledLibrariesDialog::UpdateInstalledLibrariesDialog(QDialog *parent)
+UpgradeInstalledLibrariesDialog::UpgradeInstalledLibrariesDialog(QDialog *parent)
   : QDialog(parent)
 {
   setAttribute(Qt::WA_DeleteOnClose);
-  setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::updateInstalledLibraries));
+  setWindowTitle(QString("%1 - %2").arg(Helper::applicationName, Helper::upgradeInstalledLibraries));
   setMinimumWidth(400);
-  Label *pHeadingLabel = Utilities::getHeadingLabel(Helper::updateInstalledLibraries);
+  Label *pHeadingLabel = Utilities::getHeadingLabel(Helper::upgradeInstalledLibraries);
   pHeadingLabel->setElideMode(Qt::ElideMiddle);
   // description label
-  mpDescriptLabel = new Label(tr("Click Update to upgrade the installed libraries that have been registered by the package manager."));
+  mpDescriptLabel = new Label(tr("Upgrade the installed libraries that have been registered by the package manager."));
   // installNewestVersions checkbox
-  mpInstallNewestVersionsCheckBox = new QCheckBox(tr("Install Newest Versions"));
-  mpInstallNewestVersionsCheckBox->setChecked(true);
+  mpInstallNewestVersionsCheckBox = new QCheckBox(tr("Install Newest Versions (may install the latest non-compatible versions)"));
   // Progress label
-  mpProgressLabel = new Label(tr("<b>Updating installed libraries. Please wait.</b>"));
+  mpProgressLabel = new Label(tr("<b>Upgrading installed libraries. Please wait.</b>"));
   mpProgressLabel->hide();
   // buttons
-  mpUpdateButton = new QPushButton(tr("Update"));
-  mpUpdateButton->setAutoDefault(true);
-  connect(mpUpdateButton, SIGNAL(clicked()), SLOT(updateInstalledLibraries()));
+  mpUpgradeButton = new QPushButton(tr("Upgrade"));
+  mpUpgradeButton->setAutoDefault(true);
+  connect(mpUpgradeButton, SIGNAL(clicked()), SLOT(upgradeInstalledLibraries()));
   mpCancelButton = new QPushButton(Helper::cancel);
   mpCancelButton->setAutoDefault(false);
   connect(mpCancelButton, SIGNAL(clicked()), SLOT(reject()));
   // add buttons to the button box
   mpButtonBox = new QDialogButtonBox(Qt::Horizontal);
-  mpButtonBox->addButton(mpUpdateButton, QDialogButtonBox::ActionRole);
+  mpButtonBox->addButton(mpUpgradeButton, QDialogButtonBox::ActionRole);
   mpButtonBox->addButton(mpCancelButton, QDialogButtonBox::ActionRole);
   // layout
   QGridLayout *pMainGridLayout = new QGridLayout;
@@ -290,23 +287,22 @@ UpdateInstalledLibrariesDialog::UpdateInstalledLibrariesDialog(QDialog *parent)
 }
 
 /*!
- * \brief UpdateInstalledLibrariesDialog::updateInstalledLibraries
- * Updates the installed libraries.
+ * \brief UpgradeInstalledLibrariesDialog::upgradeInstalledLibraries
+ * Upgrade the installed libraries.
  */
-void UpdateInstalledLibrariesDialog::updateInstalledLibraries()
+void UpgradeInstalledLibrariesDialog::upgradeInstalledLibraries()
 {
   mpProgressLabel->show();
-  mpUpdateButton->setEnabled(false);
+  mpUpgradeButton->setEnabled(false);
   repaint(); // repaint the dialog so progresslabel is updated.
 
   if (MainWindow::instance()->getOMCProxy()->upgradeInstalledPackages(mpInstallNewestVersionsCheckBox->isChecked())) {
-    MainWindow::instance()->getOMCProxy()->updatePackageIndex();
     MainWindow::instance()->addSystemLibraries();
     accept();
   } else {
     QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                          tr("Fail to update libraries. See Messages Browser for any possible messages."), Helper::ok);
+                          tr("Fail to upgrade libraries. See Messages Browser for any possible messages."), Helper::ok);
     mpProgressLabel->hide();
-    mpUpdateButton->setEnabled(true);
+    mpUpgradeButton->setEnabled(true);
   }
 }

--- a/OMEdit/OMEditLIB/Modeling/InstallLibraryDialog.h
+++ b/OMEdit/OMEditLIB/Modeling/InstallLibraryDialog.h
@@ -74,20 +74,20 @@ private slots:
   void installLibrary();
 };
 
-class UpdateInstalledLibrariesDialog : public QDialog
+class UpgradeInstalledLibrariesDialog : public QDialog
 {
   Q_OBJECT
 public:
-  explicit UpdateInstalledLibrariesDialog(QDialog *parent = nullptr);
+  explicit UpgradeInstalledLibrariesDialog(QDialog *parent = nullptr);
 private:
   Label *mpDescriptLabel;
   QCheckBox *mpInstallNewestVersionsCheckBox;
   Label *mpProgressLabel;
-  QPushButton *mpUpdateButton;
+  QPushButton *mpUpgradeButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;
 private slots:
-  void updateInstalledLibraries();
+  void upgradeInstalledLibraries();
 };
 
 #endif // INSTALLLIBRARYDIALOG_H

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -1491,7 +1491,7 @@ void ConvertClassUsesAnnotationDialog::convert()
   repaint(); // repaint the dialog so progresslabel is updated.
   const QString nameStructure = mpLibraryTreeItem->getNameStructure();
   bool reloadClass = false;
-  bool updatePackageIndex = false;
+  bool updateSystemLibraries = false;
   QTreeWidgetItemIterator usesLibrariesIterator(mpUsesLibrariesTreeWidget);
   while (*usesLibrariesIterator) {
     QTreeWidgetItem *pUsesLibraryTreeWidgetItem = dynamic_cast<QTreeWidgetItem*>(*usesLibrariesIterator);
@@ -1503,7 +1503,7 @@ void ConvertClassUsesAnnotationDialog::convert()
     // install the library if needed.
     if (!installed) {
       if (MainWindow::instance()->getOMCProxy()->installPackage(libraryName, libraryVersion, true)) {
-        updatePackageIndex |= true;
+        updateSystemLibraries |= true;
       }
     }
     if (MainWindow::instance()->getOMCProxy()->convertPackageToLibrary(nameStructure, libraryName, libraryVersion)) {
@@ -1527,9 +1527,8 @@ void ConvertClassUsesAnnotationDialog::convert()
   }
   // load any dependent libraries
   pLibraryTreeModel->loadDependentLibraries(MainWindow::instance()->getOMCProxy()->getClassNames());
-  // update the package index if needed
-  if (updatePackageIndex) {
-    MainWindow::instance()->getOMCProxy()->updatePackageIndex();
+  // update system libraries if needed
+  if (updateSystemLibraries) {
     MainWindow::instance()->addSystemLibraries();
   }
   accept();

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -423,7 +423,8 @@ QString Helper::systemSimulationInformation;
 QString Helper::translationFlags;
 QString Helper::send;
 QString Helper::installLibrary;
-QString Helper::updateInstalledLibraries;
+QString Helper::upgradeInstalledLibraries;
+QString Helper::updateLibraryIndex;
 QString Helper::dataReconciliation;
 
 void Helper::initHelperVariables()
@@ -726,7 +727,8 @@ void Helper::initHelperVariables()
   Helper::translationFlags = tr("Translation Flags");
   Helper::send = tr("Send");
   Helper::installLibrary = tr("Install Library");
-  Helper::updateInstalledLibraries = tr("Update Installed Libraries");
+  Helper::upgradeInstalledLibraries = tr("Upgrade Installed Libraries");
+  Helper::updateLibraryIndex = tr("Update Library Index");
   Helper::dataReconciliation = tr("Data Reconciliation");
 }
 
@@ -876,6 +878,8 @@ QString GUIMessages::getMessage(int type)
       return tr("Name <b>%1</b> is not a valid identifier.<br />A name must start with a letter, and all characters must be letters or digits. It may not be a reserved word.");
     case ENTER_SCRIPT:
       return tr("Please enter a script file.");
+    case LIBRARY_INDEX_FILE_NOT_FOUND:
+      return tr("Library index file <b>%1</b> doesn't exist.");
     default:
       return "";
   }

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -430,7 +430,8 @@ public:
   static QString translationFlags;
   static QString send;
   static QString installLibrary;
-  static QString updateInstalledLibraries;
+  static QString upgradeInstalledLibraries;
+  static QString updateLibraryIndex;
   static QString dataReconciliation;
 };
 
@@ -506,7 +507,8 @@ public:
     MULTIPLE_DECLARATIONS_COMPONENT,
     GDB_ERROR,
     INVALID_INSTANCE_NAME,
-    ENTER_SCRIPT
+    ENTER_SCRIPT,
+    LIBRARY_INDEX_FILE_NOT_FOUND
   };
 
   static QString getMessage(int type);

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -277,6 +277,10 @@ File Menu
   -  *Figaro* - Exports the current model to Figaro.
   -  *To OMNotebook* - Exports the current model to a OMNotebook file.
 -  *System Libraries* - Contains a list of system libraries.
+-  *Manage Libraries*
+  -  *Install Library* - Opens a dialog to select and install a new library. see :ref:`omedit-install-library-label`
+  -  *Upgrade Installed Libraries* - Opens a dialog to upgrade the installed libraries.
+  -  *Update Library Index* - Updates the library index.
 -  *Recent Files* - Contains a list of recent files.
 -  *Clear Recent Files* - Clears the list of recent files.
 -  *Print* - Prints the current model.
@@ -307,6 +311,18 @@ View Menu
 -  *Reset Zoom* - Resets the zoom of the current model.
 -  *Zoom In* - Zoom in the current model.
 -  *Zoom Out* - Zoom out the current model.
+-  *Fit to Diagram* - Fit the current model diagram in the view.
+
+SSP Menu
+--------
+
+-  *Add System* - Adds the system to a model.
+-  *Add/Edit Icon* - Add/Edit the system/submodel icon.
+-  *Delete Icon* - Deletes the system/submodel icon.
+-  *Add Connector* - Adds a connector to a system/submodel.
+-  *Add Bus* - Adds a bus to a system/submodel.
+-  *Add TLM Bus* - Adds a TLM bus to a system/submodel.
+-  *Add SubModel* - Adds a submodel to a system.
 
 Simulation Menu
 ---------------
@@ -324,27 +340,21 @@ Simulation Menu
 -  *Archived Simulations* - Shows the list of simulations already finished or running.
    Double clicking on any of them opens the simulation output window.
 
-Debug Menu
-----------
+Data Reconciliation
+-------------------
 
--  *Debug Configurations* - Opens the debug configurations window.
--  *Attach to Running Process* - Attaches the algorithmic debugger to a running process.
-
-SSP Menu
---------
-
--  *Add System* - Adds the system to a model.
--  *Add/Edit Icon* - Add/Edit the system/submodel icon.
--  *Delete Icon* - Deletes the system/submodel icon.
--  *Add Connector* - Adds a connector to a system/submodel.
--  *Add Bus* - Adds a bus to a system/submodel.
--  *Add TLM Bus* - Adds a TLM bus to a system/submodel.
--  *Add SubModel* - Adds a submodel to a system.
+-  *Calculate Data Reconciliation* - Opens the dialog to run the data reconciliation algorithm.
 
 Sensitivity Optimization Menu
 -----------------------------
 
 - *Run Sensitivity Analysis and Optimization* - Runs the sensitivity analysis and optimization.
+
+Debug Menu
+----------
+
+-  *Debug Configurations* - Opens the debug configurations window.
+-  *Attach to Running Process* - Attaches the algorithmic debugger to a running process.
 
 Tools Menu
 ----------
@@ -353,6 +363,7 @@ Tools Menu
    interface window.
 -  *OpenModelica Command Prompt* - Opens the OpenModelica Command Prompt (Only
    available on Windows).
+-  *Open Temporary Directory* - Opens the current temporary directory.
 -  *Open Working Directory* - Opens the current working directory.
 -  *Open Terminal* - Runs the terminal command set in :ref:`omedit-options-general`.
 -  *Options* - Opens the options window.
@@ -1726,7 +1737,7 @@ Install Library
 ---------------
 
 A new library can be installed with the help of the :ref:`package manager <packagemanagement>`.
-Click `File->Install Library` to open the install library dialog. OMEdit lists the libraries
+Click `File->Manage Libraries->Install Library` to open the install library dialog. OMEdit lists the libraries
 that are available for installation through the package manager.
 
 .. figure :: media/omedit_install_library.png


### PR DESCRIPTION
### Related Issues

Fixes #8757

### Purpose

Improve the package manager operations i.e., install, update and upgrade.

### Approach

Organize the libraries action in `Manage Libraries` menu item.
Changed `update installed libraries` to `upgrade installed libraries`.
Call updatePackageIndex once per OMEdit session.
Also allow user to call it manually if needed.
