### PR TITLE
Add missing record/array and constant variables to model info.json

### DIFF
--- a/OMCompiler/Compiler/BackEnd/Differentiate.mo
+++ b/OMCompiler/Compiler/BackEnd/Differentiate.mo
@@ -1891,7 +1891,7 @@ algorithm
         // 1. differentiate delayed expression
         (e, funcs) := differentiateExp(e2, inDiffwrtCref, inInputData, inDiffType, inFunctionTree, maxIter);
         // 2. filter all seeds from e
-        seeds := list(cref for cref guard(isSeedCref(cref)) in Expression.extractUniqueCrefsFromExp(e));
+        seeds := list(cref for cref guard(isSeedCref(cref)) in Expression.extractUniqueCrefsFromExp(e, false));
         // 3. create empty replacement rules
         repl := BackendVarTransform.emptyReplacements();
         repl := BackendVarTransform.addReplacements(repl, seeds, List.fill(DAE.ICONST(0), listLength(seeds)), NONE());

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -6075,12 +6075,16 @@ algorithm
 end traverseExpTypeDims2;
 
 public function extractUniqueCrefsFromExp
-  "Extracts all unique ComponentRef from an Expression."
+  "Extracts all unique ComponentRef from an Expression.
+  If `expand` is true crefs will be expanded."
   input DAE.Exp inExp;
+  input Boolean expand = true;
   output list<DAE.ComponentRef> ocrefs;
 algorithm
-  // ocrefs := List.unique(List.flatten(List.map1(extractCrefsFromExp(inExp), ComponentReference.expandCref, true)));
   ocrefs := List.unique(extractCrefsFromExp(inExp));
+  if expand then
+    ocrefs := List.flatten(List.map1(ocrefs, ComponentReference.expandCref, true));
+  end if;
 end extractUniqueCrefsFromExp;
 
 public function extractCrefsFromExp "
@@ -6115,7 +6119,7 @@ public function extractUniqueCrefsFromExpDerPreStart
   "author mahge: Same as extractUniqueCrefsFromExp except:
   This function will not treat der(), pre() and start() as calls
   but as unique ids. i.e. x is different from der(x) and given der(x) x will not
-  be extreacted as a unique id. Instead you get $DER.x. Same oes for pre and start.."
+  be extreacted as a unique id. Instead you get $DER.x. Same goes for pre and start."
   input DAE.Exp inExp;
   output list<DAE.ComponentRef> ocrefs;
 algorithm
@@ -6127,7 +6131,7 @@ public function extractCrefsFromExpDerPreStart
 " author mahge: Same as extractCrefsFromExp except:
   This function will not treat der(), pre() and start() as calls
   but as unique ids. i.e. x is different from der(x) and given der(x) x will not
-  be extreacted as a unique id. Instead you get $DER.x. Same oes for pre and start."
+  be extreacted as a unique id. Instead you get $DER.x. Same goes for pre and start."
   input DAE.Exp inExp;
   output list<DAE.ComponentRef> ocrefs;
 algorithm

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -6121,21 +6121,26 @@ public function extractUniqueCrefsFromExpDerPreStart
   but as unique ids. i.e. x is different from der(x) and given der(x) x will not
   be extreacted as a unique id. Instead you get $DER.x. Same goes for pre and start."
   input DAE.Exp inExp;
+  input Boolean expand = true;
   output list<DAE.ComponentRef> ocrefs;
 algorithm
-  // ocrefs := List.unique(List.flatten(List.map1(extractCrefsFromExp(inExp), ComponentReference.expandCref, true)));
-  ocrefs := List.unique(extractCrefsFromExpDerPreStart(inExp));
+  ocrefs := List.unique(extractCrefsFromExpDerPreStart(inExp, expand));
 end extractUniqueCrefsFromExpDerPreStart;
 
 public function extractCrefsFromExpDerPreStart
 " author mahge: Same as extractCrefsFromExp except:
   This function will not treat der(), pre() and start() as calls
   but as unique ids. i.e. x is different from der(x) and given der(x) x will not
-  be extreacted as a unique id. Instead you get $DER.x. Same goes for pre and start."
+  be extreacted as a unique id. Instead you get $DER.x. Same goes for pre and start.
+  If `expand` is true crefs will be expanded."
   input DAE.Exp inExp;
+  input Boolean expand;
   output list<DAE.ComponentRef> ocrefs;
 algorithm
   (_,ocrefs) := traverseExpTopDown(inExp, traversingComponentRefFinderDerPreStart, {});
+  if expand then
+    ocrefs := List.flatten(List.map1(ocrefs, ComponentReference.expandCref, true));
+  end if;
 end extractCrefsFromExpDerPreStart;
 
 public function traversingComponentRefFinderDerPreStart "
@@ -6210,22 +6215,22 @@ algorithm
 
     case DAE.STMT_ASSIGN(exp1 = exp1, exp = exp2)
       equation
-        olcrefs = extractCrefsFromExpDerPreStart(exp1);
-        orcrefs = extractCrefsFromExpDerPreStart(exp2);
+        olcrefs = extractCrefsFromExpDerPreStart(exp1, false);
+        orcrefs = extractCrefsFromExpDerPreStart(exp2, false);
       then
         (olcrefs,orcrefs);
 
     case DAE.STMT_TUPLE_ASSIGN(expExpLst = expLst, exp = exp2)
       equation
-        olcrefs = List.flatten(List.map(expLst, extractCrefsFromExpDerPreStart));
-        orcrefs = extractCrefsFromExpDerPreStart(exp2);
+        olcrefs = List.flatten(List.map1(expLst, extractCrefsFromExpDerPreStart, false));
+        orcrefs = extractCrefsFromExpDerPreStart(exp2, false);
       then
         (olcrefs,orcrefs);
 
     case DAE.STMT_ASSIGN_ARR(lhs = exp1, exp = exp2)
       equation
-        olcrefs = extractCrefsFromExpDerPreStart(exp1);
-        orcrefs = extractCrefsFromExpDerPreStart(exp2);
+        olcrefs = extractCrefsFromExpDerPreStart(exp1, false);
+        orcrefs = extractCrefsFromExpDerPreStart(exp2, false);
       then
         (olcrefs,orcrefs);
 
@@ -6255,7 +6260,7 @@ algorithm
 
     case DAE.STMT_ASSERT(cond = exp1)
       equation
-        orcrefs = extractCrefsFromExpDerPreStart(exp1);
+        orcrefs = extractCrefsFromExpDerPreStart(exp1, false);
       then
         ({},orcrefs);
 
@@ -6288,17 +6293,17 @@ algorithm
 
     case DAE.STMT_ASSIGN(exp1 = exp1)
       equation
-        lhsCrefs = extractCrefsFromExpDerPreStart(exp1);
+        lhsCrefs = extractCrefsFromExpDerPreStart(exp1, false);
       then lhsCrefs;
 
     case DAE.STMT_TUPLE_ASSIGN(expExpLst = expLst)
       equation
-        lhsCrefs = List.flatten(List.map(expLst, extractCrefsFromExpDerPreStart));
+        lhsCrefs = List.flatten(List.map1(expLst, extractCrefsFromExpDerPreStart, false));
       then lhsCrefs;
 
     case DAE.STMT_ASSIGN_ARR(lhs = exp1)
       equation
-        lhsCrefs = extractCrefsFromExpDerPreStart(exp1);
+        lhsCrefs = extractCrefsFromExpDerPreStart(exp1, false);
       then lhsCrefs;
 
     case DAE.STMT_IF(statementLst = stmtLst)

--- a/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
@@ -143,6 +143,9 @@ algorithm
         b = serializeVarsHelp(file, vars.stringAliasVars, withOperations, b);
         b = serializeVarsHelp(file, vars.extObjVars, withOperations, b);
         b = serializeVarsHelp(file, vars.constVars, withOperations, b);
+        b = serializeVarsHelp(file, vars.intConstVars, withOperations, b);
+        b = serializeVarsHelp(file, vars.boolConstVars, withOperations, b);
+        b = serializeVarsHelp(file, vars.stringConstVars, withOperations, b);
         b = serializeVarsHelp(file, vars.jacobianVars, withOperations, b);
         b = serializeVarsHelp(file, vars.sensitivityVars, withOperations, b);
       then ();

--- a/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeModelInfo.mo
@@ -464,7 +464,7 @@ algorithm
       File.write(file, ",\"section\":\"");
       File.write(file, section);
       File.write(file, "\",\"tag\":\"residual\",\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");
@@ -482,7 +482,7 @@ algorithm
       File.write(file, ",\"section\":\"");
       File.write(file, section);
       File.write(file, "\",\"tag\":\"residual\",\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");
@@ -500,7 +500,7 @@ algorithm
       File.write(file, ",\"section\":\"");
       File.write(file, section);
       File.write(file, "\",\"tag\":\"residual\",\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");
@@ -527,7 +527,7 @@ algorithm
       end if;
       writeCref(file,eq.cref,escape=JSON);
       File.write(file, "\"],\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");
@@ -596,7 +596,7 @@ algorithm
       end if;
       writeCref(file,eq.cref,escape=JSON);
       File.write(file, "\"],\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");
@@ -622,7 +622,7 @@ algorithm
       end if;
       writeCref(file,Expression.expCref(eq.lhs),escape=JSON);
       File.write(file, "\"],\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");
@@ -811,7 +811,7 @@ algorithm
       File.write(file, section + "\",\"tag\":\"algorithm\",\"defines\":[\"");
       writeCref(file, Expression.expCref(stmt.exp1),escape=JSON);
       File.write(file, "\"],\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(stmt.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(stmt.exp));
       File.write(file, "],\"equation\":[");
       serializeList(file,eq.statements,serializeStatement);
       File.write(file, "],\"source\":");
@@ -1025,7 +1025,7 @@ algorithm
             File.write(file, "\",\"tag\":\"when\",\"defines\":[");
             serializeExp(file,whenOp.left);
             File.write(file, "],\"uses\":[");
-            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExp(whenOp.right)));
+            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExpDerPreStart(whenOp.right)));
             File.write(file, "],\"equation\":[");
             serializeExp(file,whenOp.right);
             File.write(file, "],\"source\":");
@@ -1036,7 +1036,7 @@ algorithm
             File.write(file, "\",\"tag\":\"when\",\"defines\":[");
             serializeCref(file,whenOp.stateVar);
             File.write(file, "],\"uses\":[");
-            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExp(whenOp.value)));
+            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExpDerPreStart(whenOp.value)));
             File.write(file, "],\"equation\":[");
             serializeExp(file,whenOp.value);
             File.write(file, "],\"source\":");
@@ -1046,7 +1046,7 @@ algorithm
           case whenOp as BackendDAE.ASSERT() equation
             File.write(file, "\",\"tag\":\"when\"");
             File.write(file, ",\"uses\":[");
-            crefs = listAppend(Expression.extractUniqueCrefsFromExp(whenOp.condition), Expression.extractUniqueCrefsFromExp(whenOp.message));
+            crefs = listAppend(Expression.extractUniqueCrefsFromExpDerPreStart(whenOp.condition), Expression.extractUniqueCrefsFromExpDerPreStart(whenOp.message));
             serializeUses(file,List.union(eq.conditions,crefs));
             File.write(file, "],\"equation\":[");
             serializeExp(file,whenOp.message);
@@ -1057,7 +1057,7 @@ algorithm
           case whenOp as BackendDAE.TERMINATE() equation
             File.write(file, "\",\"tag\":\"when\"");
             File.write(file, ",\"uses\":[");
-            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExp(whenOp.message)));
+            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExpDerPreStart(whenOp.message)));
             File.write(file, "],\"equation\":[");
             serializeExp(file,whenOp.message);
             File.write(file, "],\"source\":");
@@ -1067,7 +1067,7 @@ algorithm
           case whenOp as BackendDAE.NORETCALL() equation
             File.write(file, "\",\"tag\":\"when\"");
             File.write(file, ",\"uses\":[");
-            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExp(whenOp.exp)));
+            serializeUses(file,List.union(eq.conditions,Expression.extractUniqueCrefsFromExpDerPreStart(whenOp.exp)));
             File.write(file, "],\"equation\":[");
             serializeExp(file,whenOp.exp);
             File.write(file, "],\"source\":");
@@ -1102,7 +1102,7 @@ algorithm
       end if;
       writeCref(file,eq.cref,escape=JSON);
       File.write(file, "\"],\"uses\":[");
-      serializeUses(file,Expression.extractUniqueCrefsFromExp(eq.exp));
+      serializeUses(file,Expression.extractUniqueCrefsFromExpDerPreStart(eq.exp));
       File.write(file, "],\"equation\":[\"");
       File.writeEscape(file,expStr(eq.exp),escape=JSON);
       File.write(file, "\"],\"source\":");

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -3827,21 +3827,6 @@ package Expression
     output Boolean outBoolean;
   end isPositiveOrZero;
 
-  function extractUniqueCrefsFromExp
-    input DAE.Exp inExp;
-    output list<DAE.ComponentRef> ocrefs;
-  end extractUniqueCrefsFromExp;
-
-  function extractUniqueCrefsFromExpDerPreStart
-    input DAE.Exp inExp;
-    output list<DAE.ComponentRef> ocrefs;
-  end extractUniqueCrefsFromExpDerPreStart;
-
-  function extractUniqueCrefsFromStatmentS
-    input list<DAE.Statement> inStmts;
-    output tuple<list<DAE.ComponentRef>,list<DAE.ComponentRef>> ocrefs;
-  end extractUniqueCrefsFromStatmentS;
-
   function isCrefListWithEqualIdents
     input list<DAE.Exp> iExpressions;
     output Boolean oCrefWithEqualIdents;


### PR DESCRIPTION
### Related Issues

Fixes #9506.

### Purpose

Fix missing variables from info.json for some record/array variables and resolve missing constants.

### Approach

Add integer constants to model info and expand record/array variables in `uses` list from ModelInfo.
Also removing some unused functions from SimCodeTV.