### PR TITLE
Greater equal for MAX_PATH to use long path

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -200,7 +200,7 @@ wchar_t* longabspath(wchar_t* unicodePath) {
     printf("GetFullPathName failed for %ls with error code %d\n", unicodePath, GetLastError());
     return NULL;
   }
-  if (wcslen(unicodeAbsPath) > MAX_PATH) {
+  if (wcslen(unicodeAbsPath) >= MAX_PATH) {
     printf("Warning: Maximum path length limitation reached while opening\n"
            "\t%ls\n"
            "Consider changing the working directory, "


### PR DESCRIPTION
### Related Issues

Fixes #8886.

### Purpose

We need to use `\\?\` when reaching MAX_PATH, not only when having a longer path.

-----------

Smallest commit ever?
