### PR TITLE
Harden FMI getNumericalJacobian when blackbox

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -231,7 +231,10 @@ static int getNumericalJacobian(struct dataAndSys* dataAndSysNum, double* jac, c
     deltaInv = 1. / delta_hh;
     solverData->xSave[i] = x[i] + delta_hh;
 
-    infoStreamPrint(LOG_NLS_JAC, 0, "%d. %s = %f (delta_hh = %f)", i+1, modelInfoGetEquation(&dataSys->data->modelData->modelDataXml,systemData->equationIndex).vars[i], solverData->xSave[i], delta_hh);
+    if(ACTIVE_STREAM(LOG_NLS_JAC))
+    {
+      infoStreamPrint(LOG_NLS_JAC, 0, "%d. %s = %f (delta_hh = %f)", i+1, modelInfoGetEquation(&dataSys->data->modelData->modelDataXml,systemData->equationIndex).vars[i], solverData->xSave[i], delta_hh);
+    }
     wrapper_fvec_hybrj(&solverData->n, (const double*) solverData->xSave, solverData->fvecSave, solverData->fjacobian, &solverData->ldfjac, &iflag, dataSys);
 
     for(j = 0; j < solverData->n; ++j)


### PR DESCRIPTION
A SimulationRuntime marked as blackbox or protected leads to a crash here.

### Related Issues

Related to #8158 

### Purpose

Avoid a crash in blackbox or protected fmi

### Approach

Avoid querying potentially non-existent modelInfo.
Will still crash if verbosity is raised.
