### PR TITLE
Add an interface PThreads library for readability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ include(cmake/omc_utils.cmake)
 include(cmake/omc_target_info.cmake)
 include(cmake/omc_check_exists.cmake)
 
+# Include the small thread library setup we have. This provides the library
+# OMCPThreads::OMCPThreads which gives us a PThreads library on Windows as
+# well as linux. See the file for more info.
+include(cmake/OMCPThreads.cmake)
+
 # Add the compiler ids to the report for convenience.
 omc_add_to_report(CMAKE_C_COMPILER_ID)
 omc_add_to_report(CMAKE_CXX_COMPILER_ID)

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -146,6 +146,8 @@ target_compile_definitions(SimulationRuntimeFMI PRIVATE OMC_MINIMAL_RUNTIME=1;OM
 
 target_include_directories(SimulationRuntimeFMI PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+target_link_libraries(SimulationRuntimeFMI PUBLIC OMCPThreads::OMCPThreads)
+
 install(TARGETS SimulationRuntimeFMI)
 
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -37,15 +37,16 @@ target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
 
 target_include_directories(OpenModelicaRuntimeC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+target_link_libraries(OpenModelicaRuntimeC PUBLIC OMCPThreads::OMCPThreads)
 
-if(WIN32)
+if(MINGW)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC dbghelp)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC regex)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC wsock32)
   target_link_options(OpenModelicaRuntimeC PRIVATE  -Wl,--export-all-symbols)
 elseif(MSVC)
   set_target_properties(OpenModelicaRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
-endif(WIN32)
+endif()
 
 
 install(TARGETS OpenModelicaRuntimeC)

--- a/cmake/OMCPThreads.cmake
+++ b/cmake/OMCPThreads.cmake
@@ -1,0 +1,24 @@
+# This little ugly hack allows us to use linux pthreads and Window's
+# PThreads4W library interchangeably without having to put if-else
+# checks everywhere.
+# It will  use either CMake's own Threads package or, if we are building for MSVC, will use PThreads4W from
+# local installation (e.g vcpkg managed)
+
+# If you want to use PThreads no matter the OS (even on Windows like
+# 3rdParty/GC and our runtime libraries do) just link to OMCPThreads::OMCPThreads
+# anywhere in OpenModelica since this file will be included in the top
+# level CMakeLists.txt.
+
+
+if(MSVC)
+  find_package(pthreads CONFIG REQUIRED)
+  add_library(OMCPThreads INTERFACE)
+  target_link_libraries(OMCPThreads INTERFACE PThreads4W::PThreads4W)
+else()
+  find_package(Threads)
+  add_library(OMCPThreads INTERFACE)
+  target_link_libraries(OMCPThreads INTERFACE Threads::Threads)
+  target_link_libraries(OMCPThreads INTERFACE ${CMAKE_DL_LIBS})
+endif()
+
+add_library(OMCPThreads::OMCPThreads ALIAS OMCPThreads)


### PR DESCRIPTION
  - A new library `OMCPThreads` provides and interface to a PThreads
    implementation on Linux as well as on Windows (if one is available)

    This is to avoid having to do repeated checks for MSVC, Linux ...
    in cases where we always want to use PThreads, e.g. 3rdParty/GC and
    our runtime libraries want to use only PThreads and not Win32 Threads.

    This allows us to have cleaner setup (I think?)
