### PR TITLE
Improve typing of `min`/`max`

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -779,6 +779,9 @@ LookupLibrary1.mo \
 loop1.mo \
 loop2.mo \
 loop3.mo \
+MaxInvalidArg1.mo \
+MaxInvalidArg2.mo \
+MaxInvalidArg3.mo \
 MergeComponents1.mo \
 MergeComponents2.mo \
 MergeComponents3.mo \
@@ -787,6 +790,9 @@ MergeComponents5.mo \
 MergeComponents6.mo \
 MergeComponents7.mo \
 MergeComponents8.mo \
+MinInvalidArg1.mo \
+MinInvalidArg2.mo \
+MinInvalidArg3.mo \
 MissingRedeclare1.mo \
 mod1.mo \
 mod10.mo \

--- a/testsuite/flattening/modelica/scodeinst/MaxInvalidArg1.mo
+++ b/testsuite/flattening/modelica/scodeinst/MaxInvalidArg1.mo
@@ -1,0 +1,28 @@
+// name: MaxInvalidArg1
+// keywords: max
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model MaxInvalidArg1
+  String s = max("str1", "str2");
+end MaxInvalidArg1;
+
+// Result:
+// Error processing file: MaxInvalidArg1.mo
+// [flattening/modelica/scodeinst/MaxInvalidArg1.mo:8:3-8:33:writable] Error: No matching function found for max("str1", "str2").
+// Candidates are:
+//   max(Real, Real) => Real
+//   max(Integer, Integer) => Integer
+//   max(Boolean, Boolean) => Boolean
+//   max(enumeration(:), enumeration(:)) => enumeration(:)
+//   max(Real[:, ...]) => Real
+//   max(Integer[:, ...]) => Integer
+//   max(Boolean[:, ...]) => Boolean
+//   max(enumeration(:)[:, ...]) => enumeration(:)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/MaxInvalidArg2.mo
+++ b/testsuite/flattening/modelica/scodeinst/MaxInvalidArg2.mo
@@ -1,0 +1,28 @@
+// name: MaxInvalidArg2
+// keywords: max
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model MaxInvalidArg2
+  String s = max({"str1", "str2"});
+end MaxInvalidArg2;
+
+// Result:
+// Error processing file: MaxInvalidArg2.mo
+// [flattening/modelica/scodeinst/MaxInvalidArg2.mo:8:3-8:35:writable] Error: No matching function found for max({"str1", "str2"}).
+// Candidates are:
+//   max(Real, Real) => Real
+//   max(Integer, Integer) => Integer
+//   max(Boolean, Boolean) => Boolean
+//   max(enumeration(:), enumeration(:)) => enumeration(:)
+//   max(Real[:, ...]) => Real
+//   max(Integer[:, ...]) => Integer
+//   max(Boolean[:, ...]) => Boolean
+//   max(enumeration(:)[:, ...]) => enumeration(:)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/MaxInvalidArg3.mo
+++ b/testsuite/flattening/modelica/scodeinst/MaxInvalidArg3.mo
@@ -1,0 +1,28 @@
+// name: MaxInvalidArg3
+// keywords: max
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model MaxInvalidArg3
+  Real x = max(1, 2, 3);
+end MaxInvalidArg3;
+
+// Result:
+// Error processing file: MaxInvalidArg3.mo
+// [flattening/modelica/scodeinst/MaxInvalidArg3.mo:8:3-8:24:writable] Error: No matching function found for max(1, 2, 3).
+// Candidates are:
+//   max(Real, Real) => Real
+//   max(Integer, Integer) => Integer
+//   max(Boolean, Boolean) => Boolean
+//   max(enumeration(:), enumeration(:)) => enumeration(:)
+//   max(Real[:, ...]) => Real
+//   max(Integer[:, ...]) => Integer
+//   max(Boolean[:, ...]) => Boolean
+//   max(enumeration(:)[:, ...]) => enumeration(:)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/MinInvalidArg1.mo
+++ b/testsuite/flattening/modelica/scodeinst/MinInvalidArg1.mo
@@ -1,0 +1,28 @@
+// name: MinInvalidArg1
+// keywords: min
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model MinInvalidArg1
+  String s = min("str1", "str2");
+end MinInvalidArg1;
+
+// Result:
+// Error processing file: MinInvalidArg1.mo
+// [flattening/modelica/scodeinst/MinInvalidArg1.mo:8:3-8:33:writable] Error: No matching function found for min("str1", "str2").
+// Candidates are:
+//   min(Real, Real) => Real
+//   min(Integer, Integer) => Integer
+//   min(Boolean, Boolean) => Boolean
+//   min(enumeration(:), enumeration(:)) => enumeration(:)
+//   min(Real[:, ...]) => Real
+//   min(Integer[:, ...]) => Integer
+//   min(Boolean[:, ...]) => Boolean
+//   min(enumeration(:)[:, ...]) => enumeration(:)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/MinInvalidArg2.mo
+++ b/testsuite/flattening/modelica/scodeinst/MinInvalidArg2.mo
@@ -1,0 +1,28 @@
+// name: MinInvalidArg2
+// keywords: min
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model MinInvalidArg2
+  String s = min({"str1", "str2"});
+end MinInvalidArg2;
+
+// Result:
+// Error processing file: MinInvalidArg2.mo
+// [flattening/modelica/scodeinst/MinInvalidArg2.mo:8:3-8:35:writable] Error: No matching function found for min({"str1", "str2"}).
+// Candidates are:
+//   min(Real, Real) => Real
+//   min(Integer, Integer) => Integer
+//   min(Boolean, Boolean) => Boolean
+//   min(enumeration(:), enumeration(:)) => enumeration(:)
+//   min(Real[:, ...]) => Real
+//   min(Integer[:, ...]) => Integer
+//   min(Boolean[:, ...]) => Boolean
+//   min(enumeration(:)[:, ...]) => enumeration(:)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/MinInvalidArg3.mo
+++ b/testsuite/flattening/modelica/scodeinst/MinInvalidArg3.mo
@@ -1,0 +1,28 @@
+// name: MinInvalidArg3
+// keywords: min
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model MinInvalidArg3
+  Real x = min(1, 2, 3);
+end MinInvalidArg3;
+
+// Result:
+// Error processing file: MinInvalidArg3.mo
+// [flattening/modelica/scodeinst/MinInvalidArg3.mo:8:3-8:24:writable] Error: No matching function found for min(1, 2, 3).
+// Candidates are:
+//   min(Real, Real) => Real
+//   min(Integer, Integer) => Integer
+//   min(Boolean, Boolean) => Boolean
+//   min(enumeration(:), enumeration(:)) => enumeration(:)
+//   min(Real[:, ...]) => Real
+//   min(Integer[:, ...]) => Integer
+//   min(Boolean[:, ...]) => Boolean
+//   min(enumeration(:)[:, ...]) => enumeration(:)
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult


### PR DESCRIPTION
- Restrict the argument type of min/max to only the types allowed by the
  specification.
- Improve the error message for wrong arguments to min/max to better
  reflect the allowed types.