### PR TITLE
Add an optional arm64-macOS (M1) job that runs on PRs.

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -498,15 +498,6 @@ def shouldWeBuildMINGW() {
   return params.BUILD_MINGW
 }
 
-def shouldWeBuildCENTOS7() {
-  if (isPR()) {
-    if (pullRequest.labels.contains("CI/Build CentOS")) {
-      return true
-    }
-  }
-  return params.BUILD_CENTOS7
-}
-
 def shouldWeDisableAllCMakeBuilds() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/CMake/Disable/All")) {

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -516,13 +516,22 @@ def shouldWeBuildCENTOS7() {
   return params.BUILD_CENTOS7
 }
 
-def shouldWeSkipCMakeBuild() {
+def shouldWeDisableAllCMakeBuilds() {
   if (isPR()) {
-    if (pullRequest.labels.contains("CI/Skip CMake Build")) {
+    if (pullRequest.labels.contains("CI/CMake/Disable/All")) {
       return true
     }
   }
-  return params.SKIP_CMAKE_BUILD
+  return params.DISABLE_ALL_CMAKE_BUILDS
+}
+
+def shouldWeEnableMacOSCMakeBuild() {
+  if (isPR()) {
+    if (pullRequest.labels.contains("CI/CMake/Enable/macOS")) {
+      return true
+    }
+  }
+  return params.ENABLE_MACOS_CMAKE_BUILD
 }
 
 def shouldWeRunTests() {

--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -489,15 +489,6 @@ def makeCommand() {
   return env.GMAKE ?: "make"
 }
 
-def shouldWeBuildOSX() {
-  if (isPR()) {
-    if (pullRequest.labels.contains("CI/Build OSX")) {
-      return true
-    }
-  }
-  return params.BUILD_OSX
-}
-
 def shouldWeBuildMINGW() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/Build MINGW")) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 def common
 def shouldWeBuildMINGW
-def shouldWeBuildCENTOS7
 def shouldWeDisableAllCMakeBuilds_value
 def shouldWeEnableMacOSCMakeBuild_value
 def shouldWeRunTests
@@ -16,7 +15,6 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'BUILD_MINGW', defaultValue: false, description: 'Build with Win/MinGW')
-    booleanParam(name: 'BUILD_CENTOS7', defaultValue: false, description: 'Build on CentOS7 with CMake 2.8')
     booleanParam(name: 'DISABLE_ALL_CMAKE_BUILDS', defaultValue: false, description: 'Skip building omc with CMake (CMake 3.17.2) on all platforms')
     booleanParam(name: 'ENABLE_MACOS_CMAKE_BUILD', defaultValue: false, description: 'Skip building omc with CMake on macOS')
   }
@@ -39,8 +37,6 @@ pipeline {
           print "isPR: ${isPR}"
           shouldWeBuildMINGW = common.shouldWeBuildMINGW()
           print "shouldWeBuildMINGW: ${shouldWeBuildMINGW}"
-          shouldWeBuildCENTOS7 = common.shouldWeBuildCENTOS7()
-          print "shouldWeBuildCENTOS7: ${shouldWeBuildCENTOS7}"
           shouldWeDisableAllCMakeBuilds_value = common.shouldWeDisableAllCMakeBuilds()
           print "shouldWeDisableAllCMakeBuilds: ${shouldWeDisableAllCMakeBuilds_value}"
           shouldWeEnableMacOSCMakeBuild_value = common.shouldWeEnableMacOSCMakeBuild()
@@ -116,35 +112,6 @@ pipeline {
                 common.buildAndRunOMEditTestsuite('')
               }
             }
-          }
-        }
-        stage('CentOS7') {
-          agent {
-            dockerfile {
-              additionalBuildArgs '--pull'
-              dir '.CI/cache-centos7'
-              label 'linux'
-              args "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
-            }
-          }
-          when {
-            beforeAgent true
-            expression { shouldWeBuildCENTOS7 }
-          }
-          environment {
-            QTDIR = "/usr/lib64/qt5/"
-          }
-          steps {
-            sh "source /opt/rh/devtoolset-8/enable"
-            script {
-              common.buildOMC(
-                '/opt/rh/devtoolset-8/root/usr/bin/gcc',
-                '/opt/rh/devtoolset-8/root/usr/bin/g++',
-                'FC=/opt/rh/devtoolset-8/root/usr/bin/gfortran CMAKE=cmake3',
-                false, // Building C++ runtime doesn't work at the moment
-                false)
-            }
-            //stash name: 'omc-centos7', includes: 'build/**, **/config.status'
           }
         }
         stage('cmake-bionic-gcc') {


### PR DESCRIPTION
[Add an optional arm64-macOS (M1) job that runs on PRs.](https://github.com/OpenModelica/OpenModelica/pull/9430/commits/899f903526aaa01dc9175a38287d5f8660338a3b) 
  - This can be enabled by setting the label:
    `CI/CMake/Enable/macOS`

  - Change the label `CI/Skip CMake build` to `CI/CMake/Disable/All`
    Setting this label disables all CMake builds. At the moment these are
      - building on x86-64 ubuntu (bionic)
      - building on arm64 macOS (even when `CI/CMake/Enable/macOS` is set)

[Remove the old non-functional osx CI job.](https://github.com/OpenModelica/OpenModelica/pull/9430/commits/40386a5d5a722bd518b54e0742084b3c90c4cc01)

[Remove the non-functional CentOS7 job.](https://github.com/OpenModelica/OpenModelica/pull/9430/commits/6c2310046f2edae0138c6e2e21ed5070fb11ef42)
