### PR TITLE
Don't load libraries when looking for builtin name

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -465,9 +465,10 @@ algorithm
             // If we're in an annotation, check in the special scope where
             // annotation classes are defined.
             cur_scope := InstNode.annotationScope(cur_scope);
-          elseif not loaded then
-            // If we haven't already tried, try to load a library with that name
-            // and then try to look it up in the top scope again.
+          elseif not loaded and not require_builtin then
+            // If we haven't already tried and we're not trying to find a
+            // builtin name, try to load a library with that name and then try
+            // to look it up in the top scope again.
             loaded := true;
             loadLibrary(name, cur_scope);
           else

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -17,10 +17,11 @@ Bug3974.mos \
 Bug3979.mos \
 Bug4209.mos \
 Bug4248.mos \
+checkAllModelsRecursive1.mos \
+choicesAllMatching.mos \
 ConvertUnits.mos \
 ConversionVersions.mos \
 CopyClass.mos \
-choicesAllMatching.mos \
 DefaultComponentName.mos \
 DeleteConnection.mos \
 DialogAnnotation.mos \

--- a/testsuite/openmodelica/interactive-API/checkAllModelsRecursive1.mos
+++ b/testsuite/openmodelica/interactive-API/checkAllModelsRecursive1.mos
@@ -1,0 +1,63 @@
+// name: checkAllModelsRecursive1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+loadString("
+  package TestCheckAll
+    model A
+      parameter Modelica.SIunits.Voltage V = 10;
+    end A;
+    encapsulated model B
+     parameter Modelica.SIunits.Current A = 5;
+    end B;
+    model C
+      parameter Modelica.SIunits.Voltage V = 10;
+    end C;
+    annotation(uses(Modelica(version = \"3.2.3\")));
+  end TestCheckAll;
+");
+
+checkAllModelsRecursive(TestCheckAll);
+getErrorString();
+
+// Result:
+// true
+// Number of classes to check: 4
+// Checking skipped: package TestCheckAll...
+// Checking: model TestCheckAll.A... OK
+// 	Check of TestCheckAll.A completed successfully.
+// 	Class TestCheckAll.A has 0 equation(s) and 0 variable(s).
+// 	0 of these are trivial equation(s).
+// Error String:
+//
+// Error Buffer:
+// Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from TestCheckAll.
+// Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
+//
+// #[+], TestCheckAll.A
+// -------------------------------------------------------------------------
+// Checking: encapsulated model TestCheckAll.B... FAILED!
+//
+// Error String:
+//
+// Error Buffer:
+// [<interactive>:7:6-7:46:writable] Error: Class Modelica.SIunits.Current not found in scope B.
+//
+// #[-], TestCheckAll.B
+// -------------------------------------------------------------------------
+// Checking: model TestCheckAll.C... OK
+// 	Check of TestCheckAll.C completed successfully.
+// 	Class TestCheckAll.C has 0 equation(s) and 0 variable(s).
+// 	0 of these are trivial equation(s).
+// Error String:
+//
+// Error Buffer:
+//
+// #[+], TestCheckAll.C
+// -------------------------------------------------------------------------
+// "Number of classes checked / failed: 4/1"
+// ""
+// endResult


### PR DESCRIPTION
- Don't load libraries when looking for a builtin element during name lookup, since that means we're in an encapsulated class and the library might already be loaded and should not be loaded again.
- Disable reporting of times when running `checkAllModelsRecursive` in a testcase to make it possible to test it.

Fixes #9554