### PR TITLE
Improve connector counting

### DIFF
--- a/testsuite/flattening/modelica/connectors/ConnectorBalance7.mo
+++ b/testsuite/flattening/modelica/connectors/ConnectorBalance7.mo
@@ -1,0 +1,39 @@
+// name: ConnectorBalance7
+// keywords: connector
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+connector C1
+  Real e1;
+  flow Real f1;
+  stream Real s1;
+end C1;
+
+connector C2
+  Real e2;
+  flow Real f2;
+end C2;
+
+connector HC
+  C1 c1;
+  C2 c2;
+end HC;
+
+model ConnectorBalance7
+  HC hc;
+end ConnectorBalance7;
+
+// Result:
+// class ConnectorBalance7
+//   Real hc.c1.e1;
+//   Real hc.c1.f1;
+//   Real hc.c1.s1;
+//   Real hc.c2.e2;
+//   Real hc.c2.f2;
+// equation
+//   hc.c1.f1 = 0.0;
+//   hc.c2.f2 = 0.0;
+// end ConnectorBalance7;
+// endResult

--- a/testsuite/flattening/modelica/connectors/Makefile
+++ b/testsuite/flattening/modelica/connectors/Makefile
@@ -41,6 +41,7 @@ ConnectorBalance3.mo \
 ConnectorBalance4.mo \
 ConnectorBalance5.mo \
 ConnectorBalance6.mo \
+ConnectorBalance7.mo \
 ConnectorComponents.mo \
 ConnectorCompOrder.mo \
 ConnectorIllegal.mo \

--- a/testsuite/flattening/modelica/scodeinst/ConnectNonConnector6.mo
+++ b/testsuite/flattening/modelica/scodeinst/ConnectNonConnector6.mo
@@ -24,6 +24,8 @@ end ConnectNonConnector6;
 
 // Result:
 // Error processing file: ConnectNonConnector6.mo
+// [flattening/modelica/scodeinst/ConnectNonConnector6.mo:20:3-20:12:writable] Warning: Connector c1 is not balanced: The number of potential variables (0) is not equal to the number of flow variables (1).
+// [flattening/modelica/scodeinst/ConnectNonConnector6.mo:20:3-20:12:writable] Warning: Connector c2 is not balanced: The number of potential variables (0) is not equal to the number of flow variables (1).
 // [flattening/modelica/scodeinst/ConnectNonConnector6.mo:22:3-22:22:writable] Error: c1.f is not a valid connector.
 //
 // # Error encountered! Exiting...


### PR DESCRIPTION
- For complex types, only count elements inside records and not e.g.
  connectors.

Fixes #8852