### PR TITLE
Jacobian util functions

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -165,18 +165,18 @@ end translateModel;
     extern const char* <%symbolName(modelNamePrefixStr,"zeroCrossingDescription")%>(int i, int **out_EquationIndexes);
     extern const char* <%symbolName(modelNamePrefixStr,"relationDescription")%>(int i);
     extern void <%symbolName(modelNamePrefixStr,"function_initSample")%>(DATA *data, threadData_t *threadData);
-    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianG")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
-    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianA")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
-    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianB")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
-    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianC")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
-    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianD")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
-    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianF")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
-    extern int <%symbolName(modelNamePrefixStr,"functionJacG_column")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
-    extern int <%symbolName(modelNamePrefixStr,"functionJacA_column")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
-    extern int <%symbolName(modelNamePrefixStr,"functionJacB_column")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
-    extern int <%symbolName(modelNamePrefixStr,"functionJacC_column")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
-    extern int <%symbolName(modelNamePrefixStr,"functionJacD_column")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
-    extern int <%symbolName(modelNamePrefixStr,"functionJacF_column")%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianG")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianA")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianB")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianC")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianD")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+    extern int <%symbolName(modelNamePrefixStr,"initialAnalyticJacobianF")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+    extern int <%symbolName(modelNamePrefixStr,"functionJacG_column")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+    extern int <%symbolName(modelNamePrefixStr,"functionJacA_column")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+    extern int <%symbolName(modelNamePrefixStr,"functionJacB_column")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+    extern int <%symbolName(modelNamePrefixStr,"functionJacC_column")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+    extern int <%symbolName(modelNamePrefixStr,"functionJacD_column")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+    extern int <%symbolName(modelNamePrefixStr,"functionJacF_column")%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
     extern const char* <%symbolName(modelNamePrefixStr,"linear_model_frame")%>(void);
     extern const char* <%symbolName(modelNamePrefixStr,"linear_model_datarecovery_frame")%>(void);
     extern int <%symbolName(modelNamePrefixStr,"mayer")%>(DATA* data, modelica_real** res, short *);
@@ -1755,8 +1755,8 @@ template symJacDefinition(list<JacobianMatrix> JacobianMatrixes, String modelNam
     extern "C" {
     #endif
       #define <%symbolName(modelNamePrefix,"INDEX_JAC_")%><%name%> <%indexJacobian%>
-      int <%symbolName(modelNamePrefix,"functionJac")%><%name%>_column(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
-      int <%symbolName(modelNamePrefix,"initialAnalyticJacobian")%><%name%>(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
+      int <%symbolName(modelNamePrefix,"functionJac")%><%name%>_column(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *thisJacobian, ANALYTIC_JACOBIAN *parentJacobian);
+      int <%symbolName(modelNamePrefix,"initialAnalyticJacobian")%><%name%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian);
     #if defined(__cplusplus)
     }
     #endif
@@ -5225,7 +5225,7 @@ template initialAnalyticJacobians(list<JacobianColumn> jacobianColumn, list<SimV
 match sparsepattern
   case {} then
     <<
-    int <%symbolName(modelNamePrefix,"initialAnalyticJacobian")%><%matrixname%>(void* inData, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian)
+    int <%symbolName(modelNamePrefix,"initialAnalyticJacobian")%><%matrixname%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian)
     {
       TRACE_PUSH
       TRACE_POP
@@ -5247,10 +5247,9 @@ match sparsepattern
       let index_ = listLength(seedVars)
       <<
       OMC_DISABLE_OPT
-      int <%symbolName(modelNamePrefix,"initialAnalyticJacobian")%><%matrixname%>(void* inData, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian)
+      int <%symbolName(modelNamePrefix,"initialAnalyticJacobian")%><%matrixname%>(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian)
       {
         TRACE_PUSH
-        DATA* data = ((DATA*)inData);
         <%colPtr%>
         <%rowIndex%>
         int i = 0;
@@ -5284,7 +5283,7 @@ template generateMatrix(list<JacobianColumn> jacobianColumn, list<SimVar> seedVa
   match nRows
   case "0" then
     <<
-    int <%symbolName(modelNamePrefix,"functionJac")%><%matrixname%>_column(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
+    int <%symbolName(modelNamePrefix,"functionJac")%><%matrixname%>_column(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
     {
       TRACE_PUSH
       TRACE_POP
@@ -5295,7 +5294,7 @@ template generateMatrix(list<JacobianColumn> jacobianColumn, list<SimVar> seedVa
     match seedVars
      case {} then
         <<
-        int <%symbolName(modelNamePrefix,"functionJac")%><%matrixname%>_column(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
+        int <%symbolName(modelNamePrefix,"functionJac")%><%matrixname%>_column(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
         {
           TRACE_PUSH
           TRACE_POP
@@ -5321,11 +5320,10 @@ template generateConstantEqns(list<SimEqSystem> constantEqns, String matrixName,
 ::=
     <<
     OMC_DISABLE_OPT
-    int <%symbolName(modelNamePrefix,"functionJac")%><%matrixName%>_constantEqns(void* inData, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
+    int <%symbolName(modelNamePrefix,"functionJac")%><%matrixName%>_constantEqns(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
     {
       TRACE_PUSH
 
-      DATA* data = ((DATA*)inData);
       int index = <%symbolName(modelNamePrefix,"INDEX_JAC_")%><%matrixName%>;
 
       <%(constantEqns |> eq => equation_callJacobian(eq, modelNamePrefix); separator="")%>
@@ -5351,11 +5349,10 @@ template functionJac(list<SimEqSystem> jacEquations, list<SimEqSystem> constantE
 
   <%constantEqns2%>
 
-  int <%symbolName(modelNamePrefix,"functionJac")%><%matrixName%>_column(void* inData, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
+  int <%symbolName(modelNamePrefix,"functionJac")%><%matrixName%>_column(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN *jacobian, ANALYTIC_JACOBIAN *parentJacobian)
   {
     TRACE_PUSH
 
-    DATA* data = ((DATA*)inData);
     int index = <%symbolName(modelNamePrefix,"INDEX_JAC_")%><%matrixName%>;
     <%(jacEquations |> eq => equation_callJacobian(eq, modelNamePrefix); separator="")%>
     TRACE_POP

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -895,6 +895,7 @@ template simulationFile_jac(SimCode simCode)
     /* Jacobians <%listLength(jacobianMatrixes)%> */
     <%simulationFileHeader(simCode.fileNamePrefix)%>
     #include "<%fileNamePrefix%>_12jac.h"
+    #include "util/jacobian_util.h"
     <%functionAnalyticJacobians(jacobianMatrixes, modelNamePrefix(simCode))%>
 
     <%\n%>
@@ -2353,9 +2354,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(void *inData, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
        {
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2406,9 +2406,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          <%vectorb%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(void *inData, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
        {
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2494,9 +2493,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(void *inData, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
        {
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2525,9 +2523,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%at.index%>(void *inData, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
        {
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData2%>
@@ -2602,9 +2599,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          <%vectorb%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(void *inData, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
        {
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2632,9 +2628,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          <%vectorb2%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%at.index%>(void *inData, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
        {
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData2%>
@@ -2884,7 +2879,7 @@ template getNLSPrototypes(Integer index)
 ::=
   <<
   void residualFunc<%index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag);
-  void initializeStaticDataNLS<%index%>(void *inData, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsPattern);
+  void initializeStaticDataNLS<%index%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsPattern);
   void getIterationVarsNLS<%index%>(struct DATA *inData, double *array);
   >>
 end getNLSPrototypes;
@@ -3134,13 +3129,8 @@ template generateStaticSparseData(String indexName, String systemType, SparsityP
         <%colPtr%>
         <%rowIndex%>
         /* sparsity pattern available */
-        inSysData->isPatternAvailable = 'T';
-        inSysData->sparsePattern = (SPARSE_PATTERN*) malloc(sizeof(SPARSE_PATTERN));
-        inSysData->sparsePattern->leadindex = (unsigned int*) malloc((<%sizeleadindex%>+1)*sizeof(unsigned int));
-        inSysData->sparsePattern->index = (unsigned int*) malloc(<%sp_size_index%>*sizeof(unsigned int));
-        inSysData->sparsePattern->numberOfNonZeros = <%sp_size_index%>;
-        inSysData->sparsePattern->colorCols = (unsigned int*) malloc(<%sizeleadindex%>*sizeof(unsigned int));
-        inSysData->sparsePattern->maxColors = <%maxColor%>;
+        inSysData->isPatternAvailable = 1;
+        inSysData->sparsePattern = allocSparsePattern(<%sizeleadindex%>, <%sp_size_index%>, <%maxColor%>);
 
         /* write lead index of compressed sparse column */
         memcpy(inSysData->sparsePattern->leadindex, colPtrIndex, (<%sizeleadindex%>+1)*sizeof(unsigned int));
@@ -3173,9 +3163,8 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName)
   <<
 
   OMC_DISABLE_OPT
-  void initializeStaticData<%indexName%>(void *inData, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *sysData, modelica_boolean initSparsPattern)
+  void initializeStaticData<%indexName%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *sysData, modelica_boolean initSparsPattern)
   {
-    DATA* data = (DATA*) inData;
     int i=0;
     <%bodyStaticData%>
     /* initial sparse pattern */
@@ -4511,13 +4500,7 @@ template initializeDAEmodeData(Integer nResVars, list<SimVar> algVars, Integer n
     daeModeData->algIndexes = (int*) malloc(sizeof(int)*<%nAlgVars%>);
     memcpy(daeModeData->algIndexes, algIndexes, <%nAlgVars%>*sizeof(int));
     /* intialize sparse pattern */
-    daeModeData->sparsePattern = (SPARSE_PATTERN*) malloc(sizeof(SPARSE_PATTERN));
-
-    daeModeData->sparsePattern->leadindex = (unsigned int*) malloc((<%sizeCols%>+1)*sizeof(int));
-    daeModeData->sparsePattern->index = (unsigned int*) malloc(<%sizeNNZ%>*sizeof(int));
-    daeModeData->sparsePattern->numberOfNonZeros = <%sizeNNZ%>;
-    daeModeData->sparsePattern->colorCols = (unsigned int*) malloc(<%sizeCols%>*sizeof(int));
-    daeModeData->sparsePattern->maxColors = <%maxColorStr%>;
+    daeModeData->sparsePattern = allocSparsePattern(<%sizeCols%>, <%sizeNNZ%>, <%maxColor%>);
 
     /* write lead index of compressed sparse column */
     memcpy(daeModeData->sparsePattern->leadindex, colPtrIndex, (1+<%sizeCols%>)*sizeof(int));
@@ -5271,19 +5254,8 @@ match sparsepattern
         <%rowIndex%>
         int i = 0;
 
-        jacobian->sizeCols = <%index_%>;
-        jacobian->sizeRows = <%indexColumn%>;
-        jacobian->sizeTmpVars = <%tmpvarsSize%>;
-        jacobian->seedVars = (modelica_real*) calloc(<%index_%>,sizeof(modelica_real));
-        jacobian->resultVars = (modelica_real*) calloc(<%indexColumn%>,sizeof(modelica_real));
-        jacobian->tmpVars = (modelica_real*) calloc(<%tmpvarsSize%>,sizeof(modelica_real));
-        jacobian->sparsePattern = (SPARSE_PATTERN*) malloc(sizeof(SPARSE_PATTERN));
-        jacobian->sparsePattern->leadindex = (unsigned int*) malloc((<%sizeleadindex%>+1)*sizeof(unsigned int));
-        jacobian->sparsePattern->index = (unsigned int*) malloc(<%sp_size_index%>*sizeof(unsigned int));
-        jacobian->sparsePattern->numberOfNonZeros = <%sp_size_index%>;
-        jacobian->sparsePattern->colorCols = (unsigned int*) malloc(<%index_%>*sizeof(unsigned int));
-        jacobian->sparsePattern->maxColors = <%maxColor%>;
-        jacobian->constantEqns = <%constantEqns%>;
+        initAnalyticJacobian(jacobian, <%index_%>, <%indexColumn%>, <%tmpvarsSize%>, <%constantEqns%>, jacobian->sparsePattern);
+        jacobian->sparsePattern = allocSparsePattern(<%sizeleadindex%>, <%sp_size_index%>, <%maxColor%>);
 
         /* write lead index of compressed sparse column */
         memcpy(jacobian->sparsePattern->leadindex, colPtrIndex, (<%sizeleadindex%>+1)*sizeof(unsigned int));

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -626,6 +626,7 @@ template simulationFile_nls(SimCode simCode)
     /* Non Linear Systems */
     <%simulationFileHeader(simCode.fileNamePrefix)%>
     #include "<%simCode.fileNamePrefix%>_12jac.h"
+    #include "util/jacobian_util.h"
     #if defined(__cplusplus)
     extern "C" {
     #endif

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -266,11 +266,11 @@ int (*initialAnalyticJacobianF)(void* data, threadData_t *threadData, ANALYTIC_J
 /*
  * These functions calculate specific jacobian column.
  */
-int (*functionJacA_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
-int (*functionJacB_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
-int (*functionJacC_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
-int (*functionJacD_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
-int (*functionJacF_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
+analyticalJacobianColumn_func_ptr functionJacA_column;
+analyticalJacobianColumn_func_ptr functionJacB_column;
+analyticalJacobianColumn_func_ptr functionJacC_column;
+analyticalJacobianColumn_func_ptr functionJacD_column;
+analyticalJacobianColumn_func_ptr functionJacF_column;
 /*#endif*/
 
 const char *(*linear_model_frame)(void); /* printf format-string with holes for 6 strings */

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -54,315 +54,315 @@ extern "C" {
 #include "util/utility.h"
 
 struct OpenModelicaGeneratedFunctionCallbacks {
-/* Defined in perform_simulation.c and omp_perform_simulation.c */
-int (*performSimulation)(DATA* data, threadData_t*, void* solverInfo);
-int (*performQSSSimulation)(DATA* data, threadData_t*, void* solverInfo);
-void (*updateContinuousSystem)(DATA *data, threadData_t*);
-/* Function for calling external object deconstructors */
-void (*callExternalObjectDestructors)(DATA *_data, threadData_t*);
+  /* Defined in perform_simulation.c and omp_perform_simulation.c */
+  int (*performSimulation)(DATA* data, threadData_t*, void* solverInfo);
+  int (*performQSSSimulation)(DATA* data, threadData_t*, void* solverInfo);
+  void (*updateContinuousSystem)(DATA *data, threadData_t*);
+  /* Function for calling external object deconstructors */
+  void (*callExternalObjectDestructors)(DATA *_data, threadData_t*);
 
-/*! \fn initialNonLinearSystem
- *
- *  This function initialize nonlinear system structure.
- *
- *  \param [ref] [data]
- */
-void (*initialNonLinearSystem)(int nNonLinearSystems, NONLINEAR_SYSTEM_DATA *data);
+  /*! \fn initialNonLinearSystem
+  *
+  *  This function initialize nonlinear system structure.
+  *
+  *  \param [ref] [data]
+  */
+  void (*initialNonLinearSystem)(int nNonLinearSystems, NONLINEAR_SYSTEM_DATA *data);
 
-/*! \fn initialLinearSystem
- *
- *  This function initialize nonlinear system structure.
- *
- *  \param [ref] [data]
- */
-void (*initialLinearSystem)(int nLinearSystems, LINEAR_SYSTEM_DATA *data);
+  /*! \fn initialLinearSystem
+  *
+  *  This function initialize nonlinear system structure.
+  *
+  *  \param [ref] [data]
+  */
+  void (*initialLinearSystem)(int nLinearSystems, LINEAR_SYSTEM_DATA *data);
 
-/*! \fn initialNonLinearSystem
- *
- *  This function initialize nonlinear system structure.
- *
- *  \param [ref] [data]
- */
-void (*initialMixedSystem)(int nMixedSystems, MIXED_SYSTEM_DATA *data);
+  /*! \fn initialNonLinearSystem
+  *
+  *  This function initialize nonlinear system structure.
+  *
+  *  \param [ref] [data]
+  */
+  void (*initialMixedSystem)(int nMixedSystems, MIXED_SYSTEM_DATA *data);
 
-/*! \fn initialNonLinearSystem
- *
- *  This function initialize state set structure.
- *
- *  \param [ref] [data]
- */
-void (*initializeStateSets)(int nStateSets, STATE_SET_DATA* statesetData, DATA *data);
+  /*! \fn initialNonLinearSystem
+  *
+  *  This function initialize state set structure.
+  *
+  *  \param [ref] [data]
+  */
+  void (*initializeStateSets)(int nStateSets, STATE_SET_DATA* statesetData, DATA *data);
 
-/*! \fn initializeDAEmodeData
- *
- *  This function to initialize the daeMode data structure in Data
- *
- *  \param [ref] [data]
- */
-int (*initializeDAEmodeData)(DATA *data, DAEMODE_DATA* daeModeData);
+  /*! \fn initializeDAEmodeData
+  *
+  *  This function to initialize the daeMode data structure in Data
+  *
+  *  \param [ref] [data]
+  */
+  int (*initializeDAEmodeData)(DATA *data, DAEMODE_DATA* daeModeData);
 
-/* functionODE contains those equations that are needed
- * to calculate the dynamic part of the system */
-int (*functionODE)(DATA *data, threadData_t*);
+  /* functionODE contains those equations that are needed
+  * to calculate the dynamic part of the system */
+  int (*functionODE)(DATA *data, threadData_t*);
 
-/* functionAlgebraics contains all continuous equations that
- * are not part of the dynamic part of the system */
-int (*functionAlgebraics)(DATA *data, threadData_t*);
+  /* functionAlgebraics contains all continuous equations that
+  * are not part of the dynamic part of the system */
+  int (*functionAlgebraics)(DATA *data, threadData_t*);
 
-/* function for calculating all equation sorting order
-   uses in EventHandle  */
-int (*functionDAE)(DATA *data, threadData_t*);
+  /* function for calculating all equation sorting order
+    uses in EventHandle  */
+  int (*functionDAE)(DATA *data, threadData_t*);
 
-/* function that evaluates all localKnownVars  */
-int (*functionLocalKnownVars)(DATA *data, threadData_t*);
+  /* function that evaluates all localKnownVars  */
+  int (*functionLocalKnownVars)(DATA *data, threadData_t*);
 
-/* functions for input and output */
-int (*input_function)(DATA*, threadData_t*);
-int (*input_function_init)(DATA*, threadData_t*);
-int (*input_function_updateStartValues)(DATA*, threadData_t*);
-/* functions for setting dataReconciliation inputs */
-int (*data_function)(DATA*, threadData_t*);
+  /* functions for input and output */
+  int (*input_function)(DATA*, threadData_t*);
+  int (*input_function_init)(DATA*, threadData_t*);
+  int (*input_function_updateStartValues)(DATA*, threadData_t*);
+  /* functions for setting dataReconciliation inputs */
+  int (*data_function)(DATA*, threadData_t*);
 
-int (*output_function)(DATA*, threadData_t*);
+  int (*output_function)(DATA*, threadData_t*);
 
-/* functions for setc data_reconciliation */
-int (*setc_function)(DATA*, threadData_t*);
-
-
-/* function for storing value histories of delayed expressions
- * called from functionDAE_output()
- */
-int (*function_storeDelayed)(DATA *data, threadData_t*);
-
-/* Functions for storing and initializing spatial distribution
- * operator.
- */
-int (*function_storeSpatialDistribution)(DATA *data, threadData_t*);
-int (*function_initSpatialDistribution)(DATA *data, threadData_t*);
-
-/*! \fn updateBoundVariableAttributes
- *
- *  This function updates all bound start, nominal, min, and max values.
- *
- *  \param [ref] [data]
- */
-
-int (*updateBoundVariableAttributes)(DATA *data, threadData_t*);
-
-/*! \fn functionInitialEquations
- *
- * function for calculate initial values from the initial equations and initial algorithms
- *
- *  \param [ref] [data]
- */
-int (*functionInitialEquations)(DATA *data, threadData_t*);
-
-/*! \var useHomotopy
- *
- * 0: local homotopy approach (equidistant lambda steps)
- * 1: global homotopy approach (equidistant lambda steps)
- * 2: new global homotopy approach (adaptive lambda steps)
- * 3: new local homotopy approach (adaptive lambda steps)
- */
-int useHomotopy;
-
-/*! \fn functionInitialEquations_lambda0
- *
- * function for calculate initial values from the initial equations and initial algorithms
- *
- *  \param [ref] [data]
- */
-int (*functionInitialEquations_lambda0)(DATA *data, threadData_t*);
-
-/*! \fn functionRemovedInitialEquations
- *
- * This function contains removed equations from the initialization problem,
- * which need to be checked to verify the consistency of the initialization
- * problem.
- *
- *  \param [ref] [data]
- */
-int (*functionRemovedInitialEquations)(DATA *data, threadData_t*);
-
-/*! \fn updateBoundParameters
- *
- *  This function calculates bound parameters that depend on other parameters,
- *  e.g. parameter Real n=1/m;
- *  obsolete: bound_parameters
- *
- *  \param [ref] [data]
- */
-int (*updateBoundParameters)(DATA *data, threadData_t*);
-
-/* function for checking for asserts and terminate */
-int (*checkForAsserts)(DATA *data, threadData_t*);
-
-/*! \fn function_ZeroCrossingsEquations
- *
- *  This function updates all equations to evaluate function_ZeroCrossings
- *
- *  \param [ref] [data]
- */
-int (*function_ZeroCrossingsEquations)(DATA *data, threadData_t*);
-
-/*! \fn function_ZeroCrossings
- *
- *  This function evaluates if a sign change occurs at the current state
- *
- *  \param [ref] [data]
- *  \param [ref] [gout]
- */
-int (*function_ZeroCrossings)(DATA *data, threadData_t*, double* gout);
-
-/*! \fn function_updateRelations
- *
- *  This function evaluates current continuous relations.
- *
- *  \param [ref] [data]
- *  \param [in]  [evalZeroCross] flag for evaluating Relation with hysteresis
- *                              function or without
- */
-int (*function_updateRelations)(DATA *data, threadData_t*, int evalZeroCross);
-
-/*! \var zeroCrossingDescription
- *
- * This variable contains a description string for zero crossing condition.
- */
-const char *(*zeroCrossingDescription)(int i, int **out_EquationIndexes);
-
-/*! \var relationDescription
- *
- * This variable contains a description string for continuous relations.
- */
-const char *(*relationDescription)(int i);
-
-/*! \fn function_initSample
- *
- *  This function initialize the sample-info struct.
- *
- *  \param [ref] [data]
- */
-void (*function_initSample)(DATA *data, threadData_t*);
-
-/* function for calculation Jacobian */
-/*#ifdef D_OMC_JACOBIAN*/
-const int INDEX_JAC_A;
-const int INDEX_JAC_B;
-const int INDEX_JAC_C;
-const int INDEX_JAC_D;
-const int INDEX_JAC_F;
-
-/*
- * These functions initialize specific jacobians.
- * Return-value 0: jac is present
- * Return-value 1: jac is not present
- */
-int (*initialAnalyticJacobianA)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-int (*initialAnalyticJacobianB)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-int (*initialAnalyticJacobianC)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-int (*initialAnalyticJacobianD)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-int (*initialAnalyticJacobianF)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-
-/*
- * These functions calculate specific jacobian column.
- */
-analyticalJacobianColumn_func_ptr functionJacA_column;
-analyticalJacobianColumn_func_ptr functionJacB_column;
-analyticalJacobianColumn_func_ptr functionJacC_column;
-analyticalJacobianColumn_func_ptr functionJacD_column;
-analyticalJacobianColumn_func_ptr functionJacF_column;
-/*#endif*/
-
-const char *(*linear_model_frame)(void); /* printf format-string with holes for 6 strings */
-const char *(*linear_model_datarecovery_frame)(void); /* printf format-string with holes for 9 strings */
-
-/*
- * This function is used only for optimization purpose
- * and calculates the mayer term. In case it's not present
- * a dummy function is added which return -1.
- */
-int (*mayer)(DATA* data, modelica_real** res, short *);
-
-/*
- * This function is used only for optimization purpose
- * and calculates the lagrange term. In case it's not present
- * a dummy function is added which return -1.
- */
-int (*lagrange)(DATA* data, modelica_real** res, short *, short *);
-
-/*
- * This function is used only for optimization purpose
- * and pick up the bounds of inputs. In case it's not present
- * a dummy function is added which return -1.
- */
-int (*pickUpBoundsForInputsInOptimization)(DATA* data, modelica_real* min, modelica_real* max, modelica_real*nominal,
-                                           modelica_boolean *useNominal, char ** name, modelica_real * start, modelica_real * startTimeOpt);
-
-/*
- * This function is used only for optimization purpose
- * and set simulationInfo->inputVars. In case it's not present
- * a dummy function is added which return -1.
- */
-int (*setInputData)(DATA* data, const modelica_boolean file);
+  /* functions for setc data_reconciliation */
+  int (*setc_function)(DATA*, threadData_t*);
 
 
-/*
- * This function is used only for optimization purpose
- * and return the time gride. In case it's not present
- * a dummy function is added which return -1.
- */
-int (*getTimeGrid)(DATA *data, modelica_integer * nsi, modelica_real**t);
+  /* function for storing value histories of delayed expressions
+  * called from functionDAE_output()
+  */
+  int (*function_storeDelayed)(DATA *data, threadData_t*);
+
+  /* Functions for storing and initializing spatial distribution
+  * operator.
+  */
+  int (*function_storeSpatialDistribution)(DATA *data, threadData_t*);
+  int (*function_initSpatialDistribution)(DATA *data, threadData_t*);
+
+  /*! \fn updateBoundVariableAttributes
+  *
+  *  This function updates all bound start, nominal, min, and max values.
+  *
+  *  \param [ref] [data]
+  */
+
+  int (*updateBoundVariableAttributes)(DATA *data, threadData_t*);
+
+  /*! \fn functionInitialEquations
+  *
+  * function for calculate initial values from the initial equations and initial algorithms
+  *
+  *  \param [ref] [data]
+  */
+  int (*functionInitialEquations)(DATA *data, threadData_t*);
+
+  /*! \var useHomotopy
+  *
+  * 0: local homotopy approach (equidistant lambda steps)
+  * 1: global homotopy approach (equidistant lambda steps)
+  * 2: new global homotopy approach (adaptive lambda steps)
+  * 3: new local homotopy approach (adaptive lambda steps)
+  */
+  int useHomotopy;
+
+  /*! \fn functionInitialEquations_lambda0
+  *
+  * function for calculate initial values from the initial equations and initial algorithms
+  *
+  *  \param [ref] [data]
+  */
+  int (*functionInitialEquations_lambda0)(DATA *data, threadData_t*);
+
+  /*! \fn functionRemovedInitialEquations
+  *
+  * This function contains removed equations from the initialization problem,
+  * which need to be checked to verify the consistency of the initialization
+  * problem.
+  *
+  *  \param [ref] [data]
+  */
+  int (*functionRemovedInitialEquations)(DATA *data, threadData_t*);
+
+  /*! \fn updateBoundParameters
+  *
+  *  This function calculates bound parameters that depend on other parameters,
+  *  e.g. parameter Real n=1/m;
+  *  obsolete: bound_parameters
+  *
+  *  \param [ref] [data]
+  */
+  int (*updateBoundParameters)(DATA *data, threadData_t*);
+
+  /* function for checking for asserts and terminate */
+  int (*checkForAsserts)(DATA *data, threadData_t*);
+
+  /*! \fn function_ZeroCrossingsEquations
+  *
+  *  This function updates all equations to evaluate function_ZeroCrossings
+  *
+  *  \param [ref] [data]
+  */
+  int (*function_ZeroCrossingsEquations)(DATA *data, threadData_t*);
+
+  /*! \fn function_ZeroCrossings
+  *
+  *  This function evaluates if a sign change occurs at the current state
+  *
+  *  \param [ref] [data]
+  *  \param [ref] [gout]
+  */
+  int (*function_ZeroCrossings)(DATA *data, threadData_t*, double* gout);
+
+  /*! \fn function_updateRelations
+  *
+  *  This function evaluates current continuous relations.
+  *
+  *  \param [ref] [data]
+  *  \param [in]  [evalZeroCross] flag for evaluating Relation with hysteresis
+  *                              function or without
+  */
+  int (*function_updateRelations)(DATA *data, threadData_t*, int evalZeroCross);
+
+  /*! \var zeroCrossingDescription
+  *
+  * This variable contains a description string for zero crossing condition.
+  */
+  const char *(*zeroCrossingDescription)(int i, int **out_EquationIndexes);
+
+  /*! \var relationDescription
+  *
+  * This variable contains a description string for continuous relations.
+  */
+  const char *(*relationDescription)(int i);
+
+  /*! \fn function_initSample
+  *
+  *  This function initialize the sample-info struct.
+  *
+  *  \param [ref] [data]
+  */
+  void (*function_initSample)(DATA *data, threadData_t*);
+
+  /* function for calculation Jacobian */
+  /*#ifdef D_OMC_JACOBIAN*/
+  const int INDEX_JAC_A;
+  const int INDEX_JAC_B;
+  const int INDEX_JAC_C;
+  const int INDEX_JAC_D;
+  const int INDEX_JAC_F;
+
+  /*
+  * These functions initialize specific jacobians.
+  * Return-value 0: jac is present
+  * Return-value 1: jac is not present
+  */
+  int (*initialAnalyticJacobianA)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianB)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianC)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianD)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianF)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+
+  /*
+  * These functions calculate specific jacobian column.
+  */
+  analyticalJacobianColumn_func_ptr functionJacA_column;
+  analyticalJacobianColumn_func_ptr functionJacB_column;
+  analyticalJacobianColumn_func_ptr functionJacC_column;
+  analyticalJacobianColumn_func_ptr functionJacD_column;
+  analyticalJacobianColumn_func_ptr functionJacF_column;
+  /*#endif*/
+
+  const char *(*linear_model_frame)(void); /* printf format-string with holes for 6 strings */
+  const char *(*linear_model_datarecovery_frame)(void); /* printf format-string with holes for 9 strings */
+
+  /*
+  * This function is used only for optimization purpose
+  * and calculates the mayer term. In case it's not present
+  * a dummy function is added which return -1.
+  */
+  int (*mayer)(DATA* data, modelica_real** res, short *);
+
+  /*
+  * This function is used only for optimization purpose
+  * and calculates the lagrange term. In case it's not present
+  * a dummy function is added which return -1.
+  */
+  int (*lagrange)(DATA* data, modelica_real** res, short *, short *);
+
+  /*
+  * This function is used only for optimization purpose
+  * and pick up the bounds of inputs. In case it's not present
+  * a dummy function is added which return -1.
+  */
+  int (*pickUpBoundsForInputsInOptimization)(DATA* data, modelica_real* min, modelica_real* max, modelica_real*nominal,
+                                            modelica_boolean *useNominal, char ** name, modelica_real * start, modelica_real * startTimeOpt);
+
+  /*
+  * This function is used only for optimization purpose
+  * and set simulationInfo->inputVars. In case it's not present
+  * a dummy function is added which return -1.
+  */
+  int (*setInputData)(DATA* data, const modelica_boolean file);
 
 
-/*
- * update parameter for symSolver
- */
+  /*
+  * This function is used only for optimization purpose
+  * and return the time gride. In case it's not present
+  * a dummy function is added which return -1.
+  */
+  int (*getTimeGrid)(DATA *data, modelica_integer * nsi, modelica_real**t);
 
-int (*symbolicInlineSystems)(DATA * data, threadData_t *threadData);
 
-/*
- * initialize clocks and subclocks info in modelData
- */
-void (*function_initSynchronous)(DATA * data, threadData_t *threadData);
+  /*
+  * update parameter for symSolver
+  */
 
-/*
- * Update base-clock interval.
- */
-void (*function_updateSynchronous)(DATA *data, threadData_t *threadData, long base_idx);
+  int (*symbolicInlineSystems)(DATA * data, threadData_t *threadData);
 
-/*
- * Sub-partition's equations
- */
-int (*function_equationsSynchronous)(DATA *data, threadData_t *threadData, long base_idx, long sub_idx);
+  /*
+  * initialize clocks and subclocks info in modelData
+  */
+  void (*function_initSynchronous)(DATA * data, threadData_t *threadData);
 
-/*
- * return input names
- */
-int (*inputNames)(DATA* modelData, char ** names);
+  /*
+  * Update base-clock interval.
+  */
+  void (*function_updateSynchronous)(DATA *data, threadData_t *threadData, long base_idx);
 
-/*
- * return variables of interest related with dataReconciliation
- */
-int (*dataReconciliationInputNames)(DATA* modelData, char ** names);
+  /*
+  * Sub-partition's equations
+  */
+  int (*function_equationsSynchronous)(DATA *data, threadData_t *threadData, long base_idx, long sub_idx);
 
-/*
- * FMU's do not need the XML-file; they use this callback instead.
- */
-void (*read_input_fmu)(MODEL_DATA* modelData, SIMULATION_INFO* simulationData);
+  /*
+  * return input names
+  */
+  int (*inputNames)(DATA* modelData, char ** names);
 
-/*
- * FMU continuous partial derivative functions
- */
-int (*initialPartialFMIDER)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-int (*functionJacFMIDER_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
-const int INDEX_JAC_FMIDER;
+  /*
+  * return variables of interest related with dataReconciliation
+  */
+  int (*dataReconciliationInputNames)(DATA* modelData, char ** names);
 
-/*
- * FMU partial derivative functions for initilization DAE
- */
-int (*initialPartialFMIDERINIT)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-int (*functionJacFMIDERINIT_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
-const int INDEX_JAC_FMIDERINIT;
+  /*
+  * FMU's do not need the XML-file; they use this callback instead.
+  */
+  void (*read_input_fmu)(MODEL_DATA* modelData, SIMULATION_INFO* simulationData);
+
+  /*
+  * FMU continuous partial derivative functions
+  */
+  int (*initialPartialFMIDER)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  analyticalJacobianColumn_func_ptr functionJacFMIDER_column;
+  const int INDEX_JAC_FMIDER;
+
+  /*
+  * FMU partial derivative functions for initilization DAE
+  */
+  int (*initialPartialFMIDERINIT)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  analyticalJacobianColumn_func_ptr functionJacFMIDERINIT_column;
+  const int INDEX_JAC_FMIDERINIT;
 };
 
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
@@ -495,8 +495,6 @@ int printCurrentStatesVector(int logLevel, double* states, DATA* data, double ti
   return 0;
 }
 
-// TODO AHeu: Remove millionths definition of a simple vector print function
-
 /* \fn printVector(int logLevel, double* y, DATA* data, double time)
  *
  * \param [in] [logLevel]

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/jacobianSymbolical.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/jacobianSymbolical.c
@@ -95,14 +95,14 @@ void allocateThreadLocalJacobians(DATA* data, ANALYTIC_JACOBIAN** jacColumns)
  * Only matrix storing format differs for them and therefore setJacElementFunc
  * is used to access matrix A.
  *
- * \param [in]      rows                Number of rows of jacobian.
- * \param [in]      columns             Number of columns of jacobian.
- * \param [in]      spp                 Pointer to sparse pattern.
- * \param [in/out]  matrixA             Internal data of solvers to store jacobian.
- * \param [in]      jacColumns          Number of colors (=number of columns for compressed structure) of jacobian.
- * \param [in]      data
- * \param [in]      threadData
- * \param [in]      setJacElementFunc   Function to set element (i,j) in matrix A.
+ * \param rows                Number of rows of jacobian.
+ * \param columns             Number of columns of jacobian.
+ * \param spp                 Pointer to sparse pattern.
+ * \param matrixA             Internal data of solvers to store jacobian.
+ * \param jacColumns          Analytic Jacobian.
+ * \param data                Runtime data struct.
+ * \param threadData          Thread data for error handling
+ * \param setJacElementFunc   Function to set element (i,j) in matrix A.
  */
 void genericColoredSymbolicJacobianEvaluation(int rows, int columns, SPARSE_PATTERN* spp,
                                               void* matrixA, ANALYTIC_JACOBIAN* jacColumns, DATA* data,

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -126,15 +126,7 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
       for (j=0; j<maxNumberThreads; ++j)
       {
         // ToDo Simplify this. Only have one location for jacobian
-        linsys[i].parDynamicData[j].jacobian = (ANALYTIC_JACOBIAN*) malloc(sizeof(ANALYTIC_JACOBIAN));
-        linsys[i].parDynamicData[j].jacobian->sizeCols = jacobian->sizeCols;
-        linsys[i].parDynamicData[j].jacobian->sizeRows = jacobian->sizeRows;
-        linsys[i].parDynamicData[j].jacobian->sizeTmpVars = jacobian->sizeTmpVars;
-        linsys[i].parDynamicData[j].jacobian->seedVars = (modelica_real*) calloc(jacobian->sizeCols, sizeof(modelica_real));
-        linsys[i].parDynamicData[j].jacobian->resultVars = (modelica_real*) calloc(jacobian->sizeRows, sizeof(modelica_real));
-        linsys[i].parDynamicData[j].jacobian->tmpVars = (modelica_real*) calloc(jacobian->sizeTmpVars, sizeof(modelica_real));
-        linsys[i].parDynamicData[j].jacobian->constantEqns = jacobian->constantEqns;
-        linsys[i].parDynamicData[j].jacobian->sparsePattern = jacobian->sparsePattern;
+        linsys[i].parDynamicData[j].jacobian = copyAnalyticJacobian(jacobian);
       }
 #else
       linsys[i].parDynamicData[0].jacobian = jacobian;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -377,11 +377,11 @@ void printParameters(DATA *data, int stream)
  * Use to print e.g. sparse Jacobian matrix.
  * Only prints if stream is active and sparse pattern is non NULL and of size > 0.
  *
- * @param [in]  sparsePattern   Matrix to print.
- * @param [in]  sizeRows        Number of rows of matrix.
- * @param [in]  sizeCols        Number of columns of matrix.
- * @param [in]  stream          Steam to print to.
- * @param [in]  name            Name of matrix.
+ * @param sparsePattern   Matrix to print.
+ * @param sizeRows        Number of rows of matrix.
+ * @param sizeCols        Number of columns of matrix.
+ * @param stream          Steam to print to.
+ * @param name            Name of matrix.
  */
 void printSparseStructure(SPARSE_PATTERN *sparsePattern, int sizeRows, int sizeCols, int stream, const char* name)
 {
@@ -404,7 +404,7 @@ void printSparseStructure(SPARSE_PATTERN *sparsePattern, int sizeRows, int sizeC
   buffer = (char*)omc_alloc_interface.malloc(sizeof(char)* 2*sizeCols + 4);
 
   infoStreamPrint(stream, 1, "Sparse structure of %s [size: %ux%u]", name, sizeRows, sizeCols);
-  infoStreamPrint(stream, 0, "%u nonzero elements", sparsePattern->numberOfNonZeros);
+  infoStreamPrint(stream, 0, "%u non-zero elements", sparsePattern->numberOfNonZeros);
 
   infoStreamPrint(stream, 1, "Transposed sparse structure (rows: states)");
   i=0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -153,8 +153,7 @@ typedef struct DATA_HOMOTOPY
   double timeValue;
   int mixedSystem;
 
-  // TODO AHeu: Don't use a void pointer here
-  void* dataHybrid;
+  DATA_HYBRD* dataHybrid;
 
 } DATA_HOMOTOPY;
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -140,8 +140,6 @@ void freeHybrdData(DATA_HYBRD* hybrdData)
   return;
 }
 
-// TODO AHeu: Remove millionths definition of a simple vector print function
-
 /*! \fn printVector
  *
  *  \param [in]  [vector]

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.h
@@ -42,11 +42,6 @@
 extern "C" {
 #endif
 
-// TODO AHeu: Why undef VOID???
-#ifdef VOID
-#undef VOID
-#endif
-
 typedef struct DATA_HYBRD
 {
   int initialized; /* 1 = initialized, else = 0*/

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -144,7 +144,7 @@ int wrapper_fvec_newton(int n, double* x, double* fvec, NLS_USERDATA* userData, 
     /* performance measurement */
     rt_ext_tp_tick(&nlsData->jacobianTimeClock);
 
-    if(nlsData->jacobianIndex != -1) {
+    if(nlsData->jacobianIndex != -1 && jacobian != NULL ) {
       getAnalyticalJacobianNewton(data, threadData, solverData->fjac, nlsData, jacobian);
     } else {
       double delta_h = sqrt(solverData->epsfcn);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -942,7 +942,6 @@ int updateInnerEquation(RESIDUAL_USERDATA* resUserData, int sysNumber, int discr
 #endif
 
   /* call residual function */
-  // TODO AHeu: Make sure residualFuncConstraints gets RESIDUAL_USERDATA* as input, was (void*) (void**)
   if (nonlinsys->strictTearingFunctionCall != NULL)
     constraintViolated = nonlinsys->residualFuncConstraints(resUserData, nonlinsys->nlsx, nonlinsys->resValues, (int*)&nonlinsys->size);
   else

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.c
@@ -704,73 +704,71 @@ _omc_matrix* _omc_multiplyMatrixMatrix(_omc_matrix* mat1, _omc_matrix* mat2)
   return mat1;
 }
 
-/*! \fn void _omc_printVector(_omc_vector* vec, char* name, int logLevel)
+/**
+ * @brief Print vector and equation info to stream.
  *
- *  outputs the _omc_vector
- *
- *  \param [in]  [vec]      !TODO: DESCRIBE ME!
- *  \param [in]  [name]     !TODO: DESCRIBE ME!
- *  \param [in]  [logLevel] !TODO: DESCRIBE ME!
+ * @param vec       Vector.
+ * @param name      Name of vector.
+ * @param stream    Log stream.
+ * @param eqnInfo   Information about equation
  */
-void _omc_printVectorWithEquationInfo(_omc_vector* vec, const char* name, const int logLevel, EQUATION_INFO eqnInfo)
+void _omc_printVectorWithEquationInfo(_omc_vector* vec, const char* name, const enum LOG_STREAM stream, EQUATION_INFO eqnInfo)
 {
   _omc_size i;
 
-  if (!ACTIVE_STREAM(logLevel))
+  if (!ACTIVE_STREAM(stream))
     return;
 
   assertStreamPrint(NULL, NULL != vec->data, "Vector data is NULL pointer");
 
-  infoStreamPrint(logLevel, 1, "%s", name);
+  infoStreamPrint(stream, 1, "%s", name);
   for (i = 0; i < vec->size; ++i)
   {
-    infoStreamPrint(logLevel, 0, "[%3d] %-40s = %20.12g",   (int)i+1, eqnInfo.vars[i], vec->data[i]);
+ //   infoStreamPrint(stream, 0, "[%3d] %-40s = %20.12g",   (int)i+1, eqnInfo.vars[i], vec->data[i]);
   }
-  messageClose(logLevel);
+  messageClose(stream);
 }
 
-/*! \fn void _omc_printVector(_omc_vector* vec, char* name, int logLevel)
+/**
+ * @brief Print vector to stream.
  *
- *  outputs the _omc_vector
- *
- *  \param [in]  [vec]      !TODO: DESCRIBE ME!
- *  \param [in]  [name]     !TODO: DESCRIBE ME!
- *  \param [in]  [logLevel] !TODO: DESCRIBE ME!
+ * @param vec       Vector.
+ * @param name      Name of vector.
+ * @param stream    Log stream.
  */
-void _omc_printVector(_omc_vector* vec, const char* name, const int logLevel)
+void _omc_printVector(_omc_vector* vec, const char* name, const enum LOG_STREAM stream)
 {
   _omc_size i;
 
-  if (!ACTIVE_STREAM(logLevel))
+  if (!ACTIVE_STREAM(stream))
     return;
 
   assertStreamPrint(NULL, NULL != vec->data, "Vector data is NULL pointer");
 
-  infoStreamPrint(logLevel, 1, "%s", name);
+  infoStreamPrint(stream, 1, "%s", name);
   for (i = 0; i < vec->size; ++i)
   {
-    infoStreamPrint(logLevel, 0, "[%2d] %20.12g", (int)i+1, vec->data[i]);
+    infoStreamPrint(stream, 0, "[%2d] %20.12g", (int)i+1, vec->data[i]);
   }
-  messageClose(logLevel);
+  messageClose(stream);
 }
 
-/*! \fn void _omc_printMatrix(_omc_matrix* mat, char* name, int logLevel)
+/**
+ * @brief Print matrix to stream.
  *
- *  outputs the _omc_matrix
- *
- *  \param [in]  [mat]      !TODO: DESCRIBE ME!
- *  \param [in]  [name]     !TODO: DESCRIBE ME!
- *  \param [in]  [logLevel] !TODO: DESCRIBE ME!
+ * @param mat       Matrix.
+ * @param name      Name of matrix.
+ * @param stream    Log stream.
  */
-void _omc_printMatrix(_omc_matrix* mat, const char* name, const int logLevel) {
-  if (ACTIVE_STREAM(logLevel))
+void _omc_printMatrix(_omc_matrix* mat, const char* name, const enum LOG_STREAM stream) {
+  if (ACTIVE_STREAM(stream))
   {
     _omc_size i, j;
     char *buffer = (char*)malloc(sizeof(char)*mat->cols*20);
 
     assertStreamPrint(NULL, NULL != mat->data, "matrix data is NULL pointer");
 
-    infoStreamPrint(logLevel, 1, "%s", name);
+    infoStreamPrint(stream, 1, "%s", name);
     for (i = 0; i < mat->rows; ++i)
     {
       buffer[0] = 0;
@@ -778,9 +776,9 @@ void _omc_printMatrix(_omc_matrix* mat, const char* name, const int logLevel) {
       {
         sprintf(buffer, "%s%10g ", buffer, _omc_getMatrixElement(mat, i, j));
       }
-      infoStreamPrint(logLevel, 0, "%s", buffer);
+      infoStreamPrint(stream, 0, "%s", buffer);
     }
-    messageClose(logLevel);
+    messageClose(stream);
     free(buffer);
   }
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.h
@@ -113,9 +113,9 @@ _omc_matrix* _omc_subtractMatrixMatrix(_omc_matrix* mat1, _omc_matrix* mat2);
 _omc_matrix* _omc_multiplyMatrixMatrix(_omc_matrix* mat1, _omc_matrix* mat2);
 
 /* print functions */
-void _omc_printVectorWithEquationInfo(_omc_vector* vec, const char* name, const int logLevel, EQUATION_INFO eqnInfo);
-void _omc_printVector(_omc_vector* vec, const char* name, const int logLevel);
-void _omc_printMatrix(_omc_matrix* mat, const char* name, const int logLevel);
+void _omc_printVectorWithEquationInfo(_omc_vector* vec, const char* name, const enum LOG_STREAM stream, EQUATION_INFO eqnInfo);
+void _omc_printVector(_omc_vector* vec, const char* name, const enum LOG_STREAM stream);
+void _omc_printMatrix(_omc_matrix* mat, const char* name, const enum LOG_STREAM stream);
 
 /* norm functions */
 _omc_scalar _omc_euclideanVectorNorm(const _omc_vector* vec);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
@@ -55,27 +55,27 @@ typedef struct SOLVERSTATS {
   unsigned int nConvergenveTestFailures;    /* Number of convergence test failures */
 } SOLVERSTATS;
 
+/**
+ * @brief Information and data needed by the ODE/DAE solver.
+ */
 typedef struct SOLVER_INFO
 {
   double currentTime;
   double currentStepSize;
   double laststep;
-  enum SOLVER_METHOD solverMethod;
-  double solverStepSize; /* used by implicit radau solver */
+  enum SOLVER_METHOD solverMethod;            /* ODE/DAE solver method */
+  double solverStepSize;                      /* used by implicit radau solver */
+                                              // TODO: Then it should be in radau solverData
 
-  /* set by solver if an internal root finding method is activated  */
-  modelica_boolean solverRootFinding;
-  /* set by solver if output points are set by step size control */
-  modelica_boolean solverNoEquidistantGrid;
+  modelica_boolean solverRootFinding;         /* Set by solver if an internal root finding method is activated  */
+  modelica_boolean solverNoEquidistantGrid;   /* Set by solver if output points are set by step size control */
   double lastdesiredStep;
 
   /* events */
   LIST* eventLst;
-  int didEventStep;
+  int didEventStep;       /* Boolean stating if during the last step an event was encountered,
+                           * Used to reinitialize ODE/DAE solver after event iteration */
 
-  /* radau_new
-  void* userdata;
-*/
   /* stats */
   unsigned long stateEvents;
   unsigned long sampleEvents;
@@ -85,9 +85,10 @@ typedef struct SOLVER_INFO
   unsigned int* solverStatsTmp;       /* tmp solver stats to update solverStats with */
 
   /* further options */
-  int integratorSteps;
+  int integratorSteps;              /* 1 => stepSizeControl; 0 => equidistant grid */
+                                    // TODO: This is a duplicate of solverNoEquidistantGrid set in DASSL/IDA/...
 
-  void* solverData;
+  void* solverData;     /* ODE/DAE solver data */
 }SOLVER_INFO;
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -61,8 +61,9 @@
 #define set_struct(TYPE, x, info) x = (TYPE)info
 #endif
 
-/* Forward declaration of DATA to avoid warnings in NONLINEAR_SYSTEM_DATA. */
+/* Forward declaration of DATA */
 struct DATA;
+typedef struct DATA DATA;
 
 /* Model info structures */
 typedef struct VAR_INFO
@@ -245,7 +246,7 @@ typedef struct STATIC_STRING_DATA
   modelica_boolean time_unvarying;     /* true if the value is only computed once during initialization */
 } STATIC_STRING_DATA;
 
-typedef int (*analyticalJacobianColumn_func_ptr)(void* data, threadData_t* threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
+typedef int (*analyticalJacobianColumn_func_ptr)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
 
 /**
  * @brief User data provided to residual functions.
@@ -253,7 +254,7 @@ typedef int (*analyticalJacobianColumn_func_ptr)(void* data, threadData_t* threa
  * Created by (non-)linear solver before evaluating a residual.
  */
 typedef struct RESIDUAL_USERDATA {
-  struct DATA* data;
+  DATA* data;
   threadData_t* threadData;
   void* solverData;           /* Optional pointer to ODE solver data.
                                * Used in NLS solving of ODE integrator step. */
@@ -291,10 +292,10 @@ typedef struct NONLINEAR_SYSTEM_DATA
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
   int (*residualFuncConstraints)(RESIDUAL_USERDATA* userData, const double*, double*, const int*);
-  void (*initializeStaticNLSData)(struct DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern);
-  int (*strictTearingFunctionCall)(struct DATA* data, threadData_t *threadData);
-  void (*getIterationVars)(struct DATA*, double*);
-  int (*checkConstraints)(struct DATA*, threadData_t *threadData);
+  void (*initializeStaticNLSData)(DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern);
+  int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
+  void (*getIterationVars)(DATA*, double*);
+  int (*checkConstraints)(DATA*, threadData_t *threadData);
 
   NONLINEAR_SOLVER nlsMethod;          /* nonlinear solver */
   void *solverData;
@@ -361,8 +362,8 @@ typedef struct LINEAR_SYSTEM_DATA
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
   void (*initializeStaticLSData)(void*, threadData_t *threadData, void*, modelica_boolean);
-  int (*strictTearingFunctionCall)(struct DATA*, threadData_t *threadData);
-  int (*checkConstraints)(struct DATA*, threadData_t *threadData);
+  int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
+  int (*checkConstraints)(DATA* data, threadData_t *threadData);
 
   /* attributes of iteration variables */
   modelica_real *min;
@@ -456,7 +457,7 @@ typedef struct DAEMODE_DATA
   modelica_real* residualVars;         /* workspace for the residual variables */
   modelica_real* auxiliaryVars;        /* workspace for the auxiliary variables */
   SPARSE_PATTERN* sparsePattern;       /* daeMode sparse pattern */
-  int (*evaluateDAEResiduals)(struct DATA*, threadData_t*, int); /* function to evaluate dynamic equations for DAE solver */
+  int (*evaluateDAEResiduals)(DATA*, threadData_t*, int); /* function to evaluate dynamic equations for DAE solver */
   int *algIndexes;                     /* index of the algebraic DAE variable in original order */
 } DAEMODE_DATA;
 

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -127,7 +127,7 @@ typedef enum {ERROR_AT_TIME,NO_PROGRESS_START_POINT,NO_PROGRESS_FACTOR,IMPROPER_
 typedef struct SPARSE_PATTERN
 {
   unsigned int* leadindex;        /* Array with column indices, size rows+1 */
-  unsigned int* index;            /* Array with row indices */
+  unsigned int* index;            /* Array with number of non-zeros indices */
   unsigned int sizeofIndex;       /* Length of array index, equal to numberOfNonZeros */
   unsigned int* colorCols;        /* Color coding of columns. First color is `1`, second is `2`, ... */
   unsigned int numberOfNonZeros;  /* Number of non-zero elements in matrix */

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -129,7 +129,8 @@ typedef struct SPARSE_PATTERN
   unsigned int* leadindex;        /* Array with column indices, size rows+1 */
   unsigned int* index;            /* Array with number of non-zeros indices */
   unsigned int sizeofIndex;       /* Length of array index, equal to numberOfNonZeros */
-  unsigned int* colorCols;        /* Color coding of columns. First color is `1`, second is `2`, ... */
+  unsigned int* colorCols;        /* Color coding of columns. First color is `1`, second is `2`, ...
+                                   * Length of array is rows */
   unsigned int numberOfNonZeros;  /* Number of non-zero elements in matrix */
   unsigned int maxColors;         /* Number of colors */
 } SPARSE_PATTERN;

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
@@ -108,6 +108,7 @@ SPARSE_PATTERN* allocSparsePattern(unsigned int n_leadIndex, unsigned int number
   SPARSE_PATTERN* sparsePattern = (SPARSE_PATTERN*) malloc(sizeof(SPARSE_PATTERN));
   sparsePattern->leadindex = (unsigned int*) malloc((n_leadIndex+1)*sizeof(unsigned int));
   sparsePattern->index = (unsigned int*) malloc(numberOfNonZeros*sizeof(unsigned int));
+  sparsePattern->sizeofIndex = numberOfNonZeros;
   sparsePattern->numberOfNonZeros = numberOfNonZeros;
   sparsePattern->colorCols = (unsigned int*) malloc(maxColors*sizeof(unsigned int));
   sparsePattern->maxColors = maxColors;

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
@@ -110,7 +110,7 @@ SPARSE_PATTERN* allocSparsePattern(unsigned int n_leadIndex, unsigned int number
   sparsePattern->index = (unsigned int*) malloc(numberOfNonZeros*sizeof(unsigned int));
   sparsePattern->sizeofIndex = numberOfNonZeros;
   sparsePattern->numberOfNonZeros = numberOfNonZeros;
-  sparsePattern->colorCols = (unsigned int*) malloc(maxColors*sizeof(unsigned int));
+  sparsePattern->colorCols = (unsigned int*) malloc(n_leadIndex*sizeof(unsigned int));
   sparsePattern->maxColors = maxColors;
 
   return sparsePattern;

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
@@ -34,19 +34,19 @@
 #include "jacobian_util.h"
 
 /**
- * @brief Allocate and initialize analytic jacobian.
+ * @brief Initialize analytic jacobian.
  *
+ * Jacobian has to be allocatd already.
+ *
+ * @param jacobian                  Jacobian to initialized.
  * @param sizeCols                  Number of columns of Jacobian
  * @param sizeRows                  Number of rows of Jacobian
  * @param sizeTmpVars               Size of tmp vars array.
  * @param constantEqns              Function pointer for constant equations of Jacobian.
  *                                  NULL if not available.
  * @param sparsePattern             Pointer to sparsity pattern of Jacobian.
- * @return ANALYTIC_JACOBIAN*       Return initialized analytic jacobian.
  */
-ANALYTIC_JACOBIAN* initAnalyticJacobian(unsigned int sizeCols, unsigned int sizeRows, unsigned int sizeTmpVars, int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian), SPARSE_PATTERN* sparsePattern) {
-  ANALYTIC_JACOBIAN* jacobian;
-  jacobian = (ANALYTIC_JACOBIAN*) malloc(sizeof(ANALYTIC_JACOBIAN));
+void initAnalyticJacobian(ANALYTIC_JACOBIAN* jacobian, unsigned int sizeCols, unsigned int sizeRows, unsigned int sizeTmpVars, int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian), SPARSE_PATTERN* sparsePattern) {
   jacobian->sizeCols = sizeCols;
   jacobian->sizeRows = sizeRows;
   jacobian->sizeTmpVars = sizeTmpVars;
@@ -55,8 +55,6 @@ ANALYTIC_JACOBIAN* initAnalyticJacobian(unsigned int sizeCols, unsigned int size
   jacobian->tmpVars = (modelica_real*) calloc(sizeTmpVars, sizeof(modelica_real));
   jacobian->constantEqns = constantEqns;
   jacobian->sparsePattern = sparsePattern;
-
-  return jacobian;
 }
 
 /**
@@ -68,11 +66,15 @@ ANALYTIC_JACOBIAN* initAnalyticJacobian(unsigned int sizeCols, unsigned int size
  * @return ANALYTIC_JACOBIAN*     Copy of source.
  */
 ANALYTIC_JACOBIAN* copyAnalyticJacobian(ANALYTIC_JACOBIAN* source) {
-  return initAnalyticJacobian(source->sizeCols,
-                              source->sizeRows,
-                              source->sizeTmpVars,
-                              source->constantEqns,
-                              source->sparsePattern);
+  ANALYTIC_JACOBIAN* jacobian = (ANALYTIC_JACOBIAN*) malloc(sizeof(ANALYTIC_JACOBIAN));
+  initAnalyticJacobian(jacobian,
+                       source->sizeCols,
+                       source->sizeRows,
+                       source->sizeTmpVars,
+                       source->constantEqns,
+                       source->sparsePattern);
+
+  return jacobian;
 }
 
 /**
@@ -91,6 +93,26 @@ void freeAnalyticJacobian(ANALYTIC_JACOBIAN *jac) {
   free(jac->resultVars); jac->resultVars = NULL;
   freeSparsePattern(jac->sparsePattern);
   free(jac->sparsePattern); jac->sparsePattern = NULL;
+}
+
+/**
+ * @brief Allocate memory for sparsity pattern.
+ *
+ * @param n_leadIndex         Number of rows or columns of Matrix.
+ *                            Depending on compression type CSR (-->rows) or CSC (-->columns).
+ * @param numberOfNonZeros    Numbe rof non-zero elements in Matrix.
+ * @param maxColors           Maximum number of colors of Matrix.
+ * @return SPARSE_PATTERN*    Pointer ot allocated sparsity pattern of Matrix.
+ */
+SPARSE_PATTERN* allocSparsePattern(unsigned int n_leadIndex, unsigned int numberOfNonZeros, unsigned int maxColors) {
+  SPARSE_PATTERN* sparsePattern = (SPARSE_PATTERN*) malloc(sizeof(SPARSE_PATTERN));
+  sparsePattern->leadindex = (unsigned int*) malloc((n_leadIndex+1)*sizeof(unsigned int));
+  sparsePattern->index = (unsigned int*) malloc(numberOfNonZeros*sizeof(unsigned int));
+  sparsePattern->numberOfNonZeros = numberOfNonZeros;
+  sparsePattern->colorCols = (unsigned int*) malloc(maxColors*sizeof(unsigned int));
+  sparsePattern->maxColors = maxColors;
+
+  return sparsePattern;
 }
 
 /**

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.c
@@ -33,7 +33,59 @@
 
 #include "jacobian_util.h"
 
+/**
+ * @brief Allocate and initialize analytic jacobian.
+ *
+ * @param sizeCols                  Number of columns of Jacobian
+ * @param sizeRows                  Number of rows of Jacobian
+ * @param sizeTmpVars               Size of tmp vars array.
+ * @param constantEqns              Function pointer for constant equations of Jacobian.
+ *                                  NULL if not available.
+ * @param sparsePattern             Pointer to sparsity pattern of Jacobian.
+ * @return ANALYTIC_JACOBIAN*       Return initialized analytic jacobian.
+ */
+ANALYTIC_JACOBIAN* initAnalyticJacobian(unsigned int sizeCols, unsigned int sizeRows, unsigned int sizeTmpVars, int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian), SPARSE_PATTERN* sparsePattern) {
+  ANALYTIC_JACOBIAN* jacobian;
+  jacobian = (ANALYTIC_JACOBIAN*) malloc(sizeof(ANALYTIC_JACOBIAN));
+  jacobian->sizeCols = sizeCols;
+  jacobian->sizeRows = sizeRows;
+  jacobian->sizeTmpVars = sizeTmpVars;
+  jacobian->seedVars = (modelica_real*) calloc(sizeCols, sizeof(modelica_real));
+  jacobian->resultVars = (modelica_real*) calloc(sizeRows, sizeof(modelica_real));
+  jacobian->tmpVars = (modelica_real*) calloc(sizeTmpVars, sizeof(modelica_real));
+  jacobian->constantEqns = constantEqns;
+  jacobian->sparsePattern = sparsePattern;
+
+  return jacobian;
+}
+
+/**
+ * @brief Copy analytic Jacobian.
+ *
+ * Sparsity pattern is not copied, only the pointer to it.
+ *
+ * @param source                  Jacobian that should be copied.
+ * @return ANALYTIC_JACOBIAN*     Copy of source.
+ */
+ANALYTIC_JACOBIAN* copyAnalyticJacobian(ANALYTIC_JACOBIAN* source) {
+  return initAnalyticJacobian(source->sizeCols,
+                              source->sizeRows,
+                              source->sizeTmpVars,
+                              source->constantEqns,
+                              source->sparsePattern);
+}
+
+/**
+ * @brief Free memory of analytic Jacobian.
+ *
+ * Also frees sparse pattern.
+ *
+ * @param jac   Pointer to Jacobian.
+ */
 void freeAnalyticJacobian(ANALYTIC_JACOBIAN *jac) {
+  if (jac == NULL) {
+    return;
+  }
   free(jac->seedVars); jac->seedVars = NULL;
   free(jac->tmpVars); jac->tmpVars = NULL;
   free(jac->resultVars); jac->resultVars = NULL;
@@ -41,6 +93,11 @@ void freeAnalyticJacobian(ANALYTIC_JACOBIAN *jac) {
   free(jac->sparsePattern); jac->sparsePattern = NULL;
 }
 
+/**
+ * @brief Free sparsity pattern
+ *
+ * @param spp   Pointer to sparsity pattern
+ */
 void freeSparsePattern(SPARSE_PATTERN *spp) {
   if (spp != NULL) {
     free(spp->index); spp->index = NULL;

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.h
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.h
@@ -40,10 +40,11 @@
 extern "C" {
 #endif
 
-ANALYTIC_JACOBIAN* initAnalyticJacobian(unsigned int sizeCols, unsigned int sizeRows, unsigned int sizeTmpVars, int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian), SPARSE_PATTERN* sparsePattern);
+void initAnalyticJacobian(ANALYTIC_JACOBIAN* jacobian, unsigned int sizeCols, unsigned int sizeRows, unsigned int sizeTmpVars, int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian), SPARSE_PATTERN* sparsePattern);
 ANALYTIC_JACOBIAN* copyAnalyticJacobian(ANALYTIC_JACOBIAN* source);
-
 void freeAnalyticJacobian(ANALYTIC_JACOBIAN* jac);
+
+SPARSE_PATTERN* allocSparsePattern(unsigned int n_leadIndex, unsigned int numberOfNonZeros, unsigned int maxColors);
 void freeSparsePattern(SPARSE_PATTERN *spp);
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/util/jacobian_util.h
+++ b/OMCompiler/SimulationRuntime/c/util/jacobian_util.h
@@ -40,18 +40,10 @@
 extern "C" {
 #endif
 
-/**
- * \brief Free struct ANALYTIC_JACOBIAN
- *
- * Frees dynamically allocated memory and sets pointers to NULL.
- */
-void freeAnalyticJacobian(ANALYTIC_JACOBIAN* jac);
+ANALYTIC_JACOBIAN* initAnalyticJacobian(unsigned int sizeCols, unsigned int sizeRows, unsigned int sizeTmpVars, int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian), SPARSE_PATTERN* sparsePattern);
+ANALYTIC_JACOBIAN* copyAnalyticJacobian(ANALYTIC_JACOBIAN* source);
 
-/**
- * \brief Free struct SPARSE_PATTERN
- *
- * Frees dynamically allocated memory and sets pointers to NULL.
- */
+void freeAnalyticJacobian(ANALYTIC_JACOBIAN* jac);
 void freeSparsePattern(SPARSE_PATTERN *spp);
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Purpose

- Less generated C code for Jacobians
  - Use alloc functions for jacobian and sparsity pattern
- Fixing warning for wrong type in `initializeStaticLSData` functions
- Typedef `int (*functionJacA_column)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);`
- Print functions using `enum LOG_STREAM stream` instead of `int stream`.
