### PR TITLE
Minor fixes and improvements.

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -189,6 +189,7 @@ add_dependencies(DEPENDENCY_UPDATE DEPENDENCY_SCAN)
 
 
 add_library(OpenModelicaCompiler SHARED ${OMC_C_SOURCE_FILES} .cmake/omc_entry_point.c)
+add_dependencies(OpenModelicaCompiler DEPENDENCY_UPDATE)
 
 target_compile_definitions(OpenModelicaCompiler PRIVATE ADD_METARECORD_DEFINITIONS=)
 
@@ -216,7 +217,14 @@ target_include_directories(OpenModelicaCompiler INTERFACE ${CMAKE_CURRENT_BINARY
 #   target_link_options(OpenModelicaCompiler PUBLIC -Wl,--stack,33554432)
 # endif()
 
-add_dependencies(OpenModelicaCompiler DEPENDENCY_UPDATE)
+# For now disable some warnings for MSVC. These should of course be fixed properly.
+if(MSVC)
+  target_compile_options(OpenModelicaCompiler PRIVATE /wd4101) # unreferenced local variable
+  target_compile_options(OpenModelicaCompiler PRIVATE /wd4102) # unreferenced label
+  target_compile_options(OpenModelicaCompiler PRIVATE /wd4267) # conversion from 'size_t' to 'int', possible loss of data
+  target_compile_options(OpenModelicaCompiler PRIVATE /wd4244) # conversion from '' to '', possible loss of data
+endif()
+
 
 
 target_link_libraries(OpenModelicaCompiler PUBLIC omc::parser)

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -28,6 +28,10 @@ if(MINGW)
   target_link_options(bomc PRIVATE -Wl,--stack,33554432)
 elseif(MSVC)
   target_link_options(bomc PRIVATE /STACK:33554432)
+endif()
+
+# For now disable some warnings for MSVC. These should of course be fixed properly.
+if(MSVC)
   target_compile_options(bomc PRIVATE /wd4101) # unreferenced local variable
   target_compile_options(bomc PRIVATE /wd4102) # unreferenced label
   target_compile_options(bomc PRIVATE /wd4267) # conversion from 'size_t' to 'int', possible loss of data
@@ -58,6 +62,13 @@ target_link_libraries(bomc PRIVATE omc::compiler::runtime)
 set_target_properties(bomc
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
+    # We need to specify these explicitly for multi-config generators like MSVC and Xcode.
+    # Otherwise they will still add the release/, debug/ ... directories within the
+    # RUNTIME_OUTPUT_DIRECTORY specified above.
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
+    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
+    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
 )
 
 # It also wants to have these builtin files in ../lib/ relative to its location.

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -40,9 +40,10 @@ extern "C" {
  */
 #if !defined(_MSC_VER)
 #include <libgen.h>
-#include <dirent.h>
 #include <unistd.h>
 #endif
+
+#include <dirent.h>
 
 #include "meta/meta_modelica.h"
 #include <limits.h>


### PR DESCRIPTION
  - Tell multi-config generator not to add the config specific folders,
    e.g., Debug/, Release/ ... inside the `RUNTIME_OUTPUT_DIRECTORY` we have
    specified for the bootstrapped omc.

  - Disable some warnings on `libOpenModelicaCompiler` with MSVC.
    These warning should be fixed eventually by fixing C code generation.

  - Include `dirent.h` with MSVC as well. We have ways of getting the header.
    It is just a lone one file implementation. It can be dropped in.

    Hiding it in a `!defined(_MSC_VER)` macro is pointless since the code
    will not compile without it anyway.
