### PR TITLE
Improve vectorization of bindings

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -155,6 +155,14 @@ public
     output Dimension dim = INTEGER(listLength(expl), Variability.CONSTANT);
   end fromExpList;
 
+  function toRange
+    input Dimension dim;
+    output Expression range;
+  algorithm
+    range := Expression.RANGE(Type.liftArrayLeft(typeOf(dim), dim),
+      lowerBoundExp(dim), NONE(), upperBoundExp(dim));
+  end toRange;
+
   function toDAE
     input Dimension dim;
     output DAE.Dimension daeDim;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -197,7 +197,7 @@ algorithm
   else
     // Remove empty arrays from variables
     flatModel.variables := List.filterOnFalse(flatModel.variables, Variable.isEmptyArray);
-    flatModel.variables := list(Flatten.vectorizeVariableBinding(v) for v in flatModel.variables);
+    flatModel.variables := list(Flatten.fillVectorizedVariableBinding(v) for v in flatModel.variables);
   end if;
 
   flatModel := InstUtil.replaceEmptyArrays(flatModel);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -240,6 +240,25 @@ public
     end match;
   end isIterator;
 
+  function toIterator
+    input Subscript sub;
+    output InstNode iterator;
+  protected
+    ComponentRef cref;
+  algorithm
+    iterator := match sub
+      case UNTYPED(exp = Expression.CREF(cref = cref))
+        guard ComponentRef.isIterator(cref)
+        then ComponentRef.node(cref);
+
+      case INDEX(index = Expression.CREF(cref = cref))
+        guard ComponentRef.isIterator(cref)
+        then ComponentRef.node(cref);
+
+      else InstNode.EMPTY_NODE();
+    end match;
+  end toIterator;
+
   function isEqual
     input Subscript subscript1;
     input Subscript subscript2;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -553,6 +553,8 @@ constant DebugFlag MERGE_COMPONENTS = DEBUG_FLAG(190, "mergeComponents", false,
   Gettext.gettext("Enables automatic merging of components into arrays."));
 constant DebugFlag DUMP_SLICE = DEBUG_FLAG(191, "dumpSlice", false,
   Gettext.gettext("Dumps information about the slicing process (pseudo-array causalization)."));
+constant DebugFlag VECTORIZE_BINDINGS = DEBUG_FLAG(192, "vectorizeBindings", false,
+  Gettext.gettext("Turns on vectorization of bindings when scalarization is turned off."));
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -247,7 +247,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DUMP_BACKEND_CLOCKS,
   Flags.DUMP_SET_BASED_GRAPHS,
   Flags.MERGE_COMPONENTS,
-  Flags.DUMP_SLICE
+  Flags.DUMP_SLICE,
+  Flags.VECTORIZE_BINDINGS
 };
 
 protected


### PR DESCRIPTION
- Create array constructors or fill expressions when vectorizing bindings, to make sure they can be evaluated properly. This is currently only enabled when using the flag `-d=vectorizeBindings`.