### PR TITLE
Use DATA* data as input instead of void*

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -2354,9 +2354,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
        {
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
        }
@@ -2386,27 +2385,24 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <<
        <%auxFunction%>
        OMC_DISABLE_OPT
-       void setLinearMatrixA<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData)
+       void setLinearMatrixA<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls%>
          <%MatrixA%>
        }
        OMC_DISABLE_OPT
-       void setLinearVectorb<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData)
+       void setLinearVectorb<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls2%>
          <%vectorb%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
        {
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
        }
@@ -2491,9 +2487,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
        {
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
        }
@@ -2521,9 +2516,8 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
        {
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData2%>
        }
@@ -2577,54 +2571,48 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <<
        <%auxFunction%>
        OMC_DISABLE_OPT
-       void setLinearMatrixA<%ls.index%>(DATA* data, void *systemData)
+       void setLinearMatrixA<%ls.index%>(DATA* data, LINEAR_SYSTEM_DATA *linearSystemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls%>
          <%MatrixA%>
        }
        OMC_DISABLE_OPT
-       void setLinearVectorb<%ls.index%>(DATA* data, void *systemData)
+       void setLinearVectorb<%ls.index%>(DATA* data, LINEAR_SYSTEM_DATA* linearSystemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls2%>
          <%vectorb%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
        {
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData%>
        }
 
        <%auxFunction2%>
        OMC_DISABLE_OPT
-       void setLinearMatrixA<%at.index%>(DATA* data, void *systemData)
+       void setLinearMatrixA<%at.index%>(DATA* data, LINEAR_SYSTEM_DATA* linearSystemData)
        {
          const int equationIndexes[2] = {1,<%at.index%>};
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls3%>
          <%MatrixA2%>
        }
        OMC_DISABLE_OPT
-       void setLinearVectorb<%at.index%>(DATA* data, void *systemData)
+       void setLinearVectorb<%at.index%>(DATA* data, LINEAR_SYSTEM_DATA* linearSystemData)
        {
          const int equationIndexes[2] = {1,<%at.index%>};
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls4%>
          <%vectorb2%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, void *systemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
        {
-         LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          int i=0;
          <%body_initializeStaticLSData2%>
        }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -2354,7 +2354,7 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
        {
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2401,7 +2401,7 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          <%vectorb%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
        {
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2487,7 +2487,7 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
        {
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2516,7 +2516,7 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          TRACE_POP
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
        {
          int i=0;
          <%body_initializeStaticLSData2%>
@@ -2587,7 +2587,7 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          <%vectorb%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%ls.index%>(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
        {
          int i=0;
          <%body_initializeStaticLSData%>
@@ -2611,7 +2611,7 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
          <%vectorb2%>
        }
        OMC_DISABLE_OPT
-       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern)
+       void initializeStaticLSData<%at.index%>(DATA* data, threadData_t *threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern)
        {
          int i=0;
          <%body_initializeStaticLSData2%>
@@ -2861,7 +2861,7 @@ template getNLSPrototypes(Integer index)
 ::=
   <<
   void residualFunc<%index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag);
-  void initializeStaticDataNLS<%index%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsPattern);
+  void initializeStaticDataNLS<%index%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsePattern);
   void getIterationVarsNLS<%index%>(DATA* data, double *array);
   >>
 end getNLSPrototypes;
@@ -3145,12 +3145,12 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName)
   <<
 
   OMC_DISABLE_OPT
-  void initializeStaticData<%indexName%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *sysData, modelica_boolean initSparsPattern)
+  void initializeStaticData<%indexName%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *sysData, modelica_boolean initSparsePattern)
   {
     int i=0;
     <%bodyStaticData%>
     /* initial sparse pattern */
-    if (initSparsPattern) {
+    if (initSparsePattern) {
       initializeSparsePattern<%indexName%>(sysData);
     }
   }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -193,8 +193,8 @@ end translateModel;
     extern int <%symbolName(modelNamePrefixStr,"inputNames")%>(DATA* data, char ** names);
     extern int <%symbolName(modelNamePrefixStr,"dataReconciliationInputNames")%>(DATA* data, char ** names);
     extern int <%symbolName(modelNamePrefixStr,"initializeDAEmodeData")%>(DATA *data, DAEMODE_DATA*);
-    extern int <%symbolName(modelNamePrefixStr,"functionLocalKnownVars")%>(DATA*, threadData_t*);
-    extern int <%symbolName(modelNamePrefixStr,"symbolicInlineSystem")%>(DATA*, threadData_t*);
+    extern int <%symbolName(modelNamePrefixStr,"functionLocalKnownVars")%>(DATA* data, threadData_t* threadData);
+    extern int <%symbolName(modelNamePrefixStr,"symbolicInlineSystem")%>(DATA* data, threadData_t* threadData);
 
     #include "<%fileNamePrefix%>_literals.h"
 
@@ -1061,7 +1061,7 @@ template simulationFile_dae(SimCode simCode)
        case SOME(JAC_MATRIX(sparsity=sparse, coloredCols=colorList, maxColorCols=maxColor)) then
          '<%initializeDAEmodeData(listLength(residualVars), algebraicVars, listLength(auxiliaryVars), sparse, colorList, maxColor, modelNamePrefixStr)%>'
        case NONE() then
-         'int <%symbolName(modelNamePrefixStr,"initializeDAEmodeData")%>(DATA *inData, DAEMODE_DATA* daeModeData){ return -1; }'
+         'int <%symbolName(modelNamePrefixStr,"initializeDAEmodeData")%>(DATA* data, DAEMODE_DATA* daeModeData){ return -1; }'
        end match
      <<
      /* DAE residuals */
@@ -1089,7 +1089,7 @@ template simulationFile_dae(SimCode simCode)
     #ifdef __cplusplus
     extern "C" {
     #endif
-    int <%symbolName(modelNamePrefixStr,"initializeDAEmodeData")%>(DATA *inData, DAEMODE_DATA* daeModeData){ return -1; }
+    int <%symbolName(modelNamePrefixStr,"initializeDAEmodeData")%>(DATA* data, DAEMODE_DATA* daeModeData){ return -1; }
     #ifdef __cplusplus
     }
     #endif<%\n%>
@@ -2103,19 +2103,17 @@ let &sub = buffer ""
           <%cref(cref, &sub)%> = <%expPart%>;
           >>
         ;separator="\n")
-       let &header += 'void updateContinuousPart<%index%>(void *);<%\n%>void updateIterationExpMixedSystem<%index%>(void *);<%\n%>'
+       let &header += 'void updateContinuousPart<%index%>(DATA* data);<%\n%>void updateIterationExpMixedSystem<%index%>(DATA* data);<%\n%>'
        <<
        <%auxFunction%>
-       void updateContinuousPart<%index%>(void *inData)
+       void updateContinuousPart<%index%>(DATA* data)
        {
-         DATA* data = (DATA*) inData;
          <%symbolName(modelNamePrefixStr,"eqFunction")%>_<%contEqsIndex%>(data, threadData);
          data->simulationInfo->mixedSystemData[<%indexMixedSystem%>].continuous_solution = <%solvedContinuous%>;
        }
 
-       void updateIterationExpMixedSystem<%index%>(void *inData)
+       void updateIterationExpMixedSystem<%index%>(DATA* data)
        {
-         DATA* data = (DATA*) inData;
          <%varDecls%>
 
          <%preDisc%>
@@ -2388,20 +2386,18 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <<
        <%auxFunction%>
        OMC_DISABLE_OPT
-       void setLinearMatrixA<%ls.index%>(void *inData, threadData_t *threadData, void *systemData)
+       void setLinearMatrixA<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls%>
          <%MatrixA%>
        }
        OMC_DISABLE_OPT
-       void setLinearVectorb<%ls.index%>(void *inData, threadData_t *threadData, void *systemData)
+       void setLinearVectorb<%ls.index%>(DATA* data, threadData_t *threadData, void *systemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls2%>
@@ -2581,20 +2577,18 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
        <<
        <%auxFunction%>
        OMC_DISABLE_OPT
-       void setLinearMatrixA<%ls.index%>(void *inData, void *systemData)
+       void setLinearMatrixA<%ls.index%>(DATA* data, void *systemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls%>
          <%MatrixA%>
        }
        OMC_DISABLE_OPT
-       void setLinearVectorb<%ls.index%>(void *inData, void *systemData)
+       void setLinearVectorb<%ls.index%>(DATA* data, void *systemData)
        {
          const int equationIndexes[2] = {1,<%ls.index%>};
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls2%>
@@ -2610,20 +2604,18 @@ template functionSetupLinearSystemsTemp(list<SimEqSystem> linearSystems, String 
 
        <%auxFunction2%>
        OMC_DISABLE_OPT
-       void setLinearMatrixA<%at.index%>(void *inData, void *systemData)
+       void setLinearMatrixA<%at.index%>(DATA* data, void *systemData)
        {
          const int equationIndexes[2] = {1,<%at.index%>};
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls3%>
          <%MatrixA2%>
        }
        OMC_DISABLE_OPT
-       void setLinearVectorb<%at.index%>(void *inData, void *systemData)
+       void setLinearVectorb<%at.index%>(DATA* data, void *systemData)
        {
          const int equationIndexes[2] = {1,<%at.index%>};
-         DATA* data = (DATA*) inData;
          LINEAR_SYSTEM_DATA* linearSystemData = (LINEAR_SYSTEM_DATA*) systemData;
          <% if ls.partOfJac then 'ANALYTIC_JACOBIAN* parentJacobian = linearSystemData->parDynamicData[omc_get_thread_num()].parentJacobian;'%>
          <%varDecls4%>
@@ -2882,7 +2874,7 @@ template getNLSPrototypes(Integer index)
   <<
   void residualFunc<%index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag);
   void initializeStaticDataNLS<%index%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsPattern);
-  void getIterationVarsNLS<%index%>(struct DATA *inData, double *array);
+  void getIterationVarsNLS<%index%>(DATA* data, double *array);
   >>
 end getNLSPrototypes;
 
@@ -3187,9 +3179,8 @@ template getIterationVars(list<ComponentRef> crefs, String indexName)
   <<
 
   OMC_DISABLE_OPT
-  void getIterationVars<%indexName%>(struct DATA *inData, double *array)
+  void getIterationVars<%indexName%>(DATA* data, double *array)
   {
-    DATA* data = (DATA*) inData;
     <%vars%>
   }
   >>
@@ -4478,10 +4469,9 @@ template initializeDAEmodeData(Integer nResVars, list<SimVar> algVars, Integer n
   <<
   /* initialize the daeMode variables */
   OMC_DISABLE_OPT
-  int <%symbolName(modelNamePrefix,"initializeDAEmodeData")%>(DATA *inData, DAEMODE_DATA* daeModeData)
+  int <%symbolName(modelNamePrefix,"initializeDAEmodeData")%>(DATA* data, DAEMODE_DATA* daeModeData)
   {
     TRACE_PUSH
-    DATA* data = ((DATA*)inData);
     /* sparse patterns */
     <%colPtr%>
     <%rowIndex%>

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
@@ -72,7 +72,7 @@ void GB_KINErrHandler(int error_code, const char *module, const char *function, 
  * @param threadData        Thread data for error handling
  * @param nonlinsys         Non-linear system data.
  */
-void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern) {
+void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsePattern) {
   for(int i=0; i<nonlinsys->size; i++) {
     // Get the nominal values of the states
     nonlinsys->nominal[i] = fmax(fabs(data->modelData->realVarsData[i].attribute.nominal), 1e-32);
@@ -81,7 +81,7 @@ void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_
   }
 
   /* Initialize sparsity pattern */
-  if (initSparsPattern) {
+  if (initSparsePattern) {
     nonlinsys->sparsePattern = initializeSparsePattern_SR(data, nonlinsys);
     nonlinsys->isPatternAvailable = TRUE;
   }
@@ -98,7 +98,7 @@ void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_
  * @param threadData        Thread data for error handling
  * @param nonlinsys         Non-linear system data.
  */
-void initializeStaticNLSData_MR(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern) {
+void initializeStaticNLSData_MR(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsePattern) {
 
   // This needs to be done each time, the fast states change!
   for(int i=0; i<nonlinsys->size; i++) {
@@ -109,7 +109,7 @@ void initializeStaticNLSData_MR(DATA* data, threadData_t *threadData, NONLINEAR_
   }
 
   /* Initialize sparsity pattern, First guess (all states are fast states) */
-  if (initSparsPattern) {
+  if (initSparsePattern) {
     nonlinsys->sparsePattern = initializeSparsePattern_SR(data, nonlinsys);
     nonlinsys->isPatternAvailable = TRUE;
   }
@@ -126,7 +126,7 @@ void initializeStaticNLSData_MR(DATA* data, threadData_t *threadData, NONLINEAR_
  * @param threadData        Thread data for error handling
  * @param nonlinsys         Non-linear system data.
  */
-void initializeStaticNLSData_IRK(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern) {
+void initializeStaticNLSData_IRK(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsePattern) {
   for(int i=0; i<nonlinsys->size; i++) {
     // Get the nominal values of the states, the non-linear system has size stages*nStates, i.e. [states, states, ...]
     int ii = i % data->modelData->nStates;
@@ -136,7 +136,7 @@ void initializeStaticNLSData_IRK(DATA* data, threadData_t *threadData, NONLINEAR
   }
 
   /* Initialize sparsity pattern */
-  if (initSparsPattern) {
+  if (initSparsePattern) {
     nonlinsys->sparsePattern = initializeSparsePattern_IRK(data, nonlinsys);
     nonlinsys->isPatternAvailable = TRUE;
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.h
@@ -43,7 +43,7 @@
 extern "C" {
 #endif
 
-void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern);
+void initializeStaticNLSData_SR(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsePattern);
 
 NONLINEAR_SYSTEM_DATA* initRK_NLS_DATA(DATA* data, threadData_t* threadData, DATA_GBODE* gbData);
 NONLINEAR_SYSTEM_DATA* initRK_NLS_DATA_MR(DATA* data, threadData_t* threadData, DATA_GBODEF* gbfData);

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -65,8 +65,6 @@
 /* Forward declarations */
 struct DATA;
 typedef struct DATA DATA;
-struct LINEAR_SYSTEM_DATA;
-typedef struct LINEAR_SYSTEM_DATA LINEAR_SYSTEM_DATA;
 
 /* Model info structures */
 typedef struct VAR_INFO
@@ -371,6 +369,8 @@ typedef struct LINEAR_SYSTEM_THREAD_DATA
 } LINEAR_SYSTEM_THREAD_DATA;
 
 #if !defined(OMC_NUM_LINEAR_SYSTEMS) || OMC_NUM_LINEAR_SYSTEMS>0
+struct LINEAR_SYSTEM_DATA;
+typedef struct LINEAR_SYSTEM_DATA LINEAR_SYSTEM_DATA;
 typedef struct LINEAR_SYSTEM_DATA
 {
   void (*setA)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData); /* set matrix A */

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -316,8 +316,8 @@ typedef struct NONLINEAR_SYSTEM_DATA
   int (*residualFuncConstraints)(RESIDUAL_USERDATA* userData, const double*, double*, const int*);
   void (*initializeStaticNLSData)(DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern);
   int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
-  void (*getIterationVars)(DATA*, double*);
-  int (*checkConstraints)(DATA*, threadData_t *threadData);
+  void (*getIterationVars)(DATA* data, double* array);
+  int (*checkConstraints)(DATA* data, threadData_t *threadData);
 
   NONLINEAR_SOLVER nlsMethod;          /* nonlinear solver */
   void *solverData;
@@ -377,10 +377,10 @@ typedef struct LINEAR_SYSTEM_DATA
   void (*setBElement)(int row, double value, void *data, threadData_t *threadData);
 
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(void*, threadData_t*, ANALYTIC_JACOBIAN*);
+  int (*initialAnalyticalJacobian)(DATA* data, threadData_t*, ANALYTIC_JACOBIAN*);
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
-  void (*initializeStaticLSData)(void*, threadData_t *threadData, void*, modelica_boolean);
+  void (*initializeStaticLSData)(DATA* data, threadData_t *threadData, void*, modelica_boolean);
   int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
   int (*checkConstraints)(DATA* data, threadData_t *threadData);
 
@@ -461,7 +461,7 @@ typedef struct STATE_SET_DATA
    * if analyticalJacobianColumn == NULL no analyticalJacobian is available
    */
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(void*, threadData_t*, ANALYTIC_JACOBIAN*);
+  int (*initialAnalyticalJacobian)(DATA* data, threadData_t*, ANALYTIC_JACOBIAN*);
   modelica_integer jacobianIndex;
 } STATE_SET_DATA;
 #else

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -314,7 +314,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
   int (*residualFuncConstraints)(RESIDUAL_USERDATA* userData, const double*, double*, const int*);
-  void (*initializeStaticNLSData)(DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsPattern);
+  void (*initializeStaticNLSData)(DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsePattern);
   int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
   void (*getIterationVars)(DATA* data, double* array);
   int (*checkConstraints)(DATA* data, threadData_t *threadData);
@@ -382,7 +382,7 @@ typedef struct LINEAR_SYSTEM_DATA
   int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
-  void (*initializeStaticLSData)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern);
+  void (*initializeStaticLSData)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern);
   int (*strictTearingFunctionCall)(DATA* data, threadData_t* threadData);
   int (*checkConstraints)(DATA* data, threadData_t* threadData);
 

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -62,9 +62,11 @@
 #define set_struct(TYPE, x, info) x = (TYPE)info
 #endif
 
-/* Forward declaration of DATA */
+/* Forward declarations */
 struct DATA;
 typedef struct DATA DATA;
+struct LINEAR_SYSTEM_DATA;
+typedef struct LINEAR_SYSTEM_DATA LINEAR_SYSTEM_DATA;
 
 /* Model info structures */
 typedef struct VAR_INFO
@@ -371,18 +373,18 @@ typedef struct LINEAR_SYSTEM_THREAD_DATA
 #if !defined(OMC_NUM_LINEAR_SYSTEMS) || OMC_NUM_LINEAR_SYSTEMS>0
 typedef struct LINEAR_SYSTEM_DATA
 {
-  void (*setA)(void* data, threadData_t *threadData, void* systemData); /* set matrix A */
-  void (*setb)(void* data, threadData_t *threadData, void* systemData); /* set vector b (rhs) */
-  void (*setAElement)(int row, int col, double value, int nth, void *data, threadData_t *threadData);
-  void (*setBElement)(int row, double value, void *data, threadData_t *threadData);
+  void (*setA)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData); /* set matrix A */
+  void (*setb)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData); /* set vector b (rhs) */
+  void (*setAElement)(int row, int col, double value, int nth, LINEAR_SYSTEM_DATA* linearSystemData, threadData_t* threadData);
+  void (*setBElement)(int row, double value, LINEAR_SYSTEM_DATA* linearSystemData, threadData_t* threadData);
 
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(DATA* data, threadData_t*, ANALYTIC_JACOBIAN*);
+  int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
-  void (*initializeStaticLSData)(DATA* data, threadData_t *threadData, void*, modelica_boolean);
-  int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
-  int (*checkConstraints)(DATA* data, threadData_t *threadData);
+  void (*initializeStaticLSData)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsPattern);
+  int (*strictTearingFunctionCall)(DATA* data, threadData_t* threadData);
+  int (*checkConstraints)(DATA* data, threadData_t* threadData);
 
   /* attributes of iteration variables */
   modelica_real *min;
@@ -461,7 +463,7 @@ typedef struct STATE_SET_DATA
    * if analyticalJacobianColumn == NULL no analyticalJacobian is available
    */
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(DATA* data, threadData_t*, ANALYTIC_JACOBIAN*);
+  int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
   modelica_integer jacobianIndex;
 } STATE_SET_DATA;
 #else


### PR DESCRIPTION
Replace void pointer by DATA pointer. Leftover from 8f15490c2345efda8e78beebe7e580d282d0e038.

### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/9258.

### Purpose

Don't cast a DATA* to void* and back to DATA* on function call.

