### PR TITLE
Consider -inputPath when looking for csv input file.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
@@ -47,14 +47,11 @@
 #include "simulation/solver/model_help.h"
 #include "simulation/options.h"
 
-static inline void externalInputallocate1(DATA* data, FILE * pFile);
 static inline void externalInputallocate2(DATA* data, char *filename);
 
 int externalInputallocate(DATA* data)
 {
-  FILE * pFile = NULL;
-  int i,j;
-  short useLibCsvH = 1;
+  int i, j;
   char * csv_input_file_opt = NULL;
   char * csv_input_file = NULL;
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
@@ -47,13 +47,13 @@
 #include "simulation/solver/model_help.h"
 #include "simulation/options.h"
 
-static inline void externalInputallocate2(DATA* data, char *filename);
+static inline void externalInputallocate2(DATA* data, const char *filename);
 
 int externalInputallocate(DATA* data)
 {
   int i, j;
-  char * csv_input_file_opt = NULL;
-  char * csv_input_file = NULL;
+  const char * csv_input_file_opt = NULL;
+  const char * csv_input_file = NULL;
 
   csv_input_file_opt = (char*)omc_flagValue[FLAG_INPUT_CSV];
   if(!csv_input_file_opt) {
@@ -90,7 +90,7 @@ int externalInputallocate(DATA* data)
 
 
 
-void externalInputallocate2(DATA* data, char *filename){
+void externalInputallocate2(DATA* data, const char *filename){
   int i, j, k;
   struct csv_data *res = read_csv(filename);
   char ** names;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
@@ -55,13 +55,21 @@ int externalInputallocate(DATA* data)
   FILE * pFile = NULL;
   int i,j;
   short useLibCsvH = 1;
+  char * csv_input_file_opt = NULL;
   char * csv_input_file = NULL;
 
-
-  csv_input_file = (char*)omc_flagValue[FLAG_INPUT_CSV];
-  if(!csv_input_file) {
+  csv_input_file_opt = (char*)omc_flagValue[FLAG_INPUT_CSV];
+  if(!csv_input_file_opt) {
     data->simulationInfo->external_input.active = 0;
     return 0;
+  }
+
+  // If '-inputPath' is specified, prefix the csv input file name with that path.
+  if (omc_flag[FLAG_INPUT_PATH]) {
+    GC_asprintf(&csv_input_file, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], csv_input_file_opt);
+  }
+  else {
+    csv_input_file = csv_input_file_opt;
   }
 
   externalInputallocate2(data, csv_input_file);


### PR DESCRIPTION
  - If `-inputPath` is specified, prefix the path to the csv file (`-csvInput`) with the specified input path.

  - Fixes #9482.
