### PR TITLE
fix: #9366

### DIFF
--- a/OMCompiler/Compiler/BackEnd/DynamicOptimization.mo
+++ b/OMCompiler/Compiler/BackEnd/DynamicOptimization.mo
@@ -264,7 +264,7 @@ algorithm
 
  for elem in constraintLst loop
    try
-     conCrefName := prefConCrefName + ComponentReference.crefModelicaStr(Expression.expCref(elem));
+     conCrefName := prefConCrefName + ComponentReference.printComponentRefStr(Expression.expCref(elem));
    else
      conCrefName := prefConCrefName + intString(i);
      i := i + 1;

--- a/testsuite/openmodelica/cruntime/optimization/basic/Makefile
+++ b/testsuite/openmodelica/cruntime/optimization/basic/Makefile
@@ -20,6 +20,7 @@ DMwarmCsv.mos \
 InputOptIssues.mos \
 LoopTest.mos \
 issue7969.mos \
+issue9366.mos \
 LRB.mos \
 LRB2.mos \
 LV.mos \

--- a/testsuite/openmodelica/cruntime/optimization/basic/issue9366.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/issue9366.mos
@@ -1,0 +1,71 @@
+// name: issue7969
+// status: correct
+
+// target: inputs attribute are set via parameters
+
+setCommandLineOptions("+gDynOpt");
+getErrorString();
+
+loadString("
+model component
+  input Real v1;
+  input Real v2;
+  output Real limit(min=0) annotation(isConstraint=true);
+  equation
+    limit = v2 - v1;
+end component;
+
+model issue9366
+  final parameter Integer n = 5;
+  input Real [n]u_set(each start = -2, each min=-2, each max = 2);
+  component c[n];
+  Real Z annotation(isLagrange = true);
+equation
+  Z = sum(c.limit);
+  for i in 1:n loop
+    u_set[i] = c[i].v1;
+    c[i].v2 = 1 - time;
+  end for;
+end issue9366;
+");
+getErrorString();
+
+optimize(issue9366, numberOfIntervals=4, tolerance = 1e-8, stopTime = 2);
+getErrorString();
+
+val(Z, {0.5,1.0, 2});
+val(u_set[1], {0.5,1.0, 2});
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "issue9366_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.0, numberOfIntervals = 4, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'issue9366', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//
+// Optimizer Variables
+// ========================================================
+// Input[0]:u_set[1](start = -2, nominal = 2, min = -2, max = 2)
+// Input[1]:u_set[2](start = -2, nominal = 2, min = -2, max = 2)
+// Input[2]:u_set[3](start = -2, nominal = 2, min = -2, max = 2)
+// Input[3]:u_set[4](start = -2, nominal = 2, min = -2, max = 2)
+// Input[4]:u_set[5](start = -2, nominal = 2, min = -2, max = 2)
+// --------------------------------------------------------
+// number of nonlinear constraints: 5
+// ========================================================
+//
+// ******************************************************************************
+// This program contains Ipopt, a library for large-scale nonlinear optimization.
+//  Ipopt is released as open source code under the Eclipse Public License (EPL).
+//          For more information visit https://github.com/coin-or/Ipopt
+// ******************************************************************************
+//
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// {-4.910006401459555e-08,-4.910000797820002e-08,-4.910019335557791e-08}
+// {0.5000000098200128,9.820001595640004e-09,-0.9999999901799613}
+// endResult

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runDrumBoiler.mos
@@ -55,13 +55,13 @@ getErrorString();
 //          For more information visit https://github.com/coin-or/Ipopt
 // ******************************************************************************
 //
-// LOG_IPOPT_ERROR   | info    | max violation is 2.49596 for the constraint $con$conSigma_con(time = 936)
-// LOG_IPOPT_ERROR   | info    | max violation is 159.505 for the constraint $con$conSigma_con(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 157.079 for the constraint $con$conSigma_con(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 138.617 for the constraint $con$conSigma_con(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 58.0565 for the constraint $con$conSigma_con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 2.49596 for the constraint $con$conSigma.con(time = 936)
+// LOG_IPOPT_ERROR   | info    | max violation is 159.505 for the constraint $con$conSigma.con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 157.079 for the constraint $con$conSigma.con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 138.617 for the constraint $con$conSigma.con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 58.0565 for the constraint $con$conSigma.con(time = 1368)
 // LOG_IPOPT_ERROR   | info    | max error is 0.545275 for the approximation of the state evaporator.p(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 36.0501 for the constraint $con$conSigma_con(time = 1080)
+// LOG_IPOPT_ERROR   | info    | max violation is 36.0501 for the constraint $con$conSigma.con(time = 1080)
 // LOG_IPOPT_ERROR   | info    | max error is 0.0412625 for the approximation of the state evaporator.p(time = 1224)
 // LOG_IPOPT_ERROR   | info    | max error is 0.0203336 for the approximation of the state evaporator.p(time = 3600)
 // LOG_IPOPT_ERROR   | info    | max error is 0.00282562 for the approximation of the state evaporator.p(time = 3600)
@@ -69,12 +69,12 @@ getErrorString();
 // LOG_IPOPT_ERROR   | info    | max error is 0.00131765 for the approximation of the state evaporator.p(time = 3600)
 // LOG_IPOPT_ERROR   | info    | max error is 5.01892e-05 for the approximation of the state evaporator.p(time = 1224)
 // LOG_IPOPT_ERROR   | info    | max error is 3.24251e-06 for the approximation of the state evaporator.p(time = 1224)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.47354e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.48405e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.49979e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.49983e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma_con(time = 360)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma_con(time = 288)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.47354e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.48405e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.49979e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.49983e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 360)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 288)
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runReduceDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runReduceDrumBoiler.mos
@@ -51,13 +51,13 @@ getErrorString();
 //          For more information visit https://github.com/coin-or/Ipopt
 // ******************************************************************************
 //
-// LOG_IPOPT_ERROR   | info    | max violation is 2.49596 for the constraint $con$conSigma_con(time = 936)
-// LOG_IPOPT_ERROR   | info    | max violation is 159.505 for the constraint $con$conSigma_con(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 157.079 for the constraint $con$conSigma_con(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 138.617 for the constraint $con$conSigma_con(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 58.0565 for the constraint $con$conSigma_con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 2.49596 for the constraint $con$conSigma.con(time = 936)
+// LOG_IPOPT_ERROR   | info    | max violation is 159.505 for the constraint $con$conSigma.con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 157.079 for the constraint $con$conSigma.con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 138.617 for the constraint $con$conSigma.con(time = 1368)
+// LOG_IPOPT_ERROR   | info    | max violation is 58.0565 for the constraint $con$conSigma.con(time = 1368)
 // LOG_IPOPT_ERROR   | info    | max error is 0.545275 for the approximation of the state evaporator.p(time = 1368)
-// LOG_IPOPT_ERROR   | info    | max violation is 36.0501 for the constraint $con$conSigma_con(time = 1080)
+// LOG_IPOPT_ERROR   | info    | max violation is 36.0501 for the constraint $con$conSigma.con(time = 1080)
 // LOG_IPOPT_ERROR   | info    | max error is 0.0412625 for the approximation of the state evaporator.p(time = 1224)
 // LOG_IPOPT_ERROR   | info    | max error is 0.0203336 for the approximation of the state evaporator.p(time = 3600)
 // LOG_IPOPT_ERROR   | info    | max error is 0.00282562 for the approximation of the state evaporator.p(time = 3600)
@@ -65,12 +65,12 @@ getErrorString();
 // LOG_IPOPT_ERROR   | info    | max error is 0.00131765 for the approximation of the state evaporator.p(time = 3600)
 // LOG_IPOPT_ERROR   | info    | max error is 5.01892e-05 for the approximation of the state evaporator.p(time = 1224)
 // LOG_IPOPT_ERROR   | info    | max error is 3.24251e-06 for the approximation of the state evaporator.p(time = 1224)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.47354e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.48405e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.49979e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.49983e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma_con(time = 216)
-// LOG_IPOPT_ERROR | info    | max violation is 1.5e-06 for the constraint $con$conSigma_con(time = 288)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.47354e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.48405e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.49979e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.49983e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 288)
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
### Related Issues

#9366

### Purpose

using `printComponentRefStr` for get string with subscriptions

### Approach

using subscriptions for generate constraints equation
