### PR TITLE
Report who requested library loading from uses annotation.

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -395,12 +395,12 @@ protected
   Boolean onlyCheckFirstModelicaPath;
   Absyn.Path path;
   list<String> versionsLst;
-  String pathStr, versions, version, thisModelicaPath, dir;
+  String pathStr, versions, version, thisModelicaPath, dir, requestedBy;
   Absyn.Program pnew;
   ErrorTypes.MessageTokens msgTokens;
   Option<Absyn.Class> cl;
 algorithm
-  (path, _, versionsLst, onlyCheckFirstModelicaPath) := modelToLoad;
+  (path, requestedBy, versionsLst, onlyCheckFirstModelicaPath) := modelToLoad;
   if onlyCheckFirstModelicaPath then
     /* Using loadFile() */
     thisModelicaPath::_ := System.strtok(modelicaPath, Autoconf.groupDelimiter);
@@ -426,7 +426,7 @@ algorithm
 
       if notifyLoad and not forceLoad then
         version := getPackageVersion(path, pnew);
-        msgTokens := {AbsynUtil.pathString(path), version};
+        msgTokens := {AbsynUtil.pathString(path), version, requestedBy};
         Error.addMessage(Error.NOTIFY_LOAD_MODEL_DUE_TO_USES, msgTokens);
         System.loadModelCallBack(AbsynUtil.pathFirstIdent(path));
       end if;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3260,7 +3260,7 @@ algorithm
   else
     str := AbsynUtil.pathFirstIdent(className);
     (p,b) := CevalScript.loadModel({(Absyn.IDENT(str),"the given model name to instantiate",{"default"},false)},Settings.getModelicaPath(Testsuite.isRunning()),p,true,true,true,false);
-    Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_LOAD_MODEL_DUE_TO_USES,{str,"default"},AbsynUtil.dummyInfo);
+    Error.assertionOrAddSourceMessage(not b,Error.NOTIFY_IMPLICIT_LOAD,{str,"default"},AbsynUtil.dummyInfo);
     System.loadModelCallBack(str);
     // print(stringDelimitList(list(AbsynUtil.pathString(path) for path in Interactive.getTopClassnames(p)), ",") + "\n");
     SymbolTable.setAbsyn(p);

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -519,7 +519,7 @@ public constant ErrorTypes.Message CONNECT_IN_INITIAL_EQUATION = ErrorTypes.MESS
 public constant ErrorTypes.Message FINAL_COMPONENT_OVERRIDE = ErrorTypes.MESSAGE(222, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Trying to override final element %s with modifier '%s'."));
 public constant ErrorTypes.Message NOTIFY_LOAD_MODEL_DUE_TO_USES = ErrorTypes.MESSAGE(223, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
-  Gettext.gettext("Automatically loaded package %s %s due to uses annotation."));
+  Gettext.gettext("Automatically loaded package %s %s due to uses annotation from %s."));
 public constant ErrorTypes.Message REINIT_MUST_BE_REAL = ErrorTypes.MESSAGE(224, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The first argument to reinit must be a subtype of Real, but %s has type %s."));
 public constant ErrorTypes.Message REINIT_MUST_BE_VAR = ErrorTypes.MESSAGE(225, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),

--- a/testsuite/flattening/libraries/3rdParty/Exercises/checkExercises.mos
+++ b/testsuite/flattening/libraries/3rdParty/Exercises/checkExercises.mos
@@ -29,9 +29,9 @@ checkModel(FourBar.TestPlanarLoops); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from Aufgabe1_1.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // "Check of Aufgabe1_1 completed successfully.
 // Class Aufgabe1_1 has 52 equation(s) and 52 variable(s).

--- a/testsuite/flattening/modelica/expandable/TestModelTotal.mos
+++ b/testsuite/flattening/modelica/expandable/TestModelTotal.mos
@@ -13,8 +13,8 @@ checkModel(TestPackage_TestModel); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // "class TestPackage_TestModel
 //   Real OutputFromBus.vehicleVelocity.y;

--- a/testsuite/flattening/modelica/scodeinst/LookupLibrary1.mo
+++ b/testsuite/flattening/modelica/scodeinst/LookupLibrary1.mo
@@ -14,8 +14,8 @@ end LookupLibrary1;
 // class LookupLibrary1
 //   Real angle(quantity = "Angle", unit = "rad", displayUnit = "deg");
 // end LookupLibrary1;
-// Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation.
+// Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
 // Notification: Automatically loaded package Modelica 4.0.0 due to usage.
 //
 // endResult

--- a/testsuite/flattening/modelica/scoping/InnerOuterSamePrefix.mo
+++ b/testsuite/flattening/modelica/scoping/InnerOuterSamePrefix.mo
@@ -5464,6 +5464,6 @@ end InnerOuterSamePrefix;// Result:
 //   pendulum.revolute.frame_a.r_0[2] = pendulum.world.frame_b.r_0[2];
 //   pendulum.revolute.frame_a.r_0[3] = pendulum.world.frame_b.r_0[3];
 // end InnerOuterSamePrefix;
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
 //
 // endResult

--- a/testsuite/omsimulator/DualMassOscillator.mos
+++ b/testsuite/omsimulator/DualMassOscillator.mos
@@ -57,9 +57,9 @@ unloadOMSimulator();
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from DualMassOscillator.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // "DualMassOscillator.System1.fmu"
 // ""

--- a/testsuite/omsimulator/DualMassOscillator_cs.mos
+++ b/testsuite/omsimulator/DualMassOscillator_cs.mos
@@ -52,9 +52,9 @@ val(system2.s2, {0.0,0.1});
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from DualMassOscillator.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // "DualMassOscillator.System1.fmu"
 // ""

--- a/testsuite/omsimulator/DualMassOscillator_me.mos
+++ b/testsuite/omsimulator/DualMassOscillator_me.mos
@@ -53,9 +53,9 @@ val(system2.s2, {0.0,0.1});
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from DualMassOscillator.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // "DualMassOscillator.System1.fmu"
 // ""

--- a/testsuite/omsimulator/cmakeFMU.mos
+++ b/testsuite/omsimulator/cmakeFMU.mos
@@ -12,9 +12,9 @@ readFile("DualMassOscillator_System1_systemCall.log");
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from DualMassOscillator.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -47,9 +47,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from CSTR_me_FMU.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -47,7 +47,7 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from CSTR_me_FMU.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from CSTR.
 // Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "

--- a/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
@@ -193,9 +193,9 @@ val(y[10], 1.0);
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'VectorizedBlocksTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from VectorizedBlocksTest.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // Notification: Automatically loaded package Modelica_Synchronous 0.93.0-dev due to uses annotation.
 // Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.

--- a/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
@@ -196,7 +196,7 @@ val(y[10], 1.0);
 // "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from VectorizedBlocksTest.
 // Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
-// Notification: Automatically loaded package Modelica_Synchronous 0.93.0-dev due to uses annotation.
+// Notification: Automatically loaded package Modelica_Synchronous 0.93.0-dev due to uses annotation from VectorizedBlocksTest.
 // Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: The initial conditions are over specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").

--- a/testsuite/openmodelica/dataReconciliation/DistillationTower.mos
+++ b/testsuite/openmodelica/dataReconciliation/DistillationTower.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/DistillationTower.mos
+++ b/testsuite/openmodelica/dataReconciliation/DistillationTower.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.DistillationTower

--- a/testsuite/openmodelica/dataReconciliation/FourFlows.mos
+++ b/testsuite/openmodelica/dataReconciliation/FourFlows.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/FourFlows.mos
+++ b/testsuite/openmodelica/dataReconciliation/FourFlows.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.FourFlows

--- a/testsuite/openmodelica/dataReconciliation/Pipe1.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe1.mos
@@ -17,9 +17,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Pipe1.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe1.mos
@@ -20,7 +20,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Pipe1

--- a/testsuite/openmodelica/dataReconciliation/Pipe2.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe2.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Pipe2

--- a/testsuite/openmodelica/dataReconciliation/Pipe2.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe2.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe3.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Pipe3

--- a/testsuite/openmodelica/dataReconciliation/Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe3.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Pipe4.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe4.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Pipe4.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe4.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Pipe4

--- a/testsuite/openmodelica/dataReconciliation/Pipe5.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe5.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Pipe5

--- a/testsuite/openmodelica/dataReconciliation/Pipe5.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe5.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Pipe6.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe6.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Pipe6.mos
+++ b/testsuite/openmodelica/dataReconciliation/Pipe6.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Pipe6

--- a/testsuite/openmodelica/dataReconciliation/Splitter.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter.mos
@@ -17,9 +17,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter.mos
@@ -20,7 +20,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter

--- a/testsuite/openmodelica/dataReconciliation/Splitter1.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter1.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter1.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter1.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter1

--- a/testsuite/openmodelica/dataReconciliation/Splitter2.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter2.mos
@@ -17,9 +17,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter2.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter2.mos
@@ -20,7 +20,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter2

--- a/testsuite/openmodelica/dataReconciliation/Splitter3.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter3.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter3.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter3.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter3

--- a/testsuite/openmodelica/dataReconciliation/Splitter4.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter4.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter4.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter4.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter4

--- a/testsuite/openmodelica/dataReconciliation/Splitter5c.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5c.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter5c.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5c.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter5c

--- a/testsuite/openmodelica/dataReconciliation/Splitter5d.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5d.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter5d.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5d.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter5d

--- a/testsuite/openmodelica/dataReconciliation/Splitter5e.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5e.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter5e.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5e.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter5e

--- a/testsuite/openmodelica/dataReconciliation/Splitter5f.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5f.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter5f.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5f.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter5f

--- a/testsuite/openmodelica/dataReconciliation/Splitter5g.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5g.mos
@@ -20,9 +20,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/Splitter5g.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5g.mos
@@ -23,7 +23,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter5g

--- a/testsuite/openmodelica/dataReconciliation/Splitter5h.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5h.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.Splitter5h

--- a/testsuite/openmodelica/dataReconciliation/Splitter5h.mos
+++ b/testsuite/openmodelica/dataReconciliation/Splitter5h.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows1.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows1.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows1.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows1.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows1

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows10.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows10.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows10.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows10.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows10

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows11.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows11.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows11.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows11.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows11

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows2.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows2.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows2.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows2.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows2

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows3.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows3

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows3.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows4.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows4.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows4.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows4.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows4

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows5.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows5.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows5

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows5.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows5.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows6.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows6.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows6.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows6.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows6

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows7.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows7.mos
@@ -20,9 +20,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows7.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows7.mos
@@ -23,7 +23,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows7

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows8.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows8.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows8

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows8.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows8.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows9.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows9.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_FourFlows9.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_FourFlows9.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_FourFlows9

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe1.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe1.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe1

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe1.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe1.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe10.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe10.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe10

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe10.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe10.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe11.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe11.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe11.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe11.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe11

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe2.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe2.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe2

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe2.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe2.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe3

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe4.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe4.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe4.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe4.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe4

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe5.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe5.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe5.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe5.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe5

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe6.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe6.mos
@@ -22,7 +22,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe6

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe6.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe6.mos
@@ -19,9 +19,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe7.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe7.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe7.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe7.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe7

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe8.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe8.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe8

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe8.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe8.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe9.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe9.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Pipe9

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe9.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe9.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter1.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter1.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter1.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter1.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter1

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter2.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter2.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter2

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter2.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter2.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter3.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter3

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter3.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter4.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter4.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter4.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter4.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter4

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter5.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter5.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter5.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter5.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter5

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter6.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter6.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter6.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter6.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter6

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter7.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter7.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.TSP_Splitter7

--- a/testsuite/openmodelica/dataReconciliation/TSP_Splitter7.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Splitter7.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/dataReconciliation/VDI2048Exple.mos
+++ b/testsuite/openmodelica/dataReconciliation/VDI2048Exple.mos
@@ -21,7 +21,7 @@ getErrorString();
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
+// Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation from NewDataReconciliationSimpleTests.
 // "
 //
 // ModelInfo: NewDataReconciliationSimpleTests.VDI2048Example_Corrected

--- a/testsuite/openmodelica/dataReconciliation/VDI2048Exple.mos
+++ b/testsuite/openmodelica/dataReconciliation/VDI2048Exple.mos
@@ -18,9 +18,9 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from NewDataReconciliationSimpleTests.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ThermoSysPro 3.2 due to uses annotation.
 // "
 //

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/JuliansBib.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/JuliansBib.mos
@@ -34,9 +34,9 @@ val(s, 1);
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from JuliansBib.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
@@ -54,9 +54,9 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 // true
 // ""
 // "fmi_attributes_17.fmu"
-// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from fmi_attributes_17.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // 0

--- a/testsuite/openmodelica/interactive-API/UsesAnnotation1.mos
+++ b/testsuite/openmodelica/interactive-API/UsesAnnotation1.mos
@@ -44,8 +44,8 @@ instantiateModel(A.B); getErrorString();
 //   x = A.B.f(time);
 // end A.B;
 // "
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from A.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // endResult

--- a/testsuite/openmodelica/uncertainties/DataReconciliationOpenCpsTests.mos
+++ b/testsuite/openmodelica/uncertainties/DataReconciliationOpenCpsTests.mos
@@ -62,8 +62,8 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
 // Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2. There is a possibility that 3.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // "
 //
@@ -144,7 +144,7 @@ getErrorString();
 // SET_C : {9, 6, 5, 7, 8}
 // SET_S: {}
 //
-// FINAL SET OF EQUATIONS After Reconciliation 
+// FINAL SET OF EQUATIONS After Reconciliation
 // ==========================================================================
 // SET_C: {9, 6, 5, 7, 8}
 // SET_S: {}
@@ -184,7 +184,7 @@ getErrorString();
 //
 // Condition-2 "All variables of interest must be involved in SET_C or SET_S"
 // ==========================================================================
-// -Passed 
+// -Passed
 //
 // -SET_C has all known variables:{3, 4, 5, 6, 2, 7, 8, 9, 1} (9)
 // ========================================
@@ -201,12 +201,12 @@ getErrorString();
 // Condition-3 "SET_C equations must be strictly less than Variable of Interest"
 // ==========================================================================
 // -Passed
-// -SET_C contains:5 equations < 9 known variables 
+// -SET_C contains:5 equations < 9 known variables
 //
 // Condition-4 "SET_S should contain all intermediate variables involved in SET_C"
 // ==========================================================================
 // -Passed
-// -SET_C contains No Intermediate Variables 
+// -SET_C contains No Intermediate Variables
 //
 // true
 // "Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2. There is a possibility that 3.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
@@ -307,7 +307,7 @@ getErrorString();
 // SET_C : {10, 11, 9}
 // SET_S: {}
 //
-// FINAL SET OF EQUATIONS After Reconciliation 
+// FINAL SET OF EQUATIONS After Reconciliation
 // ==========================================================================
 // SET_C: {10, 11, 9}
 // SET_S: {}
@@ -415,7 +415,7 @@ getErrorString();
 // SET_C : {3, 4}
 // SET_S: {}
 //
-// FINAL SET OF EQUATIONS After Reconciliation 
+// FINAL SET OF EQUATIONS After Reconciliation
 // ==========================================================================
 // SET_C: {3, 4}
 // SET_S: {}
@@ -447,7 +447,7 @@ getErrorString();
 //
 // Condition-2 "All variables of interest must be involved in SET_C or SET_S"
 // ==========================================================================
-// -Passed 
+// -Passed
 //
 // -SET_C has all known variables:{1, 2, 3, 4} (4)
 // ========================================
@@ -459,12 +459,12 @@ getErrorString();
 // Condition-3 "SET_C equations must be strictly less than Variable of Interest"
 // ==========================================================================
 // -Passed
-// -SET_C contains:2 equations < 4 known variables 
+// -SET_C contains:2 equations < 4 known variables
 //
 // Condition-4 "SET_S should contain all intermediate variables involved in SET_C"
 // ==========================================================================
 // -Passed
-// -SET_C contains No Intermediate Variables 
+// -SET_C contains No Intermediate Variables
 //
 // true
 // "Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2. There is a possibility that 3.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
@@ -757,7 +757,7 @@ getErrorString();
 // SET_C : {5, 6}
 // SET_S: {4, 3}
 //
-// FINAL SET OF EQUATIONS After Reconciliation 
+// FINAL SET OF EQUATIONS After Reconciliation
 // ==========================================================================
 // SET_C: {5, 6}
 // SET_S: {4, 3}
@@ -801,7 +801,7 @@ getErrorString();
 //
 // Condition-2 "All variables of interest must be involved in SET_C or SET_S"
 // ==========================================================================
-// -Passed 
+// -Passed
 //
 // -SET_C has known variables:{1, 2} (2)
 // ========================================
@@ -817,7 +817,7 @@ getErrorString();
 // Condition-3 "SET_C equations must be strictly less than Variable of Interest"
 // ==========================================================================
 // -Passed
-// -SET_C contains:2 equations < 4 known variables 
+// -SET_C contains:2 equations < 4 known variables
 //
 // Condition-4 "SET_S should contain all intermediate variables involved in SET_C"
 // ==========================================================================
@@ -975,7 +975,7 @@ getErrorString();
 // SET_C : {6}
 // SET_S: {4, 3, 5}
 //
-// FINAL SET OF EQUATIONS After Reconciliation 
+// FINAL SET OF EQUATIONS After Reconciliation
 // ==========================================================================
 // SET_C: {6}
 // SET_S: {4, 3, 5}
@@ -1019,7 +1019,7 @@ getErrorString();
 //
 // Condition-2 "All variables of interest must be involved in SET_C or SET_S"
 // ==========================================================================
-// -Passed 
+// -Passed
 //
 // -SET_C has known variables:{1} (1)
 // ========================================
@@ -1033,7 +1033,7 @@ getErrorString();
 // Condition-3 "SET_C equations must be strictly less than Variable of Interest"
 // ==========================================================================
 // -Passed
-// -SET_C contains:1 equations < 2 known variables 
+// -SET_C contains:1 equations < 2 known variables
 //
 // Condition-4 "SET_S should contain all intermediate variables involved in SET_C"
 // ==========================================================================

--- a/testsuite/openmodelica/uncertainties/DataReconciliationTests21jan2013.mos
+++ b/testsuite/openmodelica/uncertainties/DataReconciliationTests21jan2013.mos
@@ -56,7 +56,7 @@ getErrorString();
 // true
 // ""
 // true
-// "Notification: Automatically loaded package Complex 3.2.3 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 1.0. There are no conversion annotations for this version but 3.2.3 is newer than 1.0. There is a possibility that 1.0 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // "
 // "{{{xT2[\\[FormalT]],xT1[\\[FormalT]],xB2[\\[FormalT]],xB1[\\[FormalT]],xF2[\\[FormalT]],xF1[\\[FormalT]],T[\\[FormalT]],B[\\[FormalT]],F[\\[FormalT]]},{xT1[\\[FormalT]] + xT2[\\[FormalT]]==100,xB1[\\[FormalT]] + xB2[\\[FormalT]]==100,F[\\[FormalT]] * xF1[\\[FormalT]] + ((-B[\\[FormalT]]) * xB1[\\[FormalT]] - T[\\[FormalT]] * xT1[\\[FormalT]])==0,F[\\[FormalT]] * xF2[\\[FormalT]] + ((-B[\\[FormalT]]) * xB2[\\[FormalT]] - T[\\[FormalT]] * xT2[\\[FormalT]])==0,xF1[\\[FormalT]] + xF2[\\[FormalT]]==100}},{{},{}},{\"None\",\"None\",\"None\",\"None\",\"None\",\"None\",\"None\",\"None\",\"None\"}}"

--- a/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe1_1.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe1_1.mos
@@ -9,9 +9,9 @@ simulate(Aufgabe1_1); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from Aufgabe1_1.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "Aufgabe1_1_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe1_2.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe1_2.mos
@@ -10,9 +10,9 @@ simulate(Aufgabe1_2); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from Aufgabe1_2.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "Aufgabe1_2_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe2.Test1.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe2.Test1.mos
@@ -10,9 +10,9 @@ simulate(Aufgabe2.Test1); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from Aufgabe2.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "Aufgabe2.Test1_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe2.Test2.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/Aufgabe2.Test2.mos
@@ -10,9 +10,9 @@ simulate(Aufgabe2.Test2); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from Aufgabe2.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "Aufgabe2.Test2_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/Exercises/FourBar.TestPlanarLoops.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/FourBar.TestPlanarLoops.mos
@@ -11,9 +11,9 @@ simulate(FourBar.TestPlanarLoops); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from FourBar.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "FourBar.TestPlanarLoops_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/Exercises/ServoSystem3.Aufgabe4_2.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/ServoSystem3.Aufgabe4_2.mos
@@ -9,9 +9,9 @@ simulate(ServoSystem3.Aufgabe4_2);  getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from ServoSystem3.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "ServoSystem3.Aufgabe4_2_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/Exercises/ServoSystem3.Aufgabe4_3a.mos
+++ b/testsuite/simulation/libraries/3rdParty/Exercises/ServoSystem3.Aufgabe4_3a.mos
@@ -9,9 +9,9 @@ simulate(ServoSystem3.Aufgabe4_3a);  getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from ServoSystem3.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "ServoSystem3.Aufgabe4_3a_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/HumMod/buildHumModOMC.mos
+++ b/testsuite/simulation/libraries/3rdParty/HumMod/buildHumModOMC.mos
@@ -16,9 +16,9 @@ buildModel(HumModTest); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from HumModTest.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // {"HumModTest","HumModTest_init.xml"}
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.

--- a/testsuite/simulation/libraries/3rdParty/HumMod/checkHumModOMC.mos
+++ b/testsuite/simulation/libraries/3rdParty/HumMod/checkHumModOMC.mos
@@ -16,9 +16,9 @@ checkModel(HumModTest); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from HumModTest.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // "Check of HumModTest completed successfully.
 // Class HumModTest has 29145 equation(s) and 29145 variable(s).

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test1.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test1.mos
@@ -19,9 +19,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Col
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.ColdWater.Test1_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test2.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test2.mos
@@ -21,9 +21,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Col
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.ColdWater.Test2_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test3.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test3.mos
@@ -21,9 +21,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Col
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.ColdWater.Test3_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test4.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.ColdWater.Test4.mos
@@ -19,9 +19,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Col
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.ColdWater.Test4_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.Nitrogen.Test1.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.Nitrogen.Test1.mos
@@ -19,9 +19,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Nit
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.Nitrogen.Test1_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test1.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test1.mos
@@ -21,9 +21,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test1_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test2.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test2.mos
@@ -21,9 +21,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test2_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test3.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test3.mos
@@ -21,9 +21,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test3_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test4.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test4.mos
@@ -20,9 +20,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test4_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test5.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test5.mos
@@ -21,9 +21,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test5_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test6.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test6.mos
@@ -20,9 +20,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test6_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test7.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test7.mos
@@ -19,9 +19,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 // Result:
 // true
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test7_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test8.mos
+++ b/testsuite/simulation/libraries/3rdParty/TestMediaFrancesco/TestMedia.TestModels.WaterIF97.Test8.mos
@@ -18,9 +18,9 @@ res := OpenModelica.Scripting.compareSimulationResults("TestMedia.TestModels.Wat
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from TestMedia.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "TestMedia.TestModels.WaterIF97.Test8_res.mat",

--- a/testsuite/simulation/libraries/3rdParty/ThermoPower/Bug2537.mos
+++ b/testsuite/simulation/libraries/3rdParty/ThermoPower/Bug2537.mos
@@ -13,7 +13,7 @@ simulate(ThermoPower.Examples.CISE.CISESim120501); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/simulation/modelica/arrays/Bug3187.mos
+++ b/testsuite/simulation/modelica/arrays/Bug3187.mos
@@ -9,7 +9,7 @@ simulate(PowerSystems.Examples.Spot.AC1ph_DC.Inverter); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "PowerSystems.Examples.Spot.AC1ph_DC.Inverter_res.mat",

--- a/testsuite/simulation/modelica/arrays/ParametricInitialArrayEquationBug.mos
+++ b/testsuite/simulation/modelica/arrays/ParametricInitialArrayEquationBug.mos
@@ -9,7 +9,7 @@ translateModelFMU(TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L
 
 // Result:
 // true
-// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
+// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
 // "
 // {"TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2","TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2_init.xml"}
 // "[simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:28578:17-28582:23:writable] Warning: In relation EM.i_dens_a == 0.0, == on Real numbers is only allowed inside functions.

--- a/testsuite/simulation/modelica/events/whenInAlgorithm.mos
+++ b/testsuite/simulation/modelica/events/whenInAlgorithm.mos
@@ -12,9 +12,9 @@ simulate(whenInAlgorithm, tolerance=1e-6,startTime=0, stopTime=2,numberOfInterva
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from whenInAlgorithm.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "whenInAlgorithm_res.mat",

--- a/testsuite/simulation/modelica/external_functions/ts.mos
+++ b/testsuite/simulation/modelica/external_functions/ts.mos
@@ -47,7 +47,7 @@ val(state.s, 1);
 
 // Result:
 // true
-// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
 // "
 // "function ExternalMedia.Test.TestMedium.TestState.Medium.FluidConstants \"Automatically generated record constructor for ExternalMedia.Test.TestMedium.TestState.Medium.FluidConstants\"
 //   input String iupacName;

--- a/testsuite/simulation/modelica/functions_eval/functionEvaluation.mos
+++ b/testsuite/simulation/modelica/functions_eval/functionEvaluation.mos
@@ -10,9 +10,9 @@ simulate(functionEvaluation);getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from functionEvaluation.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // record SimulationResult
 //     resultFile = "functionEvaluation_res.mat",

--- a/testsuite/simulation/modelica/linear_system/NPendulum.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum.mos
@@ -98,9 +98,9 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum_res.m
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from NPendulum.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/simulation/modelica/linear_system/NPendulum40.mos
+++ b/testsuite/simulation/modelica/linear_system/NPendulum40.mos
@@ -23,9 +23,9 @@ res := OpenModelica.Scripting.compareSimulationResults("NPendulum.pendulum40_res
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.1 due to uses annotation from NPendulum.
+// Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.1 due to uses annotation from Modelica.
 // "
 // true
 // true

--- a/testsuite/simulation/modelica/others/NoLoadModel.mos
+++ b/testsuite/simulation/modelica/others/NoLoadModel.mos
@@ -5,8 +5,8 @@ buildModel(Modelica.Blocks.Examples.Filter);getErrorString();
 
 // Result:
 // {"Modelica.Blocks.Examples.Filter","Modelica.Blocks.Examples.Filter_init.xml"}
-// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation.
+// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
 // Notification: Automatically loaded package Modelica default due to uses annotation.
 // "
 // endResult

--- a/testsuite/simulation/modelica/others/NoLoadModel.mos
+++ b/testsuite/simulation/modelica/others/NoLoadModel.mos
@@ -7,6 +7,6 @@ buildModel(Modelica.Blocks.Examples.Filter);getErrorString();
 // {"Modelica.Blocks.Examples.Filter","Modelica.Blocks.Examples.Filter_init.xml"}
 // "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
-// Notification: Automatically loaded package Modelica default due to uses annotation.
+// Notification: Automatically loaded package Modelica default due to usage.
 // "
 // endResult

--- a/testsuite/simulation/modelica/records/ATotal.mos
+++ b/testsuite/simulation/modelica/records/ATotal.mos
@@ -10,7 +10,7 @@ simulate(A); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation.
+// "Notification: Automatically loaded package Complex 3.2.1 due to uses annotation from Modelica.
 // "
 // "function Modelica.Electrical.Spice3.Internal.Functions.energyGapDepTemp \"Temperature dependency of energy gap\"
 //   input Real temp(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";

--- a/testsuite/simulation/modelica/solver/gbode/HeatingSystem.mos
+++ b/testsuite/simulation/modelica/solver/gbode/HeatingSystem.mos
@@ -54,9 +54,9 @@ getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 4.0.0 due to uses annotation.
-// Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 4.0.0 due to uses annotation from HeatingSystem.
+// Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/simulation/modelica/synchronous_c/boolEventClock.mos
+++ b/testsuite/simulation/modelica/synchronous_c/boolEventClock.mos
@@ -41,8 +41,8 @@ simulate(boolEventClock, simflags="-lv=LOG_SYNCHRONOUS"); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation.
+// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
 // Notification: Automatically loaded package Modelica 4.0.0 due to usage.
 // "
 // endResult

--- a/testsuite/simulation/modelica/synchronous_c/intervalBase.mos
+++ b/testsuite/simulation/modelica/synchronous_c/intervalBase.mos
@@ -80,8 +80,8 @@ val(intv3, 1.0);    // 0.25
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation.
+// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
 // Notification: Automatically loaded package Modelica 4.0.0 due to usage.
 // "
 // intv1:

--- a/testsuite/simulation/modelica/tearing/Tearing12-cel.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-cel.mos
@@ -13,9 +13,9 @@ simulate(Tearing12); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from Tearing12.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/simulation/modelica/tearing/Tearing12-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-celMC3.mos
@@ -14,9 +14,9 @@ simulate(Tearing12); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from Tearing12.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // true
 // ""

--- a/testsuite/simulation/modelica/tearing/Tearing12-omc.mos
+++ b/testsuite/simulation/modelica/tearing/Tearing12-omc.mos
@@ -12,9 +12,9 @@ simulate(Tearing12); getErrorString();
 
 // Result:
 // true
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation.
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from Tearing12.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
 // "
 // true
 // ""


### PR DESCRIPTION
  - If a library is loaded due to a `uses` annotation report who requested
    the loading, i.e., which library's `uses` annotation caused the loading.