### PR TITLE
Fixes for CMake MacOS build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,11 @@ set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/omc/)
 ## This is useful for those binaries that end up in bin/ directory but not for
 ## others as it is a relative path to the lib dir from <build_dir>/<some_dir>.
 ## Maybe there is a better way to do this but it should suffice for now.
-set(CMAKE_INSTALL_RPATH "$ORIGIN:$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+if(APPLE)
+  set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+else()
+  set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+endif()
 
 ## Do not print unnecessary install messages when nothing has actually changed.
 set(CMAKE_INSTALL_MESSAGE LAZY)

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # systems we need to link explicitly to uuid. However, there is no FindUUID yet. We can add one later. Instead we use
 # find library for now. It should be okay for now since I am guessing uuid headers should be in the default include dirs
 # anyway.
-if(NOT WIN32)
+if(UNIX AND NOT APPLE)
   find_library(UUID_LIB NAMES uuid REQUIRED)
 endif()
 
@@ -94,7 +94,7 @@ target_include_directories(omcruntime PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # uuid is one of the default libs that cmake adds to any target on Win32. On non-Win systems we look for the library and
 # explicitly use it.
-if(NOT WIN32)
+if(UNIX AND NOT APPLE)
   target_link_libraries(omcruntime PUBLIC ${UUID_LIB})
 endif()
 

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaMatIO.h
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaMatIO.h
@@ -44,6 +44,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+/* For mkdtemp */
+#if defined(__APPLE__)
+#include <unistd.h>
+#endif
+
 #ifndef MATIO_PUBCONF_H
 #define MATIO_PUBCONF_H 1
 

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -3,7 +3,8 @@
 add_executable(OMEdit WIN32 MACOSX_BUNDLE main.cpp rc_omedit.rc)
 target_link_libraries(OMEdit PRIVATE OMEditLib)
 
-install(TARGETS OMEdit)
+install(TARGETS OMEdit
+        BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 
 # Install the runtime dependency dlls if we are on MSYS/MinGW.

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -107,7 +107,8 @@ target_link_libraries(OMNotebook PUBLIC OpenModelicaCompiler)
 # target_link_libraries(OMNotebook PRIVATE OMNotebookLib)
 
 # install(TARGETS OMNotebookLib)
-install(TARGETS OMNotebook)
+install(TARGETS OMNotebook
+        BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES stylesheet.xml
               commands.xml

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -42,8 +42,9 @@ target_link_libraries(OMPlotLib PUBLIC omc::simrt::runtime)
 target_link_options(OMPlotLib PRIVATE -Wl,--no-undefined)
 
 
-add_executable(OMPlot main.cpp rc_omplot.rc)
+add_executable(OMPlot WIN32 MACOSX_BUNDLE main.cpp rc_omplot.rc)
 target_link_libraries(OMPlot PRIVATE OMPlotLib)
 
 install(TARGETS OMPlotLib)
-install(TARGETS OMPlot)
+install(TARGETS OMPlot
+        BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -25,7 +25,8 @@ target_link_options(OMShellLib PRIVATE -Wl,--no-undefined)
 add_executable(OMShell WIN32 MACOSX_BUNDLE main.cpp rc_omshell.rc)
 target_link_libraries(OMShell PRIVATE OMShellLib)
 
-install(TARGETS OMShell)
+install(TARGETS OMShell
+        BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(FILES commands.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omshell)


### PR DESCRIPTION
  - Use `loader_path` when setting `rpath` of libraries/executables.

  - Distinguish Linux and MacOS. CMake's `if(UNIX)` implies both.

  - Specify bundle destinations for executables.
