### PR TITLE
Windows: Redirect stdout/stderr in runProcess

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3595,7 +3595,6 @@ algorithm
                "cd .. && rm -rf " + buildDir;
         if 0 <> System.systemCall(cmd, outFile=logfile) then
           Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {System.readFile(logfile)});
-          System.removeFile(logfile);
           fail();
         end if;
         then();

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3581,14 +3581,14 @@ algorithm
     case {"dynamic"}
       algorithm
         if isWindows then
-          CMAKE_GENERATOR := "-G MSYS Makefiles ";
+          CMAKE_GENERATOR := "-G " + dquote + "MSYS Makefiles" + dquote + " ";
         end if;
         buildDir := "build_cmake_dynamic";
         cmakeCall := "cmake " + CMAKE_GENERATOR +
                               "-DFMI_INTERFACE_HEADER_FILES_DIRECTORY=" + defaultFmiIncludeDirectoy + " " +
                               CMAKE_BUILD_TYPE +
                               " ..";
-        cmd := "cd \"" + fmuSourceDir + "\" && " +
+        cmd := "cd " + dquote + fmuSourceDir + dquote + " && " +
                "mkdir " + buildDir + " && cd " + buildDir + " && " +
                cmakeCall + " && " +
                "cmake --build . --target install && " +

--- a/omsimulator.cmake
+++ b/omsimulator.cmake
@@ -15,7 +15,7 @@ ExternalProject_Add(OMSimulator_external
                                                 BUILD_TYPE=${CMAKE_BUILD_TYPE}
                                                 CERES=OFF
                                                 host_short=${CMAKE_LIBRARY_ARCHITECTURE}
-                                                CMAKE=${CMAKE_COMMAND}
+                                                CMAKE="${CMAKE_COMMAND}"
                       COMMAND ${CMAKE_MAKE_PROGRAM} -C ${CMAKE_CURRENT_SOURCE_DIR}/OMSimulator
                                                 -j${NUM_PROCESSPRS}
                                                 config-OMSimulator
@@ -23,7 +23,7 @@ ExternalProject_Add(OMSimulator_external
                                                 OMSYSIDENT=OFF
                                                 OMBUILDDIR=${CMAKE_CURRENT_BINARY_DIR}/OMSimulator
                                                 host_short=${CMAKE_LIBRARY_ARCHITECTURE}
-                                                CMAKE=${CMAKE_COMMAND}
+                                                CMAKE="${CMAKE_COMMAND}"
     #--Build step-----------------
     BUILD_COMMAND COMMAND ${CMAKE_MAKE_PROGRAM} -C ${CMAKE_CURRENT_SOURCE_DIR}/OMSimulator
                                                 -j${NUM_PROCESSPRS}
@@ -31,7 +31,7 @@ ExternalProject_Add(OMSimulator_external
                                                 BUILD_TYPE=${CMAKE_BUILD_TYPE}
                                                 OMBUILDDIR=${CMAKE_CURRENT_BINARY_DIR}/OMSimulator
                                                 host_short=${CMAKE_LIBRARY_ARCHITECTURE}
-                                                CMAKE=${CMAKE_COMMAND}
+                                                CMAKE="${CMAKE_COMMAND}"
     #--Install step---------------
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION
### Related Issues

Fixes #9526.

### Purpose

Redirect everything from cmd call into log file.

### Approach

Create file and us eit to redirect stdout/stderr in `STARTUPINFOW si` provided to `CreateProcessW`.
Allow inheritance of handles for child processes.
