### PR TITLE
Build libSimulationRuntimeC as a DLL.

### DIFF
--- a/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -14,21 +14,15 @@ encapsulated package Autoconf
   constant String dllExt = ".dll";
   constant String libFortran = if not isNewOMDev then "-lgfortranbegin " else " ";
   constant String libMsvcrt = if not isNewOMDev then "-lmsvcrt " else " ";
-  constant String ldflags_suitesparse = " -lumfpack -lklu -lcolamd -lbtf -lamd -lsuitesparseconfig";
-  constant String ldflags_sundials = " -lsundials_nvecserial -lsundials_sunmatrixdense -lsundials_sunmatrixsparse" +
-                                     " -lsundials_sunlinsoldense -lsundials_sunlinsolklu -lsundials_sunlinsollapackdense -lsundials_sunlinsolspbcgs -lsundials_sunlinsolspfgmr -lsundials_sunlinsolspgmr -lsundials_sunlinsolsptfqmr -lsundials_sunnonlinsolnewton" +
-                                     " -lsundials_cvode -lsundials_cvodes -lsundials_idas -lsundials_kinsol";
-  constant String ldflags_basic = " -lomcgc " + linkType + "-lregex -ltre -lintl -liconv -lexpat -static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32 -llis" +
-                                  ldflags_sundials +
-                                  ldflags_suitesparse +
-                                  " -lipopt -lcoinmumps -lpthread -lm " +
+  constant String ldflags_basic = " -lomcgc " + linkType + "-static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32" +
+                                  " -lpthread -lm " +
                                   libFortran +
                                   "-lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex " +
                                   libMsvcrt +
-                                  "-luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -lcminpack -Wl,-Bdynamic";
+                                  "-luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -Wl,-Bdynamic";
 
   constant String ldflags_runtime = " -lOpenModelicaRuntimeC" + ldflags_basic;
-  constant String ldflags_runtime_sim = linkType + "-lSimulationRuntimeC -Wl,-Bdynamic " + ldflags_basic + " -lwsock32 " + linkType + " -lstdc++ -Wl,-Bdynamic ";
+  constant String ldflags_runtime_sim = "-lSimulationRuntimeC -Wl,-Bdynamic -lomcgc " + linkType + " -lstdc++ -Wl,-Bdynamic ";
   constant String ldflags_runtime_fmu = linkType + "-lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm " +
                                         libFortran +
                                         "-lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex " +

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -174,12 +174,16 @@ all_objs : $(ALL_OBJS)
 #recompile all if a header changes!
 $(ALL_OBJS) : $(ALL_HEADERS)
 
-libSimulationRuntimeC.a: $(ALL_OBJS) $(CDASKRDIR)/libcdaskr.a
-	@# You have to remove the old archive first or it may contain old objects
+libSimulationRuntimeC.dll: $(ALL_OBJS) $(CDASKRDIR)/libcdaskr.a libOpenModelicaRuntimeC.dll
 	@rm -f $@
-	cp -a $(CDASKRDIR)/libcdaskr.a $@
-	$(AR) $@ $(ALL_OBJS)
-	ranlib $@
+	$(CXX) -shared -o $@ $(ALL_OBJS) $(LDFLAGS_SIM) -L$(OMBUILDDIR)/lib/omc \
+		-L$(CDASKRDIR) -lcdaskr \
+		-lklu -lumfpack -lamd -lbtf -lcolamd -lsuitesparseconfig \
+		-lsundials_cvode -lsundials_idas -lsundials_kinsol -lsundials_sunlinsolklu -lsundials_sunlinsollapackdense \
+		-lipopt -lcoinmumps -lgfortran \
+		-llis -lcminpack -lomcgc \
+		-lopenblas -lexpat -ldbghelp -lregex -lwsock32 \
+		-Wl,--export-all-symbols,--out-implib,$@.a
 
 libSimulationRuntimeC.so: $(ALL_OBJS) $(OPTIONAL_LIBS) Makefile.objs
 	@rm -f $@
@@ -311,7 +315,14 @@ libSimulationRuntimeFMI.a: $(FMI_ME_OBJS_BUILDPATH)
 
 install: bootstrap-dependencies $(LIBSIMULATION) $(LIBFMIRUNTIME) $(ALL_OBJS) fmi-runtime RuntimeSources.mo
 	# copy libraries
-	cp -p $(LIBSIMULATION) $(LIBFMIRUNTIME) $(LIBSIMULATIONFMI) $(builddir_lib)
+ifeq (MINGW,$(findstring MINGW,$(shell uname)))
+	cp -p $(LIBSIMULATION) $(builddir_bin)
+# 	copy the import (dll.a) libs as well.
+	cp -p $(LIBSIMULATION).a $(builddir_lib)
+else
+	cp -p $(LIBSIMULATION) $(builddir_lib)
+endif
+	cp -p $(LIBFMIRUNTIME) $(LIBSIMULATIONFMI) $(builddir_lib)
 	# FMI runtime libs
 	test ! -f libSimulationRuntimeC.bc || cp libSimulationRuntimeC.bc $(builddir_lib)/emcc/libSimulationRuntimeC.so
 	test ! `uname` = Darwin || install_name_tool -change libsundials_idas.4.dylib @rpath/libsundials_idas.4.dylib $(builddir_lib)/$(LIBFMIRUNTIME)

--- a/OMCompiler/SimulationRuntime/c/Makefile.omdev.mingw
+++ b/OMCompiler/SimulationRuntime/c/Makefile.omdev.mingw
@@ -34,7 +34,7 @@ FPMATHFORTRAN =
 
 LIBMAKEFILE = Makefile.omdev.mingw
 CONFIG_H=$(top_builddir)/Compiler/runtime/config.h
-LIBSIMULATION=libSimulationRuntimeC.a
+LIBSIMULATION=libSimulationRuntimeC.dll
 LIBRUNTIME=libOpenModelicaRuntimeC.dll
 LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.a
 CMINPACK_NO_DLL=-DCMINPACK_NO_DLL

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -729,8 +729,8 @@ elif echo "$host" | grep -iq "mingw"; then
   SHREXT=".a"
   DLLEXT=".dll"
   LIBGC="$OMBUILDDIR/lib/$host_short/omc/libomcgc.a"
-  LIBSIMULATION=libSimulationRuntimeC.a
-  LIBRUNTIME=libOpenModelicaRuntimeC.a
+  LIBSIMULATION=libSimulationRuntimeC.dll
+  LIBRUNTIME=libOpenModelicaRuntimeC.dll
   LIBFMIRUNTIME=libOpenModelicaFMIRuntimeC.a
   LIBFMILIB=libfmilib.a
   LIBCMINPACKLIB=libcminpack.a


### PR DESCRIPTION
  - We now build `libSimulationRuntimeC` as a DLL ON Windows.

  - The link flags for simulation executables (in Autoconf.mo) are now
    simplified to reflect this. Most of the functions are now in
    libSimulationRuntimeC.dll itself and there is not need to link all
    the static 3rdParty libraries.

  - This can use a lot more cleanup. We can take it step by step making
    sure everything is working as we go.
