### PR TITLE
Extended nls solver status

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -1152,7 +1152,7 @@ static modelica_boolean nlsKinsolErrorHandler(int errorCode, DATA *data,
  * @param data                Runtime data struct.
  * @param threadData          Thread data for error handling.
  * @param nlsData             Pointer to non-linear system data.
- * @return modelica_boolean   Return true on success and false otherwise.
+ * @return NLS_SOLVER_STATUS  Return NLS_SOLVED on success and NLS_FAILED otherwise.
  */
 NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DATA* nlsData) {
 
@@ -1225,6 +1225,7 @@ NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR
   /* Check if solution status and reset error norm */
   if (success) {
     double fNorm;
+    // TODO: Will this do a new res evaluation?
     KINGetFuncNorm(kinsolData->kinsolMemory, &fNorm);
     if (fNorm > kinsolData->fnormtol) {
       KINSetFuncNormTol(kinsolData->kinsolMemory, kinsolData->fnormtol);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -1224,16 +1224,20 @@ NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR
                     !success && !retry && kinsolData->retries < RETRY_MAX ? "true" : "false");
   } while (!success && retry && kinsolData->retries < RETRY_MAX);
 
-  /* Check solution status and reset error norm */
+  /* Check solution status */
   if (success && kinsolData->resetTol) {
-    KINSetFuncNormTol(kinsolData->kinsolMemory, kinsolData->fnormtol);
-    KINSetScaledStepTol(kinsolData->kinsolMemory,  kinsolData->scsteptol);
     kinsolData->solved = NLS_SOLVED_LESS_ACCURARCY;
-  }
-  else if (success) {
+  } else if (success) {
     kinsolData->solved = NLS_SOLVED;
   } else {
     kinsolData->solved = NLS_FAILED;
+  }
+
+  /* Reset solver tolerance */
+  if (kinsolData->resetTol) {
+    KINSetFuncNormTol(kinsolData->kinsolMemory, kinsolData->fnormtol);
+    KINSetScaledStepTol(kinsolData->kinsolMemory,  kinsolData->scsteptol);
+    kinsolData->resetTol = FALSE;
   }
 
   if (success) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.h
@@ -73,7 +73,7 @@ typedef struct NLS_KINSOL_DATA {
   int kinsolStrategy;                  /* Strategy used to solve nonlinear systems. Has to be one
                                           of: KIN_NONE, KIN_LINESEARCH, KIN_FP, KIN_PICARD */
   int retries;                         /* Number of retries after failed solve of KINSOL */
-  int solved;                          /* If the system is once solved reuse linear matrix information */
+  NLS_SOLVER_STATUS solved;            /* If the system is once solved reuse linear matrix information */
   int nominalJac;                      /* 0/1 for disabled/enabled scaling on Jacobian */
 
   /* ### tolerances ### */
@@ -112,7 +112,7 @@ typedef struct NLS_KINSOL_DATA {
 
 NLS_KINSOL_DATA* nlsKinsolAllocate(int size, NLS_USERDATA* userData);
 void nlsKinsolFree(NLS_KINSOL_DATA* kinsolData);
-modelica_boolean nlsKinsolSolve(DATA* data, threadData_t* threadData,  NONLINEAR_SYSTEM_DATA* nlsData);
+NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DATA* nlsData);
 
 #ifdef __cplusplus
 };

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.h
@@ -82,6 +82,8 @@ typedef struct NLS_KINSOL_DATA {
   double maxstepfactor;                /* maximum newton step factor mxnewtstep = maxstepfactor
                                         * norm2(xScaling) */
   double mxnstepin;                    /* Maximum allowable scaled length of Newton step */
+  modelica_boolean resetTol;           /* True if solution with less accuracy was accepted.
+                                          Need to reset KINSOL  */
 
   /* ### work arrays ### */
   N_Vector initialGuess;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.h
@@ -46,7 +46,7 @@ typedef struct DATA_HOMOTOPY DATA_HOMOTOPY;
 
 DATA_HOMOTOPY* allocateHomotopyData(size_t size, NLS_USERDATA* userData);
 void freeHomotopyData(DATA_HOMOTOPY* homotopyData);
-modelica_boolean solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nlsData);
+NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nlsData);
 
 #ifdef __cplusplus
 };

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -424,9 +424,9 @@ static void wrapper_fvec_hybrj(const integer *n_p, const double* x, double* f, d
  * @param data                Runtime data struct.
  * @param threadData          Thread data for error handling.
  * @param nlsData             Pointer to non-linear system data.
- * @return modelica_boolean   Return true on success and false otherwise.
+ * @return NLS_SOLVER_STATUS  Return NLS_SOLVED on success and NLS_FAILED otherwise.
  */
-modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nlsData)
+NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nlsData)
 {
   DATA_HYBRD* hybrdData = (DATA_HYBRD*)nlsData->solverData;
   int eqSystemNumber = nlsData->equationIndex;
@@ -434,7 +434,7 @@ modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYST
   int i, j;
   integer iflag = 1;
   double xerror, xerror_scaled;
-  modelica_boolean success = FALSE;
+  NLS_SOLVER_STATUS success = NLS_FAILED;
   modelica_boolean catchedError;
   double local_tol = 1e-12;
   double initial_factor = hybrdData->factor;
@@ -709,7 +709,7 @@ modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYST
     {
       int scaling;
 
-      success = TRUE;
+      success = NLS_SOLVED;
       nfunc_evals += hybrdData->nfev;
       if(ACTIVE_STREAM(LOG_NLS_V))
       {
@@ -753,7 +753,7 @@ modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYST
           xerror_scaled = 1;
           xerror = 1;
           assertCalled = 1;
-          success = FALSE;
+          success = NLS_FAILED;
           giveUp = 0;
         }
       }
@@ -1063,7 +1063,7 @@ modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYST
       memcpy(nlsData->nlsx, hybrdData->x, hybrdData->n*(sizeof(double)));
 
       giveUp = 1;
-      success = FALSE;
+      success = NLS_FAILED;
       break;
     }
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.h
@@ -96,7 +96,7 @@ void hybrj_( void(*) (const integer*, const double*, double*, double *, const in
 
 DATA_HYBRD* allocateHybrdData(size_t size, NLS_USERDATA* userData);
 void freeHybrdData(DATA_HYBRD* hybrdData);
-modelica_boolean solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nlsData);
+NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nlsData);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -178,20 +178,21 @@ int wrapper_fvec_newton(int n, double* x, double* fvec, NLS_USERDATA* userData, 
   return flag;
 }
 
-/*! \fn solve non-linear system with newton method
+/**
+ * @brief Solve non-linear system with Newton method.
  *
- *  \param [in]  [data]
- *                [sysNumber] index of the corresponding non-linear system
- *
- *  \author wbraun
+ * @param data                Runtime data struct.
+ * @param threadData          Thread data for error handling.
+ * @param systemData          Pointer to non-linear system data.
+ * @return NLS_SOLVER_STATUS  Return NLS_SOLVED on success and NLS_FAILED otherwise.
  */
-int solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* systemData)
+NLS_SOLVER_STATUS solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* systemData)
 {
   DATA_NEWTON* solverData = (DATA_NEWTON*)(systemData->solverData);
   int eqSystemNumber = 0;
   int i;
   double xerror = -1, xerror_scaled = -1;
-  int success = 0;
+  NLS_SOLVER_STATUS success = NLS_FAILED;
   int nfunc_evals = 0;
   int continuous = 1;
   double local_tol = solverData->ftol;
@@ -250,7 +251,7 @@ int solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* sys
   }
 
   /* start solving loop */
-  while(!giveUp && !success)
+  while(!giveUp && success != NLS_SOLVED)
   {
 
     giveUp = 1;
@@ -275,7 +276,7 @@ int solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* sys
     /* solution found */
     if((xerror <= local_tol || xerror_scaled <= local_tol) && solverData->info > 0)
     {
-      success = 1;
+      success = NLS_SOLVED;
       nfunc_evals += solverData->nfev;
       if(ACTIVE_STREAM(LOG_NLS_V))
       {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-int solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* systemData);
+NLS_SOLVER_STATUS solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* systemData);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -164,7 +164,7 @@ int print_csvLineCallStatsHeader(OMC_WRITE_CSV* csvData)
  */
 int print_csvLineCallStats(OMC_WRITE_CSV* csvData, int num, double time,
                            int iterations, int fCalls, double solvingTime,
-                           int solved)
+                           NLS_SOLVER_STATUS solved)
 {
   char buffer[1024];
 
@@ -194,7 +194,7 @@ int print_csvLineCallStats(OMC_WRITE_CSV* csvData, int num, double time,
   fputc(csvData->seperator,csvData->handle);
 
   /* solved system */
-  sprintf(buffer, "%s", solved?"TRUE":"FALSE");
+  sprintf(buffer, "%s", (solved == NLS_SOLVED || solved == NLS_SOLVED_LESS_ACCURARCY)?"TRUE":"FALSE");
   omc_write_csv(csvData, buffer);
 
   /* finish line */
@@ -835,7 +835,21 @@ void printNonLinearFinishInfo(int logName, DATA* data, NONLINEAR_SYSTEM_DATA *no
 
   if (!ACTIVE_STREAM(logName)) return;
 
-  infoStreamPrint(logName, 1, "Solution status: %s", nonlinsys->solved?"SOLVED":"FAILED");
+  switch (nonlinsys->solved)
+  {
+  case NLS_SOLVED:
+    infoStreamPrint(logName, 1, "Solution status: SOLVED");
+    break;
+  case NLS_SOLVED_LESS_ACCURARCY:
+    infoStreamPrint(logName, 1, "Solution status: SOLVED with less accuracy");
+    break;
+  case NLS_FAILED:
+    infoStreamPrint(logName, 1, "Solution status: FAILED");
+    break;
+  default:
+    throwStreamPrint(NULL, "Unhandled case in printNonLinearFinishInfo");
+    break;
+  }
   infoStreamPrint(logName, 0, " number of iterations           : %ld", nonlinsys->numberOfIterations);
   infoStreamPrint(logName, 0, " number of function evaluations : %ld", nonlinsys->numberOfFEval);
   infoStreamPrint(logName, 0, " number of jacobian evaluations : %ld", nonlinsys->numberOfJEval);
@@ -888,7 +902,7 @@ int getInitialGuess(NONLINEAR_SYSTEM_DATA *nonlinsys, double time)
 int updateInitialGuessDB(NONLINEAR_SYSTEM_DATA *nonlinsys, double time, int context)
 {
   /* write solution to oldValue list for extrapolation */
-  if (nonlinsys->solved == 1)
+  if (nonlinsys->solved == NLS_SOLVED)
   {
     /* do not use solution of jacobian for next extrapolation */
     if (context < 4)
@@ -897,7 +911,7 @@ int updateInitialGuessDB(NONLINEAR_SYSTEM_DATA *nonlinsys, double time, int cont
               createValueElement(nonlinsys->size, time, nonlinsys->nlsx));
     }
   }
-  else if (nonlinsys->solved == 2)
+  else if (nonlinsys->solved == NLS_SOLVED_LESS_ACCURARCY)
   {
     if (listLen(((VALUES_LIST*)nonlinsys->oldValueList)->valueList)>0)
     {
@@ -910,7 +924,6 @@ int updateInitialGuessDB(NONLINEAR_SYSTEM_DATA *nonlinsys, double time, int cont
               createValueElement(nonlinsys->size, time, nonlinsys->nlsx));
     }
   }
-  messageClose(LOG_NLS_EXTRAPOLATE);
   return 0;
 }
 
@@ -978,9 +991,9 @@ int updateInnerEquation(RESIDUAL_USERDATA* resUserData, int sysNumber, int discr
  * @param nonlinsys           Pointer to non-linear system.
  * @return modelica_boolean   Return TRUE on success, FALSE otherwise.
  */
-modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys)
+NLS_SOLVER_STATUS solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys)
 {
-  modelica_boolean success = FALSE;
+  NLS_SOLVER_STATUS solver_status = NLS_FAILED;
   int casualTearingSet = nonlinsys->strictTearingFunctionCall != NULL;
   struct dataSolver *solverData;
   struct dataMixedSolver *mixedSolverData;
@@ -996,7 +1009,7 @@ modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM
     #ifndef OMC_EMCC
       MMC_TRY_INTERNAL(simulationJumpBuffer)
     #endif
-    success = solveHybrd(data, threadData, nonlinsys);
+    solver_status = solveHybrd(data, threadData, nonlinsys);
     /*catch */
     #ifndef OMC_EMCC
       MMC_CATCH_INTERNAL(simulationJumpBuffer)
@@ -1010,7 +1023,7 @@ modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM
     #ifndef OMC_EMCC
       MMC_TRY_INTERNAL(simulationJumpBuffer)
     #endif
-    success = nlsKinsolSolve(data, threadData, nonlinsys);
+    solver_status = nlsKinsolSolve(data, threadData, nonlinsys);
     /*catch */
     #ifndef OMC_EMCC
       MMC_CATCH_INTERNAL(simulationJumpBuffer)
@@ -1024,22 +1037,25 @@ modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM
     #ifndef OMC_EMCC
       MMC_TRY_INTERNAL(simulationJumpBuffer)
     #endif
-    success = solveNewton(data, threadData, nonlinsys);
+    solver_status = solveNewton(data, threadData, nonlinsys);
     /*catch */
     #ifndef OMC_EMCC
       MMC_CATCH_INTERNAL(simulationJumpBuffer)
     #endif
     /* check if solution process was successful, if not use alternative tearing set if available (dynamic tearing)*/
-    if (!success && casualTearingSet){
+    if (solver_status != NLS_SOLVED && casualTearingSet){
       debugString(LOG_DT, "Solving the casual tearing set failed! Now the strict tearing set is used.");
-      success = nonlinsys->strictTearingFunctionCall(data, threadData);
-      if (success) success=2;
+      if(nonlinsys->strictTearingFunctionCall(data, threadData)) {
+        solver_status = NLS_SOLVED;
+      } else {
+        solver_status = NLS_FAILED;
+      }
     }
     nonlinsys->solverData = solverData;
     break;
 #endif
   case NLS_HOMOTOPY:
-    success = solveHomotopy(data, threadData, nonlinsys);
+    solver_status = solveHomotopy(data, threadData, nonlinsys);
     break;
 #if !defined(OMC_MINIMAL_RUNTIME)
   case NLS_MIXED:
@@ -1050,24 +1066,25 @@ modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM
     #ifndef OMC_EMCC
       MMC_TRY_INTERNAL(simulationJumpBuffer)
     #endif
-    success = solveHomotopy(data, threadData, nonlinsys);
+    solver_status = solveHomotopy(data, threadData, nonlinsys);
 
     /* check if solution process was successful, if not use alternative tearing set if available (dynamic tearing)*/
-    if (!success && casualTearingSet){
+    if (solver_status != NLS_SOLVED && casualTearingSet){
       debugString(LOG_DT, "Solving the casual tearing set failed! Now the strict tearing set is used.");
-      success = nonlinsys->strictTearingFunctionCall(data, threadData);
-      if (success){
-        success=2;
+      if(nonlinsys->strictTearingFunctionCall(data, threadData)) {
+        solver_status = NLS_SOLVED;
+      } else {
+        solver_status = NLS_FAILED;
       }
     }
 
-    if (!success) {
+    if (solver_status != NLS_SOLVED ) {
       nonlinsys->solverData = mixedSolverData->hybridData;
-      success = solveHybrd(data, threadData, nonlinsys);
+      solver_status = solveHybrd(data, threadData, nonlinsys);
     }
 
     /* update iteration variables of nonlinsys->nlsx */
-    if (success){
+    if (solver_status == NLS_SOLVED){
       nonlinsys->getIterationVars(data, nonlinsys->nlsx);
     }
 
@@ -1082,7 +1099,7 @@ modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM
     throwStreamPrint(threadData, "unrecognized nonlinear solver");
   }
 
-  return success;
+  return solver_status;
 }
 
 /*! \fn solve system with homotopy solver
@@ -1215,7 +1232,7 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
                         || (data->callback->useHomotopy == 0     // Equidistant local homotopy is selected but homotopy is deactivated ...
                             && init_lambda_steps <= 0);          // ... by the number of steps
 
-  nonlinsys->solved = 0;
+  nonlinsys->solved = NLS_FAILED;
   nonlinsys->initHomotopy = 0;
 
   /* If homotopy is deactivated in this place or flag homotopyOnFirstTry is not set,
@@ -1330,6 +1347,7 @@ int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber)
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
 #endif
 
+  messageClose(LOG_NLS_EXTRAPOLATE);
   /* update value list database */
   updateInitialGuessDB(nonlinsys, data->localData[0]->timeValue, data->simulationInfo->currentContext);
   if (nonlinsys->solved == 1)
@@ -1409,7 +1427,7 @@ int check_nonlinear_solution(DATA *data, int printFailingSystems, int sysNumber)
   long j;
   int i = sysNumber;
 
-  if(nonlinsys[i].solved == 0)
+  if(nonlinsys[i].solved == NLS_FAILED)
   {
     int index = nonlinsys[i].equationIndex, indexes[2] = {1,index};
     if (!printFailingSystems) return 1;
@@ -1441,9 +1459,9 @@ int check_nonlinear_solution(DATA *data, int printFailingSystems, int sysNumber)
     messageCloseWarning(LOG_INIT);
     return 1;
   }
-  if(nonlinsys[i].solved == 2)
+  if(nonlinsys[i].solved == NLS_SOLVED_LESS_ACCURARCY)
   {
-    nonlinsys[i].solved = 1;
+    nonlinsys[i].solved = NLS_SOLVED;
     return 2;
   }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.h
@@ -63,7 +63,7 @@ int initializeNonlinearSystems(DATA *data, threadData_t *threadData);
 int updateStaticDataOfNonlinearSystems(DATA *data, threadData_t *threadData);
 void freeNonlinearSystems(DATA *data, threadData_t *threadData);
 void printNonLinearSystemSolvingStatistics(NONLINEAR_SYSTEM_DATA* nonlinsys, enum LOG_STREAM stream);
-modelica_boolean solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys);
+NLS_SOLVER_STATUS solveNLS(DATA *data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys);
 int solve_nonlinear_system(DATA *data, threadData_t *threadData, int sysNumber);
 int check_nonlinear_solutions(DATA *data, int printFailingSystems);
 int print_csvLineIterStats(void* csvData, int size, int num,

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -262,6 +262,12 @@ typedef struct RESIDUAL_USERDATA {
 
 typedef struct NLS_USERDATA NLS_USERDATA;
 
+typedef enum {
+  NLS_FAILED = 0,                   /* NLS Solver failed to solve system */
+  NLS_SOLVED = 1,                   /* NLS Solver solved system successfully */
+  NLS_SOLVED_LESS_ACCURARCY = 2     /* NLS Solver found a solution with low accuracy */
+} NLS_SOLVER_STATUS;
+
 #if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0
 typedef struct NONLINEAR_SYSTEM_DATA
 {
@@ -308,8 +314,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
   void *oldValueList;                  /* old values organized in a sorted list for extrapolation and interpolate, respectively */
   modelica_real *resValues;            /* memory space for evaluated residual values */
 
-  modelica_real residualError;         /* not used */
-  modelica_boolean solved;             /* true if solved in current step */
+  NLS_SOLVER_STATUS solved;            /* Specifiex if the NLS could be solved (with less accuracy) or failed */
   modelica_real lastTimeSolved;        /* save last successful solved point in time */
 
   /* statistics */
@@ -335,8 +340,6 @@ typedef struct LINEAR_SYSTEM_THREAD_DATA
   modelica_real *x;                    /* solution vector x */
   modelica_real *A;                    /* matrix A */
   modelica_real *b;                    /* vector b */
-
-  modelica_real residualError;         /* not used yet */
 
   ANALYTIC_JACOBIAN* parentJacobian;   /* if != NULL then it's the parent jacobian matrix */
   ANALYTIC_JACOBIAN* jacobian;         /* jacobian */


### PR DESCRIPTION
`nlsKinsolSolve()` is now able to report one of three status: solved, not solved, solved with less accuracy.

If the error handler reduces the tolerace for KINSOL, the tolerance is reverted after `KINSol()` finished with success.
It is possible, that this happens in each solver call. If we only want to allow this in `N` successive calls we need to add something for that as well.
