### PR TITLE
Handle unevaluable dimensions in connector check

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -339,6 +339,7 @@ function checkConnectorTypeBalance
   input InstNode component;
 protected
   Integer pots, flows, streams;
+  Boolean known_size;
   Component comp;
   InstNode parent;
 algorithm
@@ -353,7 +354,11 @@ algorithm
     return;
   end if;
 
-  (pots, flows, streams) := Component.countConnectorVars(comp);
+  (pots, flows, streams, known_size) := Component.countConnectorVars(comp);
+
+  if not known_size then
+    return;
+  end if;
 
   // Modelica 3.2 section 9.3.1:
   // For each non-partial connector class the number of flow variables shall

--- a/testsuite/flattening/modelica/connectors/ConnectorBalance8.mos
+++ b/testsuite/flattening/modelica/connectors/ConnectorBalance8.mos
@@ -1,0 +1,33 @@
+// name: ConnectorBalance8
+// keywords: connector
+// status: correct
+// cflags: -d=newInst
+//
+// Checks that the connector balance checking can handle unevaluable dimensions.
+//
+
+loadString("
+  connector C
+    parameter Integer n;
+    Real e;
+    flow Real f;
+    stream Real s[n];
+  end C;
+
+  model M
+    C c;
+  end M;
+");
+getErrorString();
+
+checkModel(M);
+getErrorString();
+
+// Result:
+// true
+// ""
+// "Check of M completed successfully.
+// Class M has 1 equation(s) and 3 variable(s).
+// 1 of these are trivial equation(s)."
+// ""
+// endResult

--- a/testsuite/flattening/modelica/connectors/Makefile
+++ b/testsuite/flattening/modelica/connectors/Makefile
@@ -42,6 +42,7 @@ ConnectorBalance4.mo \
 ConnectorBalance5.mo \
 ConnectorBalance6.mo \
 ConnectorBalance7.mo \
+ConnectorBalance8.mos \
 ConnectorComponents.mo \
 ConnectorCompOrder.mo \
 ConnectorIllegal.mo \


### PR DESCRIPTION
- Skip the connector balance check if a connector contains unevaluable
  dimensions (which can happen during e.g. checkModel).

Fixes #9160