### PR TITLE
Treat AppleClang as if it was Clang.

### DIFF
--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -48,7 +48,7 @@ omc_add_subdirectory(3rdParty)
 # declaration so that we can be consistent and correct with our inclusions.
 # We do this after 3rdParty is added!! because some libs in FMILib use implicit function declaration
 # because of missing #defines due to bad configuration for now.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
 endif()
 

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -194,7 +194,7 @@ add_dependencies(OpenModelicaCompiler DEPENDENCY_UPDATE)
 target_compile_definitions(OpenModelicaCompiler PRIVATE ADD_METARECORD_DEFINITIONS=)
 
 # Silence warnings about extra parenthesized equality checks. if((a==b))
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   target_compile_options(OpenModelicaCompiler PRIVATE -Wno-parentheses-equality)
 endif()
 

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -15,7 +15,7 @@ target_sources(bomc PRIVATE ../.cmake/omc_main.c)
 target_compile_definitions(bomc PRIVATE ADD_METARECORD_DEFINITIONS=)
 
 # Silence warnings about extra parenthesized equality checks. if((a==b)).
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   target_compile_options(bomc PRIVATE -Wno-parentheses-equality)
 endif()
 

--- a/OMCompiler/SimulationRuntime/ParModelica/auto/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ParModelica/auto/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(ParModelicaAuto PUBLIC Boost::graph)
 target_compile_definitions(ParModelicaAuto PRIVATE USE_FLOW_SCHEDULER)
 
 # For now, disable deprecation warning from the json reader. We do not plan to update any time soon.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
   target_compile_options(ParModelicaAuto PRIVATE -Wno-deprecated-declarations)
 endif()
 


### PR DESCRIPTION
  - Do for `AppleClang` whatever we are doing for `Clang` unless we have an
    explicit reason not to do so.

  - Fixes #9304.