### PR TITLE
Remove NFEquation.CREF_EQUALITY

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -744,12 +744,6 @@ protected
                                           else {Pointer.create(BEquation.SCALAR_EQUATION(ty, lhs, rhs, source, attr))};
       then result;
 
-      case FEquation.CREF_EQUALITY(lhs = lhs_cref as NFComponentRef.CREF(ty = ty), rhs = rhs_cref, source = source)
-        algorithm
-          attr := lowerEquationAttributes(ty, init);
-          // No check for complex. Simple equation is more important than complex. -> alias removal!
-      then {Pointer.create(BEquation.SIMPLE_EQUATION(ty, lhs_cref, rhs_cref, source, attr))};
-
       case FEquation.FOR(range = SOME(range))
         algorithm
         // Treat each body equation individually because they can have different equation attributes
@@ -1041,9 +1035,6 @@ protected
       // Convert other equations to assignments
       case FEquation.EQUALITY(lhs = lhs, rhs = rhs, source = source)
       then BEquation.ASSIGN(lhs, rhs, source);
-
-      case FEquation.CREF_EQUALITY(lhs = lhs_cref as NFComponentRef.CREF(ty = lhs_ty), rhs = rhs_cref as NFComponentRef.CREF(ty = rhs_ty), source = source)
-      then BEquation.ASSIGN(Expression.CREF(lhs_ty, lhs_cref), Expression.CREF(rhs_ty, rhs_cref), source);
 
       case FEquation.ARRAY_EQUALITY(lhs = lhs, rhs = rhs, source = source)
       then BEquation.ASSIGN(lhs, rhs, source);

--- a/OMCompiler/Compiler/NFFrontEnd/NFCheckModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCheckModel.mo
@@ -105,7 +105,6 @@ function countEquationSize
 algorithm
   equations := match eq
     case Equation.EQUALITY() then Type.sizeOf(eq.ty);
-    case Equation.CREF_EQUALITY() then Type.sizeOf(ComponentRef.getSubscriptedType(eq.lhs));
     case Equation.ARRAY_EQUALITY() then Type.sizeOf(eq.ty);
     case Equation.FOR() then countEquationListSize(eq.body);
     case Equation.IF() then countEquationBranchSize(listHead(eq.branches));

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -261,7 +261,7 @@ protected
 algorithm
   source := ElementSource.mergeSources(lhsSource, rhsSource);
   //source := ElementSource.addElementSourceConnect(source, (lhsCref, rhsCref));
-  equalityEq := Equation.CREF_EQUALITY(lhsCref, rhsCref, source);
+  equalityEq := Equation.makeCrefEquality(lhsCref, rhsCref, source);
 end makeEqualityEquation;
 
 function makeEqualityAssert
@@ -404,7 +404,7 @@ algorithm
       algorithm
         src := ElementSource.mergeSources(src1, src2);
       then
-        {Equation.CREF_EQUALITY(cr1, cr2, src)};
+        {Equation.makeCrefEquality(cr1, cr2, src)};
 
     // The general case with N inside connectors and M outside:
     else

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -554,10 +554,19 @@ function convertEquation
 algorithm
   elements := match eq
     local
+      Expression lhs, rhs;
       DAE.Exp e1, e2, e3;
       DAE.ComponentRef cr1, cr2;
       list<DAE.Dimension> dims;
       list<DAE.Element> body;
+
+    case Equation.EQUALITY(lhs = lhs as Expression.CREF(), rhs = rhs as Expression.CREF())
+      guard Type.isScalarBuiltin(eq.ty)
+      algorithm
+        cr1 := ComponentRef.toDAE(lhs.cref);
+        cr2 := ComponentRef.toDAE(rhs.cref);
+      then
+        DAE.Element.EQUEQUATION(cr1, cr2, eq.source) :: elements;
 
     case Equation.EQUALITY()
       algorithm
@@ -570,13 +579,6 @@ algorithm
            DAE.Element.ARRAY_EQUATION(list(Dimension.toDAE(d) for d in Type.arrayDims(eq.ty)), e1, e2, eq.source)
          else
            DAE.Element.EQUATION(e1, e2, eq.source)) :: elements;
-
-    case Equation.CREF_EQUALITY()
-      algorithm
-        cr1 := ComponentRef.toDAE(eq.lhs);
-        cr2 := ComponentRef.toDAE(eq.rhs);
-      then
-        DAE.Element.EQUEQUATION(cr1, cr2, eq.source) :: elements;
 
     case Equation.ARRAY_EQUALITY()
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
@@ -152,12 +152,6 @@ public
     DAE.ElementSource source;
   end EQUALITY;
 
-  record CREF_EQUALITY
-    ComponentRef lhs;
-    ComponentRef rhs;
-    DAE.ElementSource source;
-  end CREF_EQUALITY;
-
   record ARRAY_EQUALITY
     Expression lhs;
     Expression rhs;
@@ -222,6 +216,19 @@ public
     annotation(__OpenModelica_EarlyInline=true);
   end makeEquality;
 
+  function makeCrefEquality
+    input ComponentRef lhsCref;
+    input ComponentRef rhsCref;
+    input DAE.ElementSource src;
+    output Equation eq;
+  protected
+    Expression e1, e2;
+  algorithm
+    e1 := Expression.fromCref(lhsCref);
+    e2 := Expression.fromCref(rhsCref);
+    eq := makeEquality(e1, e2, Expression.typeOf(e1), src);
+  end makeCrefEquality;
+
   function makeBranch
     input Expression condition;
     input list<Equation> body;
@@ -247,7 +254,6 @@ public
   algorithm
     source := match eq
       case EQUALITY() then eq.source;
-      case CREF_EQUALITY() then eq.source;
       case ARRAY_EQUALITY() then eq.source;
       case CONNECT() then eq.source;
       case FOR() then eq.source;
@@ -1044,14 +1050,6 @@ public
         then
           s;
 
-      case CREF_EQUALITY()
-        algorithm
-          s := IOStream.append(s, ComponentRef.toString(eq.lhs));
-          s := IOStream.append(s, " = ");
-          s := IOStream.append(s, ComponentRef.toString(eq.rhs));
-        then
-          s;
-
       case ARRAY_EQUALITY()
         algorithm
           s := IOStream.append(s, Expression.toString(eq.lhs));
@@ -1195,14 +1193,6 @@ public
           s := IOStream.append(s, Expression.toFlatString(eq.lhs));
           s := IOStream.append(s, " = ");
           s := IOStream.append(s, Expression.toFlatString(eq.rhs));
-        then
-          s;
-
-      case CREF_EQUALITY()
-        algorithm
-          s := IOStream.append(s, ComponentRef.toFlatString(eq.lhs));
-          s := IOStream.append(s, " = ");
-          s := IOStream.append(s, ComponentRef.toFlatString(eq.rhs));
         then
           s;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFVerifyModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVerifyModel.mo
@@ -158,7 +158,6 @@ protected
     for eq in eql loop
       crefs := match eq
         case Equation.EQUALITY()       then whenEquationEqualityCrefs(eq.lhs, crefs);
-        case Equation.CREF_EQUALITY()  then eq.lhs :: crefs;
         case Equation.ARRAY_EQUALITY() then whenEquationEqualityCrefs(eq.lhs, crefs);
         case Equation.REINIT()         then whenEquationEqualityCrefs(eq.cref, crefs);
         case Equation.IF()             then whenEquationIfCrefs(eq.branches, eq.source, crefs);
@@ -422,21 +421,6 @@ protected
         guard(when_found)
         algorithm
           checkDiscreteRealExp(lhs, discreteReals);
-        then
-          ();
-
-      case Equation.CREF_EQUALITY(lhs = cref as ComponentRef.CREF(ty = ty))
-        guard Type.isReal(Type.arrayElementType((ty))) and when_found
-        algorithm
-          // remove all subscripts to handle arrays
-          UnorderedSet.add(ComponentRef.stripSubscriptsAll(cref), discreteReals);
-        then
-          ();
-
-      case Equation.CREF_EQUALITY(lhs = cref as ComponentRef.CREF(ty = ty as Type.COMPLEX(cls = cls)))
-        guard(Type.isRecord(ty) and when_found)
-        algorithm
-          checkDiscreteRealRecord(cref, cls, discreteReals);
         then
           ();
 


### PR DESCRIPTION
- Remove CREF_EQUALITY and just use EQUALITY instead, since
  having "naked" crefs complicates expression traversal and the NF
  doesn't actually need it.
- Convert EQUALITY with crefs to DAE.EQUEQUATION for the old backend,
  and just use EQUALITY directly in the new backend.