### PR TITLE
Improve MacOS rpath handling for the GUI clients.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,11 +113,11 @@ set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/${CMAKE_LIBRARY_ARCHITECTURE}/o
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/omc/)
 
 ## Set the adjusted installation lib directory as an rpath for all installed binaries.
-## This is useful for those binaries that end up in bin/ directory but not for
-## others as it is a relative path to the lib dir from <build_dir>/<some_dir>.
-## Maybe there is a better way to do this but it should suffice for now.
+## Assumes binaries end up in either 'bin' or 'lib' AND also assumes that 'bin' and 'lib' are sibling directories.
 if(APPLE)
-  set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}")
+  ## MacOS Bundles end up in bin/<BundleName>.app/Contents/MacOS/
+  ## So make sure that the lib dir is referenced from that location as well
+  set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path/../../../../${CMAKE_INSTALL_LIBDIR}")
 else()
   set(CMAKE_INSTALL_RPATH "$ORIGIN;$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
 endif()

--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(OpenSceneGraph COMPONENTS osgViewer osgDB osgGA REQUIRED)
 
 # Configure omedit_config.h. This will be generated in the build directory
 configure_file(omedit_config.h.in omedit_config.h)
-## Add a config library for OMEdit. They will provide access to common config headres such as
+## Add a config library for OMEdit. It will provide access to common config headres such as
 ## config.h. So by linking to this library you get the include directories.
 add_library(omedit_config INTERFACE)
 add_library(omedit::config ALIAS omedit_config)

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -173,12 +173,19 @@ This can be useful if you want to redirect output to a file for example.
 ## 4.4. Enabling Verbose Output
 Sometimes you might want to get a verbose output to see what CMake is actually doing and what exact commands it is issuing.
 
+If you are using CMake itself to issue builds (recommended) instead of invoking the generator directly, you can specify `-v` to the build command
+
+```sh
+cmake --build build_cmake -v
+```
+
 For Makefile generators (which, probably, is by far the most common usage), you can tell GNU Make itself to give you verbose output at compile time
 ```sh
 make VERBOSE=1
 ```
 
-This has the advantage of allowing you to get verbose output only when you want it.
+The above two approaches have the advantage of allowing you to get verbose output only when you want it.
+
 
 If you instead want to see verbose output every time you compile any change then you can tell CMake at configure time to always do that
 


### PR DESCRIPTION
  - MacOS bundles are installed in `bin/<BundleName>.app/Contents/MacOS/`
    as opposed to just `bin/` like other executables.

    Make sure the rpath handling reflects the relative path from that
    directory to the lib directory.

  - Minor update to the CMake documentation.
