### PR TITLE
Fix loadFileInteractive/loadFileInteractiveQualified

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1459,9 +1459,6 @@ end parseFile;
 function loadFileInteractiveQualified
   input String filename;
   input String encoding = "UTF-8";
-  input Boolean uses = true;
-  input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
-  input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
   output TypeName names[:];
 external "builtin";
 annotation(preferredView="text");
@@ -1470,6 +1467,9 @@ end loadFileInteractiveQualified;
 function loadFileInteractive
   input String filename;
   input String encoding = "UTF-8";
+  input Boolean uses = true;
+  input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
+  input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
   output TypeName names[:];
 external "builtin";
 annotation(preferredView="text");

--- a/testsuite/openmodelica/interactive-API/loadFileInteractiveQualified.mos
+++ b/testsuite/openmodelica/interactive-API/loadFileInteractiveQualified.mos
@@ -1,7 +1,7 @@
 // name:     API Class/Elements query
 // keywords: Graphical API interactive loading of files in a scope: loadFileInteractiveQualified, getCrefInfo, getElementsInfo, getClassInformation, getClassAttributes
 // status:   correct
-// cflags: -d=-newInst
+// cflags: -d=newInst
 //
 //  Subset of the Graphical API, interactive loading of files in a scope
 //  testing of: loadFileInteractiveQualified, getCrefInfo, getElementsInfo, getClassInformation, getClassAttributes


### PR DESCRIPTION
- Fix bad copy/paste of arguments for loadFileInteractive in
  NFModelicaBuiltin.

Fixes #9114