### PR TITLE
Fixing incompatible pointer warning during generated code compilation

### DIFF
--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -257,11 +257,11 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   * Return-value 0: jac is present
   * Return-value 1: jac is not present
   */
-  int (*initialAnalyticJacobianA)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianB)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianC)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianD)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianF)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianA)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianB)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianC)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianD)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  int (*initialAnalyticJacobianF)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
 
   /*
   * These functions calculate specific jacobian column.


### PR DESCRIPTION
Problem created in https://github.com/OpenModelica/OpenModelica/commit/bd211bfdf8f3836ec0d130e73bd6cd9455bb3e9a.

```
testSolver.problem1.c:3691:4: warning: incompatible pointer types initializing 'int (*)(void *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (*)(void *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') with an expression of type 'int (DATA *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (struct DATA *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') [-Wincompatible-pointer-types]
   testSolver_problem1_initialAnalyticJacobianA,
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
testSolver.problem1.c:3692:4: warning: incompatible pointer types initializing 'int (*)(void *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (*)(void *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') with an expression of type 'int (DATA *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (struct DATA *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') [-Wincompatible-pointer-types]
   testSolver_problem1_initialAnalyticJacobianB,
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
testSolver.problem1.c:3693:4: warning: incompatible pointer types initializing 'int (*)(void *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (*)(void *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') with an expression of type 'int (DATA *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (struct DATA *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') [-Wincompatible-pointer-types]
   testSolver_problem1_initialAnalyticJacobianC,
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
testSolver.problem1.c:3694:4: warning: incompatible pointer types initializing 'int (*)(void *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (*)(void *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') with an expression of type 'int (DATA *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (struct DATA *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') [-Wincompatible-pointer-types]
   testSolver_problem1_initialAnalyticJacobianD,
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
testSolver.problem1.c:3695:4: warning: incompatible pointer types initializing 'int (*)(void *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (*)(void *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') with an expression of type 'int (DATA *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (struct DATA *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') [-Wincompatible-pointer-types]
   testSolver_problem1_initialAnalyticJacobianF,
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
