### PR TITLE
Enable obfuscation of encrypted libraries

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -5944,5 +5944,24 @@ algorithm
   end match;
 end mapSubscriptExp;
 
+public function programContainsEncryptedClass
+  input Absyn.Program inProgram;
+  output Boolean containsEncryptedClass = false;
+protected
+  String fileName;
+algorithm
+  containsEncryptedClass := List.exist(inProgram.classes, isClassEncrypted);
+end programContainsEncryptedClass;
+
+public function isClassEncrypted
+  input Absyn.Class cls;
+  output Boolean isEncrypted;
+protected
+  String fileName;
+algorithm
+  SOURCEINFO(fileName = fileName) := cls.info;
+  isEncrypted := Util.endsWith(fileName, ".moc");
+end isClassEncrypted;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -2979,7 +2979,7 @@ algorithm
       algorithm
         // if AST contains encrypted class show nothing
         p := SymbolTable.getAbsyn();
-        true := Interactive.astContainsEncryptedClass(p);
+        true := AbsynUtil.programContainsEncryptedClass(p);
         Error.addMessage(Error.ACCESS_ENCRYPTED_PROTECTED_CONTENTS, {});
       then
         "";

--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -15552,24 +15552,5 @@ algorithm
   end try;
 end checkAccessAnnotationAndEncryption;
 
-public function astContainsEncryptedClass
-  input Absyn.Program inProgram;
-  output Boolean containsEncryptedClass = false;
-protected
-  list<Absyn.Class> classes;
-  Absyn.Program p;
-  String fileName;
-algorithm
-  classes := match(inProgram)
-    case p as Absyn.PROGRAM()
-      then p.classes;
-  end match;
-  for c in classes loop
-    Absyn.CLASS(info=SOURCEINFO(fileName=fileName)) := c;
-    containsEncryptedClass := containsEncryptedClass or Util.endsWith(fileName, ".moc");
-    if containsEncryptedClass then break; end if;
-  end for;
-end astContainsEncryptedClass;
-
 annotation(__OpenModelica_Interface="backend");
 end Interactive;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1422,7 +1422,7 @@ constant ConfigFlag SIMULATION = CONFIG_FLAG(151, "simulation",
   Gettext.gettext("Simulates the last model in the given Modelica file."));
 
 constant ConfigFlag OBFUSCATE = CONFIG_FLAG(152, "obfuscate",
-  NONE(), EXTERNAL(), STRING_LIST_FLAG({"none"}),
+  NONE(), EXTERNAL(), STRING_FLAG("none"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("No obfuscation.")),
     ("protected", Gettext.gettext("Obfuscates everything except for public variables.")),


### PR DESCRIPTION
- Enable obfuscation of protected variables when an encrypted library is
  loaded.
- Move Interactive.astContainsEncryptedClass to
  AbsynUtil.programContainsEncryptedClass to make it available for the
  frontend.
- Change the --obfuscate flag to be a string flag instead of a string
  list flag, since it's only supposed to take one argument.