### PR TITLE
cmake: download bootstrapping sources before building

### DIFF
--- a/OMCompiler/.gitignore
+++ b/OMCompiler/.gitignore
@@ -220,3 +220,4 @@ tags
 *clang_output*
 
 Compiler/Util/Autoconf.mo
+Compiler/boot/bomc/

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -1,12 +1,24 @@
 cmake_minimum_required(VERSION 3.14)
 project(bomc)
 
+# fetch the sources from the OM server, maybe we should put them in git someplace
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz")
+# do nothing!
+else()
+#download and unpack the sources
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
+file(DOWNLOAD https://build.openmodelica.org/omc/bootstrap/sources.tar.gz
+     ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz SHOW_PROGRESS)
+execute_process(COMMAND tar xzf sources.tar.gz
+                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
+endif()
+
 # OpenModelicaBootstrappingHeader.h should probably be added to source control and
 # updated just like the bootstrap-source c files.
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tarball-include/OpenModelicaBootstrappingHeader.h
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bomc/tarball-include/OpenModelicaBootstrappingHeader.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/../OpenModelicaBootstrappingHeader.h)
 
-file(GLOB BOOTSTRAP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/bootstrap-sources/build/*.c)
+file(GLOB BOOTSTRAP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/bomc/bootstrap-sources/build/*.c)
 
 add_executable(bomc)
 target_sources(bomc PRIVATE ${BOOTSTRAP_SOURCES})


### PR DESCRIPTION
### Purpose

Fix the cmake builds

### Approach

Download the latest bootstrapping sources before building using cmake.
