### PR TITLE
9036 record constants

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -377,7 +377,7 @@ algorithm
     end for;
 
     binding := match listLength(subscriptLst)
-      case 1 then DAE.ARRAY(ComponentReference.crefTypeFull(cref), false, expLst);
+      case 1 then DAE.ARRAY(ComponentReference.crefTypeFull(cref), true, expLst);
       case 2 algorithm
         dims := Types.getDimensions(ComponentReference.crefLastType(cref));
         firstDim := match List.first(dims)

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -87,6 +87,26 @@ import ZeroCrossings;
 
 protected type Functiontuple = tuple<Option<DAE.FunctionTree>,list<DAE.InlineType>>;
 
+protected type ArrayBindingList = list<tuple<list<Integer>,DAE.Exp>>;
+
+function printArrayBindingList
+  input ArrayBindingList arrayBindingList;
+  output String str = "";
+protected
+  list<Integer> subscriptLst;
+  DAE.Exp bindingExp;
+algorithm
+  for tpl in arrayBindingList loop
+    (subscriptLst, bindingExp) := tpl;
+    str := str + "[";
+    for subscript in subscriptLst loop
+      str := str + intString(subscript) + " ";
+    end for;
+    str := str + "]";
+    str := str + " : " + ExpressionDump.dumpExpStr(bindingExp, 0);
+  end for;
+end printArrayBindingList;
+
 public function lower "This function translates a DAE, which is the result from instantiating a
   class, into a more precise form, called BackendDAE.BackendDAE defined in this module.
   The BackendDAE.BackendDAE representation splits the DAE into equations and variables
@@ -120,6 +140,7 @@ protected
   Integer varSize, eqnSize, numCheckpoints;
   BackendDAE.EqSystem syst;
   UnorderedMap<DAE.ComponentRef, DAE.Type> map;
+  UnorderedMap<DAE.ComponentRef, ArrayBindingList> arrayMap;
 algorithm
   numCheckpoints:=ErrorExt.getNumCheckpoints();
   try
@@ -147,9 +168,13 @@ algorithm
 
   // 2. collect bindings from variables and update in types
   // (ToDo: update the types?)
-  _ := List.map(varlst, function collectRecordElementBindings(map = map));
-  _ := List.map(globalKnownVarLst, function collectRecordElementBindings(map = map));
-  _ := List.map(extvarlst, function collectRecordElementBindings(map = map));
+  arrayMap := UnorderedMap.new<ArrayBindingList>(ComponentReference.hashComponentRefMod, ComponentReference.crefEqual);
+
+  _ := List.map(varlst, function collectRecordElementBindings(map = map, arrayMap = arrayMap));
+  _ := List.map(globalKnownVarLst, function collectRecordElementBindings(map = map, arrayMap = arrayMap));
+  _ := List.map(extvarlst, function collectRecordElementBindings(map = map, arrayMap = arrayMap));
+
+  map := collapseArrayBindings(arrayMap, map);
 
   // 3. replace the types in eqns
   eqns  := List.map(eqns, function updateRecordTypesEqn(map = map));
@@ -218,6 +243,7 @@ end lower;
 protected function collectRecordElementBindings
   input BackendDAE.Var var;
   input UnorderedMap<DAE.ComponentRef, DAE.Type> map;
+  input UnorderedMap<DAE.ComponentRef, ArrayBindingList> arrayMap;
 protected
   DAE.ComponentRef rec_cref;
   Boolean is_rec;
@@ -228,16 +254,40 @@ algorithm
       DAE.Exp binding;
       DAE.Type ty;
 
-    case SOME(binding) guard(is_rec and UnorderedMap.contains(rec_cref, map)) algorithm
-      ty := match UnorderedMap.getSafe(rec_cref, map)
-        case ty as DAE.T_COMPLEX() algorithm
-          ty.varLst := list(updateConstantRecordElementBinding(v, binding, ComponentReference.crefLastIdent(var.varName)) for v in ty.varLst);
-        then ty;
-        else algorithm
-          Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because the type is not T_COMPLEX."});
-        then fail();
-      end match;
-      UnorderedMap.add(rec_cref, ty, map);
+      DAE.Exp arrayBinding;
+      DAE.ComponentRef arrayCref;
+      ArrayBindingList arrayBindingExpList;
+      list<DAE.Subscript> subscriptLst;
+      list<Integer> intSubLst;
+
+    case SOME(binding) guard(is_rec and UnorderedMap.contains(rec_cref, map) and Expression.isConst(binding)) algorithm
+
+      if ComponentReference.isArrayElement(var.varName) then
+        arrayCref := ComponentReference.crefStripSubsExceptModelSubs(var.varName);
+        arrayBindingExpList := UnorderedMap.getOrDefault(arrayCref, arrayMap, {});
+
+        subscriptLst := ComponentReference.crefSubs(var.varName);
+        intSubLst := list(match subscript
+          local
+            Integer i;
+          case DAE.INDEX(DAE.ICONST(i)) then i;
+          else algorithm
+            Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because index not integer."});
+          then fail();
+          end match for subscript in subscriptLst);
+        UnorderedMap.add(arrayCref, (intSubLst, binding)::arrayBindingExpList, arrayMap);
+      else
+
+        ty := match UnorderedMap.getSafe(rec_cref, map)
+          case ty as DAE.T_COMPLEX() algorithm
+            ty.varLst := list(updateConstantRecordElementBinding(v, binding, ComponentReference.crefLastIdent(var.varName)) for v in ty.varLst);
+          then ty;
+          else algorithm
+            Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because the type is not T_COMPLEX."});
+          then fail();
+        end match;
+        UnorderedMap.add(rec_cref, ty, map);
+      end if;
     then ();
     else ();
   end match;
@@ -299,6 +349,57 @@ algorithm
     else (exp, true);
   end match;
 end updateRecordTypesExp;
+
+protected function collapseArrayBindings
+  input UnorderedMap<DAE.ComponentRef, ArrayBindingList> arrayMap;
+  input output UnorderedMap<DAE.ComponentRef, DAE.Type> map;
+protected
+  DAE.ComponentRef cref;
+  DAE.ComponentRef rec_cref;
+  ArrayBindingList arrayBindingExpList;
+  list<Integer> subscriptLst;
+  DAE.Exp binding;
+  DAE.Exp scalarBinding;
+  list<DAE.Exp> expLst;
+  DAE.Type ty;
+  list<DAE.Dimension> dims;
+  Integer firstDim;
+algorithm
+
+  // TODO: Sort by index
+  for pair in UnorderedMap.toList(arrayMap) loop
+    (cref, arrayBindingExpList) := pair;
+
+    expLst := {};
+    for scalBind in arrayBindingExpList loop
+      (subscriptLst, scalarBinding) := scalBind;
+      expLst := scalarBinding :: expLst;
+    end for;
+
+    binding := match listLength(subscriptLst)
+      case 1 then DAE.ARRAY(ComponentReference.crefTypeFull(cref), false, expLst);
+      case 2 algorithm
+        dims := Types.getDimensions(ComponentReference.crefLastType(cref));;
+        firstDim := match List.first(dims)
+          case DAE.DIM_INTEGER(firstDim) then firstDim;
+        end match;
+        then DAE.MATRIX(ComponentReference.crefTypeFull(cref), firstDim, List.splitEqualParts(expLst, firstDim)); // TODO: Reshape list to list of list
+      else fail();
+    end match;
+
+    // Update binding in map
+    (rec_cref, true) := ComponentReference.crefGetFirstRec(cref);
+    ty := match UnorderedMap.getSafe(rec_cref, map)
+      case ty as DAE.T_COMPLEX() algorithm
+        ty.varLst := list(updateConstantRecordElementBinding(v, binding, ComponentReference.crefLastIdent(cref)) for v in ty.varLst);
+      then ty;
+      else algorithm
+        Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because the type is not T_COMPLEX."});
+      then fail();
+    end match;
+    UnorderedMap.add(rec_cref, ty, map);
+  end for;
+end collapseArrayBindings;
 
 protected function getExternalObjectAlias "Checks equations if there is an alias equation for external objects.
 If yes, assign alias var, replace equations, remove alias equation.

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -247,9 +247,12 @@ function updateConstantRecordElementBinding
   input output DAE.Var var;
   input DAE.Exp binding;
   input String name;
+protected
+  DAE.Const const;
 algorithm
-  if var.name == name and Expression.isConst(binding) and false then
-    var.binding := DAE.EQBOUND(binding, NONE(), DAE.C_CONST(), DAE.BINDING_FROM_DEFAULT_VALUE());
+  if var.name == name then
+    const := if Expression.isConst(binding) then DAE.C_CONST() else DAE.C_VAR();
+    var.binding := DAE.EQBOUND(binding, NONE(), const, DAE.BINDING_FROM_DEFAULT_VALUE());
   end if;
 end updateConstantRecordElementBinding;
 

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -219,16 +219,16 @@ protected function collectRecordElementBindings
   input BackendDAE.Var var;
   input UnorderedMap<DAE.ComponentRef, DAE.Type> map;
 protected
-  Option<DAE.ComponentRef> cref_opt;
+  DAE.ComponentRef rec_cref;
+  Boolean is_rec;
 algorithm
-  cref_opt := ComponentReference.traverseCref(var.varName, ComponentReference.crefGetRec, NONE());
-  () := match (var.bindExp, cref_opt)
+  (rec_cref, is_rec) := ComponentReference.crefGetFirstRec(var.varName);
+  () := match var.bindExp
     local
       DAE.Exp binding;
-      DAE.ComponentRef rec_cref;
       DAE.Type ty;
 
-    case (SOME(binding), SOME(rec_cref)) guard(UnorderedMap.contains(rec_cref, map)) algorithm
+    case SOME(binding) guard(is_rec and UnorderedMap.contains(rec_cref, map)) algorithm
       ty := match UnorderedMap.getSafe(rec_cref, map)
         case ty as DAE.T_COMPLEX() algorithm
           ty.varLst := list(updateConstantRecordElementBinding(v, binding, ComponentReference.crefLastIdent(var.varName)) for v in ty.varLst);

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -231,7 +231,7 @@ algorithm
     case (SOME(binding), SOME(rec_cref)) guard(UnorderedMap.contains(rec_cref, map)) algorithm
       ty := match UnorderedMap.getSafe(rec_cref, map)
         case ty as DAE.T_COMPLEX() algorithm
-          ty.varLst := list(updateRecordElementBinding(v, binding, ComponentReference.crefLastIdent(var.varName)) for v in ty.varLst);
+          ty.varLst := list(updateConstantRecordElementBinding(v, binding, ComponentReference.crefLastIdent(var.varName)) for v in ty.varLst);
         then ty;
         else algorithm
           Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because the type is not T_COMPLEX."});
@@ -243,18 +243,15 @@ algorithm
   end match;
 end collectRecordElementBindings;
 
-function updateRecordElementBinding
+function updateConstantRecordElementBinding
   input output DAE.Var var;
   input DAE.Exp binding;
   input String name;
-protected
-  DAE.Const const;
 algorithm
-  if var.name == name then
-    const := if Expression.isConst(binding) then DAE.C_CONST() else DAE.C_VAR();
-    var.binding := DAE.EQBOUND(binding, NONE(), const, DAE.BINDING_FROM_DEFAULT_VALUE());
+  if var.name == name and Expression.isConst(binding) and false then
+    var.binding := DAE.EQBOUND(binding, NONE(), DAE.C_CONST(), DAE.BINDING_FROM_DEFAULT_VALUE());
   end if;
-end updateRecordElementBinding;
+end updateConstantRecordElementBinding;
 
 protected function collectRecordTypesEqn
   input output BackendDAE.Equation eqn;
@@ -295,7 +292,6 @@ algorithm
       DAE.ComponentRef cref;
     case DAE.CREF(componentRef = cref) guard(UnorderedMap.contains(cref, map)) algorithm
       exp.ty := UnorderedMap.getSafe(cref, map);
-      exp.componentRef := ComponentReference.crefSetType(cref, exp.ty);
     then (exp, false);
     else (exp, true);
   end match;

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -379,7 +379,7 @@ algorithm
     binding := match listLength(subscriptLst)
       case 1 then DAE.ARRAY(ComponentReference.crefTypeFull(cref), false, expLst);
       case 2 algorithm
-        dims := Types.getDimensions(ComponentReference.crefLastType(cref));;
+        dims := Types.getDimensions(ComponentReference.crefLastType(cref));
         firstDim := match List.first(dims)
           case DAE.DIM_INTEGER(firstDim) then firstDim;
         end match;

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -136,13 +136,14 @@ algorithm
 
   // ticket #9036
   // propagate record bindings from attributes to their parent record types in all crefs of all equations O(n)
+
+  // 1. collect bindings
   map := UnorderedMap.new<DAE.Type>(ComponentReference.hashComponentRefMod, ComponentReference.crefEqual);
   _ := List.map(varlst, function collectRecordElementBindings(map = map));
   _ := List.map(globalKnownVarLst, function collectRecordElementBindings(map = map));
   _ := List.map(extvarlst, function collectRecordElementBindings(map = map));
 
-  print(UnorderedMap.toString(map, ComponentReference.crefStr, Types.printTypeStr) + "\n");
-  //print(UnorderedMap.toString(map, ComponentReference.crefStr, Types.unparseType) + "\n");
+  // 2. apply bindings in exp types
   eqns  := List.map(eqns, function updateRecordTypesEqn(map = map));
   reqns := List.map(reqns, function updateRecordTypesEqn(map = map));
   ieqns := List.map(ieqns, function updateRecordTypesEqn(map = map));
@@ -238,9 +239,12 @@ function updateRecordElementBinding
   input output DAE.Var var;
   input DAE.Exp binding;
   input String name;
+protected
+  DAE.Const const;
 algorithm
   if var.name == name then
-    var.binding := DAE.EQBOUND(binding, NONE(), DAE.C_UNKNOWN(), DAE.BINDING_FROM_DERIVED_RECORD_DECL());
+    const := if Expression.isConst(binding) then DAE.C_CONST() else DAE.C_VAR();
+    var.binding := DAE.EQBOUND(binding, NONE(), const, DAE.BINDING_FROM_DERIVED_RECORD_DECL());
   end if;
 end updateRecordElementBinding;
 

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1535,11 +1535,18 @@ algorithm
   isRec := isRecIn or Types.isRecord(crefLastType(cref));
 end crefIsRec;
 
-public function crefGetRec "traverse function to get the record cref it is"
+public function crefGetRec "traverse function to get the record part of cref"
   input DAE.ComponentRef cref;
   input output Option<DAE.ComponentRef> opt_cref = NONE();
 algorithm
-  opt_cref := if Util.isNone(opt_cref) and Types.isRecord(crefType(cref)) then SOME(cref) else opt_cref;
+  if Types.isRecord(crefType(cref)) then
+    opt_cref := match opt_cref
+      local
+        DAE.ComponentRef c;
+      case NONE() then SOME(crefFirstCref(cref));
+      case SOME(c) then SOME(crefPrependIdent(c, crefFirstIdent(cref), {}, crefType(cref)));
+    end match;
+  end if;
 end crefGetRec;
 
 protected function containWholeDim2 "
@@ -2079,7 +2086,7 @@ crefPrependIdent(a,c,{1},Integer[1]) => a.c[1] [Integer[1]]
 alternative names: crefAddSuffix, crefAddIdent
 "
   input DAE.ComponentRef icr;
-  input String ident;
+  input DAE.Ident ident;
   input list<DAE.Subscript> subs;
   input DAE.Type tp;
   output DAE.ComponentRef newCr;

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -1535,6 +1535,13 @@ algorithm
   isRec := isRecIn or Types.isRecord(crefLastType(cref));
 end crefIsRec;
 
+public function crefGetRec "traverse function to get the record cref it is"
+  input DAE.ComponentRef cref;
+  input output Option<DAE.ComponentRef> opt_cref = NONE();
+algorithm
+  opt_cref := if Util.isNone(opt_cref) and Types.isRecord(crefType(cref)) then SOME(cref) else opt_cref;
+end crefGetRec;
+
 protected function containWholeDim2 "
   A function to check if a cref contains a [:] wholedim element in the subscriptlist."
   input list<DAE.Subscript> inRef;

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -2517,24 +2517,21 @@ end crefApplySubs;
 
 public function crefSetType "
 sets the type of a cref."
-  input DAE.ComponentRef inRef;
-  input DAE.Type newType;
-  output DAE.ComponentRef outRef;
+  input output DAE.ComponentRef cref;
+  input DAE.Type ty;
 algorithm
-  outRef := match (inRef,newType)
-    local
-      DAE.Type ty;
-      DAE.ComponentRef child;
-      list<DAE.Subscript> subs;
-      DAE.Ident id;
+  cref := match cref
+    case DAE.CREF_IDENT() algorithm
+      cref.identType := ty;
+    then cref;
 
-    case(DAE.CREF_IDENT(id,_,subs),_)
-      then
-        makeCrefIdent(id,newType,subs);
+    case DAE.CREF_QUAL() algorithm
+      cref.identType := ty;
+    then cref;
 
-    case(DAE.CREF_QUAL(id,_,subs,child),_)
-      then
-        makeCrefQual(id,newType,subs,child);
+    else algorithm
+      Error.addInternalError(getInstanceName() + " was applied on a cref that has no type: " + crefStr(cref), sourceInfo());
+    then fail();
   end match;
 end crefSetType;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1086,7 +1086,7 @@ public
           // after the typing, but the new frontend doesn't use these types anyway.
           // So instead we just fetch the type of the node if the type is unknown.
           ty := if Type.isUnknown(cref.ty) then InstNode.getType(cref.node) else cref.ty;
-          dty := Type.toDAE(ty, makeTypeVars = Type.isRecord(Type.arrayElementType(ty)));
+          dty := Type.toDAE(ty, makeTypeVars = false);
           dcref := DAE.ComponentRef.CREF_QUAL(InstNode.name(cref.node), dty,
             list(Subscript.toDAE(s) for s in cref.subscripts), accumCref);
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1086,7 +1086,7 @@ public
           // after the typing, but the new frontend doesn't use these types anyway.
           // So instead we just fetch the type of the node if the type is unknown.
           ty := if Type.isUnknown(cref.ty) then InstNode.getType(cref.node) else cref.ty;
-          dty := Type.toDAE(ty, makeTypeVars = false);
+          dty := Type.toDAE(ty, makeTypeVars = Type.isRecord(Type.arrayElementType(ty)));
           dcref := DAE.ComponentRef.CREF_QUAL(InstNode.name(cref.node), dty,
             list(Subscript.toDAE(s) for s in cref.subscripts), accumCref);
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1677,6 +1677,7 @@ uniontype InstNode
 
       case CLASS_NODE()
         algorithm
+          Pointer.update(clsNode.cls, Class.DAE_TYPE(DAE.Type.T_UNKNOWN()));
           cls := Pointer.access(clsNode.cls);
         then
           match cls

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1677,7 +1677,6 @@ uniontype InstNode
 
       case CLASS_NODE()
         algorithm
-          Pointer.update(clsNode.cls, Class.DAE_TYPE(DAE.Type.T_UNKNOWN()));
           cls := Pointer.access(clsNode.cls);
         then
           match cls

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1440,6 +1440,7 @@ protected
   list<SimCode.SimEqSystem> minValueEquations;          // --> updateBoundMinValues
   list<SimCode.SimEqSystem> nominalValueEquations;      // --> updateBoundNominalValues
   list<SimCode.SimEqSystem> parameterEquations;         // --> updateBoundParameters
+  list<SimCode.SimEqSystem> jacobianEquations;
 algorithm
   numCheckpoints:=ErrorExt.getNumCheckpoints();
   try
@@ -1535,6 +1536,7 @@ algorithm
       crefToSimVarHT := SimCodeUtil.createCrefToSimVarHT(modelInfo);
       (symJacs, uniqueEqIndex) := SimCodeUtil.createSymbolicJacobianssSimCode({}, crefToSimVarHT, uniqueEqIndex, matrixnames, {});
       symJacs := listReverse(Util.getOption(daeModeSP) :: symJacs);
+      jacobianEquations := SimCodeUtil.collectAllJacobianEquations(symJacs);
     else
       tmpB := FlagsUtil.set(Flags.NO_START_CALC, true);
       modelInfo := SimCodeUtil.createModelInfo(className, p, emptyBDAE, inInitDAE, functions, {}, 0, spatialInfo.maxIndex, fileDir, 0, tempVars);
@@ -1547,6 +1549,7 @@ algorithm
         matrixnames := {"A", "B", "C", "D", "F"};
       end if;
       (symJacs, uniqueEqIndex) := SimCodeUtil.createSymbolicJacobianssSimCode({}, crefToSimVarHT, uniqueEqIndex, matrixnames, {});
+      jacobianEquations := {};
     end if;
 
     // collect symbolic jacobians in initialization loops of the overall jacobians
@@ -1636,7 +1639,7 @@ algorithm
       removedEquations            = {},
       algorithmAndEquationAsserts = {},
       equationsForZeroCrossings   = {},
-      jacobianEquations           = {},
+      jacobianEquations           = jacobianEquations,
       stateSets                   = {},
       constraints                 = {},
       classAttributes             = {},

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -1756,7 +1756,6 @@ case RECORD_CONSTRUCTOR(__) then
   {
     <%varDecls%>
     <%funArgs |> VARIABLE(__) => '<%structVar%>._<%crefStr(name)%> = omc_<%crefStr(name)%>;' ;separator="\n"%>
-    <%varInits%>
     return <%structVar%>;
   }
   <%if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS) then 'omctd_<%fname%> omc_<%fname%> = omcimpl_<%fname%>;'%>

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5225,6 +5225,19 @@ template daeExpCrefRhs(Exp exp, Context context, Text &preExp,
     else daeExpCrefRhsSimContext(exp, context, &preExp, &varDecls, &auxFunction)
 end daeExpCrefRhs;
 
+template constVarOrDaeExp(DAE.Var var, DAE.ComponentRef cr, Context context, Text &preExp, Text &varDecls, Text &auxFunction)
+::=
+  match var
+    case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.EQBOUND()) then
+      daeExp(binding.exp, context, &preExp, &varDecls, &auxFunction)
+    case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.VALBOUND()) then
+      'ERROR in constVarOrDaeExp /* val bound value */'
+    case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.UNBOUND()) then
+      'ERROR in constVarOrDaeExp /* unbound value */'
+    else
+      daeExp(makeCrefRecordExp(cr,var), context, &preExp, &varDecls, &auxFunction)
+end constVarOrDaeExp;
+
 template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
                         Text &varDecls, Text &auxFunction)
  "Generates code for a component reference in simulation context."
@@ -5235,7 +5248,7 @@ template daeExpCrefRhsSimContext(Exp ecr, Context context, Text &preExp,
     '<%contextCref(cr, context, &preExp, &varDecls, &auxFunction, &sub)%>'
 
   case ecr as CREF(componentRef = cr, ty = t as T_COMPLEX(complexClassType = record_state, varLst = var_lst)) then
-    let vars = var_lst |> v => (", " + daeExp(makeCrefRecordExp(cr,v), context, &preExp, &varDecls, &auxFunction))
+    let vars = var_lst |> v => (", " + constVarOrDaeExp(v, cr, context, &preExp, &varDecls, &auxFunction))
     let record_type_name = underscorePath(ClassInf.getStateName(record_state))
     'omc_<%record_type_name%>(threadData<%vars%>)'
 

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -2,6 +2,8 @@ TEST = ../../../rtest -v
 
 TESTFILES = \
 ATotal.mos \
+constVar1.mos \
+constVar2.mos \
 InOutRecord.mos \
 RecordConstructor1.mos \
 TestComplexSum1.mos \

--- a/testsuite/simulation/modelica/records/constVar1.mos
+++ b/testsuite/simulation/modelica/records/constVar1.mos
@@ -1,0 +1,39 @@
+// name:     constVar1.mos
+// keywords: record constants function call
+// status:   correct
+// teardown_command: rm -rf constRecModel*
+
+loadString("
+model constRecModel
+  record R
+    constant Integer m = 0;
+  end R;
+
+  function foo
+    input R r;
+    output Integer n;
+  algorithm
+    assert(r.m == 7, \"n not 7\");
+    n := r.m + 1;
+  end foo;
+
+  R r = R(m=7);
+  Integer n;
+equation
+  n = foo(r);
+end constRecModel;"); getErrorString();
+
+simulate(constRecModel); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "constRecModel_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'constRecModel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/records/constVar2.mos
+++ b/testsuite/simulation/modelica/records/constVar2.mos
@@ -1,5 +1,5 @@
 // name:     constVar2.mos
-// keywords: record constants function call
+// keywords: record constants function call alias
 // status:   correct
 // teardown_command: rm -rf constVar1M*
 
@@ -48,8 +48,8 @@ simulate(constRecModel2.Test); getErrorString();
 // true
 // ""
 // record SimulationResult
-//     resultFile = "constRecModel_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'constRecModel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     resultFile = "constRecModel2.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'constRecModel2.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/records/constVar2.mos
+++ b/testsuite/simulation/modelica/records/constVar2.mos
@@ -10,11 +10,15 @@ package constRecModel2
   end SimCenter;
 
   record BaseRecord
-    constant Integer m;
+    extends EmptyRecord;
+    constant Integer m = 2;
+    parameter Real paramArr[m] = {1,2};
+    constant Real constArr[m];
+    constant Real constMat[m,m-1];
   end BaseRecord;
 
   record ExtendedRecord1
-    extends BaseRecord(m=7);
+    extends BaseRecord(m=3, paramArr={3,2,1}, constArr={4,5,6}, constMat={{1,2},{3,4},{5,6}});
   end ExtendedRecord1;
 
   partial record EmptyRecord
@@ -24,7 +28,21 @@ package constRecModel2
     input BaseRecord rec;
     output Integer m;
   algorithm
-    assert(rec.m == 7, \"m not 7\");
+    assert(rec.m == 3, \"m not 3\");
+    assert(rec.paramArr[1] == 3, \"paramArr[1] wrong\");
+    assert(rec.paramArr[2] == 2, \"paramArr[2] wrong\");
+    assert(rec.paramArr[3] == 1, \"paramArr[3] wrong\");
+
+    assert(rec.constArr[1] == 4, \"constArr[1] wrong\");
+    assert(rec.constArr[2] == 5, \"constArr[2] wrong\");
+    assert(rec.constArr[3] == 6, \"constArr[3] wrong\");
+
+    assert(rec.constMat[1,1] == 1, \"constMat[1,1] wrong \");
+    assert(rec.constMat[1,2] == 2, \"constMat[1,1] wrong \");
+    assert(rec.constMat[2,1] == 3, \"constMat[2,1] wrong \");
+    assert(rec.constMat[2,2] == 4, \"constMat[2,2] wrong \");
+    assert(rec.constMat[3,1] == 5, \"constMat[3,1] wrong \");
+    assert(rec.constMat[3,2] == 6, \"constMat[3,2] wrong \");
     m := rec.m;
   end foo;
 

--- a/testsuite/simulation/modelica/records/constVar2.mos
+++ b/testsuite/simulation/modelica/records/constVar2.mos
@@ -1,0 +1,58 @@
+// name:     constVar2.mos
+// keywords: record constants function call
+// status:   correct
+// teardown_command: rm -rf constVar1M*
+
+loadString("
+package constRecModel2
+  model SimCenter
+    replaceable parameter ExtendedRecord1 rec constrainedby EmptyRecord;
+  end SimCenter;
+
+  record BaseRecord
+    constant Integer m;
+  end BaseRecord;
+
+  record ExtendedRecord1
+    extends BaseRecord(m=7);
+  end ExtendedRecord1;
+
+  partial record EmptyRecord
+  end EmptyRecord;
+
+  function foo
+    input BaseRecord rec;
+    output Integer m;
+  algorithm
+    assert(rec.m == 7, \"m not 7\");
+    m := rec.m;
+  end foo;
+
+  model InnerM
+    outer SimCenter simCenter;
+    parameter BaseRecord fuelModel = simCenter.rec; // <------ the important line
+    Integer m;
+  equation
+    m = foo(fuelModel);
+  end InnerM;
+
+  model Test
+    InnerM innerM;
+    inner SimCenter simCenter(replaceable ExtendedRecord1 rec);
+  end Test;
+end constRecModel2;"); getErrorString();
+
+simulate(constRecModel2.Test); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "constRecModel_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'constRecModel', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
Fixes #9036 

During the phase of lowering FE->BE:
1. traverse all equations and collect record types from exps
2. traverse all variables and update record types with bindings of record elements
3. traverse all equations and apply updated record types