### PR TITLE
Improve SCode modifiers in getModelInstance

### DIFF
--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -12,9 +12,9 @@
       "description": "The kind of class",
       "type": "string"
     },
-    "modifier": {
+    "modifiers": {
       "description": "Modifier from the SCode",
-      "type": "#/definitions/modifier"
+      "type": "#/definitions/scodeModifier"
     },
     "comment": {
       "$ref": "#/definitions/comment"
@@ -125,7 +125,7 @@
       "properties": {
         "modifiers": {
           "description": "SCode modifier on the extends clause",
-          "type": "#/definitions/modifier"
+          "type": "#/definitions/scodeModifier"
         },
         "annotation": {
           "description": "Annotation on the extends clause",
@@ -187,7 +187,7 @@
             },
             "modifiers": {
               "description": "Modifier from the SCode",
-              "type": "#/definitions/modifier"
+              "type": "#/definitions/scodeModifier"
             },
             "value": {
               "description": "The component's binding equation",
@@ -261,21 +261,29 @@
       },
       "required": ["binding"]
     },
-    "modifier": {
-      "description": "A modifier",
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "string"
+    "scodeModifier": {
+      "description": "An SCode modifier",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The string representation of the binding equation"
         },
-        "modifiers": {
-          "type": "array",
-          "items": {
-            "type": "#/definitions/modifier"
-          }
+        {
+          "type": "object",
+          "description": "A modifier with submodifiers",
+          "properties": {
+            "$value": {
+              "type": "string",
+              "description": "The string representation of the binding equation"
+            }
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/scodeModifier"
+          },
+          "required": [],
+          "minProperties": 1
         }
-      },
-      "required": []
+      ]
     }
   }
 }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -24,9 +24,7 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"pi\",
 //       \"type\": \"Real\",
-//       \"modifiers\": {
-//         \"value\": \"3\"
-//       },
+//       \"modifiers\": \"3\",
 //       \"value\": {
 //         \"binding\": 3
 //       },
@@ -38,12 +36,8 @@ getModelInstance(M, prettyPrint = true);
 //       \"name\": \"deg\",
 //       \"type\": \"Real\",
 //       \"modifiers\": {
-//         \"value\": \"2\",
-//         \"modifiers\": {
-//           \"start\": {
-//             \"value\": \"pi\"
-//           }
-//         }
+//         \"start\": \"pi\",
+//         \"$value\": \"2\"
 //       },
 //       \"value\": {
 //         \"binding\": 2

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
@@ -28,9 +28,7 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifiers\": {
-//         \"value\": \"2.0\"
-//       },
+//       \"modifiers\": \"2.0\",
 //       \"value\": {
 //         \"binding\": 2
 //       },
@@ -55,9 +53,7 @@ getModelInstance(M, prettyPrint = true);
 //                 \"3\"
 //               ]
 //             },
-//             \"modifiers\": {
-//               \"value\": \"{1, 2, 3}\"
-//             },
+//             \"modifiers\": \"{1, 2, 3}\",
 //             \"value\": {
 //               \"binding\": [
 //                 1,
@@ -78,9 +74,7 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
-//       \"modifiers\": {
-//         \"value\": \"a.x[1]\"
-//       },
+//       \"modifiers\": \"a.x[1]\",
 //       \"value\": {
 //         \"binding\": {
 //           \"$kind\": \"cref\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
@@ -29,9 +29,7 @@ getModelInstance(M, prettyPrint=true);
 //   \"extends\": [
 //     {
 //       \"modifiers\": {
-//         \"x\": {
-//           \"value\": \"1\"
-//         }
+//         \"x\": \"1\"
 //       },
 //       \"annotation\": {
 //         \"IconMap\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceMod1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceMod1.mos
@@ -1,0 +1,212 @@
+// name: GetModelInstanceMod1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model A
+    Real x;
+    Real y;
+  end A;
+
+  model B
+    A a1;
+    A a2;
+  end B;
+
+  model C
+    B b1;
+    B b2;
+  end C;
+
+  model M
+    C c(b1(a1(x = 1.0, y = 2.0), a2(x = 3.0, y = 4.0)),
+        b2(a1(x = 5.0)));
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//     {
+//       \"name\": \"c\",
+//       \"type\": {
+//         \"name\": \"C\",
+//         \"restriction\": \"model\",
+//         \"components\": [
+//           {
+//             \"name\": \"b1\",
+//             \"type\": {
+//               \"name\": \"B\",
+//               \"restriction\": \"model\",
+//               \"components\": [
+//                 {
+//                   \"name\": \"a1\",
+//                   \"type\": {
+//                     \"name\": \"A\",
+//                     \"restriction\": \"model\",
+//                     \"components\": [
+//                       {
+//                         \"name\": \"x\",
+//                         \"type\": \"Real\",
+//                         \"value\": {
+//                           \"binding\": 1
+//                         },
+//                         \"prefixes\": {
+//
+//                         }
+//                       },
+//                       {
+//                         \"name\": \"y\",
+//                         \"type\": \"Real\",
+//                         \"value\": {
+//                           \"binding\": 2
+//                         },
+//                         \"prefixes\": {
+//
+//                         }
+//                       }
+//                     ]
+//                   },
+//                   \"prefixes\": {
+//
+//                   }
+//                 },
+//                 {
+//                   \"name\": \"a2\",
+//                   \"type\": {
+//                     \"name\": \"A\",
+//                     \"restriction\": \"model\",
+//                     \"components\": [
+//                       {
+//                         \"name\": \"x\",
+//                         \"type\": \"Real\",
+//                         \"value\": {
+//                           \"binding\": 3
+//                         },
+//                         \"prefixes\": {
+//
+//                         }
+//                       },
+//                       {
+//                         \"name\": \"y\",
+//                         \"type\": \"Real\",
+//                         \"value\": {
+//                           \"binding\": 4
+//                         },
+//                         \"prefixes\": {
+//
+//                         }
+//                       }
+//                     ]
+//                   },
+//                   \"prefixes\": {
+//
+//                   }
+//                 }
+//               ]
+//             },
+//             \"prefixes\": {
+//
+//             }
+//           },
+//           {
+//             \"name\": \"b2\",
+//             \"type\": {
+//               \"name\": \"B\",
+//               \"restriction\": \"model\",
+//               \"components\": [
+//                 {
+//                   \"name\": \"a1\",
+//                   \"type\": {
+//                     \"name\": \"A\",
+//                     \"restriction\": \"model\",
+//                     \"components\": [
+//                       {
+//                         \"name\": \"x\",
+//                         \"type\": \"Real\",
+//                         \"value\": {
+//                           \"binding\": 5
+//                         },
+//                         \"prefixes\": {
+//
+//                         }
+//                       },
+//                       {
+//                         \"name\": \"y\",
+//                         \"type\": \"Real\",
+//                         \"prefixes\": {
+//
+//                         }
+//                       }
+//                     ]
+//                   },
+//                   \"prefixes\": {
+//
+//                   }
+//                 },
+//                 {
+//                   \"name\": \"a2\",
+//                   \"type\": {
+//                     \"name\": \"A\",
+//                     \"restriction\": \"model\",
+//                     \"components\": [
+//                       {
+//                         \"name\": \"x\",
+//                         \"type\": \"Real\",
+//                         \"prefixes\": {
+//
+//                         }
+//                       },
+//                       {
+//                         \"name\": \"y\",
+//                         \"type\": \"Real\",
+//                         \"prefixes\": {
+//
+//                         }
+//                       }
+//                     ]
+//                   },
+//                   \"prefixes\": {
+//
+//                   }
+//                 }
+//               ]
+//             },
+//             \"prefixes\": {
+//
+//             }
+//           }
+//         ]
+//       },
+//       \"modifiers\": {
+//         \"b1\": {
+//           \"a1\": {
+//             \"x\": \"1.0\",
+//             \"y\": \"2.0\"
+//           },
+//           \"a2\": {
+//             \"x\": \"3.0\",
+//             \"y\": \"4.0\"
+//           }
+//         },
+//         \"b2\": {
+//           \"a1\": {
+//             \"x\": \"5.0\"
+//           }
+//         }
+//       },
+//       \"prefixes\": {
+//
+//       }
+//     }
+//   ]
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
@@ -28,9 +28,7 @@ getModelInstance(M, prettyPrint = true);
 //     {
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
-//       \"modifiers\": {
-//         \"value\": \"1.0\"
-//       },
+//       \"modifiers\": \"1.0\",
 //       \"value\": {
 //         \"binding\": 1
 //       },

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -12,6 +12,7 @@ GetModelInstanceDuplicate1.mos \
 GetModelInstanceExp1.mos \
 GetModelInstanceExtends1.mos \
 GetModelInstanceInnerOuter1.mos \
+GetModelInstanceMod1.mos \
 GetModelInstanceReplaceable1.mos \
 
 


### PR DESCRIPTION
- Use `$value` for binding expressions in SCode modifiers to allow
  mixing it with submodifiers, and change the structure to be more
  compact.