### PR TITLE
Skip some crefs in Structural.isExpressionNotFixed

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
@@ -165,6 +165,7 @@ public
         Expression e;
 
       case Expression.CREF()
+        guard ComponentRef.isCref(exp.cref) and not ComponentRef.isIterator(exp.cref)
         algorithm
           node := ComponentRef.node(exp.cref);
 

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -919,6 +919,7 @@ RecordBinding8.mo \
 RecordBinding9.mo \
 RecordBinding10.mo \
 RecordBinding11.mo \
+RecordBinding12.mo \
 RecordConstructor1.mo \
 RecordConstructor2.mo \
 RecordExtends1.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordBinding12.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordBinding12.mo
@@ -1,0 +1,45 @@
+// name: RecordBinding12
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record BaseR
+  parameter E e;
+  parameter Real m = 1;
+  parameter Integer N = 1;
+  parameter Real[N] H = {0};
+end BaseR;
+
+record R
+  extends BaseR(
+    e = E.a,
+    m = 1 + sum({H[k] for k in 1:N}),
+    N = 4,
+    H = {1, 2, 3, 4});
+end R;
+
+type E = enumeration(a, b, c);
+
+model M
+  parameter BaseR material;
+equation
+  if material.e == E.b then
+  end if;
+end M;
+
+model RecordBinding12
+  M m(material = R());
+end RecordBinding12;
+
+// Result:
+// class RecordBinding12
+//   final parameter enumeration(a, b, c) m.material.e = E.a;
+//   parameter Real m.material.m = 11.0;
+//   final parameter Integer m.material.N = 4;
+//   parameter Real m.material.H[1] = 1.0;
+//   parameter Real m.material.H[2] = 2.0;
+//   parameter Real m.material.H[3] = 3.0;
+//   parameter Real m.material.H[4] = 4.0;
+// end RecordBinding12;
+// endResult


### PR DESCRIPTION
- Skip iterators and any crefs that aren't referring to a node in
  `isExpressionNotFixed`, checking them will fail and isn't necessary
  since they can't be not fixed anyway.