### PR TITLE
[NB] Collect composite events

### DIFF
--- a/testsuite/simulation/modelica/NBackend/event_handling/Makefile
+++ b/testsuite/simulation/modelica/NBackend/event_handling/Makefile
@@ -1,6 +1,7 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
+compositeEvent.mos \
 eventSystem.mos \
 hybridSys.mos \
 

--- a/testsuite/simulation/modelica/NBackend/event_handling/compositeEvent.mos
+++ b/testsuite/simulation/modelica/NBackend/event_handling/compositeEvent.mos
@@ -1,0 +1,49 @@
+// name: compositeEvent
+// keywords: NewBackend
+// status: correct
+
+loadString("
+model CompositeEvent
+  Real x(start=0, fixed=true);
+  Integer n(start=0, fixed=true);
+equation
+  der(x) = 1;
+  when x < 1 and (x > 0.5 and sample(0.125,0.25)) then
+    n = pre(n) + 1;
+  end when;
+end CompositeEvent;
+"); getErrorString();
+simulate(CompositeEvent, simflags="-lv LOG_EVENTS"); getErrorString();
+val(n,0.125);
+val(n,0.375);
+val(n,0.625);
+val(n,0.875);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "/mnt/home/ph/ws/models/compositeEvent/CompositeEvent_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'CompositeEvent', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_EVENTS        | info    | status of relations at time=0
+// LOG_EVENTS        | info    | status of zero crossings at time=0
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_EVENTS        | info    | time event at time=0.125
+// |                 | |       | | [1] sample(0.125, 0.25)
+// LOG_EVENTS        | info    | time event at time=0.375
+// |                 | |       | | [1] sample(0.125, 0.25)
+// LOG_EVENTS        | info    | time event at time=0.625
+// |                 | |       | | [1] sample(0.125, 0.25)
+// LOG_EVENTS        | info    | time event at time=0.875
+// |                 | |       | | [1] sample(0.125, 0.25)
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 0.0
+// 0.0
+// 1.0
+// 2.0
+// endResult

--- a/testsuite/simulation/modelica/NBackend/event_handling/hybridSys.mo
+++ b/testsuite/simulation/modelica/NBackend/event_handling/hybridSys.mo
@@ -1,71 +1,71 @@
 function func1
-input Real x;
-output Real func1_out;
+  input Real x;
+  output Real func1_out;
 algorithm
-func1_out := x;
+  func1_out := x;
 end func1;
 
 function func2
-input Real x1 ;
-input Real x2 ;
-output Real func2_out;
+  input Real x1;
+  input Real x2;
+  output Real func2_out;
 algorithm
-func2_out := x1 + x2;
+  func2_out := x1 + x2;
 end func2;
 
 model hybridSys
-parameter Integer Niter=4;
-//Variablesofthediscreteeventmodel
-Boolean phase_Start(start=true);
-Boolean phase_Loop1(start=false);
-Boolean phase_Loop2(start=false);
-Boolean phase_Loop3(start=false);
-Boolean phase_End(start=false);
-Real x_Start(start=0);
-Real x_Loop1(start=0);
-Real x_Loop2(start=0);
-Real x_Loop3(start=0);
-Real x_End(start=0);
-Boolean startCondition(start=false);
-Boolean loopCondition1(start=false);
-Boolean loopCondition2(start=false);
-Boolean loopCondition3(start=false);
-Boolean endCondition(start=false);
-//Variablesofthecontinuous-timemodel
-Real x1(start=10),x2;
+  parameter Integer Niter=4;
+  // Variables of the discrete event model
+  Boolean phase_Start(start=true);
+  Boolean phase_Loop1(start=false);
+  Boolean phase_Loop2(start=false);
+  Boolean phase_Loop3(start=false);
+  Boolean phase_End(start=false);
+  Real x_Start(start=0);
+  Real x_Loop1(start=0);
+  Real x_Loop2(start=0);
+  Real x_Loop3(start=0);
+  Real x_End(start=0);
+  Boolean startCondition(start=false);
+  Boolean loopCondition1(start=false);
+  Boolean loopCondition2(start=false);
+  Boolean loopCondition3(start=false);
+  Boolean endCondition(start=false);
+  // Variables of the continuous-time model
+  Real x1(start=10),x2;
 equation
-//---------------------
-//Continuous-timemodel
-der(x1)=-func1(x1);
-//Nodiscrete-to-continuousinteraction
-//x2=func1(x1);
-//Discrete-to-continuousinteraction
-x2=func2(x1,x_End);
-//--------------------
-//Discrete-eventmodel
-startCondition=time>1;
-loopCondition1=pre(x_Loop1)<Niter+1;
-loopCondition2=pre(x_Loop2)<Niter+1;
-loopCondition3=pre(x_Loop3)<Niter;
-endCondition= not loopCondition3;
-phase_Start=pre(phase_Start) and not startCondition;
-phase_Loop1=pre(phase_Start) and startCondition or pre(phase_Loop3) and loopCondition3 or pre(phase_Loop1) and not loopCondition1;
-phase_Loop2=pre(phase_Loop1) and loopCondition1 or pre(phase_Loop2) and not loopCondition2;
-phase_Loop3=pre(phase_Loop2) and loopCondition2 or pre(phase_Loop3) and not (loopCondition3 or endCondition);
-phase_End=pre(phase_Loop3) and endCondition;
- when phase_Start then
-x_Start=pre(x_Start)+1;
-end when ;
- when phase_Loop1 then
-x_Loop1=pre(x_Loop1)+1;
-end when ;
- when phase_Loop2 then
-x_Loop2=pre(x_Loop2)+1;
-end when ;
- when phase_Loop3 then
-x_Loop3=pre(x_Loop3)+1;
-end when ;
- when phase_End then
-x_End=pre(x_End)+1;
-end when ;
+  //---------------------
+  // Continuous-time model
+  der(x1) = -func1(x1);
+  // No discrete-to-continuous interaction
+  //x2 = func1(x1);
+  // Discrete-to-continuous interaction
+  x2 = func2(x1,x_End);
+  //--------------------
+  // Discrete-event model
+  startCondition = time>1;
+  loopCondition1 = pre(x_Loop1)<Niter+1;
+  loopCondition2 = pre(x_Loop2)<Niter+1;
+  loopCondition3 = pre(x_Loop3)<Niter;
+  endCondition = not loopCondition3;
+  phase_Start = pre(phase_Start) and not startCondition;
+  phase_Loop1 = pre(phase_Start) and startCondition or pre(phase_Loop3) and loopCondition3 or pre(phase_Loop1) and not loopCondition1;
+  phase_Loop2 = pre(phase_Loop1) and loopCondition1 or pre(phase_Loop2) and not loopCondition2;
+  phase_Loop3 = pre(phase_Loop2) and loopCondition2 or pre(phase_Loop3) and not (loopCondition3 or endCondition);
+  phase_End = pre(phase_Loop3) and endCondition;
+  when phase_Start then
+    x_Start = pre(x_Start)+1;
+  end when;
+  when phase_Loop1 then
+    x_Loop1 = pre(x_Loop1)+1;
+  end when;
+  when phase_Loop2 then
+    x_Loop2 = pre(x_Loop2)+1;
+  end when;
+  when phase_Loop3 then
+    x_Loop3 = pre(x_Loop3)+1;
+  end when;
+  when phase_End then
+    x_End = pre(x_End)+1;
+  end when;
 end hybridSys;


### PR DESCRIPTION
Events of the form
```modelica
  sample(t0, dt) and (f(x) > 0)
```
do not need to introduce zero crossings and can be treated
as time events.