### PR TITLE
Export all symbols from a dll on Windows + MSVC.

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -229,6 +229,8 @@ target_link_libraries(OpenModelicaCompiler PUBLIC omc::simrt::runtime)
 # lib directly and we have no way of marking specific MetaModelica functions for exporting.
 if(MINGW)
   target_link_options(OpenModelicaCompiler PRIVATE  -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(OpenModelicaCompiler PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
 # OMC Executable.

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
@@ -48,6 +48,8 @@ target_link_libraries(ModelicaExternalC_shared PUBLIC omc::simrt::runtime)
 
 if(MINGW)
   target_link_options(ModelicaExternalC_shared PRIVATE -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(ModelicaExternalC_shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
 
@@ -74,6 +76,8 @@ target_link_libraries(ModelicaMatIO_shared PUBLIC omc::simrt::runtime)
 
 if(MINGW)
   target_link_options(ModelicaMatIO_shared PRIVATE -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(ModelicaMatIO_shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
 
@@ -95,6 +99,8 @@ target_link_libraries(ModelicaIO_shared PUBLIC ModelicaMatIO_shared)
 
 if(MINGW)
   target_link_options(ModelicaIO_shared PRIVATE -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(ModelicaIO_shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
 
@@ -131,6 +137,8 @@ endif()
 
 if(MINGW)
   target_link_options(ModelicaStandardTables_shared PRIVATE -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(ModelicaStandardTables_shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -43,6 +43,8 @@ if(WIN32)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC regex)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC wsock32)
   target_link_options(OpenModelicaRuntimeC PRIVATE  -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(OpenModelicaRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif(WIN32)
 
 
@@ -79,6 +81,8 @@ target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
 
 if(WIN32)
   target_link_options(SimulationRuntimeC PRIVATE  -Wl,--export-all-symbols)
+elseif(MSVC)
+  set_target_properties(SimulationRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif(WIN32)
 
 if(WITH_IPOPT)


### PR DESCRIPTION
  - On MinGW, for some dll targets, we export all symbols from it to have
    the same behavior as linux and avoid the dllexport/dllimport markups.

    Do the same for MSVC. This can (and is usually done) by setting it
    globably for all targets. However, we have 3rdParty code and other dlls
    that we do not really want to export everything from as it is not used
    (or is already marked-up properly). So we do it on a target by target basis
    which is much better anyway.
