### PR TITLE
Ignore overloaded functions in NFInst.instClass2

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -469,6 +469,10 @@ algorithm
         else expandClassDerived(def, cdef, node, info);
       end match;
 
+    // Overloaded functions are normally handled separately in Function, but we might
+    // get here through e.g. the interactive API. In that case just ignore them.
+    case SCode.OVERLOAD() then node;
+
     else
       algorithm
         Error.assertion(false, getInstanceName() + " got unknown class:\n" + SCodeDump.unparseElementStr(def), sourceInfo());


### PR DESCRIPTION
- Ignore overloaded functions in NFInst.instClass2, they don't need to
  be instantiated and cause confusing error messages if not ignored.

Fixes #9122