### PR TITLE
Minor fixes for ModelicaExternalC and CPP runtime builds.

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SCOREP_INCLUDE_ ".")
 set(Boost_INCLUDE_ ".")
 set(Boost_LIBS_ ".")
 set(LAPACK_LIBS_ ".")
-set(LAPACK_LIBRARIES_ "-llapack -lblas")
+set(LAPACK_LIBRARIES_ "")
 set(SYSTEM_CFLAGS ${SYSTEM_CFLAGS} "-DOMC_BUILD -fPIC -DUSE_THREAD")
 
 configure_file(Modelica/ModelicaLibraryConfig_gcc.inc.in ${CMAKE_CURRENT_BINARY_DIR}/ModelicaLibraryConfig_gcc.inc)

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -5,6 +5,7 @@ add_definitions(-DOMC_BUILD)
 
 # CPP libs should be installed to in lib/<arch>/omc/cpp/ for now.
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/cpp)
+set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_LIBDIR})
 # CPP headers are installed in include/omc/cpp for now.
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/cpp)
 


### PR DESCRIPTION
  - ModelicaExternalC stand alone CMake build:
    - Link to libm only on Unix.
    - Export all symbols with MSVC. This is not needed right now as the
      stand alone build is only meant to be used for the Autoconf build
      system. The CMake build system has another (not the standalone) CMake
      file that it uses that is integrated in to the whole OpenModelica build.

  - CPP runtime
    - Fix the install directory for CPP runtime shared libs. They want to
      be in the lib folder even on Windows (instead of the bin dir).
      The should be fixed from the other side and the libraries should be
      added into the bin dir together with the other DLLs OpenModelica builds.

    - Remove unnecessary manually set LPACK libraries string. It is not needed.
