### PR TITLE
Use uppercase letters for keywords in the bat file

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15319,12 +15319,12 @@ algorithm
         locations := getDirectoriesForDLLsFromLinkLibs(code.makefileParams.libs);
         locations := locations + ";" + Settings.getInstallationDirectoryPath() + "/bin/";
         str := "@echo off\n"
-                + "set PATH=" + locations + ";%PATH%;\n"
-                + "set ERRORLEVEL=\n"
-                + "call \"%CD%/" + code.fileNamePrefix + ".exe\" %*\n"
-                + "set RESULT=%ERRORLEVEL%\n"
+                + "SET PATH=" + locations + ";%PATH%;\n"
+                + "SET ERRORLEVEL=\n"
+                + "CALL \"%CD%/" + code.fileNamePrefix + ".exe\" %*\n"
+                + "SET RESULT=%ERRORLEVEL%\n"
                 + "\n"
-                + "exit /b %RESULT%\n";
+                + "EXIT /b %RESULT%\n";
         File.write(file, str);
       then (fileName);
     else

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -591,7 +591,7 @@ QString SimulationOutputWidget::getPathsFromBatFile(QString fileName) {
   // Second line is where the PATH is set. We want that.
   line = batFile.readLine();
 
-  if (!line.startsWith("set PATH=")) {
+  if (!line.toLower().startsWith("set path=")) {
     QString warnMessage = "Failed to read the neccesary PATH values from '" + fileName + "'\n"
                           + "If simulation fails please check that you have the bat file and it is formatted correctly\n";
     writeSimulationOutput(warnMessage, StringHandler::Error, true);


### PR DESCRIPTION
  - There was an inconsistency between the bat files generated by the Cpp
    runtime vs the C runtime. The C runtime had commands in lower case.

    Now they are all uppercase. In addition, OMEdit now converts everything
    to lowercase before comparison to avoid more cases like this.