### PR TITLE
CMake FMUs library directory with spaces

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3678,7 +3678,9 @@ algorithm
         then();
     else
       algorithm
-        Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {"Unknown/unsupported platform \"" + platform + " \" for CMake FMU build"});
+        Error.addMessage(Error.SIMULATOR_BUILD_ERROR,
+                         {"Unknown/unsupported platform \"" + platform + " \" for CMake FMU build. " +
+                          "Use platforms={\"dynamic\"} for the default case."});
       then fail();
   end match;
 end configureFMU_cmake;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15558,8 +15558,13 @@ public function getCmakeLinkLibrariesCode
 protected
   list<String> locations;
   list<String> libraries;
+  function addQuotationMarks
+    input String istring;
+    output String ostring = "\""+istring+"\"";
+  end addQuotationMarks;
 algorithm
   (locations, libraries) := getDirectoriesForDLLsFromLinkLibs(libs);
+  locations := List.map(locations, addQuotationMarks);
   for lib in libraries loop
     cmakecode := cmakecode + "find_library(" + lib + "\n" +
                  "             NAMES " + lib + "\n" +


### PR DESCRIPTION
### Related Issues

Fixes #9435.

### Purpose

Support library names with spaces in them, e.g. `TILMedia 1.8.0-ClaRa`.

### Approach

  - Adding quotation marks around path
