### PR TITLE
Allow pure/impure in older Modelica versions

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Parser.mo
+++ b/OMCompiler/Compiler/FrontEnd/Parser.mo
@@ -95,9 +95,10 @@ function parsestring "Parse a string as if it were a stored definition"
   input String infoFilename = "<interactive>";
   input Integer grammar = Config.acceptedGrammar();
   input Integer languageStd = Flags.getConfigEnum(Flags.LANGUAGE_STANDARD);
+  input Boolean strict = Flags.getConfigBool(Flags.STRICT);
   output Absyn.Program outProgram;
 algorithm
-  outProgram := ParserExt.parsestring(str, infoFilename, grammar, languageStd, Testsuite.isRunning());
+  outProgram := ParserExt.parsestring(str, infoFilename, grammar, languageStd, strict, Testsuite.isRunning());
   /* Check that the program is not totally off the charts */
   _ := AbsynToSCode.translateAbsyn2SCode(outProgram);
 end parsestring;
@@ -109,13 +110,15 @@ function parsebuiltin "Like parse, but skips the SCode check to avoid infinite l
   input Option<Integer> lveInstance = NONE();
   input Integer acceptedGram=Config.acceptedGrammar();
   input Integer languageStandardInt=Flags.getConfigEnum(Flags.LANGUAGE_STANDARD);
+  input Boolean strict = Flags.getConfigBool(Flags.STRICT);
   output Absyn.Program outProgram;
   annotation(__OpenModelica_EarlyInline = true);
 protected
   String realpath;
 algorithm
   realpath := Util.replaceWindowsBackSlashWithPathDelimiter(System.realpath(filename));
-  outProgram := ParserExt.parse(realpath, Testsuite.friendly(realpath), acceptedGram, encoding, languageStandardInt, Testsuite.isRunning(), libraryPath, lveInstance);
+  outProgram := ParserExt.parse(realpath, Testsuite.friendly(realpath),
+    acceptedGram, encoding, languageStandardInt, strict, Testsuite.isRunning(), libraryPath, lveInstance);
 end parsebuiltin;
 
 function parsestringexp "Parse a string as if it was a sequence of statements"

--- a/OMCompiler/Compiler/FrontEnd/ParserExt.mo
+++ b/OMCompiler/Compiler/FrontEnd/ParserExt.mo
@@ -48,12 +48,13 @@ public function parse "Parse a mo-file"
   input Integer acceptedGram;
   input String encoding;
   input Integer languageStandardInt;
+  input Boolean strict;
   input Boolean runningTestsuite;
   input String libraryPath;
   input Option<Integer> lveInstance;
   output Absyn.Program outProgram;
 
-  external "C" outProgram=ParserExt_parse(filename, infoFilename, acceptedGram, languageStandardInt, encoding, runningTestsuite, libraryPath, lveInstance) annotation(Library = {"omparse","omantlr3","omcruntime"});
+  external "C" outProgram=ParserExt_parse(filename, infoFilename, acceptedGram, languageStandardInt, strict, encoding, runningTestsuite, libraryPath, lveInstance) annotation(Library = {"omparse","omantlr3","omcruntime"});
 end parse;
 
 public function parseexp "Parse a mos-file"
@@ -72,9 +73,10 @@ public function parsestring "Parse a string as if it were a stored definition"
   input String infoFilename = "<interactive>";
   input Integer acceptedGram;
   input Integer languageStandardInt;
+  input Boolean strict;
   input Boolean runningTestsuite;
   output Absyn.Program outProgram;
-  external "C" outProgram=ParserExt_parsestring(str,infoFilename, acceptedGram, languageStandardInt, runningTestsuite) annotation(Library = {"omparse","omantlr3","omcruntime"});
+  external "C" outProgram=ParserExt_parsestring(str,infoFilename, acceptedGram, languageStandardInt, strict, runningTestsuite) annotation(Library = {"omparse","omantlr3","omcruntime"});
 end parsestring;
 
 public function parsestringexp "Parse a string as if it was a sequence of statements"

--- a/OMCompiler/Compiler/boot/bootstrap-sources/build/ParserExt.c
+++ b/OMCompiler/Compiler/boot/bootstrap-sources/build/ParserExt.c
@@ -150,7 +150,7 @@ modelica_metatype _outProgram = NULL;
 _acceptedGram_ext = (int)_acceptedGram;
 _languageStandardInt_ext = (int)_languageStandardInt;
 _runningTestsuite_ext = (int)_runningTestsuite;
-_outProgram_ext = ParserExt_parsestring(MMC_STRINGDATA(_str), MMC_STRINGDATA(_infoFilename), _acceptedGram_ext, _languageStandardInt_ext, _runningTestsuite_ext);
+_outProgram_ext = ParserExt_parsestring(MMC_STRINGDATA(_str), MMC_STRINGDATA(_infoFilename), _acceptedGram_ext, _languageStandardInt_ext, 0, _runningTestsuite_ext);
 _outProgram = (modelica_metatype)_outProgram_ext;
 return _outProgram;
 }
@@ -204,7 +204,7 @@ _acceptedGram_ext = (int)_acceptedGram;
 _languageStandardInt_ext = (int)_languageStandardInt;
 _runningTestsuite_ext = (int)_runningTestsuite;
 _lveInstance_ext = (modelica_metatype)_lveInstance;
-_outProgram_ext = ParserExt_parse(MMC_STRINGDATA(_filename), MMC_STRINGDATA(_infoFilename), _acceptedGram_ext, _languageStandardInt_ext, MMC_STRINGDATA(_encoding), _runningTestsuite_ext, MMC_STRINGDATA(_libraryPath), _lveInstance_ext);
+_outProgram_ext = ParserExt_parse(MMC_STRINGDATA(_filename), MMC_STRINGDATA(_infoFilename), _acceptedGram_ext, _languageStandardInt_ext, 0, MMC_STRINGDATA(_encoding), _runningTestsuite_ext, MMC_STRINGDATA(_libraryPath), _lveInstance_ext);
 _outProgram = (modelica_metatype)_outProgram_ext;
 return _outProgram;
 }

--- a/OMCompiler/Compiler/boot/bootstrap-sources/build/ParserExt.h
+++ b/OMCompiler/Compiler/boot/bootstrap-sources/build/ParserExt.h
@@ -61,7 +61,7 @@ DLLExport
 modelica_metatype boxptr_ParserExt_parsestring(threadData_t *threadData, modelica_metatype _str, modelica_metatype _infoFilename, modelica_metatype _acceptedGram, modelica_metatype _languageStandardInt, modelica_metatype _runningTestsuite);
 static const MMC_DEFSTRUCTLIT(boxvar_lit_ParserExt_parsestring,2,0) {(void*) boxptr_ParserExt_parsestring,0}};
 #define boxvar_ParserExt_parsestring MMC_REFSTRUCTLIT(boxvar_lit_ParserExt_parsestring)
-extern modelica_metatype ParserExt_parsestring(const char* /*_str*/, const char* /*_infoFilename*/, int /*_acceptedGram*/, int /*_languageStandardInt*/, int /*_runningTestsuite*/);
+extern modelica_metatype ParserExt_parsestring(const char* /*_str*/, const char* /*_infoFilename*/, int /*_acceptedGram*/, int /*_languageStandardInt*/, int /*strict*/, int /*_runningTestsuite*/);
 DLLExport
 modelica_metatype omc_ParserExt_parseexp(threadData_t *threadData, modelica_string _filename, modelica_string _infoFilename, modelica_integer _acceptedGram, modelica_integer _languageStandardInt, modelica_boolean _runningTestsuite);
 DLLExport
@@ -75,7 +75,7 @@ DLLExport
 modelica_metatype boxptr_ParserExt_parse(threadData_t *threadData, modelica_metatype _filename, modelica_metatype _infoFilename, modelica_metatype _acceptedGram, modelica_metatype _encoding, modelica_metatype _languageStandardInt, modelica_metatype _runningTestsuite, modelica_metatype _libraryPath, modelica_metatype _lveInstance);
 static const MMC_DEFSTRUCTLIT(boxvar_lit_ParserExt_parse,2,0) {(void*) boxptr_ParserExt_parse,0}};
 #define boxvar_ParserExt_parse MMC_REFSTRUCTLIT(boxvar_lit_ParserExt_parse)
-extern modelica_metatype ParserExt_parse(const char* /*_filename*/, const char* /*_infoFilename*/, int /*_acceptedGram*/, int /*_languageStandardInt*/, const char* /*_encoding*/, int /*_runningTestsuite*/, const char* /*_libraryPath*/, modelica_metatype /*_lveInstance*/);
+extern modelica_metatype ParserExt_parse(const char* /*_filename*/, const char* /*_infoFilename*/, int /*_acceptedGram*/, int /*_languageStandardInt*/, int /*strict*/, const char* /*_encoding*/, int /*_runningTestsuite*/, const char* /*_libraryPath*/, modelica_metatype /*_lveInstance*/);
 #ifdef __cplusplus
 }
 #endif

--- a/OMCompiler/Parser/ModelicaParserCommon.h
+++ b/OMCompiler/Parser/ModelicaParserCommon.h
@@ -65,6 +65,7 @@ DLLDirection extern pthread_key_t modelicaParserKey;
 #define ModelicaParser_readonly ((parser_members*)pthread_getspecific(modelicaParserKey))->readonly
 #define ModelicaParser_flags ((parser_members*)pthread_getspecific(modelicaParserKey))->flags
 #define ModelicaParser_langStd ((parser_members*)pthread_getspecific(modelicaParserKey))->langStd
+#define ModelicaParser_strict ((parser_members*)pthread_getspecific(modelicaParserKey))->strict
 #define ModelicaParser_lexerError ((parser_members*)pthread_getspecific(modelicaParserKey))->lexerError
 #define ModelicaParser_encoding ((parser_members*)pthread_getspecific(modelicaParserKey))->encoding
 #define ModelicaParser_threadData ((threadData_t*)pthread_getspecific(mmc_thread_data_key))
@@ -85,6 +86,7 @@ typedef struct antlr_members_struct {
   int readonly;
   int flags;
   int langStd;
+  int strict;
 #if !defined(OMJULIA)
   threadData_t *threadData;
 #endif

--- a/OMCompiler/Parser/Modelica_3_Lexer.g
+++ b/OMCompiler/Parser/Modelica_3_Lexer.g
@@ -58,5 +58,5 @@ POWER_EW : '.^'; /* Modelica 3.0 */
 /* Modelica 3.1 */
 STREAM : 'stream' { if (ModelicaParser_langStd < 31) $type = IDENT; }; /* for Modelica 3.1 stream connectors */
 /* Modelica 3.3 */
-PURE : 'pure' { if (ModelicaParser_langStd < 33) $type = IDENT; }; /* for Modelica 3.3 pure functions */
-IMPURE : 'impure' { if (ModelicaParser_langStd < 33) $type = IDENT; }; /* for Modelica 3.3 impure functions */
+PURE : 'pure' { if (ModelicaParser_langStd < 33 && ModelicaParser_strict) $type = IDENT; }; /* for Modelica 3.3 pure functions */
+IMPURE : 'impure' { if (ModelicaParser_langStd < 33 && ModelicaParser_strict) $type = IDENT; }; /* for Modelica 3.3 impure functions */

--- a/OMCompiler/Parser/Parser_omc.c
+++ b/OMCompiler/Parser/Parser_omc.c
@@ -48,11 +48,11 @@ static int set_grammar_flag(int flags, int grammar)
   return flags;
 }
 
-void* ParserExt_parse(const char* filename, const char* infoname, int acceptedGrammar, int langStd, const char* encoding, int runningTestsuite, const char* libraryPath, void* lveInstance)
+void* ParserExt_parse(const char* filename, const char* infoname, int acceptedGrammar, int langStd, int strict, const char* encoding, int runningTestsuite, const char* libraryPath, void* lveInstance)
 {
   int flags = set_grammar_flag(PARSE_MODELICA, acceptedGrammar);
 
-  void *res = parseFile(filename, infoname, flags, encoding, langStd, runningTestsuite, libraryPath, lveInstance);
+  void *res = parseFile(filename, infoname, flags, encoding, langStd, strict, runningTestsuite, libraryPath, lveInstance);
   if (res == NULL)
     MMC_THROW();
   // printAny(res);
@@ -63,17 +63,17 @@ void* ParserExt_parseexp(const char* filename, const char* infoname, int accepte
 {
   int flags = set_grammar_flag(PARSE_EXPRESSION, acceptedGrammar);
 
-  void *res = parseFile(filename, infoname, flags, "UTF-8", langStd, runningTestsuite, "", 0);
+  void *res = parseFile(filename, infoname, flags, "UTF-8", langStd, 0, runningTestsuite, "", 0);
   if (res == NULL)
     MMC_THROW();
   return res;
 }
 
-void* ParserExt_parsestring(const char* data, const char* filename, int acceptedGrammar, int langStd, int runningTestsuite)
+void* ParserExt_parsestring(const char* data, const char* filename, int acceptedGrammar, int langStd, int strict, int runningTestsuite)
 {
   int flags = set_grammar_flag(PARSE_MODELICA, acceptedGrammar);
 
-  void *res = parseString(data, filename, flags, langStd, runningTestsuite);
+  void *res = parseString(data, filename, flags, langStd, strict, runningTestsuite);
   if (res != NULL) {
     return res;
   } else {
@@ -85,7 +85,7 @@ void* ParserExt_parsestringexp(const char* data, const char* filename, int accep
 {
   int flags = set_grammar_flag(PARSE_EXPRESSION, acceptedGrammar);
 
-  void *res = parseString(data, filename, flags, langStd, runningTestsuite);
+  void *res = parseString(data, filename, flags, langStd, 0, runningTestsuite);
   if (res != NULL) {
     return res;
   } else {
@@ -97,7 +97,7 @@ void* ParserExt_stringPath(const char* data, const char* filename, int acceptedG
 {
   int flags = set_grammar_flag(PARSE_PATH, acceptedGrammar);
 
-  void *res = parseString(data, filename, flags, langStd, runningTestsuite);
+  void *res = parseString(data, filename, flags, langStd, 0, runningTestsuite);
   if (res != NULL) {
     return res;
   } else {
@@ -109,7 +109,7 @@ void* ParserExt_stringCref(const char* data, const char* filename, int acceptedG
 {
   int flags = set_grammar_flag(PARSE_CREF, acceptedGrammar);
 
-  void *res = parseString(data, filename, flags, langStd, runningTestsuite);
+  void *res = parseString(data, filename, flags, langStd, 0, runningTestsuite);
   if (res != NULL) {
     return res;
   } else {
@@ -121,7 +121,7 @@ void* ParserExt_stringMod(const char* data, const char* filename, int acceptedGr
 {
   int flags = set_grammar_flag(PARSE_MODIFIER, acceptedGrammar);
 
-  void *res = parseString(data, filename, flags, langStd, runningTestsuite);
+  void *res = parseString(data, filename, flags, langStd, 0, runningTestsuite);
   if (res != NULL) {
     return res;
   } else {

--- a/OMCompiler/Parser/parse.c
+++ b/OMCompiler/Parser/parse.c
@@ -261,7 +261,7 @@ static void handleParseError(pANTLR3_BASE_RECOGNIZER recognizer, pANTLR3_UINT8 *
 
 }
 
-static void* parseStream(pANTLR3_INPUT_STREAM input, int langStd, int runningTestsuite)
+static void* parseStream(pANTLR3_INPUT_STREAM input, int langStd, int strict, int runningTestsuite)
 {
   pANTLR3_LEXER               pLexer;
   pANTLR3_COMMON_TOKEN_STREAM tstream;
@@ -277,6 +277,7 @@ static void* parseStream(pANTLR3_INPUT_STREAM input, int langStd, int runningTes
   ModelicaParser_filename_C = strdup(ModelicaParser_filename_C);
   ModelicaParser_filename_OMC = mmc_mk_scon(ModelicaParser_filename_C);
   ModelicaParser_langStd = langStd;
+  ModelicaParser_strict = strict;
 
   if (ModelicaParser_flags & PARSE_META_MODELICA) {
     lxr = MetaModelica_LexerNew(input);
@@ -357,7 +358,7 @@ static void* parseStream(pANTLR3_INPUT_STREAM input, int langStd, int runningTes
   return res;
 }
 
-static void* parseString(const char* data, const char* interactiveFilename, int flags, int langStd, int runningTestsuite)
+static void* parseString(const char* data, const char* interactiveFilename, int flags, int langStd, int strict, int runningTestsuite)
 {
   bool debug         = false; //check_debug_flag("parsedebug");
   time_t current_time = time(NULL);
@@ -390,14 +391,14 @@ static void* parseString(const char* data, const char* interactiveFilename, int 
     fprintf(stderr, "Unable to open file %s\n", members.filename_C); fflush(stderr);
     return NULL;
   }
-  return parseStream(input, langStd, runningTestsuite);
+  return parseStream(input, langStd, strict, runningTestsuite);
 }
 
 #ifdef OMENCRYPTION
 #include "../../OMEncryption/Parser/parseEncryption.c"
 #endif
 
-static void* parseFile(const char* fileName, const char* infoName, int flags, const char *encoding, int langStd, int runningTestsuite, const char* libraryPath, void* lveInstance)
+static void* parseFile(const char* fileName, const char* infoName, int flags, const char *encoding, int langStd, int strict, int runningTestsuite, const char* libraryPath, void* lveInstance)
 {
   bool debug         = false; //check_debug_flag("parsedebug");
   bool genBootstrappingSources = false;
@@ -449,7 +450,7 @@ static void* parseFile(const char* fileName, const char* infoName, int flags, co
   omc_stat(members.filename_C, &st);
   members.timestamp = genBootstrappingSources ? mmc_mk_rcon((double)0.0) : mmc_mk_rcon((double)st.st_mtime);
   members.filename_C = genBootstrappingSources ? members.filename_C_testsuiteFriendly : members.filename_C;
-  if (0 == st.st_size) return parseString("",members.filename_C,ModelicaParser_flags, langStd, runningTestsuite);
+  if (0 == st.st_size) return parseString("",members.filename_C,ModelicaParser_flags, langStd, strict, runningTestsuite);
 
   fName  = (pANTLR3_UINT8)fileName;
 #if defined(ANTLR_C_VERSION_3_2)
@@ -462,7 +463,7 @@ static void* parseFile(const char* fileName, const char* infoName, int flags, co
   if ( input == NULL ) {
     return NULL;
   }
-  return parseStream(input, langStd, runningTestsuite);
+  return parseStream(input, langStd, strict, runningTestsuite);
 }
 
 int startLibraryVendorExecutable(const char* path, void** lveInstance)

--- a/testsuite/openmodelica/parser/Makefile
+++ b/testsuite/openmodelica/parser/Makefile
@@ -41,6 +41,8 @@ ParseFullModelica3.1.mos \
 ParseFullModelica3.2.1.mos \
 ParseString.mos \
 PureImpure.mo \
+PureImpure2.mo \
+PureImpure3.mo \
 RealOpLexerModelica.mo \
 Redeclare.mos \
 ReloadClass.mos \

--- a/testsuite/openmodelica/parser/PureImpure2.mo
+++ b/testsuite/openmodelica/parser/PureImpure2.mo
@@ -1,0 +1,21 @@
+// name: PureImpure2
+// keywords:
+// status: correct
+// cflags: -d=newInst --std=3.2
+//
+// Checks that pure/impure are allowed in Modelica 3.2 when not using --strict.
+//
+
+pure function f1
+end f1;
+
+impure function f2
+end f2;
+
+model PureImpure2
+end PureImpure2;
+
+// Result:
+// class PureImpure2
+// end PureImpure2;
+// endResult

--- a/testsuite/openmodelica/parser/PureImpure3.mo
+++ b/testsuite/openmodelica/parser/PureImpure3.mo
@@ -1,0 +1,29 @@
+// name: PureImpure3
+// keywords:
+// status: incorrect
+// cflags: -d=newInst --std=3.2 --strict
+//
+// Checks that pure/impure are not allowed in Modelica 3.2 when using --strict.
+//
+
+pure function f1
+end f1;
+
+impure function f2
+end f2;
+
+model PureImpure3
+end PureImpure3;
+
+// Result:
+// Error processing file: PureImpure3.mo
+// Failed to parse file: PureImpure3.mo!
+//
+// [openmodelica/parser/PureImpure3.mo:9:1-9:5:writable] Error: Parser error: Unexpected token near: pure (IDENT)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+// Failed to parse file: PureImpure3.mo!
+//
+// Execution failed!
+// endResult


### PR DESCRIPTION
- Allow the use of pure/impure in Modelica versions older than 3.3 if
  `--strict` isn't used.

Fixes #8800