### PR TITLE
[NewAPI] Do not use the icon annotation as fallback

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -2653,11 +2653,8 @@ void Element::createClassInheritedElements()
 void Element::createClassShapes()
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    /* ticket:4505
-     * Only use the diagram annotation when connector is inside the component instance.
-     */
     QList<ModelInstance::Shape*> shapes;
-    if (mpModel->isConnector() && mpGraphicsView->getViewType() == StringHandler::Diagram && canUseDiagramAnnotation() && !mpModel->getDiagramAnnotation()->isGraphicsEmpty()) {
+    if (mpModel->isConnector() && mpGraphicsView->getViewType() == StringHandler::Diagram) {
       shapes = mpModel->getDiagramAnnotation()->getGraphics();
     } else {
       shapes = mpModel->getIconAnnotation()->getGraphics();
@@ -2687,8 +2684,8 @@ void Element::createClassShapes()
         }
         GraphicsView *pGraphicsView = mpLibraryTreeItem->getModelWidget()->getIconGraphicsView();
         /* ticket:4505
-           * Only use the diagram annotation when connector is inside the component instance.
-           */
+         * Only use the diagram annotation when connector is inside the component instance.
+         */
         if (mpLibraryTreeItem->isConnector() && mpGraphicsView->getViewType() == StringHandler::Diagram && canUseDiagramAnnotation()) {
           mpLibraryTreeItem->getModelWidget()->loadDiagramView();
           if (mpLibraryTreeItem->getModelWidget()->getDiagramGraphicsView()->hasAnnotation()) {

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -381,7 +381,6 @@ private:
   QString getParameterDisplayStringFromExtendsParameters(QString parameterName, QString modifierString);
   bool checkEnumerationDisplayString(QString &displayString, const QString &typeName);
   void updateToolTip();
-  bool canUseDiagramAnnotation();
 signals:
   void added();
   void transformChange(bool positionChanged);


### PR DESCRIPTION
### Related Issues

Fixes #9557

### Purpose

Fix display of connectors in the diagrams.

### Approach

For connectors, the icon layer is used to represent a connector when it is shown in the icon layer of the enclosing model. The diagram layer of the connector is used to represent it when shown in the diagram layer of the enclosing model.
