### PR TITLE
System.removeDirectory removing dead links

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -1069,6 +1069,20 @@ static int SystemImpl__removeDirectoryItem(const char *path)
             r2 = omc_unlink(buf);
           }
         }
+        else if(omc_lstat(buf, &statbuf) == 0)
+        {
+          // Dead link, that isn't pointing to a file/directory any more
+          r2 = omc_unlink(buf);
+        }
+        else {
+          const char *c_tokens[1]={buf};
+          c_add_message(NULL,85,
+            ErrorType_scripting,
+            ErrorLevel_error,
+            gettext("Failed to remove %s"),
+            c_tokens,
+            1);
+        }
       }
       retval = r2;
     }

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -137,7 +137,6 @@ size_t omc_fread(void *buffer, size_t size, size_t count, FILE *stream, int allo
 }
 
 
-
 #if defined(__MINGW32__) || defined(_MSC_VER)
 /**
  * @brief File attributes
@@ -170,6 +169,32 @@ int omc_stat(const char *filename, omc_stat_t* statbuf)
   return res;
 }
 #endif
+
+
+#if defined(__MINGW32__) || defined(_MSC_VER)
+/**
+ * @brief File attributes
+ *
+ * Using (long) unicode absolute path and `_wstat` on Windows.
+ * Using `stat` on Unix.
+ *
+ * @param filename  File name.
+ * @param statbuf   Pointer to stat structure.
+ * @return int      0 on success, -1 on error.
+ */
+int omc_lstat(const char *filename, omc_stat_t* statbuf)
+{
+  return omc_stat(filename, statbuf);
+}
+#else /* unix */
+int omc_lstat(const char *filename, omc_stat_t* statbuf)
+{
+  int res;
+  res = lstat(filename, statbuf);
+  return res;
+}
+#endif
+
 
 /**
  * @brief Unlink file.

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.h
@@ -78,6 +78,7 @@ typedef struct _stat omc_stat_t;
 typedef struct stat omc_stat_t;
 #endif
 int omc_stat(const char *filename, omc_stat_t *statbuf);
+int omc_lstat(const char *filename, omc_stat_t *statbuf);
 
 int omc_unlink(const char *filename);
 


### PR DESCRIPTION
### Related Issues

Follow-up on #9424.

### Purpose

When using `--fmuRuntimeDepends=all` omc failes to remove temp directory because the link target got removed before the link itself and `SystemImpl__removeDirectoryItem` can't handle dead symbolic links.

### Approach

  - Handling of symbolic links to SystemImpl__removeDirectoryItem
  - omc_lstat added
    - using lstat on Unix and omc_stat on Windows
  - Error message if omc_stat and omc_lstat fails

