### PR TITLE
[OMEdit] Fix crash when parsing shape visualizers

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualizer.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualizer.cpp
@@ -115,7 +115,7 @@ void OMVisualBase::initVisObjects()
   ShapeObject shape;
   rapidxml::xml_node<>* expNode;
 
-  for (rapidxml::xml_node<>* shapeNode = rootNode->first_node("shape"); shapeNode; shapeNode = shapeNode->next_sibling())
+  for (rapidxml::xml_node<>* shapeNode = rootNode->first_node("shape"); shapeNode; shapeNode = shapeNode->next_sibling("shape"))
   {
     expNode = shapeNode->first_node((const char*) "ident")->first_node();
     shape._id = std::string(expNode->value());


### PR DESCRIPTION
Since the introduction by @perost of PRs #8987 & #9000, related respectively to issues #8211 & #8076, to dump the Vector and Surface visualizers in the `<model>_visual.xml` file, OMEdit crashes as soon as an animation window is created for a model containing visualizers other than Shape.
This PR preserves the previous behavior, i.e. only Shape visualizers are drawn in the animation window while waiting for the other ones to be implemented in OMEdit.

@casella I don't think PRs #8987 & #9000 are intended to be merged in v1.19, but anyway I think it would be safer to cherry-pick this one for the coming stable release because the crash would be triggered by any other content/structure changes to the `<model>_visual.xml` file (for instance in future maintenance releases).