### PR TITLE
Avoid evaluating parameters with Evaluate=false

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -3263,6 +3263,37 @@ algorithm
   end match;
 end lookupNamedAnnotation;
 
+public function lookupNamedAnnotationBinding
+  input SCode.Annotation ann;
+  input String name;
+  output Option<Absyn.Exp> binding;
+protected
+  SCode.Mod mod;
+algorithm
+  mod := lookupNamedAnnotation(ann, name);
+
+  binding := match mod
+    case SCode.Mod.MOD() then mod.binding;
+    else NONE();
+  end match;
+end lookupNamedAnnotationBinding;
+
+public function lookupNamedBooleanAnnotation
+  input SCode.Annotation ann;
+  input String name;
+  output Option<Boolean> value;
+protected
+  Option<Absyn.Exp> binding;
+  Boolean bval;
+algorithm
+  binding := lookupNamedAnnotationBinding(ann, name);
+
+  value := match binding
+    case SOME(Absyn.Exp.BOOL(value = bval)) then SOME(bval);
+    else NONE();
+  end match;
+end lookupNamedBooleanAnnotation;
+
 public function lookupNamedAnnotations
   "Returns a list of modifiers with the given name found in the annotation."
   input SCode.Annotation ann;
@@ -3380,18 +3411,18 @@ algorithm
 end hasBooleanNamedAnnotation2;
 
 public function getEvaluateAnnotation
-"@author: adrpo
- returns true if annotation(Evaluate = true) is present,
- otherwise false"
-  input Option<SCode.Comment> inCommentOpt;
-  output Boolean evalIsTrue;
+  "Looks up the Evaluate annotation and returns the value if the annotation
+   exists and has a boolean value, otherwise NONE()."
+  input Option<SCode.Comment> cmt;
+  output Option<Boolean> value;
+protected
+  SCode.Annotation ann;
+  Option<Absyn.Exp> binding;
 algorithm
-  evalIsTrue := match (inCommentOpt)
-    local
-      SCode.Annotation ann;
-    case (SOME(SCode.COMMENT(annotation_ = SOME(ann))))
-      then hasBooleanNamedAnnotation(ann, "Evaluate");
-    else false;
+  value := match cmt
+    case SOME(SCode.COMMENT(annotation_ = SOME(ann)))
+      then lookupNamedBooleanAnnotation(ann, "Evaluate");
+    else NONE();
   end match;
 end getEvaluateAnnotation;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -3300,7 +3300,7 @@ algorithm
       algorithm
         // check if we have a parameter with (fixed = true), annotation(Evaluate = true) and no binding
         if listMember(Component.variability(component), {Variability.STRUCTURAL_PARAMETER, Variability.PARAMETER}) and
-           Component.getEvaluateAnnotation(component)
+           Util.getOptionOrDefault(Component.getEvaluateAnnotation(component), false)
         then
           // only add an error if fixed = true
           if Component.getFixedAttribute(component) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -905,7 +905,7 @@ public
 
   function getEvaluateAnnotation
     input Component component;
-    output Boolean evaluate;
+    output Option<Boolean> evaluate;
   protected
     SCode.Comment cmt;
   algorithm

--- a/testsuite/flattening/modelica/scodeinst/EvaluateFalse1.mo
+++ b/testsuite/flattening/modelica/scodeinst/EvaluateFalse1.mo
@@ -1,0 +1,33 @@
+// name: EvaluateFalse1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model EvaluateFalse1
+  constant Real a = 5.0;
+  parameter Real x = 2.0 annotation(Evaluate = false);
+  parameter Real y = 3.0;
+  Real z;
+equation
+  if x < a then
+    z = 15 *y;
+  else
+    z = 10 * y;
+  end if;
+end EvaluateFalse1;
+
+// Result:
+// class EvaluateFalse1
+//   constant Real a = 5.0;
+//   parameter Real x = 2.0;
+//   parameter Real y = 3.0;
+//   Real z;
+// equation
+//   if x < 5.0 then
+//     z = 15.0 * y;
+//   else
+//     z = 10.0 * y;
+//   end if;
+// end EvaluateFalse1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -405,6 +405,7 @@ EqualityConstraint1.mo \
 EquationInvalidType1.mo \
 EvaluateAllParams.mo \
 EvaluateAllParams2.mo \
+EvaluateFalse1.mo \
 ExpandableConnector1.mo \
 ExpandableConnector2.mo \
 ExpandableConnector3.mo \


### PR DESCRIPTION
- Mark parameters with `annotation(Evaluate=false)` as non-structural to
  try to avoid evaluating them.