### PR TITLE
Dump state machine info in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -578,21 +578,31 @@ function backSample<__Any> "First activation of clock is shifted in time before 
 </html>"));
 end backSample;
 
-function transition "Define state machine transition"
+function transition<__Block> "Define state machine transition"
+  input __Block from;
+  input __Block to;
+  input Boolean condition;
+  input Boolean immediate = true;
+  input Boolean reset = true;
+  input Boolean synchronize = false;
+  input Integer priority = 1;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'transition()'\">transition()</a>
 </html>"));
 end transition;
 
-function initialState "Define inital state of a state machine"
+function initialState<__Block> "Define inital state of a state machine"
+  input __Block state;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'initialState()'\">initialState()</a>
 </html>"));
 end initialState;
 
-function activeState "Return true if instance of a state machine is active, otherwise false"
+function activeState<__Block> "Return true if instance of a state machine is active, otherwise false"
+  input __Block state;
+  output Boolean active;
   external "builtin";
   annotation(__OpenModelica_builtin=true, Documentation(info="<html>
   See <a href=\"modelica://ModelicaReference.Operators.'activeState()'\">activeState()</a>

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2510,6 +2510,12 @@ algorithm
       then
         (actualType, matchKind);
 
+    case "__Block"
+      algorithm
+        matchKind := if Type.isComplex(actualType) then MatchKind.GENERIC else MatchKind.NOT_COMPATIBLE;
+      then
+        (actualType, matchKind);
+
     else
       algorithm
         exp := Expression.box(exp);

--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -164,6 +164,16 @@ algorithm
   end match;
 end addPair;
 
+function addPairNotNull
+  "Adds a key-value pair to a JSON object if the value is not null."
+  input String key;
+  input JSON value;
+  input JSON obj;
+  output JSON outObj;
+algorithm
+  outObj := if isNull(value) then obj else addPair(key, value, obj);
+end addPairNotNull;
+
 function toStream
   input JSON value;
   input Boolean prettyPrint = false;

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -57,6 +57,52 @@
         "required": ["lhs", "rhs"]
       }
     },
+    "initialStates": {
+      "description": "The top-level initial state machine states of the class instance",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments of an initialState call",
+            "type": "array",
+            "items": {
+              "$ref": "expression.schema.json"
+            }
+          },
+          "comment": {
+            "$ref": "#/definitions/comment"
+          },
+          "annotation": {
+            "$ref": "#/definitions/annotation"
+          }
+        },
+        "required": ["arguments"]
+      }
+    },
+    "transitions": {
+      "description": "The top-level state machine transitions of the class instance",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "arguments": {
+            "description": "The arguments of a transition call",
+            "type": "array",
+            "items": {
+              "$ref": "expression.schema.json"
+            }
+          },
+          "comment": {
+            "$ref": "#/definitions/comment"
+          },
+          "annotation": {
+            "$ref": "#/definitions/annotation"
+          }
+        },
+        "required": ["arguments"]
+      }
+    },
     "replaceable": {
       "description": "The replaceable elements of the class instance",
       "type": "array",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceStateMachine1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceStateMachine1.mos
@@ -1,0 +1,211 @@
+// name: GetModelInstanceStateMachine1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    output Real y;
+    model State1
+    output Integer i(start=2);
+    equation
+      i = previous(i) + 2;
+    end State1;
+    State1 state1;
+    model State2
+    end State2;
+    State2 state2;
+  equation
+    initialState(state1) annotation(Line(points = {{0, 0}, {100, 100}}));
+    transition(
+      state1,
+      state2,
+      state1.i > 10,
+      immediate=false) annotation(Line(points = {{-100, 0}, {100, 100}}), Text(string = \"test\"));
+    transition(
+      state2,
+      state1,
+      true,
+      immediate=false) annotation(Line(points = {{0, 0}, {10, 100}}));
+    y = previous(state1.i);
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//     {
+//       \"name\": \"y\",
+//       \"type\": \"Real\",
+//       \"prefixes\": {
+//         \"direction\": \"output\"
+//       }
+//     },
+//     {
+//       \"name\": \"state1\",
+//       \"type\": {
+//         \"name\": \"State1\",
+//         \"restriction\": \"model\",
+//         \"components\": [
+//           {
+//             \"name\": \"i\",
+//             \"type\": \"Integer\",
+//             \"modifiers\": {
+//               \"start\": \"2\"
+//             },
+//             \"prefixes\": {
+//               \"direction\": \"output\"
+//             }
+//           }
+//         ]
+//       },
+//       \"prefixes\": {
+//
+//       }
+//     },
+//     {
+//       \"name\": \"state2\",
+//       \"type\": {
+//         \"name\": \"State2\",
+//         \"restriction\": \"model\"
+//       },
+//       \"prefixes\": {
+//
+//       }
+//     }
+//   ],
+//   \"initialStates\": [
+//     {
+//       \"arguments\": [
+//         {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"state1\"
+//             }
+//           ]
+//         }
+//       ],
+//       \"annotation\": {
+//         \"Line\": {
+//           \"points\": [
+//             [
+//               0,
+//               0
+//             ],
+//             [
+//               100,
+//               100
+//             ]
+//           ]
+//         }
+//       }
+//     }
+//   ],
+//   \"transitions\": [
+//     {
+//       \"arguments\": [
+//         {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"state1\"
+//             }
+//           ]
+//         },
+//         {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"state2\"
+//             }
+//           ]
+//         },
+//         {
+//           \"$kind\": \"relation\",
+//           \"lhs\": {
+//             \"$kind\": \"cref\",
+//             \"parts\": [
+//               {
+//                 \"name\": \"state1\"
+//               },
+//               {
+//                 \"name\": \"i\"
+//               }
+//             ]
+//           },
+//           \"op\": \" > \",
+//           \"rhs\": 10
+//         },
+//         false,
+//         true,
+//         false,
+//         1
+//       ],
+//       \"annotation\": {
+//         \"Line\": {
+//           \"points\": [
+//             [
+//               -100,
+//               0
+//             ],
+//             [
+//               100,
+//               100
+//             ]
+//           ]
+//         },
+//         \"Text\": {
+//           \"string\": \"test\"
+//         }
+//       }
+//     },
+//     {
+//       \"arguments\": [
+//         {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"state2\"
+//             }
+//           ]
+//         },
+//         {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"state1\"
+//             }
+//           ]
+//         },
+//         true,
+//         false,
+//         true,
+//         false,
+//         1
+//       ],
+//       \"annotation\": {
+//         \"Line\": {
+//           \"points\": [
+//             [
+//               0,
+//               0
+//             ],
+//             [
+//               10,
+//               100
+//             ]
+//           ]
+//         }
+//       }
+//     }
+//   ]
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -15,6 +15,7 @@ GetModelInstanceInnerOuter1.mos \
 GetModelInstanceMod1.mos \
 GetModelInstanceMod2.mos \
 GetModelInstanceReplaceable1.mos \
+GetModelInstanceStateMachine1.mos \
 
 
 # test that currently fail. Move up when fixed.


### PR DESCRIPTION
- Dump information about initial states and transitions when using
  getModelInstance.
- Define transition/initialState/activeState properly in
  NFModelicaBuiltin so the operators can actually be used (they are
  still not implemented though, so for now they are just passed
  through).

Fixes #9294