### PR TITLE
Escape new line characters in xml strings.

### DIFF
--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -919,6 +919,8 @@ algorithm
   xmlString := System.stringReplace(xmlString, "\"", "&quot;");
   xmlString := System.stringReplace(xmlString, "<", "&lt;");
   xmlString := System.stringReplace(xmlString, ">", "&gt;");
+  xmlString := System.stringReplace(xmlString, "\n", "&#10;");
+  xmlString := System.stringReplace(xmlString, "\r", "&#13;");
   // TODO! FIXME!, we have issues with accented chars in comments
   // that end up in the Model_init.xml file and makes it not well
   // formed but the line below does not work if the xmlString is


### PR DESCRIPTION
  - Our xml parser (expat) does not seem to parse newlines in xml attributes. So, change
      - all new lines `(\n)` to their xml value `&#10;`
      - all carriage returns `(\r)` to their xml value `&#13;`

    before writing them to the xml files.

    It might be some settting we have to set for expat. Maybe someone who
    knows expat can suggest an alternative.

  - Fixes https://github.com/OpenModelica/OpenModelica/issues/9429.