### PR TITLE
Error message if residuum iteration variable NaN

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3122,11 +3122,11 @@ match system
       /* iteration variables */
       for (i=0; i<<%listLength(nls.crefs)%>; i++) {
         if (isinf(xloc[i]) || isnan(xloc[i])) {
-          errorStreamPrint(LOG_NLS, 0, "redidualFunc<%nls.index%>: Iteration variable xloc[%i] is nan.", i);
+          errorStreamPrint(LOG_NLS, 0, "residualFunc<%nls.index%>: Iteration variable xloc[%i] is nan.", i);
           for (j=0; j<<%listLength(nls.crefs)%>; j++) {
             res[j] = NAN;
           }
-          throwStreamPrintWithEquationIndexes(threadData, equationIndexes, "redidualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+          throwStreamPrintWithEquationIndexes(threadData, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
           <%if intEq(whichSet, 0) then "return;" else "return 1;"%>
         }
       }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3113,7 +3113,7 @@ match system
       DATA *data = userData->data;
       threadData_t *threadData = userData->threadData;
       const int equationIndexes[2] = {1,<%nls.index%>};
-      int i;<% if clockIndex then <<
+      int i,j;<% if clockIndex then <<
       const int clockIndex = <%clockIndex%>;
       >> %>
       <%varDecls%>
@@ -3122,9 +3122,11 @@ match system
       /* iteration variables */
       for (i=0; i<<%listLength(nls.crefs)%>; i++) {
         if (isinf(xloc[i]) || isnan(xloc[i])) {
-          for (i=0; i<<%listLength(nls.crefs)%>; i++) {
-            res[i] = NAN;
+          errorStreamPrint(LOG_NLS, 0, "redidualFunc<%nls.index%>: Iteration variable xloc[%i] is nan.", i);
+          for (j=0; j<<%listLength(nls.crefs)%>; j++) {
+            res[j] = NAN;
           }
+          throwStreamPrintWithEquationIndexes(threadData, equationIndexes, "redidualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
           <%if intEq(whichSet, 0) then "return;" else "return 1;"%>
         }
       }

--- a/testsuite/simulation/modelica/tearing/dynamicTearing3.mos
+++ b/testsuite/simulation/modelica/tearing/dynamicTearing3.mos
@@ -375,6 +375,9 @@ simulate(dynamicTearing3,startTime=0,stopTime=2,numberOfIntervals=500,simflags="
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_DT_CONS       | info    | The following local constraint is violated:
 // |                 | |       | abs(x) > 1e-12
+// LOG_NLS           | error   | residualFunc10: Iteration variable xloc[0] is nan.
+// assert            | debug   | residualFunc10 failed at time=0.004.
+// |                 | |       | For more information please use -lv LOG_NLS.
 // LOG_DT_CONS       | info    | The following local constraint is violated:
 // |                 | |       | abs(x) > 1e-12
 // LOG_DT_CONS       | info    | The following local constraint is violated:


### PR DESCRIPTION
### Related Issues

#9120: Break infinity loop in KINSOL.

### Purpose

When KINSOL uses iteration variables with NaN, something is going wrong.

### Approach

If NaN is detected print an error message and throw an error.
