### PR TITLE
Refactor `simplifyAddJoinTerms`

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -68,6 +68,7 @@ protected import MetaModelica.Dangerous;
 protected import Static;
 protected import System;
 protected import Types;
+protected import UnorderedMap;
 protected import Util;
 protected import Values;
 protected import ValuesUtil;
@@ -3116,74 +3117,78 @@ protected function simplifyAdd
   Simplifies terms like 2a+4b+2a+a+b"
   input list<DAE.Exp> inExpLst;
   output list<DAE.Exp> outExpLst;
+protected
+  list<tuple<DAE.Exp, Real>> coeffs;
 algorithm
-  outExpLst := matchcontinue (inExpLst)
-    local
-      list<tuple<DAE.Exp, Real>> exp_const,exp_const_1;
-      list<DAE.Exp> expl_1,expl;
-
-    case (_)
-      equation
-        exp_const = List.map(inExpLst, simplifyBinaryAddCoeff2);
-        exp_const_1 = simplifyAddJoinTerms(exp_const);
-        expl_1 = simplifyAddMakeMul(exp_const_1);
-      then
-        expl_1;
-
-    else
-      equation
-        true = Flags.isSet(Flags.FAILTRACE);
-        Debug.trace("- ExpressionSimplify.simplifyAdd failed\n");
-      then
-        fail();
-  end matchcontinue;
+  try
+    coeffs := List.map(inExpLst, simplifyBinaryAddCoeff2);
+    coeffs := simplifyAddJoinTerms(coeffs);
+    outExpLst := simplifyAddMakeMul(coeffs);
+  else
+    if Flags.isSet(Flags.FAILTRACE) then
+      Debug.trace("- ExpressionSimplify.simplifyAdd failed\n");
+    end if;
+    fail();
+  end try;
 end simplifyAdd;
 
 protected function simplifyAddJoinTerms
-"author: PA
-  Helper function to simplifyAdd.
-  Join all terms with the same expression.
-  i.e. 2a+4a gives an element (a,6) in the list."
+  "O(n)
+   author: PA
+   Helper function to simplifyAdd.
+   Join all terms with the same expression.
+   i.e. 2a+4a gives an element (a,6) in the list."
   input list<tuple<DAE.Exp, Real>> inTplExpRealLst;
-  output list<tuple<DAE.Exp, Real>> outTplExpRealLst = {};
+  output list<tuple<DAE.Exp, Real>> outTplExpRealLst;
 protected
-  list<tuple<DAE.Exp, Real>> tplExpRealLst = inTplExpRealLst;
-  tuple<DAE.Exp, Real> t;
-  DAE.Exp e;
-  Real coeff, coeff2;
+  function addCoeff
+    input Option<Real> oldCoeff;
+    input Real newCoeff;
+    output Real coeff;
+  algorithm
+    coeff := if isSome(oldCoeff) then Util.getOption(oldCoeff) + newCoeff else newCoeff;
+  end addCoeff;
 algorithm
+  outTplExpRealLst := match inTplExpRealLst
+    local
+      DAE.Exp exp1, exp2, exp3;
+      Real coeff1, coeff2, coeff3;
+      UnorderedMap<DAE.Exp, Real> coeff_map;
 
-  while not listEmpty(tplExpRealLst) loop
-    t :: tplExpRealLst := tplExpRealLst;
-    (e, coeff) := t;
-    (coeff2, tplExpRealLst) := simplifyAddJoinTermsFind(e, tplExpRealLst);
-    coeff := coeff + coeff2;
-    outTplExpRealLst := (if coeff2==0 then t else (e, coeff)) :: outTplExpRealLst;
-  end while;
-//outTplExpRealLst := listReverse(outTplExpRealLst);
+    // explicitly roll out the small cases since they happen a lot
+    case {} then {};
+    case {_} then inTplExpRealLst;
+
+    case {(exp1, coeff1), (exp2, coeff2)}
+    then if Expression.expEqual(exp1, exp2) then {(exp1, coeff1 + coeff2)} else inTplExpRealLst;
+
+    case {(exp1, coeff1), (exp2, coeff2), (exp3, coeff3)} algorithm
+      if Expression.expEqual(exp1, exp2) then
+        if Expression.expEqual(exp1, exp3) then
+          outTplExpRealLst := {(exp1, coeff1 + coeff2 + coeff3)};
+        else
+          outTplExpRealLst := {(exp1, coeff1 + coeff2), (exp3, coeff3)};
+        end if;
+      elseif Expression.expEqual(exp1, exp3) then
+        outTplExpRealLst := {(exp1, coeff1 + coeff3), (exp2, coeff2)};
+      elseif Expression.expEqual(exp2, exp3) then
+        outTplExpRealLst := {(exp1, coeff1), (exp2, coeff2 + coeff3)};
+      else
+        outTplExpRealLst := inTplExpRealLst;
+      end if;
+    then outTplExpRealLst;
+
+    // general case, this is O(n) but has a small overhead
+    else algorithm
+      coeff_map := UnorderedMap.new<Real>(Expression.hashExpMod, Expression.expEqual, listLength(inTplExpRealLst));
+      for tpl in inTplExpRealLst loop
+        (exp1, coeff1) := tpl;
+        // set the coefficient of exp1 to coeff1, add the previous coefficient if exp1 is already in the map
+        UnorderedMap.addUpdate(exp1, function addCoeff(newCoeff = coeff1), coeff_map);
+      end for;
+    then UnorderedMap.toList(coeff_map);
+  end match;
 end simplifyAddJoinTerms;
-
-protected function simplifyAddJoinTermsFind
-"author: PA
-  Helper function to simplifyAddJoinTerms, finds all occurences of Expression."
-  input DAE.Exp inExp;
-  input list<tuple<DAE.Exp, Real>> inTplExpRealLst;
-  output Real outReal = 0.0;
-  output list<tuple<DAE.Exp, Real>> outTplExpRealLst = {};
-protected
-  DAE.Exp e;
-  Real coeff;
-algorithm
-  for t in inTplExpRealLst loop
-    (e,coeff) := t;
-    if Expression.expEqual(inExp, e) then
-      outReal := outReal + coeff;
-    else
-      outTplExpRealLst := t::outTplExpRealLst;
-    end if;
-  end for;
-  outTplExpRealLst := Dangerous.listReverseInPlace(outTplExpRealLst);
-end simplifyAddJoinTermsFind;
 
 protected function simplifyAddMakeMul
 "author: PA
@@ -3191,34 +3196,19 @@ protected function simplifyAddMakeMul
   in the list, except for coefficient 1.0"
   input list<tuple<DAE.Exp, Real>> inTplExpRealLst;
   output list<DAE.Exp> outExpLst = {};
-protected
-  tuple<DAE.Exp, Real> tplExpReal;
 algorithm
-  for tplExpReal in inTplExpRealLst loop
-    outExpLst := matchcontinue (tplExpReal)
+  outExpLst := list(match tplExpReal
     local
       DAE.Exp e;
       Real r;
-      Integer tmpInt;
-
-    case (e,r)
-      guard (r == 1.0)
-      then
-        (e :: outExpLst);
-
-    case (e,r)
-      equation
-        DAE.T_INTEGER() = Expression.typeof(e);
-        tmpInt = realInt(r);
-      then
-        (DAE.BINARY(DAE.ICONST(tmpInt),DAE.MUL(DAE.T_INTEGER_DEFAULT),e) :: outExpLst);
-
-    case (e,r)
-      then
-        (DAE.BINARY(DAE.RCONST(r),DAE.MUL(DAE.T_REAL_DEFAULT),e) :: outExpLst);
-    end matchcontinue;
-
-  end for;
+    case (e, 1.0) then e;
+    case (e, -1.0) then Expression.negate(e);
+    case (e, r)
+    then match Expression.typeof(e)
+           case DAE.T_INTEGER() then DAE.BINARY(DAE.ICONST(realInt(r)), DAE.MUL(DAE.T_INTEGER_DEFAULT), e);
+                                else DAE.BINARY(DAE.RCONST(r), DAE.MUL(DAE.T_REAL_DEFAULT), e);
+         end match;
+  end match for tplExpReal in inTplExpRealLst);
 end simplifyAddMakeMul;
 
 protected function simplifyBinaryAddCoeff2

--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -236,12 +236,11 @@ public
       output V value;
     end UpdateFn;
   protected
-    Integer index, hash, bucket_count;
+    Integer index, hash;
   algorithm
     (index, hash) := find(key, map);
 
     if index > 0 then
-      bucket_count := Vector.size(map.buckets);
       value := fn(SOME(Vector.getNoBounds(map.values, index)));
       Vector.updateNoBounds(map.values, index, value);
     else

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -190,8 +190,10 @@ if true then /* Suppress output */
     "../Util/Socket.mo",
     "../Util/System.mo",
     "../Util/Testsuite.mo",
+    "../Util/UnorderedMap.mo",
     "../Util/Util.mo",
     "../Util/VarTransform.mo",
+    "../Util/Vector.mo",
     "../Util/ZeroMQ.mo"
   };
   backendfiles := if OpenModelica.Scripting.getEnvironmentVar("OPENMODELICA_BACKEND_STUBS")<>"" then
@@ -522,10 +524,8 @@ if true then /* Suppress output */
     "../Util/SBSet.mo",
     "../Util/SimulationResults.mo",
     "../Util/TaskGraphResults.mo",
-    "../Util/UnorderedMap.mo",
     "../Util/UnorderedSet.mo",
     "../Util/Unzip.mo",
-    "../Util/Vector.mo",
 
     "../../SimulationRuntime/c/RuntimeSources.mo"
   };

--- a/testsuite/openmodelica/bootstrapping/LoadCompilerSources.mos
+++ b/testsuite/openmodelica/bootstrapping/LoadCompilerSources.mos
@@ -267,8 +267,10 @@ if true then /* Suppress output */
     prefixPath + "Util/System.mo",
     prefixPath + "Util/TaskGraphResults.mo",
     prefixPath + "Util/Testsuite.mo",
+    prefixPath + "Util/UnorderedMap.mo",
     prefixPath + "Util/Util.mo",
-    prefixPath + "Util/VarTransform.mo"
+    prefixPath + "Util/VarTransform.mo",
+    prefixPath + "Util/Vector.mo"
   };
   LoadCompilerSourcesRes:= OpenModelica.Scripting.loadFiles(files,numThreads=min(5,OpenModelica.Scripting.numProcessors()));
   if not LoadCompilerSourcesRes then


### PR DESCRIPTION
The old implementation was O(n^2) since it looked at all pairs of terms
in a sum. The new implementation uses an `UnorderedMap` and is O(n).
The old still outperforms the new until around n=5.

### Related Issues

fixes #8555