### PR TITLE
Remove SCode.Equation

### DIFF
--- a/OMCompiler/Compiler/FFrontEnd/FGraphBuild.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphBuild.mo
@@ -1106,17 +1106,14 @@ protected function analyseEquation
   input Kind inKind;
   input Graph inGraph;
   output Graph outGraph;
-protected
-  SCode.EEquation equ;
 algorithm
-  SCode.EQUATION(equ) := inEquation;
-  (_, outGraph) := SCodeUtil.mapFoldEEquations(equ,
-    function analyseEEquationTraverser(ref = inParentRef, kind = inKind), inGraph);
+  (_, outGraph) := SCodeUtil.mapFoldEquations(inEquation,
+    function analyseEquationTraverser(ref = inParentRef, kind = inKind), inGraph);
 end analyseEquation;
 
-protected function analyseEEquationTraverser
+protected function analyseEquationTraverser
   "Traversal function for use in analyseEquation."
-  input output SCode.EEquation eq;
+  input output SCode.Equation eq;
   input Ref ref;
   input Kind kind;
   input output Graph graph;
@@ -1130,25 +1127,25 @@ algorithm
       algorithm
         graph := addIterators({Absyn.ITERATOR(iter_name, NONE(), NONE())}, ref, kind, graph);
       then
-        SCodeUtil.mapFoldEEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
+        SCodeUtil.mapFoldEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
 
     case SCode.EQ_REINIT(cref = Absyn.CREF(componentRef = cref1))
       algorithm
         graph := analyseCref(cref1, ref, kind, graph);
       then
-        SCodeUtil.mapFoldEEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
+        SCodeUtil.mapFoldEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
 
     else
       algorithm
-        _ := SCodeUtil.getEEquationInfo(eq);
+        _ := SCodeUtil.getEquationInfo(eq);
       then
-        SCodeUtil.mapFoldEEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
+        SCodeUtil.mapFoldEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
 
   end match;
-end analyseEEquationTraverser;
+end analyseEquationTraverser;
 
 protected function traverseExp
-  "Traversal function used by analyseEEquationTraverser and
+  "Traversal function used by analyseEquationTraverser and
   analyseStatementTraverser."
   input output Absyn.Exp exp;
   input output Graph graph;

--- a/OMCompiler/Compiler/FFrontEnd/FGraphBuildEnv.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraphBuildEnv.mo
@@ -1092,17 +1092,14 @@ protected function analyseEquation
   input Kind inKind;
   input Graph inGraph;
   output Graph outGraph;
-protected
-  SCode.EEquation equ;
 algorithm
-  SCode.EQUATION(equ) := inEquation;
-  (_, outGraph) := SCodeUtil.mapFoldEEquations(equ,
-    function analyseEEquationTraverser(ref = inParentRef, kind = inKind), inGraph);
+  (_, outGraph) := SCodeUtil.mapFoldEquations(inEquation,
+    function analyseEquationTraverser(ref = inParentRef, kind = inKind), inGraph);
 end analyseEquation;
 
-protected function analyseEEquationTraverser
+protected function analyseEquationTraverser
   "Traversal function for use in analyseEquation."
-  input output SCode.EEquation eq;
+  input output SCode.Equation eq;
   input Ref ref;
   input Kind kind;
   input output Graph graph;
@@ -1116,25 +1113,25 @@ algorithm
       algorithm
         graph := addIterators({Absyn.ITERATOR(iter_name, NONE(), NONE())}, ref, kind, graph);
       then
-        SCodeUtil.mapFoldEEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
+        SCodeUtil.mapFoldEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
 
     case SCode.EQ_REINIT(cref = Absyn.CREF(componentRef = cref1))
       algorithm
         graph := analyseCref(cref1, ref, kind, graph);
       then
-        SCodeUtil.mapFoldEEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
+        SCodeUtil.mapFoldEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
 
     else
       algorithm
-        _ := SCodeUtil.getEEquationInfo(eq);
+        _ := SCodeUtil.getEquationInfo(eq);
       then
-        SCodeUtil.mapFoldEEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
+        SCodeUtil.mapFoldEquationExps(eq, function traverseExp(ref = ref, kind = kind), graph);
 
   end match;
-end analyseEEquationTraverser;
+end analyseEquationTraverser;
 
 protected function traverseExp
-  "Traversal function used by analyseEEquationTraverser and
+  "Traversal function used by analyseEquationTraverser and
   analyseStatementTraverser."
   input output Absyn.Exp exp;
   input output Graph graph;

--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -121,7 +121,7 @@ public constant ElementSource emptyElementSource = SOURCE(AbsynUtil.dummyInfo,{}
 
 public uniontype SymbolicOperation
   record FLATTEN "From one equation/statement to an element"
-    SCode.EEquation scode;
+    SCode.Equation scode;
     Option<Element> dae;
   end FLATTEN;
   record SIMPLIFY "Before and after expression is equivalent"

--- a/OMCompiler/Compiler/FrontEnd/ElementSource.mo
+++ b/OMCompiler/Compiler/FrontEnd/ElementSource.mo
@@ -247,7 +247,7 @@ algorithm
       list<DAE.SymbolicOperation> operations;
       DAE.Exp h1,t1,t2;
       list<SCode.Comment> comment;
-      SCode.EEquation scode;
+      SCode.Equation scode;
       list<DAE.Element> elts;
     case (DAE.SOURCE(info, partOfLst, instanceOpt, connectEquationOptLst, typeLst, DAE.FLATTEN(scode,NONE())::operations,comment),_)
       then DAE.SOURCE(info, partOfLst, instanceOpt, connectEquationOptLst, typeLst, DAE.FLATTEN(scode,SOME(elt))::operations,comment);

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -526,7 +526,7 @@ algorithm
       DAE.Properties prop2;
       Boolean impl;
       Absyn.Exp aexp1,aexp2;
-      SCode.EEquation scode;
+      SCode.Equation scode;
       Absyn.ComponentRef acr;
       SourceInfo info;
       DAE.ElementSource source;

--- a/OMCompiler/Compiler/FrontEnd/InstExtends.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstExtends.mo
@@ -1117,39 +1117,11 @@ protected function fixEquation
   Analyzes the SCode datastructure and replace paths with a new path (from
   local lookup or fully qualified in the environment.
 "
-  input array<FCore.Cache> inCache;
-  input FCore.Graph inEnv;
-  input SCode.Equation inEq;
-  input AvlSetString.Tree tree;
-  output SCode.Equation outEq;
-algorithm
-  outEq := match inEq
-    local
-      SCode.EEquation eeq1,eeq2;
-
-    case SCode.EQUATION(eeq1)
-      algorithm
-        eeq2 := fixEEquation(inCache, inEnv, eeq1, tree);
-      then if referenceEq(eeq1,eeq2) then inEq else SCode.EQUATION(eeq2);
-
-    case SCode.EQUATION(eeq1)
-      equation
-        true = Flags.isSet(Flags.FAILTRACE);
-        Debug.traceln("- Inst.fixEquation failed: " + SCodeDump.equationStr(eeq1));
-      then fail();
-  end match;
-end fixEquation;
-
-protected function fixEEquation
-" All of the fix functions do the following:
-  Analyzes the SCode datastructure and replace paths with a new path (from
-  local lookup or fully qualified in the environment.
-"
   input array<FCore.Cache> cache;
   input FCore.Graph inEnv;
-  input SCode.EEquation inEeq;
+  input SCode.Equation inEeq;
   input AvlSetString.Tree tree;
-  output SCode.EEquation outEeq;
+  output SCode.Equation outEeq;
 algorithm
   outEeq := match inEeq
     local
@@ -1157,9 +1129,9 @@ algorithm
       Absyn.ComponentRef cref,cref1,cref2;
       Absyn.Exp exp,exp1,exp2,exp3;
       list<Absyn.Exp> expl;
-      list<SCode.EEquation> eql;
-      list<list<SCode.EEquation>> eqll;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> whenlst;
+      list<SCode.Equation> eql;
+      list<list<SCode.Equation>> eqll;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> whenlst;
       SCode.Comment comment;
       Option<Absyn.Exp> optExp;
       SourceInfo info;
@@ -1167,8 +1139,8 @@ algorithm
     case SCode.EQ_IF(expl,eqll,eql,comment,info)
       equation
         expl = fixList(cache,inEnv,expl,tree,fixExp);
-        eqll = fixListList(cache,inEnv,eqll,tree,fixEEquation);
-        eql = fixList(cache,inEnv,eql,tree,fixEEquation);
+        eqll = fixListList(cache,inEnv,eqll,tree,fixEquation);
+        eql = fixList(cache,inEnv,eql,tree,fixEquation);
       then (SCode.EQ_IF(expl,eqll,eql,comment,info));
     case SCode.EQ_EQUALS(exp1,exp2,comment,info)
       equation
@@ -1189,13 +1161,13 @@ algorithm
     case SCode.EQ_FOR(id,optExp,eql,comment,info)
       equation
         optExp = fixOption(cache,inEnv,optExp,tree,fixExp);
-        eql = fixList(cache,inEnv,eql,tree,fixEEquation);
+        eql = fixList(cache,inEnv,eql,tree,fixEquation);
       then (SCode.EQ_FOR(id,optExp,eql,comment,info));
     case SCode.EQ_WHEN(exp,eql,whenlst,comment,info)
       equation
         exp = fixExp(cache,inEnv,exp,tree);
-        eql = fixList(cache,inEnv,eql,tree,fixEEquation);
-        whenlst = fixListTuple2(cache,inEnv,whenlst,tree,fixExp,fixListEEquation);
+        eql = fixList(cache,inEnv,eql,tree,fixEquation);
+        whenlst = fixListTuple2(cache,inEnv,whenlst,tree,fixExp,fixListEquation);
       then (SCode.EQ_WHEN(exp,eql,whenlst,comment,info));
     case SCode.EQ_ASSERT(exp1,exp2,exp3,comment,info)
       equation
@@ -1217,21 +1189,21 @@ algorithm
         exp = fixExp(cache,inEnv,exp,tree);
       then (SCode.EQ_NORETCALL(exp,comment,info));
   end match;
-end fixEEquation;
+end fixEquation;
 
-protected function fixListEEquation
+protected function fixListEquation
 " All of the fix functions do the following:
   Analyzes the SCode datastructure and replace paths with a new path (from
   local lookup or fully qualified in the environment.
 "
   input array<FCore.Cache> cache;
   input FCore.Graph env;
-  input list<SCode.EEquation> eeq;
+  input list<SCode.Equation> eeq;
   input AvlSetString.Tree tree;
-  output list<SCode.EEquation> outEeq;
+  output list<SCode.Equation> outEeq;
 algorithm
-  outEeq := fixList(cache,env,eeq,tree,fixEEquation);
-end fixListEEquation;
+  outEeq := fixList(cache,env,eeq,tree,fixEquation);
+end fixListEquation;
 
 protected function fixAlgorithm
 " All of the fix functions do the following:

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -111,39 +111,11 @@ public function instEquation
   output Connect.Sets outSets;
   output ClassInf.State outState;
   output ConnectionGraph.ConnectionGraph outGraph;
-protected
-  SCode.EEquation eq;
 algorithm
-  SCode.EQUATION(eEquation = eq) := inEquation;
   (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
-    instEquationCommon(inCache, inEnv, inIH, inPrefix, inSets, inState, eq,
+    instEquationCommon(inCache, inEnv, inIH, inPrefix, inSets, inState, inEquation,
       SCode.NON_INITIAL(), inImpl, inGraph);
 end instEquation;
-
-protected function instEEquation
-  "Instantiation of EEquation, used in for loops and if-equations."
-  input FCore.Cache inCache;
-  input FCore.Graph inEnv;
-  input InnerOuter.InstHierarchy inIH;
-  input DAE.Prefix inPrefix;
-  input Connect.Sets inSets;
-  input ClassInf.State inState;
-  input SCode.EEquation inEEquation;
-  input Boolean inImpl;
-  input Boolean unrollForLoops "Unused, to comply with Inst.instList interface.";
-  input ConnectionGraph.ConnectionGraph inGraph;
-  output FCore.Cache outCache;
-  output FCore.Graph outEnv;
-  output InnerOuter.InstHierarchy outIH;
-  output DAE.DAElist outDae;
-  output Connect.Sets outSets;
-  output ClassInf.State outState;
-  output ConnectionGraph.ConnectionGraph outGraph;
-algorithm
-  (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
-    instEquationCommon(inCache, inEnv, inIH, inPrefix, inSets, inState, inEEquation,
-      SCode.NON_INITIAL(), inImpl, inGraph);
-end instEEquation;
 
 public function instInitialEquation
 "author: LS, ELN
@@ -166,39 +138,11 @@ public function instInitialEquation
   output Connect.Sets outSets;
   output ClassInf.State outState;
   output ConnectionGraph.ConnectionGraph outGraph;
-protected
-  SCode.EEquation eq;
 algorithm
-  SCode.EQUATION(eEquation = eq) := inEquation;
   (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
-    instEquationCommon(inCache, inEnv, inIH, inPrefix, inSets, inState, eq,
+    instEquationCommon(inCache, inEnv, inIH, inPrefix, inSets, inState, inEquation,
       SCode.INITIAL(), inImpl, inGraph);
 end instInitialEquation;
-
-protected function instEInitialEquation
-  "Instantiates initial EEquation used in for loops and if equations "
-  input FCore.Cache inCache;
-  input FCore.Graph inEnv;
-  input InnerOuter.InstHierarchy inIH;
-  input DAE.Prefix inPrefix;
-  input Connect.Sets inSets;
-  input ClassInf.State inState;
-  input SCode.EEquation inEEquation;
-  input Boolean inImpl;
-  input Boolean unrollForLoops "Unused, to comply with Inst.instList interface.";
-  input ConnectionGraph.ConnectionGraph inGraph;
-  output FCore.Cache outCache;
-  output FCore.Graph outEnv;
-  output InnerOuter.InstHierarchy outIH;
-  output DAE.DAElist outDae;
-  output Connect.Sets outSets;
-  output ClassInf.State outState;
-  output ConnectionGraph.ConnectionGraph outGraph;
-algorithm
-  (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
-    instEquationCommon(inCache, inEnv, inIH, inPrefix, inSets, inState, inEEquation,
-      SCode.INITIAL(), inImpl, inGraph);
-end instEInitialEquation;
 
 protected function instEquationCommon
   "The DAE output of the translation contains equations which
@@ -213,7 +157,7 @@ protected function instEquationCommon
   input DAE.Prefix inPrefix;
   input Connect.Sets inSets;
   input ClassInf.State inState;
-  input SCode.EEquation inEEquation;
+  input SCode.Equation inEquation;
   input SCode.Initial inInitial;
   input Boolean inImpl;
   input ConnectionGraph.ConnectionGraph inGraph;
@@ -237,7 +181,7 @@ algorithm
         state := ClassInf.trans(inState,ClassInf.FOUND_EQUATION());
         (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
           instEquationCommonWork(inCache, inEnv, inIH, inPrefix, inSets, state,
-            inEEquation, inInitial, inImpl, inGraph, DAE.FLATTEN(inEEquation,NONE()));
+            inEquation, inInitial, inImpl, inGraph, DAE.FLATTEN(inEquation,NONE()));
         outDae := DAEUtil.traverseDAE(outDae, DAE.AvlTreePathFunction.Tree.EMPTY(),
           Expression.traverseSubexpressionsHelper,
           (ExpressionSimplify.simplifyWork, ExpressionSimplifyTypes.optionSimplifyOnly));
@@ -248,7 +192,7 @@ algorithm
       algorithm
         failure(_ := ClassInf.trans(inState,ClassInf.FOUND_EQUATION()));
         s := ClassInf.printStateStr(inState);
-        Error.addSourceMessage(Error.EQUATION_TRANSITION_FAILURE, {s}, SCodeUtil.equationFileInfo(inEEquation));
+        Error.addSourceMessage(Error.EQUATION_TRANSITION_FAILURE, {s}, SCodeUtil.equationFileInfo(inEquation));
       then
         fail();
 
@@ -257,8 +201,8 @@ algorithm
     else
       algorithm
         true := errorCount == Error.getNumErrorMessages();
-        s := "\n" + SCodeDump.equationStr(inEEquation);
-        Error.addSourceMessage(Error.EQUATION_GENERIC_FAILURE, {s}, SCodeUtil.equationFileInfo(inEEquation));
+        s := "\n" + SCodeDump.equationStr(inEquation);
+        Error.addSourceMessage(Error.EQUATION_GENERIC_FAILURE, {s}, SCodeUtil.equationFileInfo(inEquation));
       then
         fail();
 
@@ -278,7 +222,7 @@ protected function instEquationCommonWork
   input DAE.Prefix inPrefix;
   input Connect.Sets inSets;
   input ClassInf.State inState;
-  input SCode.EEquation inEEquation;
+  input SCode.Equation inEquation;
   input SCode.Initial inInitial;
   input Boolean inImpl;
   input ConnectionGraph.ConnectionGraph inGraph;
@@ -291,7 +235,7 @@ protected function instEquationCommonWork
   output ClassInf.State outState;
   output ConnectionGraph.ConnectionGraph outGraph = inGraph;
 algorithm
-  (outDae, outState) := matchcontinue inEEquation
+  (outDae, outState) := matchcontinue inEquation
     local
       Absyn.ComponentRef lhs_acr, rhs_acr, acr;
       SourceInfo info;
@@ -305,8 +249,8 @@ algorithm
       DAE.Const c;
       Values.Value val;
       Integer idx;
-      list<SCode.EEquation> eql, else_branch;
-      list<list<SCode.EEquation>> branches, rest_branches;
+      list<SCode.Equation> eql, else_branch;
+      list<list<SCode.Equation>> branches, rest_branches;
       list<list<DAE.Element>> ell;
       list<DAE.Element> el, el2;
       list<DAE.ComponentRef> crefs1, crefs2;
@@ -365,11 +309,11 @@ algorithm
       algorithm
         // Elaborate all of the conditions.
         (outCache, expl, props) := Static.elabExpList(outCache, outEnv,
-          inEEquation.condition, inImpl, true, inPrefix, info);
+          inEquation.condition, inImpl, true, inPrefix, info);
 
         // Check that all conditions are Boolean.
         prop := Types.propsAnd(props);
-        checkIfConditionTypes(prop, inEEquation.condition, props, info);
+        checkIfConditionTypes(prop, inEquation.condition, props, info);
 
         // Try to select one of the branches.
         try
@@ -402,7 +346,7 @@ algorithm
           // A branch was selected, instantiate it.
           (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
             Inst.instList(outCache, inEnv, inIH, inPrefix, inSets, inState,
-              if SCodeUtil.isInitial(inInitial) then instEInitialEquation else instEEquation,
+              if SCodeUtil.isInitial(inInitial) then instInitialEquation else instEquation,
               eql, inImpl, alwaysUnroll, inGraph);
         else
           (outCache, expl) := PrefixUtil.prefixExpList(outCache, inEnv, inIH, expl, inPrefix);
@@ -438,14 +382,14 @@ algorithm
 
         (outCache, outEnv, outIH, cond_exp, el, outGraph) :=
           instWhenEqBranch(inCache, inEnv, inIH, inPrefix, inSets, inState,
-            (inEEquation.condition, inEEquation.eEquationLst), inImpl,
+            (inEquation.condition, inEquation.eEquationLst), inImpl,
             alwaysUnroll, inGraph, info);
 
         // Set the source of this element.
         source := makeEqSource(info, inEnv, inPrefix, inFlattenOp);
 
         else_when := NONE();
-        for branch in listReverse(inEEquation.elseBranches) loop
+        for branch in listReverse(inEquation.elseBranches) loop
           (outCache, outEnv, outIH, exp, el2, outGraph) :=
             instWhenEqBranch(outCache, outEnv, outIH, inPrefix, inSets, inState,
               branch, inImpl, alwaysUnroll, outGraph, info);
@@ -461,24 +405,24 @@ algorithm
       algorithm
         // Check if we have an explicit range, and use it if that's the case.
         // Otherwise, try to deduce the implicit range based on how the iterator is used.
-        if isSome(inEEquation.range) then
-          SOME(range_aexp) := inEEquation.range;
+        if isSome(inEquation.range) then
+          SOME(range_aexp) := inEquation.range;
 
           // Elaborate the range.
           (outCache, exp, DAE.PROP(type_ = DAE.T_ARRAY(ty = ty), constFlag = c)) :=
             Static.elabExp(outCache, inEnv, range_aexp, inImpl, true, inPrefix, info);
         else
-          iter_crefs := SCodeUtil.findIteratorIndexedCrefsInEEquations(
-            inEEquation.eEquationLst, inEEquation.index);
+          iter_crefs := SCodeUtil.findIteratorIndexedCrefsInEquations(
+            inEquation.eEquationLst, inEquation.index);
           (exp, DAE.PROP(type_ = DAE.T_ARRAY(ty = ty), constFlag = c), outCache) :=
-            Static.deduceIterationRange(inEEquation.index, iter_crefs, inEnv, outCache, info);
+            Static.deduceIterationRange(inEquation.index, iter_crefs, inEnv, outCache, info);
 
           // Ceval below should not fail on our generated range, but just in case...
           range_aexp := Absyn.STRING("Internal error: generated implicit range could not be evaluated.");
         end if;
 
         // Add the iterator to the environment.
-        env := addForLoopScope(inEnv, inEEquation.index, ty, SCode.VAR(), SOME(c));
+        env := addForLoopScope(inEnv, inEquation.index, ty, SCode.VAR(), SOME(c));
 
         // Try to constant evaluate the range.
         try
@@ -497,8 +441,8 @@ algorithm
         end try;
 
         (outCache, outDae, outSets, outGraph) := unroll(outCache, env, inIH,
-           inPrefix, inSets, inState, inEEquation.index, ty, val,
-           inEEquation.eEquationLst, inInitial, inImpl, inGraph);
+           inPrefix, inSets, inState, inEquation.index, ty, val,
+           inEquation.eEquationLst, inInitial, inImpl, inGraph);
         outState := instEquationCommonCiTrans(inState, inInitial);
       then
         (outDae, outState);
@@ -506,11 +450,11 @@ algorithm
     case SCode.EQ_ASSERT(info = info)
       algorithm
         (outCache, cond_exp) := instOperatorArg(outCache, inEnv, inIH, inPrefix,
-            inEEquation.condition, inImpl, DAE.T_BOOL_DEFAULT, "assert", "condition", 1, info);
+            inEquation.condition, inImpl, DAE.T_BOOL_DEFAULT, "assert", "condition", 1, info);
         (outCache, msg_exp) := instOperatorArg(outCache, inEnv, inIH, inPrefix,
-            inEEquation.message, inImpl, DAE.T_STRING_DEFAULT, "assert", "message", 2, info);
+            inEquation.message, inImpl, DAE.T_STRING_DEFAULT, "assert", "message", 2, info);
         (outCache, level_exp) := instOperatorArg(outCache, inEnv, inIH, inPrefix,
-            inEEquation.level, inImpl, DAE.T_ASSERTIONLEVEL, "assert", "level", 3, info);
+            inEquation.level, inImpl, DAE.T_ASSERTIONLEVEL, "assert", "level", 3, info);
 
         source := makeEqSource(info, inEnv, inPrefix, inFlattenOp);
         if SCodeUtil.isInitial(inInitial) then
@@ -524,7 +468,7 @@ algorithm
     case SCode.EQ_TERMINATE(info = info)
       algorithm
         (outCache, msg_exp) := instOperatorArg(outCache, inEnv, inIH, inPrefix,
-            inEEquation.message, inImpl, DAE.T_STRING_DEFAULT, "terminate", "message", 1, info);
+            inEquation.message, inImpl, DAE.T_STRING_DEFAULT, "terminate", "message", 1, info);
 
         source := makeEqSource(info, inEnv, inPrefix, inFlattenOp);
         if SCodeUtil.isInitial(inInitial) then
@@ -544,7 +488,7 @@ algorithm
 
         // Elaborate the reinit expression.
         (outCache, exp, prop) :=
-          Static.elabExp(outCache, inEnv, inEEquation.expReinit, inImpl, true, inPrefix, info);
+          Static.elabExp(outCache, inEnv, inEquation.expReinit, inImpl, true, inPrefix, info);
         (outCache, exp, prop) :=
           Ceval.cevalIfConstant(outCache, inEnv, exp, prop, inImpl, info);
 
@@ -552,7 +496,7 @@ algorithm
         exp := Types.matchProp(exp, prop, cr_prop, true);
 
         (outCache, cr_exp, exp, cr_prop) := condenseArrayEquation(outCache,
-          inEnv, inEEquation.cref, inEEquation.expReinit, cr_exp,
+          inEnv, inEquation.cref, inEquation.expReinit, cr_exp,
           exp, cr_prop, prop, inImpl, inPrefix, info);
         (outCache, cr_exp) := PrefixUtil.prefixExp(outCache, inEnv, inIH, cr_exp, inPrefix);
         (outCache, exp) := PrefixUtil.prefixExp(outCache, inEnv, inIH, exp, inPrefix);
@@ -567,14 +511,14 @@ algorithm
 
     case SCode.EQ_NORETCALL(info = info)
       algorithm
-        if isConnectionsOperator(inEEquation.exp) then
+        if isConnectionsOperator(inEquation.exp) then
           // Handle Connections.* operators.
           (outCache, outEnv, outIH, outDae, outSets, outState, outGraph) :=
             handleConnectionsOperators(inCache, inEnv, inIH, inPrefix, inSets,
-              inState, inEEquation, inInitial, inImpl, inGraph, inFlattenOp);
+              inState, inEquation, inInitial, inImpl, inGraph, inFlattenOp);
         else
           // Handle normal no return calls.
-          (outCache, exp) := Static.elabExp(inCache, inEnv, inEEquation.exp,
+          (outCache, exp) := Static.elabExp(inCache, inEnv, inEquation.exp,
             inImpl, false, inPrefix, info);
           // This is probably an external function call that the user wants to
           // evaluate at runtime, so don't ceval it.
@@ -591,7 +535,7 @@ algorithm
       algorithm
         true := Flags.isSet(Flags.FAILTRACE);
         Debug.trace("- InstSection.instEquationCommonWork failed for eqn: ");
-        Debug.traceln(SCodeDump.equationStr(inEEquation) + " in scope: " +
+        Debug.traceln(SCodeDump.equationStr(inEquation) + " in scope: " +
             FGraph.getGraphNameStr(inEnv));
       then
         fail();
@@ -729,7 +673,7 @@ protected function handleConnectionsOperators
   input DAE.Prefix inPrefix;
   input Connect.Sets inSets;
   input ClassInf.State inState;
-  input SCode.EEquation inEEquation;
+  input SCode.Equation inEquation;
   input SCode.Initial inInitial;
   input Boolean inImpl;
   input ConnectionGraph.ConnectionGraph inGraph;
@@ -743,7 +687,7 @@ protected function handleConnectionsOperators
   output ConnectionGraph.ConnectionGraph outGraph;
 algorithm
   (outCache,outEnv,outIH,outDae,outSets,outState,outGraph):=
-  matchcontinue (inCache,inEnv,inIH,inPrefix,inSets,inState,inEEquation,inInitial,inImpl,inGraph,flattenOp)
+  matchcontinue (inCache,inEnv,inIH,inPrefix,inSets,inState,inEquation,inInitial,inImpl,inGraph,flattenOp)
     local
       list<DAE.Properties> props;
       Connect.Sets csets_1,csets;
@@ -759,13 +703,13 @@ algorithm
       list<Absyn.Exp> conditions;
       DAE.Exp e1_1,e2_1,e1_2,e2_2,e_1,e_2,e3_1,e3_2,msg_1;
       DAE.Properties prop1,prop2,prop3;
-      list<SCode.EEquation> b,fb,el,eel;
-      list<list<SCode.EEquation>> tb;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> eex;
+      list<SCode.Equation> b,fb,el,eel;
+      list<list<SCode.Equation>> tb;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> eex;
       DAE.Type id_t;
       Values.Value v;
       DAE.ComponentRef cr_1;
-      SCode.EEquation eqn,eq;
+      SCode.Equation eqn,eq;
       FCore.Cache cache;
       list<Values.Value> valList;
       list<DAE.Exp> expl1;
@@ -798,7 +742,7 @@ algorithm
               functionArgs = Absyn.FUNCTIONARGS({Absyn.CREF(cr)}, {}))),_,_,graph,_)
       equation
         (cache,SOME((DAE.ARRAY(array = {}),_,_))) = Static.elabCref(cache,env, cr, false /* ??? */,false,pre,info);
-        s = SCodeDump.equationStr(inEEquation);
+        s = SCodeDump.equationStr(inEquation);
         Error.addSourceMessage(Error.OVERCONSTRAINED_OPERATOR_SIZE_ZERO, {s}, info);
       then
         (cache,env,ih,DAE.emptyDae,csets,ci_state,graph);
@@ -819,9 +763,9 @@ algorithm
               function_ = Absyn.CREF_QUAL("Connections", {}, Absyn.CREF_IDENT("potentialRoot", {})),
               functionArgs = functionArgs)),_,_,graph,_)
       equation
-        (cr,_) = potentialRootArguments(functionArgs, info, pre, inEEquation);
+        (cr,_) = potentialRootArguments(functionArgs, info, pre, inEquation);
         (cache,SOME((DAE.ARRAY(array = {}),_,_))) = Static.elabCref(cache,env, cr, false /* ??? */,false,pre,info);
-        s = SCodeDump.equationStr(inEEquation);
+        s = SCodeDump.equationStr(inEquation);
         Error.addSourceMessage(Error.OVERCONSTRAINED_OPERATOR_SIZE_ZERO, {s}, info);
       then
         (cache,env,ih,DAE.emptyDae,csets,ci_state,graph);
@@ -831,7 +775,7 @@ algorithm
               function_ = Absyn.CREF_QUAL("Connections", {}, Absyn.CREF_IDENT("potentialRoot", {})),
               functionArgs = functionArgs)),_,_,graph,_)
       equation
-        (cr, ipriority) = potentialRootArguments(functionArgs, info, pre, inEEquation);
+        (cr, ipriority) = potentialRootArguments(functionArgs, info, pre, inEquation);
         (cache,SOME((DAE.CREF(cr_,_),_,_))) = Static.elabCref(cache, env, cr, false /* ??? */,false, pre, info);
         (cache,cr_) = PrefixUtil.prefixCref(cache,env,ih,pre, cr_);
         graph = ConnectionGraph.addPotentialRoot(graph, cr_, intReal(ipriority));
@@ -843,9 +787,9 @@ algorithm
               function_ = Absyn.CREF_QUAL("Connections", {}, Absyn.CREF_IDENT("uniqueRoot", {})),
               functionArgs = functionArgs)),_,_,graph,_)
       equation
-        (cr,_) = uniqueRootArguments(functionArgs, info, pre, inEEquation);
+        (cr,_) = uniqueRootArguments(functionArgs, info, pre, inEquation);
         (cache,SOME((DAE.ARRAY(array = {}),_,_))) = Static.elabCref(cache,env, cr, false /* ??? */,false,pre,info);
-        s = SCodeDump.equationStr(inEEquation);
+        s = SCodeDump.equationStr(inEquation);
         Error.addSourceMessage(Error.OVERCONSTRAINED_OPERATOR_SIZE_ZERO, {s}, info);
         Error.addSourceMessage(Error.NON_STANDARD_OPERATOR, {"Connections.uniqueRoot"}, info);
       then
@@ -856,7 +800,7 @@ algorithm
               function_ = Absyn.CREF_QUAL("Connections", {}, Absyn.CREF_IDENT("uniqueRoot", {})),
               functionArgs = functionArgs)),_,_,graph,_)
       equation
-        (cr, msg) = uniqueRootArguments(functionArgs, info, pre, inEEquation);
+        (cr, msg) = uniqueRootArguments(functionArgs, info, pre, inEquation);
         (cache,exp,_) = Static.elabExp(cache, env, Absyn.CREF(cr), false, true, pre, info);
         (cache,msg_1,_) = Static.elabExp(cache, env, msg, false, false, pre, info);
         (cache,exp) = PrefixUtil.prefixExp(cache,env,ih,exp,pre);
@@ -878,7 +822,7 @@ algorithm
         b2 = Types.isZeroLengthArray(Expression.typeof(e_2));
         if boolOr(b1, b2)
         then // handle zero sized crefs
-          s = SCodeDump.equationStr(inEEquation);
+          s = SCodeDump.equationStr(inEquation);
           Error.addSourceMessage(Error.OVERCONSTRAINED_OPERATOR_SIZE_ZERO, {s}, info);
         else // not zero sized
           DAE.CREF(cr1_,_) = e_1;
@@ -906,7 +850,7 @@ protected function potentialRootArguments
   input Absyn.FunctionArgs inFunctionArgs;
   input SourceInfo info;
   input DAE.Prefix inPrefix;
-  input SCode.EEquation inEEquation;
+  input SCode.Equation inEquation;
   output Absyn.ComponentRef outCref;
   output Integer outPriority;
 algorithm
@@ -921,7 +865,7 @@ algorithm
     case Absyn.FUNCTIONARGS({Absyn.CREF(cr)}, {Absyn.NAMEDARG("priority", Absyn.INTEGER(p))}) then (cr, p);
     else
       algorithm
-        s1 := SCodeDump.equationStr(inEEquation);
+        s1 := SCodeDump.equationStr(inEquation);
         s2 := PrefixUtil.printPrefixStr3(inPrefix);
         Error.addSourceMessage(Error.WRONG_TYPE_OR_NO_OF_ARGS, {s1, s2}, info);
       then
@@ -933,7 +877,7 @@ protected function uniqueRootArguments
   input Absyn.FunctionArgs inFunctionArgs;
   input SourceInfo info;
   input DAE.Prefix inPrefix;
-  input SCode.EEquation inEEquation;
+  input SCode.Equation inEquation;
   output Absyn.ComponentRef outCref;
   output Absyn.Exp outMessage;
 algorithm
@@ -948,7 +892,7 @@ algorithm
     case Absyn.FUNCTIONARGS({Absyn.CREF(cr)}, {Absyn.NAMEDARG("message", msg)}) then (cr, msg);
     else
       algorithm
-        s1 := SCodeDump.equationStr(inEEquation);
+        s1 := SCodeDump.equationStr(inEquation);
         s2 := PrefixUtil.printPrefixStr3(inPrefix);
         Error.addSourceMessage(Error.WRONG_TYPE_OR_NO_OF_ARGS, {s1, s2}, info);
       then
@@ -1221,7 +1165,7 @@ protected function unroll
   input Ident inIdent;
   input DAE.Type inIteratorType;
   input Values.Value inValue;
-  input list<SCode.EEquation> inEquations;
+  input list<SCode.Equation> inEquations;
   input SCode.Initial inInitial;
   input Boolean inImplicit;
   input ConnectionGraph.ConnectionGraph inGraph;
@@ -1247,7 +1191,7 @@ algorithm
 
       (outCache, _, _, dae, outSets, ci_state, outGraph) :=
         Inst.instList(outCache, env, inIH, inPrefix, outSets, ci_state,
-          if SCodeUtil.isInitial(inInitial) then instEInitialEquation else instEEquation,
+          if SCodeUtil.isInitial(inInitial) then instInitialEquation else instEquation,
           inEquations, inImplicit, alwaysUnroll, outGraph);
 
       daes := dae :: daes;
@@ -2176,7 +2120,7 @@ algorithm
         source = ElementSource.createElementSource(AbsynUtil.dummyInfo, FGraph.getScopePath(env), pre);
 
         (cache,constraints_1,_) = Static.elabExpList(cache, env, constraints, impl, true /*vect*/, pre, AbsynUtil.dummyInfo);
-        // (constraints_1,_) = DAEUtil.traverseDAEEquationsStmts(constraints_1,Expression.traverseSubexpressionsHelper,(ExpressionSimplify.simplifyWork,false));
+        // (constraints_1,_) = DAEUtil.traverseDAEquationsStmts(constraints_1,Expression.traverseSubexpressionsHelper,(ExpressionSimplify.simplifyWork,false));
 
         dae = DAE.DAE({DAE.CONSTRAINT(DAE.CONSTRAINT_EXPS(constraints_1),source)});
       then
@@ -2618,7 +2562,7 @@ algorithm
         env_1 = FGraph.openScope(env, SCode.NOT_ENCAPSULATED(), FCore.forScopeName,NONE());
         // the iterator is not constant but the range is constant
         env_2 = FGraph.addForIterator(env_1, i, DAE.T_INTEGER_DEFAULT, DAE.VALBOUND(fst, DAE.BINDING_FROM_DEFAULT_VALUE()), SCode.CONST(), SOME(DAE.C_CONST()));
-        /* use instEEquation*/
+        /* use instEquation*/
         (cache,stmts1) = instStatements(cache, env_2, ih, pre, ci_state, algs, source, initial_, impl, unrollForLoops);
         (cache,stmts2) = loopOverRange(cache, env, ih, pre, ci_state, i, Values.ARRAY(rest,dims), algs, source, initial_, impl, unrollForLoops);
         stmts = listAppend(stmts1, stmts2);
@@ -2660,7 +2604,7 @@ protected function instIfEqBranch
   input InnerOuter.InstHierarchy inIH;
   input DAE.Prefix inPrefix;
   input ClassInf.State inState;
-  input list<SCode.EEquation> inEquations;
+  input list<SCode.Equation> inEquations;
   input Boolean inImpl;
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
@@ -2671,7 +2615,7 @@ algorithm
   checkForConnectInIfBranch(inEquations);
   (outCache, outEnv, outIH, DAE.DAE(outEquations), _, outState, _) :=
     Inst.instList(inCache, inEnv, inIH, inPrefix, Connect.emptySet, inState,
-      instEEquation, inEquations, inImpl, alwaysUnroll, ConnectionGraph.EMPTY);
+      instEquation, inEquations, inImpl, alwaysUnroll, ConnectionGraph.EMPTY);
 end instIfEqBranch;
 
 protected function instIfEqBranches
@@ -2680,7 +2624,7 @@ protected function instIfEqBranches
   input InnerOuter.InstHierarchy inIH;
   input DAE.Prefix inPrefix;
   input ClassInf.State inState;
-  input list<list<SCode.EEquation>> inBranches;
+  input list<list<SCode.Equation>> inBranches;
   input Boolean inImpl;
   input list<list<DAE.Element>> inAccumEqs = {};
   output FCore.Cache outCache;
@@ -2698,14 +2642,14 @@ algorithm
       ClassInf.State ci_state,ci_state_1,ci_state_2;
       Boolean impl;
       list<list<DAE.Element>> llb;
-      list<list<SCode.EEquation>> es;
-      list<SCode.EEquation> e;
+      list<list<SCode.Equation>> es;
+      list<SCode.Equation> e;
       FCore.Cache cache;
       FCore.Graph env;
       InnerOuter.InstHierarchy ih;
       ClassInf.State state;
-      list<SCode.EEquation> seq;
-      list<list<SCode.EEquation>> rest_seq;
+      list<SCode.Equation> seq;
+      list<list<SCode.Equation>> rest_seq;
       list<DAE.Element> deq;
       list<list<DAE.Element>> branches;
 
@@ -2730,7 +2674,7 @@ protected function instInitialIfEqBranch
   input InnerOuter.InstHierarchy inIH;
   input DAE.Prefix inPrefix;
   input ClassInf.State inState;
-  input list<SCode.EEquation> inEquations;
+  input list<SCode.Equation> inEquations;
   input Boolean inImpl;
   output FCore.Cache outCache;
   output FCore.Graph outEnv;
@@ -2741,7 +2685,7 @@ algorithm
   checkForConnectInIfBranch(inEquations);
   (outCache, outEnv, outIH, DAE.DAE(outEquations), _, outState, _) :=
     Inst.instList(inCache, inEnv, inIH, inPrefix, Connect.emptySet, inState,
-      instEInitialEquation, inEquations, inImpl, alwaysUnroll, ConnectionGraph.EMPTY);
+      instInitialEquation, inEquations, inImpl, alwaysUnroll, ConnectionGraph.EMPTY);
 end instInitialIfEqBranch;
 
 protected function instInitialIfEqBranches
@@ -2750,7 +2694,7 @@ protected function instInitialIfEqBranches
   input InnerOuter.InstHierarchy inIH;
   input DAE.Prefix inPrefix;
   input ClassInf.State inState;
-  input list<list<SCode.EEquation>> inBranches;
+  input list<list<SCode.Equation>> inBranches;
   input Boolean inImpl;
   input list<list<DAE.Element>> inAccumEqs = {};
   output FCore.Cache outCache;
@@ -2766,8 +2710,8 @@ algorithm
       FCore.Graph env;
       InnerOuter.InstHierarchy ih;
       ClassInf.State state;
-      list<SCode.EEquation> seq;
-      list<list<SCode.EEquation>> rest_seq;
+      list<SCode.Equation> seq;
+      list<list<SCode.Equation>> rest_seq;
       list<DAE.Element> deq;
       list<list<DAE.Element>> branches;
 
@@ -2790,19 +2734,19 @@ protected function checkForConnectInIfBranch
   "Checks if an if-branch (a list of equations) contains any connects, and prints
    an error if it does. This is used to check that there are no connects in
    if-equations with non-parameter conditions."
-  input list<SCode.EEquation> inEquations;
+  input list<SCode.Equation> inEquations;
 algorithm
   List.map_0(inEquations, checkForConnectInIfBranch2);
 end checkForConnectInIfBranch;
 
 protected function checkForConnectInIfBranch2
-  input SCode.EEquation inEquation;
+  input SCode.Equation inEquation;
 algorithm
   _ := match(inEquation)
     local
       Absyn.ComponentRef cr1, cr2;
       SourceInfo info;
-      list<SCode.EEquation> eqs;
+      list<SCode.Equation> eqs;
       String cr1_str, cr2_str;
 
     case SCode.EQ_CONNECT(crefLeft = cr1, crefRight = cr2, info = info)
@@ -2884,7 +2828,7 @@ protected function instWhenEqBranch
   input DAE.Prefix inPrefix;
   input Connect.Sets inSets;
   input ClassInf.State inState;
-  input tuple<Absyn.Exp, list<SCode.EEquation>> inBranch;
+  input tuple<Absyn.Exp, list<SCode.Equation>> inBranch;
   input Boolean inImpl;
   input Boolean inUnrollLoops;
   input ConnectionGraph.ConnectionGraph inGraph;
@@ -2897,7 +2841,7 @@ protected function instWhenEqBranch
   output ConnectionGraph.ConnectionGraph outGraph;
 protected
   Absyn.Exp cond;
-  list<SCode.EEquation> body;
+  list<SCode.Equation> body;
   DAE.Properties prop;
   list<Absyn.Exp> aexps;
   list<DAE.Exp> dexps;
@@ -2938,7 +2882,7 @@ algorithm
   // Instantiate the when body.
   (outCache, outEnv, outIH, DAE.DAE(outEquations), _, _, outGraph) :=
     Inst.instList(outCache, inEnv, inIH, inPrefix, inSets, inState,
-      instEEquation, body, inImpl, alwaysUnroll, inGraph);
+      instEquation, body, inImpl, alwaysUnroll, inGraph);
 end instWhenEqBranch;
 
 protected function checkWhenCondition
@@ -4841,7 +4785,7 @@ protected function checkWhenEquation
    when (initial()) then
      reinit(x, y);
    end when;"
-  input SCode.EEquation inWhenEq;
+  input SCode.Equation inWhenEq;
 algorithm
   true := checkForReinitInWhenInitialEq(inWhenEq);
   checkForNestedWhenInEquation(inWhenEq);
@@ -4850,7 +4794,7 @@ end checkWhenEquation;
 protected function checkForReinitInWhenInitialEq
   "Fails if a when (initial()) equation contains
    reinit which is not allowed in Modelica."
-  input SCode.EEquation inWhenEq;
+  input SCode.Equation inWhenEq;
   output Boolean outOK;
 algorithm
   outOK := matchcontinue(inWhenEq)
@@ -4858,8 +4802,8 @@ algorithm
       Boolean b1, b2;
       Absyn.Exp exp;
       SourceInfo info;
-      list<SCode.EEquation> el;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> tpl_el;
+      list<SCode.Equation> el;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> tpl_el;
 
     // Add an error for when initial() then reinit().
     case SCode.EQ_WHEN(condition = exp, eEquationLst = el, info = info)
@@ -4879,14 +4823,14 @@ protected function checkForNestedWhenInEquation
   "Fails if a when equation contains nested when
    equations, which are not allowed in Modelica.
    An error message is added when failing."
-  input SCode.EEquation inWhenEq;
+  input SCode.Equation inWhenEq;
 algorithm
   _ := match(inWhenEq)
     local
       SourceInfo info;
-      list<SCode.EEquation> eqs;
-      list<list<SCode.EEquation>> eqs_lst;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> tpl_el;
+      list<SCode.Equation> eqs;
+      list<list<SCode.Equation>> eqs_lst;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> tpl_el;
 
     // continue if when equations are not nested
     case SCode.EQ_WHEN(eEquationLst = eqs, elseBranches = tpl_el)
@@ -4903,7 +4847,7 @@ end checkForNestedWhenInEquation;
 protected function checkForNestedWhenInEqList
   "Helper function to checkForNestedWhen. Searches for nested when equations in
   a list of equations."
-  input list<SCode.EEquation> inEqs;
+  input list<SCode.Equation> inEqs;
 algorithm
   List.map_0(inEqs, checkForNestedWhenInEq);
 end checkForNestedWhenInEqList;
@@ -4911,12 +4855,12 @@ end checkForNestedWhenInEqList;
 protected function checkForNestedWhenInEq
   "Helper function to checkForNestedWhen. Searches for nested when equations in
   an equation."
-  input SCode.EEquation inEq;
+  input SCode.Equation inEq;
 algorithm
   _ := match(inEq)
     local
-      list<SCode.EEquation> eqs;
-      list<list<SCode.EEquation>> eqs_lst;
+      list<SCode.Equation> eqs;
+      list<list<SCode.Equation>> eqs_lst;
       Absyn.ComponentRef cr1, cr2;
       SourceInfo info;
       String cr1_str, cr2_str;

--- a/OMCompiler/Compiler/FrontEnd/InstStateMachineUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstStateMachineUtil.mo
@@ -947,8 +947,8 @@ algorithm
     local
       String name;
 
-    case SCode.EQUATION(eEquation = SCode.EQ_NORETCALL(exp = Absyn.CALL(function_ =
-        Absyn.CREF_IDENT(name = name))))
+    case SCode.EQ_NORETCALL(exp = Absyn.CALL(function_ =
+        Absyn.CREF_IDENT(name = name)))
       then (name == "transition" or name == "initialState") and
            Config.synchronousFeaturesAllowed();
 
@@ -1079,11 +1079,11 @@ algorithm
   outElement := match (inElement)
     local
       Absyn.ComponentRef cref1;
-    case SCode.EQUATION(eEquation=SCode.EQ_NORETCALL(exp=Absyn.CALL(function_=
+    case SCode.EQ_NORETCALL(exp=Absyn.CALL(function_=
       Absyn.CREF_IDENT(name="initialState"),
       functionArgs = Absyn.FUNCTIONARGS(args =
         {Absyn.CREF(componentRef = cref1)}
-        ))))
+        )))
       then cref1;
   end match;
 end extractInitialSMStates;
@@ -1099,18 +1099,18 @@ algorithm
   outElement := match (inElement)
     local
       Absyn.ComponentRef cref1, cref2;
-    case SCode.EQUATION(eEquation=SCode.EQ_NORETCALL(exp=Absyn.CALL(function_=
+    case SCode.EQ_NORETCALL(exp=Absyn.CALL(function_=
       Absyn.CREF_IDENT(name="transition"),
       functionArgs = Absyn.FUNCTIONARGS(args =
         {Absyn.CREF(componentRef = cref1),
         Absyn.CREF(componentRef = cref2),_}
-        ))))
+        )))
       then {cref1, cref2};
-    case SCode.EQUATION(eEquation=SCode.EQ_NORETCALL(exp=Absyn.CALL(function_=
+    case SCode.EQ_NORETCALL(exp=Absyn.CALL(function_=
       Absyn.CREF_IDENT(name="initialState"),
       functionArgs = Absyn.FUNCTIONARGS(args =
         {Absyn.CREF(componentRef = cref1)}
-        ))))
+        )))
       then {cref1};
     else {};
   end match;

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -5841,7 +5841,7 @@ algorithm
     eq
     for eq
     guard matchcontinue eq
-    case SCode.EQUATION(SCode.EQ_CONNECT(crefLeft=crefLeft, crefRight=crefRight))
+    case SCode.EQ_CONNECT(crefLeft=crefLeft, crefRight=crefRight)
     algorithm
       (_, ty1, _) := Lookup.lookupConnectorVar(env, ComponentReference.toExpCref(crefLeft));
       // type of left var is an expandable connector!
@@ -8237,7 +8237,7 @@ algorithm
   local
     list<Absyn.Ident> fieldNames1;
     Absyn.Exp lhs_exp, rhs_exp;
-    case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp))
+    case SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp)
       /*,domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))*/
     algorithm
       (_,fieldNames1) := AbsynUtil.traverseExpTopDown(lhs_exp, fieldInPderExp, inFieldNames);
@@ -8571,25 +8571,25 @@ algorithm
         list<Absyn.Subscript> subscripts;
 
       //PDE with domain specified, allow for field variables:
-      case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
-                  domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info))
+      case SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
+                  domain = domainCr as Absyn.CREF_IDENT(), comment = comment, info = info)
         equation
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr,info);
         then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
 
       //same as previous but with ".interior"
-      case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
+      case SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = domainCr as Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="interior")),
-                  comment = comment, info = info))
+                  comment = comment, info = info)
         equation
           domainCr1 = Absyn.CREF_IDENT(name, subscripts);
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
         then creatFieldEqs(lhs_exp, rhs_exp, domainCr, N, fieldLst, comment, info);
 
       //left boundary condition or extrapolation
-      case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
+      case SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="left")),
-                  comment = comment, info = info))
+                  comment = comment, info = info)
         equation
           domainCr1 = Absyn.CREF_IDENT(name, subscripts);
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
@@ -8599,9 +8599,9 @@ algorithm
           {newEQFun(1, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
 
       //right boundary condition or extrapolation
-      case SCode.EQUATION(SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
+      case SCode.EQ_PDE(expLeft = lhs_exp, expRight = rhs_exp,
                   domain = Absyn.CREF_QUAL(name, subscripts, Absyn.CREF_IDENT(name="right")),
-                  comment = comment, info = info))
+                  comment = comment, info = info)
         equation
           domainCr1 = Absyn.CREF_IDENT(name, subscripts);
           (N,fieldLst) = getDomNFields(inDomFieldLst,domainCr1,info);
@@ -8610,7 +8610,7 @@ algorithm
         then
           {newEQFun(N, lhs_exp, rhs_exp, domainCr1, N, true, fieldLst, comment, info)};
       //Unhandled pde
-      case SCode.EQUATION(SCode.EQ_PDE())
+      case SCode.EQ_PDE()
         equation
           print("Unhandled type of EQ_PDE in discretizePDE\n");
           fail();
@@ -8745,7 +8745,7 @@ algorithm
       i2 := N - 1;
       i3 := N - 2;
     end if;
-    outEQ := SCode.EQUATION(SCode.EQ_EQUALS(Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i1))::subscripts)),Absyn.BINARY(
+    outEQ := SCode.EQ_EQUALS(Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i1))::subscripts)),Absyn.BINARY(
                Absyn.BINARY(
                  Absyn.INTEGER(2),
                  Absyn.MUL(),
@@ -8753,7 +8753,7 @@ algorithm
                ),
                Absyn.SUB(),
                Absyn.CREF(Absyn.CREF_IDENT(name, Absyn.SUBSCRIPT(Absyn.INTEGER(i3))::subscripts))
-             ), comment, info));
+             ), comment, info);
   else
    fail();
   end if;
@@ -8814,7 +8814,7 @@ protected function newEQFun
 algorithm
   (outLhs_exp, _) := AbsynUtil.traverseExpTopDown(inLhs_exp,discretizeTraverseFun,(i,fieldLst,domainCr,info,false,N,isBC));
   (outRhs_exp, _) := AbsynUtil.traverseExpTopDown(inRhs_exp,discretizeTraverseFun,(i,fieldLst,domainCr,info,false,N,isBC));
-  outEQ := SCode.EQUATION(SCode.EQ_EQUALS(outLhs_exp, outRhs_exp, comment, info));
+  outEQ := SCode.EQ_EQUALS(outLhs_exp, outRhs_exp, comment, info);
 end newEQFun;
 
 protected function discretizeTraverseFun

--- a/OMCompiler/Compiler/FrontEnd/NFSCodeDependency.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFSCodeDependency.mo
@@ -1653,16 +1653,13 @@ protected function analyseEquation
   "Analyses an equation."
   input SCode.Equation inEquation;
   input Env inEnv;
-protected
-  SCode.EEquation equ;
 algorithm
-  SCode.EQUATION(equ) := inEquation;
-  (_, _) := SCodeUtil.mapFoldEEquations(equ, analyseEEquationTraverser, inEnv);
+  (_, _) := SCodeUtil.mapFoldEquations(inEquation, analyseEquationTraverser, inEnv);
 end analyseEquation;
 
-protected function analyseEEquationTraverser
+protected function analyseEquationTraverser
   "Traversal function for use in analyseEquation."
-  input output SCode.EEquation eq;
+  input output SCode.Equation eq;
   input output Env env;
 algorithm
   (eq, env) := match eq
@@ -1674,29 +1671,29 @@ algorithm
     case SCode.EQ_FOR(index = iter_name, info = info)
       algorithm
         env := NFSCodeEnv.extendEnvWithIterators({Absyn.ITERATOR(iter_name, NONE(), NONE())}, System.tmpTickIndex(NFSCodeEnv.tmpTickIndex), env);
-        (eq, _) := SCodeUtil.mapFoldEEquationExps(eq, traverseExp, (env, info));
+        (eq, _) := SCodeUtil.mapFoldEquationExps(eq, traverseExp, (env, info));
       then
         (eq, env);
 
     case SCode.EQ_REINIT(cref = Absyn.CREF(componentRef = cref1), info = info)
       algorithm
         analyseCref(cref1, env, info);
-        (eq, _) := SCodeUtil.mapFoldEEquationExps(eq, traverseExp, (env, info));
+        (eq, _) := SCodeUtil.mapFoldEquationExps(eq, traverseExp, (env, info));
       then
         (eq, env);
 
     else
       algorithm
-        info := SCodeUtil.getEEquationInfo(eq);
-        (eq, _) := SCodeUtil.mapFoldEEquationExps(eq, traverseExp, (env, info));
+        info := SCodeUtil.getEquationInfo(eq);
+        (eq, _) := SCodeUtil.mapFoldEquationExps(eq, traverseExp, (env, info));
       then
         (eq, env);
 
   end match;
-end analyseEEquationTraverser;
+end analyseEquationTraverser;
 
 protected function traverseExp
-  "Traversal function used by analyseEEquationTraverser and
+  "Traversal function used by analyseEquationTraverser and
   analyseStatementTraverser."
   input Absyn.Exp inExp;
   input tuple<Env, SourceInfo> inTuple;

--- a/OMCompiler/Compiler/FrontEnd/NFSCodeFlattenImports.mo
+++ b/OMCompiler/Compiler/FrontEnd/NFSCodeFlattenImports.mo
@@ -328,16 +328,12 @@ protected function flattenEquation
   input SCode.Equation inEquation;
   input Env inEnv;
   output SCode.Equation outEquation;
-protected
-  SCode.EEquation equ;
 algorithm
-  SCode.EQUATION(equ) := inEquation;
-  (equ, _) := SCodeUtil.mapFoldEEquations(equ, flattenEEquationTraverser, inEnv);
-  outEquation := SCode.EQUATION(equ);
+  (outEquation, _) := SCodeUtil.mapFoldEquations(inEquation, flattenEquationTraverser, inEnv);
 end flattenEquation;
 
-protected function flattenEEquationTraverser
-  input output SCode.EEquation eq;
+protected function flattenEquationTraverser
+  input output SCode.Equation eq;
   input output Env env;
 algorithm
   (eq, env) := match eq
@@ -351,7 +347,7 @@ algorithm
     case SCode.EQ_FOR(index = iter_name, info = info)
       algorithm
         env := NFSCodeEnv.extendEnvWithIterators({Absyn.ITERATOR(iter_name, NONE(), NONE())}, System.tmpTickIndex(NFSCodeEnv.tmpTickIndex), env);
-        (eq, _) := SCodeUtil.mapFoldEEquationExps(eq, traverseExp, (env, info));
+        (eq, _) := SCodeUtil.mapFoldEquationExps(eq, traverseExp, (env, info));
       then
         (eq, env);
 
@@ -359,19 +355,19 @@ algorithm
       algorithm
         cref := NFSCodeLookup.lookupComponentRef(cref, env, info);
         eq := SCode.EQ_REINIT(crefExp, exp, cmt, info);
-        (eq, _) := SCodeUtil.mapFoldEEquationExps(eq, traverseExp, (env, info));
+        (eq, _) := SCodeUtil.mapFoldEquationExps(eq, traverseExp, (env, info));
       then
         (eq, env);
 
     else
       algorithm
-        info := SCodeUtil.getEEquationInfo(eq);
-        (eq, _) := SCodeUtil.mapFoldEEquationExps(eq, traverseExp, (env, info));
+        info := SCodeUtil.getEquationInfo(eq);
+        (eq, _) := SCodeUtil.mapFoldEquationExps(eq, traverseExp, (env, info));
       then
         (eq, env);
 
   end match;
-end flattenEEquationTraverser;
+end flattenEquationTraverser;
 
 protected function traverseExp
   input Absyn.Exp inExp;

--- a/OMCompiler/Compiler/FrontEnd/SCode.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCode.mo
@@ -248,22 +248,14 @@ uniontype ExternalDecl "Declaration of an external function call - ExternalDecl"
 end ExternalDecl;
 
 public
-uniontype Equation "- Equations"
-  record EQUATION "an equation"
-    EEquation eEquation "an equation";
-  end EQUATION;
-
-end Equation;
-
-public
-uniontype EEquation
+uniontype Equation
 "These represent equations and are almost identical to their Absyn versions.
  In EQ_IF the elseif branches are represented as normal else branches with
  a single if statement in them."
   record EQ_IF
     list<Absyn.Exp> condition "conditional" ;
-    list<list<EEquation>> thenBranch "the true (then) branch" ;
-    list<EEquation>       elseBranch "the false (else) branch" ;
+    list<list<Equation>> thenBranch "the true (then) branch" ;
+    list<Equation>       elseBranch "the false (else) branch" ;
     Comment comment;
     SourceInfo info;
   end EQ_IF;
@@ -293,15 +285,15 @@ uniontype EEquation
   record EQ_FOR "the for equation"
     Ident index "the index name";
     Option<Absyn.Exp> range "the range of the index";
-    list<EEquation> eEquationLst "the equation list";
+    list<Equation> eEquationLst "the equation list";
     Comment comment;
     SourceInfo info;
   end EQ_FOR;
 
   record EQ_WHEN "the when equation"
     Absyn.Exp        condition "the when condition";
-    list<EEquation>  eEquationLst "the equation list";
-    list<tuple<Absyn.Exp, list<EEquation>>> elseBranches "the elsewhen expression and equation list";
+    list<Equation>  eEquationLst "the equation list";
+    list<tuple<Absyn.Exp, list<Equation>>> elseBranches "the elsewhen expression and equation list";
     Comment comment;
     SourceInfo info;
   end EQ_WHEN;
@@ -333,7 +325,7 @@ uniontype EEquation
     SourceInfo info;
   end EQ_NORETCALL;
 
-end EEquation;
+end Equation;
 
 public uniontype AlgorithmSection "- Algorithms
   The Absyn module uses the terminology from the

--- a/OMCompiler/Compiler/FrontEnd/SCodeDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeDump.mo
@@ -103,11 +103,11 @@ algorithm
 end statementStr;
 
 public function equationStr
-  input SCode.EEquation inEEquation;
+  input SCode.Equation inEquation;
   input SCodeDumpOptions options = defaultOptions;
   output String outString;
 algorithm
-  outString := Tpl.tplString2(SCodeDumpTpl.dumpEEquation, inEEquation, options);
+  outString := Tpl.tplString2(SCodeDumpTpl.dumpEquation, inEquation, options);
 end equationStr;
 
 public function printModStr
@@ -342,18 +342,6 @@ algorithm
     case (SCode.CONST()) then "constant";
   end match;
 end unparseVariability;
-
-public function equationStr2
-"Takes a SCode.Equation rather then SCode.EEquation as equationStr does."
-  input SCode.Equation eqns;
-  input SCodeDumpOptions options;
-  output String s;
-algorithm
-  s := match(eqns,options)
-    local SCode.EEquation e;
-    case(SCode.EQUATION(eEquation=e),_) then equationStr(e,options);
-  end match;
-end equationStr2;
 
 public function printInitialStr
 "prints SCode.Initial to a string"

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -917,39 +917,26 @@ algorithm
   end matchcontinue;
 end algorithmEqual2;
 
-public function equationEqual
-"Returns true if two equations are equal."
-  input SCode.Equation eqn1;
-  input SCode.Equation eqn2;
-  output Boolean equal;
-protected
-  SCode.EEquation eq1, eq2;
-algorithm
-  SCode.EQUATION(eEquation = eq1) := eqn1;
-  SCode.EQUATION(eEquation = eq2) := eqn2;
-  equal := equationEqual2(eq1, eq2);
-end equationEqual;
-
-protected function equationEqual2
-"Helper function to equationEqual"
-  input SCode.EEquation eq1;
-  input SCode.EEquation eq2;
+protected function equationEqual
+  "Returns true if two equations are equal."
+  input SCode.Equation eq1;
+  input SCode.Equation eq2;
   output Boolean equal;
 algorithm
   equal := matchcontinue(eq1,eq2)
     local
-      list<list<SCode.EEquation>> tb1,tb2;
+      list<list<SCode.Equation>> tb1,tb2;
       Absyn.Exp cond1,cond2;
       list<Absyn.Exp> ifcond1,ifcond2;
       Absyn.Exp e11,e12,e21,e22,exp1,exp2,c1,c2,m1,m2,e1,e2;
       Absyn.ComponentRef cr11,cr12,cr21,cr22,cr1,cr2;
       Absyn.Ident id1,id2;
-      list<SCode.EEquation> fb1,fb2,eql1,eql2,elst1,elst2;
+      list<SCode.Equation> fb1,fb2,eql1,eql2,elst1,elst2;
 
     case (SCode.EQ_IF(condition = ifcond1, thenBranch = tb1, elseBranch = fb1),SCode.EQ_IF(condition = ifcond2, thenBranch = tb2, elseBranch = fb2))
       equation
-        true = equationEqual22(tb1,tb2);
-        List.threadMapAllValue(fb1,fb2,equationEqual2,true);
+        true = equationEqual2(tb1,tb2);
+        List.threadMapAllValue(fb1,fb2,equationEqual,true);
         List.threadMapAllValue(ifcond1,ifcond2,AbsynUtil.expEqual,true);
       then
         true;
@@ -978,7 +965,7 @@ algorithm
 
     case (SCode.EQ_FOR(index = id1, range = SOME(exp1), eEquationLst = eql1),SCode.EQ_FOR(index = id2, range = SOME(exp2), eEquationLst = eql2))
       equation
-        List.threadMapAllValue(eql1,eql2,equationEqual2,true);
+        List.threadMapAllValue(eql1,eql2,equationEqual,true);
         true = AbsynUtil.expEqual(exp1,exp2);
         true = stringEq(id1,id2);
       then
@@ -986,14 +973,14 @@ algorithm
 
     case (SCode.EQ_FOR(index = id1, range = NONE(), eEquationLst = eql1),SCode.EQ_FOR(index = id2, range = NONE(), eEquationLst = eql2))
       equation
-        List.threadMapAllValue(eql1,eql2,equationEqual2,true);
+        List.threadMapAllValue(eql1,eql2,equationEqual,true);
         true = stringEq(id1,id2);
       then
         true;
 
     case (SCode.EQ_WHEN(condition = cond1, eEquationLst = elst1),SCode.EQ_WHEN(condition = cond2, eEquationLst = elst2)) // TODO: elsewhen not checked yet.
       equation
-        List.threadMapAllValue(elst1,elst2,equationEqual2,true);
+        List.threadMapAllValue(elst1,elst2,equationEqual,true);
         true = AbsynUtil.expEqual(cond1,cond2);
       then
         true;
@@ -1021,33 +1008,33 @@ algorithm
     // otherwise false
     else false;
   end matchcontinue;
-end equationEqual2;
+end equationEqual;
 
-protected function equationEqual22
+protected function equationEqual2
 "Author BZ
  Helper function for equationEqual2, does compare list<list<equation>> (else ifs in ifequations.)"
-  input list<list<SCode.EEquation>> inTb1;
-  input list<list<SCode.EEquation>> inTb2;
+  input list<list<SCode.Equation>> inTb1;
+  input list<list<SCode.Equation>> inTb2;
   output Boolean bOut;
 algorithm
   bOut := matchcontinue(inTb1,inTb2)
     local
-      list<SCode.EEquation> tb_1,tb_2;
-      list<list<SCode.EEquation>> tb1,tb2;
+      list<SCode.Equation> tb_1,tb_2;
+      list<list<SCode.Equation>> tb1,tb2;
 
     case({},{}) then true;
     case(_,{}) then false;
     case({},_) then false;
     case(tb_1::tb1,tb_2::tb2)
       equation
-        List.threadMapAllValue(tb_1,tb_2,equationEqual2,true);
-        true = equationEqual22(tb1,tb2);
+        List.threadMapAllValue(tb_1,tb_2,equationEqual,true);
+        true = equationEqual2(tb1,tb2);
       then
         true;
     case(_::_,_::_) then false;
 
   end matchcontinue;
-end equationEqual22;
+end equationEqual2;
 
 public function modEqual
 "Return true if two Mod:s are equal"
@@ -1339,25 +1326,25 @@ algorithm
   end matchcontinue;
 end setClassPartialPrefix;
 
-public function findIteratorIndexedCrefsInEEquations
-  input list<SCode.EEquation> inEqs;
+public function findIteratorIndexedCrefsInEquations
+  input list<SCode.Equation> inEqs;
   input String inIterator;
   input list<AbsynUtil.IteratorIndexedCref> inCrefs = {};
   output list<AbsynUtil.IteratorIndexedCref> outCrefs;
 algorithm
-  outCrefs := List.fold1(inEqs, findIteratorIndexedCrefsInEEquation, inIterator,
+  outCrefs := List.fold1(inEqs, findIteratorIndexedCrefsInEquation, inIterator,
     inCrefs);
-end findIteratorIndexedCrefsInEEquations;
+end findIteratorIndexedCrefsInEquations;
 
-public function findIteratorIndexedCrefsInEEquation
-  input SCode.EEquation inEq;
+public function findIteratorIndexedCrefsInEquation
+  input SCode.Equation inEq;
   input String inIterator;
   input list<AbsynUtil.IteratorIndexedCref> inCrefs = {};
   output list<AbsynUtil.IteratorIndexedCref> outCrefs;
 algorithm
-  outCrefs := foldEEquationsExps(inEq,
+  outCrefs := foldEquationsExps(inEq,
     function AbsynUtil.findIteratorIndexedCrefs(inIterator = inIterator), inCrefs);
-end findIteratorIndexedCrefsInEEquation;
+end findIteratorIndexedCrefsInEquation;
 
 public function findIteratorIndexedCrefsInStatements
   input list<SCode.Statement> inStatements;
@@ -1564,7 +1551,7 @@ algorithm
 end statementToAlgorithmItem;
 
 public function equationFileInfo
-  input SCode.EEquation eq;
+  input SCode.Equation eq;
   output SourceInfo info;
 algorithm
   info := match eq
@@ -1649,16 +1636,16 @@ algorithm
   end match;
 end isClass;
 
-public function foldEEquations<ArgT>
+public function foldEquations<ArgT>
   "Calls the given function on the equation and all its subequations, and
    updates the argument for each call."
-  input SCode.EEquation inEquation;
+  input SCode.Equation inEquation;
   input FoldFunc inFunc;
   input ArgT inArg;
   output ArgT outArg;
 
   partial function FoldFunc
-    input SCode.EEquation inEquation;
+    input SCode.Equation inEquation;
     input ArgT inArg;
     output ArgT outArg;
   end FoldFunc;
@@ -1667,35 +1654,35 @@ algorithm
 
   outArg := match inEquation
     local
-      list<SCode.EEquation> eql;
+      list<SCode.Equation> eql;
 
     case SCode.EQ_IF()
       algorithm
-        outArg := List.foldList1(inEquation.thenBranch, foldEEquations, inFunc, outArg);
+        outArg := List.foldList1(inEquation.thenBranch, foldEquations, inFunc, outArg);
       then
-        List.fold1(inEquation.elseBranch, foldEEquations, inFunc, outArg);
+        List.fold1(inEquation.elseBranch, foldEquations, inFunc, outArg);
 
     case SCode.EQ_FOR()
-      then List.fold1(inEquation.eEquationLst, foldEEquations, inFunc, outArg);
+      then List.fold1(inEquation.eEquationLst, foldEquations, inFunc, outArg);
 
     case SCode.EQ_WHEN()
       algorithm
-        outArg := List.fold1(inEquation.eEquationLst, foldEEquations, inFunc, outArg);
+        outArg := List.fold1(inEquation.eEquationLst, foldEquations, inFunc, outArg);
 
         for branch in inEquation.elseBranches loop
           (_, eql) := branch;
-          outArg := List.fold1(eql, foldEEquations, inFunc, outArg);
+          outArg := List.fold1(eql, foldEquations, inFunc, outArg);
         end for;
       then
         outArg;
 
   end match;
-end foldEEquations;
+end foldEquations;
 
-public function foldEEquationsExps<ArgT>
+public function foldEquationsExps<ArgT>
   "Calls the given function on all expressions inside the equation, and updates
    the argument for each call."
-  input SCode.EEquation inEquation;
+  input SCode.Equation inEquation;
   input FoldFunc inFunc;
   input ArgT inArg;
   output ArgT outArg = inArg;
@@ -1709,14 +1696,14 @@ algorithm
   outArg := match inEquation
     local
       Absyn.Exp exp;
-      list<SCode.EEquation> eql;
+      list<SCode.Equation> eql;
 
     case SCode.EQ_IF()
       algorithm
         outArg := List.fold(inEquation.condition, inFunc, outArg);
-        outArg := List.foldList1(inEquation.thenBranch, foldEEquationsExps, inFunc, outArg);
+        outArg := List.foldList1(inEquation.thenBranch, foldEquationsExps, inFunc, outArg);
       then
-        List.fold1(inEquation.elseBranch, foldEEquationsExps, inFunc, outArg);
+        List.fold1(inEquation.elseBranch, foldEquationsExps, inFunc, outArg);
 
     case SCode.EQ_EQUALS()
       algorithm
@@ -1746,16 +1733,16 @@ algorithm
           outArg := inFunc(exp, outArg);
         end if;
       then
-        List.fold1(inEquation.eEquationLst, foldEEquationsExps, inFunc, outArg);
+        List.fold1(inEquation.eEquationLst, foldEquationsExps, inFunc, outArg);
 
     case SCode.EQ_WHEN()
       algorithm
-        outArg := List.fold1(inEquation.eEquationLst, foldEEquationsExps, inFunc, outArg);
+        outArg := List.fold1(inEquation.eEquationLst, foldEquationsExps, inFunc, outArg);
 
         for branch in inEquation.elseBranches loop
           (exp, eql) := branch;
           outArg := inFunc(exp, outArg);
-          outArg := List.fold1(eql, foldEEquationsExps, inFunc, outArg);
+          outArg := List.fold1(eql, foldEquationsExps, inFunc, outArg);
         end for;
       then
         outArg;
@@ -1782,7 +1769,7 @@ algorithm
       then inFunc(inEquation.exp, outArg);
 
   end match;
-end foldEEquationsExps;
+end foldEquationsExps;
 
 public function foldStatementsExps<ArgT>
   "Calls the given function on all expressions inside the statement, and updates
@@ -1893,30 +1880,30 @@ algorithm
   end match;
 end foldStatementsExps;
 
-public function mapFoldEEquationsList<ArgT>
-  "Traverses a list of SCode.EEquations, calling mapFoldEEquations on each SCode.EEquation
+public function mapFoldEquationsList<ArgT>
+  "Traverses a list of SCode.Equations, calling mapFoldEquations on each SCode.Equation
   in the list."
-  input output list<SCode.EEquation> eql;
+  input output list<SCode.Equation> eql;
   input TraverseFunc traverser;
   input output ArgT arg;
 
   partial function TraverseFunc
-    input output SCode.EEquation eq;
+    input output SCode.Equation eq;
     input output ArgT arg;
   end TraverseFunc;
 algorithm
-  (eql, arg) := List.mapFold(eql, function mapFoldEEquations(traverser = traverser), arg);
-end mapFoldEEquationsList;
+  (eql, arg) := List.mapFold(eql, function mapFoldEquations(traverser = traverser), arg);
+end mapFoldEquationsList;
 
-public function mapFoldEEquations<ArgT>
-  "Traverses an SCode.EEquation. For each SCode.EEquation it finds it calls the given
-  function with the SCode.EEquation and an extra argument which is passed along."
-  input output SCode.EEquation eq;
+public function mapFoldEquations<ArgT>
+  "Traverses an SCode.Equation. For each SCode.Equation it finds it calls the given
+  function with the SCode.Equation and an extra argument which is passed along."
+  input output SCode.Equation eq;
   input TraverseFunc traverser;
   input output ArgT arg;
 
   partial function TraverseFunc
-    input output SCode.EEquation eq;
+    input output SCode.Equation eq;
     input output ArgT arg;
   end TraverseFunc;
 algorithm
@@ -1926,67 +1913,67 @@ algorithm
     local
       Absyn.Exp e1;
       list<Absyn.Exp> expl1;
-      list<list<SCode.EEquation>> then_branch;
-      list<SCode.EEquation> else_branch, eql;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> else_when;
+      list<list<SCode.Equation>> then_branch;
+      list<SCode.Equation> else_branch, eql;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> else_when;
       SCode.Comment comment;
       SourceInfo info;
 
     case SCode.EQ_IF(expl1, then_branch, else_branch, comment, info)
       equation
         (then_branch, arg) = List.mapFold(then_branch,
-          function mapFoldEEquationsList(traverser = traverser), arg);
-        (else_branch, arg) = mapFoldEEquationsList(else_branch, traverser, arg);
+          function mapFoldEquationsList(traverser = traverser), arg);
+        (else_branch, arg) = mapFoldEquationsList(else_branch, traverser, arg);
       then
         (SCode.EQ_IF(expl1, then_branch, else_branch, comment, info), arg);
 
     case SCode.EQ_FOR()
       algorithm
-        (eql, arg) := mapFoldEEquationsList(eq.eEquationLst, traverser, arg);
+        (eql, arg) := mapFoldEquationsList(eq.eEquationLst, traverser, arg);
         eq.eEquationLst := eql;
       then
         (eq, arg);
 
     case SCode.EQ_WHEN(e1, eql, else_when, comment, info)
       equation
-        (eql, arg) = mapFoldEEquationsList(eql, traverser, arg);
+        (eql, arg) = mapFoldEquationsList(eql, traverser, arg);
         (else_when, arg) = List.mapFold(else_when,
-           function mapFoldElseWhenEEquations(traverser = traverser), arg);
+           function mapFoldElseWhenEquations(traverser = traverser), arg);
       then
         (SCode.EQ_WHEN(e1, eql, else_when, comment, info), arg);
 
     else (eq, arg);
   end match;
-end mapFoldEEquations;
+end mapFoldEquations;
 
-protected function mapFoldElseWhenEEquations<ArgT>
-  "Traverses all SCode.EEquations in an else when branch, calling the given function
-  on each SCode.EEquation."
-  input output tuple<Absyn.Exp, list<SCode.EEquation>> elseWhen;
+protected function mapFoldElseWhenEquations<ArgT>
+  "Traverses all SCode.Equations in an else when branch, calling the given function
+  on each SCode.Equation."
+  input output tuple<Absyn.Exp, list<SCode.Equation>> elseWhen;
   input TraverseFunc traverser;
   input output ArgT arg;
 
   partial function TraverseFunc
-    input output SCode.EEquation eq;
+    input output SCode.Equation eq;
     input output ArgT arg;
   end TraverseFunc;
 
 protected
   Absyn.Exp exp;
-  list<SCode.EEquation> eql;
+  list<SCode.Equation> eql;
 algorithm
   (exp, eql) := elseWhen;
-  (eql, arg) := mapFoldEEquationsList(eql, traverser, arg);
+  (eql, arg) := mapFoldEquationsList(eql, traverser, arg);
   elseWhen := (exp, eql);
-end mapFoldElseWhenEEquations;
+end mapFoldElseWhenEquations;
 
-public function mapFoldEEquationListExps<ArgT>
-  "Traverses a list of SCode.EEquations, calling the given function on each Absyn.Exp
+public function mapFoldEquationListExps<ArgT>
+  "Traverses a list of SCode.Equations, calling the given function on each Absyn.Exp
   it encounters."
-  input list<SCode.EEquation> inEEquations;
+  input list<SCode.Equation> inEquations;
   input TraverseFunc traverser;
   input Argument inArg;
-  output list<SCode.EEquation> outEEquations;
+  output list<SCode.Equation> outEquations;
   output Argument outArg;
 
   partial function TraverseFunc
@@ -1994,14 +1981,14 @@ public function mapFoldEEquationListExps<ArgT>
     input output ArgT arg;
   end TraverseFunc;
 algorithm
-  (outEEquations, outArg) := List.map1Fold(inEEquations, mapFoldEEquationExps, traverser, inArg);
-end mapFoldEEquationListExps;
+  (outEquations, outArg) := List.map1Fold(inEquations, mapFoldEquationExps, traverser, inArg);
+end mapFoldEquationListExps;
 
-public function mapFoldEEquationExps<ArgT>
-  "Traverses an SCode.EEquation, calling the given function on each Absyn.Exp it
+public function mapFoldEquationExps<ArgT>
+  "Traverses an SCode.Equation, calling the given function on each Absyn.Exp it
   encounters. This funcion is intended to be used together with
-  mapFoldEEquations, and does NOT descend into sub-EEquations."
-  input output SCode.EEquation eq;
+  mapFoldEquations, and does NOT descend into sub-Equations."
+  input output SCode.Equation eq;
   input TraverseFunc traverser;
   input output ArgT arg;
 
@@ -2014,9 +2001,9 @@ algorithm
     local
       Absyn.Exp e1, e2, e3;
       list<Absyn.Exp> expl1;
-      list<list<SCode.EEquation>> then_branch;
-      list<SCode.EEquation> else_branch, eql;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> else_when;
+      list<list<SCode.Equation>> then_branch;
+      list<SCode.Equation> else_branch, eql;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> else_when;
       SCode.Comment comment;
       SourceInfo info;
       Absyn.ComponentRef cr1, cr2, domain;
@@ -2091,7 +2078,7 @@ algorithm
 
     else (eq, arg);
   end match;
-end mapFoldEEquationExps;
+end mapFoldEquationExps;
 
 protected function mapFoldComponentRefExps<ArgT>
   "Traverses the subscripts of a component reference and calls the given
@@ -2169,10 +2156,10 @@ end mapFoldSubscriptExps;
 protected function mapFoldElseWhenExps<ArgT>
   "Traverses the expressions in an else when branch, and calls the given
   function on the expressions."
-  input tuple<Absyn.Exp, list<SCode.EEquation>> inElseWhen;
+  input tuple<Absyn.Exp, list<SCode.Equation>> inElseWhen;
   input TraverseFunc traverser;
   input ArgT inArg;
-  output tuple<Absyn.Exp, list<SCode.EEquation>> outElseWhen;
+  output tuple<Absyn.Exp, list<SCode.Equation>> outElseWhen;
   output ArgT outArg;
 
   partial function TraverseFunc
@@ -2181,7 +2168,7 @@ protected function mapFoldElseWhenExps<ArgT>
   end TraverseFunc;
 protected
   Absyn.Exp exp;
-  list<SCode.EEquation> eql;
+  list<SCode.Equation> eql;
 algorithm
   (exp, eql) := inElseWhen;
   (exp, outArg) := traverser(exp, inArg);
@@ -2562,12 +2549,12 @@ algorithm
   end match;
 end isBuiltinFunction;
 
-public function getEEquationInfo
-  "Extracts the SourceInfo from an SCode.EEquation."
-  input SCode.EEquation inEEquation;
+public function getEquationInfo
+  "Extracts the SourceInfo from an SCode.Equation."
+  input SCode.Equation inEquation;
   output SourceInfo outInfo;
 algorithm
-  outInfo := match(inEEquation)
+  outInfo := match(inEquation)
     local
       SourceInfo info;
 
@@ -2582,7 +2569,7 @@ algorithm
     case SCode.EQ_REINIT(info = info) then info;
     case SCode.EQ_NORETCALL(info = info) then info;
   end match;
-end getEEquationInfo;
+end getEquationInfo;
 
 public function getStatementInfo
   "Extracts the SourceInfo from a Statement."
@@ -4099,13 +4086,6 @@ algorithm
   end match;
 end setClassPrefixes;
 
-public function makeEquation
-  input SCode.EEquation inEEq;
-  output SCode.Equation outEq;
-algorithm
-  outEq := SCode.EQUATION(inEEq);
-end makeEquation;
-
 public function getClassDef
   input SCode.Element inClass;
   output SCode.ClassDef outCdef;
@@ -4118,7 +4098,7 @@ end getClassDef;
 public function equationsContainReinit
 "@author:
  returns true if equations contains reinit"
-  input list<SCode.EEquation> inEqs;
+  input list<SCode.Equation> inEqs;
   output Boolean hasReinit;
 algorithm
   hasReinit := match(inEqs)
@@ -4134,15 +4114,15 @@ end equationsContainReinit;
 public function equationContainReinit
 "@author:
  returns true if equation contains reinit"
-  input SCode.EEquation inEq;
+  input SCode.Equation inEq;
   output Boolean hasReinit;
 algorithm
   hasReinit := match(inEq)
     local
       Boolean b;
-      list<SCode.EEquation> eqs;
-      list<list<SCode.EEquation>> eqs_lst;
-      list<tuple<Absyn.Exp, list<SCode.EEquation>>> tpl_el;
+      list<SCode.Equation> eqs;
+      list<list<SCode.Equation>> eqs_lst;
+      list<tuple<Absyn.Exp, list<SCode.Equation>>> tpl_el;
 
     case SCode.EQ_REINIT() then true;
     case SCode.EQ_WHEN(eEquationLst = eqs, elseBranches = tpl_el)
@@ -5387,21 +5367,13 @@ function stripCommentsFromEquation
   input Boolean stripAnn;
   input Boolean stripCmt;
 algorithm
-  eq.eEquation := stripCommentsFromEEquation(eq.eEquation, stripAnn, stripCmt);
-end stripCommentsFromEquation;
-
-function stripCommentsFromEEquation
-  input output SCode.EEquation eq;
-  input Boolean stripAnn;
-  input Boolean stripCmt;
-algorithm
   () := match eq
     case SCode.EQ_IF()
       algorithm
         eq.thenBranch := list(
-            list(stripCommentsFromEEquation(e, stripAnn, stripCmt) for e in branch)
+            list(stripCommentsFromEquation(e, stripAnn, stripCmt) for e in branch)
           for branch in eq.thenBranch);
-        eq.elseBranch := list(stripCommentsFromEEquation(e, stripAnn, stripCmt) for e in eq.elseBranch);
+        eq.elseBranch := list(stripCommentsFromEquation(e, stripAnn, stripCmt) for e in eq.elseBranch);
         eq.comment := stripCommentsFromComment(eq.comment, stripAnn, stripCmt);
       then
         ();
@@ -5426,14 +5398,14 @@ algorithm
 
     case SCode.EQ_FOR()
       algorithm
-        eq.eEquationLst := list(stripCommentsFromEEquation(e, stripAnn, stripCmt) for e in eq.eEquationLst);
+        eq.eEquationLst := list(stripCommentsFromEquation(e, stripAnn, stripCmt) for e in eq.eEquationLst);
         eq.comment := stripCommentsFromComment(eq.comment, stripAnn, stripCmt);
       then
         ();
 
     case SCode.EQ_WHEN()
       algorithm
-        eq.eEquationLst := list(stripCommentsFromEEquation(e, stripAnn, stripCmt) for e in eq.eEquationLst);
+        eq.eEquationLst := list(stripCommentsFromEquation(e, stripAnn, stripCmt) for e in eq.eEquationLst);
         eq.elseBranches := list(stripCommentsFromWhenEqBranch(b, stripAnn, stripCmt) for b in eq.elseBranches);
         eq.comment := stripCommentsFromComment(eq.comment, stripAnn, stripCmt);
       then
@@ -5464,18 +5436,18 @@ algorithm
         ();
 
   end match;
-end stripCommentsFromEEquation;
+end stripCommentsFromEquation;
 
 function stripCommentsFromWhenEqBranch
-  input output tuple<Absyn.Exp, list<SCode.EEquation>> branch;
+  input output tuple<Absyn.Exp, list<SCode.Equation>> branch;
   input Boolean stripAnn;
   input Boolean stripCmt;
 protected
   Absyn.Exp cond;
-  list<SCode.EEquation> body;
+  list<SCode.Equation> body;
 algorithm
   (cond, body) := branch;
-  body := list(stripCommentsFromEEquation(e, stripAnn, stripCmt) for e in body);
+  body := list(stripCommentsFromEquation(e, stripAnn, stripCmt) for e in body);
   branch := (cond, body);
 end stripCommentsFromWhenEqBranch;
 
@@ -5799,7 +5771,7 @@ function mapEquationsList
   input Func func;
 
   partial function Func
-    input output SCode.EEquation eq;
+    input output SCode.Equation eq;
   end Func;
 algorithm
   eql := list(mapEquations(e, func) for e in eql);
@@ -5810,50 +5782,28 @@ function mapEquations
   input Func func;
 
   partial function Func
-    input output SCode.EEquation eq;
-  end Func;
-algorithm
-  eq.eEquation := mapEEquations(eq.eEquation, func);
-end mapEquations;
-
-function mapEEquationsList
-  input output list<SCode.EEquation> eql;
-  input Func func;
-
-  partial function Func
-    input output SCode.EEquation eq;
-  end Func;
-algorithm
-  eql := list(mapEEquations(e, func) for e in eql);
-end mapEEquationsList;
-
-function mapEEquations
-  input output SCode.EEquation eq;
-  input Func func;
-
-  partial function Func
-    input output SCode.EEquation eq;
+    input output SCode.Equation eq;
   end Func;
 algorithm
   () := match eq
-    case SCode.EEquation.EQ_IF()
+    case SCode.Equation.EQ_IF()
       algorithm
-        eq.thenBranch := list(mapEEquationsList(b, func) for b in eq.thenBranch);
-        eq.elseBranch := mapEEquationsList(eq.elseBranch, func);
+        eq.thenBranch := list(mapEquationsList(b, func) for b in eq.thenBranch);
+        eq.elseBranch := mapEquationsList(eq.elseBranch, func);
       then
         ();
 
-    case SCode.EEquation.EQ_FOR()
+    case SCode.Equation.EQ_FOR()
       algorithm
-        eq.eEquationLst := mapEEquationsList(eq.eEquationLst, func);
+        eq.eEquationLst := mapEquationsList(eq.eEquationLst, func);
       then
         ();
 
-    case SCode.EEquation.EQ_WHEN()
+    case SCode.Equation.EQ_WHEN()
       algorithm
-        eq.eEquationLst := mapEEquationsList(eq.eEquationLst, func);
+        eq.eEquationLst := mapEquationsList(eq.eEquationLst, func);
         eq.elseBranches := list(
-          (Util.tuple21(b), mapEEquationsList(Util.tuple22(b), func)) for b in eq.elseBranches);
+          (Util.tuple21(b), mapEquationsList(Util.tuple22(b), func)) for b in eq.elseBranches);
       then
         ();
 
@@ -5861,10 +5811,9 @@ algorithm
   end match;
 
   eq := func(eq);
-end mapEEquations;
+end mapEquations;
 
 function mapEquationExps
-  "Applies a function to all expressions in an equation."
   input output SCode.Equation eq;
   input Func func;
 
@@ -5872,32 +5821,21 @@ function mapEquationExps
     input output Absyn.Exp exp;
   end Func;
 algorithm
-  eq.eEquation := mapEEquationExps(eq.eEquation, func);
-end mapEquationExps;
-
-function mapEEquationExps
-  input output SCode.EEquation eq;
-  input Func func;
-
-  partial function Func
-    input output Absyn.Exp exp;
-  end Func;
-algorithm
   () := match eq
-    case SCode.EEquation.EQ_IF()
+    case SCode.Equation.EQ_IF()
       algorithm
         eq.condition := list(func(e) for e in eq.condition);
       then
         ();
 
-    case SCode.EEquation.EQ_EQUALS()
+    case SCode.Equation.EQ_EQUALS()
       algorithm
         eq.expLeft := func(eq.expLeft);
         eq.expRight := func(eq.expRight);
       then
         ();
 
-    case SCode.EEquation.EQ_PDE()
+    case SCode.Equation.EQ_PDE()
       algorithm
         eq.expLeft := func(eq.expLeft);
         eq.expRight := func(eq.expRight);
@@ -5905,14 +5843,14 @@ algorithm
       then
         ();
 
-    case SCode.EEquation.EQ_CONNECT()
+    case SCode.Equation.EQ_CONNECT()
       algorithm
         eq.crefLeft := AbsynUtil.mapCrefExps(eq.crefLeft, func);
         eq.crefRight := AbsynUtil.mapCrefExps(eq.crefRight, func);
       then
         ();
 
-    case SCode.EEquation.EQ_FOR()
+    case SCode.Equation.EQ_FOR()
       algorithm
         if isSome(eq.range) then
           eq.range := SOME(func(Util.getOption(eq.range)));
@@ -5920,14 +5858,14 @@ algorithm
       then
         ();
 
-    case SCode.EEquation.EQ_WHEN()
+    case SCode.Equation.EQ_WHEN()
       algorithm
         eq.condition := func(eq.condition);
         eq.elseBranches := list(Util.applyTuple21(b, func) for b in eq.elseBranches);
       then
         ();
 
-    case SCode.EEquation.EQ_ASSERT()
+    case SCode.Equation.EQ_ASSERT()
       algorithm
         eq.condition := func(eq.condition);
         eq.message := func(eq.message);
@@ -5935,27 +5873,27 @@ algorithm
       then
         ();
 
-    case SCode.EEquation.EQ_TERMINATE()
+    case SCode.Equation.EQ_TERMINATE()
       algorithm
         eq.message := func(eq.message);
       then
         ();
 
-    case SCode.EEquation.EQ_REINIT()
+    case SCode.Equation.EQ_REINIT()
       algorithm
         eq.cref := func(eq.cref);
         eq.expReinit := func(eq.expReinit);
       then
         ();
 
-    case SCode.EEquation.EQ_NORETCALL()
+    case SCode.Equation.EQ_NORETCALL()
       algorithm
         eq.exp := func(eq.exp);
       then
         ();
 
   end match;
-end mapEEquationExps;
+end mapEquationExps;
 
 function mapAlgorithmStatements
   "Applies a function to all statements in algorithm section, and recursively

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -781,13 +781,13 @@ public
 
   function mergeScalarsEq
     "Updates the names of merged components in an equation."
-    input output SCode.EEquation eq;
+    input output SCode.Equation eq;
     input UnorderedMap<String, Absyn.ComponentRef> nameMap;
   algorithm
-    eq := SCodeUtil.mapEEquationExps(eq, function mergeScalarsExps(nameMap = nameMap));
+    eq := SCodeUtil.mapEquationExps(eq, function mergeScalarsExps(nameMap = nameMap));
 
     () := match eq
-      case SCode.EEquation.EQ_CONNECT()
+      case SCode.Equation.EQ_CONNECT()
         algorithm
           eq.crefLeft := mergeScalarsCref(eq.crefLeft, nameMap);
           eq.crefRight := mergeScalarsCref(eq.crefRight, nameMap);

--- a/OMCompiler/Compiler/Script/Obfuscate.mo
+++ b/OMCompiler/Compiler/Script/Obfuscate.mo
@@ -756,35 +756,28 @@ encapsulated package Obfuscate
     extDecl.annotation_ := obfuscateAnnotationOpt(extDecl.annotation_, env);
   end obfuscateExternalDecl;
 
+  function obfuscateEquations
+    input output list<SCode.Equation> eql;
+    input Env env;
+  algorithm
+    eql := list(obfuscateEquation(eq, env) for eq in eql);
+  end obfuscateEquations;
+
   function obfuscateEquation
     input output SCode.Equation eq;
     input Env env;
   algorithm
-    eq.eEquation := obfuscateEEquation(eq.eEquation, env);
-  end obfuscateEquation;
-
-  function obfuscateEEquations
-    input output list<SCode.EEquation> eql;
-    input Env env;
-  algorithm
-    eql := list(obfuscateEEquation(eq, env) for eq in eql);
-  end obfuscateEEquations;
-
-  function obfuscateEEquation
-    input output SCode.EEquation eq;
-    input Env env;
-  algorithm
     () := match eq
-      case SCode.EEquation.EQ_IF()
+      case SCode.Equation.EQ_IF()
         algorithm
           eq.condition := list(obfuscateExp(e, env) for e in eq.condition);
-          eq.thenBranch := list(obfuscateEEquations(e, env) for e in eq.thenBranch);
-          eq.elseBranch := obfuscateEEquations(eq.elseBranch, env);
+          eq.thenBranch := list(obfuscateEquations(e, env) for e in eq.thenBranch);
+          eq.elseBranch := obfuscateEquations(eq.elseBranch, env);
           eq.comment := obfuscateComment(eq.comment, env);
         then
           ();
 
-      case SCode.EEquation.EQ_EQUALS()
+      case SCode.Equation.EQ_EQUALS()
         algorithm
           eq.expLeft := obfuscateExp(eq.expLeft, env);
           eq.expRight := obfuscateExp(eq.expRight, env);
@@ -792,7 +785,7 @@ encapsulated package Obfuscate
         then
           ();
 
-      case SCode.EEquation.EQ_PDE()
+      case SCode.Equation.EQ_PDE()
         algorithm
           eq.expLeft := obfuscateExp(eq.expLeft, env);
           eq.expRight := obfuscateExp(eq.expRight, env);
@@ -800,7 +793,7 @@ encapsulated package Obfuscate
         then
           ();
 
-      case SCode.EEquation.EQ_CONNECT()
+      case SCode.Equation.EQ_CONNECT()
         algorithm
           eq.crefLeft := obfuscateCref(eq.crefLeft, env, ElementType.OTHER);
           eq.crefRight := obfuscateCref(eq.crefRight, env, ElementType.OTHER);
@@ -808,27 +801,27 @@ encapsulated package Obfuscate
         then
           ();
 
-      case SCode.EEquation.EQ_FOR()
+      case SCode.Equation.EQ_FOR()
         algorithm
           eq.index := obfuscateIdentifier(eq.index, env, ElementType.OTHER);
           eq.range := obfuscateExpOpt(eq.range, env);
-          eq.eEquationLst := obfuscateEEquations(eq.eEquationLst, env);
+          eq.eEquationLst := obfuscateEquations(eq.eEquationLst, env);
           eq.comment := obfuscateComment(eq.comment, env);
         then
           ();
 
-      case SCode.EEquation.EQ_WHEN()
+      case SCode.Equation.EQ_WHEN()
         algorithm
           eq.condition := obfuscateExp(eq.condition, env);
-          eq.eEquationLst := obfuscateEEquations(eq.eEquationLst, env);
+          eq.eEquationLst := obfuscateEquations(eq.eEquationLst, env);
           eq.elseBranches := list(
             (obfuscateExp(Util.tuple21(b), env),
-             obfuscateEEquations(Util.tuple22(b), env)) for b in eq.elseBranches);
+             obfuscateEquations(Util.tuple22(b), env)) for b in eq.elseBranches);
           eq.comment := obfuscateComment(eq.comment, env);
         then
           ();
 
-      case SCode.EEquation.EQ_ASSERT()
+      case SCode.Equation.EQ_ASSERT()
         algorithm
           eq.condition := obfuscateExp(eq.condition, env);
           eq.message := obfuscateMessage(eq.message, "assert");
@@ -837,14 +830,14 @@ encapsulated package Obfuscate
         then
           ();
 
-      case SCode.EEquation.EQ_TERMINATE()
+      case SCode.Equation.EQ_TERMINATE()
         algorithm
           eq.message := obfuscateMessage(eq.message, "terminate");
           eq.comment := obfuscateComment(eq.comment, env);
         then
           ();
 
-      case SCode.EEquation.EQ_REINIT()
+      case SCode.Equation.EQ_REINIT()
         algorithm
           eq.cref := obfuscateExp(eq.cref, env);
           eq.expReinit := obfuscateExp(eq.expReinit, env);
@@ -852,14 +845,14 @@ encapsulated package Obfuscate
         then
           ();
 
-      case SCode.EEquation.EQ_NORETCALL()
+      case SCode.Equation.EQ_NORETCALL()
         algorithm
           eq.exp := obfuscateExp(eq.exp, env);
           eq.comment := obfuscateComment(eq.comment, env);
         then
           ();
     end match;
-  end obfuscateEEquation;
+  end obfuscateEquation;
 
   function obfuscateMessage
     "Obfuscates the message of assert/terminate by replacing it with

--- a/OMCompiler/Compiler/Script/TotalModelDebug.mo
+++ b/OMCompiler/Compiler/Script/TotalModelDebug.mo
@@ -328,37 +328,21 @@ public
     input SCode.Equation eq;
     input UseTable used;
   algorithm
-    analyseEEquation(eq.eEquation, used);
-  end analyseEquation;
-
-  function analyseEEquations
-    input list<SCode.EEquation> eqs;
-    input UseTable used;
-  algorithm
-    for e in eqs loop
-      analyseEEquation(e, used);
-    end for;
-  end analyseEEquations;
-
-  function analyseEEquation
-    input SCode.EEquation eq;
-    input UseTable used;
-  algorithm
     () := match eq
-      case SCode.EEquation.EQ_IF()
+      case SCode.Equation.EQ_IF()
         algorithm
           analyseExpList(eq.condition, used);
 
           for b in eq.thenBranch loop
-            analyseEEquations(b, used);
+            analyseEquations(b, used);
           end for;
 
-          analyseEEquations(eq.elseBranch, used);
+          analyseEquations(eq.elseBranch, used);
           analyseComment(eq.comment, used);
         then
           ();
 
-      case SCode.EEquation.EQ_EQUALS()
+      case SCode.Equation.EQ_EQUALS()
         algorithm
           analyseExp(eq.expLeft, used);
           analyseExp(eq.expRight, used);
@@ -366,7 +350,7 @@ public
         then
           ();
 
-      case SCode.EEquation.EQ_PDE()
+      case SCode.Equation.EQ_PDE()
         algorithm
           analyseExp(eq.expLeft, used);
           analyseExp(eq.expRight, used);
@@ -374,7 +358,7 @@ public
         then
           ();
 
-      case SCode.EEquation.EQ_CONNECT()
+      case SCode.Equation.EQ_CONNECT()
         algorithm
           analyseCref(eq.crefLeft, used);
           analyseCref(eq.crefRight, used);
@@ -382,29 +366,29 @@ public
         then
           ();
 
-      case SCode.EEquation.EQ_FOR()
+      case SCode.Equation.EQ_FOR()
         algorithm
           analyseExpOpt(eq.range, used);
-          analyseEEquations(eq.eEquationLst, used);
+          analyseEquations(eq.eEquationLst, used);
           analyseComment(eq.comment, used);
         then
           ();
 
-      case SCode.EEquation.EQ_WHEN()
+      case SCode.Equation.EQ_WHEN()
         algorithm
           analyseExp(eq.condition, used);
-          analyseEEquations(eq.eEquationLst, used);
+          analyseEquations(eq.eEquationLst, used);
 
           for b in eq.elseBranches loop
             analyseExp(Util.tuple21(b), used);
-            analyseEEquations(Util.tuple22(b), used);
+            analyseEquations(Util.tuple22(b), used);
           end for;
 
           analyseComment(eq.comment, used);
         then
           ();
 
-      case SCode.EEquation.EQ_ASSERT()
+      case SCode.Equation.EQ_ASSERT()
         algorithm
           analyseExp(eq.condition, used);
           analyseExp(eq.message, used);
@@ -413,14 +397,14 @@ public
         then
           ();
 
-      case SCode.EEquation.EQ_TERMINATE()
+      case SCode.Equation.EQ_TERMINATE()
         algorithm
           analyseExp(eq.message, used);
           analyseComment(eq.comment, used);
         then
           ();
 
-      case SCode.EEquation.EQ_REINIT()
+      case SCode.Equation.EQ_REINIT()
         algorithm
           analyseExp(eq.cref, used);
           analyseExp(eq.expReinit, used);
@@ -428,14 +412,14 @@ public
         then
           ();
 
-      case SCode.EEquation.EQ_NORETCALL()
+      case SCode.Equation.EQ_NORETCALL()
         algorithm
           analyseExp(eq.exp, used);
           analyseComment(eq.comment, used);
         then
           ();
     end match;
-  end analyseEEquation;
+  end analyseEquation;
 
   function analyseAlgorithms
     input list<SCode.AlgorithmSection> algs;

--- a/OMCompiler/Compiler/Template/SCodeDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/SCodeDumpTpl.tpl
@@ -288,13 +288,9 @@ template dumpEquations(list<SCode.Equation> equations, String label, SCodeDumpOp
 end dumpEquations;
 
 template dumpEquation(SCode.Equation equation, SCodeDumpOptions options)
-::= match equation case EQUATION(__) then dumpEEquation(eEquation, options)
-end dumpEquation;
-
-template dumpEEquation(SCode.EEquation equation, SCodeDumpOptions options)
 ::=
 match equation
-  case EQ_IF(__) then dumpIfEEquation(equation, options)
+  case EQ_IF(__) then dumpIfEquation(equation, options)
   case EQ_EQUALS(__) then
     let lhs_str = AbsynDumpTpl.dumpLhsExp(expLeft)
     let rhs_str = AbsynDumpTpl.dumpExp(expRight)
@@ -305,8 +301,8 @@ match equation
     let rhs_str = AbsynDumpTpl.dumpCref(crefRight)
     let cmt_str = dumpComment(comment, options)
     'connect(<%lhs_str%>, <%rhs_str%>)<%cmt_str%>;'
-  case EQ_FOR(__) then dumpForEEquation(equation, options)
-  case EQ_WHEN(__) then dumpWhenEEquation(equation, options)
+  case EQ_FOR(__) then dumpForEquation(equation, options)
+  case EQ_WHEN(__) then dumpWhenEquation(equation, options)
   case EQ_ASSERT(__) then
     let cond_str = AbsynDumpTpl.dumpExp(condition)
     let msg_str = AbsynDumpTpl.dumpExp(message)
@@ -326,21 +322,21 @@ match equation
     let exp_str = AbsynDumpTpl.dumpExp(exp)
     let cmt_str = dumpComment(comment, options)
     '<%exp_str%><%cmt_str%>;'
-  else errorMsg("SCodeDump.dumpEEquation: Unknown EEquation.")
-end dumpEEquation;
+  else errorMsg("SCodeDump.dumpEquation: Unknown Equation.")
+end dumpEquation;
 
-template dumpIfEEquation(SCode.EEquation ifequation, SCodeDumpOptions options)
+template dumpIfEquation(SCode.Equation ifequation, SCodeDumpOptions options)
 ::=
 match ifequation
   case EQ_IF(condition = if_cond :: elseif_conds,
              thenBranch = if_branch :: elseif_branches) then
     let if_cond_str = AbsynDumpTpl.dumpExp(if_cond)
-    let if_branch_str = (if_branch |> e => dumpEEquation(e, options) ;separator="\n")
-    let elseif_str = dumpElseIfEEquation(elseif_conds, elseif_branches, options)
+    let if_branch_str = (if_branch |> e => dumpEquation(e, options) ;separator="\n")
+    let elseif_str = dumpElseIfEquation(elseif_conds, elseif_branches, options)
     let else_str = if elseBranch then
       <<
       else
-        <%elseBranch |> e => dumpEEquation(e, options) ;separator="\n"%>
+        <%elseBranch |> e => dumpEquation(e, options) ;separator="\n"%>
       >>
     let cmt_str = dumpComment(comment, options)
     <<
@@ -350,31 +346,31 @@ match ifequation
     <%else_str%>
     end if<%cmt_str%>;
     >>
-end dumpIfEEquation;
+end dumpIfEquation;
 
-template dumpElseIfEEquation(list<Absyn.Exp> condition,
-    list<list<SCode.EEquation>> branches, SCodeDumpOptions options)
+template dumpElseIfEquation(list<Absyn.Exp> condition,
+    list<list<SCode.Equation>> branches, SCodeDumpOptions options)
 ::=
 match condition
   case cond :: rest_conds then
     match branches
       case branch :: rest_branches then
         let cond_str = AbsynDumpTpl.dumpExp(cond)
-        let branch_str = (branch |> e => dumpEEquation(e, options) ;separator="\n")
-        let rest_str = dumpElseIfEEquation(rest_conds, rest_branches, options)
+        let branch_str = (branch |> e => dumpEquation(e, options) ;separator="\n")
+        let rest_str = dumpElseIfEquation(rest_conds, rest_branches, options)
         <<
         elseif <%cond_str%> then
           <%branch_str%>
         <%rest_str%>
         >>
-end dumpElseIfEEquation;
+end dumpElseIfEquation;
 
-template dumpForEEquation(SCode.EEquation for_equation, SCodeDumpOptions options)
+template dumpForEquation(SCode.Equation for_equation, SCodeDumpOptions options)
 ::=
 match for_equation
   case EQ_FOR(range=SOME(range)) then
     let range_str = AbsynDumpTpl.dumpExp(range)
-    let eq_str = (eEquationLst |> e => dumpEEquation(e, options) ;separator="\n")
+    let eq_str = (eEquationLst |> e => dumpEquation(e, options) ;separator="\n")
     let cmt_str = dumpComment(comment, options)
     <<
     for <%index%> in <%range_str%> loop
@@ -382,24 +378,24 @@ match for_equation
     end for<%cmt_str%>;
     >>
   case EQ_FOR(__) then
-    let eq_str = (eEquationLst |> e => dumpEEquation(e, options) ;separator="\n")
+    let eq_str = (eEquationLst |> e => dumpEquation(e, options) ;separator="\n")
     let cmt_str = dumpComment(comment, options)
     <<
     for <%index%> loop
       <%eq_str%>
     end for<%cmt_str%>;
     >>
-end dumpForEEquation;
+end dumpForEquation;
 
-template dumpWhenEEquation(SCode.EEquation when_equation, SCodeDumpOptions options)
+template dumpWhenEquation(SCode.Equation when_equation, SCodeDumpOptions options)
 ::=
 match when_equation
   case EQ_WHEN(__) then
     let cond_str = AbsynDumpTpl.dumpExp(condition)
-    let body_str = (eEquationLst |> e => dumpEEquation(e, options) ;separator="\n")
+    let body_str = (eEquationLst |> e => dumpEquation(e, options) ;separator="\n")
     let else_str = (elseBranches |> (else_cond, else_body) =>
       let else_cond_str = AbsynDumpTpl.dumpExp(else_cond)
-      let else_body_str = (else_body |> e => dumpEEquation(e, options) ;separator="\n")
+      let else_body_str = (else_body |> e => dumpEquation(e, options) ;separator="\n")
       <<
       elsewhen <%else_cond_str%> then
         <%else_body_str%>
@@ -411,7 +407,7 @@ match when_equation
     <%else_str%>
     end when<%cmt_str%>;
     >>
-end dumpWhenEEquation;
+end dumpWhenEquation;
 
 template dumpAssertionLevel(Absyn.Exp exp)
 ::= match exp

--- a/OMCompiler/Compiler/Template/SCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SCodeTV.mo
@@ -497,16 +497,10 @@ package SCode
   end ExternalDecl;
 
   uniontype Equation
-    record EQUATION
-      EEquation eEquation;
-    end EQUATION;
-  end Equation;
-
-  uniontype EEquation
     record EQ_IF
       list<Absyn.Exp> condition;
-      list<list<EEquation>> thenBranch;
-      list<EEquation>       elseBranch;
+      list<list<Equation>> thenBranch;
+      list<Equation>       elseBranch;
       Comment comment;
       SourceInfo info;
     end EQ_IF;
@@ -536,15 +530,15 @@ package SCode
     record EQ_FOR
       Ident index;
       Option<Absyn.Exp> range;
-      list<EEquation> eEquationLst;
+      list<Equation> eEquationLst;
       Comment comment;
       SourceInfo info;
     end EQ_FOR;
 
     record EQ_WHEN
       Absyn.Exp condition;
-      list<EEquation> eEquationLst;
-      list<tuple<Absyn.Exp, list<EEquation>>> elseBranches;
+      list<Equation> eEquationLst;
+      list<tuple<Absyn.Exp, list<Equation>>> elseBranches;
       Comment comment;
       SourceInfo info;
     end EQ_WHEN;
@@ -576,7 +570,7 @@ package SCode
       SourceInfo info;
     end EQ_NORETCALL;
 
-  end EEquation;
+  end Equation;
 
   uniontype AlgorithmSection
     record ALGORITHM


### PR DESCRIPTION
- Remove SCode.Equation since it's just an unnecessary wrapper for
  SCode.EEquation, and rename SCode.EEquation to SCode.Equation.