### PR TITLE
Add macOS nightly build using CMake.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -1,0 +1,50 @@
+def common
+pipeline {
+  agent none
+  options {
+    buildDiscarder(logRotator(numToKeepStr: "15", artifactNumToKeepStr: "5"))
+  }
+  stages {
+    stage('Environment') {
+      agent {
+        label '!windows'
+      }
+      steps {
+        script {
+          if (changeRequest()) {
+            def buildNumber = env.BUILD_NUMBER as int
+            if (buildNumber > 1) milestone(buildNumber - 1)
+            milestone(buildNumber)
+          }
+          common = load("${env.workspace}/.CI/common.groovy")
+        }
+      }
+    }
+    stage('build') {
+      parallel {
+        stage('cmake-macos-gcc') {
+          agent {
+            node {
+              label 'M1'
+            }
+          }
+          steps {
+            script {
+              echo "Running on: ${env.NODE_NAME}"
+              withEnv (["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
+                sh "echo PATH: $PATH"
+                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release" +
+                                          " -DCMAKE_INSTALL_PREFIX=build" +
+                                          " -DOM_OMC_ENABLE_FORTRAN=OFF" +
+                                          " -DOM_OMC_ENABLE_IPOPT=OFF" +
+                                          " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
+                                      )
+                sh "build/bin/omc --version"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
  - This adds a nightly arm64 macOS build job on our CI. This will help us make sure
    things do not go broken and unnoticed for long periods of time.

    The job can be found at https://test.openmodelica.org/jenkins/blue/organizations/jenkins/CMake_builds%2Farm64-macOS-clang/activity

    The existing runs were using a different branch on a private clone
    of OpenModelica. Now it runs using OpenModelica's own master.

  - Fortran is disabled for macOS builds for now. 
  - CPP runtime is disabled for macOS builds for now. It will be enabled soon.

  - We need to add a job that optionally can run on each PR.
