### PR TITLE
Fix for C89

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
@@ -296,7 +296,7 @@ double findRoot(DATA* data, threadData_t* threadData, LIST* eventList, double ti
 
   LIST_NODE* it;
   fortran_integer i=0;
-  static LIST tmpEventList = (LIST){NULL, NULL, sizeof(long), 0};
+  LIST tmpEventList = (LIST){NULL, NULL, sizeof(long), 0};
 
   /* static work arrays */
   static double *states_left = NULL;


### PR DESCRIPTION
### Related Issues

#8956 

### Purpose

As @mahge pointed out, this was not C89 compliant.

### Approach

The `static` qualifier is not needed here.