### PR TITLE
Always load MSL on startup

### DIFF
--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -757,13 +757,23 @@ void OMCProxy::loadSystemLibraries()
     loadModel("Modelica", "default");
     loadModel("ModelicaReference", "default");
   } else {
+    const bool loadLatestModelica = OptionsDialog::instance()->getLibrariesPage()->getLoadLatestModelicaCheckbox()->isChecked();
+    if (loadLatestModelica) {
+      loadModel("Modelica", "default");
+    }
     QSettings *pSettings = Utilities::getApplicationSettings();
     pSettings->beginGroup("libraries");
     QStringList libraries = pSettings->childKeys();
     pSettings->endGroup();
     foreach (QString lib, libraries) {
       QString version = pSettings->value("libraries/" + lib).toString();
-      loadModel(lib, version);
+      if (loadLatestModelica && (lib.compare(QStringLiteral("Modelica")) == 0 || lib.compare(QStringLiteral("ModelicaServices")) == 0 || lib.compare(QStringLiteral("Complex")) == 0)) {
+        QString msg = tr("Skip loading <b>%1</b> version <b>%2</b> since latest version is already loaded because of the setting <b>Load latest Modelica version on startup</b>.").arg(lib, version);
+        MessageItem messageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::notificationLevel);
+        MessagesWidget::instance()->addGUIMessage(messageItem);
+      } else {
+        loadModel(lib, version);
+      }
     }
     OptionsDialog::instance()->readLibrariesSettings();
   }

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -280,6 +280,10 @@ void OptionsDialog::readLibrariesSettings()
       mpLibrariesPage->getModelicaPathTextBox()->setText(modelicaPath);
     }
   }
+  // read load latest Modelica
+  if (mpSettings->contains("loadLatestModelica")) {
+    mpLibrariesPage->getLoadLatestModelicaCheckbox()->setChecked(mpSettings->value("loadLatestModelica").toBool());
+  }
   // read the system libraries
   int i = 0;
   while(i < mpLibrariesPage->getSystemLibrariesTree()->topLevelItemCount()) {
@@ -1123,6 +1127,8 @@ void OptionsDialog::saveLibrariesSettings()
     mpLibrariesPage->getModelicaPathTextBox()->setPlaceholderText(Helper::ModelicaPath);
     mpSettings->setValue("modelicaPath-1", "");
   }
+  // save load latest Modelica
+  mpSettings->setValue("loadLatestModelica", mpLibrariesPage->getLoadLatestModelicaCheckbox()->isChecked());
   // read the settings and add system libraries
   mpSettings->beginGroup("libraries");
   foreach (QString lib, mpSettings->childKeys()) {
@@ -2239,6 +2245,9 @@ LibrariesPage::LibrariesPage(OptionsDialog *pOptionsDialog)
   // system libraries note
   mpSystemLibrariesNoteLabel = new Label(tr("The system libraries are read from the MODELICAPATH and are always read-only."));
   mpSystemLibrariesNoteLabel->setElideMode(Qt::ElideMiddle);
+  // load latest Modeica checkbox
+  mpLoadLatestModelicaCheckbox = new QCheckBox(tr("Load latest Modelica version on startup"));
+  mpLoadLatestModelicaCheckbox->setChecked(true);
   // system libraries tree
   mpSystemLibrariesTree = new QTreeWidget;
   mpSystemLibrariesTree->setItemDelegate(new ItemDelegate(mpSystemLibrariesTree));
@@ -2268,8 +2277,9 @@ LibrariesPage::LibrariesPage(OptionsDialog *pOptionsDialog)
   QGridLayout *pSystemLibrariesLayout = new QGridLayout;
   pSystemLibrariesLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
   pSystemLibrariesLayout->addWidget(mpSystemLibrariesNoteLabel, 0, 0, 1, 2);
-  pSystemLibrariesLayout->addWidget(mpSystemLibrariesTree, 1, 0);
-  pSystemLibrariesLayout->addWidget(mpSystemLibrariesButtonBox, 1, 1);
+  pSystemLibrariesLayout->addWidget(mpLoadLatestModelicaCheckbox, 1, 0, 1, 2);
+  pSystemLibrariesLayout->addWidget(mpSystemLibrariesTree, 2, 0);
+  pSystemLibrariesLayout->addWidget(mpSystemLibrariesButtonBox, 2, 1);
   mpSystemLibrariesGroupBox->setLayout(pSystemLibrariesLayout);
   // user libraries groupbox
   mpUserLibrariesGroupBox = new QGroupBox(tr("User libraries loaded automatically on startup *"));

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -308,6 +308,7 @@ class LibrariesPage : public QWidget
 public:
   LibrariesPage(OptionsDialog *pOptionsDialog);
   QLineEdit *getModelicaPathTextBox() const {return mpModelicaPathTextBox;}
+  QCheckBox *getLoadLatestModelicaCheckbox() const {return mpLoadLatestModelicaCheckbox;}
   QTreeWidget* getSystemLibrariesTree() {return mpSystemLibrariesTree;}
   QTreeWidget* getUserLibrariesTree() {return mpUserLibrariesTree;}
   OptionsDialog *mpOptionsDialog;
@@ -316,6 +317,7 @@ private:
   Label *mpModelicaPathLabel;
   QLineEdit *mpModelicaPathTextBox;
   Label *mpSystemLibrariesNoteLabel;
+  QCheckBox *mpLoadLatestModelicaCheckbox;
   QTreeWidget *mpSystemLibrariesTree;
   QPushButton *mpAddSystemLibraryButton;
   QPushButton *mpRemoveSystemLibraryButton;

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1159,18 +1159,16 @@ General
 Libraries
 ~~~~~~~~~
 
--  *System Libraries* – The list of system libraries that should be
-   loaded every time OMEdit starts.
+-  General
 
--  *Force loading of Modelica Standard Library* – If true then Modelica
-   and ModelicaReference will always load even if user has removed
-   them from the list of system libraries.
+  -  *MODELICAPATH* – Sets the MODELICAPATH. MODELICAPATH is used to load libraries.
 
--  *Load OpenModelica library on startup* – If true then OpenModelica
-   package will be loaded when OMEdit is started.
+-  System libraries loaded automatically on startup - The list of system libraries that are loaded on startup.
 
--  *User Libraries* – The list of user libraries/files that should be
-   loaded every time OMEdit starts.
+  -  *Load latest Modelica version on startup* - Is true then the latest available version of the
+     Modelica Standard Library is always loaded alongwith its dependencies.
+
+-  User libraries loaded automatically on startup - The list of user libraries/files that are loaded on startup.
 
 .. _omedit-options-text-editor :
 


### PR DESCRIPTION
### Related Issues

#8291 

### Purpose

Always load latest version of Modelica Standard Library.

### Approach

Added a setting to enable/disable the auto loading of latest MSL version.

Updated the settings dialog,
![image](https://user-images.githubusercontent.com/4007231/191942585-79d2d5f0-5b96-40d3-b6d1-c533f4e83e22.png)

By default the option `Load latest Modelica version on startup` is enabled which makes sure that OMEdit will call `loadModel(Modelica, "default")`. Now we should fix the class loader to automatically install the MSL from cache when loadModel is called.

If `Load latest Modelica version on startup` option is checked and user also have Modelica 3.2.3 listed as system library to be loaded on startup in the second red rectangle then OMEdit skips loading that and gives a notification that Modelica is already loaded because of setting `Load latest Modelica version on startup`.




