### PR TITLE
Add more units to parameters unit drop down

### DIFF
--- a/OMCompiler/Compiler/runtime/unitparser.cpp
+++ b/OMCompiler/Compiler/runtime/unitparser.cpp
@@ -1179,6 +1179,9 @@ void UnitParser::initSIUnits() {
       Rational(3141592, 30000000), Rational(0), true);
 #endif
 
+  addDerived("Energy", "watt hour", "Wh", "J",Rational(0),
+      Rational(3600), Rational(0), true);
+
   addDerived("velocity", "knot", "kn", "m/s", Rational(0),
       Rational(1852, 3600), Rational(0), true);
 

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -930,15 +930,7 @@ bool VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
         } else { /* use unit as displayUnit */
           variableData[VariableItemData::DISPLAYUNIT] = unit;
         }
-        /* Issue #5447
-         * For angular speeds always add in the menu in the unit column, in addition to the standard "rad/s" also "rpm"
-         * For energies always add in the menu in the Display Unit column, in addition to standard "J", also "Wh" (prefixes such as kWh, MWh, GWh will be obtained automatically)
-         */
-        if (unit.compare(QStringLiteral("rad/s")) == 0) {
-          displayUnitOptions << "rpm";
-        } else if (unit.compare(QStringLiteral("J")) == 0) {
-          displayUnitOptions << "Wh";
-        }
+        Utilities::addDefaultDisplayUnit(unit, displayUnitOptions);
         displayUnitOptions.removeDuplicates();
         displayUnits << displayUnitOptions;
         variableData << displayUnits;

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -1263,6 +1263,29 @@ QStringList Utilities::variantListToStringList(const QVariantList lst)
 }
 
 /*!
+ * \brief Utilities::addDefaultDisplayUnit
+ * \param unit
+ * \param displayUnit
+ */
+void Utilities::addDefaultDisplayUnit(const QString &unit, QStringList &displayUnit)
+{
+  /* Issue #5447
+   * For angular speeds always add in the menu in the unit column, in addition to the standard "rad/s" also "rpm"
+   * For energies always add in the menu in the Display Unit column, in addition to standard "J", also "Wh" (prefixes such as kWh, MWh, GWh will be obtained automatically)
+   */
+  /* Issue #8758
+   * Whenever unit = "K", we also add "degC" even if it is not defined as displayUnits.
+   */
+  if (unit.compare(QStringLiteral("rad/s")) == 0) {
+    displayUnit << "rpm";
+  } else if (unit.compare(QStringLiteral("J")) == 0) {
+    displayUnit << "Wh";
+  } else if (unit.compare(QStringLiteral("K")) == 0) {
+    displayUnit << "degC";
+  }
+}
+
+/*!
  * \brief Utilities::convertUnitToSymbol
  * Converts the unit to a symbol.
  * \param displayUnit

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -542,6 +542,7 @@ namespace Utilities {
   void removeDirectoryRecursivly(QString path);
   qreal mapToCoOrdinateSystem(qreal value, qreal startA, qreal endA, qreal startB, qreal endB);
   QStringList variantListToStringList(const QVariantList lst);
+  void addDefaultDisplayUnit(const QString &unit, QStringList &displayUnit);
   QString convertUnitToSymbol(const QString displayUnit);
   QString convertSymbolToUnit(const QString symbol);
   QRectF adjustSceneRectangle(const QRectF sceneRectangle, const qreal factor);


### PR DESCRIPTION
### Related Issues

Fixes #8758

### Purpose

Add more units to parameters input drop-down.

### Approach

Add default units and unit prefixes.
Added Wh unit for J in unit parser.
