### PR TITLE
[janitor] Fix memory leak in findRoots

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1074,11 +1074,13 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
   data->simulationInfo->relations = (modelica_boolean*) calloc(data->modelData->nRelations, sizeof(modelica_boolean));
   data->simulationInfo->relationsPre = (modelica_boolean*) calloc(data->modelData->nRelations, sizeof(modelica_boolean));
   data->simulationInfo->storedRelations = (modelica_boolean*) calloc(data->modelData->nRelations, sizeof(modelica_boolean));
-  data->simulationInfo->zeroCrossingIndex = (long*) malloc(data->modelData->nZeroCrossings*sizeof(long));
   data->simulationInfo->mathEventsValuePre = (modelica_real*) malloc(data->modelData->nMathEvents*sizeof(modelica_real));
+  data->simulationInfo->zeroCrossingIndex = (long*) malloc(data->modelData->nZeroCrossings*sizeof(long));
   /* initialize zeroCrossingsIndex with corresponding index is used by events lists */
   for(i=0; i<data->modelData->nZeroCrossings; i++)
     data->simulationInfo->zeroCrossingIndex[i] = (long)i;
+  data->simulationInfo->states_left = (modelica_real*) malloc(data->modelData->nStates * sizeof(modelica_real));
+  data->simulationInfo->states_right = (modelica_real*) malloc(data->modelData->nStates * sizeof(modelica_real));
 
   /* buffer for old values */
   data->simulationInfo->realVarsOld = (modelica_real*) calloc(data->modelData->nVariablesReal, sizeof(modelica_real));
@@ -1298,8 +1300,10 @@ void deInitializeDataStruc(DATA *data)
   free(data->simulationInfo->relations);
   free(data->simulationInfo->relationsPre);
   free(data->simulationInfo->storedRelations);
-  free(data->simulationInfo->zeroCrossingIndex);
   free(data->simulationInfo->mathEventsValuePre);
+  free(data->simulationInfo->zeroCrossingIndex);
+  free(data->simulationInfo->states_left);
+  free(data->simulationInfo->states_right);
 
   /* free buffer for old state variables */
   free(data->simulationInfo->realVarsOld);

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -653,8 +653,8 @@ typedef struct SPATIAL_DISTRIBUTION_DATA {
 
 typedef struct SIMULATION_INFO
 {
-  modelica_real startTime;            /* Start time of the simulation */
-  modelica_real stopTime;             /* Stop time of the simulation */
+  modelica_real startTime;             /* Start time of the simulation */
+  modelica_real stopTime;              /* Stop time of the simulation */
   int useStopTime;
   modelica_integer numSteps;
   modelica_real stepSize;
@@ -717,6 +717,8 @@ typedef struct SIMULATION_INFO
   modelica_boolean* storedRelations;   /* this array contains a copy of relations each time the event iteration starts */
   modelica_real* mathEventsValuePre;
   long* zeroCrossingIndex;             /* := {0, 1, 2, ..., data->modelData->nZeroCrossings-1}; pointer for a list events at event instants */
+  modelica_real* states_left;          /* work array for findRoot in event.c */
+  modelica_real* states_right;         /* work array for findRoot in event.c */
 
   /* old vars for event handling */
   modelica_real timeValueOld;
@@ -760,10 +762,10 @@ typedef struct SIMULATION_INFO
 
   INLINE_DATA* inlineData;
 
-  void* backupSolverData;    /* Used for generic Runge-Kutta methods to get access to some solver details inside callbacks */
+  void* backupSolverData;              /* Used for generic Runge-Kutta methods to get access to some solver details inside callbacks */
 
   /* delay vars */
-  RINGBUFFER **delayStructure;        /* Array of ring buffers for delay expressions */
+  RINGBUFFER **delayStructure;         /* Array of ring buffers for delay expressions */
   const char *OPENMODELICAHOME;
 
   CHATTERING_INFO chatteringInfo;

--- a/OMCompiler/SimulationRuntime/c/util/list.c
+++ b/OMCompiler/SimulationRuntime/c/util/list.c
@@ -40,6 +40,19 @@
 #include <stdlib.h>
 #include <string.h>
 
+struct LIST_NODE
+{
+  void *data;
+  LIST_NODE *next;
+};
+
+struct LIST
+{
+  LIST_NODE *first;
+  LIST_NODE *last;
+  unsigned int itemSize;
+  unsigned int length;
+};
 
 /**
  * @brief Allocates memory for a new empty list

--- a/OMCompiler/SimulationRuntime/c/util/list.h
+++ b/OMCompiler/SimulationRuntime/c/util/list.h
@@ -42,19 +42,11 @@ extern "C" {
 #endif
 
   /* type-free list */
-  typedef struct LIST_NODE
-  {
-    void *data;
-    struct LIST_NODE *next;
-  } LIST_NODE;
+  struct LIST_NODE;
+  typedef struct LIST_NODE LIST_NODE;
 
-  typedef struct LIST
-  {
-    LIST_NODE *first;
-    LIST_NODE *last;
-    unsigned int itemSize;
-    unsigned int length;
-  } LIST;
+  struct LIST;
+  typedef struct LIST LIST;
 
   LIST *allocList(unsigned int itemSize);
   void freeList(LIST *list);


### PR DESCRIPTION
TODO use preallocated space for tmpEventList, states_left, states_right
so that it can be freed properly.