### PR TITLE
Output textColor instead of deprecated lineColor

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -256,6 +256,7 @@ QStringList FilledShape::getShapeAnnotation()
 /*!
  * \brief FilledShape::getTextShapeAnnotation
  * Returns the annotation values for Text shape.
+ * This function is used for Text annotation only.
  * \return the annotation values as a list.
  */
 QStringList FilledShape::getTextShapeAnnotation()
@@ -263,7 +264,7 @@ QStringList FilledShape::getTextShapeAnnotation()
   QStringList annotationString;
   /* get the text color */
   if (mLineColor.isDynamicSelectExpression() || mLineColor != Qt::black) {
-    annotationString.append(QString("lineColor=%1").arg(mLineColor.toQString()));
+    annotationString.append(QString("textColor=%1").arg(mLineColor.toQString()));
   }
   return annotationString;
 }
@@ -536,8 +537,7 @@ void ShapeAnnotation::applyLinePattern(QPainter *painter)
    * Use non cosmetic pens for Libraries Browser and shapes inside component when thickness is greater than 4.
    */
   if (thickness > 4
-      && ((mpGraphicsView && mpGraphicsView->isRenderingLibraryPixmap())
-          || mpParentComponent)) {
+      && ((mpGraphicsView && mpGraphicsView->isRenderingLibraryPixmap()) || mpParentComponent)) {
     pen.setCosmetic(false);
   }
   // if thickness is greater than 1 pixel then use antialiasing.

--- a/OMEdit/OMEditLIB/Element/CornerItem.cpp
+++ b/OMEdit/OMEditLIB/Element/CornerItem.cpp
@@ -72,6 +72,7 @@ CornerItem::CornerItem(qreal x, qreal y, int connectedPointIndex, ShapeAnnotatio
 void CornerItem::initialize(qreal x, qreal y, int connectedPointIndex)
 {
   mOldScenePosition = QPointF();
+  setConnectedPointIndex(connectedPointIndex);
   setCursor(Qt::ArrowCursor);
   setToolTip(Helper::clickAndDragToResize + QString::number(mConnectedPointIndex));
   setPos(x, y);


### PR DESCRIPTION
### Related Issues

Fixes #9498

### Purpose

Avoid using the deprecated `lineColor` attribute for text shapes.

### Approach

Use `textColor` when adding the annotation for text shape in the Modelica code.
