### PR TITLE
Refactor Component.Attributes

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -311,6 +311,7 @@ set(OMC_MM_BACKEND_SOURCES
     # "NFFrontEnd";
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFAlgorithm.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFArrayConnections.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFAttributes.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFBackendExtension.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFBinding.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFBuiltinCall.mo

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -44,10 +44,10 @@ public
   import SCodeUtil;
 
   //NF Imports
+  import Attributes = NFAttributes;
   import BackendExtension = NFBackendExtension;
   import NFBackendExtension.BackendInfo;
   import NFBinding.Binding;
-  import Component = NFComponent;
   import ComponentRef = NFComponentRef;
   import Dimension = NFDimension;
   import Expression = NFExpression;
@@ -79,11 +79,11 @@ public
   //               Single Variable constants and functions
   // ==========================================================================
   constant Variable DUMMY_VARIABLE = Variable.VARIABLE(ComponentRef.EMPTY(), Type.ANY(),
-    NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFComponent.DEFAULT_ATTR,
+    NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFAttributes.DEFAULT_ATTR,
     {}, {}, NONE(), SCodeUtil.dummyInfo, NFBackendExtension.DUMMY_BACKEND_INFO);
 
   constant Variable TIME_VARIABLE = Variable.VARIABLE(NFBuiltin.TIME_CREF, Type.REAL(),
-    NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFComponent.DEFAULT_ATTR,
+    NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFAttributes.DEFAULT_ATTR,
     {}, {}, NONE(), SCodeUtil.dummyInfo, BackendExtension.BACKEND_INFO(
     BackendExtension.VariableKind.TIME(), NFBackendExtension.EMPTY_VAR_ATTR_REAL));
 
@@ -146,7 +146,7 @@ public
     ty := ComponentRef.getSubscriptedType(cref, true);
     vis := InstNode.visibility(node);
     info := InstNode.info(node);
-    variable := Variable.VARIABLE(cref, ty, binding, vis, NFComponent.DEFAULT_ATTR, {}, {}, NONE(), info, NFBackendExtension.DUMMY_BACKEND_INFO);
+    variable := Variable.VARIABLE(cref, ty, binding, vis, NFAttributes.DEFAULT_ATTR, {}, {}, NONE(), info, NFBackendExtension.DUMMY_BACKEND_INFO);
   end fromCref;
 
   function makeVarPtrCyclic
@@ -423,8 +423,8 @@ public
   algorithm
     b := match Pointer.access(var)
       local
-        Component.Direction direction;
-      case Variable.VARIABLE(attributes = Component.Attributes.ATTRIBUTES(direction = NFComponent.Direction.INPUT)) then true;
+        Prefixes.Direction direction;
+      case Variable.VARIABLE(attributes = Attributes.ATTRIBUTES(direction = NFPrefixes.Direction.INPUT)) then true;
       else false;
     end match;
   end isInput;
@@ -435,8 +435,8 @@ public
   algorithm
     b := match Pointer.access(var)
       local
-        Component.Direction direction;
-      case Variable.VARIABLE(attributes = Component.Attributes.ATTRIBUTES(direction = NFComponent.Direction.OUTPUT)) then true;
+        Prefixes.Direction direction;
+      case Variable.VARIABLE(attributes = Attributes.ATTRIBUTES(direction = NFPrefixes.Direction.OUTPUT)) then true;
       else false;
     end match;
   end isOutput;

--- a/OMCompiler/Compiler/NFFrontEnd/NFAttributes.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFAttributes.mo
@@ -1,0 +1,618 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Linköping University,
+ * Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3
+ * AND THIS OSMC PUBLIC LICENSE (OSMC-PL).
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES RECIPIENT'S
+ * ACCEPTANCE OF THE OSMC PUBLIC LICENSE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from Linköping University, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS
+ * OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated uniontype NFAttributes
+
+  import InstContext = NFInstContext;
+  import NFInstNode.InstNode;
+  import NFPrefixes.*;
+  import SCode;
+  import Restriction = NFRestriction;
+
+protected
+  import Class = NFClass;
+  import IOStream;
+  import Prefixes = NFPrefixes;
+  import SCodeUtil;
+
+  import Attributes = NFAttributes;
+
+public
+  constant Attributes DEFAULT_ATTR =
+    ATTRIBUTES(
+      ConnectorType.NON_CONNECTOR,
+      Parallelism.NON_PARALLEL,
+      Variability.CONTINUOUS,
+      Direction.NONE,
+      InnerOuter.NOT_INNER_OUTER,
+      false,
+      false,
+      Replaceable.NOT_REPLACEABLE()
+    );
+
+  constant Attributes INPUT_ATTR =
+    ATTRIBUTES(
+      ConnectorType.NON_CONNECTOR,
+      Parallelism.NON_PARALLEL,
+      Variability.CONTINUOUS,
+      Direction.INPUT,
+      InnerOuter.NOT_INNER_OUTER,
+      false,
+      false,
+      Replaceable.NOT_REPLACEABLE()
+    );
+
+  constant Attributes OUTPUT_ATTR =
+    ATTRIBUTES(
+      ConnectorType.NON_CONNECTOR,
+      Parallelism.NON_PARALLEL,
+      Variability.CONTINUOUS,
+      Direction.OUTPUT,
+      InnerOuter.NOT_INNER_OUTER,
+      false,
+      false,
+      Replaceable.NOT_REPLACEABLE()
+    );
+
+  constant Attributes CONSTANT_ATTR =
+    ATTRIBUTES(
+      ConnectorType.NON_CONNECTOR,
+      Parallelism.NON_PARALLEL,
+      Variability.CONSTANT,
+      Direction.NONE,
+      InnerOuter.NOT_INNER_OUTER,
+      false,
+      false,
+      Replaceable.NOT_REPLACEABLE()
+    );
+
+  constant Attributes IMPL_DISCRETE_ATTR =
+    ATTRIBUTES(
+      ConnectorType.NON_CONNECTOR,
+      Parallelism.NON_PARALLEL,
+      Variability.IMPLICITLY_DISCRETE,
+      Direction.NONE,
+      InnerOuter.NOT_INNER_OUTER,
+      false,
+      false,
+      Replaceable.NOT_REPLACEABLE()
+    );
+
+  record ATTRIBUTES
+    ConnectorType.Type connectorType;
+    Parallelism parallelism;
+    Variability variability;
+    Direction direction;
+    InnerOuter innerOuter;
+    Boolean isFinal;
+    Boolean isRedeclare;
+    Replaceable isReplaceable;
+  end ATTRIBUTES;
+
+  function fromSCode
+    input SCode.Attributes compAttr;
+    input SCode.Prefixes compPrefs;
+    output Attributes attributes;
+  protected
+    ConnectorType.Type cty;
+    Parallelism par;
+    Variability var;
+    Direction dir;
+    InnerOuter io;
+    Boolean fin, redecl;
+    Replaceable repl;
+  algorithm
+    attributes := match (compAttr, compPrefs)
+      case (SCode.Attributes.ATTR(
+              connectorType = SCode.ConnectorType.POTENTIAL(),
+              parallelism = SCode.Parallelism.NON_PARALLEL(),
+              variability = SCode.Variability.VAR(),
+              direction = Absyn.Direction.BIDIR()),
+            SCode.Prefixes.PREFIXES(
+              redeclarePrefix = SCode.Redeclare.NOT_REDECLARE(),
+              finalPrefix = SCode.Final.NOT_FINAL(),
+              innerOuter = Absyn.InnerOuter.NOT_INNER_OUTER(),
+              replaceablePrefix = SCode.Replaceable.NOT_REPLACEABLE()))
+        then NFAttributes.DEFAULT_ATTR;
+
+      else
+        algorithm
+          cty := ConnectorType.fromSCode(compAttr.connectorType);
+          par := Prefixes.parallelismFromSCode(compAttr.parallelism);
+          var := Prefixes.variabilityFromSCode(compAttr.variability);
+          dir := Prefixes.directionFromSCode(compAttr.direction);
+          io  := Prefixes.innerOuterFromSCode(compPrefs.innerOuter);
+          fin := SCodeUtil.finalBool(compPrefs.finalPrefix);
+          redecl := SCodeUtil.redeclareBool(compPrefs.redeclarePrefix);
+          repl := Replaceable.NOT_REPLACEABLE();
+        then
+          Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl);
+    end match;
+  end fromSCode;
+
+  function fromDerivedSCode
+    input SCode.Attributes scodeAttr;
+    output Attributes attributes;
+  protected
+    ConnectorType.Type cty;
+    Variability var;
+    Direction dir;
+  algorithm
+    attributes := match scodeAttr
+      case SCode.Attributes.ATTR(
+             connectorType = SCode.ConnectorType.POTENTIAL(),
+             variability = SCode.Variability.VAR(),
+             direction = Absyn.Direction.BIDIR())
+        then DEFAULT_ATTR;
+
+      else
+        algorithm
+          cty := ConnectorType.fromSCode(scodeAttr.connectorType);
+          var := Prefixes.variabilityFromSCode(scodeAttr.variability);
+          dir := Prefixes.directionFromSCode(scodeAttr.direction);
+        then
+          ATTRIBUTES(cty, Parallelism.NON_PARALLEL,
+            var, dir, InnerOuter.NOT_INNER_OUTER, false, false, Replaceable.NOT_REPLACEABLE());
+
+    end match;
+  end fromDerivedSCode;
+
+  function mergeComponentAttributes
+    input Attributes outerAttr;
+    input Attributes innerAttr;
+    input InstNode node;
+    input Restriction parentRestriction;
+    output Attributes attr;
+  protected
+    ConnectorType.Type cty;
+    Parallelism par;
+    Variability var;
+    Direction dir;
+    Boolean fin, redecl;
+    Replaceable repl;
+  algorithm
+    if referenceEq(outerAttr, NFAttributes.DEFAULT_ATTR) and innerAttr.connectorType == 0 then
+      attr := innerAttr;
+    elseif referenceEq(innerAttr, NFAttributes.DEFAULT_ATTR) then
+      cty := ConnectorType.merge(outerAttr.connectorType, innerAttr.connectorType, node);
+      attr := Attributes.ATTRIBUTES(cty, outerAttr.parallelism,
+        outerAttr.variability, outerAttr.direction, innerAttr.innerOuter, outerAttr.isFinal,
+        innerAttr.isRedeclare, innerAttr.isReplaceable);
+    else
+      cty := ConnectorType.merge(outerAttr.connectorType, innerAttr.connectorType, node);
+      par := Prefixes.mergeParallelism(outerAttr.parallelism, innerAttr.parallelism, node);
+      var := Prefixes.variabilityMin(outerAttr.variability, innerAttr.variability);
+
+      if Restriction.isFunction(parentRestriction) then
+        dir := innerAttr.direction;
+      else
+        dir := Prefixes.mergeDirection(outerAttr.direction, innerAttr.direction, node);
+      end if;
+
+      fin := outerAttr.isFinal or innerAttr.isFinal;
+      redecl := innerAttr.isRedeclare;
+      repl := innerAttr.isReplaceable;
+      attr := Attributes.ATTRIBUTES(cty, par, var, dir, innerAttr.innerOuter, fin, redecl, repl);
+    end if;
+  end mergeComponentAttributes;
+
+  function mergeDerivedAttributes
+    input Attributes outerAttr;
+    input Attributes innerAttr;
+    input InstNode node;
+    output Attributes attr;
+  protected
+    ConnectorType.Type cty;
+    Parallelism par;
+    Variability var;
+    Direction dir;
+    InnerOuter io;
+    Boolean fin, redecl;
+    Replaceable repl;
+  algorithm
+    if referenceEq(innerAttr, NFAttributes.DEFAULT_ATTR) and outerAttr.connectorType == 0 then
+      attr := outerAttr;
+    elseif referenceEq(outerAttr, NFAttributes.DEFAULT_ATTR) and innerAttr.connectorType == 0 then
+      attr := innerAttr;
+    else
+      Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl) := outerAttr;
+      cty := ConnectorType.merge(cty, innerAttr.connectorType, node, isClass = true);
+      var := Prefixes.variabilityMin(var, innerAttr.variability);
+      dir := Prefixes.mergeDirection(dir, innerAttr.direction, node, allowSame = true);
+      attr := Attributes.ATTRIBUTES(cty, par, var, dir, innerAttr.innerOuter, fin, redecl, repl);
+    end if;
+  end mergeDerivedAttributes;
+
+  function mergeRedeclaredComponentAttributes
+    input Attributes origAttr;
+    input Attributes redeclAttr;
+    input InstNode node;
+    output Attributes attr;
+  protected
+    ConnectorType.Type cty, rcty, cty_fs, rcty_fs;
+    Parallelism par, rpar;
+    Variability var, rvar;
+    Direction dir, rdir;
+    InnerOuter io, rio;
+    Boolean fin;
+    Boolean redecl;
+    Replaceable repl;
+  algorithm
+    if referenceEq(origAttr, NFAttributes.DEFAULT_ATTR) then
+      attr := redeclAttr;
+    elseif referenceEq(redeclAttr, NFAttributes.DEFAULT_ATTR) then
+      attr := origAttr;
+    else
+      Attributes.ATTRIBUTES(cty, par, var, dir, io, _, _, _) := origAttr;
+      Attributes.ATTRIBUTES(rcty, rpar, rvar, rdir, rio, fin, redecl, repl) := redeclAttr;
+
+      // If no prefix is given for one of these attributes in the redeclaration,
+      // then the one from the original declaration is used. The redeclare is not
+      // allowed to change an existing prefix on the original declaration, except
+      // for the variability which can be lowered (e.g. parameter -> constant) and
+      // final which is always taken from the redeclare (since redeclaring a final
+      // element isn't allowed).
+
+      rcty_fs := intBitAnd(rcty, ConnectorType.FLOW_STREAM_MASK);
+      cty_fs := intBitAnd(cty, ConnectorType.FLOW_STREAM_MASK);
+      if rcty_fs > 0 then
+        if cty_fs > 0 and rcty_fs <> cty_fs then
+          printRedeclarePrefixError(node, ConnectorType.toString(rcty), ConnectorType.toString(cty));
+        end if;
+      end if;
+
+      if rpar <> Parallelism.NON_PARALLEL then
+        if par <> Parallelism.NON_PARALLEL and par <> rpar then
+          printRedeclarePrefixError(node, Prefixes.parallelismString(rpar), Prefixes.parallelismString(par));
+        end if;
+
+        par := rpar;
+      end if;
+
+      if rvar <> Variability.CONTINUOUS then
+        if rvar > var then
+          printRedeclarePrefixError(node, Prefixes.variabilityString(rvar), Prefixes.variabilityString(var));
+        end if;
+
+        var := rvar;
+      end if;
+
+      if rdir <> Direction.NONE then
+      if dir <> Direction.NONE and rdir <> dir then
+          printRedeclarePrefixError(node, Prefixes.directionString(rdir), Prefixes.directionString(dir));
+        end if;
+
+        dir := rdir;
+      end if;
+
+      if rio <> InnerOuter.NOT_INNER_OUTER then
+        if io <> InnerOuter.NOT_INNER_OUTER and rio <> io then
+          printRedeclarePrefixError(node, Prefixes.innerOuterString(rio), Prefixes.innerOuterString(io));
+        end if;
+
+        io := rio;
+      end if;
+
+      attr := Attributes.ATTRIBUTES(rcty, par, var, dir, io, fin, redecl, repl);
+    end if;
+  end mergeRedeclaredComponentAttributes;
+
+  function mergeRedeclaredClassPrefixes
+    input Class.Prefixes origPrefs;
+    input Class.Prefixes redeclPrefs;
+    input InstNode node;
+    output Class.Prefixes prefs;
+  protected
+    SCode.Encapsulated enc;
+    SCode.Partial par;
+    SCode.Final fin;
+    Absyn.InnerOuter io, rio;
+    SCode.Replaceable repl;
+  algorithm
+    if referenceEq(origPrefs, NFClass.DEFAULT_PREFIXES) then
+      prefs := redeclPrefs;
+    else
+      Class.Prefixes.PREFIXES(innerOuter = io) := origPrefs;
+      Class.Prefixes.PREFIXES(enc, par, fin, rio, repl) := redeclPrefs;
+
+      io := match (io, rio)
+        case (Absyn.InnerOuter.NOT_INNER_OUTER(), _) then rio;
+        case (_, Absyn.InnerOuter.NOT_INNER_OUTER()) then io;
+        case (Absyn.InnerOuter.INNER(), Absyn.InnerOuter.INNER()) then io;
+        case (Absyn.InnerOuter.OUTER(), Absyn.InnerOuter.OUTER()) then io;
+        case (Absyn.InnerOuter.INNER_OUTER(), Absyn.InnerOuter.INNER_OUTER()) then io;
+        else
+          algorithm
+            printRedeclarePrefixError(node,
+              Prefixes.innerOuterString(Prefixes.innerOuterFromSCode(rio)),
+              Prefixes.innerOuterString(Prefixes.innerOuterFromSCode(io)));
+          then
+            fail();
+      end match;
+
+      prefs := Class.Prefixes.PREFIXES(enc, par, fin, io, repl);
+    end if;
+  end mergeRedeclaredClassPrefixes;
+
+  function printRedeclarePrefixError
+    input InstNode node;
+    input String prefix1;
+    input String prefix2;
+  algorithm
+    Error.addSourceMessageAndFail(Error.REDECLARE_MISMATCHED_PREFIX,
+      {prefix1, InstNode.name(node), prefix2}, InstNode.info(node));
+  end printRedeclarePrefixError;
+
+  function checkDeclaredComponentAttributes
+    input output Attributes attr;
+    input Restriction parentRestriction;
+    input InstNode component;
+  algorithm
+    () := match parentRestriction
+      case Restriction.CONNECTOR()
+        algorithm
+          // Components of a connector may not have prefixes 'inner' or 'outer'.
+          assertNotInnerOuter(attr.innerOuter, component, parentRestriction);
+
+          if parentRestriction.isExpandable then
+            // Components of an expandable connector may not have the prefix 'flow'.
+            assertNotFlowStream(attr.connectorType, component, parentRestriction);
+
+            // Mark components in expandable connectors as potentially present.
+            attr.connectorType := intBitOr(attr.connectorType, ConnectorType.POTENTIALLY_PRESENT);
+          end if;
+        then
+          ();
+
+      case Restriction.RECORD()
+        algorithm
+          // Elements of a record may not have prefixes 'input', 'output', 'inner', 'outer', 'stream', or 'flow'.
+          assertNotInputOutput(attr.direction, component, parentRestriction);
+          assertNotInnerOuter(attr.innerOuter, component, parentRestriction);
+          assertNotFlowStream(attr.connectorType, component, parentRestriction);
+        then
+          ();
+
+      else ();
+    end match;
+  end checkDeclaredComponentAttributes;
+
+  function invalidComponentPrefixError
+    input String prefix;
+    input InstNode node;
+    input Restriction restriction;
+  algorithm
+    Error.addSourceMessage(Error.INVALID_COMPONENT_PREFIX,
+      {prefix, InstNode.name(node), Restriction.toString(restriction)}, InstNode.info(node));
+  end invalidComponentPrefixError;
+
+  function assertNotInputOutput
+    input Direction dir;
+    input InstNode node;
+    input Restriction restriction;
+  algorithm
+    if dir <> Direction.NONE then
+      invalidComponentPrefixError(Prefixes.directionString(dir), node, restriction);
+      fail();
+    end if;
+  end assertNotInputOutput;
+
+  function assertNotInnerOuter
+    input InnerOuter io;
+    input InstNode node;
+    input Restriction restriction;
+  algorithm
+    if io <> InnerOuter.NOT_INNER_OUTER then
+      invalidComponentPrefixError(Prefixes.innerOuterString(io), node, restriction);
+      fail();
+    end if;
+  end assertNotInnerOuter;
+
+  function assertNotFlowStream
+    input ConnectorType.Type cty;
+    input InstNode node;
+    input Restriction restriction;
+  algorithm
+    if ConnectorType.isFlowOrStream(cty) then
+      invalidComponentPrefixError(ConnectorType.toString(cty), node, restriction);
+      fail();
+    end if;
+  end assertNotFlowStream;
+
+  function updateComponentConnectorType
+    input output Attributes attributes;
+    input Restriction restriction;
+    input InstContext.Type context;
+    input InstNode component;
+  protected
+    ConnectorType.Type cty = attributes.connectorType;
+  algorithm
+    if ConnectorType.isConnectorType(cty) then
+      if Restriction.isConnector(restriction) then
+        if Restriction.isExpandableConnector(restriction) then
+          cty := ConnectorType.setPresent(cty);
+        else
+          cty := intBitAnd(cty, intBitNot(ConnectorType.EXPANDABLE));
+        end if;
+      else
+        // The connector type might have the connector or expandable bits set
+        // because of a parent node, but they should be unset if the component
+        // itself isn't a connector.
+        cty := intBitAnd(cty,
+          intBitNot(intBitOr(ConnectorType.CONNECTOR, ConnectorType.EXPANDABLE)));
+      end if;
+
+      // Connector elements that are not flow/stream are potentials.
+      if not ConnectorType.isFlowOrStream(cty) then
+        cty := ConnectorType.setPotential(cty);
+      end if;
+
+      if cty <> attributes.connectorType then
+        attributes.connectorType := cty;
+      end if;
+    elseif ConnectorType.isFlowOrStream(cty) and not InstContext.inRedeclared(context) then
+      // The Modelica specification forbids using stream outside connector
+      // declarations, but has no such restriction for flow. To compromise we
+      // print a warning for both flow and stream.
+      Error.addStrictMessage(Error.CONNECTOR_PREFIX_OUTSIDE_CONNECTOR,
+        {ConnectorType.toString(cty)}, InstNode.info(component));
+
+      // Remove the erroneous flow/stream prefix and keep going.
+      attributes.connectorType := ConnectorType.unsetFlowStream(cty);
+    end if;
+  end updateComponentConnectorType;
+
+  function updateClassConnectorType
+    input Restriction res;
+    input output Attributes attrs;
+  algorithm
+    if Restriction.isExpandableConnector(res) then
+      attrs.connectorType := ConnectorType.setExpandable(attrs.connectorType);
+    elseif Restriction.isConnector(res) then
+      attrs.connectorType := ConnectorType.setConnector(attrs.connectorType);
+    end if;
+  end updateClassConnectorType;
+
+  function updateVariability
+    "Updates the variability based on the type of the attributes' owner (e.g.
+     Integer is implicitly discrete."
+    input output Attributes attr;
+    input Class cls;
+    input InstNode clsNode;
+  protected
+    Variability var = attr.variability;
+  algorithm
+    if referenceEq(attr, NFAttributes.DEFAULT_ATTR) and InstNode.isDiscreteClass(clsNode) then
+      attr := NFAttributes.IMPL_DISCRETE_ATTR;
+    elseif var == Variability.CONTINUOUS and InstNode.isDiscreteClass(clsNode) then
+      attr.variability := Variability.IMPLICITLY_DISCRETE;
+    end if;
+  end updateVariability;
+
+  function setConnectorType
+    input ConnectorType.Type cty;
+    input output Attributes attr;
+  algorithm
+    attr.connectorType := cty;
+  end setConnectorType;
+
+  function setVariability
+    input Variability var;
+    input output Attributes attr;
+  algorithm
+    attr.variability := var;
+  end setVariability;
+
+  function setDirection
+    input Direction dir;
+    input output Attributes attr;
+  algorithm
+    attr.direction := dir;
+  end setDirection;
+
+  function setInnerOuter
+    input InnerOuter io;
+    input output Attributes attr;
+  algorithm
+    attr.innerOuter := io;
+  end setInnerOuter;
+
+  function setFinal
+    input Boolean fin;
+    input output Attributes attr;
+  algorithm
+    attr.isFinal := fin;
+  end setFinal;
+
+  function setRedeclare
+    input Boolean redecl;
+    input output Attributes attr;
+  algorithm
+    attr.isRedeclare := redecl;
+  end setRedeclare;
+
+  function setReplaceable
+    input Replaceable repl;
+    input output Attributes attr;
+  algorithm
+    attr.isReplaceable := repl;
+  end setReplaceable;
+
+  function toDAE
+    input Attributes ina;
+    input Visibility vis;
+    output DAE.Attributes outa;
+  algorithm
+    outa := DAE.ATTR(
+      ConnectorType.toDAE(ina.connectorType),
+      parallelismToSCode(ina.parallelism),
+      variabilityToSCode(ina.variability),
+      directionToAbsyn(ina.direction),
+      innerOuterToAbsyn(ina.innerOuter),
+      visibilityToSCode(vis)
+    );
+  end toDAE;
+
+  function toString
+    input Attributes attr;
+    input Type ty;
+    output String str;
+  algorithm
+    str := (if attr.isRedeclare then "redeclare " else "") +
+           (if attr.isFinal then "final " else "") +
+           Prefixes.unparseInnerOuter(attr.innerOuter) +
+           Prefixes.unparseReplaceable(attr.isReplaceable) +
+           Prefixes.unparseParallelism(attr.parallelism) +
+           ConnectorType.unparse(attr.connectorType) +
+           Prefixes.unparseVariability(attr.variability, ty) +
+           Prefixes.unparseDirection(attr.direction);
+  end toString;
+
+  function toFlatStream
+    input Attributes attr;
+    input Type ty;
+    input output IOStream.IOStream s;
+    input Boolean isTopLevel = true;
+  algorithm
+    if attr.isFinal then
+      s := IOStream.append(s, "final ");
+    end if;
+
+    s := IOStream.append(s, Prefixes.unparseVariability(attr.variability, ty));
+
+    if isTopLevel then
+      s := IOStream.append(s, Prefixes.unparseDirection(attr.direction));
+    end if;
+  end toFlatStream;
+
+annotation(__OpenModelica_Interface="frontend");
+end NFAttributes;
+

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -44,6 +44,7 @@ protected
   import SCodeUtil;
 
   //NF imports
+  import Attributes = NFAttributes;
   import NFBinding.Binding;
   import ComplexType = NFComplexType;
   import NFComponent.Component;
@@ -352,7 +353,7 @@ public
     function create
       input list<tuple<String, Binding>> attrs;
       input Type ty;
-      input Component.Attributes compAttrs;
+      input Attributes compAttrs;
       input list<Variable> children;
       input Option<SCode.Comment> comment;
       output VariableAttributes attributes;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -43,6 +43,7 @@ encapsulated package NFBuiltin
 public
 import Absyn;
 import AbsynUtil;
+import Attributes = NFAttributes;
 import SCode;
 import NFBinding;
 import Class = NFClass;
@@ -412,7 +413,7 @@ constant InstNode TIME =
       Type.REAL(),
       NFBinding.EMPTY_BINDING,
       NFBinding.EMPTY_BINDING,
-      NFComponent.INPUT_ATTR,
+      NFAttributes.INPUT_ATTR,
       NONE(),
       NONE(),
       AbsynUtil.dummyInfo)),

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -31,6 +31,7 @@
 
 encapsulated package NFBuiltinFuncs
 
+import Attributes = NFAttributes;
 import Class = NFClass;
 import NFClassTree.ClassTree;
 import NFFunction.Function;
@@ -78,7 +79,7 @@ constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
 
 // Default Integer parameter.
 constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.INTEGER(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFComponent.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+  Type.INTEGER(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   NONE(), Visibility.PUBLIC,
@@ -87,7 +88,7 @@ constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
 
 // Default Real parameter.
 constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.REAL(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFComponent.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+  Type.REAL(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   NONE(), Visibility.PUBLIC,
@@ -96,7 +97,7 @@ constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
 
 // Default Boolean parameter.
 constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.BOOLEAN(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFComponent.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+  Type.BOOLEAN(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   NONE(), Visibility.PUBLIC,
@@ -105,7 +106,7 @@ constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
 
 // Default String parameter.
 constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.STRING(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFComponent.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+  Type.STRING(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   NONE(), Visibility.PUBLIC,
@@ -114,7 +115,7 @@ constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
 
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.ENUMERATION_ANY(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFComponent.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+  Type.ENUMERATION_ANY(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   NONE(), Visibility.PUBLIC,
@@ -373,7 +374,7 @@ constant Function SAMPLE = Function.FUNCTION(Path.QUALIFIED("OMC_NO_CLOCK", Path
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Component CLOCK_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.CLOCK(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFComponent.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+  Type.CLOCK(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
 
 constant InstNode CLOCK_PARAM = InstNode.COMPONENT_NODE("s",
   NONE(), Visibility.PUBLIC,

--- a/OMCompiler/Compiler/NFFrontEnd/NFCheckModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCheckModel.mo
@@ -39,13 +39,13 @@ encapsulated package NFCheckModel
 protected
   import Type = NFType;
   import Binding = NFBinding;
-  import Component = NFComponent;
   import NFPrefixes.{Direction, Variability};
   import ComponentRef = NFComponentRef;
   import UnorderedSet;
   import Expression = NFExpression;
   import Util;
   import ExpandExp = NFExpandExp;
+  import Attributes = NFAttributes;
 
 public
 function checkModel
@@ -71,7 +71,7 @@ function countVariableSize
 protected
   Type ty;
   Binding binding;
-  Component.Attributes attr;
+  Attributes attr;
 algorithm
   Variable.VARIABLE(ty = ty, binding = binding, attributes = attr) := var;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -31,6 +31,7 @@
 
 encapsulated uniontype NFClass
 
+import Attributes = NFAttributes;
 import Component = NFComponent;
 import Dimension = NFDimension;
 import Expression = NFExpression;
@@ -119,7 +120,7 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
     Modifier ccMod;
     array<Dimension> dims;
     Prefixes prefixes;
-    Component.Attributes attributes;
+    Attributes attributes;
     Restriction restriction;
   end EXPANDED_DERIVED;
 
@@ -494,11 +495,11 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
 
   function getAttributes
     input Class cls;
-    output Component.Attributes attr;
+    output Attributes attr;
   algorithm
     attr := match cls
       case EXPANDED_DERIVED() then cls.attributes;
-      else NFComponent.DEFAULT_ATTR;
+      else NFAttributes.DEFAULT_ATTR;
     end match;
   end getAttributes;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -43,6 +43,7 @@ import Restriction = NFRestriction;
 protected
 
 import Algorithm = NFAlgorithm;
+import Attributes = NFAttributes;
 import ComponentReference;
 import ComponentRef = NFComponentRef;
 import Dimension = NFDimension;
@@ -145,7 +146,7 @@ function makeDAEVar
   input ComponentRef cref;
   input Type ty;
   input Option<DAE.Exp> binding;
-  input Component.Attributes attr;
+  input Attributes attr;
   input Visibility vis;
   input Option<DAE.VariableAttributes> vattr;
   input Option<SCode.Comment> comment;
@@ -167,7 +168,7 @@ algorithm
   end if;
 
   var := match attr
-    case Component.Attributes.ATTRIBUTES()
+    case Attributes.ATTRIBUTES()
       algorithm
         // Strip input/output from non top-level components unless
         // --useLocalDirection=true has been set.
@@ -238,7 +239,7 @@ end getComponentDirection;
 function convertVarAttributes
   input list<tuple<String, Binding>> attrs;
   input Type ty;
-  input Component.Attributes compAttrs;
+  input Attributes compAttrs;
   output Option<DAE.VariableAttributes> attributes;
 protected
   Boolean is_final;
@@ -1122,7 +1123,7 @@ protected
   SourceInfo info;
   Option<DAE.VariableAttributes> var_attr;
   ComponentRef cref;
-  Component.Attributes attr;
+  Attributes attr;
   Type ty;
   Option<DAE.Exp> binding;
   list<tuple<String, Binding>> ty_attr;
@@ -1241,14 +1242,14 @@ function makeTypeVar
   output DAE.Var typeVar;
 protected
   Component comp;
-  Component.Attributes attr;
+  Attributes attr;
 algorithm
   comp := InstNode.component(InstNode.resolveOuter(component));
   attr := Component.getAttributes(comp);
 
   typeVar := DAE.TYPES_VAR(
     InstNode.name(component),
-    Component.Attributes.toDAE(attr, InstNode.visibility(component)),
+    Attributes.toDAE(attr, InstNode.visibility(component)),
     Type.toDAE(Component.getType(comp)),
     Binding.toDAE(Component.getBinding(comp)),
     false,
@@ -1261,7 +1262,7 @@ function makeTypeRecordVar
   output DAE.Var typeVar;
 protected
   Component comp;
-  Component.Attributes attr;
+  Attributes attr;
   Visibility vis;
   Binding binding;
   Boolean bind_from_outside;
@@ -1286,7 +1287,7 @@ algorithm
 
   typeVar := DAE.TYPES_VAR(
     InstNode.name(component),
-    Component.Attributes.toDAE(attr, vis),
+    Attributes.toDAE(attr, vis),
     Type.toDAE(ty),
     Binding.toDAE(binding),
     bind_from_outside,

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandableConnectors.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandableConnectors.mo
@@ -398,7 +398,7 @@ algorithm
       elem_name := ComponentRef.prefixCref(node, ty, {}, exp_name);
       // TODO: This needs more work, the new connector might be a complex connector.
       var := Variable.VARIABLE(elem_name, ty, NFBinding.EMPTY_BINDING,
-        Visibility.PUBLIC, NFComponent.DEFAULT_ATTR, {}, {},
+        Visibility.PUBLIC, NFAttributes.DEFAULT_ATTR, {}, {},
         SOME(SCode.COMMENT(NONE(), SOME("virtual variable in expandable connector"))),
         ElementSource.getInfo(c.source), NFBackendExtension.DUMMY_BACKEND_INFO);
       vars := var :: vars;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -48,6 +48,7 @@ import Algorithm = NFAlgorithm;
 import CardinalityTable = NFCardinalityTable;
 
 protected
+import Attributes = NFAttributes;
 import ComponentRef = NFComponentRef;
 import Dimension = NFDimension;
 import ExecStat.execStat;
@@ -442,7 +443,7 @@ protected
   Type ty;
   Option<SCode.Comment> cmt;
   SourceInfo info;
-  Component.Attributes comp_attr;
+  Attributes comp_attr;
   Visibility vis;
   Equation eq;
   list<tuple<String, Binding>> ty_attrs;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -53,7 +53,7 @@ import Error;
 import InstUtil;
 import Class = NFClass;
 import Component = NFComponent;
-import NFComponent.Attributes;
+import Attributes = NFAttributes;
 import Typing = NFTyping;
 import TypeCheck = NFTypeCheck;
 import Util;
@@ -2092,7 +2092,7 @@ protected
     Visibility vis;
     Variability var;
   algorithm
-    Component.Attributes.ATTRIBUTES(
+    Attributes.ATTRIBUTES(
       connectorType = cty,
       direction = direction,
       innerOuter = io) := Component.getAttributes(InstNode.component(component));

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -62,6 +62,7 @@ import Connector = NFConnector;
 import Connection = NFConnection;
 import Algorithm = NFAlgorithm;
 import InstContext = NFInstContext;
+import Attributes = NFAttributes;
 
 protected
 import Config;
@@ -258,7 +259,7 @@ algorithm
   node := expand(node);
 
   if instPartial or not InstNode.isPartial(node) or InstContext.inRelaxed(context) then
-    node := instClass(node, Modifier.NOMOD(), NFComponent.DEFAULT_ATTR, true, 0, parent, context);
+    node := instClass(node, Modifier.NOMOD(), NFAttributes.DEFAULT_ATTR, true, 0, parent, context);
   end if;
 end instantiate;
 
@@ -743,7 +744,7 @@ protected
   Class cls;
   Class.Prefixes prefs;
   SCode.Attributes sattrs;
-  Component.Attributes attrs;
+  Attributes attrs;
   list<Dimension> dims;
   Modifier mod, cc_mod;
   Restriction res;
@@ -772,7 +773,7 @@ algorithm
     prefs.partialPrefix := SCode.Partial.PARTIAL();
   end if;
 
-  attrs := instDerivedAttributes(sattrs);
+  attrs := Attributes.fromDerivedSCode(sattrs);
   dims := list(Dimension.RAW_DIM(d, InstNode.parent(node)) for d in AbsynUtil.typeSpecDimensions(ty));
   mod := Class.getModifier(cls);
   cc_mod := Class.getCCModifier(cls);
@@ -813,37 +814,10 @@ algorithm
   node := InstNode.updateClass(cls, node);
 end expandClassDerivedComplex;
 
-function instDerivedAttributes
-  input SCode.Attributes scodeAttr;
-  output Component.Attributes attributes;
-protected
-  ConnectorType.Type cty;
-  Variability var;
-  Direction dir;
-algorithm
-  attributes := match scodeAttr
-    case SCode.Attributes.ATTR(
-           connectorType = SCode.ConnectorType.POTENTIAL(),
-           variability = SCode.Variability.VAR(),
-           direction = Absyn.Direction.BIDIR())
-      then NFComponent.DEFAULT_ATTR;
-
-    else
-      algorithm
-        cty := ConnectorType.fromSCode(scodeAttr.connectorType);
-        var := Prefixes.variabilityFromSCode(scodeAttr.variability);
-        dir := Prefixes.directionFromSCode(scodeAttr.direction);
-      then
-        Component.Attributes.ATTRIBUTES(cty, Parallelism.NON_PARALLEL,
-          var, dir, InnerOuter.NOT_INNER_OUTER, false, false, Replaceable.NOT_REPLACEABLE());
-
-  end match;
-end instDerivedAttributes;
-
 function instClass
   input output InstNode node;
   input Modifier modifier;
-  input output Component.Attributes attributes = NFComponent.DEFAULT_ATTR;
+  input output Attributes attributes = NFAttributes.DEFAULT_ATTR;
   input Boolean useBinding;
   input Integer instLevel;
   input InstNode parent = InstNode.EMPTY_NODE();
@@ -869,7 +843,7 @@ end instClass;
 function instClassDef
   input Class cls;
   input Modifier outerMod;
-  input output Component.Attributes attributes;
+  input output Attributes attributes;
   input Boolean useBinding;
   input output InstNode node;
   input InstNode parent;
@@ -882,7 +856,7 @@ protected
   Modifier mod, outer_mod;
   Restriction res;
   Type ty;
-  Component.Attributes attrs;
+  Attributes attrs;
   SCode.Element elem;
 algorithm
   () := match cls
@@ -897,7 +871,7 @@ algorithm
         end if;
 
         updateComponentType(parent, node);
-        attributes := updateClassConnectorType(res, attributes);
+        attributes := Attributes.updateClassConnectorType(res, attributes);
         inst_cls as Class.EXPANDED_CLASS(elements = cls_tree) := InstNode.getClass(node);
 
         // Fetch modification on the class definition (for class extends).
@@ -959,8 +933,8 @@ algorithm
         outer_mod := Modifier.propagate(cls.modifier, node, par);
         outer_mod := Modifier.merge(outerMod, outer_mod);
         mod := Modifier.merge(outer_mod, mod);
-        attrs := updateClassConnectorType(cls.restriction, cls.attributes);
-        attributes := mergeDerivedAttributes(attrs, attributes, parent);
+        attrs := Attributes.updateClassConnectorType(cls.restriction, cls.attributes);
+        attributes := Attributes.mergeDerivedAttributes(attrs, attributes, parent);
 
         // Instantiate the base class and update the nodes.
         (base_node, attributes) := instClass(base_node, mod, attributes, useBinding, instLevel, par, context);
@@ -1030,17 +1004,6 @@ algorithm
     component := InstNode.componentApply(component, Component.setClassInstance, cls);
   end if;
 end updateComponentType;
-
-function updateClassConnectorType
-  input Restriction res;
-  input output Component.Attributes attrs;
-algorithm
-  if Restriction.isExpandableConnector(res) then
-    attrs.connectorType := ConnectorType.setExpandable(attrs.connectorType);
-  elseif Restriction.isConnector(res) then
-    attrs.connectorType := ConnectorType.setConnector(attrs.connectorType);
-  end if;
-end updateClassConnectorType;
 
 function instExternalObjectStructors
   "Instantiates the constructor and destructor for an ExternalObject class."
@@ -1207,7 +1170,7 @@ end applyExtendsVisibility;
 
 function instExtends
   input output InstNode node;
-  input Component.Attributes attributes;
+  input Attributes attributes;
   input Boolean useBinding;
   input Integer instLevel;
   input InstContext.Type context;
@@ -1413,8 +1376,8 @@ protected
 algorithm
   rdcl_node := Mutable.access(redeclareComp);
   repl_node := Mutable.access(replaceableComp);
-  instComponent(repl_node, NFComponent.DEFAULT_ATTR, Modifier.NOMOD(), true, instLevel, NONE(), context);
-  redeclareComponent(rdcl_node, repl_node, Modifier.NOMOD(), Modifier.NOMOD(), NFComponent.DEFAULT_ATTR, rdcl_node, instLevel, context);
+  instComponent(repl_node, NFAttributes.DEFAULT_ATTR, Modifier.NOMOD(), true, instLevel, NONE(), context);
+  redeclareComponent(rdcl_node, repl_node, Modifier.NOMOD(), Modifier.NOMOD(), NFAttributes.DEFAULT_ATTR, rdcl_node, instLevel, context);
   outComp := Mutable.create(rdcl_node);
 end redeclareComponentElement;
 
@@ -1448,7 +1411,7 @@ algorithm
   //mod := Modifier.merge(mod, constrainingMod);
   mod := Modifier.merge(outerMod, mod);
 
-  prefs := mergeRedeclaredClassPrefixes(Class.getPrefixes(orig_cls),
+  prefs := Attributes.mergeRedeclaredClassPrefixes(Class.getPrefixes(orig_cls),
     Class.getPrefixes(rdcl_cls), redeclareNode);
 
   if SCodeUtil.isClassExtends(InstNode.definition(redeclareNode)) then
@@ -1554,11 +1517,11 @@ end redeclareEnum;
 
 function instComponent
   input InstNode node   "The component node to instantiate";
-  input Component.Attributes attributes "Attributes to be propagated to the component.";
+  input Attributes attributes "Attributes to be propagated to the component.";
   input Modifier innerMod;
   input Boolean useBinding "Ignore the component's binding if false.";
   input Integer instLevel;
-  input Option<Component.Attributes> originalAttr = NONE();
+  input Option<Attributes> originalAttr = NONE();
   input InstContext.Type context;
 protected
   Component comp;
@@ -1590,7 +1553,7 @@ algorithm
       outerMod = outer_mod, constrainingMod = cc_mod) := outer_mod;
 
     next_context := InstContext.set(context, NFInstContext.REDECLARED);
-    instComponentDef(def, Modifier.NOMOD(), inner_mod, NFComponent.DEFAULT_ATTR,
+    instComponentDef(def, Modifier.NOMOD(), inner_mod, NFAttributes.DEFAULT_ATTR,
       useBinding, comp_node, parent, instLevel, originalAttr, next_context);
 
     cc_mod := getConstrainingMod(def, parent, cc_mod);
@@ -1608,12 +1571,12 @@ function instComponentDef
   input SCode.Element component;
   input Modifier outerMod;
   input Modifier innerMod;
-  input Component.Attributes attributes;
+  input Attributes attributes;
   input Boolean useBinding;
   input InstNode node;
   input InstNode parent;
   input Integer instLevel;
-  input Option<Component.Attributes> originalAttr = NONE();
+  input Option<Attributes> originalAttr = NONE();
   input InstContext.Type context;
 algorithm
   () := match component
@@ -1622,7 +1585,7 @@ algorithm
       Modifier decl_mod, mod, cc_mod;
       list<Dimension> dims, ty_dims;
       Binding binding, condition;
-      Component.Attributes attr, ty_attr;
+      Attributes attr, ty_attr;
       Component inst_comp;
       InstNode ty_node;
       Class ty;
@@ -1643,12 +1606,12 @@ algorithm
         // Instantiate the component's attributes, and merge them with the
         // attributes of the component's parent (e.g. constant SomeComplexClass c).
         parent_res := Class.restriction(InstNode.getClass(parent));
-        attr := instComponentAttributes(component.attributes, component.prefixes);
-        attr := checkDeclaredComponentAttributes(attr, parent_res, node);
-        attr := mergeComponentAttributes(attributes, attr, node, parent_res);
+        attr := Attributes.fromSCode(component.attributes, component.prefixes);
+        attr := Attributes.checkDeclaredComponentAttributes(attr, parent_res, node);
+        attr := Attributes.mergeComponentAttributes(attributes, attr, node, parent_res);
 
         if isSome(originalAttr) then
-          attr := mergeRedeclaredComponentAttributes(Util.getOption(originalAttr), attr, node);
+          attr := Attributes.mergeRedeclaredComponentAttributes(Util.getOption(originalAttr), attr, node);
         end if;
 
         if not attr.isFinal and Modifier.isFinal(mod) then
@@ -1675,10 +1638,9 @@ algorithm
           checkPartialComponent(node, attr, ty_node, Class.isPartial(ty), res, context, info);
         end if;
 
-        // Update the component's variability based on its type (e.g. Integer is discrete).
-        ty_attr := updateComponentVariability(ty_attr, ty, ty_node);
-        // Update the component's connector type now that we have its type.
-        ty_attr := updateComponentConnectorType(ty_attr, res, context, node);
+        // Update some of the attributes now that we now the type of the component.
+        ty_attr := Attributes.updateVariability(ty_attr, ty, ty_node);
+        ty_attr := Attributes.updateComponentConnectorType(ty_attr, res, context, node);
 
         if not referenceEq(attr, ty_attr) then
           InstNode.componentApply(node, Component.setAttributes, ty_attr);
@@ -1767,52 +1729,9 @@ algorithm
   end match;
 end propagateRedeclaredMod;
 
-function updateComponentConnectorType
-  input output Component.Attributes attributes;
-  input Restriction restriction;
-  input InstContext.Type context;
-  input InstNode component;
-protected
-  ConnectorType.Type cty = attributes.connectorType;
-algorithm
-  if ConnectorType.isConnectorType(cty) then
-    if Restriction.isConnector(restriction) then
-      if Restriction.isExpandableConnector(restriction) then
-        cty := ConnectorType.setPresent(cty);
-      else
-        cty := intBitAnd(cty, intBitNot(ConnectorType.EXPANDABLE));
-      end if;
-    else
-      // The connector type might have the connector or expandable bits set
-      // because of a parent node, but they should be unset if the component
-      // itself isn't a connector.
-      cty := intBitAnd(cty,
-        intBitNot(intBitOr(ConnectorType.CONNECTOR, ConnectorType.EXPANDABLE)));
-    end if;
-
-    // Connector elements that are not flow/stream are potentials.
-    if not ConnectorType.isFlowOrStream(cty) then
-      cty := ConnectorType.setPotential(cty);
-    end if;
-
-    if cty <> attributes.connectorType then
-      attributes.connectorType := cty;
-    end if;
-  elseif ConnectorType.isFlowOrStream(cty) and not InstContext.inRedeclared(context) then
-    // The Modelica specification forbids using stream outside connector
-    // declarations, but has no such restriction for flow. To compromise we
-    // print a warning for both flow and stream.
-    Error.addStrictMessage(Error.CONNECTOR_PREFIX_OUTSIDE_CONNECTOR,
-      {ConnectorType.toString(cty)}, InstNode.info(component));
-
-    // Remove the erroneous flow/stream prefix and keep going.
-    attributes.connectorType := ConnectorType.unsetFlowStream(cty);
-  end if;
-end updateComponentConnectorType;
-
 function checkPartialComponent
   input InstNode compNode;
-  input Component.Attributes compAttr;
+  input Attributes compAttr;
   input InstNode clsNode;
   input Boolean isPartial;
   input Restriction res;
@@ -1840,14 +1759,14 @@ function redeclareComponent
   input InstNode originalNode;
   input Modifier outerMod;
   input Modifier constrainingMod;
-  input Component.Attributes outerAttr;
+  input Attributes outerAttr;
   input InstNode redeclaredNode;
   input Integer instLevel;
   input InstContext.Type context;
 protected
   Component orig_comp, rdcl_comp, new_comp;
   Binding binding, condition;
-  Component.Attributes attr;
+  Attributes attr;
   array<Dimension> dims;
   Option<SCode.Comment> cmt;
   InstNode rdcl_node;
@@ -1923,349 +1842,10 @@ algorithm
   end if;
 end checkOuterComponentMod;
 
-function instComponentAttributes
-  input SCode.Attributes compAttr;
-  input SCode.Prefixes compPrefs;
-  output Component.Attributes attributes;
-protected
-  ConnectorType.Type cty;
-  Parallelism par;
-  Variability var;
-  Direction dir;
-  InnerOuter io;
-  Boolean fin, redecl;
-  Replaceable repl;
-algorithm
-  attributes := match (compAttr, compPrefs)
-    case (SCode.Attributes.ATTR(
-            connectorType = SCode.ConnectorType.POTENTIAL(),
-            parallelism = SCode.Parallelism.NON_PARALLEL(),
-            variability = SCode.Variability.VAR(),
-            direction = Absyn.Direction.BIDIR()),
-          SCode.Prefixes.PREFIXES(
-            redeclarePrefix = SCode.Redeclare.NOT_REDECLARE(),
-            finalPrefix = SCode.Final.NOT_FINAL(),
-            innerOuter = Absyn.InnerOuter.NOT_INNER_OUTER(),
-            replaceablePrefix = SCode.Replaceable.NOT_REPLACEABLE()))
-      then NFComponent.DEFAULT_ATTR;
-
-    else
-      algorithm
-        cty := ConnectorType.fromSCode(compAttr.connectorType);
-        par := Prefixes.parallelismFromSCode(compAttr.parallelism);
-        var := Prefixes.variabilityFromSCode(compAttr.variability);
-        dir := Prefixes.directionFromSCode(compAttr.direction);
-        io  := Prefixes.innerOuterFromSCode(compPrefs.innerOuter);
-        fin := SCodeUtil.finalBool(compPrefs.finalPrefix);
-        redecl := SCodeUtil.redeclareBool(compPrefs.redeclarePrefix);
-        repl := Replaceable.NOT_REPLACEABLE();
-      then
-        Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl);
-  end match;
-end instComponentAttributes;
-
-function mergeComponentAttributes
-  input Component.Attributes outerAttr;
-  input Component.Attributes innerAttr;
-  input InstNode node;
-  input Restriction parentRestriction;
-  output Component.Attributes attr;
-protected
-  ConnectorType.Type cty;
-  Parallelism par;
-  Variability var;
-  Direction dir;
-  Boolean fin, redecl;
-  Replaceable repl;
-algorithm
-  if referenceEq(outerAttr, NFComponent.DEFAULT_ATTR) and innerAttr.connectorType == 0 then
-    attr := innerAttr;
-  elseif referenceEq(innerAttr, NFComponent.DEFAULT_ATTR) then
-    cty := ConnectorType.merge(outerAttr.connectorType, innerAttr.connectorType, node);
-    attr := Component.Attributes.ATTRIBUTES(cty, outerAttr.parallelism,
-      outerAttr.variability, outerAttr.direction, innerAttr.innerOuter, outerAttr.isFinal,
-      innerAttr.isRedeclare, innerAttr.isReplaceable);
-  else
-    cty := ConnectorType.merge(outerAttr.connectorType, innerAttr.connectorType, node);
-    par := Prefixes.mergeParallelism(outerAttr.parallelism, innerAttr.parallelism, node);
-    var := Prefixes.variabilityMin(outerAttr.variability, innerAttr.variability);
-
-    if Restriction.isFunction(parentRestriction) then
-      dir := innerAttr.direction;
-    else
-      dir := Prefixes.mergeDirection(outerAttr.direction, innerAttr.direction, node);
-    end if;
-
-    fin := outerAttr.isFinal or innerAttr.isFinal;
-    redecl := innerAttr.isRedeclare;
-    repl := innerAttr.isReplaceable;
-    attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, innerAttr.innerOuter, fin, redecl, repl);
-  end if;
-end mergeComponentAttributes;
-
-function checkDeclaredComponentAttributes
-  input output Component.Attributes attr;
-  input Restriction parentRestriction;
-  input InstNode component;
-algorithm
-  () := match parentRestriction
-    case Restriction.CONNECTOR()
-      algorithm
-        // Components of a connector may not have prefixes 'inner' or 'outer'.
-        assertNotInnerOuter(attr.innerOuter, component, parentRestriction);
-
-        if parentRestriction.isExpandable then
-          // Components of an expandable connector may not have the prefix 'flow'.
-          assertNotFlowStream(attr.connectorType, component, parentRestriction);
-
-          // Mark components in expandable connectors as potentially present.
-          attr.connectorType := intBitOr(attr.connectorType, ConnectorType.POTENTIALLY_PRESENT);
-        end if;
-      then
-        ();
-
-    case Restriction.RECORD()
-      algorithm
-        // Elements of a record may not have prefixes 'input', 'output', 'inner', 'outer', 'stream', or 'flow'.
-        assertNotInputOutput(attr.direction, component, parentRestriction);
-        assertNotInnerOuter(attr.innerOuter, component, parentRestriction);
-        assertNotFlowStream(attr.connectorType, component, parentRestriction);
-      then
-        ();
-
-    else ();
-  end match;
-end checkDeclaredComponentAttributes;
-
-function invalidComponentPrefixError
-  input String prefix;
-  input InstNode node;
-  input Restriction restriction;
-algorithm
-  Error.addSourceMessage(Error.INVALID_COMPONENT_PREFIX,
-    {prefix, InstNode.name(node), Restriction.toString(restriction)}, InstNode.info(node));
-end invalidComponentPrefixError;
-
-function assertNotInputOutput
-  input Direction dir;
-  input InstNode node;
-  input Restriction restriction;
-algorithm
-  if dir <> Direction.NONE then
-    invalidComponentPrefixError(Prefixes.directionString(dir), node, restriction);
-    fail();
-  end if;
-end assertNotInputOutput;
-
-function assertNotInnerOuter
-  input InnerOuter io;
-  input InstNode node;
-  input Restriction restriction;
-algorithm
-  if io <> InnerOuter.NOT_INNER_OUTER then
-    invalidComponentPrefixError(Prefixes.innerOuterString(io), node, restriction);
-    fail();
-  end if;
-end assertNotInnerOuter;
-
-function assertNotFlowStream
-  input ConnectorType.Type cty;
-  input InstNode node;
-  input Restriction restriction;
-algorithm
-  if ConnectorType.isFlowOrStream(cty) then
-    invalidComponentPrefixError(ConnectorType.toString(cty), node, restriction);
-    fail();
-  end if;
-end assertNotFlowStream;
-
-function mergeDerivedAttributes
-  input Component.Attributes outerAttr;
-  input Component.Attributes innerAttr;
-  input InstNode node;
-  output Component.Attributes attr;
-protected
-  ConnectorType.Type cty;
-  Parallelism par;
-  Variability var;
-  Direction dir;
-  InnerOuter io;
-  Boolean fin, redecl;
-  Replaceable repl;
-algorithm
-  if referenceEq(innerAttr, NFComponent.DEFAULT_ATTR) and outerAttr.connectorType == 0 then
-    attr := outerAttr;
-  elseif referenceEq(outerAttr, NFComponent.DEFAULT_ATTR) and innerAttr.connectorType == 0 then
-    attr := innerAttr;
-  else
-    Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, fin, redecl, repl) := outerAttr;
-    cty := ConnectorType.merge(cty, innerAttr.connectorType, node, isClass = true);
-    var := Prefixes.variabilityMin(var, innerAttr.variability);
-    dir := Prefixes.mergeDirection(dir, innerAttr.direction, node, allowSame = true);
-    attr := Component.Attributes.ATTRIBUTES(cty, par, var, dir, innerAttr.innerOuter, fin, redecl, repl);
-  end if;
-end mergeDerivedAttributes;
-
-function mergeRedeclaredComponentAttributes
-  input Component.Attributes origAttr;
-  input Component.Attributes redeclAttr;
-  input InstNode node;
-  output Component.Attributes attr;
-protected
-  ConnectorType.Type cty, rcty, cty_fs, rcty_fs;
-  Parallelism par, rpar;
-  Variability var, rvar;
-  Direction dir, rdir;
-  InnerOuter io, rio;
-  Boolean fin;
-  Boolean redecl;
-  Replaceable repl;
-algorithm
-  if referenceEq(origAttr, NFComponent.DEFAULT_ATTR) then
-    attr := redeclAttr;
-  elseif referenceEq(redeclAttr, NFComponent.DEFAULT_ATTR) then
-    attr := origAttr;
-  else
-    Component.Attributes.ATTRIBUTES(cty, par, var, dir, io, _, _, _) := origAttr;
-    Component.Attributes.ATTRIBUTES(rcty, rpar, rvar, rdir, rio, fin, redecl, repl) := redeclAttr;
-
-    // If no prefix is given for one of these attributes in the redeclaration,
-    // then the one from the original declaration is used. The redeclare is not
-    // allowed to change an existing prefix on the original declaration, except
-    // for the variability which can be lowered (e.g. parameter -> constant) and
-    // final which is always taken from the redeclare (since redeclaring a final
-    // element isn't allowed).
-
-    rcty_fs := intBitAnd(rcty, ConnectorType.FLOW_STREAM_MASK);
-    cty_fs := intBitAnd(cty, ConnectorType.FLOW_STREAM_MASK);
-    if rcty_fs > 0 then
-      if cty_fs > 0 and rcty_fs <> cty_fs then
-        printRedeclarePrefixError(node, ConnectorType.toString(rcty), ConnectorType.toString(cty));
-      end if;
-    end if;
-
-    if rpar <> Parallelism.NON_PARALLEL then
-      if par <> Parallelism.NON_PARALLEL and par <> rpar then
-        printRedeclarePrefixError(node, Prefixes.parallelismString(rpar), Prefixes.parallelismString(par));
-      end if;
-
-      par := rpar;
-    end if;
-
-    if rvar <> Variability.CONTINUOUS then
-      if rvar > var then
-        printRedeclarePrefixError(node, Prefixes.variabilityString(rvar), Prefixes.variabilityString(var));
-      end if;
-
-      var := rvar;
-    end if;
-
-    if rdir <> Direction.NONE then
-    if dir <> Direction.NONE and rdir <> dir then
-        printRedeclarePrefixError(node, Prefixes.directionString(rdir), Prefixes.directionString(dir));
-      end if;
-
-      dir := rdir;
-    end if;
-
-    if rio <> InnerOuter.NOT_INNER_OUTER then
-      if io <> InnerOuter.NOT_INNER_OUTER and rio <> io then
-        printRedeclarePrefixError(node, Prefixes.innerOuterString(rio), Prefixes.innerOuterString(io));
-      end if;
-
-      io := rio;
-    end if;
-
-    attr := Component.Attributes.ATTRIBUTES(rcty, par, var, dir, io, fin, redecl, repl);
-  end if;
-end mergeRedeclaredComponentAttributes;
-
-function mergeRedeclaredClassPrefixes
-  input Class.Prefixes origPrefs;
-  input Class.Prefixes redeclPrefs;
-  input InstNode node;
-  output Class.Prefixes prefs;
-protected
-  SCode.Encapsulated enc;
-  SCode.Partial par;
-  SCode.Final fin;
-  Absyn.InnerOuter io, rio;
-  SCode.Replaceable repl;
-algorithm
-  if referenceEq(origPrefs, NFClass.DEFAULT_PREFIXES) then
-    prefs := redeclPrefs;
-  else
-    Class.Prefixes.PREFIXES(innerOuter = io) := origPrefs;
-    Class.Prefixes.PREFIXES(enc, par, fin, rio, repl) := redeclPrefs;
-
-    io := match (io, rio)
-      case (Absyn.InnerOuter.NOT_INNER_OUTER(), _) then rio;
-      case (_, Absyn.InnerOuter.NOT_INNER_OUTER()) then io;
-      case (Absyn.InnerOuter.INNER(), Absyn.InnerOuter.INNER()) then io;
-      case (Absyn.InnerOuter.OUTER(), Absyn.InnerOuter.OUTER()) then io;
-      case (Absyn.InnerOuter.INNER_OUTER(), Absyn.InnerOuter.INNER_OUTER()) then io;
-      else
-        algorithm
-          printRedeclarePrefixError(node,
-            Prefixes.innerOuterString(Prefixes.innerOuterFromSCode(rio)),
-            Prefixes.innerOuterString(Prefixes.innerOuterFromSCode(io)));
-        then
-          fail();
-    end match;
-
-    prefs := Class.Prefixes.PREFIXES(enc, par, fin, io, repl);
-  end if;
-end mergeRedeclaredClassPrefixes;
-
-function printRedeclarePrefixError
-  input InstNode node;
-  input String prefix1;
-  input String prefix2;
-algorithm
-  Error.addSourceMessageAndFail(Error.REDECLARE_MISMATCHED_PREFIX,
-    {prefix1, InstNode.name(node), prefix2}, InstNode.info(node));
-end printRedeclarePrefixError;
-
-function updateComponentVariability
-  input output Component.Attributes attr;
-  input Class cls;
-  input InstNode clsNode;
-protected
-  Variability var = attr.variability;
-algorithm
-  if referenceEq(attr, NFComponent.DEFAULT_ATTR) and isDiscreteClass(clsNode) then
-    attr := NFComponent.IMPL_DISCRETE_ATTR;
-  elseif var == Variability.CONTINUOUS and isDiscreteClass(clsNode) then
-    attr.variability := Variability.IMPLICITLY_DISCRETE;
-  end if;
-end updateComponentVariability;
-
-function isDiscreteClass
-  input InstNode clsNode;
-  output Boolean isDiscrete;
-protected
-  InstNode base_node;
-  Class cls;
-  array<InstNode> exts;
-algorithm
-  base_node := Class.lastBaseClass(clsNode);
-  cls := InstNode.getClass(base_node);
-
-  isDiscrete := match cls
-    case Class.EXPANDED_CLASS(restriction = Restriction.TYPE())
-      algorithm
-        exts := ClassTree.getExtends(cls.elements);
-      then
-        if arrayLength(exts) == 1 then isDiscreteClass(exts[1]) else false;
-
-    else Type.isDiscrete(Class.getType(cls, base_node));
-  end match;
-end isDiscreteClass;
-
 function instTypeSpec
   input Absyn.TypeSpec typeSpec;
   input Modifier modifier;
-  input Component.Attributes attributes;
+  input Attributes attributes;
   input Boolean useBinding;
   input InstNode scope;
   input InstNode parent;
@@ -2273,7 +1853,7 @@ function instTypeSpec
   input Integer instLevel;
   input InstContext.Type context;
   output InstNode node;
-  output Component.Attributes outAttributes;
+  output Attributes outAttributes;
 algorithm
   node := match typeSpec
     case Absyn.TPATH()
@@ -3579,7 +3159,7 @@ algorithm
     if InstNode.isComponent(n) then
       // The component might have been instantiated during lookup, otherwise do
       // it here (instComponent will skip already instantiated components).
-      instComponent(n, NFComponent.DEFAULT_ATTR, Modifier.NOMOD(), true, 0, NONE(), NFInstContext.CLASS);
+      instComponent(n, NFAttributes.DEFAULT_ATTR, Modifier.NOMOD(), true, 0, NONE(), NFInstContext.CLASS);
 
       // If the component's class has a missingInnerMessage annotation, use it
       // to give a diagnostic message.

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -925,7 +925,7 @@ uniontype InstNode
   algorithm
     node := match node
       case COMPONENT_NODE() algorithm
-        node.component := Pointer.create(Component.setDirection(Pointer.access(node.component), direction));
+        node.component := Pointer.create(Component.setDirection(direction, Pointer.access(node.component)));
       then node;
 
       else algorithm
@@ -1859,6 +1859,28 @@ uniontype InstNode
       else false;
     end match;
   end isExtends;
+
+  function isDiscreteClass
+    input InstNode clsNode;
+    output Boolean isDiscrete;
+  protected
+    InstNode base_node;
+    Class cls;
+    array<InstNode> exts;
+  algorithm
+    base_node := Class.lastBaseClass(clsNode);
+    cls := InstNode.getClass(base_node);
+
+    isDiscrete := match cls
+      case Class.EXPANDED_CLASS(restriction = Restriction.TYPE())
+        algorithm
+          exts := ClassTree.getExtends(cls.elements);
+        then
+          if arrayLength(exts) == 1 then isDiscreteClass(exts[1]) else false;
+
+      else Type.isDiscrete(Class.getType(cls, base_node));
+    end match;
+  end isDiscreteClass;
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -37,6 +37,7 @@ encapsulated package NFLookup
 
 import Absyn;
 import AbsynUtil;
+import Attributes = NFAttributes;
 import SCode;
 import Dump;
 import ErrorTypes;
@@ -891,7 +892,7 @@ algorithm
   elseif InstNode.isGeneratedInner(scope) and Component.isDefinition(InstNode.component(scope)) then
     // The scope is a generated inner component that hasn't been instantiated,
     // it needs to be instantiated to continue lookup.
-    Inst.instComponent(scope, NFComponent.DEFAULT_ATTR, Modifier.NOMOD(), true, 0, NONE(), NFInstContext.CLASS);
+    Inst.instComponent(scope, NFAttributes.DEFAULT_ATTR, Modifier.NOMOD(), true, 0, NONE(), NFInstContext.CLASS);
   end if;
 
   name := AbsynUtil.crefFirstIdent(cref);

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -38,6 +38,7 @@ encapsulated package NFRecord
   Functions used by NFInst for handling records.
 "
 
+import Attributes = NFAttributes;
 import Binding = NFBinding;
 import Class = NFClass;
 import Component = NFComponent;
@@ -148,7 +149,7 @@ algorithm
   // Create the output record element, using the instance created above as both parent and type.
   out_comp := Component.UNTYPED_COMPONENT(ctor_node, listArray({}),
                 NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-                NFComponent.OUTPUT_ATTR, NONE(), false, AbsynUtil.dummyInfo);
+                NFAttributes.OUTPUT_ATTR, NONE(), false, AbsynUtil.dummyInfo);
   out_rec := InstNode.fromComponent("$out" + InstNode.name(ctor_node), out_comp, ctor_node);
 
   // Make a record constructor class and create a node for the constructor.
@@ -264,14 +265,8 @@ end collectRecordParam;
 function setFieldDirection
   input InstNode field;
   input Direction direction;
-protected
-  Component comp = InstNode.component(field);
-  Component.Attributes attr;
 algorithm
-  attr := Component.getAttributes(comp);
-  attr.direction := direction;
-  comp := Component.setAttributes(attr, comp);
-  InstNode.updateComponent(comp, field);
+  InstNode.componentApply(field, Component.setDirection, direction);
 end setFieldDirection;
 
 function collectRecordFields

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -35,6 +35,7 @@ import FlatModel = NFFlatModel;
 import NFFlatten.FunctionTree;
 
 protected
+import Attributes = NFAttributes;
 import NFBackendExtension.{BackendInfo, VariableAttributes};
 import ExecStat.execStat;
 import ComponentRef = NFComponentRef;
@@ -89,7 +90,7 @@ protected
   Binding binding;
   Type ty, elem_ty;
   Visibility vis;
-  Component.Attributes attr;
+  Attributes attr;
   list<tuple<String, Binding>> ty_attr;
   Option<SCode.Comment> cmt;
   SourceInfo info;

--- a/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
@@ -32,6 +32,7 @@
 encapsulated package NFStructural
   "Contains utility functions for handling structural parameters."
 
+  import Attributes = NFAttributes;
   import Component = NFComponent;
   import Binding = NFBinding;
   import NFInstNode.InstNode;
@@ -49,7 +50,7 @@ protected
 public
   function isStructuralComponent
     input Component component;
-    input Component.Attributes compAttrs;
+    input Attributes compAttrs;
     input Binding compBinding;
     input InstNode compNode;
     input Boolean compEval "If the component has an Evaluate=true annotation";

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -58,6 +58,7 @@ import Record = NFRecord;
 import InstContext = NFInstContext;
 
 protected
+import Attributes = NFAttributes;
 import Builtin = NFBuiltin;
 import BuiltinCall = NFBuiltinCall;
 import Ceval = NFCeval;
@@ -905,7 +906,7 @@ protected
   MatchKind matchKind;
   String name;
   Variability comp_var, comp_eff_var, bind_var, bind_eff_var;
-  Component.Attributes attrs;
+  Attributes attrs;
   Type ty;
 algorithm
   c := InstNode.component(node);

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -30,6 +30,7 @@
  */
 
 encapsulated uniontype NFVariable
+  import Attributes = NFAttributes;
   import Binding = NFBinding;
   import Component = NFComponent;
   import ComponentRef = NFComponentRef;
@@ -57,7 +58,7 @@ public
     Type ty;
     Binding binding;
     Visibility visibility;
-    Component.Attributes attributes;
+    Attributes attributes;
     list<tuple<String, Binding>> typeAttributes;
     list<Variable> children;
     Option<SCode.Comment> comment;
@@ -75,7 +76,7 @@ public
     Type ty;
     Binding binding;
     Visibility vis;
-    Component.Attributes attr;
+    Attributes attr;
     Option<SCode.Comment> cmt;
     SourceInfo info;
   algorithm
@@ -301,7 +302,7 @@ public
       s := IOStream.append(s, "protected ");
     end if;
 
-    s := IOStream.append(s, Component.Attributes.toString(var.attributes, var.ty));
+    s := IOStream.append(s, Attributes.toString(var.attributes, var.ty));
     s := IOStream.append(s, Type.toString(var.ty));
     s := IOStream.append(s, " ");
     s := IOStream.append(s, ComponentRef.toString(var.name));
@@ -356,7 +357,7 @@ public
   algorithm
     s := IOStream.append(s, indent);
 
-    s := Component.Attributes.toFlatStream(var.attributes, var.ty, s, ComponentRef.isSimple(var.name));
+    s := Attributes.toFlatStream(var.attributes, var.ty, s, ComponentRef.isSimple(var.name));
     s := IOStream.append(s, Type.toFlatString(var.ty));
     s := IOStream.append(s, " ");
     s := IOStream.append(s, ComponentRef.toFlatString(var.name));

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -38,6 +38,7 @@ import DAE;
 
 protected
 
+import Attributes = NFAttributes;
 import Inst = NFInst;
 import Builtin = NFBuiltin;
 import NFBinding.Binding;
@@ -217,7 +218,7 @@ algorithm
           smod := AbsynToSCode.translateMod(SOME(Absyn.CLASSMOD(stripped_mod, Absyn.NOMOD())), SCode.NOT_FINAL(), SCode.NOT_EACH(), info);
           anncls := Lookup.lookupClassName(Absyn.IDENT(annName), inst_cls, NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
           inst_anncls := NFInst.expand(anncls);
-          inst_anncls := NFInst.instClass(inst_anncls, Modifier.create(smod, annName, ModifierScope.CLASS(annName), inst_cls), NFComponent.DEFAULT_ATTR, true, 0, inst_cls, NFInstContext.NO_CONTEXT);
+          inst_anncls := NFInst.instClass(inst_anncls, Modifier.create(smod, annName, ModifierScope.CLASS(annName), inst_cls), NFAttributes.DEFAULT_ATTR, true, 0, inst_cls, NFInstContext.NO_CONTEXT);
 
           // Instantiate expressions (i.e. anything that can contains crefs, like
           // bindings, dimensions, etc). This is done as a separate step after

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -351,6 +351,7 @@ if true then /* Suppress output */
   // "NFFrontEnd";
     "../NFFrontEnd/NFAlgorithm.mo",
     "../NFFrontEnd/NFArrayConnections.mo",
+    "../NFFrontEnd/NFAttributes.mo",
     "../NFFrontEnd/NFBackendExtension.mo",
     "../NFFrontEnd/NFBinding.mo",
     "../NFFrontEnd/NFBuiltinCall.mo",


### PR DESCRIPTION
- Move Component.Attributes and the various functions that use it to its
  own file, instead of having them be spread out all over.