### PR TITLE
Put spaces around linker command fragments.

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -2658,7 +2658,7 @@ algorithm
   cflags := if stringEq(Config.simCodeTarget(),"JavaScript") then "-Os -Wno-warn-absolute-paths" else cflags;
   ldflags := System.getLDFlags();
   if Flags.getConfigBool(Flags.PARMODAUTO) then
-    ldflags := "-lParModelicaAuto -ltbb_static -lboost_system" + ldflags;
+    ldflags := " -lParModelicaAuto -ltbb_static -lboost_system " + ldflags;
   end if;
   rtlibs := if isFunction then Autoconf.ldflags_runtime else (if isFMU then Autoconf.ldflags_runtime_fmu else Autoconf.ldflags_runtime_sim);
   platform := System.modelicaPlatform();


### PR DESCRIPTION
  - This was resulting in `-lboost_system-fopenmp` when it should have
    been `-lboost_system -fopenmp`.

- Fixes #8776.