### PR TITLE
Link lapack libs (openblas) to simulation executables.

### DIFF
--- a/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -22,7 +22,7 @@ encapsulated package Autoconf
                                   "-luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -Wl,-Bdynamic";
 
   constant String ldflags_runtime = " -lOpenModelicaRuntimeC" + ldflags_basic;
-  constant String ldflags_runtime_sim = "-lSimulationRuntimeC -Wl,-Bdynamic -lomcgc " + linkType + " -lstdc++ -Wl,-Bdynamic ";
+  constant String ldflags_runtime_sim = "-lSimulationRuntimeC -Wl,-Bdynamic -lomcgc -lopenblas" + linkType + " -lstdc++ -Wl,-Bdynamic ";
   constant String ldflags_runtime_fmu = linkType + "-lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm " +
                                         libFortran +
                                         "-lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex " +


### PR DESCRIPTION
  - Normally lapack symbols should be part of the shared library `libSimulationRuntimeC`. That would mean simulation executables would not have ti link to lapack libraries explicitly.

    However, we are picking up the shared version of `libopenblas` to link into `libSimulationRuntimeC` instead of the static version. So the simulation executables need to link to it explicitly as well.

  - Fixes #9504.
