### PR TITLE
IDA fix uninitialized linearSolverMethod

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -338,7 +338,7 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
   if (omc_flag[FLAG_JACOBIAN]) {
     for (i=1; i< JAC_MAX;i++) {
       if (!strcmp((const char*)omc_flagValue[FLAG_JACOBIAN], JACOBIAN_METHOD[i])) {
-        idaData->jacobianMethod = (int)i;
+        idaData->jacobianMethod = (enum JACOBIAN_METHOD)i;
         break;
       }
     }
@@ -373,7 +373,7 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
   if (omc_flag[FLAG_IDA_LS]) {
     for (i=1; i< IDA_LS_MAX; i++) {
       if (!strcmp((const char*)omc_flagValue[FLAG_IDA_LS], IDA_LS_METHOD[i])) {
-        idaData->linearSolverMethod = (int)i;
+        idaData->linearSolverMethod = (enum IDA_LS)i;
         break;
       }
     }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -369,6 +369,28 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
     idaData->jacobianMethod = COLOREDNUMJAC;
   }
 
+  /* if FLAG_IDA_LS is set, choose ida linear solver method */
+  if (omc_flag[FLAG_IDA_LS]) {
+    for (i=1; i< IDA_LS_MAX; i++) {
+      if (!strcmp((const char*)omc_flagValue[FLAG_IDA_LS], IDA_LS_METHOD[i])) {
+        idaData->linearSolverMethod = (int)i;
+        break;
+      }
+    }
+    if (idaData->linearSolverMethod == IDA_LS_UNKNOWN) {
+      if (ACTIVE_WARNING_STREAM(LOG_SOLVER)) {
+        warningStreamPrint(LOG_SOLVER, 1, "unrecognized ida linear solver method %s, current options are:", (const char*)omc_flagValue[FLAG_IDA_LS]);
+        for(i=1; i < IDA_LS_MAX; ++i) {
+          warningStreamPrint(LOG_SOLVER, 0, "%-15s [%s]", IDA_LS_METHOD[i], IDA_LS_METHOD_DESC[i]);
+        }
+        messageClose(LOG_SOLVER);
+      }
+      throwStreamPrint(threadData,"unrecognized ida linear solver method %s", (const char*)omc_flagValue[FLAG_IDA_LS]);
+    }
+  } else {
+    idaData->linearSolverMethod = IDA_LS_KLU;
+  }
+
   /* selects the calculation method of the jacobian */
   /* in daeMode sparse pattern is already initialized in DAEMODE_DATA */
   if(!idaData->daeMode && (idaData->jacobianMethod == COLOREDNUMJAC ||
@@ -399,28 +421,6 @@ int ida_solver_initial(DATA* data, threadData_t *threadData,
     idaData->NNZ = data->simulationInfo->daeModeData->sparsePattern->numberOfNonZeros;
   } else {
     idaData->NNZ = data->simulationInfo->analyticJacobians[data->callback->INDEX_JAC_A].sparsePattern->numberOfNonZeros;
-  }
-
-  /* if FLAG_IDA_LS is set, choose ida linear solver method */
-  if (omc_flag[FLAG_IDA_LS]) {
-    for (i=1; i< IDA_LS_MAX;i++) {
-      if (!strcmp((const char*)omc_flagValue[FLAG_IDA_LS], IDA_LS_METHOD[i])) {
-        idaData->linearSolverMethod = (int)i;
-        break;
-      }
-    }
-    if (idaData->linearSolverMethod == IDA_LS_UNKNOWN) {
-      if (ACTIVE_WARNING_STREAM(LOG_SOLVER)) {
-        warningStreamPrint(LOG_SOLVER, 1, "unrecognized ida linear solver method %s, current options are:", (const char*)omc_flagValue[FLAG_IDA_LS]);
-        for(i=1; i < IDA_LS_MAX; ++i) {
-          warningStreamPrint(LOG_SOLVER, 0, "%-15s [%s]", IDA_LS_METHOD[i], IDA_LS_METHOD_DESC[i]);
-        }
-        messageClose(LOG_SOLVER);
-      }
-      throwStreamPrint(threadData,"unrecognized ida linear solver method %s", (const char*)omc_flagValue[FLAG_IDA_LS]);
-    }
-  } else {
-    idaData->linearSolverMethod = IDA_LS_KLU;
   }
 
   switch (idaData->linearSolverMethod){

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.h
@@ -65,11 +65,11 @@ typedef struct IDA_SOLVER
 {
   /* ### configuration  ### */
   int setInitialSolution;
-  int jacobianMethod;            /* specifies the method to calculate the Jacobian matrix */
-  int linearSolverMethod;        /* specifies the method to solve the linear problem */
-  int internalSteps;             /* if = 1 internal step of the integrator are used  */
-  unsigned int stepsFreq;        /* value specifies the output frequency regarding to time steps. Used in internal steps mode. */
-  double stepsTime;              /* value specifies the time increment when output happens. Used in internal steps mode. */
+  enum JACOBIAN_METHOD jacobianMethod;  /* specifies the method to calculate the Jacobian matrix */
+  enum IDA_LS linearSolverMethod;       /* specifies the method to solve the linear problem */
+  int internalSteps;                    /* if = 1 internal step of the integrator are used  */
+  unsigned int stepsFreq;               /* value specifies the output frequency regarding to time steps. Used in internal steps mode. */
+  double stepsTime;                     /* value specifies the time increment when output happens. Used in internal steps mode. */
 
   /* ### work arrays ### */
   N_Vector y;                   /* State vector */


### PR DESCRIPTION
### Purpose

Fix usage of uninitialized `linearSolverMethod` in IDA solver.
Also IDA_SOLVER more readable.

### Approach

Use `enum JACOBIAN_METHOD` and `enum IDA_LS` instead of int.
