### PR TITLE
Jacobian delay

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1775,7 +1775,7 @@ protected function differentiateCallExpNArg "
 algorithm
   (outDiffedExp,outFunctionTree) := match(name,inExpl,inAttr)
     local
-      DAE.Exp e, e1, e2, cond, etmp;
+      DAE.Exp e, e1, e2, e3, e4, cond, etmp;
       DAE.Exp res, res1, res2;
       list<DAE.Exp> expl, dexpl;
       DAE.Type tp;
@@ -1871,11 +1871,18 @@ algorithm
       then
         (res1, funcs);
 
+    case ("delay", {e1, e2, e3, e4}, _)
+      equation
+        (e, funcs) = differentiateExp(e2, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, maxIter);
+      then
+        (DAE.CALL(Absyn.IDENT(name), {e1, e, e3, e3}, inAttr), funcs);
+
     case ("sample", _, DAE.CALL_ATTR(ty=tp))
       equation
         (res1, _) = Expression.makeZeroExpression(Expression.arrayDimension(tp));
       then
        (res1, inFunctionTree);
+
     /* floor ceil and interger are expanded by the zeroCrossing index, thus they
        have 2 arguments */
     case ("floor", _, DAE.CALL_ATTR(ty=tp))

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1890,7 +1890,6 @@ algorithm
       algorithm
         // 1. differentiate delayed expression
         (e, funcs) := differentiateExp(e2, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, maxIter);
-        print("diffed:" + ExpressionDump.printExpStr(e) + "\n");
         // 2. filter all seeds from e
         seeds := list(cref for cref guard(isSeedCref(cref)) in Expression.extractUniqueCrefsFromExp(e));
         // 3. create empty replacement rules

--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1875,7 +1875,7 @@ algorithm
       equation
         (e, funcs) = differentiateExp(e2, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, maxIter);
       then
-        (DAE.CALL(Absyn.IDENT(name), {e1, e, e3, e3}, inAttr), funcs);
+        (DAE.CALL(Absyn.IDENT(name), {e1, e, e3, e4}, inAttr), funcs);
 
     case ("sample", _, DAE.CALL_ATTR(ty=tp))
       equation

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -566,11 +566,17 @@ algorithm
     (SymbolicJacs, modelInfo, SymbolicJacsTemp) := addAlgebraicLoopsModelInfoSymJacs(LinearMatrices, modelInfo);
     // append datareconciliation jacobians equation to SymbolicJacs for correct generation of equations in model_info.json
     SymbolicJacs := List.flatten({SymbolicJacsFMI, SymbolicJacs, SymbolicJacsStateSelect, SymbolicJacsdatarecon});
+    (delayedExps, maxDelayedExpIndex, SymbolicJacsNLS) := extractJacobianDelayedExpressions(delayedExps, maxDelayedExpIndex, SymbolicJacsNLS);
+    (delayedExps, maxDelayedExpIndex, SymbolicJacs) := extractJacobianDelayedExpressions(delayedExps, maxDelayedExpIndex, SymbolicJacs);
+    (delayedExps, maxDelayedExpIndex, SymbolicJacsTemp) := extractJacobianDelayedExpressions(delayedExps, maxDelayedExpIndex, SymbolicJacsTemp);
+    (delayedExps, maxDelayedExpIndex, SymbolicJacsStateSelectInternal) := extractJacobianDelayedExpressions(delayedExps, maxDelayedExpIndex, SymbolicJacsStateSelectInternal);
+
     // collect jacobian equation only for equantion info file
     jacobianEquations := collectAllJacobianEquations(SymbolicJacs);
     if debug then execStat("simCode: create Jacobian linear code"); end if;
 
     SymbolicJacs := List.flatten({listReverse(SymbolicJacsNLS), SymbolicJacs, SymbolicJacsTemp, SymbolicJacsStateSelectInternal});
+
     jacobianSimvars := collectAllJacobianVars(SymbolicJacs);
     modelInfo := setJacobianVars(jacobianSimvars, modelInfo);
     seedVars := collectAllSeedVars(SymbolicJacs);
@@ -5686,6 +5692,27 @@ algorithm
   end match;
 end collectDelayExpressions;
 
+protected function updateDelayExpressions
+"Put expression into a list and update the index if it is a call to delay().
+Useable as a function parameter for Expression.traverseExpression."
+  input output DAE.Exp e;
+  input output tuple<list<DAE.Exp>, Integer> acc;
+algorithm
+  print("old: " + ExpressionDump.printExpStr(e) + "\n");
+  (e, acc) := match (e, acc)
+    local
+      DAE.Exp res;
+      Integer i, index;
+      list<DAE.Exp> lst, rest;
+    case (DAE.CALL(path = Absyn.IDENT("delay"), expLst = DAE.ICONST(i)::rest), (lst, index)) guard(i < 0) algorithm
+      print("here!\n");
+      res := DAE.CALL(Absyn.IDENT("delay"), DAE.ICONST(index)::rest, e.attr);
+    then (res, (res :: lst, index + 1));
+    else (e, acc);
+  end match;
+  print("new: " + ExpressionDump.printExpStr(e) + "\n");
+end updateDelayExpressions;
+
 public function extractDelayedExpressions
   input BackendDAE.BackendDAE dlow;
   output list<tuple<Integer, tuple<DAE.Exp, DAE.Exp, DAE.Exp>>> delayedExps;
@@ -5708,6 +5735,39 @@ algorithm
         fail();
   end matchcontinue;
 end extractDelayedExpressions;
+
+public function extractJacobianDelayedExpressions
+  input output list<tuple<Integer, tuple<DAE.Exp, DAE.Exp, DAE.Exp>>> delayedExps;
+  input output Integer maxDelayedExpIndex;
+  input output list<SimCode.JacobianMatrix> SymJacs;
+protected
+  list<SimCode.JacobianMatrix> tmpJacs = {};
+  list<SimCode.JacobianColumn> tmpCols;
+  list<SimCode.SimEqSystem> tmpSysts;
+  list<DAE.Exp> new_delayedExps;
+algorithm
+  print("check 1\n");
+  for jac in listReverse(SymJacs) loop
+  print("check 2\n");
+    tmpCols := {};
+    for col in listReverse(jac.columns) loop
+  print("check 3\n");
+      for syst in col.columnEqns loop
+        print("old: " + simEqSystemString(syst) + "\n");
+      end for;
+      (tmpSysts, (_, (new_delayedExps, maxDelayedExpIndex))) := traverseExpsEqSystems(col.columnEqns, Expression.traverseSubexpressionsHelper, (updateDelayExpressions, ({}, maxDelayedExpIndex)), {});
+      delayedExps := listAppend(List.map(new_delayedExps, extractIdAndExpFromDelayExp), delayedExps);
+      col.columnEqns := tmpSysts;
+      for syst in col.columnEqns loop
+        print("new: " + simEqSystemString(syst) + "\n");
+      end for;
+      tmpCols := col :: tmpCols;
+    end for;
+    jac.columns := tmpCols;
+    tmpJacs := jac :: tmpJacs;
+  end for;
+  SymJacs := tmpJacs;
+end extractJacobianDelayedExpressions;
 
 function extractIdAndExpFromDelayExp
   input DAE.Exp delayCallExp;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -5698,19 +5698,16 @@ Useable as a function parameter for Expression.traverseExpression."
   input output DAE.Exp e;
   input output tuple<list<DAE.Exp>, Integer> acc;
 algorithm
-  print("old: " + ExpressionDump.printExpStr(e) + "\n");
   (e, acc) := match (e, acc)
     local
       DAE.Exp res;
       Integer i, index;
       list<DAE.Exp> lst, rest;
     case (DAE.CALL(path = Absyn.IDENT("delay"), expLst = DAE.ICONST(i)::rest), (lst, index)) guard(i < 0) algorithm
-      print("here!\n");
       res := DAE.CALL(Absyn.IDENT("delay"), DAE.ICONST(index)::rest, e.attr);
     then (res, (res :: lst, index + 1));
     else (e, acc);
   end match;
-  print("new: " + ExpressionDump.printExpStr(e) + "\n");
 end updateDelayExpressions;
 
 public function extractDelayedExpressions
@@ -5746,21 +5743,12 @@ protected
   list<SimCode.SimEqSystem> tmpSysts;
   list<DAE.Exp> new_delayedExps;
 algorithm
-  print("check 1\n");
   for jac in listReverse(SymJacs) loop
-  print("check 2\n");
     tmpCols := {};
     for col in listReverse(jac.columns) loop
-  print("check 3\n");
-      for syst in col.columnEqns loop
-        print("old: " + simEqSystemString(syst) + "\n");
-      end for;
       (tmpSysts, (_, (new_delayedExps, maxDelayedExpIndex))) := traverseExpsEqSystems(col.columnEqns, Expression.traverseSubexpressionsHelper, (updateDelayExpressions, ({}, maxDelayedExpIndex)), {});
       delayedExps := listAppend(List.map(new_delayedExps, extractIdAndExpFromDelayExp), delayedExps);
       col.columnEqns := tmpSysts;
-      for syst in col.columnEqns loop
-        print("new: " + simEqSystemString(syst) + "\n");
-      end for;
       tmpCols := col :: tmpCols;
     end for;
     jac.columns := tmpCols;

--- a/testsuite/simulation/modelica/others/TestSolve18.mos
+++ b/testsuite/simulation/modelica/others/TestSolve18.mos
@@ -38,7 +38,7 @@ val(z,1.0);
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // [BackEnd/ExpressionSolve.mo:0:0-0:0:writable] Error: Internal error Failed to solve \"time = -1.0 + y * exp(if y > 0.0 then time else 2.0 * time)\" w.r.t. \"y\"
 // [BackEnd/ExpressionSolve.mo:0:0-0:0:writable] Error: Internal error Failed to solve \"time = 5.0 * (-1.0 + exp(/*Real*/(sign(1.0 + 2.0 * x))))\" w.r.t. \"x\"
-// [BackEnd/Differentiate.mo:201:7-201:147:writable] Error: Derivative of expression \"der(z) - (x - y)\" w.r.t. \"z\" is non-existent.
+// [BackEnd/Differentiate.mo:202:7-202:147:writable] Error: Derivative of expression \"der(z) - (x - y)\" w.r.t. \"z\" is non-existent.
 // [BackEnd/ExpressionSolve.mo:0:0-0:0:writable] Error: Internal error Failed to solve \"der(z) = x - y\" w.r.t. \"z\"
 // "
 // -1.5

--- a/testsuite/simulation/modelica/parallel/ParallelPRV.mos
+++ b/testsuite/simulation/modelica/parallel/ParallelPRV.mos
@@ -22,6 +22,9 @@ val(hydr.left.p,1.01);
 //     resultFile = "PRVSystem_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.2, numberOfIntervals = 119999, tolerance = 1e-06, method = 'rungekutta', fileNamePrefix = 'PRVSystem', options = '', outputFormat = 'mat', variableFilter = 'hydr.left.p|hydr.x', cflags = '', simflags = '-noEventEmit'",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// assert | info    | The following assertion has been violated at time 1.000058
+// | | |       | hydr.x >= 0.0 and hydr.x <= 0.015
+// assert | info    | Variable violating min/max constraint: 0.0 <= hydr.x <= 0.015, has value: -3.85812e-24
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
### Related Issues
solves the delay differentiation problem of #9131 

### Purpose
differentiate the delay operator

### Approach
differentiate delay by differentiating the delayed input. If it contains seeds, duplicate it for each seed it contains and replace the corresponding seed with 1 and all others with 0. Multiply the with result with the seed and add all of these up.
Example:
`delay(x^2*z, 0.1, 0.1)`
is differentiated to
`x.Seed * delay(2xz, 0.1, 0.1) + z.Seed * delay(x^2, 0.1, 0.1)`
