### PR TITLE
Improve dumping of modifiers in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -4290,6 +4290,7 @@ algorithm
     case SCode.CLASS(classDef = SCode.DERIVED(modifications = mod)) then mod;
     case SCode.CLASS(classDef = SCode.CLASS_EXTENDS(modifications = mod)) then mod;
     case SCode.EXTENDS(modifications = mod) then mod;
+    else SCode.NOMOD();
 
   end match;
 end elementMod;

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -12,6 +12,10 @@
       "description": "The kind of class",
       "type": "string"
     },
+    "modifier": {
+      "description": "Modifier from the SCode",
+      "type": "#/definitions/modifier"
+    },
     "extends": {
       "description": "The extends clauses in the class instance",
       "type": "array",
@@ -150,7 +154,7 @@
             },
             "modifier": {
               "description": "Modifier from the SCode",
-              "type": "string"
+              "type": "#/definitions/modifier"
             },
             "value": {
               "description": "The component's binding equation",
@@ -225,6 +229,22 @@
         }
       },
       "required": ["binding"]
+    },
+    "modifier": {
+      "description": "A modifier",
+      "type": "object",
+      "properties": {
+        "value": [
+          "type": "string"
+        ],
+        "modifiers": {
+          "type": "array",
+          "items": {
+            "type": "#/definitions/modifier"
+          }
+        }
+      },
+      "required": []
     }
   }
 }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -24,7 +24,9 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"pi\",
 //       \"type\": \"Real\",
-//       \"modifier\": \" = 3\",
+//       \"modifiers\": {
+//         \"value\": \"3\"
+//       },
 //       \"value\": {
 //         \"binding\": 3
 //       },
@@ -35,7 +37,11 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"deg\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"(start = pi)\",
+//       \"modifiers\": {
+//         \"start\": {
+//           \"value\": \"pi\"
+//         }
+//       },
 //       \"prefixes\": {
 //
 //       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
@@ -43,7 +43,6 @@ getModelInstance(M, prettyPrint = true);
 //         {
 //           \"name\": \"w\",
 //           \"type\": \"Real\",
-//           \"modifier\": \"\",
 //           \"prefixes\": {
 //             \"public\": false,
 //             \"replaceable\": true,
@@ -53,7 +52,6 @@ getModelInstance(M, prettyPrint = true);
 //         {
 //           \"name\": \"z\",
 //           \"type\": \"Real\",
-//           \"modifier\": \"\",
 //           \"prefixes\": {
 //             \"inner\": true
 //           }
@@ -65,7 +63,6 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"z\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"outer\": true
 //       }
@@ -73,7 +70,6 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"final\": true
 //       }
@@ -81,7 +77,6 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"input\": true
 //       }
@@ -89,7 +84,6 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"z\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"inner\": true
 //       }
@@ -97,7 +91,6 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"w\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"public\": false,
 //         \"replaceable\": true,
@@ -113,7 +106,6 @@ getModelInstance(M, prettyPrint = true);
 //           {
 //             \"name\": \"e\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //
 //             }
@@ -121,7 +113,6 @@ getModelInstance(M, prettyPrint = true);
 //           {
 //             \"name\": \"f\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"connector\": \"flow\"
 //             }
@@ -129,14 +120,12 @@ getModelInstance(M, prettyPrint = true);
 //           {
 //             \"name\": \"s\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"connector\": \"stream\"
 //             }
 //           }
 //         ]
 //       },
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"public\": false,
 //         \"variability\": \"parameter\"

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
@@ -46,7 +46,6 @@ getModelInstance(M, prettyPrint = true);
 //               {
 //                 \"name\": \"e\",
 //                 \"type\": \"Real\",
-//                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //
 //                 }
@@ -54,14 +53,12 @@ getModelInstance(M, prettyPrint = true);
 //               {
 //                 \"name\": \"f\",
 //                 \"type\": \"Real\",
-//                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //                   \"connector\": \"flow\"
 //                 }
 //               }
 //             ]
 //           },
-//           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
@@ -75,7 +72,6 @@ getModelInstance(M, prettyPrint = true);
 //               {
 //                 \"name\": \"e\",
 //                 \"type\": \"Real\",
-//                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //
 //                 }
@@ -83,14 +79,12 @@ getModelInstance(M, prettyPrint = true);
 //               {
 //                 \"name\": \"f\",
 //                 \"type\": \"Real\",
-//                 \"modifier\": \"\",
 //                 \"prefixes\": {
 //                   \"connector\": \"flow\"
 //                 }
 //               }
 //             ]
 //           },
-//           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
@@ -108,7 +102,6 @@ getModelInstance(M, prettyPrint = true);
 //           {
 //             \"name\": \"e\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //
 //             }
@@ -116,14 +109,12 @@ getModelInstance(M, prettyPrint = true);
 //           {
 //             \"name\": \"f\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"connector\": \"flow\"
 //             }
 //           }
 //         ]
 //       },
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDuplicate1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDuplicate1.mos
@@ -31,7 +31,6 @@ getModelInstance(B, prettyPrint = true);
 //         {
 //           \"name\": \"x\",
 //           \"type\": \"Real\",
-//           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
@@ -43,7 +42,6 @@ getModelInstance(B, prettyPrint = true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
@@ -28,7 +28,9 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifier\": \" = 2.0\",
+//       \"modifiers\": {
+//         \"value\": \"2.0\"
+//       },
 //       \"value\": {
 //         \"binding\": 2
 //       },
@@ -53,7 +55,9 @@ getModelInstance(M, prettyPrint = true);
 //                 \"3\"
 //               ]
 //             },
-//             \"modifier\": \" = {1, 2, 3}\",
+//             \"modifiers\": {
+//               \"value\": \"{1, 2, 3}\"
+//             },
 //             \"value\": {
 //               \"binding\": [
 //                 1,
@@ -67,7 +71,6 @@ getModelInstance(M, prettyPrint = true);
 //           }
 //         ]
 //       },
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
@@ -75,7 +78,9 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
-//       \"modifier\": \" = a.x[1]\",
+//       \"modifiers\": {
+//         \"value\": \"a.x[1]\"
+//       },
 //       \"value\": {
 //         \"binding\": {
 //           \"$kind\": \"cref\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
@@ -32,7 +32,6 @@ getModelInstance(M, prettyPrint=true);
 //         {
 //           \"name\": \"x\",
 //           \"type\": \"Real\",
-//           \"modifier\": \"\",
 //           \"prefixes\": {
 //
 //           }
@@ -44,7 +43,6 @@ getModelInstance(M, prettyPrint=true);
 //     {
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
@@ -52,7 +50,6 @@ getModelInstance(M, prettyPrint=true);
 //     {
 //       \"name\": \"z\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter1.mos
@@ -33,14 +33,12 @@ getModelInstance(B, prettyPrint=true);
 //           {
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //               \"inner\": true
 //             }
 //           }
 //         ]
 //       },
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }
@@ -48,7 +46,6 @@ getModelInstance(B, prettyPrint=true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //         \"inner\": true
 //       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
@@ -28,7 +28,9 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifier\": \" = 1.0\",
+//       \"modifiers\": {
+//         \"value\": \"1.0\"
+//       },
 //       \"value\": {
 //         \"binding\": 1
 //       },
@@ -45,14 +47,12 @@ getModelInstance(M, prettyPrint = true);
 //           {
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
-//             \"modifier\": \"\",
 //             \"prefixes\": {
 //
 //             }
 //           }
 //         ]
 //       },
-//       \"modifier\": \"\",
 //       \"prefixes\": {
 //
 //       }


### PR DESCRIPTION
- Dump the structure of modifiers instead of just dumping them as
  strings.
- Dump modifiers for classes too, including extends clauses.
- Make the modifiers optional.