### PR TITLE
Improve printing of Absyn.InnerOuter

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -3301,9 +3301,9 @@ public function innerOuterStr
   output String str;
 algorithm
   str := match io
-    case Absyn.INNER_OUTER() then "inner outer ";
-    case Absyn.INNER() then "inner ";
-    case Absyn.OUTER() then "outer ";
+    case Absyn.INNER_OUTER() then "inner outer";
+    case Absyn.INNER() then "inner";
+    case Absyn.OUTER() then "outer";
     case Absyn.NOT_INNER_OUTER() then "";
   end match;
 end innerOuterStr;

--- a/OMCompiler/Compiler/FrontEnd/Dump.mo
+++ b/OMCompiler/Compiler/FrontEnd/Dump.mo
@@ -958,20 +958,18 @@ algorithm
   end match;
 end printInnerouter;
 
-public function unparseInnerouterStr "
-  Prettyprints the inner or outer keyword to a string.
-"
+public function unparseInnerOuterStr
+  "Prettyprints the inner or outer keyword to a string."
   input Absyn.InnerOuter inInnerOuter;
   output String outString;
 algorithm
-  outString:=
-  match (inInnerOuter)
-    case (Absyn.INNER()) then "inner ";
-    case (Absyn.OUTER()) then "outer ";
-    case (Absyn.INNER_OUTER()) then "inner outer ";
-    case (Absyn.NOT_INNER_OUTER()) then "";
+  outString:= match inInnerOuter
+    case Absyn.INNER() then "inner ";
+    case Absyn.OUTER() then "outer ";
+    case Absyn.INNER_OUTER() then "inner outer ";
+    case Absyn.NOT_INNER_OUTER() then "";
   end match;
-end unparseInnerouterStr;
+end unparseInnerOuterStr;
 
 public function printElementspec
 "Prints the ElementSpec to the Print buffer."

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -849,8 +849,8 @@ algorithm
 
         if not Config.getGraphicsExpMode() then
           s1 = n;
-          s2 = Dump.unparseInnerouterStr(io);
-          Error.addSourceMessage(Error.MISSING_INNER_CLASS,{s1, s2}, info);
+          s2 = AbsynUtil.innerOuterStr(io);
+          Error.addSourceMessage(Error.MISSING_INNER_CLASS,{s1, s2, ""}, info);
         end if;
 
         (cache,env,ih,store,ci_state,graph,csets,dae,tys,bc,oDA,equalityConstraint) =

--- a/OMCompiler/Compiler/FrontEnd/InstVar.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstVar.mo
@@ -357,7 +357,7 @@ algorithm
         // print(if_(impl, "impl crap\n", "no impl\n"));
         if not (impl and listMember(pre, {DAE.NOPRE()})) and not Config.getGraphicsExpMode() then
           s1 = ComponentReference.printComponentRefStr(crefOuter);
-          s2 = Dump.unparseInnerouterStr(io);
+          s2 = AbsynUtil.innerOuterStr(io);
           s3 = InnerOuter.getExistingInnerDeclarations(ih, componentDefinitionParentEnv);
           s1 = AbsynUtil.pathString(typePath) + " " + s1;
           Error.addSourceMessage(Error.MISSING_INNER_PREFIX,{s1, s2, s3}, info);
@@ -391,7 +391,7 @@ algorithm
         // adrpo: do NOT! display an error message if impl = true and prefix is DAE.NOPRE()
         if not (impl and listMember(pre, {DAE.NOPRE()})) and not Config.getGraphicsExpMode() then
           s1 = ComponentReference.printComponentRefStr(crefOuter);
-          s2 = Dump.unparseInnerouterStr(io);
+          s2 = AbsynUtil.innerOuterStr(io);
           s3 = InnerOuter.getExistingInnerDeclarations(ih,componentDefinitionParentEnv);
           s1 = AbsynUtil.pathString(typePath) + " " + s1;
           Error.addSourceMessage(Error.MISSING_INNER_PREFIX,{s1, s2, s3}, info);

--- a/OMCompiler/Compiler/FrontEnd/SCodeDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeDump.mo
@@ -254,7 +254,7 @@ algorithm
     case SCode.CLASS(name = n, partialPrefix = pp, prefixes = SCode.PREFIXES(innerOuter = io, redeclarePrefix = rdp, replaceablePrefix = rpp),
                      classDef = SCode.CLASS_EXTENDS())
       equation
-        ioStr = Dump.unparseInnerouterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
+        ioStr = Dump.unparseInnerOuterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
         res = stringAppendList({ioStr, "class extends ",n,";"});
       then
         res;
@@ -262,14 +262,14 @@ algorithm
     case SCode.CLASS(name = n, partialPrefix = pp, prefixes = SCode.PREFIXES(innerOuter = io, redeclarePrefix = rdp, replaceablePrefix = rpp),
                      classDef = SCode.ENUMERATION())
       equation
-        ioStr = Dump.unparseInnerouterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
+        ioStr = Dump.unparseInnerOuterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
         res = stringAppendList({ioStr, "class ",n," enumeration;"});
       then
         res;
 
     case SCode.CLASS(name = n, partialPrefix = pp, prefixes = SCode.PREFIXES(innerOuter = io, redeclarePrefix = rdp, replaceablePrefix = rpp))
       equation
-        ioStr = Dump.unparseInnerouterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
+        ioStr = Dump.unparseInnerOuterStr(io) + redeclareStr(rdp) + replaceablePrefixStr(rpp) + partialStr(pp);
         res = stringAppendList({ioStr, "class ",n,";"});
       then
         res;
@@ -482,7 +482,7 @@ algorithm
         s = visibilityStr(v) +
             redeclareStr(rd) +
             finalStr(f) +
-            AbsynUtil.innerOuterStr(io) +
+            Dump.unparseInnerOuterStr(io) +
             replaceablePrefixStr(rpl);
       then
         s;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -8249,7 +8249,7 @@ algorithm
 
         dims1 := list(Dump.printSubscriptStr(sub) for sub in attr.arrayDim);
         r_1 := Interactive.keywordReplaceable(comp.redeclareKeywords);
-        inout_str := innerOuterStr(comp.innerOuter);
+        inout_str := AbsynUtil.innerOuterStr(comp.innerOuter);
         variability_str := attrVariabilityStr(attr);
         dir_str := attrDirectionStr(attr);
 
@@ -8305,21 +8305,6 @@ algorithm
     -1
   );
 end makeGetComponentsRecord;
-
-function innerOuterStr
-"Helper function to getComponentInfo, retrieve the inner outer string."
-  input Absyn.InnerOuter inInnerOuter;
-  output String outString;
-algorithm
-  outString:=
-  match (inInnerOuter)
-    case Absyn.INNER() then "inner";
-    case Absyn.OUTER() then "outer";
-    case Absyn.NOT_INNER_OUTER() then "";
-    case Absyn.INNER_OUTER() then "inner outer";
-  end match;
-end innerOuterStr;
-
 
 function attrVariabilityStr
 "Helper function to get_component_info,

--- a/testsuite/flattening/modelica/connectors/ConnectInner2.mo
+++ b/testsuite/flattening/modelica/connectors/ConnectInner2.mo
@@ -54,13 +54,13 @@ end ConnectInner2;
 //   b.a.global.e = b.a.my.e;
 //   (-b.a.my.f) + (-b.a.global.f) = 0.0;
 // end ConnectInner2;
-// [flattening/modelica/connectors/ConnectInner2.mo:14:3-14:17:writable] Warning: No corresponding 'inner' declaration found for component .C b.a.global declared as 'outer '.
+// [flattening/modelica/connectors/ConnectInner2.mo:14:3-14:17:writable] Warning: No corresponding 'inner' declaration found for component .C b.a.global declared as 'outer'.
 //   The existing 'inner' components are:
 //     There are no 'inner' components defined in the model in any of the parent scopes of 'outer' component's scope: A.
 //   Check if you have not misspelled the 'outer' component name.
 //   Please declare an 'inner' component with the same name in the top scope.
 //   Continuing flattening by only considering the 'outer' component declaration.
-// [flattening/modelica/connectors/ConnectInner2.mo:14:3-14:17:writable] Warning: No corresponding 'inner' declaration found for component .C a.global declared as 'outer '.
+// [flattening/modelica/connectors/ConnectInner2.mo:14:3-14:17:writable] Warning: No corresponding 'inner' declaration found for component .C a.global declared as 'outer'.
 //   The existing 'inner' components are:
 //     There are no 'inner' components defined in the model in any of the parent scopes of 'outer' component's scope: A.
 //   Check if you have not misspelled the 'outer' component name.


### PR DESCRIPTION
- Remove the spaces added by AbsynUtil.innerOuterStr, we already have
  Dump.unparseInnerOuterStr that does that and need a function that just
  dumps the prefix as it is without padding it.
- Rename Dump.unparseInnerouterStr to Dump.unparseInnerOuterStr.
- Remove CevalScriptBackend.innerOuterStr, use AbsynUtil.innerOuterStr
  instead.
- Fix some uses of Error.MISSING_INNER_PREFIX in the OF where one
  argument was missing.
- Remove some dead code in FrontEnd/InnerOuter.mo.