### PR TITLE
Skip installing cached packages when running the testsuite

### DIFF
--- a/OMCompiler/Compiler/Script/PackageManagement.mo
+++ b/OMCompiler/Compiler/Script/PackageManagement.mo
@@ -527,8 +527,10 @@ protected
   JSON obj, libs_obj, lib_obj, versions_obj;
   list<String> libs;
 algorithm
-  if not listEmpty(System.subDirectories(getUserLibraryPath())) then
-    // Return if the user's library directory isn't empty.
+  if not listEmpty(System.subDirectories(getUserLibraryPath())) or Testsuite.isRunning() then
+    // Return if the user's library directory isn't empty, or if we're running
+    // e.g. rtest in which case the path might not be correct but we don't care
+    // and don't want any extra output.
     return;
   end if;
 


### PR DESCRIPTION
- The installation of cached packages doesn't work correctly when running the testsuite, but it's not needed anyway so disable it.