### PR TITLE
Fix compilation on OMDev/MinGW with CMake

### DIFF
--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -82,13 +82,14 @@ add_custom_command (
 
 
 # On Windows it also needs to have the dlls it depends on (remember bomc is being used without being installed)
-# think of this as a manual install for it. Luckily it depends only on one dll for now,
+# think of this as a manual install for it. Luckily it depends only on just two dlls for now,
 if(WIN32)
   add_custom_command (
     TARGET bomc
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:omc::simrt::runtime> ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
-    COMMENT "Copying OpenModelicaRuntimeC.dll for the bootstrapped omc (to ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin).")
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:omc::3rd::omcgc> ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin
+    COMMENT "Copying libOpenModelicaRuntimeC.dll and libomcgc.dll for the bootstrapped omc (to ${CMAKE_CURRENT_BINARY_DIR}/bootstrapped/bin).")
 endif()
 
 # add_custom_command(


### PR DESCRIPTION
  - GC has a setting where it gets compiled as a single file (a file that
    includes all source files). According to the logs of the upstream GC
    repository this is done to enable more optimizations.
    It also enabled this one-file form when it was asked to build a shared
    library with CMake. Even if it was not asked for explicitly.

    However, the markup for the functions was missing the `extern` keyword
    which leads to some confusing duplicate declaration errors.

    Add the `extern` specifier. But **also disable the automatic one-file
    compilation for shared version** behavior since the autoconf build does
    not enable it unless it is asked for explicitly.

    We are trying to be consistent to avoid ANY surprises with this useful
    (I admit) but so very intrusive and infuriating library.

  - Now that GC is a shared library copy the dll the directory where we
    generate the bootstrapped omc so that it can function.
