### PR TITLE
Improve handling of annotations in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Util/ErrorExt.mo
+++ b/OMCompiler/Compiler/Util/ErrorExt.mo
@@ -66,11 +66,21 @@ function addSourceMessage
 end addSourceMessage;
 
 function printMessagesStr
+  "Prints all error messages as a string and pops them from the message queue."
   input Boolean warningsAsErrors = false;
   output String outString;
 
   external "C" outString=Error_printMessagesStr(OpenModelica.threadData(),warningsAsErrors) annotation(Library = "omcruntime");
 end printMessagesStr;
+
+function printCheckpointMessagesStr
+  "Prints the error messages since the last checkpoint as a string and pops them
+   from the message queue."
+  input Boolean warningsAsErrors = false;
+  output String outString;
+
+  external "C" outString=Error_printCheckpointMessagesStr(OpenModelica.threadData(),warningsAsErrors) annotation(Library = "omcruntime");
+end printCheckpointMessagesStr;
 
 function getNumMessages
   output Integer num;

--- a/OMCompiler/Compiler/runtime/Error_omc.cpp
+++ b/OMCompiler/Compiler/runtime/Error_omc.cpp
@@ -77,6 +77,12 @@ extern const char* Error_printMessagesStr(threadData_t *threadData,int warningsA
   return omc_alloc_interface.malloc_strdup(res.c_str());
 }
 
+extern const char* Error_printCheckpointMessagesStr(threadData_t *threadData,int warningsAsErrors)
+{
+  std::string res = ErrorImpl__printCheckpointMessagesStr(threadData,warningsAsErrors);
+  return omc_alloc_interface.malloc_strdup(res.c_str());
+}
+
 extern void Error_addSourceMessage(threadData_t *threadData,int _id, void *msg_type, void *severity, int _sline, int _scol, int _eline, int _ecol, int _read_only, const char* _filename, const char* _msg, void* tokenlst)
 {
   ErrorMessage::TokenList tokens;

--- a/OMCompiler/Compiler/runtime/errorext.cpp
+++ b/OMCompiler/Compiler/runtime/errorext.cpp
@@ -555,13 +555,29 @@ extern std::string ErrorImpl__printErrorsNoWarning(threadData_t *threadData)
 // TODO: Use a string builder instead of creating intermediate results all the time?
 extern std::string ErrorImpl__printMessagesStr(threadData_t *threadData, int warningsAsErrors)
 {
-  errorext_members *members = getMembers(threadData);
+  auto members = getMembers(threadData);
   // fprintf(stderr, "-> ErrorImpl__printMessagesStr error messages: %d queue size: %d\n", numErrorMessages, (int)errorMessageQueue->size()); fflush(NULL);
-  std::string res("");
+  std::string res;
   while(!members->errorMessageQueue->empty()) {
-    res = members->errorMessageQueue->back()->getMessage(warningsAsErrors)+string("\n")+res;
+    res = members->errorMessageQueue->back()->getMessage(warningsAsErrors) + '\n' + res;
     pop_message(threadData,false);
   }
+  return res;
+}
+
+extern std::string ErrorImpl__printCheckpointMessagesStr(threadData_t *threadData, int warningsAsErrors)
+{
+  auto members = getMembers(threadData);
+  std::string res;
+
+  if (members->checkPoints->size() == 0) return res;
+
+  int id = members->checkPoints->back().first;
+  while (members->errorMessageQueue->size() > id) {
+    res = members->errorMessageQueue->back()->getMessage(warningsAsErrors) + '\n' + res;
+    pop_message(threadData, false);
+  }
+
   return res;
 }
 

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -91,7 +91,8 @@
     "annotation": {
       "type": "object",
       "properties": {
-        "$kind": false
+        "$kind": false,
+        "$error": false
       },
       "additionalProperties": {
         "oneOf": [
@@ -100,6 +101,20 @@
           },
           {
             "$ref": "expression.schema.json"
+          },
+          {
+            "description": "An invalid annotation",
+            "type": "object",
+            "properties": {
+              "$error": {
+                "description": "Error message",
+                "type": "string"
+              },
+              "value": {
+                "description": "Annotation dumped as a string",
+                "type": "string"
+              }
+            }
           }
         ]
       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation3.mos
@@ -1,0 +1,37 @@
+// name: GetModelInstanceAnnotation3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    Real x annotation (HideResult = b);
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//     {
+//       \"name\": \"x\",
+//       \"type\": \"Real\",
+//       \"prefixes\": {
+//
+//       },
+//       \"annotation\": {
+//         \"HideResult\": {
+//           \"$error\": \"[<interactive>:3:24-3:38:writable] Error: Variable b not found in scope M.\\n\",
+//           \"value\": \"b\"
+//         }
+//       }
+//     }
+//   ]
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -3,6 +3,7 @@ TEST = ../../rtest -v
 TESTFILES = \
 GetModelInstanceAnnotation1.mos \
 GetModelInstanceAnnotation2.mos \
+GetModelInstanceAnnotation3.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceComment1.mos \


### PR DESCRIPTION
- Catch errors when instantiating annotations and add them to the JSON
  instead of failing.
- Add ErrorExt.printCheckpointMessagesStr.

Fixes #9167