### PR TITLE
Cleanup and restructure OpenModelica typedefs

### DIFF
--- a/OMCompiler/Compiler/runtime/Dynload.cpp
+++ b/OMCompiler/Compiler/runtime/Dynload.cpp
@@ -601,10 +601,10 @@ void *type_desc_to_value(type_description *desc)
                                    varlst, namelst, mmc_mk_icon(-1));
   };
   case TYPE_DESC_REAL_ARRAY: {
-    void *ptr = (modelica_real *) desc->data.real_array.data
-      + base_array_nr_of_elements(desc->data.real_array) - 1;
-    return generate_array(TYPE_DESC_REAL, 1, desc->data.real_array.ndims,
-                          desc->data.real_array.dim_size, &ptr);
+    void *ptr = (modelica_real *) desc->data.r_array.data
+      + base_array_nr_of_elements(desc->data.r_array) - 1;
+    return generate_array(TYPE_DESC_REAL, 1, desc->data.r_array.ndims,
+                          desc->data.r_array.dim_size, &ptr);
   };
   case TYPE_DESC_INT_ARRAY: {
     void *ptr = (modelica_integer *) desc->data.int_array.data
@@ -767,8 +767,8 @@ static int parse_array(type_description *desc, void *arrdata, void *dimLst)
   dim_size = (_index_t*) malloc(sizeof(_index_t) * dims);
   switch (desc->type) {
   case TYPE_DESC_REAL_ARRAY:
-    desc->data.real_array.ndims = dims;
-    desc->data.real_array.dim_size = dim_size;
+    desc->data.r_array.ndims = dims;
+    desc->data.r_array.dim_size = dim_size;
     break;
   case TYPE_DESC_INT_ARRAY:
     desc->data.int_array.ndims = dims;
@@ -790,8 +790,8 @@ static int parse_array(type_description *desc, void *arrdata, void *dimLst)
     return -1;
   switch (desc->type) {
   case TYPE_DESC_REAL_ARRAY:
-    alloc_real_array_data(&(desc->data.real_array));
-    data = desc->data.real_array.data;
+    alloc_real_array_data(&(desc->data.r_array));
+    data = desc->data.r_array.data;
     return get_array_data(1, dims, dim_size, arrdata, TYPE_DESC_REAL, &data);
   case TYPE_DESC_INT_ARRAY:
     alloc_integer_array_data(&(desc->data.int_array));

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
@@ -71,7 +71,7 @@ size_t device_array_nr_of_elements(device_array *a){
 }
 
 
-static inline modelica_real *real_ptrget(real_array_t *a, size_t i){
+static inline modelica_real *real_ptrget(real_array *a, size_t i){
     return ((modelica_real *) a->data) + i;
 }
 
@@ -300,7 +300,7 @@ void swap_and_release(base_array_t* lhs, base_array_t* rhs){
 //which, right now, doesn't support overloading or the stdarg standard library.
 //even though the functions have the same body here they will have different body on the OpenCL counterparts
 
-modelica_real* real_array_element_addr_c99_1(real_array_t* source,int ndims,...){
+modelica_real* real_array_element_addr_c99_1(real_array* source,int ndims,...){
     va_list ap;
     modelica_real* tmp;
 
@@ -311,7 +311,7 @@ modelica_real* real_array_element_addr_c99_1(real_array_t* source,int ndims,...)
     return tmp;
 }
 
-modelica_real* real_array_element_addr_c99_2(real_array_t* source,int ndims,...){
+modelica_real* real_array_element_addr_c99_2(real_array* source,int ndims,...){
     va_list ap;
     modelica_real* tmp;
 
@@ -322,7 +322,7 @@ modelica_real* real_array_element_addr_c99_2(real_array_t* source,int ndims,...)
     return tmp;
 }
 
-modelica_real* real_array_element_addr_c99_3(real_array_t* source,int ndims,...){
+modelica_real* real_array_element_addr_c99_3(real_array* source,int ndims,...){
     va_list ap;
     modelica_real* tmp;
 
@@ -390,7 +390,7 @@ void print_array_info(device_real_array* arr){
 }
 */
 
-void print_array(real_array_t* arr){
+void print_array(real_array* arr){
   printf("\n\n");
   for(int q = 1; q < arr->dim_size[0]; q++){
     printf(" | %f", (*real_array_element_addr_c99_1(arr, 1, ((modelica_integer) q))));
@@ -400,7 +400,7 @@ void print_array(real_array_t* arr){
 
 /*
 void print_array(device_real_array* dev_arr){
-  real_array_t arr;
+  real_array arr;
   int nr_of_elm = device_array_nr_of_elements(dev_arr);
   alloc_real_array(&arr, 1, nr_of_elm);
   copy_real_array_data(dev_arr, &arr);

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
@@ -333,9 +333,9 @@ m_real* real_array_element_addr_c99_3(real_array_t* source,int ndims,...){
     return tmp;
 }
 
-m_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...){
+modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...){
     va_list ap;
-    m_integer* tmp;
+    modelica_integer* tmp;
 
     va_start(ap,ndims);
     tmp = integer_ptrget(source, ocl_calc_base_index_va(source, ndims, ap));
@@ -344,9 +344,9 @@ m_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,..
     return tmp;
 }
 
-m_integer* integer_array_element_addr_c99_2(integer_array_t* source,int ndims,...){
+modelica_integer* integer_array_element_addr_c99_2(integer_array_t* source,int ndims,...){
     va_list ap;
-    m_integer* tmp;
+    modelica_integer* tmp;
 
     va_start(ap,ndims);
     tmp = integer_ptrget(source, ocl_calc_base_index_va(source, ndims, ap));
@@ -355,9 +355,9 @@ m_integer* integer_array_element_addr_c99_2(integer_array_t* source,int ndims,..
     return tmp;
 }
 
-m_integer* integer_array_element_addr_c99_3(integer_array_t* source,int ndims,...){
+modelica_integer* integer_array_element_addr_c99_3(integer_array_t* source,int ndims,...){
     va_list ap;
-    m_integer* tmp;
+    modelica_integer* tmp;
 
     va_start(ap,ndims);
     tmp = integer_ptrget(source, ocl_calc_base_index_va(source, ndims, ap));

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
@@ -75,7 +75,7 @@ static inline modelica_real *real_ptrget(real_array *a, size_t i){
     return ((modelica_real *) a->data) + i;
 }
 
-static inline modelica_integer *integer_ptrget(integer_array_t *a, size_t i){
+static inline modelica_integer *integer_ptrget(integer_array *a, size_t i){
     return ((modelica_integer *) a->data) + i;
 }
 
@@ -333,7 +333,7 @@ modelica_real* real_array_element_addr_c99_3(real_array* source,int ndims,...){
     return tmp;
 }
 
-modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...){
+modelica_integer* integer_array_element_addr_c99_1(integer_array* source,int ndims,...){
     va_list ap;
     modelica_integer* tmp;
 
@@ -344,7 +344,7 @@ modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int n
     return tmp;
 }
 
-modelica_integer* integer_array_element_addr_c99_2(integer_array_t* source,int ndims,...){
+modelica_integer* integer_array_element_addr_c99_2(integer_array* source,int ndims,...){
     va_list ap;
     modelica_integer* tmp;
 
@@ -355,7 +355,7 @@ modelica_integer* integer_array_element_addr_c99_2(integer_array_t* source,int n
     return tmp;
 }
 
-modelica_integer* integer_array_element_addr_c99_3(integer_array_t* source,int ndims,...){
+modelica_integer* integer_array_element_addr_c99_3(integer_array* source,int ndims,...){
     va_list ap;
     modelica_integer* tmp;
 

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.cpp
@@ -300,9 +300,9 @@ void swap_and_release(base_array_t* lhs, base_array_t* rhs){
 //which, right now, doesn't support overloading or the stdarg standard library.
 //even though the functions have the same body here they will have different body on the OpenCL counterparts
 
-m_real* real_array_element_addr_c99_1(real_array_t* source,int ndims,...){
+modelica_real* real_array_element_addr_c99_1(real_array_t* source,int ndims,...){
     va_list ap;
-    m_real* tmp;
+    modelica_real* tmp;
 
     va_start(ap,ndims);
     tmp = real_ptrget(source, ocl_calc_base_index_va(source, ndims, ap));
@@ -311,9 +311,9 @@ m_real* real_array_element_addr_c99_1(real_array_t* source,int ndims,...){
     return tmp;
 }
 
-m_real* real_array_element_addr_c99_2(real_array_t* source,int ndims,...){
+modelica_real* real_array_element_addr_c99_2(real_array_t* source,int ndims,...){
     va_list ap;
-    m_real* tmp;
+    modelica_real* tmp;
 
     va_start(ap,ndims);
     tmp = real_ptrget(source, ocl_calc_base_index_va(source, ndims, ap));
@@ -322,9 +322,9 @@ m_real* real_array_element_addr_c99_2(real_array_t* source,int ndims,...){
     return tmp;
 }
 
-m_real* real_array_element_addr_c99_3(real_array_t* source,int ndims,...){
+modelica_real* real_array_element_addr_c99_3(real_array_t* source,int ndims,...){
     va_list ap;
-    m_real* tmp;
+    modelica_real* tmp;
 
     va_start(ap,ndims);
     tmp = real_ptrget(source, ocl_calc_base_index_va(source, ndims, ap));

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.h
@@ -67,7 +67,7 @@
 
 // sets the number of threads for subsequent parallel operations
 // arguments are arrays of work_dim size specifying each workgroup dimension
-void ocl_set_num_threads(integer_array_t global_threads_in, integer_array_t local_threads_in);
+void ocl_set_num_threads(integer_array global_threads_in, integer_array local_threads_in);
 
 
 // sets the number of threads for subsequent parallel operations.
@@ -148,11 +148,11 @@ modelica_real* real_array_element_addr_c99_2(real_array* source,int ndims,...);
 
 modelica_real* real_array_element_addr_c99_3(real_array* source,int ndims,...);
 
-modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...);
+modelica_integer* integer_array_element_addr_c99_1(integer_array* source,int ndims,...);
 
-modelica_integer* integer_array_element_addr_c99_2(integer_array_t* source,int ndims,...);
+modelica_integer* integer_array_element_addr_c99_2(integer_array* source,int ndims,...);
 
-modelica_integer* integer_array_element_addr_c99_3(integer_array_t* source,int ndims,...);
+modelica_integer* integer_array_element_addr_c99_3(integer_array* source,int ndims,...);
 
 
 //array dimension size functions. returns the size of a given dimension for device real array

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_interface.h
@@ -142,11 +142,11 @@ void swap_and_release(base_array_t* lhs, base_array_t* rhs);
 //which right now doesn't support overloading or the stdarg standard library.
 //even though the functions have the same body here they will have different body on the OpenCL counterparts
 
-modelica_real* real_array_element_addr_c99_1(real_array_t* source,int ndims,...);
+modelica_real* real_array_element_addr_c99_1(real_array* source,int ndims,...);
 
-modelica_real* real_array_element_addr_c99_2(real_array_t* source,int ndims,...);
+modelica_real* real_array_element_addr_c99_2(real_array* source,int ndims,...);
 
-modelica_real* real_array_element_addr_c99_3(real_array_t* source,int ndims,...);
+modelica_real* real_array_element_addr_c99_3(real_array* source,int ndims,...);
 
 modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...);
 
@@ -172,7 +172,7 @@ void free_device_array(base_array_t* dest);
 void print_array_info(device_real_array* arr);
 
 //prints array. useful for debugging.
-void print_array(real_array_t* arr);
+void print_array(real_array* arr);
 
 //ATTENTION: printing a device array means copying back and then printing. Expensive Operation.
 //void print_array(device_real_array* dev_arr);

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.cpp
@@ -486,7 +486,7 @@ void ocl_execute_kernel(cl_kernel kernel){
 }
 
 
-void ocl_set_num_threads(integer_array_t global_threads_in, integer_array_t local_threads_in){
+void ocl_set_num_threads(integer_array global_threads_in, integer_array local_threads_in){
 
     WORK_DIM = global_threads_in.dim_size[0];
 

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.h
@@ -72,7 +72,7 @@ extern const char* omc_ocl_kernels_source;
 extern unsigned int default_ocl_device;
 
 
-extern modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...);
+extern modelica_integer* integer_array_element_addr_c99_1(integer_array* source,int ndims,...);
 
 
 //Reads kernels from a file
@@ -110,7 +110,7 @@ void ocl_execute_kernel(cl_kernel kernel);
 
 // sets the number of threads for subsequent parallel operations
 // arguments are arrays of work_dim size specifiying each workgroup dimension
-void ocl_set_num_threads(integer_array_t global_threads_in, integer_array_t local_threads_in);
+void ocl_set_num_threads(integer_array global_threads_in, integer_array local_threads_in);
 
 // sets the number of threads for subsequent parallel operations.
 // similar to the above function with arrays of size 1 only.

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.h
@@ -72,7 +72,7 @@ extern const char* omc_ocl_kernels_source;
 extern unsigned int default_ocl_device;
 
 
-extern m_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...);
+extern modelica_integer* integer_array_element_addr_c99_1(integer_array_t* source,int ndims,...);
 
 
 //Reads kernels from a file

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -255,9 +255,9 @@ omc_alloc_interface_t omc_alloc_interface = {
 };
 
 /* allocates n reals in the real_buffer */
-m_real* real_alloc(int n)
+modelica_real* real_alloc(int n)
 {
-  return (m_real*) omc_alloc_interface.malloc_atomic(n*sizeof(m_real));
+  return (modelica_real*) omc_alloc_interface.malloc_atomic(n*sizeof(modelica_real));
 }
 
 /* allocates n integers in the integer_buffer */

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -273,9 +273,9 @@ m_string* string_alloc(int n)
 }
 
 /* allocates n booleans in the boolean_buffer */
-m_boolean* boolean_alloc(int n)
+modelica_boolean* boolean_alloc(int n)
 {
-  return (m_boolean*) omc_alloc_interface.malloc_atomic(n*sizeof(m_boolean));
+  return (modelica_boolean*) omc_alloc_interface.malloc_atomic(n*sizeof(modelica_boolean));
 }
 
 _index_t* size_alloc(int n)

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -267,9 +267,9 @@ modelica_integer* integer_alloc(int n)
 }
 
 /* allocates n strings in the string_buffer */
-m_string* string_alloc(int n)
+modelica_string* string_alloc(int n)
 {
-  return (m_string*) omc_alloc_interface.malloc(n*sizeof(m_string));
+  return (modelica_string*) omc_alloc_interface.malloc(n*sizeof(modelica_string));
 }
 
 /* allocates n booleans in the boolean_buffer */

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -261,9 +261,9 @@ m_real* real_alloc(int n)
 }
 
 /* allocates n integers in the integer_buffer */
-m_integer* integer_alloc(int n)
+modelica_integer* integer_alloc(int n)
 {
-  return (m_integer*) omc_alloc_interface.malloc_atomic(n*sizeof(m_integer));
+  return (modelica_integer*) omc_alloc_interface.malloc_atomic(n*sizeof(modelica_integer));
 }
 
 /* allocates n strings in the string_buffer */

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
@@ -41,7 +41,7 @@ extern "C" {
 /* Allocation functions */
 extern modelica_real* real_alloc(int n);
 extern modelica_integer* integer_alloc(int n);
-extern m_string* string_alloc(int n);
+extern modelica_string* string_alloc(int n);
 extern modelica_boolean* boolean_alloc(int n);
 extern _index_t* size_alloc(int n);
 extern _index_t** index_alloc(int n);

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
@@ -39,7 +39,7 @@ extern "C" {
 #endif
 
 /* Allocation functions */
-extern m_real* real_alloc(int n);
+extern modelica_real* real_alloc(int n);
 extern modelica_integer* integer_alloc(int n);
 extern m_string* string_alloc(int n);
 extern m_boolean* boolean_alloc(int n);

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
@@ -40,7 +40,7 @@ extern "C" {
 
 /* Allocation functions */
 extern m_real* real_alloc(int n);
-extern m_integer* integer_alloc(int n);
+extern modelica_integer* integer_alloc(int n);
 extern m_string* string_alloc(int n);
 extern m_boolean* boolean_alloc(int n);
 extern _index_t* size_alloc(int n);

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
@@ -42,7 +42,7 @@ extern "C" {
 extern modelica_real* real_alloc(int n);
 extern modelica_integer* integer_alloc(int n);
 extern m_string* string_alloc(int n);
-extern m_boolean* boolean_alloc(int n);
+extern modelica_boolean* boolean_alloc(int n);
 extern _index_t* size_alloc(int n);
 extern _index_t** index_alloc(int n);
 

--- a/OMCompiler/SimulationRuntime/c/openmodelica.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica.h
@@ -131,7 +131,7 @@ struct type_desc_s {
     modelica_integer integer;
     integer_array int_array;
     modelica_boolean boolean;
-    boolean_array_t bool_array;
+    boolean_array bool_array;
     modelica_string string;
     string_array_t string_array;
     struct _tuple {

--- a/OMCompiler/SimulationRuntime/c/openmodelica.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica.h
@@ -129,7 +129,7 @@ struct type_desc_s {
     modelica_real real;
     real_array r_array;
     modelica_integer integer;
-    integer_array_t int_array;
+    integer_array int_array;
     modelica_boolean boolean;
     boolean_array_t bool_array;
     modelica_string string;

--- a/OMCompiler/SimulationRuntime/c/openmodelica.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica.h
@@ -127,7 +127,7 @@ struct type_desc_s {
   int retval : 1;
   union _data {
     modelica_real real;
-    real_array_t real_array;
+    real_array r_array;
     modelica_integer integer;
     integer_array_t int_array;
     modelica_boolean boolean;

--- a/OMCompiler/SimulationRuntime/c/openmodelica.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica.h
@@ -133,7 +133,7 @@ struct type_desc_s {
     modelica_boolean boolean;
     boolean_array bool_array;
     modelica_string string;
-    string_array_t string_array;
+    string_array string_array;
     struct _tuple {
       size_t elements;
       struct type_desc_s *element;

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -111,7 +111,6 @@ typedef int mmc_sint_t;
 #define OMC_INT_FORMAT "%*ld"
 #endif
 
-typedef double            m_real;
 typedef modelica_metatype m_string;
 typedef signed char       m_boolean;
 typedef mmc_sint_t         _index_t;

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -154,9 +154,8 @@ typedef base_array_t string_array_t;
 
 typedef base_array_t boolean_array_t;
 typedef base_array_t real_array;
-typedef base_array_t integer_array_t;
+typedef base_array_t integer_array;
 
-typedef integer_array_t integer_array;
 typedef boolean_array_t boolean_array;
 typedef string_array_t string_array;
 

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -152,11 +152,10 @@ typedef base_array_t string_array_t;
 #define TRUE 1
 #endif
 
-typedef base_array_t boolean_array_t;
+typedef base_array_t boolean_array;
 typedef base_array_t real_array;
 typedef base_array_t integer_array;
 
-typedef boolean_array_t boolean_array;
 typedef string_array_t string_array;
 
 #include "gc/omc_gc.h" /* for threadData_t */

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -112,10 +112,9 @@ typedef int mmc_sint_t;
 #endif
 
 typedef double            m_real;
-typedef mmc_sint_t        m_integer;
 typedef modelica_metatype m_string;
 typedef signed char       m_boolean;
-typedef m_integer         _index_t;
+typedef mmc_sint_t         _index_t;
 
 /* This structure holds indexes when subscripting an array.
  * ndims - number of subscripts, E.g. A[1,{2,3},:] => ndims = 3
@@ -160,7 +159,7 @@ typedef base_array_t boolean_array_t;
 typedef double modelica_real;
 typedef base_array_t real_array_t;
 
-typedef m_integer modelica_integer;
+typedef mmc_sint_t modelica_integer;
 typedef base_array_t integer_array_t;
 
 typedef real_array_t real_array;

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -108,9 +108,11 @@ typedef int mmc_sint_t;
 #define OMC_INT_FORMAT "%*ld"
 #endif
 
+typedef double modelica_real;
+typedef mmc_sint_t modelica_integer;
+typedef signed char modelica_boolean;
 /* When MetaModelica grammar is enabled, all strings are boxed */
 typedef modelica_metatype modelica_string;
-typedef signed char modelica_boolean;
 typedef mmc_sint_t         _index_t;
 
 /* This structure holds indexes when subscripting an array.
@@ -151,14 +153,9 @@ typedef base_array_t string_array_t;
 #endif
 
 typedef base_array_t boolean_array_t;
-
-typedef double modelica_real;
-typedef base_array_t real_array_t;
-
-typedef mmc_sint_t modelica_integer;
+typedef base_array_t real_array;
 typedef base_array_t integer_array_t;
 
-typedef real_array_t real_array;
 typedef integer_array_t integer_array;
 typedef boolean_array_t boolean_array;
 typedef string_array_t string_array;

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -142,7 +142,6 @@ struct base_array_s
 
 typedef struct base_array_s base_array_t;
 
-typedef base_array_t string_array_t;
 
 #ifndef FALSE
 #define FALSE 0
@@ -155,8 +154,7 @@ typedef base_array_t string_array_t;
 typedef base_array_t boolean_array;
 typedef base_array_t real_array;
 typedef base_array_t integer_array;
-
-typedef string_array_t string_array;
+typedef base_array_t string_array;
 
 #include "gc/omc_gc.h" /* for threadData_t */
 

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -39,20 +39,6 @@
 extern "C" {
 #endif
 
-typedef int integer;
-typedef unsigned int uinteger;
-typedef double doublereal;
-#define maxmacro(X,Y) X > Y ? X : Y
-#define minmacro(X,Y) X > Y ? Y : X
-
-typedef void* modelica_complex; /* currently only External objects are represented using modelica_complex.*/
-typedef void* modelica_metatype; /* MetaModelica extension, added by sjoelund */
-/* MetaModelica extension.
-We actually store function-pointers in lists, etc...
-So it needs to be void*. If we use a platform with different sizes of function-
-pointers, some changes need to be done to code generation */
-typedef void* modelica_fnptr;
-
 #if defined(_LP64) /* linux 64bit*/
 
 #define MMC_SIZE_DBL 8
@@ -108,12 +94,44 @@ typedef int mmc_sint_t;
 #define OMC_INT_FORMAT "%*ld"
 #endif
 
+typedef void* modelica_complex; /* currently only External objects are represented using modelica_complex.*/
+typedef void* modelica_metatype; /* MetaModelica extension, added by sjoelund */
+/* MetaModelica extension.
+We actually store function-pointers in lists, etc...
+So it needs to be void*. If we use a platform with different sizes of function-
+pointers, some changes need to be done to code generation */
+typedef void* modelica_fnptr;
+
 typedef double modelica_real;
 typedef mmc_sint_t modelica_integer;
 typedef signed char modelica_boolean;
 /* When MetaModelica grammar is enabled, all strings are boxed */
 typedef modelica_metatype modelica_string;
 typedef mmc_sint_t         _index_t;
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+
+struct base_array_s
+{
+  int ndims;
+  _index_t *dim_size;
+  void *data;
+  modelica_boolean flexible;
+};
+typedef struct base_array_s base_array_t;
+
+typedef base_array_t boolean_array;
+typedef base_array_t real_array;
+typedef base_array_t integer_array;
+typedef base_array_t string_array;
+
 
 /* This structure holds indexes when subscripting an array.
  * ndims - number of subscripts, E.g. A[1,{2,3},:] => ndims = 3
@@ -132,29 +150,13 @@ struct index_spec_s
 };
 typedef struct index_spec_s index_spec_t;
 
-struct base_array_s
-{
-  int ndims;
-  _index_t *dim_size;
-  void *data;
-  modelica_boolean flexible;
-};
-
-typedef struct base_array_s base_array_t;
 
 
-#ifndef FALSE
-#define FALSE 0
-#endif
 
-#ifndef TRUE
-#define TRUE 1
-#endif
-
-typedef base_array_t boolean_array;
-typedef base_array_t real_array;
-typedef base_array_t integer_array;
-typedef base_array_t string_array;
+// This typedfes should be removed and their uses replaced by the corresponding data types.
+typedef int integer;
+typedef unsigned int uinteger;
+typedef double doublereal;
 
 #include "gc/omc_gc.h" /* for threadData_t */
 

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -53,9 +53,6 @@ So it needs to be void*. If we use a platform with different sizes of function-
 pointers, some changes need to be done to code generation */
 typedef void* modelica_fnptr;
 
-/* When MetaModelica grammar is enabled, all strings are boxed */
-typedef modelica_metatype modelica_string;
-
 #if defined(_LP64) /* linux 64bit*/
 
 #define MMC_SIZE_DBL 8
@@ -111,7 +108,8 @@ typedef int mmc_sint_t;
 #define OMC_INT_FORMAT "%*ld"
 #endif
 
-typedef modelica_metatype m_string;
+/* When MetaModelica grammar is enabled, all strings are boxed */
+typedef modelica_metatype modelica_string;
 typedef signed char modelica_boolean;
 typedef mmc_sint_t         _index_t;
 

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -112,7 +112,7 @@ typedef int mmc_sint_t;
 #endif
 
 typedef modelica_metatype m_string;
-typedef signed char       m_boolean;
+typedef signed char modelica_boolean;
 typedef mmc_sint_t         _index_t;
 
 /* This structure holds indexes when subscripting an array.
@@ -137,14 +137,13 @@ struct base_array_s
   int ndims;
   _index_t *dim_size;
   void *data;
-  m_boolean flexible;
+  modelica_boolean flexible;
 };
 
 typedef struct base_array_s base_array_t;
 
 typedef base_array_t string_array_t;
 
-typedef signed char modelica_boolean;
 #ifndef FALSE
 #define FALSE 0
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/base_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/base_array.c
@@ -437,7 +437,7 @@ void clone_reverse_base_array_spec(const base_array_t* source, base_array_t* des
     }
 }
 
-void index_alloc_base_array_size(const real_array_t * source,
+void index_alloc_base_array_size(const real_array * source,
                                  const index_spec_t* source_spec,
                                  base_array_t* dest)
 {

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.c
@@ -41,38 +41,38 @@
 #include <stdarg.h>
 
 
-modelica_boolean boolean_get(const boolean_array_t a, size_t i)
+modelica_boolean boolean_get(const boolean_array a, size_t i)
 {
     return ((modelica_boolean *) a.data)[i];
 }
 
-modelica_boolean boolean_get_2D(const boolean_array_t a, size_t i, size_t j)
+modelica_boolean boolean_get_2D(const boolean_array a, size_t i, size_t j)
 {
     return boolean_get(a, getIndex_2D(a.dim_size,i,j));
 }
 
-modelica_boolean boolean_get_3D(const boolean_array_t a, size_t i, size_t j, size_t k)
+modelica_boolean boolean_get_3D(const boolean_array a, size_t i, size_t j, size_t k)
 {
     return boolean_get(a, getIndex_3D(a.dim_size,i,j,k));
 }
 
-modelica_boolean boolean_get_4D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l)
+modelica_boolean boolean_get_4D(const boolean_array a, size_t i, size_t j, size_t k, size_t l)
 {
     return boolean_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
-modelica_boolean boolean_get_5D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+modelica_boolean boolean_get_5D(const boolean_array a, size_t i, size_t j, size_t k, size_t l, size_t m)
 {
     return boolean_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
 }
 
 
-static inline modelica_boolean *boolean_ptrget(const boolean_array_t *a, size_t i)
+static inline modelica_boolean *boolean_ptrget(const boolean_array *a, size_t i)
 {
     return ((modelica_boolean *) a->data) + i;
 }
 
-static inline void boolean_set(boolean_array_t *a, size_t i, modelica_boolean r)
+static inline void boolean_set(boolean_array *a, size_t i, modelica_boolean r)
 {
     ((modelica_boolean *) a->data)[i] = r;
 }
@@ -82,7 +82,7 @@ static inline void boolean_set(boolean_array_t *a, size_t i, modelica_boolean r)
  ** sets all fields in a boolean_array, i.e. data, ndims and dim_size.
  **/
 
-void boolean_array_create(boolean_array_t *dest, modelica_boolean *data,
+void boolean_array_create(boolean_array *dest, modelica_boolean *data,
                           int ndims, ...)
 {
     va_list ap;
@@ -91,17 +91,17 @@ void boolean_array_create(boolean_array_t *dest, modelica_boolean *data,
     va_end(ap);
 }
 
-void simple_alloc_1d_boolean_array(boolean_array_t* dest, int n)
+void simple_alloc_1d_boolean_array(boolean_array* dest, int n)
 {
     simple_alloc_1d_base_array(dest, n, boolean_alloc(n));
 }
 
-void simple_alloc_2d_boolean_array(boolean_array_t* dest, int r, int c)
+void simple_alloc_2d_boolean_array(boolean_array* dest, int r, int c)
 {
     simple_alloc_2d_base_array(dest, r, c, boolean_alloc(r * c));
 }
 
-void alloc_boolean_array(boolean_array_t *dest, int ndims, ...)
+void alloc_boolean_array(boolean_array *dest, int ndims, ...)
 {
     size_t elements = 0;
     va_list ap;
@@ -111,12 +111,12 @@ void alloc_boolean_array(boolean_array_t *dest, int ndims, ...)
     dest->data = boolean_alloc(elements);
 }
 
-void alloc_boolean_array_data(boolean_array_t* a)
+void alloc_boolean_array_data(boolean_array* a)
 {
     a->data = boolean_alloc(base_array_nr_of_elements(*a));
 }
 
-void and_boolean_array(const boolean_array_t *source1, const boolean_array_t *source2, boolean_array_t *dest)
+void and_boolean_array(const boolean_array *source1, const boolean_array *source2, boolean_array *dest)
 {
     size_t i, nr_of_elements;
 
@@ -137,7 +137,7 @@ void and_boolean_array(const boolean_array_t *source1, const boolean_array_t *so
     }
 }
 
-void or_boolean_array(const boolean_array_t *source1, const boolean_array_t *source2, boolean_array_t *dest)
+void or_boolean_array(const boolean_array *source1, const boolean_array *source2, boolean_array *dest)
 {
     size_t i, nr_of_elements;
 
@@ -158,7 +158,7 @@ void or_boolean_array(const boolean_array_t *source1, const boolean_array_t *sou
     }
 }
 
-void not_boolean_array(const boolean_array_t source, boolean_array_t *dest)
+void not_boolean_array(const boolean_array source, boolean_array *dest)
 {
     size_t i, nr_of_elements;
 
@@ -175,7 +175,7 @@ void not_boolean_array(const boolean_array_t source, boolean_array_t *dest)
     }
 }
 
-void copy_boolean_array_data_mem(const boolean_array_t source, modelica_boolean *dest)
+void copy_boolean_array_data_mem(const boolean_array source, modelica_boolean *dest)
 {
     size_t i, nr_of_elements;
 
@@ -188,7 +188,7 @@ void copy_boolean_array_data_mem(const boolean_array_t source, modelica_boolean 
     }
 }
 
-void copy_boolean_array(const boolean_array_t source, boolean_array_t *dest)
+void copy_boolean_array(const boolean_array source, boolean_array *dest)
 {
     boolean_array_alloc_copy(source,*dest);
 }
@@ -198,7 +198,7 @@ void copy_boolean_array(const boolean_array_t source, boolean_array_t *dest)
 */
 
 static inline modelica_boolean *calc_boolean_index_spec(int ndims, const _index_t* idx_vec,
-                                                        const boolean_array_t *arr,
+                                                        const boolean_array *arr,
                                                         const index_spec_t *spec)
 {
     return boolean_ptrget(arr, calc_base_index_spec(ndims, idx_vec, arr, spec));
@@ -206,19 +206,19 @@ static inline modelica_boolean *calc_boolean_index_spec(int ndims, const _index_
 
 /* Uses zero based indexing */
 modelica_boolean *calc_boolean_index(int ndims, const _index_t *idx_vec,
-                                     const boolean_array_t *arr)
+                                     const boolean_array *arr)
 {
     return boolean_ptrget(arr, calc_base_index(ndims, idx_vec, arr));
 }
 
 /* One based index*/
-modelica_boolean *calc_boolean_index_va(const boolean_array_t *source, int ndims,
+modelica_boolean *calc_boolean_index_va(const boolean_array *source, int ndims,
                                         va_list ap)
 {
     return boolean_ptrget(source, calc_base_index_va(source, ndims, ap));
 }
 
-void print_boolean_matrix(const boolean_array_t *source)
+void print_boolean_matrix(const boolean_array *source)
 {
     _index_t i,j;
     modelica_boolean value;
@@ -237,7 +237,7 @@ void print_boolean_matrix(const boolean_array_t *source)
     }
 }
 
-void print_boolean_array(const boolean_array_t *source)
+void print_boolean_array(const boolean_array *source)
 {
     _index_t i,j;
     modelica_boolean *data;
@@ -279,7 +279,7 @@ char print_boolean(modelica_boolean value)
     return value ? 'T' : 'F';
 }
 
-void put_boolean_element(modelica_boolean value, int i1, boolean_array_t *dest)
+void put_boolean_element(modelica_boolean value, int i1, boolean_array *dest)
 {
     /* Assert that dest has correct dimension */
     /* Assert that i1 is a valid index */
@@ -287,7 +287,7 @@ void put_boolean_element(modelica_boolean value, int i1, boolean_array_t *dest)
 }
 
 void put_boolean_matrix_element(modelica_boolean value, int r, int c,
-                                boolean_array_t* dest)
+                                boolean_array* dest)
 {
     /* Assert that dest hast correct dimension */
     /* Assert that r and c are valid indices */
@@ -296,18 +296,18 @@ void put_boolean_matrix_element(modelica_boolean value, int r, int c,
 }
 
 /* Zero based index */
-void simple_indexed_assign_boolean_array1(const boolean_array_t* source,
+void simple_indexed_assign_boolean_array1(const boolean_array* source,
                                           int i1,
-                                          boolean_array_t* dest)
+                                          boolean_array* dest)
 {
     /* Assert that source has the correct dimension */
     /* Assert that dest has the correct dimension */
     boolean_set(dest, i1, boolean_get(*source, i1));
 }
 
-void simple_indexed_assign_boolean_array2(const boolean_array_t* source,
+void simple_indexed_assign_boolean_array2(const boolean_array* source,
                                           int i1, int i2,
-                                          boolean_array_t* dest)
+                                          boolean_array* dest)
 {
     size_t index;
     /* Assert that source has correct dimension */
@@ -316,7 +316,7 @@ void simple_indexed_assign_boolean_array2(const boolean_array_t* source,
     boolean_set(dest, index, boolean_get(*source, index));
 }
 
-void indexed_assign_boolean_array(const boolean_array_t source, boolean_array_t* dest,
+void indexed_assign_boolean_array(const boolean_array source, boolean_array* dest,
                                   const index_spec_t* dest_spec)
 {
     _index_t *idx_vec1, *idx_size;
@@ -346,9 +346,9 @@ void indexed_assign_boolean_array(const boolean_array_t source, boolean_array_t*
  *
  */
 
-void index_boolean_array(const boolean_array_t* source,
+void index_boolean_array(const boolean_array* source,
                          const index_spec_t* source_spec,
-                         boolean_array_t* dest)
+                         boolean_array* dest)
 {
     _index_t* idx_vec1;
     _index_t* idx_vec2;
@@ -413,9 +413,9 @@ void index_boolean_array(const boolean_array_t* source,
  * a := b[1:3];
  */
 
-void index_alloc_boolean_array(const boolean_array_t* source,
+void index_alloc_boolean_array(const boolean_array* source,
                                const index_spec_t* source_spec,
-                               boolean_array_t* dest)
+                               boolean_array* dest)
 {
     index_alloc_base_array_size(source, source_spec, dest);
     alloc_boolean_array_data(dest);
@@ -423,8 +423,8 @@ void index_alloc_boolean_array(const boolean_array_t* source,
 }
 
 /* Returns dest := source[i1,:,:...]*/
-void simple_index_alloc_boolean_array1(const boolean_array_t* source, int i1,
-                                       boolean_array_t* dest)
+void simple_index_alloc_boolean_array1(const boolean_array* source, int i1,
+                                       boolean_array* dest)
 {
     int i;
     assert(base_array_ok(source));
@@ -440,8 +440,8 @@ void simple_index_alloc_boolean_array1(const boolean_array_t* source, int i1,
     simple_index_boolean_array1(source, i1, dest);
 }
 
-void simple_index_boolean_array1(const boolean_array_t* source, int i1,
-                                 boolean_array_t* dest)
+void simple_index_boolean_array1(const boolean_array* source, int i1,
+                                 boolean_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -454,9 +454,9 @@ void simple_index_boolean_array1(const boolean_array_t* source, int i1,
     }
 }
 
-void simple_index_boolean_array2(const boolean_array_t* source,
+void simple_index_boolean_array2(const boolean_array* source,
                                  int i1, int i2,
-                                 boolean_array_t* dest)
+                                 boolean_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -467,18 +467,18 @@ void simple_index_boolean_array2(const boolean_array_t* source,
     }
 }
 
-void array_boolean_array(boolean_array_t* dest,int n,boolean_array_t first,...)
+void array_boolean_array(boolean_array* dest,int n,boolean_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    boolean_array_t *elts=(boolean_array_t*)malloc(sizeof(boolean_array_t) * n);
+    boolean_array *elts=(boolean_array*)malloc(sizeof(boolean_array) * n);
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, boolean_array_t);
+        elts[i] = va_arg(ap, boolean_array);
     }
     va_end(ap);
 
@@ -494,19 +494,19 @@ void array_boolean_array(boolean_array_t* dest,int n,boolean_array_t first,...)
     free(elts);
 }
 
-void array_alloc_boolean_array(boolean_array_t* dest, int n,
-                               boolean_array_t first,...)
+void array_alloc_boolean_array(boolean_array* dest, int n,
+                               boolean_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    boolean_array_t *elts = (boolean_array_t*)malloc(sizeof(boolean_array_t) * n);
+    boolean_array *elts = (boolean_array*)malloc(sizeof(boolean_array) * n);
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, boolean_array_t);
+        elts[i] = va_arg(ap, boolean_array);
     }
     va_end(ap);
 
@@ -539,7 +539,7 @@ void array_alloc_boolean_array(boolean_array_t* dest, int n,
  * Creates(incl allocation) an array from scalar elements.
  */
 
-void array_alloc_scalar_boolean_array(boolean_array_t* dest, int n, ...)
+void array_alloc_scalar_boolean_array(boolean_array* dest, int n, ...)
 {
     int i;
     va_list ap;
@@ -557,14 +557,14 @@ void array_alloc_scalar_boolean_array(boolean_array_t* dest, int n, ...)
  * Concatenates n boolean arrays along the k:th dimension.
  * k is one based
  */
-void cat_boolean_array(int k, boolean_array_t* dest, int n,
-                    const boolean_array_t* first,...)
+void cat_boolean_array(int k, boolean_array* dest, int n,
+                    const boolean_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const boolean_array_t **elts = (const boolean_array_t**)malloc(sizeof(boolean_array_t *) * n);
+    const boolean_array **elts = (const boolean_array**)malloc(sizeof(boolean_array *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -572,7 +572,7 @@ void cat_boolean_array(int k, boolean_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const boolean_array_t*);
+        elts[i] = va_arg(ap,const boolean_array*);
     }
     va_end(ap);
 
@@ -619,14 +619,14 @@ void cat_boolean_array(int k, boolean_array_t* dest, int n,
  * allocates space in dest array
  * k is one based
  */
-void cat_alloc_boolean_array(int k, boolean_array_t* dest, int n,
-                          const boolean_array_t* first,...)
+void cat_alloc_boolean_array(int k, boolean_array* dest, int n,
+                          const boolean_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const boolean_array_t **elts = (const boolean_array_t**)malloc(sizeof(boolean_array_t *) * n);
+    const boolean_array **elts = (const boolean_array**)malloc(sizeof(boolean_array *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -634,7 +634,7 @@ void cat_alloc_boolean_array(int k, boolean_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const boolean_array_t*);
+        elts[i] = va_arg(ap,const boolean_array*);
     }
     va_end(ap);
 
@@ -687,8 +687,8 @@ void cat_alloc_boolean_array(int k, boolean_array_t* dest, int n,
  * Implementation of promote(A,n) same as promote_boolean_array except
  * that the destination array is allocated.
  */
-void promote_alloc_boolean_array(const boolean_array_t* a, int n,
-                                 boolean_array_t* dest)
+void promote_alloc_boolean_array(const boolean_array* a, int n,
+                                 boolean_array* dest)
 {
     clone_boolean_array_spec(a,dest);
     alloc_boolean_array_data(dest);
@@ -703,7 +703,7 @@ void promote_alloc_boolean_array(const boolean_array_t* a, int n,
  * promote_exp( {1,2},1) => {{1},{2}}
  * promote_exp( {1,2},2) => { {{1}},{{2}} }
 */
-void promote_boolean_array(const boolean_array_t* a, int n,boolean_array_t* dest)
+void promote_boolean_array(const boolean_array* a, int n,boolean_array* dest)
 {
     int i;
 
@@ -726,7 +726,7 @@ void promote_boolean_array(const boolean_array_t* a, int n,boolean_array_t* dest
  */
 
 void promote_scalar_boolean_array(modelica_boolean s,int n,
-                                  boolean_array_t* dest)
+                                  boolean_array* dest)
 {
     int i;
 
@@ -746,7 +746,7 @@ void promote_scalar_boolean_array(modelica_boolean s,int n,
     }
 }
 
-void size_boolean_array(const boolean_array_t* a, integer_array* dest)
+void size_boolean_array(const boolean_array* a, integer_array* dest)
 {
     /* This should be an integer array dest instead */
     int i;
@@ -759,7 +759,7 @@ void size_boolean_array(const boolean_array_t* a, integer_array* dest)
     }
 }
 
-modelica_boolean scalar_boolean_array(const boolean_array_t* a)
+modelica_boolean scalar_boolean_array(const boolean_array* a)
 {
     assert(base_array_ok(a));
     assert(base_array_one_element_ok(a));
@@ -767,7 +767,7 @@ modelica_boolean scalar_boolean_array(const boolean_array_t* a)
     return boolean_get(*a, 0);
 }
 
-void vector_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
+void vector_boolean_array(const boolean_array* a, boolean_array* dest)
 {
     size_t i, nr_of_elements;
 
@@ -779,13 +779,13 @@ void vector_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
     }
 }
 
-void vector_boolean_scalar(modelica_boolean a,boolean_array_t* dest)
+void vector_boolean_scalar(modelica_boolean a,boolean_array* dest)
 {
     /* Assert that dest is a 1-vector */
     boolean_set(dest, 0, a);
 }
 
-void matrix_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
+void matrix_boolean_array(const boolean_array* a, boolean_array* dest)
 {
     size_t i, cnt;
     /* Assert that size(A,i)=1 for 2 <i<=ndims(A)*/
@@ -799,7 +799,7 @@ void matrix_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
     }
 }
 
-void matrix_boolean_scalar(modelica_boolean a, boolean_array_t* dest)
+void matrix_boolean_scalar(modelica_boolean a, boolean_array* dest)
 {
     dest->ndims = 2;
     dest->dim_size[0] = 1;
@@ -813,7 +813,7 @@ void matrix_boolean_scalar(modelica_boolean a, boolean_array_t* dest)
  * except that destionation array is allocated.
  */
 
-void transpose_alloc_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
+void transpose_alloc_boolean_array(const boolean_array* a, boolean_array* dest)
 {
     clone_boolean_array_spec(a,dest); /* allocation*/
 
@@ -832,7 +832,7 @@ void transpose_alloc_boolean_array(const boolean_array_t* a, boolean_array_t* de
  *
  * Implementation of transpose(A) for matrix A.
  */
-void transpose_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
+void transpose_boolean_array(const boolean_array* a, boolean_array* dest)
 {
     size_t i;
     size_t j;
@@ -858,7 +858,7 @@ void transpose_boolean_array(const boolean_array_t* a, boolean_array_t* dest)
     }
 }
 
-void fill_boolean_array(boolean_array_t* dest,modelica_boolean s)
+void fill_boolean_array(boolean_array* dest,modelica_boolean s)
 {
     size_t nr_of_elements;
     size_t i;
@@ -869,8 +869,8 @@ void fill_boolean_array(boolean_array_t* dest,modelica_boolean s)
     }
 }
 
-void convert_alloc_boolean_array_to_f77(const boolean_array_t* a,
-                                        boolean_array_t* dest)
+void convert_alloc_boolean_array_to_f77(const boolean_array* a,
+                                        boolean_array* dest)
 {
     int i;
     clone_reverse_base_array_spec(a, dest);
@@ -881,8 +881,8 @@ void convert_alloc_boolean_array_to_f77(const boolean_array_t* a,
     }
 }
 
-void convert_alloc_boolean_array_from_f77(const boolean_array_t* a,
-                                          boolean_array_t* dest)
+void convert_alloc_boolean_array_from_f77(const boolean_array* a,
+                                          boolean_array* dest)
 {
     int i;
     clone_reverse_base_array_spec(a,dest);
@@ -896,7 +896,7 @@ void convert_alloc_boolean_array_from_f77(const boolean_array_t* a,
 }
 
 /* Fills an array with a value. */
-void fill_alloc_boolean_array(boolean_array_t* dest, modelica_boolean value, int ndims, ...)
+void fill_alloc_boolean_array(boolean_array* dest, modelica_boolean value, int ndims, ...)
 {
     size_t i;
     size_t elements = 0;
@@ -911,7 +911,7 @@ void fill_alloc_boolean_array(boolean_array_t* dest, modelica_boolean value, int
     }
 }
 
-modelica_boolean min_boolean_array(const boolean_array_t a)
+modelica_boolean min_boolean_array(const boolean_array a)
 {
   size_t nr_of_elements;
 
@@ -926,7 +926,7 @@ modelica_boolean min_boolean_array(const boolean_array_t a)
   return 1;
 }
 
-modelica_boolean max_boolean_array(const boolean_array_t a)
+modelica_boolean max_boolean_array(const boolean_array a)
 {
   size_t nr_of_elements;
 

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.c
@@ -274,19 +274,19 @@ void print_boolean_array(const boolean_array_t *source)
     }
 }
 
-char print_boolean(m_boolean value)
+char print_boolean(modelica_boolean value)
 {
     return value ? 'T' : 'F';
 }
 
-void put_boolean_element(m_boolean value, int i1, boolean_array_t *dest)
+void put_boolean_element(modelica_boolean value, int i1, boolean_array_t *dest)
 {
     /* Assert that dest has correct dimension */
     /* Assert that i1 is a valid index */
     boolean_set(dest, i1, value);
 }
 
-void put_boolean_matrix_element(m_boolean value, int r, int c,
+void put_boolean_matrix_element(modelica_boolean value, int r, int c,
                                 boolean_array_t* dest)
 {
     /* Assert that dest hast correct dimension */
@@ -546,7 +546,7 @@ void array_alloc_scalar_boolean_array(boolean_array_t* dest, int n, ...)
     simple_alloc_1d_boolean_array(dest,n);
     va_start(ap,n);
     for(i = 0; i < n; ++i) {
-        put_boolean_element((m_boolean) va_arg(ap, int),i,dest);
+        put_boolean_element((modelica_boolean) va_arg(ap, int),i,dest);
     }
     va_end(ap);
 }
@@ -759,7 +759,7 @@ void size_boolean_array(const boolean_array_t* a, integer_array_t* dest)
     }
 }
 
-m_boolean scalar_boolean_array(const boolean_array_t* a)
+modelica_boolean scalar_boolean_array(const boolean_array_t* a)
 {
     assert(base_array_ok(a));
     assert(base_array_one_element_ok(a));

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.c
@@ -746,7 +746,7 @@ void promote_scalar_boolean_array(modelica_boolean s,int n,
     }
 }
 
-void size_boolean_array(const boolean_array_t* a, integer_array_t* dest)
+void size_boolean_array(const boolean_array_t* a, integer_array* dest)
 {
     /* This should be an integer array dest instead */
     int i;

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.h
@@ -151,7 +151,7 @@ extern void promote_alloc_boolean_array(const boolean_array_t* a, int n,
 static inline int ndims_boolean_array(const boolean_array_t* a)
 { return ndims_base_array(a); }
 
-extern void size_boolean_array(const boolean_array_t* a, integer_array_t* dest);
+extern void size_boolean_array(const boolean_array_t* a, integer_array* dest);
 extern modelica_boolean scalar_boolean_array(const boolean_array_t* a);
 extern void vector_boolean_array(const boolean_array_t* a, boolean_array_t* dest);
 extern void vector_boolean_scalar(modelica_boolean a,boolean_array_t* dest);

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.h
@@ -38,142 +38,142 @@
 #include "omc_msvc.h"
 #include <stdarg.h>
 
-modelica_boolean boolean_get(const boolean_array_t a, size_t i);
-modelica_boolean boolean_get_2D(const boolean_array_t a, size_t i, size_t j);
-modelica_boolean boolean_get_3D(const boolean_array_t a, size_t i, size_t j, size_t k);
-modelica_boolean boolean_get_4D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l);
-modelica_boolean boolean_get_5D(const boolean_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
+modelica_boolean boolean_get(const boolean_array a, size_t i);
+modelica_boolean boolean_get_2D(const boolean_array a, size_t i, size_t j);
+modelica_boolean boolean_get_3D(const boolean_array a, size_t i, size_t j, size_t k);
+modelica_boolean boolean_get_4D(const boolean_array a, size_t i, size_t j, size_t k, size_t l);
+modelica_boolean boolean_get_5D(const boolean_array a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Setting the fields of a boolean_array */
-extern void boolean_array_create(boolean_array_t *dest, modelica_boolean *data, int ndims, ...);
+extern void boolean_array_create(boolean_array *dest, modelica_boolean *data, int ndims, ...);
 
 /* Allocation of a vector */
-extern void simple_alloc_1d_boolean_array(boolean_array_t* dest, int n);
+extern void simple_alloc_1d_boolean_array(boolean_array* dest, int n);
 
 /* Allocation of a matrix */
-extern void simple_alloc_2d_boolean_array(boolean_array_t *dest, int r, int c);
+extern void simple_alloc_2d_boolean_array(boolean_array *dest, int r, int c);
 
-extern void alloc_boolean_array(boolean_array_t *dest, int ndims, ...);
+extern void alloc_boolean_array(boolean_array *dest, int ndims, ...);
 
 /* Allocation of boolean data */
-extern void alloc_boolean_array_data(boolean_array_t* a);
+extern void alloc_boolean_array_data(boolean_array* a);
 
 /* Frees memory*/
-extern void free_boolean_array_data(boolean_array_t* a);
+extern void free_boolean_array_data(boolean_array* a);
 
 /* Clones data*/
-static inline void clone_boolean_array_spec(const boolean_array_t* src,
-                                            boolean_array_t* dst)
+static inline void clone_boolean_array_spec(const boolean_array* src,
+                                            boolean_array* dst)
 { clone_base_array_spec(src, dst); }
 
 /* Copy boolean data given memory ptr*/
-extern void copy_boolean_array_data_mem(const boolean_array_t source, modelica_boolean* dest);
+extern void copy_boolean_array_data_mem(const boolean_array source, modelica_boolean* dest);
 
 /* Copy boolean array*/
-extern void copy_boolean_array(const boolean_array_t source, boolean_array_t* dest);
+extern void copy_boolean_array(const boolean_array source, boolean_array* dest);
 
 /* 'and' two boolean arrays*/
-void and_boolean_array(const boolean_array_t *source1, const boolean_array_t *source2, boolean_array_t *dest);
+void and_boolean_array(const boolean_array *source1, const boolean_array *source2, boolean_array *dest);
 
 /* 'or' two boolean arrays*/
-void or_boolean_array(const boolean_array_t *source1, const boolean_array_t *source2, boolean_array_t *dest);
+void or_boolean_array(const boolean_array *source1, const boolean_array *source2, boolean_array *dest);
 
 /* 'not' a boolean array*/
-void not_boolean_array(const boolean_array_t source, boolean_array_t *dest);
+void not_boolean_array(const boolean_array source, boolean_array *dest);
 
-extern modelica_boolean* calc_boolean_index(int ndims, const _index_t* idx_vec, const boolean_array_t* arr);
-extern modelica_boolean* calc_boolean_index_va(const boolean_array_t* source,int ndims,va_list ap);
+extern modelica_boolean* calc_boolean_index(int ndims, const _index_t* idx_vec, const boolean_array* arr);
+extern modelica_boolean* calc_boolean_index_va(const boolean_array* source,int ndims,va_list ap);
 
-extern void put_boolean_element(modelica_boolean value,int i1,boolean_array_t* dest);
-extern void put_boolean_matrix_element(modelica_boolean value, int r, int c, boolean_array_t* dest);
+extern void put_boolean_element(modelica_boolean value,int i1,boolean_array* dest);
+extern void put_boolean_matrix_element(modelica_boolean value, int r, int c, boolean_array* dest);
 
-extern void print_boolean_matrix(const boolean_array_t* source);
-extern void print_boolean_array(const boolean_array_t* source);
+extern void print_boolean_matrix(const boolean_array* source);
+extern void print_boolean_array(const boolean_array* source);
 extern char print_boolean(modelica_boolean value);
 /*
 
  a[1:3] := b;
 
 */
-extern void indexed_assign_boolean_array(const boolean_array_t source,
-                                  boolean_array_t* dest,
+extern void indexed_assign_boolean_array(const boolean_array source,
+                                  boolean_array* dest,
                                   const index_spec_t* dest_spec);
-extern void simple_indexed_assign_boolean_array1(const boolean_array_t* source,
+extern void simple_indexed_assign_boolean_array1(const boolean_array* source,
                                           int i1,
-                                          boolean_array_t* dest);
-extern void simple_indexed_assign_boolean_array2(const boolean_array_t* source,
+                                          boolean_array* dest);
+extern void simple_indexed_assign_boolean_array2(const boolean_array* source,
                                           int i1, int i2,
-                                          boolean_array_t* dest);
+                                          boolean_array* dest);
 
 /*
 
  a := b[1:3];
 
 */
-extern void index_boolean_array(const boolean_array_t* source,
+extern void index_boolean_array(const boolean_array* source,
                          const index_spec_t* source_spec,
-                         boolean_array_t* dest);
-extern void index_alloc_boolean_array(const boolean_array_t* source,
+                         boolean_array* dest);
+extern void index_alloc_boolean_array(const boolean_array* source,
                                const index_spec_t* source_spec,
-                               boolean_array_t* dest);
+                               boolean_array* dest);
 
-extern void simple_index_alloc_boolean_array1(const boolean_array_t* source, int i1,
-                                       boolean_array_t* dest);
+extern void simple_index_alloc_boolean_array1(const boolean_array* source, int i1,
+                                       boolean_array* dest);
 
-extern void simple_index_boolean_array1(const boolean_array_t* source,
+extern void simple_index_boolean_array1(const boolean_array* source,
                                  int i1,
-                                 boolean_array_t* dest);
-extern void simple_index_boolean_array2(const boolean_array_t* source,
+                                 boolean_array* dest);
+extern void simple_index_boolean_array2(const boolean_array* source,
                                  int i1, int i2,
-                                 boolean_array_t* dest);
+                                 boolean_array* dest);
 
 /* array(A,B,C) for arrays A,B,C */
-extern void array_boolean_array(boolean_array_t* dest,int n,
-                         boolean_array_t first,...);
-extern void array_alloc_boolean_array(boolean_array_t* dest,int n,
-                               boolean_array_t first,...);
+extern void array_boolean_array(boolean_array* dest,int n,
+                         boolean_array first,...);
+extern void array_alloc_boolean_array(boolean_array* dest,int n,
+                               boolean_array first,...);
 
 /* array(s1,s2,s3)  for scalars s1,s2,s3 */
-extern void array_scalar_boolean_array(boolean_array_t* dest,int n,...);
-extern void array_alloc_scalar_boolean_array(boolean_array_t* dest,int n,...);
+extern void array_scalar_boolean_array(boolean_array* dest,int n,...);
+extern void array_alloc_scalar_boolean_array(boolean_array* dest,int n,...);
 
-extern void cat_boolean_array(int k,boolean_array_t* dest, int n,
-                       const boolean_array_t* first,...);
-extern void cat_alloc_boolean_array(int k,boolean_array_t* dest, int n,
-                             const boolean_array_t* first,...);
+extern void cat_boolean_array(int k,boolean_array* dest, int n,
+                       const boolean_array* first,...);
+extern void cat_alloc_boolean_array(int k,boolean_array* dest, int n,
+                             const boolean_array* first,...);
 
-extern void promote_boolean_array(const boolean_array_t* a, int n,boolean_array_t* dest);
+extern void promote_boolean_array(const boolean_array* a, int n,boolean_array* dest);
 extern void promote_scalar_boolean_array(modelica_boolean s,int n,
-                                  boolean_array_t* dest);
-extern void promote_alloc_boolean_array(const boolean_array_t* a, int n,
-                                 boolean_array_t* dest);
+                                  boolean_array* dest);
+extern void promote_alloc_boolean_array(const boolean_array* a, int n,
+                                 boolean_array* dest);
 
-static inline int ndims_boolean_array(const boolean_array_t* a)
+static inline int ndims_boolean_array(const boolean_array* a)
 { return ndims_base_array(a); }
 
-extern void size_boolean_array(const boolean_array_t* a, integer_array* dest);
-extern modelica_boolean scalar_boolean_array(const boolean_array_t* a);
-extern void vector_boolean_array(const boolean_array_t* a, boolean_array_t* dest);
-extern void vector_boolean_scalar(modelica_boolean a,boolean_array_t* dest);
-extern void matrix_boolean_array(const boolean_array_t* a, boolean_array_t* dest);
-extern void matrix_boolean_scalar(modelica_boolean a,boolean_array_t* dest);
-extern void transpose_alloc_boolean_array(const boolean_array_t* a, boolean_array_t* dest);
-extern void transpose_boolean_array(const boolean_array_t* a, boolean_array_t* dest);
+extern void size_boolean_array(const boolean_array* a, integer_array* dest);
+extern modelica_boolean scalar_boolean_array(const boolean_array* a);
+extern void vector_boolean_array(const boolean_array* a, boolean_array* dest);
+extern void vector_boolean_scalar(modelica_boolean a,boolean_array* dest);
+extern void matrix_boolean_array(const boolean_array* a, boolean_array* dest);
+extern void matrix_boolean_scalar(modelica_boolean a,boolean_array* dest);
+extern void transpose_alloc_boolean_array(const boolean_array* a, boolean_array* dest);
+extern void transpose_boolean_array(const boolean_array* a, boolean_array* dest);
 
-extern void fill_boolean_array(boolean_array_t* dest,modelica_boolean s);
+extern void fill_boolean_array(boolean_array* dest,modelica_boolean s);
 
-static inline void clone_reverse_boolean_array_spec(const boolean_array_t*source,
-                                                    boolean_array_t *dest)
+static inline void clone_reverse_boolean_array_spec(const boolean_array*source,
+                                                    boolean_array *dest)
 { clone_reverse_base_array_spec(source, dest); }
-extern void convert_alloc_boolean_array_to_f77(const boolean_array_t* a,
-                                        boolean_array_t* dest);
-extern void convert_alloc_boolean_array_from_f77(const boolean_array_t* a,
-                                          boolean_array_t* dest);
-extern void fill_alloc_boolean_array(boolean_array_t* dest, modelica_boolean value, int ndims, ...);
+extern void convert_alloc_boolean_array_to_f77(const boolean_array* a,
+                                        boolean_array* dest);
+extern void convert_alloc_boolean_array_from_f77(const boolean_array* a,
+                                          boolean_array* dest);
+extern void fill_alloc_boolean_array(boolean_array* dest, modelica_boolean value, int ndims, ...);
 
 /* Returns the smallest value in the given array, or true if the array is empty. */
-extern modelica_boolean min_boolean_array(const boolean_array_t a);
+extern modelica_boolean min_boolean_array(const boolean_array a);
 /* Returns the largest value in the given array, or false if the array is empty. */
-extern modelica_boolean max_boolean_array(const boolean_array_t a);
+extern modelica_boolean max_boolean_array(const boolean_array a);
 
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/boolean_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/boolean_array.h
@@ -84,12 +84,12 @@ void not_boolean_array(const boolean_array_t source, boolean_array_t *dest);
 extern modelica_boolean* calc_boolean_index(int ndims, const _index_t* idx_vec, const boolean_array_t* arr);
 extern modelica_boolean* calc_boolean_index_va(const boolean_array_t* source,int ndims,va_list ap);
 
-extern void put_boolean_element(m_boolean value,int i1,boolean_array_t* dest);
-extern void put_boolean_matrix_element(m_boolean value, int r, int c, boolean_array_t* dest);
+extern void put_boolean_element(modelica_boolean value,int i1,boolean_array_t* dest);
+extern void put_boolean_matrix_element(modelica_boolean value, int r, int c, boolean_array_t* dest);
 
 extern void print_boolean_matrix(const boolean_array_t* source);
 extern void print_boolean_array(const boolean_array_t* source);
-extern char print_boolean(m_boolean value);
+extern char print_boolean(modelica_boolean value);
 /*
 
  a[1:3] := b;
@@ -152,7 +152,7 @@ static inline int ndims_boolean_array(const boolean_array_t* a)
 { return ndims_base_array(a); }
 
 extern void size_boolean_array(const boolean_array_t* a, integer_array_t* dest);
-extern m_boolean scalar_boolean_array(const boolean_array_t* a);
+extern modelica_boolean scalar_boolean_array(const boolean_array_t* a);
 extern void vector_boolean_array(const boolean_array_t* a, boolean_array_t* dest);
 extern void vector_boolean_scalar(modelica_boolean a,boolean_array_t* dest);
 extern void matrix_boolean_array(const boolean_array_t* a, boolean_array_t* dest);

--- a/OMCompiler/SimulationRuntime/c/util/generic_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/generic_array.h
@@ -103,7 +103,7 @@ void generic_array_set(base_array_t* dst, void* val, copy_func cp_func, size_t s
 
 #define data_of_string_array(arr)                  (modelica_string*) ((arr).data)
 // This one needs some manual processing. It is implemented in string_array.c/h
-// const char** data_of_string_c89_array(const string_array_t *a);
+// const char** data_of_string_c89_array(const string_array *a);
 
 
 

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.c
@@ -43,37 +43,37 @@
 #include "omc_error.h"
 #include "../meta/meta_modelica.h"
 
-static OMC_INLINE modelica_integer *integer_ptrget(const integer_array_t *a, size_t i)
+static OMC_INLINE modelica_integer *integer_ptrget(const integer_array *a, size_t i)
 {
   return ((modelica_integer *) a->data) + i;
 }
 
-static OMC_INLINE void integer_set(integer_array_t *a, size_t i, modelica_integer r)
+static OMC_INLINE void integer_set(integer_array *a, size_t i, modelica_integer r)
 {
   ((modelica_integer *) a->data)[i] = r;
 }
 
-modelica_integer integer_get(const integer_array_t a, size_t i)
+modelica_integer integer_get(const integer_array a, size_t i)
 {
   return ((modelica_integer *) a.data)[i];
 }
 
-modelica_integer integer_get_2D(const integer_array_t a, size_t i, size_t j)
+modelica_integer integer_get_2D(const integer_array a, size_t i, size_t j)
 {
   return integer_get(a, getIndex_2D(a.dim_size,i,j));
 }
 
-modelica_integer integer_get_3D(const integer_array_t a, size_t i, size_t j, size_t k)
+modelica_integer integer_get_3D(const integer_array a, size_t i, size_t j, size_t k)
 {
   return integer_get(a, getIndex_3D(a.dim_size,i,j,k));
 }
 
-modelica_integer integer_get_4D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l)
+modelica_integer integer_get_4D(const integer_array a, size_t i, size_t j, size_t k, size_t l)
 {
   return integer_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
-modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+modelica_integer integer_get_5D(const integer_array a, size_t i, size_t j, size_t k, size_t l, size_t m)
 {
   return integer_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
 }
@@ -82,7 +82,7 @@ modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, siz
  **
  ** sets all fields in a integer_array, i.e. data, ndims and dim_size.
  **/
-void integer_array_create(integer_array_t *dest, modelica_integer *data,
+void integer_array_create(integer_array *dest, modelica_integer *data,
                           int ndims, ...)
 {
     va_list ap;
@@ -92,17 +92,17 @@ void integer_array_create(integer_array_t *dest, modelica_integer *data,
 }
 
 
-void simple_alloc_1d_integer_array(integer_array_t* dest, int n)
+void simple_alloc_1d_integer_array(integer_array* dest, int n)
 {
     simple_alloc_1d_base_array(dest, n, n ? integer_alloc(n) : NULL);
 }
 
-void simple_alloc_2d_integer_array(integer_array_t* dest, int r, int c)
+void simple_alloc_2d_integer_array(integer_array* dest, int r, int c)
 {
     simple_alloc_2d_base_array(dest, r, c, integer_alloc(r * c));
 }
 
-void alloc_integer_array(integer_array_t* dest,int ndims,...)
+void alloc_integer_array(integer_array* dest,int ndims,...)
 {
     size_t elements = 0;
     va_list ap;
@@ -112,12 +112,12 @@ void alloc_integer_array(integer_array_t* dest,int ndims,...)
     dest->data = integer_alloc(elements);
 }
 
-void alloc_integer_array_data(integer_array_t* a)
+void alloc_integer_array_data(integer_array* a)
 {
     a->data = integer_alloc(base_array_nr_of_elements(*a));
 }
 
-void copy_integer_array_data_mem(const integer_array_t source,
+void copy_integer_array_data_mem(const integer_array source,
                                  modelica_integer *dest)
 {
     size_t i, nr_of_elements;
@@ -131,7 +131,7 @@ void copy_integer_array_data_mem(const integer_array_t source,
     }
 }
 
-void copy_integer_array(const integer_array_t source, integer_array_t *dest)
+void copy_integer_array(const integer_array source, integer_array *dest)
 {
     integer_array_alloc_copy(source,*dest);
 }
@@ -148,7 +148,7 @@ static modelica_integer integer_ge(modelica_integer x, modelica_integer y)
 
 /* Creates an integer array from a range with a start, stop and step value.
  * Ex: 1:2:6 => {1,3,5} */
-void create_integer_array_from_range(integer_array_t *dest, modelica_integer start, modelica_integer step, modelica_integer stop)
+void create_integer_array_from_range(integer_array *dest, modelica_integer start, modelica_integer step, modelica_integer stop)
 {
     size_t elements;
     size_t i;
@@ -172,7 +172,7 @@ void create_integer_array_from_range(integer_array_t *dest, modelica_integer sta
  * e.g: Integer a[10], b[2][10]; a := 1:2:6; b[1] := 1:10;
  *
 */
-void fill_integer_array_from_range(integer_array_t *dest, modelica_integer start, modelica_integer step,
+void fill_integer_array_from_range(integer_array *dest, modelica_integer start, modelica_integer step,
                                    modelica_integer stop/*, size_t dim*/)
 {
     size_t elements;
@@ -195,7 +195,7 @@ void fill_integer_array_from_range(integer_array_t *dest, modelica_integer start
 */
 
 static inline modelica_integer* calc_integer_index_spec(int ndims, const _index_t* idx_vec,
-                                                        const integer_array_t * arr,
+                                                        const integer_array * arr,
                                                         const index_spec_t* spec)
 {
     return integer_ptrget(arr, calc_base_index_spec(ndims, idx_vec, arr, spec));
@@ -203,19 +203,19 @@ static inline modelica_integer* calc_integer_index_spec(int ndims, const _index_
 
 /* Uses zero based indexing */
 modelica_integer* calc_integer_index(int ndims, const _index_t* idx_vec,
-                                     const integer_array_t * arr)
+                                     const integer_array * arr)
 {
     return integer_ptrget(arr, calc_base_index(ndims, idx_vec, arr));
 }
 
 /* One based index*/
-modelica_integer* calc_integer_index_va(const integer_array_t * source,int ndims,
+modelica_integer* calc_integer_index_va(const integer_array * source,int ndims,
                                         va_list ap)
 {
     return integer_ptrget(source, calc_base_index_va(source, ndims, ap));
 }
 
-void print_integer_matrix(const integer_array_t * source)
+void print_integer_matrix(const integer_array * source)
 {
     _index_t i,j;
     modelica_integer value;
@@ -234,7 +234,7 @@ void print_integer_matrix(const integer_array_t * source)
     }
 }
 
-void print_integer_array(const integer_array_t * source)
+void print_integer_array(const integer_array * source)
 {
     _index_t i,j;
     modelica_integer *data;
@@ -271,7 +271,7 @@ void print_integer_array(const integer_array_t * source)
     }
 }
 
-void put_integer_element(modelica_integer value, int i1, integer_array_t* dest)
+void put_integer_element(modelica_integer value, int i1, integer_array* dest)
 {
     /* Assert that dest has correct dimension */
     /* Assert that i1 is a valid index */
@@ -279,7 +279,7 @@ void put_integer_element(modelica_integer value, int i1, integer_array_t* dest)
 }
 
 void put_integer_matrix_element(modelica_integer value, int r, int c,
-                                integer_array_t* dest)
+                                integer_array* dest)
 {
     /* Assert that dest hast correct dimension */
     /* Assert that r and c are valid indices */
@@ -288,18 +288,18 @@ void put_integer_matrix_element(modelica_integer value, int r, int c,
 }
 
 /* Zero based index */
-void simple_indexed_assign_integer_array1(const integer_array_t * source,
+void simple_indexed_assign_integer_array1(const integer_array * source,
                                           int i1,
-                                          integer_array_t* dest)
+                                          integer_array* dest)
 {
     /* Assert that source has the correct dimension */
     /* Assert that dest has the correct dimension */
     integer_set(dest, i1, integer_get(*source, i1));
 }
 
-void simple_indexed_assign_integer_array2(const integer_array_t * source,
+void simple_indexed_assign_integer_array2(const integer_array * source,
                                           int i1, int i2,
-                                          integer_array_t* dest)
+                                          integer_array* dest)
 {
     size_t index;
     /* Assert that source has correct dimension */
@@ -308,7 +308,7 @@ void simple_indexed_assign_integer_array2(const integer_array_t * source,
     integer_set(dest, index, integer_get(*source, index));
 }
 
-void indexed_assign_integer_array(const integer_array_t source, integer_array_t* dest,
+void indexed_assign_integer_array(const integer_array source, integer_array* dest,
                                   const index_spec_t* dest_spec)
 {
     _index_t *idx_vec1, *idx_size;
@@ -338,9 +338,9 @@ void indexed_assign_integer_array(const integer_array_t source, integer_array_t*
  *
 */
 
-void index_integer_array(const integer_array_t * source,
+void index_integer_array(const integer_array * source,
                          const index_spec_t* source_spec,
-                         integer_array_t* dest)
+                         integer_array* dest)
 {
     _index_t* idx_vec1;
     _index_t* idx_vec2;
@@ -405,9 +405,9 @@ void index_integer_array(const integer_array_t * source,
  * a := b[1:3];
  */
 
-void index_alloc_integer_array(const integer_array_t * source,
+void index_alloc_integer_array(const integer_array * source,
              const index_spec_t* source_spec,
-             integer_array_t* dest)
+             integer_array* dest)
 {
     index_alloc_base_array_size(source, source_spec, dest);
     alloc_integer_array_data(dest);
@@ -416,8 +416,8 @@ void index_alloc_integer_array(const integer_array_t * source,
 
 /* idx(a[i,j,k]) = i * a->dim_size[1] * a->dim_size[2] + j * a->dim_size[2] + k */
 /* Returns dest := source[i1,:,:...]*/
-void simple_index_alloc_integer_array1(const integer_array_t * source, int i1,
-                                       integer_array_t* dest)
+void simple_index_alloc_integer_array1(const integer_array * source, int i1,
+                                       integer_array* dest)
 {
     int i;
     omc_assert_macro(base_array_ok(source));
@@ -434,9 +434,9 @@ void simple_index_alloc_integer_array1(const integer_array_t * source, int i1,
 }
 
 /* Returns dest := source[i1,:,:...]*/
-void simple_index_integer_array1(const integer_array_t * source,
+void simple_index_integer_array1(const integer_array * source,
                                  int i1,
-                                 integer_array_t* dest)
+                                 integer_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -450,9 +450,9 @@ void simple_index_integer_array1(const integer_array_t * source,
 }
 
 /* Returns dest := source[i1,i2,:,:...]*/
-void simple_index_integer_array2(const integer_array_t * source,
+void simple_index_integer_array2(const integer_array * source,
                                  int i1, int i2,
-                                 integer_array_t* dest)
+                                 integer_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -463,18 +463,18 @@ void simple_index_integer_array2(const integer_array_t * source,
     }
 }
 
-void array_integer_array(integer_array_t* dest,int n,integer_array_t first,...)
+void array_integer_array(integer_array* dest,int n,integer_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    integer_array_t *elts=(integer_array_t*)malloc(sizeof(integer_array_t) * n);
+    integer_array *elts=(integer_array*)malloc(sizeof(integer_array) * n);
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, integer_array_t);
+        elts[i] = va_arg(ap, integer_array);
     }
     va_end(ap);
 
@@ -490,19 +490,19 @@ void array_integer_array(integer_array_t* dest,int n,integer_array_t first,...)
     free(elts);
 }
 
-void array_alloc_integer_array(integer_array_t* dest,int n,
-                               integer_array_t first,...)
+void array_alloc_integer_array(integer_array* dest,int n,
+                               integer_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    integer_array_t *elts=(integer_array_t*)malloc(sizeof(integer_array_t) * n);
+    integer_array *elts=(integer_array*)malloc(sizeof(integer_array) * n);
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, integer_array_t);
+        elts[i] = va_arg(ap, integer_array);
     }
     va_end(ap);
 
@@ -534,7 +534,7 @@ void array_alloc_integer_array(integer_array_t* dest,int n,
  *
  * Creates(incl allocation) an array from scalar elements.
  */
-void array_alloc_scalar_integer_array(integer_array_t* dest, int n,
+void array_alloc_scalar_integer_array(integer_array* dest, int n,
                                       modelica_integer first,...)
 {
     int i;
@@ -553,14 +553,14 @@ void array_alloc_scalar_integer_array(integer_array_t* dest, int n,
  * Concatenates n integer arrays along the k:th dimension.
  * k is one based
  */
-void cat_integer_array(int k, integer_array_t* dest, int n,
-                    const integer_array_t* first,...)
+void cat_integer_array(int k, integer_array* dest, int n,
+                    const integer_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const integer_array_t **elts = (const integer_array_t**)malloc(sizeof(integer_array_t *) * n);
+    const integer_array **elts = (const integer_array**)malloc(sizeof(integer_array *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -568,7 +568,7 @@ void cat_integer_array(int k, integer_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const integer_array_t*);
+        elts[i] = va_arg(ap,const integer_array*);
     }
     va_end(ap);
 
@@ -615,14 +615,14 @@ void cat_integer_array(int k, integer_array_t* dest, int n,
  * allocates space in dest array
  * k is one based
  */
-void cat_alloc_integer_array(int k, integer_array_t* dest, int n,
-                          const integer_array_t* first,...)
+void cat_alloc_integer_array(int k, integer_array* dest, int n,
+                          const integer_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const integer_array_t **elts = (const integer_array_t**)malloc(sizeof(integer_array_t *) * n);
+    const integer_array **elts = (const integer_array**)malloc(sizeof(integer_array *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -630,7 +630,7 @@ void cat_alloc_integer_array(int k, integer_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const integer_array_t*);
+        elts[i] = va_arg(ap,const integer_array*);
     }
     va_end(ap);
 
@@ -678,7 +678,7 @@ void cat_alloc_integer_array(int k, integer_array_t* dest, int n,
     free(elts);
 }
 
-void range_alloc_integer_array(modelica_integer start, modelica_integer stop, modelica_integer inc, integer_array_t* dest)
+void range_alloc_integer_array(modelica_integer start, modelica_integer stop, modelica_integer inc, integer_array* dest)
 {
     int n;
 
@@ -687,7 +687,7 @@ void range_alloc_integer_array(modelica_integer start, modelica_integer stop, mo
     range_integer_array(start,stop,inc,dest);
 }
 
-void range_integer_array(modelica_integer start, modelica_integer stop, modelica_integer inc, integer_array_t* dest)
+void range_integer_array(modelica_integer start, modelica_integer stop, modelica_integer inc, integer_array* dest)
 {
     size_t i;
     /* Assert that dest has correct size */
@@ -696,7 +696,7 @@ void range_integer_array(modelica_integer start, modelica_integer stop, modelica
     }
 }
 
-void usub_integer_array(integer_array_t* a)
+void usub_integer_array(integer_array* a)
 {
     size_t nr_of_elements, i;
 
@@ -707,7 +707,7 @@ void usub_integer_array(integer_array_t* a)
     }
 }
 
-void usub_alloc_integer_array(const integer_array_t a, integer_array_t* dest)
+void usub_alloc_integer_array(const integer_array a, integer_array* dest)
 {
     size_t nr_of_elements, i;
     clone_integer_array_spec(&a,dest);
@@ -720,7 +720,7 @@ void usub_alloc_integer_array(const integer_array_t a, integer_array_t* dest)
     }
 }
 
-void add_integer_array(const integer_array_t * a, const integer_array_t * b, integer_array_t* dest)
+void add_integer_array(const integer_array * a, const integer_array * b, integer_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -737,16 +737,16 @@ void add_integer_array(const integer_array_t * a, const integer_array_t * b, int
     }
 }
 
-integer_array_t add_alloc_integer_array(const integer_array_t a, const integer_array_t  b)
+integer_array add_alloc_integer_array(const integer_array a, const integer_array  b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&a,&dest);
     alloc_integer_array_data(&dest);
     add_integer_array(&a,&b,&dest);
     return dest;
 }
 
-void sub_integer_array(const integer_array_t * a, const integer_array_t * b, integer_array_t* dest)
+void sub_integer_array(const integer_array * a, const integer_array * b, integer_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -763,7 +763,7 @@ void sub_integer_array(const integer_array_t * a, const integer_array_t * b, int
     }
 }
 
-void sub_integer_array_data_mem(const integer_array_t * a, const integer_array_t * b,
+void sub_integer_array_data_mem(const integer_array * a, const integer_array * b,
                                 modelica_integer* dest)
 {
     size_t nr_of_elements;
@@ -780,16 +780,16 @@ void sub_integer_array_data_mem(const integer_array_t * a, const integer_array_t
     }
 }
 
-integer_array_t sub_alloc_integer_array(const integer_array_t a, const integer_array_t b)
+integer_array sub_alloc_integer_array(const integer_array a, const integer_array b)
 {
-  integer_array_t dest;
+  integer_array dest;
   clone_integer_array_spec(&a, &dest);
   alloc_integer_array_data(&dest);
   sub_integer_array(&a, &b, &dest);
   return dest;
 }
 
-void mul_scalar_integer_array(modelica_integer a,const integer_array_t * b,integer_array_t* dest)
+void mul_scalar_integer_array(modelica_integer a,const integer_array * b,integer_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -804,16 +804,16 @@ void mul_scalar_integer_array(modelica_integer a,const integer_array_t * b,integ
     }
 }
 
-integer_array_t mul_alloc_scalar_integer_array(modelica_integer a, const integer_array_t b)
+integer_array mul_alloc_scalar_integer_array(modelica_integer a, const integer_array b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&b,&dest);
     alloc_integer_array_data(&dest);
     mul_scalar_integer_array(a,&b,&dest);
     return dest;
 }
 
-void mul_integer_array_scalar(const integer_array_t * a,modelica_integer b,integer_array_t* dest)
+void mul_integer_array_scalar(const integer_array * a,modelica_integer b,integer_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -828,16 +828,16 @@ void mul_integer_array_scalar(const integer_array_t * a,modelica_integer b,integ
     }
 }
 
-integer_array_t mul_alloc_integer_array(const integer_array_t a, integer_array_t b)
+integer_array mul_alloc_integer_array(const integer_array a, integer_array b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&a,&dest);
     alloc_integer_array_data(&dest);
     mul_integer_array(&a,&b,&dest);
     return dest;
 }
 
-void mul_integer_array(const integer_array_t *a,const integer_array_t *b,integer_array_t* dest)
+void mul_integer_array(const integer_array *a,const integer_array *b,integer_array* dest)
 {
   size_t nr_of_elements;
   size_t i;
@@ -849,9 +849,9 @@ void mul_integer_array(const integer_array_t *a,const integer_array_t *b,integer
 }
 
 
-integer_array_t mul_alloc_integer_array_scalar(const integer_array_t a, modelica_integer b)
+integer_array mul_alloc_integer_array_scalar(const integer_array a, modelica_integer b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&a,&dest);
     alloc_integer_array_data(&dest);
     mul_integer_array_scalar(&a,b,&dest);
@@ -859,7 +859,7 @@ integer_array_t mul_alloc_integer_array_scalar(const integer_array_t a, modelica
 }
 
 
-modelica_integer mul_integer_scalar_product(const integer_array_t a, const integer_array_t b)
+modelica_integer mul_integer_scalar_product(const integer_array a, const integer_array b)
 {
     size_t nr_of_elements;
     size_t i;
@@ -879,7 +879,7 @@ modelica_integer mul_integer_scalar_product(const integer_array_t a, const integ
     return res;
 }
 
-void mul_integer_matrix_product(const integer_array_t * a,const integer_array_t * b,integer_array_t* dest)
+void mul_integer_matrix_product(const integer_array * a,const integer_array * b,integer_array* dest)
 {
     modelica_integer tmp;
     size_t i_size;
@@ -905,7 +905,7 @@ void mul_integer_matrix_product(const integer_array_t * a,const integer_array_t 
     }
 }
 
-void mul_integer_matrix_vector(const integer_array_t * a, const integer_array_t * b,integer_array_t* dest)
+void mul_integer_matrix_vector(const integer_array * a, const integer_array * b,integer_array* dest)
 {
     size_t i;
     size_t j;
@@ -933,7 +933,7 @@ void mul_integer_matrix_vector(const integer_array_t * a, const integer_array_t 
 }
 
 
-void mul_integer_vector_matrix(const integer_array_t * a, const integer_array_t * b,integer_array_t* dest)
+void mul_integer_vector_matrix(const integer_array * a, const integer_array * b,integer_array* dest)
 {
     size_t i;
     size_t j;
@@ -959,9 +959,9 @@ void mul_integer_vector_matrix(const integer_array_t * a, const integer_array_t 
     }
 }
 
-integer_array_t mul_alloc_integer_matrix_product_smart(const integer_array_t a, const integer_array_t b)
+integer_array mul_alloc_integer_matrix_product_smart(const integer_array a, const integer_array b)
 {
-    integer_array_t dest;
+    integer_array dest;
     if((a.ndims == 1) && (b.ndims == 2)) {
         simple_alloc_1d_integer_array(&dest,b.dim_size[1]);
         mul_integer_vector_matrix(&a,&b,&dest);
@@ -977,7 +977,7 @@ integer_array_t mul_alloc_integer_matrix_product_smart(const integer_array_t a, 
     return dest;
 }
 
-void div_integer_array_scalar(const integer_array_t * a,modelica_integer b,integer_array_t* dest)
+void div_integer_array_scalar(const integer_array * a,modelica_integer b,integer_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -993,16 +993,16 @@ void div_integer_array_scalar(const integer_array_t * a,modelica_integer b,integ
     }
 }
 
-integer_array_t div_alloc_integer_array_scalar(const integer_array_t a,modelica_integer b)
+integer_array div_alloc_integer_array_scalar(const integer_array a,modelica_integer b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&a,&dest);
     alloc_integer_array_data(&dest);
     div_integer_array_scalar(&a,b,&dest);
     return dest;
 }
 
-void division_integer_array_scalar(threadData_t *threadData, const integer_array_t * a,modelica_integer b,integer_array_t* dest, const char* division_str)
+void division_integer_array_scalar(threadData_t *threadData, const integer_array * a,modelica_integer b,integer_array* dest, const char* division_str)
 {
     size_t nr_of_elements;
     size_t i;
@@ -1017,16 +1017,16 @@ void division_integer_array_scalar(threadData_t *threadData, const integer_array
     }
 }
 
-integer_array_t division_alloc_integer_array_scalar(threadData_t *threadData,const integer_array_t a,modelica_integer b, const char* division_str)
+integer_array division_alloc_integer_array_scalar(threadData_t *threadData,const integer_array a,modelica_integer b, const char* division_str)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&a,&dest);
     alloc_integer_array_data(&dest);
     division_integer_array_scalar(threadData,&a,b,&dest,division_str);
     return dest;
 }
 
-void div_scalar_integer_array(modelica_integer a, const integer_array_t* b, integer_array_t* dest)
+void div_scalar_integer_array(modelica_integer a, const integer_array* b, integer_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -1038,16 +1038,16 @@ void div_scalar_integer_array(modelica_integer a, const integer_array_t* b, inte
     }
 }
 
-integer_array_t div_alloc_scalar_integer_array(modelica_integer a, const integer_array_t b)
+integer_array div_alloc_scalar_integer_array(modelica_integer a, const integer_array b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&b,&dest);
     alloc_integer_array_data(&dest);
     div_scalar_integer_array(a,&b,&dest);
     return dest;
 }
 
-void pow_integer_array_scalar(const integer_array_t *a, modelica_integer b, integer_array_t* dest)
+void pow_integer_array_scalar(const integer_array *a, modelica_integer b, integer_array* dest)
 {
   size_t nr_of_elements = base_array_nr_of_elements(*a);
   size_t i;
@@ -1059,16 +1059,16 @@ void pow_integer_array_scalar(const integer_array_t *a, modelica_integer b, inte
   }
 }
 
-integer_array_t pow_alloc_integer_array_scalar(const integer_array a, modelica_integer b)
+integer_array pow_alloc_integer_array_scalar(const integer_array a, modelica_integer b)
 {
-  integer_array_t dest;
+  integer_array dest;
   clone_integer_array_spec(&a, &dest);
   alloc_integer_array_data(&dest);
   pow_integer_array_scalar(&a, b, &dest);
   return dest;
 }
 
-void exp_integer_array(const integer_array_t * a, modelica_integer n, integer_array_t* dest)
+void exp_integer_array(const integer_array * a, modelica_integer n, integer_array* dest)
 {
     /* Assert n>=0 */
     omc_assert_macro(n >= 0);
@@ -1089,9 +1089,9 @@ void exp_integer_array(const integer_array_t * a, modelica_integer n, integer_ar
         } else {
             modelica_integer i;
 
-            integer_array_t tmp;
-            integer_array_t * b;
-            integer_array_t * c;
+            integer_array tmp;
+            integer_array * b;
+            integer_array * c;
 
             /* prepare temporary array */
             clone_integer_array_spec(a,&tmp);
@@ -1106,7 +1106,7 @@ void exp_integer_array(const integer_array_t * a, modelica_integer n, integer_ar
             }
             mul_integer_matrix_product(a,a,b);
             for( i = 2; i < n; ++i) {
-                integer_array_t * x;
+                integer_array * x;
 
                 mul_integer_matrix_product(a,b,c);
 
@@ -1120,9 +1120,9 @@ void exp_integer_array(const integer_array_t * a, modelica_integer n, integer_ar
     }
 }
 
-integer_array_t exp_alloc_integer_array(const integer_array_t a,modelica_integer b)
+integer_array exp_alloc_integer_array(const integer_array a,modelica_integer b)
 {
-    integer_array_t dest;
+    integer_array dest;
     clone_integer_array_spec(&a,&dest);
     alloc_integer_array_data(&dest);
     exp_integer_array(&a,b,&dest);
@@ -1134,7 +1134,7 @@ integer_array_t exp_alloc_integer_array(const integer_array_t a,modelica_integer
  * Implementation of promote(A,n) same as promote_integer_array except
  * that the destination array is allocated.
  */
-void promote_alloc_integer_array(const integer_array_t * a, int n, integer_array_t* dest)
+void promote_alloc_integer_array(const integer_array * a, int n, integer_array* dest)
 {
     clone_integer_array_spec(a,dest);
     alloc_integer_array_data(dest);
@@ -1149,7 +1149,7 @@ void promote_alloc_integer_array(const integer_array_t * a, int n, integer_array
  * promote_exp( {1,2},1) => {{1},{2}}
  * promote_exp( {1,2},2) => { {{1}},{{2}} }
 */
-void promote_integer_array(const integer_array_t * a, int n,integer_array_t* dest)
+void promote_integer_array(const integer_array * a, int n,integer_array* dest)
 {
     int i;
 
@@ -1169,7 +1169,7 @@ void promote_integer_array(const integer_array_t * a, int n,integer_array_t* des
  *
  * promotes a scalar value to an n dimensional array.
  */
-void promote_scalar_integer_array(modelica_integer s,int n,integer_array_t* dest)
+void promote_scalar_integer_array(modelica_integer s,int n,integer_array* dest)
 {
     int i;
 
@@ -1190,7 +1190,7 @@ void promote_scalar_integer_array(modelica_integer s,int n,integer_array_t* dest
 }
 
 /* return a vector of length ndims(a) containing the dimension sizes of a */
-void size_integer_array(const integer_array_t * a, integer_array_t* dest)
+void size_integer_array(const integer_array * a, integer_array* dest)
 {
     int i;
 
@@ -1202,7 +1202,7 @@ void size_integer_array(const integer_array_t * a, integer_array_t* dest)
     }
 }
 
-modelica_integer scalar_integer_array(const integer_array_t * a)
+modelica_integer scalar_integer_array(const integer_array * a)
 {
     omc_assert_macro(base_array_ok(a));
     omc_assert_macro(base_array_one_element_ok(a));
@@ -1210,7 +1210,7 @@ modelica_integer scalar_integer_array(const integer_array_t * a)
     return integer_get(*a, 0);
 }
 
-void vector_integer_array(const integer_array_t * a, integer_array_t* dest)
+void vector_integer_array(const integer_array * a, integer_array* dest)
 {
     size_t i, nr_of_elements;
 
@@ -1222,13 +1222,13 @@ void vector_integer_array(const integer_array_t * a, integer_array_t* dest)
     }
 }
 
-void vector_integer_scalar(modelica_integer a,integer_array_t* dest)
+void vector_integer_scalar(modelica_integer a,integer_array* dest)
 {
     /* Assert that dest is a 1-vector */
     integer_set(dest, 0, a);
 }
 
-void matrix_integer_array(const integer_array_t * a, integer_array_t* dest)
+void matrix_integer_array(const integer_array * a, integer_array* dest)
 {
     size_t i, cnt;
     /* Assert that size(A,i)=1 for 2 <i<=ndims(A)*/
@@ -1242,7 +1242,7 @@ void matrix_integer_array(const integer_array_t * a, integer_array_t* dest)
     }
 }
 
-void matrix_integer_scalar(modelica_integer a,integer_array_t* dest)
+void matrix_integer_scalar(modelica_integer a,integer_array* dest)
 {
     dest->ndims = 2;
     dest->dim_size[0] = 1;
@@ -1256,7 +1256,7 @@ void matrix_integer_scalar(modelica_integer a,integer_array_t* dest)
  * except that destionation array is allocated.
  */
 
-void transpose_alloc_integer_array(const integer_array_t * a, integer_array_t* dest)
+void transpose_alloc_integer_array(const integer_array * a, integer_array* dest)
 {
     clone_integer_array_spec(a,dest); /* allocation*/
 
@@ -1275,7 +1275,7 @@ void transpose_alloc_integer_array(const integer_array_t * a, integer_array_t* d
  *
  * Implementation of transpose(A) for matrix A.
  */
-void transpose_integer_array(const integer_array_t * a, integer_array_t* dest)
+void transpose_integer_array(const integer_array * a, integer_array* dest)
 {
     size_t i;
     size_t j;
@@ -1301,7 +1301,7 @@ void transpose_integer_array(const integer_array_t * a, integer_array_t* dest)
     }
 }
 
-void outer_product_integer_array(const integer_array_t * v1,const integer_array_t * v2, integer_array_t* dest)
+void outer_product_integer_array(const integer_array * v1,const integer_array * v2, integer_array* dest)
 {
   size_t i;
   size_t j;
@@ -1321,7 +1321,7 @@ void outer_product_integer_array(const integer_array_t * v1,const integer_array_
   }
 }
 
-void outer_product_alloc_integer_array(const integer_array_t* v1, const integer_array_t* v2, integer_array_t* dest)
+void outer_product_alloc_integer_array(const integer_array* v1, const integer_array* v2, integer_array* dest)
 {
   size_t dim1,dim2;
   omc_assert_macro(base_array_ok(v1));
@@ -1332,7 +1332,7 @@ void outer_product_alloc_integer_array(const integer_array_t* v1, const integer_
 }
 
 /* Fills an array with a value. */
-void fill_alloc_integer_array(integer_array_t* dest, modelica_integer value, int ndims, ...)
+void fill_alloc_integer_array(integer_array* dest, modelica_integer value, int ndims, ...)
 {
     size_t i;
     size_t elements = 0;
@@ -1347,7 +1347,7 @@ void fill_alloc_integer_array(integer_array_t* dest, modelica_integer value, int
     }
 }
 
-void identity_integer_array(int n, integer_array_t* dest)
+void identity_integer_array(int n, integer_array* dest)
 {
     int i;
     int j;
@@ -1368,13 +1368,13 @@ void identity_integer_array(int n, integer_array_t* dest)
     }
 }
 
-void identity_alloc_integer_array(int n,integer_array_t* dest)
+void identity_alloc_integer_array(int n,integer_array* dest)
 {
     alloc_integer_array(dest,2,n,n);
     identity_integer_array(n,dest);
 }
 
-static void diagonal_integer_array_impl(const integer_array_t *v, integer_array_t* dest)
+static void diagonal_integer_array_impl(const integer_array *v, integer_array* dest)
 {
     size_t i;
     size_t j;
@@ -1392,7 +1392,7 @@ static void diagonal_integer_array_impl(const integer_array_t *v, integer_array_
     }
 }
 
-void diagonal_integer_array(const integer_array_t * v,integer_array_t* dest)
+void diagonal_integer_array(const integer_array * v,integer_array* dest)
 {
     size_t n;
 
@@ -1407,7 +1407,7 @@ void diagonal_integer_array(const integer_array_t * v,integer_array_t* dest)
     diagonal_integer_array_impl(v, dest);
 }
 
-void diagonal_alloc_integer_array(const integer_array_t* v, integer_array_t* dest)
+void diagonal_alloc_integer_array(const integer_array* v, integer_array* dest)
 {
     size_t n;
 
@@ -1420,7 +1420,7 @@ void diagonal_alloc_integer_array(const integer_array_t* v, integer_array_t* des
     diagonal_integer_array_impl(v, dest);
 }
 
-void fill_integer_array(integer_array_t* dest,modelica_integer s)
+void fill_integer_array(integer_array* dest,modelica_integer s)
 {
     size_t nr_of_elements;
     size_t i;
@@ -1432,7 +1432,7 @@ void fill_integer_array(integer_array_t* dest,modelica_integer s)
 }
 
 void linspace_integer_array(modelica_integer x1, modelica_integer x2, int n,
-                            integer_array_t* dest)
+                            integer_array* dest)
 {
     int i;
 
@@ -1443,7 +1443,7 @@ void linspace_integer_array(modelica_integer x1, modelica_integer x2, int n,
     }
 }
 
-modelica_integer max_integer_array(const integer_array_t a)
+modelica_integer max_integer_array(const integer_array a)
 {
     size_t nr_of_elements;
     modelica_integer max_element = LONG_MIN;
@@ -1465,7 +1465,7 @@ modelica_integer max_integer_array(const integer_array_t a)
     return max_element;
 }
 
-modelica_integer min_integer_array(const integer_array_t a)
+modelica_integer min_integer_array(const integer_array a)
 {
   size_t nr_of_elements;
   modelica_integer min_element = LONG_MAX;
@@ -1486,7 +1486,7 @@ modelica_integer min_integer_array(const integer_array_t a)
   return min_element;
 }
 
-modelica_integer sum_integer_array(const integer_array_t a)
+modelica_integer sum_integer_array(const integer_array a)
 {
     size_t i;
     size_t nr_of_elements;
@@ -1503,7 +1503,7 @@ modelica_integer sum_integer_array(const integer_array_t a)
     return sum;
 }
 
-modelica_integer product_integer_array(const integer_array_t a)
+modelica_integer product_integer_array(const integer_array a)
 {
     size_t i;
     size_t nr_of_elements;
@@ -1520,7 +1520,7 @@ modelica_integer product_integer_array(const integer_array_t a)
     return product;
 }
 
-void symmetric_integer_array(const integer_array_t * a,integer_array_t* dest)
+void symmetric_integer_array(const integer_array * a,integer_array* dest)
 {
     size_t i;
     size_t j;
@@ -1551,7 +1551,7 @@ void symmetric_integer_array(const integer_array_t * a,integer_array_t* dest)
  ** create_index_spec defined in index_spec.c
  */
 
-_index_t* integer_array_make_index_array(const integer_array_t arr)
+_index_t* integer_array_make_index_array(const integer_array arr)
 {
     return arr.data;
 }
@@ -1559,7 +1559,7 @@ _index_t* integer_array_make_index_array(const integer_array_t arr)
 /* Converts the elements of an integer_array to int and packs them. I.e. if the
  * array element type is 64 bits and int is 32 bits then the data will be packed
  * in the first half of the array. */
-void pack_integer_array(integer_array_t *a)
+void pack_integer_array(integer_array *a)
 {
   if(sizeof(int) != sizeof(modelica_integer)) {
     long i;
@@ -1573,7 +1573,7 @@ void pack_integer_array(integer_array_t *a)
 }
 
 /* Unpacks an integer_array that was packed with pack_integer_array */
-void unpack_integer_array(integer_array_t *a)
+void unpack_integer_array(integer_array *a)
 {
   if(sizeof(int) != sizeof(modelica_integer)) {
     long i;
@@ -1595,7 +1595,7 @@ void unpack_integer_array(integer_array_t *a)
  * packed into the first half of the new array.
  *
  * The case where int is larger than modelica_integer is not implemented. */
-void pack_alloc_integer_array(integer_array_t *a, integer_array_t *dest)
+void pack_alloc_integer_array(integer_array *a, integer_array *dest)
 {
   if (sizeof(int) == sizeof(modelica_integer)) {
     *dest = *a;
@@ -1623,7 +1623,7 @@ void pack_alloc_integer_array(integer_array_t *a, integer_array_t *dest)
  * destination array. If packing hasn't been done, i.e. if the size of int and
  * modelica_integer is the same, then the function does nothing since both the
  * source and destination is assumed to be the same array. */
-void unpack_copy_integer_array(const integer_array_t *a, integer_array_t *dest)
+void unpack_copy_integer_array(const integer_array *a, integer_array *dest)
 {
   if(sizeof(int) != sizeof(modelica_integer)) {
     long i;
@@ -1636,8 +1636,8 @@ void unpack_copy_integer_array(const integer_array_t *a, integer_array_t *dest)
   }
 }
 
-void convert_alloc_integer_array_to_f77(const integer_array_t * a,
-                                        integer_array_t* dest)
+void convert_alloc_integer_array_to_f77(const integer_array * a,
+                                        integer_array* dest)
 {
     int i;
     clone_reverse_integer_array_spec(a,dest);
@@ -1653,8 +1653,8 @@ void convert_alloc_integer_array_to_f77(const integer_array_t * a,
     }
 }
 
-void convert_alloc_integer_array_from_f77(const integer_array_t * a,
-                                          integer_array_t* dest)
+void convert_alloc_integer_array_from_f77(const integer_array * a,
+                                          integer_array* dest)
 {
     int i;
     clone_reverse_integer_array_spec(a,dest);
@@ -1670,7 +1670,7 @@ void convert_alloc_integer_array_from_f77(const integer_array_t * a,
     unpack_integer_array(dest);
 }
 
-void sizes_of_dimensions_base_array(const base_array_t *a, integer_array_t *dest)
+void sizes_of_dimensions_base_array(const base_array_t *a, integer_array *dest)
 {
   int i = ndims_base_array(a);
   simple_alloc_1d_integer_array(dest, i);

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.c
@@ -543,7 +543,7 @@ void array_alloc_scalar_integer_array(integer_array_t* dest, int n,
     va_start(ap,first);
     put_integer_element(first,0,dest);
     for(i = 1; i < n; ++i) {
-        put_integer_element(va_arg(ap, m_integer),i,dest);
+        put_integer_element(va_arg(ap, modelica_integer),i,dest);
     }
     va_end(ap);
 }

--- a/OMCompiler/SimulationRuntime/c/util/integer_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/integer_array.h
@@ -39,219 +39,219 @@
 #include "index_spec.h"
 #include <stdarg.h>
 
-modelica_integer integer_get(const integer_array_t a, size_t i);
-modelica_integer integer_get_2D(const integer_array_t a, size_t i, size_t j);
-modelica_integer integer_get_3D(const integer_array_t a, size_t i, size_t j, size_t k);
-modelica_integer integer_get_4D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l);
-modelica_integer integer_get_5D(const integer_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
+modelica_integer integer_get(const integer_array a, size_t i);
+modelica_integer integer_get_2D(const integer_array a, size_t i, size_t j);
+modelica_integer integer_get_3D(const integer_array a, size_t i, size_t j, size_t k);
+modelica_integer integer_get_4D(const integer_array a, size_t i, size_t j, size_t k, size_t l);
+modelica_integer integer_get_5D(const integer_array a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Settings the fields of a integer_array */
-extern void integer_array_create(integer_array_t *dest, modelica_integer *data,
+extern void integer_array_create(integer_array *dest, modelica_integer *data,
                                  int ndims, ...);
 
 /* Allocation of a vector */
-extern void simple_alloc_1d_integer_array(integer_array_t* dest, int n);
+extern void simple_alloc_1d_integer_array(integer_array* dest, int n);
 
 /* Allocation of a matrix */
-extern void simple_alloc_2d_integer_array(integer_array_t* dest, int r, int c);
+extern void simple_alloc_2d_integer_array(integer_array* dest, int r, int c);
 
-extern void alloc_integer_array(integer_array_t *dest,int ndims,...);
+extern void alloc_integer_array(integer_array *dest,int ndims,...);
 
 /* Allocation of integer data */
-extern void alloc_integer_array_data(integer_array_t *a);
+extern void alloc_integer_array_data(integer_array *a);
 
 /* Frees memory*/
-extern void free_integer_array_data(integer_array_t* a);
+extern void free_integer_array_data(integer_array* a);
 
 /* Clones data*/
-static inline void clone_integer_array_spec(const integer_array_t * source,
-                                            integer_array_t* dest)
+static inline void clone_integer_array_spec(const integer_array * source,
+                                            integer_array* dest)
 { clone_base_array_spec(source, dest); }
 
 /* Copy integer data given memory ptr*/
-extern void copy_integer_array_data_mem(const integer_array_t source,
+extern void copy_integer_array_data_mem(const integer_array source,
                                         modelica_integer *dest);
 
 /* Copy integer array*/
-extern void copy_integer_array(const integer_array_t source, integer_array_t* dest);
+extern void copy_integer_array(const integer_array source, integer_array* dest);
 
-extern void create_integer_array_from_range(integer_array_t *dest, modelica_integer start, modelica_integer step, modelica_integer stop);
+extern void create_integer_array_from_range(integer_array *dest, modelica_integer start, modelica_integer step, modelica_integer stop);
 
-void fill_integer_array_from_range(integer_array_t *dest, modelica_integer start,
+void fill_integer_array_from_range(integer_array *dest, modelica_integer start,
                                    modelica_integer step, modelica_integer stop/*, size_t dim*/);
 
 extern modelica_integer* calc_integer_index(int ndims, const _index_t* idx_vec,
-                                            const integer_array_t * arr);
-extern modelica_integer* calc_integer_index_va(const integer_array_t * source,int ndims,
+                                            const integer_array * arr);
+extern modelica_integer* calc_integer_index_va(const integer_array * source,int ndims,
                                                va_list ap);
 
-extern void put_integer_element(modelica_integer value,int i1,integer_array_t* dest);
+extern void put_integer_element(modelica_integer value,int i1,integer_array* dest);
 extern void put_integer_matrix_element(modelica_integer value, int r, int c,
-                                       integer_array_t* dest);
+                                       integer_array* dest);
 
-extern void print_integer_matrix(const integer_array_t * source);
-extern void print_integer_array(const integer_array_t * source);
+extern void print_integer_matrix(const integer_array * source);
+extern void print_integer_array(const integer_array * source);
 /*
 
  a[1:3] := b;
 
 */
-extern void indexed_assign_integer_array(const integer_array_t source,
-                                         integer_array_t* dest,
+extern void indexed_assign_integer_array(const integer_array source,
+                                         integer_array* dest,
                                          const index_spec_t* dest_spec);
-extern void simple_indexed_assign_integer_array1(const integer_array_t * source,
+extern void simple_indexed_assign_integer_array1(const integer_array * source,
                                                  int i1,
-                                                 integer_array_t* dest);
-extern void simple_indexed_assign_integer_array2(const integer_array_t * source,
+                                                 integer_array* dest);
+extern void simple_indexed_assign_integer_array2(const integer_array * source,
                                                  int i1, int i2,
-                                                 integer_array_t* dest);
+                                                 integer_array* dest);
 
 /*
 
  a := b[1:3];
 
 */
-extern void index_integer_array(const integer_array_t * source,
+extern void index_integer_array(const integer_array * source,
                                 const index_spec_t* source_spec,
-                                integer_array_t* dest);
-extern void index_alloc_integer_array(const integer_array_t * source,
+                                integer_array* dest);
+extern void index_alloc_integer_array(const integer_array * source,
                     const index_spec_t* source_spec,
-                    integer_array_t* dest);
+                    integer_array* dest);
 
-extern void simple_index_alloc_integer_array1(const integer_array_t * source,int i1,
-                                              integer_array_t* dest);
+extern void simple_index_alloc_integer_array1(const integer_array * source,int i1,
+                                              integer_array* dest);
 
-extern void simple_index_integer_array1(const integer_array_t * source,
+extern void simple_index_integer_array1(const integer_array * source,
                                         int i1,
-                                        integer_array_t* dest);
-extern void simple_index_integer_array2(const integer_array_t * source,
+                                        integer_array* dest);
+extern void simple_index_integer_array2(const integer_array * source,
                                         int i1, int i2,
-                                        integer_array_t* dest);
+                                        integer_array* dest);
 
 /* array(A,B,C) for arrays A,B,C */
-extern void array_integer_array(integer_array_t* dest,int n,
-                                integer_array_t first,...);
-extern void array_alloc_integer_array(integer_array_t* dest,int n,
-                                      integer_array_t first,...);
+extern void array_integer_array(integer_array* dest,int n,
+                                integer_array first,...);
+extern void array_alloc_integer_array(integer_array* dest,int n,
+                                      integer_array first,...);
 
 /* array(s1,s2,s3)  for scalars s1,s2,s3 */
-extern void array_scalar_integer_array(integer_array_t* dest,int n,
+extern void array_scalar_integer_array(integer_array* dest,int n,
                                        modelica_integer first,...);
-extern void array_alloc_scalar_integer_array(integer_array_t* dest,int n,
+extern void array_alloc_scalar_integer_array(integer_array* dest,int n,
                                              modelica_integer first,...);
 
-extern void cat_integer_array(int k,integer_array_t* dest, int n,
-                              const integer_array_t* first,...);
-extern void cat_alloc_integer_array(int k,integer_array_t* dest, int n,
-                                    const integer_array_t* first,...);
+extern void cat_integer_array(int k,integer_array* dest, int n,
+                              const integer_array* first,...);
+extern void cat_alloc_integer_array(int k,integer_array* dest, int n,
+                                    const integer_array* first,...);
 
 extern void range_alloc_integer_array(modelica_integer start, modelica_integer stop,
-                                      modelica_integer inc,integer_array_t* dest);
+                                      modelica_integer inc,integer_array* dest);
 extern void range_integer_array(modelica_integer start,modelica_integer stop,
-                                modelica_integer inc,integer_array_t* dest);
+                                modelica_integer inc,integer_array* dest);
 
-extern integer_array_t add_alloc_integer_array(const integer_array_t a, const integer_array_t b);
-extern void add_integer_array(const integer_array_t * a, const integer_array_t * b,
-                              integer_array_t* dest);
+extern integer_array add_alloc_integer_array(const integer_array a, const integer_array b);
+extern void add_integer_array(const integer_array * a, const integer_array * b,
+                              integer_array* dest);
 
 /* Unary subtraction */
-extern void usub_integer_array(integer_array_t* a);
-extern void usub_alloc_integer_array(const integer_array_t a, integer_array_t* dest);
-extern void sub_integer_array(const integer_array_t * a, const integer_array_t * b,
-                              integer_array_t* dest);
-extern integer_array_t sub_alloc_integer_array(const integer_array_t a, const integer_array_t b);
-extern void sub_integer_array_data_mem(const integer_array_t * a, const integer_array_t * b,
+extern void usub_integer_array(integer_array* a);
+extern void usub_alloc_integer_array(const integer_array a, integer_array* dest);
+extern void sub_integer_array(const integer_array * a, const integer_array * b,
+                              integer_array* dest);
+extern integer_array sub_alloc_integer_array(const integer_array a, const integer_array b);
+extern void sub_integer_array_data_mem(const integer_array * a, const integer_array * b,
                                        modelica_integer* dest);
 
-extern void mul_scalar_integer_array(modelica_integer a,const integer_array_t * b,
-                                     integer_array_t* dest);
-extern integer_array_t mul_alloc_scalar_integer_array(modelica_integer a,const integer_array_t b);
+extern void mul_scalar_integer_array(modelica_integer a,const integer_array * b,
+                                     integer_array* dest);
+extern integer_array mul_alloc_scalar_integer_array(modelica_integer a,const integer_array b);
 
-extern void mul_integer_array_scalar(const integer_array_t * a,modelica_integer b,
-                                     integer_array_t* dest);
-extern void mul_integer_array(const integer_array_t *a,const integer_array_t *b,integer_array_t* dest);
-extern integer_array_t mul_alloc_integer_array(const integer_array_t a, integer_array_t b);
-extern integer_array_t mul_alloc_integer_array_scalar(const integer_array_t a,modelica_integer b);
+extern void mul_integer_array_scalar(const integer_array * a,modelica_integer b,
+                                     integer_array* dest);
+extern void mul_integer_array(const integer_array *a,const integer_array *b,integer_array* dest);
+extern integer_array mul_alloc_integer_array(const integer_array a, integer_array b);
+extern integer_array mul_alloc_integer_array_scalar(const integer_array a,modelica_integer b);
 
-extern modelica_integer mul_integer_scalar_product(const integer_array_t a,
-                                                   const integer_array_t b);
+extern modelica_integer mul_integer_scalar_product(const integer_array a,
+                                                   const integer_array b);
 
-extern void mul_integer_matrix_product(const integer_array_t *a,const integer_array_t *b,
-                                       integer_array_t*dest);
-extern void mul_integer_matrix_vector(const integer_array_t * a, const integer_array_t * b,
-                                      integer_array_t* dest);
-extern void mul_integer_vector_matrix(const integer_array_t * a, const integer_array_t * b,
-                                      integer_array_t* dest);
-extern integer_array_t mul_alloc_integer_matrix_product_smart(const integer_array_t a, const integer_array_t b);
+extern void mul_integer_matrix_product(const integer_array *a,const integer_array *b,
+                                       integer_array*dest);
+extern void mul_integer_matrix_vector(const integer_array * a, const integer_array * b,
+                                      integer_array* dest);
+extern void mul_integer_vector_matrix(const integer_array * a, const integer_array * b,
+                                      integer_array* dest);
+extern integer_array mul_alloc_integer_matrix_product_smart(const integer_array a, const integer_array b);
 
-extern void div_integer_array_scalar(const integer_array_t * a,modelica_integer b,
-                                     integer_array_t* dest);
-extern integer_array_t div_alloc_integer_array_scalar(const integer_array_t a,modelica_integer b);
+extern void div_integer_array_scalar(const integer_array * a,modelica_integer b,
+                                     integer_array* dest);
+extern integer_array div_alloc_integer_array_scalar(const integer_array a,modelica_integer b);
 
-extern void division_integer_array_scalar(threadData_t*,const integer_array_t * a,modelica_integer b,
-                                          integer_array_t* dest, const char* division_str);
-extern integer_array_t division_alloc_integer_array_scalar(threadData_t *threadData,const integer_array_t a,modelica_integer b, const char* division_str);
-extern void div_scalar_integer_array(modelica_integer a, const integer_array_t* b, integer_array_t* dest);
-extern integer_array_t div_alloc_scalar_integer_array(modelica_integer a, const integer_array_t b);
-extern void pow_integer_array_scalar(const integer_array_t *a, modelica_integer b, integer_array_t* dest);
-extern integer_array_t pow_alloc_integer_array_scalar(const integer_array a, modelica_integer b);
+extern void division_integer_array_scalar(threadData_t*,const integer_array * a,modelica_integer b,
+                                          integer_array* dest, const char* division_str);
+extern integer_array division_alloc_integer_array_scalar(threadData_t *threadData,const integer_array a,modelica_integer b, const char* division_str);
+extern void div_scalar_integer_array(modelica_integer a, const integer_array* b, integer_array* dest);
+extern integer_array div_alloc_scalar_integer_array(modelica_integer a, const integer_array b);
+extern void pow_integer_array_scalar(const integer_array *a, modelica_integer b, integer_array* dest);
+extern integer_array pow_alloc_integer_array_scalar(const integer_array a, modelica_integer b);
 
-extern void exp_integer_array(const integer_array_t * a, modelica_integer n,
-                              integer_array_t* dest);
-extern integer_array_t exp_alloc_integer_array(const integer_array_t a, modelica_integer b);
+extern void exp_integer_array(const integer_array * a, modelica_integer n,
+                              integer_array* dest);
+extern integer_array exp_alloc_integer_array(const integer_array a, modelica_integer b);
 
-extern void promote_integer_array(const integer_array_t * a, int n,integer_array_t* dest);
+extern void promote_integer_array(const integer_array * a, int n,integer_array* dest);
 extern void promote_scalar_integer_array(modelica_integer s,int n,
-                                         integer_array_t* dest);
-extern void promote_alloc_integer_array(const integer_array_t * a, int n,
-                                        integer_array_t* dest);
+                                         integer_array* dest);
+extern void promote_alloc_integer_array(const integer_array * a, int n,
+                                        integer_array* dest);
 
-static inline int ndims_integer_array(const integer_array_t * a)
+static inline int ndims_integer_array(const integer_array * a)
 { return ndims_base_array(a); }
 /* This is defined in integer_array since we return an integer array */
-extern void sizes_of_dimensions_base_array(const base_array_t *a, integer_array_t *dest);
+extern void sizes_of_dimensions_base_array(const base_array_t *a, integer_array *dest);
 
-extern void size_integer_array(const integer_array_t * a,integer_array_t* dest);
-extern modelica_integer scalar_integer_array(const integer_array_t * a);
-extern void vector_integer_array(const integer_array_t * a, integer_array_t* dest);
-extern void vector_integer_scalar(modelica_integer a,integer_array_t* dest);
-extern void matrix_integer_array(const integer_array_t * a, integer_array_t* dest);
-extern void matrix_integer_scalar(modelica_integer a,integer_array_t* dest);
-extern void transpose_integer_array(const integer_array_t * a, integer_array_t* dest);
-extern void transpose_alloc_integer_array(const integer_array_t * a, integer_array_t* dest);
-extern void outer_product_alloc_integer_array(const integer_array_t * v1,const integer_array_t * v2, integer_array_t* dest);
-extern void outer_product_integer_array(const integer_array_t * v1,const integer_array_t * v2, integer_array_t* dest);
-extern void fill_alloc_integer_array(integer_array_t* dest, modelica_integer value, int ndims, ...);
-extern void identity_integer_array(int n, integer_array_t* dest);
-extern void identity_alloc_integer_array(int n, integer_array_t* dest);
+extern void size_integer_array(const integer_array * a,integer_array* dest);
+extern modelica_integer scalar_integer_array(const integer_array * a);
+extern void vector_integer_array(const integer_array * a, integer_array* dest);
+extern void vector_integer_scalar(modelica_integer a,integer_array* dest);
+extern void matrix_integer_array(const integer_array * a, integer_array* dest);
+extern void matrix_integer_scalar(modelica_integer a,integer_array* dest);
+extern void transpose_integer_array(const integer_array * a, integer_array* dest);
+extern void transpose_alloc_integer_array(const integer_array * a, integer_array* dest);
+extern void outer_product_alloc_integer_array(const integer_array * v1,const integer_array * v2, integer_array* dest);
+extern void outer_product_integer_array(const integer_array * v1,const integer_array * v2, integer_array* dest);
+extern void fill_alloc_integer_array(integer_array* dest, modelica_integer value, int ndims, ...);
+extern void identity_integer_array(int n, integer_array* dest);
+extern void identity_alloc_integer_array(int n, integer_array* dest);
 
-extern void diagonal_integer_array(const integer_array_t * v,integer_array_t* dest);
-extern void diagonal_alloc_integer_array(const integer_array_t *v, integer_array_t* dest);
-extern void fill_integer_array(integer_array_t* dest,modelica_integer s);
+extern void diagonal_integer_array(const integer_array * v,integer_array* dest);
+extern void diagonal_alloc_integer_array(const integer_array *v, integer_array* dest);
+extern void fill_integer_array(integer_array* dest,modelica_integer s);
 extern void linspace_integer_array(modelica_integer x1,modelica_integer x2,int n,
-                                   integer_array_t* dest);
-extern modelica_integer min_integer_array(const integer_array_t a);
-extern modelica_integer max_integer_array(const integer_array_t a);
-extern modelica_integer sum_integer_array(const integer_array_t a);
-extern modelica_integer product_integer_array(const integer_array_t a);
-extern void symmetric_integer_array(const integer_array_t * a,integer_array_t* dest);
-extern void cross_integer_array(const integer_array_t * x,const integer_array_t * y,integer_array_t* dest);
-extern void cross_alloc_integer_array(const integer_array_t * x,const integer_array_t * y,integer_array_t* dest);
-extern void skew_integer_array(const integer_array_t * x,integer_array_t* dest);
+                                   integer_array* dest);
+extern modelica_integer min_integer_array(const integer_array a);
+extern modelica_integer max_integer_array(const integer_array a);
+extern modelica_integer sum_integer_array(const integer_array a);
+extern modelica_integer product_integer_array(const integer_array a);
+extern void symmetric_integer_array(const integer_array * a,integer_array* dest);
+extern void cross_integer_array(const integer_array * x,const integer_array * y,integer_array* dest);
+extern void cross_alloc_integer_array(const integer_array * x,const integer_array * y,integer_array* dest);
+extern void skew_integer_array(const integer_array * x,integer_array* dest);
 
-extern _index_t* integer_array_make_index_array(const integer_array_t arr);
+extern _index_t* integer_array_make_index_array(const integer_array arr);
 
-static inline void clone_reverse_integer_array_spec(const integer_array_t * source,
-                                                    integer_array_t* dest)
+static inline void clone_reverse_integer_array_spec(const integer_array * source,
+                                                    integer_array* dest)
 { clone_reverse_base_array_spec(source, dest); }
-extern void convert_alloc_integer_array_to_f77(const integer_array_t * a,
-                                               integer_array_t* dest);
-extern void convert_alloc_integer_array_from_f77(const integer_array_t * a,
-                                                 integer_array_t* dest);
+extern void convert_alloc_integer_array_to_f77(const integer_array * a,
+                                               integer_array* dest);
+extern void convert_alloc_integer_array_from_f77(const integer_array * a,
+                                                 integer_array* dest);
 
-void pack_integer_array(integer_array_t *a);
-void unpack_integer_array(integer_array_t *a);
-void pack_alloc_integer_array(integer_array_t *a, integer_array_t *dest);
-void unpack_copy_integer_array(const integer_array_t *a, integer_array_t *dest);
+void pack_integer_array(integer_array *a);
+void unpack_integer_array(integer_array *a);
+void pack_alloc_integer_array(integer_array *a, integer_array *dest);
+void unpack_copy_integer_array(const integer_array *a, integer_array *dest);
 
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/read_write.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.c
@@ -81,17 +81,17 @@ void puttype(const type_description *desc)
     break;
   case TYPE_DESC_REAL_ARRAY: {
       int d;
-      fprintf(stderr, "REAL ARRAY [%d] (", desc->data.real_array.ndims);
-      for(d = 0; d < desc->data.real_array.ndims; ++d) {
-        fprintf(stderr, "%d, ", (int) desc->data.real_array.dim_size[d]);
+      fprintf(stderr, "REAL ARRAY [%d] (", desc->data.r_array.ndims);
+      for(d = 0; d < desc->data.r_array.ndims; ++d) {
+        fprintf(stderr, "%d, ", (int) desc->data.r_array.dim_size[d]);
       }
       fprintf(stderr, ")\n");
-      if(desc->data.real_array.ndims == 1) {
+      if(desc->data.r_array.ndims == 1) {
         int e;
         fprintf(stderr, "\t[");
-        for(e = 0; e < desc->data.real_array.dim_size[0]; ++e) {
+        for(e = 0; e < desc->data.r_array.dim_size[0]; ++e) {
           fprintf(stderr, "%g, ",
-                  ((modelica_real *) desc->data.real_array.data)[e]);
+                  ((modelica_real *) desc->data.r_array.data)[e]);
         }
         fprintf(stderr, "]\n");
       }
@@ -208,8 +208,8 @@ void free_type_description(type_description *desc)
     break;
   case TYPE_DESC_REAL_ARRAY:
     if(desc->retval) {
-      free(desc->data.real_array.dim_size);
-      free(desc->data.real_array.data);
+      free(desc->data.r_array.dim_size);
+      free(desc->data.r_array.data);
     }
     break;
   case TYPE_DESC_INT_ARRAY:
@@ -313,12 +313,12 @@ int read_modelica_boolean(type_description **descptr, modelica_boolean *data)
   return -1;
 }
 
-int read_real_array(type_description **descptr, real_array_t *arr)
+int read_real_array(type_description **descptr, real_array *arr)
 {
   type_description *desc = (*descptr)++;
   switch (desc->type) {
   case TYPE_DESC_REAL_ARRAY:
-    *arr = desc->data.real_array;
+    *arr = desc->data.r_array;
     return 0;
   case TYPE_DESC_INT_ARRAY:
     cast_integer_array_to_real(&(desc->data.int_array), arr);
@@ -341,9 +341,9 @@ int read_integer_array(type_description **descptr, integer_array_t *arr)
     return 0;
   case TYPE_DESC_REAL_ARRAY:
     /* Empty arrays automaticly get to be real arrays */
-    if(desc->data.real_array.dim_size[desc->data.real_array.ndims - 1] == 0) {
-      int dims = desc->data.real_array.ndims;
-      _index_t *dim_size = desc->data.real_array.dim_size;
+    if(desc->data.r_array.dim_size[desc->data.r_array.ndims - 1] == 0) {
+      int dims = desc->data.r_array.ndims;
+      _index_t *dim_size = desc->data.r_array.dim_size;
       desc->type = TYPE_DESC_INT_ARRAY;
       desc->data.int_array.ndims = dims;
       desc->data.int_array.dim_size = dim_size;
@@ -370,9 +370,9 @@ int read_boolean_array(type_description **descptr, boolean_array_t *arr)
     return 0;
   case TYPE_DESC_REAL_ARRAY:
     /* Empty arrays automaticly get to be real arrays */
-    if(desc->data.real_array.dim_size[desc->data.real_array.ndims - 1] == 0) {
-      int dims = desc->data.real_array.ndims;
-      _index_t *dim_size = desc->data.real_array.dim_size;
+    if(desc->data.r_array.dim_size[desc->data.r_array.ndims - 1] == 0) {
+      int dims = desc->data.r_array.ndims;
+      _index_t *dim_size = desc->data.r_array.dim_size;
       desc->type = TYPE_DESC_BOOL_ARRAY;
       desc->data.bool_array.ndims = dims;
       desc->data.bool_array.dim_size = dim_size;
@@ -399,9 +399,9 @@ int read_string_array(type_description **descptr, string_array_t *arr)
     return 0;
   case TYPE_DESC_REAL_ARRAY:
     /* Empty arrays automaticly get to be real arrays */
-    if(desc->data.real_array.dim_size[desc->data.real_array.ndims - 1] == 0) {
-      int dims = desc->data.real_array.ndims;
-      _index_t *dim_size = desc->data.real_array.dim_size;
+    if(desc->data.r_array.dim_size[desc->data.r_array.ndims - 1] == 0) {
+      int dims = desc->data.r_array.ndims;
+      _index_t *dim_size = desc->data.r_array.dim_size;
       desc->type = TYPE_DESC_STRING_ARRAY;
       desc->data.string_array.ndims = dims;
       desc->data.string_array.dim_size = dim_size;
@@ -451,7 +451,7 @@ void write_noretcall(type_description *desc)
   desc->type = TYPE_DESC_NORETCALL;
 }
 
-void write_real_array(type_description *desc, const real_array_t *arr)
+void write_real_array(type_description *desc, const real_array *arr)
 {
   if(desc->type != TYPE_DESC_NONE) {
     desc = add_tuple_item(desc);
@@ -460,15 +460,15 @@ void write_real_array(type_description *desc, const real_array_t *arr)
   if(desc->retval) {
     /* Can't use memory pool for these */
     size_t nr_elements;
-    desc->data.real_array.ndims = arr->ndims;
-    desc->data.real_array.dim_size = (_index_t*)malloc(sizeof(*(arr->dim_size)) * arr->ndims);
-    memcpy(desc->data.real_array.dim_size, arr->dim_size, sizeof(*(arr->dim_size)) * arr->ndims);
+    desc->data.r_array.ndims = arr->ndims;
+    desc->data.r_array.dim_size = (_index_t*)malloc(sizeof(*(arr->dim_size)) * arr->ndims);
+    memcpy(desc->data.r_array.dim_size, arr->dim_size, sizeof(*(arr->dim_size)) * arr->ndims);
     nr_elements = base_array_nr_of_elements(*arr);
-    desc->data.real_array.data = malloc(sizeof(modelica_real) * nr_elements);
-    memcpy(desc->data.real_array.data, arr->data,
+    desc->data.r_array.data = malloc(sizeof(modelica_real) * nr_elements);
+    memcpy(desc->data.r_array.data, arr->data,
            sizeof(modelica_real) * nr_elements);
   } else {
-    copy_real_array(*arr, &(desc->data.real_array));
+    copy_real_array(*arr, &(desc->data.r_array));
   }
 }
 
@@ -673,7 +673,7 @@ static int read_modelica_record_helper(type_description **descptr, va_list *arg)
         read_modelica_real(&elem, va_arg(*arg, modelica_real *));
         break;
       case TYPE_DESC_REAL_ARRAY:
-        read_real_array(&elem, va_arg(*arg, real_array_t *));
+        read_real_array(&elem, va_arg(*arg, real_array *));
         break;
       case TYPE_DESC_INT:
         read_modelica_integer(&elem, va_arg(*arg, modelica_integer *));
@@ -785,7 +785,7 @@ static void write_modelica_record_helper(type_description *desc, const void* rec
       write_modelica_real(elem, va_arg(*arg, modelica_real *));
       break;
     case TYPE_DESC_REAL_ARRAY:
-      write_real_array(elem, va_arg(*arg, real_array_t *));
+      write_real_array(elem, va_arg(*arg, real_array *));
       break;
     case TYPE_DESC_INT:
       write_modelica_integer(elem, va_arg(*arg, modelica_integer *));

--- a/OMCompiler/SimulationRuntime/c/util/read_write.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.c
@@ -390,7 +390,7 @@ int read_boolean_array(type_description **descptr, boolean_array *arr)
   return -1;
 }
 
-int read_string_array(type_description **descptr, string_array_t *arr)
+int read_string_array(type_description **descptr, string_array *arr)
 {
   type_description *desc = (*descptr)++;
   switch (desc->type) {
@@ -515,7 +515,7 @@ void write_boolean_array(type_description *desc, const boolean_array *arr)
   }
 }
 
-void write_string_array(type_description *desc, const string_array_t *arr)
+void write_string_array(type_description *desc, const string_array *arr)
 {
   if(desc->type != TYPE_DESC_NONE) {
     desc = add_tuple_item(desc);
@@ -691,7 +691,7 @@ static int read_modelica_record_helper(type_description **descptr, va_list *arg)
         read_modelica_string(&elem, va_arg(*arg, modelica_string *));
         break;
       case TYPE_DESC_STRING_ARRAY:
-        read_string_array(&elem, va_arg(*arg, string_array_t *));
+        read_string_array(&elem, va_arg(*arg, string_array *));
         break;
       case TYPE_DESC_TUPLE:
         in_report("tuple in record is unsupported.");
@@ -803,7 +803,7 @@ static void write_modelica_record_helper(type_description *desc, const void* rec
       write_modelica_string(elem, va_arg(*arg, modelica_string *));
       break;
     case TYPE_DESC_STRING_ARRAY:
-      write_string_array(elem, va_arg(*arg, string_array_t *));
+      write_string_array(elem, va_arg(*arg, string_array *));
       break;
     case TYPE_DESC_COMPLEX:
       write_modelica_complex(elem, va_arg(*arg, modelica_complex *));

--- a/OMCompiler/SimulationRuntime/c/util/read_write.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.c
@@ -361,7 +361,7 @@ int read_integer_array(type_description **descptr, integer_array *arr)
   return -1;
 }
 
-int read_boolean_array(type_description **descptr, boolean_array_t *arr)
+int read_boolean_array(type_description **descptr, boolean_array *arr)
 {
   type_description *desc = (*descptr)++;
   switch (desc->type) {
@@ -494,7 +494,7 @@ void write_integer_array(type_description *desc, const integer_array *arr)
   }
 }
 
-void write_boolean_array(type_description *desc, const boolean_array_t *arr)
+void write_boolean_array(type_description *desc, const boolean_array *arr)
 {
   if(desc->type != TYPE_DESC_NONE) {
     desc = add_tuple_item(desc);
@@ -685,7 +685,7 @@ static int read_modelica_record_helper(type_description **descptr, va_list *arg)
         read_modelica_boolean(&elem, va_arg(*arg, modelica_boolean *));
         break;
       case TYPE_DESC_BOOL_ARRAY:
-        read_boolean_array(&elem, va_arg(*arg, boolean_array_t *));
+        read_boolean_array(&elem, va_arg(*arg, boolean_array *));
         break;
       case TYPE_DESC_STRING:
         read_modelica_string(&elem, va_arg(*arg, modelica_string *));
@@ -797,7 +797,7 @@ static void write_modelica_record_helper(type_description *desc, const void* rec
       write_modelica_boolean(elem, va_arg(*arg, modelica_boolean *));
       break;
     case TYPE_DESC_BOOL_ARRAY:
-      write_boolean_array(elem, va_arg(*arg, boolean_array_t *));
+      write_boolean_array(elem, va_arg(*arg, boolean_array *));
       break;
     case TYPE_DESC_STRING:
       write_modelica_string(elem, va_arg(*arg, modelica_string *));

--- a/OMCompiler/SimulationRuntime/c/util/read_write.c
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.c
@@ -332,7 +332,7 @@ int read_real_array(type_description **descptr, real_array *arr)
   return -1;
 }
 
-int read_integer_array(type_description **descptr, integer_array_t *arr)
+int read_integer_array(type_description **descptr, integer_array *arr)
 {
   type_description *desc = (*descptr)++;
   switch (desc->type) {
@@ -472,7 +472,7 @@ void write_real_array(type_description *desc, const real_array *arr)
   }
 }
 
-void write_integer_array(type_description *desc, const integer_array_t *arr)
+void write_integer_array(type_description *desc, const integer_array *arr)
 {
   if(desc->type != TYPE_DESC_NONE) {
     desc = add_tuple_item(desc);
@@ -679,7 +679,7 @@ static int read_modelica_record_helper(type_description **descptr, va_list *arg)
         read_modelica_integer(&elem, va_arg(*arg, modelica_integer *));
         break;
       case TYPE_DESC_INT_ARRAY:
-        read_integer_array(&elem, va_arg(*arg, integer_array_t *));
+        read_integer_array(&elem, va_arg(*arg, integer_array *));
         break;
       case TYPE_DESC_BOOL:
         read_modelica_boolean(&elem, va_arg(*arg, modelica_boolean *));
@@ -791,7 +791,7 @@ static void write_modelica_record_helper(type_description *desc, const void* rec
       write_modelica_integer(elem, va_arg(*arg, modelica_integer *));
       break;
     case TYPE_DESC_INT_ARRAY:
-      write_integer_array(elem, va_arg(*arg, integer_array_t *));
+      write_integer_array(elem, va_arg(*arg, integer_array *));
       break;
     case TYPE_DESC_BOOL:
       write_modelica_boolean(elem, va_arg(*arg, modelica_boolean *));

--- a/OMCompiler/SimulationRuntime/c/util/read_write.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.h
@@ -63,9 +63,9 @@ extern void write_modelica_boolean(type_description *desc, const modelica_boolea
 extern void write_boolean_array(type_description *desc, const boolean_array *arr);
 
 extern int read_modelica_string(type_description **descptr, modelica_string *str);
-extern int read_string_array(type_description ** descptr, string_array_t *arr);
+extern int read_string_array(type_description ** descptr, string_array *arr);
 extern void write_modelica_string(type_description *desc, modelica_string *str);
-extern void write_string_array(type_description *desc, const string_array_t *arr);
+extern void write_string_array(type_description *desc, const string_array *arr);
 
 extern int read_modelica_complex(type_description **descptr, modelica_complex *data);
 extern void write_modelica_complex(type_description *desc, const modelica_complex *data);

--- a/OMCompiler/SimulationRuntime/c/util/read_write.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.h
@@ -53,9 +53,9 @@ extern void write_modelica_real(type_description *desc, const modelica_real *dat
 extern void write_real_array(type_description *desc, const real_array *arr);
 
 extern int read_modelica_integer(type_description **descptr, modelica_integer *data);
-extern int read_integer_array(type_description ** descptr, integer_array_t *arr);
+extern int read_integer_array(type_description ** descptr, integer_array *arr);
 extern void write_modelica_integer(type_description *desc, const modelica_integer *data);
-extern void write_integer_array(type_description *desc, const integer_array_t *arr);
+extern void write_integer_array(type_description *desc, const integer_array *arr);
 
 extern int read_modelica_boolean(type_description **descptr, modelica_boolean *data);
 extern int read_boolean_array(type_description ** descptr, boolean_array_t *arr);

--- a/OMCompiler/SimulationRuntime/c/util/read_write.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.h
@@ -58,9 +58,9 @@ extern void write_modelica_integer(type_description *desc, const modelica_intege
 extern void write_integer_array(type_description *desc, const integer_array *arr);
 
 extern int read_modelica_boolean(type_description **descptr, modelica_boolean *data);
-extern int read_boolean_array(type_description ** descptr, boolean_array_t *arr);
+extern int read_boolean_array(type_description ** descptr, boolean_array *arr);
 extern void write_modelica_boolean(type_description *desc, const modelica_boolean *data);
-extern void write_boolean_array(type_description *desc, const boolean_array_t *arr);
+extern void write_boolean_array(type_description *desc, const boolean_array *arr);
 
 extern int read_modelica_string(type_description **descptr, modelica_string *str);
 extern int read_string_array(type_description ** descptr, string_array_t *arr);

--- a/OMCompiler/SimulationRuntime/c/util/read_write.h
+++ b/OMCompiler/SimulationRuntime/c/util/read_write.h
@@ -48,9 +48,9 @@ extern void init_type_description(type_description * desc);
 extern void free_type_description(type_description * desc);
 
 extern int read_modelica_real(type_description ** descptr, modelica_real * data);
-extern int read_real_array(type_description ** descptr, real_array_t *arr);
+extern int read_real_array(type_description ** descptr, real_array *arr);
 extern void write_modelica_real(type_description *desc, const modelica_real *data);
-extern void write_real_array(type_description *desc, const real_array_t *arr);
+extern void write_real_array(type_description *desc, const real_array *arr);
 
 extern int read_modelica_integer(type_description **descptr, modelica_integer *data);
 extern int read_integer_array(type_description ** descptr, integer_array_t *arr);

--- a/OMCompiler/SimulationRuntime/c/util/real_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.c
@@ -1196,7 +1196,7 @@ void promote_scalar_real_array(modelica_real s,int n,real_array* dest)
 }
 
 /* return a vector of length ndims(a) containing the dimension sizes of a */
-void size_real_array(const real_array * a, integer_array_t* dest)
+void size_real_array(const real_array * a, integer_array* dest)
 {
     /* This should be an integer array dest instead */
     int i;
@@ -1592,7 +1592,7 @@ void convert_alloc_real_array_from_f77(const real_array * a, real_array* dest)
     transpose_real_array(a, dest);
 }
 
-void cast_integer_array_to_real(const integer_array_t* a, real_array* dest)
+void cast_integer_array_to_real(const integer_array* a, real_array* dest)
 {
     int els = base_array_nr_of_elements(*a);
     int i;
@@ -1603,7 +1603,7 @@ void cast_integer_array_to_real(const integer_array_t* a, real_array* dest)
     }
 }
 
-void cast_real_array_to_integer(const real_array * a, integer_array_t* dest)
+void cast_real_array_to_integer(const real_array * a, integer_array* dest)
 {
     int els = base_array_nr_of_elements(*a);
     int i;

--- a/OMCompiler/SimulationRuntime/c/util/real_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.c
@@ -43,38 +43,38 @@
 #include <math.h>
 #include <float.h>
 
-static inline modelica_real *real_ptrget(const real_array_t *a, size_t i)
+static inline modelica_real *real_ptrget(const real_array *a, size_t i)
 {
     return ((modelica_real *) a->data) + i;
 }
 
-static inline void real_set(real_array_t *a, size_t i, modelica_real r)
+static inline void real_set(real_array *a, size_t i, modelica_real r)
 {
     ((modelica_real *) a->data)[i] = r;
 }
 
 
-modelica_real real_get(const real_array_t a, size_t i)
+modelica_real real_get(const real_array a, size_t i)
 {
   return ((modelica_real *) a.data)[i];
 }
 
-modelica_real real_get_2D(const real_array_t a, size_t i, size_t j)
+modelica_real real_get_2D(const real_array a, size_t i, size_t j)
 {
   return real_get(a, getIndex_2D(a.dim_size,i,j));
 }
 
-modelica_real real_get_3D(const real_array_t a, size_t i, size_t j, size_t k)
+modelica_real real_get_3D(const real_array a, size_t i, size_t j, size_t k)
 {
   return real_get(a, getIndex_3D(a.dim_size,i,j,k));
 }
 
-modelica_real real_get_4D(const real_array_t a, size_t i, size_t j, size_t k, size_t l)
+modelica_real real_get_4D(const real_array a, size_t i, size_t j, size_t k, size_t l)
 {
   return real_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
-modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+modelica_real real_get_5D(const real_array a, size_t i, size_t j, size_t k, size_t l, size_t m)
 {
   return real_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
 }
@@ -84,7 +84,7 @@ modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, si
  ** sets all fields in a real_array, i.e. data, ndims and dim_size.
  **/
 
-void real_array_create(real_array_t *dest, modelica_real *data, int ndims, ...)
+void real_array_create(real_array *dest, modelica_real *data, int ndims, ...)
 {
     va_list ap;
     va_start(ap, ndims);
@@ -92,17 +92,17 @@ void real_array_create(real_array_t *dest, modelica_real *data, int ndims, ...)
     va_end(ap);
 }
 
-void simple_alloc_1d_real_array(real_array_t* dest, int n)
+void simple_alloc_1d_real_array(real_array* dest, int n)
 {
     simple_alloc_1d_base_array(dest, n, real_alloc(n));
 }
 
-void simple_alloc_2d_real_array(real_array_t* dest, int r, int c)
+void simple_alloc_2d_real_array(real_array* dest, int r, int c)
 {
     simple_alloc_2d_base_array(dest, r, c, real_alloc(r * c));
 }
 
-void alloc_real_array(real_array_t *dest, int ndims, ...)
+void alloc_real_array(real_array *dest, int ndims, ...)
 {
     size_t elements = 0;
     va_list ap;
@@ -112,12 +112,12 @@ void alloc_real_array(real_array_t *dest, int ndims, ...)
     dest->data = real_alloc(elements);
 }
 
-void alloc_real_array_data(real_array_t *a)
+void alloc_real_array_data(real_array *a)
 {
     a->data = real_alloc(base_array_nr_of_elements(*a));
 }
 
-void copy_real_array_data_mem(const real_array_t source, modelica_real *dest)
+void copy_real_array_data_mem(const real_array source, modelica_real *dest)
 {
     size_t i, nr_of_elements;
 
@@ -130,7 +130,7 @@ void copy_real_array_data_mem(const real_array_t source, modelica_real *dest)
     }
 }
 
-void copy_real_array(const real_array_t source, real_array_t *dest)
+void copy_real_array(const real_array source, real_array *dest)
 {
     real_array_alloc_copy(source,*dest);
 }
@@ -153,7 +153,7 @@ static modelica_real real_ge(modelica_real x, modelica_real y)
  * e.g: Real a[10], b[2][10]; a := 1.0:2.5:10.0; b[1] := 1.0:10.0;
  *
 */
-void fill_real_array_from_range(real_array_t *dest, modelica_real start, modelica_real step,
+void fill_real_array_from_range(real_array *dest, modelica_real start, modelica_real step,
                                 modelica_real stop/*, size_t dim*/)
 {
     size_t elements;
@@ -175,25 +175,25 @@ void fill_real_array_from_range(real_array_t *dest, modelica_real start, modelic
 */
 
 static inline modelica_real *calc_real_index_spec(int ndims, const _index_t *idx_vec,
-                                                  const real_array_t *arr,
+                                                  const real_array *arr,
                                                   const index_spec_t *spec)
 {
     return real_ptrget(arr, calc_base_index_spec(ndims, idx_vec, arr, spec));
 }
 
 /* Uses zero based indexing */
-modelica_real *calc_real_index(int ndims, const _index_t *idx_vec, const real_array_t *arr)
+modelica_real *calc_real_index(int ndims, const _index_t *idx_vec, const real_array *arr)
 {
     return real_ptrget(arr, calc_base_index(ndims, idx_vec, arr));
 }
 
 /* One based index*/
-modelica_real *calc_real_index_va(const real_array_t *source, int ndims, va_list ap)
+modelica_real *calc_real_index_va(const real_array *source, int ndims, va_list ap)
 {
     return real_ptrget(source, calc_base_index_va(source, ndims, ap));
 }
 
-void print_real_matrix(const real_array_t *source)
+void print_real_matrix(const real_array *source)
 {
     _index_t i,j;
     modelica_real value;
@@ -212,7 +212,7 @@ void print_real_matrix(const real_array_t *source)
     }
 }
 
-void print_real_array(const real_array_t *source)
+void print_real_array(const real_array *source)
 {
     _index_t i,j;
     modelica_real *data;
@@ -250,14 +250,14 @@ void print_real_array(const real_array_t *source)
     }
 }
 
-void put_real_element(modelica_real value, int i1, real_array_t *dest)
+void put_real_element(modelica_real value, int i1, real_array *dest)
 {
     /* Assert that dest has correct dimension */
     /* Assert that i1 is a valid index */
     real_set(dest, i1, value);
 }
 
-void put_real_matrix_element(modelica_real value, int r, int c, real_array_t* dest)
+void put_real_matrix_element(modelica_real value, int r, int c, real_array* dest)
 {
     /* Assert that dest hast correct dimension */
     /* Assert that r and c are valid indices */
@@ -266,18 +266,18 @@ void put_real_matrix_element(modelica_real value, int r, int c, real_array_t* de
 }
 
 /* Zero based index */
-void simple_indexed_assign_real_array1(const real_array_t * source,
+void simple_indexed_assign_real_array1(const real_array * source,
                int i1,
-               real_array_t* dest)
+               real_array* dest)
 {
     /* Assert that source has the correct dimension */
     /* Assert that dest has the correct dimension */
     real_set(dest, i1, real_get(*source, i1));
 }
 
-void simple_indexed_assign_real_array2(const real_array_t * source,
+void simple_indexed_assign_real_array2(const real_array * source,
                int i1, int i2,
-               real_array_t* dest)
+               real_array* dest)
 {
     size_t index;
     /* Assert that source has correct dimension */
@@ -286,7 +286,7 @@ void simple_indexed_assign_real_array2(const real_array_t * source,
     real_set(dest, index, real_get(*source, index));
 }
 
-void indexed_assign_real_array(const real_array_t source, real_array_t* dest,
+void indexed_assign_real_array(const real_array source, real_array* dest,
                                const index_spec_t* dest_spec)
 {
     _index_t *idx_vec1, *idx_size;
@@ -316,9 +316,9 @@ void indexed_assign_real_array(const real_array_t source, real_array_t* dest,
  *
  */
 
-void index_real_array(const real_array_t * source,
+void index_real_array(const real_array * source,
                       const index_spec_t* source_spec,
-                      real_array_t* dest)
+                      real_array* dest)
 {
     _index_t* idx_vec1;
     _index_t* idx_size;
@@ -399,9 +399,9 @@ void index_real_array(const real_array_t * source,
  * a := b[1:3];
  */
 
-void index_alloc_real_array(const real_array_t * source,
+void index_alloc_real_array(const real_array * source,
                             const index_spec_t* source_spec,
-                            real_array_t* dest)
+                            real_array* dest)
 {
     index_alloc_base_array_size(source, source_spec, dest);
     alloc_real_array_data(dest);
@@ -410,8 +410,8 @@ void index_alloc_real_array(const real_array_t * source,
 
 /* idx(a[i,j,k]) = i * a->dim_size[1] * a->dim_size[2] + j * a->dim_size[2] + k */
 /* Returns dest := source[i1,:,:...]*/
-void simple_index_alloc_real_array1(const real_array_t * source, int i1,
-                                       real_array_t* dest)
+void simple_index_alloc_real_array1(const real_array * source, int i1,
+                                       real_array* dest)
 {
     int i;
     omc_assert_macro(base_array_ok(source));
@@ -429,9 +429,9 @@ void simple_index_alloc_real_array1(const real_array_t * source, int i1,
 }
 
 /* Returns dest := source[i1,:,:...]*/
-void simple_index_real_array1(const real_array_t * source,
+void simple_index_real_array1(const real_array * source,
                                  int i1,
-                                 real_array_t* dest)
+                                 real_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -443,9 +443,9 @@ void simple_index_real_array1(const real_array_t * source,
 }
 
 /* Returns dest := source[i1,i2,:,:...]*/
-void simple_index_real_array2(const real_array_t * source,
+void simple_index_real_array2(const real_array * source,
                                  int i1, int i2,
-                                 real_array_t* dest)
+                                 real_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -456,18 +456,18 @@ void simple_index_real_array2(const real_array_t * source,
     }
 }
 
-void array_real_array(real_array_t* dest,int n,real_array_t first,...)
+void array_real_array(real_array* dest,int n,real_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    real_array_t *elts = (real_array_t*)malloc(sizeof(real_array_t) * n);
+    real_array *elts = (real_array*)malloc(sizeof(real_array) * n);
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, real_array_t);
+        elts[i] = va_arg(ap, real_array);
     }
     va_end(ap);
 
@@ -483,18 +483,18 @@ void array_real_array(real_array_t* dest,int n,real_array_t first,...)
     free(elts);
 }
 
-void array_alloc_real_array(real_array_t* dest, int n, real_array_t first,...)
+void array_alloc_real_array(real_array* dest, int n, real_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    real_array_t *elts = (real_array_t*)malloc(sizeof(real_array_t) * n);
+    real_array *elts = (real_array*)malloc(sizeof(real_array) * n);
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, real_array_t);
+        elts[i] = va_arg(ap, real_array);
     }
     va_end(ap);
 
@@ -527,7 +527,7 @@ void array_alloc_real_array(real_array_t* dest, int n, real_array_t first,...)
  * Creates(incl allocation) an array from scalar elements.
  */
 
-void array_alloc_scalar_real_array(real_array_t* dest, int n, modelica_real first,...)
+void array_alloc_scalar_real_array(real_array* dest, int n, modelica_real first,...)
 {
     int i;
     va_list ap;
@@ -546,14 +546,14 @@ void array_alloc_scalar_real_array(real_array_t* dest, int n, modelica_real firs
  * Concatenates n real arrays along the k:th dimension.
  * k is one based
  */
-void cat_real_array(int k, real_array_t* dest, int n,
-                    const real_array_t* first,...)
+void cat_real_array(int k, real_array* dest, int n,
+                    const real_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const real_array_t **elts = (const real_array_t**)malloc(sizeof(real_array_t *) * n);
+    const real_array **elts = (const real_array**)malloc(sizeof(real_array *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -561,7 +561,7 @@ void cat_real_array(int k, real_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const real_array_t*);
+        elts[i] = va_arg(ap,const real_array*);
     }
     va_end(ap);
 
@@ -608,14 +608,14 @@ void cat_real_array(int k, real_array_t* dest, int n,
  * allocates space in dest array
  * k is one based
  */
-void cat_alloc_real_array(int k, real_array_t* dest, int n,
-                          const real_array_t* first,...)
+void cat_alloc_real_array(int k, real_array* dest, int n,
+                          const real_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const real_array_t **elts = (const real_array_t**)malloc(sizeof(real_array_t *) * n);
+    const real_array **elts = (const real_array**)malloc(sizeof(real_array *) * n);
 
     omc_assert_macro(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -623,7 +623,7 @@ void cat_alloc_real_array(int k, real_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const real_array_t*);
+        elts[i] = va_arg(ap,const real_array*);
     }
     va_end(ap);
 
@@ -671,7 +671,7 @@ void cat_alloc_real_array(int k, real_array_t* dest, int n,
     free(elts);
 }
 
-void range_alloc_real_array(modelica_real start, modelica_real stop, modelica_real inc, real_array_t* dest)
+void range_alloc_real_array(modelica_real start, modelica_real stop, modelica_real inc, real_array* dest)
 {
     int n;
 
@@ -680,7 +680,7 @@ void range_alloc_real_array(modelica_real start, modelica_real stop, modelica_re
     range_real_array(start,stop,inc,dest);
 }
 
-void range_real_array(modelica_real start, modelica_real stop, modelica_real inc, real_array_t* dest)
+void range_real_array(modelica_real start, modelica_real stop, modelica_real inc, real_array* dest)
 {
     int i;
     modelica_real v = start;
@@ -690,7 +690,7 @@ void range_real_array(modelica_real start, modelica_real stop, modelica_real inc
     }
 }
 
-void add_real_array(const real_array_t * a, const real_array_t * b, real_array_t* dest)
+void add_real_array(const real_array * a, const real_array * b, real_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -703,19 +703,19 @@ void add_real_array(const real_array_t * a, const real_array_t * b, real_array_t
     }
 }
 
-real_array_t add_alloc_real_array(const real_array_t a, const real_array_t b)
+real_array add_alloc_real_array(const real_array a, const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     add_real_array(&a,&b,&dest);
     return dest;
 }
 
-real_array_t add_alloc_real_array_scalar(const real_array_t arr, const modelica_real sc)
+real_array add_alloc_real_array_scalar(const real_array arr, const modelica_real sc)
 {
   size_t nr_of_elements, i;
-  real_array_t dest;
+  real_array dest;
   clone_real_array_spec(&arr, &dest);
   alloc_real_array_data(&dest);
   nr_of_elements = base_array_nr_of_elements(arr);
@@ -725,10 +725,10 @@ real_array_t add_alloc_real_array_scalar(const real_array_t arr, const modelica_
   return dest;
 }
 
-real_array_t sub_alloc_scalar_real_array(modelica_real sc, const real_array_t arr)
+real_array sub_alloc_scalar_real_array(modelica_real sc, const real_array arr)
 {
   size_t nr_of_elements, i;
-  real_array_t dest;
+  real_array dest;
   clone_real_array_spec(&arr, &dest);
   alloc_real_array_data(&dest);
   nr_of_elements = base_array_nr_of_elements(arr);
@@ -738,7 +738,7 @@ real_array_t sub_alloc_scalar_real_array(modelica_real sc, const real_array_t ar
   return dest;
 }
 
-void usub_real_array(real_array_t* a)
+void usub_real_array(real_array* a)
 {
     size_t nr_of_elements, i;
 
@@ -749,7 +749,7 @@ void usub_real_array(real_array_t* a)
     }
 }
 
-void usub_alloc_real_array(const real_array_t a, real_array_t* dest)
+void usub_alloc_real_array(const real_array a, real_array* dest)
 {
     size_t nr_of_elements, i;
     clone_real_array_spec(&a,dest);
@@ -762,7 +762,7 @@ void usub_alloc_real_array(const real_array_t a, real_array_t* dest)
     }
 }
 
-void sub_real_array(const real_array_t * a, const real_array_t * b, real_array_t* dest)
+void sub_real_array(const real_array * a, const real_array * b, real_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -775,7 +775,7 @@ void sub_real_array(const real_array_t * a, const real_array_t * b, real_array_t
     }
 }
 
-void sub_real_array_data_mem(const real_array_t * a, const real_array_t * b,
+void sub_real_array_data_mem(const real_array * a, const real_array * b,
                              modelica_real* dest)
 {
     size_t nr_of_elements;
@@ -789,16 +789,16 @@ void sub_real_array_data_mem(const real_array_t * a, const real_array_t * b,
     }
 }
 
-real_array_t sub_alloc_real_array(const real_array_t a, const real_array_t b)
+real_array sub_alloc_real_array(const real_array a, const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a, &dest);
     alloc_real_array_data(&dest);
     sub_real_array(&a, &b, &dest);
     return dest;
 }
 
-void mul_scalar_real_array(modelica_real a,const real_array_t * b,real_array_t* dest)
+void mul_scalar_real_array(modelica_real a,const real_array * b,real_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -810,16 +810,16 @@ void mul_scalar_real_array(modelica_real a,const real_array_t * b,real_array_t* 
 }
 
 // TODO: remove me.
-real_array_t mul_alloc_scalar_real_array(modelica_real a,const real_array_t b)
+real_array mul_alloc_scalar_real_array(modelica_real a,const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&b,&dest);
     alloc_real_array_data(&dest);
     mul_scalar_real_array(a,&b,&dest);
     return dest;
 }
 
-void mul_real_array_scalar(const real_array_t * a,modelica_real b,real_array_t* dest)
+void mul_real_array_scalar(const real_array * a,modelica_real b,real_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -830,16 +830,16 @@ void mul_real_array_scalar(const real_array_t * a,modelica_real b,real_array_t* 
     }
 }
 
-real_array_t mul_alloc_real_array_scalar(const real_array_t a, const modelica_real b)
+real_array mul_alloc_real_array_scalar(const real_array a, const modelica_real b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     mul_real_array_scalar(&a,b,&dest);
     return dest;
 }
 
-void mul_real_array(const real_array_t *a,const real_array_t *b,real_array_t* dest)
+void mul_real_array(const real_array *a,const real_array *b,real_array* dest)
 {
   size_t nr_of_elements;
   size_t i;
@@ -850,16 +850,16 @@ void mul_real_array(const real_array_t *a,const real_array_t *b,real_array_t* de
   }
 }
 
-real_array_t mul_alloc_real_array(const real_array_t a,const real_array_t b)
+real_array mul_alloc_real_array(const real_array a,const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     mul_real_array(&a,&b,&dest);
     return dest;
 }
 
-modelica_real mul_real_scalar_product(const real_array_t a, const real_array_t b)
+modelica_real mul_real_scalar_product(const real_array a, const real_array b)
 {
     size_t nr_of_elements;
     size_t i;
@@ -875,7 +875,7 @@ modelica_real mul_real_scalar_product(const real_array_t a, const real_array_t b
     return res;
 }
 
-void mul_real_matrix_product(const real_array_t * a,const real_array_t * b,real_array_t* dest)
+void mul_real_matrix_product(const real_array * a,const real_array * b,real_array* dest)
 {
     modelica_real tmp;
     size_t i_size;
@@ -901,7 +901,7 @@ void mul_real_matrix_product(const real_array_t * a,const real_array_t * b,real_
     }
 }
 
-void mul_real_matrix_vector(const real_array_t * a, const real_array_t * b,real_array_t* dest)
+void mul_real_matrix_vector(const real_array * a, const real_array * b,real_array* dest)
 {
     size_t i;
     size_t j;
@@ -926,7 +926,7 @@ void mul_real_matrix_vector(const real_array_t * a, const real_array_t * b,real_
 }
 
 
-void mul_real_vector_matrix(const real_array_t * a, const real_array_t * b,real_array_t* dest)
+void mul_real_vector_matrix(const real_array * a, const real_array * b,real_array* dest)
 {
     size_t i;
     size_t j;
@@ -950,9 +950,9 @@ void mul_real_vector_matrix(const real_array_t * a, const real_array_t * b,real_
     }
 }
 
-real_array_t mul_alloc_real_matrix_product_smart(const real_array_t a, const real_array_t b)
+real_array mul_alloc_real_matrix_product_smart(const real_array a, const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     if((a.ndims == 1) && (b.ndims == 2)) {
         simple_alloc_1d_real_array(&dest,b.dim_size[1]);
         mul_real_vector_matrix(&a,&b,&dest);
@@ -968,7 +968,7 @@ real_array_t mul_alloc_real_matrix_product_smart(const real_array_t a, const rea
     return dest;
 }
 
-void div_real_array_scalar(const real_array_t * a,modelica_real b,real_array_t* dest)
+void div_real_array_scalar(const real_array * a,modelica_real b,real_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -980,16 +980,16 @@ void div_real_array_scalar(const real_array_t * a,modelica_real b,real_array_t* 
     }
 }
 
-real_array_t div_alloc_real_array_scalar(const real_array_t a, const modelica_real b)
+real_array div_alloc_real_array_scalar(const real_array a, const modelica_real b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     div_real_array_scalar(&a,b,&dest);
     return dest;
 }
 
-void division_real_array_scalar(threadData_t *threadData, const real_array_t * a,modelica_real b,real_array_t* dest, const char* division_str)
+void division_real_array_scalar(threadData_t *threadData, const real_array * a,modelica_real b,real_array* dest, const char* division_str)
 {
     size_t nr_of_elements;
     size_t i;
@@ -1000,16 +1000,16 @@ void division_real_array_scalar(threadData_t *threadData, const real_array_t * a
     }
 }
 
-real_array_t division_alloc_real_array_scalar(threadData_t *threadData,const real_array_t a,modelica_real b,const char* division_str)
+real_array division_alloc_real_array_scalar(threadData_t *threadData,const real_array a,modelica_real b,const char* division_str)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     division_real_array_scalar(threadData,&a,b,&dest,division_str);
     return dest;
 }
 
-void div_scalar_real_array(modelica_real a, const real_array_t* b, real_array_t* dest)
+void div_scalar_real_array(modelica_real a, const real_array* b, real_array* dest)
 {
     size_t nr_of_elements;
     size_t i;
@@ -1021,16 +1021,16 @@ void div_scalar_real_array(modelica_real a, const real_array_t* b, real_array_t*
     }
 }
 
-real_array_t div_alloc_scalar_real_array(modelica_real a, const real_array_t b)
+real_array div_alloc_scalar_real_array(modelica_real a, const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&b,&dest);
     alloc_real_array_data(&dest);
     div_scalar_real_array(a,&b,&dest);
     return dest;
 }
 
-void div_real_array(const real_array_t *a, const real_array_t *b, real_array_t* dest)
+void div_real_array(const real_array *a, const real_array *b, real_array* dest)
 {
   size_t nr_of_elements;
   size_t i;
@@ -1041,9 +1041,9 @@ void div_real_array(const real_array_t *a, const real_array_t *b, real_array_t* 
   }
 }
 
-real_array_t div_alloc_real_array(const real_array_t a, const real_array_t b)
+real_array div_alloc_real_array(const real_array a, const real_array b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     div_real_array(&a, &b, &dest);
@@ -1051,7 +1051,7 @@ real_array_t div_alloc_real_array(const real_array_t a, const real_array_t b)
 }
 
 
-void pow_real_array_scalar(const real_array_t *a, modelica_real b, real_array_t* dest)
+void pow_real_array_scalar(const real_array *a, modelica_real b, real_array* dest)
 {
   size_t nr_of_elements = base_array_nr_of_elements(*a);
   size_t i;
@@ -1063,16 +1063,16 @@ void pow_real_array_scalar(const real_array_t *a, modelica_real b, real_array_t*
   }
 }
 
-real_array_t pow_alloc_real_array_scalar(const real_array_t a, const modelica_real b)
+real_array pow_alloc_real_array_scalar(const real_array a, const modelica_real b)
 {
-  real_array_t dest;
+  real_array dest;
   clone_real_array_spec(&a, &dest);
   alloc_real_array_data(&dest);
   pow_real_array_scalar(&a, b, &dest);
   return dest;
 }
 
-void exp_real_array(const real_array_t * a, modelica_integer n, real_array_t* dest)
+void exp_real_array(const real_array * a, modelica_integer n, real_array* dest)
 {
     /* Assert n>=0 */
     omc_assert_macro(n >= 0);
@@ -1093,9 +1093,9 @@ void exp_real_array(const real_array_t * a, modelica_integer n, real_array_t* de
         } else {
             modelica_integer i;
 
-            real_array_t tmp;
-            real_array_t * b;
-            real_array_t * c;
+            real_array tmp;
+            real_array * b;
+            real_array * c;
 
             /* prepare temporary array */
             clone_real_array_spec(a,&tmp);
@@ -1110,7 +1110,7 @@ void exp_real_array(const real_array_t * a, modelica_integer n, real_array_t* de
             }
             mul_real_matrix_product(a,a,b);
             for( i = 2; i < n; ++i) {
-                real_array_t * x;
+                real_array * x;
 
                 mul_real_matrix_product(a,b,c);
 
@@ -1124,9 +1124,9 @@ void exp_real_array(const real_array_t * a, modelica_integer n, real_array_t* de
     }
 }
 
-real_array_t exp_alloc_real_array(const real_array_t a,modelica_integer b)
+real_array exp_alloc_real_array(const real_array a,modelica_integer b)
 {
-    real_array_t dest;
+    real_array dest;
     clone_real_array_spec(&a,&dest);
     alloc_real_array_data(&dest);
     exp_real_array(&a,b,&dest);
@@ -1138,7 +1138,7 @@ real_array_t exp_alloc_real_array(const real_array_t a,modelica_integer b)
  * Implementation of promote(A,n) same as promote_real_array except
  * that the destination array is allocated.
  */
-void promote_alloc_real_array(const real_array_t * a, int n, real_array_t* dest)
+void promote_alloc_real_array(const real_array * a, int n, real_array* dest)
 {
     clone_real_array_spec(a,dest);
     alloc_real_array_data(dest);
@@ -1153,7 +1153,7 @@ void promote_alloc_real_array(const real_array_t * a, int n, real_array_t* dest)
  * promote_exp( {1,2},1) => {{1},{2}}
  * promote_exp( {1,2},2) => { {{1}},{{2}} }
 */
-void promote_real_array(const real_array_t * a, int n,real_array_t* dest)
+void promote_real_array(const real_array * a, int n,real_array* dest)
 {
     int i;
 
@@ -1175,7 +1175,7 @@ void promote_real_array(const real_array_t * a, int n,real_array_t* dest)
  * promotes a scalar value to an n dimensional array.
  */
 
-void promote_scalar_real_array(modelica_real s,int n,real_array_t* dest)
+void promote_scalar_real_array(modelica_real s,int n,real_array* dest)
 {
     int i;
 
@@ -1196,7 +1196,7 @@ void promote_scalar_real_array(modelica_real s,int n,real_array_t* dest)
 }
 
 /* return a vector of length ndims(a) containing the dimension sizes of a */
-void size_real_array(const real_array_t * a, integer_array_t* dest)
+void size_real_array(const real_array * a, integer_array_t* dest)
 {
     /* This should be an integer array dest instead */
     int i;
@@ -1209,7 +1209,7 @@ void size_real_array(const real_array_t * a, integer_array_t* dest)
     }
 }
 
-modelica_real scalar_real_array(const real_array_t* a)
+modelica_real scalar_real_array(const real_array* a)
 {
     omc_assert_macro(base_array_ok(a));
     omc_assert_macro(base_array_one_element_ok(a));
@@ -1217,7 +1217,7 @@ modelica_real scalar_real_array(const real_array_t* a)
     return real_get(*a, 0);
 }
 
-void vector_real_array(const real_array_t * a, real_array_t* dest)
+void vector_real_array(const real_array * a, real_array* dest)
 {
     size_t i, nr_of_elements;
 
@@ -1229,13 +1229,13 @@ void vector_real_array(const real_array_t * a, real_array_t* dest)
     }
 }
 
-void vector_real_scalar(modelica_real a,real_array_t* dest)
+void vector_real_scalar(modelica_real a,real_array* dest)
 {
     /* Assert that dest is a 1-vector */
     real_set(dest, 0, a);
 }
 
-void matrix_real_array(const real_array_t * a, real_array_t* dest)
+void matrix_real_array(const real_array * a, real_array* dest)
 {
     size_t i, cnt;
     /* Assert that size(A,i)=1 for 2 <i<=ndims(A)*/
@@ -1249,7 +1249,7 @@ void matrix_real_array(const real_array_t * a, real_array_t* dest)
     }
 }
 
-void matrix_real_scalar(modelica_real a, real_array_t* dest)
+void matrix_real_scalar(modelica_real a, real_array* dest)
 {
     dest->ndims = 2;
     dest->dim_size[0] = 1;
@@ -1263,7 +1263,7 @@ void matrix_real_scalar(modelica_real a, real_array_t* dest)
  * except that destionation array is allocated.
  */
 
-void transpose_alloc_real_array(const real_array_t * a, real_array_t* dest)
+void transpose_alloc_real_array(const real_array * a, real_array* dest)
 {
     clone_real_array_spec(a,dest); /* allocation*/
 
@@ -1282,7 +1282,7 @@ void transpose_alloc_real_array(const real_array_t * a, real_array_t* dest)
  *
  * Implementation of transpose(A) for matrix A.
  */
-void transpose_real_array(const real_array_t * a, real_array_t* dest)
+void transpose_real_array(const real_array * a, real_array* dest)
 {
     size_t i;
     size_t j;
@@ -1308,8 +1308,8 @@ void transpose_real_array(const real_array_t * a, real_array_t* dest)
     }
 }
 
-void outer_product_real_array(const real_array_t * v1, const real_array_t * v2,
-                              real_array_t* dest)
+void outer_product_real_array(const real_array * v1, const real_array * v2,
+                              real_array* dest)
 {
     size_t i;
     size_t j;
@@ -1330,7 +1330,7 @@ void outer_product_real_array(const real_array_t * v1, const real_array_t * v2,
     }
 }
 
-void outer_product_alloc_real_array(real_array_t* v1, real_array_t* v2, real_array_t* dest)
+void outer_product_alloc_real_array(real_array* v1, real_array* v2, real_array* dest)
 {
   size_t dim1,dim2;
   omc_assert_macro(base_array_ok(v1));
@@ -1340,7 +1340,7 @@ void outer_product_alloc_real_array(real_array_t* v1, real_array_t* v2, real_arr
   outer_product_real_array(v1,v2,dest);
 }
 
-void identity_real_array(int n, real_array_t* dest)
+void identity_real_array(int n, real_array* dest)
 {
     int i;
     int j;
@@ -1361,7 +1361,7 @@ void identity_real_array(int n, real_array_t* dest)
     }
 }
 
-static void diagonal_real_array_impl(const real_array_t *v, real_array_t* dest)
+static void diagonal_real_array_impl(const real_array *v, real_array* dest)
 {
     size_t i;
     size_t j;
@@ -1379,7 +1379,7 @@ static void diagonal_real_array_impl(const real_array_t *v, real_array_t* dest)
     }
 }
 
-void diagonal_real_array(const real_array_t * v,real_array_t* dest)
+void diagonal_real_array(const real_array * v,real_array* dest)
 {
     size_t i;
     size_t j;
@@ -1396,7 +1396,7 @@ void diagonal_real_array(const real_array_t * v,real_array_t* dest)
     diagonal_real_array_impl(v, dest);
 }
 
-void diagonal_alloc_real_array(const real_array_t* v, real_array_t* dest)
+void diagonal_alloc_real_array(const real_array* v, real_array* dest)
 {
   size_t n;
 
@@ -1409,7 +1409,7 @@ void diagonal_alloc_real_array(const real_array_t* v, real_array_t* dest)
   diagonal_real_array_impl(v, dest);
 }
 
-void fill_real_array(real_array_t* dest,modelica_real s)
+void fill_real_array(real_array* dest,modelica_real s)
 {
     size_t nr_of_elements;
     size_t i;
@@ -1421,7 +1421,7 @@ void fill_real_array(real_array_t* dest,modelica_real s)
 }
 
 void linspace_real_array(modelica_real x1, modelica_real x2, int n,
-                         real_array_t* dest)
+                         real_array* dest)
 {
     int i;
 
@@ -1432,7 +1432,7 @@ void linspace_real_array(modelica_real x1, modelica_real x2, int n,
     }
 }
 
-modelica_real max_real_array(const real_array_t a)
+modelica_real max_real_array(const real_array a)
 {
     size_t nr_of_elements;
     modelica_real max_element = DBL_MIN;
@@ -1454,7 +1454,7 @@ modelica_real max_real_array(const real_array_t a)
     return max_element;
 }
 
-modelica_real min_real_array(const real_array_t a)
+modelica_real min_real_array(const real_array a)
 {
     size_t nr_of_elements;
     modelica_real min_element = DBL_MAX;
@@ -1476,7 +1476,7 @@ modelica_real min_real_array(const real_array_t a)
     return min_element;
 }
 
-modelica_real sum_real_array(const real_array_t a)
+modelica_real sum_real_array(const real_array a)
 {
     size_t i;
     size_t nr_of_elements;
@@ -1493,7 +1493,7 @@ modelica_real sum_real_array(const real_array_t a)
     return sum;
 }
 
-modelica_real product_real_array(const real_array_t a)
+modelica_real product_real_array(const real_array a)
 {
     size_t i;
     size_t nr_of_elements;
@@ -1510,7 +1510,7 @@ modelica_real product_real_array(const real_array_t a)
     return product;
 }
 
-void symmetric_real_array(const real_array_t * a,real_array_t* dest)
+void symmetric_real_array(const real_array * a,real_array* dest)
 {
     size_t i;
     size_t j;
@@ -1532,7 +1532,7 @@ void symmetric_real_array(const real_array_t * a,real_array_t* dest)
     }
 }
 
-void cross_real_array(const real_array_t * x,const real_array_t * y, real_array_t* dest)
+void cross_real_array(const real_array * x,const real_array * y, real_array* dest)
 {
     /* Assert x and y are vectors */
     omc_assert_macro((x->ndims == 1) && (x->dim_size[0] == 3));
@@ -1546,13 +1546,13 @@ void cross_real_array(const real_array_t * x,const real_array_t * y, real_array_
     real_set(dest, 2, (real_get(*x,0) * real_get(*y,1)) - (real_get(*x,1) * real_get(*y,0)));
 }
 
-void cross_alloc_real_array(const real_array_t * x,const real_array_t * y, real_array_t* dest)
+void cross_alloc_real_array(const real_array * x,const real_array * y, real_array* dest)
 {
     alloc_real_array(dest,1,3);
     cross_real_array(x,y,dest);
 }
 
-void skew_real_array(const real_array_t * x,real_array_t* dest)
+void skew_real_array(const real_array * x,real_array* dest)
 {
     /* Assert x vector*/
     /* Assert x has size 3*/
@@ -1568,7 +1568,7 @@ void skew_real_array(const real_array_t * x,real_array_t* dest)
     real_set(dest, 8, 0);
 }
 
-void convert_alloc_real_array_to_f77(const real_array_t * a, real_array_t* dest)
+void convert_alloc_real_array_to_f77(const real_array * a, real_array* dest)
 {
     int i;
     clone_reverse_base_array_spec(a, dest);
@@ -1579,7 +1579,7 @@ void convert_alloc_real_array_to_f77(const real_array_t * a, real_array_t* dest)
     }
 }
 
-void convert_alloc_real_array_from_f77(const real_array_t * a, real_array_t* dest)
+void convert_alloc_real_array_from_f77(const real_array * a, real_array* dest)
 {
     int i;
     clone_reverse_base_array_spec(a,dest);
@@ -1592,7 +1592,7 @@ void convert_alloc_real_array_from_f77(const real_array_t * a, real_array_t* des
     transpose_real_array(a, dest);
 }
 
-void cast_integer_array_to_real(const integer_array_t* a, real_array_t* dest)
+void cast_integer_array_to_real(const integer_array_t* a, real_array* dest)
 {
     int els = base_array_nr_of_elements(*a);
     int i;
@@ -1603,7 +1603,7 @@ void cast_integer_array_to_real(const integer_array_t* a, real_array_t* dest)
     }
 }
 
-void cast_real_array_to_integer(const real_array_t * a, integer_array_t* dest)
+void cast_real_array_to_integer(const real_array * a, integer_array_t* dest)
 {
     int els = base_array_nr_of_elements(*a);
     int i;
@@ -1615,7 +1615,7 @@ void cast_real_array_to_integer(const real_array_t * a, integer_array_t* dest)
 }
 
 /* Fills an array with a value. */
-void fill_alloc_real_array(real_array_t* dest, modelica_real value, int ndims, ...)
+void fill_alloc_real_array(real_array* dest, modelica_real value, int ndims, ...)
 {
     size_t i;
     size_t elements = 0;
@@ -1630,7 +1630,7 @@ void fill_alloc_real_array(real_array_t* dest, modelica_real value, int ndims, .
     }
 }
 
-void identity_alloc_real_array(int n,real_array_t* dest)
+void identity_alloc_real_array(int n,real_array* dest)
 {
     alloc_real_array(dest,2,n,n);
     identity_real_array(n,dest);
@@ -1638,7 +1638,7 @@ void identity_alloc_real_array(int n,real_array_t* dest)
 
 /* Creates a real array from a range with a start, stop and step value.
  * Ex: 1.0:2.0:6.0 => {1.0,3.0,5.0} */
-void create_real_array_from_range(real_array_t *dest, modelica_real start, modelica_real step, modelica_real stop)
+void create_real_array_from_range(real_array *dest, modelica_real start, modelica_real step, modelica_real stop)
 {
     size_t elements;
     size_t i;

--- a/OMCompiler/SimulationRuntime/c/util/real_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.h
@@ -40,198 +40,198 @@
 #include "omc_msvc.h"
 #include <stdarg.h>
 
-modelica_real real_get(const real_array_t a, size_t i);
-modelica_real real_get_2D(const real_array_t a, size_t i, size_t j);
-modelica_real real_get_3D(const real_array_t a, size_t i, size_t j, size_t k);
-modelica_real real_get_4D(const real_array_t a, size_t i, size_t j, size_t k, size_t l);
-modelica_real real_get_5D(const real_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
+modelica_real real_get(const real_array a, size_t i);
+modelica_real real_get_2D(const real_array a, size_t i, size_t j);
+modelica_real real_get_3D(const real_array a, size_t i, size_t j, size_t k);
+modelica_real real_get_4D(const real_array a, size_t i, size_t j, size_t k, size_t l);
+modelica_real real_get_5D(const real_array a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Setting the fields of a real_array */
-extern void real_array_create(real_array_t *dest, modelica_real *data, int ndims, ...);
+extern void real_array_create(real_array *dest, modelica_real *data, int ndims, ...);
 
 /* Allocation of a vector */
-extern void simple_alloc_1d_real_array(real_array_t* dest, int n);
+extern void simple_alloc_1d_real_array(real_array* dest, int n);
 
 /* Allocation of a matrix */
-extern void simple_alloc_2d_real_array(real_array_t* dest, int r, int c);
+extern void simple_alloc_2d_real_array(real_array* dest, int r, int c);
 
-extern void alloc_real_array(real_array_t* dest,int ndims,...);
+extern void alloc_real_array(real_array* dest,int ndims,...);
 
 /* Allocation of real data */
-extern void alloc_real_array_data(real_array_t* a);
+extern void alloc_real_array_data(real_array* a);
 
 /* Frees memory*/
-extern void free_real_array_data(real_array_t* a);
+extern void free_real_array_data(real_array* a);
 
 /* Clones data*/
-static inline void clone_real_array_spec(const real_array_t *src, real_array_t* dst)
+static inline void clone_real_array_spec(const real_array *src, real_array* dst)
 { clone_base_array_spec(src, dst); }
 
 /* Copy real data given memory ptr*/
-extern void copy_real_array_data_mem(const real_array_t source, modelica_real* dest);
+extern void copy_real_array_data_mem(const real_array source, modelica_real* dest);
 
 /* Copy real array*/
-extern void copy_real_array(const real_array_t source, real_array_t* dest);
+extern void copy_real_array(const real_array source, real_array* dest);
 
-extern void create_real_array_from_range(real_array_t *dest, modelica_real start, modelica_real step, modelica_real stop);
+extern void create_real_array_from_range(real_array *dest, modelica_real start, modelica_real step, modelica_real stop);
 
-void fill_real_array_from_range(real_array_t *dest, modelica_real start, modelica_real step,
+void fill_real_array_from_range(real_array *dest, modelica_real start, modelica_real step,
                                 modelica_real stop/*, size_t dim*/);
 
-extern modelica_real* calc_real_index(int ndims, const _index_t* idx_vec, const real_array_t * arr);
-extern modelica_real* calc_real_index_va(const real_array_t * source,int ndims,va_list ap);
+extern modelica_real* calc_real_index(int ndims, const _index_t* idx_vec, const real_array * arr);
+extern modelica_real* calc_real_index_va(const real_array * source,int ndims,va_list ap);
 
-extern void put_real_element(modelica_real value,int i1,real_array_t* dest);
-extern void put_real_matrix_element(modelica_real value, int r, int c, real_array_t* dest);
+extern void put_real_element(modelica_real value,int i1,real_array* dest);
+extern void put_real_matrix_element(modelica_real value, int r, int c, real_array* dest);
 
-extern void print_real_matrix(const real_array_t * source);
-extern void print_real_array(const real_array_t * source);
+extern void print_real_matrix(const real_array * source);
+extern void print_real_array(const real_array * source);
 /*
 
  a[1:3] := b;
 
 */
-extern void indexed_assign_real_array(const real_array_t source,
-             real_array_t* dest,
+extern void indexed_assign_real_array(const real_array source,
+             real_array* dest,
              const index_spec_t* dest_spec);
-extern void simple_indexed_assign_real_array1(const real_array_t * source,
+extern void simple_indexed_assign_real_array1(const real_array * source,
                int i1,
-               real_array_t* dest);
-extern void simple_indexed_assign_real_array2(const real_array_t * source,
+               real_array* dest);
+extern void simple_indexed_assign_real_array2(const real_array * source,
                int i1, int i2,
-               real_array_t* dest);
+               real_array* dest);
 
 /*
 
  a := b[1:3];
 
 */
-extern void index_real_array(const real_array_t * source,
+extern void index_real_array(const real_array * source,
                       const index_spec_t* source_spec,
-                      real_array_t* dest);
-extern void index_alloc_real_array(const real_array_t * source,
+                      real_array* dest);
+extern void index_alloc_real_array(const real_array * source,
                             const index_spec_t* source_spec,
-                            real_array_t* dest);
+                            real_array* dest);
 
-extern void simple_index_alloc_real_array1(const real_array_t * source, int i1,
-                                    real_array_t* dest);
+extern void simple_index_alloc_real_array1(const real_array * source, int i1,
+                                    real_array* dest);
 
-extern void simple_index_real_array1(const real_array_t * source,
+extern void simple_index_real_array1(const real_array * source,
                               int i1,
-                              real_array_t* dest);
-extern void simple_index_real_array2(const real_array_t * source,
+                              real_array* dest);
+extern void simple_index_real_array2(const real_array * source,
                               int i1, int i2,
-                              real_array_t* dest);
+                              real_array* dest);
 
 /* array(A,B,C) for arrays A,B,C */
-extern void array_real_array(real_array_t* dest,int n,real_array_t first,...);
-extern void array_alloc_real_array(real_array_t* dest,int n,real_array_t first,...);
+extern void array_real_array(real_array* dest,int n,real_array first,...);
+extern void array_alloc_real_array(real_array* dest,int n,real_array first,...);
 
 /* array(s1,s2,s3)  for scalars s1,s2,s3 */
-extern void array_scalar_real_array(real_array_t* dest,int n,modelica_real first,...);
-extern void array_alloc_scalar_real_array(real_array_t* dest,int n,modelica_real first,...);
+extern void array_scalar_real_array(real_array* dest,int n,modelica_real first,...);
+extern void array_alloc_scalar_real_array(real_array* dest,int n,modelica_real first,...);
 
-extern void cat_real_array(int k,real_array_t* dest, int n, const real_array_t* first,...);
-extern void cat_alloc_real_array(int k,real_array_t* dest, int n, const real_array_t* first,...);
+extern void cat_real_array(int k,real_array* dest, int n, const real_array* first,...);
+extern void cat_alloc_real_array(int k,real_array* dest, int n, const real_array* first,...);
 
 extern void range_alloc_real_array(modelica_real start,modelica_real stop,modelica_real inc,
-                            real_array_t* dest);
-extern void range_real_array(modelica_real start,modelica_real stop, modelica_real inc,real_array_t* dest);
+                            real_array* dest);
+extern void range_real_array(modelica_real start,modelica_real stop, modelica_real inc,real_array* dest);
 
-extern real_array_t add_alloc_real_array(const real_array_t a, const real_array_t b);
-extern void add_real_array(const real_array_t * a, const real_array_t * b, real_array_t* dest);
-extern real_array_t add_alloc_real_array_scalar(const real_array_t arr, const modelica_real sc);
-extern real_array_t sub_alloc_scalar_real_array(const modelica_real sc, const real_array_t arr);
+extern real_array add_alloc_real_array(const real_array a, const real_array b);
+extern void add_real_array(const real_array * a, const real_array * b, real_array* dest);
+extern real_array add_alloc_real_array_scalar(const real_array arr, const modelica_real sc);
+extern real_array sub_alloc_scalar_real_array(const modelica_real sc, const real_array arr);
 
 /* Unary subtraction */
-extern void usub_real_array(real_array_t* a);
-extern void usub_alloc_real_array(const real_array_t a, real_array_t* dest);
-extern void sub_real_array(const real_array_t * a, const real_array_t * b, real_array_t* dest);
-extern real_array_t sub_alloc_real_array(const real_array_t a, const real_array_t b);
+extern void usub_real_array(real_array* a);
+extern void usub_alloc_real_array(const real_array a, real_array* dest);
+extern void sub_real_array(const real_array * a, const real_array * b, real_array* dest);
+extern real_array sub_alloc_real_array(const real_array a, const real_array b);
 
-extern void sub_real_array_data_mem(const real_array_t * a, const real_array_t * b,
+extern void sub_real_array_data_mem(const real_array * a, const real_array * b,
                              modelica_real* dest);
 
-extern void mul_scalar_real_array(modelica_real a,const real_array_t * b,real_array_t* dest);
-extern real_array_t mul_alloc_scalar_real_array(modelica_real a,const real_array_t b);
+extern void mul_scalar_real_array(modelica_real a,const real_array * b,real_array* dest);
+extern real_array mul_alloc_scalar_real_array(modelica_real a,const real_array b);
 
-extern void mul_real_array_scalar(const real_array_t * a,modelica_real b,real_array_t* dest);
-extern real_array_t mul_alloc_real_array_scalar(const real_array_t a, const modelica_real b);
+extern void mul_real_array_scalar(const real_array * a,modelica_real b,real_array* dest);
+extern real_array mul_alloc_real_array_scalar(const real_array a, const modelica_real b);
 
-extern void mul_real_array(const real_array_t *a,const real_array_t *b,real_array_t* dest);
-extern real_array_t mul_alloc_real_array(const real_array_t a,const real_array_t b);
+extern void mul_real_array(const real_array *a,const real_array *b,real_array* dest);
+extern real_array mul_alloc_real_array(const real_array a,const real_array b);
 
-extern modelica_real mul_real_scalar_product(const real_array_t a, const real_array_t b);
+extern modelica_real mul_real_scalar_product(const real_array a, const real_array b);
 
-extern void mul_real_matrix_product(const real_array_t *a,const real_array_t *b,real_array_t*dest);
-extern void mul_real_matrix_vector(const real_array_t * a, const real_array_t * b,
-                            real_array_t* dest);
-extern void mul_real_vector_matrix(const real_array_t * a, const real_array_t * b,
-                            real_array_t* dest);
-extern real_array_t mul_alloc_real_matrix_product_smart(const real_array_t a, const real_array_t b);
+extern void mul_real_matrix_product(const real_array *a,const real_array *b,real_array*dest);
+extern void mul_real_matrix_vector(const real_array * a, const real_array * b,
+                            real_array* dest);
+extern void mul_real_vector_matrix(const real_array * a, const real_array * b,
+                            real_array* dest);
+extern real_array mul_alloc_real_matrix_product_smart(const real_array a, const real_array b);
 
-extern void div_real_array(const real_array_t *a,const real_array_t *b,real_array_t* dest);
-extern real_array_t div_alloc_real_array(const real_array_t a,const real_array_t b);
+extern void div_real_array(const real_array *a,const real_array *b,real_array* dest);
+extern real_array div_alloc_real_array(const real_array a,const real_array b);
 
 
-extern void div_real_array_scalar(const real_array_t * a,modelica_real b,real_array_t* dest);
-extern real_array_t div_alloc_real_array_scalar(const real_array_t a, const modelica_real b);
+extern void div_real_array_scalar(const real_array * a,modelica_real b,real_array* dest);
+extern real_array div_alloc_real_array_scalar(const real_array a, const modelica_real b);
 
-extern void division_real_array_scalar(threadData_t*,const real_array_t * a,modelica_real b,real_array_t* dest, const char* division_str);
-extern real_array_t division_alloc_real_array_scalar(threadData_t*,const real_array_t a,modelica_real b, const char* division_str);
-extern void div_scalar_real_array(modelica_real a, const real_array_t* b, real_array_t* dest);
-extern real_array_t div_alloc_scalar_real_array(modelica_real a, const real_array_t b);
-extern void pow_real_array_scalar(const real_array_t *a, modelica_real b, real_array_t* dest);
-extern real_array_t pow_alloc_real_array_scalar(const real_array_t a, const modelica_real b);
+extern void division_real_array_scalar(threadData_t*,const real_array * a,modelica_real b,real_array* dest, const char* division_str);
+extern real_array division_alloc_real_array_scalar(threadData_t*,const real_array a,modelica_real b, const char* division_str);
+extern void div_scalar_real_array(modelica_real a, const real_array* b, real_array* dest);
+extern real_array div_alloc_scalar_real_array(modelica_real a, const real_array b);
+extern void pow_real_array_scalar(const real_array *a, modelica_real b, real_array* dest);
+extern real_array pow_alloc_real_array_scalar(const real_array a, const modelica_real b);
 
-extern void exp_real_array(const real_array_t * a, modelica_integer n, real_array_t* dest);
-extern real_array_t exp_alloc_real_array(const real_array_t a, modelica_integer b);
+extern void exp_real_array(const real_array * a, modelica_integer n, real_array* dest);
+extern real_array exp_alloc_real_array(const real_array a, modelica_integer b);
 
-extern void promote_real_array(const real_array_t * a, int n,real_array_t* dest);
-extern void promote_scalar_real_array(modelica_real s,int n,real_array_t* dest);
-extern void promote_alloc_real_array(const real_array_t * a, int n, real_array_t* dest);
+extern void promote_real_array(const real_array * a, int n,real_array* dest);
+extern void promote_scalar_real_array(modelica_real s,int n,real_array* dest);
+extern void promote_alloc_real_array(const real_array * a, int n, real_array* dest);
 
-static inline int ndims_real_array(const real_array_t * a)
+static inline int ndims_real_array(const real_array * a)
 { return ndims_base_array(a); }
 
-extern void size_real_array(const real_array_t * a,integer_array_t* dest);
-extern modelica_real scalar_real_array(const real_array_t * a);
-extern void vector_real_array(const real_array_t * a, real_array_t* dest);
-extern void vector_real_scalar(modelica_real a,real_array_t* dest);
-extern void matrix_real_array(const real_array_t * a, real_array_t* dest);
-extern void matrix_real_scalar(modelica_real a,real_array_t* dest);
-extern void transpose_alloc_real_array(const real_array_t * a, real_array_t* dest);
-extern void transpose_real_array(const real_array_t * a, real_array_t* dest);
-extern void outer_product_alloc_real_array(real_array_t* v1, real_array_t* v2, real_array_t* dest);
-extern void outer_product_real_array(const real_array_t * v1,const real_array_t * v2, real_array_t* dest);
-extern void identity_real_array(int n, real_array_t* dest);
-extern void diagonal_real_array(const real_array_t * v,real_array_t* dest);
-extern void diagonal_alloc_real_array(const real_array_t* v, real_array_t* dest);
-extern void fill_real_array(real_array_t* dest,modelica_real s);
+extern void size_real_array(const real_array * a,integer_array_t* dest);
+extern modelica_real scalar_real_array(const real_array * a);
+extern void vector_real_array(const real_array * a, real_array* dest);
+extern void vector_real_scalar(modelica_real a,real_array* dest);
+extern void matrix_real_array(const real_array * a, real_array* dest);
+extern void matrix_real_scalar(modelica_real a,real_array* dest);
+extern void transpose_alloc_real_array(const real_array * a, real_array* dest);
+extern void transpose_real_array(const real_array * a, real_array* dest);
+extern void outer_product_alloc_real_array(real_array* v1, real_array* v2, real_array* dest);
+extern void outer_product_real_array(const real_array * v1,const real_array * v2, real_array* dest);
+extern void identity_real_array(int n, real_array* dest);
+extern void diagonal_real_array(const real_array * v,real_array* dest);
+extern void diagonal_alloc_real_array(const real_array* v, real_array* dest);
+extern void fill_real_array(real_array* dest,modelica_real s);
 extern void linspace_real_array(modelica_real x1,modelica_real x2,int n,
-                         real_array_t* dest);
-extern modelica_real min_real_array(const real_array_t a);
-extern modelica_real max_real_array(const real_array_t a);
-extern modelica_real sum_real_array(const real_array_t a);
-extern modelica_real product_real_array(const real_array_t a);
-extern void symmetric_real_array(const real_array_t * a,real_array_t* dest);
-extern void cross_real_array(const real_array_t * x,const real_array_t * y, real_array_t* dest);
-extern void cross_alloc_real_array(const real_array_t * x,const real_array_t * y, real_array_t* dest);
-extern void skew_real_array(const real_array_t * x,real_array_t* dest);
+                         real_array* dest);
+extern modelica_real min_real_array(const real_array a);
+extern modelica_real max_real_array(const real_array a);
+extern modelica_real sum_real_array(const real_array a);
+extern modelica_real product_real_array(const real_array a);
+extern void symmetric_real_array(const real_array * a,real_array* dest);
+extern void cross_real_array(const real_array * x,const real_array * y, real_array* dest);
+extern void cross_alloc_real_array(const real_array * x,const real_array * y, real_array* dest);
+extern void skew_real_array(const real_array * x,real_array* dest);
 
 #define real_array_nr_of_elements(X) base_array_nr_of_elements(X)
 
-static inline void clone_reverse_real_array_spec(const real_array_t *source,
-                                                 real_array_t *dest)
+static inline void clone_reverse_real_array_spec(const real_array *source,
+                                                 real_array *dest)
 { clone_reverse_base_array_spec(source, dest); }
-extern void convert_alloc_real_array_to_f77(const real_array_t * a, real_array_t* dest);
-extern void convert_alloc_real_array_from_f77(const real_array_t * a, real_array_t* dest);
+extern void convert_alloc_real_array_to_f77(const real_array * a, real_array* dest);
+extern void convert_alloc_real_array_from_f77(const real_array * a, real_array* dest);
 
-extern void cast_integer_array_to_real(const integer_array_t * a, real_array_t * dest);
-extern void cast_real_array_to_integer(const real_array_t * a, integer_array_t * dest);
+extern void cast_integer_array_to_real(const integer_array_t * a, real_array * dest);
+extern void cast_real_array_to_integer(const real_array * a, integer_array_t * dest);
 
-extern void fill_alloc_real_array(real_array_t* dest, modelica_real value, int ndims, ...);
+extern void fill_alloc_real_array(real_array* dest, modelica_real value, int ndims, ...);
 
-extern void identity_alloc_real_array(int n, real_array_t* dest);
+extern void identity_alloc_real_array(int n, real_array* dest);
 
 #endif

--- a/OMCompiler/SimulationRuntime/c/util/real_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/real_array.h
@@ -194,7 +194,7 @@ extern void promote_alloc_real_array(const real_array * a, int n, real_array* de
 static inline int ndims_real_array(const real_array * a)
 { return ndims_base_array(a); }
 
-extern void size_real_array(const real_array * a,integer_array_t* dest);
+extern void size_real_array(const real_array * a,integer_array* dest);
 extern modelica_real scalar_real_array(const real_array * a);
 extern void vector_real_array(const real_array * a, real_array* dest);
 extern void vector_real_scalar(modelica_real a,real_array* dest);
@@ -227,8 +227,8 @@ static inline void clone_reverse_real_array_spec(const real_array *source,
 extern void convert_alloc_real_array_to_f77(const real_array * a, real_array* dest);
 extern void convert_alloc_real_array_from_f77(const real_array * a, real_array* dest);
 
-extern void cast_integer_array_to_real(const integer_array_t * a, real_array * dest);
-extern void cast_real_array_to_integer(const real_array * a, integer_array_t * dest);
+extern void cast_integer_array_to_real(const integer_array * a, real_array * dest);
+extern void cast_real_array_to_integer(const real_array * a, integer_array * dest);
 
 extern void fill_alloc_real_array(real_array* dest, modelica_real value, int ndims, ...);
 

--- a/OMCompiler/SimulationRuntime/c/util/string_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.c
@@ -41,37 +41,37 @@
 #include <assert.h>
 #include <stdarg.h>
 
-static inline modelica_string *string_ptrget(const string_array_t *a, size_t i)
+static inline modelica_string *string_ptrget(const string_array *a, size_t i)
 {
     return ((modelica_string *) a->data) + i;
 }
 
-static inline void string_set(string_array_t *a, size_t i, modelica_string r)
+static inline void string_set(string_array *a, size_t i, modelica_string r)
 {
     ((modelica_string *) a->data)[i] = r;
 }
 
-modelica_string string_get(const string_array_t a, size_t i)
+modelica_string string_get(const string_array a, size_t i)
 {
     return ((modelica_string *) a.data)[i];
 }
 
-modelica_string string_get_2D(const string_array_t a, size_t i, size_t j)
+modelica_string string_get_2D(const string_array a, size_t i, size_t j)
 {
   return string_get(a, getIndex_2D(a.dim_size,i,j));
 }
 
-modelica_string string_get_3D(const string_array_t a, size_t i, size_t j, size_t k)
+modelica_string string_get_3D(const string_array a, size_t i, size_t j, size_t k)
 {
   return string_get(a, getIndex_3D(a.dim_size,i,j,k));
 }
 
-modelica_string string_get_4D(const string_array_t a, size_t i, size_t j, size_t k, size_t l)
+modelica_string string_get_4D(const string_array a, size_t i, size_t j, size_t k, size_t l)
 {
   return string_get(a, getIndex_4D(a.dim_size,i,j,k,l));
 }
 
-modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m)
+modelica_string string_get_5D(const string_array a, size_t i, size_t j, size_t k, size_t l, size_t m)
 {
   return string_get(a, getIndex_5D(a.dim_size,i,j,k,l,m));
 }
@@ -82,7 +82,7 @@ modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t
  ** sets all fields in a string_array, i.e. data, ndims and dim_size.
  **/
 
-void string_array_create(string_array_t *dest, modelica_string *data,
+void string_array_create(string_array *dest, modelica_string *data,
                          int ndims, ...)
 {
     va_list ap;
@@ -91,17 +91,17 @@ void string_array_create(string_array_t *dest, modelica_string *data,
     va_end(ap);
 }
 
-void simple_alloc_1d_string_array(string_array_t* dest, int n)
+void simple_alloc_1d_string_array(string_array* dest, int n)
 {
     simple_alloc_1d_base_array(dest, n, string_alloc(n));
 }
 
-void simple_alloc_2d_string_array(string_array_t* dest, int r, int c)
+void simple_alloc_2d_string_array(string_array* dest, int r, int c)
 {
     simple_alloc_2d_base_array(dest, r, c, string_alloc(r * c));
 }
 
-void alloc_string_array(string_array_t *dest, int ndims, ...)
+void alloc_string_array(string_array *dest, int ndims, ...)
 {
     size_t elements = 0;
     va_list ap;
@@ -111,12 +111,12 @@ void alloc_string_array(string_array_t *dest, int ndims, ...)
     dest->data = string_alloc(elements);
 }
 
-void alloc_string_array_data(string_array_t* a)
+void alloc_string_array_data(string_array* a)
 {
     a->data = string_alloc(base_array_nr_of_elements(*a));
 }
 
-void copy_string_array_data_mem(const string_array_t source, modelica_string *dest)
+void copy_string_array_data_mem(const string_array source, modelica_string *dest)
 {
     size_t i, nr_of_elements;
 
@@ -129,7 +129,7 @@ void copy_string_array_data_mem(const string_array_t source, modelica_string *de
     }
 }
 
-void copy_string_array(const string_array_t source, string_array_t *dest)
+void copy_string_array(const string_array source, string_array *dest)
 {
     string_array_alloc_copy(source,*dest);
 }
@@ -139,7 +139,7 @@ void copy_string_array(const string_array_t source, string_array_t *dest)
 */
 
 static inline modelica_string *calc_string_index_spec(int ndims, const _index_t *idx_vec,
-                                                        const string_array_t *arr,
+                                                        const string_array *arr,
                                                         const index_spec_t *spec)
 {
     return string_ptrget(arr, calc_base_index_spec(ndims, idx_vec, arr, spec));
@@ -147,19 +147,19 @@ static inline modelica_string *calc_string_index_spec(int ndims, const _index_t 
 
 /* Uses zero based indexing */
 modelica_string *calc_string_index(int ndims, const _index_t *idx_vec,
-                                     const string_array_t *arr)
+                                     const string_array *arr)
 {
     return string_ptrget(arr, calc_base_index(ndims, idx_vec, arr));
 }
 
 /* One based index*/
-modelica_string *calc_string_index_va(const string_array_t *source, int ndims,
+modelica_string *calc_string_index_va(const string_array *source, int ndims,
                                         va_list ap)
 {
     return string_ptrget(source, calc_base_index_va(source, ndims, ap));
 }
 
-void print_string_matrix(const string_array_t *source)
+void print_string_matrix(const string_array *source)
 {
     if(source->ndims == 2) {
         _index_t i,j;
@@ -178,7 +178,7 @@ void print_string_matrix(const string_array_t *source)
     }
 }
 
-void print_string_array(const string_array_t *source)
+void print_string_array(const string_array *source)
 {
     _index_t i;
     modelica_string *data;
@@ -217,7 +217,7 @@ void print_string_array(const string_array_t *source)
     }
 }
 
-void put_string_element(modelica_string value, int i1, string_array_t *dest)
+void put_string_element(modelica_string value, int i1, string_array *dest)
 {
     /* Assert that dest has correct dimension */
     /* Assert that i1 is a valid index */
@@ -225,7 +225,7 @@ void put_string_element(modelica_string value, int i1, string_array_t *dest)
 }
 
 void put_string_matrix_element(modelica_string value, int r, int c,
-                               string_array_t* dest)
+                               string_array* dest)
 {
     /* Assert that dest hast correct dimension */
     /* Assert that r and c are valid indices */
@@ -234,18 +234,18 @@ void put_string_matrix_element(modelica_string value, int r, int c,
 }
 
 /* Zero based index */
-void simple_indexed_assign_string_array1(const string_array_t * source,
+void simple_indexed_assign_string_array1(const string_array * source,
                                          int i1,
-                                         string_array_t* dest)
+                                         string_array* dest)
 {
     /* Assert that source has the correct dimension */
     /* Assert that dest has the correct dimension */
     string_set(dest, i1, string_get(*source, i1));
 }
 
-void simple_indexed_assign_string_array2(const string_array_t * source,
+void simple_indexed_assign_string_array2(const string_array * source,
                                          int i1, int i2,
-                                         string_array_t* dest)
+                                         string_array* dest)
 {
     size_t index;
     /* Assert that source has correct dimension */
@@ -254,8 +254,8 @@ void simple_indexed_assign_string_array2(const string_array_t * source,
     string_set(dest, index, string_get(*source, index));
 }
 
-void indexed_assign_string_array(const string_array_t source,
-                                 string_array_t* dest,
+void indexed_assign_string_array(const string_array source,
+                                 string_array* dest,
                                  const index_spec_t* dest_spec)
 {
     _index_t *idx_vec1, *idx_size;
@@ -285,9 +285,9 @@ void indexed_assign_string_array(const string_array_t source,
  *
  */
 
-void index_string_array(const string_array_t * source,
+void index_string_array(const string_array * source,
                         const index_spec_t* source_spec,
-                        string_array_t* dest)
+                        string_array* dest)
 {
     _index_t* idx_vec1;
     _index_t* idx_vec2;
@@ -352,9 +352,9 @@ void index_string_array(const string_array_t * source,
  * a := b[1:3];
  */
 
-void index_alloc_string_array(const string_array_t * source,
+void index_alloc_string_array(const string_array * source,
                               const index_spec_t* source_spec,
-                              string_array_t* dest)
+                              string_array* dest)
 {
     index_alloc_base_array_size(source, source_spec, dest);
     alloc_string_array_data(dest);
@@ -362,8 +362,8 @@ void index_alloc_string_array(const string_array_t * source,
 }
 
 /* Returns dest := source[i1,:,:...]*/
-void simple_index_alloc_string_array1(const string_array_t * source, int i1,
-                                      string_array_t* dest)
+void simple_index_alloc_string_array1(const string_array * source, int i1,
+                                      string_array* dest)
 {
     int i;
     assert(base_array_ok(source));
@@ -379,8 +379,8 @@ void simple_index_alloc_string_array1(const string_array_t * source, int i1,
     simple_index_string_array1(source, i1, dest);
 }
 
-void simple_index_string_array1(const string_array_t * source, int i1,
-                                string_array_t* dest)
+void simple_index_string_array1(const string_array * source, int i1,
+                                string_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -393,9 +393,9 @@ void simple_index_string_array1(const string_array_t * source, int i1,
     }
 }
 
-void simple_index_string_array2(const string_array_t * source,
+void simple_index_string_array2(const string_array * source,
                                 int i1, int i2,
-                                string_array_t* dest)
+                                string_array* dest)
 {
     size_t i;
     size_t nr_of_elements = base_array_nr_of_elements(*dest);
@@ -406,18 +406,18 @@ void simple_index_string_array2(const string_array_t * source,
     }
 }
 
-void array_string_array(string_array_t* dest,int n,string_array_t first,...)
+void array_string_array(string_array* dest,int n,string_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    string_array_t *elts=(string_array_t*)malloc(sizeof(string_array_t) * n);
+    string_array *elts=(string_array*)malloc(sizeof(string_array) * n);
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, string_array_t);
+        elts[i] = va_arg(ap, string_array);
     }
     va_end(ap);
 
@@ -433,19 +433,19 @@ void array_string_array(string_array_t* dest,int n,string_array_t first,...)
     free(elts);
 }
 
-void array_alloc_string_array(string_array_t* dest, int n,
-                              string_array_t first,...)
+void array_alloc_string_array(string_array* dest, int n,
+                              string_array first,...)
 {
     int i,j,c;
     va_list ap;
 
-    string_array_t *elts = (string_array_t*)malloc(sizeof(string_array_t) * n);
+    string_array *elts = (string_array*)malloc(sizeof(string_array) * n);
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
     va_start(ap,first);
     elts[0] = first;
     for(i = 1; i < n; ++i) {
-        elts[i] = va_arg(ap, string_array_t);
+        elts[i] = va_arg(ap, string_array);
     }
     va_end(ap);
 
@@ -478,7 +478,7 @@ void array_alloc_string_array(string_array_t* dest, int n,
  * Creates(incl allocation) an array from scalar elements.
  */
 
-void array_alloc_scalar_string_array(string_array_t* dest, int n,
+void array_alloc_scalar_string_array(string_array* dest, int n,
                                      modelica_string first,...)
 {
     int i;
@@ -498,14 +498,14 @@ void array_alloc_scalar_string_array(string_array_t* dest, int n,
  * Concatenates n string arrays along the k:th dimension.
  * k is one based
  */
-void cat_string_array(int k, string_array_t* dest, int n,
-                    const string_array_t* first,...)
+void cat_string_array(int k, string_array* dest, int n,
+                    const string_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const string_array_t **elts = (const string_array_t**)malloc(sizeof(string_array_t *) * n);
+    const string_array **elts = (const string_array**)malloc(sizeof(string_array *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -513,7 +513,7 @@ void cat_string_array(int k, string_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const string_array_t*);
+        elts[i] = va_arg(ap,const string_array*);
     }
     va_end(ap);
 
@@ -560,14 +560,14 @@ void cat_string_array(int k, string_array_t* dest, int n,
  * allocates space in dest array
  * k is one based
  */
-void cat_alloc_string_array(int k, string_array_t* dest, int n,
-                          const string_array_t* first,...)
+void cat_alloc_string_array(int k, string_array* dest, int n,
+                          const string_array* first,...)
 {
     va_list ap;
     int i, j, r, c;
     int n_sub = 1, n_super = 1;
     int new_k_dim_size = 0;
-    const string_array_t **elts = (const string_array_t**)malloc(sizeof(string_array_t *) * n);
+    const string_array **elts = (const string_array**)malloc(sizeof(string_array *) * n);
 
     assert(elts);
     /* collect all array ptrs to simplify traversal.*/
@@ -575,7 +575,7 @@ void cat_alloc_string_array(int k, string_array_t* dest, int n,
     elts[0] = first;
 
     for(i = 1; i < n; i++) {
-        elts[i] = va_arg(ap,const string_array_t*);
+        elts[i] = va_arg(ap,const string_array*);
     }
     va_end(ap);
 
@@ -628,8 +628,8 @@ void cat_alloc_string_array(int k, string_array_t* dest, int n,
  * Implementation of promote(A,n) same as promote_string_array except
  * that the destination array is allocated.
  */
-void promote_alloc_string_array(const string_array_t * a, int n,
-                                string_array_t* dest)
+void promote_alloc_string_array(const string_array * a, int n,
+                                string_array* dest)
 {
     clone_string_array_spec(a,dest);
     alloc_string_array_data(dest);
@@ -644,7 +644,7 @@ void promote_alloc_string_array(const string_array_t * a, int n,
  * promote_exp( {1,2},1) => {{1},{2}}
  * promote_exp( {1,2},2) => { {{1}},{{2}} }
 */
-void promote_string_array(const string_array_t * a, int n,string_array_t* dest)
+void promote_string_array(const string_array * a, int n,string_array* dest)
 {
     int i;
 
@@ -667,7 +667,7 @@ void promote_string_array(const string_array_t * a, int n,string_array_t* dest)
  */
 
 void promote_scalar_string_array(modelica_string s,int n,
-                                 string_array_t* dest)
+                                 string_array* dest)
 {
     int i;
 
@@ -688,7 +688,7 @@ void promote_scalar_string_array(modelica_string s,int n,
 }
 
 /* return a vector of length ndims(a) containing the dimension sizes of a */
-void size_string_array(const string_array_t * a, integer_array* dest)
+void size_string_array(const string_array * a, integer_array* dest)
 {
     int i;
 
@@ -700,7 +700,7 @@ void size_string_array(const string_array_t * a, integer_array* dest)
     }
 }
 
-modelica_string scalar_string_array(const string_array_t * a)
+modelica_string scalar_string_array(const string_array * a)
 {
     assert(base_array_ok(a));
     assert(base_array_one_element_ok(a));
@@ -708,7 +708,7 @@ modelica_string scalar_string_array(const string_array_t * a)
     return string_get(*a, 0);
 }
 
-void vector_string_array(const string_array_t * a, string_array_t* dest)
+void vector_string_array(const string_array * a, string_array* dest)
 {
     size_t i, nr_of_elements;
 
@@ -720,13 +720,13 @@ void vector_string_array(const string_array_t * a, string_array_t* dest)
     }
 }
 
-void vector_string_scalar(modelica_string a,string_array_t* dest)
+void vector_string_scalar(modelica_string a,string_array* dest)
 {
     /* Assert that dest is a 1-vector */
     string_set(dest, 0, a);
 }
 
-void matrix_string_array(const string_array_t * a, string_array_t* dest)
+void matrix_string_array(const string_array * a, string_array* dest)
 {
     size_t i, cnt;
     /* Assert that size(A,i)=1 for 2 <i<=ndims(A)*/
@@ -740,7 +740,7 @@ void matrix_string_array(const string_array_t * a, string_array_t* dest)
     }
 }
 
-void matrix_string_scalar(modelica_string a, string_array_t* dest)
+void matrix_string_scalar(modelica_string a, string_array* dest)
 {
     dest->ndims = 2;
     dest->dim_size[0] = 1;
@@ -754,7 +754,7 @@ void matrix_string_scalar(modelica_string a, string_array_t* dest)
  * except that destionation array is allocated.
  */
 
-void transpose_alloc_string_array(const string_array_t * a, string_array_t* dest)
+void transpose_alloc_string_array(const string_array * a, string_array* dest)
 {
     clone_string_array_spec(a,dest); /* allocation*/
 
@@ -773,7 +773,7 @@ void transpose_alloc_string_array(const string_array_t * a, string_array_t* dest
  *
  * Implementation of transpose(A) for matrix A.
  */
-void transpose_string_array(const string_array_t * a, string_array_t* dest)
+void transpose_string_array(const string_array * a, string_array* dest)
 {
     size_t i;
     size_t j;
@@ -799,7 +799,7 @@ void transpose_string_array(const string_array_t * a, string_array_t* dest)
     }
 }
 
-void fill_string_array(string_array_t* dest,modelica_string s)
+void fill_string_array(string_array* dest,modelica_string s)
 {
     size_t nr_of_elements;
     size_t i;
@@ -810,8 +810,8 @@ void fill_string_array(string_array_t* dest,modelica_string s)
     }
 }
 
-void convert_alloc_string_array_to_f77(const string_array_t * a,
-                                       string_array_t* dest)
+void convert_alloc_string_array_to_f77(const string_array * a,
+                                       string_array* dest)
 {
     int i;
     clone_reverse_base_array_spec(a, dest);
@@ -822,8 +822,8 @@ void convert_alloc_string_array_to_f77(const string_array_t * a,
     }
 }
 
-void convert_alloc_string_array_from_f77(const string_array_t * a,
-                                         string_array_t* dest)
+void convert_alloc_string_array_from_f77(const string_array * a,
+                                         string_array* dest)
 {
     int i;
     clone_reverse_base_array_spec(a,dest);
@@ -836,7 +836,7 @@ void convert_alloc_string_array_from_f77(const string_array_t * a,
     transpose_string_array(a, dest);
 }
 
-void fill_alloc_string_array(string_array_t* dest, modelica_string value, int ndims, ...)
+void fill_alloc_string_array(string_array* dest, modelica_string value, int ndims, ...)
 {
   size_t i;
   size_t elements = 0;
@@ -851,7 +851,7 @@ void fill_alloc_string_array(string_array_t* dest, modelica_string value, int nd
   }
 }
 
-const char** data_of_string_c89_array(const string_array_t a)
+const char** data_of_string_c89_array(const string_array a)
 {
   long i;
   size_t sz = base_array_nr_of_elements(a);
@@ -862,7 +862,7 @@ const char** data_of_string_c89_array(const string_array_t a)
   return res;
 }
 
-void unpack_string_array(const string_array_t *a, const char **data)
+void unpack_string_array(const string_array *a, const char **data)
 {
   size_t sz = base_array_nr_of_elements(*a);
   long i;

--- a/OMCompiler/SimulationRuntime/c/util/string_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.c
@@ -688,7 +688,7 @@ void promote_scalar_string_array(modelica_string s,int n,
 }
 
 /* return a vector of length ndims(a) containing the dimension sizes of a */
-void size_string_array(const string_array_t * a, integer_array_t* dest)
+void size_string_array(const string_array_t * a, integer_array* dest)
 {
     int i;
 

--- a/OMCompiler/SimulationRuntime/c/util/string_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.h
@@ -166,7 +166,7 @@ extern void convert_alloc_string_array_to_f77(const string_array_t * a,
 extern void convert_alloc_string_array_from_f77(const string_array_t * a,
                                                 string_array_t* dest);
 
-extern void fill_alloc_real_array(real_array_t* dest, modelica_real value, int ndims, ...);
+extern void fill_alloc_real_array(real_array* dest, modelica_real value, int ndims, ...);
 
 extern void unpack_string_array(const string_array_t *a, const char **data);
 

--- a/OMCompiler/SimulationRuntime/c/util/string_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.h
@@ -147,7 +147,7 @@ static inline int ndims_string_array(const string_array_t * a)
 
 extern const char** data_of_string_c89_array(const string_array_t a);
 
-extern void size_string_array(const string_array_t * a, integer_array_t* dest);
+extern void size_string_array(const string_array_t * a, integer_array* dest);
 extern modelica_string scalar_string_array(const string_array_t * a);
 extern void vector_string_array(const string_array_t * a, string_array_t* dest);
 extern void vector_string_scalar(modelica_string a,string_array_t* dest);

--- a/OMCompiler/SimulationRuntime/c/util/string_array.h
+++ b/OMCompiler/SimulationRuntime/c/util/string_array.h
@@ -37,137 +37,137 @@
 #include "generic_array.h"
 
 /* Indexing */
-modelica_string string_get(const string_array_t a, size_t i);
-modelica_string string_get_2D(const string_array_t a, size_t i, size_t j);
-modelica_string string_get_3D(const string_array_t a, size_t i, size_t j, size_t k);
-modelica_string string_get_4D(const string_array_t a, size_t i, size_t j, size_t k, size_t l);
-modelica_string string_get_5D(const string_array_t a, size_t i, size_t j, size_t k, size_t l, size_t m);
+modelica_string string_get(const string_array a, size_t i);
+modelica_string string_get_2D(const string_array a, size_t i, size_t j);
+modelica_string string_get_3D(const string_array a, size_t i, size_t j, size_t k);
+modelica_string string_get_4D(const string_array a, size_t i, size_t j, size_t k, size_t l);
+modelica_string string_get_5D(const string_array a, size_t i, size_t j, size_t k, size_t l, size_t m);
 
 /* Setting the fields of a string_array */
-extern void string_array_create(string_array_t *dest, modelica_string *data, int ndims, ...);
+extern void string_array_create(string_array *dest, modelica_string *data, int ndims, ...);
 
 /* Allocation of a vector */
-extern void simple_alloc_1d_string_array(string_array_t* dest, int n);
+extern void simple_alloc_1d_string_array(string_array* dest, int n);
 
 /* Allocation of a matrix */
-extern void simple_alloc_2d_string_array(string_array_t *dest, int r, int c);
+extern void simple_alloc_2d_string_array(string_array *dest, int r, int c);
 
-extern void alloc_string_array(string_array_t *dest, int ndims, ...);
-extern void fill_alloc_string_array(string_array_t* dest, modelica_string value, int ndims, ...);
+extern void alloc_string_array(string_array *dest, int ndims, ...);
+extern void fill_alloc_string_array(string_array* dest, modelica_string value, int ndims, ...);
 
 /* Allocation of string data */
-extern void alloc_string_array_data(string_array_t* a);
+extern void alloc_string_array_data(string_array* a);
 
 /* Frees memory*/
-extern void free_string_array_data(string_array_t* a);
+extern void free_string_array_data(string_array* a);
 
 /* Clones data*/
-static inline void clone_string_array_spec(const string_array_t * src,
-                                           string_array_t* dst)
+static inline void clone_string_array_spec(const string_array * src,
+                                           string_array* dst)
 { clone_base_array_spec(src, dst); }
 
 /* Copy string data given memory ptr*/
-extern void copy_string_array_data_mem(const string_array_t source,modelica_string* dest);
+extern void copy_string_array_data_mem(const string_array source,modelica_string* dest);
 
 /* Copy string array*/
-extern void copy_string_array(const string_array_t source, string_array_t* dest);
+extern void copy_string_array(const string_array source, string_array* dest);
 
-extern modelica_string* calc_string_index(int ndims, const _index_t* idx_vec, const string_array_t * arr);
-extern modelica_string* calc_string_index_va(const string_array_t * source,int ndims,
+extern modelica_string* calc_string_index(int ndims, const _index_t* idx_vec, const string_array * arr);
+extern modelica_string* calc_string_index_va(const string_array * source,int ndims,
                                                va_list ap);
 
-extern void put_string_element(modelica_string value,int i1,string_array_t* dest);
+extern void put_string_element(modelica_string value,int i1,string_array* dest);
 extern void put_string_matrix_element(modelica_string value, int r, int c,
-                                      string_array_t* dest);
+                                      string_array* dest);
 
-extern void print_string_matrix(const string_array_t * source);
-extern void print_string_array(const string_array_t * source);
+extern void print_string_matrix(const string_array * source);
+extern void print_string_array(const string_array * source);
 /*
 
  a[1:3] := b;
 
 */
-extern void indexed_assign_string_array(const string_array_t source,
-                                        string_array_t* dest,
+extern void indexed_assign_string_array(const string_array source,
+                                        string_array* dest,
                                         const index_spec_t* dest_spec);
-extern void simple_indexed_assign_string_array1(const string_array_t * source,
+extern void simple_indexed_assign_string_array1(const string_array * source,
                                                 int i1,
-                                                string_array_t* dest);
-extern void simple_indexed_assign_string_array2(const string_array_t * source,
+                                                string_array* dest);
+extern void simple_indexed_assign_string_array2(const string_array * source,
                                                 int i1, int i2,
-                                                string_array_t* dest);
+                                                string_array* dest);
 
 /*
 
  a := b[1:3];
 
 */
-extern void index_string_array(const string_array_t * source,
+extern void index_string_array(const string_array * source,
                                const index_spec_t* source_spec,
-                               string_array_t* dest);
-extern void index_alloc_string_array(const string_array_t * source,
+                               string_array* dest);
+extern void index_alloc_string_array(const string_array * source,
                                      const index_spec_t* source_spec,
-                                     string_array_t* dest);
+                                     string_array* dest);
 
-extern void simple_index_alloc_string_array1(const string_array_t * source, int i1,
-                                      string_array_t* dest);
+extern void simple_index_alloc_string_array1(const string_array * source, int i1,
+                                      string_array* dest);
 
-extern void simple_index_string_array1(const string_array_t * source,
+extern void simple_index_string_array1(const string_array * source,
                                        int i1,
-                                       string_array_t* dest);
-extern void simple_index_string_array2(const string_array_t * source,
+                                       string_array* dest);
+extern void simple_index_string_array2(const string_array * source,
                                        int i1, int i2,
-                                       string_array_t* dest);
+                                       string_array* dest);
 
 /* array(A,B,C) for arrays A,B,C */
-extern void array_string_array(string_array_t* dest,int n,
-                               string_array_t first,...);
-extern void array_alloc_string_array(string_array_t* dest,int n,
-                                     string_array_t first,...);
+extern void array_string_array(string_array* dest,int n,
+                               string_array first,...);
+extern void array_alloc_string_array(string_array* dest,int n,
+                                     string_array first,...);
 
 /* array(s1,s2,s3)  for scalars s1,s2,s3 */
-extern void array_scalar_string_array(string_array_t* dest,int n,
+extern void array_scalar_string_array(string_array* dest,int n,
                                       modelica_string first,...);
-extern void array_alloc_scalar_string_array(string_array_t* dest,int n,
+extern void array_alloc_scalar_string_array(string_array* dest,int n,
                                             modelica_string first,...);
 
-extern void cat_string_array(int k,string_array_t* dest, int n,
-                             const string_array_t* first,...);
-extern void cat_alloc_string_array(int k,string_array_t* dest, int n,
-                                   const string_array_t* first,...);
+extern void cat_string_array(int k,string_array* dest, int n,
+                             const string_array* first,...);
+extern void cat_alloc_string_array(int k,string_array* dest, int n,
+                                   const string_array* first,...);
 
-extern void promote_string_array(const string_array_t * a, int n,string_array_t* dest);
+extern void promote_string_array(const string_array * a, int n,string_array* dest);
 extern void promote_scalar_string_array(modelica_string s,int n,
-                                        string_array_t* dest);
-extern void promote_alloc_string_array(const string_array_t * a, int n,
-                                       string_array_t* dest);
+                                        string_array* dest);
+extern void promote_alloc_string_array(const string_array * a, int n,
+                                       string_array* dest);
 
-static inline int ndims_string_array(const string_array_t * a)
+static inline int ndims_string_array(const string_array * a)
 { return ndims_base_array(a); }
 
-extern const char** data_of_string_c89_array(const string_array_t a);
+extern const char** data_of_string_c89_array(const string_array a);
 
-extern void size_string_array(const string_array_t * a, integer_array* dest);
-extern modelica_string scalar_string_array(const string_array_t * a);
-extern void vector_string_array(const string_array_t * a, string_array_t* dest);
-extern void vector_string_scalar(modelica_string a,string_array_t* dest);
-extern void matrix_string_array(const string_array_t * a, string_array_t* dest);
-extern void matrix_string_scalar(modelica_string a,string_array_t* dest);
-extern void transpose_alloc_string_array(const string_array_t * a, string_array_t* dest);
-extern void transpose_string_array(const string_array_t * a, string_array_t* dest);
+extern void size_string_array(const string_array * a, integer_array* dest);
+extern modelica_string scalar_string_array(const string_array * a);
+extern void vector_string_array(const string_array * a, string_array* dest);
+extern void vector_string_scalar(modelica_string a,string_array* dest);
+extern void matrix_string_array(const string_array * a, string_array* dest);
+extern void matrix_string_scalar(modelica_string a,string_array* dest);
+extern void transpose_alloc_string_array(const string_array * a, string_array* dest);
+extern void transpose_string_array(const string_array * a, string_array* dest);
 
-extern void fill_string_array(string_array_t* dest,modelica_string s);
+extern void fill_string_array(string_array* dest,modelica_string s);
 
-static inline void clone_reverse_string_array_spec(const string_array_t *source,
-                                                   string_array_t *dest)
+static inline void clone_reverse_string_array_spec(const string_array *source,
+                                                   string_array *dest)
 { clone_reverse_base_array_spec(source, dest); }
-extern void convert_alloc_string_array_to_f77(const string_array_t * a,
-                                              string_array_t* dest);
-extern void convert_alloc_string_array_from_f77(const string_array_t * a,
-                                                string_array_t* dest);
+extern void convert_alloc_string_array_to_f77(const string_array * a,
+                                              string_array* dest);
+extern void convert_alloc_string_array_from_f77(const string_array * a,
+                                                string_array* dest);
 
 extern void fill_alloc_real_array(real_array* dest, modelica_real value, int ndims, ...);
 
-extern void unpack_string_array(const string_array_t *a, const char **data);
+extern void unpack_string_array(const string_array *a, const char **data);
 
 #endif


### PR DESCRIPTION
- Remove `m_integer` and replace its uses with `modelica_integer`. 

  - It adds nothing more than confusion. It is the same as `modelica_integer`
 
- Remove `m_real` and replace its uses with `modelica_real`. 

  - It adds nothing more than confusion. It is the same as `modelica_real`
 
- Remove `m_boolean` and replace its uses with `modelica_boolean`. 

  - It adds nothing more than confusion. It is the same as `modelica_boolean`
 
- Remove `m_string` and replace its uses with `modelica_string`. 

  - It adds nothing more than confusion. It is the same as `modelica_string`
 
- Remove `real_array_t` and replace its uses with `real_array`. 

  - It adds nothing more than confusion. It is the same as `real_array`

  - This could also have been done the other way around. Changeing the code
    generators to generate `real_array_t` instead of `real_array`

  - A member previously named `real_array` in the union `type_desc_s._data`
    in the header `openmodelica.h` is now renamed to `r_array` to avoid
    confusion.
 
- Remove `integer_array_t` and replace its uses with `integer_array`. 

  - It adds nothing more than confusion. It is the same as `integer_array`

  - This could also have been done the other way around. Changeing the code
    generators to generate `integer_array_t` instead of `integer_array`
 
- Remove `boolean_array_t` and replace its uses with `boolean_array`. 

  - It adds nothing more than confusion. It is the same as `boolean_array`

  - This could also have been done the other way around. Changeing the code
    generators to generate `boolean_array_t` instead of `boolean_array`
 
- Remove `string_array_t` and replace its uses with `string_array`. 

  - It adds nothing more than confusion. It is the same as `string_array`

  - This could also have been done the other way around. Changeing the code
    generators to generate `string_array_t` instead of `string_array`
 
- Cleanup restructure `openmodelica_types.h`. 

  - Move things around so that they are ordered logically.

  - Removed unused macros `maxmacro` and `minmacro`.
