### PR TITLE
Add function omc_file_exists.

### DIFF
--- a/OMCompiler/Compiler/runtime/TaskGraphResultsCmp.cpp
+++ b/OMCompiler/Compiler/runtime/TaskGraphResultsCmp.cpp
@@ -149,8 +149,7 @@ GraphParser::~GraphParser()
 
 bool GraphParser::CheckIfFileExists(const char* fileName)
 {
-  omc_stat_t stats;
-  return 0 == omc_stat(fileName, &stats);
+  return omc_file_exists(fileName);
 }
 
 GraphMLParser::GraphMLParser() : GraphParser()

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -1070,7 +1070,7 @@ static int SystemImpl__removeDirectoryItem(const char *path)
     while ((retval == 0) && (p = readdir(d)))
     {
       int r2 = -1;
-      char * buf;
+      char * dir_name;
       size_t len;
 
       /* Do not recurse on "." and ".." */
@@ -1080,30 +1080,30 @@ static int SystemImpl__removeDirectoryItem(const char *path)
       }
 
       len = path_len + strlen(p->d_name) + 2;
-      buf = (char *)omc_alloc_interface.malloc_atomic(len);
-      if (buf != NULL)
+      dir_name = (char *)omc_alloc_interface.malloc_atomic(len);
+      if (dir_name != NULL)
       {
         omc_stat_t statbuf;
 
-        snprintf(buf, len, "%s/%s", path, p->d_name);
-        if (omc_stat(buf, &statbuf) == 0)
+        snprintf(dir_name, len, "%s/%s", path, p->d_name);
+        if (omc_stat(dir_name, &statbuf) == 0)
         {
           if (S_ISDIR(statbuf.st_mode))
           {
-            r2 = 0==SystemImpl__removeDirectory(buf);
+            r2 = 0==SystemImpl__removeDirectory(dir_name);
           }
           else
           {
-            r2 = omc_unlink(buf);
+            r2 = omc_unlink(dir_name);
           }
         }
-        else if(omc_lstat(buf, &statbuf) == 0)
+        else if(omc_lstat(dir_name, &statbuf) == 0)
         {
           // Dead link, that isn't pointing to a file/directory any more
-          r2 = omc_unlink(buf);
+          r2 = omc_unlink(dir_name);
         }
         else {
-          const char *c_tokens[1]={buf};
+          const char *c_tokens[1]={dir_name};
           c_add_message(NULL,85,
             ErrorType_scripting,
             ErrorLevel_error,

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -486,21 +486,20 @@ static void readInfoJson(const char *str, MODEL_DATA_XML *xml)
  */
 void modelInfoInit(MODEL_DATA_XML* xml)
 {
-  omc_stat_t buf = {0};
   // check for file exists, as --fmiFilter=blackBox or protected will not export the _info.json file
-  int fileStatus;
+  int fileExists;
   if (omc_flag[FLAG_INPUT_PATH])
   {
     const char *jsonFile;
     GC_asprintf(&jsonFile, "%s/%s", omc_flagValue[FLAG_INPUT_PATH], xml->fileName);
-    fileStatus = omc_stat(jsonFile, &buf);
+    fileExists = omc_file_exists(jsonFile);
   }
   else
   {
-    fileStatus = omc_stat(xml->fileName, &buf);
+    fileExists = omc_file_exists(xml->fileName);
   }
 
-  if (fileStatus != 0)
+  if (!fileExists)
   {
     xml->fileName = NULL;
     return;

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -557,11 +557,10 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
     init_initMethod = omc_flagValue[FLAG_IIM];
   }
   if(omc_flag[FLAG_IIF]) {
-    omc_stat_t attrib;
     if (omc_flag[FLAG_INPUT_PATH]) {
       const char *tmp_filename;
 
-      if (omc_stat(omc_flagValue[FLAG_IIF], &attrib ) == 0) {
+      if (omc_file_exists(omc_flagValue[FLAG_IIF])) {
         if (0 > GC_asprintf(&tmp_filename, "%s", omc_flagValue[FLAG_IIF] )) {
           throwStreamPrint(NULL, "simulation_runtime.cpp: Error: can not allocate memory.");
         }
@@ -576,7 +575,7 @@ int startNonInteractiveSimulation(int argc, char**argv, DATA* data, threadData_t
     else {
       init_file = omc_flagValue[FLAG_IIF];
     }
-    if (omc_stat(init_file.c_str(), &attrib ) != 0) {
+    if (!omc_file_exists(init_file.c_str())) {
       throwStreamPrint(NULL, "Initialization file \"%s\" doesn't exist.", init_file.c_str());
     }
   }

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -195,6 +195,18 @@ int omc_lstat(const char *filename, omc_stat_t* statbuf)
 }
 #endif
 
+/**
+ * @brief checks if a file/folder exists on the system.
+ * NOTE: Will return success even for directories, i.e., will not confirm that it is indeed a file.
+ *
+ * @param filename  the filename to check for existence.
+ * @return int  returns 1 if the file/folder exists, 0 otherwise.
+ */
+int omc_file_exists(const char* filename) {
+  omc_stat_t statbuf;
+  return omc_stat(filename, &statbuf) == 0;
+}
+
 
 /**
  * @brief Unlink file.

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.h
@@ -80,6 +80,15 @@ typedef struct stat omc_stat_t;
 int omc_stat(const char *filename, omc_stat_t *statbuf);
 int omc_lstat(const char *filename, omc_stat_t *statbuf);
 
+/**
+ * @brief checks if a file/folder exists on the system.
+ * NOTE: Will return success even for directories, i.e., will not confirm that it is indeed a file.
+ *
+ * @param filename  the filename to check for existence.
+ * @return int  returns 1 if the file/folder exists, 0 otherwise.
+ */
+int omc_file_exists(const char* filename);
+
 int omc_unlink(const char *filename);
 
 #if defined(__MINGW32__) || defined(_MSC_VER)


### PR DESCRIPTION
  - Checks if a file/folder exists on the system. It will return success even for directories, i.e., will not confirm that it is indeed a file.
    The function takes a filename as an argument and returns 1 if the file/folder exists, returns 0 otherwise.

  - Replace some uses of `omc_stat` with `omc_file_exists`. These are places where `omc_stat` was used just for checking existence.
