### PR TITLE
Fixing CMakeLists.txt.in for CVODE FMUs

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -52,9 +52,10 @@ add_library(${FMU_NAME} SHARED
 target_link_libraries(${FMU_NAME} PRIVATE Threads::Threads)
 
 target_include_directories(${FMU_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories(${FMU_NAME} PRIVATE ${FMI_INTERFACE_HEADER_FILES_DIRECTORY})
+target_include_directories(${FMU_NAME} PRIVATE ${FMI_INTERFACE_HEADER_FILES_DIRECTORY}
+                                               sundials)
 
-target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;DOMC_FMI_RUNTIME=1;CMINPACK_NO_DLL)
+target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL)
 
 install(TARGETS ${FMU_NAME}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
### Related Issues

Fixes #9330.

### Purpose

Fix CVODE FMU build with CMake for cross-compilation with Docker.

### Approach

Remove a `D` and added an include directory.
