### PR TITLE
Build libOpenModelicaRuntimeC and libomcgc as DLLs.

### DIFF
--- a/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -18,7 +18,7 @@ encapsulated package Autoconf
   constant String ldflags_sundials = " -lsundials_nvecserial -lsundials_sunmatrixdense -lsundials_sunmatrixsparse" +
                                      " -lsundials_sunlinsoldense -lsundials_sunlinsolklu -lsundials_sunlinsollapackdense -lsundials_sunlinsolspbcgs -lsundials_sunlinsolspfgmr -lsundials_sunlinsolspgmr -lsundials_sunlinsolsptfqmr -lsundials_sunnonlinsolnewton" +
                                      " -lsundials_cvode -lsundials_cvodes -lsundials_idas -lsundials_kinsol";
-  constant String ldflags_basic = linkType + "-lomcgc -lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis" +
+  constant String ldflags_basic = " -lomcgc " + linkType + "-lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis" +
                                   ldflags_sundials +
                                   ldflags_suitesparse +
                                   " -lipopt -lcoinmumps -lpthread -lm " +

--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -144,9 +144,10 @@ libgc-dev: /usr/include/gc/new_gc_alloc.h
 libgc-dev: /usr/include/gc/weakpointer.h
 
 boehm-gc:  boehm-gc-lib $(OMBUILDDIR)/include/omc/c/gc.h $(OMBUILDDIR)/include/omc/c/gc_config_macros.h $(OMBUILDDIR)/include/omc/c/gc_version.h $(OMBUILDDIR)/include/omc/c/gc_pthread_redirects.h
-$(OMBUILDDIR)/$(LIB_OMC)/libomcgc.a: 3rdParty/gc/.libs/libomcgc.a
+$(builddir_bin)/libomcgc-1.dll: 3rdParty/gc/.libs/libomcgc-1.dll
 	cp -p $< $@
-3rdParty/gc/.libs/libomcgc.a: 3rdParty/gc/Makefile
+	cp -p 3rdParty/gc/.libs/libomcgc.dll.a $(builddir_lib)/omc/libomcgc.dll.a
+3rdParty/gc/.libs/libomcgc-1.dll: 3rdParty/gc/Makefile
 	$(MAKE) -C 3rdParty/gc/ libomcgc.la
 $(OMBUILDDIR)/include/omc/c/gc.h: 3rdParty/gc/include/gc.h
 	cp -pPR $< $@
@@ -157,7 +158,7 @@ $(OMBUILDDIR)/include/omc/c/gc_version.h: 3rdParty/gc/include/gc_version.h
 $(OMBUILDDIR)/include/omc/c/gc_pthread_redirects.h: 3rdParty/gc/include/gc_pthread_redirects.h
 	cp -pPR $< $@
 3rdParty/gc/Makefile: 3rdParty/gc/configure.ac
-	(cd 3rdParty/gc && mkdir -p m4 libatomic_ops/m4 && autoreconf -vif && automake --add-missing && ./configure --prefix="`pwd`" "--host=$(host)" $(LIBGC_EXTRA_CONFIGURATION) --enable-static --disable-gcj-support --disable-java-finalization --enable-large-config CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS) -DLARGE_CONFIG -DTHREAD_LOCAL_ALLOC")
+	(cd 3rdParty/gc && mkdir -p m4 libatomic_ops/m4 && autoreconf -vif && automake --add-missing && ./configure --prefix="`pwd`" "--host=$(host)" $(LIBGC_EXTRA_CONFIGURATION) --enable-shared --disable-static --disable-gcj-support --disable-java-finalization --enable-large-config CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS) -DLARGE_CONFIG -DTHREAD_LOCAL_ALLOC")
 
 ipopt:
 	mkdir -p $(OMC_IPOPT_ROOT)/build

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -327,7 +327,7 @@ copycppmsvcheader_old: getMSVCversion
 omc:  interactive fmil omdev_extra_dlls breakprocess opencl_rt CMinpack metis Cdaskr $(IPOPT_TARGET) $(SEMLA_LIB) OMSI parmodauto ModelicaExternalC
 	(time $(MAKE) -f $(defaultMakefileTarget) CFLAGS="$(CFLAGS)" omc-bootstrapped OMBUILDDIR=$(OMBUILDDIR))
 
-boehm-gc-lib: $(OMBUILDDIR)/$(LIB_OMC)/libomcgc.a
+boehm-gc-lib: $(builddir_bin)/libomcgc-1.dll
 
 
 zlib_msvc: $(LIBMODELICAZLIB_MSVC)

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -196,6 +196,10 @@ libOpenModelicaRuntimeC.so: $(BASE_OBJS) $(GCOBJPATH_MINIMAL) Makefile.objs
 	@rm -f $@
 	$(CC) -shared -o $@ $(BASE_OBJS) $(GCOBJPATH_MINIMAL) $(LDFLAGS)
 
+libOpenModelicaRuntimeC.dll: $(BASE_OBJS) Makefile.objs
+	@rm -f $@
+	$(CC) -shared -o $@ $(BASE_OBJS) $(LDFLAGS) -L$(OMBUILDDIR)/lib/omc -lomcgc -ldbghelp -lregex -Wl,--export-all-symbols,--out-implib,$@.a
+
 libOpenModelicaRuntimeC.dylib: $(BASE_OBJS) $(GCOBJPATH_MINIMAL) Makefile.objs
 	@rm -f $@
 	$(CC) -shared -o $@ $(BASE_OBJS) $(GCOBJPATH_MINIMAL) $(LDFLAGS) -undefined dynamic_lookup -install_name '@rpath/$@'
@@ -270,7 +274,13 @@ $(EXTERNAL_SOLVER_OBJSPATH):$(BUILDPATH)/%$(OBJ_EXT): $(builddir_inc)/c/%.c
 $(BUILDPATH)/simulation/socket$(OBJ_EXT): simulation/socket_win.inc simulation/socket_unix.inc
 
 bootstrap-dependencies: $(LIBRUNTIME)
+ifeq (MINGW,$(findstring MINGW,$(shell uname)))
+	cp -p $(LIBRUNTIME) $(builddir_bin)
+# 	copy the import (dll.a) lib as well.
+	cp -p $(LIBRUNTIME).a $(builddir_lib)
+else
 	cp -p $(LIBRUNTIME) $(builddir_lib)
+endif
 	# copy header files
 	cp -p $(RUNTIME_HEADERS) $(builddir_inc)/c/
 	cp -p $(RUNTIMELINEAR_HEADERS) $(builddir_inc)/c/linearization/

--- a/OMCompiler/SimulationRuntime/c/Makefile.omdev.mingw
+++ b/OMCompiler/SimulationRuntime/c/Makefile.omdev.mingw
@@ -35,7 +35,7 @@ FPMATHFORTRAN =
 LIBMAKEFILE = Makefile.omdev.mingw
 CONFIG_H=$(top_builddir)/Compiler/runtime/config.h
 LIBSIMULATION=libSimulationRuntimeC.a
-LIBRUNTIME=libOpenModelicaRuntimeC.a
+LIBRUNTIME=libOpenModelicaRuntimeC.dll
 LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.a
 CMINPACK_NO_DLL=-DCMINPACK_NO_DLL
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -87,7 +87,7 @@ if(MINGW)
 elseif(MSVC)
   target_link_libraries(SimulationRuntimeC PUBLIC wsock32)
   set_target_properties(SimulationRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
-endif(WIN32)
+endif(MINGW)
 
 if(OM_OMC_ENABLE_IPOPT)
   target_sources(SimulationRuntimeC PRIVATE ${OMC_SIMRT_OPTIMIZATION_SOURCES})

--- a/OMCompiler/omc_config.h
+++ b/OMCompiler/omc_config.h
@@ -88,7 +88,7 @@
 #define CONFIG_TRIPLE ""
 
 /* adrpo: add -loleaut32 as is used by ExternalMedia */
-#define DEFAULT_LDFLAGS "-fopenmp -Wl,-Bstatic -lregex -ltre -lintl -liconv -lexpat -lomcgc -lpthread -loleaut32 -limagehlp -lhdf5 -lz -lszip -Wl,-Bdynamic"
+#define DEFAULT_LDFLAGS "-fopenmp -Wl,-Bstatic -lregex -ltre -lintl -liconv -lexpat -lpthread -loleaut32 -limagehlp -lhdf5 -lz -lszip -Wl,-Bdynamic"
 
 #define CONFIG_WITH_OPENMP 1
 


### PR DESCRIPTION
  - We now build both of these libs as dlls on Windows. They are already
    built as shared libraries on linux.

    We build `libomcgc` as shared library because we do not want to ever have
    two instances of the garbage collector linked into one binary (exe or dll)
    ever. Having two instances of the garbage collector leads to quite
    ominous bugs that would be vey difficult to find. See #8738 and #8955
    Just avoid the possibility altogether.

    We build `libOpenModelicaRuntimeC` as a dll because it saves memory.
    It is linked to every simulation executable we generate and there is
    no reason to duplicate it in every one of those executables. We will
    see what implications this will have for FMUs.

    Fixes #8738.
