### PR TITLE
Multiple fixes for SimulationRuntime/c and Windows.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
+find_package(LAPACK REQUIRED)
+
 file(GLOB OMC_SIMRT_UTIL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/util/*.c)
 file(GLOB OMC_SIMRT_UTIL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/util/*.h)
 
@@ -48,7 +50,6 @@ elseif(MSVC)
   set_target_properties(OpenModelicaRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
-
 install(TARGETS OpenModelicaRuntimeC)
 
 
@@ -79,10 +80,12 @@ target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::suitesparse::config)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cminpack)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::cdaskr)
 target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::lis)
+target_link_libraries(SimulationRuntimeC PUBLIC ${LAPACK_LIBRARIES})
 
-if(WIN32)
+if(MINGW)
   target_link_options(SimulationRuntimeC PRIVATE  -Wl,--export-all-symbols)
 elseif(MSVC)
+  target_link_libraries(SimulationRuntimeC PUBLIC wsock32)
   set_target_properties(SimulationRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif(WIN32)
 
@@ -91,9 +94,6 @@ if(OM_OMC_ENABLE_IPOPT)
   target_compile_definitions(SimulationRuntimeC PRIVATE OMC_HAVE_IPOPT)
   target_link_libraries(SimulationRuntimeC PUBLIC omc::3rd::ipopt)
 endif()
-
-# Fix me. Make an interface (header only library) out of 3rdParty/dgesv
-target_include_directories(SimulationRuntimeC PRIVATE ${OMCompiler_SOURCE_DIR}/3rdParty/dgesv/include/)
 
 install(TARGETS SimulationRuntimeC)
 

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.h
@@ -41,7 +41,7 @@ extern "C" {
 #include <sys/types.h>
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
-#include <windows.h>
+#include <winsock2.h>
 #else
 #include <unistd.h>
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
@@ -64,7 +64,7 @@ int vasprintf(char **strp, const char *fmt, va_list ap) {
 
 #if !defined(OMC_MINIMAL_RUNTIME)
 
-#include <windows.h>
+#include <winsock2.h>
 #include <tlhelp32.h>
 #include <time.h>
 
@@ -226,7 +226,7 @@ void* omc_dlopen(const char *filename, int flag)
   return (void*) LoadLibrary(filename);
 }
 
-#include <windows.h>
+#include <winsock2.h>
 #include <imagehlp.h>
 
 static const char* GetLastErrorAsString()
@@ -389,7 +389,7 @@ This file has no copyright assigned and is placed in the Public Domain.
 Written by Nach M. S. September 8, 2005
 */
 
-#include <windows.h>
+#include <winsock2.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <errno.h>

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.h
@@ -174,7 +174,7 @@ int dladdr(void *addr, Dl_info *info);
 
 #if defined(_MSC_VER)
 
-#include <windows.h>
+#include <winsock2.h>
 #if !defined(PATH_MAX)
 #define PATH_MAX MAX_PATH
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/rtclock.h
+++ b/OMCompiler/SimulationRuntime/c/util/rtclock.h
@@ -91,7 +91,7 @@ enum omc_rt_clock_t {
 };
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
-#include <windows.h>
+#include <winsock2.h>
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif


### PR DESCRIPTION
[Link SimulationRuntimeC with Lapack explicitly.](https://github.com/OpenModelica/OpenModelica/commit/71048310cf2de9bc0db1954c6d17d2147fdef585) 

  - It was including the headers from 3rdParty/dgesv and linking to lapack
    transitively from sunlinsollapackdense. Remove the dependency on
    3rdParty/dgesv and use the package Lapack only.

    Note: 3rdParty/dgesv is not meant to be used by any library in
    OpenModelica itself!
    It is there for FMUs only. It is there to be packaged with source
    code FMUs and provides only the functions that are needed by our FMUs.
 
[Use winsock2.h instead of windows.h.](https://github.com/OpenModelica/OpenModelica/commit/bfc35dbf754b21f44de7110090eb2290bce2e776) 

  - `winsock2.h` and winsock.h can not be used simultaneously. Which is okay
    since `winsock2.h` should provide everything from `winsock.h` in a backward
    compatible way. So far so good except for the fact that `windows.h`
    includes `winsock.h` by default. This can be avoided by defining
    `WIN32_LEAN_AND_MEAN` before including it everywhere.

    It can also be avoided by not including `windows.h` att all and including
    `winsock2.h` instead which will include `windows.h`. We have gone for
    the latter option for our code which can possibly include winsock2.h
    at a latter point for actual socket related purposes.

    This is all kind of messy but it should be good enough for now until
    someone incldues windows.h and suddenly gets duplicate declration errors.