### PR TITLE
Disable ParModAuto if required boost libs are not found.

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ParModelica/CMakeLists.txt
@@ -1,5 +1,10 @@
 
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/ParModelica)
-omc_add_subdirectory(auto)
 
+find_package(Boost COMPONENTS graph chrono)
 
+if(Boost_graph_FOUND AND Boost_chrono_FOUND)
+  omc_add_subdirectory(auto)
+else()
+  message(STATUS "Required boost libraries (graph, chrono) not found for ParModAuto. Disabling ParModAuto.")
+endif()


### PR DESCRIPTION
  - Instead of failing configuration completely when the required boost
    libraries are not found, simply disable ParModAuto and continue as it
    is an optional component anyway.

  - We can add a configuration option for this but seems like it is an
    overkill to add an option just for this at the moment.

  - We should probably handle the CPP runtime in a similar manner. Instead
    of requiring users to add yet another option to their configuration
    commandline.
