### PR TITLE
Handle mapping of record members to external C code types and layout.

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -894,8 +894,8 @@ constant Type T_ANYTYPE_DEFAULT     = T_ANYTYPE(NONE());
 constant Type T_UNKNOWN_DEFAULT     = T_UNKNOWN();
 constant Type T_NORETCALL_DEFAULT   = T_NORETCALL();
 constant Type T_METATYPE_DEFAULT    = T_METATYPE(T_UNKNOWN_DEFAULT);
-constant Type T_COMPLEX_DEFAULT     = T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")), {}, NONE()) "default complex with unknown CiState";
-constant Type T_COMPLEX_DEFAULT_RECORD = T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("")), {}, NONE()) "default complex with record CiState";
+constant Type T_COMPLEX_DEFAULT     = T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")), {}, NONE(), false) "default complex with unknown CiState";
+constant Type T_COMPLEX_DEFAULT_RECORD = T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("")), {}, NONE(), false) "default complex with record CiState";
 
 constant Type T_SOURCEINFO_DEFAULT_METARECORD = T_METARECORD(Absyn.QUALIFIED("SourceInfo",Absyn.IDENT("SOURCEINFO")), Absyn.IDENT("SourceInfo"), {}, 1, {
     TYPES_VAR("fileName", dummyAttrVar, T_STRING_DEFAULT, UNBOUND(), false, NONE()),
@@ -964,6 +964,7 @@ public uniontype Type "models the different front-end and back-end types"
     ClassInf.State complexClassType "The type of a class";
     list<Var> varLst "The variables of a complex type";
     EqualityConstraint equalityConstraint;
+    Boolean needsExternalConversion "If the record is passed to an external function at any point, we need to generate conversion functions for it (for instance to convert 'modelica_integer' to 'int')";
   end T_COMPLEX;
 
   record T_SUBTYPE_BASIC

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -1012,7 +1012,7 @@ algorithm
       end for;
       tvars := listReverse(tvars);
 
-    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint);
+    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint, inType.needsExternalConversion);
   end match;
 
 end markDerivedRecordOutsideBindings;
@@ -1084,7 +1084,7 @@ algorithm
       end for;
       tvars := listReverse(tvars);
 
-    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint);
+    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint, inType.needsExternalConversion);
   end match;
 
 end markTypesVarsOutsideBindings;

--- a/OMCompiler/Compiler/FrontEnd/InstBinding.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstBinding.mo
@@ -122,7 +122,8 @@ public constant DAE.Type distributionType =
                     false,
                     NONE())
                 },
-                NONE());
+                NONE(),
+                false);
 
 protected function instBinding
 "This function investigates a modification and extracts the

--- a/OMCompiler/Compiler/FrontEnd/InstFunction.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstFunction.mo
@@ -800,6 +800,8 @@ algorithm
       list<DAE.FuncArg> fargs;
       DAE.EqualityConstraint eqCo;
       String name, newName;
+      Boolean extConvert;
+
 
       case(_, _, _)
         equation
@@ -821,7 +823,7 @@ algorithm
             UnitAbsynBuilder.emptyInstStore(), DAE.NOMOD(), DAE.NOPRE(), recordCl,
             {}, true, InstTypes.INNER_CALL(), ConnectionGraph.EMPTY, Connect.emptySet);
 
-          DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo) = recType;
+          DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo, extConvert) = recType;
 
           vars = Types.filterRecordComponents(vars, SCodeUtil.elementInfo(recordCl));
           (inputs,locals) = List.extractOnTrue(vars, Types.isModifiableTypesVar);
@@ -830,7 +832,7 @@ algorithm
           vars = listAppend(inputs,locals);
 
           path = AbsynUtil.makeFullyQualified(path);
-          fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo);
+          fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo, extConvert);
           fargs = Types.makeFargsList(inputs);
           funcTy = DAE.T_FUNCTION(fargs, fixedTy, DAE.FUNCTION_ATTRIBUTES_DEFAULT, path);
           func = DAE.RECORD_CONSTRUCTOR(path,funcTy,DAE.emptyElementSource);
@@ -839,7 +841,7 @@ algorithm
 
           // add the instance record constructor too!
           path = AbsynUtil.pathSetLastIdent(path, name);
-          fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo);
+          fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo, extConvert);
           fargs = Types.makeFargsList(inputs);
           funcTy = DAE.T_FUNCTION(fargs, fixedTy, DAE.FUNCTION_ATTRIBUTES_DEFAULT, path);
           func = DAE.RECORD_CONSTRUCTOR(path,funcTy,DAE.emptyElementSource);
@@ -878,6 +880,7 @@ algorithm
       FCore.Graph recordEnv;
       DAE.Function func;
       list<DAE.FuncArg> fargs;
+      Boolean extConvert;
 
     // try to instantiate class
     case (cache, _, DAE.T_COMPLEX(complexClassType=ClassInf.RECORD(path)), _)
@@ -888,7 +891,7 @@ algorithm
         cache;
 
     // if previous stuff didn't work, try to use the ty directly
-    case (cache, _, DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo), _)
+    case (cache, _, DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo, extConvert), _)
       equation
         path = AbsynUtil.makeFullyQualified(path);
 
@@ -898,7 +901,7 @@ algorithm
         locals = List.map(locals,Types.setVarProtected);
         vars = listAppend(inputs,locals);
 
-        fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo);
+        fixedTy = DAE.T_COMPLEX(ClassInf.RECORD(path), vars, eqCo, extConvert);
         fargs = Types.makeFargsList(inputs);
         funcTy = DAE.T_FUNCTION(fargs, fixedTy, DAE.FUNCTION_ATTRIBUTES_DEFAULT, path);
         func = DAE.RECORD_CONSTRUCTOR(path,funcTy,DAE.emptyElementSource);

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -3108,7 +3108,7 @@ algorithm
       equation
         vars = List.sort(vars, connectorCompGt);
       then
-        DAE.T_COMPLEX(ci_state, vars, ec);
+        DAE.T_COMPLEX(ci_state, vars, ec, inType.needsExternalConversion);
 
     else inType;
 

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -5545,7 +5545,7 @@ algorithm
     case (_,st,l,NONE(),equalityConstraint,_)
       equation
         failure(ClassInf.META_UNIONTYPE(_) = st);
-      then DAE.T_COMPLEX(st,l,equalityConstraint);
+      then DAE.T_COMPLEX(st,l,equalityConstraint, false);
 
     // extending
     case (_,st,l,SOME(bc),equalityConstraint,_)
@@ -5646,7 +5646,7 @@ algorithm
 
     // not extending basic type!
     case (_,st,l,NONE(),_)
-      then DAE.T_COMPLEX(st,l,NONE()); // adrpo: TODO! check equalityConstraint!
+      then DAE.T_COMPLEX(st,l,NONE(), false); // adrpo: TODO! check equalityConstraint!
 
     case (_,st,l,SOME(bc),_)
       then DAE.T_SUBTYPE_BASIC(st,l,bc,NONE());

--- a/OMCompiler/Compiler/FrontEnd/Lookup.mo
+++ b/OMCompiler/Compiler/FrontEnd/Lookup.mo
@@ -2198,12 +2198,12 @@ algorithm
     // function_name cardinality
     case (_,"cardinality")
       then {DAE.T_FUNCTION(
-              {DAE.FUNCARG("x",DAE.T_COMPLEX(ClassInf.CONNECTOR(Absyn.IDENT("$$"),false),{},NONE()),DAE.C_VAR(),DAE.NON_PARALLEL(),NONE())},
+              {DAE.FUNCARG("x",DAE.T_COMPLEX(ClassInf.CONNECTOR(Absyn.IDENT("$$"),false),{},NONE(), false),DAE.C_VAR(),DAE.NON_PARALLEL(),NONE())},
               DAE.T_INTEGER_DEFAULT,
               DAE.FUNCTION_ATTRIBUTES_DEFAULT,
               Absyn.IDENT("cardinality")),
             DAE.T_FUNCTION(
-              {DAE.FUNCARG("x",DAE.T_COMPLEX(ClassInf.CONNECTOR(Absyn.IDENT("$$"),true),{},NONE()),DAE.C_VAR(),DAE.NON_PARALLEL(),NONE())},
+              {DAE.FUNCARG("x",DAE.T_COMPLEX(ClassInf.CONNECTOR(Absyn.IDENT("$$"),true),{},NONE(), false),DAE.C_VAR(),DAE.NON_PARALLEL(),NONE())},
               DAE.T_INTEGER_DEFAULT,
               DAE.FUNCTION_ATTRIBUTES_DEFAULT,
               Absyn.IDENT("cardinality"))};

--- a/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/PrefixUtil.mo
@@ -413,7 +413,7 @@ algorithm
     case (cache,_,_,DAE.PREFIX(DAE.NOCOMPPRE(),_),SOME(cref)) then (cache,cref);
     case (cache,env,_,DAE.PREFIX(DAE.PRE(prefix = i,dimensions=ds,subscripts = s,next = xs,ci_state=ci_state),cp),NONE())
       equation
-        ident_ty = Expression.liftArrayLeftList(DAE.T_COMPLEX(ci_state, {}, NONE()), ds);
+        ident_ty = Expression.liftArrayLeftList(DAE.T_COMPLEX(ci_state, {}, NONE(), false), ds);
         cref_ = ComponentReference.makeCrefIdent(i,ident_ty,s);
         (cache,cref_1) = prefixToCref2(cache,env,inIH,DAE.PREFIX(xs,cp), SOME(cref_));
       then
@@ -421,7 +421,7 @@ algorithm
     case (cache,env,_,DAE.PREFIX(DAE.PRE(prefix = i,dimensions=ds,subscripts = s,next = xs,ci_state=ci_state),cp),SOME(cref))
       equation
         (cache,cref) = prefixSubscriptsInCref(cache,env,inIH,inPrefix,cref);
-        ident_ty = Expression.liftArrayLeftList(DAE.T_COMPLEX(ci_state, {}, NONE()), ds);
+        ident_ty = Expression.liftArrayLeftList(DAE.T_COMPLEX(ci_state, {}, NONE(), false), ds);
         cref_2 = ComponentReference.makeCrefQual(i,ident_ty,s,cref);
         (cache,cref_1) = prefixToCref2(cache,env,inIH,DAE.PREFIX(xs,cp), SOME(cref_2));
       then
@@ -456,13 +456,13 @@ algorithm
     case (DAE.PREFIX(DAE.NOCOMPPRE(),_),SOME(cref)) then SOME(cref);
     case (DAE.PREFIX(DAE.PRE(prefix = i,subscripts = s,next = xs),cp),NONE())
       equation
-        cref_ = ComponentReference.makeCrefIdent(i,DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")), {}, NONE()),s);
+        cref_ = ComponentReference.makeCrefIdent(i,DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")), {}, NONE(), false),s);
         cref_1 = prefixToCrefOpt2(DAE.PREFIX(xs,cp), SOME(cref_));
       then
         cref_1;
     case (DAE.PREFIX(DAE.PRE(prefix = i,subscripts = s,next = xs),cp),SOME(cref))
       equation
-        cref_ = ComponentReference.makeCrefQual(i,DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")), {}, NONE()),s,cref);
+        cref_ = ComponentReference.makeCrefQual(i,DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("")), {}, NONE(), false),s,cref);
         cref_1 = prefixToCrefOpt2(DAE.PREFIX(xs,cp), SOME(cref_));
       then
         cref_1;

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -2146,19 +2146,19 @@ algorithm
       then DAE.T_CODE(DAE.C_VARIABLENAME());
 
     case Absyn.C_EQUATIONSECTION()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("EquationSection")),{},NONE());
+      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("EquationSection")),{},NONE(), false);
 
     case Absyn.C_ALGORITHMSECTION()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("AlgorithmSection")),{},NONE());
+      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("AlgorithmSection")),{},NONE(), false);
 
     case Absyn.C_ELEMENT()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Element")),{},NONE());
+      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Element")),{},NONE(), false);
 
     case Absyn.C_EXPRESSION()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Expression")),{},NONE());
+      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Expression")),{},NONE(), false);
 
     case Absyn.C_MODIFICATION()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Modification")),{},NONE());
+      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Modification")),{},NONE(), false);
   end match;
 end elabCodeType;
 
@@ -9426,7 +9426,7 @@ algorithm
   end for;
 
   vars := listReverse(vars);
-  outType := DAE.T_COMPLEX(complexClassType, vars, NONE());
+  outType := DAE.T_COMPLEX(complexClassType, vars, NONE(), false);
 end complexTypeFromSlots;
 
 protected function slotListArgs

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -441,7 +441,7 @@ algorithm
       equation
         vars = List.map(vars, convertFromExpToTypesVar);
       then
-        DAE.T_COMPLEX(CIS, vars, ec);
+        DAE.T_COMPLEX(CIS, vars, ec, inType.needsExternalConversion);
 
     case DAE.T_SUBTYPE_BASIC(CIS, vars, ty, ec)
       equation
@@ -1159,7 +1159,7 @@ algorithm
     case Values.RECORD(record_ = cname,orderd = vl,comp = ids, index = -1)
       equation
         vars = valuesToVars(vl, ids);
-      then DAE.T_COMPLEX(ClassInf.RECORD(cname),vars,NONE());
+      then DAE.T_COMPLEX(ClassInf.RECORD(cname),vars,NONE(), false);
 
       // MetaModelica Uniontype
     case Values.RECORD(record_ = cname,orderd = vl,comp = ids, index = index)
@@ -3871,7 +3871,7 @@ algorithm
         true = Config.acceptMetaModelicaGrammar();
         varLst = list(simplifyVar(v) for v in varLst);
       then
-        DAE.T_COMPLEX(CIS, varLst, ec);
+        DAE.T_COMPLEX(CIS, varLst, ec, inType.needsExternalConversion);
 
     // do this for records too, otherwise:
     // frame.R = Modelica.Mechanics.MultiBody.Frames.Orientation({const_matrix);
@@ -3880,7 +3880,7 @@ algorithm
       equation
         varLst = list(simplifyVar(v) for v in varLst);
       then
-        DAE.T_COMPLEX(CIS, varLst, ec);
+        DAE.T_COMPLEX(CIS, varLst, ec, inType.needsExternalConversion);
 
     // otherwise just return the same!
     case DAE.T_COMPLEX() then inType;

--- a/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
@@ -127,7 +127,7 @@ algorithm
     case(Values.RECORD(path,valLst,nameLst,_)) equation
       eltTps = List.map(valLst,valueExpType);
       varLst = List.threadMap(eltTps,nameLst,valueExpTypeExpVar);
-    then DAE.T_COMPLEX(ClassInf.RECORD(path),varLst,NONE());
+    then DAE.T_COMPLEX(ClassInf.RECORD(path),varLst,NONE(), false);
 
     case _
       equation
@@ -885,7 +885,7 @@ algorithm
         expl = List.map(vallist,function valueExp(originalExp=NONE()));
         tpl = List.map(expl,Expression.typeof);
         varlst = List.threadMap(namelst,tpl,Expression.makeVar);
-        t = DAE.T_COMPLEX(ClassInf.RECORD(path),varlst,NONE());
+        t = DAE.T_COMPLEX(ClassInf.RECORD(path),varlst,NONE(), false);
       then DAE.RECORD(path,expl,namelst,t);
 
     case(Values.ENUM_LITERAL(name = path, index = ix))

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1670,7 +1670,7 @@ uniontype InstNode
               algorithm
                 state := Restriction.toDAE(Class.restriction(cls), fullPath(clsNode));
               then
-                DAE.Type.T_COMPLEX(state, {}, NONE());
+                DAE.Type.T_COMPLEX(state, {}, NONE(), false);
 
           end match;
     end match;
@@ -1712,7 +1712,7 @@ uniontype InstNode
               algorithm
                 state := Restriction.toDAE(Class.restriction(cls), fullPath(clsNode));
                 vars := ConvertDAE.makeTypeVars(clsNode);
-                outType := DAE.Type.T_COMPLEX(state, vars, NONE());
+                outType := DAE.Type.T_COMPLEX(state, vars, NONE(), false);
                 Pointer.update(clsNode.cls, Class.DAE_TYPE(outType));
               then
                 outType;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -146,7 +146,7 @@ protected constant DAE.Type simulationResultType_rtest = DAE.T_COMPLEX(ClassInf.
   DAE.TYPES_VAR("resultFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
   DAE.TYPES_VAR("simulationOptions",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
   DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())
-  },NONE());
+  },NONE(), false);
 
 protected constant DAE.Type simulationResultType_full = DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationResult")),{
   DAE.TYPES_VAR("resultFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
@@ -159,13 +159,13 @@ protected constant DAE.Type simulationResultType_full = DAE.T_COMPLEX(ClassInf.R
   DAE.TYPES_VAR("timeCompile",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
   DAE.TYPES_VAR("timeSimulation",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
   DAE.TYPES_VAR("timeTotal",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE())
-  },NONE());
+  },NONE(), false);
 
 protected constant DAE.Type simulationResultType_drModelica = DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationResult")),{
   DAE.TYPES_VAR("messages",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
   DAE.TYPES_VAR("flatteningTime",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE()),
   DAE.TYPES_VAR("simulationTime",DAE.dummyAttrVar,DAE.T_REAL_DEFAULT,DAE.UNBOUND(),false,NONE())
-  },NONE());
+  },NONE(), false);
 
 //these are in reversed order than above
 protected constant list<tuple<String,Values.Value>> zeroAdditionalSimulationResultValues =

--- a/OMCompiler/Compiler/Script/StaticScript.mo
+++ b/OMCompiler/Compiler/Script/StaticScript.mo
@@ -377,7 +377,7 @@ algorithm
         DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationObject")),
         {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
          DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())},
-          NONE());
+          NONE(), false);
       then
         (cache,Expression.makePureBuiltinCall("translateModelCPP",
           {DAE.CODE(Absyn.C_TYPENAME(className),DAE.T_UNKNOWN_DEFAULT),filenameprefix},DAE.T_STRING_DEFAULT),DAE.PROP(recordtype,DAE.C_VAR()));
@@ -392,7 +392,7 @@ algorithm
           DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationObject")),
           {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
            DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())},
-           NONE());
+           NONE(), false);
       then
         (cache,Expression.makePureBuiltinCall("translateModelXML",
           {DAE.CODE(Absyn.C_TYPENAME(className),DAE.T_UNKNOWN_DEFAULT),filenameprefix},DAE.T_STRING_DEFAULT),DAE.PROP(recordtype,DAE.C_VAR()));
@@ -407,7 +407,7 @@ algorithm
           DAE.T_COMPLEX(ClassInf.RECORD(Absyn.IDENT("SimulationObject")),
           {DAE.TYPES_VAR("flatClass",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE()),
            DAE.TYPES_VAR("exeFile",DAE.dummyAttrVar,DAE.T_STRING_DEFAULT,DAE.UNBOUND(),false,NONE())},
-           NONE());
+           NONE(), false);
       then
         (cache,Expression.makePureBuiltinCall("exportDAEtoMatlab",
           {DAE.CODE(Absyn.C_TYPENAME(className),DAE.T_UNKNOWN_DEFAULT),filenameprefix},DAE.T_STRING_DEFAULT),DAE.PROP(recordtype,DAE.C_VAR()));

--- a/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
@@ -120,6 +120,7 @@ uniontype RecordDeclaration
     Option<String> aliasName "alias of struct (record) name ? encoded. Code generators can generate an aliasing typedef using this, and avoid problems when casting a record from one type to another (*(othertype*)(&var)), which only works if you have a lhs value.";
     Absyn.Path defPath "definition path";
     list<Variable> variables "only name and type";
+    Boolean needsExternalConversion "If the record is passed to an external function at any point, we need to generate conversion functions for it (for instance to convert 'modelica_integer' to 'int')";
   end RECORD_DECL_FULL;
 
   record RECORD_DECL_ADD_CONSTRCTOR

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1630,7 +1630,7 @@ algorithm
             (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
 
             vars := List.map(varlst, typesVar);
-            recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars);
+            recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars, false);
           else
             vars := List.map(varlst, typesVar);
             recDecl := SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(sname, name, vars);
@@ -2590,11 +2590,12 @@ algorithm
       Absyn.Path name;
       String str,sname;
       Option<String> alias;
-    case (SimCodeFunction.RECORD_DECL_FULL(sname, _, name, vars),_)
+      Boolean extConvert;
+    case (SimCodeFunction.RECORD_DECL_FULL(sname, _, name, vars, extConvert),_)
       equation
         str = stringDelimitList(List.map(vars, variableString), "\n");
         (alias,ht) = aliasRecordDeclarations2(str, name, inHt);
-      then (SimCodeFunction.RECORD_DECL_FULL(sname, alias, name, vars),ht);
+      then (SimCodeFunction.RECORD_DECL_FULL(sname, alias, name, vars, extConvert),ht);
     else (inDecl,inHt);
   end match;
 end aliasRecordDeclarations;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -533,8 +533,13 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
 
       <<
       <% match aliasName
-      case SOME(str) then 'typedef <%str%> <%rec_name%>;'
-      else <<
+      case SOME(str) then
+      <<
+      typedef <%str%> <%rec_name%>;
+      typedef <%str%>_external <%rec_name%>_external;
+      >>
+      else
+      <<
       typedef struct {
         <%r.variables |> var as VARIABLE(__) => '<%varType(var)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
       } <%rec_name%>;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -427,6 +427,7 @@ template recordDeclaration(RecordDeclaration recDecl)
     <%recordModelicaCallConstrctor(r.name, r.variables)%>
 
     <%recordCopyDef(r.name, r.variables)%>
+    <%recordCopyExternalDefs(r.name, r.variables)%>
     >>
   case r as RECORD_DECL_ADD_CONSTRCTOR(__) then
     <<
@@ -453,9 +454,9 @@ end recordDeclarationHeader;
 
 template recordDeclarationExtraCtor(RecordDeclaration recDecl)
  "Generates structs for a extra record declaration. An extra
-  record declration is a constrctor with some of its elements provided
+  record declration is a constructor with some of its elements provided
   from outside. Modelica puts a lot of freedom on record creation. You can
-  generaly provide none, some or all elements to create a record without
+  generally provide none, some or all elements to create a record without
   providing a single constructor. Which means a record with N elements
   can have 2^N possible constructions.
   e.g.,
@@ -518,6 +519,11 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
     let cpy_macro_name = '<%rec_name%>_copy'
     let cpy_func_name = '<%cpy_macro_name%>_p'
 
+    let cpy_to_external_macro_name = '<%rec_name%>_copy_to_external'
+    let cpy_to_external_func_name = '<%cpy_to_external_macro_name%>_p'
+    let cpy_from_external_macro_name = '<%rec_name%>_copy_from_external'
+    let cpy_from_external_func_name = '<%cpy_from_external_macro_name%>_p'
+
     let copy_to_vars_name = '<%rec_name%>_copy_to_vars'
     let copy_to_vars_name_p = '<%copy_to_vars_name%>_p'
     let copy_to_vars_inputs = r.variables |> var as VARIABLE(__) => (", " + varType(var) + "* in_" + crefStr(var.name))
@@ -532,6 +538,9 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       typedef struct {
         <%r.variables |> var as VARIABLE(__) => '<%varType(var)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
       } <%rec_name%>;
+      typedef struct {
+        <%r.variables |> var as VARIABLE(__) => '<%extType(var.ty, true, false, false)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
+      } <%rec_name%>_external;
       >> %>
       extern struct record_description <%underscorePath(r.defPath)%>__desc;
 
@@ -539,6 +548,10 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       #define <%ctor_macro_name%>(td, ths <%ctor_macro_additional_inputs%>) <%ctor_func_name%>(td, &ths <%ctor_macro_additional_inputs%>)
       void <%cpy_func_name%>(void* v_src, void* v_dst);
       #define <%cpy_macro_name%>(src,dst) <%cpy_func_name%>(&src, &dst)
+      void <%cpy_to_external_func_name%>(void* v_src, void* v_dst);
+      #define <%cpy_to_external_macro_name%>(src,dst) <%cpy_to_external_func_name%>(&src, &dst)
+      void <%cpy_from_external_func_name%>(void* v_src, void* v_dst);
+      #define <%cpy_from_external_macro_name%>(src,dst) <%cpy_from_external_func_name%>(&src, &dst)
 
       // This function should eventually replace the default 'modelica' record constructor funcition
       // that omc used to generate, i.e., replace functionBodyRecordConstructor template.
@@ -578,6 +591,35 @@ template recordCopyDef(String rec_name, list<Variable> variables)
   >>
 end recordCopyDef;
 
+template recordCopyExternalDefs(String rec_name, list<Variable> variables)
+ "Generates code for copying a record to/from the extrenal C counterpart.
+ The external C counterpart of a record has data types set according to the
+ Modelica Standard. The main difference right now is Intger tyepes. In
+ OpenModelica Integer types are represented by 'long' a.k.a modelica_integer.
+ In the external counter part of the record they are 'int'. These functions
+ make sure the conversion is done using assigment (possiblly truncating values)
+ to make sure that the data is not interpreted wrong due to the size differences.
+ See #8591 for more info."
+::=
+  let &varCopies = buffer ""
+  let &auxFunction = buffer ""
+  let dst_pref = 'dst->'
+  let src_pref = 'src->'
+  let _ = (variables |> var => recordMemberCopyExternals(var, src_pref, dst_pref, &varCopies, &auxFunction) ;separator="\n")
+  <<
+  void <%rec_name%>_copy_to_external_p(void* v_src, void* v_dst) {
+    <%rec_name%>* src = (<%rec_name%>*)(v_src);
+    <%rec_name%>_external* dst = (<%rec_name%>_external*)(v_dst);
+    <%varCopies%>
+  }
+  void <%rec_name%>_copy_from_external_p(void* v_src, void* v_dst) {
+    <%rec_name%>_external* src = (<%rec_name%>_external*)(v_src);
+    <%rec_name%>* dst = (<%rec_name%>*)(v_dst);
+    <%varCopies%>
+  }
+  >>
+end recordCopyExternalDefs;
+
 template recordModelicaCallConstrctor(String rec_name, list<Variable> variables)
  "Generates code for creating and initializing a record given values for
   ALL its members. This is basically what we used to generate before. However
@@ -608,12 +650,12 @@ template recordModelicaCallConstrctor(String rec_name, list<Variable> variables)
                             (", " + varType(var) + " " + src_pref + contextCrefNoPrevExp(var.name, contextFunction, &auxFunction))
                 )
   <<
-  // This function should eventualy replace the default 'modelica' record constructor funcition
+  // This function should eventually replace the default 'modelica' record constructor funcition
   // that omc used to generate, i.e., replace functionBodyRecordConstructor template.
   /*
   <%rec_name%> omc_<%rec_name%>(threadData_t *threadData <%inputs%>) {
     <%rec_name%> dst;
-    // TODO Improve me. No need to initalize the record members with defaults in <%rec_name%>_construct
+    // TODO Improve me. No need to initialize the record members with defaults in <%rec_name%>_construct
     // We should just do the allocs here and then copy the input parameters as default values instead.
     <%rec_name%>_construct(threadData, dst);
     <%varCopies%>
@@ -649,6 +691,31 @@ case var as VARIABLE(__) then
 
   end match
 end recordMemberCopy;
+
+template recordMemberCopyExternals(Variable var, String src_pref, String dst_pref, Text &varCopies, Text &auxFunction)
+  "Generates code for copying memembers of a record during a record copy  to/from the version
+   of the record created for use with external C code.
+   Right now this does not support copying of array or record record memebers. It only handles
+   simple scalar assignments"
+::=
+match var
+case var as VARIABLE(__) then
+  let dstName = dst_pref + contextCrefNoPrevExp(var.name, contextFunction, &auxFunction)
+  let srcName = src_pref + contextCrefNoPrevExp(var.name, contextFunction, &auxFunction)
+
+  match ty
+    case ty as T_ARRAY(__) then
+      let &varCopies += 'assert("Copying of array record members to/from external functions is not yet supported.");<%\n%>'
+      ""
+    case ty as T_COMPLEX(complexClassType=RECORD(__)) then
+      let &varCopies += 'assert("Copying of record record members to/from external functions is not yet supported.");<%\n%>'
+      ""
+    else
+      let &varCopies += '<%dstName%> = <%srcName%>;<%\n%>'
+      ""
+
+  end match
+end recordMemberCopyExternals;
 
 template recordConstructorDef(String ctor_name, String rec_name, list<Variable> variables)
  "Generates code for constructing a record. This means allocating memory for all
@@ -1192,7 +1259,9 @@ template extReturnType(SimExtArg extArg)
  "Generates return type for external function."
 ::=
   match extArg
-  case ex as SIMEXTARG(__)    then extType(type_,true /*Treat this as an input (pass by value, except for records)*/,false,true)
+  /* For records use the externl type version of the record */
+  case ex as SIMEXTARG(type_ = ty as T_COMPLEX(complexClassType=RECORD(__)))  then '<%expTypeShort(ty)%>_external'
+  case ex as SIMEXTARG(__) then extType(type_,true /*Treat this as an input (pass by value, except for records)*/,false,true)
   case SIMNOEXTARG(__)  then "void"
   case SIMEXTARGEXP(__) then error(sourceInfo(), 'Expression types are unsupported as return arguments <%ExpressionDumpTpl.dumpExp(exp,"\"")%>')
   else error(sourceInfo(), "Unsupported return argument")
@@ -2468,13 +2537,15 @@ template extFunCallVardecl(SimExtArg arg, Text &varDecls, Text &auxFunction, Boo
     else
       let lhs = extVarName(c)
       let rhs = contextCrefNoPrevExp(c,contextFunction,&auxFunction)
-      let &varDecls += '<%extType(ty,true,false,false)%> <%lhs%>;<%\n%>'
-      match ty case T_COMPLEX(complexClassType=RECORD(__)) then
+      match ty
+      case T_COMPLEX(complexClassType=RECORD(__)) then
         let rec_typename = expTypeShort(ty)
+        let &varDecls += '<%rec_typename%>_external <%lhs%>;<%\n%>'
         <<
-        <%expTypeShort(ty)%>_copy(<%rhs%>, <%lhs%>);
+        <%rec_typename%>_copy_to_external(<%rhs%>, <%lhs%>);
         >>
-        else
+      else
+        let &varDecls += '<%extType(ty,true,false,false)%> <%lhs%>;<%\n%>'
         <<
         <%lhs%> = (<%extType(ty,true,false,false)%>)<%rhs%>;
         >>
@@ -2483,8 +2554,14 @@ template extFunCallVardecl(SimExtArg arg, Text &varDecls, Text &auxFunction, Boo
     match oi case 0 then
       ""
     else
-      let &varDecls += '<%extType(ty,true,false,true)%> <%extVarName(c)%>;<%\n%>'
-      ""
+      match ty
+      case T_COMPLEX(complexClassType=RECORD(__)) then
+        let rec_typename = expTypeShort(ty)
+        let &varDecls += '<%rec_typename%>_external <%extVarName(c)%>;<%\n%>'
+        ""
+      else
+        let &varDecls += '<%extType(ty,true,false,true)%> <%extVarName(c)%>;<%\n%>'
+        ""
 end extFunCallVardecl;
 
 template extFunCallVardeclF77(SimExtArg arg, Text &varDecls, Text &auxFunction)
@@ -2587,7 +2664,7 @@ case SIMEXTARG(outputIndex=oi, isArray=false, type_ = ty as T_COMPLEX(complexCla
     let lhs = contextCrefNoPrevExp(c,contextFunction,&auxFunction)
     let rec_typename = expTypeShort(ty)
     <<
-    <%expTypeShort(ty)%>_copy(<%rhs%>, <%lhs%>);
+    <%expTypeShort(ty)%>_copy_from_external(<%rhs%>, <%lhs%>);
     >>
 case SIMEXTARG(outputIndex=oi, isArray=false, type_=ty, cref=c) then
     let cr = '<%extVarName(c)%>'


### PR DESCRIPTION
[Cleanup external function handling.](https://github.com/OpenModelica/OpenModelica/commit/e5f21c3d6aefe71a26e94fb8a19171c902e73011) 

  - This is done in preparation for implementing of conversion types and
    function for sending and receiving record types to external C functions
    while making sure that types are interpreted correctly
      `modelica_integer` (a.k.a `long`) vs int right now.'
 
[Handle mapping of recrods to external function arguments.](https://github.com/OpenModelica/OpenModelica/commit/7ed6ed2fc605e53a1c2d0a3277c5d0529f79a184) 

  - Each Modelica record now gets two struct definitions. The first,
    already existing, version uses OpenModelica types for the record members.

    The new additional type uses types specified in Modelica Standard for
    mapping of external arguments, i.e., uses `double`, `int`, `int`, '
    `const char*`, and `int` for Real, Integer, Boolean, String, and Enumeration
    repsectively, regardless of our internal representations.

  - Each Modelica record also gets two addition functions for converting
    to/from one representation of the record to the other.

  - This is a lot of additional code generation. However, it can be mitigated
    by identifying the only records that need it and avoiding it for the others.

  - Records that contain arrays or other records are not yet supported in
    this mode.
 
[Add mapping support for record record members.](https://github.com/OpenModelica/OpenModelica/commit/1e1f9721846162ac37886db5a3e3713d0f7bba42) 

  - Extend the record conversion functions to handle nested records.
  - We do not support arrays yet.
 
[typedef external versions for alias records too.](https://github.com/OpenModelica/OpenModelica/commit/82bb5347ce257ce2116cc035ac2c568ac4647560)


 
[Add marker for records needing conversion to external versions.](https://github.com/OpenModelica/OpenModelica/commit/71caa0d539ab0e744794191fa6e90d202beb1654) 

  - This marker is set to false for all record types at the moment. The
    additional code is generated for all records regardless of the value.

    Once we implement the necessary analysis, we can change the value for
    records that need it and disable the generation being done for all
    records right now.


Improves #8591.