### PR TITLE
Fix for CPP-runtime when boost is not in system directories.

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/auto/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ParModelica/auto/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 project(ParModelicaAuto)
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/auto)
 
-find_package(Boost REQUIRED COMPONENTS graph chrono)
+find_package(Boost COMPONENTS graph chrono REQUIRED)
 
 set(PARMODAUTO_SOURCES om_pm_equation.cpp om_pm_interface.cpp om_pm_model.cpp pm_utility.cpp)
 
@@ -18,6 +18,8 @@ endif()
 
 target_link_libraries(ParModelicaAuto PUBLIC omc::simrt::runtime)
 target_link_libraries(ParModelicaAuto PUBLIC omc::3rd::tbb)
+target_link_libraries(ParModelicaAuto PUBLIC Boost::graph)
+
 target_compile_definitions(ParModelicaAuto PRIVATE USE_FLOW_SCHEDULER)
 
 # For now, disable deprecation warning from the json reader. We do not plan to update any time soon.

--- a/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/Core/CMakeLists.txt
@@ -243,8 +243,6 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 
 
 #####################################################################################################
-find_package(Boost COMPONENTS filesystem REQUIRED)
-
 # OMCppSimulationSettings
 set(OMC_SIMRT_CPP_CORE_SIM_SETTINGS_SOURCES SimulationSettings/GlobalSettings.cpp
                                             SimulationSettings/Factory.cpp

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
@@ -2,10 +2,6 @@
 
 #####################################################################################################
 # OMCppOMCFactory
-find_package(Boost COMPONENTS program_options filesystem REQUIRED)
-find_package(Threads REQUIRED)
-
-
 set(OMC_SIMRT_CPP_SIMCOREFACTORY_OMCFACTORY_SOURCES OMCFactory/OMCFactory.cpp)
 
 add_library(OMCppOMCFactory SHARED)

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -1,7 +1,7 @@
 
 project(SimRT_CPP)
 
-add_definitions(-DOMC_BUILD)
+# add_definitions(-DOMC_BUILD)
 
 # CPP libs should be installed to in lib/<arch>/omc/cpp/ for now.
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR}/cpp)
@@ -11,13 +11,29 @@ set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/cpp)
 
 
 
-# An interface library for providing common include directories for all the CPP libs.
+# Boost and a threading library are required for the CPP-runtime.
+find_package(Boost COMPONENTS program_options filesystem REQUIRED)
+find_package(Threads REQUIRED)
+
+
+# An interface library for providing common include directories and other settings
+# for all the CPP-runtime libraries.
 add_library(OMCppConfig INTERFACE)
 add_library(omc::simrt::cpp::config ALIAS OMCppConfig)
 
+# Make the current source directory, current binary directory (contains generated files), and
+# the Include/ directory available to all libraries that link to OMCppConfig (which means all CPP-runtime libs)
 target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(OMCppConfig INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/Include)
+
+# Make boost headers transitively available to all CPP-runtime libraries
+# (note that they all link to 'OMCppConfig' a.k.a 'omc::simrt::cpp::config')
+target_link_libraries(OMCppConfig INTERFACE Boost::boost)
+
+# This should be defined for all CPP-runtime library compilations.
+# Signifies that we are building the source code (instead of consuming, say the headers ...).
+target_compile_definitions(OMCppConfig INTERFACE OMC_BUILD)
 
 
 # Subdirectories


### PR DESCRIPTION
  - Make sure CPP runtime libraries can find boost headers even when boost
    is not installed in system directories.

    We do this by linking `Boost:boost` (which provides access to the header
    only libraries, e.g., ublas) with `OMCppConfig` (`omc::simrt::cpp::config`)

    All CPP-runtime libraries link to `OMCppConfig`. This means all of them
    will get access to boost headers transitively.

  - Make sure the `ParModAuto` library can find boost headers even when boost
    is not installed in system directories.

    For this one we can link to Boost::graph (Boost::boost would have worked
    equally fine)