### PR TITLE
Avoid sorting the variables when inserting them

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -776,16 +776,6 @@ bool VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
   }
   // create hash based VariableNode
   VariableNode *pTopVariableNode = new VariableNode(variabledata);
-
-  // sort the variables using natural sort
-#if defined(__APPLE__) // avoid crash on MacOS, see #9180
-  QMap<QString, QString> m;
-  for (auto variableName : variablesList)
-    m[StringHandler::cleanResultVariable(variableName)] = variableName;
-  variablesList = QStringList(m.values());
-#endif
-  std::sort(variablesList.begin(), variablesList.end(), StringHandler::naturalSortForResultVariables);
-
   // remove time from variables list
   variablesList.removeOne("time");
   /* Fixes issue #7551

--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -1649,29 +1649,6 @@ bool StringHandler::naturalSort(const QString &s1, const QString &s2) {
   }
 }
 
-QString StringHandler::cleanResultVariable(const QString &variable)
-{
-  QString str = variable;
-  if (str.startsWith("der(")) {
-    str.chop((str.lastIndexOf("der(")/4)+1);
-    str = str.mid(str.lastIndexOf("der(") + 4);
-  } else if (str.startsWith("previous(")) {
-    str.chop((str.lastIndexOf("previous(")/9)+1);
-    str = str.mid(str.lastIndexOf("previous(") + 9);
-  } else {
-    // do nothing
-  }
-  return str;
-}
-
-bool StringHandler::naturalSortForResultVariables(const QString &s1, const QString &s2)
-{
-  QString s3 = StringHandler::cleanResultVariable(s1);
-  QString s4 = StringHandler::cleanResultVariable(s2);
-
-  return StringHandler::naturalSort(s3, s4);
-}
-
 #if defined(_WIN32)
 /*!
  * \brief StringHandler::simulationProcessEnvironment

--- a/OMEdit/OMEditLIB/Util/StringHandler.h
+++ b/OMEdit/OMEditLIB/Util/StringHandler.h
@@ -151,8 +151,6 @@ public:
   static QStringList makeVariableParts(QString variable);
   static QStringList makeVariablePartsWithInd(QString variable);
   static bool naturalSort(const QString &s1, const QString &s2);
-  static QString cleanResultVariable(const QString &variable);
-  static bool naturalSortForResultVariables(const QString &s1, const QString &s2);
 #if defined(_WIN32)
   static QProcessEnvironment simulationProcessEnvironment();
 #endif


### PR DESCRIPTION
### Related Issues

#9180 

### Purpose

Avoid crashing OMEdit.

### Approach

The natural sort is not really needed anymore. It was added to improve the performance of variables browser. The code is obsolete now as we use the hash based algorithm for adding items to the variables tree.
