### PR TITLE
Fix wrong address operator for kinsol user data

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -893,7 +893,7 @@ static void nlsKinsolFScaling(DATA *data, NLS_KINSOL_DATA *kinsolData,
       } else {
         /* Update f(x) for the numerical jacobian matrix */
         nlsKinsolResiduals(x, kinsolData->fTmp, kinsolData->userData);
-        nlsSparseJac(x, kinsolData->fTmp, spJac, &kinsolData->userData, tmp1, tmp2);
+        nlsSparseJac(x, kinsolData->fTmp, spJac, kinsolData->userData, tmp1, tmp2);
       }
     } else {
       /* Update f(x) for the numerical jacobian matrix */


### PR DESCRIPTION
### Related Issues

Fixing #9183.

### Purpose

Fix segmentation fault in `nlsSparseJac()`.

### Approach

Wrong address-operator `&`, so we got `void**` instead of `void*`.
