### PR TITLE
Dump components as array in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5834,6 +5834,15 @@ public
   function toJSON
     input Expression exp;
     output JSON json;
+  protected
+    function dump_arg
+      input String name;
+      input Expression arg;
+      output JSON json = JSON.emptyObject();
+    algorithm
+      json := JSON.addPair("name", JSON.makeString(name), json);
+      json := JSON.addPair("value", toJSON(arg), json);
+    end dump_arg;
   algorithm
     json := match exp
       case Expression.INTEGER() then JSON.makeInteger(exp.value);
@@ -6036,8 +6045,7 @@ public
           json := JSON.addPair("kind", JSON.makeString("function"), json);
           json := JSON.addPair("name", JSON.makeString(ComponentRef.toString(exp.fn)), json);
           json := JSON.addPair("arguments", JSON.makeArray(
-            list(JSON.fromPair(name, toJSON(arg)) threaded for arg in exp.args, name in exp.argNames)),
-            json);
+            list(dump_arg(name, arg) threaded for arg in exp.args, name in exp.argNames)), json);
         then
           json;
 

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -976,13 +976,13 @@ end dumpJSONExtends;
 
 function dumpJSONComponents
   input list<InstanceTree> components;
-  output JSON json = JSON.emptyObject();
+  output JSON json = JSON.emptyArray();
 protected
   InstNode node;
 algorithm
   for comp in components loop
     InstanceTree.COMPONENT(node = node) := comp;
-    json := JSON.addPair(InstNode.name(node), dumpJSONComponent(comp), json);
+    json := JSON.addElement(dumpJSONComponent(comp), json);
   end for;
 end dumpJSONComponents;
 
@@ -1013,6 +1013,7 @@ algorithm
 
     case (Component.TYPED_COMPONENT(), SCode.Element.COMPONENT())
       algorithm
+        json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
         json := JSON.addPair("type", dumpJSONComponentType(cls, comp.ty), json);
 
         if Type.isArray(comp.ty) then

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -19,8 +19,9 @@ getModelInstance(M, prettyPrint = true);
 // true
 // "{
 //   \"name\": \"M\",
-//   \"components\": {
-//     \"pi\": {
+//   \"components\": [
+//     {
+//       \"name\": \"pi\",
 //       \"type\": \"Real\",
 //       \"modifier\": \" = 3\",
 //       \"value\": {
@@ -30,13 +31,14 @@ getModelInstance(M, prettyPrint = true);
 //         \"variability\": \"parameter\"
 //       }
 //     },
-//     \"deg\": {
+//     {
+//       \"name\": \"deg\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"(start = pi)\",
 //       \"prefixes\": {
 //
 //       }
 //     }
-//   }
+//   ]
 // }"
 // endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
@@ -37,8 +37,9 @@ getModelInstance(M, prettyPrint = true);
 //   \"extends\": [
 //     {
 //       \"name\": \"A\",
-//       \"components\": {
-//         \"w\": {
+//       \"components\": [
+//         {
+//           \"name\": \"w\",
 //           \"type\": \"Real\",
 //           \"modifier\": \"\",
 //           \"prefixes\": {
@@ -47,39 +48,52 @@ getModelInstance(M, prettyPrint = true);
 //             \"redeclare\": true
 //           }
 //         },
-//         \"z\": {
+//         {
+//           \"name\": \"z\",
 //           \"type\": \"Real\",
 //           \"modifier\": \"\",
 //           \"prefixes\": {
 //             \"inner\": true
 //           }
 //         }
-//       }
+//       ]
 //     }
 //   ],
-//   \"components\": {
-//     \"z\": {
+//   \"components\": [
+//     {
+//       \"name\": \"z\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
-//         \"inner\": true
+//         \"outer\": true
 //       }
 //     },
-//     \"x\": {
+//     {
+//       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"final\": true
 //       }
 //     },
-//     \"y\": {
+//     {
+//       \"name\": \"y\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"direction\": \"input \"
 //       }
 //     },
-//     \"w\": {
+//     {
+//       \"name\": \"z\",
+//       \"type\": \"Real\",
+//       \"modifier\": \"\",
+//       \"prefixes\": {
+//         \"inner\": true
+//       }
+//     },
+//     {
+//       \"name\": \"w\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
@@ -88,32 +102,36 @@ getModelInstance(M, prettyPrint = true);
 //         \"redeclare\": true
 //       }
 //     },
-//     \"c\": {
+//     {
+//       \"name\": \"c\",
 //       \"type\": {
 //         \"name\": \"C\",
-//         \"components\": {
-//           \"e\": {
+//         \"components\": [
+//           {
+//             \"name\": \"e\",
 //             \"type\": \"Real\",
 //             \"modifier\": \"\",
 //             \"prefixes\": {
 //
 //             }
 //           },
-//           \"f\": {
+//           {
+//             \"name\": \"f\",
 //             \"type\": \"Real\",
 //             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"connector\": \"flow\"
 //             }
 //           },
-//           \"s\": {
+//           {
+//             \"name\": \"s\",
 //             \"type\": \"Real\",
 //             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"connector\": \"stream\"
 //             }
 //           }
-//         }
+//         ]
 //       },
 //       \"modifier\": \"\",
 //       \"prefixes\": {
@@ -121,7 +139,7 @@ getModelInstance(M, prettyPrint = true);
 //         \"variability\": \"parameter\"
 //       }
 //     }
-//   },
+//   ],
 //   \"replaceable\": [
 //     {
 //       \"name\": \"w\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
@@ -34,87 +34,96 @@ getModelInstance(M, prettyPrint = true);
 //   \"extends\": [
 //     {
 //       \"name\": \"A\",
-//       \"components\": {
-//         \"c1\": {
+//       \"components\": [
+//         {
+//           \"name\": \"c1\",
 //           \"type\": {
 //             \"name\": \"C\",
-//             \"components\": {
-//               \"e\": {
+//             \"components\": [
+//               {
+//                 \"name\": \"e\",
 //                 \"type\": \"Real\",
 //                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //
 //                 }
 //               },
-//               \"f\": {
+//               {
+//                 \"name\": \"f\",
 //                 \"type\": \"Real\",
 //                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //                   \"connector\": \"flow\"
 //                 }
 //               }
-//             }
+//             ]
 //           },
 //           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
 //         },
-//         \"c2\": {
+//         {
+//           \"name\": \"c2\",
 //           \"type\": {
 //             \"name\": \"C\",
-//             \"components\": {
-//               \"e\": {
+//             \"components\": [
+//               {
+//                 \"name\": \"e\",
 //                 \"type\": \"Real\",
 //                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //
 //                 }
 //               },
-//               \"f\": {
+//               {
+//                 \"name\": \"f\",
 //                 \"type\": \"Real\",
 //                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //                   \"connector\": \"flow\"
 //                 }
 //               }
-//             }
+//             ]
 //           },
 //           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
 //         }
-//       }
+//       ]
 //     }
 //   ],
-//   \"components\": {
-//     \"c3\": {
+//   \"components\": [
+//     {
+//       \"name\": \"c3\",
 //       \"type\": {
 //         \"name\": \"C\",
-//         \"components\": {
-//           \"e\": {
+//         \"components\": [
+//           {
+//             \"name\": \"e\",
 //             \"type\": \"Real\",
 //             \"modifier\": \"\",
 //             \"prefixes\": {
 //
 //             }
 //           },
-//           \"f\": {
+//           {
+//             \"name\": \"f\",
 //             \"type\": \"Real\",
 //             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"connector\": \"flow\"
 //             }
 //           }
-//         }
+//         ]
 //       },
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
 //     }
-//   },
+//   ],
 //   \"connections\": [
 //     {
 //       \"lhs\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDuplicate1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDuplicate1.mos
@@ -25,25 +25,27 @@ getModelInstance(B, prettyPrint = true);
 //   \"extends\": [
 //     {
 //       \"name\": \"A\",
-//       \"components\": {
-//         \"x\": {
+//       \"components\": [
+//         {
+//           \"name\": \"x\",
 //           \"type\": \"Real\",
 //           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
 //         }
-//       }
+//       ]
 //     }
 //   ],
-//   \"components\": {
-//     \"x\": {
+//   \"components\": [
+//     {
+//       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
 //     }
-//   }
+//   ]
 // }"
 // endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
@@ -23,8 +23,9 @@ getModelInstance(M, prettyPrint = true);
 // true
 // "{
 //   \"name\": \"M\",
-//   \"components\": {
-//     \"x\": {
+//   \"components\": [
+//     {
+//       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"modifier\": \" = 2.0\",
 //       \"value\": {
@@ -34,11 +35,13 @@ getModelInstance(M, prettyPrint = true);
 //
 //       }
 //     },
-//     \"a\": {
+//     {
+//       \"name\": \"a\",
 //       \"type\": {
 //         \"name\": \"A\",
-//         \"components\": {
-//           \"x\": {
+//         \"components\": [
+//           {
+//             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"dims\": {
 //               \"absyn\": [
@@ -60,14 +63,15 @@ getModelInstance(M, prettyPrint = true);
 //
 //             }
 //           }
-//         }
+//         ]
 //       },
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
 //     },
-//     \"y\": {
+//     {
+//       \"name\": \"y\",
 //       \"type\": \"Real\",
 //       \"modifier\": \" = a.x[1]\",
 //       \"value\": {
@@ -90,6 +94,6 @@ getModelInstance(M, prettyPrint = true);
 //
 //       }
 //     }
-//   }
+//   ]
 // }"
 // endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
@@ -26,32 +26,35 @@ getModelInstance(M, prettyPrint=true);
 //   \"extends\": [
 //     {
 //       \"name\": \"A\",
-//       \"components\": {
-//         \"x\": {
+//       \"components\": [
+//         {
+//           \"name\": \"x\",
 //           \"type\": \"Real\",
 //           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
 //         }
-//       }
+//       ]
 //     }
 //   ],
-//   \"components\": {
-//     \"y\": {
+//   \"components\": [
+//     {
+//       \"name\": \"y\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
 //     },
-//     \"z\": {
+//     {
+//       \"name\": \"z\",
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
 //     }
-//   }
+//   ]
 // }"
 // endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
@@ -23,8 +23,9 @@ getModelInstance(M, prettyPrint = true);
 // true
 // "{
 //   \"name\": \"M\",
-//   \"components\": {
-//     \"x\": {
+//   \"components\": [
+//     {
+//       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"modifier\": \" = 1.0\",
 //       \"value\": {
@@ -34,25 +35,27 @@ getModelInstance(M, prettyPrint = true);
 //         \"replaceable\": true
 //       }
 //     },
-//     \"m\": {
+//     {
+//       \"name\": \"m\",
 //       \"type\": {
 //         \"name\": \"M\",
-//         \"components\": {
-//           \"x\": {
+//         \"components\": [
+//           {
+//             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"modifier\": \"\",
 //             \"prefixes\": {
 //
 //             }
 //           }
-//         }
+//         ]
 //       },
 //       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
 //     }
-//   },
+//   ],
 //   \"replaceable\": [
 //     {
 //       \"name\": \"x\",


### PR DESCRIPTION
- Dump the components as an array in the instance API instead of as an
  object, to guarantee that the ordering is preserved.