### PR TITLE
Compile static libs with position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 omc_add_to_report(CMAKE_BUILD_TYPE)
 
+## Set position independent code for everything built in OpenModelica.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 if(OM_USE_CCACHE)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -35,14 +35,6 @@ string(REPLACE "-DNDEBUG" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}
 string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
-## Set position independent code OMCompiler/ wide. We will take some performance hit from this.
-## However it allows us to build all static libs and combine them later to single shared libs
-## for easy configuration. Instead of having dozens of shared libs.
-## This can of course be turned of if we do not care about memory and are happy to sacrifice a
-## bunch of memory for some performance gain. If so disable this and change the few libraries
-## we build as shared to static (see SimulationRuntime/c, which contains the only shared libs to come).
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 ## Add a config library for OMC. They will provide access to common config headres such as
 ## config.h, version.h ... These headers, right now for us, are in 'OMCompiler' directory. So
 ## by linking to this library you get the include directories.

--- a/OMParser/Makefile
+++ b/OMParser/Makefile
@@ -31,7 +31,7 @@ libOMParser.a: $(OBJS)
 $(OBJS): $(CPP_FILES) install/lib/libantlr4-runtime.a
 
 3rdParty/antlr4/runtime/Cpp/build/Makefile:
-	(cd 3rdParty/antlr4/runtime/Cpp/build && $(CMAKE) -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE:Bool=OFF -DCMAKE_INSTALL_PREFIX:String=../../../../../install -DWITH_LIBCXX:Bool=OFF ../ -G $(CMAKE_TARGET))
+	(cd 3rdParty/antlr4/runtime/Cpp/build && $(CMAKE) -DCMAKE_VERBOSE_MAKEFILE:Bool=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_COLOR_MAKEFILE:Bool=OFF -DCMAKE_INSTALL_PREFIX:String=../../../../../install -DWITH_LIBCXX:Bool=OFF ../ -DCMAKE_POSITION_INDEPENDENT_CODE=ON -G $(CMAKE_TARGET))
 
 install/lib/libantlr4-runtime.a: 3rdParty/antlr4/runtime/Cpp/CMakeLists.txt
 	mkdir -p 3rdParty/antlr4/runtime/Cpp/build


### PR DESCRIPTION
  - For the CMake build system set position independent code OpenModelica/
    wide instead of just OpenModelica/OMCompiler/

  - For the Makefile build, compile libantlr4 as position independent code.

  For the motivation behind this change, see the extended discussion in #8738.
