### PR TITLE
Temporary fix for conflicting Qt and OpenSceneGraph headers.

### DIFF
--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -31,7 +31,8 @@
  * @author Volker Waurich <volker.waurich@tu-dresden.de>
  */
 
-#include <QOpenGLContext> // must be first include to fix undefined GLDEBUGPROC
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osg/MatrixTransform>
 #include <osg/Vec3>
 #include <osgDB/ReadFile>

--- a/OMEdit/OMEditLIB/Animation/AbstractVisualizer.h
+++ b/OMEdit/OMEditLIB/Animation/AbstractVisualizer.h
@@ -39,6 +39,8 @@
 
 #include "rapidxml.hpp"
 
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osg/Vec3f>
 #include <osg/Matrix>
 #include <osg/Uniform>

--- a/OMEdit/OMEditLIB/Animation/AnimationUtil.h
+++ b/OMEdit/OMEditLIB/Animation/AnimationUtil.h
@@ -39,6 +39,8 @@
 #include <QRegExp>
 #include <QFileInfo>
 
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <sys/stat.h>
 #include <string>
 #include <osg/Vec3>

--- a/OMEdit/OMEditLIB/Animation/ExtraShapes.h
+++ b/OMEdit/OMEditLIB/Animation/ExtraShapes.h
@@ -37,6 +37,8 @@
 
 #include "Visualization.h"
 
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osg/Node>
 #include <osg/Group>
 #include <osg/Geode>

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -31,6 +31,8 @@
  * @author Adeel Asghar <adeel.asghar@liu.se>
  */
 
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osgGA/MultiTouchTrackballManipulator>
 #include <osgViewer/ViewerEventHandlers>
 

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.h
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.h
@@ -34,6 +34,8 @@
 #ifndef VIEWERWIDGET_H
 #define VIEWERWIDGET_H
 
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osg/ref_ptr>
 #include <osgViewer/GraphicsWindow>
 #include <osgViewer/CompositeViewer>

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -37,6 +37,9 @@
 #if (QT_VERSION < QT_VERSION_CHECK(5, 2, 0))
 #include <QGLWidget>
 #endif
+
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osg/Image>
 #include <osg/Shape>
 #include <osg/Node>

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -40,6 +40,7 @@
 #include <iostream>
 
 #include <QImage>
+#include <QOpenGLContext> // must be included before OSG headers
 
 #include <osg/NodeVisitor>
 #include <osg/Geode>

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -32,7 +32,6 @@
  * @author Adeel Asghar <adeel.asghar@liu.se>
  */
 
-#include <QOpenGLContext> // must be first include to fix undefined GLDEBUGPROC
 #include "MainWindow.h"
 /* Keep PlotWindowContainer on top to include OSG first */
 #include "Plotting/PlotWindowContainer.h"

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -32,7 +32,6 @@
  * @author Adeel Asghar <adeel.asghar@liu.se>
  */
 
-#include <QOpenGLContext> // must be first include to fix undefined GLDEBUGPROC
 #include "PlotWindowContainer.h"
 #include "MainWindow.h"
 #include "Options/OptionsDialog.h"

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -63,10 +63,10 @@ There is nothing special to be done for linux. You can follow the examples above
 ## 3.3. macOS
 On macOS there are a few pitfalls/issues which need attention.
 
-- If you plan to build the OpenModelica GUI clients (e.g. OMEdit) you need to install a Qt5 version that comes with `qt-webkit`. Unfortunately, the Qt formulae from `homebrew` does not provide `qt-webkit` anymore. Therefore, you will have to find a way of getting `qt-webkit` on your machine. The recommend and probably the easiest way to do this is using macports to install Qt:
+- If you plan to build the OpenModelica GUI clients (e.g. OMEdit) you need to install a Qt5 version that comes with `qt-webkit`. Unfortunately, the Qt formulae from `homebrew` does not provide `qt-webkit` anymore. Therefore, you will have to find a way of getting `qt-webkit` on your machine. The recommend and probably the easiest way to do this is using macports to install Qt and qt5-webkit:
 
   ```sh
-  port install qt5
+  port install qt5 qt5-qtwebkit
   ```
 
   once Qt5 is installed, you will need to note the installation directory. It should be `/opt/local` by default. If it is not, you can run


### PR DESCRIPTION
  - Always include Qt's `QOpenGLContext` header before including any OSG
    headers.

  - See #9145 and https://bugreports.qt.io/browse/QTBUG-104673 for reasons
    behind this requirement.

  - Improves #9145.
