### PR TITLE
Fixes for icons and config for macos OMEdit bundle

### DIFF
--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -1,7 +1,20 @@
 
 
+if(APPLE)
+  set(MACOSX_BUNDLE_ICON_FILE omedit.icns)
+
+  # The following tells CMake where to find and install the file itself.
+  set(app_icon_macos "${CMAKE_CURRENT_SOURCE_DIR}/../OMEditLIB/Resources/icons/omedit.icns")
+  set_source_files_properties(${app_icon_macos} PROPERTIES
+       MACOSX_PACKAGE_LOCATION "Resources")
+endif()
+
 add_executable(OMEdit WIN32 MACOSX_BUNDLE main.cpp rc_omedit.rc)
 target_link_libraries(OMEdit PRIVATE OMEditLib)
+
+if(APPLE)
+  set_target_properties(OMEdit PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+endif()
 
 install(TARGETS OMEdit
         BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})


### PR DESCRIPTION
  - Tell CMake where to find and where to install the icon for OMEdit.

  - Tell CMake where to find the Info.plist file.

  - These changes are not guaranteed to work. We can see what changes and
    adjust them as needed.
