### PR TITLE
Fix warnings in bundled FMU sources.

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -208,7 +208,7 @@ fmi2Boolean isCategoryLogged(ModelInstance *comp, int categoryIndex)
 
 static void omc_assert_fmi_common(threadData_t *threadData, fmi2Status status, int categoryIndex, FILE_INFO info, const char *msg, va_list args)
 {
-  char *str;
+  const char *str;
   ModelInstance* c = (ModelInstance*) threadData->localRoots[LOCAL_ROOT_FMI_DATA];
   GC_vasprintf(&str, msg, args);
   if (info.lineStart) {

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
@@ -178,7 +178,8 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
   strcat(flags_filename, comp->fmuData->modelData->modelFilePrefix);
   strcat(flags_filename, "_flags.json");
   FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Trying to find simulation settings %s.", flags_filename)
-  if( access( flags_filename, 0 ) != -1 )
+
+  if( omc_file_exists( flags_filename) )
   {
     FILTERED_LOG(comp, fmi2OK, LOG_ALL, "fmi2Instantiate: Found simulation settings %s.", flags_filename)
     omc_mmap_read mmap_reader = {0};


### PR DESCRIPTION
  - These files are copied into FMU sources and compiled. Their warnings are hidden/not-reported by `omc` unless compilation actually fails.

    This made it confusing to separate what is new from what is hidden.