### PR TITLE
Instance API improvements

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -31,12 +31,13 @@
 
 encapsulated package AbsynUtil
 
-protected import Absyn;
-protected import Dump;
-protected import Error;
-protected import List;
-protected import System;
-protected import Util;
+protected
+import Absyn;
+import Dump;
+import Error;
+import List;
+import System;
+import Util;
 import MetaModelica.Dangerous.listReverseInPlace;
 
 public constant Absyn.ClassDef dummyParts = Absyn.PARTS({},{},{},{},NONE());

--- a/OMCompiler/Compiler/NFFrontEnd/NFClockKind.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClockKind.mo
@@ -37,6 +37,7 @@ encapsulated uniontype NFClockKind
 protected
   import AbsynUtil;
   import ClockKind = NFClockKind;
+  import JSON;
 
 public
   record INFERRED_CLOCK
@@ -514,6 +515,52 @@ public
 
     str := "Clock(" + str + ")";
   end toFlatString;
+
+  function toJSON
+    input ClockKind clk;
+    output JSON json = JSON.emptyObject();
+  algorithm
+    json := JSON.addPair("kind", JSON.makeString("clock"), json);
+
+    () := match clk
+      case INFERRED_CLOCK()
+        algorithm
+          json := JSON.addPair("type", JSON.makeString("inferred"), json);
+        then
+          ();
+
+      case RATIONAL_CLOCK()
+        algorithm
+          json := JSON.addPair("type", JSON.makeString("rational"), json);
+          json := JSON.addPair("intervalCounter", Expression.toJSON(clk.intervalCounter), json);
+          json := JSON.addPair("resolution", Expression.toJSON(clk.resolution), json);
+        then
+          ();
+
+      case REAL_CLOCK()
+        algorithm
+          json := JSON.addPair("type", JSON.makeString("real"), json);
+          json := JSON.addPair("interval", Expression.toJSON(clk.interval), json);
+        then
+          ();
+
+      case EVENT_CLOCK()
+        algorithm
+          json := JSON.addPair("type", JSON.makeString("event"), json);
+          json := JSON.addPair("condition", Expression.toJSON(clk.condition), json);
+          json := JSON.addPair("startInterval", Expression.toJSON(clk.startInterval), json);
+        then
+          ();
+
+      case SOLVER_CLOCK()
+        algorithm
+          json := JSON.addPair("type", JSON.makeString("solver"), json);
+          json := JSON.addPair("c", Expression.toJSON(clk.c), json);
+          json := JSON.addPair("solverMethod", Expression.toJSON(clk.solverMethod), json);
+        then
+          ();
+    end match;
+  end toJSON;
 
 annotation(__OpenModelica_Interface="frontend");
 end NFClockKind;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -52,6 +52,7 @@ protected
   import ValuesUtil;
   import MetaModelica.Dangerous.*;
   import RangeIterator = NFRangeIterator;
+  import JSON;
 
 public
   import Absyn.Path;
@@ -5829,6 +5830,222 @@ public
       else ();
     end match;
   end clone;
+
+  function toJSON
+    input Expression exp;
+    output JSON json;
+  algorithm
+    json := match exp
+      case Expression.INTEGER() then JSON.makeInteger(exp.value);
+      case Expression.REAL() then JSON.makeNumber(exp.value);
+      case Expression.STRING() then JSON.makeString(exp.value);
+      case Expression.BOOLEAN() then JSON.makeBoolean(exp.value);
+      case Expression.ENUM_LITERAL()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("enum"), json);
+          json := JSON.addPair("name", JSON.makeString(Expression.toString(exp)), json);
+          json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
+        then
+          json;
+
+      case Expression.CLKCONST()
+        then ClockKind.toJSON(exp.clk);
+
+      case Expression.CREF() then ComponentRef.toJSON(exp.cref);
+
+      case Expression.TYPENAME()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("typename"), json);
+          json := JSON.addPair("name", JSON.makeString(Type.toString(exp.ty)), json);
+        then
+          json;
+
+      case Expression.ARRAY()
+        algorithm
+          json := JSON.emptyArray(arrayLength(exp.elements));
+          for e in exp.elements loop
+            json := JSON.addElement(toJSON(e), json);
+          end for;
+        then
+          json;
+
+      case Expression.RANGE()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("range"), json);
+          json := JSON.addPair("start", toJSON(exp.start), json);
+
+          if isSome(exp.step) then
+            json := JSON.addPair("step", toJSON(Util.getOption(exp.step)), json);
+          end if;
+
+          json := JSON.addPair("stop", toJSON(exp.stop), json);
+        then
+          json;
+
+      case Expression.TUPLE()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("tuple"), json);
+          json := JSON.addPair("elements",
+            JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
+        then
+          json;
+
+      case Expression.RECORD()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("record"), json);
+          json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(exp.path)), json);
+          json := JSON.addPair("elements",
+            JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
+        then
+          json;
+
+      case Expression.CALL()
+        then Call.toJSON(exp.call);
+
+      case Expression.SIZE()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("size"), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+
+          if isSome(exp.dimIndex) then
+            json := JSON.addPair("index", toJSON(Util.getOption(exp.dimIndex)), json);
+          end if;
+        then
+          json;
+
+      case Expression.BINARY()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("lhs", toJSON(exp.exp1), json);
+          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
+          json := JSON.addPair("rhs", toJSON(exp.exp2), json);
+        then
+          json;
+
+      case Expression.UNARY()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("unary_op"), json);
+          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+        then
+          json;
+
+      case Expression.LBINARY()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("lhs", toJSON(exp.exp1), json);
+          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
+          json := JSON.addPair("rhs", toJSON(exp.exp2), json);
+        then
+          json;
+
+      case Expression.LUNARY()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("unary_op"), json);
+          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+        then
+          json;
+
+      case Expression.RELATION()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("relation"), json);
+          json := JSON.addPair("lhs", toJSON(exp.exp1), json);
+          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
+          json := JSON.addPair("rhs", toJSON(exp.exp2), json);
+        then
+          json;
+
+      case Expression.IF()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("if"), json);
+          json := JSON.addPair("condition", toJSON(exp.condition), json);
+          json := JSON.addPair("true", toJSON(exp.trueBranch), json);
+          json := JSON.addPair("false", toJSON(exp.falseBranch), json);
+        then
+          json;
+
+      case Expression.CAST()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("cast"), json);
+          json := JSON.addPair("type", JSON.makeString(Type.toString(exp.ty)), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+        then
+          json;
+
+      case Expression.BOX()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("box"), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+        then
+          json;
+
+      case Expression.UNBOX()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("unbox"), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+        then
+          json;
+
+      case Expression.SUBSCRIPTED_EXP()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("sub"), json);
+          json := JSON.addPair("exp", toJSON(exp.exp), json);
+          json := JSON.addPair("subscripts", Subscript.toJSONList(exp.subscripts), json);
+        then
+          json;
+
+      case Expression.TUPLE_ELEMENT()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("tuple_element"), json);
+          json := JSON.addPair("exp", toJSON(exp.tupleExp), json);
+          json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
+        then
+          json;
+
+      case Expression.RECORD_ELEMENT()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("record_element"), json);
+          json := JSON.addPair("exp", toJSON(exp.recordExp), json);
+          json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
+          json := JSON.addPair("field", JSON.makeString(exp.fieldName), json);
+        then
+          json;
+
+      case Expression.PARTIAL_FUNCTION_APPLICATION()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("kind", JSON.makeString("function"), json);
+          json := JSON.addPair("name", JSON.makeString(ComponentRef.toString(exp.fn)), json);
+          json := JSON.addPair("arguments", JSON.makeArray(
+            list(JSON.fromPair(name, toJSON(arg)) threaded for arg in exp.args, name in exp.argNames)),
+            json);
+        then
+          json;
+
+      else JSON.makeString(toString(exp));
+    end match;
+  end toJSON;
+
+
 
 annotation(__OpenModelica_Interface="frontend");
 end NFExpression;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
@@ -60,7 +60,7 @@ encapsulated package NFInstContext
   constant Type CONNECT         = intBitLShift(1, 21); // Part of connect argument.
   constant Type NOEVENT         = intBitLShift(1, 22); // Part of noEvent argument.
   constant Type ASSERT          = intBitLShift(1, 23); // Part of assert argument.
-  constant Type GRAPHICAL_EXP   = intBitLShift(1, 24); // Part of a graphical expression.
+  constant Type ANNOTATION      = intBitLShift(1, 24); // Part of an annotation.
 
   // Combined flags:
   constant Type EQ_SUBEXPRESSION = intBitOr(EQUATION, SUBEXPRESSION);
@@ -214,10 +214,10 @@ encapsulated package NFInstContext
     output Boolean res = intBitAnd(context, ASSERT) > 0;
   end inAssert;
 
-  function inGraphicalExp
+  function inAnnotation
     input Type context;
-    output Boolean res = intBitAnd(context, GRAPHICAL_EXP) > 0;
-  end inGraphicalExp;
+    output Boolean res = intBitAnd(context, ANNOTATION) > 0;
+  end inAnnotation;
 
   function inValidTypenameScope
     input Type context;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -315,13 +315,13 @@ algorithm
   (foundCref, foundScope, state) := match cref
     case Absyn.ComponentRef.CREF_IDENT()
       algorithm
-        (_, foundCref, foundScope, state) := lookupSimpleCref(cref.name, cref.subscripts, scope);
+        (_, foundCref, foundScope, state) := lookupSimpleCref(cref.name, cref.subscripts, scope, context);
       then
         (foundCref, foundScope, state);
 
     case Absyn.ComponentRef.CREF_QUAL()
       algorithm
-        (node, foundCref, foundScope, state) := lookupSimpleCref(cref.name, cref.subscripts, scope);
+        (node, foundCref, foundScope, state) := lookupSimpleCref(cref.name, cref.subscripts, scope, context);
         (foundCref, foundScope, state) :=
           lookupCrefInNode(cref.componentRef, node, foundCref, foundScope, state, context);
       then
@@ -423,6 +423,7 @@ end lookupLocalSimpleName;
 function lookupSimpleName
   input String name;
   input InstNode scope;
+  input InstContext.Type context;
   output InstNode node;
 protected
   InstNode cur_scope = scope;
@@ -452,11 +453,21 @@ algorithm
         node := cur_scope;
         return;
       else
-        if InstNode.isTopScope(cur_scope) and not loaded then
-          // If the name couldn't be found in any scope, try to load a library
-          // with that name and then try the look it up in the top scope again.
-          loaded := true;
-          loadLibrary(name, cur_scope);
+        if InstNode.isTopScope(cur_scope) then
+          // If the name couldn't be found in any scope...
+          if InstContext.inAnnotation(context) then
+            // If we're in an annotation, check in the special scope where
+            // annotation classes are defined.
+            cur_scope := InstNode.annotationScope(cur_scope);
+          elseif not loaded then
+            // If we haven't already tried, try to load a library with that name
+            // and then try to look it up in the top scope again.
+            loaded := true;
+            loadLibrary(name, cur_scope);
+          else
+            // Nothing more to try, just fail.
+            fail();
+          end if;
         else
           // Otherwise, continue in the enclosing scope.
           cur_scope := InstNode.parentScope(cur_scope);
@@ -499,13 +510,13 @@ algorithm
   (node, state) := match name
     // Simple name, look it up in the given scope.
     case Absyn.Path.IDENT()
-      then lookupFirstIdent(name.name, scope);
+      then lookupFirstIdent(name.name, scope, context);
 
     // Qualified name, look up first part in the given scope and look up the
     // rest of the name in the found element.
     case Absyn.Path.QUALIFIED()
       algorithm
-        (node, state) := lookupFirstIdent(name.name, scope);
+        (node, state) := lookupFirstIdent(name.name, scope, context);
       then
         lookupLocalName(name.path, node, state, context, checkAccessViolations, isSelfReference(node, scope));
 
@@ -549,7 +560,7 @@ algorithm
     // Simple name, look it up in the given scope.
     case Absyn.Path.IDENT()
       algorithm
-        (node, state) := lookupFirstIdent(name.name, scope);
+        (node, state) := lookupFirstIdent(name.name, scope, context);
       then
         ({node}, state);
 
@@ -557,7 +568,7 @@ algorithm
     // rest of the name in the found element.
     case Absyn.Path.QUALIFIED()
       algorithm
-        (node, state) := lookupFirstIdent(name.name, scope);
+        (node, state) := lookupFirstIdent(name.name, scope, context);
       then
         lookupLocalNames(name.path, node, {node}, state, context, isSelfReference(node, scope));
 
@@ -572,6 +583,7 @@ function lookupFirstIdent
   "Looks up the first part of a name."
   input String name;
   input InstNode scope;
+  input InstContext.Type context;
   output InstNode node;
   output LookupState state;
 algorithm
@@ -581,7 +593,7 @@ algorithm
     state := LookupState.PREDEF_CLASS();
   else
     // Otherwise, check each scope until the name is found.
-    node := lookupSimpleName(name, scope);
+    node := lookupSimpleName(name, scope, context);
     state := LookupState.nodeState(node);
   end try;
 end lookupFirstIdent;
@@ -748,6 +760,7 @@ function lookupSimpleCref
   input String name;
   input list<Absyn.Subscript> subs;
   input InstNode scope;
+  input InstContext.Type context;
   output InstNode node;
   output ComponentRef cref;
   output InstNode foundScope = scope;
@@ -798,11 +811,21 @@ algorithm
           foundScope := InstNode.topScope(InstNode.parentScope(foundScope));
           require_builtin := true;
         else
-          if InstNode.isTopScope(foundScope) and not loaded then
-            // If the name couldn't be found in any scope, try to load a library
-            // with that name and then try the look it up in the top scope again.
-            loaded := true;
-            loadLibrary(name, foundScope);
+          if InstNode.isTopScope(foundScope) then
+            // If the name couldn't be found in any scope...
+            if InstContext.inAnnotation(context) then
+              // If we're in an annotation, check in the special scope where
+              // annotation classes are defined.
+              foundScope := InstNode.annotationScope(foundScope);
+            elseif not loaded then
+              // If we haven't already tried, try to load a library with that
+              // name and then try to look it up in the top scope again.
+              loaded := true;
+              loadLibrary(name, foundScope);
+            else
+              // Nothing more to try, just fail.
+              fail();
+            end if;
           else
             // Look in the next enclosing scope.
             foundScope := InstNode.parentScope(foundScope);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -42,6 +42,7 @@ protected
   import Ceval = NFCeval;
   import MetaModelica.Dangerous.listReverseInPlace;
   import Util;
+  import JSON;
 
 public
   import Expression = NFExpression;
@@ -739,6 +740,27 @@ public
   algorithm
     string := List.toString(subscripts, toFlatString, "", "[", ",", "]", false);
   end toFlatStringList;
+
+  function toJSON
+    input Subscript subscript;
+    output JSON json;
+  algorithm
+    json := match subscript
+      case UNTYPED() then Expression.toJSON(subscript.exp);
+      case INDEX() then Expression.toJSON(subscript.index);
+      case SLICE() then Expression.toJSON(subscript.slice);
+      else JSON.makeString(toString(subscript));
+    end match;
+  end toJSON;
+
+  function toJSONList
+    input list<Subscript> subscripts;
+    output JSON json = JSON.makeNull();
+  algorithm
+    for s in subscripts loop
+      json := JSON.addElement(toJSON(s), json);
+    end for;
+  end toJSONList;
 
   function eval
     input Subscript subscript;

--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -72,10 +72,24 @@ algorithm
   obj := OBJECT(UnorderedMap.new<JSON>(stringHashDjb2Mod, stringEq));
 end emptyObject;
 
+function fromPair
+  input String key;
+  input JSON value;
+  output JSON obj;
+algorithm
+  obj := emptyObject();
+  obj := addPair(key, value, obj);
+end fromPair;
+
 function emptyArray
   input Integer capacity = 0;
   output JSON obj = ARRAY(Vector.new<JSON>(capacity));
 end emptyArray;
+
+function makeArray
+  input list<JSON> elements;
+  output JSON obj = ARRAY(Vector.fromList(elements));
+end makeArray;
 
 function makeString
   input String str;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3358,30 +3358,26 @@ public function runFrontEndWorkNF
   output NFFlatten.FunctionTree functions;
   output String flatString;
 protected
-  Absyn.Program placement_p;
-  SCode.Program builtin_p, scode_p, graphic_p;
+  SCode.Program builtin_p, scode_p, annotation_p;
   Boolean b;
 algorithm
   (_, builtin_p) := FBuiltin.getInitialFunctions();
   scode_p := listAppend(builtin_p, SymbolTable.getSCode());
   ExecStat.execStat("FrontEnd - Absyn->SCode");
 
-  // add also the graphics annotations if we are using the NF_API
-  if Flags.isSet(Flags.NF_API) then
-    placement_p := InteractiveUtil.modelicaAnnotationProgram(Config.getAnnotationVersion());
-    graphic_p := AbsynToSCode.translateAbsyn2SCode(placement_p);
-    scode_p := listAppend(graphic_p, scode_p);
-  end if;
+  annotation_p := AbsynToSCode.translateAbsyn2SCode(
+    InteractiveUtil.modelicaAnnotationProgram(Config.getAnnotationVersion()));
 
   // make sure we don't run the default instantiateModel using -d=nfAPI
   // only the stuff going via NFApi.mo should have this flag activated
   b := FlagsUtil.set(Flags.NF_API, false);
   try
-    (flatModel, functions, flatString) := NFInst.instClassInProgram(className, scode_p, dumpFlat);
-  FlagsUtil.set(Flags.NF_API, b);
+    (flatModel, functions, flatString) :=
+      NFInst.instClassInProgram(className, scode_p, annotation_p, dumpFlat);
+    FlagsUtil.set(Flags.NF_API, b);
   else
     FlagsUtil.set(Flags.NF_API, b);
-  fail();
+    fail();
   end try;
 end runFrontEndWorkNF;
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation1.mos
@@ -23,10 +23,42 @@ getModelInstance(M, prettyPrint=true);
 //     \"Icon\": {
 //       \"graphics\": [
 //         {
-//           \"kind\": \"call\",
+//           \"kind\": \"record\",
 //           \"name\": \"Rectangle\",
-//           \"namedArgs\": {
-//             \"extent\": [
+//           \"elements\": [
+//             true,
+//             [
+//               0,
+//               0
+//             ],
+//             0,
+//             [
+//               28,
+//               108,
+//               200
+//             ],
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             {
+//               \"kind\": \"enum\",
+//               \"name\": \"LinePattern.Solid\",
+//               \"index\": 2
+//             },
+//             {
+//               \"kind\": \"enum\",
+//               \"name\": \"FillPattern.None\",
+//               \"index\": 1
+//             },
+//             0.25,
+//             {
+//               \"kind\": \"enum\",
+//               \"name\": \"BorderPattern.None\",
+//               \"index\": 1
+//             },
+//             [
 //               [
 //                 -66,
 //                 78
@@ -36,22 +68,45 @@ getModelInstance(M, prettyPrint=true);
 //                 -56
 //               ]
 //             ],
-//             \"lineColor\": [
-//               28,
-//               108,
-//               200
-//             ]
-//           }
+//             0
+//           ]
 //         }
 //       ]
 //     },
 //     \"Diagram\": {
 //       \"graphics\": [
 //         {
-//           \"kind\": \"call\",
+//           \"kind\": \"record\",
 //           \"name\": \"Ellipse\",
-//           \"namedArgs\": {
-//             \"extent\": [
+//           \"elements\": [
+//             true,
+//             [
+//               0,
+//               0
+//             ],
+//             0,
+//             [
+//               28,
+//               108,
+//               200
+//             ],
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             {
+//               \"kind\": \"enum\",
+//               \"name\": \"LinePattern.Solid\",
+//               \"index\": 2
+//             },
+//             {
+//               \"kind\": \"enum\",
+//               \"name\": \"FillPattern.None\",
+//               \"index\": 1
+//             },
+//             0.25,
+//             [
 //               [
 //                 -62,
 //                 68
@@ -61,12 +116,14 @@ getModelInstance(M, prettyPrint=true);
 //                 -60
 //               ]
 //             ],
-//             \"lineColor\": [
-//               28,
-//               108,
-//               200
-//             ]
-//           }
+//             0,
+//             360,
+//             {
+//               \"kind\": \"enum\",
+//               \"name\": \"EllipseClosure.Chord\",
+//               \"index\": 2
+//             }
+//           ]
 //         }
 //       ]
 //     }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -39,7 +39,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"type\": \"Real\",
 //       \"modifier\": \" = 3\",
 //       \"value\": {
-//         \"binding\": \"3.0\"
+//         \"binding\": 3
 //       },
 //       \"prefixes\": {
 //         \"public\": true,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
@@ -189,8 +189,22 @@ getModelInstance(M, prettyPrint = true);
 //   },
 //   \"connections\": [
 //     {
-//       \"lhs\": \"c1\",
-//       \"rhs\": \"c3\",
+//       \"lhs\": {
+//         \"kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c1\"
+//           }
+//         ]
+//       },
+//       \"rhs\": {
+//         \"kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c3\"
+//           }
+//         ]
+//       },
 //       \"annotation\": {
 //         \"Line\": {
 //           \"points\": [
@@ -215,8 +229,22 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
-//       \"lhs\": \"c1\",
-//       \"rhs\": \"c2\"
+//       \"lhs\": {
+//         \"kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c1\"
+//           }
+//         ]
+//       },
+//       \"rhs\": {
+//         \"kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c2\"
+//           }
+//         ]
+//       }
 //     }
 //   ]
 // }"

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
@@ -1,4 +1,4 @@
-// name: GetModelInstanceAttributes1
+// name: GetModelInstanceExp1
 // keywords:
 // status: correct
 // cflags: -d=newInst
@@ -6,14 +6,14 @@
 //
 
 loadString("
+  model A
+    Real x[3] = {1, 2, 3};
+  end A;
+
   model M
-    replaceable Real x = 1.0;
-
-    replaceable model M
-      Real x;
-    end M;
-
-    M m;
+    Real x = 2.0;
+    A a;
+    Real y = a.x[1];
   end M;
 ");
 
@@ -24,13 +24,59 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"components\": {
-//     \"m\": {
+//     \"y\": {
+//       \"type\": \"Real\",
+//       \"modifier\": \" = a.x[1]\",
+//       \"value\": {
+//         \"binding\": {
+//           \"kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"a\"
+//             },
+//             {
+//               \"name\": \"x\",
+//               \"subscripts\": [
+//                 1
+//               ]
+//             }
+//           ]
+//         }
+//       },
+//       \"prefixes\": {
+//         \"public\": true,
+//         \"final\": false,
+//         \"inner\": false,
+//         \"outer\": false,
+//         \"replaceable\": false,
+//         \"redeclare\": false,
+//         \"connector\": \"\",
+//         \"variability\": \"\",
+//         \"direction\": \"\"
+//       }
+//     },
+//     \"a\": {
 //       \"type\": {
-//         \"name\": \"M\",
+//         \"name\": \"A\",
 //         \"components\": {
 //           \"x\": {
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
+//             \"dims\": {
+//               \"absyn\": [
+//                 \"3\"
+//               ],
+//               \"typed\": [
+//                 \"3\"
+//               ]
+//             },
+//             \"modifier\": \" = {1, 2, 3}\",
+//             \"value\": {
+//               \"binding\": [
+//                 1,
+//                 2,
+//                 3
+//               ]
+//             },
 //             \"prefixes\": {
 //               \"public\": true,
 //               \"final\": false,
@@ -60,29 +106,22 @@ getModelInstance(M, prettyPrint = true);
 //     },
 //     \"x\": {
 //       \"type\": \"Real\",
-//       \"modifier\": \" = 1.0\",
+//       \"modifier\": \" = 2.0\",
 //       \"value\": {
-//         \"binding\": 1
+//         \"binding\": 2
 //       },
 //       \"prefixes\": {
 //         \"public\": true,
 //         \"final\": false,
 //         \"inner\": false,
 //         \"outer\": false,
-//         \"replaceable\": true,
+//         \"replaceable\": false,
 //         \"redeclare\": false,
 //         \"connector\": \"\",
 //         \"variability\": \"\",
 //         \"direction\": \"\"
 //       }
 //     }
-//   },
-//   \"replaceable\": [
-//     {
-//       \"name\": \"x\",
-//       \"type\": \"Real\"
-//     },
-//     \"M\"
-//   ]
+//   }
 // }"
 // endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -2,10 +2,11 @@ TEST = ../../rtest -v
 
 TESTFILES = \
 GetModelInstanceAnnotation1.mos \
-GetModelInstanceComment1.mos \
 GetModelInstanceAttributes1.mos \
+GetModelInstanceComment1.mos \
 GetModelInstanceConnection1.mos \
 GetModelInstanceDuplicate1.mos \
+GetModelInstanceExp1.mos \
 GetModelInstanceReplaceable1.mos \
 
 


### PR DESCRIPTION
- Put builtin annotation class definition in a special scope that's only
  reachable when in an annotation context, to avoid the need to pollute
  the top scope and make it easier to instantiate annotation expressions.
- Instantiate annotation expression before dumping them in the instance
  API.
- Dump expressions as JSON structures instead of strings.