### PR TITLE
Remove -Wl,--no-undefined from linker options.

### DIFF
--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -265,18 +265,18 @@ if(WIN32)
   set(CONFIG_OS "Windows_NT")
 
   set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -lopenblas -lm -lpthread")
-  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lopenblas -lm -lpthread -lgfortran -lstdc++ -Wl,--no-undefined")
-  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -lopenblas -lm -lpthread -Wl,--no-undefined")
-  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -lopenblas -lm -lpthread -lgfortran -lstdc++ -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lopenblas -lm -lpthread -lgfortran -lstdc++ ")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -lopenblas -lm -lpthread ")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -lopenblas -lm -lpthread -lgfortran -lstdc++ ")
 
 
 else()
   set(CONFIG_OS ${OMC_TARGET_SYSTEM_NAME})
 
   set(RT_LDFLAGS_GENERATED_CODE " -lOpenModelicaRuntimeC -llapack -lblas -lm -lpthread -rdynamic")
-  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
-  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas -lm -lpthread -rdynamic -Wl,--no-undefined")
-  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic -Wl,--no-undefined")
+  set(RT_LDFLAGS_GENERATED_CODE_SIM " -lSimulationRuntimeC -lOpenModelicaRuntimeC -lzlib -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic ")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU " -llapack -lblas -lm -lpthread -rdynamic ")
+  set(RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC "-Wl,-Bstatic -lSimulationRuntimeFMI -Wl,-Bdynamic -llapack -lblas -lm -ldl -lpthread -lgfortran -lstdc++ -rdynamic ")
 
 
 endif()

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -92,8 +92,6 @@ endif()
 # Fix me. Make an interface (header only library) out of 3rdParty/dgesv
 target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
 
-# target_link_options(SimulationRuntimeC PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS SimulationRuntimeC)
 
 

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -33,8 +33,6 @@ target_sources(OMCppDataExchange PRIVATE ${OMC_SIMRT_CPP_CORE_DATAEXCHANGE_SOURC
 
 target_link_libraries(OMCppDataExchange PUBLIC omc::simrt::cpp::config)
 
-target_link_options(OMCppDataExchange PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppDataExchange)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -54,8 +52,6 @@ add_library(omc::simrt::cpp::core::modelica ALIAS OMCppModelica)
 target_sources(OMCppModelica PRIVATE ${OMC_SIMRT_CPP_CORE_MODELICA_SOURCES})
 
 target_link_libraries(OMCppModelica PUBLIC omc::simrt::cpp::config)
-
-target_link_options(OMCppModelica PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppModelica)
 
@@ -81,8 +77,6 @@ add_library(omc::simrt::cpp::core::math ALIAS OMCppMath)
 target_sources(OMCppMath PRIVATE ${OMC_SIMRT_CPP_CORE_MATH_SOURCES})
 
 target_link_libraries(OMCppMath PUBLIC omc::simrt::cpp::config)
-
-target_link_options(OMCppMath PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppMath)
 
@@ -123,8 +117,6 @@ target_sources(OMCppSolver PRIVATE ${OMC_SIMRT_CPP_CORE_SOLVER_SOURCES})
 target_link_libraries(OMCppSolver PUBLIC omc::simrt::cpp::config)
 target_link_libraries(OMCppSolver PUBLIC omc::simrt::cpp::core::math)
 
-target_link_options(OMCppSolver PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppSolver)
 
 # OMCppSolver_static
@@ -162,8 +154,6 @@ target_sources(OMCppExtensionUtilities PRIVATE ${OMC_SIMRT_CPP_CORE_UTILS_EXTENS
 
 target_link_libraries(OMCppExtensionUtilities PUBLIC omc::simrt::cpp::config)
 
-target_link_options(OMCppExtensionUtilities PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppExtensionUtilities)
 
 # OMCppExtensionUtilities_static
@@ -198,8 +188,6 @@ add_library(omc::simrt::cpp::core::utils::modelica ALIAS OMCppModelicaUtilities)
 target_sources(OMCppModelicaUtilities PRIVATE ${OMC_SIMRT_CPP_CORE_UTILS_MODELICA_SOURCES})
 
 target_link_libraries(OMCppModelicaUtilities PUBLIC omc::simrt::cpp::config)
-
-target_link_options(OMCppModelicaUtilities PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppModelicaUtilities)
 
@@ -241,8 +229,6 @@ target_link_libraries(OMCppSimController PUBLIC omc::simrt::cpp::simcorefactory:
 target_link_libraries(OMCppSimController PUBLIC omc::simrt::cpp::core::utils::modelica)
 target_link_libraries(OMCppSimController PUBLIC Boost::filesystem)
 
-target_link_options(OMCppSimController PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppSimController)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -268,8 +254,6 @@ target_sources(OMCppSimulationSettings PRIVATE ${OMC_SIMRT_CPP_CORE_SIM_SETTINGS
 target_link_libraries(OMCppSimulationSettings PUBLIC omc::simrt::cpp::config)
 target_link_libraries(OMCppSimulationSettings PUBLIC omc::simrt::cpp::simcorefactory::omcfactory)
 target_link_libraries(OMCppSimulationSettings PUBLIC Boost::filesystem)
-
-target_link_options(OMCppSimulationSettings PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppSimulationSettings)
 
@@ -301,8 +285,6 @@ target_sources(OMCppSystem PRIVATE ${OMC_SIMRT_CPP_CORE_SYSTEM_SOURCES})
 target_link_libraries(OMCppSystem PUBLIC omc::simrt::cpp::config)
 target_link_libraries(OMCppSystem PUBLIC omc::simrt::cpp::simcorefactory::omcfactory)
 target_link_libraries(OMCppSystem PUBLIC Boost::filesystem)
-
-target_link_options(OMCppSystem PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppSystem)
 

--- a/OMCompiler/SimulationRuntime/cpp/FMU/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/FMU/cmake_3.14.cmake
@@ -10,8 +10,6 @@ target_sources(OMCppFMU PRIVATE ${OMC_SIMRT_CPP_FMU_SOURCES})
 target_link_libraries(OMCppFMU PUBLIC omc::simrt::cpp::config)
 target_link_libraries(OMCppFMU PUBLIC omc::simrt::cpp::core::utils::extension)
 
-target_link_options(OMCppFMU PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppFMU)
 
 # OMCppFMU_static

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
@@ -25,8 +25,6 @@ if(WIN32)
   target_link_libraries(OMCppOMCFactory PUBLIC ws2_32)
 endif()
 
-target_link_options(OMCppOMCFactory PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppOMCFactory)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/CMakeLists.txt
@@ -16,8 +16,6 @@ target_link_libraries(OMCppCVode PRIVATE omc::simrt::cpp::core::modelica)
 target_link_libraries(OMCppCVode PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppCVode PRIVATE omc::3rd::sundials::cvode)
 
-target_link_options(OMCppCVode PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppCVode)
 
 
@@ -36,8 +34,6 @@ target_link_libraries(OMCppDASSL PRIVATE omc::simrt::cpp::core::modelica)
 target_link_libraries(OMCppDASSL PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppDASSL PRIVATE omc::3rd::cdaskr)
 
-target_link_options(OMCppDASSL PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppDASSL)
 
 
@@ -55,8 +51,6 @@ target_sources(OMCppDgesvSolver PRIVATE ${OMC_SIMRT_CPP_SOLVER_DGESV_SOURCES})
 target_link_libraries(OMCppDgesvSolver PRIVATE omc::simrt::cpp::core::modelica)
 target_link_libraries(OMCppDgesvSolver PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppDgesvSolver PRIVATE ${LAPACK_LIBRARIES})
-
-target_link_options(OMCppDgesvSolver PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppDgesvSolver)
 
@@ -90,8 +84,6 @@ target_link_libraries(OMCppKinsol PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppKinsol PRIVATE omc::3rd::sundials::kinsol)
 target_link_libraries(OMCppKinsol PRIVATE ${LAPACK_LIBRARIES})
 
-target_link_options(OMCppKinsol PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppKinsol)
 
 
@@ -110,8 +102,6 @@ target_link_libraries(OMCppLinearSolver PRIVATE omc::simrt::cpp::core::modelica)
 target_link_libraries(OMCppLinearSolver PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppLinearSolver PRIVATE ${LAPACK_LIBRARIES})
 
-target_link_options(OMCppLinearSolver PRIVATE  -Wl,--no-undefined)
-
 install(TARGETS OMCppLinearSolver)
 
 
@@ -129,8 +119,6 @@ target_sources(OMCppNewton PRIVATE ${OMC_SIMRT_CPP_SOLVER_NEWTON_SOURCES})
 target_link_libraries(OMCppNewton PRIVATE omc::simrt::cpp::core::modelica)
 target_link_libraries(OMCppNewton PRIVATE omc::simrt::cpp::core::solver)
 target_link_libraries(OMCppNewton PRIVATE ${LAPACK_LIBRARIES})
-
-target_link_options(OMCppNewton PRIVATE  -Wl,--no-undefined)
 
 install(TARGETS OMCppNewton)
 

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -295,6 +295,3 @@ endif()
 
 target_include_directories(OMEditLib PRIVATE
   ${OMCompiler_SOURCE_DIR}/Compiler/Script)
-
-target_link_options(OMEditLib PRIVATE -Wl,--no-undefined)
-

--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -100,13 +100,7 @@ target_link_libraries(OMNotebook PUBLIC Qt5::WebKitWidgets)
 target_link_libraries(OMNotebook PUBLIC OMPlotLib)
 target_link_libraries(OMNotebook PUBLIC OpenModelicaCompiler)
 
-# target_link_options(OMNotebook PRIVATE -Wl,--no-undefined)
 
-
-# add_executable(OMNotebook qtapp.cpp)
-# target_link_libraries(OMNotebook PRIVATE OMNotebookLib)
-
-# install(TARGETS OMNotebookLib)
 install(TARGETS OMNotebook
         BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -39,9 +39,6 @@ target_link_libraries(OMPlotLib PUBLIC Qt5::PrintSupport)
 target_link_libraries(OMPlotLib PUBLIC qwt)
 target_link_libraries(OMPlotLib PUBLIC omc::simrt::runtime)
 
-target_link_options(OMPlotLib PRIVATE -Wl,--no-undefined)
-
-
 add_executable(OMPlot WIN32 MACOSX_BUNDLE main.cpp rc_omplot.rc)
 target_link_libraries(OMPlot PRIVATE OMPlotLib)
 

--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -255,8 +255,4 @@ set_target_properties(qwt PROPERTIES
   AUTOMOC ON)
 target_compile_definitions(qwt PRIVATE QWT_MOC_INCLUDE)
 
-target_link_options(qwt PRIVATE -Wl,--no-undefined)
-
-
-# install (FILES ${QWT_HEADERS} DESTINATION include/qwt)
 install (TARGETS qwt)

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -19,8 +19,6 @@ target_link_libraries(OMShellLib PUBLIC Qt5::PrintSupport)
 target_link_libraries(OMShellLib PUBLIC Qt5::WebKitWidgets)
 target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
 
-target_link_options(OMShellLib PRIVATE -Wl,--no-undefined)
-
 
 add_executable(OMShell WIN32 MACOSX_BUNDLE main.cpp rc_omshell.rc)
 target_link_libraries(OMShell PRIVATE OMShellLib)


### PR DESCRIPTION
  - This option was added explicitly to make sure we do not create create
    shared libraries that contained undefined references to some symbols.

    Shared libraries on linux (.so) are allowed to have undefined references.
    However, Windows shared libs (DLLs) can not. So we want to make sure
    that we do not have undefined references in our shared libs for them
    to be compilable on both.

  - However, the best way to enforce this is not to add it manually to
    every shared library without any checks to see if the flag is supported.
    It should only be done on systems and compilers that know the option.

    We can probably do a check to see which option enforces this behavior
    for the respective linker and then add that globally to
    `CMAKE_SHARED_LINKER_FLAGS`.

