### PR TITLE
[OMEdit] Additional parameters for vector scaling

### DIFF
--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -418,7 +418,7 @@ bool AbstractAnimationWindow::loadVisualization()
     //add scene for the chosen visualization
     mpViewerWidget->getSceneView()->setSceneData(mpVisualization->getOMVisScene()->getScene().getRootNode().get());
     //choose suitable scales for the vector visualizers so that they fit well in the scene
-    mpVisualization->chooseVectorScales(mpViewerWidget->getSceneView(), mpViewerWidget->getFrameMutex(), std::bind(&ViewerWidget::frame, mpViewerWidget));
+    mpVisualization->getBaseData()->chooseVectorScales(mpViewerWidget->getSceneView(), mpViewerWidget->getFrameMutex(), std::bind(&ViewerWidget::frame, mpViewerWidget));
   }
   //add window title
   setWindowTitle(QString::fromStdString(mFileName));

--- a/OMEdit/OMEditLIB/Animation/Vector.h
+++ b/OMEdit/OMEditLIB/Animation/Vector.h
@@ -59,11 +59,14 @@ public:
   float getScaleTransf() const {return mScaleTransf;}
   void setAutoScaleCancellationRequired(const bool required) {mAutoScaleCancellationRequired = required;}
   bool getAutoScaleCancellationRequired() const {return mAutoScaleCancellationRequired;}
+  void setCoordinates(const float x, const float y, const float z) {_coords[0].exp = x, _coords[1].exp = y, _coords[2].exp = z;}
+  void getCoordinates(float* x, float* y, float* z) const {*x = _coords[0].exp, *y = _coords[1].exp, *z = _coords[2].exp;}
   float getLength    () const {return mScaleTransf * mScaleLength * std::sqrt(_coords[0].exp * _coords[0].exp + _coords[1].exp * _coords[1].exp + _coords[2].exp * _coords[2].exp);}
   float getRadius    () const {return mScaleTransf * mScaleRadius * kRadius    ;}
   float getHeadLength() const {return mScaleTransf * mScaleRadius * kHeadLength;}
   float getHeadRadius() const {return mScaleTransf * mScaleRadius * kHeadRadius;}
   VectorQuantity getQuantity() const {return static_cast<VectorQuantity>(_quantity.exp);}
+  bool areCoordinatesConstant() const {return _coords[0].isConst && _coords[1].isConst && _coords[2].isConst;}
   bool hasHeadAtOrigin() const {return _headAtOrigin.exp;}
   bool isTwoHeadedArrow() const {return _twoHeadedArrow.exp;}
   bool isAdjustableRadius() const {return getQuantity() != VectorQuantity::relativePosition;}

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -473,17 +473,7 @@ void ViewerWidget::removeTexture()
  */
 void ViewerWidget::resetTransparencyAndTextureForAllVisualizers()
 {
-  std::vector<ShapeObject>& shapes = mpAnimationWidget->getVisualization()->getBaseData()->_shapes;
-  std::vector<VectorObject>& vectors = mpAnimationWidget->getVisualization()->getBaseData()->_vectors;
-  std::vector<std::reference_wrapper<AbstractVisualizerObject>> visualizers;
-  visualizers.reserve(shapes.size() + vectors.size());
-  for (ShapeObject& shape : shapes) {
-    visualizers.push_back(shape);
-  }
-  for (VectorObject& vector : vectors) {
-    visualizers.push_back(vector);
-  }
-  for (AbstractVisualizerObject& visualizer : visualizers) {
+  for (AbstractVisualizerObject& visualizer : mpAnimationWidget->getVisualization()->getBaseData()->getVisualizerObjects()) {
     visualizer.setTransparency(0.0);
     visualizer.setTextureImagePath("");
     mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(visualizer);

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -342,7 +342,7 @@ void ViewerWidget::changeVisualizerTransparency()
                                                   currentTransparency, min, max, step, &ok);
     if (ok) { // Picked transparency is not OK if the user cancels the dialog
       mpSelectedVisualizer->setTransparency((float) (transparency - min) / (max - min));
-      mpAnimationWidget->getVisualization()->modifyVisualizer(mpSelectedVisualizer);
+      mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     }
     mpSelectedVisualizer = nullptr;
   }
@@ -365,7 +365,7 @@ void ViewerWidget::makeVisualizerInvisible()
       }
     }
     mpSelectedVisualizer->setTransparency(1.0);
-    mpAnimationWidget->getVisualization()->modifyVisualizer(mpSelectedVisualizer);
+    mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     mpSelectedVisualizer = nullptr;
   }
 }
@@ -390,7 +390,7 @@ void ViewerWidget::changeVisualizerColor()
     const QColor color = QColorDialog::getColor(currentColor, this, Helper::chooseColor);
     if (color.isValid()) { // Picked color is invalid if the user cancels the dialog
       mpSelectedVisualizer->setColor(color);
-      mpAnimationWidget->getVisualization()->modifyVisualizer(mpSelectedVisualizer);
+      mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     }
     mpSelectedVisualizer = nullptr;
   }
@@ -413,7 +413,7 @@ void ViewerWidget::applyCheckerTexture()
       }
     }
     mpSelectedVisualizer->setTextureImagePath(":/Resources/bitmaps/check.png");
-    mpAnimationWidget->getVisualization()->modifyVisualizer(mpSelectedVisualizer);
+    mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     mpSelectedVisualizer = nullptr;
   }
 }
@@ -439,7 +439,7 @@ void ViewerWidget::applyCustomTexture()
                                                             (QString*) currentFileName, Helper::bitmapFileTypes, nullptr);
     if (!fileName.isEmpty()) { // Picked file name is empty if the user cancels the dialog
       mpSelectedVisualizer->setTextureImagePath(fileName.toStdString());
-      mpAnimationWidget->getVisualization()->modifyVisualizer(mpSelectedVisualizer);
+      mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     }
     mpSelectedVisualizer = nullptr;
   }
@@ -462,7 +462,7 @@ void ViewerWidget::removeTexture()
       }
     }
     mpSelectedVisualizer->setTextureImagePath("");
-    mpAnimationWidget->getVisualization()->modifyVisualizer(mpSelectedVisualizer);
+    mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     mpSelectedVisualizer = nullptr;
   }
 }
@@ -486,7 +486,7 @@ void ViewerWidget::resetTransparencyAndTextureForAllVisualizers()
   for (AbstractVisualizerObject& visualizer : visualizers) {
     visualizer.setTransparency(0.0);
     visualizer.setTextureImagePath("");
-    mpAnimationWidget->getVisualization()->modifyVisualizer(visualizer);
+    mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(visualizer);
   }
 }
 

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -117,12 +117,11 @@ const std::string OMVisualBase::getXMLFileName() const
 }
 
 /*!
- * \brief OMVisualBase::getVisualizerObjectByIdx
- * get the AbstractVisualizerObject with the same visualizerIdx
- *\param the index of the visualizer
- *\return the selected visualizer
+ * \brief OMVisualBase::getVisualizerObjects
+ * get a container of AbstractVisualizerObject
+ * \return all the visualizers
  */
-AbstractVisualizerObject* OMVisualBase::getVisualizerObjectByIdx(const std::size_t visualizerIdx)
+std::vector<std::reference_wrapper<AbstractVisualizerObject>> OMVisualBase::getVisualizerObjects()
 {
   std::vector<std::reference_wrapper<AbstractVisualizerObject>> visualizers;
   visualizers.reserve(_shapes.size() + _vectors.size());
@@ -132,6 +131,18 @@ AbstractVisualizerObject* OMVisualBase::getVisualizerObjectByIdx(const std::size
   for (VectorObject& vector : _vectors) {
     visualizers.push_back(vector);
   }
+  return visualizers;
+}
+
+/*!
+ * \brief OMVisualBase::getVisualizerObjectByIdx
+ * get the AbstractVisualizerObject with the same visualizerIdx
+ * \param the index of the visualizer
+ * \return the selected visualizer
+ */
+AbstractVisualizerObject* OMVisualBase::getVisualizerObjectByIdx(const std::size_t visualizerIdx)
+{
+  std::vector<std::reference_wrapper<AbstractVisualizerObject>> visualizers = getVisualizerObjects();
   if (visualizerIdx < visualizers.size()) {
     return &visualizers.at(visualizerIdx).get();
   }
@@ -141,20 +152,12 @@ AbstractVisualizerObject* OMVisualBase::getVisualizerObjectByIdx(const std::size
 /*!
  * \brief OMVisualBase::getVisualizerObjectByID
  * get the AbstractVisualizerObject with the same visualizerID
- *\param the name of the visualizer
- *\return the selected visualizer
+ * \param the name of the visualizer
+ * \return the selected visualizer
  */
 AbstractVisualizerObject* OMVisualBase::getVisualizerObjectByID(const std::string& visualizerID)
 {
-  std::vector<std::reference_wrapper<AbstractVisualizerObject>> visualizers;
-  visualizers.reserve(_shapes.size() + _vectors.size());
-  for (ShapeObject& shape : _shapes) {
-    visualizers.push_back(shape);
-  }
-  for (VectorObject& vector : _vectors) {
-    visualizers.push_back(vector);
-  }
-  for (AbstractVisualizerObject& visualizer : visualizers) {
+  for (AbstractVisualizerObject& visualizer : getVisualizerObjects()) {
     if (visualizer._id == visualizerID) {
       return &visualizer;
     }
@@ -165,21 +168,13 @@ AbstractVisualizerObject* OMVisualBase::getVisualizerObjectByID(const std::strin
 /*!
  * \brief OMVisualBase::getVisualizerObjectIndexByID
  * get the index of the AbstractVisualizerObject with the same visualizerID
- *\param the name of the visualizer
- *\return the selected visualizer index
+ * \param the name of the visualizer
+ * \return the selected visualizer index
  */
 int OMVisualBase::getVisualizerObjectIndexByID(const std::string& visualizerID)
 {
   int i = 0;
-  std::vector<std::reference_wrapper<AbstractVisualizerObject>> visualizers;
-  visualizers.reserve(_shapes.size() + _vectors.size());
-  for (ShapeObject& shape : _shapes) {
-    visualizers.push_back(shape);
-  }
-  for (VectorObject& vector : _vectors) {
-    visualizers.push_back(vector);
-  }
-  for (AbstractVisualizerObject& visualizer : visualizers) {
+  for (AbstractVisualizerObject& visualizer : getVisualizerObjects()) {
     if (visualizer._id == visualizerID) {
       return i;
     }

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -388,6 +388,224 @@ void OMVisualBase::initVisObjects()
   }
 }
 
+void OMVisualBase::setFmuVarRefInVisObjects()
+{
+  try
+  {
+    for (ShapeObject& shape : _shapes)
+    {
+      //std::cout<<"shape "<<shape._id <<std::endl;
+
+      shape._T[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[0]);
+      shape._T[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[1]);
+      shape._T[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[2]);
+      shape._T[3].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[3]);
+      shape._T[4].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[4]);
+      shape._T[5].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[5]);
+      shape._T[6].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[6]);
+      shape._T[7].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[7]);
+      shape._T[8].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._T[8]);
+
+      shape._r[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._r[0]);
+      shape._r[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._r[1]);
+      shape._r[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._r[2]);
+
+      shape._color[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._color[0]);
+      shape._color[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._color[1]);
+      shape._color[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._color[2]);
+
+      shape._specCoeff.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._specCoeff);
+
+      shape._rShape[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._rShape[0]);
+      shape._rShape[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._rShape[1]);
+      shape._rShape[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._rShape[2]);
+
+      shape._lDir[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._lDir[0]);
+      shape._lDir[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._lDir[1]);
+      shape._lDir[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._lDir[2]);
+
+      shape._wDir[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._wDir[0]);
+      shape._wDir[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._wDir[1]);
+      shape._wDir[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._wDir[2]);
+
+      shape._length.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._length);
+      shape._width.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._width);
+      shape._height.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._height);
+
+      shape._extra.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(shape._extra);
+
+      //shape.dumpVisualizerAttributes();
+    }
+
+    for (VectorObject& vector : _vectors)
+    {
+      //std::cout<<"vector "<<vector._id <<std::endl;
+
+      vector._T[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[0]);
+      vector._T[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[1]);
+      vector._T[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[2]);
+      vector._T[3].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[3]);
+      vector._T[4].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[4]);
+      vector._T[5].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[5]);
+      vector._T[6].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[6]);
+      vector._T[7].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[7]);
+      vector._T[8].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._T[8]);
+
+      vector._r[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._r[0]);
+      vector._r[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._r[1]);
+      vector._r[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._r[2]);
+
+      vector._color[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._color[0]);
+      vector._color[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._color[1]);
+      vector._color[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._color[2]);
+
+      vector._specCoeff.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._specCoeff);
+
+      vector._coords[0].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._coords[0]);
+      vector._coords[1].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._coords[1]);
+      vector._coords[2].fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._coords[2]);
+
+      vector._quantity.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._quantity);
+
+      vector._headAtOrigin.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._headAtOrigin);
+
+      vector._twoHeadedArrow.fmuValueRef = getFmuVariableReferenceForVisualizerAttribute(vector._twoHeadedArrow);
+
+      //vector.dumpVisualizerAttributes();
+    }
+  }
+  catch (std::exception& ex)
+  {
+    QString msg = QString(QObject::tr("Something went wrong in OMVisualBase::setFmuVarRefInVisObjects:\n%1."))
+                  .arg(ex.what());
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
+    throw(msg.toStdString());
+  }
+}
+
+void OMVisualBase::updateVisObjects(const double time)
+{
+  // Update all visualizers
+  //std::cout<<"updateVisObjects at "<<time <<std::endl;
+
+  try
+  {
+    for (ShapeObject& shape : _shapes)
+    {
+      // Get the values for the scene graph objects
+      //std::cout<<"shape "<<shape._id <<std::endl;
+
+      updateVisualizerAttribute(shape._T[0], time);
+      updateVisualizerAttribute(shape._T[1], time);
+      updateVisualizerAttribute(shape._T[2], time);
+      updateVisualizerAttribute(shape._T[3], time);
+      updateVisualizerAttribute(shape._T[4], time);
+      updateVisualizerAttribute(shape._T[5], time);
+      updateVisualizerAttribute(shape._T[6], time);
+      updateVisualizerAttribute(shape._T[7], time);
+      updateVisualizerAttribute(shape._T[8], time);
+
+      updateVisualizerAttribute(shape._r[0], time);
+      updateVisualizerAttribute(shape._r[1], time);
+      updateVisualizerAttribute(shape._r[2], time);
+
+      updateVisualizerAttribute(shape._color[0], time);
+      updateVisualizerAttribute(shape._color[1], time);
+      updateVisualizerAttribute(shape._color[2], time);
+
+      updateVisualizerAttribute(shape._specCoeff, time);
+
+      updateVisualizerAttribute(shape._rShape[0], time);
+      updateVisualizerAttribute(shape._rShape[1], time);
+      updateVisualizerAttribute(shape._rShape[2], time);
+
+      updateVisualizerAttribute(shape._lDir[0], time);
+      updateVisualizerAttribute(shape._lDir[1], time);
+      updateVisualizerAttribute(shape._lDir[2], time);
+
+      updateVisualizerAttribute(shape._wDir[0], time);
+      updateVisualizerAttribute(shape._wDir[1], time);
+      updateVisualizerAttribute(shape._wDir[2], time);
+
+      updateVisualizerAttribute(shape._length, time);
+      updateVisualizerAttribute(shape._width, time);
+      updateVisualizerAttribute(shape._height, time);
+
+      updateVisualizerAttribute(shape._extra, time);
+
+      rAndT rT = rotateModelica2OSG(
+          osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
+                       shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
+                       shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
+          osg::Vec3f(shape._r[0].exp, shape._r[1].exp, shape._r[2].exp),
+          osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
+          osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
+          osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
+          shape._type);
+      assemblePokeMatrix(shape._mat, rT._T, rT._r);
+
+      // Update the shapes
+      updateVisualizer(shape, true);
+      //shape.dumpVisualizerAttributes();
+    }
+
+    for (VectorObject& vector : _vectors)
+    {
+      // Get the values for the scene graph objects
+      //std::cout<<"vector "<<vector._id <<std::endl;
+
+      updateVisualizerAttribute(vector._T[0], time);
+      updateVisualizerAttribute(vector._T[1], time);
+      updateVisualizerAttribute(vector._T[2], time);
+      updateVisualizerAttribute(vector._T[3], time);
+      updateVisualizerAttribute(vector._T[4], time);
+      updateVisualizerAttribute(vector._T[5], time);
+      updateVisualizerAttribute(vector._T[6], time);
+      updateVisualizerAttribute(vector._T[7], time);
+      updateVisualizerAttribute(vector._T[8], time);
+
+      updateVisualizerAttribute(vector._r[0], time);
+      updateVisualizerAttribute(vector._r[1], time);
+      updateVisualizerAttribute(vector._r[2], time);
+
+      updateVisualizerAttribute(vector._color[0], time);
+      updateVisualizerAttribute(vector._color[1], time);
+      updateVisualizerAttribute(vector._color[2], time);
+
+      updateVisualizerAttribute(vector._specCoeff, time);
+
+      updateVisualizerAttribute(vector._coords[0], time);
+      updateVisualizerAttribute(vector._coords[1], time);
+      updateVisualizerAttribute(vector._coords[2], time);
+
+      updateVisualizerAttribute(vector._quantity, time);
+
+      updateVisualizerAttribute(vector._headAtOrigin, time);
+
+      updateVisualizerAttribute(vector._twoHeadedArrow, time);
+
+      rAndT rT = rotateModelica2OSG(
+          osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
+                       vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
+                       vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
+          osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
+          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
+      assemblePokeMatrix(vector._mat, rT._T, rT._r);
+
+      // Update the vectors
+      updateVisualizer(vector, true);
+      //vector.dumpVisualizerAttributes();
+    }
+  }
+  catch (std::exception& ex)
+  {
+    QString msg = QString(QObject::tr("Error in OMVisualBase::updateVisObjects at time point %1\n%2."))
+                  .arg(QString::number(time), ex.what());
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
+    throw(msg.toStdString());
+  }
+}
+
 
 ///--------------------------------------------------///
 ///ABSTRACT VISUALIZATION CLASS----------------------///
@@ -411,6 +629,18 @@ VisualizationAbstract::VisualizationAbstract(const std::string& modelFile, const
   mpTimeManager = new TimeManager(0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 100.0);
   mpOMVisualBase = new OMVisualBase(modelFile, path);
   mpOMVisScene->getScene().setPath(path);
+  mpOMVisualBase->getFmuVariableReferenceForVisualizerAttribute =
+      std::bind(static_cast<unsigned int(VisualizationAbstract::*)(        VisualizerAttribute&              )>
+          (&VisualizationAbstract::getFmuVariableReferenceForVisualizerAttribute),
+              this, std::placeholders::_1                       );
+  mpOMVisualBase->                    updateVisualizerAttribute =
+      std::bind(static_cast<void        (VisualizationAbstract::*)(        VisualizerAttribute&, const double)>
+          (&VisualizationAbstract::                    updateVisualizerAttribute),
+              this, std::placeholders::_1, std::placeholders::_2);
+  mpOMVisualBase->                    updateVisualizer          =
+      std::bind(static_cast<void        (VisualizationAbstract::*)(AbstractVisualizerObject   &, const bool  )>
+          (&VisualizationAbstract::                    updateVisualizer         ),
+              this, std::placeholders::_1, std::placeholders::_2);
 }
 
 VisType VisualizationAbstract::getVisType() const
@@ -491,6 +721,21 @@ void VisualizationAbstract::modifyVisualizer(AbstractVisualizerObject& visualize
 void VisualizationAbstract::initData()
 {
   getBaseData()->initVisObjects();
+}
+
+void VisualizationAbstract::setFmuVarRefInVisAttributes()
+{
+  getBaseData()->setFmuVarRefInVisObjects();
+}
+
+void VisualizationAbstract::initializeVisAttributes(const double time)
+{
+  getBaseData()->updateVisObjects(time);
+}
+
+void VisualizationAbstract::updateVisAttributes(const double time)
+{
+  getBaseData()->updateVisObjects(time);
 }
 
 void VisualizationAbstract::setUpScene()

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -209,6 +209,7 @@ public:
 
   void setUpScene();
 
+  void updateVectorCoords(VectorObject& vector, const double time);
   void chooseVectorScales(osgViewer::View* view, OpenThreads::Mutex* mutex = nullptr, std::function<void()> frame = nullptr);
 private:
   std::string _modelFile;

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -193,6 +193,8 @@ public:
   AbstractVisualizerObject* getVisualizerObjectByID(const std::string& visualizerID);
   int getVisualizerObjectIndexByID(const std::string& visualizerID);
   void initVisObjects();
+  void setFmuVarRefInVisObjects();
+  void updateVisObjects(const double time);
 private:
   std::string _modelFile;
   std::string _path;
@@ -200,6 +202,10 @@ private:
 public:
   std::vector<ShapeObject> _shapes;
   std::vector<VectorObject> _vectors;
+public:
+  std::function<unsigned int(VisualizerAttribute&)> getFmuVariableReferenceForVisualizerAttribute;
+  std::function<void(VisualizerAttribute&, const double)> updateVisualizerAttribute;
+  std::function<void(AbstractVisualizerObject&, const bool)> updateVisualizer;
 };
 
 class VisualizationAbstract
@@ -223,8 +229,11 @@ public:
   void modifyVisualizer(AbstractVisualizerObject& visualizer, const bool changeMaterialProperties = true);
 
   virtual void initData();
-  virtual void initializeVisAttributes(const double time) = 0;
-  virtual void updateVisAttributes(const double time) = 0;
+  virtual void setFmuVarRefInVisAttributes();
+  virtual unsigned int getFmuVariableReferenceForVisualizerAttribute(VisualizerAttribute& attr) {Q_UNUSED(attr); return 0;}
+  virtual void initializeVisAttributes(const double time);
+  virtual void updateVisAttributes(const double time);
+  virtual void updateVisualizerAttribute(VisualizerAttribute& attr, const double time) = 0;
   virtual void updateScene(const double time) = 0;
   virtual void simulate(TimeManager& omvm) = 0;
 

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -191,6 +191,7 @@ public:
   const std::string getPath() const;
   const std::string getXMLFileName() const;
 
+  std::vector<std::reference_wrapper<AbstractVisualizerObject>> getVisualizerObjects();
   AbstractVisualizerObject* getVisualizerObjectByIdx(const std::size_t visualizerIdx);
   AbstractVisualizerObject* getVisualizerObjectByID(const std::string& visualizerID);
   int getVisualizerObjectIndexByID(const std::string& visualizerID);

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -216,7 +216,6 @@ private:
   std::string _xmlFileName;
   UpdateVisitor _updateVisitor;
   VisualizationAbstract* _visualization;
-public:
   std::vector<ShapeObject> _shapes;
   std::vector<VectorObject> _vectors;
 };

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -154,11 +154,11 @@ public:
   ~OSGScene() = default;
   OSGScene(const OSGScene& osgs) = delete;
   OSGScene& operator=(const OSGScene& osgs) = delete;
-  void setUpScene(std::vector<ShapeObject>& shapes);
-  void setUpScene(std::vector<VectorObject>& vectors);
   osg::ref_ptr<osg::Group> getRootNode();
   std::string getPath() const;
   void setPath(const std::string path);
+  void setUpScene(std::vector<ShapeObject>& shapes);
+  void setUpScene(std::vector<VectorObject>& vectors);
 private:
   osg::ref_ptr<AutoTransformCullCallback> _atCullCallback;
   osg::ref_ptr<osg::Group> _rootNode;
@@ -170,10 +170,10 @@ class OMVisScene
 public:
   OMVisScene(VisualizationAbstract* visualization);
   ~OMVisScene() = default;
-  OMVisScene(const OMVisScene& omvv) = delete;
-  OMVisScene& operator=(const OMVisScene& omvv) = delete;
-  void dumpOSGTreeDebug();
+  OMVisScene(const OMVisScene& omvs) = delete;
+  OMVisScene& operator=(const OMVisScene& omvs) = delete;
   OSGScene& getScene();
+  void dumpOSGTreeDebug();
 private:
   OSGScene _scene;
 };
@@ -186,22 +186,20 @@ public:
   ~OMVisualBase() = default;
   OMVisualBase(const OMVisualBase& omvb) = delete;
   OMVisualBase& operator=(const OMVisualBase& omvb) = delete;
-  void initVisObjects();
   const std::string getModelFile() const;
   const std::string getPath() const;
   const std::string getXMLFileName() const;
   AbstractVisualizerObject* getVisualizerObjectByIdx(const std::size_t visualizerIdx);
   AbstractVisualizerObject* getVisualizerObjectByID(const std::string& visualizerID);
   int getVisualizerObjectIndexByID(const std::string& visualizerID);
-private:
-  void appendVisVariable(const rapidxml::xml_node<>* node, std::vector<std::string>& visVariables) const;
-public:
-  std::vector<ShapeObject> _shapes;
-  std::vector<VectorObject> _vectors;
+  void initVisObjects();
 private:
   std::string _modelFile;
   std::string _path;
   std::string _xmlFileName;
+public:
+  std::vector<ShapeObject> _shapes;
+  std::vector<VectorObject> _vectors;
 };
 
 class VisualizationAbstract
@@ -211,38 +209,39 @@ public:
   VisualizationAbstract(const std::string& modelFile, const std::string& path, const VisType visType = VisType::NONE);
   virtual ~VisualizationAbstract() = default;
 
+  VisType getVisType() const;
+  std::string getModelFile() const;
+  OMVisualBase* getBaseData() const;
+  OMVisScene* getOMVisScene() const;
+  TimeManager* getTimeManager() const;
+
+  void updateVisualizer(const std::string& visualizerName   , const bool changeMaterialProperties = true);
+  void modifyVisualizer(const std::string& visualizerName   , const bool changeMaterialProperties = true);
+  void updateVisualizer(AbstractVisualizerObject* visualizer, const bool changeMaterialProperties = true);
+  void modifyVisualizer(AbstractVisualizerObject* visualizer, const bool changeMaterialProperties = true);
+  void updateVisualizer(AbstractVisualizerObject& visualizer, const bool changeMaterialProperties = true);
+  void modifyVisualizer(AbstractVisualizerObject& visualizer, const bool changeMaterialProperties = true);
+
   virtual void initData();
-  void initVisualization();
-  void setUpScene();
   virtual void initializeVisAttributes(const double time) = 0;
   virtual void updateVisAttributes(const double time) = 0;
-  void chooseVectorScales(osgViewer::View* view, OpenThreads::Mutex* mutex = nullptr, std::function<void()> frame = nullptr);
-  void sceneUpdate();
-  void updateVisualizer(const std::string& visualizerName   , bool changeMaterialProperties = true);
-  void modifyVisualizer(const std::string& visualizerName   , bool changeMaterialProperties = true);
-  void updateVisualizer(AbstractVisualizerObject* visualizer, bool changeMaterialProperties = true);
-  void modifyVisualizer(AbstractVisualizerObject* visualizer, bool changeMaterialProperties = true);
-  void updateVisualizer(AbstractVisualizerObject& visualizer, bool changeMaterialProperties = true);
-  void modifyVisualizer(AbstractVisualizerObject& visualizer, bool changeMaterialProperties = true);
-  virtual void simulate(TimeManager& omvm) = 0;
   virtual void updateScene(const double time) = 0;
+  virtual void simulate(TimeManager& omvm) = 0;
 
-  TimeManager* getTimeManager() const;
-  OMVisualBase* getBaseData() const;
-  VisType getVisType() const;
-  OMVisScene* getOMVisScene() const;
-  std::string getModelFile() const;
+  void setUpScene();
+  void sceneUpdate();
 
-  //virtual void setSimulationSettings(const UserSimSettingsFMU& simSetFMU) { };
-  //virtual void simulate(TimeManager& omvm) = 0;
-  virtual void startVisualization();
-  virtual void pauseVisualization();
+  void initVisualization();
+  void startVisualization();
+  void pauseVisualization();
+
+  void chooseVectorScales(osgViewer::View* view, OpenThreads::Mutex* mutex = nullptr, std::function<void()> frame = nullptr);
 protected:
   const VisType _visType;
   OMVisualBase* mpOMVisualBase;
   OMVisScene* mpOMVisScene;
-  UpdateVisitor* mpUpdateVisitor;
   TimeManager* mpTimeManager;
+  UpdateVisitor* mpUpdateVisitor;
 };
 
 osg::Vec3f Mat3mulV3(osg::Matrix3 M, osg::Vec3f V);

--- a/OMEdit/OMEditLIB/Animation/VisualizationCSV.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationCSV.cpp
@@ -34,9 +34,9 @@
 #include "VisualizationCSV.h"
 
 VisualizationCSV::VisualizationCSV(const std::string& modelFile, const std::string& path)
-  : VisualizationAbstract(modelFile, path, VisType::CSV), mpCSVData(0)
+  : VisualizationAbstract(modelFile, path, VisType::CSV),
+    mpCSVData(nullptr)
 {
-
 }
 
 VisualizationCSV::~VisualizationCSV()
@@ -86,131 +86,6 @@ void VisualizationCSV::readCSV(const std::string& modelFile, const std::string& 
   }
 }
 
-void VisualizationCSV::updateVisAttributes(const double time)
-{
-  // Update all visualizers
-  //std::cout<<"updateVisAttributes at "<<time <<std::endl;
-
-  try
-  {
-    for (ShapeObject& shape : mpOMVisualBase->_shapes)
-    {
-      // Get the values for the scene graph objects
-      //std::cout<<"shape "<<shape._id <<std::endl;
-
-      updateVisualizerAttributeCSV(shape._T[0], time);
-      updateVisualizerAttributeCSV(shape._T[1], time);
-      updateVisualizerAttributeCSV(shape._T[2], time);
-      updateVisualizerAttributeCSV(shape._T[3], time);
-      updateVisualizerAttributeCSV(shape._T[4], time);
-      updateVisualizerAttributeCSV(shape._T[5], time);
-      updateVisualizerAttributeCSV(shape._T[6], time);
-      updateVisualizerAttributeCSV(shape._T[7], time);
-      updateVisualizerAttributeCSV(shape._T[8], time);
-
-      updateVisualizerAttributeCSV(shape._r[0], time);
-      updateVisualizerAttributeCSV(shape._r[1], time);
-      updateVisualizerAttributeCSV(shape._r[2], time);
-
-      updateVisualizerAttributeCSV(shape._color[0], time);
-      updateVisualizerAttributeCSV(shape._color[1], time);
-      updateVisualizerAttributeCSV(shape._color[2], time);
-
-      updateVisualizerAttributeCSV(shape._specCoeff, time);
-
-      updateVisualizerAttributeCSV(shape._rShape[0], time);
-      updateVisualizerAttributeCSV(shape._rShape[1], time);
-      updateVisualizerAttributeCSV(shape._rShape[2], time);
-
-      updateVisualizerAttributeCSV(shape._lDir[0], time);
-      updateVisualizerAttributeCSV(shape._lDir[1], time);
-      updateVisualizerAttributeCSV(shape._lDir[2], time);
-
-      updateVisualizerAttributeCSV(shape._wDir[0], time);
-      updateVisualizerAttributeCSV(shape._wDir[1], time);
-      updateVisualizerAttributeCSV(shape._wDir[2], time);
-
-      updateVisualizerAttributeCSV(shape._length, time);
-      updateVisualizerAttributeCSV(shape._width, time);
-      updateVisualizerAttributeCSV(shape._height, time);
-
-      updateVisualizerAttributeCSV(shape._extra, time);
-
-      rAndT rT = rotateModelica2OSG(
-          osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
-                       shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
-                       shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
-          osg::Vec3f(shape._r[0].exp, shape._r[1].exp, shape._r[2].exp),
-          osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
-          osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
-          osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
-          shape._type);
-      assemblePokeMatrix(shape._mat, rT._T, rT._r);
-
-      // Update the shapes
-      updateVisualizer(shape);
-      //shape.dumpVisualizerAttributes();
-      //mpOMVisScene->dumpOSGTreeDebug();
-    }
-
-    for (VectorObject& vector : mpOMVisualBase->_vectors)
-    {
-      // Get the values for the scene graph objects
-      //std::cout<<"vector "<<vector._id <<std::endl;
-
-      updateVisualizerAttributeCSV(vector._T[0], time);
-      updateVisualizerAttributeCSV(vector._T[1], time);
-      updateVisualizerAttributeCSV(vector._T[2], time);
-      updateVisualizerAttributeCSV(vector._T[3], time);
-      updateVisualizerAttributeCSV(vector._T[4], time);
-      updateVisualizerAttributeCSV(vector._T[5], time);
-      updateVisualizerAttributeCSV(vector._T[6], time);
-      updateVisualizerAttributeCSV(vector._T[7], time);
-      updateVisualizerAttributeCSV(vector._T[8], time);
-
-      updateVisualizerAttributeCSV(vector._r[0], time);
-      updateVisualizerAttributeCSV(vector._r[1], time);
-      updateVisualizerAttributeCSV(vector._r[2], time);
-
-      updateVisualizerAttributeCSV(vector._color[0], time);
-      updateVisualizerAttributeCSV(vector._color[1], time);
-      updateVisualizerAttributeCSV(vector._color[2], time);
-
-      updateVisualizerAttributeCSV(vector._specCoeff, time);
-
-      updateVisualizerAttributeCSV(vector._coords[0], time);
-      updateVisualizerAttributeCSV(vector._coords[1], time);
-      updateVisualizerAttributeCSV(vector._coords[2], time);
-
-      updateVisualizerAttributeCSV(vector._quantity, time);
-
-      updateVisualizerAttributeCSV(vector._headAtOrigin, time);
-
-      updateVisualizerAttributeCSV(vector._twoHeadedArrow, time);
-
-      rAndT rT = rotateModelica2OSG(
-          osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
-                       vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
-                       vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
-          osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
-          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
-      assemblePokeMatrix(vector._mat, rT._T, rT._r);
-
-      // Update the vectors
-      updateVisualizer(vector);
-      //vector.dumpVisualizerAttributes();
-      //mpOMVisScene->dumpOSGTreeDebug();
-    }
-  }
-  catch (std::exception& ex)
-  {
-    QString msg = QString(QObject::tr("Error in VisualizationCSV::updateVisAttributes at time point %1\n%2."))
-                  .arg(QString::number(time), ex.what());
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
-    throw(msg.toStdString());
-  }
-}
-
 void VisualizationCSV::updateScene(const double time)
 {
   mpTimeManager->updateTick();  //for real-time measurement
@@ -221,14 +96,19 @@ void VisualizationCSV::updateScene(const double time)
   mpTimeManager->setRealTimeFactor(mpTimeManager->getHVisual() / visTime);
 }
 
-void VisualizationCSV::updateVisualizerAttributeCSV(VisualizerAttribute& attr, double time)
+void VisualizationCSV::updateVisualizerAttribute(VisualizerAttribute& attr, const double time)
+{
+  updateVisualizerAttributeCSV(attr, time);
+}
+
+void VisualizationCSV::updateVisualizerAttributeCSV(VisualizerAttribute& attr, const double time)
 {
   if (!attr.isConst) {
     attr.exp = omcGetVarValue(attr.cref.c_str(), time);
   }
 }
 
-double VisualizationCSV::omcGetVarValue(const char* varName, double time)
+double VisualizationCSV::omcGetVarValue(const char* varName, const double time)
 {
   double *timeDataSet = read_csv_dataset(mpCSVData, "time");
   for (int i = 0 ; i < mpCSVData->numsteps ; i++) {

--- a/OMEdit/OMEditLIB/Animation/VisualizationCSV.h
+++ b/OMEdit/OMEditLIB/Animation/VisualizationCSV.h
@@ -46,13 +46,13 @@ public:
   VisualizationCSV(const VisualizationCSV& omvm) = delete;
   VisualizationCSV& operator=(const VisualizationCSV& omvm) = delete;
   void initData() override;
-  void initializeVisAttributes(const double time = -1.0) override;
+  void initializeVisAttributes(const double time) override;
   void readCSV(const std::string& modelFile, const std::string& path);
   void simulate(TimeManager& omvm) override {Q_UNUSED(omvm);}
-  void updateVisAttributes(const double time) override;
   void updateScene(const double time) override;
-  void updateVisualizerAttributeCSV(VisualizerAttribute& attr, double time);
-  double omcGetVarValue(const char* varName, double time);
+  void updateVisualizerAttribute(VisualizerAttribute& attr, const double time) override;
+  void updateVisualizerAttributeCSV(VisualizerAttribute& attr, const double time);
+  double omcGetVarValue(const char* varName, const double time);
 private:
   csv_data *mpCSVData;
 };

--- a/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
@@ -35,18 +35,18 @@
 #include "VisualizationFMU.h"
 
 VisualizationFMU::VisualizationFMU(const std::string& modelFile, const std::string& path)
-    : VisualizationAbstract(modelFile, path, VisType::FMU),
-      mpFMU(nullptr),
-      mpSimSettings(new SimSettingsFMU())
+  : VisualizationAbstract(modelFile, path, VisType::FMU),
+    mpFMU(nullptr),
+    mpSimSettings(new SimSettingsFMU())
 {
 }
- VisualizationFMU::~VisualizationFMU()
- {
-   if (mpFMU){
-     free(mpFMU);
-   }
- }
 
+ VisualizationFMU::~VisualizationFMU()
+{
+  if (mpFMU) {
+    free(mpFMU);
+  }
+}
 
 void VisualizationFMU::initData()
 {
@@ -54,9 +54,7 @@ void VisualizationFMU::initData()
   loadFMU(mpOMVisualBase->getModelFile(), mpOMVisualBase->getPath());
   mpSimSettings->setTend(mpTimeManager->getEndTime());
   mpSimSettings->setHdef(0.001);
-  setVarReferencesInVisAttributes();
-
-  //OMVisualizationFMU::initializeVisAttributes(_omvManager->getStartTime());
+  setFmuVarRefInVisAttributes();
 }
 
 void VisualizationFMU::loadFMU(const std::string& modelFile, const std::string& path)
@@ -102,113 +100,18 @@ void VisualizationFMU::allocateContext(const std::string& modelFile, const std::
   mVersion = fmi_import_get_fmi_version(mpContext.get(), fmuFileName.c_str(), path.c_str());
 }
 
+unsigned int VisualizationFMU::getFmuVariableReferenceForVisualizerAttribute(VisualizerAttribute& attr)
+{
+  return getFmuVariableReferenceForVisualizerAttributeFMU(attr);
+}
 
-unsigned int VisualizationFMU::getVariableReferenceForVisualizerAttribute(VisualizerAttribute& attr)
+unsigned int VisualizationFMU::getFmuVariableReferenceForVisualizerAttributeFMU(VisualizerAttribute& attr)
 {
   unsigned int vr = 0;
   if (!attr.isConst) {
     vr = mpFMU->fmi_get_variable_by_name(attr.cref.c_str());
   }
   return vr;
-}
-
-int VisualizationFMU::setVarReferencesInVisAttributes()
-{
-  int isOk = 0;
-
-  try
-  {
-    for (ShapeObject& shape : mpOMVisualBase->_shapes)
-    {
-      //std::cout<<"shape "<<shape._id <<std::endl;
-
-      shape._T[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[0]);
-      shape._T[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[1]);
-      shape._T[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[2]);
-      shape._T[3].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[3]);
-      shape._T[4].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[4]);
-      shape._T[5].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[5]);
-      shape._T[6].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[6]);
-      shape._T[7].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[7]);
-      shape._T[8].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._T[8]);
-
-      shape._r[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._r[0]);
-      shape._r[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._r[1]);
-      shape._r[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._r[2]);
-
-      shape._color[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._color[0]);
-      shape._color[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._color[1]);
-      shape._color[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._color[2]);
-
-      shape._specCoeff.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._specCoeff);
-
-      shape._rShape[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._rShape[0]);
-      shape._rShape[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._rShape[1]);
-      shape._rShape[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._rShape[2]);
-
-      shape._lDir[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._lDir[0]);
-      shape._lDir[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._lDir[1]);
-      shape._lDir[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._lDir[2]);
-
-      shape._wDir[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._wDir[0]);
-      shape._wDir[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._wDir[1]);
-      shape._wDir[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._wDir[2]);
-
-      shape._length.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._length);
-      shape._width.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._width);
-      shape._height.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._height);
-
-      shape._extra.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._extra);
-
-      //shape.dumpVisualizerAttributes();
-    }
-
-    for (VectorObject& vector : mpOMVisualBase->_vectors)
-    {
-      //std::cout<<"vector "<<vector._id <<std::endl;
-
-      vector._T[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[0]);
-      vector._T[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[1]);
-      vector._T[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[2]);
-      vector._T[3].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[3]);
-      vector._T[4].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[4]);
-      vector._T[5].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[5]);
-      vector._T[6].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[6]);
-      vector._T[7].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[7]);
-      vector._T[8].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._T[8]);
-
-      vector._r[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._r[0]);
-      vector._r[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._r[1]);
-      vector._r[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._r[2]);
-
-      vector._color[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._color[0]);
-      vector._color[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._color[1]);
-      vector._color[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._color[2]);
-
-      vector._specCoeff.fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._specCoeff);
-
-      vector._coords[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._coords[0]);
-      vector._coords[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._coords[1]);
-      vector._coords[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._coords[2]);
-
-      vector._quantity.fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._quantity);
-
-      vector._headAtOrigin.fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._headAtOrigin);
-
-      vector._twoHeadedArrow.fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._twoHeadedArrow);
-
-      //vector.dumpVisualizerAttributes();
-    }
-  }
-  catch (std::exception& ex)
-  {
-    QString msg = QString(QObject::tr("Something went wrong in VisualizationFMU::setVarReferencesInVisAttributes:\n%1."))
-                  .arg(ex.what());
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
-    isOk = 1;
-  }
-
-  return isOk;
 }
 
 void VisualizationFMU::simulate(TimeManager& omvm)
@@ -233,7 +136,6 @@ void VisualizationFMU::updateSystem()
   mpFMU->completedIntegratorStep(mpSimSettings->getCallEventUpdate());
   updateVisAttributes(mpTimeManager->getVisTime());
 }
-
 
 double VisualizationFMU::simulateStep(const double time)
 {
@@ -281,131 +183,11 @@ void VisualizationFMU::initializeVisAttributes(const double time)
 {
   Q_UNUSED(time);
   mpFMU->initialize(mpSimSettings);
-  //std::cout<<"VisualizationFMU::loadFMU: FMU was successfully initialized."<<std::endl;
+  //std::cout<<"VisualizationFMU::initializeVisAttributes: FMU was successfully initialized."<<std::endl;
 
   mpTimeManager->setVisTime(mpTimeManager->getStartTime());
   mpTimeManager->setSimTime(mpTimeManager->getStartTime());
-  setVarReferencesInVisAttributes();
   updateVisAttributes(mpTimeManager->getVisTime());
-}
-
-void VisualizationFMU::updateVisAttributes(const double time)
-{
-  // Update all visualizers
-  //std::cout<<"updateVisAttributes at "<<time <<std::endl;
-
-  try
-  {
-    for (ShapeObject& shape : mpOMVisualBase->_shapes)
-    {
-      // Get the values for the scene graph objects
-      //std::cout<<"shape "<<shape._id <<std::endl;
-
-      updateVisualizerAttributeFMU(shape._T[0]);
-      updateVisualizerAttributeFMU(shape._T[1]);
-      updateVisualizerAttributeFMU(shape._T[2]);
-      updateVisualizerAttributeFMU(shape._T[3]);
-      updateVisualizerAttributeFMU(shape._T[4]);
-      updateVisualizerAttributeFMU(shape._T[5]);
-      updateVisualizerAttributeFMU(shape._T[6]);
-      updateVisualizerAttributeFMU(shape._T[7]);
-      updateVisualizerAttributeFMU(shape._T[8]);
-
-      updateVisualizerAttributeFMU(shape._r[0]);
-      updateVisualizerAttributeFMU(shape._r[1]);
-      updateVisualizerAttributeFMU(shape._r[2]);
-
-      updateVisualizerAttributeFMU(shape._rShape[0]);
-      updateVisualizerAttributeFMU(shape._rShape[1]);
-      updateVisualizerAttributeFMU(shape._rShape[2]);
-
-      updateVisualizerAttributeFMU(shape._lDir[0]);
-      updateVisualizerAttributeFMU(shape._lDir[1]);
-      updateVisualizerAttributeFMU(shape._lDir[2]);
-
-      updateVisualizerAttributeFMU(shape._wDir[0]);
-      updateVisualizerAttributeFMU(shape._wDir[1]);
-      updateVisualizerAttributeFMU(shape._wDir[2]);
-
-      updateVisualizerAttributeFMU(shape._length);
-      updateVisualizerAttributeFMU(shape._width);
-      updateVisualizerAttributeFMU(shape._height);
-
-      updateVisualizerAttributeFMU(shape._extra);
-
-      rAndT rT = rotateModelica2OSG(
-          osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
-                       shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
-                       shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
-          osg::Vec3f(shape._r[0].exp, shape._r[1].exp, shape._r[2].exp),
-          osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
-          osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
-          osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
-          shape._type);
-      assemblePokeMatrix(shape._mat, rT._T, rT._r);
-
-      // Update the shapes
-      updateVisualizer(shape);
-      //shape.dumpVisualizerAttributes();
-      //mpOMVisScene->dumpOSGTreeDebug();
-    }
-
-    for (VectorObject& vector : mpOMVisualBase->_vectors)
-    {
-      // Get the values for the scene graph objects
-      //std::cout<<"vector "<<vector._id <<std::endl;
-
-      updateVisualizerAttributeFMU(vector._T[0]);
-      updateVisualizerAttributeFMU(vector._T[1]);
-      updateVisualizerAttributeFMU(vector._T[2]);
-      updateVisualizerAttributeFMU(vector._T[3]);
-      updateVisualizerAttributeFMU(vector._T[4]);
-      updateVisualizerAttributeFMU(vector._T[5]);
-      updateVisualizerAttributeFMU(vector._T[6]);
-      updateVisualizerAttributeFMU(vector._T[7]);
-      updateVisualizerAttributeFMU(vector._T[8]);
-
-      updateVisualizerAttributeFMU(vector._r[0]);
-      updateVisualizerAttributeFMU(vector._r[1]);
-      updateVisualizerAttributeFMU(vector._r[2]);
-
-      updateVisualizerAttributeFMU(vector._color[0]);
-      updateVisualizerAttributeFMU(vector._color[1]);
-      updateVisualizerAttributeFMU(vector._color[2]);
-
-      updateVisualizerAttributeFMU(vector._specCoeff);
-
-      updateVisualizerAttributeFMU(vector._coords[0]);
-      updateVisualizerAttributeFMU(vector._coords[1]);
-      updateVisualizerAttributeFMU(vector._coords[2]);
-
-      updateVisualizerAttributeFMU(vector._quantity);
-
-      updateVisualizerAttributeFMU(vector._headAtOrigin);
-
-      updateVisualizerAttributeFMU(vector._twoHeadedArrow);
-
-      rAndT rT = rotateModelica2OSG(
-          osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
-                       vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
-                       vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
-          osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
-          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
-      assemblePokeMatrix(vector._mat, rT._T, rT._r);
-
-      // Update the vectors
-      updateVisualizer(vector);
-      //vector.dumpVisualizerAttributes();
-      //mpOMVisScene->dumpOSGTreeDebug();
-    }
-  }
-  catch (std::exception& ex)
-  {
-    QString msg = QString(QObject::tr("Error in VisualizationFMU::updateVisAttributes at time point %1\n%2."))
-                  .arg(QString::number(time), ex.what());
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
-    throw(msg.toStdString());
-  }
 }
 
 void VisualizationFMU::updateScene(const double time)
@@ -425,6 +207,12 @@ void VisualizationFMU::updateScene(const double time)
   mpTimeManager->updateTick();                     //for real-time measurement
   mpTimeManager->setRealTimeFactor(mpTimeManager->getHVisual() / (mpTimeManager->getRealTime() - vis1));
   updateVisAttributes(mpTimeManager->getVisTime());
+}
+
+void VisualizationFMU::updateVisualizerAttribute(VisualizerAttribute& attr, const double time)
+{
+  Q_UNUSED(time);
+  updateVisualizerAttributeFMU(attr);
 }
 
 void VisualizationFMU::updateVisualizerAttributeFMU(VisualizerAttribute& attr)

--- a/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationFMU.cpp
@@ -136,6 +136,12 @@ int VisualizationFMU::setVarReferencesInVisAttributes()
       shape._r[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._r[1]);
       shape._r[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._r[2]);
 
+      shape._color[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._color[0]);
+      shape._color[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._color[1]);
+      shape._color[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._color[2]);
+
+      shape._specCoeff.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._specCoeff);
+
       shape._rShape[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._rShape[0]);
       shape._rShape[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._rShape[1]);
       shape._rShape[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._rShape[2]);
@@ -151,6 +157,8 @@ int VisualizationFMU::setVarReferencesInVisAttributes()
       shape._length.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._length);
       shape._width.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._width);
       shape._height.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._height);
+
+      shape._extra.fmuValueRef = getVariableReferenceForVisualizerAttribute(shape._extra);
 
       //shape.dumpVisualizerAttributes();
     }
@@ -172,6 +180,12 @@ int VisualizationFMU::setVarReferencesInVisAttributes()
       vector._r[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._r[0]);
       vector._r[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._r[1]);
       vector._r[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._r[2]);
+
+      vector._color[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._color[0]);
+      vector._color[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._color[1]);
+      vector._color[2].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._color[2]);
+
+      vector._specCoeff.fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._specCoeff);
 
       vector._coords[0].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._coords[0]);
       vector._coords[1].fmuValueRef = getVariableReferenceForVisualizerAttribute(vector._coords[1]);
@@ -316,6 +330,8 @@ void VisualizationFMU::updateVisAttributes(const double time)
       updateVisualizerAttributeFMU(shape._length);
       updateVisualizerAttributeFMU(shape._width);
       updateVisualizerAttributeFMU(shape._height);
+
+      updateVisualizerAttributeFMU(shape._extra);
 
       rAndT rT = rotateModelica2OSG(
           osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,

--- a/OMEdit/OMEditLIB/Animation/VisualizationFMU.h
+++ b/OMEdit/OMEditLIB/Animation/VisualizationFMU.h
@@ -49,15 +49,15 @@ public:
   void allocateContext(const std::string& modelFile, const std::string& path);
   void loadFMU(const std::string& modelFile, const std::string& path);
   void initData() override;
-  void initializeVisAttributes(const double time = 0.0) override;
-  unsigned int getVariableReferenceForVisualizerAttribute(VisualizerAttribute& attr);
-  int setVarReferencesInVisAttributes();
+  void initializeVisAttributes(const double time) override;
   void simulate(TimeManager& omvm) override;
   double simulateStep(const double time);
   void updateSystem();
-  void updateVisAttributes(const double time) override;
-  void updateScene(const double time = 0.0) override;
+  void updateScene(const double time) override;
+  void updateVisualizerAttribute(VisualizerAttribute& attr, const double time) override;
   void updateVisualizerAttributeFMU(VisualizerAttribute& attr);
+  unsigned int getFmuVariableReferenceForVisualizerAttribute(VisualizerAttribute& attr) override;
+  unsigned int getFmuVariableReferenceForVisualizerAttributeFMU(VisualizerAttribute& attr);
   void setSimulationSettings(double stepsize, Solver solver, bool iterateEvents);
   FMUWrapperAbstract* getFMU();
 private:

--- a/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
+++ b/OMEdit/OMEditLIB/Animation/VisualizationMAT.cpp
@@ -38,7 +38,6 @@ VisualizationMAT::VisualizationMAT(const std::string& modelFile, const std::stri
   : VisualizationAbstract(modelFile, path, VisType::MAT),
     _matReader()
 {
-
 }
 
 /*!
@@ -107,131 +106,6 @@ void VisualizationMAT::setSimulationSettings(const UserSimSettingsMAT& simSetMAT
   mpTimeManager->setHVisual(newVal);
 }
 
-void VisualizationMAT::updateVisAttributes(const double time)
-{
-  // Update all visualizers
-  //std::cout<<"updateVisAttributes at "<<time <<std::endl;
-
-  try
-  {
-    for (ShapeObject& shape : mpOMVisualBase->_shapes)
-    {
-      // Get the values for the scene graph objects
-      //std::cout<<"shape "<<shape._id <<std::endl;
-
-      updateVisualizerAttributeMAT(shape._T[0], time);
-      updateVisualizerAttributeMAT(shape._T[1], time);
-      updateVisualizerAttributeMAT(shape._T[2], time);
-      updateVisualizerAttributeMAT(shape._T[3], time);
-      updateVisualizerAttributeMAT(shape._T[4], time);
-      updateVisualizerAttributeMAT(shape._T[5], time);
-      updateVisualizerAttributeMAT(shape._T[6], time);
-      updateVisualizerAttributeMAT(shape._T[7], time);
-      updateVisualizerAttributeMAT(shape._T[8], time);
-
-      updateVisualizerAttributeMAT(shape._r[0], time);
-      updateVisualizerAttributeMAT(shape._r[1], time);
-      updateVisualizerAttributeMAT(shape._r[2], time);
-
-      updateVisualizerAttributeMAT(shape._color[0], time);
-      updateVisualizerAttributeMAT(shape._color[1], time);
-      updateVisualizerAttributeMAT(shape._color[2], time);
-
-      updateVisualizerAttributeMAT(shape._specCoeff, time);
-
-      updateVisualizerAttributeMAT(shape._rShape[0], time);
-      updateVisualizerAttributeMAT(shape._rShape[1], time);
-      updateVisualizerAttributeMAT(shape._rShape[2], time);
-
-      updateVisualizerAttributeMAT(shape._lDir[0], time);
-      updateVisualizerAttributeMAT(shape._lDir[1], time);
-      updateVisualizerAttributeMAT(shape._lDir[2], time);
-
-      updateVisualizerAttributeMAT(shape._wDir[0], time);
-      updateVisualizerAttributeMAT(shape._wDir[1], time);
-      updateVisualizerAttributeMAT(shape._wDir[2], time);
-
-      updateVisualizerAttributeMAT(shape._length, time);
-      updateVisualizerAttributeMAT(shape._width, time);
-      updateVisualizerAttributeMAT(shape._height, time);
-
-      updateVisualizerAttributeMAT(shape._extra, time);
-
-      rAndT rT = rotateModelica2OSG(
-          osg::Matrix3(shape._T[0].exp, shape._T[1].exp, shape._T[2].exp,
-                       shape._T[3].exp, shape._T[4].exp, shape._T[5].exp,
-                       shape._T[6].exp, shape._T[7].exp, shape._T[8].exp),
-          osg::Vec3f(shape._r[0].exp, shape._r[1].exp, shape._r[2].exp),
-          osg::Vec3f(shape._rShape[0].exp, shape._rShape[1].exp, shape._rShape[2].exp),
-          osg::Vec3f(shape._lDir[0].exp, shape._lDir[1].exp, shape._lDir[2].exp),
-          osg::Vec3f(shape._wDir[0].exp, shape._wDir[1].exp, shape._wDir[2].exp),
-          shape._type);
-      assemblePokeMatrix(shape._mat, rT._T, rT._r);
-
-      // Update the shapes
-      updateVisualizer(shape);
-      //shape.dumpVisualizerAttributes();
-      //mpOMVisScene->dumpOSGTreeDebug();
-    }
-
-    for (VectorObject& vector : mpOMVisualBase->_vectors)
-    {
-      // Get the values for the scene graph objects
-      //std::cout<<"vector "<<vector._id <<std::endl;
-
-      updateVisualizerAttributeMAT(vector._T[0], time);
-      updateVisualizerAttributeMAT(vector._T[1], time);
-      updateVisualizerAttributeMAT(vector._T[2], time);
-      updateVisualizerAttributeMAT(vector._T[3], time);
-      updateVisualizerAttributeMAT(vector._T[4], time);
-      updateVisualizerAttributeMAT(vector._T[5], time);
-      updateVisualizerAttributeMAT(vector._T[6], time);
-      updateVisualizerAttributeMAT(vector._T[7], time);
-      updateVisualizerAttributeMAT(vector._T[8], time);
-
-      updateVisualizerAttributeMAT(vector._r[0], time);
-      updateVisualizerAttributeMAT(vector._r[1], time);
-      updateVisualizerAttributeMAT(vector._r[2], time);
-
-      updateVisualizerAttributeMAT(vector._color[0], time);
-      updateVisualizerAttributeMAT(vector._color[1], time);
-      updateVisualizerAttributeMAT(vector._color[2], time);
-
-      updateVisualizerAttributeMAT(vector._specCoeff, time);
-
-      updateVisualizerAttributeMAT(vector._coords[0], time);
-      updateVisualizerAttributeMAT(vector._coords[1], time);
-      updateVisualizerAttributeMAT(vector._coords[2], time);
-
-      updateVisualizerAttributeMAT(vector._quantity, time);
-
-      updateVisualizerAttributeMAT(vector._headAtOrigin, time);
-
-      updateVisualizerAttributeMAT(vector._twoHeadedArrow, time);
-
-      rAndT rT = rotateModelica2OSG(
-          osg::Matrix3(vector._T[0].exp, vector._T[1].exp, vector._T[2].exp,
-                       vector._T[3].exp, vector._T[4].exp, vector._T[5].exp,
-                       vector._T[6].exp, vector._T[7].exp, vector._T[8].exp),
-          osg::Vec3f(vector._r[0].exp, vector._r[1].exp, vector._r[2].exp),
-          osg::Vec3f(vector._coords[0].exp, vector._coords[1].exp, vector._coords[2].exp));
-      assemblePokeMatrix(vector._mat, rT._T, rT._r);
-
-      // Update the vectors
-      updateVisualizer(vector);
-      //vector.dumpVisualizerAttributes();
-      //mpOMVisScene->dumpOSGTreeDebug();
-    }
-  }
-  catch (std::exception& ex)
-  {
-    QString msg = QString(QObject::tr("Error in VisualizationMAT::updateVisAttributes at time point %1\n%2."))
-                  .arg(QString::number(time), ex.what());
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel));
-    throw(msg.toStdString());
-  }
-}
-
 void VisualizationMAT::updateScene(const double time)
 {
   mpTimeManager->updateTick();  //for real-time measurement
@@ -242,14 +116,19 @@ void VisualizationMAT::updateScene(const double time)
   mpTimeManager->setRealTimeFactor(mpTimeManager->getHVisual() / visTime);
 }
 
-void VisualizationMAT::updateVisualizerAttributeMAT(VisualizerAttribute& attr, double time)
+void VisualizationMAT::updateVisualizerAttribute(VisualizerAttribute& attr, const double time)
+{
+  updateVisualizerAttributeMAT(attr, time);
+}
+
+void VisualizationMAT::updateVisualizerAttributeMAT(VisualizerAttribute& attr, const double time)
 {
   if (!attr.isConst) {
     attr.exp = omcGetVarValue(&_matReader, attr.cref.c_str(), time);
   }
 }
 
-double VisualizationMAT::omcGetVarValue(ModelicaMatReader* reader, const char* varName, double time)
+double VisualizationMAT::omcGetVarValue(ModelicaMatReader* reader, const char* varName, const double time)
 {
   double val = 0.0;
   ModelicaMatVariable_t* var = nullptr;

--- a/OMEdit/OMEditLIB/Animation/VisualizationMAT.h
+++ b/OMEdit/OMEditLIB/Animation/VisualizationMAT.h
@@ -47,14 +47,14 @@ public:
   VisualizationMAT(const VisualizationMAT& omvm) = delete;
   VisualizationMAT& operator=(const VisualizationMAT& omvm) = delete;
   void initData() override;
-  void initializeVisAttributes(const double time = -1.0) override;
+  void initializeVisAttributes(const double time) override;
   void readMat(const std::string& modelFile, const std::string& path);
   void setSimulationSettings(const UserSimSettingsMAT& simSetMAT);
   void simulate(TimeManager& omvm) override {Q_UNUSED(omvm);}
-  void updateVisAttributes(const double time) override;
   void updateScene(const double time) override;
-  void updateVisualizerAttributeMAT(VisualizerAttribute& attr, double time);
-  double omcGetVarValue(ModelicaMatReader* reader, const char* varName, double time);
+  void updateVisualizerAttribute(VisualizerAttribute& attr, const double time) override;
+  void updateVisualizerAttributeMAT(VisualizerAttribute& attr, const double time);
+  double omcGetVarValue(ModelicaMatReader* reader, const char* varName, const double time);
 private:
   ModelicaMatReader _matReader;
 };


### PR DESCRIPTION
### Purpose

This PR provides new parameters for the vector scaling heuristics introduced in #9389 in order to be fully customizable and handle time-varying lengths.
Some refactoring was involved to also remove duplicate code and improve data privacy.

### Approach

Additions to the length scale adjustment by providing [two new parameters](https://github.com/OpenModelica/OpenModelica/pull/9428/commits/d2e49b3c3fd9c82fc289d96bfb2a14afd0270f9c#diff-003ee05536a1844c1876692266cec5626d4a656eaa622da88191b5ffcf95d3d6R745-R746), one for each of the constraints, along with [a bit of documentation](https://github.com/OpenModelica/OpenModelica/pull/9428/commits/d2e49b3c3fd9c82fc289d96bfb2a14afd0270f9c#diff-003ee05536a1844c1876692266cec5626d4a656eaa622da88191b5ffcf95d3d6R706-R711).
This way, each constraint can be separately enabled/disabled, and also time-varying vector lengths can be efficiently accounted for.

### Tests

- `Modelica.Mechanics.MultiBody.Examples.Elementary.ForceAndTorque`
- Below model containing only visualizers (shapes and vectors), identical to the one in #9389 except for an additional setting
<details><summary>TestScalingVectorVisualizers.mo (click to expand)</summary>

```modelica
model TestScalingVectorVisualizers "Demonstrate animation of vector visualizers with automatic scaling"
  constant Boolean testMinimumLengthConstraint=true;
  constant Boolean testTimeVaryingLengths=true;
  import MB = Modelica.Mechanics.MultiBody;
  inner MB.World world;
  MB.Visualizers.Advanced.Shape s1(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s2(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s3(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s4(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Shape s5(
    shapeType="cylinder",
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    r_shape={0,0,0},
    lengthDirection={-1,0,0},
    widthDirection={0,1,0},
    length=0.45,
    width=0.035,
    height=0.035,
    extra=0.0,
    color={255,0,0},
    specularCoefficient=0.7
  );
  MB.Visualizers.Advanced.Vector v1(
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    coordinates={(time+1)*1200,0,0},
    color={0,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Force,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v2(
    R=MB.Frames.nullRotation(),
    r={0,0,0},
    coordinates={-(time+1)*120,0,0},
    color={0,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Torque,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v3(
    R=MB.Frames.nullRotation(),
    r={0,0.1,0},
    coordinates=if testTimeVaryingLengths then {(1/(time+1))*2*1200,0,0} else {(time+1)*2*1200,0,0},
    color={0,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Force,
    headAtOrigin=true,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v4(
    R=MB.Frames.nullRotation(),
    r={0,0.1,0},
    coordinates=if testTimeVaryingLengths then {-(1/(time+1))*2*120,0,0} else {-(time+1)*2*120,0,0},
    color={0,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Torque,
    headAtOrigin=true,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v5(
    R=MB.Frames.nullRotation(),
    r={0,0.2,0},
    coordinates={(time+1)*8*1200,0,0},
    color={0,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Force,
    headAtOrigin=false,
    twoHeadedArrow=false
  ) if testMinimumLengthConstraint;
  MB.Visualizers.Advanced.Vector v6(
    R=MB.Frames.nullRotation(),
    r={0,0.2,0},
    coordinates={-(time+1)*8*120,0,0},
    color={0,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Torque,
    headAtOrigin=false,
    twoHeadedArrow=false
  ) if testMinimumLengthConstraint;
  MB.Visualizers.Advanced.Vector v7(
    R=MB.Frames.nullRotation(),
    r={-0.1,0.3,0},
    coordinates={-1,2,0},
    color={255,0,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Velocity,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v8(
    R=MB.Frames.nullRotation(),
    r={-0.1,0.3,0},
    coordinates={-2,1,0},
    color={255,255,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.Acceleration,
    headAtOrigin=false,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v9(
    R=MB.Frames.nullRotation(),
    r={-0.1,-0.2,0},
    coordinates={-1,-2,0},
    color={255,0,155},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.AngularVelocity,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
  MB.Visualizers.Advanced.Vector v10(
    R=MB.Frames.nullRotation(),
    r={-0.1,-0.2,0},
    coordinates={-2,-1,0},
    color={255,155,0},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.AngularAcceleration,
    headAtOrigin=false,
    twoHeadedArrow=true
  );
  MB.Visualizers.Advanced.Vector v11(
    R=MB.Frames.nullRotation(),
    r={0,-0.25,0},
    coordinates={0.5,0.75,0},
    color={0,255,255},
    specularCoefficient=0.7,
    quantity=MB.Types.VectorQuantity.RelativePosition,
    headAtOrigin=false,
    twoHeadedArrow=false
  );
end TestScalingVectorVisualizers;
```
</details>

### Related Issues

- Fixes "TODO" in PR #9389
- Complementary fix for #8211
- Proposal for custom annotations in #9390
- MSL discussion on scaling vectors by tools: modelica/ModelicaStandardLibrary#3991
- MSL `ForceAndTorque` model has color issue: modelica/ModelicaStandardLibrary#3989