### PR TITLE
Add bin directory to EXTERNAL_LIBDIRECTORIES

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15564,6 +15564,7 @@ protected
   end addQuotationMarks;
 algorithm
   (locations, libraries) := getDirectoriesForDLLsFromLinkLibs(libs);
+  locations := listAppend({Settings.getInstallationDirectoryPath() + "/bin"}, locations);   // pthread located in OpenModelica/bin/ on Windows
   locations := List.map(locations, addQuotationMarks);
   // Use target_link_directories when CMake 3.13 is available and skip the find_library part
   cmakecode := cmakecode + "set(EXTERNAL_LIBDIRECTORIES " + stringDelimitList(locations, "\n                            ") + ")\n";


### PR DESCRIPTION
### Related Issues

Fixes #9568.

### Purpose

  - Fixes missing pthread when building CMake FMUs on Windows.

### Approach

  - Key word `DIRECTORIES` needs to contain locations for default C libraries like pthread and m.
  - Adding OpenModelica/bin/ to library locations. There is a copy of pthread.dll on Windows systems.
