### PR TITLE
Improve OMParser antlr4 configuration.

### DIFF
--- a/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
@@ -31,19 +31,11 @@ add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 target_include_directories(antlr4_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(antlr4_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
+target_include_directories(antlr4_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(antlr4_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 # Anything that links to the static lib should use the ANTLR4CPP_STATIC define as well.
-target_compile_definitions(antlr4_static INTERFACE -DANTLR4CPP_STATIC)
-
-set(LIB_OUTPUT_DIR "${CMAKE_HOME_DIRECTORY}/dist") # put generated libraries here.
-message(STATUS "Output libraries to ${LIB_OUTPUT_DIR}")
-
-# make sure 'make' works fine even if ${LIB_OUTPUT_DIR} is deleted.
-add_custom_target(make_lib_output_dir ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_OUTPUT_DIR}
-    )
-
-add_dependencies(antlr4_shared make_lib_output_dir)
-add_dependencies(antlr4_static make_lib_output_dir)
+target_compile_definitions(antlr4_static PUBLIC ANTLR4CPP_STATIC)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(antlr4_shared ${UUID_LIBRARIES})
@@ -96,18 +88,10 @@ set_target_properties(antlr4_shared
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME antlr4-runtime
-                                 LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 # TODO: test in windows. DLL is treated as runtime.
-                                 # see https://cmake.org/cmake/help/v3.0/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html
-                                 RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
 
 set_target_properties(antlr4_static
-                      PROPERTIES VERSION   ${ANTLR_VERSION}
-                                 SOVERSION ${ANTLR_VERSION}
-                                 OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
-                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+                      PROPERTIES OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 
 install(TARGETS antlr4_shared antlr4_static

--- a/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/src/atn/ATNState.h
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/src/atn/ATNState.h
@@ -70,7 +70,7 @@ namespace atn {
   ///
   /// <embed src="images/OptionalNonGreedy.svg" type="image/svg+xml"/>
   /// </summary>
-  class ANTLR4CPP_PUBLIC ATN;
+  class ATN;
 
   class ANTLR4CPP_PUBLIC ATNState {
   public:


### PR DESCRIPTION
  - Add transitive include directories for the shared version of `libantlr4`
    They were added for the static version and overlooked for the shared
    version.

  - Remove unnecessary OUTPUT_DIRECOTRY specifiers on both shared and static
    libraries. There is no needed to have them as far as I can see. It is
    confusing to output libraries in unexpected locations.

  - Remove attributes on a forward declaration of a class. The class seems
    to already be defined at that forward declaration point (the header where
    the class is defined in is probably included indirectly). Avoids repeated
    warnings about it.
