### PR TITLE
Fix #9132 - be more clever about displaying numbers in the diagrams

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -32,6 +32,7 @@
  * @author Adeel Asghar <adeel.asghar@liu.se>
  */
 
+#include <iostream>
 #include "TextAnnotation.h"
 #include "Modeling/Commands.h"
 
@@ -559,7 +560,7 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
 {
   int pos = 0;
   while ((pos = regExp.indexIn(mTextString, pos)) != -1) {
-    QString variable = regExp.cap(0).trimmed();
+    QString variable = regExp.cap(0).trimmed(); QString qs;
     if ((!variable.isEmpty()) && (variable.compare("%%") != 0) && (variable.compare("%name") != 0) && (variable.compare("%class") != 0)) {
       variable.remove("%");
       variable = StringHandler::removeFirstLastCurlBrackets(variable);
@@ -585,8 +586,9 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
               displayUnit = unit;
             }
           }
-          if (displayUnit.isEmpty() || unit.isEmpty()) {
-            mTextString.replace(pos, regExp.matchedLength(), textValue);
+          // do not do any conversion if unit or displayUnit is empty of if both are 1!
+          if (displayUnit.isEmpty() || unit.isEmpty() || (displayUnit.compare("1") == 0 && unit.compare("1") == 0)) {
+            qs = mTextString.replace(pos, regExp.matchedLength(), textValue);
             pos += textValue.length();
           } else {
             QString textValueWithDisplayUnit;
@@ -594,14 +596,14 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
             OMCInterface::convertUnits_res convertUnit = pOMCProxy->convertUnits(unit, displayUnit);
             if (convertUnit.unitsCompatible) {
               qreal convertedValue = Utilities::convertUnit(textValue.toDouble(), convertUnit.offset, convertUnit.scaleFactor);
-              textValue = StringHandler::number(convertedValue);
+              textValue = StringHandler::number(convertedValue, textValue);
               displayUnit = Utilities::convertUnitToSymbol(displayUnit);
               textValueWithDisplayUnit = QString("%1 %2").arg(textValue, displayUnit);
             } else {
               unit = Utilities::convertUnitToSymbol(unit);
               textValueWithDisplayUnit = QString("%1 %2").arg(textValue, unit);
             }
-            mTextString.replace(pos, regExp.matchedLength(), textValueWithDisplayUnit);
+            qs = mTextString.replace(pos, regExp.matchedLength(), textValueWithDisplayUnit);
             pos += textValueWithDisplayUnit.length();
           }
         } else { /* if the value of %\\W* is empty then remove the % sign. */

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -1958,13 +1958,20 @@ QString StringHandler::insertClassAtPosition(QString parentClassText, QString ch
  * \brief StringHandler::number
  * Helper for QString::number with default precision of 16 instead of 6.
  * \param value
+ * \param hint - default "" otherwise previous value to get a hint on how to format the new one
  * \param format
  * \param precision
  * \return
  */
-QString StringHandler::number(double value, char format, int precision)
+QString StringHandler::number(double value, QString hint, char format, int precision)
 {
-  return QString::number(value, format, precision);
+  // we have a hint, see if we can use it to display the number in a similar fashion
+  if (hint.contains("e", Qt::CaseInsensitive)) {
+    // we have an e in the hint, attempt to shorten the number!
+    return QString::number(value, format, QLocale::FloatingPointShortest);
+  } else {
+    return QString::number(value, format, precision);
+  }
 }
 
 static std::string cmt = "";

--- a/OMEdit/OMEditLIB/Util/StringHandler.h
+++ b/OMEdit/OMEditLIB/Util/StringHandler.h
@@ -170,7 +170,7 @@ public:
   static QString removeLeadingSpaces(QString contents);
   static QString removeLine(QString text, QString lineToRemove);
   static QString insertClassAtPosition(QString parentClassText, QString childClassText, int linePosition, int nestedLevel);
-  static QString number(double value, char format = 'g', int precision = 16);
+  static QString number(double value, QString hint = "", char format = 'g', int precision = 16);
   static QString getModelicaComment(QString element);
   static QString convertSemVertoReadableString(const QString &semver);
 protected:


### PR DESCRIPTION
- use the previous number as a hint on how to display the converted one
- if unit and displayUnit is one do not do any conversion

