### PR TITLE
Improve ModelicaExternalC compilation for MSVC.

### DIFF
--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -28,6 +28,10 @@ if(MINGW)
   target_link_options(bomc PRIVATE -Wl,--stack,33554432)
 elseif(MSVC)
   target_link_options(bomc PRIVATE /STACK:33554432)
+  target_compile_options(bomc PRIVATE /wd4101) # unreferenced local variable
+  target_compile_options(bomc PRIVATE /wd4102) # unreferenced label
+  target_compile_options(bomc PRIVATE /wd4267) # conversion from 'size_t' to 'int', possible loss of data
+  target_compile_options(bomc PRIVATE /wd4244) # conversion from '' to '', possible loss of data
 endif()
 
 

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
@@ -20,11 +20,18 @@ set(libModelicaExternalC_SOURCES C-Sources/ModelicaFFT.c
                                  C-Sources/ModelicaRandom.c
                                  C-Sources/ModelicaStrings.c)
 
+if(MSVC)
+  set(libModelicaExternalC_SOURCES ${libModelicaExternalC_SOURCES} C-Sources/win32_dirent.c)
+endif()
+
 # Static version
 add_library(ModelicaExternalC STATIC ${libModelicaExternalC_SOURCES})
 add_library(omc::simrt::Modelica::ExternalC ALIAS ModelicaExternalC)
 
-target_link_libraries(ModelicaExternalC PUBLIC m)
+if(UNIX)
+  target_link_libraries(ModelicaExternalC PUBLIC m)
+endif()
+
 target_link_libraries(ModelicaExternalC PUBLIC omc::simrt::runtime)
 
 # Shared version.
@@ -33,9 +40,13 @@ add_library(omc::simrt::Modelica::ExternalC::shared ALIAS ModelicaExternalC_shar
 set_target_properties(ModelicaExternalC_shared
                       PROPERTIES OUTPUT_NAME ModelicaExternalC CLEAN_DIRECT_OUTPUT 1)
 
-target_link_libraries(ModelicaExternalC_shared PUBLIC m)
+if(UNIX)
+  target_link_libraries(ModelicaExternalC_shared PUBLIC m)
+endif()
+
 target_link_libraries(ModelicaExternalC_shared PUBLIC omc::simrt::runtime)
-if(WIN32)
+
+if(MINGW)
   target_link_options(ModelicaExternalC_shared PRIVATE -Wl,--export-all-symbols)
 endif()
 
@@ -60,7 +71,8 @@ set_target_properties(ModelicaMatIO_shared
 target_compile_definitions(ModelicaMatIO_shared PUBLIC HAVE_ZLIB)
 target_link_libraries(ModelicaMatIO_shared PUBLIC omc::3rd::zlib)
 target_link_libraries(ModelicaMatIO_shared PUBLIC omc::simrt::runtime)
-if(WIN32)
+
+if(MINGW)
   target_link_options(ModelicaMatIO_shared PRIVATE -Wl,--export-all-symbols)
 endif()
 
@@ -80,7 +92,8 @@ set_target_properties(ModelicaIO_shared
                       PROPERTIES OUTPUT_NAME ModelicaIO CLEAN_DIRECT_OUTPUT 1)
 
 target_link_libraries(ModelicaIO_shared PUBLIC ModelicaMatIO_shared)
-if(WIN32)
+
+if(MINGW)
   target_link_options(ModelicaIO_shared PRIVATE -Wl,--export-all-symbols)
 endif()
 
@@ -97,7 +110,9 @@ add_library(omc::simrt::Modelica::StandardTables ALIAS ModelicaStandardTables)
 target_compile_definitions(ModelicaStandardTables PRIVATE DUMMY_FUNCTION_USERTAB)
 
 target_link_libraries(ModelicaStandardTables PUBLIC ModelicaIO)
-target_link_libraries(ModelicaStandardTables PUBLIC m)
+if(UNIX)
+  target_link_libraries(ModelicaStandardTables PUBLIC m)
+endif()
 
 # Shared version
 add_library(ModelicaStandardTables_shared SHARED ${ModelicaStandardTables_SOURCES})
@@ -109,8 +124,12 @@ set_target_properties(ModelicaStandardTables_shared
 target_compile_definitions(ModelicaStandardTables_shared PRIVATE DUMMY_FUNCTION_USERTAB)
 
 target_link_libraries(ModelicaStandardTables_shared PUBLIC ModelicaIO_shared)
-target_link_libraries(ModelicaStandardTables_shared PUBLIC m)
-if(WIN32)
+
+if(UNIX)
+  target_link_libraries(ModelicaStandardTables_shared PUBLIC m)
+endif()
+
+if(MINGW)
   target_link_options(ModelicaStandardTables_shared PRIVATE -Wl,--export-all-symbols)
 endif()
 

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/MEC_standalone_2.8.cmake
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/MEC_standalone_2.8.cmake
@@ -138,7 +138,7 @@ install(TARGETS ModelicaExternalC
 
 # Install the shared libs to a directory 'ffi' within the lib dir.
 # This is so that they are not on the normal link path of simulation executables.
-# We do not want to have them for anything other than FFI based for constant
+# We do not want to have them for anything other than FFI based constant
 # evaluation by omc (They are only loaded never linked)
 install(TARGETS ModelicaExternalC_shared
                 ModelicaMatIO_shared


### PR DESCRIPTION
  - Fix ModelicaExternalC compilation
    - Link to `libm` only on linux.
    - `export-all-symbols` only on MinGW.
    - use the provided `dirent.h` replacement implementation (`win32_dirent.h`)
      on MSVC.

  - Disable some warnings on bootstrap sources. These should of course be
    fixed by updating the source code AND the generating code as well. For
    now disable them because the code is not "changing code".

