### PR TITLE
Fix macOS build.

### DIFF
--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml XmlPatterns OpenGL Network Svg REQUIRED)
 find_package(OpenSceneGraph COMPONENTS osg osgViewer osgUtil osgDB osgGA REQUIRED)
+find_package(OpenGL REQUIRED)
 
 # Configure omedit_config.h. This will be generated in the build directory
 configure_file(omedit_config.h.in omedit_config.h)

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -276,7 +276,7 @@ target_include_directories(OMEditLib PUBLIC ${OPENSCENEGRAPH_INCLUDE_DIRS})
 # qmake adds -DUNICODE by defult (As far as I can gather).
 # So add it for CMake as well to avoid having to modify the code.
 if(WIN32)
-  target_compile_definitions(OMEditLib PRIVATE -DUNICODE)
+  target_compile_definitions(OMEditLib PRIVATE UNICODE)
 endif()
 
 target_link_libraries(OMEditLib PUBLIC omedit::config)
@@ -295,12 +295,11 @@ target_link_libraries(OMEditLib PUBLIC omc::3rd::opcua)
 target_link_libraries(OMEditLib PUBLIC OMPlotLib)
 target_link_libraries(OMEditLib PUBLIC OpenModelicaCompiler)
 target_link_libraries(OMEditLib PUBLIC ${OPENSCENEGRAPH_LIBRARIES})
-target_link_libraries(OMEditLib PUBLIC GL)
+target_link_libraries(OMEditLib PUBLIC OpenGL::GL)
 
 if(MINGW)
   target_link_libraries(OMEditLib PUBLIC binutils::bfd)
   target_link_libraries(OMEditLib PUBLIC zlib)
 endif()
 
-target_include_directories(OMEditLib PRIVATE
-  ${OMCompiler_SOURCE_DIR}/Compiler/Script)
+target_include_directories(OMEditLib PRIVATE ${OMCompiler_SOURCE_DIR}/Compiler/Script)

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -297,6 +297,11 @@ target_link_libraries(OMEditLib PUBLIC OpenModelicaCompiler)
 target_link_libraries(OMEditLib PUBLIC ${OPENSCENEGRAPH_LIBRARIES})
 target_link_libraries(OMEditLib PUBLIC OpenGL::GL)
 
+# Silence OpenGL deprecation warnings on macOS
+if(APPLE)
+  target_compile_definitions(OMEditLib PRIVATE GL_SILENCE_DEPRECATION)
+endif()
+
 if(MINGW)
   target_link_libraries(OMEditLib PUBLIC binutils::bfd)
   target_link_libraries(OMEditLib PUBLIC zlib)


### PR DESCRIPTION
- [Use the CMake import name of OpenGL.](https://github.com/OpenModelica/OpenModelica/commit/2e191c9e3407fd7b3ed7fd23fb8b0cd203a86bac) 

  - OpenGL is handled differently on different platforms (e.g macOS has it
    as a framework). So linking to GL directly (-lGL) does not always work.

    Use the imported name OpenGL::GL to let CMake handle the actual linking
    command-line.

 
- [Silence OpenGL deprecation warnings on macOS.](https://github.com/OpenModelica/OpenModelica/commit/b61b2f9fecf6d8fea88d2b3a4741ab8c53313ce6)

