### PR TITLE
Catch index out of bound in modelInfoGetEquation

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -586,6 +586,17 @@ EQUATION_INFO modelInfoGetDummyEquation(MODEL_DATA_XML* xml)
   return equationInfo;
 }
 
+/**
+ * @brief Get equation info for equation with index `ix`.
+ *
+ * Return dummy equation info if xml->fileName == NULL, e.g. for
+ * --fmiFilter=blackBox and protected.
+ * Return dummy equation info if `ix` is out of range.
+ *
+ * @param xml             Model info XML.
+ * @param ix              Equation index.
+ * @return EQUATION_INFO  Equation info for equation `ix`.
+ */
 EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix)
 {
   /* check for xml->fileName == NULL for --fmiFilter=blackBox and protected
@@ -599,6 +610,10 @@ EQUATION_INFO modelInfoGetEquation(MODEL_DATA_XML* xml, size_t ix)
     modelInfoInit(xml);
   }
   assert(xml->equationInfo);
+  if (ix<0 || ix > xml->nEquations) {
+    errorStreamPrint(LOG_STDOUT, 0, "modelInfoGetEquation failed to get info for equation %zu, out of range.\n", ix);
+    return modelInfoGetDummyEquation(xml);
+  }
   return xml->equationInfo[ix];
 }
 


### PR DESCRIPTION

### Related Issues

Partial fix for #9423.
Prevents the segmentation fault, but doesn't solve the cause for the wrong iteration variable in https://github.com/OpenModelica/OpenModelica/blob/master/OMCompiler/SimulationRuntime/c/simulation/modelinfo.c#L632-L638.

### Purpose

  - Prevents segmentation fault, issue an error can continue. The profiling could be wrong.


### Approach

Check if `ix` is out of bounds and print error.
