### PR TITLE
More minor fixes for portable compilation.

### DIFF
--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 # than that.
 if(MINGW)
   target_link_options(bomc PRIVATE -Wl,--stack,33554432)
+elseif(MSVC)
+  target_link_options(bomc PRIVATE /STACK:33554432)
 endif()
 
 

--- a/OMCompiler/Compiler/runtime/zeromqimpl.c
+++ b/OMCompiler/Compiler/runtime/zeromqimpl.c
@@ -30,8 +30,13 @@
 
 #include <zmq.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <string.h>
+
+#if defined(__MINGW32__) || defined(_MSC_VER)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "meta/meta_modelica.h"
 #include "util/modelica_string.h"

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -144,6 +144,8 @@ target_sources(SimulationRuntimeFMI PRIVATE ${SOURCE_FMU_COMMON_FILES_LIST}
 
 target_compile_definitions(SimulationRuntimeFMI PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL)
 
+target_include_directories(SimulationRuntimeFMI PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 install(TARGETS SimulationRuntimeFMI)
 
 

--- a/OMCompiler/SimulationRuntime/c/dataReconciliation/dataReconciliation.cpp
+++ b/OMCompiler/SimulationRuntime/c/dataReconciliation/dataReconciliation.cpp
@@ -1174,10 +1174,12 @@ void solveSystemFstar(int n, int nhrs, double *tmpMatrixD, double *tmpMatrixC, o
   int NRHS = nhrs;  // number of columns of Matrix B
   int LDA = N;
   int LDB = N;
-  int ipiv[N];
+  int* ipiv = new int[N];
   int info;
   // call the external function
   dgesv_(&N, &NRHS, tmpMatrixD, &LDA, ipiv, tmpMatrixC, &LDB, &info);
+  delete[] ipiv;
+
   if (info > 0)
   {
     //cout << "The solution could not be computed, The info satus is : " << info;
@@ -2165,7 +2167,7 @@ void checkExpensiveMatrixInverse()
   int N = 3;
   int LDA = N;
   int LDB = N;
-  int ipiv[N];
+  int ipiv[3];
   int info = 1;
   int LWORK = N;
   double *WORK = (double*) calloc(LWORK, sizeof(double));

--- a/OMCompiler/omc_config.h
+++ b/OMCompiler/omc_config.h
@@ -131,7 +131,9 @@
 /* On Windows (with OMDev) assume we have lapack*/
 #define HAVE_LAPACK
 /* On Windows (with OMDev) assume we have deprecated lapack functions*/
+#if !defined(_MSC_VER)
 #define HAVE_LAPACK_DEPRECATED
+#endif
 
 #else /* Unix */ /* #if !defined(MSYS2_AUTOCONF) && (defined(__MINGW32__) || defined(_MSC_VER)) */
 


### PR DESCRIPTION
  - Add missing define checks for MSVC
  - Use `windows.h` instead of `unistd.h` on Windows.

  - `stricmp` vs `strcasecmp`
  - `ctime_s` vs `ctime_r`

  - Remove more variable length arrays.
