### PR TITLE
Save the CMake executable in our MM config file.

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3584,14 +3584,14 @@ algorithm
           CMAKE_GENERATOR := "-G " + dquote + "MSYS Makefiles" + dquote + " ";
         end if;
         buildDir := "build_cmake_dynamic";
-        cmakeCall := "cmake " + CMAKE_GENERATOR +
+        cmakeCall := Autoconf.cmake + " " + CMAKE_GENERATOR +
                               "-DFMI_INTERFACE_HEADER_FILES_DIRECTORY=" + defaultFmiIncludeDirectoy + " " +
                               CMAKE_BUILD_TYPE +
                               " ..";
         cmd := "cd " + dquote + fmuSourceDir + dquote + " && " +
                "mkdir " + buildDir + " && cd " + buildDir + " && " +
                cmakeCall + " && " +
-               "cmake --build . --target install && " +
+               Autoconf.cmake + " --build . --target install && " +
                "cd .. && rm -rf " + buildDir;
         if 0 <> System.systemCall(cmd, outFile=logfile) then
           Error.addMessage(Error.SIMULATOR_BUILD_ERROR, {System.readFile(logfile)});
@@ -3639,7 +3639,7 @@ algorithm
         else
           fmiTarget := "";
         end if;
-        cmakeCall := "cmake -DFMI_INTERFACE_HEADER_FILES_DIRECTORY=/fmu/fmiInclude " +
+        cmakeCall := Autoconf.cmake + " -DFMI_INTERFACE_HEADER_FILES_DIRECTORY=/fmu/fmiInclude " +
                             fmiTarget +
                             CMAKE_BUILD_TYPE +
                             " ..";
@@ -3648,7 +3648,7 @@ algorithm
                   "cd " + dquote + "/fmu/" + fmuSourceDir + dquote + " && " +
                   "mkdir " + buildDir + " && cd " + buildDir + " && " +
                   cmakeCall + " && " +
-                  "cmake --build . && " + Autoconf.make + " install && " +
+                  Autoconf.cmake + " --build . && " + Autoconf.make + " install && " +
                   "cd .. && rm -rf " + buildDir +
                 dquote;
         runDockerCmd(cmd, dockerLogFile, cleanup=true, volumeID=volumeID, containerID=containerID);

--- a/OMCompiler/Compiler/Util/Autoconf.mo.in
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.in
@@ -9,6 +9,8 @@ encapsulated package Autoconf
   constant String platform = if isWindows and is64Bit then "WIN64" elseif isWindows then "WIN32" else "Unix";
 
   constant String make = "@OMC_MAKE_EXE@";
+  constant String cmake = "\"@OMC_CMAKE_EXE@\"";
+
   constant String exeExt = if isWindows then ".exe" else "";
   constant String dllExt = "@SHREXT@";
 

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -243,6 +243,7 @@ endif()
 # which is the MSYS make.) since the latter is not supposed to be used on Windows shells.
 # (systemCall uses 'cmd \c' to issue commands.)
 set(OMC_MAKE_EXE "mingw32-make")
+set(OMC_CMAKE_EXE "${CMAKE_COMMAND}")
 
 string(REPLACE ";" " " LAPACK_LIBRARIES_SPACE "${LAPACK_LIBRARIES}")
 

--- a/OMCompiler/Makefile.in
+++ b/OMCompiler/Makefile.in
@@ -17,7 +17,7 @@ host = @host@
 host_short = @host_short@
 FC = @FC@
 FCFLAGS = @FCFLAGS@
-CMAKE=@CMAKE@
+CMAKE=@OMC_CMAKE_EXE@
 # Use the system's default cmake if nothing is passed to configure script, i.e., no CMAKE=<some_path> is specified
 ifeq ($(CMAKE),)
 	CMAKE=cmake

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
@@ -34,6 +34,7 @@
 #include "../util/simulation_options.h"
 #include "../simulation/solver/cvode_solver.h"
 #include "../util/omc_mmap.h"
+#include "../util/omc_file.h"
 
 /**
  * @ Skips to a given character or end of file

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -96,7 +96,7 @@ AC_SUBST(OMENCRYPTION)
 AC_SUBST(MINGW_EXTRA_LIBS)
 AC_SUBST(BSTATIC)
 AC_SUBST(EXTRA_MACOS_FLAGS_SUNDIALS)
-AC_SUBST(CMAKE)
+AC_SUBST(OMC_CMAKE_EXE)
 
 FINAL_MESSAGES="\nConfigured OpenModelica successfully using the following options:"
 
@@ -137,6 +137,12 @@ fi
 
 if test -z "$MAKE"; then
   OMC_MAKE_EXE=make
+fi
+
+if test -z "$CMAKE"; then
+  OMC_CMAKE_EXE=cmake
+else
+  OMC_CMAKE_EXE="$CMAKE"
 fi
 
 dnl Disables the default CXXFLAGS="-g -O2"


### PR DESCRIPTION
  - This allows us to provide a non-default CMake executable to our autoconf config or CMake config. OpenModelica now remembers this selection and uses that exact CMake executable for all its internal uses as well.

  - Improves #9509.
