### PR TITLE
Define the common config variables in the Makefiles.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,6 +2,15 @@
 
 defaultMakefileTarget = Makefile.unix
 
+host=@host@
+host_short=@host_short@
+CC=@CC@
+CXX=@CXX@
+CPPFLAGS=@CPPFLAGS@
+CFLAGS=@CFLAGS@
+CXXFLAGS=@CXXFLAGS@
+LDFLAGS=@LDFLAGS@
+
 CMAKE = @CMAKE@
 # Use the system's default cmake if nothing is passed to configure script, i.e., no CMAKE=<some_path> is specified
 ifeq ($(CMAKE),)


### PR DESCRIPTION
  - Define the common configuration variables globally on the Makefile. 
    This way anything invoked downwards from this Makefile can pick up 
    these variables without us having to set them for every sub invocation manually.

    If we do not do this, the sub-invocations will pick up these values 
    from the environment  and this leads to some inconsistencies that 
    will be difficult to track down.
