### PR TITLE
Do not look for 'output-' or 'anti-' dependencies.

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp
@@ -58,17 +58,17 @@ bool Equation::depends_on(const TaskNode& other_b) const {
     // True dependency
     found_dep = utility::has_intersection(this->rhs.begin(), this->rhs.end(), other.lhs.begin(), other.lhs.end());
     // Anti-dependency
-    if (!found_dep) {
-        found_dep = utility::has_intersection(this->lhs.begin(), this->lhs.end(), other.rhs.begin(), other.rhs.end());
-        if (found_dep)
-            std::cout << "found anti-dep" << this->index << " and " << other.index << std::endl;
-    }
-    // output-dependency
-    if (!found_dep) {
-        found_dep = utility::has_intersection(this->lhs.begin(), this->lhs.end(), other.lhs.begin(), other.lhs.end());
-        if (found_dep)
-            std::cout << "found output-dep" << this->index << " and " << other.index << std::endl;
-    }
+    // if (!found_dep) {
+    //     found_dep = utility::has_intersection(this->lhs.begin(), this->lhs.end(), other.rhs.begin(), other.rhs.end());
+    //     if (found_dep)
+    //         std::cout << "found anti-dep" << this->index << " and " << other.index << std::endl;
+    // }
+    // // output-dependency
+    // if (!found_dep) {
+    //     found_dep = utility::has_intersection(this->lhs.begin(), this->lhs.end(), other.lhs.begin(), other.lhs.end());
+    //     if (found_dep)
+    //         std::cout << "found output-dep" << this->index << " and " << other.index << std::endl;
+    // }
 
     return found_dep;
 }


### PR DESCRIPTION
  - They are not supposed to happen in causalized simulation assignments.
    The check was there as a paranoia check since a bug like that would
    have had additional implications in multi-threaded code.

    It adds up to the time we spend parsing and processing the simulation
    dependencies graph. Disable it to save some time.