### PR TITLE
Create a new scale engine

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlot.h
@@ -51,7 +51,6 @@ class PlotGrid;
 class PlotZoomer;
 class PlotPanner;
 class PlotPicker;
-class LinearScaleEngine;
 class ScaleDraw;
 class PlotCurve;
 
@@ -62,8 +61,6 @@ private:
   PlotWindow *mpParentPlotWindow;
   Legend *mpLegend;
   PlotGrid *mpPlotGrid;
-  LinearScaleEngine *mpXLinearScaleEngine;
-  LinearScaleEngine *mpYLinearScaleEngine;
   ScaleDraw *mpXScaleDraw;
   ScaleDraw *mpYScaleDraw;
   PlotZoomer *mpPlotZoomer;
@@ -81,8 +78,6 @@ public:
   Legend* getLegend();
   PlotPicker *getPlotPicker();
   PlotGrid* getPlotGrid();
-  LinearScaleEngine* getXLinearScaleEngine() const {return mpXLinearScaleEngine;}
-  LinearScaleEngine* getYLinearScaleEngine() const {return mpYLinearScaleEngine;}
   ScaleDraw *getXScaleDraw() const {return mpXScaleDraw;}
   ScaleDraw *getYScaleDraw() const {return mpYScaleDraw;}
   PlotZoomer* getPlotZoomer();

--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -55,11 +55,11 @@ Plot::Plot(PlotWindow *pParent)
   // create an instance of grid
   mpPlotGrid = new PlotGrid(this);
   // create the scale engine
-  mpXLinearScaleEngine = new LinearScaleEngine;
-  setAxisScaleEngine(QwtPlot::xBottom, mpXLinearScaleEngine);
+  LinearScaleEngine *pXLinearScaleEngine = new LinearScaleEngine;
+  setAxisScaleEngine(QwtPlot::xBottom, pXLinearScaleEngine);
   setAxisAutoScale(QwtPlot::xBottom);
-  mpYLinearScaleEngine = new LinearScaleEngine;
-  setAxisScaleEngine(QwtPlot::yLeft, mpYLinearScaleEngine);
+  LinearScaleEngine *pYLinearScaleEngine = new LinearScaleEngine;
+  setAxisScaleEngine(QwtPlot::yLeft, pYLinearScaleEngine);
   setAxisAutoScale(QwtPlot::yLeft);
   // create the scale draw
   mpXScaleDraw = new ScaleDraw(QwtPlot::xBottom, this);

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -1809,7 +1809,7 @@ void PlotWindow::setLogX(bool on)
   }
   else
   {
-    mpPlot->setAxisScaleEngine(QwtPlot::xBottom, mpPlot->getXLinearScaleEngine());
+    mpPlot->setAxisScaleEngine(QwtPlot::xBottom, new LinearScaleEngine);
   }
   mpPlot->setAxisAutoScale(QwtPlot::xBottom);
   mpLogXCheckBox->blockSignals(true);
@@ -1830,7 +1830,7 @@ void PlotWindow::setLogY(bool on)
   }
   else
   {
-    mpPlot->setAxisScaleEngine(QwtPlot::yLeft, mpPlot->getYLinearScaleEngine());
+    mpPlot->setAxisScaleEngine(QwtPlot::yLeft, new LinearScaleEngine);
   }
   mpPlot->setAxisAutoScale(QwtPlot::yLeft);
   mpLogYCheckBox->blockSignals(true);


### PR DESCRIPTION
### Purpose

Avoid crash when switching between logarithmic plots.

### Approach

Qwt deletes the existing scale engine when it sets the new one. So always a create a new scale engine.
