### PR TITLE
Residual user data struct instead of void**

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -2333,11 +2333,11 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <%auxFunction%>
        <%tmp%>
 
-       void residualFunc<%ls.index%>(void** dataIn, const double* xloc, double* res, const int* iflag)
+       void residualFunc<%ls.index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag)
        {
          TRACE_PUSH
-         DATA *data = (DATA*) ((void**)dataIn[0]);
-         threadData_t *threadData = (threadData_t*) ((void**)dataIn[1]);
+         DATA *data = userData->data;
+         threadData_t *threadData = userData->threadData;
          const int equationIndexes[2] = {1,<%ls.index%>};
          <% if ls.partOfJac then
            'ANALYTIC_JACOBIAN* parentJacobian = data->simulationInfo->linearSystemData[<%ls.indexLinearSystem%>].parDynamicData[omc_get_thread_num()].parentJacobian;'
@@ -2474,11 +2474,11 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <%auxFunction%>
        <%tmp%>
 
-       void residualFunc<%ls.index%>(void** dataIn, const double* xloc, double* res, const int* iflag)
+       void residualFunc<%ls.index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag)
        {
          TRACE_PUSH
-         DATA *data = (DATA*) ((void**)dataIn[0]);
-         threadData_t *threadData = (threadData_t*) ((void**)dataIn[1]);
+         DATA *data = userData->data;
+         threadData_t *threadData = userData->threadData;
          const int equationIndexes[2] = {1,<%ls.index%>};
          <% if ls.partOfJac then
            'ANALYTIC_JACOBIAN* parentJacobian = data->simulationInfo->linearSystemData[<%ls.indexLinearSystem%>].parDynamicData[omc_get_thread_num()].parentJacobian;'
@@ -2505,11 +2505,11 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <%auxFunction2%>
        <%tmp2%>
 
-       void residualFunc<%at.index%>(void** dataIn, const double* xloc, double* res, const int* iflag)
+       void residualFunc<%at.index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag)
        {
          TRACE_PUSH
-         DATA *data = (DATA*) ((void**)dataIn[0]);
-         threadData_t *threadData = (threadData_t*) ((void**)dataIn[1]);
+         DATA *data = userData->data;
+         threadData_t *threadData = userData->threadData;
          const int equationIndexes[2] = {1,<%at.index%>};
          <% if ls.partOfJac then
            'ANALYTIC_JACOBIAN* parentJacobian = data->simulationInfo->linearSystemData[<%ls.indexLinearSystem%>].parDynamicData[omc_get_thread_num()].parentJacobian;'
@@ -2883,8 +2883,8 @@ end functionNonLinearResidualsMultiFile2;
 template getNLSPrototypes(Integer index)
 ::=
   <<
-  void residualFunc<%index%>(void** dataIn, const double* xloc, double* res, const int* iflag);
-  void initializeStaticDataNLS<%index%>(void *inData, threadData_t *threadData, void *inSystemData, modelica_boolean initSparsPattern);
+  void residualFunc<%index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag);
+  void initializeStaticDataNLS<%index%>(void *inData, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsPattern);
   void getIterationVarsNLS<%index%>(struct DATA *inData, double *array);
   >>
 end getNLSPrototypes;
@@ -2903,7 +2903,7 @@ template functionNonLinearResiduals(list<SimEqSystem> nonlinearSystems, String m
       let residualFunction = generateNonLinearResidualFunction(nls, modelNamePrefix, 0)
       let indexName = 'NLS<%nls.index%>'
       let sparseData = generateStaticSparseData(indexName, 'NONLINEAR_SYSTEM_DATA', sparsePattern, colorList, maxColor)
-      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName, 'NONLINEAR_SYSTEM_DATA')
+      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName)
       let updateIterationVars = getIterationVars(nls.crefs, indexName)
       let &prototypes += getNLSPrototypes(nls.index)
       <<
@@ -2916,7 +2916,7 @@ template functionNonLinearResiduals(list<SimEqSystem> nonlinearSystems, String m
       let residualFunction = generateNonLinearResidualFunction(nls, modelNamePrefix, 0)
       let indexName = 'NLS<%nls.index%>'
       let sparseData = generateStaticEmptySparseData(indexName, 'NONLINEAR_SYSTEM_DATA')
-      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName, 'NONLINEAR_SYSTEM_DATA')
+      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName)
       let updateIterationVars = getIterationVars(nls.crefs, indexName)
       let &prototypes += getNLSPrototypes(nls.index)
       <<
@@ -2935,13 +2935,13 @@ template functionNonLinearResiduals(list<SimEqSystem> nonlinearSystems, String m
       let residualFunction = generateNonLinearResidualFunction(nls, modelNamePrefix, 0)
       let indexName = 'NLS<%nls.index%>'
       let sparseData = generateStaticSparseData(indexName, 'NONLINEAR_SYSTEM_DATA', sparsePattern, colorList, maxColor)
-      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName, 'NONLINEAR_SYSTEM_DATA')
+      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName)
       let updateIterationVars = getIterationVars(nls.crefs, indexName)
       // for casual tearing set
       let residualFunctionCasual = generateNonLinearResidualFunction(at, modelNamePrefix, 1)
       let indexName = 'NLS<%at.index%>'
       let sparseDataCasual = generateStaticSparseData(indexName, 'NONLINEAR_SYSTEM_DATA', sparsePattern, colorList, maxColor)
-      let bodyStaticDataCasual = generateStaticInitialData(at.crefs, indexName, 'NONLINEAR_SYSTEM_DATA')
+      let bodyStaticDataCasual = generateStaticInitialData(at.crefs, indexName)
       let updateIterationVarsCasual = getIterationVars(at.crefs, indexName)
       let &prototypes += getNLSPrototypes(nls.index)
       <<
@@ -2965,13 +2965,13 @@ template functionNonLinearResiduals(list<SimEqSystem> nonlinearSystems, String m
       let residualFunction = generateNonLinearResidualFunction(nls, modelNamePrefix, 0)
       let indexName = 'NLS<%nls.index%>'
       let sparseData = generateStaticEmptySparseData(indexName, 'NONLINEAR_SYSTEM_DATA')
-      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName, 'NONLINEAR_SYSTEM_DATA')
+      let bodyStaticData = generateStaticInitialData(nls.crefs, indexName)
       let updateIterationVars = getIterationVars(nls.crefs, indexName)
       // for casual tearing set
       let residualFunctionCasual = generateNonLinearResidualFunction(at, modelNamePrefix, 1)
       let indexName = 'NLS<%at.index%>'
       let sparseDataCasual = generateStaticEmptySparseData(indexName, 'NONLINEAR_SYSTEM_DATA')
-      let bodyStaticDataCasual = generateStaticInitialData(at.crefs, indexName, 'NONLINEAR_SYSTEM_DATA')
+      let bodyStaticDataCasual = generateStaticInitialData(at.crefs, indexName)
       let updateIterationVarsCasual = getIterationVars(at.crefs, indexName)
       let &prototypes += getNLSPrototypes(nls.index)
       <<
@@ -3046,9 +3046,9 @@ match system
         ;separator="\n")
     let residualFunctionHeader =
       if intEq(whichSet, 0) then
-        'void residualFunc<%nls.index%>(void** dataIn, const double* xloc, double* res, const int* iflag)'
+        'void residualFunc<%nls.index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag)'
       else
-        'int residualFuncConstraints<%nls.index%>(void** dataIn, const double* xloc, double* res, const int* iflag)'
+        'int residualFuncConstraints<%nls.index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag)'
     let returnValue = if intEq(whichSet, 1) then 'return 0;'
     <<
     <%innerNLSSystems%>
@@ -3059,8 +3059,8 @@ match system
     <%residualFunctionHeader%>
     {
       TRACE_PUSH
-      DATA *data = (DATA*) ((void**)dataIn[0]);
-      threadData_t *threadData = (threadData_t*) ((void**)dataIn[1]);
+      DATA *data = userData->data;
+      threadData_t *threadData = userData->threadData;
       const int equationIndexes[2] = {1,<%nls.index%>};
       int i;<% if clockIndex then <<
       const int clockIndex = <%clockIndex%>;
@@ -3158,9 +3158,10 @@ template generateStaticSparseData(String indexName, String systemType, SparsityP
    end match
 end generateStaticSparseData;
 
-template generateStaticInitialData(list<ComponentRef> crefs, String indexName, String systemType)
+template generateStaticInitialData(list<ComponentRef> crefs, String indexName)
   "Generates initial function for nonlinear loops."
 ::=
+  let systemType = 'NONLINEAR_SYSTEM_DATA'
   let bodyStaticData = (crefs |> cr hasindex i0 =>
     <<
     /* static nls data for <%crefStrNoUnderscore(cr)%> */
@@ -3172,10 +3173,9 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName, S
   <<
 
   OMC_DISABLE_OPT
-  void initializeStaticData<%indexName%>(void *inData, threadData_t *threadData, void *inSystemData, modelica_boolean initSparsPattern)
+  void initializeStaticData<%indexName%>(void *inData, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *sysData, modelica_boolean initSparsPattern)
   {
     DATA* data = (DATA*) inData;
-    <%systemType%>* sysData = (<%systemType%>*) inSystemData;
     int i=0;
     <%bodyStaticData%>
     /* initial sparse pattern */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
@@ -513,7 +513,7 @@ void cvodeGetConfig(CVODE_CONFIG *config, threadData_t *threadData, booleantype 
 /**
  * @brief Allocate memory, initialize and set configurations for CVODE solver
  *
- * @param data              Runtime data struckt
+ * @param data              Runtime data struct
  * @param threadData        Thread data for error handling
  * @param solverInfo        Information about main solver. Unused at the moment.
  * @param cvodeData         CVODE solver data struckt.
@@ -713,7 +713,7 @@ int cvode_solver_initial(DATA *data, threadData_t *threadData, SOLVER_INFO *solv
  * Provide required problem specifications and reinitialize CVODE.
  * If scaling is used y will be scaled accordingly.
  *
- * @param data              Runtime data struckt.
+ * @param data              Runtime data struct.
  * @param threadData        Thread data for error handling.
  * @param solverInfo        Information about main solver. Unused at the moment.
  * @param cvodeData         CVODE solver data struckt.
@@ -846,7 +846,7 @@ void cvode_save_statistics(void *cvode_mem, unsigned int *solverStatsTmp, thread
  *
  * Integrates on current time intervall.
  *
- * @param data              Runtime data struckt
+ * @param data              Runtime data struct
  * @param threadData        Thread data for error handling
  * @param cvodeData         CVODE solver data struckt.
  * @return int              Returns 0 on success and return flag from CVode else.
@@ -993,7 +993,7 @@ int cvode_solver_step(DATA *data, threadData_t *threadData, SOLVER_INFO *solverI
 /**
  * @brief Integration step with CVODE for fmi2DoStep
  *
- * @param data              Runtime data struckt
+ * @param data              Runtime data struct
  * @param threadData        Thread data for error handling.
  * @param solverInfo        CVODE solver data struckt.
  * @param tNext             Next desired time step for integrator to end.

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -293,9 +293,9 @@ static int nlsKinsolResiduals(N_Vector x, N_Vector f, void* userData) {
   NLS_USERDATA* kinsolUserData = (NLS_USERDATA*)userData;
   DATA* data = kinsolUserData->data;
   threadData_t* threadData = kinsolUserData->threadData;
-  void* dataAndThreadData[2] = {data, threadData};
   NONLINEAR_SYSTEM_DATA* nlsData = kinsolUserData->nlsData;
   NLS_KINSOL_DATA* kinsolData = (NLS_KINSOL_DATA*)nlsData->solverData;
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=kinsolUserData->solverData};
   int iflag = 1 /* recoverable error */;
 
   /* Update statistics */
@@ -306,7 +306,7 @@ static int nlsKinsolResiduals(N_Vector x, N_Vector f, void* userData) {
 #endif
 
   /* call residual function */
-  nlsData->residualFunc(dataAndThreadData, xdata, fdata, (const int *)&iflag);
+  nlsData->residualFunc(&resUserData, xdata, fdata, (const int *)&iflag);
   iflag = 0 /* success */;
 
 #ifndef OMC_EMCC

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -295,7 +295,7 @@ static int nlsKinsolResiduals(N_Vector x, N_Vector f, void* userData) {
   threadData_t* threadData = kinsolUserData->threadData;
   NONLINEAR_SYSTEM_DATA* nlsData = kinsolUserData->nlsData;
   NLS_KINSOL_DATA* kinsolData = (NLS_KINSOL_DATA*)nlsData->solverData;
-  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=kinsolUserData->solverData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 1 /* recoverable error */;
 
   /* Update statistics */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
@@ -168,11 +168,10 @@ static int getAnalyticalJacobian(DATA* data, threadData_t *threadData,
 /*! \fn residual_wrapper for the residual function
  *
  */
-static int residual_wrapper(double* x, double* f, void** data, int sysNumber)
+static int residual_wrapper(double* x, double* f, RESIDUAL_USERDATA* userData, int sysNumber)
 {
   int iflag = 0;
-
-  (*((DATA*)data[0])->simulationInfo->linearSystemData[sysNumber].residualFunc)(data, x, f, &iflag);
+  userData->data->simulationInfo->linearSystemData[sysNumber].residualFunc(userData, x, f, &iflag);
   return 0;
 }
 
@@ -186,7 +185,7 @@ static int residual_wrapper(double* x, double* f, void** data, int sysNumber)
  */
 int solveKlu(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 {
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
   DATA_KLU* solverData = (DATA_KLU*)systemData->parDynamicData[omc_get_thread_num()].solverData[0];
   _omc_scalar residualNorm = 0;
@@ -227,7 +226,7 @@ int solveKlu(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
     /* calculate vector b (rhs) */
     memcpy(solverData->work, aux_x, sizeof(double)*solverData->n_row);
 
-  residual_wrapper(solverData->work, systemData->parDynamicData[omc_get_thread_num()].b, dataAndThreadData, sysNumber);
+    residual_wrapper(solverData->work, systemData->parDynamicData[omc_get_thread_num()].b, &resUserData, sysNumber);
   }
   tmpJacEvalTime = rt_ext_tp_tock(&(solverData->timeClock));
   systemData->jacobianTime += tmpJacEvalTime;
@@ -309,7 +308,7 @@ int solveKlu(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
         aux_x[i] += systemData->parDynamicData[omc_get_thread_num()].b[i];
 
       /* update inner equations */
-      residual_wrapper(aux_x, solverData->work, dataAndThreadData, sysNumber);
+      residual_wrapper(aux_x, solverData->work, &resUserData, sysNumber);
       residualNorm = _omc_gen_euclideanVectorNorm(solverData->work, solverData->n_row);
 
       if ((isnan(residualNorm)) || (residualNorm>1e-4)){

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
@@ -153,11 +153,11 @@ int getAnalyticalJacobianLapack(DATA* data, threadData_t *threadData, double* ja
 /*! \fn wrapper_fvec_lapack for the residual function
  *
  */
-static int wrapper_fvec_lapack(_omc_vector* x, _omc_vector* f, int* iflag, void** data, int sysNumber)
+static int wrapper_fvec_lapack(_omc_vector* x, _omc_vector* f, int* iflag, RESIDUAL_USERDATA* resUserData, int sysNumber)
 {
   int currentSys = sysNumber;
 
-  (*((DATA*)data[0])->simulationInfo->linearSystemData[currentSys].residualFunc)(data, x->data, f->data, iflag);
+  resUserData->data->simulationInfo->linearSystemData[currentSys].residualFunc(resUserData, x->data, f->data, iflag);
   return 0;
 }
 
@@ -170,7 +170,7 @@ static int wrapper_fvec_lapack(_omc_vector* x, _omc_vector* f, int* iflag, void*
  */
 int solveLapack(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 {
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int i, iflag = 1;
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
 
@@ -219,7 +219,7 @@ int solveLapack(DATA *data, threadData_t *threadData, int sysNumber, double* aux
     /* calculate vector b (rhs) */
     _omc_copyVector(solverData->work, solverData->x);
 
-    wrapper_fvec_lapack(solverData->work, solverData->b, &iflag, dataAndThreadData, sysNumber);
+    wrapper_fvec_lapack(solverData->work, solverData->b, &iflag, &resUserData, sysNumber);
   }
   tmpJacEvalTime = rt_ext_tp_tock(&(solverData->timeClock));
   systemData->jacobianTime += tmpJacEvalTime;
@@ -294,7 +294,7 @@ int solveLapack(DATA *data, threadData_t *threadData, int sysNumber, double* aux
       solverData->x = _omc_addVectorVector(solverData->x, solverData->work, solverData->b); // x = xold(work) + xnew(b)
 
       /* update inner equations */
-      wrapper_fvec_lapack(solverData->x, solverData->work, &iflag, dataAndThreadData, sysNumber);
+      wrapper_fvec_lapack(solverData->x, solverData->work, &iflag, &resUserData, sysNumber);
       residualNorm = _omc_euclideanVectorNorm(solverData->work);
 
       if ((isnan(residualNorm)) || (residualNorm>1e-4)){

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -183,11 +183,11 @@ int getAnalyticalJacobianLis(DATA* data, threadData_t *threadData, int sysNumber
 /*! \fn wrapper_fvec_lis for the residual function
  *
  */
-static int wrapper_fvec_lis(double* x, double* f, void** data, int sysNumber)
+static int wrapper_fvec_lis(double* x, double* f, RESIDUAL_USERDATA* resUserData , int sysNumber)
 {
   int iflag = 0;
 
-  (*((DATA*)data[0])->simulationInfo->linearSystemData[sysNumber].residualFunc)(data, x, f, &iflag);
+  resUserData->data->simulationInfo->linearSystemData[sysNumber].residualFunc(resUserData, x, f, &iflag);
   return 0;
 }
 
@@ -200,7 +200,7 @@ static int wrapper_fvec_lis(double* x, double* f, void** data, int sysNumber)
  */
 int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 {
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
   DATA_LIS* solverData = (DATA_LIS*)systemData->parDynamicData[omc_get_thread_num()].solverData[0];
 
@@ -243,7 +243,7 @@ int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 
     /* calculate vector b (rhs) */
     memcpy(solverData->work, aux_x, sizeof(double)*solverData->n_row);
-    wrapper_fvec_lis(solverData->work, systemData->parDynamicData[omc_get_thread_num()].b, dataAndThreadData, sysNumber);
+    wrapper_fvec_lis(solverData->work, systemData->parDynamicData[omc_get_thread_num()].b, &resUserData, sysNumber);
 
 	/* set b vector */
     for(i=0; i<n; i++) {
@@ -294,7 +294,7 @@ int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
         aux_x[i] += solverData->work[i];
 
       /* update inner equations */
-      wrapper_fvec_lis(aux_x, solverData->work, dataAndThreadData, sysNumber);
+      wrapper_fvec_lis(aux_x, solverData->work, &resUserData, sysNumber);
       residualNorm = _omc_gen_euclideanVectorNorm(solverData->work, solverData->n_row);
 
       if ((isnan(residualNorm)) || (residualNorm>1e-4)){

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -176,11 +176,11 @@ int getAnalyticalJacobianUmfPack(DATA* data, threadData_t *threadData, int sysNu
 /*! \fn wrapper_fvec_umfpack for the residual function
  *
  */
-static int wrapper_fvec_umfpack(double* x, double* f, void** data, int sysNumber)
+static int wrapper_fvec_umfpack(double* x, double* f, RESIDUAL_USERDATA* resUserData, int sysNumber)
 {
   int iflag = 0;
 
-  (*((DATA*)data[0])->simulationInfo->linearSystemData[sysNumber].residualFunc)(data, x, f, &iflag);
+  resUserData->data->simulationInfo->linearSystemData[sysNumber].residualFunc(resUserData, x, f, &iflag);
   return 0;
 }
 
@@ -195,7 +195,7 @@ static int wrapper_fvec_umfpack(double* x, double* f, void** data, int sysNumber
 int
 solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 {
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   LINEAR_SYSTEM_DATA* systemData = &(data->simulationInfo->linearSystemData[sysNumber]);
   DATA_UMFPACK* solverData = (DATA_UMFPACK*)systemData->parDynamicData[omc_get_thread_num()].solverData[0];
   _omc_scalar residualNorm = 0;
@@ -236,7 +236,7 @@ solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 
     /* calculate vector b (rhs) */
     memcpy(solverData->work, aux_x, sizeof(double)*solverData->n_row);
-    wrapper_fvec_umfpack(solverData->work, systemData->parDynamicData[omc_get_thread_num()].b, dataAndThreadData, sysNumber);
+    wrapper_fvec_umfpack(solverData->work, systemData->parDynamicData[omc_get_thread_num()].b, &resUserData, sysNumber);
   }
   tmpJacEvalTime = rt_ext_tp_tock(&(solverData->timeClock));
   systemData->jacobianTime += tmpJacEvalTime;
@@ -308,7 +308,7 @@ solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
         aux_x[i] += solverData->work[i];
 
       /* update inner equations */
-      wrapper_fvec_umfpack(aux_x, solverData->work, dataAndThreadData, sysNumber);
+      wrapper_fvec_umfpack(aux_x, solverData->work, &resUserData, sysNumber);
       residualNorm = _omc_gen_euclideanVectorNorm(solverData->work, solverData->n_row);
 
       if ((isnan(residualNorm)) || (residualNorm>1e-4)){

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -936,11 +936,11 @@ static int wrapper_fvec(DATA_HOMOTOPY* solverData, double* x, double* f)
   DATA* data = solverData->userData->data;
   threadData_t* threadData = solverData->userData->threadData;
   NONLINEAR_SYSTEM_DATA* nlsData = solverData->userData->nlsData;
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 0;
 
   /* TODO: change input to residualFunc from data to systemData */
-  nlsData->residualFunc(dataAndThreadData, x, f, &iflag);
+  nlsData->residualFunc(&resUserData, x, f, &iflag);
   solverData->numberOfFunctionEvaluations++;
 
   return 0;
@@ -957,12 +957,12 @@ int wrapper_fvec_constraints(DATA_HOMOTOPY* solverData, double* x, double* f)
   DATA* data = solverData->userData->data;
   threadData_t* threadData = solverData->userData->threadData;
   NONLINEAR_SYSTEM_DATA* nlsData = solverData->userData->nlsData;
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int iflag = 0;
   int retVal;
 
   /* TODO: change input to residualFunc from data to systemData */
-  retVal = nlsData->residualFuncConstraints(dataAndThreadData, x, f, &iflag);
+  retVal = nlsData->residualFuncConstraints(&resUserData, x, f, &iflag);
   solverData->numberOfFunctionEvaluations++;
 
   return retVal;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -331,7 +331,7 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
   NONLINEAR_SYSTEM_DATA* systemData = userData->nlsData;
   DATA_HYBRD* hybrdData = (DATA_HYBRD*)(systemData->solverData);
   int continuous = data->simulationInfo->solveContinuous;
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=userData->solverData};
 
   switch(*iflag)
   {
@@ -350,9 +350,9 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
 
     /* call residual function */
     if(hybrdData->useXScaling){
-      (systemData->residualFunc)(dataAndThreadData, (const double*) hybrdData->xScaled, f, (const int*)iflag);
+      (systemData->residualFunc)(&resUserData, (const double*) hybrdData->xScaled, f, (const int*)iflag);
     } else {
-      (systemData->residualFunc)(dataAndThreadData, x, f, (const int*)iflag);
+      (systemData->residualFunc)(&resUserData, x, f, (const int*)iflag);
     }
 
     /* debug output */
@@ -738,7 +738,7 @@ modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYST
 
       /* try */
       {
-        int catchedError = TRUE;
+        catchedError = TRUE;
 #ifndef OMC_EMCC
         MMC_TRY_INTERNAL(simulationJumpBuffer)
 #endif

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -331,7 +331,7 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
   NONLINEAR_SYSTEM_DATA* systemData = userData->nlsData;
   DATA_HYBRD* hybrdData = (DATA_HYBRD*)(systemData->solverData);
   int continuous = data->simulationInfo->solveContinuous;
-  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=userData->solverData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
 
   switch(*iflag)
   {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -135,11 +135,11 @@ int wrapper_fvec_newton(int n, double* x, double* fvec, NLS_USERDATA* userData, 
   ANALYTIC_JACOBIAN* jacobian = userData->analyticJacobian;
 
   DATA_NEWTON* solverData = (DATA_NEWTON*)(nlsData->solverData);
-  void *dataAndThreadData[2] = {data, threadData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=userData->solverData};
   int flag = 1;
 
   if (fj) {
-    (nlsData->residualFunc)(dataAndThreadData, x, fvec, &flag);
+    (nlsData->residualFunc)(&resUserData, x, fvec, &flag);
   } else {
     /* performance measurement */
     rt_ext_tp_tick(&nlsData->jacobianTimeClock);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -135,7 +135,7 @@ int wrapper_fvec_newton(int n, double* x, double* fvec, NLS_USERDATA* userData, 
   ANALYTIC_JACOBIAN* jacobian = userData->analyticJacobian;
 
   DATA_NEWTON* solverData = (DATA_NEWTON*)(nlsData->solverData);
-  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=userData->solverData};
+  RESIDUAL_USERDATA resUserData = {.data=data, .threadData=threadData, .solverData=NULL};
   int flag = 1;
 
   if (fj) {

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -259,6 +259,17 @@ typedef struct STATIC_STRING_DATA
   modelica_boolean time_unvarying;     /* true if the value is only computed once during initialization */
 } STATIC_STRING_DATA;
 
+/**
+ * @brief User data provided to residual functions.
+ *
+ * Created by (non-)linear solver before evaluating a residual.
+ */
+typedef struct RESIDUAL_USERDATA {
+  struct DATA* data;
+  threadData_t* threadData;
+  void* solverData;           /* Optional pointer to ODE solver data.
+                               * Used in NLS solving of ODE integrator step. */
+} RESIDUAL_USERDATA;
 
 typedef struct NLS_USERDATA NLS_USERDATA;
 
@@ -290,12 +301,10 @@ typedef struct NONLINEAR_SYSTEM_DATA
   SPARSE_PATTERN *sparsePattern;       /* sparse pattern if no jacobian is available */
   modelica_boolean isPatternAvailable;
 
-  // TODO Make type for void** {data, threadData}
-  // Also add a documentation
-  void (*residualFunc)(void** dataAndThreadData, const double* x, double* fx, const int* iflag);
-  int (*residualFuncConstraints)(void**, const double*, double*, const int*);
-  void (*initializeStaticNLSData)(void*, threadData_t *threadData, void*, modelica_boolean);
-  int (*strictTearingFunctionCall)(struct DATA*, threadData_t *threadData);
+  void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
+  int (*residualFuncConstraints)(RESIDUAL_USERDATA* userData, const double*, double*, const int*);
+  void (*initializeStaticNLSData)(struct DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern);
+  int (*strictTearingFunctionCall)(struct DATA* data, threadData_t *threadData);
   void (*getIterationVars)(struct DATA*, double*);
   int (*checkConstraints)(struct DATA*, threadData_t *threadData);
 
@@ -362,7 +371,7 @@ typedef struct LINEAR_SYSTEM_DATA
   int (*analyticalJacobianColumn)(void*, threadData_t*, ANALYTIC_JACOBIAN*, ANALYTIC_JACOBIAN* parentJacobian);
   int (*initialAnalyticalJacobian)(void*, threadData_t*, ANALYTIC_JACOBIAN*);
 
-  void (*residualFunc)(void**, const double*, double*, const int*);
+  void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
   void (*initializeStaticLSData)(void*, threadData_t *threadData, void*, modelica_boolean);
   int (*strictTearingFunctionCall)(struct DATA*, threadData_t *threadData);
   int (*checkConstraints)(struct DATA*, threadData_t *threadData);


### PR DESCRIPTION
### Purpose

Doing
```C
void foo(void** dataIn) {
  DATA *data = (DATA*) ((void**)dataIn[0]);
}
```

is not very safe, so let's use a struct with actual names. The compiler can even type-check the code!

### Approach

Give all residual functions the same user data struct
```C
typedef struct RESIDUAL_USERDATA {
  struct DATA* data;
  threadData_t* threadData;
  void* solverData;           /* Optional pointer to ODE solver data.
                                        * Used in NLS solving of ODE integrator step. */
} RESIDUAL_USERDATA;
```

`solverData` is not used at the moment, but will be used by GBODE solver from @bernhardbachmann.