### PR TITLE
Remove Fortran from hard requirements for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.14)
-project(OpenModelica C CXX Fortran)
+project(OpenModelica C CXX)
 
 # Any custom Find* modules should be placed here.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.14)
-project(OMCompiler C CXX Fortran)
+project(OMCompiler C CXX)
 
 ## OPTIONS #################################################################################################
 
-omc_option(OM_OMC_ENABLE_CPP_RUNTIME "Enable, build, and install the C++ simulation runtime libraries." ON)
+omc_option(OM_OMC_ENABLE_FORTRAN "Enable Fortran support. Fortran is required if you enable IPOPT support." ON)
+if(OM_OMC_ENABLE_FORTRAN)
+  enable_language(Fortran)
+endif()
+
 
 omc_option(WITH_IPOPT "Should we enable dynamic optimization support with Ipopt." ON)
+if(WITH_IPOPT AND NOT OM_OMC_ENABLE_FORTRAN)
+message(FATAL_ERROR "Ipopt support requires Fortran support to be enabled.
+    ***Note: currently it is not possible to disable IPOPT from OpenModelica. This Option is here as a placeholder. ")
+endif()
+
+omc_option(OM_OMC_ENABLE_CPP_RUNTIME "Enable, build, and install the C++ simulation runtime libraries." ON)
+
 omc_option(OM_OMC_USE_CORBA "Should use corba." OFF)
 
 omc_option(OM_OMC_USE_LPSOLVE "Should we use lpsolve." OFF)


### PR DESCRIPTION
[](https://github.com/mahge)@mahge
[Remove Fortran from hard requirements for CMake](https://github.com/OpenModelica/OpenModelica/pull/8787/commits/cb09f7e2279a3a45d20526e99efe4573b91b7027) 
[cb09f7e](https://github.com/OpenModelica/OpenModelica/pull/8787/commits/cb09f7e2279a3a45d20526e99efe4573b91b7027)
  - The option CAN NOT be disabled for now. compilation will fail if you
    disable it. It is here as a placeholder and we still require Fortran
    in our 3rdParty code.

  - Fortran does not need to be a must to compile and use most of OpenModelica

    The only component that needs Fortran (as far as I can tell) is the
    MUMPS solver that Ipopt uses in 3rdParty code. MUMPS (and IPOPT) are
    required only for dynamic optimization support and we should be able
    to disabl them safely if that feature is not needed.

    However, our simulation runtime (libSimulationRuntimeC) seems to depend
    on IPOPT unconditionally. There is a macro `WITH_IPOPT` that is supposed
    to disable the requirement.

    Unfortunately, it is not working as intended at the moment. In fact it
    is always set no matter what configuration options we use. Until that
    get fixed we pretend like Fortran is optional even though it is not
    yet.

[](https://github.com/mahge)@mahge
[Fix 3rdParty optional component enabling.](https://github.com/OpenModelica/OpenModelica/pull/8787/commits/d16aff08009884ef1efa8c33fbacc52d28f641ac) 
[d16aff0](https://github.com/OpenModelica/OpenModelica/pull/8787/commits/d16aff08009884ef1efa8c33fbacc52d28f641ac)
  - Disable Fortran dependent sundials library if Fortran is disabled from
    OpenModelica build.

  - Add Ipopt only if WITH_IPOPT is set. WITH_IPOPT can not be set if Fortran
    support is disabled.