### PR TITLE
Add flag for allowing access of protected elements

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
@@ -418,7 +418,8 @@ uniontype LookupState
       else
         algorithm
           // A protected element generates an error.
-          if InstNode.isProtected(node) then
+          if InstNode.isProtected(node) and
+             not Flags.isConfigFlagSet(Flags.ALLOW_NON_STANDARD_MODELICA, "protectedAccess") then
             Error.addSourceMessage(Error.PROTECTED_ACCESS,
               {InstNode.name(node)}, InstNode.info(node));
             fail();

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1386,7 +1386,8 @@ constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG(146, "allowNonStan
     ("nonStdMultipleExternalDeclarations", Gettext.gettext("Allow several external declarations in functions.\nSee: https://specification.modelica.org/maint/3.5/functions.html#function-as-a-specialized-class")),
     ("nonStdEnumerationAsIntegers", Gettext.gettext("Allow enumeration as integer without casting via Integer(Enum).\nSee: https://specification.modelica.org/maint/3.5/class-predefined-types-and-declarations.html#type-conversion-of-enumeration-values-to-string-or-integer")),
     ("nonStdIntegersAsEnumeration", Gettext.gettext("Allow integer as enumeration without casting via Enum(Integer).\nSee: https://specification.modelica.org/maint/3.5/class-predefined-types-and-declarations.html#type-conversion-of-integer-to-enumeration-values")),
-    ("nonStdDifferentCaseFileVsClassName", Gettext.gettext("Allow directory or file with different case in the name than the contained class name.\nSee: https://specification.modelica.org/maint/3.5/packages.html#mapping-package-class-structures-to-a-hierarchical-file-system"))
+    ("nonStdDifferentCaseFileVsClassName", Gettext.gettext("Allow directory or file with different case in the name than the contained class name.\nSee: https://specification.modelica.org/maint/3.5/packages.html#mapping-package-class-structures-to-a-hierarchical-file-system")),
+    ("protectedAccess", Gettext.gettext("Allow access of protected elements"))
     })),
   Gettext.gettext("Flags to allow non-standard Modelica."));
 


### PR DESCRIPTION
- Add flag `--allowNonStandardModelica=protectedAcess` to allow access
  to protected elements.

Fixes #9059