### PR TITLE
Add icons for OMNotebook, OMShell and OMPlot on macOS

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/CMakeLists.txt
@@ -88,7 +88,19 @@ set(OMNOTEBOOKLIB_HEADERS application.h
                           indent.h)
 
 
-add_executable(OMNotebook WIN32 MACOSX_BUNDLE ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc)
+
+if(APPLE)
+  set(MACOSX_BUNDLE_ICON_FILE OMNotebook_icon.icns)
+
+  # The following tells CMake where to find and install the file itself.
+  set(app_icon_macos "${CMAKE_CURRENT_SOURCE_DIR}/Resources/OMNotebook_icon.icns")
+  set_source_files_properties(${app_icon_macos} PROPERTIES
+       MACOSX_PACKAGE_LOCATION "Resources")
+else()
+  set(app_icon_macos "")
+endif()
+
+add_executable(OMNotebook WIN32 MACOSX_BUNDLE ${OMNOTEBOOKLIB_SOURCES} ${OMNOTEBOOKLIB_HEADERS} rc_omnotebook.rc ${app_icon_macos})
 target_compile_definitions(OMNotebook PRIVATE OMNOTEBOOKLIB_MOC_INCLUDE)
 
 target_include_directories(OMNotebook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -100,10 +112,13 @@ target_link_libraries(OMNotebook PUBLIC Qt5::WebKitWidgets)
 target_link_libraries(OMNotebook PUBLIC OMPlotLib)
 target_link_libraries(OMNotebook PUBLIC OpenModelicaCompiler)
 
+if(APPLE)
+  set_target_properties(OMNotebook PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+endif()
+
 
 install(TARGETS OMNotebook
         BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
-
 install(FILES stylesheet.xml
               commands.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omnotebook/)

--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -39,8 +39,22 @@ target_link_libraries(OMPlotLib PUBLIC Qt5::PrintSupport)
 target_link_libraries(OMPlotLib PUBLIC qwt)
 target_link_libraries(OMPlotLib PUBLIC omc::simrt::runtime)
 
-add_executable(OMPlot WIN32 MACOSX_BUNDLE main.cpp rc_omplot.rc)
+
+
+if(APPLE)
+  set(MACOSX_BUNDLE_ICON_FILE omplot.ico)
+
+  # The following tells CMake where to find and install the file itself.
+  set(app_icon_macos "${CMAKE_CURRENT_SOURCE_DIR}/Resources/icons/omplot.ico")
+  set_source_files_properties(${app_icon_macos} PROPERTIES
+       MACOSX_PACKAGE_LOCATION "Resources")
+else()
+  set(app_icon_macos "")
+endif()
+
+add_executable(OMPlot WIN32 MACOSX_BUNDLE main.cpp rc_omplot.rc ${app_icon_macos})
 target_link_libraries(OMPlot PRIVATE OMPlotLib)
+
 
 install(TARGETS OMPlotLib)
 install(TARGETS OMPlot

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -20,11 +20,23 @@ target_link_libraries(OMShellLib PUBLIC Qt5::WebKitWidgets)
 target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
 
 
-add_executable(OMShell WIN32 MACOSX_BUNDLE main.cpp rc_omshell.rc)
+
+if(APPLE)
+  set(MACOSX_BUNDLE_ICON_FILE omshell.icns)
+
+  # The following tells CMake where to find and install the file itself.
+  set(app_icon_macos "${CMAKE_CURRENT_SOURCE_DIR}/Resources/omshell.icns")
+  set_source_files_properties(${app_icon_macos} PROPERTIES
+       MACOSX_PACKAGE_LOCATION "Resources")
+else()
+  set(app_icon_macos "")
+endif()
+
+add_executable(OMShell WIN32 MACOSX_BUNDLE main.cpp rc_omshell.rc ${app_icon_macos})
 target_link_libraries(OMShell PRIVATE OMShellLib)
+
 
 install(TARGETS OMShell
         BUNDLE DESTINATION ${OM_MACOS_INSTALL_BUNDLEDIR})
-
 install(FILES commands.xml
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omshell)


### PR DESCRIPTION
  - This follows what is done in #9236 and #9315 for OMEdit.

  - The icon for OMPlot is a `.ico` (instead of `.icns` like the others). This
    probably won't work. If it does not, we will need to convert it to
    icns and add it.