### PR TITLE
Improve instantiation in relaxed contexts

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -153,7 +153,8 @@ algorithm
 
   // Flatten the model and evaluate constants in it.
   flatModel := Flatten.flatten(inst_cls, name);
-  flatModel := EvalConstants.evaluate(flatModel);
+  flatModel := EvalConstants.evaluate(flatModel, context);
+
   InstUtil.dumpFlatModelDebug("eval", flatModel);
 
   // Do unit checking

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -104,7 +104,7 @@ protected
   Binding.Source bind_src;
   Boolean force_scalar_attributes = false;
 algorithm
-  if Type.isArray(var.ty) then
+  if Type.isArray(var.ty) and Type.hasKnownSize(var.ty) then
     try
       Variable.VARIABLE(name, ty, binding, vis, attr, ty_attr, _, cmt, info, binfo) := var;
       crefs := ComponentRef.scalarize(name);

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -722,7 +722,7 @@ algorithm
 
   // Flatten and simplify the model.
   flat_model := Flatten.flatten(inst_cls, name);
-  flat_model := EvalConstants.evaluate(flat_model);
+  flat_model := EvalConstants.evaluate(flat_model, NFInstContext.RELAXED);
   flat_model := UnitCheck.checkUnits(flat_model);
   flat_model := SimplifyModel.simplify(flat_model);
   flat_model := Package.collectConstants(flat_model);


### PR DESCRIPTION
- Allow dimensions to be unevaluable in relaxed contexts.
- Avoid scalarizing array variables with unknown dimensions.
- Allow variables to have unevaluable bindings in EvalConstants in
  relaxed contexts.

Fixes #3944