### PR TITLE
Add CI jobs for extra CMake related builds.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.omdev.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.omdev.gcc
@@ -1,0 +1,47 @@
+def common
+pipeline {
+  agent none
+  options {
+    buildDiscarder(logRotator(numToKeepStr: "5", artifactNumToKeepStr: "2"))
+  }
+  stages {
+    stage('Environment') {
+      agent {
+        label '!windows'
+      }
+      steps {
+        script {
+          if (changeRequest()) {
+            def buildNumber = env.BUILD_NUMBER as int
+            if (buildNumber > 1) milestone(buildNumber - 1)
+            milestone(buildNumber)
+          }
+          common = load("${env.workspace}/.CI/common.groovy")
+        }
+      }
+    }
+    stage('build') {
+      parallel {
+        stage('cmake-OMDev-gcc') {
+          agent {
+            node {
+              label 'windows'
+            }
+          }
+          environment {
+            RUNTESTDB = '/c/dev/'
+            LIBRARIES = '/c/dev/jenkins-cache/omlibrary/'
+          }
+          steps {
+            script {
+              withEnv (["PATH=C:\\OMDev\\tools\\msys\\usr\\bin;C:\\Program Files\\TortoiseSVN\\bin;c:\\bin\\jdk\\bin;c:\\bin\\nsis\\;${env.PATH};c:\\bin\\git\\bin;"]) {
+                bat "echo PATH: %PATH%"
+                common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOM_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build -G "MSYS Makefiles"')
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -1,0 +1,144 @@
+def common
+pipeline {
+  agent none
+  options {
+    buildDiscarder(logRotator(numToKeepStr: "5", artifactNumToKeepStr: "2"))
+  }
+  stages {
+    stage('Environment') {
+      agent {
+        label '!windows'
+      }
+      steps {
+        script {
+          if (changeRequest()) {
+            def buildNumber = env.BUILD_NUMBER as int
+            if (buildNumber > 1) milestone(buildNumber - 1)
+            milestone(buildNumber)
+          }
+          common = load("${env.workspace}/.CI/common.groovy")
+        }
+      }
+    }
+    stage('build') {
+      parallel {
+        stage('autoconf-bionic-gcc') {
+          agent {
+            docker {
+              image 'docker.openmodelica.org/build-deps:v1.16.3'
+              label 'linux'
+              alwaysPull true
+              args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                    "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          steps {
+            script { common.buildOMC('gcc', 'g++', '', true, false) }
+            stash name: 'omc-gcc', includes: 'build/bin/OMCppOSUSimulation, build/include/omc/omsi/**, build/include/omc/omsic/**, build/lib/x86_64-linux-gnu/omc/omsi/**, build/lib/x86_64-linux-gnu/omc/omsicpp/**, **/config.status'
+          }
+        }
+        stage('cmake-bionic-gcc') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-bionic-cmake-3.17.2'
+              label 'linux'
+              alwaysPull true
+              args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                    "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          steps {
+            script {
+              common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOM_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build -DSUNDIALS_BUILD_SHARED_LIBS=ON', '/opt/cmake-3.17.2/bin/cmake')
+              sh "build/bin/omc --version"
+            }
+            stash name: 'omc-cmake-gcc', includes: 'build/**'
+          }
+        }
+      }
+    }
+
+    stage('tests') {
+      parallel {
+        stage('testsuite-cmake-gcc 1/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-bionic-cmake-3.17.2'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-gcc'
+              unstash 'omc-cmake-gcc'
+              common.makeLibsAndCache()
+              common.partest(1, 3)
+            }
+          }
+        }
+      }
+      stage('testsuite-cmake-gcc 2/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-bionic-cmake-3.17.2'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-gcc'
+              unstash 'omc-cmake-gcc'
+              common.makeLibsAndCache()
+              common.partest(2, 3)
+            }
+          }
+        }
+      }
+      stage('testsuite-cmake-gcc 3/3') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-bionic-cmake-3.17.2'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
+                   "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          steps {
+            script {
+              common.standardSetup()
+              unstash 'omc-gcc'
+              unstash 'omc-cmake-gcc'
+              common.makeLibsAndCache()
+              common.partest(3, 3)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -318,11 +318,11 @@ void buildOMC_CMake(cmake_args, cmake_exe='cmake') {
      echo export MSYS_WORKSPACE="`cygpath '${WORKSPACE}'`"
      echo echo MSYS_WORKSPACE: \${MSYS_WORKSPACE}
      echo cd \${MSYS_WORKSPACE}
-     echo export MAKETHREADS=16
      echo set -ex
      echo mkdir build_cmake
-     echo cmake -S ./ -B ./build_cmake ${cmake_args}
-     echo time cmake --build ./build_cmake --parallel \${MAKETHREADS} --target install
+     echo ${cmake_exe} --version
+     echo ${cmake_exe} -S ./ -B ./build_cmake ${cmake_args}
+     echo time ${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install
      ) > buildOMCWindows.sh
 
      set MSYSTEM=MINGW64
@@ -332,6 +332,7 @@ void buildOMC_CMake(cmake_args, cmake_exe='cmake') {
   }
   else {
     sh "mkdir ./build_cmake"
+    sh "${cmake_exe} --version"
     sh "${cmake_exe} -S ./ -B ./build_cmake ${cmake_args}"
     sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target install"
     sh "${cmake_exe} --build ./build_cmake --parallel ${numPhysicalCPU()} --target testsuite-depends"


### PR DESCRIPTION
  - A new job is added that builds OpenModelica on Windows with `OMDev` and
    `gcc` using `CMake`.

  - A new job is added that builds OpenModelica on Ubuntu with `gcc` and then
    runs the testsuite with it. For this job a normal (`autoconf`) build is
    also performed to build some things that the `CMake` build does not build
    yet, e.g. OMSI runtimes. The relevant files from the `autoconf` build are
    then stashed and used together with the stash from the `CMake` build.

  - These jobs are planned to be run nightly and are NOT part of the commit
    based CI
    They can reached at
    https://test.openmodelica.org/jenkins/job/periodic/job/CMake_builds/
