### PR TITLE
Improve propagation of redeclare modifiers

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -892,7 +892,7 @@ algorithm
   elseif InstNode.isGeneratedInner(scope) and Component.isDefinition(InstNode.component(scope)) then
     // The scope is a generated inner component that hasn't been instantiated,
     // it needs to be instantiated to continue lookup.
-    Inst.instComponent(scope, NFAttributes.DEFAULT_ATTR, Modifier.NOMOD(), true, 0, NONE(), NFInstContext.CLASS);
+    Inst.instComponent(scope, NFAttributes.DEFAULT_ATTR, Modifier.NOMOD(), true, 0, NFInstContext.CLASS);
   end if;
 
   name := AbsynUtil.crefFirstIdent(cref);

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -966,6 +966,7 @@ RedeclareMod6.mo \
 RedeclareMod7.mo \
 RedeclareMod8.mo \
 RedeclareMod9.mo \
+RedeclareMod10.mo \
 redeclare10.mo \
 redeclare11.mo \
 redeclare12.mo \

--- a/testsuite/flattening/modelica/scodeinst/RedeclareMod10.mo
+++ b/testsuite/flattening/modelica/scodeinst/RedeclareMod10.mo
@@ -1,0 +1,28 @@
+// name: RedeclareMod10
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model A
+  Real x;
+end A;
+
+model B
+  replaceable A a;
+end B;
+
+model C
+  B b[2];
+end C;
+
+model RedeclareMod10
+  extends C(b(redeclare A a(x = {1, 2})));
+end RedeclareMod10;
+
+// Result:
+// class RedeclareMod10
+//   Real b[1].a.x = 1.0;
+//   Real b[2].a.x = 2.0;
+// end RedeclareMod10;
+// endResult


### PR DESCRIPTION
- Save propagated subscripts for redeclared components and apply them
  later when instantiating them.

Fixes #9027