### PR TITLE
Fix implicit declaration of jacobian function generated code.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -118,6 +118,7 @@ end translateModel;
     #include "simulation/simulation_runtime.h"
     #include "util/omc_error.h"
     #include "util/parallel_helper.h"
+    #include "util/jacobian_util.h"
     #include "simulation/simulation_omc_assert.h"
     #include "simulation/solver/model_help.h"
     #include "simulation/solver/delay.h"


### PR DESCRIPTION
  - Include `util/jacobian_util.h` in the generated `<prefix>_model.h` file
    to get declaration of `allocSparsePattern`.

    This was declaring it implicitly as `int allocSparsePattern` and
    segfaulting later on the CMake built `omc` and `libSimulationRuntimeC`.