### PR TITLE
Initialization file without inputPath

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -542,9 +542,13 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
     init_initMethod = omc_flagValue[FLAG_IIM];
   }
   if(omc_flag[FLAG_IIF]) {
+      #if defined(__MINGW32__) || defined(_MSC_VER)
+        struct _stat attrib;
+      #else
+        struct stat attrib;
+      #endif
     if (omc_flag[FLAG_INPUT_PATH]) {
       const char *tmp_filename;
-      struct stat attrib;
 
       if (omc_stat(omc_flagValue[FLAG_IIF], &attrib ) == 0) {
         if (0 > GC_asprintf(&tmp_filename, "%s", omc_flagValue[FLAG_IIF] )) {
@@ -561,7 +565,7 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
     else {
       init_file = omc_flagValue[FLAG_IIF];
     }
-    if (stat(init_file.c_str(), &attrib ) != 0) {
+    if (omc_stat(init_file.c_str(), &attrib ) != 0) {
       throwStreamPrint(NULL, "Initialization file \"%s\" doesn't exist.", init_file.c_str());
     }
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -544,13 +544,25 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
   if(omc_flag[FLAG_IIF]) {
     if (omc_flag[FLAG_INPUT_PATH]) {
       const char *tmp_filename;
-      if (0 > GC_asprintf(&tmp_filename, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], omc_flagValue[FLAG_IIF])) {
-        throwStreamPrint(NULL, "simulation_runtime.cpp: Error: can not allocate memory.");
+      struct stat attrib;
+
+      if (omc_stat(omc_flagValue[FLAG_IIF], &attrib ) == 0) {
+        if (0 > GC_asprintf(&tmp_filename, "%s", omc_flagValue[FLAG_IIF] )) {
+          throwStreamPrint(NULL, "simulation_runtime.cpp: Error: can not allocate memory.");
+        }
+      }
+      else {
+        if (0 > GC_asprintf(&tmp_filename, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], omc_flagValue[FLAG_IIF])) {
+          throwStreamPrint(NULL, "simulation_runtime.cpp: Error: can not allocate memory.");
+        }
       }
       init_file = tmp_filename;
     }
     else {
       init_file = omc_flagValue[FLAG_IIF];
+    }
+    if (stat(init_file.c_str(), &attrib ) != 0) {
+      throwStreamPrint(NULL, "Initialization file \"%s\" doesn't exist.", init_file.c_str());
     }
   }
   if(omc_flag[FLAG_IIT]) {


### PR DESCRIPTION


### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/8765

### Purpose

Used when the initialization file is given via `-iif` as absolute absolute path but `-inputPath` is set as well.

### Approach

Check if initialization file exists, if so use it.
Otherwise check if it exists in path given with `-inputPath`.

Return an error if input file can't be found.
