### PR TITLE
Fix dumping of component direction in instance API

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1187,9 +1187,12 @@ algorithm
     json := JSON.addPair("variability", JSON.makeString(s), json);
   end if;
 
-  s := Dump.unparseDirectionSymbolStr(attrs.direction);
-  if not stringEmpty(s) then
-    json := JSON.addPair("direction", JSON.makeString(s), json);
+  if AbsynUtil.isInput(attrs.direction) then
+    json := JSON.addPair("input", JSON.makeBoolean(true), json);
+  end if;
+
+  if AbsynUtil.isOutput(attrs.direction) then
+    json := JSON.addPair("output", JSON.makeBoolean(true), json);
   end if;
 end dumpJSONAttributes;
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
@@ -81,7 +81,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"type\": \"Real\",
 //       \"modifier\": \"\",
 //       \"prefixes\": {
-//         \"direction\": \"input \"
+//         \"input\": true
 //       }
 //     },
 //     {


### PR DESCRIPTION
- The previous code added an unnecessary space at the end of `input` or
  `output`. To avoid that and make the direction behave more like the
  other prefixes, split the direction into separate boolean input and
  output properties.
