### PR TITLE
Fixing function type of initialAnalyticalJacobian

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -292,7 +292,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
    * if analyticalJacobianColumn == NULL no analyticalJacobian is available
    */
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(void*, threadData_t*, ANALYTIC_JACOBIAN*);
+  int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
   modelica_integer jacobianIndex;
 
   SPARSE_PATTERN *sparsePattern;       /* sparse pattern if no jacobian is available */


### PR DESCRIPTION
### Issue

Fix warnings like
```
warning: incompatible pointer types assigning to 'int (*)(void *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (*)(void *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') from 'int (DATA *, threadData_t *, ANALYTIC_JACOBIAN *)' (aka 'int (struct DATA *, struct threadData_s *, struct ANALYTIC_JACOBIAN *)') [-Wincompatible-pointer-types]
```
for `nonLinearSystemData`.

### Approach

  - Use DATA* instead of void*
