### PR TITLE
Improve check for access into partial package

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -688,12 +688,14 @@ algorithm
   if not selfReference then
     node := Inst.instPackage(node, context);
 
-    // Disabled due to the MSL containing classes that extends from classes
-    // inside partial packages.
-    //if InstNode.isPartial(node) then
-    //  state := LookupState.ERROR(LookupState.PARTIAL_CLASS());
-    //  return;
-    //end if;
+    // PartialModelicaServices is mistakenly partial in MSL versions older than
+    // 3.2.3. We can't just check for Modelica 3.2 since that will break e.g. 3.2.2,
+    // so just disable the check specifically for PartialModelicaServices instead.
+    if InstNode.isPartial(node) and not InstContext.inRelaxed(context) and
+       not InstNode.name(node) == "PartialModelicaServices" then
+      state := LookupState.ERROR(LookupState.PARTIAL_CLASS());
+      return;
+    end if;
   end if;
 
   // Look up the path in the scope.

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -885,6 +885,7 @@ PartialFunction1.mo \
 PartialFunction2.mo \
 PartialLookup1.mo \
 PartialLookup2.mo \
+PartialLookup3.mo \
 PartialType1.mo \
 PartialType2.mo \
 PartialType3.mo \

--- a/testsuite/flattening/modelica/scodeinst/PartialLookup3.mo
+++ b/testsuite/flattening/modelica/scodeinst/PartialLookup3.mo
@@ -1,0 +1,29 @@
+// name:     PartialLookup3
+// keywords: lookup partial redeclare
+// status:   incorrect
+// cflags: -d=newInst
+//
+// Checks that it's not allowed to look up a name in a partial class.
+//
+
+package P
+  partial package P2
+      model A
+        Real x;
+      end A;
+  end P2;
+end P;
+
+model PartialLookup3
+  extends P.P2.A;
+end PartialLookup3;
+
+// Result:
+// Error processing file: PartialLookup3.mo
+// [flattening/modelica/scodeinst/PartialLookup3.mo:18:3-18:17:writable] Error: P2 is partial, name lookup is not allowed in partial classes.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult


### PR DESCRIPTION
- Enable the previously disabled check for access into a partial package
  in Lookup.lookupLocalNames, but disable it for PartialModelicaServices
  to work around the reason why it was disabled in the first place.