### PR TITLE
Close all top level windows before closing the MainWindow

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -579,6 +579,13 @@ int MainWindow::askForExit()
  */
 void MainWindow::beforeClosingMainWindow()
 {
+  // Issue #9101. Close all top level windows
+  foreach (QWidget *pWidget, QApplication::topLevelWidgets())  {
+    if (pWidget == this) {
+      continue;
+    }
+    pWidget->close();
+  }
   mpOMCProxy->quitOMC();
   delete mpOMCProxy;
   // delete the OMSProxy object


### PR DESCRIPTION
### Related Issues

Fixes #9101

### Purpose

Avoid crashing OMEdit when quitting with a dialog left open.

### Approach

Close all top level windows before quitting the application.
