### PR TITLE
Fix scope when instantiating component annotations

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1037,7 +1037,7 @@ algorithm
         end if;
 
         json := JSON.addPair("prefixes", dumpJSONAttributes(elem.attributes, elem.prefixes), json);
-        json := dumpJSONCommentOpt(comp.comment, node, json);
+        json := dumpJSONCommentOpt(comp.comment, InstNode.parent(node), json);
       then
         ();
 


### PR DESCRIPTION
- Use the parent of a component as the scope when instantiating the
  component's annotation instead of the component itself.