### PR TITLE
Only update constant record component bindings at lowering

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -313,7 +313,7 @@ function updateConstantRecordElementBinding
 protected
   DAE.Const const;
 algorithm
-  if var.name == name then
+  if DAEUtil.isConstVar(var) and var.name == name then
     const := if Expression.isConst(binding) then DAE.C_CONST() else DAE.C_VAR();
     var.binding := DAE.EQBOUND(binding, NONE(), const, DAE.BINDING_FROM_DEFAULT_VALUE());
   end if;
@@ -334,6 +334,7 @@ algorithm
 end updateRecordTypesEqn;
 
 protected function collectRecordTypesExp
+  "Collect all crefs with record type anda t least one constant record component."
   input output DAE.Exp exp;
   output Boolean cont;
   input output UnorderedMap<DAE.ComponentRef, DAE.Type> map;
@@ -341,7 +342,7 @@ algorithm
   cont := match exp
     local
       DAE.ComponentRef cref;
-    case DAE.CREF(componentRef = cref) guard(Types.isRecord(exp.ty)) algorithm
+    case DAE.CREF(componentRef = cref) guard(Types.isRecord(exp.ty) and Types.recordHasConstVar(exp.ty)) algorithm
       UnorderedMap.add(cref, exp.ty, map);
     then false;
     else true;

--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -141,6 +141,7 @@ protected
   BackendDAE.EqSystem syst;
   UnorderedMap<DAE.ComponentRef, DAE.Type> map;
   UnorderedMap<DAE.ComponentRef, ArrayBindingList> arrayMap;
+  Boolean debug = false;
 algorithm
   numCheckpoints:=ErrorExt.getNumCheckpoints();
   try
@@ -166,6 +167,11 @@ algorithm
   reqns := List.map(reqns, function collectRecordTypesEqn(map = map));
   ieqns := List.map(ieqns, function collectRecordTypesEqn(map = map));
 
+  if (debug) then
+    print(UnorderedMap.toString(map, ComponentReference.printComponentRefStr, Types.printTypeStr) + "\n");
+    print("-------------------\n\n");
+  end if;
+
   // 2. collect bindings from variables and update in types
   // (ToDo: update the types?)
   arrayMap := UnorderedMap.new<ArrayBindingList>(ComponentReference.hashComponentRefMod, ComponentReference.crefEqual);
@@ -175,6 +181,13 @@ algorithm
   _ := List.map(extvarlst, function collectRecordElementBindings(map = map, arrayMap = arrayMap));
 
   map := collapseArrayBindings(arrayMap, map);
+
+  if (debug) then
+    print("----------arrayMap--\n\n");
+    print(UnorderedMap.toString(arrayMap, ComponentReference.printComponentRefStr, printArrayBindingList) + "\n");
+    print("----arrayMap-----\n\n");
+    print(UnorderedMap.toString(map, ComponentReference.printComponentRefStr, Types.printTypeStr) + "\n");
+  end if;
 
   // 3. replace the types in eqns
   eqns  := List.map(eqns, function updateRecordTypesEqn(map = map));

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -1556,6 +1556,17 @@ algorithm
   outIsParamOrConst := SCodeUtil.isParameterOrConst(var);
 end isParamOrConstVar;
 
+public function isConstVar
+  "Return true if variable has variability CONST."
+  input DAE.Var var;
+  output Boolean isConstVar = false;
+algorithm
+  isConstVar := match var.attributes.variability
+    case SCode.CONST() then true;
+    else false;
+  end match;
+end isConstVar;
+
 public function isNotParamOrConstVar
   input DAE.Var inVar;
   output Boolean outIsNotParamOrConst;

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -498,6 +498,27 @@ algorithm
   end match;
 end isRecord;
 
+public function recordHasConstVar
+  "Returns true if an record has at least one component of type CONST.
+   Fails if input type ty is not an record."
+  input DAE.Type ty;
+  output Boolean hasConstType = false;
+algorithm
+  () := match ty
+    case (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(_))) algorithm
+        for var in ty.varLst loop
+          if DAEUtil.isConstVar(var) then
+            hasConstType := true;
+            break;
+          end if;
+        end for;
+      then();
+    else algorithm
+      Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed because input type is not a record."});
+    then fail();
+  end match;
+end recordHasConstVar;
+
 public function getRecordPath "gets the record path"
   input DAE.Type tp;
   output Absyn.Path p;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5230,9 +5230,9 @@ template constVarOrDaeExp(DAE.Var var, DAE.ComponentRef cr, Context context, Tex
     case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.EQBOUND()) then
       daeExp(binding.exp, context, &preExp, &varDecls, &auxFunction)
     case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.VALBOUND()) then
-      'ERROR in constVarOrDaeExp /* val bound value */'
+      error(sourceInfo(), 'constVarOrDaeExp failed; Constant variable <%name%> is value bound. Not yet implemented.')
     case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.UNBOUND()) then
-      'ERROR in constVarOrDaeExp /* unbound value */'
+      error(sourceInfo(), 'constVarOrDaeExp failed; Constant variable <%name%> has no binding. This indicates a problem in the lowering from Frontend to old Backend.')
     else
       daeExp(makeCrefRecordExp(cr,var), context, &preExp, &varDecls, &auxFunction)
 end constVarOrDaeExp;

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -4,7 +4,6 @@ TESTFILES = \
 ATotal.mos \
 constVar1.mos \
 constVar2.mos \
-constVar3.mos \
 InOutRecord.mos \
 RecordConstructor1.mos \
 TestComplexSum1.mos \
@@ -14,7 +13,7 @@ Ticket5134.mos
 # test that currently fail. Move up when fixed. 
 # Run make testfailing
 FAILINGTESTFILES=  \
-
+constVar3.mos \
 
 
 # Dependency files that are not .mo .mos or Makefile

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 ATotal.mos \
 constVar1.mos \
 constVar2.mos \
+constVar3.mos \
 InOutRecord.mos \
 RecordConstructor1.mos \
 TestComplexSum1.mos \

--- a/testsuite/simulation/modelica/records/constVar2.mos
+++ b/testsuite/simulation/modelica/records/constVar2.mos
@@ -1,7 +1,7 @@
 // name:     constVar2.mos
 // keywords: record constants function call alias
 // status:   correct
-// teardown_command: rm -rf constVar1M*
+// teardown_command: rm -rf constRecModel2*
 
 loadString("
 package constRecModel2

--- a/testsuite/simulation/modelica/records/constVar3.mos
+++ b/testsuite/simulation/modelica/records/constVar3.mos
@@ -1,8 +1,7 @@
-// name:     constVar2.mos
+// name:     constVar3.mos
 // keywords: record constants function call array
 // status:   correct
 // teardown_command: rm -rf constRecModel3*
-
 
 loadString("
 package constRecModel3

--- a/testsuite/simulation/modelica/records/constVar3.mos
+++ b/testsuite/simulation/modelica/records/constVar3.mos
@@ -1,0 +1,58 @@
+// name:     constVar2.mos
+// keywords: record constants function call array
+// status:   correct
+// teardown_command: rm -rf constRecModel3*
+
+
+loadString("
+package constRecModel3
+  record BaseRecord
+    constant Integer m = 0;
+  end BaseRecord;
+
+  record ExtendedRecord
+    extends BaseRecord(m=7);
+  end ExtendedRecord;
+
+  function foo
+    input BaseRecord r;
+    output Integer n;
+  algorithm
+    assert(r.m == 7, \"n not 7\");
+    n := r.m + 1;
+  end foo;
+
+  function bar
+    input BaseRecord[:] r_array;
+    output Integer n;
+  algorithm
+    for i in r_array loop
+      assert(r_array[i].m == 7, \"n not 7\");
+    end for;
+    n := r_array[end].m + 1;
+  end bar;
+
+  model Test1
+    ExtendedRecord r[2];
+    Integer n1;
+    Integer n2;
+  equation
+    n1 = foo(r[1]);
+    n2 = bar(r);
+  end Test1;
+end constRecModel3;"); getErrorString();
+
+simulate(constRecModel3.Test1); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "constRecModel3.Test1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'constRecModel2.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/9036

### Purpose

Fix [regressions](https://libraries.openmodelica.org/branches/history/master/2022-07-14%2004:46:18..2022-07-16%2000:54:08.html) introduced in dfb10fcecb8d1366a6500d80d7f9bcdae3c7ded5.

```
Buildings_8 | Buildings.Applications.DataCenters.ChillerCooled.Equipment.Validation.IntegratedPrimaryLoadSide (sim) | Simulate → FrontEnd
-- | -- | --
Buildings_8 | Buildings.Applications.DataCenters.ChillerCooled.Equipment.Validation.PumpParallel (sim) | Simulate → FrontEnd
Buildings_8 | Buildings.Applications.DataCenters.ChillerCooled.Examples.IntegratedPrimaryLoadSideEconomizer (sim) | Simulate → FrontEnd
Buildings_8 | Buildings.Applications.DataCenters.ChillerCooled.Examples.IntegratedPrimarySecondaryEconomizer (sim) | Simulate → FrontEnd
Buildings_8 | Buildings.Applications.DataCenters.ChillerCooled.Examples.NonIntegratedPrimarySecondaryEconomizer (sim) | Simulate → FrontEnd
Buildings_8 | Buildings.Experimental.DHC.CentralPlants.Cooling.Examples.Plant (sim) | Compile → FrontEnd
Buildings_8 | Buildings.Experimental.DHC.Examples.Combined.Generation5.Examples.SeriesConstantFlow (sim) | Simulate → Templates
Buildings_8 | Buildings.Experimental.DHC.Examples.Combined.Generation5.Examples.SeriesVariableFlow (sim) | Simulate → Templates
Buildings_8 | Buildings.Experimental.DHC.Loads.Examples.CouplingRCZ6 (sim) | Simulate → Templates
Buildings_8 | Buildings.Experimental.DHC.Loads.Examples.CouplingSpawnZ6 (sim) | Compile → Templates
Buildings_8 | Buildings.Experimental.DHC.Loads.Validation.BenchmarkFlowDistribution1 (sim) | Simulate → Templates
Buildings_8 | Buildings.Experimental.DHC.Loads.Validation.BenchmarkFlowDistribution2 (sim) | Simulate → Templates
Buildings_8 | Buildings.Experimental.DHC.Loads.Validation.FlowDistributionPumpControl (sim) | Simulate → Templates
Buildings_8 | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.SingleCircuitMultipleCircuitEpsilonNTU (sim) | Simulate → Templates
Buildings_8 | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.SingleCircuitMultipleCircuitFiniteDifference (sim) | Simulate → Templates
Buildings_8 | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.StepResponseEpsilonNTU (sim) | Simulate → Templates
Buildings_8 | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.StepResponseFiniteDifference (sim) | Simulate → Templates
Buildings_8 | Buildings.ThermalZones.EnergyPlus.Examples.SingleFamilyHouse.RadiantHeatingCooling (sim) | Simulate → Templates
Buildings_8 | Buildings.ThermalZones.EnergyPlus.Examples.SingleFamilyHouse.RadiantHeatingWithGroundHeatTransfer (sim) | Simulate → Templates
Buildings_8 | Buildings.ThermalZones.EnergyPlus.Validation.ThermalZone.Infiltration (sim) | Simulate → Templates
Buildings_latest | Buildings.Applications.BaseClasses.Equipment.Validation.PumpParallel (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Applications.DataCenters.ChillerCooled.Equipment.Validation.IntegratedPrimaryLoadSide (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Applications.DataCenters.ChillerCooled.Examples.IntegratedPrimaryLoadSideEconomizer (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Applications.DataCenters.ChillerCooled.Examples.IntegratedPrimarySecondaryEconomizer (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Applications.DataCenters.ChillerCooled.Examples.NonIntegratedPrimarySecondaryEconomizer (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Examples.VAVReheat.ASHRAE2006 (sim) | Compile → Templates
Buildings_latest | Buildings.Examples.VAVReheat.Guideline36 (sim) | Compile → Templates
Buildings_latest | Buildings.Examples.VAVReheat.Validation.Guideline36SteadyState (sim) | Compile → Templates
Buildings_latest | Buildings.Examples.VAVReheat.Validation.TraceSubstance (sim) | Compile → Templates
Buildings_latest | Buildings.Experimental.DHC.Examples.Combined.SeriesConstantFlow (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Experimental.DHC.Examples.Combined.SeriesVariableFlow (sim) | Simulate → FrontEnd
Buildings_latest | Buildings.Experimental.DHC.Loads.BaseClasses.Examples.CouplingRCZ6 (sim) | Simulate → Templates
Buildings_latest | Buildings.Experimental.DHC.Loads.BaseClasses.Examples.CouplingSpawnZ6 (sim) | Compile → Templates
Buildings_latest | Buildings.Experimental.DHC.Loads.BaseClasses.Validation.BenchmarkFlowDistribution1 (sim) | Simulate → Templates
Buildings_latest | Buildings.Experimental.DHC.Loads.BaseClasses.Validation.BenchmarkFlowDistribution2 (sim) | Simulate → Templates
Buildings_latest | Buildings.Experimental.DHC.Loads.BaseClasses.Validation.FlowDistributionPumpControl (sim) | Simulate → Templates
Buildings_latest | Buildings.Experimental.DHC.Plants.Cooling.Examples.ElectricChillerParallel (sim) | Compile → FrontEnd
Buildings_latest | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.SingleCircuitMultipleCircuitEpsilonNTU (sim) | Simulate → Templates
Buildings_latest | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.SingleCircuitMultipleCircuitFiniteDifference (sim) | Simulate → Templates
Buildings_latest | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.StepResponseEpsilonNTU (sim) | Simulate → Templates
Buildings_latest | Buildings.Fluid.HeatExchangers.RadiantSlabs.Examples.StepResponseFiniteDifference (sim) | Simulate → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SingleFamilyHouse.RadiantHeatingCooling_TRoom (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SingleFamilyHouse.RadiantHeatingCooling_TSurface (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SingleFamilyHouse.RadiantHeatingWithGroundHeatTransfer (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SmallOffice.ASHRAE2006Spring (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SmallOffice.ASHRAE2006Summer (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SmallOffice.ASHRAE2006Winter (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SmallOffice.Guideline36Spring (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SmallOffice.Guideline36Summer (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Examples.SmallOffice.Guideline36Winter (sim) | Compile → Templates
Buildings_latest | Buildings.ThermalZones.EnergyPlus_9_6_0.Validation.ThermalZone.Infiltration (sim) | Compile → Templates
ClaRa | ClaRa.Examples.SteamCycle_01 (sim) | SimCode performance 11.97 → 4.11
ClaRa | ClaRa.Examples.SteamPowerPlant_01 (sim) | Compile → Templates
ClaRa | ClaRa.Examples.SteamPowerPlant_CombinedComponents_01 (sim) | Compile → Templates
ClaRa | ClaRa.StaticCycles.Boundaries.Check.TestNewBoundaries (sim) | Compile → Templates
ClaRa_dev | ClaRa.Components.MechanicalSeparation.Check.TestBalanceTank (sim) | Compile → Failed
ClaRa_dev | ClaRa.Examples.SteamPowerPlant_01 (sim) | Compile → Templates
ClaRa_dev | ClaRa.Examples.SteamPowerPlant_CombinedComponents_01 (sim) | Failed → Templates
ClaRa_dev | ClaRa.StaticCycles.Boundaries.Check.TestNewBoundaries (sim) | Compile → Templates
Modelica_DeviceDrivers | Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_MQTT (sim) | Compile → Simulate
Modelica_DeviceDrivers | Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_TCPIPServer (sim) | Compile → Simulate
Modelica_DeviceDrivers | Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_TCPIPServerMultipleClients (sim) | Simulate → Compile
Modelica_DeviceDrivers | Modelica_DeviceDrivers.Blocks.Examples.TestSerialPackager_UDPExternalTrigger (sim) | Compile → Simulate
```

### Approach

Don't change bindings of parameter components of records.
Improve error messages.