### PR TITLE
Stop at root classes in InstNode.scopePathClass

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -1843,7 +1843,7 @@ protected
     InstNode scope;
   algorithm
     Call.UNTYPED_CALL(call_scope = scope) := call;
-    result := Expression.STRING(AbsynUtil.pathString(InstNode.scopePath(scope, includeRoot = true)));
+    result := Expression.STRING(AbsynUtil.pathString(InstNode.rootPath(scope)));
   end typeGetInstanceName;
 
   function typeClockCall

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -798,7 +798,7 @@ algorithm
     args := arg :: args;
   end for;
 
-  exp := Expression.makeRecord(InstNode.scopePath(recordNode, includeRoot = true), recordType, args);
+  exp := Expression.makeRecord(InstNode.fullPath(recordNode), recordType, args);
 end makeRecordBindingExp;
 
 function evalTypename

--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -780,7 +780,7 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
     ty as Type.COMPLEX(complexTy = ComplexType.RECORD(ty_node)) := getType(cls, clsNode);
     fields := ClassTree.getComponents(classTree(cls));
     args := list(Binding.getExp(Component.getImplicitBinding(InstNode.component(f))) for f in fields);
-    exp := Expression.makeRecord(InstNode.scopePath(ty_node, includeRoot = true), ty, args);
+    exp := Expression.makeRecord(InstNode.fullPath(ty_node), ty, args);
   end makeRecordExp;
 
   function toFlatStream

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -396,7 +396,7 @@ algorithm
         UnorderedMap.apply(local_map, function applyBindingReplacement(map = local_map));
         bindings := UnorderedMap.valueList(local_map);
       then
-        Expression.makeRecord(InstNode.scopePath(cls_node, includeRoot = true), cls.ty, bindings);
+        Expression.makeRecord(InstNode.fullPath(cls_node), cls.ty, bindings);
 
     case Class.TYPED_DERIVED() then buildRecordBinding(cls.baseClass, map, mutableParams);
   end match;
@@ -1441,7 +1441,7 @@ algorithm
       expl := getExternalOutputResult(c, map) :: expl;
     end for;
 
-    exp := Expression.makeRecord(InstNode.scopePath(cls_node, includeRoot = true),
+    exp := Expression.makeRecord(InstNode.fullPath(cls_node),
       InstNode.getType(cls_node), listReverseInPlace(expl));
   else
     Error.assertion(false, getInstanceName() +

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -398,7 +398,7 @@ uniontype Function
       case CachedData.FUNCTION() then ();
       else
         algorithm
-          node := instFunction2(InstNode.scopePath(node, includeRoot = true), node, context, info);
+          node := instFunction2(InstNode.fullPath(node), node, context, info);
         then
           ();
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2182,11 +2182,9 @@ algorithm
         InstNode.cacheInitFunc(node);
 
         if SCodeUtil.isOperatorRecord(InstNode.definition(node)) then
-          OperatorOverloading.instConstructor(
-            InstNode.scopePath(node, includeRoot = true), node, context, InstNode.info(node));
+          OperatorOverloading.instConstructor(InstNode.fullPath(node), node, context, InstNode.info(node));
         else
-          Record.instDefaultConstructor(
-            InstNode.scopePath(node, includeRoot = true), node, context, InstNode.info(node));
+          Record.instDefaultConstructor(InstNode.fullPath(node), node, context, InstNode.info(node));
         end if;
       then
         ();

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperatorOverloading.mo
@@ -72,7 +72,7 @@ public
       // If it has an overloaded constructor, instantiate it and add the
       // function(s) to the record node.
       (_, ctor_node) := Function.instFunctionRef(ctor_ref, context, info);
-      ctor_path := InstNode.scopePath(ctor_node, includeRoot = true);
+      ctor_path := InstNode.fullPath(ctor_node);
 
       for f in Function.getCachedFuncs(ctor_node) loop
         checkOperatorConstructorOutput(f, Class.lastBaseClass(recordNode), ctor_path, info);
@@ -124,7 +124,7 @@ public
   algorithm
     if not SCodeUtil.isElementEncapsulated(InstNode.definition(operatorNode)) then
       Error.addSourceMessage(Error.OPERATOR_NOT_ENCAPSULATED,
-        {AbsynUtil.pathString(InstNode.scopePath(operatorNode, includeRoot = true))},
+        {AbsynUtil.pathString(InstNode.fullPath(operatorNode))},
         InstNode.info(operatorNode));
       fail();
     end if;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -530,7 +530,7 @@ algorithm
       cls := Lookup.lookupClassName(pathToQualify, expanded_cls, NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
     end if;
 
-    qualPath := InstNode.scopePath(cls, true);
+    qualPath := InstNode.fullPath(cls);
 
     if not Flags.isSet(Flags.NF_API_NOISE) then
       ErrorExt.rollBack("NFApi.mkFullyQual");
@@ -820,8 +820,8 @@ algorithm
   cls := InstNode.getClass(cls_node);
 
   extendsPaths := match cls
-    case Class.EXPANDED_DERIVED() then {InstNode.scopePath(cls.baseClass, true, true)};
-    else list(InstNode.scopePath(e, true, true) for e in ClassTree.getExtends(Class.classTree(cls)));
+    case Class.EXPANDED_DERIVED() then {InstNode.fullPath(cls.baseClass, true)};
+    else list(InstNode.fullPath(e, true) for e in ClassTree.getExtends(Class.classTree(cls)));
   end match;
 end getInheritedClasses;
 


### PR DESCRIPTION
- Stop when reaching a root class in InstNode.scopePathClass to conform
  to the definition of fully qualified name used for getInstanceName in
  the specification.