### PR TITLE
Fix evaluation of array constructors

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -2474,6 +2474,13 @@ public
     end match;
   end dimensionCount;
 
+  function dimensions
+    input Expression exp;
+    output list<Dimension> dims;
+  algorithm
+    dims := Type.arrayDims(typeOf(exp));
+  end dimensions;
+
   function map
     input Expression exp;
     input MapFunc func;


### PR DESCRIPTION
- Compute the sizes of the created arrays based on the results instead
  of taking them from the ranges, since the dimensions of the ranges
  might not have been evaluated.