### PR TITLE
Remove Call.getLastPathName

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -47,7 +47,6 @@ protected
   import ComponentRef = NFComponentRef;
   import Expression = NFExpression;
   import NFFlatten.FunctionTreeImpl;
-  import NFFunction.Function;
   import Operator = NFOperator;
   import Prefixes = NFPrefixes;
   import Variable = NFVariable;
@@ -728,7 +727,6 @@ protected
     exp := match exp
       local
         Bucket bucket;
-        Function fn;
 
       // logical binarys: e.g. (a and b)
       // Todo: this might not always be correct -> check with something like "contains relation?"
@@ -744,7 +742,7 @@ protected
       then exp;
 
       // sample functions
-      case Expression.CALL(call = Call.TYPED_CALL(fn = fn)) guard(Call.getLastPathName(fn.path) == "sample") algorithm
+      case Expression.CALL() guard(Call.isNamed(exp.call, "sample")) algorithm
         (exp, bucket) := collectEventsCondition(exp, Pointer.access(bucket_ptr), eqn_ptr);
         Pointer.update(bucket_ptr, bucket);
       then exp;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -902,7 +902,7 @@ public
 
       // try some simple known cases
       case (Expression.CALL()) algorithm
-        ret := match Call.getLastPathName(Call.functionName(exp.call))
+        ret := match Call.functionNameLast(exp.call)
           case "sample" then Expression.BOOLEAN(false);
           else fail();
         end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -588,6 +588,16 @@ public
     end match;
   end functionName;
 
+  function functionNameLast
+    input Call call;
+    output String ident = AbsynUtil.pathLastIdent(functionName(call));
+  end functionNameLast;
+
+  function functionNameFirst
+    input Call call;
+    output String ident = AbsynUtil.pathFirstIdent(functionName(call));
+  end functionNameFirst;
+
   function isNamed
     input Call call;
     input String name;
@@ -1916,30 +1926,16 @@ public
         list<Expression> args;
 
       case Call.UNTYPED_CALL(arguments = args)
-      then (ComponentRef.firstName(call.ref), args);
+        then (ComponentRef.firstName(call.ref), args);
 
       case Call.TYPED_CALL(fn = fn, arguments = args)
-      then (getLastPathName(fn.path), args);
+        then (AbsynUtil.pathLastIdent(fn.path), args);
 
       else algorithm
         Error.assertion(false, getInstanceName() + ": unhandled case for " + toString(call), sourceInfo());
       then fail();
     end match;
   end getNameAndArgs;
-
-  function getLastPathName
-    input Absyn.Path path;
-    output String name;
-  algorithm
-    name := match path
-      case Absyn.IDENT()          then path.name;
-      case Absyn.QUALIFIED()      then getLastPathName(path.path);
-      case Absyn.FULLYQUALIFIED() then getLastPathName(path.path);
-      else algorithm
-        Error.assertion(false, getInstanceName() + " failed.", sourceInfo());
-      then fail();
-    end match;
-  end getLastPathName;
 
 protected
   function instNormalCall


### PR DESCRIPTION
- Remove Call.getLastPathName since it's just a copy of
  AbsynUtil.pathLastIdent and doesn't really belong in Call.