### PR TITLE
[BE] update evalFunction

### DIFF
--- a/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
+++ b/OMCompiler/Compiler/BackEnd/EvaluateFunctions.mo
@@ -1621,6 +1621,7 @@ protected
 algorithm
   (varScalarCrefs,funcAlgs) := varPart;
   (constScalarCrefs,constScalarExps,constComplCrefs,constComplExps,constScalarCrefsOut) := constPart;
+
   funcAlgs := List.filterOnTrue(funcAlgs,DAEUtil.isAlgorithm);// get only the algs, not protected vars or stuff
   // generate the additional equations for the constant scalar values and the constant complex ones
   lhsExps1 := List.map(constScalarCrefsOut,Expression.crefExp);
@@ -1836,6 +1837,15 @@ algorithm
     case({},{},_)
       then
         eqsIn;
+
+    // ignore wildcards
+    // solves ticket #8381
+    case ((lhs as DAE.CREF(componentRef = DAE.WILD()))::lrest,rhs::rrest,_)
+      equation
+        eqs = generateConstEqs(lrest,rrest,eqsIn);
+    then
+      eqs;
+
     case(lhs::lrest,rhs::rrest,_)
       equation
         eq = BackendDAE.EQUATION(lhs,rhs,DAE.emptyElementSource,BackendDAE.EQ_ATTR_DEFAULT_DYNAMIC);

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2696,6 +2696,7 @@ try
   reqns := BackendEquation.getList(inResidualequations, inEqns);
   reqns := BackendEquation.replaceDerOpInEquationList(reqns);
   outResidualEqns := BackendEquation.listEquation(reqns);
+
   // create  residual equations
   (_, reqns) := BackendEquation.traverseEquationArray(outResidualEqns, BackendEquation.traverseEquationToScalarResidualForm, (funcTree, {}));
   reqns := listReverse(reqns);
@@ -3112,7 +3113,7 @@ protected
 algorithm
   (outExp, (expList, cont, _)) := Expression.traverseExpTopDown(inExp, hasEqnNonDiffParts, inTpl);
   if Flags.isSet(Flags.DUMP_EXCLUDED_EXP) and not cont then
-    print("Traverser for catching functions, that should not differentiated\n");
+    print("Traverser for catching functions, that should not be differentiated\n");
     print(stringDelimitList(List.map(expList, ExpressionDump.printExpStr), "\n"));
     print("\n\n");
   end if;
@@ -3132,6 +3133,7 @@ algorithm
     list<DAE.Exp> expLst, expLst1;
     Boolean b, insideCall;
     DAE.Type ty;
+
     case (DAE.CALL(path=Absyn.IDENT("delay")), (expLst, _, insideCall)) then (inExp, false, (inExp::expLst, false, insideCall));
 
 // For now exclude all not built in calls

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -3406,6 +3406,8 @@ algorithm
       Type ty1,ty2;
       list<DAE.Subscript> subs;
 
+    case DAE.WILD() then DAE.CREF(cr, DAE.T_UNKNOWN());
+
     case _
       equation
         ty1 = ComponentReference.crefLastType(cr);


### PR DESCRIPTION
 
### Related Issues

- fixes ticket #8381

### Purpose

 - allows correct detection of unability to differentiate functions

### Approach

 - updates the evaluation of function bodies to remove empty outputs (wild cards)
