### PR TITLE
Reset Global.packageIndexCacheIndex when ModelicaPath is changed

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -802,6 +802,7 @@ algorithm
       algorithm
         // cmd = Util.rawStringToInputString(cmd);
         Settings.setModelicaPath(cmd);
+        setGlobalRoot(Global.packageIndexCacheIndex, 0);
       then
         Values.BOOL(true);
 

--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -292,7 +292,8 @@ algorithm
   userLibraries := getUserLibraryPath();
   packageIndex := userLibraries + "index.json";
   obj := JSON.emptyObject();
-  if not listMember(userLibraries, mps) then
+  // User library path ends with forward slash so compare the path with and without leading forward slash
+  if not listMember(userLibraries, mps) and not listMember(Util.removeLastNChar(userLibraries, 1), mps) then
     if printError then
       Error.addMessage(Error.ERROR_PKG_INDEX_NOT_ON_PATH, {mp, userLibraries});
     end if;


### PR DESCRIPTION
### Related Issues

#8881, #8882

### Purpose

Fix ModelicaPath issues.

### Approach

Handle all possible values of ModelicaPath against the PackageManage path.
