### PR TITLE
Fix OMEdit on macOS

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -2714,6 +2714,7 @@ void MainWindow::runOMSensPlugin()
 #ifdef Q_OS_MAC
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("OMSens is not supported on MacOS"), Helper::scriptingKind, Helper::errorLevel));
     return;
+  }
 #else
 #ifdef Q_OS_WIN
     QPluginLoader loader(QString("%1/lib/omc/omsensplugin.dll").arg(Helper::OpenModelicaHome));


### PR DESCRIPTION
OMEdit does not compile on macOS.

- [x] fix missing closing brace in `OMEdit/OMEditLIB/MainWindow.cpp`

- [ ]  fix libantlr4-runtime linking (macOS ld does not support `-Bdynamic` and `-Bstatic`)