### PR TITLE
Fix variability check of `der`

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -624,7 +624,8 @@ protected
 
     // The argument must be differentiable, i.e. not discrete, unless where in a
     // scope where everything is discrete (like an initial equation).
-    if variability == Variability.DISCRETE and not InstContext.inDiscreteScope(context) then
+    if Prefixes.effectiveVariability(variability) == Variability.DISCRETE and
+       not InstContext.inDiscreteScope(context) then
       Error.addSourceMessageAndFail(Error.DER_OF_NONDIFFERENTIABLE_EXP,
         {Expression.toString(arg)}, info);
     end if;

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo
@@ -1,0 +1,26 @@
+// name: FuncBuiltinDerInvalid2
+// keywords: der
+// status: incorrect
+// cflags: -d=newInst
+//
+// Tests the builtin der operator.
+//
+
+model FuncBuiltinDerInvalid2
+  Real x = 0;
+  Real y = der(x);
+equation
+  when initial() then
+    x = 1.0;
+  end when;
+end FuncBuiltinDerInvalid2;
+
+// Result:
+// Error processing file: FuncBuiltinDerInvalid2.mo
+// [flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo:11:3-11:18:writable] Error: Argument ‘x‘ of der is not differentiable.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -504,6 +504,7 @@ FuncBuiltinCross.mo \
 FuncBuiltinDelay.mo \
 FuncBuiltinDer.mo \
 FuncBuiltinDerInvalid1.mo \
+FuncBuiltinDerInvalid2.mo \
 FuncBuiltinDiagonal.mo \
 FuncBuiltinDiv.mo \
 FuncBuiltinEdge.mo \


### PR DESCRIPTION
- Use the effective variability when checking that the argument to `der`
  isn't discrete, to also catch variables that are implicitly discrete.