### PR TITLE
Include directories for CMake FMUs

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -916,8 +916,9 @@ algorithm
           cmakelistsStr := System.stringReplace(cmakelistsStr, "@WITH_SUNDIALS@", "");
         end if;
 
-        // Check for external libraries
+        // Add external libraries and includes
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_LIBS@", SimCodeUtil.getCmakeLinkLibrariesCode(simCode.makefileParams.libs));
+        cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_INCLUDES@", SimCodeUtil.make2CMakeInclude(simCode.makefileParams.includes));
 
         System.writeFile(fmu_tmp_sources_dir + "CMakeLists.txt", cmakelistsStr);
 

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15469,5 +15469,16 @@ algorithm
   end for;
 end getCmakeLinkLibrariesCode;
 
+public function make2CMakeInclude
+  "Convert makefile include directories to CMake include directories"
+  input list<String> includes;
+  output String cmakecode = "";
+algorithm
+  for include in includes loop
+    cmakecode := cmakecode + "\n                                               " +
+                 "\"" + System.trim(include, "\"-I") + "\"";
+  end for;
+end make2CMakeInclude;
+
 annotation(__OpenModelica_Interface="backend");
 end SimCodeUtil;

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -54,7 +54,7 @@ target_link_libraries(${FMU_NAME} PRIVATE Threads::Threads)
 
 target_include_directories(${FMU_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(${FMU_NAME} PRIVATE ${FMI_INTERFACE_HEADER_FILES_DIRECTORY}
-                                               sundials)
+                                               sundials@FMU_ADDITIONAL_INCLUDES@)
 
 target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL)
 


### PR DESCRIPTION
### Related Issues

Fixes #9348.

### Purpose

Fix broken CMake compilation for FMUs with external libraries.

### Approach

Add include directories from external C libraries to CMakeLists.txt.
