### PR TITLE
[OMEdit] Heuristics for scaling vector visualizers

### DIFF
--- a/OMCompiler/Compiler/Template/VisualXMLTpl.tpl
+++ b/OMCompiler/Compiler/Template/VisualXMLTpl.tpl
@@ -140,9 +140,13 @@ end dumpVecExp;
 template dumpExp (DAE.Exp expIn)
 ::=
     match expIn
+        case expIn as ENUM_LITERAL(__) then
+            <<
+            <enum><%intString(index)%></enum>
+            >>
         case expIn as BCONST(__) then
             <<
-            <bexp><%ExpressionDump.printExpStr(expIn)%></bexp>
+            <bconst><%ExpressionDump.printExpStr(expIn)%></bconst>
             >>
         case expIn as CREF(__) then
             <<

--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml XmlPatterns OpenGL Network Svg REQUIRED)
-find_package(OpenSceneGraph COMPONENTS osgViewer osgDB osgGA REQUIRED)
+find_package(OpenSceneGraph COMPONENTS osg osgViewer osgUtil osgDB osgGA REQUIRED)
 
 # Configure omedit_config.h. This will be generated in the build directory
 configure_file(omedit_config.h.in omedit_config.h)

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -416,7 +416,7 @@ bool AbstractAnimationWindow::loadVisualization()
     mpVisualization->setUpScene();
     mpVisualization->initVisualization();
     //add scene for the chosen visualization
-    mpViewerWidget->getSceneView()->setSceneData(mpVisualization->getOMVisScene()->getScene().getRootNode());
+    mpViewerWidget->getSceneView()->setSceneData(mpVisualization->getOMVisScene()->getScene().getRootNode().get());
   }
   //add window title
   setWindowTitle(QString::fromStdString(mFileName));

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -417,6 +417,8 @@ bool AbstractAnimationWindow::loadVisualization()
     mpVisualization->initVisualization();
     //add scene for the chosen visualization
     mpViewerWidget->getSceneView()->setSceneData(mpVisualization->getOMVisScene()->getScene().getRootNode().get());
+    //choose suitable scales for the vector visualizers so that they fit well in the scene
+    mpVisualization->chooseVectorScales(mpViewerWidget->getSceneView(), mpViewerWidget->getFrameMutex(), std::bind(&ViewerWidget::frame, mpViewerWidget));
   }
   //add window title
   setWindowTitle(QString::fromStdString(mFileName));

--- a/OMEdit/OMEditLIB/Animation/AbstractVisualizer.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractVisualizer.cpp
@@ -101,6 +101,7 @@ std::string VisualizerAttribute::getValueString() const
 AbstractVisualizerObject::AbstractVisualizerObject(const VisualizerType type)
     : mVisualizerType(type),
       mStateSetAction(StateSetAction::update),
+      mTransformNode(nullptr),
       mTextureImagePath(""),
       mTransparency(0.0),
       _id(""),

--- a/OMEdit/OMEditLIB/Animation/AbstractVisualizer.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractVisualizer.cpp
@@ -154,11 +154,14 @@ VisualizerAttribute getVisualizerAttributeForNode(const rapidxml::xml_node<>* no
   if (strcmp("cref", node->name()) == 0) {
     oa.cref = std::string(node->value());
     oa.isConst = false;
+  } else if (strcmp("bconst", node->name()) == 0) {
+    oa.exp = (strcmp("true", node->value()) == 0);
+    oa.isConst = true;
+  } else if (strcmp("enum", node->name()) == 0) {
+    oa.exp = std::strtol(node->value(), nullptr, 0);
+    oa.isConst = true;
   } else if (strcmp("exp", node->name()) == 0) {
     oa.exp = std::strtof(node->value(), nullptr);
-    oa.isConst = true;
-  } else if (strcmp("bexp", node->name()) == 0) {
-    oa.exp = (strcmp("true", node->value()) == 0);
     oa.isConst = true;
   }
   return oa;

--- a/OMEdit/OMEditLIB/Animation/AbstractVisualizer.h
+++ b/OMEdit/OMEditLIB/Animation/AbstractVisualizer.h
@@ -35,17 +35,18 @@
 #ifndef ABSTRACTVISUALIZER_H
 #define ABSTRACTVISUALIZER_H
 
+#include <string>
 #include <iostream>
 
-#include "rapidxml.hpp"
-
 #include <QOpenGLContext> // must be included before OSG headers
+#include <QColor>
 
 #include <osg/Vec3f>
 #include <osg/Matrix>
 #include <osg/Uniform>
+#include <osg/Transform>
 
-#include <QColor>
+#include "rapidxml.hpp"
 
 enum class VisualizerType {shape, vector, surface};
 
@@ -94,18 +95,27 @@ public:
   unsigned int fmuValueRef;
 };
 
+class ShapeObject;
+class VectorObject;
+typedef void SurfaceObject;
+
 class AbstractVisualizerObject
 {
 public:
   AbstractVisualizerObject(const VisualizerType type);
   virtual ~AbstractVisualizerObject() = 0;
   virtual void dumpVisualizerAttributes() const;
+  virtual ShapeObject* asShape() {return nullptr;}
+  virtual VectorObject* asVector() {return nullptr;}
+  virtual SurfaceObject* asSurface() {return nullptr;}
   virtual bool isShape() const final {return mVisualizerType == VisualizerType::shape;}
   virtual bool isVector() const final {return mVisualizerType == VisualizerType::vector;}
   virtual bool isSurface() const final {return mVisualizerType == VisualizerType::surface;}
   virtual VisualizerType getVisualizerType() const final {return mVisualizerType;}
   virtual StateSetAction getStateSetAction() const final {return mStateSetAction;}
   virtual void setStateSetAction(const StateSetAction action) final {mStateSetAction = action;}
+  virtual osg::ref_ptr<osg::Transform> getTransformNode() const final {return mTransformNode;}
+  virtual void setTransformNode(const osg::ref_ptr<osg::Transform> transform) final {mTransformNode = transform;}
   virtual std::string getTextureImagePath() const final {return mTextureImagePath;}
   virtual void setTextureImagePath(const std::string texture) final {mTextureImagePath = texture;}
   virtual float getTransparency() const final {return mTransparency;}
@@ -117,6 +127,7 @@ public:
 private:
   VisualizerType mVisualizerType;
   StateSetAction mStateSetAction;
+  osg::ref_ptr<osg::Transform> mTransformNode;
   std::string mTextureImagePath;
   float mTransparency;
 public:

--- a/OMEdit/OMEditLIB/Animation/Shape.h
+++ b/OMEdit/OMEditLIB/Animation/Shape.h
@@ -44,6 +44,7 @@ public:
   ~ShapeObject() = default;
   ShapeObject(const ShapeObject&) = default;
   ShapeObject& operator=(const ShapeObject&) = default;
+  ShapeObject* asShape() override final {return this;}
   void dumpVisualizerAttributes() const override;
 public:
   std::string _type;

--- a/OMEdit/OMEditLIB/Animation/Vector.cpp
+++ b/OMEdit/OMEditLIB/Animation/Vector.cpp
@@ -31,6 +31,12 @@
 
 #include "Vector.h"
 
+VectorQuantity& operator++(VectorQuantity& quantity)
+{
+  quantity = static_cast<VectorQuantity>(static_cast<int>(quantity) + 1);
+  return quantity;
+}
+
 std::ostream& operator<<(std::ostream& os, const VectorQuantity quantity)
 {
   switch (quantity)

--- a/OMEdit/OMEditLIB/Animation/Vector.cpp
+++ b/OMEdit/OMEditLIB/Animation/Vector.cpp
@@ -31,8 +31,6 @@
 
 #include "Vector.h"
 
-#include <cmath>
-
 std::ostream& operator<<(std::ostream& os, const VectorQuantity quantity)
 {
   switch (quantity)
@@ -58,6 +56,10 @@ std::ostream& operator<<(std::ostream& os, const VectorQuantity quantity)
 
 VectorObject::VectorObject()
     : AbstractVisualizerObject(VisualizerType::vector),
+      mScaleLength(1.0),
+      mScaleRadius(1.0),
+      mScaleTransf(1.0),
+      mAutoScaleCancellationRequired(false),
       _quantity(VisualizerAttribute(0.0)),
       _headAtOrigin(VisualizerAttribute(0.0)),
       _twoHeadedArrow(VisualizerAttribute(0.0))
@@ -74,22 +76,4 @@ void VectorObject::dumpVisualizerAttributes() const
   std::cout << "quantity " << _quantity.getValueString() << " = " << getQuantity() << std::endl;
   std::cout << "headAtOrigin " << _headAtOrigin.getValueString() << " = " << (hasHeadAtOrigin() ? "true" : "false") << std::endl;
   std::cout << "twoHeadedArrow " << _twoHeadedArrow.getValueString() << " = " << (isTwoHeadedArrow() ? "true" : "false") << std::endl;
-}
-
-float VectorObject::getScale() const
-{
-  switch (getQuantity())
-  {
-    case VectorQuantity::force:
-      return kScaleForce;
-    case VectorQuantity::torque:
-      return kScaleTorque;
-    default:
-      return 1;
-  }
-}
-
-float VectorObject::getLength() const
-{
-  return std::sqrt(std::pow(_coords[0].exp, 2) + std::pow(_coords[1].exp, 2) + std::pow(_coords[2].exp, 2)) / getScale();
 }

--- a/OMEdit/OMEditLIB/Animation/Vector.h
+++ b/OMEdit/OMEditLIB/Animation/Vector.h
@@ -46,6 +46,7 @@ public:
   ~VectorObject() = default;
   VectorObject(const VectorObject&) = default;
   VectorObject& operator=(const VectorObject&) = default;
+  VectorObject* asVector() override final {return this;}
   void dumpVisualizerAttributes() const override;
   float getScale() const;
   float getLength() const;

--- a/OMEdit/OMEditLIB/Animation/Vector.h
+++ b/OMEdit/OMEditLIB/Animation/Vector.h
@@ -38,7 +38,9 @@
 #include <limits>
 
 /*! Equivalent to Modelica.Mechanics.MultiBody.Types.VectorQuantity */
-enum class VectorQuantity {force = 1, torque, velocity, acceleration, angularVelocity, angularAcceleration, relativePosition};
+enum class VectorQuantity {force = 1, torque, velocity, acceleration, angularVelocity, angularAcceleration, relativePosition, END, BEGIN = force};
+
+VectorQuantity& operator++(VectorQuantity& quantity);
 
 std::ostream& operator<<(std::ostream& os, const VectorQuantity quantity);
 
@@ -72,8 +74,8 @@ public:
   static constexpr float kRadius      = 0.0125; //!< Modelica.Mechanics.MultiBody.World.defaultArrowDiameter / 2 = 1 / 40 / 2 = 0.0125
   static constexpr float kHeadLength  = 0.1000; //!< Modelica.Mechanics.MultiBody.Types.Defaults.ArrowHeadLengthFraction * (2 * kRadius) = 4 * 0.025 = 0.1000
   static constexpr float kHeadRadius  = 0.0375; //!< Modelica.Mechanics.MultiBody.Types.Defaults.ArrowHeadWidthFraction * (2 * kRadius) / 2 = 3 * 0.025 / 2 = 0.0375
-  static constexpr float kScaleForce  =   1200; //!< Modelica.Mechanics.MultiBody.Examples.Elementary.ForceAndTorque.world.defaultN_to_m = 1200
-  static constexpr float kScaleTorque =    120; //!< Modelica.Mechanics.MultiBody.Examples.Elementary.ForceAndTorque.world.defaultNm_to_m = 120
+  static constexpr float kScaleForce  =   1000; //!< Modelica.Mechanics.MultiBody.World.defaultN_to_m = 1000
+  static constexpr float kScaleTorque =   1000; //!< Modelica.Mechanics.MultiBody.World.defaultNm_to_m = 1000
   static constexpr char  kAutoScaleRenderBinName[] = "RenderBin"; //!< See class RenderBinPrototypeList in osgUtil/RenderBin.cpp
   static constexpr int   kAutoScaleRenderBinNum    = std::numeric_limits<int>::max(); //!< To be rendered last
 private:

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -95,7 +95,7 @@ ViewerWidget::ViewerWidget(QWidget* parent, Qt::WindowFlags flags)
   mpViewer->addView(mpSceneView);
   // get the viewer widget
   osg::ref_ptr<osg::Camera> camera = mpSceneView->getCamera();
-  camera->setGraphicsContext(mpGraphicsWindow);
+  camera->setGraphicsContext(mpGraphicsWindow.get());
   camera->setClearColor(osg::Vec4(0.95, 0.95, 0.95, 1.0));
   camera->setViewport(new osg::Viewport(0, 0, width(), height()));
   camera->setProjectionMatrixAsPerspective(30.0f, static_cast<double>(width()/2) / static_cast<double>(height()/2), 1.0f, 10000.0f);

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.h
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.h
@@ -40,6 +40,8 @@
 #include <osgViewer/GraphicsWindow>
 #include <osgViewer/CompositeViewer>
 
+#include <OpenThreads/Mutex>
+
 #include <iostream>
 
 #include <QMenu>
@@ -75,9 +77,11 @@ class ViewerWidget : public GLWidget
 public:
   ViewerWidget(QWidget *pParent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   osgViewer::View* getSceneView() {return mpSceneView;}
+  OpenThreads::Mutex* getFrameMutex() {return mpFrameMutex;}
   std::string getSelectedVisualizer() {return mSelectedVisualizer;}
   void setSelectedVisualizer(std::string visualizer) {mSelectedVisualizer = visualizer;}
   void pickVisualizer(int x, int y);
+  void frame();
 protected:
   virtual void paintEvent(QPaintEvent *paintEvent) override;
   virtual void paintGL() override;
@@ -95,6 +99,7 @@ private:
   osg::ref_ptr<osgViewer::GraphicsWindowEmbedded> mpGraphicsWindow;
   osg::ref_ptr<Viewer> mpViewer;
   osgViewer::View* mpSceneView;
+  OpenThreads::Mutex* mpFrameMutex;
   std::string mSelectedVisualizer;
   AbstractAnimationWindow *mpAnimationWidget;
 public slots:

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.h
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.h
@@ -78,8 +78,8 @@ public:
   ViewerWidget(QWidget *pParent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   osgViewer::View* getSceneView() {return mpSceneView;}
   OpenThreads::Mutex* getFrameMutex() {return mpFrameMutex;}
-  std::string getSelectedVisualizer() {return mSelectedVisualizer;}
-  void setSelectedVisualizer(std::string visualizer) {mSelectedVisualizer = visualizer;}
+  AbstractVisualizerObject* getSelectedVisualizer() {return mpSelectedVisualizer;}
+  void setSelectedVisualizer(AbstractVisualizerObject* visualizer) {mpSelectedVisualizer = visualizer;}
   void pickVisualizer(int x, int y);
   void frame();
 protected:
@@ -100,8 +100,8 @@ private:
   osg::ref_ptr<Viewer> mpViewer;
   osgViewer::View* mpSceneView;
   OpenThreads::Mutex* mpFrameMutex;
-  std::string mSelectedVisualizer;
-  AbstractAnimationWindow *mpAnimationWidget;
+  AbstractAnimationWindow* mpAnimationWidget;
+  AbstractVisualizerObject* mpSelectedVisualizer;
 public slots:
   void changeVisualizerTransparency();
   void makeVisualizerInvisible();

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -691,18 +691,15 @@ void UpdateVisitor::apply(osg::Geode& node)
         draw->dirtyDisplayList();
         if (shape->_type == "pipe")
         {
-          node.removeDrawable(draw.get());
-          draw = new Pipecylinder(shape->_width.exp * shape->_extra.exp / 2, shape->_width.exp / 2, shape->_length.exp);
+          node.setDrawable(0, new Pipecylinder(shape->_width.exp * shape->_extra.exp / 2, shape->_width.exp / 2, shape->_length.exp));
         }
         else if (shape->_type == "pipecylinder")
         {
-          node.removeDrawable(draw.get());
-          draw = new Pipecylinder(shape->_width.exp * shape->_extra.exp / 2, shape->_width.exp / 2, shape->_length.exp);
+          node.setDrawable(0, new Pipecylinder(shape->_width.exp * shape->_extra.exp / 2, shape->_width.exp / 2, shape->_length.exp));
         }
         else if (shape->_type == "spring")
         {
-          node.removeDrawable(draw.get());
-          draw = new Spring(shape->_width.exp, shape->_height.exp, shape->_extra.exp, shape->_length.exp);
+          node.setDrawable(0, new Spring(shape->_width.exp, shape->_height.exp, shape->_extra.exp, shape->_length.exp));
         }
         else if (shape->_type == "box")
         {
@@ -728,7 +725,6 @@ void UpdateVisitor::apply(osg::Geode& node)
           draw->setShape(new osg::Capsule(osg::Vec3f(), 0.1, 0.5));
         }
         //std::cout<<"SHAPE "<<draw->getShape()->className()<<std::endl;
-        node.addDrawable(draw.get());
       }
       break;
      }//end case type shape

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -40,12 +40,13 @@
 
 #include <QOpenGLContext> // must be included before OSG headers
 
-#include <osg/Image>
+#include <osg/Drawable>
+#include <osg/Material>
 #include <osg/Shape>
-#include <osg/Node>
-#include <osgDB/Export>
-#include <osgDB/Registry>
-#include <osgDB/WriteFile>
+#include <osg/ShapeDrawable>
+#include <osg/StateAttribute>
+#include <osg/Texture2D>
+#include <osgDB/ReadFile>
 
 OMVisualBase::OMVisualBase(const std::string& modelFile, const std::string& path)
   : _shapes(),

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -688,6 +688,7 @@ void UpdateVisitor::apply(osg::Geode& node)
       {
         //it's a drawable and not a cad file so we have to create a new drawable
         osg::ref_ptr<osg::Drawable> draw = node.getDrawable(0);
+        draw->dirtyBound();
         draw->dirtyDisplayList();
         if (shape->_type == "pipe")
         {
@@ -752,16 +753,19 @@ void UpdateVisitor::apply(osg::Geode& node)
       head2Shape->setCenter(head2Shape->getCenter() - vectorDirection * head2Shape->getBaseOffset());
 
       osg::ref_ptr<osg::Drawable> draw0 = node.getDrawable(0); // shaft cylinder
+      draw0->dirtyBound();
       draw0->dirtyDisplayList();
       draw0->setShape(shaftShape.get());
       //std::cout<<"VECTOR shaft "<<draw0->getShape()->className()<<std::endl;
 
       osg::ref_ptr<osg::Drawable> draw1 = node.getDrawable(1); // first head cone
+      draw1->dirtyBound();
       draw1->dirtyDisplayList();
       draw1->setShape(head1Shape.get());
       //std::cout<<"VECTOR first head "<<draw1->getShape()->className()<<std::endl;
 
       osg::ref_ptr<osg::Drawable> draw2 = node.getDrawable(2); // second head cone
+      draw2->dirtyBound();
       draw2->dirtyDisplayList();
       if (vector->isTwoHeadedArrow())
       {

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -552,13 +552,13 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(shape._fileName);
       if (node.valid())
       {
+        node->setName(shape._id);
+
         osg::ref_ptr<osg::Material> material = new osg::Material();
         material->setDiffuse(osg::Material::FRONT, osg::Vec4f(0.0, 0.0, 0.0, 0.0));
 
         osg::ref_ptr<osg::StateSet> ss = node->getOrCreateStateSet();
         ss->setAttribute(material.get());
-
-        node->setStateSet(ss.get());
 
         transf->addChild(node.get());
       }
@@ -569,6 +569,7 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       osg::ref_ptr<DXFile> dxfDraw = new DXFile(shape._fileName);
 
       osg::ref_ptr<osg::Geode> geode = new osg::Geode();
+      geode->setName(shape._id);
       geode->addDrawable(dxfDraw.get());
 
       transf->addChild(geode.get());
@@ -579,6 +580,7 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       shapeDraw->setColor(osg::Vec4(1.0, 1.0, 1.0, 1.0));
 
       osg::ref_ptr<osg::Geode> geode = new osg::Geode();
+      geode->setName(shape._id);
       geode->addDrawable(shapeDraw.get());
 
       osg::ref_ptr<osg::Material> material = new osg::Material();
@@ -586,8 +588,6 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
 
       osg::ref_ptr<osg::StateSet> ss = geode->getOrCreateStateSet();
       ss->setAttribute(material.get());
-
-      geode->setStateSet(ss.get());
 
       transf->addChild(geode.get());
     }
@@ -616,6 +616,7 @@ void OSGScene::setUpScene(std::vector<VectorObject>& vectors)
     shapeDraw2->setColor(osg::Vec4(1.0, 1.0, 1.0, 1.0));
 
     osg::ref_ptr<osg::Geode> geode = new osg::Geode();
+    geode->setName(vector._id);
     geode->addDrawable(shapeDraw0.get());
     geode->addDrawable(shapeDraw1.get());
     geode->addDrawable(shapeDraw2.get());
@@ -625,8 +626,6 @@ void OSGScene::setUpScene(std::vector<VectorObject>& vectors)
 
     osg::ref_ptr<osg::StateSet> ss = geode->getOrCreateStateSet();
     ss->setAttribute(material.get());
-
-    geode->setStateSet(ss.get());
 
     transf->addChild(geode.get());
 
@@ -675,8 +674,6 @@ void UpdateVisitor::apply(osg::MatrixTransform& node)
 void UpdateVisitor::apply(osg::Geode& node)
 {
   //std::cout<<"GEODE "<< _visualizer->_id<<" "<<_visualizer->getTransparency()<<std::endl;
-  osg::ref_ptr<osg::StateSet> ss = node.getOrCreateStateSet();
-  node.setName(_visualizer->_id);
   switch (_visualizer->getStateSetAction())
   {
   case StateSetAction::update:
@@ -791,7 +788,7 @@ void UpdateVisitor::apply(osg::Geode& node)
   case StateSetAction::modify:
    {
      //apply texture
-     applyTexture(ss.get(), _visualizer->getTextureImagePath());
+     applyTexture(node.getOrCreateStateSet(), _visualizer->getTextureImagePath());
      break;
    }//end case action modify
 
@@ -803,13 +800,12 @@ void UpdateVisitor::apply(osg::Geode& node)
   if (_changeMaterialProperties) {
     //set color
     if (!_visualizer->isShape() or _visualizer->asShape()->_type.compare("dxf") != 0)
-      changeColor(ss.get(), _visualizer->_color[0].exp, _visualizer->_color[1].exp, _visualizer->_color[2].exp);
+      changeColor(node.getOrCreateStateSet(), _visualizer->_color[0].exp, _visualizer->_color[1].exp, _visualizer->_color[2].exp);
 
     //set transparency
-    changeTransparency(ss.get(), _visualizer->getTransparency());
+    changeTransparency(node.getOrCreateStateSet(), _visualizer->getTransparency());
   }
 
-  node.setStateSet(ss.get());
   traverse(node);
 }
 

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -800,7 +800,7 @@ void UpdateVisitor::apply(osg::Geode& node)
   if (_changeMaterialProperties) {
     //set color
     if (!_visualizer->isShape() or _visualizer->asShape()->_type.compare("dxf") != 0)
-      changeColor(node.getOrCreateStateSet(), _visualizer->_color[0].exp, _visualizer->_color[1].exp, _visualizer->_color[2].exp);
+      changeColor(node.getOrCreateStateSet(), _visualizer->getColor());
 
     //set transparency
     changeTransparency(node.getOrCreateStateSet(), _visualizer->getTransparency());
@@ -884,13 +884,13 @@ void UpdateVisitor::applyTexture(osg::StateSet* ss, const std::string& imagePath
  * \brief UpdateVisitor::changeColor
  * changes color for a geode
  */
-void UpdateVisitor::changeColor(osg::StateSet* ss, float r, float g, float b)
+void UpdateVisitor::changeColor(osg::StateSet* ss, const QColor color)
 {
   if (ss)
   {
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
     if (!material.valid()) material = new osg::Material();
-    material->setDiffuse(osg::Material::FRONT, osg::Vec4f(r / 255, g / 255, b / 255, 1.0));
+    material->setDiffuse(osg::Material::FRONT, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
     ss->setAttribute(material.get());
   }
 }
@@ -899,16 +899,16 @@ void UpdateVisitor::changeColor(osg::StateSet* ss, float r, float g, float b)
  * \brief UpdateVisitor::changeTransparency
  * changes transparency for a geode
  */
-void UpdateVisitor::changeTransparency(osg::StateSet* ss, float transpCoeff)
+void UpdateVisitor::changeTransparency(osg::StateSet* ss, const float transparency)
 {
-  if (ss and _visualizer->getTransparency())
+  if (ss)
   {
-    ss->setMode(GL_BLEND, osg::StateAttribute::ON);
-    ss->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
     if (!material.valid()) material = new osg::Material();
-    material->setTransparency(osg::Material::FRONT_AND_BACK, transpCoeff);
+    material->setTransparency(osg::Material::FRONT_AND_BACK, transparency);
     ss->setAttributeAndModes(material.get(), osg::StateAttribute::OVERRIDE);
+    ss->setMode(GL_BLEND, transparency ? osg::StateAttribute::ON : osg::StateAttribute::OFF);
+    ss->setRenderingHint(transparency ? osg::StateSet::TRANSPARENT_BIN : osg::StateSet::OPAQUE_BIN);
   }
 }
 

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -550,8 +550,7 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
     { //cad node
       //std::cout<<"It's a stl and the filename is "<<shape._fileName<<std::endl;
       osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(shape._fileName);
-
-      if (node)
+      if (node.valid())
       {
         osg::ref_ptr<osg::Material> material = new osg::Material();
         material->setDiffuse(osg::Material::FRONT, osg::Vec4f(0.0, 0.0, 0.0, 0.0));
@@ -856,7 +855,7 @@ void UpdateVisitor::applyTexture(osg::StateSet* ss, const std::string& imagePath
         QImage* qim = new QImage(QString::fromStdString(imagePath));
         image = convertImage(*qim);
         delete qim;
-        if (image.get())
+        if (image.valid())
         {
           image->setInternalTextureFormat(GL_RGBA);
         }
@@ -865,7 +864,7 @@ void UpdateVisitor::applyTexture(osg::StateSet* ss, const std::string& imagePath
       {
         image = osgDB::readImageFile(imagePath);
       }
-      if (image.get())
+      if (image.valid())
       {
         osg::ref_ptr<osg::Texture2D> texture = new osg::Texture2D();
         texture->setDataVariance(osg::Object::DYNAMIC);
@@ -894,7 +893,7 @@ void UpdateVisitor::changeColor(osg::StateSet* ss, float r, float g, float b)
   if (ss)
   {
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
-    if (!material.get()) material = new osg::Material();
+    if (!material.valid()) material = new osg::Material();
     material->setDiffuse(osg::Material::FRONT, osg::Vec4f(r / 255, g / 255, b / 255, 1.0));
     ss->setAttribute(material.get());
   }
@@ -911,7 +910,7 @@ void UpdateVisitor::changeTransparency(osg::StateSet* ss, float transpCoeff)
     ss->setMode(GL_BLEND, osg::StateAttribute::ON);
     ss->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
-    if (!material.get()) material = new osg::Material();
+    if (!material.valid()) material = new osg::Material();
     material->setTransparency(osg::Material::FRONT_AND_BACK, transpCoeff);
     ss->setAttributeAndModes(material.get(), osg::StateAttribute::OVERRIDE);
   }

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -43,14 +43,13 @@
 #include <QImage>
 #include <QOpenGLContext> // must be included before OSG headers
 
-#include <osg/NodeVisitor>
-#include <osg/Geode>
 #include <osg/MatrixTransform>
-#include <osg/ShapeDrawable>
-#include <osg/Material>
-#include <osgDB/ReadFile>
-#include <osg/Texture2D>
-#include <osg/TexMat>
+#include <osg/StateSet>
+#include <osg/Image>
+#include <osg/Geode>
+#include <osg/Group>
+#include <osg/Node>
+#include <osg/NodeVisitor>
 
 #include "ExtraShapes.h"
 

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -39,6 +39,7 @@
 #include <memory.h>
 #include <iostream>
 
+#include <QColor>
 #include <QImage>
 #include <QOpenGLContext> // must be included before OSG headers
 
@@ -77,8 +78,8 @@ public:
   virtual void apply(osg::MatrixTransform& node) override;
   osg::Image* convertImage(const QImage& iImage);
   void applyTexture(osg::StateSet* ss, const std::string& imagePath);
-  void changeColor(osg::StateSet* ss, float r, float g, float b);
-  void changeTransparency(osg::StateSet* ss, float transpCoeff);
+  void changeColor(osg::StateSet* ss, const QColor color);
+  void changeTransparency(osg::StateSet* ss, const float transparency);
 public:
   AbstractVisualizerObject* _visualizer;
   bool _changeMaterialProperties;

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -81,6 +81,7 @@ public:
   void changeTransparency(osg::StateSet* ss, float transpCoeff);
 public:
   AbstractVisualizerObject* _visualizer;
+  bool _changeMaterialProperties;
 };
 
 class InfoVisitor : public osg::NodeVisitor
@@ -104,8 +105,8 @@ public:
   ~OSGScene() = default;
   OSGScene(const OSGScene& osgs) = delete;
   OSGScene& operator=(const OSGScene& osgs) = delete;
-  void setUpScene(const std::vector<ShapeObject>& shapes);
-  void setUpScene(const std::vector<VectorObject>& vectors);
+  void setUpScene(std::vector<ShapeObject>& shapes);
+  void setUpScene(std::vector<VectorObject>& vectors);
   osg::ref_ptr<osg::Group> getRootNode();
   std::string getPath() const;
   void setPath(const std::string path);
@@ -139,6 +140,7 @@ public:
   const std::string getModelFile() const;
   const std::string getPath() const;
   const std::string getXMLFileName() const;
+  AbstractVisualizerObject* getVisualizerObjectByIdx(const std::size_t visualizerIdx);
   AbstractVisualizerObject* getVisualizerObjectByID(const std::string& visualizerID);
   int getVisualizerObjectIndexByID(const std::string& visualizerID);
 private:
@@ -165,7 +167,12 @@ public:
   virtual void initializeVisAttributes(const double time) = 0;
   virtual void updateVisAttributes(const double time) = 0;
   void sceneUpdate();
-  void modifyVisualizer(const std::string& visualizerName);
+  void updateVisualizer(const std::string& visualizerName   , bool changeMaterialProperties = true);
+  void modifyVisualizer(const std::string& visualizerName   , bool changeMaterialProperties = true);
+  void updateVisualizer(AbstractVisualizerObject* visualizer, bool changeMaterialProperties = true);
+  void modifyVisualizer(AbstractVisualizerObject* visualizer, bool changeMaterialProperties = true);
+  void updateVisualizer(AbstractVisualizerObject& visualizer, bool changeMaterialProperties = true);
+  void modifyVisualizer(AbstractVisualizerObject& visualizer, bool changeMaterialProperties = true);
   virtual void simulate(TimeManager& omvm) = 0;
   virtual void updateScene(const double time) = 0;
 

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <iostream>
+#include <functional>
 
 #include <QColor>
 #include <QImage>
@@ -56,6 +57,9 @@
 #include <osg/RenderInfo>
 #include <osgUtil/RenderBin>
 #include <osgUtil/RenderLeaf>
+#include <osgViewer/View>
+
+#include <OpenThreads/Mutex>
 
 #include "ExtraShapes.h"
 
@@ -212,6 +216,7 @@ public:
   void setUpScene();
   virtual void initializeVisAttributes(const double time) = 0;
   virtual void updateVisAttributes(const double time) = 0;
+  void chooseVectorScales(osgViewer::View* view, OpenThreads::Mutex* mutex = nullptr, std::function<void()> frame = nullptr);
   void sceneUpdate();
   void updateVisualizer(const std::string& visualizerName   , bool changeMaterialProperties = true);
   void modifyVisualizer(const std::string& visualizerName   , bool changeMaterialProperties = true);

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -201,7 +201,7 @@ osg::Vec3f normalize(osg::Vec3f vec);
 osg::Vec3f cross(osg::Vec3f vec1, osg::Vec3f vec2);
 Directions fixDirections(osg::Vec3f lDir, osg::Vec3f wDir);
 void assemblePokeMatrix(osg::Matrix& M, const osg::Matrix3& T, const osg::Vec3f& r);
-rAndT rotateModelica2OSG(osg::Matrix3 T, osg::Vec3f r, osg::Vec3f r_shape, osg::Vec3f lDir, osg::Vec3f wDir, float length/*, float width, float height*/, std::string type);
-rAndT rotateModelica2OSG(osg::Matrix3 T, osg::Vec3f r, osg::Vec3f dir, float length);
+rAndT rotateModelica2OSG(osg::Matrix3 T, osg::Vec3f r, osg::Vec3f r_shape, osg::Vec3f lDir, osg::Vec3f wDir, std::string type);
+rAndT rotateModelica2OSG(osg::Matrix3 T, osg::Vec3f r, osg::Vec3f dir);
 
 #endif

--- a/OMEdit/OMEditLIB/Animation/VisualizationCSV.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationCSV.cpp
@@ -144,7 +144,7 @@ void VisualizationCSV::updateVisAttributes(const double time)
           osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
           osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
           osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
-          shape._length.exp/*, shape._width.exp, shape._height.exp*/, shape._type);
+          shape._type);
       assemblePokeMatrix(shape._mat, rT._T, rT._r);
 
       // Update the shapes
@@ -193,8 +193,7 @@ void VisualizationCSV::updateVisAttributes(const double time)
                        vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
                        vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
           osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
-          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp),
-          vector.hasHeadAtOrigin() ? -vector.getLength() : vector.getLength());
+          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
       assemblePokeMatrix(vector._mat, rT._T, rT._r);
 
       // Update the vectors

--- a/OMEdit/OMEditLIB/Animation/VisualizationCSV.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationCSV.cpp
@@ -91,10 +91,6 @@ void VisualizationCSV::updateVisAttributes(const double time)
   // Update all visualizers
   //std::cout<<"updateVisAttributes at "<<time <<std::endl;
 
-  rAndT rT;
-  osg::ref_ptr<osg::Node> child = nullptr;
-  unsigned int visualizerIdx = 0;
-
   try
   {
     for (ShapeObject& shape : mpOMVisualBase->_shapes)
@@ -140,7 +136,7 @@ void VisualizationCSV::updateVisAttributes(const double time)
 
       updateVisualizerAttributeCSV(shape._extra, time);
 
-      rT = rotateModelica2OSG(
+      rAndT rT = rotateModelica2OSG(
           osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
                        shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
                        shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
@@ -152,12 +148,9 @@ void VisualizationCSV::updateVisAttributes(const double time)
       assemblePokeMatrix(shape._mat, rT._T, rT._r);
 
       // Update the shapes
-      mpUpdateVisitor->_visualizer = static_cast<AbstractVisualizerObject*>(&shape);
+      updateVisualizer(shape);
       //shape.dumpVisualizerAttributes();
       //mpOMVisScene->dumpOSGTreeDebug();
-      child = mpOMVisScene->getScene().getRootNode()->getChild(visualizerIdx);
-      child->accept(*mpUpdateVisitor);
-      ++visualizerIdx;
     }
 
     for (VectorObject& vector : mpOMVisualBase->_vectors)
@@ -195,7 +188,7 @@ void VisualizationCSV::updateVisAttributes(const double time)
 
       updateVisualizerAttributeCSV(vector._twoHeadedArrow, time);
 
-      rT = rotateModelica2OSG(
+      rAndT rT = rotateModelica2OSG(
           osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
                        vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
                        vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
@@ -205,12 +198,9 @@ void VisualizationCSV::updateVisAttributes(const double time)
       assemblePokeMatrix(vector._mat, rT._T, rT._r);
 
       // Update the vectors
-      mpUpdateVisitor->_visualizer = static_cast<AbstractVisualizerObject*>(&vector);
+      updateVisualizer(vector);
       //vector.dumpVisualizerAttributes();
       //mpOMVisScene->dumpOSGTreeDebug();
-      child = mpOMVisScene->getScene().getRootNode()->getChild(visualizerIdx);
-      child->accept(*mpUpdateVisitor);
-      ++visualizerIdx;
     }
   }
   catch (std::exception& ex)

--- a/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
@@ -280,10 +280,6 @@ void VisualizationFMU::updateVisAttributes(const double time)
   // Update all visualizers
   //std::cout<<"updateVisAttributes at "<<time <<std::endl;
 
-  rAndT rT;
-  osg::ref_ptr<osg::Node> child = nullptr;
-  unsigned int visualizerIdx = 0;
-
   try
   {
     for (ShapeObject& shape : mpOMVisualBase->_shapes)
@@ -321,7 +317,7 @@ void VisualizationFMU::updateVisAttributes(const double time)
       updateVisualizerAttributeFMU(shape._width);
       updateVisualizerAttributeFMU(shape._height);
 
-      rT = rotateModelica2OSG(
+      rAndT rT = rotateModelica2OSG(
           osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
                        shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
                        shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
@@ -333,12 +329,9 @@ void VisualizationFMU::updateVisAttributes(const double time)
       assemblePokeMatrix(shape._mat, rT._T, rT._r);
 
       // Update the shapes
-      mpUpdateVisitor->_visualizer = static_cast<AbstractVisualizerObject*>(&shape);
+      updateVisualizer(shape);
       //shape.dumpVisualizerAttributes();
       //mpOMVisScene->dumpOSGTreeDebug();
-      child = mpOMVisScene->getScene().getRootNode()->getChild(visualizerIdx);
-      child->accept(*mpUpdateVisitor);
-      ++visualizerIdx;
     }
 
     for (VectorObject& vector : mpOMVisualBase->_vectors)
@@ -376,7 +369,7 @@ void VisualizationFMU::updateVisAttributes(const double time)
 
       updateVisualizerAttributeFMU(vector._twoHeadedArrow);
 
-      rT = rotateModelica2OSG(
+      rAndT rT = rotateModelica2OSG(
           osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
                        vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
                        vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
@@ -386,12 +379,9 @@ void VisualizationFMU::updateVisAttributes(const double time)
       assemblePokeMatrix(vector._mat, rT._T, rT._r);
 
       // Update the vectors
-      mpUpdateVisitor->_visualizer = static_cast<AbstractVisualizerObject*>(&vector);
+      updateVisualizer(vector);
       //vector.dumpVisualizerAttributes();
       //mpOMVisScene->dumpOSGTreeDebug();
-      child = mpOMVisScene->getScene().getRootNode()->getChild(visualizerIdx);
-      child->accept(*mpUpdateVisitor);
-      ++visualizerIdx;
     }
   }
   catch (std::exception& ex)

--- a/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
@@ -325,7 +325,7 @@ void VisualizationFMU::updateVisAttributes(const double time)
           osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
           osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
           osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
-          shape._length.exp/*, shape._width.exp, shape._height.exp*/, shape._type);
+          shape._type);
       assemblePokeMatrix(shape._mat, rT._T, rT._r);
 
       // Update the shapes
@@ -374,8 +374,7 @@ void VisualizationFMU::updateVisAttributes(const double time)
                        vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
                        vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
           osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
-          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp),
-          vector.hasHeadAtOrigin() ? -vector.getLength() : vector.getLength());
+          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
       assemblePokeMatrix(vector._mat, rT._T, rT._r);
 
       // Update the vectors

--- a/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
@@ -165,7 +165,7 @@ void VisualizationMAT::updateVisAttributes(const double time)
           osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
           osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
           osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
-          shape._length.exp/*, shape._width.exp, shape._height.exp*/, shape._type);
+          shape._type);
       assemblePokeMatrix(shape._mat, rT._T, rT._r);
 
       // Update the shapes
@@ -214,8 +214,7 @@ void VisualizationMAT::updateVisAttributes(const double time)
                        vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
                        vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
           osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
-          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp),
-          vector.hasHeadAtOrigin() ? -vector.getLength() : vector.getLength());
+          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
       assemblePokeMatrix(vector._mat, rT._T, rT._r);
 
       // Update the vectors

--- a/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
@@ -112,10 +112,6 @@ void VisualizationMAT::updateVisAttributes(const double time)
   // Update all visualizers
   //std::cout<<"updateVisAttributes at "<<time <<std::endl;
 
-  rAndT rT;
-  osg::ref_ptr<osg::Node> child = nullptr;
-  unsigned int visualizerIdx = 0;
-
   try
   {
     for (ShapeObject& shape : mpOMVisualBase->_shapes)
@@ -161,7 +157,7 @@ void VisualizationMAT::updateVisAttributes(const double time)
 
       updateVisualizerAttributeMAT(shape._extra, time);
 
-      rT = rotateModelica2OSG(
+      rAndT rT = rotateModelica2OSG(
           osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
                        shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
                        shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
@@ -173,12 +169,9 @@ void VisualizationMAT::updateVisAttributes(const double time)
       assemblePokeMatrix(shape._mat, rT._T, rT._r);
 
       // Update the shapes
-      mpUpdateVisitor->_visualizer = static_cast<AbstractVisualizerObject*>(&shape);
+      updateVisualizer(shape);
       //shape.dumpVisualizerAttributes();
       //mpOMVisScene->dumpOSGTreeDebug();
-      child = mpOMVisScene->getScene().getRootNode()->getChild(visualizerIdx);
-      child->accept(*mpUpdateVisitor);
-      ++visualizerIdx;
     }
 
     for (VectorObject& vector : mpOMVisualBase->_vectors)
@@ -216,7 +209,7 @@ void VisualizationMAT::updateVisAttributes(const double time)
 
       updateVisualizerAttributeMAT(vector._twoHeadedArrow, time);
 
-      rT = rotateModelica2OSG(
+      rAndT rT = rotateModelica2OSG(
           osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
                        vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
                        vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
@@ -226,12 +219,9 @@ void VisualizationMAT::updateVisAttributes(const double time)
       assemblePokeMatrix(vector._mat, rT._T, rT._r);
 
       // Update the vectors
-      mpUpdateVisitor->_visualizer = static_cast<AbstractVisualizerObject*>(&vector);
+      updateVisualizer(vector);
       //vector.dumpVisualizerAttributes();
       //mpOMVisScene->dumpOSGTreeDebug();
-      child = mpOMVisScene->getScene().getRootNode()->getChild(visualizerIdx);
-      child->accept(*mpUpdateVisitor);
-      ++visualizerIdx;
     }
   }
   catch (std::exception& ex)

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -295,6 +295,7 @@ target_link_libraries(OMEditLib PUBLIC omc::3rd::opcua)
 target_link_libraries(OMEditLib PUBLIC OMPlotLib)
 target_link_libraries(OMEditLib PUBLIC OpenModelicaCompiler)
 target_link_libraries(OMEditLib PUBLIC ${OPENSCENEGRAPH_LIBRARIES})
+target_link_libraries(OMEditLib PUBLIC GL)
 
 if(MINGW)
   target_link_libraries(OMEditLib PUBLIC binutils::bfd)

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -627,8 +627,8 @@ void MessagesWidget::addGUIMessage(MessageItem messageItem)
  */
 void MessagesWidget::clearMessages()
 {
-  mpAllMessageWidget->clearAllTabsMessages();
-  mpNotificationMessageWidget->clearAllTabsMessages();
-  mpWarningMessageWidget->clearAllTabsMessages();
-  mpErrorMessageWidget->clearAllTabsMessages();
+  mpAllMessageWidget->clearThisTabMessages();
+  mpNotificationMessageWidget->clearThisTabMessages();
+  mpWarningMessageWidget->clearThisTabMessages();
+  mpErrorMessageWidget->clearThisTabMessages();
 }

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.h
@@ -37,6 +37,9 @@
 
 #include "Util/StringHandler.h"
 
+#include <QQueue>
+#include <QMutex>
+#include <QMutexLocker>
 #include <QTextBrowser>
 
 class SimulationOutputWidget;
@@ -128,6 +131,9 @@ private:
   QVector<QWidget*> mSimulationWidgetsVector;
 
   QStringList mSuppressMessagesList;
+  QQueue<MessageItem> mPendingMessagesQueue;
+  QMutex mPendingMessagesMutex;
+  bool mShowingPendingMessages;
 public:
   static MessagesWidget* instance() {return mpInstance;}
   MessageWidget* getAllMessageWidget() {return mpAllMessageWidget;}
@@ -145,6 +151,8 @@ private slots:
   bool closeTab(int index);
 public slots:
   void addGUIMessage(MessageItem messageItem);
+  void addPendingMessage(MessageItem messageItem);
+  void showPendingMessages();
   void clearMessages();
 };
 

--- a/OMEdit/configure.ac
+++ b/OMEdit/configure.ac
@@ -120,7 +120,7 @@ if test "$WITH_OSG" = 0; then
   AC_MSG_RESULT("Disabled OSG")
 else
   QMAKE_CONFIG_OSG="CONFIG += osg"
-  LIBOSG="-losg -losgViewer -losgDB -losgGA -lOpenThreads"
+  LIBOSG="-losg -losgViewer -losgUtil -losgDB -losgGA -lOpenThreads -lGL"
   AC_MSG_RESULT("OSG is enabled")
 fi
 

--- a/testsuite/openmodelica/visualization/ForceAndTorque.mos
+++ b/testsuite/openmodelica/visualization/ForceAndTorque.mos
@@ -499,7 +499,7 @@ getErrorString();
 //       <specCoeff><cref>forceAndTorque.forceArrow.arrowLine.specularCoefficient</cref></specCoeff>
 //       <quantity><cref>forceAndTorque.forceArrow.arrowLine.quantity</cref></quantity>
 //       <headAtOrigin><cref>forceAndTorque.forceArrow.arrowLine.headAtOrigin</cref></headAtOrigin>
-//       <twoHeadedArrow><bexp>false</bexp></twoHeadedArrow>
+//       <twoHeadedArrow><bconst>false</bconst></twoHeadedArrow>
 //   </vector>
 //   <vector>
 //       <ident>forceAndTorque.torqueArrow.arrowLine</ident>
@@ -532,7 +532,7 @@ getErrorString();
 //       <specCoeff><cref>forceAndTorque.torqueArrow.arrowLine.specularCoefficient</cref></specCoeff>
 //       <quantity><cref>forceAndTorque.torqueArrow.arrowLine.quantity</cref></quantity>
 //       <headAtOrigin><cref>forceAndTorque.torqueArrow.arrowLine.headAtOrigin</cref></headAtOrigin>
-//       <twoHeadedArrow><bexp>true</bexp></twoHeadedArrow>
+//       <twoHeadedArrow><bconst>true</bconst></twoHeadedArrow>
 //   </vector>
 //   <shape>
 //       <ident>body.frameTranslation.shape</ident>

--- a/testsuite/openmodelica/visualization/Surfaces.mos
+++ b/testsuite/openmodelica/visualization/Surfaces.mos
@@ -534,7 +534,7 @@ getErrorString();
 //       <nu><cref>torus.surface.nu</cref></nu>
 //       <nv><cref>torus.surface.nv</cref></nv>
 //       <wireframe><cref>torus.surface.wireframe</cref></wireframe>
-//       <multiColored><bexp>false</bexp></multiColored>
+//       <multiColored><bconst>false</bconst></multiColored>
 //       <color>
 //           <cref>torus.surface.color[1]</cref>
 //           <cref>torus.surface.color[2]</cref>
@@ -563,8 +563,8 @@ getErrorString();
 //       </r>
 //       <nu><cref>pipeWithScalarField.pipe.surface.nu</cref></nu>
 //       <nv><cref>pipeWithScalarField.pipe.surface.nv</cref></nv>
-//       <wireframe><bexp>false</bexp></wireframe>
-//       <multiColored><bexp>false</bexp></multiColored>
+//       <wireframe><bconst>false</bconst></wireframe>
+//       <multiColored><bconst>false</bconst></multiColored>
 //       <color>
 //           <exp>255.0</exp>
 //           <exp>0.0</exp>
@@ -638,8 +638,8 @@ getErrorString();
 //       </r>
 //       <nu><cref>wheel.torus.nu</cref></nu>
 //       <nv><cref>wheel.torus.nv</cref></nv>
-//       <wireframe><bexp>false</bexp></wireframe>
-//       <multiColored><bexp>false</bexp></multiColored>
+//       <wireframe><bconst>false</bconst></wireframe>
+//       <multiColored><bconst>false</bconst></multiColored>
 //       <color>
 //           <cref>wheel.torus.color[1]</cref>
 //           <cref>wheel.torus.color[2]</cref>
@@ -668,8 +668,8 @@ getErrorString();
 //       </r>
 //       <nu><exp>50</exp></nu>
 //       <nv><exp>50</exp></nv>
-//       <wireframe><bexp>false</bexp></wireframe>
-//       <multiColored><bexp>false</bexp></multiColored>
+//       <wireframe><bconst>false</bconst></wireframe>
+//       <multiColored><bconst>false</bconst></multiColored>
 //       <color>
 //           <exp>255.0</exp>
 //           <exp>0.0</exp>
@@ -878,8 +878,8 @@ getErrorString();
 //       </r>
 //       <nu><exp>2</exp></nu>
 //       <nv><exp>2</exp></nv>
-//       <wireframe><bexp>false</bexp></wireframe>
-//       <multiColored><bexp>false</bexp></multiColored>
+//       <wireframe><bconst>false</bconst></wireframe>
+//       <multiColored><bconst>false</bconst></multiColored>
 //       <color>
 //           <exp>215.0</exp>
 //           <exp>215.0</exp>


### PR DESCRIPTION
### Purpose

This PR implements methods for the automatic adjustment of radius & length scales of vector visualizers at initialization.
Some fixes are provided for non-critical issues.
Improvements in efficiency are also included.

### Approach

Four new attributes are attached to each vector visualizer and can be independently enabled or disabled:
- adjustable-radius,
- adjustable-length,
- scale-invariant,
- drawn-on-top.

The first two attributes inform whether radius scale and length scale can be adjusted, respectively.
The third attribute allows to continuously maintain a constant pixel size through the auto-scale feature of OSG's AutoTransform, particularly when zooming in/out the scene, which is very convenient to be able to compare vector lengths (meaning, their relative strength) all along the simulation.
The fourth attribute serves as a reinforcement for the previous one, because it renders vectors on top of everything else drawn in the scene, therefore not only small vectors but also tips of arrow heads are always visible and comparable (although this may sometimes break the notion of perspective).

Two separate kinds of adjustments are applied:
1. Radius scale: Browse fixed-radius vectors as well as relevant shapes to compute the median of their radii, and use this median value (± some constant factor) to scale the default radius of adjustable-radius vectors.
2. Length scale: For each vector quantity independently, increase the length of adjustable-length vectors for them to be clearly visible, while ensuring that the following two constraints are satisfied (both ± some constant margin), the first one taking precedence over the second one:
   - shaft lengths must be greater than zero in order to be comparable,
   - final camera distance to focal center must not be greater than initial distance computed without drawing adjustable-length vectors.

Implemented heuristics are thoroughly documented above and inside method [`VisualizationAbstract::chooseVectorScales`](https://github.com/OpenModelica/OpenModelica/pull/9389/commits/364b2cd9e7f939437fbdb03dfdaa96e65613592a#diff-003ee05536a1844c1876692266cec5626d4a656eaa622da88191b5ffcf95d3d6R620).
Default values of their parameters are defined [at the beginning of this same method](https://github.com/OpenModelica/OpenModelica/pull/9389/commits/364b2cd9e7f939437fbdb03dfdaa96e65613592a#diff-003ee05536a1844c1876692266cec5626d4a656eaa622da88191b5ffcf95d3d6R627-R633).

### Tests

- `Modelica.Mechanics.MultiBody.Examples.Elementary.ForceAndTorque`
- Below model containing only visualizers (shapes and vectors)
<details><summary>TestScalingVectorVisualizers.mo (click to expand)</summary>

```modelica
model TestScalingVectorVisualizers "Demonstrate animation of vector visualizers with automatic initial scaling"
  constant Boolean testMinimumLengthConstraint=true;
  import MB = Modelica.Mechanics.MultiBody;
  inner MB.World world;
  MB.Visualizers.Advanced.Shape s1(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s2(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s3(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s4(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s5(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Vector v1(
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    coordinates={(time+1)*1200,0,0},
    color={0,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Force,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v2(
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    coordinates={-(time+1)*120,0,0},
    color={0,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Torque,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v3(
    R=MB.Frames.nullRotation(),
    r={0,0.1,0},
    coordinates={(time+1)*2*1200,0,0},
    color={0,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Force,
    headAtOrigin=true,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v4(
    R=MB.Frames.nullRotation(),
    r={0,0.1,0},
    coordinates={-(time+1)*2*120,0,0},
    color={0,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Torque,
    headAtOrigin=true,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v5(
    R=MB.Frames.nullRotation(),
    r={0,0.2,0},
    coordinates={(time+1)*8*1200,0,0},
    color={0,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Force,
    headAtOrigin=false,
    twoHeadedArrow=false
  ) if testMinimumLengthConstraint;
  MB.Visualizers.Advanced.Vector v6(
    R=MB.Frames.nullRotation(),
    r={0,0.2,0},
    coordinates={-(time+1)*8*120,0,0},
    color={0,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Torque,
    headAtOrigin=false,
    twoHeadedArrow=false
  ) if testMinimumLengthConstraint;
  MB.Visualizers.Advanced.Vector v7(
    R=MB.Frames.nullRotation(),
    r={-0.1,0.3,0},
    coordinates={-1,2,0},
    color={255,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Velocity,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v8(
    R=MB.Frames.nullRotation(),
    r={-0.1,0.3,0},
    coordinates={-2,1,0},
    color={255,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Acceleration,
    headAtOrigin=false,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v9(
    R=MB.Frames.nullRotation(),
    r={-0.1,-0.2,0},
    coordinates={-1,-2,0},
    color={255,0,155},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.AngularVelocity,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v10(
    R=MB.Frames.nullRotation(),
    r={-0.1,-0.2,0},
    coordinates={-2,-1,0},
    color={255,155,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.AngularAcceleration,
    headAtOrigin=false,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v11(
    R=MB.Frames.nullRotation(),
    r={0,-0.25,0},
    coordinates={0.5,0.75,0},
    color={0,255,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.RelativePosition,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
end TestScalingVectorVisualizers;
```
</details>

### Related Issues

- Complementary fix for #8211
- Proposal for custom annotations in #9390
- MSL discussion on scaling vectors by tools: modelica/ModelicaStandardLibrary#3991
- MSL `ForceAndTorque` model has color issue: modelica/ModelicaStandardLibrary#3989
- **TODO**: Consider the entire simulation interval (between start time and stop time) to determine if the length scale has shrunk the vectors too much, but this requires consistent discretization and might lead to highly expensive evaluations for long simulation intervals.