### PR TITLE
Improve dumping of derived types in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -279,6 +279,17 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
     output Option<Expression> value = Binding.typedExp(lookupAttributeBinding(name, cls));
   end lookupAttributeValue;
 
+  function isOnlyBuiltin
+    input Class cls;
+    output Boolean builtin;
+  algorithm
+    builtin := match cls
+      case PARTIAL_BUILTIN() then true;
+      case INSTANCED_BUILTIN() then true;
+      else false;
+    end match;
+  end isOnlyBuiltin;
+
   function isBuiltin
     input Class cls;
     output Boolean isBuiltin;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
@@ -37,30 +37,31 @@ encapsulated package NFInstContext
   // Flag values:
   constant Type NO_CONTEXT      = 0;
   constant Type RELAXED         = intBitLShift(1,  0); // Relaxed instantiation, used by e.g. checkModel.
-  constant Type CLASS           = intBitLShift(1,  1); // In class.
-  constant Type FUNCTION        = intBitLShift(1,  2); // In function.
-  constant Type REDECLARED      = intBitLShift(1,  3); // In an element that will be replaced with a redeclare.
-  constant Type ALGORITHM       = intBitLShift(1,  4); // In algorithm section.
-  constant Type EQUATION        = intBitLShift(1,  5); // In equation section.
-  constant Type INITIAL         = intBitLShift(1,  6); // In initial section.
-  constant Type LHS             = intBitLShift(1,  7); // On left hand side of equality/assignment.
-  constant Type RHS             = intBitLShift(1,  8); // On right hand side of equality/assignment.
-  constant Type WHEN            = intBitLShift(1,  9); // In when equation/statement.
-  constant Type CLOCKED         = intBitLShift(1, 10); // Part of a clocked when equation.
-  constant Type FOR             = intBitLShift(1, 11); // In a for loop.
-  constant Type IF              = intBitLShift(1, 12); // In an if equation/statement.
-  constant Type WHILE           = intBitLShift(1, 13); // In a while loop.
-  constant Type NONEXPANDABLE   = intBitLShift(1, 14); // In non-parameter if/for.
-  constant Type ITERATION_RANGE = intBitLShift(1, 15); // In range used for iteration.
-  constant Type DIMENSION       = intBitLShift(1, 16); // In dimension.
-  constant Type BINDING         = intBitLShift(1, 17); // In binding.
-  constant Type CONDITION       = intBitLShift(1, 18); // In conditional expression.
-  constant Type SUBSCRIPT       = intBitLShift(1, 19); // In subscript.
-  constant Type SUBEXPRESSION   = intBitLShift(1, 20); // Part of a larger expression.
-  constant Type CONNECT         = intBitLShift(1, 21); // Part of connect argument.
-  constant Type NOEVENT         = intBitLShift(1, 22); // Part of noEvent argument.
-  constant Type ASSERT          = intBitLShift(1, 23); // Part of assert argument.
-  constant Type ANNOTATION      = intBitLShift(1, 24); // Part of an annotation.
+  constant Type INSTANCE_API    = intBitLShift(1,  1); // Instantiation for the model instance API.
+  constant Type CLASS           = intBitLShift(1,  2); // In class.
+  constant Type FUNCTION        = intBitLShift(1,  3); // In function.
+  constant Type REDECLARED      = intBitLShift(1,  4); // In an element that will be replaced with a redeclare.
+  constant Type ALGORITHM       = intBitLShift(1,  5); // In algorithm section.
+  constant Type EQUATION        = intBitLShift(1,  6); // In equation section.
+  constant Type INITIAL         = intBitLShift(1,  7); // In initial section.
+  constant Type LHS             = intBitLShift(1,  8); // On left hand side of equality/assignment.
+  constant Type RHS             = intBitLShift(1,  9); // On right hand side of equality/assignment.
+  constant Type WHEN            = intBitLShift(1, 10); // In when equation/statement.
+  constant Type CLOCKED         = intBitLShift(1, 11); // Part of a clocked when equation.
+  constant Type FOR             = intBitLShift(1, 12); // In a for loop.
+  constant Type IF              = intBitLShift(1, 13); // In an if equation/statement.
+  constant Type WHILE           = intBitLShift(1, 14); // In a while loop.
+  constant Type NONEXPANDABLE   = intBitLShift(1, 15); // In non-parameter if/for.
+  constant Type ITERATION_RANGE = intBitLShift(1, 16); // In range used for iteration.
+  constant Type DIMENSION       = intBitLShift(1, 17); // In dimension.
+  constant Type BINDING         = intBitLShift(1, 18); // In binding.
+  constant Type CONDITION       = intBitLShift(1, 19); // In conditional expression.
+  constant Type SUBSCRIPT       = intBitLShift(1, 20); // In subscript.
+  constant Type SUBEXPRESSION   = intBitLShift(1, 21); // Part of a larger expression.
+  constant Type CONNECT         = intBitLShift(1, 22); // Part of connect argument.
+  constant Type NOEVENT         = intBitLShift(1, 23); // Part of noEvent argument.
+  constant Type ASSERT          = intBitLShift(1, 24); // Part of assert argument.
+  constant Type ANNOTATION      = intBitLShift(1, 25); // Part of an annotation.
 
   // Combined flags:
   constant Type EQ_SUBEXPRESSION = intBitOr(EQUATION, SUBEXPRESSION);
@@ -98,6 +99,11 @@ encapsulated package NFInstContext
     input Type context;
     output Boolean res = intBitAnd(context, RELAXED) > 0;
   end inRelaxed;
+
+  function inInstanceAPI
+    input Type context;
+    output Boolean res = intBitAnd(context, INSTANCE_API) > 0;
+  end inInstanceAPI;
 
   function inClass
     input Type context;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -890,6 +890,16 @@ uniontype InstNode
     end match;
   end nodeType;
 
+  function derivedNodeType
+    input InstNode node;
+    output InstNodeType ty;
+  algorithm
+    ty := match node
+      case CLASS_NODE(nodeType = InstNodeType.DERIVED_CLASS(ty = ty)) then ty;
+      else nodeType(node);
+    end match;
+  end derivedNodeType;
+
   function setNodeType
     input InstNodeType nodeType;
     input output InstNode node;
@@ -925,7 +935,7 @@ uniontype InstNode
     input InstNode node;
     output SCode.Element definition;
   algorithm
-    CLASS_NODE(nodeType = InstNodeType.BASE_CLASS(definition = definition)) := node;
+    InstNodeType.BASE_CLASS(definition = definition) := derivedNodeType(node);
   end extendsDefinition;
 
   function setDefinition

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -167,9 +167,14 @@ algorithm
     case Class.TYPED_DERIVED()
       algorithm
         typeComponents(c.baseClass, context);
-        c2 := InstNode.getClass(c.baseClass);
-        c2 := Class.setRestriction(c.restriction, c2);
-        InstNode.updateClass(c2, cls);
+
+        // Only collapse for the normal instantiation, for the instance API we
+        // need the derived class chains.
+        if not InstContext.inInstanceAPI(context) then
+          c2 := InstNode.getClass(c.baseClass);
+          c2 := Class.setRestriction(c.restriction, c2);
+          InstNode.updateClass(c2, cls);
+        end if;
       then
         ();
 

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -43,6 +43,18 @@
         },
         "encapsulated": {
           "type": "boolean"
+        },
+        "connector": {
+          "type": "string",
+          "enum": ["flow", "stream"]
+        },
+        "variability": {
+          "type": "string",
+          "enum": ["constant", "parameter", "discrete"]
+        },
+        "direction": {
+          "type": "string",
+          "enum": ["input", "output"]
         }
       }
     },
@@ -55,10 +67,19 @@
     },
     "extends": {
       "description": "The extends clauses in the class instance",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/extends"
-      }
+      "oneOf": [
+        {
+          "description": "The extends clauses in a long class definition",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/extends"
+          }
+        },
+        {
+          "description": "The extended class in a short class definition",
+          "$ref": "#/definitions/extends"
+        }
+      ]
     },
     "components": {
       "description": "The components in the class instance",
@@ -216,7 +237,16 @@
         },
         "baseClass": {
           "description": "The class instance of the extended class",
-          "$ref": "#"
+          "oneOf": [
+            {
+              "description": "Class type",
+              "$ref": "#"
+            },
+            {
+              "description": "Builtin type",
+              "type": "string"
+            }
+          ]
         }
       }
     },

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -34,7 +34,26 @@ getModelInstance(M, prettyPrint = true);
 //     },
 //     {
 //       \"name\": \"deg\",
-//       \"type\": \"Real\",
+//       \"type\": {
+//         \"name\": \"Angle\",
+//         \"restriction\": \"type\",
+//         \"modifiers\": {
+//           \"quantity\": {
+//             \"final\": true,
+//             \"$value\": \"\\\"Angle\\\"\"
+//           }
+//         },
+//         \"extends\": {
+//           \"baseClass\": \"Real\"
+//         },
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 3,
+//           \"columnStart\": 5,
+//           \"lineEnd\": 3,
+//           \"columnEnd\": 48
+//         }
+//       },
 //       \"modifiers\": {
 //         \"start\": \"pi\",
 //         \"$value\": \"2\"

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
@@ -1,0 +1,92 @@
+// name: GetModelInstanceAnnotation1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  type RealInput = input Real;
+  type RealInput2 = RealInput(start = 1.0);
+
+  model M
+    RealInput x;
+    RealInput2 y;
+  end M;
+");
+
+getModelInstance(M, true);
+getErrorString();
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//     {
+//       \"name\": \"x\",
+//       \"type\": {
+//         \"name\": \"RealInput\",
+//         \"restriction\": \"type\",
+//         \"prefixes\": {
+//           \"direction\": \"input\"
+//         },
+//         \"extends\": {
+//           \"baseClass\": \"Real\"
+//         },
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 2,
+//           \"columnEnd\": 30
+//         }
+//       }
+//     },
+//     {
+//       \"name\": \"y\",
+//       \"type\": {
+//         \"name\": \"RealInput2\",
+//         \"restriction\": \"type\",
+//         \"modifiers\": {
+//           \"start\": \"1.0\"
+//         },
+//         \"extends\": {
+//           \"baseClass\": {
+//             \"name\": \"RealInput\",
+//             \"restriction\": \"type\",
+//             \"prefixes\": {
+//               \"direction\": \"input\"
+//             },
+//             \"extends\": {
+//               \"baseClass\": \"Real\"
+//             },
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 2,
+//               \"columnStart\": 3,
+//               \"lineEnd\": 2,
+//               \"columnEnd\": 30
+//             }
+//           }
+//         },
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 3,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 3,
+//           \"columnEnd\": 43
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 5,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 8,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -9,11 +9,13 @@ GetModelInstanceAttributes2.mos \
 GetModelInstanceComment1.mos \
 GetModelInstanceConditional1.mos \
 GetModelInstanceConnection1.mos \
+GetModelInstanceDerived1.mos \
 GetModelInstanceDuplicate1.mos \
 GetModelInstanceEnum1.mos \
 GetModelInstanceEnum2.mos \
 GetModelInstanceExp1.mos \
 GetModelInstanceExtends1.mos \
+GetModelInstanceExtends2.mos \
 GetModelInstanceInnerOuter1.mos \
 GetModelInstanceInnerOuter2.mos \
 GetModelInstanceMod1.mos \


### PR DESCRIPTION
- Dump the whole extends chain for short class definition types and not just the builtin types they ultimately extend from.
- Dump attributes for short class definitions.

Fixes #9374