### PR TITLE
Improve handling of `fill`

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill2.mo
@@ -8,12 +8,12 @@
 
 model FuncBuiltinFill2
   Integer n = 3;
-  Real x[3] = fill(0, n);
+  Real x[1, 3] = fill(0, 1, n);
 end FuncBuiltinFill2;
 
 // Result:
 // Error processing file: FuncBuiltinFill2.mo
-// [flattening/modelica/scodeinst/FuncBuiltinFill2.mo:11:3-11:25:writable] Error: Expression ‘n‘ that determines the size of dimension ‘1‘ of ‘fill(0, n)‘ is not an evaluable parameter expression.
+// [flattening/modelica/scodeinst/FuncBuiltinFill2.mo:11:3-11:31:writable] Error: Expression ‘n‘ that determines the size of dimension ‘2‘ of ‘fill(0, 1, n)‘ is not an evaluable parameter expression.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.


### PR DESCRIPTION
- Disable evaluation of `fill` during typing and let the simplification
  handle it instead, since evaluating it that early doesn't seem to be
  necessary and causes issues with the instance-based API.
- Fix the index counter used by the error message for non-parameter
  dimension expressions in `fill`.