### PR TITLE
Improve #9399 using additions from #9408

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -964,7 +964,7 @@ public uniontype Type "models the different front-end and back-end types"
     ClassInf.State complexClassType "The type of a class";
     list<Var> varLst "The variables of a complex type";
     EqualityConstraint equalityConstraint;
-    Boolean needsExternalConversion "If the record is passed to an external function at any point, we need to generate conversion functions for it (for instance to convert 'modelica_integer' to 'int')";
+    Boolean usedExternally "If the record is passed to an external function at any point, we need to generate conversion functions for it (for instance to convert 'modelica_integer' to 'int')";
   end T_COMPLEX;
 
   record T_SUBTYPE_BASIC

--- a/OMCompiler/Compiler/FrontEnd/Inst.mo
+++ b/OMCompiler/Compiler/FrontEnd/Inst.mo
@@ -1012,7 +1012,7 @@ algorithm
       end for;
       tvars := listReverse(tvars);
 
-    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint, inType.needsExternalConversion);
+    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint, inType.usedExternally);
   end match;
 
 end markDerivedRecordOutsideBindings;
@@ -1084,7 +1084,7 @@ algorithm
       end for;
       tvars := listReverse(tvars);
 
-    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint, inType.needsExternalConversion);
+    then DAE.T_COMPLEX(inType.complexClassType, tvars, inType.equalityConstraint, inType.usedExternally);
   end match;
 
 end markTypesVarsOutsideBindings;

--- a/OMCompiler/Compiler/FrontEnd/InstSection.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstSection.mo
@@ -3108,7 +3108,7 @@ algorithm
       equation
         vars = List.sort(vars, connectorCompGt);
       then
-        DAE.T_COMPLEX(ci_state, vars, ec, inType.needsExternalConversion);
+        DAE.T_COMPLEX(ci_state, vars, ec, inType.usedExternally);
 
     else inType;
 

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -5545,7 +5545,7 @@ algorithm
     case (_,st,l,NONE(),equalityConstraint,_)
       equation
         failure(ClassInf.META_UNIONTYPE(_) = st);
-      then DAE.T_COMPLEX(st,l,equalityConstraint, false);
+      then DAE.T_COMPLEX(st,l,equalityConstraint, true);
 
     // extending
     case (_,st,l,SOME(bc),equalityConstraint,_)
@@ -5646,7 +5646,7 @@ algorithm
 
     // not extending basic type!
     case (_,st,l,NONE(),_)
-      then DAE.T_COMPLEX(st,l,NONE(), false); // adrpo: TODO! check equalityConstraint!
+      then DAE.T_COMPLEX(st,l,NONE(), true); // adrpo: TODO! check equalityConstraint!
 
     case (_,st,l,SOME(bc),_)
       then DAE.T_SUBTYPE_BASIC(st,l,bc,NONE());

--- a/OMCompiler/Compiler/FrontEnd/Types.mo
+++ b/OMCompiler/Compiler/FrontEnd/Types.mo
@@ -441,7 +441,7 @@ algorithm
       equation
         vars = List.map(vars, convertFromExpToTypesVar);
       then
-        DAE.T_COMPLEX(CIS, vars, ec, inType.needsExternalConversion);
+        DAE.T_COMPLEX(CIS, vars, ec, inType.usedExternally);
 
     case DAE.T_SUBTYPE_BASIC(CIS, vars, ty, ec)
       equation
@@ -3871,7 +3871,7 @@ algorithm
         true = Config.acceptMetaModelicaGrammar();
         varLst = list(simplifyVar(v) for v in varLst);
       then
-        DAE.T_COMPLEX(CIS, varLst, ec, inType.needsExternalConversion);
+        DAE.T_COMPLEX(CIS, varLst, ec, inType.usedExternally);
 
     // do this for records too, otherwise:
     // frame.R = Modelica.Mechanics.MultiBody.Frames.Orientation({const_matrix);
@@ -3880,7 +3880,7 @@ algorithm
       equation
         varLst = list(simplifyVar(v) for v in varLst);
       then
-        DAE.T_COMPLEX(CIS, varLst, ec, inType.needsExternalConversion);
+        DAE.T_COMPLEX(CIS, varLst, ec, inType.usedExternally);
 
     // otherwise just return the same!
     case DAE.T_COMPLEX() then inType;

--- a/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunction.mo
@@ -120,7 +120,7 @@ uniontype RecordDeclaration
     Option<String> aliasName "alias of struct (record) name ? encoded. Code generators can generate an aliasing typedef using this, and avoid problems when casting a record from one type to another (*(othertype*)(&var)), which only works if you have a lhs value.";
     Absyn.Path defPath "definition path";
     list<Variable> variables "only name and type";
-    Boolean needsExternalConversion "If the record is passed to an external function at any point, we need to generate conversion functions for it (for instance to convert 'modelica_integer' to 'int')";
+    Boolean usedExternally "If the record is passed to an external function at any point, we need to generate conversion functions for it (for instance to convert 'modelica_integer' to 'int')";
   end RECORD_DECL_FULL;
 
   record RECORD_DECL_ADD_CONSTRCTOR

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1678,6 +1678,7 @@ algorithm
           fieldNames = List.map(varlst, generateVarName);
           accRecDecls = SimCodeFunction.RECORD_DECL_DEF(path, fieldNames) :: accRecDecls;
           rt_1 = sname::rt;
+          UnorderedMap.add(sname, SimCodeFunction.RECORD_DECL_DEF(path, fieldNames), declMap);
           (accRecDecls, rt_1) = elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1, declMap);
         else
           rt_1 = rt;
@@ -1878,6 +1879,7 @@ algorithm
         b = listMember(name, rt);
         accRecDecls = List.consOnTrue(not b, SimCodeFunction.RECORD_DECL_DEF(path, fieldNames), accRecDecls);
         rt_1 = List.consOnTrue(not b, name, rt);
+        UnorderedMap.add(name, SimCodeFunction.RECORD_DECL_DEF(path, fieldNames), declMap);
         (accRecDecls, rt_2) = elaborateRecordDeclarationsForMetarecords(rest, accRecDecls, rt_1, declMap);
       then (accRecDecls, rt_2);
    case (_::rest, accRecDecls, rt)

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1659,21 +1659,21 @@ algorithm
         end if;
 
 
-        if not listMember(sname, rt_1) then
-          rt_1 := sname :: rt_1;
+        // if not listMember(sname, rt_1) then
+        //   rt_1 := sname :: rt_1;
 
-          if is_default then
-            (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1, declMap);
+        //   if is_default then
+        //     (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1, declMap);
 
-            vars := List.map(varlst, typesVar);
-            recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars, needsExternalConversion);
-          else
-            vars := List.map(varlst, typesVar);
-            recDecl := SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(sname, name, vars);
-          end if;
+        //     vars := List.map(varlst, typesVar);
+        //     recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars, needsExternalConversion);
+        //   else
+        //     vars := List.map(varlst, typesVar);
+        //     recDecl := SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(sname, name, vars);
+        //   end if;
 
-          accRecDecls := List.appendElt(recDecl, accRecDecls);
-        end if;
+        //   accRecDecls := List.appendElt(recDecl, accRecDecls);
+        // end if;
 
 
       then (accRecDecls, rt_1);

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1613,9 +1613,9 @@ algorithm
       list<SimCodeFunction.Variable> vars;
       Integer varnum;
       SimCodeFunction.RecordDeclaration recDecl;
-      Boolean is_default;
+      Boolean is_default, needsExternalConversion;
 
-    case (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path), varLst = varlst), accRecDecls, rt)
+    case (DAE.T_COMPLEX(complexClassType = ClassInf.RECORD(path), varLst = varlst, needsExternalConversion = needsExternalConversion), accRecDecls, rt)
       algorithm
         name := AbsynUtil.pathStringUnquoteReplaceDot(path, "_");
         rt_1 := rt;
@@ -1630,7 +1630,7 @@ algorithm
             (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1);
 
             vars := List.map(varlst, typesVar);
-            recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars, false);
+            recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars, needsExternalConversion);
           else
             vars := List.map(varlst, typesVar);
             recDecl := SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(sname, name, vars);

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -481,7 +481,7 @@ public function elaborateFunctions
   output list<String> libpaths;
 protected
   list<SimCodeFunction.Function> fns;
-  list<String> outRecordTypes;
+  list<String> outRecordTypes, recordNames;
   HashTableStringToPath.HashTable ht;
   list<tuple<SimCodeFunction.RecordDeclaration,list<SimCodeFunction.RecordDeclaration>>> g;
   UnorderedMap<String, SimCodeFunction.RecordDeclaration> declMap;
@@ -493,7 +493,20 @@ algorithm
   (functions, outRecordTypes, extraRecordDecls, outIncludes, includeDirs, libs,libpaths) := elaborateFunctions2(program, daeElements, {}, outRecordTypes, extraRecordDecls, includes, {}, {},{}, declMap);
   extraRecordDecls := List.unique(extraRecordDecls);
   (extraRecordDecls, _) := elaborateRecordDeclarationsFromTypes(metarecordTypes, extraRecordDecls, outRecordTypes, declMap);
+
+  extraRecordDecls := UnorderedMap.valueList(declMap);
+
   extraRecordDecls := List.sort(extraRecordDecls, orderRecordDecls);
+
+
+  recordNames := UnorderedMap.keyList(declMap);
+
+
+  // if not List.isEqual(recordNames, outRecordTypes, true) then
+  //   Error.addInternalError("Records collected do not match: \n", sourceInfo());
+  // end if;
+
+
   ht := HashTableStringToPath.emptyHashTableSized(BaseHashTable.lowBucketSize);
   (extraRecordDecls,_) := List.mapFold(extraRecordDecls, aliasRecordDeclarations, ht);
   // Topological sort since we have no guarantees in the order of generated records

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -713,7 +713,7 @@ algorithm
 
         outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
-        elaborateRecordDeclarations(daeElts, declMap);
+        collectRecDeclsFromElems(daeElts, declMap);
         vars = List.filterOnTrue(daeElts, isVarQ);
         varDecls = List.map(vars, daeInOutSimVar);
         bodyStmts = listAppend(elaborateStatement(e) for e guard DAEUtil.isAlgorithm(e) in daeElts);
@@ -732,7 +732,7 @@ algorithm
 
         outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
-        elaborateRecordDeclarations(daeElts, declMap);
+        collectRecDeclsFromElems(daeElts, declMap);
         vars = List.filterOnTrue(daeElts, isVarNotInputNotOutput);
         varDecls = List.map(vars, daeInOutSimVar);
         bodyStmts = listAppend(elaborateStatement(e) for e guard DAEUtil.isAlgorithm(e) in daeElts);
@@ -751,7 +751,7 @@ algorithm
 
         outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         funArgs = List.map1(args, typesSimFunctionArg, NONE());
-        elaborateRecordDeclarations(daeElts, declMap);
+        collectRecDeclsFromElems(daeElts, declMap);
         vars = List.filterOnTrue(daeElts, isVarQ);
         varDecls = List.map(vars, daeInOutSimVar);
         bodyStmts = listAppend(elaborateStatement(e) for e guard DAEUtil.isAlgorithm(e) in daeElts);
@@ -773,7 +773,7 @@ algorithm
         outVars = List.map(DAEUtil.getOutputElements(daeElts), daeInOutSimVar);
         inVars = List.map(DAEUtil.getInputVars(daeElts), daeInOutSimVar);
         biVars = List.map(DAEUtil.getBidirElements(daeElts), daeInOutSimVar);
-        elaborateRecordDeclarations(daeElts, declMap);
+        collectRecDeclsFromElems(daeElts, declMap);
         info = ElementSource.getElementSourceFileInfo(source);
         (fn_includes, fn_includeDirs, fn_libs, fn_paths,dynamicLoad) = generateExtFunctionIncludes(program, fpath, ann, info);
         includes = List.union(fn_includes, includes);
@@ -1404,7 +1404,7 @@ algorithm
   end for;
 end collectRecDeclsFromTypes;
 
-protected function elaborateRecordDeclarations
+protected function collectRecDeclsFromElems
 "Translate all records used by varlist to structs."
   input list<DAE.Element> inVars;
   input UnorderedMap<String, SimCodeFunction.RecordDeclaration> declMap;
@@ -1426,7 +1426,7 @@ algorithm
         if Util.isSome(binding) and Config.acceptMetaModelicaGrammar() then
           (_, _) = Expression.traverseExpBottomUp(Util.getOption(binding), collectRecDeclsFromMetaRecCallExp, declMap);
         end if;
-        elaborateRecordDeclarations(rest, declMap);
+        collectRecDeclsFromElems(rest, declMap);
       then
         ();
 
@@ -1435,17 +1435,17 @@ algorithm
         true = Config.acceptMetaModelicaGrammar();
         (_, _) = DAEUtil.traverseAlgorithmExps(algorithm_, Expression.traverseSubexpressionsHelper, (collectRecDeclsFromMetaRecCallExp, declMap));
         // TODO: ? what about rest ? , can be there something else after the ALGORITHM
-        elaborateRecordDeclarations(rest, declMap);
+        collectRecDeclsFromElems(rest, declMap);
       then
         ();
 
     case (_ :: rest)
       equation
-        elaborateRecordDeclarations(rest, declMap);
+        collectRecDeclsFromElems(rest, declMap);
       then
         ();
   end matchcontinue;
-end elaborateRecordDeclarations;
+end collectRecDeclsFromElems;
 
 protected function isVarQ
 "Succeeds if inElement is a variable or constant that is not input."
@@ -1758,7 +1758,7 @@ algorithm
 end generateVarName;
 
 protected function collectRecDeclsFromTypesVars
-"Helper function to elaborateRecordDeclarations."
+"Helper function to collectRecDeclsFromElems."
   input list<DAE.Var> inRecordTypeVars;
   input UnorderedMap<String, SimCodeFunction.RecordDeclaration> declMap;
 algorithm

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -1647,11 +1647,11 @@ algorithm
         // is_default := stringEqual(sname,name);
 
         if is_default then
-          (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1, declMap);
-
           vars := List.map(varlst, typesVar);
           recDecl := SimCodeFunction.RECORD_DECL_FULL(sname, NONE(), path, vars, needsExternalConversion);
           UnorderedMap.add(sname, recDecl, declMap);
+
+          (accRecDecls, rt_1) := elaborateNestedRecordDeclarations(varlst, accRecDecls, rt_1, declMap);
         else
           vars := List.map(varlst, typesVar);
           recDecl := SimCodeFunction.RECORD_DECL_ADD_CONSTRCTOR(sname, name, vars);

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -427,7 +427,7 @@ template recordDeclaration(RecordDeclaration recDecl)
     <%recordModelicaCallConstrctor(r.name, r.variables)%>
 
     <%recordCopyDef(r.name, r.variables)%>
-    <%if r.needsExternalConversion then recordCopyExternalDefs(r.name, r.variables)%>
+    <%if r.usedExternally then recordCopyExternalDefs(r.name, r.variables)%>
     >>
   case r as RECORD_DECL_ADD_CONSTRCTOR(__) then
     <<
@@ -536,7 +536,7 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       case SOME(str) then
       <<
       typedef <%str%> <%rec_name%>;
-      <% if r.needsExternalConversion then
+      <% if r.usedExternally then
         <<
         typedef <%str%>_external <%rec_name%>_external;
         >>
@@ -547,7 +547,7 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       typedef struct {
         <%r.variables |> var as VARIABLE(__) => '<%varType(var)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
       } <%rec_name%>;
-      <% if r.needsExternalConversion then
+      <% if r.usedExternally then
         <<
         typedef struct {
           <%r.variables |> var as VARIABLE(__) => '<%extType(var.ty, true, false, false)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
@@ -563,7 +563,7 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       void <%cpy_func_name%>(void* v_src, void* v_dst);
       #define <%cpy_macro_name%>(src,dst) <%cpy_func_name%>(&src, &dst)
 
-      <%if r.needsExternalConversion then
+      <%if r.usedExternally then
         <<
         void <%cpy_to_external_func_name%>(void* v_src, void* v_dst);
         #define <%cpy_to_external_macro_name%>(src,dst) <%cpy_to_external_func_name%>(&src, &dst)

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -427,7 +427,7 @@ template recordDeclaration(RecordDeclaration recDecl)
     <%recordModelicaCallConstrctor(r.name, r.variables)%>
 
     <%recordCopyDef(r.name, r.variables)%>
-    <%recordCopyExternalDefs(r.name, r.variables)%>
+    <%if r.needsExternalConversion then recordCopyExternalDefs(r.name, r.variables)%>
     >>
   case r as RECORD_DECL_ADD_CONSTRCTOR(__) then
     <<
@@ -498,7 +498,7 @@ end recordDeclarationExtraCtor;
 
 template recordDeclarationFullHeader(RecordDeclaration recDecl)
  "Generates structs for a record declaration. This will generate
-  a default record construtor function (no argumens) and a record copy function.
+  a default record constructor function (no arguments) and a record copy function.
   These generated functions are fully recursive. That means records in records
   will be handled properly.
   It will also generate (#define) array versions of these functions."
@@ -536,28 +536,41 @@ template recordDeclarationFullHeader(RecordDeclaration recDecl)
       case SOME(str) then
       <<
       typedef <%str%> <%rec_name%>;
-      typedef <%str%>_external <%rec_name%>_external;
+      <% if r.needsExternalConversion then
+        <<
+        typedef <%str%>_external <%rec_name%>_external;
+        >>
+      %>
       >>
       else
       <<
       typedef struct {
         <%r.variables |> var as VARIABLE(__) => '<%varType(var)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
       } <%rec_name%>;
-      typedef struct {
-        <%r.variables |> var as VARIABLE(__) => '<%extType(var.ty, true, false, false)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
-      } <%rec_name%>_external;
-      >> %>
+      <% if r.needsExternalConversion then
+        <<
+        typedef struct {
+          <%r.variables |> var as VARIABLE(__) => '<%extType(var.ty, true, false, false)%> _<%crefStr(var.name)%>;' ;separator="\n"%>
+        } <%rec_name%>_external;
+        >>
+      %>
+      >>
+      %>
       extern struct record_description <%underscorePath(r.defPath)%>__desc;
 
       void <%ctor_func_name%>(threadData_t *threadData, void* v_ths <%ctor_additional_inputs%>);
       #define <%ctor_macro_name%>(td, ths <%ctor_macro_additional_inputs%>) <%ctor_func_name%>(td, &ths <%ctor_macro_additional_inputs%>)
       void <%cpy_func_name%>(void* v_src, void* v_dst);
       #define <%cpy_macro_name%>(src,dst) <%cpy_func_name%>(&src, &dst)
-      void <%cpy_to_external_func_name%>(void* v_src, void* v_dst);
-      #define <%cpy_to_external_macro_name%>(src,dst) <%cpy_to_external_func_name%>(&src, &dst)
-      void <%cpy_from_external_func_name%>(void* v_src, void* v_dst);
-      #define <%cpy_from_external_macro_name%>(src,dst) <%cpy_from_external_func_name%>(&src, &dst)
 
+      <%if r.needsExternalConversion then
+        <<
+        void <%cpy_to_external_func_name%>(void* v_src, void* v_dst);
+        #define <%cpy_to_external_macro_name%>(src,dst) <%cpy_to_external_func_name%>(&src, &dst)
+        void <%cpy_from_external_func_name%>(void* v_src, void* v_dst);
+        #define <%cpy_from_external_macro_name%>(src,dst) <%cpy_from_external_func_name%>(&src, &dst)
+        >>
+      %>
       // This function should eventually replace the default 'modelica' record constructor funcition
       // that omc used to generate, i.e., replace functionBodyRecordConstructor template.
       // <%rec_name%> <%modelica_ctor_name%>(threadData_t *threadData <%modelica_ctor_inputs%>);

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1045,6 +1045,7 @@ package SimCodeFunction
       Option<String> aliasName;
       Absyn.Path defPath;
       list<Variable> variables;
+      Boolean needsExternalConversion;
     end RECORD_DECL_FULL;
     record RECORD_DECL_ADD_CONSTRCTOR
       String ctor_name;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1045,7 +1045,7 @@ package SimCodeFunction
       Option<String> aliasName;
       Absyn.Path defPath;
       list<Variable> variables;
-      Boolean needsExternalConversion;
+      Boolean usedExternally;
     end RECORD_DECL_FULL;
     record RECORD_DECL_ADD_CONSTRCTOR
       String ctor_name;


### PR DESCRIPTION
This improves the fix for #8591 (done in #9399) using the additional information from the NF provided by #9408. 

After these changes, the NF will generate the additional external conversion code only when it is needed. The OF will still cause generation of unnecessary code. However, it is minimal or none for MetaModelica usage. For Modelica usage it generates more but is not supposed to be used for that purpose anymore. It only affects some tests in the test suite that still use the OF for now.


----------------------------------------------------------
      
- [Use the externally used records marker.](https://github.com/OpenModelica/OpenModelica/commit/aaa1fafd08a973f4af4ef6f206344ee9978e9295)

 
- [Set marker to always be true for the OF.](https://github.com/OpenModelica/OpenModelica/commit/27d853c50715fd2ac20e1ea381a40da147021a18)

 
- [Use a map/dictionary instead of keeping separate lists.](https://github.com/OpenModelica/OpenModelica/commit/40d42e23adaa4986b4fbfd83d57aae10c50c91d6) 

  - Use a map (string, record Declaration) to keep a track of records in
    the SimCode. This allows for a simpler and quicker check. In addition
    we can update entries easily.
 
- [Add MetaModelica records to the map as well.](https://github.com/OpenModelica/OpenModelica/commit/b013cbf412021fa7f7df5211ad237f2d46fe6f8d)

 
- [Debug help](https://github.com/OpenModelica/OpenModelica/commit/3e0be2f07ecd138cde5a9dadab6193f821521bd3)

 
- [Fix traversal order to avoid possible(?) infinite recursion.](https://github.com/OpenModelica/OpenModelica/commit/5c49ce6b2d63b5be051f59a60e61a4ed57789831)

 
- [Disable the old creation of record declarations.](https://github.com/OpenModelica/OpenModelica/commit/0a0dffce22c453c407029d7de4c52ffbab4b948f) 

  - See what fails in the testsuite.
  - It was actually affecting some tests because nested records were cycling
    back and messing with the order. Not exactly sure how but is not
    relevant anymore.
 
- [Simplify processing of record declrations.](https://github.com/OpenModelica/OpenModelica/commit/2fc57eee60723365eecabbdfe95976995f2eb976) 

  - Remove returned lists from functions:
     elaborateNestedRecordDeclarations
     elaborateRecordDeclarationsFromTypes
     elaborateRecordDeclarationsForRecord
     elaborateNestedRecordDeclarations

  - Remove input lists from functions:
    - elaborateRecordDeclarationsFromTypes
 
- [Make sure we do not overwrite true values to false.](https://github.com/OpenModelica/OpenModelica/commit/488e93937191994e4e7bd4fe85e7e74a3b6d7b4a) 

  - If an entry already exists in the map and we always update, then there
    is a chance we might overwrite a 'true' value with a 'false' value
    for external conversion marker.

    Check if the entry exists and if it is marked false while then new
    incoming entry is marked true, then update it. Otherwise do nothing.
 
- [Remove input lists from functions](https://github.com/OpenModelica/OpenModelica/commit/37622964704f0ec7a6d1f3ec4b172d85295d677c) 

  - Remove input lists from functions:
    - elaborateNestedRecordDeclarations
    - elaborateRecordDeclarationsForRecord
 
- [Remove input and output lists from more functions.](https://github.com/OpenModelica/OpenModelica/commit/8eb7c590cd7ba8cdfc36da9cc1503a8ae2285fdf) 

  - Removed from
    - elaborateRecordDeclarationsForMetarecords
 
- [Remove input and output lists from elaborateRecordDeclarations.](https://github.com/OpenModelica/OpenModelica/commit/75ae70dd33dc0d4d26e03b8271196c28763072ee)

 
- [Remove input and output lists from more functions.](https://github.com/OpenModelica/OpenModelica/commit/703ef91b3082cab9c36ab159daf444443721a9ba) 

  - Remove input and output lists from functions:
    - elaborateFunctions2
    - elaborateFunction
 
- [Convert recursive functions to loops.](https://github.com/OpenModelica/OpenModelica/commit/72e4c0419ef4cb1982aafa88d6004fd40e373134) 

  - Recursive functions converted to loops:
    - elaborateNestedRecordDeclarations
    - elaborateRecordDeclarationsForMetarecords
    - elaborateRecordDeclarationsFromTypes
 
- [Rename some functions to be more descriptive.](https://github.com/OpenModelica/OpenModelica/commit/3f1c929a952ed6f5f1680d20b959c2d551b08d01) 

  - elaborateRecordDeclarationsForMetarecords -> collectRecDeclsFromMetaRecordCallExps
  - elaborateNestedRecordDeclarations -> collectRecDeclsFromTypesVars
  - elaborateRecordDeclarationsFromTypes -> collectRecDeclsFromTypes
  - elaborateRecordDeclarationsForRecord -> collectRecDeclsFromType
 
- [Change how records are collected from metarecordcalls](https://github.com/OpenModelica/OpenModelica/commit/2c081a32d17d0942883fbabe258964133b5d2030) 

  - Instead of:
    - traversing all expressions, collecting all meta record calls to a list,
      and then traversing this list to collect record declarations

    - collect record declarations while traversing all expressions (without
      collecting metarecordcalls into a whole new list.)
 
- [Rename functions to be more descriptive.](https://github.com/OpenModelica/OpenModelica/commit/237d047ab583aea982d6d27d13bcd80dd3591cc9) 

  - elaborateRecordDeclarations -> collectRecDeclsFromElems
 
- [Convert recursive functions to loops.](https://github.com/OpenModelica/OpenModelica/commit/fc9cdbf4999e96f6387bace2d550d55c992e9c61) 

  - Convert recursive functions to loops:
    - collectRecDeclsFromElems (used to be `elaborateRecordDeclarations`)
 
- [Some minor cleanup and renaming.](https://github.com/OpenModelica/OpenModelica/commit/cffb19923bb2e9382f3e7ac50e07fa8e7b907c7e) 

  - declMap -> recDeclsMap
  - needsExternalConversion -> usedExternally












































































































































