### PR TITLE
Check if buffer is empty before accessing it

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/delay.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/delay.c
@@ -124,10 +124,12 @@ void storeDelayedExpression(DATA* data, threadData_t *threadData, int exprNumber
   /* Check if time is greater equal then last stored time in delay structure */
   if (length > 0) {
     lastElem = getRingData(data->simulationInfo->delayStructure[exprNumber], length-1);
-    while (time < lastElem->t) {
+    while (time < lastElem->t && length > 0) {
       removeLastRingData(data->simulationInfo->delayStructure[exprNumber],1);
       length = ringBufferLength(data->simulationInfo->delayStructure[exprNumber]);
-      lastElem = getRingData(data->simulationInfo->delayStructure[exprNumber], length-1);
+      if (length > 0) {
+        lastElem = getRingData(data->simulationInfo->delayStructure[exprNumber], length-1);
+      }
     }
   }
 


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/9116.

### Purpose

Check if ringBuffer is empty after removing all previously stored delay values before accessing it.

