### PR TITLE
check for .json file is NULL and return dummy equation and function info

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -467,22 +467,15 @@ FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix)
 
 FUNCTION_INFO modelInfoGetDummyFunction(MODEL_DATA_XML* xml)
 {
-  xml->functionNames = (FUNCTION_INFO*) calloc(1, sizeof(FUNCTION_INFO));
-  FILE_INFO fileInfo = omc_dummyFileInfo;
-  xml->functionNames[0].id = 0;
-  xml->functionNames[0].name = "";
-  xml->functionNames[0].info = fileInfo;
-  return xml->functionNames[0];
+  FUNCTION_INFO functionInfo = omc_dummyFunctionInfo;
+  return functionInfo;
 }
 
 EQUATION_INFO modelInfoGetDummyEquation(MODEL_DATA_XML* xml)
 {
-  xml->equationInfo = (EQUATION_INFO*) calloc(1, sizeof(EQUATION_INFO));
-  xml->equationInfo[0].id = 0;
-  xml->equationInfo[0].profileBlockIndex = 0;
-  xml->equationInfo[0].numVar = 0;
-  xml->equationInfo[0].vars = "";
-  return xml->equationInfo[0];
+  const char * var = "";
+  EQUATION_INFO equationInfo = {-1, 0, 0, -1, &var}; // omc_dummyEquationInfo is not working in mingw
+  return equationInfo;
 }
 
 EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix)

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -393,7 +393,10 @@ void modelInfoInit(MODEL_DATA_XML* xml)
   }
 
   if (fileStatus != 0)
+  {
+    xml->fileName = NULL;
     return;
+  }
 
 #if !defined(OMC_NO_FILESYSTEM)
   omc_mmap_read mmap_reader = {0};
@@ -447,6 +450,13 @@ void modelInfoDeinit(MODEL_DATA_XML* xml)
 
 FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix)
 {
+  /* check for xml->fileName == NULL for --fmiFilter=blackBox and protected
+   * and return dummy function info to make the fmu's simulation work, as
+   * the _json.info will not be exported for the above --fmiFilter combinations
+  */
+  if (xml->fileName == NULL)
+    return modelInfoGetDummyFunction(xml);
+
   if(xml->functionNames == NULL)
   {
     modelInfoInit(xml);
@@ -455,8 +465,35 @@ FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix)
   return xml->functionNames[ix];
 }
 
+FUNCTION_INFO modelInfoGetDummyFunction(MODEL_DATA_XML* xml)
+{
+  xml->functionNames = (FUNCTION_INFO*) calloc(1, sizeof(FUNCTION_INFO));
+  FILE_INFO fileInfo = omc_dummyFileInfo;
+  xml->functionNames[0].id = 0;
+  xml->functionNames[0].name = "";
+  xml->functionNames[0].info = fileInfo;
+  return xml->functionNames[0];
+}
+
+EQUATION_INFO modelInfoGetDummyEquation(MODEL_DATA_XML* xml)
+{
+  xml->equationInfo = (EQUATION_INFO*) calloc(1, sizeof(EQUATION_INFO));
+  xml->equationInfo[0].id = 0;
+  xml->equationInfo[0].profileBlockIndex = 0;
+  xml->equationInfo[0].numVar = 0;
+  xml->equationInfo[0].vars = "";
+  return xml->equationInfo[0];
+}
+
 EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix)
 {
+  /* check for xml->fileName == NULL for --fmiFilter=blackBox and protected
+   * and return dummy equation info to make the fmu's simulation work, as
+   * the _json.info will not be exported for the above --fmiFilter combinations
+  */
+  if (xml->fileName == NULL)
+    return modelInfoGetDummyEquation(xml);
+
   if (xml->equationInfo == NULL) {
     modelInfoInit(xml);
   }
@@ -466,6 +503,13 @@ EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix)
 
 EQUATION_INFO modelInfoGetEquationIndexByProfileBlock(MODEL_DATA_XML* xml, size_t ix)
 {
+  /* check for xml->fileName == NULL for --fmiFilter=blackBox and protected
+   * and return dummy equation info to make the fmu's simulation work, as
+   * the _json.info will not be exported for the above --fmiFilter combinations
+  */
+  if (xml->fileName == NULL)
+    return modelInfoGetDummyEquation(xml);
+
   int i;
   if(xml->equationInfo == NULL)
   {

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.h
@@ -40,8 +40,10 @@ extern "C" {
 void modelInfoInit(MODEL_DATA_XML* xml);
 void modelInfoDeinit(MODEL_DATA_XML* xml);
 FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix);
+FUNCTION_INFO modelInfoGetDummyFunction(MODEL_DATA_XML* xml);
 EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix);
 EQUATION_INFO modelInfoGetEquationIndexByProfileBlock(MODEL_DATA_XML* xml, size_t ix);
+EQUATION_INFO modelInfoDummyEquation(MODEL_DATA_XML* xml);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.h
@@ -43,7 +43,7 @@ FUNCTION_INFO modelInfoGetFunction(MODEL_DATA_XML* xml, size_t ix);
 FUNCTION_INFO modelInfoGetDummyFunction(MODEL_DATA_XML* xml);
 EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix);
 EQUATION_INFO modelInfoGetEquationIndexByProfileBlock(MODEL_DATA_XML* xml, size_t ix);
-EQUATION_INFO modelInfoDummyEquation(MODEL_DATA_XML* xml);
+EQUATION_INFO modelInfoGetDummyEquation(MODEL_DATA_XML* xml);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/8641

### Purpose

This PR fixes the regression tests related to https://libraries.openmodelica.org/branches/history/master-fmi/2022-02-17%2001:51:48..2022-02-19%2001:39:48.html. 

### Approach
When exporting Fmu with `--fmiFilter= blackBox or protected` , we do not export the `_info.json` which is basically used for debugging purpose and this should not affect the fmu simulation, but the regression tests failed because of the '_info.json' file is not exported and resulting in some assertion when called from nonlinear solvers. see the related  failing test https://libraries.openmodelica.org/branches/master-fmi/ModelicaTest_4.0.0/files/ModelicaTest_4.0.0_ModelicaTest.Fluid.TestComponents.Sensors.TestPressure.sim. 
So when these functions are called for example `modelInfoGetEquation` during fmu simulation,  currently a dummy `EQUATION_INFO` AND  `FUNCTION_INFO` are returned to fix the regressions


