### PR TITLE
Fix `omc__escapedStringLength`

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/modelica_string.c
+++ b/OMCompiler/SimulationRuntime/c/util/modelica_string.c
@@ -261,7 +261,7 @@ extern int omc__escapedStringLength(const char* str, int nl, int *hasEscape)
       case '\b':
       case '\f':
       case '\v': i++; *hasEscape=1; break;
-      case '\r': if(nl) {i++; *hasEscape=1; if(str[1] == '\n') str++;} break;
+      case '\r':
       case '\n': if(nl) {i++; *hasEscape=1;} break;
       default: break;
     }


### PR DESCRIPTION
- Don't skip counting `\n` after `\r`, `omc__escapedString` no longer has a special case for this since 9b852f1 and will allocate too little memory if this is done.