### PR TITLE
Remove unnecessary static function in headers.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/base_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/base_array.c
@@ -39,6 +39,56 @@
 #include <assert.h>
 #include <stdarg.h>
 
+
+_index_t getIndex_2D(_index_t * dim, int i, int j) {
+  return i * dim[1] + j;
+}
+
+_index_t getIndex_3D(_index_t * dim, int i, int j, int k) {
+  return (i * dim[1] + j) * dim[2] + k;
+}
+
+_index_t getIndex_4D(_index_t * dim, int i, int j, int k, int l) {
+  return ((i * dim[1] + j) * dim[2] + k) * dim[3] + l;
+}
+
+_index_t getIndex_5D(_index_t * dim, int i, int j, int k, int l, int m) {
+  return (((i * dim[1] + j) * dim[2] + k) * dim[3] + l) * dim[4] + m;
+}
+
+/* Number of elements in array. */
+_index_t base_array_nr_of_elements(const base_array_t a)
+{
+  int i;
+  _index_t nr_of_elements = 1;
+  for(i = 0; i < a.ndims; ++i) {
+     nr_of_elements *= a.dim_size[i];
+  }
+  return nr_of_elements;
+}
+
+/* size of the ith dimension of an array */
+_index_t size_of_dimension_base_array(const base_array_t a, int i)
+{
+  /* assert(base_array_ok(&a)); */
+  if ((i > 0) && (i <= a.ndims)) {
+    return a.dim_size[i-1];
+  }
+  /* This is a weird work-around to return 0 if the dimension is out of bounds and a dimension is 0
+   * The reason is that we lose the dimensions in the DAE.ARRAY after a 0-dimension
+   * Note: We return size(arr,2)=0 if arr has dimensions [0,2], and not the expected 2
+   */
+  for (i=0; i<a.ndims; i++) {
+    if (a.dim_size[i] == 0) {
+      return 0;
+    }
+  }
+  fprintf(stderr, "size_of_dimension_base_array failed for i=%d, ndims=%d (ndims out of bounds)\n", i, a.ndims);
+  abort();
+}
+
+
+
 /** function: base_array_create
  **
  ** sets all fields in a base_array, i.e. data, ndims and dim_size.

--- a/OMCompiler/SimulationRuntime/c/util/base_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/base_array.h
@@ -36,10 +36,10 @@
 #include <stdarg.h>
 #include "omc_msvc.h"
 
-static OMC_INLINE size_t getIndex_2D(_index_t *dim, int i, int j) {return i*dim[1]+j;}
-static OMC_INLINE size_t getIndex_3D(_index_t *dim, int i, int j, int k) {return (i*dim[1]+j)*dim[2]+k;}
-static OMC_INLINE size_t getIndex_4D(_index_t *dim, int i, int j, int k, int l) {return ((i*dim[1]+j)*dim[2]+k)*dim[3]+l;}
-static OMC_INLINE size_t getIndex_5D(_index_t *dim, int i, int j, int k, int l, int m) {return (((i*dim[1]+j)*dim[2]+k)*dim[3]+l)*dim[4]+m;}
+_index_t getIndex_2D(_index_t *dim, int i, int j);
+_index_t getIndex_3D(_index_t *dim, int i, int j, int k);
+_index_t getIndex_4D(_index_t *dim, int i, int j, int k, int l);
+_index_t getIndex_5D(_index_t *dim, int i, int j, int k, int l, int m);
 
 /* Settings the fields of a base_array */
 void base_array_create(base_array_t *dest, void *data, int ndims, va_list ap);
@@ -54,15 +54,8 @@ void simple_alloc_2d_base_array(base_array_t *dest, int r, int c, void *data);
 size_t alloc_base_array(base_array_t *dest, int ndims, va_list ap);
 
 /* Number of elements in array. */
-static OMC_INLINE size_t base_array_nr_of_elements(const base_array_t a)
-{
-  int i;
-  size_t nr_of_elements = 1;
-  for(i = 0; i < a.ndims; ++i) {
-     nr_of_elements *= a.dim_size[i];
-  }
-  return nr_of_elements;
-}
+_index_t base_array_nr_of_elements(const base_array_t a);
+
 
 /* Clones fields */
 void clone_base_array_spec(const base_array_t *source, base_array_t *dest);
@@ -70,24 +63,9 @@ void clone_base_array_spec(const base_array_t *source, base_array_t *dest);
 void clone_reverse_base_array_spec(const base_array_t* source, base_array_t* dest);
 
 int ndims_base_array(const base_array_t* a);
-static OMC_INLINE int size_of_dimension_base_array(const base_array_t a, int i)
-{
-  /* assert(base_array_ok(&a)); */
-  if ((i > 0) && (i <= a.ndims)) {
-    return a.dim_size[i-1];
-  }
-  /* This is a weird work-around to return 0 if the dimension is out of bounds and a dimension is 0
-   * The reason is that we lose the dimensions in the DAE.ARRAY after a 0-dimension
-   * Note: We return size(arr,2)=0 if arr has dimensions [0,2], and not the expected 2
-   */
-  for (i=0; i<a.ndims; i++) {
-    if (a.dim_size[i] == 0) {
-      return 0;
-    }
-  }
-  fprintf(stderr, "size_of_dimension_base_array failed for i=%d, ndims=%d (ndims out of bounds)\n", i, a.ndims);
-  abort();
-}
+
+/* size of the ith dimension of an array */
+_index_t size_of_dimension_base_array(const base_array_t a, int i);
 
 /* Helper functions */
 int base_array_ok(const base_array_t *a);

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.c
@@ -40,6 +40,33 @@
 #include <assert.h>
 #include <stdarg.h>
 
+
+modelica_boolean boolean_get(const boolean_array_t a, size_t i)
+{
+    return ((modelica_boolean *) a.data)[i];
+}
+
+modelica_boolean boolean_get_2D(const boolean_array_t a, size_t i, size_t j)
+{
+    return boolean_get(a, getIndex_2D(a.dim_size,i,j));
+}
+
+modelica_boolean boolean_get_3D(const boolean_array_t a, size_t i, size_t j, size_t k)
+{
+    return boolean_get(a, getIndex_3D(a.dim_size,i,j,k));
+}
+
+modelica_boolean boolean_get_4D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l)
+{
+    return boolean_get(a, getIndex_4D(a.dim_size,i,j,k,l));
+}
+
+modelica_boolean boolean_get_5D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+    return boolean_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
+
 static inline modelica_boolean *boolean_ptrget(const boolean_array_t *a, size_t i)
 {
     return ((modelica_boolean *) a->data) + i;

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.h
@@ -38,30 +38,11 @@
 #include "omc_msvc.h"
 #include <stdarg.h>
 
-static OMC_INLINE modelica_boolean boolean_get(const boolean_array_t a, size_t i)
-{
-    return ((modelica_boolean *) a.data)[i];
-}
-
-static OMC_INLINE modelica_boolean boolean_get_2D(const boolean_array_t a, size_t i, size_t j)
-{
-    return boolean_get(a, getIndex_2D(a.dim_size,i,j));
-}
-
-static OMC_INLINE modelica_boolean boolean_get_3D(const boolean_array_t a, size_t i, size_t j, size_t k)
-{
-    return boolean_get(a, getIndex_3D(a.dim_size,i,j,k));
-}
-
-static OMC_INLINE modelica_boolean boolean_get_4D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l)
-{
-    return boolean_get(a, getIndex_4D(a.dim_size,i,j,k,l));
-}
-
-static OMC_INLINE modelica_boolean boolean_get_5D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
-{
-    return boolean_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
-}
+modelica_boolean boolean_get(const boolean_array_t a, size_t i);
+modelica_boolean boolean_get_2D(const boolean_array_t a, size_t i, size_t j);
+modelica_boolean boolean_get_3D(const boolean_array_t a, size_t i, size_t j, size_t k);
+modelica_boolean boolean_get_4D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l);
+modelica_boolean boolean_get_5D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Setting the fields of a boolean_array */
 extern void boolean_array_create(boolean_array_t *dest, modelica_boolean *data, int ndims, ...);

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.c
@@ -53,6 +53,31 @@ static OMC_INLINE void integer_set(integer_array_t *a, size_t i, modelica_intege
   ((modelica_integer *) a->data)[i] = r;
 }
 
+modelica_integer integer_get(const integer_array_t a, size_t i)
+{
+  return ((modelica_integer *) a.data)[i];
+}
+
+modelica_integer integer_get_2D(const integer_array_t a, size_t i, size_t j)
+{
+  return integer_get(a, getIndex_2D(a.dim_size,i,j));
+}
+
+modelica_integer integer_get_3D(const integer_array_t a, size_t i, size_t j, size_t k)
+{
+  return integer_get(a, getIndex_3D(a.dim_size,i,j,k));
+}
+
+modelica_integer integer_get_4D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l)
+{
+  return integer_get(a, getIndex_4D(a.dim_size,i,j,k,l));
+}
+
+modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+  return integer_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
 /** function: integer_array_create
  **
  ** sets all fields in a integer_array, i.e. data, ndims and dim_size.

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.h
@@ -39,30 +39,11 @@
 #include "index_spec.h"
 #include <stdarg.h>
 
-static OMC_INLINE modelica_integer integer_get(const integer_array_t a, size_t i)
-{
-  return ((modelica_integer *) a.data)[i];
-}
-
-static OMC_INLINE modelica_integer integer_get_2D(const integer_array_t a, size_t i, size_t j)
-{
-  return integer_get(a, getIndex_2D(a.dim_size,i,j));
-}
-
-static OMC_INLINE modelica_integer integer_get_3D(const integer_array_t a, size_t i, size_t j, size_t k)
-{
-  return integer_get(a, getIndex_3D(a.dim_size,i,j,k));
-}
-
-static OMC_INLINE modelica_integer integer_get_4D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l)
-{
-  return integer_get(a, getIndex_4D(a.dim_size,i,j,k,l));
-}
-
-static OMC_INLINE modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
-{
-  return integer_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
-}
+modelica_integer integer_get(const integer_array_t a, size_t i);
+modelica_integer integer_get_2D(const integer_array_t a, size_t i, size_t j);
+modelica_integer integer_get_3D(const integer_array_t a, size_t i, size_t j, size_t k);
+modelica_integer integer_get_4D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l);
+modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Settings the fields of a integer_array */
 extern void integer_array_create(integer_array_t *dest, modelica_integer *data,

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
@@ -279,6 +279,30 @@ int omc_dladdr(void *addr, Dl_info *info)
 {
   return 0;
 }
+
+
+void* dlopen(const char *filename, int flag) {
+  return omc_dlopen(filename, flag);
+}
+
+char* dlerror() {
+  return omc_dlerror();
+}
+
+void* dlsym(void *handle, const char *symbol) {
+  return omc_dlsym(handle, symbol);
+}
+
+int dlclose(void *handle) {
+  return omc_dlclose(handle);
+}
+
+int dladdr(void *addr, Dl_info *info) {
+  return omc_dladdr(addr, info);
+}
+
+
+
 #else /* MINGW */
 
 /*

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.h
@@ -162,25 +162,11 @@ void* omc_dlsym(void *handle, const char *symbol);
 int omc_dlclose(void *handle);
 int omc_dladdr(void *addr, Dl_info *info);
 
-static OMC_INLINE void* dlopen(const char *filename, int flag) {
-  return omc_dlopen(filename, flag);
-}
-
-static OMC_INLINE char* dlerror() {
-  return omc_dlerror();
-}
-
-static OMC_INLINE void* dlsym(void *handle, const char *symbol) {
-  return omc_dlsym(handle, symbol);
-}
-
-static OMC_INLINE int dlclose(void *handle) {
-  return omc_dlclose(handle);
-}
-
-static OMC_INLINE int dladdr(void *addr, Dl_info *info) {
-  return omc_dladdr(addr, info);
-}
+void* dlopen(const char *filename, int flag);
+char* dlerror();
+void* dlsym(void *handle, const char *symbol);
+int dlclose(void *handle);
+int dladdr(void *addr, Dl_info *info);
 
 #endif
 

--- a/OMCompiler/SimulationRuntime/c/util/real_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.c
@@ -53,6 +53,32 @@ static inline void real_set(real_array_t *a, size_t i, modelica_real r)
     ((modelica_real *) a->data)[i] = r;
 }
 
+
+modelica_real real_get(const real_array_t a, size_t i)
+{
+  return ((modelica_real *) a.data)[i];
+}
+
+modelica_real real_get_2D(const real_array_t a, size_t i, size_t j)
+{
+  return real_get(a, getIndex_2D(a.dim_size,i,j));
+}
+
+modelica_real real_get_3D(const real_array_t a, size_t i, size_t j, size_t k)
+{
+  return real_get(a, getIndex_3D(a.dim_size,i,j,k));
+}
+
+modelica_real real_get_4D(const real_array_t a, size_t i, size_t j, size_t k, size_t l)
+{
+  return real_get(a, getIndex_4D(a.dim_size,i,j,k,l));
+}
+
+modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+  return real_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
 /** function: real_array_create
  **
  ** sets all fields in a real_array, i.e. data, ndims and dim_size.

--- a/OMCompiler/SimulationRuntime/c/util/real_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.h
@@ -40,30 +40,11 @@
 #include "omc_msvc.h"
 #include <stdarg.h>
 
-static OMC_INLINE modelica_real real_get(const real_array_t a, size_t i)
-{
-  return ((modelica_real *) a.data)[i];
-}
-
-static OMC_INLINE modelica_real real_get_2D(const real_array_t a, size_t i, size_t j)
-{
-  return real_get(a, getIndex_2D(a.dim_size,i,j));
-}
-
-static OMC_INLINE modelica_real real_get_3D(const real_array_t a, size_t i, size_t j, size_t k)
-{
-  return real_get(a, getIndex_3D(a.dim_size,i,j,k));
-}
-
-static OMC_INLINE modelica_real real_get_4D(const real_array_t a, size_t i, size_t j, size_t k, size_t l)
-{
-  return real_get(a, getIndex_4D(a.dim_size,i,j,k,l));
-}
-
-static OMC_INLINE modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
-{
-  return real_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
-}
+modelica_real real_get(const real_array_t a, size_t i);
+modelica_real real_get_2D(const real_array_t a, size_t i, size_t j);
+modelica_real real_get_3D(const real_array_t a, size_t i, size_t j, size_t k);
+modelica_real real_get_4D(const real_array_t a, size_t i, size_t j, size_t k, size_t l);
+modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Setting the fields of a real_array */
 extern void real_array_create(real_array_t *dest, modelica_real *data, int ndims, ...);

--- a/OMCompiler/SimulationRuntime/c/util/string_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.c
@@ -51,6 +51,32 @@ static inline void string_set(string_array_t *a, size_t i, modelica_string r)
     ((modelica_string *) a->data)[i] = r;
 }
 
+modelica_string string_get(const string_array_t a, size_t i)
+{
+    return ((modelica_string *) a.data)[i];
+}
+
+modelica_string string_get_2D(const string_array_t a, size_t i, size_t j)
+{
+  return string_get(a, getIndex_2D(a.dim_size,i,j));
+}
+
+modelica_string string_get_3D(const string_array_t a, size_t i, size_t j, size_t k)
+{
+  return string_get(a, getIndex_3D(a.dim_size,i,j,k));
+}
+
+modelica_string string_get_4D(const string_array_t a, size_t i, size_t j, size_t k, size_t l)
+{
+  return string_get(a, getIndex_4D(a.dim_size,i,j,k,l));
+}
+
+modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+{
+  return string_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
+}
+
+
 /** function: string_array_create
  **
  ** sets all fields in a string_array, i.e. data, ndims and dim_size.

--- a/OMCompiler/SimulationRuntime/c/util/string_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.h
@@ -37,30 +37,11 @@
 #include "generic_array.h"
 
 /* Indexing */
-static OMC_INLINE modelica_string string_get(const string_array_t a, size_t i)
-{
-    return ((modelica_string *) a.data)[i];
-}
-
-static OMC_INLINE modelica_string string_get_2D(const string_array_t a, size_t i, size_t j)
-{
-  return string_get(a, getIndex_2D(a.dim_size,i,j));
-}
-
-static OMC_INLINE modelica_string string_get_3D(const string_array_t a, size_t i, size_t j, size_t k)
-{
-  return string_get(a, getIndex_3D(a.dim_size,i,j,k));
-}
-
-static OMC_INLINE modelica_string string_get_4D(const string_array_t a, size_t i, size_t j, size_t k, size_t l)
-{
-  return string_get(a, getIndex_4D(a.dim_size,i,j,k,l));
-}
-
-static OMC_INLINE modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
-{
-  return string_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
-}
+modelica_string string_get(const string_array_t a, size_t i);
+modelica_string string_get_2D(const string_array_t a, size_t i, size_t j);
+modelica_string string_get_3D(const string_array_t a, size_t i, size_t j, size_t k);
+modelica_string string_get_4D(const string_array_t a, size_t i, size_t j, size_t k, size_t l);
+modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Setting the fields of a string_array */
 extern void string_array_create(string_array_t *dest, modelica_string *data, int ndims, ...);


### PR DESCRIPTION
  - They will just get duplicated in every compilation unit. There seems
    to be no need to have them as header-file static functions.

  - Fix some incompatible size returns: `int` vs `size_t`.