### PR TITLE
Issue 9036 unbound bindings

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Initialization.mo
+++ b/OMCompiler/Compiler/BackEnd/Initialization.mo
@@ -46,13 +46,14 @@ import Util;
 
 protected
 import Array;
+import BackendDAECreate;
 import BackendDAEEXT;
 import BackendDAEOptimize;
 import BackendDAEUtil;
 import BackendDump;
 import BackendEquation;
-import BackendVarTransform;
 import BackendVariable;
+import BackendVarTransform;
 import BaseHashSet;
 import CheckModel;
 import ComponentReference;
@@ -94,6 +95,7 @@ protected
   BackendDAE.EqSystem initsyst;
   BackendDAE.EqSystems systs;
   BackendDAE.EquationArray eqns, reeqns;
+  list<BackendDAE.Equation> eqnsLst, reeqnsLst;
   BackendDAE.Shared shared;
   BackendDAE.Variables initVars;
   BackendDAE.Variables vars, fixvars;
@@ -164,6 +166,13 @@ algorithm
     (vars, fixvars, eqns, reeqns) := collectInitialVarsEqnsSystem(dae.eqs, vars, fixvars, eqns, reeqns, hs, allPrimaryParameters, datarecon);
     ((eqns, reeqns)) := BackendVariable.traverseBackendDAEVars(vars, collectInitialBindings, (eqns, reeqns));
     execStat("collectInitialBindings (initialization)");
+
+    // Fix types of constant components in record bindings
+    eqnsLst := BackendEquation.equationList(eqns);
+    reeqnsLst := BackendEquation.equationList(reeqns);
+    (_, eqnsLst, reeqnsLst, _) := BackendDAECreate.patchRecordBindings({}, {}, BackendVariable.varList(dae.shared.globalKnownVars), eqnsLst, reeqnsLst, {});
+    eqns := BackendEquation.listEquation(eqnsLst);
+    reeqns := BackendEquation.listEquation(reeqnsLst);
 
     // scalarize variables after collecting bindings
     if Flags.isSet(Flags.NF_SCALARIZE) then

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5230,9 +5230,9 @@ template constVarOrDaeExp(DAE.Var var, DAE.ComponentRef cr, Context context, Tex
     case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.EQBOUND()) then
       daeExp(binding.exp, context, &preExp, &varDecls, &auxFunction)
     case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.VALBOUND()) then
-      error(sourceInfo(), 'constVarOrDaeExp failed; Constant variable <%name%> is value bound. Not yet implemented.')
+      error(sourceInfo(), 'constVarOrDaeExp failed; Constant variable <%name%> is value bound. Not yet implemented')
     case DAE.TYPES_VAR(attributes = DAE.ATTR(variability = CONST()), binding = DAE.UNBOUND()) then
-      error(sourceInfo(), 'constVarOrDaeExp failed; Constant variable <%name%> has no binding. This indicates a problem in the lowering from Frontend to old Backend.')
+      error(sourceInfo(), 'constVarOrDaeExp failed; Constant variable <%name%> has no binding. This indicates a problem in the lowering from Frontend to old Backend')
     else
       daeExp(makeCrefRecordExp(cr,var), context, &preExp, &varDecls, &auxFunction)
 end constVarOrDaeExp;

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 ATotal.mos \
 constVar1.mos \
 constVar2.mos \
+constVar4.mos \
 InOutRecord.mos \
 RecordConstructor1.mos \
 TestComplexSum1.mos \

--- a/testsuite/simulation/modelica/records/constVar4.mos
+++ b/testsuite/simulation/modelica/records/constVar4.mos
@@ -1,0 +1,60 @@
+// name:     constVar4.mos
+// keywords: record constants function call parameter
+// status:   correct
+// teardown_command: rm -rf FinalParamConstRecCompExample.Test*
+
+loadString("package FinalParamConstRecCompExample
+  record EmptyRecord
+  end EmptyRecord;
+
+  record BaseRecord
+    extends EmptyRecord;
+    constant Integer n=2;
+    parameter Real C[n] = {1,1};
+    constant Real constArray[n - 1];
+  end BaseRecord;
+
+  record ExtendedRecord
+    extends BaseRecord(
+      n=3,
+      C={1.0,2.0,3.0},
+      constArray={-1,1.2345});
+  end ExtendedRecord;
+
+  function foo
+    input BaseRecord fuelType = ExtendedRecord();
+    output Real x;
+  algorithm
+    x := 1.2345;
+  end foo;
+
+  model InnerOuterModel
+    replaceable parameter ExtendedRecord extendedRec constrainedby EmptyRecord;
+  end InnerOuterModel;
+
+  model Dispatcher
+    outer InnerOuterModel innerOuterModel;
+    parameter BaseRecord fuelModel = innerOuterModel.extendedRec;
+    final parameter Real xParam = foo(fuelModel);
+  end Dispatcher;
+
+  model Test
+    inner InnerOuterModel innerOuterModel;
+    Dispatcher dispatcher;
+  end Test;
+end FinalParamConstRecCompExample;"); getErrorString();
+
+simulate(FinalParamConstRecCompExample.Test); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "FinalParamConstRecCompExample.Test_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'FinalParamConstRecCompExample.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

Another fix for #9036.

### Purpose

Handle equations that are generated for the initialization system only and not during lowering.

### Approach

Collected new functionality in `patchRecordBindings` and call it during lowering and initialization system generation.
Added sorting of patched array indizes.
