### PR TITLE
Change tag name from kind to $kind in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -836,7 +836,7 @@ public
       case TYPED_CALL()
         algorithm
           path := Function.nameConsiderBuiltin(call.fn);
-          json := JSON.addPair("kind", JSON.makeString("call"), json);
+          json := JSON.addPair("$kind", JSON.makeString("call"), json);
           json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(path)), json);
           json := JSON.addPair("arguments", JSON.makeArray(
             list(Expression.toJSON(a) for a in call.arguments)), json);
@@ -845,7 +845,7 @@ public
 
       case TYPED_ARRAY_CONSTRUCTOR()
         algorithm
-          json := JSON.addPair("kind", JSON.makeString("array_constructor"), json);
+          json := JSON.addPair("$kind", JSON.makeString("array_constructor"), json);
           json := JSON.addPair("exp", Expression.toJSON(call.exp), json);
           json := JSON.addPair("iterators", iterators_json(call.iters), json);
         then
@@ -854,7 +854,7 @@ public
       case TYPED_REDUCTION()
         algorithm
           path := Function.nameConsiderBuiltin(call.fn);
-          json := JSON.addPair("kind", JSON.makeString("reduction"), json);
+          json := JSON.addPair("$kind", JSON.makeString("reduction"), json);
           json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(path)), json);
           json := JSON.addPair("exp", Expression.toJSON(call.exp), json);
           json := JSON.addPair("iterators", iterators_json(call.iters), json);
@@ -863,7 +863,7 @@ public
 
       else
         algorithm
-          json := JSON.addPair("kind", JSON.makeString("call"), json);
+          json := JSON.addPair("$kind", JSON.makeString("call"), json);
         then
           ();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1179,7 +1179,7 @@ public
       case CREF()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("cref"), json);
+          json := JSON.addPair("$kind", JSON.makeString("cref"), json);
           json := JSON.addPair("parts", JSON.makeArray(toJSON_impl(cref)), json);
         then
           json;
@@ -1189,7 +1189,7 @@ public
       case WILD()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("cref"), json);
+          json := JSON.addPair("$kind", JSON.makeString("cref"), json);
           json := JSON.addPair("parts", JSON.makeArray(
             {JSON.fromPair("name", JSON.makeString("_"))}), json);
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5852,7 +5852,7 @@ public
       case Expression.ENUM_LITERAL()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("enum"), json);
+          json := JSON.addPair("$kind", JSON.makeString("enum"), json);
           json := JSON.addPair("name", JSON.makeString(Expression.toString(exp)), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
         then
@@ -5866,7 +5866,7 @@ public
       case Expression.TYPENAME()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("typename"), json);
+          json := JSON.addPair("$kind", JSON.makeString("typename"), json);
           json := JSON.addPair("name", JSON.makeString(Type.toString(exp.ty)), json);
         then
           json;
@@ -5883,7 +5883,7 @@ public
       case Expression.RANGE()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("range"), json);
+          json := JSON.addPair("$kind", JSON.makeString("range"), json);
           json := JSON.addPair("start", toJSON(exp.start), json);
 
           if isSome(exp.step) then
@@ -5897,7 +5897,7 @@ public
       case Expression.TUPLE()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("tuple"), json);
+          json := JSON.addPair("$kind", JSON.makeString("tuple"), json);
           json := JSON.addPair("elements",
             JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
         then
@@ -5906,7 +5906,7 @@ public
       case Expression.RECORD()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("record"), json);
+          json := JSON.addPair("$kind", JSON.makeString("record"), json);
           json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(exp.path)), json);
           json := JSON.addPair("elements",
             JSON.makeArray(list(toJSON(e) for e in exp.elements)), json);
@@ -5919,7 +5919,7 @@ public
       case Expression.SIZE()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("size"), json);
+          json := JSON.addPair("$kind", JSON.makeString("size"), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
 
           if isSome(exp.dimIndex) then
@@ -5931,7 +5931,7 @@ public
       case Expression.BINARY()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("$kind", JSON.makeString("binary_op"), json);
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
           json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
@@ -5941,7 +5941,7 @@ public
       case Expression.UNARY()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("unary_op"), json);
+          json := JSON.addPair("$kind", JSON.makeString("unary_op"), json);
           json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
@@ -5950,7 +5950,7 @@ public
       case Expression.LBINARY()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("binary_op"), json);
+          json := JSON.addPair("$kind", JSON.makeString("binary_op"), json);
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
           json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
@@ -5960,7 +5960,7 @@ public
       case Expression.LUNARY()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("unary_op"), json);
+          json := JSON.addPair("$kind", JSON.makeString("unary_op"), json);
           json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
@@ -5969,7 +5969,7 @@ public
       case Expression.RELATION()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("relation"), json);
+          json := JSON.addPair("$kind", JSON.makeString("relation"), json);
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
           json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator)), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
@@ -5979,7 +5979,7 @@ public
       case Expression.IF()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("if"), json);
+          json := JSON.addPair("$kind", JSON.makeString("if"), json);
           json := JSON.addPair("condition", toJSON(exp.condition), json);
           json := JSON.addPair("true", toJSON(exp.trueBranch), json);
           json := JSON.addPair("false", toJSON(exp.falseBranch), json);
@@ -5989,7 +5989,7 @@ public
       case Expression.CAST()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("cast"), json);
+          json := JSON.addPair("$kind", JSON.makeString("cast"), json);
           json := JSON.addPair("type", JSON.makeString(Type.toString(exp.ty)), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
@@ -5998,7 +5998,7 @@ public
       case Expression.BOX()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("box"), json);
+          json := JSON.addPair("$kind", JSON.makeString("box"), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
           json;
@@ -6006,7 +6006,7 @@ public
       case Expression.UNBOX()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("unbox"), json);
+          json := JSON.addPair("$kind", JSON.makeString("unbox"), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
         then
           json;
@@ -6014,7 +6014,7 @@ public
       case Expression.SUBSCRIPTED_EXP()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("sub"), json);
+          json := JSON.addPair("$kind", JSON.makeString("sub"), json);
           json := JSON.addPair("exp", toJSON(exp.exp), json);
           json := JSON.addPair("subscripts", Subscript.toJSONList(exp.subscripts), json);
         then
@@ -6023,7 +6023,7 @@ public
       case Expression.TUPLE_ELEMENT()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("tuple_element"), json);
+          json := JSON.addPair("$kind", JSON.makeString("tuple_element"), json);
           json := JSON.addPair("exp", toJSON(exp.tupleExp), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
         then
@@ -6032,7 +6032,7 @@ public
       case Expression.RECORD_ELEMENT()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("record_element"), json);
+          json := JSON.addPair("$kind", JSON.makeString("record_element"), json);
           json := JSON.addPair("exp", toJSON(exp.recordExp), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
           json := JSON.addPair("field", JSON.makeString(exp.fieldName), json);
@@ -6042,7 +6042,7 @@ public
       case Expression.PARTIAL_FUNCTION_APPLICATION()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("kind", JSON.makeString("function"), json);
+          json := JSON.addPair("$kind", JSON.makeString("function"), json);
           json := JSON.addPair("name", JSON.makeString(ComponentRef.toString(exp.fn)), json);
           json := JSON.addPair("arguments", JSON.makeArray(
             list(dump_arg(name, arg) threaded for arg in exp.args, name in exp.argNames)), json);

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1306,7 +1306,7 @@ algorithm
     case Absyn.Exp.CALL()
       algorithm
         json := JSON.emptyObject();
-        json := JSON.addPair("kind", JSON.makeString("call"), json);
+        json := JSON.addPair("$kind", JSON.makeString("call"), json);
         json := JSON.addPair("name", dumpJSONAbsynCref(exp.function_), json);
         json := dumpJSONAbsynFunctionArgs(exp.functionArgs, json);
       then

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation1.mos
@@ -23,7 +23,7 @@ getModelInstance(M, prettyPrint=true);
 //     \"Icon\": {
 //       \"graphics\": [
 //         {
-//           \"kind\": \"record\",
+//           \"$kind\": \"record\",
 //           \"name\": \"Rectangle\",
 //           \"elements\": [
 //             true,
@@ -43,18 +43,18 @@ getModelInstance(M, prettyPrint=true);
 //               0
 //             ],
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"LinePattern.Solid\",
 //               \"index\": 2
 //             },
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"FillPattern.None\",
 //               \"index\": 1
 //             },
 //             0.25,
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"BorderPattern.None\",
 //               \"index\": 1
 //             },
@@ -76,7 +76,7 @@ getModelInstance(M, prettyPrint=true);
 //     \"Diagram\": {
 //       \"graphics\": [
 //         {
-//           \"kind\": \"record\",
+//           \"$kind\": \"record\",
 //           \"name\": \"Ellipse\",
 //           \"elements\": [
 //             true,
@@ -96,12 +96,12 @@ getModelInstance(M, prettyPrint=true);
 //               0
 //             ],
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"LinePattern.Solid\",
 //               \"index\": 2
 //             },
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"FillPattern.None\",
 //               \"index\": 1
 //             },
@@ -119,7 +119,7 @@ getModelInstance(M, prettyPrint=true);
 //             0,
 //             360,
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"EllipseClosure.Chord\",
 //               \"index\": 2
 //             }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation2.mos
@@ -23,7 +23,7 @@ getModelInstance(M, prettyPrint=true);
 //     \"Icon\": {
 //       \"graphics\": [
 //         {
-//           \"kind\": \"record\",
+//           \"$kind\": \"record\",
 //           \"name\": \"Rectangle\",
 //           \"elements\": [
 //             true,
@@ -43,18 +43,18 @@ getModelInstance(M, prettyPrint=true);
 //               0
 //             ],
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"LinePattern.Solid\",
 //               \"index\": 2
 //             },
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"FillPattern.None\",
 //               \"index\": 1
 //             },
 //             0.25,
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"BorderPattern.None\",
 //               \"index\": 1
 //             },
@@ -72,7 +72,7 @@ getModelInstance(M, prettyPrint=true);
 //           ]
 //         },
 //         {
-//           \"kind\": \"record\",
+//           \"$kind\": \"record\",
 //           \"name\": \"Ellipse\",
 //           \"elements\": [
 //             true,
@@ -92,12 +92,12 @@ getModelInstance(M, prettyPrint=true);
 //               0
 //             ],
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"LinePattern.Solid\",
 //               \"index\": 2
 //             },
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"FillPattern.None\",
 //               \"index\": 1
 //             },
@@ -115,7 +115,7 @@ getModelInstance(M, prettyPrint=true);
 //             0,
 //             360,
 //             {
-//               \"kind\": \"enum\",
+//               \"$kind\": \"enum\",
 //               \"name\": \"EllipseClosure.Chord\",
 //               \"index\": 2
 //             }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
@@ -127,7 +127,7 @@ getModelInstance(M, prettyPrint = true);
 //   \"connections\": [
 //     {
 //       \"lhs\": {
-//         \"kind\": \"cref\",
+//         \"$kind\": \"cref\",
 //         \"parts\": [
 //           {
 //             \"name\": \"c1\"
@@ -135,7 +135,7 @@ getModelInstance(M, prettyPrint = true);
 //         ]
 //       },
 //       \"rhs\": {
-//         \"kind\": \"cref\",
+//         \"$kind\": \"cref\",
 //         \"parts\": [
 //           {
 //             \"name\": \"c3\"
@@ -167,7 +167,7 @@ getModelInstance(M, prettyPrint = true);
 //     },
 //     {
 //       \"lhs\": {
-//         \"kind\": \"cref\",
+//         \"$kind\": \"cref\",
 //         \"parts\": [
 //           {
 //             \"name\": \"c1\"
@@ -175,7 +175,7 @@ getModelInstance(M, prettyPrint = true);
 //         ]
 //       },
 //       \"rhs\": {
-//         \"kind\": \"cref\",
+//         \"$kind\": \"cref\",
 //         \"parts\": [
 //           {
 //             \"name\": \"c2\"

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
@@ -76,7 +76,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"modifier\": \" = a.x[1]\",
 //       \"value\": {
 //         \"binding\": {
-//           \"kind\": \"cref\",
+//           \"$kind\": \"cref\",
 //           \"parts\": [
 //             {
 //               \"name\": \"a\"

--- a/testsuite/openmodelica/instance-API/test.mos
+++ b/testsuite/openmodelica/instance-API/test.mos
@@ -1,0 +1,30 @@
+// name: GetModelInstanceAnnotation2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    annotation (kind = \"call\", name = \"fn\", arguments = {1, 2, 3});
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"annotation\": {
+//     \"kind\": \"call\",
+//     \"name\": \"fn\",
+//     \"arguments\": [
+//       1,
+//       2,
+//       3
+//     ]
+//   }
+// }"
+// endResult


### PR DESCRIPTION
- Use `$kind` instead of `kind` as the tag name for expressions in the
  instance API, to make it possible to differentiate between expressions
  and annotations.