### PR TITLE
Improve obfuscation

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -1226,7 +1226,7 @@ public
     (statements, diffArguments) := List.mapFold(alg.statements, differentiateStatement, diffArguments);
     statements_flat := List.flatten(statements);
     (inputs, outputs) := Algorithm.getInputsOutputs(statements_flat);
-    alg := Algorithm.ALGORITHM(statements_flat, inputs, outputs, alg.source);
+    alg := Algorithm.ALGORITHM(statements_flat, inputs, outputs, alg.scope, alg.source);
   end differentiateAlgorithm;
 
   function differentiateStatement

--- a/OMCompiler/Compiler/NFFrontEnd/NFAlgorithm.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFAlgorithm.mo
@@ -53,6 +53,7 @@ public
     list<Statement> statements;
     list<ComponentRef> inputs;
     list<ComponentRef> outputs;
+    InstNode scope;
     DAE.ElementSource source;
   end ALGORITHM;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
@@ -505,9 +505,9 @@ protected
           ty := Expression.typeOf(l);
 
           if Type.isArray(ty) then
-            eq := Equation.ARRAY_EQUALITY(l, r, ty, DAE.emptyElementSource);
+            eq := Equation.ARRAY_EQUALITY(l, r, ty, InstNode.EMPTY_NODE(), DAE.emptyElementSource);
           else
-            eq := Equation.EQUALITY(l, r, ty, DAE.emptyElementSource);
+            eq := Equation.EQUALITY(l, r, ty, InstNode.EMPTY_NODE(), DAE.emptyElementSource);
           end if;
 
           equations := eq :: equations;
@@ -574,7 +574,7 @@ protected
       end while;
 
       ty := Expression.typeOf(sum_exp);
-      eq := Equation.EQUALITY(sum_exp, Expression.makeZero(ty), ty, DAE.emptyElementSource);
+      eq := Equation.EQUALITY(sum_exp, Expression.makeZero(ty), ty, InstNode.EMPTY_NODE(), DAE.emptyElementSource);
       equations := generateForLoop({eq}, iterators, ranges, equations);
     end if;
   end generateFlowEquation;
@@ -610,7 +610,7 @@ protected
         // instead of creating an unnecessary for loop here.
         body := Equation.replaceIteratorList(body, iterators[i], ranges[i]);
       else
-        body := {Equation.FOR(iterators[i], SOME(ranges[i]), body, DAE.emptyElementSource)};
+        body := {Equation.FOR(iterators[i], SOME(ranges[i]), body, InstNode.EMPTY_NODE(), DAE.emptyElementSource)};
       end if;
     end for;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -261,7 +261,7 @@ protected
 algorithm
   source := ElementSource.mergeSources(lhsSource, rhsSource);
   //source := ElementSource.addElementSourceConnect(source, (lhsCref, rhsCref));
-  equalityEq := Equation.makeCrefEquality(lhsCref, rhsCref, source);
+  equalityEq := Equation.makeCrefEquality(lhsCref, rhsCref, InstNode.EMPTY_NODE(), source);
 end makeEqualityEquation;
 
 function makeEqualityAssert
@@ -293,7 +293,7 @@ algorithm
     exp := Expression.RELATION(lhs_exp, Operator.makeEqual(ty), rhs_exp);
   end if;
 
-  equalityAssert := Equation.ASSERT(exp, EQ_ASSERT_STR, NFBuiltin.ASSERTIONLEVEL_ERROR, source);
+  equalityAssert := Equation.ASSERT(exp, EQ_ASSERT_STR, NFBuiltin.ASSERTIONLEVEL_ERROR, InstNode.EMPTY_NODE(), source);
 end makeEqualityAssert;
 
 //protected function shouldFlipPotentialEquation
@@ -340,7 +340,7 @@ algorithm
     end for;
   end if;
 
-  equations := {Equation.EQUALITY(sum, Expression.REAL(0.0), c.ty, src)};
+  equations := {Equation.EQUALITY(sum, Expression.REAL(0.0), c.ty, InstNode.EMPTY_NODE(), src)};
 end generateFlowEquations;
 
 function makeFlowExp
@@ -394,8 +394,8 @@ algorithm
         e2 := makeInStreamCall(cref1);
         src := ElementSource.mergeSources(src1, src2);
       then
-        {Equation.EQUALITY(cref1, e1, Type.REAL(), src),
-         Equation.EQUALITY(cref2, e2, Type.REAL(), src)};
+        {Equation.EQUALITY(cref1, e1, Type.REAL(), InstNode.EMPTY_NODE(), src),
+         Equation.EQUALITY(cref2, e2, Type.REAL(), InstNode.EMPTY_NODE(), src)};
 
     // One inside, one outside:
     // cr1 = cr2;
@@ -404,7 +404,7 @@ algorithm
       algorithm
         src := ElementSource.mergeSources(src1, src2);
       then
-        {Equation.makeCrefEquality(cr1, cr2, src)};
+        {Equation.makeCrefEquality(cr1, cr2, InstNode.EMPTY_NODE(), src)};
 
     // The general case with N inside connectors and M outside:
     else
@@ -433,7 +433,7 @@ algorithm
     outside := removeStreamSetElement(e.name, outsideElements);
     res := streamSumEquationExp(outside, insideElements, flowThreshold, variables);
     src := ElementSource.addAdditionalComment(e.source, " equation generated from stream connection");
-    equations := Equation.EQUALITY(cref_exp, res, Type.REAL(), src) :: equations;
+    equations := Equation.EQUALITY(cref_exp, res, Type.REAL(), InstNode.EMPTY_NODE(), src) :: equations;
   end for;
 end streamEquationGeneral;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
@@ -149,6 +149,7 @@ public
     Expression lhs "The left hand side expression.";
     Expression rhs "The right hand side expression.";
     Type ty;
+    InstNode scope;
     DAE.ElementSource source;
   end EQUALITY;
 
@@ -156,12 +157,14 @@ public
     Expression lhs;
     Expression rhs;
     Type ty;
+    InstNode scope;
     DAE.ElementSource source;
   end ARRAY_EQUALITY;
 
   record CONNECT
     Expression lhs;
     Expression rhs;
+    InstNode scope;
     DAE.ElementSource source;
   end CONNECT;
 
@@ -169,16 +172,19 @@ public
     InstNode iterator;
     Option<Expression> range;
     list<Equation> body   "The body of the for loop.";
+    InstNode scope;
     DAE.ElementSource source;
   end FOR;
 
   record IF
     list<Branch> branches;
+    InstNode scope;
     DAE.ElementSource source;
   end IF;
 
   record WHEN
     list<Branch> branches;
+    InstNode scope;
     DAE.ElementSource source;
   end WHEN;
 
@@ -186,22 +192,26 @@ public
     Expression condition "The assert condition.";
     Expression message "The message to display if the assert fails.";
     Expression level "Error or warning";
+    InstNode scope;
     DAE.ElementSource source;
   end ASSERT;
 
   record TERMINATE
     Expression message "The message to display if the terminate triggers.";
+    InstNode scope;
     DAE.ElementSource source;
   end TERMINATE;
 
   record REINIT
     Expression cref "The variable to reinitialize.";
     Expression reinitExp "The new value of the variable.";
+    InstNode scope;
     DAE.ElementSource source;
   end REINIT;
 
   record NORETCALL
     Expression exp;
+    InstNode scope;
     DAE.ElementSource source;
   end NORETCALL;
 
@@ -209,16 +219,18 @@ public
     input Expression lhs;
     input Expression rhs;
     input Type ty;
+    input InstNode scope;
     input DAE.ElementSource src;
     output Equation eq;
   algorithm
-    eq := EQUALITY(lhs, rhs, ty, src);
+    eq := EQUALITY(lhs, rhs, ty, scope, src);
     annotation(__OpenModelica_EarlyInline=true);
   end makeEquality;
 
   function makeCrefEquality
     input ComponentRef lhsCref;
     input ComponentRef rhsCref;
+    input InstNode scope;
     input DAE.ElementSource src;
     output Equation eq;
   protected
@@ -226,7 +238,7 @@ public
   algorithm
     e1 := Expression.fromCref(lhsCref);
     e2 := Expression.fromCref(rhsCref);
-    eq := makeEquality(e1, e2, Expression.typeOf(e1), src);
+    eq := makeEquality(e1, e2, Expression.typeOf(e1), scope, src);
   end makeCrefEquality;
 
   function makeBranch
@@ -241,10 +253,11 @@ public
 
   function makeIf
     input list<Branch> branches;
+    input InstNode scope;
     input DAE.ElementSource src;
     output Equation eq;
   algorithm
-    eq := IF(branches, src);
+    eq := IF(branches, scope, src);
     annotation(__OpenModelica_EarlyInline=true);
   end makeIf;
 
@@ -265,6 +278,42 @@ public
       case NORETCALL() then eq.source;
     end match;
   end source;
+
+  function setSource
+    input DAE.ElementSource source;
+    input output Equation eq;
+  algorithm
+    () := match eq
+      case EQUALITY()       algorithm eq.source := source; then ();
+      case ARRAY_EQUALITY() algorithm eq.source := source; then ();
+      case CONNECT()        algorithm eq.source := source; then ();
+      case FOR()            algorithm eq.source := source; then ();
+      case IF()             algorithm eq.source := source; then ();
+      case WHEN()           algorithm eq.source := source; then ();
+      case ASSERT()         algorithm eq.source := source; then ();
+      case TERMINATE()      algorithm eq.source := source; then ();
+      case REINIT()         algorithm eq.source := source; then ();
+      case NORETCALL()      algorithm eq.source := source; then ();
+    end match;
+  end setSource;
+
+  function scope
+    input Equation eq;
+    output InstNode scope;
+  algorithm
+    scope := match eq
+      case EQUALITY() then eq.scope;
+      case ARRAY_EQUALITY() then eq.scope;
+      case CONNECT() then eq.scope;
+      case FOR() then eq.scope;
+      case IF() then eq.scope;
+      case WHEN() then eq.scope;
+      case ASSERT() then eq.scope;
+      case TERMINATE() then eq.scope;
+      case REINIT() then eq.scope;
+      case NORETCALL() then eq.scope;
+    end match;
+  end scope;
 
   function info
     input Equation eq;
@@ -532,7 +581,7 @@ public
           e2 := func(eq.rhs);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else EQUALITY(e1, e2, eq.ty, eq.source);
+            then eq else EQUALITY(e1, e2, eq.ty, eq.scope, eq.source);
 
       case ARRAY_EQUALITY()
         algorithm
@@ -540,7 +589,7 @@ public
           e2 := func(eq.rhs);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else ARRAY_EQUALITY(e1, e2, eq.ty, eq.source);
+            then eq else ARRAY_EQUALITY(e1, e2, eq.ty, eq.scope, eq.source);
 
       //case CREF_EQUALITY()
       //  algorithm
@@ -555,7 +604,7 @@ public
           e2 := func(eq.rhs);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else CONNECT(e1, e2, eq.source);
+            then eq else CONNECT(e1, e2, eq.scope, eq.source);
 
       case FOR()
         algorithm
@@ -583,13 +632,13 @@ public
           e3 := func(eq.level);
         then
           if referenceEq(e1, eq.condition) and referenceEq(e2, eq.message) and
-            referenceEq(e3, eq.level) then eq else ASSERT(e1, e2, e3, eq.source);
+            referenceEq(e3, eq.level) then eq else ASSERT(e1, e2, e3, eq.scope, eq.source);
 
       case TERMINATE()
         algorithm
           e1 := func(eq.message);
         then
-          if referenceEq(e1, eq.message) then eq else TERMINATE(e1, eq.source);
+          if referenceEq(e1, eq.message) then eq else TERMINATE(e1, eq.scope, eq.source);
 
       case REINIT()
         algorithm
@@ -597,13 +646,13 @@ public
           e2 := func(eq.reinitExp);
         then
           if referenceEq(e1, eq.cref) and referenceEq(e2, eq.reinitExp) then
-            eq else REINIT(e1, e2, eq.source);
+            eq else REINIT(e1, e2, eq.scope, eq.source);
 
       case NORETCALL()
         algorithm
           e1 := func(eq.exp);
         then
-          if referenceEq(e1, eq.exp) then eq else NORETCALL(e1, eq.source);
+          if referenceEq(e1, eq.exp) then eq else NORETCALL(e1, eq.scope, eq.source);
 
       else eq;
     end match;
@@ -623,7 +672,7 @@ public
           e2 := func(eq.rhs);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else EQUALITY(e1, e2, eq.ty, eq.source);
+            then eq else EQUALITY(e1, e2, eq.ty, eq.scope, eq.source);
 
       case ARRAY_EQUALITY()
         algorithm
@@ -631,7 +680,7 @@ public
           e2 := func(eq.rhs);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else ARRAY_EQUALITY(e1, e2, eq.ty, eq.source);
+            then eq else ARRAY_EQUALITY(e1, e2, eq.ty, eq.scope, eq.source);
 
       case CONNECT()
         algorithm
@@ -639,7 +688,7 @@ public
           e2 := func(eq.rhs);
         then
           if referenceEq(e1, eq.lhs) and referenceEq(e2, eq.rhs)
-            then eq else CONNECT(e1, e2, eq.source);
+            then eq else CONNECT(e1, e2, eq.scope, eq.source);
 
       case FOR()
         algorithm
@@ -666,13 +715,13 @@ public
           e3 := func(eq.level);
         then
           if referenceEq(e1, eq.condition) and referenceEq(e2, eq.message) and
-            referenceEq(e3, eq.level) then eq else ASSERT(e1, e2, e3, eq.source);
+            referenceEq(e3, eq.level) then eq else ASSERT(e1, e2, e3, eq.scope, eq.source);
 
       case TERMINATE()
         algorithm
           e1 := func(eq.message);
         then
-          if referenceEq(e1, eq.message) then eq else TERMINATE(e1, eq.source);
+          if referenceEq(e1, eq.message) then eq else TERMINATE(e1, eq.scope, eq.source);
 
       case REINIT()
         algorithm
@@ -680,13 +729,13 @@ public
           e2 := func(eq.reinitExp);
         then
           if referenceEq(e1, eq.cref) and referenceEq(e2, eq.reinitExp) then
-            eq else REINIT(e1, e2, eq.source);
+            eq else REINIT(e1, e2, eq.scope, eq.source);
 
       case NORETCALL()
         algorithm
           e1 := func(eq.exp);
         then
-          if referenceEq(e1, eq.exp) then eq else NORETCALL(e1, eq.source);
+          if referenceEq(e1, eq.exp) then eq else NORETCALL(e1, eq.scope, eq.source);
 
       else eq;
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -385,14 +385,14 @@ algorithm
         e1 := evaluateExp(eq.lhs, info);
         e2 := evaluateExp(eq.rhs, info);
       then
-        Equation.EQUALITY(e1, e2, ty, eq.source);
+        Equation.EQUALITY(e1, e2, ty, eq.scope, eq.source);
 
     case Equation.ARRAY_EQUALITY()
       algorithm
         ty := Type.mapDims(eq.ty, function evaluateDimension(info = info));
         e2 := evaluateExp(eq.rhs, info);
       then
-        Equation.ARRAY_EQUALITY(eq.lhs, e2, ty, eq.source);
+        Equation.ARRAY_EQUALITY(eq.lhs, e2, ty, eq.scope, eq.source);
 
     case Equation.FOR()
       algorithm
@@ -420,7 +420,7 @@ algorithm
         e2 := evaluateExp(eq.message, info);
         e3 := evaluateExp(eq.level, info);
       then
-        Equation.ASSERT(e1, e2, e3, eq.source);
+        Equation.ASSERT(e1, e2, e3, eq.scope, eq.source);
 
     case Equation.TERMINATE()
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -217,6 +217,11 @@ algorithm
 
   flatModel := InstUtil.combineSubscripts(flatModel);
 
+  if Flags.getConfigString(Flags.OBFUSCATE) == "protected" or
+     Flags.getConfigString(Flags.OBFUSCATE) == "encrypted" then
+    flatModel := FlatModel.obfuscate(flatModel);
+  end if;
+
   //(var_count, eq_count) := CheckModel.checkModel(flatModel);
   //print(name + " has " + String(var_count) + " variable(s) and " + String(eq_count) + " equation(s).\n");
 end instClassInProgram;
@@ -2821,7 +2826,7 @@ algorithm
         exp1 := instExp(scodeEq.expLeft, scope, context, info);
         exp2 := instExp(scodeEq.expRight, scope, context, info);
       then
-        Equation.EQUALITY(exp1, exp2, Type.UNKNOWN(), makeSource(scodeEq.comment, info));
+        Equation.EQUALITY(exp1, exp2, Type.UNKNOWN(), scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_CONNECT(info = info)
       algorithm
@@ -2835,7 +2840,7 @@ algorithm
         exp1 := instConnectorCref(scodeEq.crefLeft, scope, context, info);
         exp2 := instConnectorCref(scodeEq.crefRight, scope, context, info);
       then
-        Equation.CONNECT(exp1, exp2, makeSource(scodeEq.comment, info));
+        Equation.CONNECT(exp1, exp2, scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_FOR(info = info)
       algorithm
@@ -2845,7 +2850,7 @@ algorithm
         next_origin := InstContext.set(context, NFInstContext.FOR);
         eql := instEquations(scodeEq.eEquationLst, for_scope, next_origin);
       then
-        Equation.FOR(iter, oexp, eql, makeSource(scodeEq.comment, info));
+        Equation.FOR(iter, oexp, eql, scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_IF(info = info)
       algorithm
@@ -2868,7 +2873,7 @@ algorithm
           branches := Equation.makeBranch(Expression.BOOLEAN(true), eql) :: branches;
         end if;
       then
-        Equation.IF(listReverse(branches), makeSource(scodeEq.comment, info));
+        Equation.IF(listReverse(branches), scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_WHEN(info = info)
       algorithm
@@ -2889,7 +2894,7 @@ algorithm
           branches := Equation.makeBranch(exp1, eql) :: branches;
         end for;
       then
-        Equation.WHEN(listReverse(branches), makeSource(scodeEq.comment, info));
+        Equation.WHEN(listReverse(branches), scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_ASSERT(info = info)
       algorithm
@@ -2897,13 +2902,13 @@ algorithm
         exp2 := instExp(scodeEq.message, scope, context, info);
         exp3 := instExp(scodeEq.level, scope, context, info);
       then
-        Equation.ASSERT(exp1, exp2, exp3, makeSource(scodeEq.comment, info));
+        Equation.ASSERT(exp1, exp2, exp3, scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_TERMINATE(info = info)
       algorithm
         exp1 := instExp(scodeEq.message, scope, context, info);
       then
-        Equation.TERMINATE(exp1, makeSource(scodeEq.comment, info));
+        Equation.TERMINATE(exp1, scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_REINIT(info = info)
       algorithm
@@ -2915,13 +2920,13 @@ algorithm
         exp1 := instExp(scodeEq.cref, scope, context, info);
         exp2 := instExp(scodeEq.expReinit, scope, context, info);
       then
-        Equation.REINIT(exp1, exp2, makeSource(scodeEq.comment, info));
+        Equation.REINIT(exp1, exp2, scope, makeSource(scodeEq.comment, info));
 
     case SCode.Equation.EQ_NORETCALL(info = info)
       algorithm
         exp1 := instExp(scodeEq.exp, scope, context, info);
       then
-        Equation.NORETCALL(exp1, makeSource(scodeEq.comment, info));
+        Equation.NORETCALL(exp1, scope, makeSource(scodeEq.comment, info));
 
     else
       algorithm
@@ -2982,7 +2987,7 @@ protected
 algorithm
   statements := instStatements(algorithmSection.statements, scope, context);
   (inputs_lst, outputs_lst) := Algorithm.getInputsOutputs(statements);
-  alg := Algorithm.ALGORITHM(statements, inputs_lst, outputs_lst, DAE.emptyElementSource);
+  alg := Algorithm.ALGORITHM(statements, inputs_lst, outputs_lst, scope, DAE.emptyElementSource);
 end instAlgorithmSection;
 
 function instStatements

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1580,6 +1580,11 @@ uniontype InstNode
     end match;
   end isProtected;
 
+  function isPublic
+    input InstNode node;
+    output Boolean isPublic = not isProtected(node);
+  end isPublic;
+
   function protectClass
     input output InstNode cls;
   algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -312,7 +312,7 @@ algorithm
 
         (expLHS, ty, var) := Typing.typeExp(expLHS, context, ElementSource.getInfo(source));
 
-        replaceEq := Equation.EQUALITY(expRHS, expLHS, ty, source);
+        replaceEq := Equation.EQUALITY(expRHS, expLHS, ty, InstNode.EMPTY_NODE(), source);
 
         eqsEqualityConstraint := {replaceEq};
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFScalarize.mo
@@ -57,6 +57,7 @@ import DAE;
 import Statement = NFStatement;
 import Algorithm = NFAlgorithm;
 import ExpandExp = NFExpandExp;
+import NFInstNode.InstNode;
 
 public
 function scalarize
@@ -330,7 +331,7 @@ algorithm
     case Equation.EQUALITY(lhs = lhs, rhs = rhs, ty = ty, source = src) guard Type.isArray(ty)
       algorithm
         if Expression.hasArrayCall(lhs) or Expression.hasArrayCall(rhs) then
-          equations := Equation.ARRAY_EQUALITY(lhs, rhs, ty, src) :: equations;
+          equations := Equation.ARRAY_EQUALITY(lhs, rhs, ty, eq.scope, src) :: equations;
         else
           lhs_iter := ExpressionIterator.fromExp(lhs);
           rhs_iter := ExpressionIterator.fromExp(rhs);
@@ -344,22 +345,19 @@ algorithm
 
             (lhs_iter, lhs) := ExpressionIterator.next(lhs_iter);
             (rhs_iter, rhs) := ExpressionIterator.next(rhs_iter);
-            equations := Equation.EQUALITY(lhs, rhs, ty, src) :: equations;
+            equations := Equation.EQUALITY(lhs, rhs, ty, eq.scope, src) :: equations;
           end while;
         end if;
       then
         equations;
 
-    case Equation.ARRAY_EQUALITY()
-      then Equation.ARRAY_EQUALITY(eq.lhs, eq.rhs, eq.ty, eq.source) :: equations;
-
     case Equation.CONNECT() then equations;
 
     case Equation.IF()
-      then scalarizeIfEquation(eq.branches, eq.source, equations);
+      then scalarizeIfEquation(eq.branches, eq.scope, eq.source, equations);
 
     case Equation.WHEN()
-      then scalarizeWhenEquation(eq.branches, eq.source, equations);
+      then scalarizeWhenEquation(eq.branches, eq.scope, eq.source, equations);
 
     else eq :: equations;
   end match;
@@ -367,6 +365,7 @@ end scalarizeEquation;
 
 function scalarizeIfEquation
   input list<Equation.Branch> branches;
+  input InstNode scope;
   input DAE.ElementSource source;
   input output list<Equation> equations;
 protected
@@ -388,12 +387,13 @@ algorithm
   // Add the scalarized if equation to the list of equations unless we don't
   // have any branches left.
   if not listEmpty(bl) then
-    equations := Equation.IF(listReverseInPlace(bl), source) :: equations;
+    equations := Equation.IF(listReverseInPlace(bl), scope, source) :: equations;
   end if;
 end scalarizeIfEquation;
 
 function scalarizeWhenEquation
   input list<Equation.Branch> branches;
+  input InstNode scope;
   input DAE.ElementSource source;
   input output list<Equation> equations;
 protected
@@ -413,7 +413,7 @@ algorithm
     bl := Equation.makeBranch(cond, body, var) :: bl;
   end for;
 
-  equations := Equation.WHEN(listReverseInPlace(bl), source) :: equations;
+  equations := Equation.WHEN(listReverseInPlace(bl), scope, source) :: equations;
 end scalarizeWhenEquation;
 
 function scalarizeAlgorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
@@ -169,6 +169,26 @@ public
     end match;
   end source;
 
+  function setSource
+    input DAE.ElementSource source;
+    input output Statement stmt;
+  algorithm
+    () := match stmt
+      case ASSIGNMENT()          algorithm stmt.source := source; then ();
+      case FUNCTION_ARRAY_INIT() algorithm stmt.source := source; then ();
+      case FOR()                 algorithm stmt.source := source; then ();
+      case IF()                  algorithm stmt.source := source; then ();
+      case WHEN()                algorithm stmt.source := source; then ();
+      case ASSERT()              algorithm stmt.source := source; then ();
+      case TERMINATE()           algorithm stmt.source := source; then ();
+      case NORETCALL()           algorithm stmt.source := source; then ();
+      case WHILE()               algorithm stmt.source := source; then ();
+      case RETURN()              algorithm stmt.source := source; then ();
+      case BREAK()               algorithm stmt.source := source; then ();
+      case FAILURE()             algorithm stmt.source := source; then ();
+    end match;
+  end setSource;
+
   function info
     input Statement stmt;
     output SourceInfo info = ElementSource.getInfo(source(stmt));

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
@@ -223,7 +223,7 @@ algorithm
   if Type.isReal(var.ty) and Binding.isBound(var.binding) then
     binding_exp := Binding.getTypedExp(var.binding);
     eq := Equation.makeEquality(Expression.fromCref(var.name), binding_exp, var.ty,
-      ElementSource.createElementSource(var.info));
+      InstNode.EMPTY_NODE(), ElementSource.createElementSource(var.info));
     foldEquation(eq, htCr2U, htS2U, htU2S, fnCache, dumpEqInitStruct);
   end if;
 end foldBindingExp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -249,6 +249,16 @@ public
     output Boolean isPublic = variable.visibility == Visibility.PUBLIC;
   end isPublic;
 
+  function isProtected
+    input Variable variable;
+    output Boolean isProtected = variable.visibility == Visibility.PROTECTED;
+  end isProtected;
+
+  function isEncrypted
+    input Variable variable;
+    output Boolean isEncrypted = Util.endsWith(variable.info.fileName, ".moc");
+  end isEncrypted;
+
   function lookupTypeAttribute
     input String name;
     input Variable var;

--- a/OMCompiler/Compiler/Script/Obfuscate.mo
+++ b/OMCompiler/Compiler/Script/Obfuscate.mo
@@ -489,7 +489,7 @@ encapsulated package Obfuscate
     if isSome(oldId) then
       SOME(id) := oldId;
     else
-      id := "n" + String(index);
+      id := "$n" + String(index);
     end if;
   end makeId;
 

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1428,7 +1428,8 @@ constant ConfigFlag OBFUSCATE = CONFIG_FLAG(152, "obfuscate",
   NONE(), EXTERNAL(), STRING_FLAG("none"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("No obfuscation.")),
-    ("protected", Gettext.gettext("Obfuscates everything except for public variables.")),
+    ("encrypted", Gettext.gettext("Obfuscates protected variables in encrypted models")),
+    ("protected", Gettext.gettext("Obfuscates protected variables in all models.")),
     ("full", Gettext.gettext("Obfuscates everything."))
   })),
   Gettext.gettext("Obfuscates identifiers in the simulation model"));

--- a/testsuite/openmodelica/interactive-API/Obfuscation1.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation1.mos
@@ -15,3661 +15,3661 @@ readFile("BranchingDynamicPipes.mo");
 // ""
 // true
 // ""
-// "package n0
-//   extends n1.n2.n3;
+// "package $n0
+//   extends $n1.$n2.$n3;
 //
-//   package n4
-//     extends n1.n2.n3;
-//     final constant Real n5 = 1e-15;
-//     final constant Real n6 = 1e-60;
-//     final constant Real n7 = 1e60;
-//     final constant Integer n8 = OpenModelica.Internal.Architecture.integerMax();
-//   end n4;
+//   package $n4
+//     extends $n1.$n2.$n3;
+//     final constant Real $n5 = 1e-15;
+//     final constant Real $n6 = 1e-60;
+//     final constant Real $n7 = 1e60;
+//     final constant Integer $n8 = OpenModelica.Internal.Architecture.integerMax();
+//   end $n4;
 //   annotation(version = \"3.2.3\", versionBuild = 4, versionDate = \"2019-01-23\", dateModified = \"2020-06-04 11:00:00Z\");
-// end n0;
+// end $n0;
 //
-// package n1
-//   extends n1.n2.n3;
+// package $n1
+//   extends $n1.$n2.$n3;
 //
-//   package n9
-//     import n10 = n1.n11;
-//     extends n1.n2.n3;
+//   package $n9
+//     import $n10 = $n1.$n11;
+//     extends $n1.$n2.$n3;
 //
-//     package n12
-//       import n1.n11;
-//       extends n1.n2.n13;
-//       connector n14 = input Real;
-//       connector n15 = output Real;
+//     package $n12
+//       import $n1.$n11;
+//       extends $n1.$n2.$n13;
+//       connector $n14 = input Real;
+//       connector $n15 = output Real;
 //
-//       partial block n16
-//         extends n1.n9.n2.n17;
-//         n15 n18;
-//       end n16;
+//       partial block $n16
+//         extends $n1.$n9.$n2.$n17;
+//         $n15 $n18;
+//       end $n16;
 //
-//       partial block n19
-//         extends n16;
-//         parameter Real n20 = 0;
-//         parameter n11.n22 n21 = 0;
-//       end n19;
-//     end n12;
+//       partial block $n19
+//         extends $n16;
+//         parameter Real $n20 = 0;
+//         parameter $n11.$n22 $n21 = 0;
+//       end $n19;
+//     end $n12;
 //
-//     package n23
-//       import n1.n9.n12;
-//       import n1.n11;
-//       extends n1.n2.n24;
+//     package $n23
+//       import $n1.$n9.$n12;
+//       import $n1.$n11;
+//       extends $n1.$n2.$n24;
 //
-//       block n25
-//         parameter Real n26 = 1;
-//         parameter n1.n11.n22 n27(min = 0.0, start = 2);
-//         extends n12.n19;
+//       block $n25
+//         parameter Real $n26 = 1;
+//         parameter $n1.$n11.$n22 $n27(min = 0.0, start = 2);
+//         extends $n12.$n19;
 //       equation
-//         n18 = n20 + (if time < n21 then 0 else if time < (n21 + n27) then (time - n21) * n26 / n27 else n26);
-//       end n25;
-//     end n23;
+//         $n18 = $n20 + (if time < $n21 then 0 else if time < ($n21 + $n27) then (time - $n21) * $n26 / $n27 else $n26);
+//       end $n25;
+//     end $n23;
 //
-//     package n2
-//       extends n1.n2.n28;
+//     package $n2
+//       extends $n1.$n2.$n28;
 //
-//       partial block n17 end n17;
-//     end n2;
-//   end n9;
+//       partial block $n17 end $n17;
+//     end $n2;
+//   end $n9;
 //
-//   package n29
-//     extends n1.n2.n3;
-//     import n10 = n1.n11;
-//     import n30 = n1.n11.n31;
+//   package $n29
+//     extends $n1.$n2.$n3;
+//     import $n10 = $n1.$n11;
+//     import $n30 = $n1.$n11.$n31;
 //
-//     package n32
-//       extends n1.n2.n33;
+//     package $n32
+//       extends $n1.$n2.$n33;
 //
-//       model n34
-//         extends n1.n2.n35;
-//         replaceable package n36 = n1.n37.n39.n40 constrainedby n1.n37.n12.n38;
-//         inner n1.n29.n42 n41(n43 = n1.n29.n44.n45.n46, n47 = n1.n29.n44.n45.n46);
-//         n1.n29.n23.n49 n48(n50 = 1, redeclare package n36 = n36, n51 = 150000);
-//         n53.n54 n52(redeclare package n36 = n36, n55 = true, n56 = 5, n57 = 2.54e-2, n58 = 0.02, n59 = 50, n60 = 50, n61 = 150000, n62 = 130000, n63 = n1.n29.n44.n64.n65);
-//         n53.n54 n66(redeclare package n36 = n36, n55 = true, n56 = 5, redeclare model n67 = n1.n29.n53.n68.n67.n69, n70 = true, n57 = 2.54e-2, n58 = 0.01, n60 = 50, n59 = 25, n61 = 130000, n62 = 120000, n63 = n1.n29.n44.n64.n71);
-//         n53.n54 n72(redeclare package n36 = n36, n55 = true, n56 = 5, n57 = 2.54e-2, n58 = 0.01, n60 = 25, n59 = 25, n61 = 130000, n62 = 120000, n63 = n1.n29.n44.n64.n65);
-//         n53.n54 n73(redeclare package n36 = n36, n55 = true, n56 = 5, n57 = 2.54e-2, n58 = 0.02, n59 = 50, n60 = 50, n61 = 120000, n62 = 100000, n63 = n1.n29.n44.n64.n65);
-//         n1.n29.n23.n49 n74(n50 = 1, redeclare package n36 = n36, n75 = true, n76 = false, n51 = 100000);
-//         n1.n9.n23.n25 n77(n20 = 1e5, n21 = 2, n26 = 1e5, n27 = 0);
-//         n1.n79.n67.n23.n80[n66.n56] n78(n81 = 200 * n66.n82, n83 = -1e-2 * ones(n66.n84));
+//       model $n34
+//         extends $n1.$n2.$n35;
+//         replaceable package $n36 = $n1.$n37.$n39.$n40 constrainedby $n1.$n37.$n12.$n38;
+//         inner $n1.$n29.$n42 $n41($n43 = $n1.$n29.$n44.$n45.$n46, $n47 = $n1.$n29.$n44.$n45.$n46);
+//         $n1.$n29.$n23.$n49 $n48($n50 = 1, redeclare package $n36 = $n36, $n51 = 150000);
+//         $n53.$n54 $n52(redeclare package $n36 = $n36, $n55 = true, $n56 = 5, $n57 = 2.54e-2, $n58 = 0.02, $n59 = 50, $n60 = 50, $n61 = 150000, $n62 = 130000, $n63 = $n1.$n29.$n44.$n64.$n65);
+//         $n53.$n54 $n66(redeclare package $n36 = $n36, $n55 = true, $n56 = 5, redeclare model $n67 = $n1.$n29.$n53.$n68.$n67.$n69, $n70 = true, $n57 = 2.54e-2, $n58 = 0.01, $n60 = 50, $n59 = 25, $n61 = 130000, $n62 = 120000, $n63 = $n1.$n29.$n44.$n64.$n71);
+//         $n53.$n54 $n72(redeclare package $n36 = $n36, $n55 = true, $n56 = 5, $n57 = 2.54e-2, $n58 = 0.01, $n60 = 25, $n59 = 25, $n61 = 130000, $n62 = 120000, $n63 = $n1.$n29.$n44.$n64.$n65);
+//         $n53.$n54 $n73(redeclare package $n36 = $n36, $n55 = true, $n56 = 5, $n57 = 2.54e-2, $n58 = 0.02, $n59 = 50, $n60 = 50, $n61 = 120000, $n62 = 100000, $n63 = $n1.$n29.$n44.$n64.$n65);
+//         $n1.$n29.$n23.$n49 $n74($n50 = 1, redeclare package $n36 = $n36, $n75 = true, $n76 = false, $n51 = 100000);
+//         $n1.$n9.$n23.$n25 $n77($n20 = 1e5, $n21 = 2, $n26 = 1e5, $n27 = 0);
+//         $n1.$n79.$n67.$n23.$n80[$n66.$n56] $n78($n81 = 200 * $n66.$n82, $n83 = -1e-2 * ones($n66.$n84));
 //       equation
-//         connect(n77.n18, n74.n85);
-//         connect(n48.n86[1], n52.n87);
-//         connect(n52.n88, n66.n87);
-//         connect(n52.n88, n72.n87);
-//         connect(n66.n88, n73.n87);
-//         connect(n72.n88, n73.n87);
-//         connect(n73.n88, n74.n86[1]);
-//         connect(n78.n89, n66.n90);
+//         connect($n77.$n18, $n74.$n85);
+//         connect($n48.$n86[1], $n52.$n87);
+//         connect($n52.$n88, $n66.$n87);
+//         connect($n52.$n88, $n72.$n87);
+//         connect($n66.$n88, $n73.$n87);
+//         connect($n72.$n88, $n73.$n87);
+//         connect($n73.$n88, $n74.$n86[1]);
+//         connect($n78.$n89, $n66.$n90);
 //         annotation(experiment(StopTime = 10));
-//       end n34;
-//     end n32;
+//       end $n34;
+//     end $n32;
 //
-//     model n42
-//       parameter n1.n11.n92 n91 = 101325;
-//       parameter n1.n11.n94 n93 = 293.15;
-//       parameter n1.n11.n96 n95 = n1.n97.n98;
-//       parameter Boolean n99 = true annotation(Evaluate = true);
-//       parameter n1.n29.n44.n45 n43 = n1.n29.n44.n45.n100 annotation(Evaluate = true);
-//       parameter n1.n29.n44.n45 n101 = n43 annotation(Evaluate = true);
-//       final parameter n1.n29.n44.n45 n102 = n101 annotation(Evaluate = true);
-//       final parameter n1.n29.n44.n45 n103 = n101 annotation(Evaluate = true);
-//       parameter n1.n29.n44.n45 n47 = n1.n29.n44.n45.n104 annotation(Evaluate = true);
-//       parameter n1.n11.n105 n58 = 0;
-//       parameter n1.n11.n92 n106 = n91;
-//       parameter n1.n11.n94 n107 = n93;
-//       parameter Boolean n108 = false annotation(Evaluate = true);
-//       parameter n1.n11.n105 n109 = if n108 then 1 else 1e2 * n110;
-//       parameter Real n111(min = 0) = 1e-4;
-//       parameter n1.n11.n92 n112(min = 0) = 1;
-//       parameter n1.n11.n105 n110(min = 0) = 1e-2;
-//     end n42;
+//     model $n42
+//       parameter $n1.$n11.$n92 $n91 = 101325;
+//       parameter $n1.$n11.$n94 $n93 = 293.15;
+//       parameter $n1.$n11.$n96 $n95 = $n1.$n97.$n98;
+//       parameter Boolean $n99 = true annotation(Evaluate = true);
+//       parameter $n1.$n29.$n44.$n45 $n43 = $n1.$n29.$n44.$n45.$n100 annotation(Evaluate = true);
+//       parameter $n1.$n29.$n44.$n45 $n101 = $n43 annotation(Evaluate = true);
+//       final parameter $n1.$n29.$n44.$n45 $n102 = $n101 annotation(Evaluate = true);
+//       final parameter $n1.$n29.$n44.$n45 $n103 = $n101 annotation(Evaluate = true);
+//       parameter $n1.$n29.$n44.$n45 $n47 = $n1.$n29.$n44.$n45.$n104 annotation(Evaluate = true);
+//       parameter $n1.$n11.$n105 $n58 = 0;
+//       parameter $n1.$n11.$n92 $n106 = $n91;
+//       parameter $n1.$n11.$n94 $n107 = $n93;
+//       parameter Boolean $n108 = false annotation(Evaluate = true);
+//       parameter $n1.$n11.$n105 $n109 = if $n108 then 1 else 1e2 * $n110;
+//       parameter Real $n111(min = 0) = 1e-4;
+//       parameter $n1.$n11.$n92 $n112(min = 0) = 1;
+//       parameter $n1.$n11.$n105 $n110(min = 0) = 1e-2;
+//     end $n42;
 //
-//     package n53
-//       extends n1.n2.n113;
+//     package $n53
+//       extends $n1.$n2.$n113;
 //
-//       model n54
-//         import n1.n29.n44.n64;
-//         extends n1.n29.n53.n68.n114(final n115 = (n63 == n64.n116) or (n63 == n64.n71), final n117 = (n63 == n64.n118) or (n63 == n64.n71));
-//         extends n68.n119(final n120 = fill(n60 / n84, n84), final n121 = fill(n122, n84), final n123 = fill(4 * n122 / n124, n84), final n125 = fill(n126, n84), final n127 = n59 * n82);
-//         parameter Boolean n70 = false;
-//         replaceable model n67 = n1.n29.n53.n68.n67.n129 constrainedby n1.n29.n53.n68.n67.n128;
-//         n12.n130[n56] n90 if n70;
-//         n67 n131(redeclare final package n36 = n36, final n84 = n84, final n132 = n132, final n133 = n124 * n120, final n120 = n120, final n123 = n123, final n125 = n125, final n134 = n135.n136, final n137 = n137, final n138 = n70);
-//         final parameter Real[n84] n82 = n120 / sum(n120);
+//       model $n54
+//         import $n1.$n29.$n44.$n64;
+//         extends $n1.$n29.$n53.$n68.$n114(final $n115 = ($n63 == $n64.$n116) or ($n63 == $n64.$n71), final $n117 = ($n63 == $n64.$n118) or ($n63 == $n64.$n71));
+//         extends $n68.$n119(final $n120 = fill($n60 / $n84, $n84), final $n121 = fill($n122, $n84), final $n123 = fill(4 * $n122 / $n124, $n84), final $n125 = fill($n126, $n84), final $n127 = $n59 * $n82);
+//         parameter Boolean $n70 = false;
+//         replaceable model $n67 = $n1.$n29.$n53.$n68.$n67.$n129 constrainedby $n1.$n29.$n53.$n68.$n67.$n128;
+//         $n12.$n130[$n56] $n90 if $n70;
+//         $n67 $n131(redeclare final package $n36 = $n36, final $n84 = $n84, final $n132 = $n132, final $n133 = $n124 * $n120, final $n120 = $n120, final $n123 = $n123, final $n125 = $n125, final $n134 = $n135.$n136, final $n137 = $n137, final $n138 = $n70);
+//         final parameter Real[$n84] $n82 = $n120 / sum($n120);
 //       equation
-//         n139 = n131.n140;
-//         if n84 == 1 or n141 then
-//           n142 = n82 * ((n137 * n82) * (n121 * n82) * ((n88.n51 - n87.n51) + sum(n143.n144) - n41.n95 * (n127 * n135.n145))) * n132;
+//         $n139 = $n131.$n140;
+//         if $n84 == 1 or $n141 then
+//           $n142 = $n82 * (($n137 * $n82) * ($n121 * $n82) * (($n88.$n51 - $n87.$n51) + sum($n143.$n144) - $n41.$n95 * ($n127 * $n135.$n145))) * $n132;
 //         else
-//           if n63 == n64.n71 or n63 == n64.n116 then
-//             n142[2:n84 - 1] = {n137[n146] * n121[n146] * ((n135[n146 + 1].n51 - n135[n146 - 1].n51) / 2 + (n143.n144[n146 - 1] + n143.n144[n146]) / 2 - n41.n95 * n127[n146] * n135[n146].n145) for n146 in 2:n84 - 1} * n132;
+//           if $n63 == $n64.$n71 or $n63 == $n64.$n116 then
+//             $n142[2:$n84 - 1] = {$n137[$n146] * $n121[$n146] * (($n135[$n146 + 1].$n51 - $n135[$n146 - 1].$n51) / 2 + ($n143.$n144[$n146 - 1] + $n143.$n144[$n146]) / 2 - $n41.$n95 * $n127[$n146] * $n135[$n146].$n145) for $n146 in 2:$n84 - 1} * $n132;
 //           else
-//             n142[2:n84 - 1] = {n137[n146] * n121[n146] * ((n135[n146 + 1].n51 - n135[n146 - 1].n51) / 2 + (n143.n144[n146] + n143.n144[n146 + 1]) / 2 - n41.n95 * n127[n146] * n135[n146].n145) for n146 in 2:n84 - 1} * n132;
+//             $n142[2:$n84 - 1] = {$n137[$n146] * $n121[$n146] * (($n135[$n146 + 1].$n51 - $n135[$n146 - 1].$n51) / 2 + ($n143.$n144[$n146] + $n143.$n144[$n146 + 1]) / 2 - $n41.$n95 * $n127[$n146] * $n135[$n146].$n145) for $n146 in 2:$n84 - 1} * $n132;
 //           end if;
-//           if n63 == n64.n71 then
-//             n142[1] = n137[1] * n121[1] * ((n135[2].n51 - n135[1].n51) / 2 + n143.n144[1] / 2 - n41.n95 * n127[1] * n135[1].n145) * n132;
-//             n142[n84] = n137[n84] * n121[n84] * ((n135[n84].n51 - n135[n84 - 1].n51) / 2 + n143.n144[n84 - 1] / 2 - n41.n95 * n127[n84] * n135[n84].n145) * n132;
-//           elseif n63 == n64.n116 then
-//             n142[1] = n137[1] * n121[1] * ((n135[2].n51 - n135[1].n51) / 2 + n143.n144[1] / 2 - n41.n95 * n127[1] * n135[1].n145) * n132;
-//             n142[n84] = n137[n84] * n121[n84] * ((n88.n51 - n135[n84 - 1].n51) / 1.5 + n143.n144[n84 - 1] / 2 + n143.n144[n84] - n41.n95 * n127[n84] * n135[n84].n145) * n132;
-//           elseif n63 == n64.n118 then
-//             n142[1] = n137[1] * n121[1] * ((n135[2].n51 - n87.n51) / 1.5 + n143.n144[1] + n143.n144[2] / 2 - n41.n95 * n127[1] * n135[1].n145) * n132;
-//             n142[n84] = n137[n84] * n121[n84] * ((n135[n84].n51 - n135[n84 - 1].n51) / 2 + n143.n144[n84] / 2 - n41.n95 * n127[n84] * n135[n84].n145) * n132;
-//           elseif n63 == n64.n65 then
-//             n142[1] = n137[1] * n121[1] * ((n135[2].n51 - n87.n51) / 1.5 + n143.n144[1] + n143.n144[2] / 2 - n41.n95 * n127[1] * n135[1].n145) * n132;
-//             n142[n84] = n137[n84] * n121[n84] * ((n88.n51 - n135[n84 - 1].n51) / 1.5 + n143.n144[n84] / 2 + n143.n144[n84 + 1] - n41.n95 * n127[n84] * n135[n84].n145) * n132;
+//           if $n63 == $n64.$n71 then
+//             $n142[1] = $n137[1] * $n121[1] * (($n135[2].$n51 - $n135[1].$n51) / 2 + $n143.$n144[1] / 2 - $n41.$n95 * $n127[1] * $n135[1].$n145) * $n132;
+//             $n142[$n84] = $n137[$n84] * $n121[$n84] * (($n135[$n84].$n51 - $n135[$n84 - 1].$n51) / 2 + $n143.$n144[$n84 - 1] / 2 - $n41.$n95 * $n127[$n84] * $n135[$n84].$n145) * $n132;
+//           elseif $n63 == $n64.$n116 then
+//             $n142[1] = $n137[1] * $n121[1] * (($n135[2].$n51 - $n135[1].$n51) / 2 + $n143.$n144[1] / 2 - $n41.$n95 * $n127[1] * $n135[1].$n145) * $n132;
+//             $n142[$n84] = $n137[$n84] * $n121[$n84] * (($n88.$n51 - $n135[$n84 - 1].$n51) / 1.5 + $n143.$n144[$n84 - 1] / 2 + $n143.$n144[$n84] - $n41.$n95 * $n127[$n84] * $n135[$n84].$n145) * $n132;
+//           elseif $n63 == $n64.$n118 then
+//             $n142[1] = $n137[1] * $n121[1] * (($n135[2].$n51 - $n87.$n51) / 1.5 + $n143.$n144[1] + $n143.$n144[2] / 2 - $n41.$n95 * $n127[1] * $n135[1].$n145) * $n132;
+//             $n142[$n84] = $n137[$n84] * $n121[$n84] * (($n135[$n84].$n51 - $n135[$n84 - 1].$n51) / 2 + $n143.$n144[$n84] / 2 - $n41.$n95 * $n127[$n84] * $n135[$n84].$n145) * $n132;
+//           elseif $n63 == $n64.$n65 then
+//             $n142[1] = $n137[1] * $n121[1] * (($n135[2].$n51 - $n87.$n51) / 1.5 + $n143.$n144[1] + $n143.$n144[2] / 2 - $n41.$n95 * $n127[1] * $n135[1].$n145) * $n132;
+//             $n142[$n84] = $n137[$n84] * $n121[$n84] * (($n88.$n51 - $n135[$n84 - 1].$n51) / 1.5 + $n143.$n144[$n84] / 2 + $n143.$n144[$n84 + 1] - $n41.$n95 * $n127[$n84] * $n135[$n84].$n145) * $n132;
 //           else
 //             assert(false, \"assert message 1657443506449019625\");
 //           end if;
 //         end if;
-//         connect(n90, n131.n90);
-//       end n54;
+//         connect($n90, $n131.$n90);
+//       end $n54;
 //
-//       package n68
-//         extends n1.n2.n147;
+//       package $n68
+//         extends $n1.$n2.$n147;
 //
-//         partial model n114
-//           extends n1.n29.n12.n148;
-//           parameter Real n132(min = 1) = 1;
-//           parameter n10.n149 n60;
-//           parameter Boolean n150 = true;
-//           parameter n10.n151 n57;
-//           parameter n10.n152 n122 = n1.n97.n153 * n57 * n57 / 4;
-//           parameter n10.n149 n124(min = 0) = n1.n97.n153 * n57;
-//           parameter n1.n29.n44.n154 n126 = 2.5e-5;
-//           final parameter n10.n156 n155 = n122 * n60 * n132;
-//           parameter n10.n149 n59 = 0;
+//         partial model $n114
+//           extends $n1.$n29.$n12.$n148;
+//           parameter Real $n132(min = 1) = 1;
+//           parameter $n10.$n149 $n60;
+//           parameter Boolean $n150 = true;
+//           parameter $n10.$n151 $n57;
+//           parameter $n10.$n152 $n122 = $n1.$n97.$n153 * $n57 * $n57 / 4;
+//           parameter $n10.$n149 $n124(min = 0) = $n1.$n97.$n153 * $n57;
+//           parameter $n1.$n29.$n44.$n154 $n126 = 2.5e-5;
+//           final parameter $n10.$n156 $n155 = $n122 * $n60 * $n132;
+//           parameter $n10.$n149 $n59 = 0;
 //         equation
-//           assert(n60 >= n59, \"assert message 6139111501035849916\");
-//         end n114;
+//           assert($n60 >= $n59, \"assert message 6139111501035849916\");
+//         end $n114;
 //
-//         partial model n119
-//           import n1.n29.n44.n64;
-//           extends n1.n29.n12.n148(final n115 = (n63 == n64.n116) or (n63 == n64.n71), final n117 = (n63 == n64.n118) or (n63 == n64.n71));
-//           extends n1.n29.n12.n157(final n84 = n56, final n158 = {n121[n146] * n120[n146] for n146 in 1:n84} * n132);
-//           parameter Real n132(min = 1) = 1;
-//           parameter n10.n149[n84] n120;
-//           parameter n10.n152[n84] n121;
-//           parameter n10.n149[n84] n123;
-//           parameter n1.n29.n44.n154[n84] n125;
-//           parameter n10.n149[n84] n127 = zeros(n84) annotation(Evaluate = true);
-//           parameter n44.n45 n47 = n41.n47 annotation(Evaluate = true);
-//           parameter n36.n105 n58 = n41.n58 annotation(Evaluate = true);
-//           parameter Integer n56(min = 1) = 2 annotation(Evaluate = true);
-//           parameter n44.n64 n63 = n44.n64.n71 annotation(Evaluate = true);
-//           parameter Boolean n141 = false annotation(Evaluate = true);
-//           final parameter Integer n159 = if n141 then n160 else n161;
-//           final parameter Integer n161 = if n63 == n44.n64.n65 then n84 + 1 else if (n63 == n44.n64.n118 or n63 == n44.n64.n116) then n84 else n84 - 1;
-//           final parameter Integer n160 = if n63 == n44.n64.n65 then 2 else 1;
-//           final parameter Integer n162 = integer(n84 / 2) + 1 annotation(Evaluate = true);
-//           parameter Boolean n163 = false annotation(Evaluate = true);
-//           n36.n165 n164;
-//           n36.n165 n166;
-//           n36.n165[n159 + 1] n167;
-//           replaceable model n168 = n1.n29.n53.n68.n169.n171 constrainedby n1.n29.n53.n68.n169.n170;
-//           n168 n143(redeclare final package n36 = n36, final n84 = n159 + 1, final n134 = n167, final n137 = n172, final n47 = n47, final n99 = n99, final n61 = n61, final n62 = n62, final n58 = n58, final n132 = n132, final n173 = n173, final n121 = n174, final n123 = n175, final n125 = n176, final n127 = n177, final n95 = n41.n95);
-//           n36.n105[n84 + 1] n178(each min = if n99 then -n1.n97.n7 else 0, each start = n58);
-//           n36.n105[n84 + 1, n36.n180] n179;
-//           n36.n105[n84 + 1, n36.n182] n181;
-//           n36.n184[n84 + 1] n183;
-//           n10.n185[n84] n137 = {0.5 * (n178[n146] + n178[n146 + 1]) / n135[n146].n145 / n121[n146] for n146 in 1:n84} / n132;
+//         partial model $n119
+//           import $n1.$n29.$n44.$n64;
+//           extends $n1.$n29.$n12.$n148(final $n115 = ($n63 == $n64.$n116) or ($n63 == $n64.$n71), final $n117 = ($n63 == $n64.$n118) or ($n63 == $n64.$n71));
+//           extends $n1.$n29.$n12.$n157(final $n84 = $n56, final $n158 = {$n121[$n146] * $n120[$n146] for $n146 in 1:$n84} * $n132);
+//           parameter Real $n132(min = 1) = 1;
+//           parameter $n10.$n149[$n84] $n120;
+//           parameter $n10.$n152[$n84] $n121;
+//           parameter $n10.$n149[$n84] $n123;
+//           parameter $n1.$n29.$n44.$n154[$n84] $n125;
+//           parameter $n10.$n149[$n84] $n127 = zeros($n84) annotation(Evaluate = true);
+//           parameter $n44.$n45 $n47 = $n41.$n47 annotation(Evaluate = true);
+//           parameter $n36.$n105 $n58 = $n41.$n58 annotation(Evaluate = true);
+//           parameter Integer $n56(min = 1) = 2 annotation(Evaluate = true);
+//           parameter $n44.$n64 $n63 = $n44.$n64.$n71 annotation(Evaluate = true);
+//           parameter Boolean $n141 = false annotation(Evaluate = true);
+//           final parameter Integer $n159 = if $n141 then $n160 else $n161;
+//           final parameter Integer $n161 = if $n63 == $n44.$n64.$n65 then $n84 + 1 else if ($n63 == $n44.$n64.$n118 or $n63 == $n44.$n64.$n116) then $n84 else $n84 - 1;
+//           final parameter Integer $n160 = if $n63 == $n44.$n64.$n65 then 2 else 1;
+//           final parameter Integer $n162 = integer($n84 / 2) + 1 annotation(Evaluate = true);
+//           parameter Boolean $n163 = false annotation(Evaluate = true);
+//           $n36.$n165 $n164;
+//           $n36.$n165 $n166;
+//           $n36.$n165[$n159 + 1] $n167;
+//           replaceable model $n168 = $n1.$n29.$n53.$n68.$n169.$n171 constrainedby $n1.$n29.$n53.$n68.$n169.$n170;
+//           $n168 $n143(redeclare final package $n36 = $n36, final $n84 = $n159 + 1, final $n134 = $n167, final $n137 = $n172, final $n47 = $n47, final $n99 = $n99, final $n61 = $n61, final $n62 = $n62, final $n58 = $n58, final $n132 = $n132, final $n173 = $n173, final $n121 = $n174, final $n123 = $n175, final $n125 = $n176, final $n127 = $n177, final $n95 = $n41.$n95);
+//           $n36.$n105[$n84 + 1] $n178(each min = if $n99 then -$n1.$n97.$n7 else 0, each start = $n58);
+//           $n36.$n105[$n84 + 1, $n36.$n180] $n179;
+//           $n36.$n105[$n84 + 1, $n36.$n182] $n181;
+//           $n36.$n184[$n84 + 1] $n183;
+//           $n10.$n185[$n84] $n137 = {0.5 * ($n178[$n146] + $n178[$n146 + 1]) / $n135[$n146].$n145 / $n121[$n146] for $n146 in 1:$n84} / $n132;
 //         protected
-//           n10.n149[n159] n173;
-//           n10.n149[n159] n177;
-//           n10.n152[n159 + 1] n174;
-//           n10.n185[n159 + 1] n172;
-//           n10.n149[n159 + 1] n175;
-//           n1.n29.n44.n154[n159 + 1] n176;
+//           $n10.$n149[$n159] $n173;
+//           $n10.$n149[$n159] $n177;
+//           $n10.$n152[$n159 + 1] $n174;
+//           $n10.$n185[$n159 + 1] $n172;
+//           $n10.$n149[$n159 + 1] $n175;
+//           $n1.$n29.$n44.$n154[$n159 + 1] $n176;
 //         equation
-//           assert(n56 > 1 or n63 <> n64.n71, \"assert message 2525241109997939028\");
-//           if n141 then
-//             if n63 <> n64.n65 then
-//               n173[1] = sum(n120);
-//               n177[1] = sum(n127);
-//               if n84 == 1 then
-//                 n174[1:2] = {n121[1], n121[1]};
-//                 n175[1:2] = {n123[1], n123[1]};
-//                 n176[1:2] = {n125[1], n125[1]};
+//           assert($n56 > 1 or $n63 <> $n64.$n71, \"assert message 2525241109997939028\");
+//           if $n141 then
+//             if $n63 <> $n64.$n65 then
+//               $n173[1] = sum($n120);
+//               $n177[1] = sum($n127);
+//               if $n84 == 1 then
+//                 $n174[1:2] = {$n121[1], $n121[1]};
+//                 $n175[1:2] = {$n123[1], $n123[1]};
+//                 $n176[1:2] = {$n125[1], $n125[1]};
 //               else
-//                 n174[1:2] = {sum(n121[1:n162 - 1]) / (n162 - 1), sum(n121[n162:n84]) / (n84 - n162 + 1)};
-//                 n175[1:2] = {sum(n123[1:n162 - 1]) / (n162 - 1), sum(n123[n162:n84]) / (n84 - n162 + 1)};
-//                 n176[1:2] = {sum(n125[1:n162 - 1]) / (n162 - 1), sum(n125[n162:n84]) / (n84 - n162 + 1)};
+//                 $n174[1:2] = {sum($n121[1:$n162 - 1]) / ($n162 - 1), sum($n121[$n162:$n84]) / ($n84 - $n162 + 1)};
+//                 $n175[1:2] = {sum($n123[1:$n162 - 1]) / ($n162 - 1), sum($n123[$n162:$n84]) / ($n84 - $n162 + 1)};
+//                 $n176[1:2] = {sum($n125[1:$n162 - 1]) / ($n162 - 1), sum($n125[$n162:$n84]) / ($n84 - $n162 + 1)};
 //               end if;
 //             else
-//               if n84 == 1 then
-//                 n173[1:2] = {n120[1] / 2, n120[1] / 2};
-//                 n177[1:2] = {n127[1] / 2, n127[1] / 2};
-//                 n174[1:3] = {n121[1], n121[1], n121[1]};
-//                 n175[1:3] = {n123[1], n123[1], n123[1]};
-//                 n176[1:3] = {n125[1], n125[1], n125[1]};
+//               if $n84 == 1 then
+//                 $n173[1:2] = {$n120[1] / 2, $n120[1] / 2};
+//                 $n177[1:2] = {$n127[1] / 2, $n127[1] / 2};
+//                 $n174[1:3] = {$n121[1], $n121[1], $n121[1]};
+//                 $n175[1:3] = {$n123[1], $n123[1], $n123[1]};
+//                 $n176[1:3] = {$n125[1], $n125[1], $n125[1]};
 //               else
-//                 n173[1:2] = {sum(n120[1:n162 - 1]), sum(n120[n162:n84])};
-//                 n177[1:2] = {sum(n127[1:n162 - 1]), sum(n127[n162:n84])};
-//                 n174[1:3] = {sum(n121[1:n162 - 1]) / (n162 - 1), sum(n121) / n84, sum(n121[n162:n84]) / (n84 - n162 + 1)};
-//                 n175[1:3] = {sum(n123[1:n162 - 1]) / (n162 - 1), sum(n123) / n84, sum(n123[n162:n84]) / (n84 - n162 + 1)};
-//                 n176[1:3] = {sum(n125[1:n162 - 1]) / (n162 - 1), sum(n125) / n84, sum(n125[n162:n84]) / (n84 - n162 + 1)};
+//                 $n173[1:2] = {sum($n120[1:$n162 - 1]), sum($n120[$n162:$n84])};
+//                 $n177[1:2] = {sum($n127[1:$n162 - 1]), sum($n127[$n162:$n84])};
+//                 $n174[1:3] = {sum($n121[1:$n162 - 1]) / ($n162 - 1), sum($n121) / $n84, sum($n121[$n162:$n84]) / ($n84 - $n162 + 1)};
+//                 $n175[1:3] = {sum($n123[1:$n162 - 1]) / ($n162 - 1), sum($n123) / $n84, sum($n123[$n162:$n84]) / ($n84 - $n162 + 1)};
+//                 $n176[1:3] = {sum($n125[1:$n162 - 1]) / ($n162 - 1), sum($n125) / $n84, sum($n125[$n162:$n84]) / ($n84 - $n162 + 1)};
 //               end if;
 //             end if;
 //           else
-//             if n63 == n64.n71 then
-//               if n84 == 2 then
-//                 n173[1] = n120[1] + n120[2];
-//                 n177[1] = n127[1] + n127[2];
+//             if $n63 == $n64.$n71 then
+//               if $n84 == 2 then
+//                 $n173[1] = $n120[1] + $n120[2];
+//                 $n177[1] = $n127[1] + $n127[2];
 //               else
-//                 n173[1:n84 - 1] = cat(1, {n120[1] + 0.5 * n120[2]}, 0.5 * (n120[2:n84 - 2] + n120[3:n84 - 1]), {0.5 * n120[n84 - 1] + n120[n84]});
-//                 n177[1:n84 - 1] = cat(1, {n127[1] + 0.5 * n127[2]}, 0.5 * (n127[2:n84 - 2] + n127[3:n84 - 1]), {0.5 * n127[n84 - 1] + n127[n84]});
+//                 $n173[1:$n84 - 1] = cat(1, {$n120[1] + 0.5 * $n120[2]}, 0.5 * ($n120[2:$n84 - 2] + $n120[3:$n84 - 1]), {0.5 * $n120[$n84 - 1] + $n120[$n84]});
+//                 $n177[1:$n84 - 1] = cat(1, {$n127[1] + 0.5 * $n127[2]}, 0.5 * ($n127[2:$n84 - 2] + $n127[3:$n84 - 1]), {0.5 * $n127[$n84 - 1] + $n127[$n84]});
 //               end if;
-//               n174[1:n84] = n121;
-//               n175[1:n84] = n123;
-//               n176[1:n84] = n125;
-//             elseif n63 == n64.n116 then
-//               n173[1:n84] = n120;
-//               n177[1:n84] = n127;
-//               n174[1:n84 + 1] = cat(1, n121[1:n84], {n121[n84]});
-//               n175[1:n84 + 1] = cat(1, n123[1:n84], {n123[n84]});
-//               n176[1:n84 + 1] = cat(1, n125[1:n84], {n125[n84]});
-//             elseif n63 == n64.n118 then
-//               n173[1:n84] = n120;
-//               n177[1:n84] = n127;
-//               n174[1:n84 + 1] = cat(1, {n121[1]}, n121[1:n84]);
-//               n175[1:n84 + 1] = cat(1, {n123[1]}, n123[1:n84]);
-//               n176[1:n84 + 1] = cat(1, {n125[1]}, n125[1:n84]);
-//             elseif n63 == n64.n65 then
-//               n173[1:n84 + 1] = cat(1, {0.5 * n120[1]}, 0.5 * (n120[1:n84 - 1] + n120[2:n84]), {0.5 * n120[n84]});
-//               n177[1:n84 + 1] = cat(1, {0.5 * n127[1]}, 0.5 * (n127[1:n84 - 1] + n127[2:n84]), {0.5 * n127[n84]});
-//               n174[1:n84 + 2] = cat(1, {n121[1]}, n121[1:n84], {n121[n84]});
-//               n175[1:n84 + 2] = cat(1, {n123[1]}, n123[1:n84], {n123[n84]});
-//               n176[1:n84 + 2] = cat(1, {n125[1]}, n125[1:n84], {n125[n84]});
+//               $n174[1:$n84] = $n121;
+//               $n175[1:$n84] = $n123;
+//               $n176[1:$n84] = $n125;
+//             elseif $n63 == $n64.$n116 then
+//               $n173[1:$n84] = $n120;
+//               $n177[1:$n84] = $n127;
+//               $n174[1:$n84 + 1] = cat(1, $n121[1:$n84], {$n121[$n84]});
+//               $n175[1:$n84 + 1] = cat(1, $n123[1:$n84], {$n123[$n84]});
+//               $n176[1:$n84 + 1] = cat(1, $n125[1:$n84], {$n125[$n84]});
+//             elseif $n63 == $n64.$n118 then
+//               $n173[1:$n84] = $n120;
+//               $n177[1:$n84] = $n127;
+//               $n174[1:$n84 + 1] = cat(1, {$n121[1]}, $n121[1:$n84]);
+//               $n175[1:$n84 + 1] = cat(1, {$n123[1]}, $n123[1:$n84]);
+//               $n176[1:$n84 + 1] = cat(1, {$n125[1]}, $n125[1:$n84]);
+//             elseif $n63 == $n64.$n65 then
+//               $n173[1:$n84 + 1] = cat(1, {0.5 * $n120[1]}, 0.5 * ($n120[1:$n84 - 1] + $n120[2:$n84]), {0.5 * $n120[$n84]});
+//               $n177[1:$n84 + 1] = cat(1, {0.5 * $n127[1]}, 0.5 * ($n127[1:$n84 - 1] + $n127[2:$n84]), {0.5 * $n127[$n84]});
+//               $n174[1:$n84 + 2] = cat(1, {$n121[1]}, $n121[1:$n84], {$n121[$n84]});
+//               $n175[1:$n84 + 2] = cat(1, {$n123[1]}, $n123[1:$n84], {$n123[$n84]});
+//               $n176[1:$n84 + 2] = cat(1, {$n125[1]}, $n125[1:$n84], {$n125[$n84]});
 //             else
 //               assert(false, \"assert message 1657443506449019625\");
 //             end if;
 //           end if;
-//           for n146 in 1:n84 loop
-//             n186[n146] = n178[n146] - n178[n146 + 1];
-//             n187[n146, :] = n179[n146, :] - n179[n146 + 1, :];
-//             n188[n146, :] = n181[n146, :] - n181[n146 + 1, :];
-//             n189[n146] = n183[n146] - n183[n146 + 1];
+//           for $n146 in 1:$n84 loop
+//             $n186[$n146] = $n178[$n146] - $n178[$n146 + 1];
+//             $n187[$n146, :] = $n179[$n146, :] - $n179[$n146 + 1, :];
+//             $n188[$n146, :] = $n181[$n146, :] - $n181[$n146 + 1, :];
+//             $n189[$n146] = $n183[$n146] - $n183[$n146 + 1];
 //           end for;
-//           for n146 in 2:n84 loop
-//             n183[n146] = semiLinear(n178[n146], n135[n146 - 1].n190, n135[n146].n190);
-//             n179[n146, :] = semiLinear(n178[n146], n135[n146 - 1].n191, n135[n146].n191);
-//             n181[n146, :] = semiLinear(n178[n146], n192[n146 - 1, :], n192[n146, :]);
+//           for $n146 in 2:$n84 loop
+//             $n183[$n146] = semiLinear($n178[$n146], $n135[$n146 - 1].$n190, $n135[$n146].$n190);
+//             $n179[$n146, :] = semiLinear($n178[$n146], $n135[$n146 - 1].$n191, $n135[$n146].$n191);
+//             $n181[$n146, :] = semiLinear($n178[$n146], $n192[$n146 - 1, :], $n192[$n146, :]);
 //           end for;
-//           n183[1] = semiLinear(n87.n193, inStream(n87.n194), n135[1].n190);
-//           n183[n84 + 1] = -semiLinear(n88.n193, inStream(n88.n194), n135[n84].n190);
-//           n179[1, :] = semiLinear(n87.n193, inStream(n87.n195), n135[1].n191);
-//           n179[n84 + 1, :] = -semiLinear(n88.n193, inStream(n88.n195), n135[n84].n191);
-//           n181[1, :] = semiLinear(n87.n193, inStream(n87.n196), n192[1, :]);
-//           n181[n84 + 1, :] = -semiLinear(n88.n193, inStream(n88.n196), n192[n84, :]);
-//           n87.n193 = n178[1];
-//           n88.n193 = -n178[n84 + 1];
-//           n87.n194 = n135[1].n190;
-//           n88.n194 = n135[n84].n190;
-//           n87.n195 = n135[1].n191;
-//           n88.n195 = n135[n84].n191;
-//           n87.n196 = n192[1, :];
-//           n88.n196 = n192[n84, :];
-//           if n163 and n84 > 0 then
-//             n164 = n36.n197(n87.n51, n135[1].n190, n135[1].n191);
-//             n166 = n36.n197(n88.n51, n135[n84].n190, n135[n84].n191);
+//           $n183[1] = semiLinear($n87.$n193, inStream($n87.$n194), $n135[1].$n190);
+//           $n183[$n84 + 1] = -semiLinear($n88.$n193, inStream($n88.$n194), $n135[$n84].$n190);
+//           $n179[1, :] = semiLinear($n87.$n193, inStream($n87.$n195), $n135[1].$n191);
+//           $n179[$n84 + 1, :] = -semiLinear($n88.$n193, inStream($n88.$n195), $n135[$n84].$n191);
+//           $n181[1, :] = semiLinear($n87.$n193, inStream($n87.$n196), $n192[1, :]);
+//           $n181[$n84 + 1, :] = -semiLinear($n88.$n193, inStream($n88.$n196), $n192[$n84, :]);
+//           $n87.$n193 = $n178[1];
+//           $n88.$n193 = -$n178[$n84 + 1];
+//           $n87.$n194 = $n135[1].$n190;
+//           $n88.$n194 = $n135[$n84].$n190;
+//           $n87.$n195 = $n135[1].$n191;
+//           $n88.$n195 = $n135[$n84].$n191;
+//           $n87.$n196 = $n192[1, :];
+//           $n88.$n196 = $n192[$n84, :];
+//           if $n163 and $n84 > 0 then
+//             $n164 = $n36.$n197($n87.$n51, $n135[1].$n190, $n135[1].$n191);
+//             $n166 = $n36.$n197($n88.$n51, $n135[$n84].$n190, $n135[$n84].$n191);
 //           else
-//             n164 = n36.n197(n87.n51, inStream(n87.n194), inStream(n87.n195));
-//             n166 = n36.n197(n88.n51, inStream(n88.n194), inStream(n88.n195));
+//             $n164 = $n36.$n197($n87.$n51, inStream($n87.$n194), inStream($n87.$n195));
+//             $n166 = $n36.$n197($n88.$n51, inStream($n88.$n194), inStream($n88.$n195));
 //           end if;
-//           if n141 then
-//             if n63 <> n64.n71 then
-//               fill(n135[1].n51, n84 - 1) = n135[2:n84].n51;
-//             elseif n84 > 2 then
-//               fill(n135[1].n51, n162 - 2) = n135[2:n162 - 1].n51;
-//               fill(n135[n84].n51, n84 - n162) = n135[n162:n84 - 1].n51;
+//           if $n141 then
+//             if $n63 <> $n64.$n71 then
+//               fill($n135[1].$n51, $n84 - 1) = $n135[2:$n84].$n51;
+//             elseif $n84 > 2 then
+//               fill($n135[1].$n51, $n162 - 2) = $n135[2:$n162 - 1].$n51;
+//               fill($n135[$n84].$n51, $n84 - $n162) = $n135[$n162:$n84 - 1].$n51;
 //             end if;
-//             if n63 == n64.n71 then
-//               n87.n51 = n135[1].n51;
-//               n167[1] = n135[1].n136;
-//               n178[n162] = n143.n178[1];
-//               n167[2] = n135[n84].n136;
-//               n88.n51 = n135[n84].n51;
-//               n172[1] = n137[1:n162 - 1] * n120[1:n162 - 1] / sum(n120[1:n162 - 1]);
-//               n172[2] = n137[n162:n84] * n120[n162:n84] / sum(n120[n162:n84]);
-//             elseif n63 == n64.n116 then
-//               n87.n51 = n135[1].n51;
-//               n167[1] = n135[n162].n136;
-//               n167[2] = n166;
-//               n178[n84 + 1] = n143.n178[1];
-//               n172[1] = n137 * n120 / sum(n120);
-//               n172[2] = n178[n84 + 1] / n36.n198(n166) / n121[n84] / n132;
-//             elseif n63 == n64.n118 then
-//               n178[1] = n143.n178[1];
-//               n167[1] = n164;
-//               n167[2] = n135[n162].n136;
-//               n88.n51 = n135[n84].n51;
-//               n172[1] = n178[1] / n36.n198(n164) / n121[1] / n132;
-//               n172[2] = n137 * n120 / sum(n120);
-//             elseif n63 == n64.n65 then
-//               n178[1] = n143.n178[1];
-//               n167[1] = n164;
-//               n167[2] = n135[n162].n136;
-//               n167[3] = n166;
-//               n178[n84 + 1] = n143.n178[2];
-//               n172[1] = n178[1] / n36.n198(n164) / n121[1] / n132;
-//               n172[2] = n137 * n120 / sum(n120);
-//               n172[3] = n178[n84 + 1] / n36.n198(n166) / n121[n84] / n132;
+//             if $n63 == $n64.$n71 then
+//               $n87.$n51 = $n135[1].$n51;
+//               $n167[1] = $n135[1].$n136;
+//               $n178[$n162] = $n143.$n178[1];
+//               $n167[2] = $n135[$n84].$n136;
+//               $n88.$n51 = $n135[$n84].$n51;
+//               $n172[1] = $n137[1:$n162 - 1] * $n120[1:$n162 - 1] / sum($n120[1:$n162 - 1]);
+//               $n172[2] = $n137[$n162:$n84] * $n120[$n162:$n84] / sum($n120[$n162:$n84]);
+//             elseif $n63 == $n64.$n116 then
+//               $n87.$n51 = $n135[1].$n51;
+//               $n167[1] = $n135[$n162].$n136;
+//               $n167[2] = $n166;
+//               $n178[$n84 + 1] = $n143.$n178[1];
+//               $n172[1] = $n137 * $n120 / sum($n120);
+//               $n172[2] = $n178[$n84 + 1] / $n36.$n198($n166) / $n121[$n84] / $n132;
+//             elseif $n63 == $n64.$n118 then
+//               $n178[1] = $n143.$n178[1];
+//               $n167[1] = $n164;
+//               $n167[2] = $n135[$n162].$n136;
+//               $n88.$n51 = $n135[$n84].$n51;
+//               $n172[1] = $n178[1] / $n36.$n198($n164) / $n121[1] / $n132;
+//               $n172[2] = $n137 * $n120 / sum($n120);
+//             elseif $n63 == $n64.$n65 then
+//               $n178[1] = $n143.$n178[1];
+//               $n167[1] = $n164;
+//               $n167[2] = $n135[$n162].$n136;
+//               $n167[3] = $n166;
+//               $n178[$n84 + 1] = $n143.$n178[2];
+//               $n172[1] = $n178[1] / $n36.$n198($n164) / $n121[1] / $n132;
+//               $n172[2] = $n137 * $n120 / sum($n120);
+//               $n172[3] = $n178[$n84 + 1] / $n36.$n198($n166) / $n121[$n84] / $n132;
 //             else
 //               assert(false, \"assert message 1657443506449019625\");
 //             end if;
 //           else
-//             if n63 == n64.n71 then
-//               n167[1:n84] = n135[1:n84].n136;
-//               n178[2:n84] = n143.n178[1:n84 - 1];
-//               n172[1:n84] = n137;
-//               n87.n51 = n135[1].n51;
-//               n88.n51 = n135[n84].n51;
-//             elseif n63 == n64.n116 then
-//               n167[1:n84] = n135[1:n84].n136;
-//               n167[n84 + 1] = n166;
-//               n178[2:n84 + 1] = n143.n178[1:n84];
-//               n172[1:n84] = n137;
-//               n172[n84 + 1] = n178[n84 + 1] / n36.n198(n166) / n121[n84] / n132;
-//               n87.n51 = n135[1].n51;
-//             elseif n63 == n64.n118 then
-//               n167[1] = n164;
-//               n167[2:n84 + 1] = n135[1:n84].n136;
-//               n178[1:n84] = n143.n178[1:n84];
-//               n172[1] = n178[1] / n36.n198(n164) / n121[1] / n132;
-//               n172[2:n84 + 1] = n137;
-//               n88.n51 = n135[n84].n51;
-//             elseif n63 == n64.n65 then
-//               n167[1] = n164;
-//               n167[2:n84 + 1] = n135[1:n84].n136;
-//               n167[n84 + 2] = n166;
-//               n178[1:n84 + 1] = n143.n178[1:n84 + 1];
-//               n172[1] = n178[1] / n36.n198(n164) / n121[1] / n132;
-//               n172[2:n84 + 1] = n137;
-//               n172[n84 + 2] = n178[n84 + 1] / n36.n198(n166) / n121[n84] / n132;
+//             if $n63 == $n64.$n71 then
+//               $n167[1:$n84] = $n135[1:$n84].$n136;
+//               $n178[2:$n84] = $n143.$n178[1:$n84 - 1];
+//               $n172[1:$n84] = $n137;
+//               $n87.$n51 = $n135[1].$n51;
+//               $n88.$n51 = $n135[$n84].$n51;
+//             elseif $n63 == $n64.$n116 then
+//               $n167[1:$n84] = $n135[1:$n84].$n136;
+//               $n167[$n84 + 1] = $n166;
+//               $n178[2:$n84 + 1] = $n143.$n178[1:$n84];
+//               $n172[1:$n84] = $n137;
+//               $n172[$n84 + 1] = $n178[$n84 + 1] / $n36.$n198($n166) / $n121[$n84] / $n132;
+//               $n87.$n51 = $n135[1].$n51;
+//             elseif $n63 == $n64.$n118 then
+//               $n167[1] = $n164;
+//               $n167[2:$n84 + 1] = $n135[1:$n84].$n136;
+//               $n178[1:$n84] = $n143.$n178[1:$n84];
+//               $n172[1] = $n178[1] / $n36.$n198($n164) / $n121[1] / $n132;
+//               $n172[2:$n84 + 1] = $n137;
+//               $n88.$n51 = $n135[$n84].$n51;
+//             elseif $n63 == $n64.$n65 then
+//               $n167[1] = $n164;
+//               $n167[2:$n84 + 1] = $n135[1:$n84].$n136;
+//               $n167[$n84 + 2] = $n166;
+//               $n178[1:$n84 + 1] = $n143.$n178[1:$n84 + 1];
+//               $n172[1] = $n178[1] / $n36.$n198($n164) / $n121[1] / $n132;
+//               $n172[2:$n84 + 1] = $n137;
+//               $n172[$n84 + 2] = $n178[$n84 + 1] / $n36.$n198($n166) / $n121[$n84] / $n132;
 //             else
 //               assert(false, \"assert message 1657443506449019625\");
 //             end if;
 //           end if;
-//         end n119;
+//         end $n119;
 //
-//         package n169
-//           extends n1.n2.n3;
+//         package $n169
+//           extends $n1.$n2.$n3;
 //
-//           partial model n170
-//             replaceable package n36 = n1.n37.n12.n38;
-//             parameter Integer n84 = 2;
-//             input n36.n165[n84] n134;
-//             input n1.n11.n185[n84] n137;
-//             parameter Real n132;
-//             input n10.n152[n84] n121;
-//             input n10.n149[n84] n123;
-//             input n1.n29.n44.n154[n84] n125;
-//             input n10.n149[n84 - 1] n127;
-//             parameter n10.n96 n95 = n41.n95;
-//             parameter Boolean n99 = n41.n99 annotation(Evaluate = true);
-//             parameter n1.n29.n44.n45 n47 = n41.n47 annotation(Evaluate = true);
-//             parameter n36.n105 n58 = n41.n58;
-//             parameter n36.n92 n61;
-//             parameter n36.n92 n62;
-//             extends n1.n29.n12.n199(final n200 = n84 - 1);
-//             parameter Boolean n201 = true annotation(Evaluate = true);
-//             parameter Boolean n202 = n47 <> n44.n45.n104 annotation(Evaluate = true);
-//             n36.n204[n84] n203 = if n205 then fill(n206, n84) else n36.n198(n134);
-//             n36.n204[n84 - 1] n207;
-//             n36.n209[n84] n208 = if n210 then fill(n211, n84) else n36.n212(n134);
-//             n36.n209[n84 - 1] n213;
-//             n1.n11.n214[n84 - 1] n144(each start = (n61 - n62) / (n84 - 1));
-//             parameter n10.n216 n215 = 4000;
-//             parameter Boolean n217 = false annotation(Evaluate = true);
-//             n10.n216[n84] n218 = n1.n29.n53.n68.n219.n216(n137, n203, n208, n123) if n217;
-//             n36.n105[n84 - 1] n220 = {n132 * (n121[n146] + n121[n146 + 1]) / (n123[n146] + n123[n146 + 1]) * n213[n146] * n215 for n146 in 1:n84 - 1} if n217;
+//           partial model $n170
+//             replaceable package $n36 = $n1.$n37.$n12.$n38;
+//             parameter Integer $n84 = 2;
+//             input $n36.$n165[$n84] $n134;
+//             input $n1.$n11.$n185[$n84] $n137;
+//             parameter Real $n132;
+//             input $n10.$n152[$n84] $n121;
+//             input $n10.$n149[$n84] $n123;
+//             input $n1.$n29.$n44.$n154[$n84] $n125;
+//             input $n10.$n149[$n84 - 1] $n127;
+//             parameter $n10.$n96 $n95 = $n41.$n95;
+//             parameter Boolean $n99 = $n41.$n99 annotation(Evaluate = true);
+//             parameter $n1.$n29.$n44.$n45 $n47 = $n41.$n47 annotation(Evaluate = true);
+//             parameter $n36.$n105 $n58 = $n41.$n58;
+//             parameter $n36.$n92 $n61;
+//             parameter $n36.$n92 $n62;
+//             extends $n1.$n29.$n12.$n199(final $n200 = $n84 - 1);
+//             parameter Boolean $n201 = true annotation(Evaluate = true);
+//             parameter Boolean $n202 = $n47 <> $n44.$n45.$n104 annotation(Evaluate = true);
+//             $n36.$n204[$n84] $n203 = if $n205 then fill($n206, $n84) else $n36.$n198($n134);
+//             $n36.$n204[$n84 - 1] $n207;
+//             $n36.$n209[$n84] $n208 = if $n210 then fill($n211, $n84) else $n36.$n212($n134);
+//             $n36.$n209[$n84 - 1] $n213;
+//             $n1.$n11.$n214[$n84 - 1] $n144(each start = ($n61 - $n62) / ($n84 - 1));
+//             parameter $n10.$n216 $n215 = 4000;
+//             parameter Boolean $n217 = false annotation(Evaluate = true);
+//             $n10.$n216[$n84] $n218 = $n1.$n29.$n53.$n68.$n219.$n216($n137, $n203, $n208, $n123) if $n217;
+//             $n36.$n105[$n84 - 1] $n220 = {$n132 * ($n121[$n146] + $n121[$n146 + 1]) / ($n123[$n146] + $n123[$n146 + 1]) * $n213[$n146] * $n215 for $n146 in 1:$n84 - 1} if $n217;
 //           protected
-//             parameter Boolean n205 = false annotation(Evaluate = true);
-//             parameter n10.n204 n206 = n36.n224(n36.n221, n36.n222, n36.n223);
-//             parameter Boolean n210 = false annotation(Evaluate = true);
-//             parameter n10.n209 n211 = n36.n212(n36.n225(n36.n221, n36.n222, n36.n223));
+//             parameter Boolean $n205 = false annotation(Evaluate = true);
+//             parameter $n10.$n204 $n206 = $n36.$n224($n36.$n221, $n36.$n222, $n36.$n223);
+//             parameter Boolean $n210 = false annotation(Evaluate = true);
+//             parameter $n10.$n209 $n211 = $n36.$n212($n36.$n225($n36.$n221, $n36.$n222, $n36.$n223));
 //           equation
-//             if not n99 then
-//               n207 = n203[1:n84 - 1];
-//               n213 = n208[1:n84 - 1];
-//             elseif not n201 then
-//               n207 = 0.5 * (n203[1:n84 - 1] + n203[2:n84]);
-//               n213 = 0.5 * (n208[1:n84 - 1] + n208[2:n84]);
+//             if not $n99 then
+//               $n207 = $n203[1:$n84 - 1];
+//               $n213 = $n208[1:$n84 - 1];
+//             elseif not $n201 then
+//               $n207 = 0.5 * ($n203[1:$n84 - 1] + $n203[2:$n84]);
+//               $n213 = 0.5 * ($n208[1:$n84 - 1] + $n208[2:$n84]);
 //             else
-//               for n146 in 1:n84 - 1 loop
-//                 n207[n146] = noEvent(if n178[n146] > 0 then n203[n146] else n203[n146 + 1]);
-//                 n213[n146] = noEvent(if n178[n146] > 0 then n208[n146] else n208[n146 + 1]);
+//               for $n146 in 1:$n84 - 1 loop
+//                 $n207[$n146] = noEvent(if $n178[$n146] > 0 then $n203[$n146] else $n203[$n146 + 1]);
+//                 $n213[$n146] = noEvent(if $n178[$n146] > 0 then $n208[$n146] else $n208[$n146 + 1]);
 //               end for;
 //             end if;
-//             if n202 then
-//               n226 = n132 * {n203[n146] * n137[n146] * n137[n146] * n121[n146] - n203[n146 + 1] * n137[n146 + 1] * n137[n146 + 1] * n121[n146 + 1] for n146 in 1:n84 - 1};
+//             if $n202 then
+//               $n226 = $n132 * {$n203[$n146] * $n137[$n146] * $n137[$n146] * $n121[$n146] - $n203[$n146 + 1] * $n137[$n146 + 1] * $n137[$n146 + 1] * $n121[$n146 + 1] for $n146 in 1:$n84 - 1};
 //             else
-//               n226 = zeros(n84 - 1);
+//               $n226 = zeros($n84 - 1);
 //             end if;
-//             n227 = n132 * {0.5 * (n121[n146] + n121[n146 + 1]) * (n36.n228(n134[n146 + 1]) - n36.n228(n134[n146])) for n146 in 1:n84 - 1};
-//             n144 = {n229[n146] / n132 * 2 / (n121[n146] + n121[n146 + 1]) for n146 in 1:n84 - 1};
-//           end n170;
+//             $n227 = $n132 * {0.5 * ($n121[$n146] + $n121[$n146 + 1]) * ($n36.$n228($n134[$n146 + 1]) - $n36.$n228($n134[$n146])) for $n146 in 1:$n84 - 1};
+//             $n144 = {$n229[$n146] / $n132 * 2 / ($n121[$n146] + $n121[$n146 + 1]) for $n146 in 1:$n84 - 1};
+//           end $n170;
 //
-//           partial model n230
-//             parameter Boolean n231 = n47 >= n44.n45.n46 annotation(Evaluate = true);
-//             extends n1.n29.n53.n68.n169.n170(final n215 = 4000);
-//             replaceable package n232 = n1.n29.n53.n68.n232.n234 constrainedby n1.n29.n53.n68.n232.n233;
-//             input n10.n149[n84 - 1] n235;
-//             input n10.n216[n84 - 1] n236 = n215 * ones(n84 - 1);
-//             parameter n10.n92 n237;
-//             parameter n10.n105 n109;
-//             parameter n10.n105 n110 = if n41.n108 then n41.n111 * n109 else n41.n110;
+//           partial model $n230
+//             parameter Boolean $n231 = $n47 >= $n44.$n45.$n46 annotation(Evaluate = true);
+//             extends $n1.$n29.$n53.$n68.$n169.$n170(final $n215 = 4000);
+//             replaceable package $n232 = $n1.$n29.$n53.$n68.$n232.$n234 constrainedby $n1.$n29.$n53.$n68.$n232.$n233;
+//             input $n10.$n149[$n84 - 1] $n235;
+//             input $n10.$n216[$n84 - 1] $n236 = $n215 * ones($n84 - 1);
+//             parameter $n10.$n92 $n237;
+//             parameter $n10.$n105 $n109;
+//             parameter $n10.$n105 $n110 = if $n41.$n108 then $n41.$n111 * $n109 else $n41.$n110;
 //           protected
-//             parameter n10.n92 n112(start = 1, fixed = false);
-//             final parameter Boolean n238 = n205 and (n210 or not n232.n239) annotation(Evaluate = true);
-//             final parameter Boolean n240 = (not n201) or n238 or not n99 annotation(Evaluate = true);
-//             n10.n149[n84 - 1] n241 = 0.5 * (n123[1:n84 - 1] + n123[2:n84]);
-//             n10.n92 n242 = sum(n232.n243(n109 / n132, n206, n206, n211, n211, n235, n241, (n121[1:n84 - 1] + n121[2:n84]) / 2, (n125[1:n84 - 1] + n125[2:n84]) / 2, n110 / n132, n236));
+//             parameter $n10.$n92 $n112(start = 1, fixed = false);
+//             final parameter Boolean $n238 = $n205 and ($n210 or not $n232.$n239) annotation(Evaluate = true);
+//             final parameter Boolean $n240 = (not $n201) or $n238 or not $n99 annotation(Evaluate = true);
+//             $n10.$n149[$n84 - 1] $n241 = 0.5 * ($n123[1:$n84 - 1] + $n123[2:$n84]);
+//             $n10.$n92 $n242 = sum($n232.$n243($n109 / $n132, $n206, $n206, $n211, $n211, $n235, $n241, ($n121[1:$n84 - 1] + $n121[2:$n84]) / 2, ($n125[1:$n84 - 1] + $n125[2:$n84]) / 2, $n110 / $n132, $n236));
 //           initial equation
-//             if n41.n108 then
-//               n112 = n242 / n109 * n110;
+//             if $n41.$n108 then
+//               $n112 = $n242 / $n109 * $n110;
 //             else
-//               n112 = n41.n112;
+//               $n112 = $n41.$n112;
 //             end if;
 //           equation
-//             for n146 in 1:n84 - 1 loop
-//               assert(n178[n146] > -n110 or n99, \"assert message 2390926804306210368\");
+//             for $n146 in 1:$n84 - 1 loop
+//               assert($n178[$n146] > -$n110 or $n99, \"assert message 2390926804306210368\");
 //             end for;
-//             if n240 then
-//               if n231 and not n232.n244 then
-//                 n178 = homotopy(actual = n232.n245(n144 - {n95 * n127[n146] * n207[n146] for n146 in 1:n84 - 1}, n207, n207, n213, n213, n235, n241, (n121[1:n84 - 1] + n121[2:n84]) / 2, (n125[1:n84 - 1] + n125[2:n84]) / 2, n112 / (n84 - 1), n236) * n132, simplified = n109 / n237 * (n144 - n95 * n127 * n206));
+//             if $n240 then
+//               if $n231 and not $n232.$n244 then
+//                 $n178 = homotopy(actual = $n232.$n245($n144 - {$n95 * $n127[$n146] * $n207[$n146] for $n146 in 1:$n84 - 1}, $n207, $n207, $n213, $n213, $n235, $n241, ($n121[1:$n84 - 1] + $n121[2:$n84]) / 2, ($n125[1:$n84 - 1] + $n125[2:$n84]) / 2, $n112 / ($n84 - 1), $n236) * $n132, simplified = $n109 / $n237 * ($n144 - $n95 * $n127 * $n206));
 //               else
-//                 n144 = homotopy(actual = n232.n243(n178 / n132, n207, n207, n213, n213, n235, n241, (n121[1:n84 - 1] + n121[2:n84]) / 2, (n125[1:n84 - 1] + n125[2:n84]) / 2, n110 / n132, n236) + {n95 * n127[n146] * n207[n146] for n146 in 1:n84 - 1}, simplified = n237 / n109 * n178 + n95 * n127 * n206);
+//                 $n144 = homotopy(actual = $n232.$n243($n178 / $n132, $n207, $n207, $n213, $n213, $n235, $n241, ($n121[1:$n84 - 1] + $n121[2:$n84]) / 2, ($n125[1:$n84 - 1] + $n125[2:$n84]) / 2, $n110 / $n132, $n236) + {$n95 * $n127[$n146] * $n207[$n146] for $n146 in 1:$n84 - 1}, simplified = $n237 / $n109 * $n178 + $n95 * $n127 * $n206);
 //               end if;
 //             else
-//               if n231 and not n232.n244 then
-//                 n178 = homotopy(actual = n232.n246(n144, n203[1:n84 - 1], n203[2:n84], n208[1:n84 - 1], n208[2:n84], n235, n241, n95 * n127, (n121[1:n84 - 1] + n121[2:n84]) / 2, (n125[1:n84 - 1] + n125[2:n84]) / 2, n112 / (n84 - 1), n236) * n132, simplified = n109 / n237 * (n144 - n95 * n127 * n206));
+//               if $n231 and not $n232.$n244 then
+//                 $n178 = homotopy(actual = $n232.$n246($n144, $n203[1:$n84 - 1], $n203[2:$n84], $n208[1:$n84 - 1], $n208[2:$n84], $n235, $n241, $n95 * $n127, ($n121[1:$n84 - 1] + $n121[2:$n84]) / 2, ($n125[1:$n84 - 1] + $n125[2:$n84]) / 2, $n112 / ($n84 - 1), $n236) * $n132, simplified = $n109 / $n237 * ($n144 - $n95 * $n127 * $n206));
 //               else
-//                 n144 = homotopy(actual = n232.n247(n178 / n132, n203[1:n84 - 1], n203[2:n84], n208[1:n84 - 1], n208[2:n84], n235, n241, n95 * n127, (n121[1:n84 - 1] + n121[2:n84]) / 2, (n125[1:n84 - 1] + n125[2:n84]) / 2, n110 / n132, n236), simplified = n237 / n109 * n178 + n95 * n127 * n206);
+//                 $n144 = homotopy(actual = $n232.$n247($n178 / $n132, $n203[1:$n84 - 1], $n203[2:$n84], $n208[1:$n84 - 1], $n208[2:$n84], $n235, $n241, $n95 * $n127, ($n121[1:$n84 - 1] + $n121[2:$n84]) / 2, ($n125[1:$n84 - 1] + $n125[2:$n84]) / 2, $n110 / $n132, $n236), simplified = $n237 / $n109 * $n178 + $n95 * $n127 * $n206);
 //               end if;
 //             end if;
-//           end n230;
+//           end $n230;
 //
-//           model n171
-//             extends n1.n29.n53.n68.n169.n230(redeclare package n232 = n1.n29.n53.n68.n232.n234, n235 = n173, n237(start = 1, fixed = false), n109 = if n41.n108 then n41.n109 else 1e2 * n110, n236 = n215 * ones(n84 - 1));
+//           model $n171
+//             extends $n1.$n29.$n53.$n68.$n169.$n230(redeclare package $n232 = $n1.$n29.$n53.$n68.$n232.$n234, $n235 = $n173, $n237(start = 1, fixed = false), $n109 = if $n41.$n108 then $n41.$n109 else 1e2 * $n110, $n236 = $n215 * ones($n84 - 1));
 //           initial equation
-//             if n41.n108 then
-//               n237 = n242 + n95 * sum(n127) * n206;
+//             if $n41.$n108 then
+//               $n237 = $n242 + $n95 * sum($n127) * $n206;
 //             else
-//               n237 = 1e3 * n112;
+//               $n237 = 1e3 * $n112;
 //             end if;
-//           end n171;
-//         end n169;
+//           end $n171;
+//         end $n169;
 //
-//         package n67
-//           extends n1.n2.n3;
+//         package $n67
+//           extends $n1.$n2.$n3;
 //
-//           partial model n128
-//             extends n1.n29.n12.n248;
-//             input n10.n185[n84] n137;
-//             parameter Real n132;
-//             input n10.n149[n84] n120;
-//             input n10.n149[n84] n123;
-//             input n1.n29.n44.n154[n84] n125;
-//           end n128;
+//           partial model $n128
+//             extends $n1.$n29.$n12.$n248;
+//             input $n10.$n185[$n84] $n137;
+//             parameter Real $n132;
+//             input $n10.$n149[$n84] $n120;
+//             input $n10.$n149[$n84] $n123;
+//             input $n1.$n29.$n44.$n154[$n84] $n125;
+//           end $n128;
 //
-//           model n129
-//             extends n128;
+//           model $n129
+//             extends $n128;
 //           equation
-//             n249 = n90.n250;
-//           end n129;
+//             $n249 = $n90.$n250;
+//           end $n129;
 //
-//           partial model n251
-//             extends n128;
-//             parameter n10.n253 n252 = 100;
-//             n10.n253[n84] n254(each start = n252);
-//             Real[n84] n218;
-//             Real[n84] n255;
-//             Real[n84] n256;
-//             n36.n204[n84] n257;
-//             n36.n209[n84] n208;
-//             n36.n259[n84] n258;
-//             n10.n149[n84] n241 = n123;
+//           partial model $n251
+//             extends $n128;
+//             parameter $n10.$n253 $n252 = 100;
+//             $n10.$n253[$n84] $n254(each start = $n252);
+//             Real[$n84] $n218;
+//             Real[$n84] $n255;
+//             Real[$n84] $n256;
+//             $n36.$n204[$n84] $n257;
+//             $n36.$n209[$n84] $n208;
+//             $n36.$n259[$n84] $n258;
+//             $n10.$n149[$n84] $n241 = $n123;
 //           equation
-//             n257 = n36.n198(n134);
-//             n208 = n36.n212(n134);
-//             n258 = n36.n260(n134);
-//             n255 = n36.n261(n134);
-//             n218 = n219.n216(n137, n257, n208, n241);
-//             n256 = n219.n262(n254, n241, n258);
-//             n140 = {n254[n146] * n133[n146] * (n90[n146].n250 - n249[n146]) * n132 for n146 in 1:n84};
-//           end n251;
+//             $n257 = $n36.$n198($n134);
+//             $n208 = $n36.$n212($n134);
+//             $n258 = $n36.$n260($n134);
+//             $n255 = $n36.$n261($n134);
+//             $n218 = $n219.$n216($n137, $n257, $n208, $n241);
+//             $n256 = $n219.$n262($n254, $n241, $n258);
+//             $n140 = {$n254[$n146] * $n133[$n146] * ($n90[$n146].$n250 - $n249[$n146]) * $n132 for $n146 in 1:$n84};
+//           end $n251;
 //
-//           model n69
-//             extends n251;
+//           model $n69
+//             extends $n251;
 //           protected
-//             Real[n84] n263;
-//             Real[n84] n264;
-//             Real n265;
-//             Real[n84] n266;
-//             Real[n84] n267;
+//             Real[$n84] $n263;
+//             Real[$n84] $n264;
+//             Real $n265;
+//             Real[$n84] $n266;
+//             Real[$n84] $n267;
 //           equation
-//             n265 = 3.66;
-//             for n146 in 1:n84 loop
-//               n263[n146] = smooth(0, (n267[n146] / 8) * abs(n218[n146]) * n255[n146] / (1 + 12.7 * (n267[n146] / 8) ^ 0.5 * (n255[n146] ^ (2 / 3) - 1)) * (1 + 1 / 3 * (n241[n146] / n120[n146] / (if n137[n146] >= 0 then (n146 - 0.5) else (n84 - n146 + 0.5))) ^ (2 / 3)));
-//               n267[n146] = (1.8 * n1.n268.log10(max(1e-10, n218[n146])) - 1.5) ^ (-2);
-//               n264[n146] = (n265 ^ 3 + 0.7 ^ 3 + (n266[n146] - 0.7) ^ 3) ^ (1 / 3);
-//               n266[n146] = smooth(0, 1.077 * (abs(n218[n146]) * n255[n146] * n241[n146] / n120[n146] / (if n137[n146] >= 0 then (n146 - 0.5) else (n84 - n146 + 0.5))) ^ (1 / 3));
-//               n256[n146] = n1.n37.n39.n40.n269.n270(n263[n146], n264[n146], n218[n146] - 6150, 3850);
+//             $n265 = 3.66;
+//             for $n146 in 1:$n84 loop
+//               $n263[$n146] = smooth(0, ($n267[$n146] / 8) * abs($n218[$n146]) * $n255[$n146] / (1 + 12.7 * ($n267[$n146] / 8) ^ 0.5 * ($n255[$n146] ^ (2 / 3) - 1)) * (1 + 1 / 3 * ($n241[$n146] / $n120[$n146] / (if $n137[$n146] >= 0 then ($n146 - 0.5) else ($n84 - $n146 + 0.5))) ^ (2 / 3)));
+//               $n267[$n146] = (1.8 * $n1.$n268.log10(max(1e-10, $n218[$n146])) - 1.5) ^ (-2);
+//               $n264[$n146] = ($n265 ^ 3 + 0.7 ^ 3 + ($n266[$n146] - 0.7) ^ 3) ^ (1 / 3);
+//               $n266[$n146] = smooth(0, 1.077 * (abs($n218[$n146]) * $n255[$n146] * $n241[$n146] / $n120[$n146] / (if $n137[$n146] >= 0 then ($n146 - 0.5) else ($n84 - $n146 + 0.5))) ^ (1 / 3));
+//               $n256[$n146] = $n1.$n37.$n39.$n40.$n269.$n270($n263[$n146], $n264[$n146], $n218[$n146] - 6150, 3850);
 //             end for;
-//           end n69;
-//         end n67;
+//           end $n69;
+//         end $n67;
 //
-//         package n219
-//           extends n1.n2.n3;
+//         package $n219
+//           extends $n1.$n2.$n3;
 //
-//           function n216
-//             extends n1.n2.n271;
-//             input n10.n185 n272;
-//             input n10.n204 n273;
-//             input n10.n209 n274;
-//             input n10.n149 n275;
-//             output n10.n216 n276;
+//           function $n216
+//             extends $n1.$n2.$n271;
+//             input $n10.$n185 $n272;
+//             input $n10.$n204 $n273;
+//             input $n10.$n209 $n274;
+//             input $n10.$n149 $n275;
+//             output $n10.$n216 $n276;
 //           algorithm
-//             n276 := abs(n272) * n273 * n275 / n274;
-//           end n216;
+//             $n276 := abs($n272) * $n273 * $n275 / $n274;
+//           end $n216;
 //
-//           function n262
-//             extends n1.n2.n271;
-//             input n10.n253 n83;
-//             input n10.n149 n275;
-//             input n10.n259 n277;
-//             output n10.n262 n278;
+//           function $n262
+//             extends $n1.$n2.$n271;
+//             input $n10.$n253 $n83;
+//             input $n10.$n149 $n275;
+//             input $n10.$n259 $n277;
+//             output $n10.$n262 $n278;
 //           algorithm
-//             n278 := n83 * n275 / n277;
-//           end n262;
-//         end n219;
+//             $n278 := $n83 * $n275 / $n277;
+//           end $n262;
+//         end $n219;
 //
-//         package n232
-//           extends n1.n2.n3;
+//         package $n232
+//           extends $n1.$n2.$n3;
 //
-//           partial package n233
-//             extends n1.n2.n3;
-//             import n1.n97.n153;
-//             constant Boolean n239 = true;
-//             constant Boolean n279 = true;
-//             constant Boolean n280 = true;
-//             constant Boolean n281 = true;
-//             constant Boolean n244 = false;
-//             constant Boolean n282 = true;
+//           partial package $n233
+//             extends $n1.$n2.$n3;
+//             import $n1.$n97.$n153;
+//             constant Boolean $n239 = true;
+//             constant Boolean $n279 = true;
+//             constant Boolean $n280 = true;
+//             constant Boolean $n281 = true;
+//             constant Boolean $n244 = false;
+//             constant Boolean $n282 = true;
 //
-//             replaceable partial function n245
-//               extends n1.n2.n271;
-//               input n10.n214 n283;
-//               input n10.n204 n284;
-//               input n10.n204 n285;
-//               input n10.n209 n286;
-//               input n10.n209 n287;
-//               input n10.n149 n60;
-//               input n10.n151 n57;
-//               input n10.n152 n122 = n153 * n57 ^ 2 / 4;
-//               input n1.n29.n44.n154 n126 = 2.5e-5;
-//               input n10.n92 n112 = 1;
-//               input n10.n216 n215 = 4000;
-//               output n10.n105 n193;
-//             end n245;
+//             replaceable partial function $n245
+//               extends $n1.$n2.$n271;
+//               input $n10.$n214 $n283;
+//               input $n10.$n204 $n284;
+//               input $n10.$n204 $n285;
+//               input $n10.$n209 $n286;
+//               input $n10.$n209 $n287;
+//               input $n10.$n149 $n60;
+//               input $n10.$n151 $n57;
+//               input $n10.$n152 $n122 = $n153 * $n57 ^ 2 / 4;
+//               input $n1.$n29.$n44.$n154 $n126 = 2.5e-5;
+//               input $n10.$n92 $n112 = 1;
+//               input $n10.$n216 $n215 = 4000;
+//               output $n10.$n105 $n193;
+//             end $n245;
 //
-//             replaceable partial function n246
-//               extends n1.n2.n271;
-//               input n10.n214 n283;
-//               input n10.n204 n284;
-//               input n10.n204 n285;
-//               input n10.n209 n286;
-//               input n10.n209 n287;
-//               input n10.n149 n60;
-//               input n10.n151 n57;
-//               input Real n288(unit = \"m2/s2\");
-//               input n10.n152 n122 = n153 * n57 ^ 2 / 4;
-//               input n1.n29.n44.n154 n126 = 2.5e-5;
-//               input n10.n92 n112 = 1;
-//               input n10.n216 n215 = 4000;
-//               output n10.n105 n193;
-//             end n246;
+//             replaceable partial function $n246
+//               extends $n1.$n2.$n271;
+//               input $n10.$n214 $n283;
+//               input $n10.$n204 $n284;
+//               input $n10.$n204 $n285;
+//               input $n10.$n209 $n286;
+//               input $n10.$n209 $n287;
+//               input $n10.$n149 $n60;
+//               input $n10.$n151 $n57;
+//               input Real $n288(unit = \"m2/s2\");
+//               input $n10.$n152 $n122 = $n153 * $n57 ^ 2 / 4;
+//               input $n1.$n29.$n44.$n154 $n126 = 2.5e-5;
+//               input $n10.$n92 $n112 = 1;
+//               input $n10.$n216 $n215 = 4000;
+//               output $n10.$n105 $n193;
+//             end $n246;
 //
-//             replaceable partial function n243
-//               extends n1.n2.n271;
-//               input n10.n105 n193;
-//               input n10.n204 n284;
-//               input n10.n204 n285;
-//               input n10.n209 n286;
-//               input n10.n209 n287;
-//               input n10.n149 n60;
-//               input n10.n151 n57;
-//               input n10.n152 n122 = n153 * n57 ^ 2 / 4;
-//               input n1.n29.n44.n154 n126 = 2.5e-5;
-//               input n10.n105 n110 = 0.01;
-//               input n10.n216 n215 = 4000;
-//               output n10.n214 n283;
-//             end n243;
+//             replaceable partial function $n243
+//               extends $n1.$n2.$n271;
+//               input $n10.$n105 $n193;
+//               input $n10.$n204 $n284;
+//               input $n10.$n204 $n285;
+//               input $n10.$n209 $n286;
+//               input $n10.$n209 $n287;
+//               input $n10.$n149 $n60;
+//               input $n10.$n151 $n57;
+//               input $n10.$n152 $n122 = $n153 * $n57 ^ 2 / 4;
+//               input $n1.$n29.$n44.$n154 $n126 = 2.5e-5;
+//               input $n10.$n105 $n110 = 0.01;
+//               input $n10.$n216 $n215 = 4000;
+//               output $n10.$n214 $n283;
+//             end $n243;
 //
-//             replaceable partial function n247
-//               extends n1.n2.n271;
-//               input n10.n105 n193;
-//               input n10.n204 n284;
-//               input n10.n204 n285;
-//               input n10.n209 n286;
-//               input n10.n209 n287;
-//               input n10.n149 n60;
-//               input n10.n151 n57;
-//               input Real n288(unit = \"m2/s2\");
-//               input n10.n152 n122 = n153 * n57 ^ 2 / 4;
-//               input n1.n29.n44.n154 n126 = 2.5e-5;
-//               input n10.n105 n110 = 0.01;
-//               input n10.n216 n215 = 4000;
-//               output n10.n214 n283;
-//             end n247;
-//           end n233;
+//             replaceable partial function $n247
+//               extends $n1.$n2.$n271;
+//               input $n10.$n105 $n193;
+//               input $n10.$n204 $n284;
+//               input $n10.$n204 $n285;
+//               input $n10.$n209 $n286;
+//               input $n10.$n209 $n287;
+//               input $n10.$n149 $n60;
+//               input $n10.$n151 $n57;
+//               input Real $n288(unit = \"m2/s2\");
+//               input $n10.$n152 $n122 = $n153 * $n57 ^ 2 / 4;
+//               input $n1.$n29.$n44.$n154 $n126 = 2.5e-5;
+//               input $n10.$n105 $n110 = 0.01;
+//               input $n10.$n216 $n215 = 4000;
+//               output $n10.$n214 $n283;
+//             end $n247;
+//           end $n233;
 //
-//           package n234
-//             extends n233(final n239 = true, final n279 = true, final n280 = true, final n281 = true, final n282 = true);
-//             import n289 = n1.n268.n290;
-//             import n1.n268.n291;
-//             import n1.n268.n292;
+//           package $n234
+//             extends $n233(final $n239 = true, final $n279 = true, final $n280 = true, final $n281 = true, final $n282 = true);
+//             import $n289 = $n1.$n268.$n290;
+//             import $n1.$n268.$n291;
+//             import $n1.$n268.$n292;
 //
-//             redeclare function extends n245
-//               import n1.n268;
+//             redeclare function extends $n245
+//               import $n1.$n268;
 //             protected
-//               Real n293(min = 0) = n126 / n57;
-//               n10.n216 n294 = min((745 * n268.exp(if n293 <= 0.0065 then 1 else 0.0065 / n293)) ^ 0.97, n215);
-//               n10.n216 n295 = n215;
-//               n10.n209 n274;
-//               n10.n204 n273;
-//               n10.n216 n276;
-//               Real n296;
+//               Real $n293(min = 0) = $n126 / $n57;
+//               $n10.$n216 $n294 = min((745 * $n268.exp(if $n293 <= 0.0065 then 1 else 0.0065 / $n293)) ^ 0.97, $n215);
+//               $n10.$n216 $n295 = $n215;
+//               $n10.$n209 $n274;
+//               $n10.$n204 $n273;
+//               $n10.$n216 $n276;
+//               Real $n296;
 //
-//               function n297
-//                 input Real n215;
-//                 input n10.n216 n294;
-//                 input n10.n216 n295;
-//                 input Real n293;
-//                 input Real n296;
-//                 output n10.n216 n276;
+//               function $n297
+//                 input Real $n215;
+//                 input $n10.$n216 $n294;
+//                 input $n10.$n216 $n295;
+//                 input Real $n293;
+//                 input Real $n296;
+//                 output $n10.$n216 $n276;
 //               protected
-//                 Real n298 = n268.log10(64 * n294);
-//                 Real n299 = n268.log10(n294);
-//                 Real n300 = 1;
-//                 Real n301 = (0.5 / n268.log(10)) * 5.74 * 0.9;
-//                 Real n302 = n293 / 3.7 + 5.74 / n295 ^ 0.9;
-//                 Real n303 = n268.log10(n302);
-//                 Real n304 = 0.25 * (n295 / n303) ^ 2;
-//                 Real n305 = 2.51 / sqrt(n304) + 0.27 * n293;
-//                 Real n306 = -2 * sqrt(n304) * n268.log10(n305);
-//                 Real n307 = n268.log10(n304);
-//                 Real n308 = n268.log10(n306);
-//                 Real n309 = 0.5 + (2.51 / n268.log(10)) / (n306 * n305);
-//                 Real n310 = n307 - n298;
-//                 Real n200 = (n308 - n299) / n310;
-//                 Real n311 = (3 * n200 - 2 * n300 - n309) / n310;
-//                 Real n312 = (n300 + n309 - 2 * n200) / (n310 * n310);
-//                 Real n313 = 64 * n294;
-//                 Real n314;
+//                 Real $n298 = $n268.log10(64 * $n294);
+//                 Real $n299 = $n268.log10($n294);
+//                 Real $n300 = 1;
+//                 Real $n301 = (0.5 / $n268.log(10)) * 5.74 * 0.9;
+//                 Real $n302 = $n293 / 3.7 + 5.74 / $n295 ^ 0.9;
+//                 Real $n303 = $n268.log10($n302);
+//                 Real $n304 = 0.25 * ($n295 / $n303) ^ 2;
+//                 Real $n305 = 2.51 / sqrt($n304) + 0.27 * $n293;
+//                 Real $n306 = -2 * sqrt($n304) * $n268.log10($n305);
+//                 Real $n307 = $n268.log10($n304);
+//                 Real $n308 = $n268.log10($n306);
+//                 Real $n309 = 0.5 + (2.51 / $n268.log(10)) / ($n306 * $n305);
+//                 Real $n310 = $n307 - $n298;
+//                 Real $n200 = ($n308 - $n299) / $n310;
+//                 Real $n311 = (3 * $n200 - 2 * $n300 - $n309) / $n310;
+//                 Real $n312 = ($n300 + $n309 - 2 * $n200) / ($n310 * $n310);
+//                 Real $n313 = 64 * $n294;
+//                 Real $n314;
 //               algorithm
-//                 n314 := n268.log10(n296 / n313);
-//                 n276 := n294 * (n296 / n313) ^ (1 + n314 * (n311 + n314 * n312));
+//                 $n314 := $n268.log10($n296 / $n313);
+//                 $n276 := $n294 * ($n296 / $n313) ^ (1 + $n314 * ($n311 + $n314 * $n312));
 //                 annotation(smoothOrder = 1);
-//               end n297;
+//               end $n297;
 //             algorithm
-//               n273 := if n283 >= 0 then n284 else n285;
-//               n274 := if n283 >= 0 then n286 else n287;
-//               n296 := abs(n283) * 2 * n57 ^ 3 * n273 / (n60 * n274 * n274);
-//               n276 := n296 / 64;
-//               if n276 > n294 then
-//                 n276 := -2 * sqrt(n296) * n268.log10(2.51 / sqrt(n296) + 0.27 * n293);
-//                 if n276 < n295 then
-//                   n276 := n297(n276, n294, n295, n293, n296);
+//               $n273 := if $n283 >= 0 then $n284 else $n285;
+//               $n274 := if $n283 >= 0 then $n286 else $n287;
+//               $n296 := abs($n283) * 2 * $n57 ^ 3 * $n273 / ($n60 * $n274 * $n274);
+//               $n276 := $n296 / 64;
+//               if $n276 > $n294 then
+//                 $n276 := -2 * sqrt($n296) * $n268.log10(2.51 / sqrt($n296) + 0.27 * $n293);
+//                 if $n276 < $n295 then
+//                   $n276 := $n297($n276, $n294, $n295, $n293, $n296);
 //                 else
 //                 end if;
 //               else
 //               end if;
-//               n193 := n122 / n57 * n274 * (if n283 >= 0 then n276 else -n276);
+//               $n193 := $n122 / $n57 * $n274 * (if $n283 >= 0 then $n276 else -$n276);
 //               annotation(smoothOrder = 1);
-//             end n245;
+//             end $n245;
 //
-//             redeclare function extends n243
-//               import n1.n268;
-//               import n1.n97.n153;
+//             redeclare function extends $n243
+//               import $n1.$n268;
+//               import $n1.$n97.$n153;
 //             protected
-//               Real n293(min = 0) = n126 / n57;
-//               n10.n216 n294 = min(745 * n268.exp(if n293 <= 0.0065 then 1 else 0.0065 / n293), n215);
-//               n10.n216 n295 = n215;
-//               n10.n209 n274;
-//               n10.n204 n273;
-//               n10.n216 n276;
-//               Real n296;
+//               Real $n293(min = 0) = $n126 / $n57;
+//               $n10.$n216 $n294 = min(745 * $n268.exp(if $n293 <= 0.0065 then 1 else 0.0065 / $n293), $n215);
+//               $n10.$n216 $n295 = $n215;
+//               $n10.$n209 $n274;
+//               $n10.$n204 $n273;
+//               $n10.$n216 $n276;
+//               Real $n296;
 //
-//               function n297
-//                 input n10.n216 n276;
-//                 input n10.n216 n294;
-//                 input n10.n216 n295;
-//                 input Real n293;
-//                 output Real n296;
+//               function $n297
+//                 input $n10.$n216 $n276;
+//                 input $n10.$n216 $n294;
+//                 input $n10.$n216 $n295;
+//                 input Real $n293;
+//                 output Real $n296;
 //               protected
-//                 Real n298 = n268.log10(n294);
-//                 Real n299 = n268.log10(64 * n294);
-//                 Real n300 = 1;
-//                 Real n301 = (0.5 / n268.log(10)) * 5.74 * 0.9;
-//                 Real n302 = n293 / 3.7 + 5.74 / n295 ^ 0.9;
-//                 Real n303 = n268.log10(n302);
-//                 Real n304 = 0.25 * (n295 / n303) ^ 2;
-//                 Real n305 = 2.51 / sqrt(n304) + 0.27 * n293;
-//                 Real n306 = -2 * sqrt(n304) * n268.log10(n305);
-//                 Real n307 = n268.log10(n295);
-//                 Real n308 = n268.log10(n304);
-//                 Real n309 = 2 + 4 * n301 / (n302 * n303 * (n295) ^ 0.9);
-//                 Real n310 = n307 - n298;
-//                 Real n200 = (n308 - n299) / n310;
-//                 Real n311 = (3 * n200 - 2 * n300 - n309) / n310;
-//                 Real n312 = (n300 + n309 - 2 * n200) / (n310 * n310);
-//                 Real n314;
+//                 Real $n298 = $n268.log10($n294);
+//                 Real $n299 = $n268.log10(64 * $n294);
+//                 Real $n300 = 1;
+//                 Real $n301 = (0.5 / $n268.log(10)) * 5.74 * 0.9;
+//                 Real $n302 = $n293 / 3.7 + 5.74 / $n295 ^ 0.9;
+//                 Real $n303 = $n268.log10($n302);
+//                 Real $n304 = 0.25 * ($n295 / $n303) ^ 2;
+//                 Real $n305 = 2.51 / sqrt($n304) + 0.27 * $n293;
+//                 Real $n306 = -2 * sqrt($n304) * $n268.log10($n305);
+//                 Real $n307 = $n268.log10($n295);
+//                 Real $n308 = $n268.log10($n304);
+//                 Real $n309 = 2 + 4 * $n301 / ($n302 * $n303 * ($n295) ^ 0.9);
+//                 Real $n310 = $n307 - $n298;
+//                 Real $n200 = ($n308 - $n299) / $n310;
+//                 Real $n311 = (3 * $n200 - 2 * $n300 - $n309) / $n310;
+//                 Real $n312 = ($n300 + $n309 - 2 * $n200) / ($n310 * $n310);
+//                 Real $n314;
 //               algorithm
-//                 n314 := n268.log10(n276 / n294);
-//                 n296 := 64 * n294 * (n276 / n294) ^ (1 + n314 * (n311 + n314 * n312));
+//                 $n314 := $n268.log10($n276 / $n294);
+//                 $n296 := 64 * $n294 * ($n276 / $n294) ^ (1 + $n314 * ($n311 + $n314 * $n312));
 //                 annotation(smoothOrder = 1);
-//               end n297;
+//               end $n297;
 //             algorithm
-//               n273 := if n193 >= 0 then n284 else n285;
-//               n274 := if n193 >= 0 then n286 else n287;
-//               n276 := n57 * abs(n193) / (n122 * n274);
-//               n296 := if n276 <= n294 then 64 * n276 else (if n276 >= n295 then 0.25 * (n276 / n268.log10(n293 / 3.7 + 5.74 / n276 ^ 0.9)) ^ 2 else n297(n276, n294, n295, n293));
-//               n283 := n60 * n274 * n274 / (2 * n273 * n57 * n57 * n57) * (if n193 >= 0 then n296 else -n296);
+//               $n273 := if $n193 >= 0 then $n284 else $n285;
+//               $n274 := if $n193 >= 0 then $n286 else $n287;
+//               $n276 := $n57 * abs($n193) / ($n122 * $n274);
+//               $n296 := if $n276 <= $n294 then 64 * $n276 else (if $n276 >= $n295 then 0.25 * ($n276 / $n268.log10($n293 / 3.7 + 5.74 / $n276 ^ 0.9)) ^ 2 else $n297($n276, $n294, $n295, $n293));
+//               $n283 := $n60 * $n274 * $n274 / (2 * $n273 * $n57 * $n57 * $n57) * (if $n193 >= 0 then $n296 else -$n296);
 //               annotation(smoothOrder = 1);
-//             end n243;
+//             end $n243;
 //
-//             redeclare function extends n246
+//             redeclare function extends $n246
 //             protected
-//               Real n293(min = 0) = n126 / n57;
-//               n10.n216 n276;
-//               n10.n216 n294 = min((745 * exp(if n293 <= 0.0065 then 1 else 0.0065 / n293)) ^ 0.97, n215);
-//               n10.n216 n295 = n215;
-//               n10.n214 n315;
-//               n10.n214 n316;
-//               n10.n105 n317;
-//               n10.n105 n318;
-//               n10.n105 n319;
-//               n10.n105 n320;
-//               n10.n214 n321 = n288 * n284;
-//               n10.n214 n322 = n288 * n285;
-//               n10.n105 n323 = 0;
-//               n10.n214 n324 = (n321 + n322) / 2;
-//               Real n325;
+//               Real $n293(min = 0) = $n126 / $n57;
+//               $n10.$n216 $n276;
+//               $n10.$n216 $n294 = min((745 * exp(if $n293 <= 0.0065 then 1 else 0.0065 / $n293)) ^ 0.97, $n215);
+//               $n10.$n216 $n295 = $n215;
+//               $n10.$n214 $n315;
+//               $n10.$n214 $n316;
+//               $n10.$n105 $n317;
+//               $n10.$n105 $n318;
+//               $n10.$n105 $n319;
+//               $n10.$n105 $n320;
+//               $n10.$n214 $n321 = $n288 * $n284;
+//               $n10.$n214 $n322 = $n288 * $n285;
+//               $n10.$n105 $n323 = 0;
+//               $n10.$n214 $n324 = ($n321 + $n322) / 2;
+//               Real $n325;
 //             algorithm
-//               n315 := max(n321, n322) + n112;
-//               n316 := min(n321, n322) - n112;
-//               if n283 >= n315 then
-//                 n193 := n326.n327(n283 - n321, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293);
-//               elseif n283 <= n316 then
-//                 n193 := n326.n327(n283 - n322, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293);
+//               $n315 := max($n321, $n322) + $n112;
+//               $n316 := min($n321, $n322) - $n112;
+//               if $n283 >= $n315 then
+//                 $n193 := $n326.$n327($n283 - $n321, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293);
+//               elseif $n283 <= $n316 then
+//                 $n193 := $n326.$n327($n283 - $n322, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293);
 //               else
-//                 (n317, n319) := n326.n327(n315 - n321, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293);
-//                 (n318, n320) := n326.n327(n316 - n322, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293);
-//                 (n193, n325) := n269.n328(n324, n316, n315, n318, n317, n320, n319);
-//                 if n283 > n324 then
-//                   n193 := n269.n328(n283, n324, n315, n323, n317, n325, n319);
+//                 ($n317, $n319) := $n326.$n327($n315 - $n321, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293);
+//                 ($n318, $n320) := $n326.$n327($n316 - $n322, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293);
+//                 ($n193, $n325) := $n269.$n328($n324, $n316, $n315, $n318, $n317, $n320, $n319);
+//                 if $n283 > $n324 then
+//                   $n193 := $n269.$n328($n283, $n324, $n315, $n323, $n317, $n325, $n319);
 //                 else
-//                   n193 := n269.n328(n283, n316, n324, n318, n323, n320, n325);
+//                   $n193 := $n269.$n328($n283, $n316, $n324, $n318, $n323, $n320, $n325);
 //                 end if;
 //               end if;
 //               annotation(smoothOrder = 1);
-//             end n246;
+//             end $n246;
 //
-//             redeclare function extends n247
+//             redeclare function extends $n247
 //             protected
-//               Real n293(min = 0) = n126 / n57;
-//               n10.n216 n294 = min(745 * exp(if n293 <= 0.0065 then 1 else 0.0065 / n293), n215);
-//               n10.n216 n295 = n215;
-//               n10.n105 n317;
-//               n10.n105 n318;
-//               n10.n214 n315;
-//               n10.n214 n316;
-//               n10.n214 n321 = n288 * n284;
-//               n10.n214 n322 = n288 * n285;
-//               Real n329;
-//               Real n330;
-//               n10.n105 n323 = 0;
-//               n10.n214 n324 = (n321 + n322) / 2;
-//               Real n331;
+//               Real $n293(min = 0) = $n126 / $n57;
+//               $n10.$n216 $n294 = min(745 * exp(if $n293 <= 0.0065 then 1 else 0.0065 / $n293), $n215);
+//               $n10.$n216 $n295 = $n215;
+//               $n10.$n105 $n317;
+//               $n10.$n105 $n318;
+//               $n10.$n214 $n315;
+//               $n10.$n214 $n316;
+//               $n10.$n214 $n321 = $n288 * $n284;
+//               $n10.$n214 $n322 = $n288 * $n285;
+//               Real $n329;
+//               Real $n330;
+//               $n10.$n105 $n323 = 0;
+//               $n10.$n214 $n324 = ($n321 + $n322) / 2;
+//               Real $n331;
 //             algorithm
-//               n317 := if n321 < n322 then n326.n327(n322 - n321, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293) + n110 else n110;
-//               n318 := if n321 < n322 then n326.n327(n321 - n322, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293) - n110 else -n110;
-//               if n193 >= n317 then
-//                 n283 := n326.n332(n193, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293) + n321;
-//               elseif n193 <= n318 then
-//                 n283 := n326.n332(n193, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293) + n322;
+//               $n317 := if $n321 < $n322 then $n326.$n327($n322 - $n321, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293) + $n110 else $n110;
+//               $n318 := if $n321 < $n322 then $n326.$n327($n321 - $n322, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293) - $n110 else -$n110;
+//               if $n193 >= $n317 then
+//                 $n283 := $n326.$n332($n193, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293) + $n321;
+//               elseif $n193 <= $n318 then
+//                 $n283 := $n326.$n332($n193, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293) + $n322;
 //               else
-//                 (n315, n329) := n326.n332(n317, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293);
-//                 n315 := n315 + n321;
-//                 (n316, n330) := n326.n332(n318, n284, n285, n286, n287, n60, n57, n122, n294, n295, n293);
-//                 n316 := n316 + n322;
-//                 (n283, n331) := n269.n328(n323, n318, n317, n316, n315, n330, n329);
-//                 if n193 > n323 then
-//                   n283 := n269.n328(n193, n323, n317, n324, n315, n331, n329);
+//                 ($n315, $n329) := $n326.$n332($n317, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293);
+//                 $n315 := $n315 + $n321;
+//                 ($n316, $n330) := $n326.$n332($n318, $n284, $n285, $n286, $n287, $n60, $n57, $n122, $n294, $n295, $n293);
+//                 $n316 := $n316 + $n322;
+//                 ($n283, $n331) := $n269.$n328($n323, $n318, $n317, $n316, $n315, $n330, $n329);
+//                 if $n193 > $n323 then
+//                   $n283 := $n269.$n328($n193, $n323, $n317, $n324, $n315, $n331, $n329);
 //                 else
-//                   n283 := n269.n328(n193, n318, n323, n316, n324, n330, n331);
+//                   $n283 := $n269.$n328($n193, $n318, $n323, $n316, $n324, $n330, $n331);
 //                 end if;
 //               end if;
 //               annotation(smoothOrder = 1);
-//             end n247;
+//             end $n247;
 //
-//             package n326
-//               extends n1.n2.n333;
+//             package $n326
+//               extends $n1.$n2.$n333;
 //
-//               function n327
-//                 extends n1.n2.n271;
-//                 input n10.n214 n334;
-//                 input n10.n204 n284;
-//                 input n10.n204 n285;
-//                 input n10.n209 n286;
-//                 input n10.n209 n287;
-//                 input n10.n149 n60;
-//                 input n10.n151 n57;
-//                 input n10.n152 n122;
-//                 input n10.n216 n294;
-//                 input n10.n216 n295;
-//                 input Real n293(min = 0);
-//                 output n10.n105 n193;
-//                 output Real n335;
+//               function $n327
+//                 extends $n1.$n2.$n271;
+//                 input $n10.$n214 $n334;
+//                 input $n10.$n204 $n284;
+//                 input $n10.$n204 $n285;
+//                 input $n10.$n209 $n286;
+//                 input $n10.$n209 $n287;
+//                 input $n10.$n149 $n60;
+//                 input $n10.$n151 $n57;
+//                 input $n10.$n152 $n122;
+//                 input $n10.$n216 $n294;
+//                 input $n10.$n216 $n295;
+//                 input Real $n293(min = 0);
+//                 output $n10.$n105 $n193;
+//                 output Real $n335;
 //
 //               protected
-//                 function n336
-//                   extends n1.n2.n271;
-//                   input Real n296;
-//                   input n10.n216 n294;
-//                   input n10.n216 n295;
-//                   input Real n293(min = 0);
-//                   input n10.n214 n334;
-//                   output n10.n216 n276;
-//                   output Real n337;
+//                 function $n336
+//                   extends $n1.$n2.$n271;
+//                   input Real $n296;
+//                   input $n10.$n216 $n294;
+//                   input $n10.$n216 $n295;
+//                   input Real $n293(min = 0);
+//                   input $n10.$n214 $n334;
+//                   output $n10.$n216 $n276;
+//                   output Real $n337;
 //                 protected
-//                   Real n298 = log10(64 * n294);
-//                   Real n299 = log10(n294);
-//                   Real n338 = 1;
-//                   Real n302 = n293 / 3.7 + 5.74 / n295 ^ 0.9;
-//                   Real n303 = log10(n302);
-//                   Real n304 = 0.25 * (n295 / n303) ^ 2;
-//                   Real n305 = 2.51 / sqrt(n304) + 0.27 * n293;
-//                   Real n306 = -2 * sqrt(n304) * log10(n305);
-//                   Real n307 = log10(n304);
-//                   Real n308 = log10(n306);
-//                   Real n339 = 0.5 + (2.51 / log(10)) / (n306 * n305);
-//                   Real n340 = log10(n296);
-//                   Real n18;
-//                   Real n341;
+//                   Real $n298 = log10(64 * $n294);
+//                   Real $n299 = log10($n294);
+//                   Real $n338 = 1;
+//                   Real $n302 = $n293 / 3.7 + 5.74 / $n295 ^ 0.9;
+//                   Real $n303 = log10($n302);
+//                   Real $n304 = 0.25 * ($n295 / $n303) ^ 2;
+//                   Real $n305 = 2.51 / sqrt($n304) + 0.27 * $n293;
+//                   Real $n306 = -2 * sqrt($n304) * log10($n305);
+//                   Real $n307 = log10($n304);
+//                   Real $n308 = log10($n306);
+//                   Real $n339 = 0.5 + (2.51 / log(10)) / ($n306 * $n305);
+//                   Real $n340 = log10($n296);
+//                   Real $n18;
+//                   Real $n341;
 //                 algorithm
-//                   (n18, n341) := n269.n342(n340, n298, n307, n299, n308, n338, n339);
-//                   n276 := 10 ^ n18;
-//                   n337 := n276 / abs(n334) * n341;
+//                   ($n18, $n341) := $n269.$n342($n340, $n298, $n307, $n299, $n308, $n338, $n339);
+//                   $n276 := 10 ^ $n18;
+//                   $n337 := $n276 / abs($n334) * $n341;
 //                   annotation(smoothOrder = 1);
-//                 end n336;
+//                 end $n336;
 //
-//                 n10.n209 n274;
-//                 n10.n204 n273;
-//                 Real n296;
-//                 n10.n216 n276;
-//                 Real n337;
-//                 Real n301;
-//                 Real n302;
+//                 $n10.$n209 $n274;
+//                 $n10.$n204 $n273;
+//                 Real $n296;
+//                 $n10.$n216 $n276;
+//                 Real $n337;
+//                 Real $n301;
+//                 Real $n302;
 //               algorithm
-//                 if n334 >= 0 then
-//                   n273 := n284;
-//                   n274 := n286;
+//                 if $n334 >= 0 then
+//                   $n273 := $n284;
+//                   $n274 := $n286;
 //                 else
-//                   n273 := n285;
-//                   n274 := n287;
+//                   $n273 := $n285;
+//                   $n274 := $n287;
 //                 end if;
-//                 n296 := abs(n334) * 2 * n57 ^ 3 * n273 / (n60 * n274 * n274);
-//                 n301 := (2 * n57 ^ 3 * n273) / (n60 * n274 ^ 2);
-//                 n276 := n296 / 64;
-//                 n337 := n301 / 64;
-//                 if n276 > n294 then
-//                   n276 := -2 * sqrt(n296) * log10(2.51 / sqrt(n296) + 0.27 * n293);
-//                   n302 := sqrt(n301 * abs(n334));
-//                   n337 := 1 / log(10) * (-2 * log(2.51 / n302 + 0.27 * n293) * n301 / (2 * n302) + 2 * 2.51 / (2 * abs(n334) * (2.51 / n302 + 0.27 * n293)));
-//                   if n276 < n295 then
-//                     (n276, n337) := n336(n296, n294, n295, n293, n334);
+//                 $n296 := abs($n334) * 2 * $n57 ^ 3 * $n273 / ($n60 * $n274 * $n274);
+//                 $n301 := (2 * $n57 ^ 3 * $n273) / ($n60 * $n274 ^ 2);
+//                 $n276 := $n296 / 64;
+//                 $n337 := $n301 / 64;
+//                 if $n276 > $n294 then
+//                   $n276 := -2 * sqrt($n296) * log10(2.51 / sqrt($n296) + 0.27 * $n293);
+//                   $n302 := sqrt($n301 * abs($n334));
+//                   $n337 := 1 / log(10) * (-2 * log(2.51 / $n302 + 0.27 * $n293) * $n301 / (2 * $n302) + 2 * 2.51 / (2 * abs($n334) * (2.51 / $n302 + 0.27 * $n293)));
+//                   if $n276 < $n295 then
+//                     ($n276, $n337) := $n336($n296, $n294, $n295, $n293, $n334);
 //                   else
 //                   end if;
 //                 else
 //                 end if;
-//                 n193 := n122 / n57 * n274 * (if n334 >= 0 then n276 else -n276);
-//                 n335 := n122 / n57 * n274 * n337;
+//                 $n193 := $n122 / $n57 * $n274 * (if $n334 >= 0 then $n276 else -$n276);
+//                 $n335 := $n122 / $n57 * $n274 * $n337;
 //                 annotation(smoothOrder = 1);
-//               end n327;
+//               end $n327;
 //
-//               function n332
-//                 extends n1.n2.n271;
-//                 input n10.n105 n193;
-//                 input n10.n204 n284;
-//                 input n10.n204 n285;
-//                 input n10.n209 n286;
-//                 input n10.n209 n287;
-//                 input n10.n149 n60;
-//                 input n10.n151 n57;
-//                 input n10.n152 n122;
-//                 input n10.n216 n294;
-//                 input n10.n216 n295;
-//                 input Real n293(min = 0);
-//                 output n10.n214 n334;
-//                 output Real n343;
+//               function $n332
+//                 extends $n1.$n2.$n271;
+//                 input $n10.$n105 $n193;
+//                 input $n10.$n204 $n284;
+//                 input $n10.$n204 $n285;
+//                 input $n10.$n209 $n286;
+//                 input $n10.$n209 $n287;
+//                 input $n10.$n149 $n60;
+//                 input $n10.$n151 $n57;
+//                 input $n10.$n152 $n122;
+//                 input $n10.$n216 $n294;
+//                 input $n10.$n216 $n295;
+//                 input Real $n293(min = 0);
+//                 output $n10.$n214 $n334;
+//                 output Real $n343;
 //
 //               protected
-//                 function n297
-//                   extends n1.n2.n271;
-//                   input n10.n216 n276;
-//                   input n10.n216 n294;
-//                   input n10.n216 n295;
-//                   input Real n293(min = 0);
-//                   input n10.n105 n193;
-//                   output Real n296;
-//                   output Real n344;
+//                 function $n297
+//                   extends $n1.$n2.$n271;
+//                   input $n10.$n216 $n276;
+//                   input $n10.$n216 $n294;
+//                   input $n10.$n216 $n295;
+//                   input Real $n293(min = 0);
+//                   input $n10.$n105 $n193;
+//                   output Real $n296;
+//                   output Real $n344;
 //                 protected
-//                   Real n298 = log10(n294);
-//                   Real n299 = log10(64 * n294);
-//                   Real n338 = 1;
-//                   Real n302 = n293 / 3.7 + 5.74 / n295 ^ 0.9;
-//                   Real n303 = log10(n302);
-//                   Real n304 = 0.25 * (n295 / n303) ^ 2;
-//                   Real n307 = log10(n295);
-//                   Real n308 = log10(n304);
-//                   Real n339 = 2 + (2 * 5.74 * 0.9) / (log(n302) * n295 ^ 0.9 * n302);
-//                   Real n340 = log10(n276);
-//                   Real n18;
-//                   Real n341;
+//                   Real $n298 = log10($n294);
+//                   Real $n299 = log10(64 * $n294);
+//                   Real $n338 = 1;
+//                   Real $n302 = $n293 / 3.7 + 5.74 / $n295 ^ 0.9;
+//                   Real $n303 = log10($n302);
+//                   Real $n304 = 0.25 * ($n295 / $n303) ^ 2;
+//                   Real $n307 = log10($n295);
+//                   Real $n308 = log10($n304);
+//                   Real $n339 = 2 + (2 * 5.74 * 0.9) / (log($n302) * $n295 ^ 0.9 * $n302);
+//                   Real $n340 = log10($n276);
+//                   Real $n18;
+//                   Real $n341;
 //                 algorithm
-//                   (n18, n341) := n269.n342(n340, n298, n307, n299, n308, n338, n339);
-//                   n296 := 10 ^ n18;
-//                   n344 := n296 / abs(n193) * n341;
+//                   ($n18, $n341) := $n269.$n342($n340, $n298, $n307, $n299, $n308, $n338, $n339);
+//                   $n296 := 10 ^ $n18;
+//                   $n344 := $n296 / abs($n193) * $n341;
 //                   annotation(smoothOrder = 1);
-//                 end n297;
+//                 end $n297;
 //
-//                 n10.n209 n274;
-//                 n10.n204 n273;
-//                 n10.n216 n276;
-//                 Real n296;
-//                 Real n344;
-//                 Real n301;
-//                 Real n302;
+//                 $n10.$n209 $n274;
+//                 $n10.$n204 $n273;
+//                 $n10.$n216 $n276;
+//                 Real $n296;
+//                 Real $n344;
+//                 Real $n301;
+//                 Real $n302;
 //               algorithm
-//                 if n193 >= 0 then
-//                   n273 := n284;
-//                   n274 := n286;
+//                 if $n193 >= 0 then
+//                   $n273 := $n284;
+//                   $n274 := $n286;
 //                 else
-//                   n273 := n285;
-//                   n274 := n287;
+//                   $n273 := $n285;
+//                   $n274 := $n287;
 //                 end if;
-//                 n276 := abs(n193) * n57 / (n122 * n274);
-//                 n301 := n57 / (n122 * n274);
-//                 if n276 <= n294 then
-//                   n296 := 64 * n276;
-//                   n344 := 64 * n301;
-//                 elseif n276 >= n295 then
-//                   n296 := 0.25 * (n276 / log10(n293 / 3.7 + 5.74 / n276 ^ 0.9)) ^ 2;
-//                   n302 := n293 / 3.7 + 5.74 / ((n301 * abs(n193)) ^ 0.9);
-//                   n344 := 0.5 * n301 * n276 * log(10) ^ 2 * (1 / (log(n302) ^ 2) + (5.74 * 0.9) / (log(n302) ^ 3 * n276 ^ 0.9 * n302));
+//                 $n276 := abs($n193) * $n57 / ($n122 * $n274);
+//                 $n301 := $n57 / ($n122 * $n274);
+//                 if $n276 <= $n294 then
+//                   $n296 := 64 * $n276;
+//                   $n344 := 64 * $n301;
+//                 elseif $n276 >= $n295 then
+//                   $n296 := 0.25 * ($n276 / log10($n293 / 3.7 + 5.74 / $n276 ^ 0.9)) ^ 2;
+//                   $n302 := $n293 / 3.7 + 5.74 / (($n301 * abs($n193)) ^ 0.9);
+//                   $n344 := 0.5 * $n301 * $n276 * log(10) ^ 2 * (1 / (log($n302) ^ 2) + (5.74 * 0.9) / (log($n302) ^ 3 * $n276 ^ 0.9 * $n302));
 //                 else
-//                   (n296, n344) := n297(n276, n294, n295, n293, n193);
+//                   ($n296, $n344) := $n297($n276, $n294, $n295, $n293, $n193);
 //                 end if;
-//                 n334 := n60 * n274 * n274 / (2 * n273 * n57 * n57 * n57) * (if n193 >= 0 then n296 else -n296);
-//                 n343 := (n60 * n274 ^ 2) / (2 * n57 ^ 3 * n273) * n344;
+//                 $n334 := $n60 * $n274 * $n274 / (2 * $n273 * $n57 * $n57 * $n57) * (if $n193 >= 0 then $n296 else -$n296);
+//                 $n343 := ($n60 * $n274 ^ 2) / (2 * $n57 ^ 3 * $n273) * $n344;
 //                 annotation(smoothOrder = 1);
-//               end n332;
-//             end n326;
-//           end n234;
-//         end n232;
-//       end n68;
-//     end n53;
+//               end $n332;
+//             end $n326;
+//           end $n234;
+//         end $n232;
+//       end $n68;
+//     end $n53;
 //
-//     package n23
-//       extends n1.n2.n24;
+//     package $n23
+//       extends $n1.$n2.$n24;
 //
-//       model n49
-//         import n1.n37.n12.n345.n346;
-//         extends n23.n68.n347;
-//         parameter Boolean n75 = false annotation(Evaluate = true, HideResult = true);
-//         parameter Boolean n76 = false annotation(Evaluate = true, HideResult = true);
-//         parameter Boolean n348 = false annotation(Evaluate = true, HideResult = true);
-//         parameter Boolean n349 = false annotation(Evaluate = true, HideResult = true);
-//         parameter n36.n92 n51 = n36.n221;
-//         parameter n36.n94 n250 = n36.n222;
-//         parameter n36.n352[n36.n351] n350 = n36.n223;
-//         parameter n36.n354[n36.n182] n353(quantity = n36.n355) = n36.n356;
-//         n1.n9.n12.n14 n85 if n75;
-//         n1.n9.n12.n14 n357 if n76;
-//         n1.n9.n12.n14[n36.n351] n358 if n348;
-//         n1.n9.n12.n14[n36.n182] n359 if n349;
+//       model $n49
+//         import $n1.$n37.$n12.$n345.$n346;
+//         extends $n23.$n68.$n347;
+//         parameter Boolean $n75 = false annotation(Evaluate = true, HideResult = true);
+//         parameter Boolean $n76 = false annotation(Evaluate = true, HideResult = true);
+//         parameter Boolean $n348 = false annotation(Evaluate = true, HideResult = true);
+//         parameter Boolean $n349 = false annotation(Evaluate = true, HideResult = true);
+//         parameter $n36.$n92 $n51 = $n36.$n221;
+//         parameter $n36.$n94 $n250 = $n36.$n222;
+//         parameter $n36.$n352[$n36.$n351] $n350 = $n36.$n223;
+//         parameter $n36.$n354[$n36.$n182] $n353(quantity = $n36.$n355) = $n36.$n356;
+//         $n1.$n9.$n12.$n14 $n85 if $n75;
+//         $n1.$n9.$n12.$n14 $n357 if $n76;
+//         $n1.$n9.$n12.$n14[$n36.$n351] $n358 if $n348;
+//         $n1.$n9.$n12.$n14[$n36.$n182] $n359 if $n349;
 //       protected
-//         n1.n9.n12.n14 n360;
-//         n1.n9.n12.n14 n361;
-//         n1.n9.n12.n14[n36.n351] n362;
-//         n1.n9.n12.n14[n36.n182] n363;
+//         $n1.$n9.$n12.$n14 $n360;
+//         $n1.$n9.$n12.$n14 $n361;
+//         $n1.$n9.$n12.$n14[$n36.$n351] $n362;
+//         $n1.$n9.$n12.$n14[$n36.$n182] $n363;
 //       equation
-//         n1.n29.n269.n367(n36.n364, n36.n365, n36.n366, true, n362, \"Boundary_pT\");
-//         connect(n85, n360);
-//         connect(n357, n361);
-//         connect(n358, n362);
-//         connect(n359, n363);
-//         if not n75 then
-//           n360 = n51;
+//         $n1.$n29.$n269.$n367($n36.$n364, $n36.$n365, $n36.$n366, true, $n362, \"Boundary_pT\");
+//         connect($n85, $n360);
+//         connect($n357, $n361);
+//         connect($n358, $n362);
+//         connect($n359, $n363);
+//         if not $n75 then
+//           $n360 = $n51;
 //         end if;
-//         if not n76 then
-//           n361 = n250;
+//         if not $n76 then
+//           $n361 = $n250;
 //         end if;
-//         if not n348 then
-//           n362 = n350;
+//         if not $n348 then
+//           $n362 = $n350;
 //         end if;
-//         if not n349 then
-//           n363 = n353;
+//         if not $n349 then
+//           $n363 = $n353;
 //         end if;
-//         n368.n51 = n360;
-//         if n36.n369 == n346.n370 or n36.n369 == n346.n371 then
-//           n368.n190 = n36.n372(n36.n225(n360, n361, n362));
+//         $n368.$n51 = $n360;
+//         if $n36.$n369 == $n346.$n370 or $n36.$n369 == $n346.$n371 then
+//           $n368.$n190 = $n36.$n372($n36.$n225($n360, $n361, $n362));
 //         else
-//           n368.n250 = n361;
+//           $n368.$n250 = $n361;
 //         end if;
-//         n368.n191 = n362[1:n36.n180];
-//         n86.n196 = fill(n363, n50);
-//       end n49;
+//         $n368.$n191 = $n362[1:$n36.$n180];
+//         $n86.$n196 = fill($n363, $n50);
+//       end $n49;
 //
-//       package n68
-//         extends n1.n2.n147;
+//       package $n68
+//         extends $n1.$n2.$n147;
 //
-//         partial model n347
-//           import n1.n97;
-//           parameter Integer n50 = 0;
-//           replaceable package n36 = n1.n37.n12.n38 annotation(choicesAllMatching = true);
-//           n36.n373 n368;
-//           n12.n374[n50] n86(redeclare each package n36 = n36, n193(each max = if n375 == n44.n376.n377 then 0 else +n97.n7, each min = if n375 == n44.n376.n378 then 0 else -n97.n7));
+//         partial model $n347
+//           import $n1.$n97;
+//           parameter Integer $n50 = 0;
+//           replaceable package $n36 = $n1.$n37.$n12.$n38 annotation(choicesAllMatching = true);
+//           $n36.$n373 $n368;
+//           $n12.$n374[$n50] $n86(redeclare each package $n36 = $n36, $n193(each max = if $n375 == $n44.$n376.$n377 then 0 else +$n97.$n7, each min = if $n375 == $n44.$n376.$n378 then 0 else -$n97.$n7));
 //         protected
-//           parameter n44.n376 n375 = n44.n376.n379 annotation(Evaluate = true);
+//           parameter $n44.$n376 $n375 = $n44.$n376.$n379 annotation(Evaluate = true);
 //         equation
-//           for n146 in 1:n50 loop
-//             assert(cardinality(n86[n146]) <= 1, \"assert message 7359952004242900210\");
-//             n86[n146].n51 = n368.n51;
-//             n86[n146].n194 = n368.n190;
-//             n86[n146].n195 = n368.n191;
+//           for $n146 in 1:$n50 loop
+//             assert(cardinality($n86[$n146]) <= 1, \"assert message 7359952004242900210\");
+//             $n86[$n146].$n51 = $n368.$n51;
+//             $n86[$n146].$n194 = $n368.$n190;
+//             $n86[$n146].$n195 = $n368.$n191;
 //           end for;
-//         end n347;
-//       end n68;
-//     end n23;
+//         end $n347;
+//       end $n68;
+//     end $n23;
 //
-//     package n12
-//       extends n1.n2.n13;
+//     package $n12
+//       extends $n1.$n2.$n13;
 //
-//       connector n380
-//         replaceable package n36 = n1.n37.n12.n38 annotation(choicesAllMatching = true);
-//         flow n36.n105 n193;
-//         n36.n92 n51;
-//         stream n36.n381 n194;
-//         stream n36.n352[n36.n180] n195;
-//         stream n36.n354[n36.n182] n196;
-//       end n380;
+//       connector $n380
+//         replaceable package $n36 = $n1.$n37.$n12.$n38 annotation(choicesAllMatching = true);
+//         flow $n36.$n105 $n193;
+//         $n36.$n92 $n51;
+//         stream $n36.$n381 $n194;
+//         stream $n36.$n352[$n36.$n180] $n195;
+//         stream $n36.$n354[$n36.$n182] $n196;
+//       end $n380;
 //
-//       connector n382
-//         extends n380;
-//       end n382;
+//       connector $n382
+//         extends $n380;
+//       end $n382;
 //
-//       connector n383
-//         extends n380;
-//       end n383;
+//       connector $n383
+//         extends $n380;
+//       end $n383;
 //
-//       connector n374
-//         extends n380;
-//       end n374;
+//       connector $n374
+//         extends $n380;
+//       end $n374;
 //
-//       partial model n148
-//         import n1.n97;
-//         outer n1.n29.n42 n41;
-//         replaceable package n36 = n1.n37.n12.n38 annotation(choicesAllMatching = true);
-//         parameter Boolean n99 = n41.n99 annotation(Evaluate = true);
-//         n1.n29.n12.n382 n87(redeclare package n36 = n36, n193(min = if n99 then -n97.n7 else 0));
-//         n1.n29.n12.n383 n88(redeclare package n36 = n36, n193(max = if n99 then +n97.n7 else 0));
+//       partial model $n148
+//         import $n1.$n97;
+//         outer $n1.$n29.$n42 $n41;
+//         replaceable package $n36 = $n1.$n37.$n12.$n38 annotation(choicesAllMatching = true);
+//         parameter Boolean $n99 = $n41.$n99 annotation(Evaluate = true);
+//         $n1.$n29.$n12.$n382 $n87(redeclare package $n36 = $n36, $n193(min = if $n99 then -$n97.$n7 else 0));
+//         $n1.$n29.$n12.$n383 $n88(redeclare package $n36 = $n36, $n193(max = if $n99 then +$n97.$n7 else 0));
 //       protected
-//         parameter Boolean n115 = false;
-//         parameter Boolean n117 = false;
-//         parameter Boolean n384 = true;
-//       end n148;
+//         parameter Boolean $n115 = false;
+//         parameter Boolean $n117 = false;
+//         parameter Boolean $n384 = true;
+//       end $n148;
 //
-//       connector n130
-//         extends n1.n79.n67.n12.n385;
-//       end n130;
+//       connector $n130
+//         extends $n1.$n79.$n67.$n12.$n385;
+//       end $n130;
 //
-//       partial model n248
-//         replaceable package n36 = n1.n37.n12.n38;
-//         parameter Integer n84 = 1 annotation(Evaluate = true);
-//         input n36.n165[n84] n134;
-//         input n10.n152[n84] n133;
-//         output n10.n386[n84] n140;
-//         parameter Boolean n138 = false;
-//         parameter n10.n253 n387 = 0 annotation(Evaluate = true);
-//         parameter n10.n94 n93 = n41.n93;
-//         outer n1.n29.n42 n41;
-//         n1.n29.n12.n130[n84] n90;
-//         n10.n94[n84] n249 = n36.n388(n134);
+//       partial model $n248
+//         replaceable package $n36 = $n1.$n37.$n12.$n38;
+//         parameter Integer $n84 = 1 annotation(Evaluate = true);
+//         input $n36.$n165[$n84] $n134;
+//         input $n10.$n152[$n84] $n133;
+//         output $n10.$n386[$n84] $n140;
+//         parameter Boolean $n138 = false;
+//         parameter $n10.$n253 $n387 = 0 annotation(Evaluate = true);
+//         parameter $n10.$n94 $n93 = $n41.$n93;
+//         outer $n1.$n29.$n42 $n41;
+//         $n1.$n29.$n12.$n130[$n84] $n90;
+//         $n10.$n94[$n84] $n249 = $n36.$n388($n134);
 //       equation
-//         if n138 then
-//           n140 = n90.n81 + {n387 * n133[n146] * (n93 - n90[n146].n250) for n146 in 1:n84};
+//         if $n138 then
+//           $n140 = $n90.$n81 + {$n387 * $n133[$n146] * ($n93 - $n90[$n146].$n250) for $n146 in 1:$n84};
 //         else
-//           n140 = n90.n81;
+//           $n140 = $n90.$n81;
 //         end if;
-//       end n248;
+//       end $n248;
 //
-//       partial model n157
-//         import n1.n29.n44;
-//         import n1.n29.n44.n45;
-//         import n1.n37.n12.n345.n346;
-//         outer n1.n29.n42 n41;
-//         replaceable package n36 = n1.n37.n12.n38 annotation(choicesAllMatching = true);
-//         parameter Integer n84 = 2;
-//         input n10.n156[n84] n158;
-//         parameter n44.n45 n43 = n41.n43 annotation(Evaluate = true);
-//         parameter n44.n45 n101 = n41.n101 annotation(Evaluate = true);
-//         final parameter n44.n45 n102 = n101 annotation(Evaluate = true);
-//         final parameter n44.n45 n103 = n101 annotation(Evaluate = true);
-//         parameter n36.n92 n61 = n41.n106;
-//         parameter n36.n92 n62 = n61;
-//         final parameter n36.n92[n84] n389 = if n84 > 1 then linspace(n61, n62, n84) else {(n61 + n62) / 2};
-//         parameter Boolean n55 = true annotation(Evaluate = true);
-//         parameter n36.n94 n107 = if n55 then n41.n107 else n36.n392((n61 + n62) / 2, n390, n391) annotation(Evaluate = true);
-//         parameter n36.n381 n390 = if n55 then n36.n393((n61 + n62) / 2, n107, n391) else n36.n394 annotation(Evaluate = true);
-//         parameter n36.n352[n36.n351] n391 = n36.n223;
-//         parameter n36.n354[n36.n182] n395(quantity = n36.n355) = n36.n356;
-//         n10.n397[n84] n396;
-//         n10.n399[n84] n398;
-//         n10.n399[n84, n36.n180] n400;
-//         n10.n399[n84, n36.n182] n401;
-//         n10.n399[n84, n36.n182] n402;
-//         n36.n354[n84, n36.n182] n192;
-//         n36.n373[n84] n135(each n403 = true, n51(start = n389), each n190(start = n390), each n250(start = n107), each n191(start = n391[1:n36.n180]));
-//         n36.n105[n84] n186;
-//         n36.n105[n84, n36.n180] n187;
-//         n36.n404[n84, n36.n182] n188;
-//         n10.n184[n84] n189;
-//         n10.n386[n84] n139;
-//         n10.n405[n84] n142;
+//       partial model $n157
+//         import $n1.$n29.$n44;
+//         import $n1.$n29.$n44.$n45;
+//         import $n1.$n37.$n12.$n345.$n346;
+//         outer $n1.$n29.$n42 $n41;
+//         replaceable package $n36 = $n1.$n37.$n12.$n38 annotation(choicesAllMatching = true);
+//         parameter Integer $n84 = 2;
+//         input $n10.$n156[$n84] $n158;
+//         parameter $n44.$n45 $n43 = $n41.$n43 annotation(Evaluate = true);
+//         parameter $n44.$n45 $n101 = $n41.$n101 annotation(Evaluate = true);
+//         final parameter $n44.$n45 $n102 = $n101 annotation(Evaluate = true);
+//         final parameter $n44.$n45 $n103 = $n101 annotation(Evaluate = true);
+//         parameter $n36.$n92 $n61 = $n41.$n106;
+//         parameter $n36.$n92 $n62 = $n61;
+//         final parameter $n36.$n92[$n84] $n389 = if $n84 > 1 then linspace($n61, $n62, $n84) else {($n61 + $n62) / 2};
+//         parameter Boolean $n55 = true annotation(Evaluate = true);
+//         parameter $n36.$n94 $n107 = if $n55 then $n41.$n107 else $n36.$n392(($n61 + $n62) / 2, $n390, $n391) annotation(Evaluate = true);
+//         parameter $n36.$n381 $n390 = if $n55 then $n36.$n393(($n61 + $n62) / 2, $n107, $n391) else $n36.$n394 annotation(Evaluate = true);
+//         parameter $n36.$n352[$n36.$n351] $n391 = $n36.$n223;
+//         parameter $n36.$n354[$n36.$n182] $n395(quantity = $n36.$n355) = $n36.$n356;
+//         $n10.$n397[$n84] $n396;
+//         $n10.$n399[$n84] $n398;
+//         $n10.$n399[$n84, $n36.$n180] $n400;
+//         $n10.$n399[$n84, $n36.$n182] $n401;
+//         $n10.$n399[$n84, $n36.$n182] $n402;
+//         $n36.$n354[$n84, $n36.$n182] $n192;
+//         $n36.$n373[$n84] $n135(each $n403 = true, $n51(start = $n389), each $n190(start = $n390), each $n250(start = $n107), each $n191(start = $n391[1:$n36.$n180]));
+//         $n36.$n105[$n84] $n186;
+//         $n36.$n105[$n84, $n36.$n180] $n187;
+//         $n36.$n404[$n84, $n36.$n182] $n188;
+//         $n10.$n184[$n84] $n189;
+//         $n10.$n386[$n84] $n139;
+//         $n10.$n405[$n84] $n142;
 //       protected
-//         parameter Boolean n406 = not n36.n366;
+//         parameter Boolean $n406 = not $n36.$n366;
 //       initial equation
-//         if n43 == n45.n409 then
-//           if n36.n369 == n346.n370 or n36.n369 == n346.n371 then
-//             n135.n190 = fill(n390, n84);
+//         if $n43 == $n45.$n409 then
+//           if $n36.$n369 == $n346.$n370 or $n36.$n369 == $n346.$n371 then
+//             $n135.$n190 = fill($n390, $n84);
 //           else
-//             n135.n250 = fill(n107, n84);
+//             $n135.$n250 = fill($n107, $n84);
 //           end if;
-//         elseif n43 == n45.n46 then
-//           if n36.n369 == n346.n370 or n36.n369 == n346.n371 then
-//             der(n135.n190) = zeros(n84);
+//         elseif $n43 == $n45.$n46 then
+//           if $n36.$n369 == $n346.$n370 or $n36.$n369 == $n346.$n371 then
+//             der($n135.$n190) = zeros($n84);
 //           else
-//             der(n135.n250) = zeros(n84);
+//             der($n135.$n250) = zeros($n84);
 //           end if;
 //         end if;
-//         if n101 == n45.n409 then
-//           if n406 then
-//             n135.n51 = n389;
+//         if $n101 == $n45.$n409 then
+//           if $n406 then
+//             $n135.$n51 = $n389;
 //           end if;
-//         elseif n101 == n45.n46 then
-//           if n406 then
-//             der(n135.n51) = zeros(n84);
+//         elseif $n101 == $n45.$n46 then
+//           if $n406 then
+//             der($n135.$n51) = zeros($n84);
 //           end if;
 //         end if;
-//         if n102 == n45.n409 then
-//           n135.n191 = fill(n391[1:n36.n180], n84);
-//         elseif n102 == n45.n46 then
-//           for n146 in 1:n84 loop
-//             der(n135[n146].n191) = zeros(n36.n180);
+//         if $n102 == $n45.$n409 then
+//           $n135.$n191 = fill($n391[1:$n36.$n180], $n84);
+//         elseif $n102 == $n45.$n46 then
+//           for $n146 in 1:$n84 loop
+//             der($n135[$n146].$n191) = zeros($n36.$n180);
 //           end for;
 //         end if;
-//         if n103 == n45.n409 then
-//           n192 = fill(n395[1:n36.n182], n84);
-//         elseif n103 == n45.n46 then
-//           for n146 in 1:n84 loop
-//             der(n401[n146, :]) = zeros(n36.n182);
+//         if $n103 == $n45.$n409 then
+//           $n192 = fill($n395[1:$n36.$n182], $n84);
+//         elseif $n103 == $n45.$n46 then
+//           for $n146 in 1:$n84 loop
+//             der($n401[$n146, :]) = zeros($n36.$n182);
 //           end for;
 //         end if;
 //       equation
-//         assert(not (n43 <> n45.n104 and n101 == n45.n104) or n36.n366, \"assert message 3268591434625411949\");
-//         for n146 in 1:n84 loop
-//           n398[n146] = n158[n146] * n135[n146].n145;
-//           n400[n146, :] = n398[n146] * n135[n146].n191;
-//           n401[n146, :] = n398[n146] * n192[n146, :];
-//           n396[n146] = n398[n146] * n135[n146].n407;
+//         assert(not ($n43 <> $n45.$n104 and $n101 == $n45.$n104) or $n36.$n366, \"assert message 3268591434625411949\");
+//         for $n146 in 1:$n84 loop
+//           $n398[$n146] = $n158[$n146] * $n135[$n146].$n145;
+//           $n400[$n146, :] = $n398[$n146] * $n135[$n146].$n191;
+//           $n401[$n146, :] = $n398[$n146] * $n192[$n146, :];
+//           $n396[$n146] = $n398[$n146] * $n135[$n146].$n407;
 //         end for;
-//         if n43 == n45.n104 then
-//           for n146 in 1:n84 loop
-//             0 = n189[n146] + n142[n146] + n139[n146];
+//         if $n43 == $n45.$n104 then
+//           for $n146 in 1:$n84 loop
+//             0 = $n189[$n146] + $n142[$n146] + $n139[$n146];
 //           end for;
 //         else
-//           for n146 in 1:n84 loop
-//             der(n396[n146]) = n189[n146] + n142[n146] + n139[n146];
+//           for $n146 in 1:$n84 loop
+//             der($n396[$n146]) = $n189[$n146] + $n142[$n146] + $n139[$n146];
 //           end for;
 //         end if;
-//         if n101 == n45.n104 then
-//           for n146 in 1:n84 loop
-//             0 = n186[n146];
+//         if $n101 == $n45.$n104 then
+//           for $n146 in 1:$n84 loop
+//             0 = $n186[$n146];
 //           end for;
 //         else
-//           for n146 in 1:n84 loop
-//             der(n398[n146]) = n186[n146];
+//           for $n146 in 1:$n84 loop
+//             der($n398[$n146]) = $n186[$n146];
 //           end for;
 //         end if;
-//         if n102 == n45.n104 then
-//           for n146 in 1:n84 loop
-//             zeros(n36.n180) = n187[n146, :];
+//         if $n102 == $n45.$n104 then
+//           for $n146 in 1:$n84 loop
+//             zeros($n36.$n180) = $n187[$n146, :];
 //           end for;
 //         else
-//           for n146 in 1:n84 loop
-//             der(n400[n146, :]) = n187[n146, :];
+//           for $n146 in 1:$n84 loop
+//             der($n400[$n146, :]) = $n187[$n146, :];
 //           end for;
 //         end if;
-//         if n103 == n45.n104 then
-//           for n146 in 1:n84 loop
-//             zeros(n36.n182) = n188[n146, :];
+//         if $n103 == $n45.$n104 then
+//           for $n146 in 1:$n84 loop
+//             zeros($n36.$n182) = $n188[$n146, :];
 //           end for;
 //         else
-//           for n146 in 1:n84 loop
-//             der(n402[n146, :]) = n188[n146, :] ./ n36.n408;
-//             n401[n146, :] = n402[n146, :] .* n36.n408;
+//           for $n146 in 1:$n84 loop
+//             der($n402[$n146, :]) = $n188[$n146, :] ./ $n36.$n408;
+//             $n401[$n146, :] = $n402[$n146, :] .* $n36.$n408;
 //           end for;
 //         end if;
-//       end n157;
+//       end $n157;
 //
-//       partial model n199
-//         outer n1.n29.n42 n41;
-//         replaceable package n36 = n1.n37.n12.n38;
-//         parameter Boolean n99 = n41.n99 annotation(Evaluate = true);
-//         parameter Integer n200 = 1;
-//         input n10.n149[n200] n173;
-//         n36.n105[n200] n178(each min = if n99 then -n1.n97.n7 else 0, each start = n58, each stateSelect = if n47 == n44.n45.n104 then StateSelect.default else StateSelect.prefer);
-//         parameter n1.n29.n44.n45 n47 = n41.n47 annotation(Evaluate = true);
-//         parameter n36.n105 n58 = n41.n58;
-//         n10.n411[n200] n410;
-//         n10.n412[n200] n226;
-//         n10.n412[n200] n227;
-//         n10.n412[n200] n229;
+//       partial model $n199
+//         outer $n1.$n29.$n42 $n41;
+//         replaceable package $n36 = $n1.$n37.$n12.$n38;
+//         parameter Boolean $n99 = $n41.$n99 annotation(Evaluate = true);
+//         parameter Integer $n200 = 1;
+//         input $n10.$n149[$n200] $n173;
+//         $n36.$n105[$n200] $n178(each min = if $n99 then -$n1.$n97.$n7 else 0, each start = $n58, each stateSelect = if $n47 == $n44.$n45.$n104 then StateSelect.default else StateSelect.prefer);
+//         parameter $n1.$n29.$n44.$n45 $n47 = $n41.$n47 annotation(Evaluate = true);
+//         parameter $n36.$n105 $n58 = $n41.$n58;
+//         $n10.$n411[$n200] $n410;
+//         $n10.$n412[$n200] $n226;
+//         $n10.$n412[$n200] $n227;
+//         $n10.$n412[$n200] $n229;
 //       initial equation
-//         if n47 == n44.n45.n409 then
-//           n178 = fill(n58, n200);
-//         elseif n47 == n44.n45.n46 then
-//           der(n178) = zeros(n200);
+//         if $n47 == $n44.$n45.$n409 then
+//           $n178 = fill($n58, $n200);
+//         elseif $n47 == $n44.$n45.$n46 then
+//           der($n178) = zeros($n200);
 //         end if;
 //       equation
-//         n410 = {n178[n146] * n173[n146] for n146 in 1:n200};
-//         if n47 == n44.n45.n104 then
-//           zeros(n200) = n226 - n227 - n229;
+//         $n410 = {$n178[$n146] * $n173[$n146] for $n146 in 1:$n200};
+//         if $n47 == $n44.$n45.$n104 then
+//           zeros($n200) = $n226 - $n227 - $n229;
 //         else
-//           der(n410) = n226 - n227 - n229;
+//           der($n410) = $n226 - $n227 - $n229;
 //         end if;
-//       end n199;
-//     end n12;
+//       end $n199;
+//     end $n12;
 //
-//     package n44
-//       extends n1.n2.n413;
-//       type n154 = n1.n2.n414(final quantity = \"Length\", final unit = \"m\", displayUnit = \"mm\", min = 0);
-//       type n45 = enumeration(n100, n409, n46, n104);
-//       type n376 = enumeration(n378, n377, n379);
-//       type n64 = enumeration(n71, n65, n116, n118);
-//     end n44;
+//     package $n44
+//       extends $n1.$n2.$n413;
+//       type $n154 = $n1.$n2.$n414(final quantity = \"Length\", final unit = \"m\", displayUnit = \"mm\", min = 0);
+//       type $n45 = enumeration($n100, $n409, $n46, $n104);
+//       type $n376 = enumeration($n378, $n377, $n379);
+//       type $n64 = enumeration($n71, $n65, $n116, $n118);
+//     end $n44;
 //
-//     package n269
-//       extends n1.n2.n415;
+//     package $n269
+//       extends $n1.$n2.$n415;
 //
-//       function n367
-//         extends n1.n2.n271;
-//         input String n364;
-//         input String[:] n365;
-//         input Boolean n366;
-//         input Boolean n416;
-//         input Real[:] n417;
-//         input String n418 = \"??? boundary ???\";
+//       function $n367
+//         extends $n1.$n2.$n271;
+//         input String $n364;
+//         input String[:] $n365;
+//         input Boolean $n366;
+//         input Boolean $n416;
+//         input Real[:] $n417;
+//         input String $n418 = \"??? boundary ???\";
 //       protected
-//         Integer n351 = size(n417, 1);
-//         String n419;
+//         Integer $n351 = size($n417, 1);
+//         String $n419;
 //       algorithm
-//         assert(not n366 or n366 and n416, \"assert message 405342961918706907\");
-//         for n146 in 1:n351 loop
-//           assert(n417[n146] >= 0.0, \"assert message 837991791729573288\");
+//         assert(not $n366 or $n366 and $n416, \"assert message 405342961918706907\");
+//         for $n146 in 1:$n351 loop
+//           assert($n417[$n146] >= 0.0, \"assert message 837991791729573288\");
 //         end for;
-//         if n351 > 0 and abs(sum(n417) - 1.0) > 1e-10 then
-//           n419 := \"\";
-//           for n146 in 1:n351 loop
-//             n419 := n419 + \"   X_boundary[\" + String(n146) + \"] = \" + String(n417[n146]) + \" \\\"\" + n365[n146] + \"\\\"\\n\";
+//         if $n351 > 0 and abs(sum($n417) - 1.0) > 1e-10 then
+//           $n419 := \"\";
+//           for $n146 in 1:$n351 loop
+//             $n419 := $n419 + \"   X_boundary[\" + String($n146) + \"] = \" + String($n417[$n146]) + \" \\\"\" + $n365[$n146] + \"\\\"\\n\";
 //           end for;
-//           n1.n269.n420.n421(\"The boundary mass fractions in medium \\\"\" + n364 + \"\\\" in model \\\"\" + n418 + \"\\\"\\n\" + \"do not sum up to 1. Instead, sum(X_boundary) = \" + String(sum(n417)) + \":\\n\" + n419);
+//           $n1.$n269.$n420.$n421(\"The boundary mass fractions in medium \\\"\" + $n364 + \"\\\" in model \\\"\" + $n418 + \"\\\"\\n\" + \"do not sum up to 1. Instead, sum(X_boundary) = \" + String(sum($n417)) + \":\\n\" + $n419);
 //         else
 //         end if;
-//       end n367;
+//       end $n367;
 //
-//       function n328
-//         extends n1.n2.n271;
-//         input Real n340;
-//         input Real n422;
-//         input Real n298;
-//         input Real n423;
-//         input Real n299;
-//         input Real n424;
-//         input Real n338;
-//         output Real n18;
-//         output Real n425;
+//       function $n328
+//         extends $n1.$n2.$n271;
+//         input Real $n340;
+//         input Real $n422;
+//         input Real $n298;
+//         input Real $n423;
+//         input Real $n299;
+//         input Real $n424;
+//         input Real $n338;
+//         output Real $n18;
+//         output Real $n425;
 //       protected
-//         Real n426;
-//         Real n427;
-//         Real n428;
-//         Real n274;
-//         Real n429;
-//         Real n430;
-//         Real n273;
-//         Real n431;
-//         Real n432;
-//         Real n433;
-//         Real n434;
-//         Real n435;
-//         Real n436;
-//         Real n437;
-//         Real n438;
-//         Real n439;
-//         Real n440;
-//         Real n441;
-//         Boolean n442 = false;
+//         Real $n426;
+//         Real $n427;
+//         Real $n428;
+//         Real $n274;
+//         Real $n429;
+//         Real $n430;
+//         Real $n273;
+//         Real $n431;
+//         Real $n432;
+//         Real $n433;
+//         Real $n434;
+//         Real $n435;
+//         Real $n436;
+//         Real $n437;
+//         Real $n438;
+//         Real $n439;
+//         Real $n440;
+//         Real $n441;
+//         Boolean $n442 = false;
 //       algorithm
-//         assert(n422 < n298, \"assert message 8766466662519165273\");
-//         if n424 * n338 >= 0 then
+//         assert($n422 < $n298, \"assert message 8766466662519165273\");
+//         if $n424 * $n338 >= 0 then
 //         else
-//           assert(abs(n424) < n1.n97.n5 or abs(n338) < n1.n97.n5, \"assert message 1884851029044619375\");
+//           assert(abs($n424) < $n1.$n97.$n5 or abs($n338) < $n1.$n97.$n5, \"assert message 1884851029044619375\");
 //         end if;
-//         n426 := n298 - n422;
-//         n427 := (n299 - n423) / n426;
-//         if abs(n427) <= 0 then
-//           n18 := n423 + n427 * (n340 - n422);
-//           n425 := 0;
-//         elseif abs(n338 + n424 - 2 * n427) < 100 * n1.n97.n5 then
-//           n18 := n423 + (n340 - n422) * (n424 + (n340 - n422) / n426 * ((-2 * n424 - n338 + 3 * n427) + (n340 - n422) * (n424 + n338 - 2 * n427) / n426));
-//           n440 := (n422 + n298) / 2;
-//           n425 := 3 * (n424 + n338 - 2 * n427) * (n440 - n422) ^ 2 / n426 ^ 2 + 2 * (-2 * n424 - n338 + 3 * n427) * (n440 - n422) / n426 + n424;
+//         $n426 := $n298 - $n422;
+//         $n427 := ($n299 - $n423) / $n426;
+//         if abs($n427) <= 0 then
+//           $n18 := $n423 + $n427 * ($n340 - $n422);
+//           $n425 := 0;
+//         elseif abs($n338 + $n424 - 2 * $n427) < 100 * $n1.$n97.$n5 then
+//           $n18 := $n423 + ($n340 - $n422) * ($n424 + ($n340 - $n422) / $n426 * ((-2 * $n424 - $n338 + 3 * $n427) + ($n340 - $n422) * ($n424 + $n338 - 2 * $n427) / $n426));
+//           $n440 := ($n422 + $n298) / 2;
+//           $n425 := 3 * ($n424 + $n338 - 2 * $n427) * ($n440 - $n422) ^ 2 / $n426 ^ 2 + 2 * (-2 * $n424 - $n338 + 3 * $n427) * ($n440 - $n422) / $n426 + $n424;
 //         else
-//           n428 := 1 / 3 * (-3 * n422 * n424 - 3 * n422 * n338 + 6 * n422 * n427 - 2 * n426 * n424 - n426 * n338 + 3 * n426 * n427) / (-n424 - n338 + 2 * n427);
-//           n274 := n428 - n422;
-//           n429 := n298 - n428;
-//           n430 := 3 * (n424 + n338 - 2 * n427) * (n428 - n422) ^ 2 / n426 ^ 2 + 2 * (-2 * n424 - n338 + 3 * n427) * (n428 - n422) / n426 + n424;
-//           n440 := 0.25 * sign(n427) * min(abs(n430), abs(n427));
-//           if abs(n424 - n338) <= 100 * n1.n97.n5 then
-//             n441 := n424;
-//             if n299 > n423 + n424 * (n298 - n422) then
-//               n442 := true;
+//           $n428 := 1 / 3 * (-3 * $n422 * $n424 - 3 * $n422 * $n338 + 6 * $n422 * $n427 - 2 * $n426 * $n424 - $n426 * $n338 + 3 * $n426 * $n427) / (-$n424 - $n338 + 2 * $n427);
+//           $n274 := $n428 - $n422;
+//           $n429 := $n298 - $n428;
+//           $n430 := 3 * ($n424 + $n338 - 2 * $n427) * ($n428 - $n422) ^ 2 / $n426 ^ 2 + 2 * (-2 * $n424 - $n338 + 3 * $n427) * ($n428 - $n422) / $n426 + $n424;
+//           $n440 := 0.25 * sign($n427) * min(abs($n430), abs($n427));
+//           if abs($n424 - $n338) <= 100 * $n1.$n97.$n5 then
+//             $n441 := $n424;
+//             if $n299 > $n423 + $n424 * ($n298 - $n422) then
+//               $n442 := true;
 //             else
 //             end if;
-//           elseif abs(n338 + n424 - 2 * n427) < 100 * n1.n97.n5 then
-//             n441 := (6 * n427 * (n338 + n424 - 3 / 2 * n427) - n338 * n424 - n338 ^ 2 - n424 ^ 2) * (if (n338 + n424 - 2 * n427) >= 0 then 1 else -1) * n1.n97.n7;
+//           elseif abs($n338 + $n424 - 2 * $n427) < 100 * $n1.$n97.$n5 then
+//             $n441 := (6 * $n427 * ($n338 + $n424 - 3 / 2 * $n427) - $n338 * $n424 - $n338 ^ 2 - $n424 ^ 2) * (if ($n338 + $n424 - 2 * $n427) >= 0 then 1 else -1) * $n1.$n97.$n7;
 //           else
-//             n441 := (6 * n427 * (n338 + n424 - 3 / 2 * n427) - n338 * n424 - n338 ^ 2 - n424 ^ 2) / (3 * (n338 + n424 - 2 * n427));
+//             $n441 := (6 * $n427 * ($n338 + $n424 - 3 / 2 * $n427) - $n338 * $n424 - $n338 ^ 2 - $n424 ^ 2) / (3 * ($n338 + $n424 - 2 * $n427));
 //           end if;
-//           if (((n274 > 0) and (n429 < n426) and (n427 * n430 <= 0)) or (abs(n440) < abs(n441) and n441 * n427 >= 0) or (abs(n440) < abs(0.1 * n427))) and not n442 then
-//             n425 := n440;
-//             if abs(n425) < abs(n441) and n441 * n427 >= 0 then
-//               n425 := n441;
+//           if ((($n274 > 0) and ($n429 < $n426) and ($n427 * $n430 <= 0)) or (abs($n440) < abs($n441) and $n441 * $n427 >= 0) or (abs($n440) < abs(0.1 * $n427))) and not $n442 then
+//             $n425 := $n440;
+//             if abs($n425) < abs($n441) and $n441 * $n427 >= 0 then
+//               $n425 := $n441;
 //             else
 //             end if;
-//             if abs(n425) < abs(0.1 * n427) then
-//               n425 := 0.1 * n427;
+//             if abs($n425) < abs(0.1 * $n427) then
+//               $n425 := 0.1 * $n427;
 //             else
 //             end if;
-//             n431 := (n424 * n274 + n338 * n429) / n426;
-//             if abs(n431 - n425) < 1e-6 then
-//               n425 := (1 - 1e-6) * n431;
+//             $n431 := ($n424 * $n274 + $n338 * $n429) / $n426;
+//             if abs($n431 - $n425) < 1e-6 then
+//               $n425 := (1 - 1e-6) * $n431;
 //             else
 //             end if;
-//             n273 := 3 * (n427 - n425) / (n431 - n425);
-//             n432 := n273 * n274;
-//             n433 := n273 * n429;
-//             n434 := n422 + n432;
-//             n435 := n298 - n433;
-//             n436 := (n424 - n425) / max(n432 ^ 2, 100 * n1.n97.n5);
-//             n437 := (n338 - n425) / max(n433 ^ 2, 100 * n1.n97.n5);
-//             n438 := n423 - n436 / 3 * (n422 - n434) ^ 3 - n425 * n422;
-//             n439 := n299 - n437 / 3 * (n298 - n435) ^ 3 - n425 * n298;
-//             if (n340 < n434) then
-//               n18 := n436 / 3 * (n340 - n434) ^ 3 + n425 * n340 + n438;
-//             elseif (n340 < n435) then
-//               n18 := n425 * n340 + n438;
+//             $n273 := 3 * ($n427 - $n425) / ($n431 - $n425);
+//             $n432 := $n273 * $n274;
+//             $n433 := $n273 * $n429;
+//             $n434 := $n422 + $n432;
+//             $n435 := $n298 - $n433;
+//             $n436 := ($n424 - $n425) / max($n432 ^ 2, 100 * $n1.$n97.$n5);
+//             $n437 := ($n338 - $n425) / max($n433 ^ 2, 100 * $n1.$n97.$n5);
+//             $n438 := $n423 - $n436 / 3 * ($n422 - $n434) ^ 3 - $n425 * $n422;
+//             $n439 := $n299 - $n437 / 3 * ($n298 - $n435) ^ 3 - $n425 * $n298;
+//             if ($n340 < $n434) then
+//               $n18 := $n436 / 3 * ($n340 - $n434) ^ 3 + $n425 * $n340 + $n438;
+//             elseif ($n340 < $n435) then
+//               $n18 := $n425 * $n340 + $n438;
 //             else
-//               n18 := n437 / 3 * (n340 - n435) ^ 3 + n425 * n340 + n439;
+//               $n18 := $n437 / 3 * ($n340 - $n435) ^ 3 + $n425 * $n340 + $n439;
 //             end if;
 //           else
-//             n18 := n423 + (n340 - n422) * (n424 + (n340 - n422) / n426 * ((-2 * n424 - n338 + 3 * n427) + (n340 - n422) * (n424 + n338 - 2 * n427) / n426));
-//             n440 := (n422 + n298) / 2;
-//             n425 := 3 * (n424 + n338 - 2 * n427) * (n440 - n422) ^ 2 / n426 ^ 2 + 2 * (-2 * n424 - n338 + 3 * n427) * (n440 - n422) / n426 + n424;
+//             $n18 := $n423 + ($n340 - $n422) * ($n424 + ($n340 - $n422) / $n426 * ((-2 * $n424 - $n338 + 3 * $n427) + ($n340 - $n422) * ($n424 + $n338 - 2 * $n427) / $n426));
+//             $n440 := ($n422 + $n298) / 2;
+//             $n425 := 3 * ($n424 + $n338 - 2 * $n427) * ($n440 - $n422) ^ 2 / $n426 ^ 2 + 2 * (-2 * $n424 - $n338 + 3 * $n427) * ($n440 - $n422) / $n426 + $n424;
 //           end if;
 //         end if;
 //         annotation(smoothOrder = 1);
-//       end n328;
+//       end $n328;
 //
-//       function n342
-//         extends n1.n2.n271;
-//         input Real n340;
-//         input Real n298;
-//         input Real n307;
-//         input Real n299;
-//         input Real n308;
-//         input Real n338;
-//         input Real n339;
-//         output Real n18;
-//         output Real n341;
+//       function $n342
+//         extends $n1.$n2.$n271;
+//         input Real $n340;
+//         input Real $n298;
+//         input Real $n307;
+//         input Real $n299;
+//         input Real $n308;
+//         input Real $n338;
+//         input Real $n339;
+//         output Real $n18;
+//         output Real $n341;
 //       protected
-//         Real n190;
-//         Real n443;
-//         Real n444;
-//         Real n445;
-//         Real n446;
-//         Real n447;
-//         Real n448;
-//         Real n449;
-//         Real n450;
-//         Real n451;
-//         Real n303;
-//         Real n302;
+//         Real $n190;
+//         Real $n443;
+//         Real $n444;
+//         Real $n445;
+//         Real $n446;
+//         Real $n447;
+//         Real $n448;
+//         Real $n449;
+//         Real $n450;
+//         Real $n451;
+//         Real $n303;
+//         Real $n302;
 //       algorithm
-//         n190 := n307 - n298;
-//         if abs(n190) > 0 then
-//           n443 := (n340 - n298) / n190;
-//           n303 := n443 ^ 3;
-//           n302 := n443 ^ 2;
-//           n444 := 2 * n303 - 3 * n302 + 1;
-//           n445 := n303 - 2 * n302 + n443;
-//           n446 := -2 * n303 + 3 * n302;
-//           n447 := n303 - n302;
-//           n448 := 6 * (n302 - n443);
-//           n449 := 3 * n302 - 4 * n443 + 1;
-//           n450 := 6 * (n443 - n302);
-//           n451 := 3 * n302 - 2 * n443;
-//           n18 := n299 * n444 + n190 * n338 * n445 + n308 * n446 + n190 * n339 * n447;
-//           n341 := n299 * n448 / n190 + n338 * n449 + n308 * n450 / n190 + n339 * n451;
+//         $n190 := $n307 - $n298;
+//         if abs($n190) > 0 then
+//           $n443 := ($n340 - $n298) / $n190;
+//           $n303 := $n443 ^ 3;
+//           $n302 := $n443 ^ 2;
+//           $n444 := 2 * $n303 - 3 * $n302 + 1;
+//           $n445 := $n303 - 2 * $n302 + $n443;
+//           $n446 := -2 * $n303 + 3 * $n302;
+//           $n447 := $n303 - $n302;
+//           $n448 := 6 * ($n302 - $n443);
+//           $n449 := 3 * $n302 - 4 * $n443 + 1;
+//           $n450 := 6 * ($n443 - $n302);
+//           $n451 := 3 * $n302 - 2 * $n443;
+//           $n18 := $n299 * $n444 + $n190 * $n338 * $n445 + $n308 * $n446 + $n190 * $n339 * $n447;
+//           $n341 := $n299 * $n448 / $n190 + $n338 * $n449 + $n308 * $n450 / $n190 + $n339 * $n451;
 //         else
-//           n18 := (n299 + n308) / 2;
-//           n341 := sign(n308 - n299) * n1.n97.n7;
+//           $n18 := ($n299 + $n308) / 2;
+//           $n341 := sign($n308 - $n299) * $n1.$n97.$n7;
 //         end if;
 //         annotation(smoothOrder = 3);
-//       end n342;
-//     end n269;
-//   end n29;
+//       end $n342;
+//     end $n269;
+//   end $n29;
 //
-//   package n37
-//     extends n1.n2.n3;
-//     import n10 = n1.n11;
-//     import n30 = n1.n11.n31;
+//   package $n37
+//     extends $n1.$n2.$n3;
+//     import $n10 = $n1.$n11;
+//     import $n30 = $n1.$n11.$n31;
 //
-//     package n12
-//       extends n1.n2.n13;
+//     package $n12
+//       extends $n1.$n2.$n13;
 //
-//       partial package n38
-//         extends n1.n37.n12.n44;
-//         extends n1.n2.n452;
-//         constant n1.n37.n12.n345.n346 n369;
-//         constant String n364 = \"unusablePartialMedium\";
-//         constant String[:] n365 = {n364};
-//         constant String[:] n355 = fill(\"\", 0);
-//         constant Boolean n366;
-//         constant Boolean n453 = true;
-//         constant Boolean n454 = false;
-//         constant n92 n455 = 101325;
-//         constant n352[n351] n456 = fill(1 / n351, n351);
-//         constant n92 n221 = 101325;
-//         constant n94 n222 = n1.n11.n31.n457(20);
-//         constant n381 n394 = n393(n221, n222, n223);
-//         constant n352[n351] n223 = n456;
-//         constant n354[n182] n356 = fill(0, n182);
-//         final constant Integer n458 = size(n365, 1);
-//         constant Integer n351 = n458;
-//         constant Integer n180 = if n454 then 0 else if n453 then n458 - 1 else n458;
-//         final constant Integer n182 = size(n355, 1);
-//         constant Real[n182] n408(min = fill(n1.n97.n5, n182)) = 1.0e-6 * ones(n182);
-//         replaceable record n459 = n1.n37.n12.n44.n460.n459;
+//       partial package $n38
+//         extends $n1.$n37.$n12.$n44;
+//         extends $n1.$n2.$n452;
+//         constant $n1.$n37.$n12.$n345.$n346 $n369;
+//         constant String $n364 = \"unusablePartialMedium\";
+//         constant String[:] $n365 = {$n364};
+//         constant String[:] $n355 = fill(\"\", 0);
+//         constant Boolean $n366;
+//         constant Boolean $n453 = true;
+//         constant Boolean $n454 = false;
+//         constant $n92 $n455 = 101325;
+//         constant $n352[$n351] $n456 = fill(1 / $n351, $n351);
+//         constant $n92 $n221 = 101325;
+//         constant $n94 $n222 = $n1.$n11.$n31.$n457(20);
+//         constant $n381 $n394 = $n393($n221, $n222, $n223);
+//         constant $n352[$n351] $n223 = $n456;
+//         constant $n354[$n182] $n356 = fill(0, $n182);
+//         final constant Integer $n458 = size($n365, 1);
+//         constant Integer $n351 = $n458;
+//         constant Integer $n180 = if $n454 then 0 else if $n453 then $n458 - 1 else $n458;
+//         final constant Integer $n182 = size($n355, 1);
+//         constant Real[$n182] $n408(min = fill($n1.$n97.$n5, $n182)) = 1.0e-6 * ones($n182);
+//         replaceable record $n459 = $n1.$n37.$n12.$n44.$n460.$n459;
 //
-//         replaceable record n165
-//           extends n1.n2.n461;
-//         end n165;
+//         replaceable record $n165
+//           extends $n1.$n2.$n461;
+//         end $n165;
 //
-//         replaceable partial model n373
-//           n462 n51;
-//           n463[n180] n191(start = n456[1:n180]);
-//           n464 n190;
-//           n204 n145;
-//           n94 n250;
-//           n352[n351] n350(start = n456);
-//           n465 n407;
-//           n467 n466;
-//           n469 n468;
-//           n165 n136;
-//           parameter Boolean n403 = false annotation(Evaluate = true);
-//           parameter Boolean n470 = true;
-//           n10.n31.n472.n473 n471 = n1.n11.n31.n474(n250);
-//           n10.n31.n472.n476 n475 = n1.n11.n31.n477(n51);
-//           connector n462 = input n10.n92;
-//           connector n464 = input n10.n381;
-//           connector n463 = input n10.n352;
+//         replaceable partial model $n373
+//           $n462 $n51;
+//           $n463[$n180] $n191(start = $n456[1:$n180]);
+//           $n464 $n190;
+//           $n204 $n145;
+//           $n94 $n250;
+//           $n352[$n351] $n350(start = $n456);
+//           $n465 $n407;
+//           $n467 $n466;
+//           $n469 $n468;
+//           $n165 $n136;
+//           parameter Boolean $n403 = false annotation(Evaluate = true);
+//           parameter Boolean $n470 = true;
+//           $n10.$n31.$n472.$n473 $n471 = $n1.$n11.$n31.$n474($n250);
+//           $n10.$n31.$n472.$n476 $n475 = $n1.$n11.$n31.$n477($n51);
+//           connector $n462 = input $n10.$n92;
+//           connector $n464 = input $n10.$n381;
+//           connector $n463 = input $n10.$n352;
 //         equation
-//           if n470 then
-//             n191 = n350[1:n180];
-//             if n454 then
-//               n350 = n456;
+//           if $n470 then
+//             $n191 = $n350[1:$n180];
+//             if $n454 then
+//               $n350 = $n456;
 //             end if;
-//             if n453 and not n454 then
-//               n350[n351] = 1 - sum(n191);
+//             if $n453 and not $n454 then
+//               $n350[$n351] = 1 - sum($n191);
 //             end if;
-//             for n146 in 1:n351 loop
-//               assert(n350[n146] >= -1.e-5 and n350[n146] <= 1 + 1.e-5, \"assert message 1370699107527140891\");
+//             for $n146 in 1:$n351 loop
+//               assert($n350[$n146] >= -1.e-5 and $n350[$n146] <= 1 + 1.e-5, \"assert message 1370699107527140891\");
 //             end for;
 //           end if;
-//           assert(n51 >= 0.0, \"assert message 2590312994638120201\");
-//         end n373;
+//           assert($n51 >= 0.0, \"assert message 2590312994638120201\");
+//         end $n373;
 //
-//         replaceable partial function n225
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n94 n250;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
-//         end n225;
+//         replaceable partial function $n225
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n94 $n250;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
+//         end $n225;
 //
-//         replaceable partial function n197
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n381 n190;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
-//         end n197;
+//         replaceable partial function $n197
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n381 $n190;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
+//         end $n197;
 //
-//         replaceable partial function n478
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n480 n479;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
-//         end n478;
+//         replaceable partial function $n478
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n480 $n479;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
+//         end $n478;
 //
-//         replaceable partial function n481
-//           extends n1.n2.n271;
-//           input n204 n145;
-//           input n94 n250;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
-//         end n481;
+//         replaceable partial function $n481
+//           extends $n1.$n2.$n271;
+//           input $n204 $n145;
+//           input $n94 $n250;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
+//         end $n481;
 //
-//         replaceable partial function n482
-//           extends n1.n2.n271;
-//           input Real n340;
-//           input n165 n164;
-//           input n165 n166;
-//           input Real n483(min = 0);
-//           output n165 n136;
-//         end n482;
+//         replaceable partial function $n482
+//           extends $n1.$n2.$n271;
+//           input Real $n340;
+//           input $n165 $n164;
+//           input $n165 $n166;
+//           input Real $n483(min = 0);
+//           output $n165 $n136;
+//         end $n482;
 //
-//         replaceable partial function n212
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n209 n429;
-//         end n212;
+//         replaceable partial function $n212
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n209 $n429;
+//         end $n212;
 //
-//         replaceable partial function n260
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n259 n277;
-//         end n260;
+//         replaceable partial function $n260
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n259 $n277;
+//         end $n260;
 //
-//         replaceable function n261
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n485 n484;
+//         replaceable function $n261
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n485 $n484;
 //         algorithm
-//           n484 := n212(n136) * n486(n136) / n260(n136);
-//         end n261;
+//           $n484 := $n212($n136) * $n486($n136) / $n260($n136);
+//         end $n261;
 //
-//         replaceable partial function n228
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n92 n51;
-//         end n228;
+//         replaceable partial function $n228
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n92 $n51;
+//         end $n228;
 //
-//         replaceable partial function n388
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n94 n250;
-//         end n388;
+//         replaceable partial function $n388
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n94 $n250;
+//         end $n388;
 //
-//         replaceable partial function n198
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n204 n145;
-//         end n198;
+//         replaceable partial function $n198
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n204 $n145;
+//         end $n198;
 //
-//         replaceable partial function n372
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n381 n190;
-//         end n372;
+//         replaceable partial function $n372
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n381 $n190;
+//         end $n372;
 //
-//         replaceable partial function n487
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n488 n407;
-//         end n487;
+//         replaceable partial function $n487
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n488 $n407;
+//         end $n487;
 //
-//         replaceable partial function n489
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n480 n479;
-//         end n489;
+//         replaceable partial function $n489
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n480 $n479;
+//         end $n489;
 //
-//         replaceable partial function n490
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n488 n95;
-//         end n490;
+//         replaceable partial function $n490
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n488 $n95;
+//         end $n490;
 //
-//         replaceable partial function n491
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n488 n492;
-//         end n491;
+//         replaceable partial function $n491
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n488 $n492;
+//         end $n491;
 //
-//         replaceable partial function n486
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n467 n493;
-//         end n486;
+//         replaceable partial function $n486
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n467 $n493;
+//         end $n486;
 //
-//         replaceable partial function n494
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n467 n495;
-//         end n494;
+//         replaceable partial function $n494
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n467 $n495;
+//         end $n494;
 //
-//         replaceable partial function n496
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n498 n497;
-//         end n496;
+//         replaceable partial function $n496
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n498 $n497;
+//         end $n496;
 //
-//         replaceable partial function n499
-//           extends n1.n2.n271;
-//           input n92 n500;
-//           input n165 n501;
-//           output n381 n502;
-//         end n499;
+//         replaceable partial function $n499
+//           extends $n1.$n2.$n271;
+//           input $n92 $n500;
+//           input $n165 $n501;
+//           output $n381 $n502;
+//         end $n499;
 //
-//         replaceable partial function n503
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n505 n504;
-//         end n503;
+//         replaceable partial function $n503
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n505 $n504;
+//         end $n503;
 //
-//         replaceable partial function n506
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n508 n507;
-//         end n506;
+//         replaceable partial function $n506
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n508 $n507;
+//         end $n506;
 //
-//         replaceable partial function n509
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n10.n511 n510;
-//         end n509;
+//         replaceable partial function $n509
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n10.$n511 $n510;
+//         end $n509;
 //
-//         replaceable partial function n512
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n514 n513;
-//         end n512;
+//         replaceable partial function $n512
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n514 $n513;
+//         end $n512;
 //
-//         replaceable partial function n515
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n517 n516;
-//         end n515;
+//         replaceable partial function $n515
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n517 $n516;
+//         end $n515;
 //
-//         replaceable partial function n518
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n514 n519;
-//         end n518;
+//         replaceable partial function $n518
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n514 $n519;
+//         end $n518;
 //
-//         replaceable partial function n520
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n522 n521;
-//         end n520;
+//         replaceable partial function $n520
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n522 $n521;
+//         end $n520;
 //
-//         replaceable partial function n523
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n204[n351] n524;
-//         end n523;
+//         replaceable partial function $n523
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n204[$n351] $n524;
+//         end $n523;
 //
-//         replaceable partial function n525
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n469 n468;
-//         end n525;
+//         replaceable partial function $n525
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n469 $n468;
+//         end $n525;
 //
-//         replaceable function n393
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n94 n250;
-//           input n352[:] n350 = n456;
-//           output n381 n190;
+//         replaceable function $n393
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n94 $n250;
+//           input $n352[:] $n350 = $n456;
+//           output $n381 $n190;
 //         algorithm
-//           n190 := n372(n225(n51, n250, n350));
-//           annotation(inverse(n250 = n392(n51, n190, n350)));
-//         end n393;
+//           $n190 := $n372($n225($n51, $n250, $n350));
+//           annotation(inverse($n250 = $n392($n51, $n190, $n350)));
+//         end $n393;
 //
-//         replaceable function n224
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n94 n250;
-//           input n352[:] n350;
-//           output n204 n145;
+//         replaceable function $n224
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n94 $n250;
+//           input $n352[:] $n350;
+//           output $n204 $n145;
 //         algorithm
-//           n145 := n198(n225(n51, n250, n350));
-//         end n224;
+//           $n145 := $n198($n225($n51, $n250, $n350));
+//         end $n224;
 //
-//         replaceable function n392
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n381 n190;
-//           input n352[:] n350 = n456;
-//           output n94 n250;
+//         replaceable function $n392
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n381 $n190;
+//           input $n352[:] $n350 = $n456;
+//           output $n94 $n250;
 //         algorithm
-//           n250 := n388(n197(n51, n190, n350));
-//         end n392;
+//           $n250 := $n388($n197($n51, $n190, $n350));
+//         end $n392;
 //
-//         type n105 = n10.n105(quantity = \"MassFlowRate.\" + n364, min = -1.0e5, max = 1.e5);
-//       end n38;
+//         type $n105 = $n10.$n105(quantity = \"MassFlowRate.\" + $n364, min = -1.0e5, max = 1.e5);
+//       end $n38;
 //
-//       partial package n526
-//         extends n38(redeclare replaceable record n459 = n1.n37.n12.n44.n527.n459);
+//       partial package $n526
+//         extends $n38(redeclare replaceable record $n459 = $n1.$n37.$n12.$n44.$n527.$n459);
 //
-//         redeclare replaceable record extends n165
-//           n92 n51;
-//           n94 n250;
-//           n352[n351] n350(start = n456);
-//         end n165;
+//         redeclare replaceable record extends $n165
+//           $n92 $n51;
+//           $n94 $n250;
+//           $n352[$n351] $n350(start = $n456);
+//         end $n165;
 //
-//         constant n459[n458] n528;
+//         constant $n459[$n458] $n528;
 //
-//         replaceable function n529
-//           extends n1.n2.n271;
-//           input n165 n136;
-//           output n10.n467 n466;
-//         end n529;
+//         replaceable function $n529
+//           extends $n1.$n2.$n271;
+//           input $n165 $n136;
+//           output $n10.$n467 $n466;
+//         end $n529;
 //
-//         function n530
-//           extends n1.n2.n271;
-//           input n10.n352[:] n350;
-//           input n10.n469[:] n531;
-//           output n10.n533[size(n350, 1)] n532;
+//         function $n530
+//           extends $n1.$n2.$n271;
+//           input $n10.$n352[:] $n350;
+//           input $n10.$n469[:] $n531;
+//           output $n10.$n533[size($n350, 1)] $n532;
 //         protected
-//           Real[size(n350, 1)] n534;
-//           n10.n469 n535;
+//           Real[size($n350, 1)] $n534;
+//           $n10.$n469 $n535;
 //         algorithm
-//           for n146 in 1:size(n350, 1) loop
-//             n534[n146] := 1 / n531[n146];
+//           for $n146 in 1:size($n350, 1) loop
+//             $n534[$n146] := 1 / $n531[$n146];
 //           end for;
-//           n535 := 1 / (n350 * n534);
-//           for n146 in 1:size(n350, 1) loop
-//             n532[n146] := n535 * n350[n146] / n531[n146];
+//           $n535 := 1 / ($n350 * $n534);
+//           for $n146 in 1:size($n350, 1) loop
+//             $n532[$n146] := $n535 * $n350[$n146] / $n531[$n146];
 //           end for;
 //           annotation(smoothOrder = 5);
-//         end n530;
-//       end n526;
+//         end $n530;
+//       end $n526;
 //
-//       partial package n536
-//         extends n526(n369 = n1.n37.n12.n345.n346.n537);
+//       partial package $n536
+//         extends $n526($n369 = $n1.$n37.$n12.$n345.$n346.$n537);
 //
-//         replaceable partial function n538
-//           extends n1.n2.n271;
-//           input n94 n539;
-//           output n92 n540;
-//         end n538;
+//         replaceable partial function $n538
+//           extends $n1.$n2.$n271;
+//           input $n94 $n539;
+//           output $n92 $n540;
+//         end $n538;
 //
-//         replaceable partial function n541
-//           extends n1.n2.n271;
-//           input n94 n250;
-//           output n381 n542;
-//         end n541;
+//         replaceable partial function $n541
+//           extends $n1.$n2.$n271;
+//           input $n94 $n250;
+//           output $n381 $n542;
+//         end $n541;
 //
-//         replaceable partial function n543
-//           extends n1.n2.n271;
-//           input n94 n250;
-//           output n381 n190;
-//         end n543;
+//         replaceable partial function $n543
+//           extends $n1.$n2.$n271;
+//           input $n94 $n250;
+//           output $n381 $n190;
+//         end $n543;
 //
-//         replaceable partial function n544
-//           extends n1.n2.n271;
-//           input n94 n250;
-//           input n352[:] n350;
-//           output n381 n190;
-//         end n544;
+//         replaceable partial function $n544
+//           extends $n1.$n2.$n271;
+//           input $n94 $n250;
+//           input $n352[:] $n350;
+//           output $n381 $n190;
+//         end $n544;
 //
-//         replaceable partial function n545
-//           extends n1.n2.n271;
-//           input n94 n250;
-//           output n381 n190;
-//         end n545;
+//         replaceable partial function $n545
+//           extends $n1.$n2.$n271;
+//           input $n94 $n250;
+//           output $n381 $n190;
+//         end $n545;
 //
-//         replaceable partial function n546
-//           extends n1.n2.n271;
-//           input n94 n250;
-//           output n381 n190;
-//         end n546;
-//       end n536;
+//         replaceable partial function $n546
+//           extends $n1.$n2.$n271;
+//           input $n94 $n250;
+//           output $n381 $n190;
+//         end $n546;
+//       end $n536;
 //
-//       package n345
-//         extends n1.n2.n3;
-//         type n346 = enumeration(n250, n547, n370, n371, n537, n548);
-//         type n549 = enumeration(n550, n551, n552) annotation(Evaluate = true);
-//       end n345;
+//       package $n345
+//         extends $n1.$n2.$n3;
+//         type $n346 = enumeration($n250, $n547, $n370, $n371, $n537, $n548);
+//         type $n549 = enumeration($n550, $n551, $n552) annotation(Evaluate = true);
+//       end $n345;
 //
-//       package n44
-//         extends n1.n2.n3;
-//         type n92 = n10.n92(min = 0, max = 1.e8, nominal = 1.e5, start = 1.e5);
-//         type n204 = n10.n204(min = 0, max = 1.e5, nominal = 1, start = 1);
-//         type n209 = n10.n209(min = 0, max = 1.e8, nominal = 1.e-3, start = 1.e-3);
-//         type n184 = n10.n184(nominal = 1000.0, min = -1.0e8, max = 1.e8);
-//         type n352 = Real(quantity = \"MassFraction\", final unit = \"kg/kg\", min = 0, max = 1, nominal = 0.1);
-//         type n533 = Real(quantity = \"MoleFraction\", final unit = \"mol/mol\", min = 0, max = 1, nominal = 0.1);
-//         type n469 = n10.n469(min = 0.001, max = 0.25, nominal = 0.032);
-//         type n553 = n10.n553(min = 1e-6, max = 1.0e6, nominal = 1.0);
-//         type n498 = n10.n554(min = 1, max = 500000, nominal = 1.2, start = 1.2);
-//         type n488 = n10.n488(min = -1.0e8, max = 1.e8, nominal = 1.e6);
-//         type n465 = n488;
-//         type n381 = n10.n381(min = -1.0e10, max = 1.e10, nominal = 1.e6);
-//         type n480 = n10.n480(min = -1.e7, max = 1.e7, nominal = 1.e3);
-//         type n467 = n10.n467(min = 0, max = 1.e7, nominal = 1.e3, start = 1.e3);
-//         type n94 = n10.n94(min = 1, max = 1.e4, nominal = 300, start = 288.15);
-//         type n259 = n10.n259(min = 0, max = 500, nominal = 1, start = 1);
-//         type n485 = n10.n485(min = 1e-3, max = 1e5, nominal = 1.0);
-//         type n505 = n10.n185(min = 0, max = 1.e5, nominal = 1000, start = 1000);
-//         type n354 = Real(min = 0.0, start = 1.0);
-//         type n404 = Real(unit = \"kg/s\");
-//         type n508 = Real(min = 0, max = 1.0e8, unit = \"1/K\");
-//         type n555 = Real(min = 0.0, max = 2.0, unit = \"debye\", quantity = \"ElectricDipoleMoment\");
-//         type n514 = n10.n514;
-//         type n517 = n10.n517;
-//         type n522 = n10.n522;
+//       package $n44
+//         extends $n1.$n2.$n3;
+//         type $n92 = $n10.$n92(min = 0, max = 1.e8, nominal = 1.e5, start = 1.e5);
+//         type $n204 = $n10.$n204(min = 0, max = 1.e5, nominal = 1, start = 1);
+//         type $n209 = $n10.$n209(min = 0, max = 1.e8, nominal = 1.e-3, start = 1.e-3);
+//         type $n184 = $n10.$n184(nominal = 1000.0, min = -1.0e8, max = 1.e8);
+//         type $n352 = Real(quantity = \"MassFraction\", final unit = \"kg/kg\", min = 0, max = 1, nominal = 0.1);
+//         type $n533 = Real(quantity = \"MoleFraction\", final unit = \"mol/mol\", min = 0, max = 1, nominal = 0.1);
+//         type $n469 = $n10.$n469(min = 0.001, max = 0.25, nominal = 0.032);
+//         type $n553 = $n10.$n553(min = 1e-6, max = 1.0e6, nominal = 1.0);
+//         type $n498 = $n10.$n554(min = 1, max = 500000, nominal = 1.2, start = 1.2);
+//         type $n488 = $n10.$n488(min = -1.0e8, max = 1.e8, nominal = 1.e6);
+//         type $n465 = $n488;
+//         type $n381 = $n10.$n381(min = -1.0e10, max = 1.e10, nominal = 1.e6);
+//         type $n480 = $n10.$n480(min = -1.e7, max = 1.e7, nominal = 1.e3);
+//         type $n467 = $n10.$n467(min = 0, max = 1.e7, nominal = 1.e3, start = 1.e3);
+//         type $n94 = $n10.$n94(min = 1, max = 1.e4, nominal = 300, start = 288.15);
+//         type $n259 = $n10.$n259(min = 0, max = 500, nominal = 1, start = 1);
+//         type $n485 = $n10.$n485(min = 1e-3, max = 1e5, nominal = 1.0);
+//         type $n505 = $n10.$n185(min = 0, max = 1.e5, nominal = 1000, start = 1000);
+//         type $n354 = Real(min = 0.0, start = 1.0);
+//         type $n404 = Real(unit = \"kg/s\");
+//         type $n508 = Real(min = 0, max = 1.0e8, unit = \"1/K\");
+//         type $n555 = Real(min = 0.0, max = 2.0, unit = \"debye\", quantity = \"ElectricDipoleMoment\");
+//         type $n514 = $n10.$n514;
+//         type $n517 = $n10.$n517;
+//         type $n522 = $n10.$n522;
 //
-//         package n460
-//           extends n2.n3;
+//         package $n460
+//           extends $n2.$n3;
 //
-//           record n459
-//             extends n1.n2.n461;
-//             String n556;
-//             String n557;
-//             String n558;
-//             String n559;
-//             n469 n525;
-//           end n459;
-//         end n460;
+//           record $n459
+//             extends $n1.$n2.$n461;
+//             String $n556;
+//             String $n557;
+//             String $n558;
+//             String $n559;
+//             $n469 $n525;
+//           end $n459;
+//         end $n460;
 //
-//         package n527
-//           extends n2.n3;
+//         package $n527
+//           extends $n2.$n3;
 //
-//           record n459
-//             extends n1.n37.n12.n44.n460.n459;
-//             n94 n560;
-//             n92 n561;
-//             n553 n562;
-//             Real n563;
-//             n94 n564;
-//             n94 n565;
-//             n555 n566;
-//             Boolean n567 = false;
-//             Boolean n568 = false;
-//             Boolean n569 = false;
-//             Boolean n570 = false;
-//             Boolean n571 = false;
-//             Boolean n572 = false;
-//             Boolean n573 = false;
-//             Boolean n574 = false;
-//             Boolean n575 = false;
-//             Boolean n576 = false;
-//             n381 n577 = 0.0;
-//             n480 n578 = 0.0;
-//             n381 n579 = 0.0;
-//             n480 n580 = 0.0;
-//           end n459;
-//         end n527;
-//       end n44;
-//     end n12;
+//           record $n459
+//             extends $n1.$n37.$n12.$n44.$n460.$n459;
+//             $n94 $n560;
+//             $n92 $n561;
+//             $n553 $n562;
+//             Real $n563;
+//             $n94 $n564;
+//             $n94 $n565;
+//             $n555 $n566;
+//             Boolean $n567 = false;
+//             Boolean $n568 = false;
+//             Boolean $n569 = false;
+//             Boolean $n570 = false;
+//             Boolean $n571 = false;
+//             Boolean $n572 = false;
+//             Boolean $n573 = false;
+//             Boolean $n574 = false;
+//             Boolean $n575 = false;
+//             Boolean $n576 = false;
+//             $n381 $n577 = 0.0;
+//             $n480 $n578 = 0.0;
+//             $n381 $n579 = 0.0;
+//             $n480 $n580 = 0.0;
+//           end $n459;
+//         end $n527;
+//       end $n44;
+//     end $n12;
 //
-//     package n581
-//       extends n1.n2.n3;
-//       constant Real n582 = 1.0e-9;
+//     package $n581
+//       extends $n1.$n2.$n3;
+//       constant Real $n582 = 1.0e-9;
 //
-//       function n583
-//         extends n1.n2.n271;
-//         input Real n340;
-//         input Real n299;
-//         input Real n308;
-//         input Real n483(min = 0) = 1e-5;
-//         output Real n18;
+//       function $n583
+//         extends $n1.$n2.$n271;
+//         input Real $n340;
+//         input Real $n299;
+//         input Real $n308;
+//         input Real $n483(min = 0) = 1e-5;
+//         output Real $n18;
 //       algorithm
-//         n18 := smooth(1, if n340 > n483 then n299 else if n340 < -n483 then n308 else if abs(n483) > 0 then (n340 / n483) * ((n340 / n483) ^ 2 - 3) * (n308 - n299) / 4 + (n299 + n308) / 2 else (n299 + n308) / 2);
+//         $n18 := smooth(1, if $n340 > $n483 then $n299 else if $n340 < -$n483 then $n308 else if abs($n483) > 0 then ($n340 / $n483) * (($n340 / $n483) ^ 2 - 3) * ($n308 - $n299) / 4 + ($n299 + $n308) / 2 else ($n299 + $n308) / 2);
 //         annotation(Inline = true, smoothOrder = 1);
-//       end n583;
+//       end $n583;
 //
-//       package n584
-//         extends n1.n2.n3;
+//       package $n584
+//         extends $n1.$n2.$n3;
 //
-//         replaceable record n585
-//           extends n1.n2.n461;
-//         end n585;
+//         replaceable record $n585
+//           extends $n1.$n2.$n461;
+//         end $n585;
 //
-//         replaceable partial function n586
-//           extends n1.n2.n271;
-//           input Real n340;
-//           input Real n51 = 0.0;
-//           input Real[:] n350 = fill(0, 0);
-//           input n585 n587;
-//           output Real n18;
-//         end n586;
+//         replaceable partial function $n586
+//           extends $n1.$n2.$n271;
+//           input Real $n340;
+//           input Real $n51 = 0.0;
+//           input Real[:] $n350 = fill(0, 0);
+//           input $n585 $n587;
+//           output Real $n18;
+//         end $n586;
 //
-//         replaceable function n588
-//           import n1.n269.n420.n421;
-//           extends n1.n2.n271;
-//           input Real n589;
-//           input Real n590;
-//           input Real n591;
-//           input Real n228 = 0.0;
-//           input Real[:] n350 = fill(0, 0);
-//           input n585 n587;
-//           input Real n592 = 100 * n1.n97.n5;
-//           output Real n593;
+//         replaceable function $n588
+//           import $n1.$n269.$n420.$n421;
+//           extends $n1.$n2.$n271;
+//           input Real $n589;
+//           input Real $n590;
+//           input Real $n591;
+//           input Real $n228 = 0.0;
+//           input Real[:] $n350 = fill(0, 0);
+//           input $n585 $n587;
+//           input Real $n592 = 100 * $n1.$n97.$n5;
+//           output Real $n593;
 //         protected
-//           constant Real n5 = n1.n97.n5;
-//           constant Real n594 = 1e-10;
-//           Real n595 = n590 - n594;
-//           Real n596 = n591 + n594;
-//           Real n504 = n595;
-//           Real n597 = n596;
-//           Real n425;
-//           Real n145;
-//           Real n598;
-//           Real n200;
-//           Real n479;
-//           Real n51;
-//           Real n599;
-//           Real n600;
-//           Real n601;
-//           Real n602;
-//           Real n603;
-//           Real n604;
-//           Boolean n605 = false;
+//           constant Real $n5 = $n1.$n97.$n5;
+//           constant Real $n594 = 1e-10;
+//           Real $n595 = $n590 - $n594;
+//           Real $n596 = $n591 + $n594;
+//           Real $n504 = $n595;
+//           Real $n597 = $n596;
+//           Real $n425;
+//           Real $n145;
+//           Real $n598;
+//           Real $n200;
+//           Real $n479;
+//           Real $n51;
+//           Real $n599;
+//           Real $n600;
+//           Real $n601;
+//           Real $n602;
+//           Real $n603;
+//           Real $n604;
+//           Boolean $n605 = false;
 //         algorithm
-//           n602 := n586(n595, n228, n350, n587) - n589;
-//           n603 := n586(n596, n228, n350, n587) - n589;
-//           n604 := n603;
-//           if n602 > 0.0 and n603 > 0.0 or n602 < 0.0 and n603 < 0.0 then
-//             n421(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)\\n\" + \"do not bracket the root of the single non-linear equation:\\n\" + \"  x_min  = \" + String(n595) + \"\\n\" + \"  x_max  = \" + String(n596) + \"\\n\" + \"  y_zero = \" + String(n589) + \"\\n\" + \"  fa = f(x_min) - y_zero = \" + String(n602) + \"\\n\" + \"  fb = f(x_max) - y_zero = \" + String(n603) + \"\\n\" + \"fa and fb must have opposite sign which is not the case\");
+//           $n602 := $n586($n595, $n228, $n350, $n587) - $n589;
+//           $n603 := $n586($n596, $n228, $n350, $n587) - $n589;
+//           $n604 := $n603;
+//           if $n602 > 0.0 and $n603 > 0.0 or $n602 < 0.0 and $n603 < 0.0 then
+//             $n421(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)\\n\" + \"do not bracket the root of the single non-linear equation:\\n\" + \"  x_min  = \" + String($n595) + \"\\n\" + \"  x_max  = \" + String($n596) + \"\\n\" + \"  y_zero = \" + String($n589) + \"\\n\" + \"  fa = f(x_min) - y_zero = \" + String($n602) + \"\\n\" + \"  fb = f(x_max) - y_zero = \" + String($n603) + \"\\n\" + \"fa and fb must have opposite sign which is not the case\");
 //           else
 //           end if;
-//           n425 := n504;
-//           n604 := n602;
-//           n598 := n597 - n504;
-//           n145 := n598;
-//           while not n605 loop
-//             if abs(n604) < abs(n603) then
-//               n504 := n597;
-//               n597 := n425;
-//               n425 := n504;
-//               n602 := n603;
-//               n603 := n604;
-//               n604 := n602;
+//           $n425 := $n504;
+//           $n604 := $n602;
+//           $n598 := $n597 - $n504;
+//           $n145 := $n598;
+//           while not $n605 loop
+//             if abs($n604) < abs($n603) then
+//               $n504 := $n597;
+//               $n597 := $n425;
+//               $n425 := $n504;
+//               $n602 := $n603;
+//               $n603 := $n604;
+//               $n604 := $n602;
 //             else
 //             end if;
-//             n601 := 2 * n5 * abs(n597) + n592;
-//             n200 := (n425 - n597) / 2;
-//             if abs(n200) <= n601 or n603 == 0.0 then
-//               n605 := true;
-//               n593 := n597;
+//             $n601 := 2 * $n5 * abs($n597) + $n592;
+//             $n200 := ($n425 - $n597) / 2;
+//             if abs($n200) <= $n601 or $n603 == 0.0 then
+//               $n605 := true;
+//               $n593 := $n597;
 //             else
-//               if abs(n598) < n601 or abs(n602) <= abs(n603) then
-//                 n598 := n200;
-//                 n145 := n598;
+//               if abs($n598) < $n601 or abs($n602) <= abs($n603) then
+//                 $n598 := $n200;
+//                 $n145 := $n598;
 //               else
-//                 n479 := n603 / n602;
-//                 if n504 == n425 then
-//                   n51 := 2 * n200 * n479;
-//                   n599 := 1 - n479;
+//                 $n479 := $n603 / $n602;
+//                 if $n504 == $n425 then
+//                   $n51 := 2 * $n200 * $n479;
+//                   $n599 := 1 - $n479;
 //                 else
-//                   n599 := n602 / n604;
-//                   n600 := n603 / n604;
-//                   n51 := n479 * (2 * n200 * n599 * (n599 - n600) - (n597 - n504) * (n600 - 1));
-//                   n599 := (n599 - 1) * (n600 - 1) * (n479 - 1);
+//                   $n599 := $n602 / $n604;
+//                   $n600 := $n603 / $n604;
+//                   $n51 := $n479 * (2 * $n200 * $n599 * ($n599 - $n600) - ($n597 - $n504) * ($n600 - 1));
+//                   $n599 := ($n599 - 1) * ($n600 - 1) * ($n479 - 1);
 //                 end if;
-//                 if n51 > 0 then
-//                   n599 := -n599;
+//                 if $n51 > 0 then
+//                   $n599 := -$n599;
 //                 else
-//                   n51 := -n51;
+//                   $n51 := -$n51;
 //                 end if;
-//                 n479 := n598;
-//                 n598 := n145;
-//                 if 2 * n51 < 3 * n200 * n599 - abs(n601 * n599) and n51 < abs(0.5 * n479 * n599) then
-//                   n145 := n51 / n599;
+//                 $n479 := $n598;
+//                 $n598 := $n145;
+//                 if 2 * $n51 < 3 * $n200 * $n599 - abs($n601 * $n599) and $n51 < abs(0.5 * $n479 * $n599) then
+//                   $n145 := $n51 / $n599;
 //                 else
-//                   n598 := n200;
-//                   n145 := n598;
+//                   $n598 := $n200;
+//                   $n145 := $n598;
 //                 end if;
 //               end if;
-//               n504 := n597;
-//               n602 := n603;
-//               n597 := n597 + (if abs(n145) > n601 then n145 else if n200 > 0 then n601 else -n601);
-//               n603 := n586(n597, n228, n350, n587) - n589;
-//               if n603 > 0 and n604 > 0 or n603 < 0 and n604 < 0 then
-//                 n425 := n504;
-//                 n604 := n602;
-//                 n598 := n597 - n504;
-//                 n145 := n598;
+//               $n504 := $n597;
+//               $n602 := $n603;
+//               $n597 := $n597 + (if abs($n145) > $n601 then $n145 else if $n200 > 0 then $n601 else -$n601);
+//               $n603 := $n586($n597, $n228, $n350, $n587) - $n589;
+//               if $n603 > 0 and $n604 > 0 or $n603 < 0 and $n604 < 0 then
+//                 $n425 := $n504;
+//                 $n604 := $n602;
+//                 $n598 := $n597 - $n504;
+//                 $n145 := $n598;
 //               else
 //               end if;
 //             end if;
 //           end while;
-//         end n588;
-//       end n584;
-//     end n581;
+//         end $n588;
+//       end $n584;
+//     end $n581;
 //
-//     package n39
-//       extends n1.n2.n113;
+//     package $n39
+//       extends $n1.$n2.$n113;
 //
-//       package n40
-//         extends n12.n536(n364 = \"Moist air\", n365 = {\"water\", \"air\"}, final n453 = true, final n366 = false, n456 = {0.01, 0.99}, n528 = {n606.n581.n607.n608, n606.n581.n607.n609}, n94(min = 190, max = 647));
-//         import n1.n37.n606.n581.n610;
-//         constant Integer n611 = 1;
-//         constant Integer n39 = 2;
-//         constant Real n612 = n613.n468 / n614.n468;
-//         constant n606.n581.n615 n614 = n606.n581.n616.n39;
-//         constant n606.n581.n615 n613 = n606.n581.n616.n608;
-//         constant n10.n469[2] n531 = {n613.n468, n614.n468};
-//         import n1.n37.n12;
-//         import n1.n268;
-//         import n1.n97;
-//         import n1.n37.n606.n581.n617;
-//         import n1.n37.n12.n345.n549;
+//       package $n40
+//         extends $n12.$n536($n364 = \"Moist air\", $n365 = {\"water\", \"air\"}, final $n453 = true, final $n366 = false, $n456 = {0.01, 0.99}, $n528 = {$n606.$n581.$n607.$n608, $n606.$n581.$n607.$n609}, $n94(min = 190, max = 647));
+//         import $n1.$n37.$n606.$n581.$n610;
+//         constant Integer $n611 = 1;
+//         constant Integer $n39 = 2;
+//         constant Real $n612 = $n613.$n468 / $n614.$n468;
+//         constant $n606.$n581.$n615 $n614 = $n606.$n581.$n616.$n39;
+//         constant $n606.$n581.$n615 $n613 = $n606.$n581.$n616.$n608;
+//         constant $n10.$n469[2] $n531 = {$n613.$n468, $n614.$n468};
+//         import $n1.$n37.$n12;
+//         import $n1.$n268;
+//         import $n1.$n97;
+//         import $n1.$n37.$n606.$n581.$n617;
+//         import $n1.$n37.$n12.$n345.$n549;
 //
-//         redeclare record extends n165 end n165;
+//         redeclare record extends $n165 end $n165;
 //
-//         redeclare replaceable model extends n373(n250(stateSelect = if n403 then StateSelect.prefer else StateSelect.default), n51(stateSelect = if n403 then StateSelect.prefer else StateSelect.default), n191(each stateSelect = if n403 then StateSelect.prefer else StateSelect.default), final n470 = true)
-//           n352 n618;
-//           Real n619;
+//         redeclare replaceable model extends $n373($n250(stateSelect = if $n403 then StateSelect.prefer else StateSelect.default), $n51(stateSelect = if $n403 then StateSelect.prefer else StateSelect.default), $n191(each stateSelect = if $n403 then StateSelect.prefer else StateSelect.default), final $n470 = true)
+//           $n352 $n618;
+//           Real $n619;
 //         protected
-//           n352 n620;
-//           n352 n621;
-//           n352 n622;
-//           n352 n623;
-//           n352 n624;
-//           n92 n625;
+//           $n352 $n620;
+//           $n352 $n621;
+//           $n352 $n622;
+//           $n352 $n623;
+//           $n352 $n624;
+//           $n92 $n625;
 //         equation
-//           assert(n250 >= 190 and n250 <= 647, \"assert message 315810245365667762\");
-//           n468 = 1 / (n191[n611] / n531[n611] + (1.0 - n191[n611]) / n531[n39]);
-//           n625 = min(n538(n250), 0.999 * n51);
-//           n623 = min(n625 * n612 / max(100 * n97.n5, n51 - n625) * (1 - n191[n611]), 1.0);
-//           n620 = max(n191[n611] - n623, 0.0);
-//           n621 = n191[n611] - n620;
-//           n622 = 1 - n191[n611];
-//           n190 = n393(n51, n250, n191);
-//           n466 = n614.n466 * (n622 / (1 - n620)) + n613.n466 * n621 / (1 - n620);
-//           n407 = n190 - n466 * n250;
-//           n145 = n51 / (n466 * n250);
-//           n136.n51 = n51;
-//           n136.n250 = n250;
-//           n136.n350 = n350;
-//           n624 = n612 * n625 / max(100 * n97.n5, n51 - n625);
-//           n618 = n191[n611] / max(n622, 100 * n97.n5);
-//           n619 = n51 / n625 * n191[n611] / (n191[n611] + n612 * n622);
-//         end n373;
+//           assert($n250 >= 190 and $n250 <= 647, \"assert message 315810245365667762\");
+//           $n468 = 1 / ($n191[$n611] / $n531[$n611] + (1.0 - $n191[$n611]) / $n531[$n39]);
+//           $n625 = min($n538($n250), 0.999 * $n51);
+//           $n623 = min($n625 * $n612 / max(100 * $n97.$n5, $n51 - $n625) * (1 - $n191[$n611]), 1.0);
+//           $n620 = max($n191[$n611] - $n623, 0.0);
+//           $n621 = $n191[$n611] - $n620;
+//           $n622 = 1 - $n191[$n611];
+//           $n190 = $n393($n51, $n250, $n191);
+//           $n466 = $n614.$n466 * ($n622 / (1 - $n620)) + $n613.$n466 * $n621 / (1 - $n620);
+//           $n407 = $n190 - $n466 * $n250;
+//           $n145 = $n51 / ($n466 * $n250);
+//           $n136.$n51 = $n51;
+//           $n136.$n250 = $n250;
+//           $n136.$n350 = $n350;
+//           $n624 = $n612 * $n625 / max(100 * $n97.$n5, $n51 - $n625);
+//           $n618 = $n191[$n611] / max($n622, 100 * $n97.$n5);
+//           $n619 = $n51 / $n625 * $n191[$n611] / ($n191[$n611] + $n612 * $n622);
+//         end $n373;
 //
-//         redeclare function n225
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n94 n250;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
+//         redeclare function $n225
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n94 $n250;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
 //         algorithm
-//           n136 := if size(n350, 1) == n351 then n165(n51 = n51, n250 = n250, n350 = n350) else n165(n51 = n51, n250 = n250, n350 = cat(1, n350, {1 - sum(n350)}));
+//           $n136 := if size($n350, 1) == $n351 then $n165($n51 = $n51, $n250 = $n250, $n350 = $n350) else $n165($n51 = $n51, $n250 = $n250, $n350 = cat(1, $n350, {1 - sum($n350)}));
 //           annotation(smoothOrder = 2);
-//         end n225;
+//         end $n225;
 //
-//         redeclare function n197
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n381 n190;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
+//         redeclare function $n197
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n381 $n190;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
 //         algorithm
-//           n136 := if size(n350, 1) == n351 then n165(n51 = n51, n250 = n626(n51, n190, n350), n350 = n350) else n165(n51 = n51, n250 = n626(n51, n190, n350), n350 = cat(1, n350, {1 - sum(n350)}));
+//           $n136 := if size($n350, 1) == $n351 then $n165($n51 = $n51, $n250 = $n626($n51, $n190, $n350), $n350 = $n350) else $n165($n51 = $n51, $n250 = $n626($n51, $n190, $n350), $n350 = cat(1, $n350, {1 - sum($n350)}));
 //           annotation(smoothOrder = 2);
-//         end n197;
+//         end $n197;
 //
-//         redeclare function n481
-//           extends n1.n2.n271;
-//           input n204 n145;
-//           input n94 n250;
-//           input n352[:] n350 = n456;
-//           output n165 n136;
+//         redeclare function $n481
+//           extends $n1.$n2.$n271;
+//           input $n204 $n145;
+//           input $n94 $n250;
+//           input $n352[:] $n350 = $n456;
+//           output $n165 $n136;
 //         algorithm
-//           n136 := if size(n350, 1) == n351 then n165(n51 = n145 * ({n613.n466, n614.n466} * n350) * n250, n250 = n250, n350 = n350) else n165(n51 = n145 * ({n613.n466, n614.n466} * cat(1, n350, {1 - sum(n350)})) * n250, n250 = n250, n350 = cat(1, n350, {1 - sum(n350)}));
+//           $n136 := if size($n350, 1) == $n351 then $n165($n51 = $n145 * ({$n613.$n466, $n614.$n466} * $n350) * $n250, $n250 = $n250, $n350 = $n350) else $n165($n51 = $n145 * ({$n613.$n466, $n614.$n466} * cat(1, $n350, {1 - sum($n350)})) * $n250, $n250 = $n250, $n350 = cat(1, $n350, {1 - sum($n350)}));
 //           annotation(smoothOrder = 2);
-//         end n481;
+//         end $n481;
 //
-//         redeclare function extends n482
+//         redeclare function extends $n482
 //         algorithm
-//           n136 := n165(n51 = n37.n581.n583(n340, n164.n51, n166.n51, n483), n250 = n37.n581.n583(n340, n164.n250, n166.n250, n483), n350 = n37.n581.n583(n340, n164.n350, n166.n350, n483));
-//         end n482;
+//           $n136 := $n165($n51 = $n37.$n581.$n583($n340, $n164.$n51, $n166.$n51, $n483), $n250 = $n37.$n581.$n583($n340, $n164.$n250, $n166.$n250, $n483), $n350 = $n37.$n581.$n583($n340, $n164.$n350, $n166.$n350, $n483));
+//         end $n482;
 //
-//         redeclare function extends n529
+//         redeclare function extends $n529
 //         algorithm
-//           n466 := n614.n466 * (1 - n136.n350[n611]) + n613.n466 * n136.n350[n611];
+//           $n466 := $n614.$n466 * (1 - $n136.$n350[$n611]) + $n613.$n466 * $n136.$n350[$n611];
 //           annotation(smoothOrder = 2);
-//         end n529;
+//         end $n529;
 //
-//         function n627
-//           extends n1.n2.n271;
-//           input n10.n94 n539;
-//           output n10.n92 n540;
+//         function $n627
+//           extends $n1.$n2.$n271;
+//           input $n10.$n94 $n539;
+//           output $n10.$n92 $n540;
 //         protected
-//           n10.n94 n628 = 647.096;
-//           n10.n92 n629 = 22.064e6;
-//           Real n630 = (1 - n539 / n628);
-//           Real[:] n504 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//           Real[:] n84 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
+//           $n10.$n94 $n628 = 647.096;
+//           $n10.$n92 $n629 = 22.064e6;
+//           Real $n630 = (1 - $n539 / $n628);
+//           Real[:] $n504 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
+//           Real[:] $n84 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
 //         algorithm
-//           n540 := exp(((n504[1] * n630 ^ n84[1] + n504[2] * n630 ^ n84[2] + n504[3] * n630 ^ n84[3] + n504[4] * n630 ^ n84[4] + n504[5] * n630 ^ n84[5] + n504[6] * n630 ^ n84[6]) * n628) / n539) * n629;
-//           annotation(derivative = n631, Inline = false, smoothOrder = 5);
-//         end n627;
+//           $n540 := exp((($n504[1] * $n630 ^ $n84[1] + $n504[2] * $n630 ^ $n84[2] + $n504[3] * $n630 ^ $n84[3] + $n504[4] * $n630 ^ $n84[4] + $n504[5] * $n630 ^ $n84[5] + $n504[6] * $n630 ^ $n84[6]) * $n628) / $n539) * $n629;
+//           annotation(derivative = $n631, Inline = false, smoothOrder = 5);
+//         end $n627;
 //
-//         function n631
-//           extends n1.n2.n271;
-//           input n10.n94 n539;
-//           input Real n632(unit = \"K/s\");
-//           output Real n633(unit = \"Pa/s\");
+//         function $n631
+//           extends $n1.$n2.$n271;
+//           input $n10.$n94 $n539;
+//           input Real $n632(unit = \"K/s\");
+//           output Real $n633(unit = \"Pa/s\");
 //         protected
-//           n10.n94 n628 = 647.096;
-//           n10.n92 n629 = 22.064e6;
-//           Real n630 = (1 - n539 / n628);
-//           Real n634 = -1 / n628 * n632;
-//           Real[:] n504 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//           Real[:] n84 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//           Real n635 = (n504[1] * n630 ^ n84[1] + n504[2] * n630 ^ n84[2] + n504[3] * n630 ^ n84[3] + n504[4] * n630 ^ n84[4] + n504[5] * n630 ^ n84[5] + n504[6] * n630 ^ n84[6]);
+//           $n10.$n94 $n628 = 647.096;
+//           $n10.$n92 $n629 = 22.064e6;
+//           Real $n630 = (1 - $n539 / $n628);
+//           Real $n634 = -1 / $n628 * $n632;
+//           Real[:] $n504 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
+//           Real[:] $n84 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
+//           Real $n635 = ($n504[1] * $n630 ^ $n84[1] + $n504[2] * $n630 ^ $n84[2] + $n504[3] * $n630 ^ $n84[3] + $n504[4] * $n630 ^ $n84[4] + $n504[5] * $n630 ^ $n84[5] + $n504[6] * $n630 ^ $n84[6]);
 //         algorithm
-//           n633 := exp((n635 * n628) / n539) * n629 * ((n504[1] * (n630 ^ (n84[1] - 1) * n84[1] * n634) + n504[2] * (n630 ^ (n84[2] - 1) * n84[2] * n634) + n504[3] * (n630 ^ (n84[3] - 1) * n84[3] * n634) + n504[4] * (n630 ^ (n84[4] - 1) * n84[4] * n634) + n504[5] * (n630 ^ (n84[5] - 1) * n84[5] * n634) + n504[6] * (n630 ^ (n84[6] - 1) * n84[6] * n634)) * n628 / n539 - n635 * n628 * n632 / n539 ^ 2);
+//           $n633 := exp(($n635 * $n628) / $n539) * $n629 * (($n504[1] * ($n630 ^ ($n84[1] - 1) * $n84[1] * $n634) + $n504[2] * ($n630 ^ ($n84[2] - 1) * $n84[2] * $n634) + $n504[3] * ($n630 ^ ($n84[3] - 1) * $n84[3] * $n634) + $n504[4] * ($n630 ^ ($n84[4] - 1) * $n84[4] * $n634) + $n504[5] * ($n630 ^ ($n84[5] - 1) * $n84[5] * $n634) + $n504[6] * ($n630 ^ ($n84[6] - 1) * $n84[6] * $n634)) * $n628 / $n539 - $n635 * $n628 * $n632 / $n539 ^ 2);
 //           annotation(Inline = false, smoothOrder = 5);
-//         end n631;
+//         end $n631;
 //
-//         function n636
-//           extends n1.n2.n271;
-//           input n10.n94 n539;
-//           output n10.n92 n540;
+//         function $n636
+//           extends $n1.$n2.$n271;
+//           input $n10.$n94 $n539;
+//           output $n10.$n92 $n540;
 //         protected
-//           n10.n94 n637 = 273.16;
-//           n10.n92 n638 = 611.657;
-//           Real n630 = n539 / n637;
-//           Real[:] n504 = {-13.9281690, 34.7078238};
-//           Real[:] n84 = {-1.5, -1.25};
+//           $n10.$n94 $n637 = 273.16;
+//           $n10.$n92 $n638 = 611.657;
+//           Real $n630 = $n539 / $n637;
+//           Real[:] $n504 = {-13.9281690, 34.7078238};
+//           Real[:] $n84 = {-1.5, -1.25};
 //         algorithm
-//           n540 := exp(n504[1] - n504[1] * n630 ^ n84[1] + n504[2] - n504[2] * n630 ^ n84[2]) * n638;
-//           annotation(Inline = false, smoothOrder = 5, derivative = n639);
-//         end n636;
+//           $n540 := exp($n504[1] - $n504[1] * $n630 ^ $n84[1] + $n504[2] - $n504[2] * $n630 ^ $n84[2]) * $n638;
+//           annotation(Inline = false, smoothOrder = 5, derivative = $n639);
+//         end $n636;
 //
-//         function n639
-//           extends n1.n2.n271;
-//           input n10.n94 n539;
-//           input Real n632(unit = \"K/s\");
-//           output Real n633(unit = \"Pa/s\");
+//         function $n639
+//           extends $n1.$n2.$n271;
+//           input $n10.$n94 $n539;
+//           input Real $n632(unit = \"K/s\");
+//           output Real $n633(unit = \"Pa/s\");
 //         protected
-//           n10.n94 n637 = 273.16;
-//           n10.n92 n638 = 611.657;
-//           Real n630 = n539 / n637;
-//           Real n634 = n632 / n637;
-//           Real[:] n504 = {-13.9281690, 34.7078238};
-//           Real[:] n84 = {-1.5, -1.25};
+//           $n10.$n94 $n637 = 273.16;
+//           $n10.$n92 $n638 = 611.657;
+//           Real $n630 = $n539 / $n637;
+//           Real $n634 = $n632 / $n637;
+//           Real[:] $n504 = {-13.9281690, 34.7078238};
+//           Real[:] $n84 = {-1.5, -1.25};
 //         algorithm
-//           n633 := exp(n504[1] - n504[1] * n630 ^ n84[1] + n504[2] - n504[2] * n630 ^ n84[2]) * n638 * (-(n504[1] * (n630 ^ (n84[1] - 1) * n84[1] * n634)) - (n504[2] * (n630 ^ (n84[2] - 1) * n84[2] * n634)));
+//           $n633 := exp($n504[1] - $n504[1] * $n630 ^ $n84[1] + $n504[2] - $n504[2] * $n630 ^ $n84[2]) * $n638 * (-($n504[1] * ($n630 ^ ($n84[1] - 1) * $n84[1] * $n634)) - ($n504[2] * ($n630 ^ ($n84[2] - 1) * $n84[2] * $n634)));
 //           annotation(Inline = false, smoothOrder = 5);
-//         end n639;
+//         end $n639;
 //
-//         redeclare function extends n538
+//         redeclare function extends $n538
 //         algorithm
-//           n540 := n269.n270(n627(n539), n636(n539), n539 - 273.16, 1.0);
-//           annotation(Inline = false, smoothOrder = 5, derivative = n640);
-//         end n538;
+//           $n540 := $n269.$n270($n627($n539), $n636($n539), $n539 - 273.16, 1.0);
+//           annotation(Inline = false, smoothOrder = 5, derivative = $n640);
+//         end $n538;
 //
-//         function n640
-//           extends n1.n2.n271;
-//           input n94 n539;
-//           input Real n632(unit = \"K/s\");
-//           output Real n633(unit = \"Pa/s\");
+//         function $n640
+//           extends $n1.$n2.$n271;
+//           input $n94 $n539;
+//           input Real $n632(unit = \"K/s\");
+//           output Real $n633(unit = \"Pa/s\");
 //         algorithm
-//           n633 := n269.n641(n627(n539), n636(n539), n539 - 273.16, 1.0, n631(n539 = n539, n632 = n632), n639(n539 = n539, n632 = n632), n632, 0);
+//           $n633 := $n269.$n641($n627($n539), $n636($n539), $n539 - 273.16, 1.0, $n631($n539 = $n539, $n632 = $n632), $n639($n539 = $n539, $n632 = $n632), $n632, 0);
 //           annotation(Inline = false, smoothOrder = 5);
-//         end n640;
+//         end $n640;
 //
-//         redeclare function extends n541
+//         redeclare function extends $n541
 //         protected
-//           Real n628 = 647.096;
-//           Real n642 = 322;
-//           Real n629 = 22.064e6;
-//           Real[:] n84 = {1, 1.5, 3, 3.5, 4, 7.5};
-//           Real[:] n504 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//           Real[:] n200 = {1 / 3, 2 / 3, 5 / 3, 16 / 3, 43 / 3, 110 / 3};
-//           Real[:] n597 = {1.99274064, 1.09965342, -0.510839303, -1.75493479, -45.5170352, -6.74694450e5};
-//           Real[:] n643 = {2 / 6, 4 / 6, 8 / 6, 18 / 6, 37 / 6, 71 / 6};
-//           Real[:] n425 = {-2.03150240, -2.68302940, -5.38626492, -17.2991605, -44.7586581, -63.9201063};
-//           Real n644 = 1 - n250 / n628;
-//           Real n630 = (n504[1] * n628 * n644 ^ n84[1]) / n250 + (n504[2] * n628 * n644 ^ n84[2]) / n250 + (n504[3] * n628 * n644 ^ n84[3]) / n250 + (n504[4] * n628 * n644 ^ n84[4]) / n250 + (n504[5] * n628 * n644 ^ n84[5]) / n250 + (n504[6] * n628 * n644 ^ n84[6]) / n250;
-//           Real n635 = n504[1] * n84[1] * n644 ^ n84[1] + n504[2] * n84[2] * n644 ^ n84[2] + n504[3] * n84[3] * n644 ^ n84[3] + n504[4] * n84[4] * n644 ^ n84[4] + n504[5] * n84[5] * n644 ^ n84[5] + n504[6] * n84[6] * n644 ^ n84[6];
-//           Real n283 = n642 * (1 + n597[1] * n644 ^ n200[1] + n597[2] * n644 ^ n200[2] + n597[3] * n644 ^ n200[3] + n597[4] * n644 ^ n200[4] + n597[5] * n644 ^ n200[5] + n597[6] * n644 ^ n200[6]);
-//           Real n645 = n642 * exp(n425[1] * n644 ^ n643[1] + n425[2] * n644 ^ n643[2] + n425[3] * n644 ^ n643[3] + n425[4] * n644 ^ n643[4] + n425[5] * n644 ^ n643[5] + n425[6] * n644 ^ n643[6]);
+//           Real $n628 = 647.096;
+//           Real $n642 = 322;
+//           Real $n629 = 22.064e6;
+//           Real[:] $n84 = {1, 1.5, 3, 3.5, 4, 7.5};
+//           Real[:] $n504 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
+//           Real[:] $n200 = {1 / 3, 2 / 3, 5 / 3, 16 / 3, 43 / 3, 110 / 3};
+//           Real[:] $n597 = {1.99274064, 1.09965342, -0.510839303, -1.75493479, -45.5170352, -6.74694450e5};
+//           Real[:] $n643 = {2 / 6, 4 / 6, 8 / 6, 18 / 6, 37 / 6, 71 / 6};
+//           Real[:] $n425 = {-2.03150240, -2.68302940, -5.38626492, -17.2991605, -44.7586581, -63.9201063};
+//           Real $n644 = 1 - $n250 / $n628;
+//           Real $n630 = ($n504[1] * $n628 * $n644 ^ $n84[1]) / $n250 + ($n504[2] * $n628 * $n644 ^ $n84[2]) / $n250 + ($n504[3] * $n628 * $n644 ^ $n84[3]) / $n250 + ($n504[4] * $n628 * $n644 ^ $n84[4]) / $n250 + ($n504[5] * $n628 * $n644 ^ $n84[5]) / $n250 + ($n504[6] * $n628 * $n644 ^ $n84[6]) / $n250;
+//           Real $n635 = $n504[1] * $n84[1] * $n644 ^ $n84[1] + $n504[2] * $n84[2] * $n644 ^ $n84[2] + $n504[3] * $n84[3] * $n644 ^ $n84[3] + $n504[4] * $n84[4] * $n644 ^ $n84[4] + $n504[5] * $n84[5] * $n644 ^ $n84[5] + $n504[6] * $n84[6] * $n644 ^ $n84[6];
+//           Real $n283 = $n642 * (1 + $n597[1] * $n644 ^ $n200[1] + $n597[2] * $n644 ^ $n200[2] + $n597[3] * $n644 ^ $n200[3] + $n597[4] * $n644 ^ $n200[4] + $n597[5] * $n644 ^ $n200[5] + $n597[6] * $n644 ^ $n200[6]);
+//           Real $n645 = $n642 * exp($n425[1] * $n644 ^ $n643[1] + $n425[2] * $n644 ^ $n643[2] + $n425[3] * $n644 ^ $n643[3] + $n425[4] * $n644 ^ $n643[4] + $n425[5] * $n644 ^ $n643[5] + $n425[6] * $n644 ^ $n643[6]);
 //         algorithm
-//           n542 := -(((n283 - n645) * exp(n630) * n629 * (n635 + n630 * n644)) / (n283 * n645 * n644));
+//           $n542 := -((($n283 - $n645) * exp($n630) * $n629 * ($n635 + $n630 * $n644)) / ($n283 * $n645 * $n644));
 //           annotation(smoothOrder = 2);
-//         end n541;
+//         end $n541;
 //
-//         redeclare function extends n543
+//         redeclare function extends $n543
 //         algorithm
-//           n190 := (n250 - 273.15) * 1e3 * (4.2166 - 0.5 * (n250 - 273.15) * (0.0033166 + 0.333333 * (n250 - 273.15) * (0.00010295 - 0.25 * (n250 - 273.15) * (1.3819e-6 + 0.2 * (n250 - 273.15) * 7.3221e-9))));
+//           $n190 := ($n250 - 273.15) * 1e3 * (4.2166 - 0.5 * ($n250 - 273.15) * (0.0033166 + 0.333333 * ($n250 - 273.15) * (0.00010295 - 0.25 * ($n250 - 273.15) * (1.3819e-6 + 0.2 * ($n250 - 273.15) * 7.3221e-9))));
 //           annotation(Inline = false, smoothOrder = 5);
-//         end n543;
+//         end $n543;
 //
-//         redeclare function extends n544
+//         redeclare function extends $n544
 //         algorithm
-//           n190 := n1.n37.n606.n581.n610.n649(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5) * n350[n611] + n1.n37.n606.n581.n610.n649(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684) * (1.0 - n350[n611]);
+//           $n190 := $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5) * $n350[$n611] + $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684) * (1.0 - $n350[$n611]);
 //           annotation(Inline = false, smoothOrder = 5);
-//         end n544;
+//         end $n544;
 //
-//         redeclare function extends n545
+//         redeclare function extends $n545
 //         algorithm
-//           n190 := n1.n37.n606.n581.n610.n649(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5);
+//           $n190 := $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5);
 //           annotation(Inline = false, smoothOrder = 5);
-//         end n545;
+//         end $n545;
 //
-//         redeclare function extends n546
+//         redeclare function extends $n546
 //         algorithm
-//           n190 := n1.n37.n606.n581.n610.n649(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684);
+//           $n190 := $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684);
 //           annotation(Inline = false, smoothOrder = 1);
-//         end n546;
+//         end $n546;
 //
-//         function n650
-//           extends n1.n2.n271;
-//           input n11.n94 n250;
-//           output n11.n381 n190;
+//         function $n650
+//           extends $n1.$n2.$n271;
+//           input $n11.$n94 $n250;
+//           output $n11.$n381 $n190;
 //         algorithm
-//           n190 := n269.n270(4200 * (n250 - 273.15), 2050 * (n250 - 273.15) - 333000, n250 - 273.16, 0.1);
-//           annotation(derivative = n651);
-//         end n650;
+//           $n190 := $n269.$n270(4200 * ($n250 - 273.15), 2050 * ($n250 - 273.15) - 333000, $n250 - 273.16, 0.1);
+//           annotation(derivative = $n651);
+//         end $n650;
 //
-//         function n651
-//           extends n1.n2.n271;
-//           input n11.n94 n250;
-//           input Real n652(unit = \"K/s\");
-//           output Real n653(unit = \"J/(kg.s)\");
+//         function $n651
+//           extends $n1.$n2.$n271;
+//           input $n11.$n94 $n250;
+//           input Real $n652(unit = \"K/s\");
+//           output Real $n653(unit = \"J/(kg.s)\");
 //         algorithm
-//           n653 := n269.n641(4200 * (n250 - 273.15), 2050 * (n250 - 273.15) - 333000, n250 - 273.16, 0.1, 4200 * n652, 2050 * n652, n652, 0);
-//         end n651;
+//           $n653 := $n269.$n641(4200 * ($n250 - 273.15), 2050 * ($n250 - 273.15) - 333000, $n250 - 273.16, 0.1, 4200 * $n652, 2050 * $n652, $n652, 0);
+//         end $n651;
 //
-//         redeclare function extends n228
+//         redeclare function extends $n228
 //         algorithm
-//           n51 := n136.n51;
+//           $n51 := $n136.$n51;
 //           annotation(smoothOrder = 2);
-//         end n228;
+//         end $n228;
 //
-//         redeclare function extends n388
+//         redeclare function extends $n388
 //         algorithm
-//           n250 := n136.n250;
+//           $n250 := $n136.$n250;
 //           annotation(smoothOrder = 2);
-//         end n388;
+//         end $n388;
 //
-//         function n626
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n381 n190;
-//           input n352[:] n350;
-//           output n94 n250;
+//         function $n626
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n381 $n190;
+//           input $n352[:] $n350;
+//           output $n94 $n250;
 //
 //         protected
-//           package n326
-//             extends n1.n37.n581.n584;
+//           package $n326
+//             extends $n1.$n37.$n581.$n584;
 //
-//             redeclare record extends n585
-//               extends n1.n37.n606.n581.n615;
-//             end n585;
+//             redeclare record extends $n585
+//               extends $n1.$n37.$n606.$n581.$n615;
+//             end $n585;
 //
-//             redeclare function extends n586
+//             redeclare function extends $n586
 //             algorithm
-//               n18 := n654(n51, n340, n350);
-//             end n586;
+//               $n18 := $n654($n51, $n340, $n350);
+//             end $n586;
 //
-//             redeclare function extends n588 end n588;
-//           end n326;
+//             redeclare function extends $n588 end $n588;
+//           end $n326;
 //         algorithm
-//           n250 := n326.n588(n190, 190, 647, n51, n350[1:n180], n613);
-//         end n626;
+//           $n250 := $n326.$n588($n190, 190, 647, $n51, $n350[1:$n180], $n613);
+//         end $n626;
 //
-//         redeclare function extends n198
+//         redeclare function extends $n198
 //         algorithm
-//           n145 := n136.n51 / (n529(n136) * n136.n250);
+//           $n145 := $n136.$n51 / ($n529($n136) * $n136.$n250);
 //           annotation(smoothOrder = 2);
-//         end n198;
+//         end $n198;
 //
-//         redeclare function extends n372
+//         redeclare function extends $n372
 //         algorithm
-//           n190 := n654(n136.n51, n136.n250, n136.n350);
+//           $n190 := $n654($n136.$n51, $n136.$n250, $n136.$n350);
 //           annotation(smoothOrder = 2);
-//         end n372;
+//         end $n372;
 //
-//         function n654
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input n10.n352[:] n350;
-//           output n10.n381 n190;
+//         function $n654
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input $n10.$n352[:] $n350;
+//           output $n10.$n381 $n190;
 //         protected
-//           n10.n92 n625;
-//           n10.n352 n623;
-//           n10.n352 n620;
-//           n10.n352 n621;
-//           n10.n352 n622;
+//           $n10.$n92 $n625;
+//           $n10.$n352 $n623;
+//           $n10.$n352 $n620;
+//           $n10.$n352 $n621;
+//           $n10.$n352 $n622;
 //         algorithm
-//           n625 := n538(n250);
-//           n623 := min(n625 * n612 / max(100 * n97.n5, n51 - n625) * (1 - n350[n611]), 1.0);
-//           n620 := max(n350[n611] - n623, 0.0);
-//           n621 := n350[n611] - n620;
-//           n622 := 1 - n350[n611];
-//           n190 := {n1.n37.n606.n581.n610.n649(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5), n1.n37.n606.n581.n610.n649(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684)} * {n621, n622} + n650(n250) * n620;
-//           annotation(derivative = n655, Inline = false);
-//         end n654;
+//           $n625 := $n538($n250);
+//           $n623 := min($n625 * $n612 / max(100 * $n97.$n5, $n51 - $n625) * (1 - $n350[$n611]), 1.0);
+//           $n620 := max($n350[$n611] - $n623, 0.0);
+//           $n621 := $n350[$n611] - $n620;
+//           $n622 := 1 - $n350[$n611];
+//           $n190 := {$n1.$n37.$n606.$n581.$n610.$n649($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5), $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684)} * {$n621, $n622} + $n650($n250) * $n620;
+//           annotation(derivative = $n655, Inline = false);
+//         end $n654;
 //
-//         function n655
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input n10.n352[:] n350;
-//           input Real n283(unit = \"Pa/s\");
-//           input Real n652(unit = \"K/s\");
-//           input Real[:] n656(each unit = \"1/s\");
-//           output Real n657(unit = \"J/(kg.s)\");
+//         function $n655
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input $n10.$n352[:] $n350;
+//           input Real $n283(unit = \"Pa/s\");
+//           input Real $n652(unit = \"K/s\");
+//           input Real[:] $n656(each unit = \"1/s\");
+//           output Real $n657(unit = \"J/(kg.s)\");
 //         protected
-//           n10.n92 n625;
-//           n10.n352 n623;
-//           n10.n352 n620;
-//           n10.n352 n621;
-//           n10.n352 n622;
-//           n10.n352 n624;
-//           Real n658(unit = \"1/s\");
-//           Real n659(unit = \"1/s\");
-//           Real n660(unit = \"1/s\");
-//           Real n661(unit = \"Pa/s\");
-//           Real n662(unit = \"1/s\");
+//           $n10.$n92 $n625;
+//           $n10.$n352 $n623;
+//           $n10.$n352 $n620;
+//           $n10.$n352 $n621;
+//           $n10.$n352 $n622;
+//           $n10.$n352 $n624;
+//           Real $n658(unit = \"1/s\");
+//           Real $n659(unit = \"1/s\");
+//           Real $n660(unit = \"1/s\");
+//           Real $n661(unit = \"Pa/s\");
+//           Real $n662(unit = \"1/s\");
 //         algorithm
-//           n625 := n538(n250);
-//           n624 := n625 * n612 / max(100 * n1.n97.n5, n51 - n625);
-//           n623 := min(n624 * (1 - n350[n611]), 1.0);
-//           n620 := n269.n663(n350[n611] - n623, 0.0, 1e-5);
-//           n621 := n350[n611] - n620;
-//           n622 := 1 - n350[n611];
-//           n659 := -n656[n611];
-//           n661 := n640(n539 = n250, n632 = n652);
-//           n662 := n612 * (n661 * (n51 - n625) - n625 * (n283 - n661)) / (n51 - n625) / (n51 - n625);
-//           n660 := n269.n664(n350[n611] - n623, 0.0, 1e-5, (1 + n624) * n656[n611] - (1 - n350[n611]) * n662, 0, 0);
-//           n658 := n656[n611] - n660;
-//           n657 := n621 * n1.n37.n606.n581.n610.n665(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5, n652 = n652) + n658 * n1.n37.n606.n581.n610.n649(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5) + n622 * n1.n37.n606.n581.n610.n665(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684, n652 = n652) + n659 * n1.n37.n606.n581.n610.n649(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684) + n620 * n651(n250 = n250, n652 = n652) + n660 * n650(n250);
+//           $n625 := $n538($n250);
+//           $n624 := $n625 * $n612 / max(100 * $n1.$n97.$n5, $n51 - $n625);
+//           $n623 := min($n624 * (1 - $n350[$n611]), 1.0);
+//           $n620 := $n269.$n663($n350[$n611] - $n623, 0.0, 1e-5);
+//           $n621 := $n350[$n611] - $n620;
+//           $n622 := 1 - $n350[$n611];
+//           $n659 := -$n656[$n611];
+//           $n661 := $n640($n539 = $n250, $n632 = $n652);
+//           $n662 := $n612 * ($n661 * ($n51 - $n625) - $n625 * ($n283 - $n661)) / ($n51 - $n625) / ($n51 - $n625);
+//           $n660 := $n269.$n664($n350[$n611] - $n623, 0.0, 1e-5, (1 + $n624) * $n656[$n611] - (1 - $n350[$n611]) * $n662, 0, 0);
+//           $n658 := $n656[$n611] - $n660;
+//           $n657 := $n621 * $n1.$n37.$n606.$n581.$n610.$n665($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5, $n652 = $n652) + $n658 * $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5) + $n622 * $n1.$n37.$n606.$n581.$n610.$n665($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684, $n652 = $n652) + $n659 * $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684) + $n620 * $n651($n250 = $n250, $n652 = $n652) + $n660 * $n650($n250);
 //           annotation(Inline = false, smoothOrder = 1);
-//         end n655;
+//         end $n655;
 //
-//         redeclare function extends n496
+//         redeclare function extends $n496
 //         algorithm
-//           n497 := n486(n136) / n494(n136);
-//         end n496;
+//           $n497 := $n486($n136) / $n494($n136);
+//         end $n496;
 //
-//         redeclare function extends n487
-//           extends n1.n2.n271;
+//         redeclare function extends $n487
+//           extends $n1.$n2.$n271;
 //         algorithm
-//           n407 := n666(n136.n51, n136.n250, n136.n350);
+//           $n407 := $n666($n136.$n51, $n136.$n250, $n136.$n350);
 //           annotation(smoothOrder = 2);
-//         end n487;
+//         end $n487;
 //
-//         function n666
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input n10.n352[:] n350;
-//           output n10.n465 n407;
+//         function $n666
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input $n10.$n352[:] $n350;
+//           output $n10.$n465 $n407;
 //         protected
-//           n10.n92 n625;
-//           n10.n352 n620;
-//           n10.n352 n621;
-//           n10.n352 n622;
-//           n10.n352 n623;
-//           Real n667;
+//           $n10.$n92 $n625;
+//           $n10.$n352 $n620;
+//           $n10.$n352 $n621;
+//           $n10.$n352 $n622;
+//           $n10.$n352 $n623;
+//           Real $n667;
 //         algorithm
-//           n625 := n538(n250);
-//           n623 := min(n625 * n612 / max(100 * n97.n5, n51 - n625) * (1 - n350[n611]), 1.0);
-//           n620 := max(n350[n611] - n623, 0.0);
-//           n621 := n350[n611] - n620;
-//           n622 := 1 - n350[n611];
-//           n667 := n614.n466 * n622 / (1 - n620) + n613.n466 * n621 / (1 - n620);
-//           n407 := n621 * n1.n37.n606.n581.n610.n649(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5) + n622 * n1.n37.n606.n581.n610.n649(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684) + n650(n250) * n620 - n667 * n250;
-//           annotation(derivative = n668);
-//         end n666;
+//           $n625 := $n538($n250);
+//           $n623 := min($n625 * $n612 / max(100 * $n97.$n5, $n51 - $n625) * (1 - $n350[$n611]), 1.0);
+//           $n620 := max($n350[$n611] - $n623, 0.0);
+//           $n621 := $n350[$n611] - $n620;
+//           $n622 := 1 - $n350[$n611];
+//           $n667 := $n614.$n466 * $n622 / (1 - $n620) + $n613.$n466 * $n621 / (1 - $n620);
+//           $n407 := $n621 * $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5) + $n622 * $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684) + $n650($n250) * $n620 - $n667 * $n250;
+//           annotation(derivative = $n668);
+//         end $n666;
 //
-//         function n668
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input n10.n352[:] n350;
-//           input Real n283(unit = \"Pa/s\");
-//           input Real n652(unit = \"K/s\");
-//           input Real[:] n656(each unit = \"1/s\");
-//           output Real n669(unit = \"J/(kg.s)\");
+//         function $n668
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input $n10.$n352[:] $n350;
+//           input Real $n283(unit = \"Pa/s\");
+//           input Real $n652(unit = \"K/s\");
+//           input Real[:] $n656(each unit = \"1/s\");
+//           output Real $n669(unit = \"J/(kg.s)\");
 //         protected
-//           n10.n92 n625;
-//           n10.n352 n620;
-//           n10.n352 n621;
-//           n10.n352 n622;
-//           n10.n352 n623;
-//           n10.n467 n667;
-//           n10.n352 n624;
-//           Real n658(unit = \"1/s\");
-//           Real n659(unit = \"1/s\");
-//           Real n660(unit = \"1/s\");
-//           Real n661(unit = \"Pa/s\");
-//           Real n662(unit = \"1/s\");
-//           Real n670(unit = \"J/(kg.K.s)\");
+//           $n10.$n92 $n625;
+//           $n10.$n352 $n620;
+//           $n10.$n352 $n621;
+//           $n10.$n352 $n622;
+//           $n10.$n352 $n623;
+//           $n10.$n467 $n667;
+//           $n10.$n352 $n624;
+//           Real $n658(unit = \"1/s\");
+//           Real $n659(unit = \"1/s\");
+//           Real $n660(unit = \"1/s\");
+//           Real $n661(unit = \"Pa/s\");
+//           Real $n662(unit = \"1/s\");
+//           Real $n670(unit = \"J/(kg.K.s)\");
 //         algorithm
-//           n625 := n538(n250);
-//           n624 := n625 * n612 / max(100 * n1.n97.n5, n51 - n625);
-//           n623 := min(n624 * (1 - n350[n611]), 1.0);
-//           n620 := n269.n270(n350[n611] - n623, 0.0, n350[n611] - n623, 1e-6);
-//           n621 := n350[n611] - n620;
-//           n622 := 1 - n350[n611];
-//           n667 := n613.n466 * n621 / (1 - n620) + n614.n466 * n622 / (1 - n620);
-//           n659 := -n656[n611];
-//           n661 := n640(n539 = n250, n632 = n652);
-//           n662 := n612 * (n661 * (n51 - n625) - n625 * (n283 - n661)) / (n51 - n625) / (n51 - n625);
-//           n660 := n269.n641(n350[n611] - n623, 0.0, n350[n611] - n623, 1e-6, (1 + n624) * n656[n611] - (1 - n350[n611]) * n662, 0.0, (1 + n624) * n656[n611] - (1 - n350[n611]) * n662, 0.0);
-//           n658 := n656[n611] - n660;
-//           n670 := (n613.n466 * (n658 * (1 - n620) + n660 * n621) + n614.n466 * (n659 * (1 - n620) + n660 * n622)) / (1 - n620) / (1 - n620);
-//           n669 := n621 * n1.n37.n606.n581.n610.n665(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5, n652 = n652) + n658 * n1.n37.n606.n581.n610.n649(n646 = n613, n250 = n250, n647 = n549.n552, n648 = 46479.819 + 2501014.5) + n622 * n1.n37.n606.n581.n610.n665(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684, n652 = n652) + n659 * n1.n37.n606.n581.n610.n649(n646 = n614, n250 = n250, n647 = n549.n552, n648 = 25104.684) + n620 * n651(n250 = n250, n652 = n652) + n660 * n650(n250) - n670 * n250 - n667 * n652;
-//         end n668;
+//           $n625 := $n538($n250);
+//           $n624 := $n625 * $n612 / max(100 * $n1.$n97.$n5, $n51 - $n625);
+//           $n623 := min($n624 * (1 - $n350[$n611]), 1.0);
+//           $n620 := $n269.$n270($n350[$n611] - $n623, 0.0, $n350[$n611] - $n623, 1e-6);
+//           $n621 := $n350[$n611] - $n620;
+//           $n622 := 1 - $n350[$n611];
+//           $n667 := $n613.$n466 * $n621 / (1 - $n620) + $n614.$n466 * $n622 / (1 - $n620);
+//           $n659 := -$n656[$n611];
+//           $n661 := $n640($n539 = $n250, $n632 = $n652);
+//           $n662 := $n612 * ($n661 * ($n51 - $n625) - $n625 * ($n283 - $n661)) / ($n51 - $n625) / ($n51 - $n625);
+//           $n660 := $n269.$n641($n350[$n611] - $n623, 0.0, $n350[$n611] - $n623, 1e-6, (1 + $n624) * $n656[$n611] - (1 - $n350[$n611]) * $n662, 0.0, (1 + $n624) * $n656[$n611] - (1 - $n350[$n611]) * $n662, 0.0);
+//           $n658 := $n656[$n611] - $n660;
+//           $n670 := ($n613.$n466 * ($n658 * (1 - $n620) + $n660 * $n621) + $n614.$n466 * ($n659 * (1 - $n620) + $n660 * $n622)) / (1 - $n620) / (1 - $n620);
+//           $n669 := $n621 * $n1.$n37.$n606.$n581.$n610.$n665($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5, $n652 = $n652) + $n658 * $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n613, $n250 = $n250, $n647 = $n549.$n552, $n648 = 46479.819 + 2501014.5) + $n622 * $n1.$n37.$n606.$n581.$n610.$n665($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684, $n652 = $n652) + $n659 * $n1.$n37.$n606.$n581.$n610.$n649($n646 = $n614, $n250 = $n250, $n647 = $n549.$n552, $n648 = 25104.684) + $n620 * $n651($n250 = $n250, $n652 = $n652) + $n660 * $n650($n250) - $n670 * $n250 - $n667 * $n652;
+//         end $n668;
 //
-//         redeclare function extends n489
+//         redeclare function extends $n489
 //         algorithm
-//           n479 := n671(n136.n51, n136.n250, n136.n350);
+//           $n479 := $n671($n136.$n51, $n136.$n250, $n136.$n350);
 //           annotation(Inline = false, smoothOrder = 2);
-//         end n489;
+//         end $n489;
 //
-//         redeclare function extends n490
-//           extends n1.n2.n271;
+//         redeclare function extends $n490
+//           extends $n1.$n2.$n271;
 //         algorithm
-//           n95 := n654(n136.n51, n136.n250, n136.n350) - n136.n250 * n489(n136);
+//           $n95 := $n654($n136.$n51, $n136.$n250, $n136.$n350) - $n136.$n250 * $n489($n136);
 //           annotation(smoothOrder = 2);
-//         end n490;
+//         end $n490;
 //
-//         redeclare function extends n491
-//           extends n1.n2.n271;
+//         redeclare function extends $n491
+//           extends $n1.$n2.$n271;
 //         algorithm
-//           n492 := n654(n136.n51, n136.n250, n136.n350) - n529(n136) * n136.n250 - n136.n250 * n489(n136);
+//           $n492 := $n654($n136.$n51, $n136.$n250, $n136.$n350) - $n529($n136) * $n136.$n250 - $n136.$n250 * $n489($n136);
 //           annotation(smoothOrder = 2);
-//         end n491;
+//         end $n491;
 //
-//         redeclare function extends n486
+//         redeclare function extends $n486
 //         protected
-//           Real n652(unit = \"s/K\") = 1.0;
+//           Real $n652(unit = \"s/K\") = 1.0;
 //         algorithm
-//           n493 := n655(n136.n51, n136.n250, n136.n350, 0.0, 1.0, zeros(size(n136.n350, 1))) * n652;
+//           $n493 := $n655($n136.$n51, $n136.$n250, $n136.$n350, 0.0, 1.0, zeros(size($n136.$n350, 1))) * $n652;
 //           annotation(Inline = false, smoothOrder = 2);
-//         end n486;
+//         end $n486;
 //
-//         redeclare function extends n494
+//         redeclare function extends $n494
 //         algorithm
-//           n495 := n1.n37.n606.n581.n610.n672(n614, n136.n250) * (1 - n136.n350[n611]) + n1.n37.n606.n581.n610.n672(n613, n136.n250) * n136.n350[n611] - n529(n136);
+//           $n495 := $n1.$n37.$n606.$n581.$n610.$n672($n614, $n136.$n250) * (1 - $n136.$n350[$n611]) + $n1.$n37.$n606.$n581.$n610.$n672($n613, $n136.$n250) * $n136.$n350[$n611] - $n529($n136);
 //           annotation(Inline = false, smoothOrder = 2);
-//         end n494;
+//         end $n494;
 //
-//         redeclare function extends n212
-//           import n1.n37.n673.n674.n675;
+//         redeclare function extends $n212
+//           import $n1.$n37.$n673.$n674.$n675;
 //         algorithm
-//           n429 := 1e-6 * n675.n676({9.7391102886305869E-15, -3.1353724870333906E-11, 4.3004876595642225E-08, -3.8228016291758240E-05, 5.0427874367180762E-02, 1.7239260139242528E+01}, n30.n474(123.15), n30.n474(1273.15), n30.n474(n136.n250));
+//           $n429 := 1e-6 * $n675.$n676({9.7391102886305869E-15, -3.1353724870333906E-11, 4.3004876595642225E-08, -3.8228016291758240E-05, 5.0427874367180762E-02, 1.7239260139242528E+01}, $n30.$n474(123.15), $n30.$n474(1273.15), $n30.$n474($n136.$n250));
 //           annotation(smoothOrder = 2);
-//         end n212;
+//         end $n212;
 //
-//         redeclare function extends n260
-//           import n1.n37.n673.n674.n675;
-//           import n30 = n1.n11.n31;
+//         redeclare function extends $n260
+//           import $n1.$n37.$n673.$n674.$n675;
+//           import $n30 = $n1.$n11.$n31;
 //         algorithm
-//           n277 := 1e-3 * n675.n676({6.5691470817717812E-15, -3.4025961923050509E-11, 5.3279284846303157E-08, -4.5340839289219472E-05, 7.6129675309037664E-02, 2.4169481088097051E+01}, n30.n474(123.15), n30.n474(1273.15), n30.n474(n136.n250));
+//           $n277 := 1e-3 * $n675.$n676({6.5691470817717812E-15, -3.4025961923050509E-11, 5.3279284846303157E-08, -4.5340839289219472E-05, 7.6129675309037664E-02, 2.4169481088097051E+01}, $n30.$n474(123.15), $n30.$n474(1273.15), $n30.$n474($n136.$n250));
 //           annotation(smoothOrder = 2);
-//         end n260;
+//         end $n260;
 //
-//         redeclare function extends n503
+//         redeclare function extends $n503
 //         algorithm
-//           n504 := sqrt(n496(n136) * n529(n136) * n388(n136));
-//         end n503;
+//           $n504 := sqrt($n496($n136) * $n529($n136) * $n388($n136));
+//         end $n503;
 //
-//         redeclare function extends n506
+//         redeclare function extends $n506
 //         algorithm
-//           n507 := 1 / n388(n136);
-//         end n506;
+//           $n507 := 1 / $n388($n136);
+//         end $n506;
 //
-//         redeclare function extends n509
+//         redeclare function extends $n509
 //         algorithm
-//           n510 := 1 / n228(n136);
-//         end n509;
+//           $n510 := 1 / $n228($n136);
+//         end $n509;
 //
-//         redeclare function extends n512
+//         redeclare function extends $n512
 //         algorithm
-//           n513 := 1 / (n529(n136) * n388(n136));
-//         end n512;
+//           $n513 := 1 / ($n529($n136) * $n388($n136));
+//         end $n512;
 //
-//         redeclare function extends n515
+//         redeclare function extends $n515
 //         algorithm
-//           n516 := -n198(n136) / (n486(n136) * n388(n136));
-//         end n515;
+//           $n516 := -$n198($n136) / ($n486($n136) * $n388($n136));
+//         end $n515;
 //
-//         redeclare function extends n518
+//         redeclare function extends $n518
 //         algorithm
-//           n519 := 1 / (n529(n136) * n388(n136));
-//         end n518;
+//           $n519 := 1 / ($n529($n136) * $n388($n136));
+//         end $n518;
 //
-//         redeclare function extends n520
+//         redeclare function extends $n520
 //         algorithm
-//           n521 := -n198(n136) / n388(n136);
-//         end n520;
+//           $n521 := -$n198($n136) / $n388($n136);
+//         end $n520;
 //
-//         redeclare function extends n523
+//         redeclare function extends $n523
 //         algorithm
-//           n524[n611] := -n228(n136) * (n613.n466 - n614.n466) / (((n613.n466 - n614.n466) * n136.n350[n611] + n614.n466) ^ 2 * n388(n136));
-//           n524[n39] := -n228(n136) * (n614.n466 - n613.n466) / ((n613.n466 + (n614.n466 - n613.n466) * n136.n350[n39]) ^ 2 * n388(n136));
-//         end n523;
+//           $n524[$n611] := -$n228($n136) * ($n613.$n466 - $n614.$n466) / ((($n613.$n466 - $n614.$n466) * $n136.$n350[$n611] + $n614.$n466) ^ 2 * $n388($n136));
+//           $n524[$n39] := -$n228($n136) * ($n614.$n466 - $n613.$n466) / (($n613.$n466 + ($n614.$n466 - $n613.$n466) * $n136.$n350[$n39]) ^ 2 * $n388($n136));
+//         end $n523;
 //
-//         redeclare function extends n525
+//         redeclare function extends $n525
 //         algorithm
-//           n468 := n1.n97.n466 / n1.n37.n39.n40.n529(n136);
-//         end n525;
+//           $n468 := $n1.$n97.$n466 / $n1.$n37.$n39.$n40.$n529($n136);
+//         end $n525;
 //
-//         function n677
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n480 n479;
-//           input n352[:] n350;
-//           output n94 n250;
+//         function $n677
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n480 $n479;
+//           input $n352[:] $n350;
+//           output $n94 $n250;
 //
 //         protected
-//           package n326
-//             extends n1.n37.n581.n584;
+//           package $n326
+//             extends $n1.$n37.$n581.$n584;
 //
-//             redeclare record extends n585
-//               extends n1.n37.n606.n581.n615;
-//             end n585;
+//             redeclare record extends $n585
+//               extends $n1.$n37.$n606.$n581.$n615;
+//             end $n585;
 //
-//             redeclare function extends n586
+//             redeclare function extends $n586
 //             algorithm
-//               n18 := n671(n51, n340, n350);
-//             end n586;
+//               $n18 := $n671($n51, $n340, $n350);
+//             end $n586;
 //
-//             redeclare function extends n588 end n588;
-//           end n326;
+//             redeclare function extends $n588 end $n588;
+//           end $n326;
 //         algorithm
-//           n250 := n326.n588(n479, 190, 647, n51, n350[1:n351], n613);
-//         end n677;
+//           $n250 := $n326.$n588($n479, 190, 647, $n51, $n350[1:$n351], $n613);
+//         end $n677;
 //
-//         redeclare function extends n478
+//         redeclare function extends $n478
 //         algorithm
-//           n136 := if size(n350, 1) == n351 then n165(n51 = n51, n250 = n677(n51, n479, n350), n350 = n350) else n165(n51 = n51, n250 = n677(n51, n479, n350), n350 = cat(1, n350, {1 - sum(n350)}));
+//           $n136 := if size($n350, 1) == $n351 then $n165($n51 = $n51, $n250 = $n677($n51, $n479, $n350), $n350 = $n350) else $n165($n51 = $n51, $n250 = $n677($n51, $n479, $n350), $n350 = cat(1, $n350, {1 - sum($n350)}));
 //           annotation(smoothOrder = 2);
-//         end n478;
+//         end $n478;
 //
-//         function n671
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input n10.n352[:] n350;
-//           output n10.n480 n479;
+//         function $n671
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input $n10.$n352[:] $n350;
+//           output $n10.$n480 $n479;
 //         protected
-//           n533[2] n678 = n530(n350, {n613.n468, n614.n468});
+//           $n533[2] $n678 = $n530($n350, {$n613.$n468, $n614.$n468});
 //         algorithm
-//           n479 := n1.n37.n606.n581.n610.n679(n614, n250) * (1 - n350[n611]) + n1.n37.n606.n581.n610.n679(n613, n250) * n350[n611] - n1.n97.n466 * (n269.n663(n350[n611] / n531[n611], 0.0, 1e-9) * n1.n268.log(max(n678[n611], n1.n97.n5) * n51 / n455) + n269.n663((1 - n350[n611]) / n531[n39], 0.0, 1e-9) * n1.n268.log(max(n678[n39], n1.n97.n5) * n51 / n455));
-//           annotation(derivative = n680, Inline = false);
-//         end n671;
+//           $n479 := $n1.$n37.$n606.$n581.$n610.$n679($n614, $n250) * (1 - $n350[$n611]) + $n1.$n37.$n606.$n581.$n610.$n679($n613, $n250) * $n350[$n611] - $n1.$n97.$n466 * ($n269.$n663($n350[$n611] / $n531[$n611], 0.0, 1e-9) * $n1.$n268.log(max($n678[$n611], $n1.$n97.$n5) * $n51 / $n455) + $n269.$n663((1 - $n350[$n611]) / $n531[$n39], 0.0, 1e-9) * $n1.$n268.log(max($n678[$n39], $n1.$n97.$n5) * $n51 / $n455));
+//           annotation(derivative = $n680, Inline = false);
+//         end $n671;
 //
-//         function n680
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input n10.n352[:] n350;
-//           input Real n283(unit = \"Pa/s\");
-//           input Real n652(unit = \"K/s\");
-//           input Real[n351] n656(each unit = \"1/s\");
-//           output Real n257(unit = \"J/(kg.K.s)\");
+//         function $n680
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input $n10.$n352[:] $n350;
+//           input Real $n283(unit = \"Pa/s\");
+//           input Real $n652(unit = \"K/s\");
+//           input Real[$n351] $n656(each unit = \"1/s\");
+//           output Real $n257(unit = \"J/(kg.K.s)\");
 //         protected
-//           n533[2] n678 = n530(n350, {n613.n468, n614.n468});
-//           n469 n468;
+//           $n533[2] $n678 = $n530($n350, {$n613.$n468, $n614.$n468});
+//           $n469 $n468;
 //         algorithm
-//           n468 := n531[n611] * n531[n39] / (n350[n611] * n531[n39] + n350[n39] * n531[n611]);
-//           n257 := n606.n581.n610.n681(n614, n250, n652) * (1 - n350[n611]) + n606.n581.n610.n681(n613, n250, n652) * n350[n611] + n1.n37.n606.n581.n610.n679(n614, n250) * n656[n39] + n1.n37.n606.n581.n610.n679(n613, n250) * n656[n611] - n1.n97.n466 * (1 / n531[n611] * (n269.n664(n350[n611], 0.0, 1e-9, n656[n611], 0.0, 0.0) * (n1.n268.log(max(n678[n611], n1.n97.n5) * n51 / n455) + n468 / n531[n39]) + n283 / n51 * n269.n663(n350[n611], 0.0, 1e-9)) + 1 / n531[n39] * (n269.n664(n350[n39], 0.0, 1e-9, n656[n39], 0.0, 0.0) * (n1.n268.log(max(n678[n39], n1.n97.n5) * n51 / n455) + n468 / n531[n611]) + n283 / n51 * n269.n663(n350[n39], 0.0, 1e-9)));
+//           $n468 := $n531[$n611] * $n531[$n39] / ($n350[$n611] * $n531[$n39] + $n350[$n39] * $n531[$n611]);
+//           $n257 := $n606.$n581.$n610.$n681($n614, $n250, $n652) * (1 - $n350[$n611]) + $n606.$n581.$n610.$n681($n613, $n250, $n652) * $n350[$n611] + $n1.$n37.$n606.$n581.$n610.$n679($n614, $n250) * $n656[$n39] + $n1.$n37.$n606.$n581.$n610.$n679($n613, $n250) * $n656[$n611] - $n1.$n97.$n466 * (1 / $n531[$n611] * ($n269.$n664($n350[$n611], 0.0, 1e-9, $n656[$n611], 0.0, 0.0) * ($n1.$n268.log(max($n678[$n611], $n1.$n97.$n5) * $n51 / $n455) + $n468 / $n531[$n39]) + $n283 / $n51 * $n269.$n663($n350[$n611], 0.0, 1e-9)) + 1 / $n531[$n39] * ($n269.$n664($n350[$n39], 0.0, 1e-9, $n656[$n39], 0.0, 0.0) * ($n1.$n268.log(max($n678[$n39], $n1.$n97.$n5) * $n51 / $n455) + $n468 / $n531[$n611]) + $n283 / $n51 * $n269.$n663($n350[$n39], 0.0, 1e-9)));
 //           annotation(Inline = false, smoothOrder = 1);
-//         end n680;
+//         end $n680;
 //
-//         redeclare function extends n499
-//           extends n1.n2.n271;
+//         redeclare function extends $n499
+//           extends $n1.$n2.$n271;
 //         algorithm
-//           n502 := n1.n37.n39.n40.n654(n500, n1.n37.n39.n40.n677(n500, n1.n37.n39.n40.n489(n501), n501.n350), n501.n350);
-//         end n499;
+//           $n502 := $n1.$n37.$n39.$n40.$n654($n500, $n1.$n37.$n39.$n40.$n677($n500, $n1.$n37.$n39.$n40.$n489($n501), $n501.$n350), $n501.$n350);
+//         end $n499;
 //
-//         package n269
-//           extends n1.n2.n415;
+//         package $n269
+//           extends $n1.$n2.$n415;
 //
-//           function n270
-//             extends n1.n2.n271;
-//             input Real n682;
-//             input Real n683;
-//             input Real n340;
-//             input Real n684 = 1;
-//             output Real n685;
+//           function $n270
+//             extends $n1.$n2.$n271;
+//             input Real $n682;
+//             input Real $n683;
+//             input Real $n340;
+//             input Real $n684 = 1;
+//             output Real $n685;
 //           protected
-//             Real n686;
-//             Real n687;
-//             Real n18;
+//             Real $n686;
+//             Real $n687;
+//             Real $n18;
 //           algorithm
-//             n687 := n340 / n684;
-//             n686 := n687 * n1.n268.asin(1);
-//             if n687 <= -0.999999999 then
-//               n18 := 0;
-//             elseif n687 >= 0.999999999 then
-//               n18 := 1;
+//             $n687 := $n340 / $n684;
+//             $n686 := $n687 * $n1.$n268.asin(1);
+//             if $n687 <= -0.999999999 then
+//               $n18 := 0;
+//             elseif $n687 >= 0.999999999 then
+//               $n18 := 1;
 //             else
-//               n18 := (n1.n268.tanh(n1.n268.tan(n686)) + 1) / 2;
+//               $n18 := ($n1.$n268.tanh($n1.$n268.tan($n686)) + 1) / 2;
 //             end if;
-//             n685 := n682 * n18 + (1 - n18) * n683;
-//             annotation(derivative = n641);
-//           end n270;
+//             $n685 := $n682 * $n18 + (1 - $n18) * $n683;
+//             annotation(derivative = $n641);
+//           end $n270;
 //
-//           function n641
-//             extends n1.n2.n271;
-//             input Real n682;
-//             input Real n683;
-//             input Real n340;
-//             input Real n684 = 1;
-//             input Real n688;
-//             input Real n689;
-//             input Real n314;
-//             input Real n690 = 0;
-//             output Real n685;
+//           function $n641
+//             extends $n1.$n2.$n271;
+//             input Real $n682;
+//             input Real $n683;
+//             input Real $n340;
+//             input Real $n684 = 1;
+//             input Real $n688;
+//             input Real $n689;
+//             input Real $n314;
+//             input Real $n690 = 0;
+//             output Real $n685;
 //           protected
-//             Real n686;
-//             Real n687;
-//             Real n691;
-//             Real n18;
+//             Real $n686;
+//             Real $n687;
+//             Real $n691;
+//             Real $n18;
 //           algorithm
-//             n687 := n340 / n684;
-//             n686 := n687 * n1.n268.asin(1);
-//             n691 := (n314 - n687 * n690) / n684;
-//             if n687 <= -0.99999999999 then
-//               n18 := 0;
-//             elseif n687 >= 0.9999999999 then
-//               n18 := 1;
+//             $n687 := $n340 / $n684;
+//             $n686 := $n687 * $n1.$n268.asin(1);
+//             $n691 := ($n314 - $n687 * $n690) / $n684;
+//             if $n687 <= -0.99999999999 then
+//               $n18 := 0;
+//             elseif $n687 >= 0.9999999999 then
+//               $n18 := 1;
 //             else
-//               n18 := (n1.n268.tanh(n1.n268.tan(n686)) + 1) / 2;
+//               $n18 := ($n1.$n268.tanh($n1.$n268.tan($n686)) + 1) / 2;
 //             end if;
-//             n685 := n688 * n18 + (1 - n18) * n689;
-//             if (abs(n687) < 1) then
-//               n685 := n685 + (n682 - n683) * n691 * n1.n268.asin(1) / 2 / (n1.n268.cosh(n1.n268.tan(n686)) * n1.n268.cos(n686)) ^ 2;
+//             $n685 := $n688 * $n18 + (1 - $n18) * $n689;
+//             if (abs($n687) < 1) then
+//               $n685 := $n685 + ($n682 - $n683) * $n691 * $n1.$n268.asin(1) / 2 / ($n1.$n268.cosh($n1.$n268.tan($n686)) * $n1.$n268.cos($n686)) ^ 2;
 //             else
 //             end if;
-//           end n641;
+//           end $n641;
 //
-//           function n663
-//             extends n1.n2.n271;
-//             import n1.n268;
-//             input Real n298;
-//             input Real n307;
-//             input Real n314;
-//             output Real n18;
+//           function $n663
+//             extends $n1.$n2.$n271;
+//             import $n1.$n268;
+//             input Real $n298;
+//             input Real $n307;
+//             input Real $n314;
+//             output Real $n18;
 //           algorithm
-//             n18 := max(n298, n307) + n268.log((exp((4 / n314) * (n298 - max(n298, n307)))) + (exp((4 / n314) * (n307 - max(n298, n307))))) / (4 / n314);
+//             $n18 := max($n298, $n307) + $n268.log((exp((4 / $n314) * ($n298 - max($n298, $n307)))) + (exp((4 / $n314) * ($n307 - max($n298, $n307))))) / (4 / $n314);
 //             annotation(smoothOrder = 2);
-//           end n663;
+//           end $n663;
 //
-//           function n664
-//             extends n1.n2.n271;
-//             import n1.n268.n292;
-//             import n1.n268.n290;
-//             input Real n298;
-//             input Real n307;
-//             input Real n314;
-//             input Real n692;
-//             input Real n693;
-//             input Real n694;
-//             output Real n695;
+//           function $n664
+//             extends $n1.$n2.$n271;
+//             import $n1.$n268.$n292;
+//             import $n1.$n268.$n290;
+//             input Real $n298;
+//             input Real $n307;
+//             input Real $n314;
+//             input Real $n692;
+//             input Real $n693;
+//             input Real $n694;
+//             output Real $n695;
 //           algorithm
-//             n695 := (if n298 > n307 then n692 else n693) + 0.25 * (((4 * (n692 - (if n298 > n307 then n692 else n693)) / n314 - 4 * (n298 - max(n298, n307)) * n694 / n314 ^ 2) * exp(4 * (n298 - max(n298, n307)) / n314) + (4 * (n693 - (if n298 > n307 then n692 else n693)) / n314 - 4 * (n307 - max(n298, n307)) * n694 / n314 ^ 2) * exp(4 * (n307 - max(n298, n307)) / n314)) * n314 / (exp(4 * (n298 - max(n298, n307)) / n314) + exp(4 * (n307 - max(n298, n307)) / n314)) + log(exp(4 * (n298 - max(n298, n307)) / n314) + exp(4 * (n307 - max(n298, n307)) / n314)) * n694);
-//           end n664;
-//         end n269;
-//       end n40;
-//     end n39;
+//             $n695 := (if $n298 > $n307 then $n692 else $n693) + 0.25 * (((4 * ($n692 - (if $n298 > $n307 then $n692 else $n693)) / $n314 - 4 * ($n298 - max($n298, $n307)) * $n694 / $n314 ^ 2) * exp(4 * ($n298 - max($n298, $n307)) / $n314) + (4 * ($n693 - (if $n298 > $n307 then $n692 else $n693)) / $n314 - 4 * ($n307 - max($n298, $n307)) * $n694 / $n314 ^ 2) * exp(4 * ($n307 - max($n298, $n307)) / $n314)) * $n314 / (exp(4 * ($n298 - max($n298, $n307)) / $n314) + exp(4 * ($n307 - max($n298, $n307)) / $n314)) + log(exp(4 * ($n298 - max($n298, $n307)) / $n314) + exp(4 * ($n307 - max($n298, $n307)) / $n314)) * $n694);
+//           end $n664;
+//         end $n269;
+//       end $n40;
+//     end $n39;
 //
-//     package n606
-//       extends n1.n2.n113;
+//     package $n606
+//       extends $n1.$n2.$n113;
 //
-//       package n581
-//         extends n1.n2.n3;
+//       package $n581
+//         extends $n1.$n2.$n3;
 //
-//         record n615
-//           extends n1.n2.n461;
-//           String n696;
-//           n10.n469 n468;
-//           n10.n381 n697;
-//           n10.n381 n698;
-//           n10.n94 n699;
-//           Real[7] n700;
-//           Real[2] n701;
-//           Real[7] n702;
-//           Real[2] n703;
-//           n10.n467 n466;
-//         end n615;
+//         record $n615
+//           extends $n1.$n2.$n461;
+//           String $n696;
+//           $n10.$n469 $n468;
+//           $n10.$n381 $n697;
+//           $n10.$n381 $n698;
+//           $n10.$n94 $n699;
+//           Real[7] $n700;
+//           Real[2] $n701;
+//           Real[7] $n702;
+//           Real[2] $n703;
+//           $n10.$n467 $n466;
+//         end $n615;
 //
-//         package n610
-//           extends n1.n2.n704;
-//           constant Boolean n705 = true;
-//           constant n1.n37.n12.n345.n549 n706 = n1.n37.n12.n345.n549.n550;
-//           constant n1.n37.n12.n44.n381 n707 = 0.0;
+//         package $n610
+//           extends $n1.$n2.$n704;
+//           constant Boolean $n705 = true;
+//           constant $n1.$n37.$n12.$n345.$n549 $n706 = $n1.$n37.$n12.$n345.$n549.$n550;
+//           constant $n1.$n37.$n12.$n44.$n381 $n707 = 0.0;
 //
-//           function n672
-//             extends n1.n2.n271;
-//             input n606.n581.n615 n646;
-//             input n10.n94 n250;
-//             output n10.n467 n493;
+//           function $n672
+//             extends $n1.$n2.$n271;
+//             input $n606.$n581.$n615 $n646;
+//             input $n10.$n94 $n250;
+//             output $n10.$n467 $n493;
 //           algorithm
-//             n493 := n646.n466 * (1 / (n250 * n250) * (n646.n700[1] + n250 * (n646.n700[2] + n250 * (1. * n646.n700[3] + n250 * (n646.n700[4] + n250 * (n646.n700[5] + n250 * (n646.n700[6] + n646.n700[7] * n250)))))));
-//             annotation(Inline = false, derivative(zeroDerivative = n646) = n708);
-//           end n672;
+//             $n493 := $n646.$n466 * (1 / ($n250 * $n250) * ($n646.$n700[1] + $n250 * ($n646.$n700[2] + $n250 * (1. * $n646.$n700[3] + $n250 * ($n646.$n700[4] + $n250 * ($n646.$n700[5] + $n250 * ($n646.$n700[6] + $n646.$n700[7] * $n250)))))));
+//             annotation(Inline = false, derivative(zeroDerivative = $n646) = $n708);
+//           end $n672;
 //
-//           function n708
-//             extends n1.n2.n271;
-//             input n606.n581.n615 n646;
-//             input n10.n94 n250;
-//             input Real n652;
-//             output Real n709;
+//           function $n708
+//             extends $n1.$n2.$n271;
+//             input $n606.$n581.$n615 $n646;
+//             input $n10.$n94 $n250;
+//             input Real $n652;
+//             output Real $n709;
 //           algorithm
-//             n709 := n652 * n646.n466 / (n250 * n250 * n250) * (-2 * n646.n700[1] + n250 * (-n646.n700[2] + n250 * n250 * (n646.n700[4] + n250 * (2. * n646.n700[5] + n250 * (3. * n646.n700[6] + 4. * n646.n700[7] * n250)))));
+//             $n709 := $n652 * $n646.$n466 / ($n250 * $n250 * $n250) * (-2 * $n646.$n700[1] + $n250 * (-$n646.$n700[2] + $n250 * $n250 * ($n646.$n700[4] + $n250 * (2. * $n646.$n700[5] + $n250 * (3. * $n646.$n700[6] + 4. * $n646.$n700[7] * $n250)))));
 //             annotation(smoothOrder = 2);
-//           end n708;
+//           end $n708;
 //
-//           function n649
-//             import n1.n37.n12.n345;
-//             extends n1.n2.n271;
-//             input n606.n581.n615 n646;
-//             input n10.n94 n250;
-//             input Boolean n710 = n705;
-//             input n1.n37.n12.n345.n549 n647 = n706;
-//             input n10.n381 n648 = n707;
-//             output n10.n381 n190;
+//           function $n649
+//             import $n1.$n37.$n12.$n345;
+//             extends $n1.$n2.$n271;
+//             input $n606.$n581.$n615 $n646;
+//             input $n10.$n94 $n250;
+//             input Boolean $n710 = $n705;
+//             input $n1.$n37.$n12.$n345.$n549 $n647 = $n706;
+//             input $n10.$n381 $n648 = $n707;
+//             output $n10.$n381 $n190;
 //           algorithm
-//             n190 := n646.n466 * ((-n646.n700[1] + n250 * (n646.n701[1] + n646.n700[2] * n268.log(n250) + n250 * (1. * n646.n700[3] + n250 * (0.5 * n646.n700[4] + n250 * (1 / 3 * n646.n700[5] + n250 * (0.25 * n646.n700[6] + 0.2 * n646.n700[7] * n250)))))) / n250) + (if n710 then -n646.n697 else 0.0) + (if (n647 == n345.n549.n550) then n646.n698 else 0.0) + (if n647 == n345.n549.n552 then n648 else 0.0);
+//             $n190 := $n646.$n466 * ((-$n646.$n700[1] + $n250 * ($n646.$n701[1] + $n646.$n700[2] * $n268.log($n250) + $n250 * (1. * $n646.$n700[3] + $n250 * (0.5 * $n646.$n700[4] + $n250 * (1 / 3 * $n646.$n700[5] + $n250 * (0.25 * $n646.$n700[6] + 0.2 * $n646.$n700[7] * $n250)))))) / $n250) + (if $n710 then -$n646.$n697 else 0.0) + (if ($n647 == $n345.$n549.$n550) then $n646.$n698 else 0.0) + (if $n647 == $n345.$n549.$n552 then $n648 else 0.0);
 //             annotation(Inline = false, smoothOrder = 2);
-//           end n649;
+//           end $n649;
 //
-//           function n665
-//             import n1.n37.n12.n345;
-//             extends n1.n2.n271;
-//             input n606.n581.n615 n646;
-//             input n10.n94 n250;
-//             input Boolean n710 = n705;
-//             input n1.n37.n12.n345.n549 n647 = n706;
-//             input n10.n381 n648 = n707;
-//             input Real n652(unit = \"K/s\");
-//             output Real n657(unit = \"J/(kg.s)\");
+//           function $n665
+//             import $n1.$n37.$n12.$n345;
+//             extends $n1.$n2.$n271;
+//             input $n606.$n581.$n615 $n646;
+//             input $n10.$n94 $n250;
+//             input Boolean $n710 = $n705;
+//             input $n1.$n37.$n12.$n345.$n549 $n647 = $n706;
+//             input $n10.$n381 $n648 = $n707;
+//             input Real $n652(unit = \"K/s\");
+//             output Real $n657(unit = \"J/(kg.s)\");
 //           algorithm
-//             n657 := n652 * n1.n37.n606.n581.n610.n672(n646, n250);
+//             $n657 := $n652 * $n1.$n37.$n606.$n581.$n610.$n672($n646, $n250);
 //             annotation(Inline = true, smoothOrder = 2);
-//           end n665;
+//           end $n665;
 //
-//           function n679
-//             extends n1.n2.n271;
-//             input n606.n581.n615 n646;
-//             input n10.n94 n250;
-//             output n10.n480 n479;
+//           function $n679
+//             extends $n1.$n2.$n271;
+//             input $n606.$n581.$n615 $n646;
+//             input $n10.$n94 $n250;
+//             output $n10.$n480 $n479;
 //           algorithm
-//             n479 := n646.n466 * (n646.n701[2] - 0.5 * n646.n700[1] / (n250 * n250) - n646.n700[2] / n250 + n646.n700[3] * n268.log(n250) + n250 * (n646.n700[4] + n250 * (0.5 * n646.n700[5] + n250 * (1 / 3 * n646.n700[6] + 0.25 * n646.n700[7] * n250))));
+//             $n479 := $n646.$n466 * ($n646.$n701[2] - 0.5 * $n646.$n700[1] / ($n250 * $n250) - $n646.$n700[2] / $n250 + $n646.$n700[3] * $n268.log($n250) + $n250 * ($n646.$n700[4] + $n250 * (0.5 * $n646.$n700[5] + $n250 * (1 / 3 * $n646.$n700[6] + 0.25 * $n646.$n700[7] * $n250))));
 //             annotation(Inline = true, smoothOrder = 2);
-//           end n679;
+//           end $n679;
 //
-//           function n681
-//             extends n1.n2.n271;
-//             input n606.n581.n615 n646;
-//             input n10.n94 n250;
-//             input Real n711(unit = \"K/s\");
-//             output Real n712(unit = \"J/(kg.K.s)\");
+//           function $n681
+//             extends $n1.$n2.$n271;
+//             input $n606.$n581.$n615 $n646;
+//             input $n10.$n94 $n250;
+//             input Real $n711(unit = \"K/s\");
+//             output Real $n712(unit = \"J/(kg.K.s)\");
 //           algorithm
-//             n712 := n646.n466 * n711 * (n646.n700[1] / (n250 * n250 * n250) + n646.n700[2] / (n250 * n250) + n646.n700[3] / n250 + n646.n700[4] + n250 * (n646.n700[5] + n250 * (n646.n700[6] + n250 * n646.n700[7])));
+//             $n712 := $n646.$n466 * $n711 * ($n646.$n700[1] / ($n250 * $n250 * $n250) + $n646.$n700[2] / ($n250 * $n250) + $n646.$n700[3] / $n250 + $n646.$n700[4] + $n250 * ($n646.$n700[5] + $n250 * ($n646.$n700[6] + $n250 * $n646.$n700[7])));
 //             annotation(Inline = true);
-//           end n681;
-//         end n610;
+//           end $n681;
+//         end $n610;
 //
-//         package n607
-//           extends n1.n2.n3;
-//           import n1.n37.n12.n526;
-//           import n1.n37.n606.n581.n616;
-//           constant n1.n37.n12.n44.n527.n459 n609(n558 = \"N2\", n556 = \"unknown\", n559 = \"unknown\", n557 = \"7727-37-9\", n564 = 63.15, n565 = 77.35, n560 = 126.20, n561 = 33.98e5, n562 = 90.10e-6, n563 = 0.037, n566 = 0.0, n525 = n616.n609.n468, n569 = true, n567 = true, n568 = true, n576 = true);
-//           constant n1.n37.n12.n44.n527.n459 n608(n558 = \"H2O\", n556 = \"oxidane\", n559 = \"H2O\", n557 = \"7732-18-5\", n564 = 273.15, n565 = 373.124, n560 = 647.096, n561 = 220.64e5, n562 = 55.95e-6, n563 = 0.344, n566 = 1.8, n525 = n616.n608.n468, n569 = true, n567 = true, n568 = true, n576 = true);
-//         end n607;
+//         package $n607
+//           extends $n1.$n2.$n3;
+//           import $n1.$n37.$n12.$n526;
+//           import $n1.$n37.$n606.$n581.$n616;
+//           constant $n1.$n37.$n12.$n44.$n527.$n459 $n609($n558 = \"N2\", $n556 = \"unknown\", $n559 = \"unknown\", $n557 = \"7727-37-9\", $n564 = 63.15, $n565 = 77.35, $n560 = 126.20, $n561 = 33.98e5, $n562 = 90.10e-6, $n563 = 0.037, $n566 = 0.0, $n525 = $n616.$n609.$n468, $n569 = true, $n567 = true, $n568 = true, $n576 = true);
+//           constant $n1.$n37.$n12.$n44.$n527.$n459 $n608($n558 = \"H2O\", $n556 = \"oxidane\", $n559 = \"H2O\", $n557 = \"7732-18-5\", $n564 = 273.15, $n565 = 373.124, $n560 = 647.096, $n561 = 220.64e5, $n562 = 55.95e-6, $n563 = 0.344, $n566 = 1.8, $n525 = $n616.$n608.$n468, $n569 = true, $n567 = true, $n568 = true, $n576 = true);
+//         end $n607;
 //
-//         package n616
-//           extends n1.n2.n3;
-//           constant n606.n581.n615 n39(n696 = \"Air\", n468 = 0.0289651159, n697 = -4333.833858403446, n698 = 298609.6803431054, n699 = 1000, n700 = {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-005, -7.94029797e-009, 2.18523191e-012}, n701 = {-176.796731, -3.921504225}, n702 = {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-008, -1.07148349e-011, 6.57780015e-016}, n703 = {6462.26319, -8.147411905}, n466 = 287.0512249529787);
-//           constant n606.n581.n615 n713(n696 = \"Ar\", n468 = 0.039948, n697 = 0, n698 = 155137.3785921698, n699 = 1000, n700 = {0, 0, 2.5, 0, 0, 0, 0}, n701 = {-745.375, 4.37967491}, n702 = {20.10538475, -0.05992661069999999, 2.500069401, -3.99214116e-008, 1.20527214e-011, -1.819015576e-015, 1.078576636e-019}, n703 = {-744.993961, 4.37918011}, n466 = 208.1323720837088);
-//           constant n606.n581.n615 n714(n696 = \"CH4\", n468 = 0.01604246, n697 = -4650159.63885838, n698 = 624355.7409524474, n699 = 1000, n700 = {-176685.0998, 2786.18102, -12.0257785, 0.0391761929, -3.61905443e-005, 2.026853043e-008, -4.976705489999999e-012}, n701 = {-23313.1436, 89.0432275}, n702 = {3730042.76, -13835.01485, 20.49107091, -0.001961974759, 4.72731304e-007, -3.72881469e-011, 1.623737207e-015}, n703 = {75320.6691, -121.9124889}, n466 = 518.2791167938085);
-//           constant n606.n581.n615 n715(n696 = \"CH3OH\", n468 = 0.03204186, n697 = -6271171.523750494, n698 = 356885.5553329301, n699 = 1000, n700 = {-241664.2886, 4032.14719, -20.46415436, 0.0690369807, -7.59893269e-005, 4.59820836e-008, -1.158706744e-011}, n701 = {-44332.61169999999, 140.014219}, n702 = {3411570.76, -13455.00201, 22.61407623, -0.002141029179, 3.73005054e-007, -3.49884639e-011, 1.366073444e-015}, n703 = {56360.8156, -127.7814279}, n466 = 259.4878075117987);
-//           constant n606.n581.n615 n716(n696 = \"CO\", n468 = 0.0280101, n697 = -3946262.098314536, n698 = 309570.6191695138, n699 = 1000, n700 = {14890.45326, -292.2285939, 5.72452717, -0.008176235030000001, 1.456903469e-005, -1.087746302e-008, 3.027941827e-012}, n701 = {-13031.31878, -7.85924135}, n702 = {461919.725, -1944.704863, 5.91671418, -0.0005664282830000001, 1.39881454e-007, -1.787680361e-011, 9.62093557e-016}, n703 = {-2466.261084, -13.87413108}, n466 = 296.8383547363272);
-//           constant n606.n581.n615 n717(n696 = \"CO2\", n468 = 0.0440095, n697 = -8941478.544405185, n698 = 212805.6215135368, n699 = 1000, n700 = {49436.5054, -626.411601, 5.30172524, 0.002503813816, -2.127308728e-007, -7.68998878e-010, 2.849677801e-013}, n701 = {-45281.9846, -7.04827944}, n702 = {117696.2419, -1788.791477, 8.29152319, -9.22315678e-005, 4.86367688e-009, -1.891053312e-012, 6.330036589999999e-016}, n703 = {-39083.5059, -26.52669281}, n466 = 188.9244822140674);
-//           constant n606.n581.n615 n718(n696 = \"C2H2_vinylidene\", n468 = 0.02603728, n697 = 15930556.80163212, n698 = 417638.4015534649, n699 = 1000, n700 = {-14660.42239, 278.9475593, 1.276229776, 0.01395015463, -1.475702649e-005, 9.476298110000001e-009, -2.567602217e-012}, n701 = {47361.1018, 16.58225704}, n702 = {1940838.725, -6892.718150000001, 13.39582494, -0.0009368968669999999, 1.470804368e-007, -1.220040365e-011, 4.12239166e-016}, n703 = {91071.1293, -63.3750293}, n466 = 319.3295152181795);
-//           constant n606.n581.n615 n719(n696 = \"C2H4\", n468 = 0.02805316, n697 = 1871446.924339362, n698 = 374955.5843263291, n699 = 1000, n700 = {-116360.5836, 2554.85151, -16.09746428, 0.0662577932, -7.885081859999999e-005, 5.12522482e-008, -1.370340031e-011}, n701 = {-6176.19107, 109.3338343}, n702 = {3408763.67, -13748.47903, 23.65898074, -0.002423804419, 4.43139566e-007, -4.35268339e-011, 1.775410633e-015}, n703 = {88204.2938, -137.1278108}, n466 = 296.3827247982046);
-//           constant n606.n581.n615 n720(n696 = \"C2H6\", n468 = 0.03006904, n697 = -2788633.890539904, n698 = 395476.3437741943, n699 = 1000, n700 = {-186204.4161, 3406.19186, -19.51705092, 0.0756583559, -8.20417322e-005, 5.0611358e-008, -1.319281992e-011}, n701 = {-27029.3289, 129.8140496}, n702 = {5025782.13, -20330.22397, 33.2255293, -0.00383670341, 7.23840586e-007, -7.3191825e-011, 3.065468699e-015}, n703 = {111596.395, -203.9410584}, n466 = 276.5127187299628);
-//           constant n606.n581.n615 n721(n696 = \"C2H5OH\", n468 = 0.04606844, n697 = -5100020.751733725, n698 = 315659.1801241805, n699 = 1000, n700 = {-234279.1392, 4479.18055, -27.44817302, 0.1088679162, -0.0001305309334, 8.437346399999999e-008, -2.234559017e-011}, n701 = {-50222.29, 176.4829211}, n702 = {4694817.65, -19297.98213, 34.4758404, -0.00323616598, 5.78494772e-007, -5.56460027e-011, 2.2262264e-015}, n703 = {86016.22709999999, -203.4801732}, n466 = 180.4808671619877);
-//           constant n606.n581.n615 n722(n696 = \"C3H6_propylene\", n468 = 0.04207974, n697 = 475288.1077687267, n698 = 322020.9535515191, n699 = 1000, n700 = {-191246.2174, 3542.07424, -21.14878626, 0.0890148479, -0.0001001429154, 6.267959389999999e-008, -1.637870781e-011}, n701 = {-15299.61824, 140.7641382}, n702 = {5017620.34, -20860.84035, 36.4415634, -0.00388119117, 7.27867719e-007, -7.321204500000001e-011, 3.052176369e-015}, n703 = {126124.5355, -219.5715757}, n466 = 197.588483198803);
-//           constant n606.n581.n615 n723(n696 = \"C3H8\", n468 = 0.04409562, n697 = -2373931.923397381, n698 = 334301.1845620949, n699 = 1000, n700 = {-243314.4337, 4656.27081, -29.39466091, 0.1188952745, -0.0001376308269, 8.814823909999999e-008, -2.342987994e-011}, n701 = {-35403.3527, 184.1749277}, n702 = {6420731.680000001, -26597.91134, 45.3435684, -0.00502066392, 9.471216939999999e-007, -9.57540523e-011, 4.00967288e-015}, n703 = {145558.2459, -281.8374734}, n466 = 188.5555073270316);
-//           constant n606.n581.n615 n724(n696 = \"C4H8_1_butene\", n468 = 0.05610631999999999, n697 = -9624.584182316718, n698 = 305134.9651875226, n699 = 1000, n700 = {-272149.2014, 5100.079250000001, -31.8378625, 0.1317754442, -0.0001527359339, 9.714761109999999e-008, -2.56020447e-011}, n701 = {-25230.96386, 200.6932108}, n702 = {6257948.609999999, -26603.76305, 47.6492005, -0.00438326711, 7.12883844e-007, -5.991020839999999e-011, 2.051753504e-015}, n703 = {156925.2657, -291.3869761}, n466 = 148.1913623991023);
-//           constant n606.n581.n615 n725(n696 = \"C4H10_n_butane\", n468 = 0.0581222, n697 = -2164233.28779709, n698 = 330832.0228759407, n699 = 1000, n700 = {-317587.254, 6176.331819999999, -38.9156212, 0.1584654284, -0.0001860050159, 1.199676349e-007, -3.20167055e-011}, n701 = {-45403.63390000001, 237.9488665}, n702 = {7682322.45, -32560.5151, 57.3673275, -0.00619791681, 1.180186048e-006, -1.221893698e-010, 5.250635250000001e-015}, n703 = {177452.656, -358.791876}, n466 = 143.0515706563069);
-//           constant n606.n581.n615 n726(n696 = \"C5H10_1_pentene\", n468 = 0.07013290000000001, n697 = -303423.9279995551, n698 = 309127.3852927798, n699 = 1000, n700 = {-534054.813, 9298.917380000001, -56.6779245, 0.2123100266, -0.000257129829, 1.666834304e-007, -4.43408047e-011}, n701 = {-47906.8218, 339.60364}, n702 = {3744014.97, -21044.85321, 47.3612699, -0.00042442012, -3.89897505e-008, 1.367074243e-011, -9.31319423e-016}, n703 = {115409.1373, -278.6177449000001}, n466 = 118.5530899192818);
-//           constant n606.n581.n615 n727(n696 = \"C5H12_n_pentane\", n468 = 0.07214878, n697 = -2034130.029641527, n698 = 335196.2430965569, n699 = 1000, n700 = {-276889.4625, 5834.28347, -36.1754148, 0.1533339707, -0.0001528395882, 8.191092e-008, -1.792327902e-011}, n701 = {-46653.7525, 226.5544053}, n702 = {-2530779.286, -8972.59326, 45.3622326, -0.002626989916, 3.135136419e-006, -5.31872894e-010, 2.886896868e-014}, n703 = {14846.16529, -251.6550384}, n466 = 115.2406457877736);
-//           constant n606.n581.n615 n728(n696 = \"C6H6\", n468 = 0.07811184, n697 = 1061042.730525872, n698 = 181735.4577743912, n699 = 1000, n700 = {-167734.0902, 4404.50004, -37.1737791, 0.1640509559, -0.0002020812374, 1.307915264e-007, -3.4442841e-011}, n701 = {-10354.55401, 216.9853345}, n702 = {4538575.72, -22605.02547, 46.940073, -0.004206676830000001, 7.90799433e-007, -7.9683021e-011, 3.32821208e-015}, n703 = {139146.4686, -286.8751333}, n466 = 106.4431717393932);
-//           constant n606.n581.n615 n729(n696 = \"C6H12_1_hexene\", n468 = 0.08415948000000001, n697 = -498458.4030224521, n698 = 311788.9986962847, n699 = 1000, n700 = {-666883.165, 11768.64939, -72.70998330000001, 0.2709398396, -0.00033332464, 2.182347097e-007, -5.85946882e-011}, n701 = {-62157.8054, 428.682564}, n702 = {733290.696, -14488.48641, 46.7121549, 0.00317297847, -5.24264652e-007, 4.28035582e-011, -1.472353254e-015}, n703 = {66977.4041, -262.3643854}, n466 = 98.79424159940152);
-//           constant n606.n581.n615 n730(n696 = \"C6H14_n_hexane\", n468 = 0.08617535999999999, n697 = -1936980.593988816, n698 = 333065.0431863586, n699 = 1000, n700 = {-581592.67, 10790.97724, -66.3394703, 0.2523715155, -0.0002904344705, 1.802201514e-007, -4.617223680000001e-011}, n701 = {-72715.4457, 393.828354}, n702 = {-3106625.684, -7346.087920000001, 46.94131760000001, 0.001693963977, 2.068996667e-006, -4.21214168e-010, 2.452345845e-014}, n703 = {523.750312, -254.9967718}, n466 = 96.48317105956971);
-//           constant n606.n581.n615 n731(n696 = \"C7H14_1_heptene\", n468 = 0.09818605999999999, n697 = -639194.6066478277, n698 = 313588.3036756949, n699 = 1000, n700 = {-744940.284, 13321.79893, -82.81694379999999, 0.3108065994, -0.000378677992, 2.446841042e-007, -6.488763869999999e-011}, n701 = {-72178.8501, 485.667149}, n702 = {-1927608.174, -9125.024420000002, 47.4817797, 0.00606766053, -8.684859080000001e-007, 5.81399526e-011, -1.473979569e-015}, n703 = {26009.14656, -256.2880707}, n466 = 84.68077851377274);
-//           constant n606.n581.n615 n732(n696 = \"C7H16_n_heptane\", n468 = 0.10020194, n697 = -1874015.612871368, n698 = 331540.487140269, n699 = 1000, n700 = {-612743.289, 11840.85437, -74.87188599999999, 0.2918466052, -0.000341679549, 2.159285269e-007, -5.65585273e-011}, n701 = {-80134.0894, 440.721332}, n702 = {9135632.469999999, -39233.1969, 78.8978085, -0.00465425193, 2.071774142e-006, -3.4425393e-010, 1.976834775e-014}, n703 = {205070.8295, -485.110402}, n466 = 82.97715593131233);
-//           constant n606.n581.n615 n733(n696 = \"C8H10_ethylbenz\", n468 = 0.106165, n697 = 281825.4603682946, n698 = 209862.0072528611, n699 = 1000, n700 = {-469494, 9307.16836, -65.2176947, 0.2612080237, -0.000318175348, 2.051355473e-007, -5.40181735e-011}, n701 = {-40738.7021, 378.090436}, n702 = {5551564.100000001, -28313.80598, 60.6124072, 0.001042112857, -1.327426719e-006, 2.166031743e-010, -1.142545514e-014}, n703 = {164224.1062, -369.176982}, n466 = 78.31650732350586);
-//           constant n606.n581.n615 n734(n696 = \"C8H18_n_octane\", n468 = 0.11422852, n697 = -1827477.060895125, n698 = 330740.51909278, n699 = 1000, n700 = {-698664.715, 13385.01096, -84.1516592, 0.327193666, -0.000377720959, 2.339836988e-007, -6.01089265e-011}, n701 = {-90262.2325, 493.922214}, n702 = {6365406.949999999, -31053.64657, 69.6916234, 0.01048059637, -4.12962195e-006, 5.543226319999999e-010, -2.651436499e-014}, n703 = {150096.8785, -416.989565}, n466 = 72.78805678301707);
-//           constant n606.n581.n615 n735(n696 = \"CL2\", n468 = 0.07090600000000001, n697 = 0, n698 = 129482.8364313316, n699 = 1000, n700 = {34628.1517, -554.7126520000001, 6.20758937, -0.002989632078, 3.17302729e-006, -1.793629562e-009, 4.260043590000001e-013}, n701 = {1534.069331, -9.438331107}, n702 = {6092569.42, -19496.27662, 28.54535795, -0.01449968764, 4.46389077e-006, -6.35852586e-010, 3.32736029e-014}, n703 = {121211.7724, -169.0778824}, n466 = 117.2604857134798);
-//           constant n606.n581.n615 n736(n696 = \"F2\", n468 = 0.0379968064, n697 = 0, n698 = 232259.1511269747, n699 = 1000, n700 = {10181.76308, 22.74241183, 1.97135304, 0.008151604010000001, -1.14896009e-005, 7.95865253e-009, -2.167079526e-012}, n701 = {-958.6943, 11.30600296}, n702 = {-2941167.79, 9456.5977, -7.73861615, 0.00764471299, -2.241007605e-006, 2.915845236e-010, -1.425033974e-014}, n703 = {-60710.0561, 84.23835080000001}, n466 = 218.8202848542556);
-//           constant n606.n581.n615 n737(n696 = \"H2\", n468 = 0.00201588, n697 = 0, n698 = 4200697.462150524, n699 = 1000, n700 = {40783.2321, -800.918604, 8.21470201, -0.01269714457, 1.753605076e-005, -1.20286027e-008, 3.36809349e-012}, n701 = {2682.484665, -30.43788844}, n702 = {560812.801, -837.150474, 2.975364532, 0.001252249124, -3.74071619e-007, 5.936625200000001e-011, -3.6069941e-015}, n703 = {5339.82441, -2.202774769}, n466 = 4124.487568704486);
-//           constant n606.n581.n615 n608(n696 = \"H2O\", n468 = 0.01801528, n697 = -13423382.81725291, n698 = 549760.6476280135, n699 = 1000, n700 = {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-006, 4.95504349e-009, -1.336933246e-012}, n701 = {-33039.7431, 17.24205775}, n702 = {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-007, 9.426468930000001e-011, -4.82238053e-015}, n703 = {-13842.86509, -7.97814851}, n466 = 461.5233290850878);
-//           constant n606.n581.n615 n738(n696 = \"He\", n468 = 0.004002602, n697 = 0, n698 = 1548349.798456104, n699 = 1000, n700 = {0, 0, 2.5, 0, 0, 0, 0}, n701 = {-745.375, 0.9287239740000001}, n702 = {0, 0, 2.5, 0, 0, 0, 0}, n703 = {-745.375, 0.9287239740000001}, n466 = 2077.26673798694);
-//           constant n606.n581.n615 n739(n696 = \"NH3\", n468 = 0.01703052, n697 = -2697510.117130892, n698 = 589713.1150428759, n699 = 1000, n700 = {-76812.26149999999, 1270.951578, -3.89322913, 0.02145988418, -2.183766703e-005, 1.317385706e-008, -3.33232206e-012}, n701 = {-12648.86413, 43.66014588}, n702 = {2452389.535, -8040.89424, 12.71346201, -0.000398018658, 3.55250275e-008, 2.53092357e-012, -3.32270053e-016}, n703 = {43861.91959999999, -64.62330602}, n466 = 488.2101075011215);
-//           constant n606.n581.n615 n740(n696 = \"NO\", n468 = 0.0300061, n697 = 3041758.509103149, n698 = 305908.1320131574, n699 = 1000, n700 = {-11439.16503, 153.6467592, 3.43146873, -0.002668592368, 8.48139912e-006, -7.685111050000001e-009, 2.386797655e-012}, n701 = {9098.214410000001, 6.72872549}, n702 = {223901.8716, -1289.651623, 5.43393603, -0.00036560349, 9.880966450000001e-008, -1.416076856e-011, 9.380184619999999e-016}, n703 = {17503.17656, -8.50166909}, n466 = 277.0927244793559);
-//           constant n606.n581.n615 n741(n696 = \"NO2\", n468 = 0.0460055, n697 = 743237.6346306421, n698 = 221890.3174620426, n699 = 1000, n700 = {-56420.3878, 963.308572, -2.434510974, 0.01927760886, -1.874559328e-005, 9.145497730000001e-009, -1.777647635e-012}, n701 = {-1547.925037, 40.6785121}, n702 = {721300.157, -3832.6152, 11.13963285, -0.002238062246, 6.54772343e-007, -7.6113359e-011, 3.32836105e-015}, n703 = {25024.97403, -43.0513004}, n466 = 180.7277825477389);
-//           constant n606.n581.n615 n609(n696 = \"N2\", n468 = 0.0280134, n697 = 0, n698 = 309498.4543111511, n699 = 1000, n700 = {22103.71497, -381.846182, 6.08273836, -0.00853091441, 1.384646189e-005, -9.62579362e-009, 2.519705809e-012}, n701 = {710.846086, -10.76003744}, n702 = {587712.406, -2239.249073, 6.06694922, -0.00061396855, 1.491806679e-007, -1.923105485e-011, 1.061954386e-015}, n703 = {12832.10415, -15.86640027}, n466 = 296.8033869505308);
-//           constant n606.n581.n615 n742(n696 = \"N2O\", n468 = 0.0440128, n697 = 1854006.107314236, n698 = 217685.1961247637, n699 = 1000, n700 = {42882.2597, -644.011844, 6.03435143, 0.0002265394436, 3.47278285e-006, -3.62774864e-009, 1.137969552e-012}, n701 = {11794.05506, -10.0312857}, n702 = {343844.804, -2404.557558, 9.125636220000001, -0.000540166793, 1.315124031e-007, -1.4142151e-011, 6.38106687e-016}, n703 = {21986.32638, -31.47805016}, n466 = 188.9103169986913);
-//           constant n606.n581.n615 n743(n696 = \"Ne\", n468 = 0.0201797, n697 = 0, n698 = 307111.9986917546, n699 = 1000, n700 = {0, 0, 2.5, 0, 0, 0, 0}, n701 = {-745.375, 3.35532272}, n702 = {0, 0, 2.5, 0, 0, 0, 0}, n703 = {-745.375, 3.35532272}, n466 = 412.0215860493466);
-//           constant n606.n581.n615 n744(n696 = \"O2\", n468 = 0.0319988, n697 = 0, n698 = 271263.4223783392, n699 = 1000, n700 = {-34255.6342, 484.700097, 1.119010961, 0.00429388924, -6.83630052e-007, -2.0233727e-009, 1.039040018e-012}, n701 = {-3391.45487, 18.4969947}, n702 = {-1037939.022, 2344.830282, 1.819732036, 0.001267847582, -2.188067988e-007, 2.053719572e-011, -8.193467050000001e-016}, n703 = {-16890.10929, 17.38716506}, n466 = 259.8369938872708);
-//           constant n606.n581.n615 n745(n696 = \"SO2\", n468 = 0.0640638, n697 = -4633037.690552231, n698 = 164650.3485587805, n699 = 1000, n700 = {-53108.4214, 909.031167, -2.356891244, 0.02204449885, -2.510781471e-005, 1.446300484e-008, -3.36907094e-012}, n701 = {-41137.52080000001, 40.45512519}, n702 = {-112764.0116, -825.226138, 7.61617863, -0.000199932761, 5.65563143e-008, -5.45431661e-012, 2.918294102e-016}, n703 = {-33513.0869, -16.55776085}, n466 = 129.7842463294403);
-//           constant n606.n581.n615 n746(n696 = \"SO3\", n468 = 0.0800632, n697 = -4944843.573576874, n698 = 145990.9046852986, n699 = 1000, n700 = {-39528.5529, 620.857257, -1.437731716, 0.02764126467, -3.144958662e-005, 1.792798e-008, -4.12638666e-012}, n701 = {-51841.0617, 33.91331216}, n702 = {-216692.3781, -1301.022399, 10.96287985, -0.000383710002, 8.466889039999999e-008, -9.70539929e-012, 4.49839754e-016}, n703 = {-43982.83990000001, -36.55217314}, n466 = 103.8488594010732);
-//         end n616;
-//       end n581;
-//     end n606;
+//         package $n616
+//           extends $n1.$n2.$n3;
+//           constant $n606.$n581.$n615 $n39($n696 = \"Air\", $n468 = 0.0289651159, $n697 = -4333.833858403446, $n698 = 298609.6803431054, $n699 = 1000, $n700 = {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-005, -7.94029797e-009, 2.18523191e-012}, $n701 = {-176.796731, -3.921504225}, $n702 = {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-008, -1.07148349e-011, 6.57780015e-016}, $n703 = {6462.26319, -8.147411905}, $n466 = 287.0512249529787);
+//           constant $n606.$n581.$n615 $n713($n696 = \"Ar\", $n468 = 0.039948, $n697 = 0, $n698 = 155137.3785921698, $n699 = 1000, $n700 = {0, 0, 2.5, 0, 0, 0, 0}, $n701 = {-745.375, 4.37967491}, $n702 = {20.10538475, -0.05992661069999999, 2.500069401, -3.99214116e-008, 1.20527214e-011, -1.819015576e-015, 1.078576636e-019}, $n703 = {-744.993961, 4.37918011}, $n466 = 208.1323720837088);
+//           constant $n606.$n581.$n615 $n714($n696 = \"CH4\", $n468 = 0.01604246, $n697 = -4650159.63885838, $n698 = 624355.7409524474, $n699 = 1000, $n700 = {-176685.0998, 2786.18102, -12.0257785, 0.0391761929, -3.61905443e-005, 2.026853043e-008, -4.976705489999999e-012}, $n701 = {-23313.1436, 89.0432275}, $n702 = {3730042.76, -13835.01485, 20.49107091, -0.001961974759, 4.72731304e-007, -3.72881469e-011, 1.623737207e-015}, $n703 = {75320.6691, -121.9124889}, $n466 = 518.2791167938085);
+//           constant $n606.$n581.$n615 $n715($n696 = \"CH3OH\", $n468 = 0.03204186, $n697 = -6271171.523750494, $n698 = 356885.5553329301, $n699 = 1000, $n700 = {-241664.2886, 4032.14719, -20.46415436, 0.0690369807, -7.59893269e-005, 4.59820836e-008, -1.158706744e-011}, $n701 = {-44332.61169999999, 140.014219}, $n702 = {3411570.76, -13455.00201, 22.61407623, -0.002141029179, 3.73005054e-007, -3.49884639e-011, 1.366073444e-015}, $n703 = {56360.8156, -127.7814279}, $n466 = 259.4878075117987);
+//           constant $n606.$n581.$n615 $n716($n696 = \"CO\", $n468 = 0.0280101, $n697 = -3946262.098314536, $n698 = 309570.6191695138, $n699 = 1000, $n700 = {14890.45326, -292.2285939, 5.72452717, -0.008176235030000001, 1.456903469e-005, -1.087746302e-008, 3.027941827e-012}, $n701 = {-13031.31878, -7.85924135}, $n702 = {461919.725, -1944.704863, 5.91671418, -0.0005664282830000001, 1.39881454e-007, -1.787680361e-011, 9.62093557e-016}, $n703 = {-2466.261084, -13.87413108}, $n466 = 296.8383547363272);
+//           constant $n606.$n581.$n615 $n717($n696 = \"CO2\", $n468 = 0.0440095, $n697 = -8941478.544405185, $n698 = 212805.6215135368, $n699 = 1000, $n700 = {49436.5054, -626.411601, 5.30172524, 0.002503813816, -2.127308728e-007, -7.68998878e-010, 2.849677801e-013}, $n701 = {-45281.9846, -7.04827944}, $n702 = {117696.2419, -1788.791477, 8.29152319, -9.22315678e-005, 4.86367688e-009, -1.891053312e-012, 6.330036589999999e-016}, $n703 = {-39083.5059, -26.52669281}, $n466 = 188.9244822140674);
+//           constant $n606.$n581.$n615 $n718($n696 = \"C2H2_vinylidene\", $n468 = 0.02603728, $n697 = 15930556.80163212, $n698 = 417638.4015534649, $n699 = 1000, $n700 = {-14660.42239, 278.9475593, 1.276229776, 0.01395015463, -1.475702649e-005, 9.476298110000001e-009, -2.567602217e-012}, $n701 = {47361.1018, 16.58225704}, $n702 = {1940838.725, -6892.718150000001, 13.39582494, -0.0009368968669999999, 1.470804368e-007, -1.220040365e-011, 4.12239166e-016}, $n703 = {91071.1293, -63.3750293}, $n466 = 319.3295152181795);
+//           constant $n606.$n581.$n615 $n719($n696 = \"C2H4\", $n468 = 0.02805316, $n697 = 1871446.924339362, $n698 = 374955.5843263291, $n699 = 1000, $n700 = {-116360.5836, 2554.85151, -16.09746428, 0.0662577932, -7.885081859999999e-005, 5.12522482e-008, -1.370340031e-011}, $n701 = {-6176.19107, 109.3338343}, $n702 = {3408763.67, -13748.47903, 23.65898074, -0.002423804419, 4.43139566e-007, -4.35268339e-011, 1.775410633e-015}, $n703 = {88204.2938, -137.1278108}, $n466 = 296.3827247982046);
+//           constant $n606.$n581.$n615 $n720($n696 = \"C2H6\", $n468 = 0.03006904, $n697 = -2788633.890539904, $n698 = 395476.3437741943, $n699 = 1000, $n700 = {-186204.4161, 3406.19186, -19.51705092, 0.0756583559, -8.20417322e-005, 5.0611358e-008, -1.319281992e-011}, $n701 = {-27029.3289, 129.8140496}, $n702 = {5025782.13, -20330.22397, 33.2255293, -0.00383670341, 7.23840586e-007, -7.3191825e-011, 3.065468699e-015}, $n703 = {111596.395, -203.9410584}, $n466 = 276.5127187299628);
+//           constant $n606.$n581.$n615 $n721($n696 = \"C2H5OH\", $n468 = 0.04606844, $n697 = -5100020.751733725, $n698 = 315659.1801241805, $n699 = 1000, $n700 = {-234279.1392, 4479.18055, -27.44817302, 0.1088679162, -0.0001305309334, 8.437346399999999e-008, -2.234559017e-011}, $n701 = {-50222.29, 176.4829211}, $n702 = {4694817.65, -19297.98213, 34.4758404, -0.00323616598, 5.78494772e-007, -5.56460027e-011, 2.2262264e-015}, $n703 = {86016.22709999999, -203.4801732}, $n466 = 180.4808671619877);
+//           constant $n606.$n581.$n615 $n722($n696 = \"C3H6_propylene\", $n468 = 0.04207974, $n697 = 475288.1077687267, $n698 = 322020.9535515191, $n699 = 1000, $n700 = {-191246.2174, 3542.07424, -21.14878626, 0.0890148479, -0.0001001429154, 6.267959389999999e-008, -1.637870781e-011}, $n701 = {-15299.61824, 140.7641382}, $n702 = {5017620.34, -20860.84035, 36.4415634, -0.00388119117, 7.27867719e-007, -7.321204500000001e-011, 3.052176369e-015}, $n703 = {126124.5355, -219.5715757}, $n466 = 197.588483198803);
+//           constant $n606.$n581.$n615 $n723($n696 = \"C3H8\", $n468 = 0.04409562, $n697 = -2373931.923397381, $n698 = 334301.1845620949, $n699 = 1000, $n700 = {-243314.4337, 4656.27081, -29.39466091, 0.1188952745, -0.0001376308269, 8.814823909999999e-008, -2.342987994e-011}, $n701 = {-35403.3527, 184.1749277}, $n702 = {6420731.680000001, -26597.91134, 45.3435684, -0.00502066392, 9.471216939999999e-007, -9.57540523e-011, 4.00967288e-015}, $n703 = {145558.2459, -281.8374734}, $n466 = 188.5555073270316);
+//           constant $n606.$n581.$n615 $n724($n696 = \"C4H8_1_butene\", $n468 = 0.05610631999999999, $n697 = -9624.584182316718, $n698 = 305134.9651875226, $n699 = 1000, $n700 = {-272149.2014, 5100.079250000001, -31.8378625, 0.1317754442, -0.0001527359339, 9.714761109999999e-008, -2.56020447e-011}, $n701 = {-25230.96386, 200.6932108}, $n702 = {6257948.609999999, -26603.76305, 47.6492005, -0.00438326711, 7.12883844e-007, -5.991020839999999e-011, 2.051753504e-015}, $n703 = {156925.2657, -291.3869761}, $n466 = 148.1913623991023);
+//           constant $n606.$n581.$n615 $n725($n696 = \"C4H10_n_butane\", $n468 = 0.0581222, $n697 = -2164233.28779709, $n698 = 330832.0228759407, $n699 = 1000, $n700 = {-317587.254, 6176.331819999999, -38.9156212, 0.1584654284, -0.0001860050159, 1.199676349e-007, -3.20167055e-011}, $n701 = {-45403.63390000001, 237.9488665}, $n702 = {7682322.45, -32560.5151, 57.3673275, -0.00619791681, 1.180186048e-006, -1.221893698e-010, 5.250635250000001e-015}, $n703 = {177452.656, -358.791876}, $n466 = 143.0515706563069);
+//           constant $n606.$n581.$n615 $n726($n696 = \"C5H10_1_pentene\", $n468 = 0.07013290000000001, $n697 = -303423.9279995551, $n698 = 309127.3852927798, $n699 = 1000, $n700 = {-534054.813, 9298.917380000001, -56.6779245, 0.2123100266, -0.000257129829, 1.666834304e-007, -4.43408047e-011}, $n701 = {-47906.8218, 339.60364}, $n702 = {3744014.97, -21044.85321, 47.3612699, -0.00042442012, -3.89897505e-008, 1.367074243e-011, -9.31319423e-016}, $n703 = {115409.1373, -278.6177449000001}, $n466 = 118.5530899192818);
+//           constant $n606.$n581.$n615 $n727($n696 = \"C5H12_n_pentane\", $n468 = 0.07214878, $n697 = -2034130.029641527, $n698 = 335196.2430965569, $n699 = 1000, $n700 = {-276889.4625, 5834.28347, -36.1754148, 0.1533339707, -0.0001528395882, 8.191092e-008, -1.792327902e-011}, $n701 = {-46653.7525, 226.5544053}, $n702 = {-2530779.286, -8972.59326, 45.3622326, -0.002626989916, 3.135136419e-006, -5.31872894e-010, 2.886896868e-014}, $n703 = {14846.16529, -251.6550384}, $n466 = 115.2406457877736);
+//           constant $n606.$n581.$n615 $n728($n696 = \"C6H6\", $n468 = 0.07811184, $n697 = 1061042.730525872, $n698 = 181735.4577743912, $n699 = 1000, $n700 = {-167734.0902, 4404.50004, -37.1737791, 0.1640509559, -0.0002020812374, 1.307915264e-007, -3.4442841e-011}, $n701 = {-10354.55401, 216.9853345}, $n702 = {4538575.72, -22605.02547, 46.940073, -0.004206676830000001, 7.90799433e-007, -7.9683021e-011, 3.32821208e-015}, $n703 = {139146.4686, -286.8751333}, $n466 = 106.4431717393932);
+//           constant $n606.$n581.$n615 $n729($n696 = \"C6H12_1_hexene\", $n468 = 0.08415948000000001, $n697 = -498458.4030224521, $n698 = 311788.9986962847, $n699 = 1000, $n700 = {-666883.165, 11768.64939, -72.70998330000001, 0.2709398396, -0.00033332464, 2.182347097e-007, -5.85946882e-011}, $n701 = {-62157.8054, 428.682564}, $n702 = {733290.696, -14488.48641, 46.7121549, 0.00317297847, -5.24264652e-007, 4.28035582e-011, -1.472353254e-015}, $n703 = {66977.4041, -262.3643854}, $n466 = 98.79424159940152);
+//           constant $n606.$n581.$n615 $n730($n696 = \"C6H14_n_hexane\", $n468 = 0.08617535999999999, $n697 = -1936980.593988816, $n698 = 333065.0431863586, $n699 = 1000, $n700 = {-581592.67, 10790.97724, -66.3394703, 0.2523715155, -0.0002904344705, 1.802201514e-007, -4.617223680000001e-011}, $n701 = {-72715.4457, 393.828354}, $n702 = {-3106625.684, -7346.087920000001, 46.94131760000001, 0.001693963977, 2.068996667e-006, -4.21214168e-010, 2.452345845e-014}, $n703 = {523.750312, -254.9967718}, $n466 = 96.48317105956971);
+//           constant $n606.$n581.$n615 $n731($n696 = \"C7H14_1_heptene\", $n468 = 0.09818605999999999, $n697 = -639194.6066478277, $n698 = 313588.3036756949, $n699 = 1000, $n700 = {-744940.284, 13321.79893, -82.81694379999999, 0.3108065994, -0.000378677992, 2.446841042e-007, -6.488763869999999e-011}, $n701 = {-72178.8501, 485.667149}, $n702 = {-1927608.174, -9125.024420000002, 47.4817797, 0.00606766053, -8.684859080000001e-007, 5.81399526e-011, -1.473979569e-015}, $n703 = {26009.14656, -256.2880707}, $n466 = 84.68077851377274);
+//           constant $n606.$n581.$n615 $n732($n696 = \"C7H16_n_heptane\", $n468 = 0.10020194, $n697 = -1874015.612871368, $n698 = 331540.487140269, $n699 = 1000, $n700 = {-612743.289, 11840.85437, -74.87188599999999, 0.2918466052, -0.000341679549, 2.159285269e-007, -5.65585273e-011}, $n701 = {-80134.0894, 440.721332}, $n702 = {9135632.469999999, -39233.1969, 78.8978085, -0.00465425193, 2.071774142e-006, -3.4425393e-010, 1.976834775e-014}, $n703 = {205070.8295, -485.110402}, $n466 = 82.97715593131233);
+//           constant $n606.$n581.$n615 $n733($n696 = \"C8H10_ethylbenz\", $n468 = 0.106165, $n697 = 281825.4603682946, $n698 = 209862.0072528611, $n699 = 1000, $n700 = {-469494, 9307.16836, -65.2176947, 0.2612080237, -0.000318175348, 2.051355473e-007, -5.40181735e-011}, $n701 = {-40738.7021, 378.090436}, $n702 = {5551564.100000001, -28313.80598, 60.6124072, 0.001042112857, -1.327426719e-006, 2.166031743e-010, -1.142545514e-014}, $n703 = {164224.1062, -369.176982}, $n466 = 78.31650732350586);
+//           constant $n606.$n581.$n615 $n734($n696 = \"C8H18_n_octane\", $n468 = 0.11422852, $n697 = -1827477.060895125, $n698 = 330740.51909278, $n699 = 1000, $n700 = {-698664.715, 13385.01096, -84.1516592, 0.327193666, -0.000377720959, 2.339836988e-007, -6.01089265e-011}, $n701 = {-90262.2325, 493.922214}, $n702 = {6365406.949999999, -31053.64657, 69.6916234, 0.01048059637, -4.12962195e-006, 5.543226319999999e-010, -2.651436499e-014}, $n703 = {150096.8785, -416.989565}, $n466 = 72.78805678301707);
+//           constant $n606.$n581.$n615 $n735($n696 = \"CL2\", $n468 = 0.07090600000000001, $n697 = 0, $n698 = 129482.8364313316, $n699 = 1000, $n700 = {34628.1517, -554.7126520000001, 6.20758937, -0.002989632078, 3.17302729e-006, -1.793629562e-009, 4.260043590000001e-013}, $n701 = {1534.069331, -9.438331107}, $n702 = {6092569.42, -19496.27662, 28.54535795, -0.01449968764, 4.46389077e-006, -6.35852586e-010, 3.32736029e-014}, $n703 = {121211.7724, -169.0778824}, $n466 = 117.2604857134798);
+//           constant $n606.$n581.$n615 $n736($n696 = \"F2\", $n468 = 0.0379968064, $n697 = 0, $n698 = 232259.1511269747, $n699 = 1000, $n700 = {10181.76308, 22.74241183, 1.97135304, 0.008151604010000001, -1.14896009e-005, 7.95865253e-009, -2.167079526e-012}, $n701 = {-958.6943, 11.30600296}, $n702 = {-2941167.79, 9456.5977, -7.73861615, 0.00764471299, -2.241007605e-006, 2.915845236e-010, -1.425033974e-014}, $n703 = {-60710.0561, 84.23835080000001}, $n466 = 218.8202848542556);
+//           constant $n606.$n581.$n615 $n737($n696 = \"H2\", $n468 = 0.00201588, $n697 = 0, $n698 = 4200697.462150524, $n699 = 1000, $n700 = {40783.2321, -800.918604, 8.21470201, -0.01269714457, 1.753605076e-005, -1.20286027e-008, 3.36809349e-012}, $n701 = {2682.484665, -30.43788844}, $n702 = {560812.801, -837.150474, 2.975364532, 0.001252249124, -3.74071619e-007, 5.936625200000001e-011, -3.6069941e-015}, $n703 = {5339.82441, -2.202774769}, $n466 = 4124.487568704486);
+//           constant $n606.$n581.$n615 $n608($n696 = \"H2O\", $n468 = 0.01801528, $n697 = -13423382.81725291, $n698 = 549760.6476280135, $n699 = 1000, $n700 = {-39479.6083, 575.573102, 0.931782653, 0.00722271286, -7.34255737e-006, 4.95504349e-009, -1.336933246e-012}, $n701 = {-33039.7431, 17.24205775}, $n702 = {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-007, 9.426468930000001e-011, -4.82238053e-015}, $n703 = {-13842.86509, -7.97814851}, $n466 = 461.5233290850878);
+//           constant $n606.$n581.$n615 $n738($n696 = \"He\", $n468 = 0.004002602, $n697 = 0, $n698 = 1548349.798456104, $n699 = 1000, $n700 = {0, 0, 2.5, 0, 0, 0, 0}, $n701 = {-745.375, 0.9287239740000001}, $n702 = {0, 0, 2.5, 0, 0, 0, 0}, $n703 = {-745.375, 0.9287239740000001}, $n466 = 2077.26673798694);
+//           constant $n606.$n581.$n615 $n739($n696 = \"NH3\", $n468 = 0.01703052, $n697 = -2697510.117130892, $n698 = 589713.1150428759, $n699 = 1000, $n700 = {-76812.26149999999, 1270.951578, -3.89322913, 0.02145988418, -2.183766703e-005, 1.317385706e-008, -3.33232206e-012}, $n701 = {-12648.86413, 43.66014588}, $n702 = {2452389.535, -8040.89424, 12.71346201, -0.000398018658, 3.55250275e-008, 2.53092357e-012, -3.32270053e-016}, $n703 = {43861.91959999999, -64.62330602}, $n466 = 488.2101075011215);
+//           constant $n606.$n581.$n615 $n740($n696 = \"NO\", $n468 = 0.0300061, $n697 = 3041758.509103149, $n698 = 305908.1320131574, $n699 = 1000, $n700 = {-11439.16503, 153.6467592, 3.43146873, -0.002668592368, 8.48139912e-006, -7.685111050000001e-009, 2.386797655e-012}, $n701 = {9098.214410000001, 6.72872549}, $n702 = {223901.8716, -1289.651623, 5.43393603, -0.00036560349, 9.880966450000001e-008, -1.416076856e-011, 9.380184619999999e-016}, $n703 = {17503.17656, -8.50166909}, $n466 = 277.0927244793559);
+//           constant $n606.$n581.$n615 $n741($n696 = \"NO2\", $n468 = 0.0460055, $n697 = 743237.6346306421, $n698 = 221890.3174620426, $n699 = 1000, $n700 = {-56420.3878, 963.308572, -2.434510974, 0.01927760886, -1.874559328e-005, 9.145497730000001e-009, -1.777647635e-012}, $n701 = {-1547.925037, 40.6785121}, $n702 = {721300.157, -3832.6152, 11.13963285, -0.002238062246, 6.54772343e-007, -7.6113359e-011, 3.32836105e-015}, $n703 = {25024.97403, -43.0513004}, $n466 = 180.7277825477389);
+//           constant $n606.$n581.$n615 $n609($n696 = \"N2\", $n468 = 0.0280134, $n697 = 0, $n698 = 309498.4543111511, $n699 = 1000, $n700 = {22103.71497, -381.846182, 6.08273836, -0.00853091441, 1.384646189e-005, -9.62579362e-009, 2.519705809e-012}, $n701 = {710.846086, -10.76003744}, $n702 = {587712.406, -2239.249073, 6.06694922, -0.00061396855, 1.491806679e-007, -1.923105485e-011, 1.061954386e-015}, $n703 = {12832.10415, -15.86640027}, $n466 = 296.8033869505308);
+//           constant $n606.$n581.$n615 $n742($n696 = \"N2O\", $n468 = 0.0440128, $n697 = 1854006.107314236, $n698 = 217685.1961247637, $n699 = 1000, $n700 = {42882.2597, -644.011844, 6.03435143, 0.0002265394436, 3.47278285e-006, -3.62774864e-009, 1.137969552e-012}, $n701 = {11794.05506, -10.0312857}, $n702 = {343844.804, -2404.557558, 9.125636220000001, -0.000540166793, 1.315124031e-007, -1.4142151e-011, 6.38106687e-016}, $n703 = {21986.32638, -31.47805016}, $n466 = 188.9103169986913);
+//           constant $n606.$n581.$n615 $n743($n696 = \"Ne\", $n468 = 0.0201797, $n697 = 0, $n698 = 307111.9986917546, $n699 = 1000, $n700 = {0, 0, 2.5, 0, 0, 0, 0}, $n701 = {-745.375, 3.35532272}, $n702 = {0, 0, 2.5, 0, 0, 0, 0}, $n703 = {-745.375, 3.35532272}, $n466 = 412.0215860493466);
+//           constant $n606.$n581.$n615 $n744($n696 = \"O2\", $n468 = 0.0319988, $n697 = 0, $n698 = 271263.4223783392, $n699 = 1000, $n700 = {-34255.6342, 484.700097, 1.119010961, 0.00429388924, -6.83630052e-007, -2.0233727e-009, 1.039040018e-012}, $n701 = {-3391.45487, 18.4969947}, $n702 = {-1037939.022, 2344.830282, 1.819732036, 0.001267847582, -2.188067988e-007, 2.053719572e-011, -8.193467050000001e-016}, $n703 = {-16890.10929, 17.38716506}, $n466 = 259.8369938872708);
+//           constant $n606.$n581.$n615 $n745($n696 = \"SO2\", $n468 = 0.0640638, $n697 = -4633037.690552231, $n698 = 164650.3485587805, $n699 = 1000, $n700 = {-53108.4214, 909.031167, -2.356891244, 0.02204449885, -2.510781471e-005, 1.446300484e-008, -3.36907094e-012}, $n701 = {-41137.52080000001, 40.45512519}, $n702 = {-112764.0116, -825.226138, 7.61617863, -0.000199932761, 5.65563143e-008, -5.45431661e-012, 2.918294102e-016}, $n703 = {-33513.0869, -16.55776085}, $n466 = 129.7842463294403);
+//           constant $n606.$n581.$n615 $n746($n696 = \"SO3\", $n468 = 0.0800632, $n697 = -4944843.573576874, $n698 = 145990.9046852986, $n699 = 1000, $n700 = {-39528.5529, 620.857257, -1.437731716, 0.02764126467, -3.144958662e-005, 1.792798e-008, -4.12638666e-012}, $n701 = {-51841.0617, 33.91331216}, $n702 = {-216692.3781, -1301.022399, 10.96287985, -0.000383710002, 8.466889039999999e-008, -9.70539929e-012, 4.49839754e-016}, $n703 = {-43982.83990000001, -36.55217314}, $n466 = 103.8488594010732);
+//         end $n616;
+//       end $n581;
+//     end $n606;
 //
-//     package n673
-//       extends n1.n2.n113;
-//       import n1.n97;
-//       import n1.n268;
+//     package $n673
+//       extends $n1.$n2.$n113;
+//       import $n1.$n97;
+//       import $n1.$n268;
 //
-//       package n581
-//         extends n1.n2.n3;
+//       package $n581
+//         extends $n1.$n2.$n3;
 //
-//         record n747
-//           extends n1.n2.n461;
-//           n10.n94 n250;
-//           n10.n214 n51;
-//         end n747;
-//       end n581;
+//         record $n747
+//           extends $n1.$n2.$n461;
+//           $n10.$n94 $n250;
+//           $n10.$n214 $n51;
+//         end $n747;
+//       end $n581;
 //
-//       package n674
-//         import n748 = n1.n37.n673.n674.n675;
-//         extends n1.n37.n12.n38(n369 = if n749 then n1.n37.n12.n345.n346.n250 else n1.n37.n12.n345.n346.n547, final n453 = true, final n454 = true, n364 = \"tableMedium\", redeclare record n165 = n581.n747, n366 = true, n455 = 1.013e5, n94(min = n750, max = n751));
-//         constant Boolean n749 = true;
-//         constant Boolean n752 = size(n753, 1) > 1;
-//         constant n1.n11.n94 n750;
-//         constant n1.n11.n94 n751;
-//         constant n94 n754 = 273.15;
-//         constant n381 n426 = 0;
-//         constant n480 n755 = 0;
-//         constant n469 n756 = 0.1;
-//         constant Integer n757 = 2;
-//         constant Integer n758 = n757;
-//         constant Integer n759 = n757;
-//         constant Integer n760 = n757;
-//         constant Integer n761 = n757;
-//         constant Integer n762 = n757;
-//         constant Integer n763 = size(n764, 1);
-//         constant Real[:, 2] n753;
-//         constant Real[:, 2] n765;
-//         constant Real[:, 2] n764;
-//         constant Real[:, 2] n766;
-//         constant Real[:, 2] n767;
-//         constant Boolean n768;
-//         constant Boolean n769 = not (size(n753, 1) == 0);
-//         constant Boolean n770 = not (size(n765, 1) == 0);
-//         constant Boolean n771 = not (size(n764, 1) == 0);
-//         constant Boolean n772 = not (size(n766, 1) == 0);
-//         final constant Real[n763] n773 = if size(n764, 1) > 0 then (if n768 then 1 ./ n764[:, 1] else 1 ./ n30.n457(n764[:, 1])) else fill(0, n763);
-//         final constant Real[:] n774 = if n769 then n748.n775(n753[:, 1], n753[:, 2], n758) else zeros(n758 + 1);
-//         final constant Real[:] n776 = if n770 then n748.n775(n765[:, 1], n765[:, 2], n759) else zeros(n759 + 1);
-//         final constant Real[:] n777 = if n771 then n748.n775(n773, n268.log(n764[:, 2]), n760) else zeros(n760 + 1);
-//         final constant Real[:] n778 = if size(n767, 1) > 0 then n748.n775(n767[:, 1], n767[:, 2], n762) else zeros(n762 + 1);
+//       package $n674
+//         import $n748 = $n1.$n37.$n673.$n674.$n675;
+//         extends $n1.$n37.$n12.$n38($n369 = if $n749 then $n1.$n37.$n12.$n345.$n346.$n250 else $n1.$n37.$n12.$n345.$n346.$n547, final $n453 = true, final $n454 = true, $n364 = \"tableMedium\", redeclare record $n165 = $n581.$n747, $n366 = true, $n455 = 1.013e5, $n94(min = $n750, max = $n751));
+//         constant Boolean $n749 = true;
+//         constant Boolean $n752 = size($n753, 1) > 1;
+//         constant $n1.$n11.$n94 $n750;
+//         constant $n1.$n11.$n94 $n751;
+//         constant $n94 $n754 = 273.15;
+//         constant $n381 $n426 = 0;
+//         constant $n480 $n755 = 0;
+//         constant $n469 $n756 = 0.1;
+//         constant Integer $n757 = 2;
+//         constant Integer $n758 = $n757;
+//         constant Integer $n759 = $n757;
+//         constant Integer $n760 = $n757;
+//         constant Integer $n761 = $n757;
+//         constant Integer $n762 = $n757;
+//         constant Integer $n763 = size($n764, 1);
+//         constant Real[:, 2] $n753;
+//         constant Real[:, 2] $n765;
+//         constant Real[:, 2] $n764;
+//         constant Real[:, 2] $n766;
+//         constant Real[:, 2] $n767;
+//         constant Boolean $n768;
+//         constant Boolean $n769 = not (size($n753, 1) == 0);
+//         constant Boolean $n770 = not (size($n765, 1) == 0);
+//         constant Boolean $n771 = not (size($n764, 1) == 0);
+//         constant Boolean $n772 = not (size($n766, 1) == 0);
+//         final constant Real[$n763] $n773 = if size($n764, 1) > 0 then (if $n768 then 1 ./ $n764[:, 1] else 1 ./ $n30.$n457($n764[:, 1])) else fill(0, $n763);
+//         final constant Real[:] $n774 = if $n769 then $n748.$n775($n753[:, 1], $n753[:, 2], $n758) else zeros($n758 + 1);
+//         final constant Real[:] $n776 = if $n770 then $n748.$n775($n765[:, 1], $n765[:, 2], $n759) else zeros($n759 + 1);
+//         final constant Real[:] $n777 = if $n771 then $n748.$n775($n773, $n268.log($n764[:, 2]), $n760) else zeros($n760 + 1);
+//         final constant Real[:] $n778 = if size($n767, 1) > 0 then $n748.$n775($n767[:, 1], $n767[:, 2], $n762) else zeros($n762 + 1);
 //
-//         redeclare model extends n373(final n470 = true, n475 = n30.n477(n51), n471(start = n107 - 273.15) = n30.n474(n250), n250(start = n107, stateSelect = if n403 then StateSelect.prefer else StateSelect.default))
-//           n10.n467 n493;
-//           parameter n10.n94 n107 = 298.15;
+//         redeclare model extends $n373(final $n470 = true, $n475 = $n30.$n477($n51), $n471(start = $n107 - 273.15) = $n30.$n474($n250), $n250(start = $n107, stateSelect = if $n403 then StateSelect.prefer else StateSelect.default))
+//           $n10.$n467 $n493;
+//           parameter $n10.$n94 $n107 = 298.15;
 //         equation
-//           assert(n769, \"assert message 6728461303302419086\");
-//           assert(n250 >= n750 and n250 <= n751, \"assert message 8955042438122138910\");
-//           n466 = n1.n97.n466 / n756;
-//           n493 = n748.n779(n776, if n768 then n250 else n471);
-//           n190 = n780(n51, n250, n752);
-//           n407 = n190 - (if n366 then n455 / n145 else n136.n51 / n145);
-//           n145 = n748.n779(n774, if n768 then n250 else n471);
-//           n136.n250 = n250;
-//           n136.n51 = n51;
-//           n468 = n756;
-//         end n373;
+//           assert($n769, \"assert message 6728461303302419086\");
+//           assert($n250 >= $n750 and $n250 <= $n751, \"assert message 8955042438122138910\");
+//           $n466 = $n1.$n97.$n466 / $n756;
+//           $n493 = $n748.$n779($n776, if $n768 then $n250 else $n471);
+//           $n190 = $n780($n51, $n250, $n752);
+//           $n407 = $n190 - (if $n366 then $n455 / $n145 else $n136.$n51 / $n145);
+//           $n145 = $n748.$n779($n774, if $n768 then $n250 else $n471);
+//           $n136.$n250 = $n250;
+//           $n136.$n51 = $n51;
+//           $n468 = $n756;
+//         end $n373;
 //
-//         redeclare function extends n225
+//         redeclare function extends $n225
 //         algorithm
-//           n136 := n165(n51 = n51, n250 = n250);
+//           $n136 := $n165($n51 = $n51, $n250 = $n250);
 //           annotation(smoothOrder = 3);
-//         end n225;
+//         end $n225;
 //
-//         redeclare function extends n481
+//         redeclare function extends $n481
 //         algorithm
 //           assert(false, \"assert message 6474340924986620138\");
-//         end n481;
+//         end $n481;
 //
-//         redeclare function extends n197
+//         redeclare function extends $n197
 //         algorithm
-//           n136 := n165(n51 = n51, n250 = n781(n51, n190));
+//           $n136 := $n165($n51 = $n51, $n250 = $n781($n51, $n190));
 //           annotation(Inline = true, smoothOrder = 3);
-//         end n197;
+//         end $n197;
 //
-//         redeclare function extends n478
+//         redeclare function extends $n478
 //         algorithm
-//           n136 := n165(n51 = n51, n250 = n782(n51, n479));
+//           $n136 := $n165($n51 = $n51, $n250 = $n782($n51, $n479));
 //           annotation(Inline = true, smoothOrder = 3);
-//         end n478;
+//         end $n478;
 //
-//         redeclare function extends n482
+//         redeclare function extends $n482
 //         algorithm
-//           n136 := n165(n51 = n37.n581.n583(n340, n164.n51, n166.n51, n483), n250 = n37.n581.n583(n340, n164.n250, n166.n250, n483));
+//           $n136 := $n165($n51 = $n37.$n581.$n583($n340, $n164.$n51, $n166.$n51, $n483), $n250 = $n37.$n581.$n583($n340, $n164.$n250, $n166.$n250, $n483));
 //           annotation(Inline = true, smoothOrder = 3);
-//         end n482;
+//         end $n482;
 //
-//         redeclare function extends n494
+//         redeclare function extends $n494
 //         algorithm
-//           assert(n770, \"assert message 8414355670950930722\");
-//           n495 := n748.n779(n776, if n768 then n136.n250 else n136.n250 - 273.15);
+//           assert($n770, \"assert message 8414355670950930722\");
+//           $n495 := $n748.$n779($n776, if $n768 then $n136.$n250 else $n136.$n250 - 273.15);
 //           annotation(smoothOrder = 2);
-//         end n494;
+//         end $n494;
 //
-//         redeclare function extends n486
+//         redeclare function extends $n486
 //         algorithm
-//           assert(n770, \"assert message 8414355670950930722\");
-//           n493 := n748.n779(n776, if n768 then n136.n250 else n136.n250 - 273.15);
+//           assert($n770, \"assert message 8414355670950930722\");
+//           $n493 := $n748.$n779($n776, if $n768 then $n136.$n250 else $n136.$n250 - 273.15);
 //           annotation(smoothOrder = 2);
-//         end n486;
+//         end $n486;
 //
-//         redeclare function extends n212
+//         redeclare function extends $n212
 //         algorithm
-//           assert(size(n764, 1) > 0, \"assert message 4607081640477087195\");
-//           n429 := n268.exp(n748.n779(n777, 1 / n136.n250));
+//           assert(size($n764, 1) > 0, \"assert message 4607081640477087195\");
+//           $n429 := $n268.exp($n748.$n779($n777, 1 / $n136.$n250));
 //           annotation(smoothOrder = 2);
-//         end n212;
+//         end $n212;
 //
-//         redeclare function extends n260
+//         redeclare function extends $n260
 //         algorithm
-//           assert(size(n767, 1) > 0, \"assert message 7086601837081427742\");
-//           n277 := n748.n779(n778, if n768 then n136.n250 else n30.n474(n136.n250));
+//           assert(size($n767, 1) > 0, \"assert message 7086601837081427742\");
+//           $n277 := $n748.$n779($n778, if $n768 then $n136.$n250 else $n30.$n474($n136.$n250));
 //           annotation(smoothOrder = 2);
-//         end n260;
+//         end $n260;
 //
-//         function n783
-//           extends n1.n2.n271;
-//           input n94 n250;
-//           output n480 n479;
+//         function $n783
+//           extends $n1.$n2.$n271;
+//           input $n94 $n250;
+//           output $n480 $n479;
 //         algorithm
-//           n479 := n755 + (if n768 then n748.n784(n776[1:n757], n250, n754) else n748.n784(n776[1:n757], n30.n474(n250), n30.n474(n754))) + n1.n268.log(n250 / n754) * n748.n779(n776, if n768 then 0 else n1.n97.n785);
+//           $n479 := $n755 + (if $n768 then $n748.$n784($n776[1:$n757], $n250, $n754) else $n748.$n784($n776[1:$n757], $n30.$n474($n250), $n30.$n474($n754))) + $n1.$n268.log($n250 / $n754) * $n748.$n779($n776, if $n768 then 0 else $n1.$n97.$n785);
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n783;
+//         end $n783;
 //
-//         redeclare function extends n489
+//         redeclare function extends $n489
 //         protected
-//           Integer n757 = size(n776, 1) - 1;
+//           Integer $n757 = size($n776, 1) - 1;
 //         algorithm
-//           assert(n770, \"assert message 1574321203922144642\");
-//           n479 := n783(n136.n250);
+//           assert($n770, \"assert message 1574321203922144642\");
+//           $n479 := $n783($n136.$n250);
 //           annotation(smoothOrder = 2);
-//         end n489;
+//         end $n489;
 //
-//         function n786
-//           import n1.n11.n31.n474;
-//           extends n1.n2.n271;
-//           input n10.n94 n250;
-//           output n10.n381 n190;
+//         function $n786
+//           import $n1.$n11.$n31.$n474;
+//           extends $n1.$n2.$n271;
+//           input $n10.$n94 $n250;
+//           output $n10.$n381 $n190;
 //         algorithm
-//           n190 := n426 + n748.n784(n776, if n768 then n250 else n30.n474(n250), if n768 then n754 else n30.n474(n754));
-//           annotation(derivative = n787);
-//         end n786;
+//           $n190 := $n426 + $n748.$n784($n776, if $n768 then $n250 else $n30.$n474($n250), if $n768 then $n754 else $n30.$n474($n754));
+//           annotation(derivative = $n787);
+//         end $n786;
 //
-//         function n787
-//           import n1.n11.n31.n474;
-//           extends n1.n2.n271;
-//           input n10.n94 n250;
-//           input Real n652;
-//           output Real n653;
+//         function $n787
+//           import $n1.$n11.$n31.$n474;
+//           extends $n1.$n2.$n271;
+//           input $n10.$n94 $n250;
+//           input Real $n652;
+//           output Real $n653;
 //         algorithm
-//           n653 := n748.n779(n776, if n768 then n250 else n30.n474(n250)) * n652;
+//           $n653 := $n748.$n779($n776, if $n768 then $n250 else $n30.$n474($n250)) * $n652;
 //           annotation(smoothOrder = 1);
-//         end n787;
+//         end $n787;
 //
-//         function n788
-//           import n1.n11.n31.n474;
-//           extends n1.n2.n271;
-//           input n10.n214 n51;
-//           input n10.n94 n250;
-//           input Boolean n752 = false;
-//           output n10.n381 n190;
+//         function $n788
+//           import $n1.$n11.$n31.$n474;
+//           extends $n1.$n2.$n271;
+//           input $n10.$n214 $n51;
+//           input $n10.$n94 $n250;
+//           input Boolean $n752 = false;
+//           output $n10.$n381 $n190;
 //         algorithm
-//           n190 := n426 + n748.n784(n776, if n768 then n250 else n30.n474(n250), if n768 then n754 else n30.n474(n754)) + (n51 - n455) / n748.n779(n774, if n768 then n250 else n30.n474(n250)) * (if n752 then (1 + n250 / n748.n779(n774, if n768 then n250 else n30.n474(n250)) * n748.n789(n774, if n768 then n250 else n30.n474(n250))) else 1.0);
+//           $n190 := $n426 + $n748.$n784($n776, if $n768 then $n250 else $n30.$n474($n250), if $n768 then $n754 else $n30.$n474($n754)) + ($n51 - $n455) / $n748.$n779($n774, if $n768 then $n250 else $n30.$n474($n250)) * (if $n752 then (1 + $n250 / $n748.$n779($n774, if $n768 then $n250 else $n30.$n474($n250)) * $n748.$n789($n774, if $n768 then $n250 else $n30.$n474($n250))) else 1.0);
 //           annotation(smoothOrder = 2);
-//         end n788;
+//         end $n788;
 //
-//         redeclare function extends n388
+//         redeclare function extends $n388
 //         algorithm
-//           n250 := n136.n250;
+//           $n250 := $n136.$n250;
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n388;
+//         end $n388;
 //
-//         redeclare function extends n228
+//         redeclare function extends $n228
 //         algorithm
-//           n51 := n136.n51;
+//           $n51 := $n136.$n51;
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n228;
+//         end $n228;
 //
-//         redeclare function extends n198
+//         redeclare function extends $n198
 //         algorithm
-//           n145 := n748.n779(n774, if n768 then n136.n250 else n30.n474(n136.n250));
+//           $n145 := $n748.$n779($n774, if $n768 then $n136.$n250 else $n30.$n474($n136.$n250));
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n198;
+//         end $n198;
 //
-//         redeclare function extends n372
+//         redeclare function extends $n372
 //         algorithm
-//           n190 := n780(n136.n51, n136.n250);
+//           $n190 := $n780($n136.$n51, $n136.$n250);
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n372;
+//         end $n372;
 //
-//         redeclare function extends n487
+//         redeclare function extends $n487
 //         algorithm
-//           n407 := n780(n136.n51, n136.n250) - (if n366 then n455 else n136.n51) / n198(n136);
+//           $n407 := $n780($n136.$n51, $n136.$n250) - (if $n366 then $n455 else $n136.$n51) / $n198($n136);
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n487;
+//         end $n487;
 //
-//         function n781
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n381 n190;
-//           output n94 n250;
+//         function $n781
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n381 $n190;
+//           output $n94 $n250;
 //
 //         protected
-//           package n326
-//             extends n1.n37.n581.n584;
+//           package $n326
+//             extends $n1.$n37.$n581.$n584;
 //
-//             redeclare record extends n585
-//               constant Real[5] n790 = {1, 2, 3, 4, 5};
-//             end n585;
+//             redeclare record extends $n585
+//               constant Real[5] $n790 = {1, 2, 3, 4, 5};
+//             end $n585;
 //
-//             redeclare function extends n586
+//             redeclare function extends $n586
 //             algorithm
-//               n18 := n780(n51, n340);
-//             end n586;
-//           end n326;
+//               $n18 := $n780($n51, $n340);
+//             end $n586;
+//           end $n326;
 //         algorithm
-//           n250 := n326.n588(n190, n750, n751, n51, {1}, n326.n585());
-//           annotation(Inline = false, LateInline = true, inverse(n190 = n780(n51, n250)));
-//         end n781;
+//           $n250 := $n326.$n588($n190, $n750, $n751, $n51, {1}, $n326.$n585());
+//           annotation(Inline = false, LateInline = true, inverse($n190 = $n780($n51, $n250)));
+//         end $n781;
 //
-//         function n782
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n480 n479;
-//           output n94 n250;
+//         function $n782
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n480 $n479;
+//           output $n94 $n250;
 //
 //         protected
-//           package n326
-//             extends n1.n37.n581.n584;
+//           package $n326
+//             extends $n1.$n37.$n581.$n584;
 //
-//             redeclare record extends n585
-//               constant Real[5] n790 = {1, 2, 3, 4, 5};
-//             end n585;
+//             redeclare record extends $n585
+//               constant Real[5] $n790 = {1, 2, 3, 4, 5};
+//             end $n585;
 //
-//             redeclare function extends n586
+//             redeclare function extends $n586
 //             algorithm
-//               n18 := n783(n340);
-//             end n586;
-//           end n326;
+//               $n18 := $n783($n340);
+//             end $n586;
+//           end $n326;
 //         algorithm
-//           n250 := n326.n588(n479, n750, n751, n51, {1}, n326.n585());
-//         end n782;
+//           $n250 := $n326.$n588($n479, $n750, $n751, $n51, {1}, $n326.$n585());
+//         end $n782;
 //
-//         package n675
-//           extends n1.n2.n3;
+//         package $n675
+//           extends $n1.$n2.$n3;
 //
-//           function n779
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n407;
-//             output Real n18;
+//           function $n779
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n407;
+//             output Real $n18;
 //           algorithm
-//             n18 := n51[1];
-//             for n791 in 2:size(n51, 1) loop
-//               n18 := n51[n791] + n407 * n18;
+//             $n18 := $n51[1];
+//             for $n791 in 2:size($n51, 1) loop
+//               $n18 := $n51[$n791] + $n407 * $n18;
 //             end for;
-//             annotation(derivative(zeroDerivative = n51) = n792);
-//           end n779;
+//             annotation(derivative(zeroDerivative = $n51) = $n792);
+//           end $n779;
 //
-//           function n676
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n793;
-//             input Real n794;
-//             input Real n407;
-//             output Real n18;
+//           function $n676
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n793;
+//             input Real $n794;
+//             input Real $n407;
+//             output Real $n18;
 //           algorithm
-//             if n407 < n793 then
-//               n18 := n779(n51, n793) - n792(n51, n793, n793 - n407);
-//             elseif n407 > n794 then
-//               n18 := n779(n51, n794) + n792(n51, n794, n407 - n794);
+//             if $n407 < $n793 then
+//               $n18 := $n779($n51, $n793) - $n792($n51, $n793, $n793 - $n407);
+//             elseif $n407 > $n794 then
+//               $n18 := $n779($n51, $n794) + $n792($n51, $n794, $n407 - $n794);
 //             else
-//               n18 := n779(n51, n407);
+//               $n18 := $n779($n51, $n407);
 //             end if;
-//             annotation(derivative(zeroDerivative = n51, zeroDerivative = n793, zeroDerivative = n794) = n795);
-//           end n676;
+//             annotation(derivative(zeroDerivative = $n51, zeroDerivative = $n793, zeroDerivative = $n794) = $n795);
+//           end $n676;
 //
-//           function n789
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n407;
-//             output Real n18;
+//           function $n789
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n407;
+//             output Real $n18;
 //           protected
-//             Integer n84 = size(n51, 1);
+//             Integer $n84 = size($n51, 1);
 //           algorithm
-//             n18 := n51[1] * (n84 - 1);
-//             for n791 in 2:size(n51, 1) - 1 loop
-//               n18 := n51[n791] * (n84 - n791) + n407 * n18;
+//             $n18 := $n51[1] * ($n84 - 1);
+//             for $n791 in 2:size($n51, 1) - 1 loop
+//               $n18 := $n51[$n791] * ($n84 - $n791) + $n407 * $n18;
 //             end for;
-//             annotation(derivative(zeroDerivative = n51) = n796);
-//           end n789;
+//             annotation(derivative(zeroDerivative = $n51) = $n796);
+//           end $n789;
 //
-//           function n797
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n407;
-//             output Real n18;
+//           function $n797
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n407;
+//             output Real $n18;
 //           protected
-//             Integer n84 = size(n51, 1);
+//             Integer $n84 = size($n51, 1);
 //           algorithm
-//             n18 := n51[1] * (n84 - 1) * (n84 - 2);
-//             for n791 in 2:size(n51, 1) - 2 loop
-//               n18 := n51[n791] * (n84 - n791) * (n84 - n791 - 1) + n407 * n18;
+//             $n18 := $n51[1] * ($n84 - 1) * ($n84 - 2);
+//             for $n791 in 2:size($n51, 1) - 2 loop
+//               $n18 := $n51[$n791] * ($n84 - $n791) * ($n84 - $n791 - 1) + $n407 * $n18;
 //             end for;
-//           end n797;
+//           end $n797;
 //
-//           function n784
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n798;
-//             input Real n799 = 0;
-//             output Real n800 = 0.0;
+//           function $n784
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n798;
+//             input Real $n799 = 0;
+//             output Real $n800 = 0.0;
 //           protected
-//             Integer n84 = size(n51, 1);
-//             Real n801 = 0;
+//             Integer $n84 = size($n51, 1);
+//             Real $n801 = 0;
 //           algorithm
-//             for n791 in 1:n84 loop
-//               n800 := n798 * (n51[n791] / (n84 - n791 + 1) + n800);
-//               n801 := n799 * (n51[n791] / (n84 - n791 + 1) + n801);
+//             for $n791 in 1:$n84 loop
+//               $n800 := $n798 * ($n51[$n791] / ($n84 - $n791 + 1) + $n800);
+//               $n801 := $n799 * ($n51[$n791] / ($n84 - $n791 + 1) + $n801);
 //             end for;
-//             n800 := n800 - n801;
-//             annotation(derivative(zeroDerivative = n51) = n802);
-//           end n784;
+//             $n800 := $n800 - $n801;
+//             annotation(derivative(zeroDerivative = $n51) = $n802);
+//           end $n784;
 //
-//           function n775
-//             extends n1.n2.n271;
-//             input Real[:] n407;
-//             input Real[size(n407, 1)] n18;
-//             input Integer n84(min = 1);
-//             output Real[n84 + 1] n51;
+//           function $n775
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n407;
+//             input Real[size($n407, 1)] $n18;
+//             input Integer $n84(min = 1);
+//             output Real[$n84 + 1] $n51;
 //           protected
-//             Real[size(n407, 1), n84 + 1] n155;
+//             Real[size($n407, 1), $n84 + 1] $n155;
 //           algorithm
-//             n155[:, n84 + 1] := ones(size(n407, 1));
-//             for n791 in n84:-1:1 loop
-//               n155[:, n791] := {n407[n146] * n155[n146, n791 + 1] for n146 in 1:size(n407, 1)};
+//             $n155[:, $n84 + 1] := ones(size($n407, 1));
+//             for $n791 in $n84:-1:1 loop
+//               $n155[:, $n791] := {$n407[$n146] * $n155[$n146, $n791 + 1] for $n146 in 1:size($n407, 1)};
 //             end for;
-//             n51 := n1.n268.n803.n804(n155, n18);
-//           end n775;
+//             $n51 := $n1.$n268.$n803.$n804($n155, $n18);
+//           end $n775;
 //
-//           function n792
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n407;
-//             input Real n805;
-//             output Real n695;
+//           function $n792
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n407;
+//             input Real $n805;
+//             output Real $n695;
 //           protected
-//             Integer n84 = size(n51, 1);
+//             Integer $n84 = size($n51, 1);
 //           algorithm
-//             n695 := n51[1] * (n84 - 1);
-//             for n791 in 2:size(n51, 1) - 1 loop
-//               n695 := n51[n791] * (n84 - n791) + n407 * n695;
+//             $n695 := $n51[1] * ($n84 - 1);
+//             for $n791 in 2:size($n51, 1) - 1 loop
+//               $n695 := $n51[$n791] * ($n84 - $n791) + $n407 * $n695;
 //             end for;
-//             n695 := n695 * n805;
-//           end n792;
+//             $n695 := $n695 * $n805;
+//           end $n792;
 //
-//           function n795
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n793;
-//             input Real n794;
-//             input Real n407;
-//             input Real n805;
-//             output Real n695;
+//           function $n795
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n793;
+//             input Real $n794;
+//             input Real $n407;
+//             input Real $n805;
+//             output Real $n695;
 //           algorithm
-//             if n407 < n793 then
-//               n695 := n792(n51, n793, n805);
-//             elseif n407 > n794 then
-//               n695 := n792(n51, n794, n805);
+//             if $n407 < $n793 then
+//               $n695 := $n792($n51, $n793, $n805);
+//             elseif $n407 > $n794 then
+//               $n695 := $n792($n51, $n794, $n805);
 //             else
-//               n695 := n792(n51, n407, n805);
+//               $n695 := $n792($n51, $n407, $n805);
 //             end if;
-//           end n795;
+//           end $n795;
 //
-//           function n802
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n798;
-//             input Real n799 = 0;
-//             input Real n806;
-//             input Real n807 = 0;
-//             output Real n808 = 0.0;
+//           function $n802
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n798;
+//             input Real $n799 = 0;
+//             input Real $n806;
+//             input Real $n807 = 0;
+//             output Real $n808 = 0.0;
 //           algorithm
-//             n808 := n779(n51, n798) * n806;
-//           end n802;
+//             $n808 := $n779($n51, $n798) * $n806;
+//           end $n802;
 //
-//           function n796
-//             extends n1.n2.n271;
-//             input Real[:] n51;
-//             input Real n407;
-//             input Real n805;
-//             output Real n695;
+//           function $n796
+//             extends $n1.$n2.$n271;
+//             input Real[:] $n51;
+//             input Real $n407;
+//             input Real $n805;
+//             output Real $n695;
 //           protected
-//             Integer n84 = size(n51, 1);
+//             Integer $n84 = size($n51, 1);
 //           algorithm
-//             n695 := n797(n51, n407) * n805;
-//           end n796;
-//         end n675;
+//             $n695 := $n797($n51, $n407) * $n805;
+//           end $n796;
+//         end $n675;
 //
 //       protected
-//         function n780
-//           extends n1.n2.n271;
-//           input n92 n51;
-//           input n94 n250;
-//           input Boolean n752 = false;
-//           output n381 n190;
+//         function $n780
+//           extends $n1.$n2.$n271;
+//           input $n92 $n51;
+//           input $n94 $n250;
+//           input Boolean $n752 = false;
+//           output $n381 $n190;
 //         algorithm
-//           n190 := if n749 then n786(n250) else n788(n51, n250, n752);
+//           $n190 := if $n749 then $n786($n250) else $n788($n51, $n250, $n752);
 //           annotation(Inline = true, smoothOrder = 2);
-//         end n780;
-//       end n674;
-//     end n673;
-//   end n37;
+//         end $n780;
+//       end $n674;
+//     end $n673;
+//   end $n37;
 //
-//   package n79
-//     extends n1.n2.n3;
+//   package $n79
+//     extends $n1.$n2.$n3;
 //
-//     package n67
-//       extends n1.n2.n3;
+//     package $n67
+//       extends $n1.$n2.$n3;
 //
-//       package n23
-//         extends n1.n2.n24;
+//       package $n23
+//         extends $n1.$n2.$n24;
 //
-//         model n80
-//           parameter n1.n11.n386 n81;
-//           parameter n1.n11.n94 n809 = 293.15;
-//           parameter n1.n11.n810 n83 = 0;
-//           n12.n811 n89;
+//         model $n80
+//           parameter $n1.$n11.$n386 $n81;
+//           parameter $n1.$n11.$n94 $n809 = 293.15;
+//           parameter $n1.$n11.$n810 $n83 = 0;
+//           $n12.$n811 $n89;
 //         equation
-//           n89.n81 = -n81 * (1 + n83 * (n89.n250 - n809));
-//         end n80;
-//       end n23;
+//           $n89.$n81 = -$n81 * (1 + $n83 * ($n89.$n250 - $n809));
+//         end $n80;
+//       end $n23;
 //
-//       package n12
-//         extends n1.n2.n13;
+//       package $n12
+//         extends $n1.$n2.$n13;
 //
-//         partial connector n385
-//           n1.n11.n94 n250;
-//           flow n1.n11.n386 n81;
-//         end n385;
+//         partial connector $n385
+//           $n1.$n11.$n94 $n250;
+//           flow $n1.$n11.$n386 $n81;
+//         end $n385;
 //
-//         connector n811
-//           extends n385;
-//         end n811;
-//       end n12;
-//     end n67;
-//   end n79;
+//         connector $n811
+//           extends $n385;
+//         end $n811;
+//       end $n12;
+//     end $n67;
+//   end $n79;
 //
-//   package n268
-//     import n10 = n1.n11;
-//     extends n1.n2.n3;
+//   package $n268
+//     import $n10 = $n1.$n11;
+//     extends $n1.$n2.$n3;
 //
-//     package n803
-//       extends n1.n2.n3;
+//     package $n803
+//       extends $n1.$n2.$n3;
 //
-//       function n804
-//         extends n1.n2.n271;
-//         input Real[:, :] n812;
-//         input Real[size(n812, 1)] n597;
-//         input Real n813 = 100 * n1.n97.n5;
-//         output Real[size(n812, 2)] n340;
-//         output Integer n814;
+//       function $n804
+//         extends $n1.$n2.$n271;
+//         input Real[:, :] $n812;
+//         input Real[size($n812, 1)] $n597;
+//         input Real $n813 = 100 * $n1.$n97.$n5;
+//         output Real[size($n812, 2)] $n340;
+//         output Integer $n814;
 //       protected
-//         Integer n815;
-//         Real[max(size(n812, 1), size(n812, 2))] n816;
+//         Integer $n815;
+//         Real[max(size($n812, 1), size($n812, 2))] $n816;
 //       algorithm
-//         if min(size(n812)) > 0 then
-//           (n816, n815, n814) := n817.n818(n812, n597, n813);
-//           n340 := n816[1:size(n812, 2)];
-//           assert(n815 == 0, \"assert message 5875596942301705422\");
+//         if min(size($n812)) > 0 then
+//           ($n816, $n815, $n814) := $n817.$n818($n812, $n597, $n813);
+//           $n340 := $n816[1:size($n812, 2)];
+//           assert($n815 == 0, \"assert message 5875596942301705422\");
 //         else
-//           n340 := fill(0.0, size(n812, 2));
+//           $n340 := fill(0.0, size($n812, 2));
 //         end if;
-//       end n804;
+//       end $n804;
 //
-//       package n817
-//         extends n1.n2.n3;
+//       package $n817
+//         extends $n1.$n2.$n3;
 //
-//         function n818
-//           extends n1.n2.n271;
-//           input Real[:, :] n812;
-//           input Real[size(n812, 1)] n597;
-//           input Real n813 = 0.0;
-//           output Real[max(size(n812, 1), size(n812, 2))] n340 = cat(1, n597, zeros(max(n819, n820) - n819));
-//           output Integer n815;
-//           output Integer n814;
+//         function $n818
+//           extends $n1.$n2.$n271;
+//           input Real[:, :] $n812;
+//           input Real[size($n812, 1)] $n597;
+//           input Real $n813 = 0.0;
+//           output Real[max(size($n812, 1), size($n812, 2))] $n340 = cat(1, $n597, zeros(max($n819, $n820) - $n819));
+//           output Integer $n815;
+//           output Integer $n814;
 //         protected
-//           Integer n819 = size(n812, 1);
-//           Integer n820 = size(n812, 2);
-//           Integer n821 = 1;
-//           Integer n822 = max(n819, n820);
-//           Integer n823 = max(min(n819, n820) + 3 * n820 + 1, 2 * min(n819, n820) + 1);
-//           Real[max(min(size(n812, 1), size(n812, 2)) + 3 * size(n812, 2) + 1, 2 * min(size(n812, 1), size(n812, 2)) + 1)] n824;
-//           Real[size(n812, 1), size(n812, 2)] n825 = n812;
-//           Integer[size(n812, 2)] n826 = zeros(n820);
-//           external \"FORTRAN 77\" dgelsy(n819, n820, n821, n825, n819, n340, n822, n826, n813, n814, n824, n823, n815) annotation(Library = \"lapack\");
-//         end n818;
-//       end n817;
-//     end n803;
+//           Integer $n819 = size($n812, 1);
+//           Integer $n820 = size($n812, 2);
+//           Integer $n821 = 1;
+//           Integer $n822 = max($n819, $n820);
+//           Integer $n823 = max(min($n819, $n820) + 3 * $n820 + 1, 2 * min($n819, $n820) + 1);
+//           Real[max(min(size($n812, 1), size($n812, 2)) + 3 * size($n812, 2) + 1, 2 * min(size($n812, 1), size($n812, 2)) + 1)] $n824;
+//           Real[size($n812, 1), size($n812, 2)] $n825 = $n812;
+//           Integer[size($n812, 2)] $n826 = zeros($n820);
+//           external \"FORTRAN 77\" dgelsy($n819, $n820, $n821, $n825, $n819, $n340, $n822, $n826, $n813, $n814, $n824, $n823, $n815) annotation(Library = \"lapack\");
+//         end $n818;
+//       end $n817;
+//     end $n803;
 //
-//     package n2
-//       extends n1.n2.n28;
+//     package $n2
+//       extends $n1.$n2.$n28;
 //
-//       partial function n827 end n827;
+//       partial function $n827 end $n827;
 //
-//       partial function n828 end n828;
-//     end n2;
+//       partial function $n828 end $n828;
+//     end $n2;
 //
 //     function cos
-//       extends n1.n268.n2.n827;
-//       input n10.n829 n407;
-//       output Real n18;
-//       external \"builtin\" n18 = cos(n407);
+//       extends $n1.$n268.$n2.$n827;
+//       input $n10.$n829 $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = cos($n407);
 //     end cos;
 //
 //     function tan
-//       extends n1.n268.n2.n828;
-//       input n10.n829 n407;
-//       output Real n18;
-//       external \"builtin\" n18 = tan(n407);
+//       extends $n1.$n268.$n2.$n828;
+//       input $n10.$n829 $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = tan($n407);
 //     end tan;
 //
 //     function asin
-//       extends n1.n268.n2.n828;
-//       input Real n407;
-//       output n10.n829 n18;
-//       external \"builtin\" n18 = asin(n407);
+//       extends $n1.$n268.$n2.$n828;
+//       input Real $n407;
+//       output $n10.$n829 $n18;
+//       external \"builtin\" $n18 = asin($n407);
 //     end asin;
 //
 //     function cosh
-//       extends n1.n268.n2.n828;
-//       input Real n407;
-//       output Real n18;
-//       external \"builtin\" n18 = cosh(n407);
+//       extends $n1.$n268.$n2.$n828;
+//       input Real $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = cosh($n407);
 //     end cosh;
 //
 //     function tanh
-//       extends n1.n268.n2.n828;
-//       input Real n407;
-//       output Real n18;
-//       external \"builtin\" n18 = tanh(n407);
+//       extends $n1.$n268.$n2.$n828;
+//       input Real $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = tanh($n407);
 //     end tanh;
 //
 //     function exp
-//       extends n1.n268.n2.n828;
-//       input Real n407;
-//       output Real n18;
-//       external \"builtin\" n18 = exp(n407);
+//       extends $n1.$n268.$n2.$n828;
+//       input Real $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = exp($n407);
 //     end exp;
 //
 //     function log
-//       extends n1.n268.n2.n827;
-//       input Real n407;
-//       output Real n18;
-//       external \"builtin\" n18 = log(n407);
+//       extends $n1.$n268.$n2.$n827;
+//       input Real $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = log($n407);
 //     end log;
 //
 //     function log10
-//       extends n1.n268.n2.n827;
-//       input Real n407;
-//       output Real n18;
-//       external \"builtin\" n18 = log10(n407);
+//       extends $n1.$n268.$n2.$n827;
+//       input Real $n407;
+//       output Real $n18;
+//       external \"builtin\" $n18 = log10($n407);
 //     end log10;
-//   end n268;
+//   end $n268;
 //
-//   package n269
-//     extends n1.n2.n415;
+//   package $n269
+//     extends $n1.$n2.$n415;
 //
-//     package n420
-//       extends n1.n2.n704;
+//     package $n420
+//       extends $n1.$n2.$n704;
 //
-//       function n421
-//         extends n1.n2.n271;
-//         input String n830;
-//         external \"C\" ModelicaError(n830) annotation(Library = \"ModelicaExternalC\");
-//       end n421;
-//     end n420;
-//   end n269;
+//       function $n421
+//         extends $n1.$n2.$n271;
+//         input String $n830;
+//         external \"C\" ModelicaError($n830) annotation(Library = \"ModelicaExternalC\");
+//       end $n421;
+//     end $n420;
+//   end $n269;
 //
-//   package n97
-//     import n10 = n1.n11;
-//     import n831 = n1.n11.n31.n472;
-//     extends n1.n2.n3;
-//     final constant Real n153 = 2 * n1.n268.asin(1.0);
-//     final constant Real n5 = n0.n4.n5;
-//     final constant Real n7 = n0.n4.n7;
-//     final constant n10.n185 n425 = 299792458;
-//     final constant n10.n96 n98 = 9.80665;
-//     final constant n10.n833 n832 = 9.648533289e4;
-//     final constant Real n466(final unit = \"J/(mol.K)\") = 8.3144598;
-//     final constant Real n834(final unit = \"1/mol\") = 6.022140857e23;
-//     final constant Real n835(final unit = \"N/A2\") = 4 * n153 * 1.e-7;
-//     final constant n831.n473 n785 = -273.15;
-//   end n97;
+//   package $n97
+//     import $n10 = $n1.$n11;
+//     import $n831 = $n1.$n11.$n31.$n472;
+//     extends $n1.$n2.$n3;
+//     final constant Real $n153 = 2 * $n1.$n268.asin(1.0);
+//     final constant Real $n5 = $n0.$n4.$n5;
+//     final constant Real $n7 = $n0.$n4.$n7;
+//     final constant $n10.$n185 $n425 = 299792458;
+//     final constant $n10.$n96 $n98 = 9.80665;
+//     final constant $n10.$n833 $n832 = 9.648533289e4;
+//     final constant Real $n466(final unit = \"J/(mol.K)\") = 8.3144598;
+//     final constant Real $n834(final unit = \"1/mol\") = 6.022140857e23;
+//     final constant Real $n835(final unit = \"N/A2\") = 4 * $n153 * 1.e-7;
+//     final constant $n831.$n473 $n785 = -273.15;
+//   end $n97;
 //
-//   package n2
-//     extends n2.n3;
+//   package $n2
+//     extends $n2.$n3;
 //
-//     partial package n33
-//       extends n1.n2.n3;
-//     end n33;
+//     partial package $n33
+//       extends $n1.$n2.$n3;
+//     end $n33;
 //
-//     partial model n35 end n35;
+//     partial model $n35 end $n35;
 //
-//     partial package n3 end n3;
+//     partial package $n3 end $n3;
 //
-//     partial package n147
-//       extends n1.n2.n3;
-//     end n147;
+//     partial package $n147
+//       extends $n1.$n2.$n3;
+//     end $n147;
 //
-//     partial package n113
-//       extends n1.n2.n3;
-//     end n113;
+//     partial package $n113
+//       extends $n1.$n2.$n3;
+//     end $n113;
 //
-//     partial package n13
-//       extends n1.n2.n3;
-//     end n13;
+//     partial package $n13
+//       extends $n1.$n2.$n3;
+//     end $n13;
 //
-//     partial package n24
-//       extends n1.n2.n3;
-//     end n24;
+//     partial package $n24
+//       extends $n1.$n2.$n3;
+//     end $n24;
 //
-//     partial package n415
-//       extends n1.n2.n3;
-//     end n415;
+//     partial package $n415
+//       extends $n1.$n2.$n3;
+//     end $n415;
 //
-//     partial package n413
-//       extends n1.n2.n3;
-//     end n413;
+//     partial package $n413
+//       extends $n1.$n2.$n3;
+//     end $n413;
 //
-//     partial package n704
-//       extends n1.n2.n3;
-//     end n704;
+//     partial package $n704
+//       extends $n1.$n2.$n3;
+//     end $n704;
 //
-//     partial package n28
-//       extends n1.n2.n3;
-//     end n28;
+//     partial package $n28
+//       extends $n1.$n2.$n3;
+//     end $n28;
 //
-//     partial package n333 end n333;
+//     partial package $n333 end $n333;
 //
-//     partial package n452
-//       extends n1.n2.n3;
-//     end n452;
+//     partial package $n452
+//       extends $n1.$n2.$n3;
+//     end $n452;
 //
-//     partial function n271 end n271;
+//     partial function $n271 end $n271;
 //
-//     partial record n461 end n461;
+//     partial record $n461 end $n461;
 //
-//     type n414
+//     type $n414
 //       extends Real;
-//     end n414;
-//   end n2;
+//     end $n414;
+//   end $n2;
 //
-//   package n11
-//     extends n1.n2.n3;
+//   package $n11
+//     extends $n1.$n2.$n3;
 //
-//     package n2
-//       extends n1.n2.n28;
+//     package $n2
+//       extends $n1.$n2.$n28;
 //
-//       partial function n836 end n836;
-//     end n2;
+//       partial function $n836 end $n836;
+//     end $n2;
 //
-//     package n31
-//       extends n1.n2.n3;
+//     package $n31
+//       extends $n1.$n2.$n3;
 //
-//       package n472
-//         extends n1.n2.n3;
-//         type n473 = Real(final quantity = \"ThermodynamicTemperature\", final unit = \"degC\") annotation(absoluteValue = true);
-//         type n476 = Real(final quantity = \"Pressure\", final unit = \"bar\");
-//       end n472;
+//       package $n472
+//         extends $n1.$n2.$n3;
+//         type $n473 = Real(final quantity = \"ThermodynamicTemperature\", final unit = \"degC\") annotation(absoluteValue = true);
+//         type $n476 = Real(final quantity = \"Pressure\", final unit = \"bar\");
+//       end $n472;
 //
-//       function n474
-//         extends n1.n11.n2.n836;
-//         input n94 n837;
-//         output n472.n473 n838;
+//       function $n474
+//         extends $n1.$n11.$n2.$n836;
+//         input $n94 $n837;
+//         output $n472.$n473 $n838;
 //       algorithm
-//         n838 := n837 + n1.n97.n785;
+//         $n838 := $n837 + $n1.$n97.$n785;
 //         annotation(Inline = true);
-//       end n474;
+//       end $n474;
 //
-//       function n457
-//         extends n1.n11.n2.n836;
-//         input n472.n473 n838;
-//         output n94 n837;
+//       function $n457
+//         extends $n1.$n11.$n2.$n836;
+//         input $n472.$n473 $n838;
+//         output $n94 $n837;
 //       algorithm
-//         n837 := n838 - n1.n97.n785;
+//         $n837 := $n838 - $n1.$n97.$n785;
 //         annotation(Inline = true);
-//       end n457;
+//       end $n457;
 //
-//       function n477
-//         extends n1.n11.n2.n836;
-//         input n214 n839;
-//         output n472.n476 n840;
+//       function $n477
+//         extends $n1.$n11.$n2.$n836;
+//         input $n214 $n839;
+//         output $n472.$n476 $n840;
 //       algorithm
-//         n840 := n839 / 1e5;
+//         $n840 := $n839 / 1e5;
 //         annotation(Inline = true);
-//       end n477;
-//     end n31;
+//       end $n477;
+//     end $n31;
 //
-//     type n829 = Real(final quantity = \"Angle\", final unit = \"rad\", displayUnit = \"deg\");
-//     type n149 = Real(final quantity = \"Length\", final unit = \"m\");
-//     type n151 = n149(min = 0);
-//     type n152 = Real(final quantity = \"Area\", final unit = \"m2\");
-//     type n156 = Real(final quantity = \"Volume\", final unit = \"m3\");
-//     type n22 = Real(final quantity = \"Time\", final unit = \"s\");
-//     type n185 = Real(final quantity = \"Velocity\", final unit = \"m/s\");
-//     type n96 = Real(final quantity = \"Acceleration\", final unit = \"m/s2\");
-//     type n399 = Real(quantity = \"Mass\", final unit = \"kg\", min = 0);
-//     type n204 = Real(final quantity = \"Density\", final unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//     type n411 = Real(final quantity = \"Momentum\", final unit = \"kg.m/s\");
-//     type n412 = Real(final quantity = \"Force\", final unit = \"N\");
-//     type n214 = Real(final quantity = \"Pressure\", final unit = \"Pa\", displayUnit = \"bar\");
-//     type n92 = n214(min = 0.0, nominal = 1e5);
-//     type n209 = Real(final quantity = \"DynamicViscosity\", final unit = \"Pa.s\", min = 0);
-//     type n397 = Real(final quantity = \"Energy\", final unit = \"J\");
-//     type n405 = Real(final quantity = \"Power\", final unit = \"W\");
-//     type n184 = Real(final quantity = \"EnthalpyFlowRate\", final unit = \"W\");
-//     type n105 = Real(quantity = \"MassFlowRate\", final unit = \"kg/s\");
-//     type n841 = Real(final quantity = \"MomentumFlux\", final unit = \"N\");
-//     type n842 = Real(final quantity = \"ThermodynamicTemperature\", final unit = \"K\", min = 0.0, start = 288.15, nominal = 300, displayUnit = \"degC\") annotation(absoluteValue = true);
-//     type n94 = n842;
-//     type n810 = Real(final quantity = \"LinearTemperatureCoefficient\", final unit = \"1/K\");
-//     type n843 = Real(final quantity = \"Compressibility\", final unit = \"1/Pa\");
-//     type n511 = n843;
-//     type n386 = Real(final quantity = \"Power\", final unit = \"W\");
-//     type n259 = Real(final quantity = \"ThermalConductivity\", final unit = \"W/(m.K)\");
-//     type n253 = Real(final quantity = \"CoefficientOfHeatTransfer\", final unit = \"W/(m2.K)\");
-//     type n467 = Real(final quantity = \"SpecificHeatCapacity\", final unit = \"J/(kg.K)\");
-//     type n554 = Real(final quantity = \"RatioOfSpecificHeatCapacities\", final unit = \"1\");
-//     type n844 = Real(final quantity = \"Entropy\", final unit = \"J/K\");
-//     type n480 = Real(final quantity = \"SpecificEntropy\", final unit = \"J/(kg.K)\");
-//     type n488 = Real(final quantity = \"SpecificEnergy\", final unit = \"J/kg\");
-//     type n465 = n488;
-//     type n381 = n488;
-//     type n517 = Real(final unit = \"kg.s2/m5\");
-//     type n514 = Real(final unit = \"s2/m2\");
-//     type n522 = Real(final unit = \"kg/(m3.K)\");
-//     type n845 = Real(final quantity = \"ElectricCharge\", final unit = \"C\");
-//     type n846 = Real(final quantity = \"AmountOfSubstance\", final unit = \"mol\", min = 0);
-//     type n469 = Real(final quantity = \"MolarMass\", final unit = \"kg/mol\", min = 0);
-//     type n553 = Real(final quantity = \"MolarVolume\", final unit = \"m3/mol\", min = 0);
-//     type n352 = Real(final quantity = \"MassFraction\", final unit = \"1\", min = 0, max = 1);
-//     type n533 = Real(final quantity = \"MoleFraction\", final unit = \"1\", min = 0, max = 1);
-//     type n833 = Real(final quantity = \"FaradayConstant\", final unit = \"C/mol\");
-//     type n216 = Real(final quantity = \"ReynoldsNumber\", final unit = \"1\");
-//     type n262 = Real(final quantity = \"NusseltNumber\", final unit = \"1\");
-//     type n485 = Real(final quantity = \"PrandtlNumber\", final unit = \"1\");
-//   end n11;
+//     type $n829 = Real(final quantity = \"Angle\", final unit = \"rad\", displayUnit = \"deg\");
+//     type $n149 = Real(final quantity = \"Length\", final unit = \"m\");
+//     type $n151 = $n149(min = 0);
+//     type $n152 = Real(final quantity = \"Area\", final unit = \"m2\");
+//     type $n156 = Real(final quantity = \"Volume\", final unit = \"m3\");
+//     type $n22 = Real(final quantity = \"Time\", final unit = \"s\");
+//     type $n185 = Real(final quantity = \"Velocity\", final unit = \"m/s\");
+//     type $n96 = Real(final quantity = \"Acceleration\", final unit = \"m/s2\");
+//     type $n399 = Real(quantity = \"Mass\", final unit = \"kg\", min = 0);
+//     type $n204 = Real(final quantity = \"Density\", final unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
+//     type $n411 = Real(final quantity = \"Momentum\", final unit = \"kg.m/s\");
+//     type $n412 = Real(final quantity = \"Force\", final unit = \"N\");
+//     type $n214 = Real(final quantity = \"Pressure\", final unit = \"Pa\", displayUnit = \"bar\");
+//     type $n92 = $n214(min = 0.0, nominal = 1e5);
+//     type $n209 = Real(final quantity = \"DynamicViscosity\", final unit = \"Pa.s\", min = 0);
+//     type $n397 = Real(final quantity = \"Energy\", final unit = \"J\");
+//     type $n405 = Real(final quantity = \"Power\", final unit = \"W\");
+//     type $n184 = Real(final quantity = \"EnthalpyFlowRate\", final unit = \"W\");
+//     type $n105 = Real(quantity = \"MassFlowRate\", final unit = \"kg/s\");
+//     type $n841 = Real(final quantity = \"MomentumFlux\", final unit = \"N\");
+//     type $n842 = Real(final quantity = \"ThermodynamicTemperature\", final unit = \"K\", min = 0.0, start = 288.15, nominal = 300, displayUnit = \"degC\") annotation(absoluteValue = true);
+//     type $n94 = $n842;
+//     type $n810 = Real(final quantity = \"LinearTemperatureCoefficient\", final unit = \"1/K\");
+//     type $n843 = Real(final quantity = \"Compressibility\", final unit = \"1/Pa\");
+//     type $n511 = $n843;
+//     type $n386 = Real(final quantity = \"Power\", final unit = \"W\");
+//     type $n259 = Real(final quantity = \"ThermalConductivity\", final unit = \"W/(m.K)\");
+//     type $n253 = Real(final quantity = \"CoefficientOfHeatTransfer\", final unit = \"W/(m2.K)\");
+//     type $n467 = Real(final quantity = \"SpecificHeatCapacity\", final unit = \"J/(kg.K)\");
+//     type $n554 = Real(final quantity = \"RatioOfSpecificHeatCapacities\", final unit = \"1\");
+//     type $n844 = Real(final quantity = \"Entropy\", final unit = \"J/K\");
+//     type $n480 = Real(final quantity = \"SpecificEntropy\", final unit = \"J/(kg.K)\");
+//     type $n488 = Real(final quantity = \"SpecificEnergy\", final unit = \"J/kg\");
+//     type $n465 = $n488;
+//     type $n381 = $n488;
+//     type $n517 = Real(final unit = \"kg.s2/m5\");
+//     type $n514 = Real(final unit = \"s2/m2\");
+//     type $n522 = Real(final unit = \"kg/(m3.K)\");
+//     type $n845 = Real(final quantity = \"ElectricCharge\", final unit = \"C\");
+//     type $n846 = Real(final quantity = \"AmountOfSubstance\", final unit = \"mol\", min = 0);
+//     type $n469 = Real(final quantity = \"MolarMass\", final unit = \"kg/mol\", min = 0);
+//     type $n553 = Real(final quantity = \"MolarVolume\", final unit = \"m3/mol\", min = 0);
+//     type $n352 = Real(final quantity = \"MassFraction\", final unit = \"1\", min = 0, max = 1);
+//     type $n533 = Real(final quantity = \"MoleFraction\", final unit = \"1\", min = 0, max = 1);
+//     type $n833 = Real(final quantity = \"FaradayConstant\", final unit = \"C/mol\");
+//     type $n216 = Real(final quantity = \"ReynoldsNumber\", final unit = \"1\");
+//     type $n262 = Real(final quantity = \"NusseltNumber\", final unit = \"1\");
+//     type $n485 = Real(final quantity = \"PrandtlNumber\", final unit = \"1\");
+//   end $n11;
 //   annotation(version = \"3.2.3\", versionBuild = 4, versionDate = \"2019-01-23\", dateModified = \"2020-06-04 11:00:00Z\");
-// end n1;
+// end $n1;
 //
-// model n34_total
-//   extends n1.n29.n32.n34;
+// model $n34_total
+//   extends $n1.$n29.$n32.$n34;
 //  annotation(experiment(StopTime = 10));
-// end n34_total;
+// end $n34_total;
 // "
 // endResult

--- a/testsuite/openmodelica/interactive-API/Obfuscation2.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation2.mos
@@ -12,3984 +12,3995 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 // true
 // true
 // ""
-// "function n1.n101.n946.n949
-//   input Real n7804(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n1737(quantity = \"ThermodynamicTemperature\", unit = \"degC\");
+// "function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   n1737 := n7804 - 273.15;
-// end n1.n101.n946.n949;
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX;
 //
-// function n1.n101.n946.n993
-//   input Real n12888(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   output Real n12889(quantity = \"Pressure\", unit = \"bar\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear
+//   input Real x \"Independent variable of function\";
+//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
+//   output Real y \"= f_nonlinear(x)\";
 // algorithm
-//   n12889 := n12888 / 100000.0;
-// end n1.n101.n946.n993;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX(p, x, X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear;
 //
-// function n1.n11.n681.n682
-//   input String n12660;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output f_nonlinear_Data res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data;
 //
-//   external \"C\" ModelicaError(n12660);
-// end n1.n11.n681.n682;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10111
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1)));
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.solve
+//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
+//   input Real x_min \"Minimum value of x\";
+//   input Real x_max \"Maximum value of x\";
+//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
+//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
+//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f_nonlinear(a) - y_zero\";
+//   protected Real fb \"= f_nonlinear(b) - y_zero\";
+//   protected Real fc;
+//   protected Boolean found = false;
+//   protected Real x_min2 = x_min - x_eps;
+//   protected Real x_max2 = x_max + x_eps;
+//   protected Real a = x_min2 \"Current best minimum interval value\";
+//   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n8551(n3331, 190.0, 647.0, n403, n6343[1:1], n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
-// end n1.n7656.n102.n8149.n7835.n7670.n10111;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n8551
-//   input Real n9469;
-//   input Real n5250;
-//   input Real n5263;
-//   input Real n7786 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9471 n9476;
-//   input Real n9964 = 1e-13;
-//   output Real n9472;
-//   protected constant Real n23 = 1e-15;
-//   protected constant Real n9965 = 1e-10;
-//   protected Real n58;
-//   protected Real n136;
-//   protected Real n768;
-//   protected Real n497;
-//   protected Real n61;
-//   protected Real n403;
-//   protected Real n769;
-//   protected Real n723;
-//   protected Real n770;
-//   protected Real n771;
-//   protected Real n772;
-//   protected Real n773;
-//   protected Boolean n774 = false;
-//   protected Real n9966 = n5250 - n9965;
-//   protected Real n9967 = n5263 + n9965;
-//   protected Real n130 = n9966;
-//   protected Real n490 = n9967;
-// algorithm
-//   n771 := n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9475(n9966, n7786, n6343, n9476) - n9469;
-//   n772 := n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9475(n9967, n7786, n6343, n9476) - n9469;
-//   n773 := n772;
-//   if n771 > 0.0 and n772 > 0.0 or n771 < 0.0 and n772 < 0.0 then
-//     n1.n11.n681.n682(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
+//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
+//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
 //     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(n9966, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(n9967, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(n9469, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(n771, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(n772, 6, 0, true) + \"
+//       x_min  = \" + String(x_min2, 6, 0, true) + \"
+//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
+//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
+//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
 //     \" + \"fa and fb must have opposite sign which is not the case\");
 //   end if;
-//   n58 := n130;
-//   n773 := n771;
-//   n768 := n490 - n130;
-//   n136 := n768;
-//   while not n774 loop
-//     if abs(n773) < abs(n772) then
-//       n130 := n490;
-//       n490 := n58;
-//       n58 := n130;
-//       n771 := n772;
-//       n772 := n773;
-//       n773 := n771;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
 //     end if;
-//     n770 := 2.0 * n23 * abs(n490) + n9964;
-//     n497 := (n58 - n490) / 2.0;
-//     if abs(n497) <= n770 or n772 == 0.0 then
-//       n774 := true;
-//       n9472 := n490;
+//     tol := 2.0 * eps * abs(b) + x_tol;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       x_zero := b;
 //     else
-//       if abs(n768) < n770 or abs(n771) <= abs(n772) then
-//         n768 := n497;
-//         n136 := n768;
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
 //       else
-//         n61 := n772 / n771;
-//         if n130 == n58 then
-//           n403 := 2.0 * n497 * n61;
-//           n769 := 1.0 - n61;
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
 //         else
-//           n769 := n771 / n773;
-//           n723 := n772 / n773;
-//           n403 := n61 * (2.0 * n497 * n769 * (n769 - n723) - (n490 - n130) * (n723 - 1.0));
-//           n769 := (n769 - 1.0) * (n723 - 1.0) * (n61 - 1.0);
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
 //         end if;
-//         if n403 > 0.0 then
-//           n769 := -n769;
+//         if p > 0.0 then
+//           q := -q;
 //         else
-//           n403 := -n403;
+//           p := -p;
 //         end if;
-//         n61 := n768;
-//         n768 := n136;
-//         if 2.0 * n403 < 3.0 * n497 * n769 - abs(n770 * n769) and n403 < abs(0.5 * n61 * n769) then
-//           n136 := n403 / n769;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
 //         else
-//           n768 := n497;
-//           n136 := n768;
+//           e := m;
+//           d := e;
 //         end if;
 //       end if;
-//       n130 := n490;
-//       n771 := n772;
-//       n490 := n490 + (if abs(n136) > n770 then n136 else if n497 > 0.0 then n770 else -n770);
-//       n772 := n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9475(n490, n7786, n6343, n9476) - n9469;
-//       if n772 > 0.0 and n773 > 0.0 or n772 < 0.0 and n773 < 0.0 then
-//         n58 := n130;
-//         n773 := n771;
-//         n768 := n490 - n130;
-//         n136 := n768;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
 //       end if;
 //     end if;
 //   end while;
-// end n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n8551;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX.Internal.solve;
 //
-// function n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9471 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9471\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n9471 res;
-// end n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9471;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState;
 //
-// function n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9475
-//   input Real n637;
-//   input Real n403 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9471 n9476;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n159 := n1.n7656.n102.n8149.n7835.n7670.n10138(n403, n637, n6343);
-// end n1.n7656.n102.n8149.n7835.n7670.n10111.n12.n9475;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n7835.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n7835.n7670.n10117;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n7835.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n7835.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n7835.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n7835.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n7835.n7670.n11.n10129(n1.n7656.n102.n8149.n7835.n7670.n10117(n7827), n1.n7656.n102.n8149.n7835.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n7835.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n7835.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n7835.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7835.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n7835.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n7835.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n7835.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10138
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7835.n7670.n8562(n217);
-//   n10108 := min(n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110) * (1.0 - n6343[1]), 1.0);
-//   n10105 := max(n6343[1] - n10108, 0.0);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n3331 := n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) * n10106 + n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) * n10107 + n1.n7656.n102.n8149.n7835.n7670.n10136(n217) * n10105;
-// end n1.n7656.n102.n8149.n7835.n7670.n10138;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7835.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n7835.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n7835.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n7835.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n7835.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n7835.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n7835.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n7835.n7670.n11.n10129;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n7835.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n7835.n7670.n11.n10145;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
-// algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n7835.n7670.n11.n10146;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n7835.n7670.n11.n8436;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n523
-//   input n1.n7656.n102.n8149.n7835.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
-// algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n7835.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n7835.n7670.n523;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n7785
-//   input n1.n7656.n102.n8149.n7835.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n7835.n7670.n7785;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n7955
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n1.n7656.n102.n8149.n7835.n7670.n7785(n1.n7656.n102.n8149.n7835.n7670.n8338(n403, n3331, n6343));
-// end n1.n7656.n102.n8149.n7835.n7670.n7955;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n7957
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7835.n7670.n8732(n1.n7656.n102.n8149.n7835.n7670.n8396(n403, n217, n6343));
-// end n1.n7656.n102.n8149.n7835.n7670.n7957;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n8338
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n7835.n7670.n8367 n865;
-// algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n7835.n7670.n8367(n403, n1.n7656.n102.n8149.n7835.n7670.n10111(n403, n3331, n6343), n6343) else n1.n7656.n102.n8149.n7835.n7670.n8367(n403, n1.n7656.n102.n8149.n7835.n7670.n10111(n403, n3331, n6343), cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n7835.n7670.n8338;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7835.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7835.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n8396
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n7835.n7670.n8367 n865;
-// algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n7835.n7670.n8367(n403, n217, n6343) else n1.n7656.n102.n8149.n7835.n7670.n8367(n403, n217, cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n7835.n7670.n8396;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-// algorithm
-//   n7826 := n1.n7656.n102.n8149.n7835.n7670.n11.n8436(n1.n7656.n102.n8149.n7835.n7670.n10117(n7827), n1.n7656.n102.n8149.n7835.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n7835.n7670.n8562;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n8732
-//   input n1.n7656.n102.n8149.n7835.n7670.n8367 n865;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7835.n7670.n10138(n865.n403, n865.n217, n865.n6343);
-// end n1.n7656.n102.n8149.n7835.n7670.n8732;
-//
-// function n1.n7656.n102.n8149.n7835.n7670.n9583
-//   input n1.n7656.n102.n8149.n7835.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
-// algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n7835.n7670.n9583;
-//
-// function n1.n7656.n102.n8149.n7835.n7988.n7670.n7785
-//   input n1.n7656.n102.n8149.n7835.n7988.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n7835.n7988.n7670.n7785;
-//
-// function n1.n7656.n102.n8149.n7835.n7988.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7835.n7988.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7835.n7988.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   output Real n8479;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n8487;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8498;
-//   protected Real n1201;
-//   protected Real n1202;
-// algorithm
-//   if n8478 >= 0.0 then
-//     n5456 := n8443;
-//     n457 := n8445;
-//   else
-//     n5456 := n8444;
-//     n457 := n8446;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
 //   end if;
-//   n8487 := abs(n8478) * 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 * n457);
-//   n1201 := 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 ^ 2.0);
-//   n2800 := n8487 / 64.0;
-//   n8498 := n1201 / 64.0;
-//   if n2800 > n8474 then
-//     n2800 := -2.0 * sqrt(n8487) * log10(2.51 / sqrt(n8487) + 0.27 * n3083);
-//     n1202 := sqrt(n1201 * abs(n8478));
-//     n8498 := 0.4342944819032518 * ((-2.0 * log(2.51 / n1202 + 0.27 * n3083) * n1201 / (2.0 * n1202)) + 5.02 / (2.0 * abs(n8478) * (2.51 / n1202 + 0.27 * n3083)));
-//     if n2800 < n8475 then
-//       (n2800, n8498) := n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476.n8497(n8487, n8474, n8475, n3083, n8478);
-//     end if;
-//   end if;
-//   n7744 := n7704 / n6099 * n457 * (if n8478 >= 0.0 then n2800 else -n2800);
-//   n8479 := n7704 / n6099 * n457 * n8498;
-// end n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction_der;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476.n8497
-//   input Real n8487;
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   output Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   output Real n8498;
-//   protected Real n703 = log10(64.0 * n8474);
-//   protected Real n233 = log10(n8474);
-//   protected Real n8499 = 1.0;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n637 = log10(n8487);
-//   protected Real n159;
-//   protected Real n8501;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n704 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n231 = log10(n8492);
-//   protected Real n8500 = 0.5 + 1.090079149577162 / (n8492 * n8491);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
 // algorithm
-//   (n159, n8501) := n1.n7656.n11.n8483(n637, n703, n704, n233, n231, n8499, n8500);
-//   n2800 := 10.0 ^ n159;
-//   n8498 := n2800 / abs(n8478) * n8501;
-// end n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476.n8497;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7663.n8412
-//   input Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n7750(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8487;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083), n8328);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
 // algorithm
-//   n5456 := if n7744 >= 0.0 then n8443 else n8444;
-//   n457 := if n7744 >= 0.0 then n8445 else n8446;
-//   n2800 := n6099 * abs(n7744) / (n7704 * n457);
-//   n8487 := if n2800 <= n8474 then 64.0 * n2800 else if n2800 >= n8475 then 0.25 * (n2800 / log10(n3083 / 3.7 + 5.74 / n2800 ^ 0.9)) ^ 2.0 else n1.n7656.n102.n8149.n7835.n8346.n7663.n8412.n8488(n2800, n8474, n8475, n3083);
-//   n4510 := n2194 * n457 * n457 / (2.0 * n5456 * n6099 * n6099 * n6099) * (if n7744 >= 0.0 then n8487 else -n8487);
-// end n1.n7656.n102.n8149.n7835.n8346.n7663.n8412;
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater_der;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7663.n8412.n8488
-//   input Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083;
-//   output Real n8487;
-//   protected Real n703 = log10(n8474);
-//   protected Real n233 = log10(64.0 * n8474);
-//   protected Real n8489 = 1.0;
-//   protected Real n1201 = 1.121782646756099;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n704 = log10(n8475);
-//   protected Real n8496;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n8494 = n704 - n703;
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8493 = 2.0 + 4.0 * n1201 / (n1202 * n8490 * n8475 ^ 0.9);
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n231 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n497 = (n231 - n233) / n8494;
-//   protected Real n43 = (3.0 * n497 - 2.0 * n8489 - n8493) / n8494;
-//   protected Real n45 = (n8489 + n8493 - 2.0 * n497) / (n8494 * n8494);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
 // algorithm
-//   n8496 := log10(n2800 / n8474);
-//   n8487 := 64.0 * n8474 * (n2800 / n8474) ^ (1.0 + n8496 * (n43 + n8496 * n45));
-// end n1.n7656.n102.n8149.n7835.n8346.n7663.n8412.n8488;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure(T);
+//   X_sat := min(p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat) * (1.0 - X[1]), 1.0);
+//   X_liquid := max(X[1] - X_sat, 0.0);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   h := Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) * X_steam + Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) * X_air + Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater(T) * X_liquid;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7663.n8415
-//   input Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n8447(unit = \"m2/s2\");
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n8455(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8456(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8457(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8458(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8453(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8454(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8451(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8443;
-//   protected Real n8452(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8444;
-//   protected Real n8459(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
-//   protected Real n8461;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083)) ^ 0.97, n8328);
-//   protected Real n8460(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (n8451 + n8452) / 2.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
 // algorithm
-//   n8455 := max(n8451, n8452) + n8308;
-//   n8456 := min(n8451, n8452) - n8308;
-//   if n4510 >= n8455 then
-//     n7744 := n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476(n4510 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
-//   elseif n4510 <= n8456 then
-//     n7744 := n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476(n4510 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
-//   else
-//     (n8457, n8453) := n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476(n8455 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n8458, n8454) := n1.n7656.n102.n8149.n7835.n8346.n7663.n12.n8476(n8456 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n7744, n8461) := n1.n7656.n11.n8462(n8460, n8456, n8455, n8458, n8457, n8454, n8453);
-//     if n4510 > n8460 then
-//       n7744 := n1.n7656.n11.n8462(n4510, n8460, n8455, n8459, n8457, n8461, n8453)[1];
-//     else
-//       n7744 := n1.n7656.n11.n8462(n4510, n8456, n8460, n8458, n8459, n8454, n8461)[1];
-//     end if;
-//   end if;
-// end n1.n7656.n102.n8149.n7835.n8346.n7663.n8415;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX_der;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7670.n523
-//   input n1.n7656.n102.n8149.n7835.n8346.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n7835.n8346.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n7835.n8346.n7670.n523;
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7670.n7786
-//   input n1.n7656.n102.n8149.n7835.n8346.n7670.n8367 n865;
-//   output Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
 // algorithm
-//   n403 := n865.n403;
-// end n1.n7656.n102.n8149.n7835.n8346.n7670.n7786;
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7670.n8340
-//   input n1.n7656.n102.n8149.n7835.n8346.n7670.n8367 n865;
-//   output Real n4890(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
 // algorithm
-//   n4890 := 1e-06 * n1.n7671.n8128.n9970.n9971.n9972({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, n1.n101.n946.n949(n865.n217));
-// end n1.n7656.n102.n8149.n7835.n8346.n7670.n8340;
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid_der;
 //
-// function n1.n7656.n102.n8149.n7835.n8346.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7835.n8346.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7835.n8346.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7835.n8346.n7670.n9583
-//   input n1.n7656.n102.n8149.n7835.n8346.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
 // algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n7835.n8346.n7670.n9583;
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n10111
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1)));
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.setState_pTX \"Return thermodynamic state as function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n8551(n3331, 190.0, 647.0, n403, n6343[1:1], n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
-// end n1.n7656.n102.n8149.n7836.n7670.n10111;
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState(p, T, X) else Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState(p, T, cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.setState_pTX;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n8551
-//   input Real n9469;
-//   input Real n5250;
-//   input Real n5263;
-//   input Real n7786 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9471 n9476;
-//   input Real n9964 = 1e-13;
-//   output Real n9472;
-//   protected constant Real n23 = 1e-15;
-//   protected constant Real n9965 = 1e-10;
-//   protected Real n58;
-//   protected Real n136;
-//   protected Real n768;
-//   protected Real n497;
-//   protected Real n61;
-//   protected Real n403;
-//   protected Real n769;
-//   protected Real n723;
-//   protected Real n770;
-//   protected Real n771;
-//   protected Real n772;
-//   protected Real n773;
-//   protected Boolean n774 = false;
-//   protected Real n9966 = n5250 - n9965;
-//   protected Real n9967 = n5263 + n9965;
-//   protected Real n130 = n9966;
-//   protected Real n490 = n9967;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.setState_phX \"Return thermodynamic state as function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   n771 := n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9475(n9966, n7786, n6343, n9476) - n9469;
-//   n772 := n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9475(n9967, n7786, n6343, n9476) - n9469;
-//   n773 := n772;
-//   if n771 > 0.0 and n772 > 0.0 or n771 < 0.0 and n772 < 0.0 then
-//     n1.n11.n681.n682(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX(p, h, X), X) else Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.T_phX(p, h, X), cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.setState_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy \"Return specific enthalpy of moist air as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.h_pTX(state.p, state.T, state.X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy_pTX \"Return specific enthalpy from p, T, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.setState_pTX(p, T, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
+// algorithm
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
+// algorithm
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.sublimationPressureIce_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.temperature_phX \"Return temperature from p, h, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.temperature(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.setState_phX(p, h, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.temperature_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear
+//   input Real x \"Independent variable of function\";
+//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
+//   output Real y \"= f_nonlinear(x)\";
+// algorithm
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX(p, x, X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output f_nonlinear_Data res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.solve
+//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
+//   input Real x_min \"Minimum value of x\";
+//   input Real x_max \"Maximum value of x\";
+//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
+//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
+//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f_nonlinear(a) - y_zero\";
+//   protected Real fb \"= f_nonlinear(b) - y_zero\";
+//   protected Real fc;
+//   protected Boolean found = false;
+//   protected Real x_min2 = x_min - x_eps;
+//   protected Real x_max2 = x_max + x_eps;
+//   protected Real a = x_min2 \"Current best minimum interval value\";
+//   protected Real b = x_max2 \"Current best maximum interval value\";
+// algorithm
+//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
+//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
 //     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(n9966, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(n9967, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(n9469, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(n771, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(n772, 6, 0, true) + \"
+//       x_min  = \" + String(x_min2, 6, 0, true) + \"
+//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
+//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
+//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
 //     \" + \"fa and fb must have opposite sign which is not the case\");
 //   end if;
-//   n58 := n130;
-//   n773 := n771;
-//   n768 := n490 - n130;
-//   n136 := n768;
-//   while not n774 loop
-//     if abs(n773) < abs(n772) then
-//       n130 := n490;
-//       n490 := n58;
-//       n58 := n130;
-//       n771 := n772;
-//       n772 := n773;
-//       n773 := n771;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
 //     end if;
-//     n770 := 2.0 * n23 * abs(n490) + n9964;
-//     n497 := (n58 - n490) / 2.0;
-//     if abs(n497) <= n770 or n772 == 0.0 then
-//       n774 := true;
-//       n9472 := n490;
+//     tol := 2.0 * eps * abs(b) + x_tol;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       x_zero := b;
 //     else
-//       if abs(n768) < n770 or abs(n771) <= abs(n772) then
-//         n768 := n497;
-//         n136 := n768;
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
 //       else
-//         n61 := n772 / n771;
-//         if n130 == n58 then
-//           n403 := 2.0 * n497 * n61;
-//           n769 := 1.0 - n61;
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
 //         else
-//           n769 := n771 / n773;
-//           n723 := n772 / n773;
-//           n403 := n61 * (2.0 * n497 * n769 * (n769 - n723) - (n490 - n130) * (n723 - 1.0));
-//           n769 := (n769 - 1.0) * (n723 - 1.0) * (n61 - 1.0);
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
 //         end if;
-//         if n403 > 0.0 then
-//           n769 := -n769;
+//         if p > 0.0 then
+//           q := -q;
 //         else
-//           n403 := -n403;
+//           p := -p;
 //         end if;
-//         n61 := n768;
-//         n768 := n136;
-//         if 2.0 * n403 < 3.0 * n497 * n769 - abs(n770 * n769) and n403 < abs(0.5 * n61 * n769) then
-//           n136 := n403 / n769;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
 //         else
-//           n768 := n497;
-//           n136 := n768;
+//           e := m;
+//           d := e;
 //         end if;
 //       end if;
-//       n130 := n490;
-//       n771 := n772;
-//       n490 := n490 + (if abs(n136) > n770 then n136 else if n497 > 0.0 then n770 else -n770);
-//       n772 := n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9475(n490, n7786, n6343, n9476) - n9469;
-//       if n772 > 0.0 and n773 > 0.0 or n772 < 0.0 and n773 < 0.0 then
-//         n58 := n130;
-//         n773 := n771;
-//         n768 := n490 - n130;
-//         n136 := n768;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
 //       end if;
 //     end if;
 //   end while;
-// end n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n8551;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX.Internal.solve;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9471 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9471\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n9471 res;
-// end n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9471;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9475
-//   input Real n637;
-//   input Real n403 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9471 n9476;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n159 := n1.n7656.n102.n8149.n7836.n7670.n10138(n403, n637, n6343);
-// end n1.n7656.n102.n8149.n7836.n7670.n10111.n12.n9475;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n7836.n7670.n10117;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n7836.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n7836.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n7836.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n7836.n7670.n11.n10129(n1.n7656.n102.n8149.n7836.n7670.n10117(n7827), n1.n7656.n102.n8149.n7836.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n7836.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n7836.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n7836.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7836.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n7836.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n7836.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n7836.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10138
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7836.n7670.n8562(n217);
-//   n10108 := min(n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110) * (1.0 - n6343[1]), 1.0);
-//   n10105 := max(n6343[1] - n10108, 0.0);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n3331 := n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) * n10106 + n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) * n10107 + n1.n7656.n102.n8149.n7836.n7670.n10136(n217) * n10105;
-// end n1.n7656.n102.n8149.n7836.n7670.n10138;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7836.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n7836.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n7836.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n7836.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n7836.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n7836.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n7836.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n7836.n7670.n11.n10129;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n7836.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n7836.n7670.n11.n10145;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
-// algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n7836.n7670.n11.n10146;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n7836.n7670.n11.n8436;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n7785
-//   input n1.n7656.n102.n8149.n7836.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n7836.n7670.n7785;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n7955
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n1.n7656.n102.n8149.n7836.n7670.n7785(n1.n7656.n102.n8149.n7836.n7670.n8338(n403, n3331, n6343));
-// end n1.n7656.n102.n8149.n7836.n7670.n7955;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n7957
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7836.n7670.n8732(n1.n7656.n102.n8149.n7836.n7670.n8396(n403, n217, n6343));
-// end n1.n7656.n102.n8149.n7836.n7670.n7957;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n8338
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n7836.n7670.n8367 n865;
-// algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n7836.n7670.n8367(n403, n1.n7656.n102.n8149.n7836.n7670.n10111(n403, n3331, n6343), n6343) else n1.n7656.n102.n8149.n7836.n7670.n8367(n403, n1.n7656.n102.n8149.n7836.n7670.n10111(n403, n3331, n6343), cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n7836.n7670.n8338;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7836.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7836.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n8396
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n7836.n7670.n8367 n865;
-// algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n7836.n7670.n8367(n403, n217, n6343) else n1.n7656.n102.n8149.n7836.n7670.n8367(n403, n217, cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n7836.n7670.n8396;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-// algorithm
-//   n7826 := n1.n7656.n102.n8149.n7836.n7670.n11.n8436(n1.n7656.n102.n8149.n7836.n7670.n10117(n7827), n1.n7656.n102.n8149.n7836.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n7836.n7670.n8562;
-//
-// function n1.n7656.n102.n8149.n7836.n7670.n8732
-//   input n1.n7656.n102.n8149.n7836.n7670.n8367 n865;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7836.n7670.n10138(n865.n403, n865.n217, n865.n6343);
-// end n1.n7656.n102.n8149.n7836.n7670.n8732;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-// algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10117;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
-// algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10129(n1.n7656.n102.n8149.n7836.n7988.n7670.n10117(n7827), n1.n7656.n102.n8149.n7836.n7988.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n7836.n7988.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n7836.n7988.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7836.n7988.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n7836.n7988.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n7836.n7988.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n7836.n7988.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
-//   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10129;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10145;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
 // algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n10146;
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
 // algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
-//   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
-//   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n8436;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure(T);
+//   X_sat := min(p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat) * (1.0 - X[1]), 1.0);
+//   X_liquid := max(X[1] - X_sat, 0.0);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   h := Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) * X_steam + Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) * X_air + Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater(T) * X_liquid;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n523
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n7836.n7988.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n523;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n7785
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
 // algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n7785;
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n8340
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n4890(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
 // algorithm
-//   n4890 := 1e-06 * n1.n7671.n8128.n9970.n9971.n9972({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, n1.n101.n946.n949(n865.n217));
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n8340;
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7836.n7988.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n8428
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n474(quantity = \"ThermalConductivity\", unit = \"W/(m.K)\", min = 0.0, max = 500.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
 // algorithm
-//   n474 := 0.001 * n1.n7671.n8128.n9970.n9971.n9972({6.569147081771781e-15, -3.402596192305051e-11, 5.327928484630316e-08, -4.534083928921947e-05, 0.07612967530903766, 24.16948108809705}, -150.0, 1000.0, n1.n101.n946.n949(n865.n217));
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n8428;
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n8429
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n5989(quantity = \"PrandtlNumber\", unit = \"1\", min = 0.001, max = 100000.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
 // algorithm
-//   n5989 := n1.n7656.n102.n8149.n7836.n7988.n7670.n8340(n865) * n1.n7656.n102.n8149.n7836.n7988.n7670.n9354(n865) / n1.n7656.n102.n8149.n7836.n7988.n7670.n8428(n865);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n8429;
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure_der;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.setState_pTX \"Return thermodynamic state as function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   n7826 := n1.n7656.n102.n8149.n7836.n7988.n7670.n11.n8436(n1.n7656.n102.n8149.n7836.n7988.n7670.n10117(n7827), n1.n7656.n102.n8149.n7836.n7988.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n8562;
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState(p, T, X) else Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState(p, T, cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.setState_pTX;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n9354
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n4554(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 10000000.0, start = 1000.0, nominal = 1000.0);
-//   protected Real n8197(unit = \"s/K\") = 1.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.setState_phX \"Return thermodynamic state as function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   n4554 := n1.n7656.n102.n8149.n7836.n7988.n7670.n10139(n865.n403, n865.n217, n865.n6343, 0.0, 1.0, {0.0, 0.0}) * n8197;
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n9354;
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX(p, h, X), X) else Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.T_phX(p, h, X), cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.setState_phX;
 //
-// function n1.n7656.n102.n8149.n7836.n7988.n7670.n9583
-//   input n1.n7656.n102.n8149.n7836.n7988.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy \"Return specific enthalpy of moist air as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
 // algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n7836.n7988.n7670.n9583;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.h_pTX(state.p, state.T, state.X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   output Real n8479;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n8487;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8498;
-//   protected Real n1201;
-//   protected Real n1202;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy_pTX \"Return specific enthalpy from p, T, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
 // algorithm
-//   if n8478 >= 0.0 then
-//     n5456 := n8443;
-//     n457 := n8445;
-//   else
-//     n5456 := n8444;
-//     n457 := n8446;
-//   end if;
-//   n8487 := abs(n8478) * 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 * n457);
-//   n1201 := 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 ^ 2.0);
-//   n2800 := n8487 / 64.0;
-//   n8498 := n1201 / 64.0;
-//   if n2800 > n8474 then
-//     n2800 := -2.0 * sqrt(n8487) * log10(2.51 / sqrt(n8487) + 0.27 * n3083);
-//     n1202 := sqrt(n1201 * abs(n8478));
-//     n8498 := 0.4342944819032518 * ((-2.0 * log(2.51 / n1202 + 0.27 * n3083) * n1201 / (2.0 * n1202)) + 5.02 / (2.0 * abs(n8478) * (2.51 / n1202 + 0.27 * n3083)));
-//     if n2800 < n8475 then
-//       (n2800, n8498) := n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476.n8497(n8487, n8474, n8475, n3083, n8478);
-//     end if;
-//   end if;
-//   n7744 := n7704 / n6099 * n457 * (if n8478 >= 0.0 then n2800 else -n2800);
-//   n8479 := n7704 / n6099 * n457 * n8498;
-// end n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.setState_pTX(p, T, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy_pTX;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476.n8497
-//   input Real n8487;
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   output Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   output Real n8498;
-//   protected Real n703 = log10(64.0 * n8474);
-//   protected Real n233 = log10(n8474);
-//   protected Real n8499 = 1.0;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n637 = log10(n8487);
-//   protected Real n159;
-//   protected Real n8501;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n704 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n231 = log10(n8492);
-//   protected Real n8500 = 0.5 + 1.090079149577162 / (n8492 * n8491);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
 // algorithm
-//   (n159, n8501) := n1.n7656.n11.n8483(n637, n703, n704, n233, n231, n8499, n8500);
-//   n2800 := 10.0 ^ n159;
-//   n8498 := n2800 / abs(n8478) * n8501;
-// end n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476.n8497;
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7663.n8412
-//   input Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n7750(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8487;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083), n8328);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
 // algorithm
-//   n5456 := if n7744 >= 0.0 then n8443 else n8444;
-//   n457 := if n7744 >= 0.0 then n8445 else n8446;
-//   n2800 := n6099 * abs(n7744) / (n7704 * n457);
-//   n8487 := if n2800 <= n8474 then 64.0 * n2800 else if n2800 >= n8475 then 0.25 * (n2800 / log10(n3083 / 3.7 + 5.74 / n2800 ^ 0.9)) ^ 2.0 else n1.n7656.n102.n8149.n7836.n8346.n7663.n8412.n8488(n2800, n8474, n8475, n3083);
-//   n4510 := n2194 * n457 * n457 / (2.0 * n5456 * n6099 * n6099 * n6099) * (if n7744 >= 0.0 then n8487 else -n8487);
-// end n1.n7656.n102.n8149.n7836.n8346.n7663.n8412;
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.sublimationPressureIce_der;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7663.n8412.n8488
-//   input Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083;
-//   output Real n8487;
-//   protected Real n703 = log10(n8474);
-//   protected Real n233 = log10(64.0 * n8474);
-//   protected Real n8489 = 1.0;
-//   protected Real n1201 = 1.121782646756099;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n704 = log10(n8475);
-//   protected Real n8496;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n8494 = n704 - n703;
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8493 = 2.0 + 4.0 * n1201 / (n1202 * n8490 * n8475 ^ 0.9);
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n231 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n497 = (n231 - n233) / n8494;
-//   protected Real n43 = (3.0 * n497 - 2.0 * n8489 - n8493) / n8494;
-//   protected Real n45 = (n8489 + n8493 - 2.0 * n497) / (n8494 * n8494);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   n8496 := log10(n2800 / n8474);
-//   n8487 := 64.0 * n8474 * (n2800 / n8474) ^ (1.0 + n8496 * (n43 + n8496 * n45));
-// end n1.n7656.n102.n8149.n7836.n8346.n7663.n8412.n8488;
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.temperature;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7663.n8415
-//   input Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n8447(unit = \"m2/s2\");
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n8455(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8456(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8457(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8458(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8453(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8454(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8451(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8443;
-//   protected Real n8452(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8444;
-//   protected Real n8459(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
-//   protected Real n8461;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083)) ^ 0.97, n8328);
-//   protected Real n8460(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (n8451 + n8452) / 2.0;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.temperature_phX \"Return temperature from p, h, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   n8455 := max(n8451, n8452) + n8308;
-//   n8456 := min(n8451, n8452) - n8308;
-//   if n4510 >= n8455 then
-//     n7744 := n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476(n4510 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
-//   elseif n4510 <= n8456 then
-//     n7744 := n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476(n4510 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
-//   else
-//     (n8457, n8453) := n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476(n8455 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n8458, n8454) := n1.n7656.n102.n8149.n7836.n8346.n7663.n12.n8476(n8456 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n7744, n8461) := n1.n7656.n11.n8462(n8460, n8456, n8455, n8458, n8457, n8454, n8453);
-//     if n4510 > n8460 then
-//       n7744 := n1.n7656.n11.n8462(n4510, n8460, n8455, n8459, n8457, n8461, n8453)[1];
-//     else
-//       n7744 := n1.n7656.n11.n8462(n4510, n8456, n8460, n8458, n8459, n8454, n8461)[1];
-//     end if;
-//   end if;
-// end n1.n7656.n102.n8149.n7836.n8346.n7663.n8415;
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.temperature(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.setState_phX(p, h, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.temperature_phX;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7670.n523
-//   input n1.n7656.n102.n8149.n7836.n8346.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n7836.n8346.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n7836.n8346.n7670.n523;
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7670.n7786
-//   input n1.n7656.n102.n8149.n7836.n8346.n7670.n8367 n865;
-//   output Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear
+//   input Real x \"Independent variable of function\";
+//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
+//   output Real y \"= f_nonlinear(x)\";
 // algorithm
-//   n403 := n865.n403;
-// end n1.n7656.n102.n8149.n7836.n8346.n7670.n7786;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX(p, x, X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear;
 //
-// function n1.n7656.n102.n8149.n7836.n8346.n7670.n8340
-//   input n1.n7656.n102.n8149.n7836.n8346.n7670.n8367 n865;
-//   output Real n4890(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output f_nonlinear_Data res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.solve
+//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
+//   input Real x_min \"Minimum value of x\";
+//   input Real x_max \"Maximum value of x\";
+//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
+//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
+//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f_nonlinear(a) - y_zero\";
+//   protected Real fb \"= f_nonlinear(b) - y_zero\";
+//   protected Real fc;
+//   protected Boolean found = false;
+//   protected Real x_min2 = x_min - x_eps;
+//   protected Real x_max2 = x_max + x_eps;
+//   protected Real a = x_min2 \"Current best minimum interval value\";
+//   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
-//   n4890 := 1e-06 * n1.n7671.n8128.n9970.n9971.n9972({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, n1.n101.n946.n949(n865.n217));
-// end n1.n7656.n102.n8149.n7836.n8346.n7670.n8340;
-//
-// function n1.n7656.n102.n8149.n7836.n8346.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7836.n8346.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7836.n8346.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7836.n8346.n7670.n9583
-//   input n1.n7656.n102.n8149.n7836.n8346.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
-// algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n7836.n8346.n7670.n9583;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10111
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1)));
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n8551(n3331, 190.0, 647.0, n403, n6343[1:1], n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
-// end n1.n7656.n102.n8149.n7837.n7670.n10111;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n8551
-//   input Real n9469;
-//   input Real n5250;
-//   input Real n5263;
-//   input Real n7786 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9471 n9476;
-//   input Real n9964 = 1e-13;
-//   output Real n9472;
-//   protected constant Real n23 = 1e-15;
-//   protected constant Real n9965 = 1e-10;
-//   protected Real n58;
-//   protected Real n136;
-//   protected Real n768;
-//   protected Real n497;
-//   protected Real n61;
-//   protected Real n403;
-//   protected Real n769;
-//   protected Real n723;
-//   protected Real n770;
-//   protected Real n771;
-//   protected Real n772;
-//   protected Real n773;
-//   protected Boolean n774 = false;
-//   protected Real n9966 = n5250 - n9965;
-//   protected Real n9967 = n5263 + n9965;
-//   protected Real n130 = n9966;
-//   protected Real n490 = n9967;
-// algorithm
-//   n771 := n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9475(n9966, n7786, n6343, n9476) - n9469;
-//   n772 := n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9475(n9967, n7786, n6343, n9476) - n9469;
-//   n773 := n772;
-//   if n771 > 0.0 and n772 > 0.0 or n771 < 0.0 and n772 < 0.0 then
-//     n1.n11.n681.n682(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
+//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
+//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
 //     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(n9966, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(n9967, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(n9469, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(n771, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(n772, 6, 0, true) + \"
+//       x_min  = \" + String(x_min2, 6, 0, true) + \"
+//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
+//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
+//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
 //     \" + \"fa and fb must have opposite sign which is not the case\");
 //   end if;
-//   n58 := n130;
-//   n773 := n771;
-//   n768 := n490 - n130;
-//   n136 := n768;
-//   while not n774 loop
-//     if abs(n773) < abs(n772) then
-//       n130 := n490;
-//       n490 := n58;
-//       n58 := n130;
-//       n771 := n772;
-//       n772 := n773;
-//       n773 := n771;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
 //     end if;
-//     n770 := 2.0 * n23 * abs(n490) + n9964;
-//     n497 := (n58 - n490) / 2.0;
-//     if abs(n497) <= n770 or n772 == 0.0 then
-//       n774 := true;
-//       n9472 := n490;
+//     tol := 2.0 * eps * abs(b) + x_tol;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       x_zero := b;
 //     else
-//       if abs(n768) < n770 or abs(n771) <= abs(n772) then
-//         n768 := n497;
-//         n136 := n768;
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
 //       else
-//         n61 := n772 / n771;
-//         if n130 == n58 then
-//           n403 := 2.0 * n497 * n61;
-//           n769 := 1.0 - n61;
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
 //         else
-//           n769 := n771 / n773;
-//           n723 := n772 / n773;
-//           n403 := n61 * (2.0 * n497 * n769 * (n769 - n723) - (n490 - n130) * (n723 - 1.0));
-//           n769 := (n769 - 1.0) * (n723 - 1.0) * (n61 - 1.0);
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
 //         end if;
-//         if n403 > 0.0 then
-//           n769 := -n769;
+//         if p > 0.0 then
+//           q := -q;
 //         else
-//           n403 := -n403;
+//           p := -p;
 //         end if;
-//         n61 := n768;
-//         n768 := n136;
-//         if 2.0 * n403 < 3.0 * n497 * n769 - abs(n770 * n769) and n403 < abs(0.5 * n61 * n769) then
-//           n136 := n403 / n769;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
 //         else
-//           n768 := n497;
-//           n136 := n768;
+//           e := m;
+//           d := e;
 //         end if;
 //       end if;
-//       n130 := n490;
-//       n771 := n772;
-//       n490 := n490 + (if abs(n136) > n770 then n136 else if n497 > 0.0 then n770 else -n770);
-//       n772 := n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9475(n490, n7786, n6343, n9476) - n9469;
-//       if n772 > 0.0 and n773 > 0.0 or n772 < 0.0 and n773 < 0.0 then
-//         n58 := n130;
-//         n773 := n771;
-//         n768 := n490 - n130;
-//         n136 := n768;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
 //       end if;
 //     end if;
 //   end while;
-// end n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n8551;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX.Internal.solve;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9471 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9471\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n9471 res;
-// end n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9471;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9475
-//   input Real n637;
-//   input Real n403 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9471 n9476;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n159 := n1.n7656.n102.n8149.n7837.n7670.n10138(n403, n637, n6343);
-// end n1.n7656.n102.n8149.n7837.n7670.n10111.n12.n9475;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n7837.n7670.n10117;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n7837.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n7837.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n7837.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n7837.n7670.n11.n10129(n1.n7656.n102.n8149.n7837.n7670.n10117(n7827), n1.n7656.n102.n8149.n7837.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n7837.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n7837.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n7837.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n7837.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n7837.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n7837.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n7837.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10138
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7837.n7670.n8562(n217);
-//   n10108 := min(n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110) * (1.0 - n6343[1]), 1.0);
-//   n10105 := max(n6343[1] - n10108, 0.0);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n3331 := n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) * n10106 + n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) * n10107 + n1.n7656.n102.n8149.n7837.n7670.n10136(n217) * n10105;
-// end n1.n7656.n102.n8149.n7837.n7670.n10138;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n7837.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n7837.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n7837.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n7837.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n7837.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n7837.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n7837.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n7837.n7670.n11.n10129;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n7837.n7670.n11.n10145;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
-// algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n7837.n7670.n11.n10146;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n7837.n7670.n11.n8436;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
+//   end if;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction_der;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n523
-//   input n1.n7656.n102.n8149.n7837.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n7837.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n7837.n7670.n523;
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.density;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n7785
-//   input n1.n7656.n102.n8149.n7837.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
 // algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n7837.n7670.n7785;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n7955
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n7837.n7670.n7785(n1.n7656.n102.n8149.n7837.n7670.n8338(n403, n3331, n6343));
-// end n1.n7656.n102.n8149.n7837.n7670.n7955;
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater_der;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n7957
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   n3331 := n1.n7656.n102.n8149.n7837.n7670.n8732(n1.n7656.n102.n8149.n7837.n7670.n8396(n403, n217, n6343));
-// end n1.n7656.n102.n8149.n7837.n7670.n7957;
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.gasConstant;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n8338
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n7837.n7670.n8367 n865;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
 // algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n7837.n7670.n8367(n403, n1.n7656.n102.n8149.n7837.n7670.n10111(n403, n3331, n6343), n6343) else n1.n7656.n102.n8149.n7837.n7670.n8367(n403, n1.n7656.n102.n8149.n7837.n7670.n10111(n403, n3331, n6343), cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n7837.n7670.n8338;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(T);
+//   X_sat := min(p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat) * (1.0 - X[1]), 1.0);
+//   X_liquid := max(X[1] - X_sat, 0.0);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   h := Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) * X_steam + Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) * X_air + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater(T) * X_liquid;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7837.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7837.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7837.n7670.n8396
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n7837.n7670.n8367 n865;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
 // algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n7837.n7670.n8367(n403, n217, n6343) else n1.n7656.n102.n8149.n7837.n7670.n8367(n403, n217, cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n7837.n7670.n8396;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX_der;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
 // algorithm
-//   n7826 := n1.n7656.n102.n8149.n7837.n7670.n11.n8436(n1.n7656.n102.n8149.n7837.n7670.n10117(n7827), n1.n7656.n102.n8149.n7837.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n7837.n7670.n8562;
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n8732
-//   input n1.n7656.n102.n8149.n7837.n7670.n8367 n865;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
 // algorithm
-//   n3331 := n1.n7656.n102.n8149.n7837.n7670.n10138(n865.n403, n865.n217, n865.n6343);
-// end n1.n7656.n102.n8149.n7837.n7670.n8732;
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid;
 //
-// function n1.n7656.n102.n8149.n7837.n7670.n9583
-//   input n1.n7656.n102.n8149.n7837.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
 // algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n7837.n7670.n9583;
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid_der;
 //
-// function n1.n7656.n102.n8149.n7837.n7988.n7670.n7785
-//   input n1.n7656.n102.n8149.n7837.n7988.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
 // algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n7837.n7988.n7670.n7785;
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure_der;
 //
-// function n1.n7656.n102.n8149.n7837.n7988.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7837.n7988.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7837.n7988.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   output Real n8479;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n8487;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8498;
-//   protected Real n1201;
-//   protected Real n1202;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_pTX \"Return thermodynamic state as function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   if n8478 >= 0.0 then
-//     n5456 := n8443;
-//     n457 := n8445;
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState(p, T, X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState(p, T, cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_phX \"Return thermodynamic state as function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state\";
+// algorithm
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX(p, h, X), X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.T_phX(p, h, X), cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy \"Return specific enthalpy of moist air as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.h_pTX(state.p, state.T, state.X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX \"Return specific enthalpy from p, T, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_pTX(p, T, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
+// algorithm
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
+// algorithm
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.sublimationPressureIce_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.temperature_phX \"Return temperature from p, h, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.temperature(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_phX(p, h, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.temperature_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
+// algorithm
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.density;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.dynamicViscosity \"Return dynamic viscosity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
+// algorithm
+//   eta := 1e-06 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, Modelica.SIunits.Conversions.to_degC(state.T));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.dynamicViscosity;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+// algorithm
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.gasConstant;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+// algorithm
+//   p := state.p;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.pressure;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric \"Calculate mass flow rate as function of pressure drop due to friction\"
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") \"Inner cross section area\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   output Real dm_flow_ddp_fric \"Derivative of mass flow rate with dp_fric\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real dRe_ddp \"dRe/ddp\";
+//   protected Real aux1;
+//   protected Real aux2;
+// algorithm
+//   if dp_fric >= 0.0 then
+//     rho := rho_a;
+//     mu := mu_a;
 //   else
-//     n5456 := n8444;
-//     n457 := n8446;
+//     rho := rho_b;
+//     mu := mu_b;
 //   end if;
-//   n8487 := abs(n8478) * 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 * n457);
-//   n1201 := 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 ^ 2.0);
-//   n2800 := n8487 / 64.0;
-//   n8498 := n1201 / 64.0;
-//   if n2800 > n8474 then
-//     n2800 := -2.0 * sqrt(n8487) * log10(2.51 / sqrt(n8487) + 0.27 * n3083);
-//     n1202 := sqrt(n1201 * abs(n8478));
-//     n8498 := 0.4342944819032518 * ((-2.0 * log(2.51 / n1202 + 0.27 * n3083) * n1201 / (2.0 * n1202)) + 5.02 / (2.0 * abs(n8478) * (2.51 / n1202 + 0.27 * n3083)));
-//     if n2800 < n8475 then
-//       (n2800, n8498) := n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476.n8497(n8487, n8474, n8475, n3083, n8478);
+//   lambda2 := abs(dp_fric) * 2.0 * diameter ^ 3.0 * rho / (length * mu * mu) \"Known as lambda2=f(dp)\";
+//   aux1 := 2.0 * diameter ^ 3.0 * rho / (length * mu ^ 2.0);
+//   Re := lambda2 / 64.0 \"Hagen-Poiseuille\";
+//   dRe_ddp := aux1 / 64.0 \"Hagen-Poiseuille\";
+//   if Re > Re1 then
+//     Re := -2.0 * sqrt(lambda2) * log10(2.51 / sqrt(lambda2) + 0.27 * Delta) \"Colebrook-White\";
+//     aux2 := sqrt(aux1 * abs(dp_fric));
+//     dRe_ddp := 0.4342944819032518 * ((-2.0 * log(2.51 / aux2 + 0.27 * Delta) * aux1 / (2.0 * aux2)) + 5.02 / (2.0 * abs(dp_fric) * (2.51 / aux2 + 0.27 * Delta)));
+//     if Re < Re2 then
+//       (Re, dRe_ddp) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative(lambda2, Re1, Re2, Delta, dp_fric);
 //     end if;
 //   end if;
-//   n7744 := n7704 / n6099 * n457 * (if n8478 >= 0.0 then n2800 else -n2800);
-//   n8479 := n7704 / n6099 * n457 * n8498;
-// end n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476;
+//   m_flow := crossArea / diameter * mu * (if dp_fric >= 0.0 then Re else -Re);
+//   dm_flow_ddp_fric := crossArea / diameter * mu * dRe_ddp;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric;
 //
-// function n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476.n8497
-//   input Real n8487;
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   output Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   output Real n8498;
-//   protected Real n703 = log10(64.0 * n8474);
-//   protected Real n233 = log10(n8474);
-//   protected Real n8499 = 1.0;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n637 = log10(n8487);
-//   protected Real n159;
-//   protected Real n8501;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n704 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n231 = log10(n8492);
-//   protected Real n8500 = 0.5 + 1.090079149577162 / (n8492 * n8491);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative \"Interpolation in log-log space using a cubic Hermite polynomial, where x=log10(lambda2), y=log10(Re)\"
+//   input Real lambda2 \"Known independent variable\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   output Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Unknown return variable\";
+//   output Real dRe_ddp \"Derivative of return value\";
+//   protected Real x1 = log10(64.0 * Re1);
+//   protected Real y1 = log10(Re1);
+//   protected Real y1d = 1.0;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x = log10(lambda2);
+//   protected Real y;
+//   protected Real dy_dx \"Derivative in transformed space\";
+//   protected Real aux3 = log10(aux2);
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real x2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real y2 = log10(aux5);
+//   protected Real y2d = 0.5 + 1.090079149577162 / (aux5 * aux4);
 // algorithm
-//   (n159, n8501) := n1.n7656.n11.n8483(n637, n703, n704, n233, n231, n8499, n8500);
-//   n2800 := 10.0 ^ n159;
-//   n8498 := n2800 / abs(n8478) * n8501;
-// end n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476.n8497;
+//   (y, dy_dx) := Modelica.Fluid.Utilities.cubicHermite_withDerivative(x, x1, x2, y1, y2, y1d, y2d);
+//   Re := 10.0 ^ y;
+//   dRe_ddp := Re / abs(dp_fric) * dy_dx;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative;
 //
-// function n1.n7656.n102.n8149.n7837.n8346.n7663.n8412
-//   input Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n7750(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8487;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083), n8328);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.massFlowRate_dp_staticHead \"Return mass flow rate m_flow as function of pressure loss dp, i.e., m_flow = f(dp), due to wall friction and static head\"
+//   input Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real g_times_height_ab(unit = \"m2/s2\") \"Gravity times (Height(port_b) - Height(port_a))\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real dp_small(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0 \"Regularization of zero flow if |dp| < dp_small (dummy if use_dp_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Boundary between transition and turbulent regime\";
+//   protected Real dp_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Upper end of regularization domain of the m_flow(dp) relation\";
+//   protected Real dp_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Lower end of regularization domain of the m_flow(dp) relation\";
+//   protected Real m_flow_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at upper end of regularization domain\";
+//   protected Real m_flow_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at lower end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at upper end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at lower end of regularization domain\";
+//   protected Real dp_grav_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_a \"Static head if mass flows in design direction (a to b)\";
+//   protected Real dp_grav_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_b \"Static head if mass flows against design direction (b to a)\";
+//   protected Real m_flow_zero(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
+//   protected Real dm_flow_ddp_fric_zero;
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta)) ^ 0.97, Re_turbulent) \"Boundary between laminar regime and transition\";
+//   protected Real dp_zero(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (dp_grav_a + dp_grav_b) / 2.0;
 // algorithm
-//   n5456 := if n7744 >= 0.0 then n8443 else n8444;
-//   n457 := if n7744 >= 0.0 then n8445 else n8446;
-//   n2800 := n6099 * abs(n7744) / (n7704 * n457);
-//   n8487 := if n2800 <= n8474 then 64.0 * n2800 else if n2800 >= n8475 then 0.25 * (n2800 / log10(n3083 / 3.7 + 5.74 / n2800 ^ 0.9)) ^ 2.0 else n1.n7656.n102.n8149.n7837.n8346.n7663.n8412.n8488(n2800, n8474, n8475, n3083);
-//   n4510 := n2194 * n457 * n457 / (2.0 * n5456 * n6099 * n6099 * n6099) * (if n7744 >= 0.0 then n8487 else -n8487);
-// end n1.n7656.n102.n8149.n7837.n8346.n7663.n8412;
-//
-// function n1.n7656.n102.n8149.n7837.n8346.n7663.n8412.n8488
-//   input Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083;
-//   output Real n8487;
-//   protected Real n703 = log10(n8474);
-//   protected Real n233 = log10(64.0 * n8474);
-//   protected Real n8489 = 1.0;
-//   protected Real n1201 = 1.121782646756099;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n704 = log10(n8475);
-//   protected Real n8496;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n8494 = n704 - n703;
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8493 = 2.0 + 4.0 * n1201 / (n1202 * n8490 * n8475 ^ 0.9);
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n231 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n497 = (n231 - n233) / n8494;
-//   protected Real n43 = (3.0 * n497 - 2.0 * n8489 - n8493) / n8494;
-//   protected Real n45 = (n8489 + n8493 - 2.0 * n497) / (n8494 * n8494);
-// algorithm
-//   n8496 := log10(n2800 / n8474);
-//   n8487 := 64.0 * n8474 * (n2800 / n8474) ^ (1.0 + n8496 * (n43 + n8496 * n45));
-// end n1.n7656.n102.n8149.n7837.n8346.n7663.n8412.n8488;
-//
-// function n1.n7656.n102.n8149.n7837.n8346.n7663.n8415
-//   input Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n8447(unit = \"m2/s2\");
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n8455(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8456(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8457(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8458(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8453(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8454(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8451(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8443;
-//   protected Real n8452(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8444;
-//   protected Real n8459(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
-//   protected Real n8461;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083)) ^ 0.97, n8328);
-//   protected Real n8460(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (n8451 + n8452) / 2.0;
-// algorithm
-//   n8455 := max(n8451, n8452) + n8308;
-//   n8456 := min(n8451, n8452) - n8308;
-//   if n4510 >= n8455 then
-//     n7744 := n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476(n4510 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
-//   elseif n4510 <= n8456 then
-//     n7744 := n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476(n4510 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
+//   dp_a := max(dp_grav_a, dp_grav_b) + dp_small;
+//   dp_b := min(dp_grav_a, dp_grav_b) - dp_small;
+//   if dp >= dp_a then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
+//   elseif dp <= dp_b then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
 //   else
-//     (n8457, n8453) := n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476(n8455 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n8458, n8454) := n1.n7656.n102.n8149.n7837.n8346.n7663.n12.n8476(n8456 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n7744, n8461) := n1.n7656.n11.n8462(n8460, n8456, n8455, n8458, n8457, n8454, n8453);
-//     if n4510 > n8460 then
-//       n7744 := n1.n7656.n11.n8462(n4510, n8460, n8455, n8459, n8457, n8461, n8453)[1];
+//     (m_flow_a, dm_flow_ddp_fric_a) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_a - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow_b, dm_flow_ddp_fric_b) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_b - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow, dm_flow_ddp_fric_zero) := Modelica.Fluid.Utilities.regFun3(dp_zero, dp_b, dp_a, m_flow_b, m_flow_a, dm_flow_ddp_fric_b, dm_flow_ddp_fric_a);
+//     if dp > dp_zero then
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_zero, dp_a, m_flow_zero, m_flow_a, dm_flow_ddp_fric_zero, dm_flow_ddp_fric_a)[1];
 //     else
-//       n7744 := n1.n7656.n11.n8462(n4510, n8456, n8460, n8458, n8459, n8454, n8461)[1];
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_b, dp_zero, m_flow_b, m_flow_zero, dm_flow_ddp_fric_b, dm_flow_ddp_fric_zero)[1];
 //     end if;
 //   end if;
-// end n1.n7656.n102.n8149.n7837.n8346.n7663.n8415;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.massFlowRate_dp_staticHead;
 //
-// function n1.n7656.n102.n8149.n7837.n8346.n7670.n523
-//   input n1.n7656.n102.n8149.n7837.n8346.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow \"Return pressure loss dp as function of mass flow rate m_flow, i.e., dp = f(m_flow), due to wall friction\"
+//   input Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01 \"Regularization of zero flow if |m_flow| < m_flow_small (dummy if use_m_flow_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Re entering turbulent curve\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta), Re_turbulent) \"Re leaving laminar curve\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n7837.n8346.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n7837.n8346.n7670.n523;
+//   rho := if m_flow >= 0.0 then rho_a else rho_b;
+//   mu := if m_flow >= 0.0 then mu_a else mu_b;
+//   Re := diameter * abs(m_flow) / (crossArea * mu);
+//   lambda2 := if Re <= Re1 then 64.0 * Re else if Re >= Re2 then 0.25 * (Re / log10(Delta / 3.7 + 5.74 / Re ^ 0.9)) ^ 2.0 else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2(Re, Re1, Re2, Delta);
+//   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow;
 //
-// function n1.n7656.n102.n8149.n7837.n8346.n7670.n7786
-//   input n1.n7656.n102.n8149.n7837.n8346.n7670.n8367 n865;
-//   output Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Delta;
+//   output Real lambda2;
+//   protected Real x1 = log10(Re1);
+//   protected Real y1 = log10(64.0 * Re1);
+//   protected Real yd1 = 1.0;
+//   protected Real aux1 = 1.121782646756099;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x2 = log10(Re2);
+//   protected Real dx;
+//   protected Real aux3 = log10(aux2);
+//   protected Real diff_x = x2 - x1;
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real y2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real m = (y2 - y1) / diff_x;
+//   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
+//   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
 // algorithm
-//   n403 := n865.n403;
-// end n1.n7656.n102.n8149.n7837.n8346.n7670.n7786;
+//   dx := log10(Re / Re1);
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
 //
-// function n1.n7656.n102.n8149.n7837.n8346.n7670.n8340
-//   input n1.n7656.n102.n8149.n7837.n8346.n7670.n8367 n865;
-//   output Real n4890(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   n4890 := 1e-06 * n1.n7671.n8128.n9970.n9971.n9972({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, n1.n101.n946.n949(n865.n217));
-// end n1.n7656.n102.n8149.n7837.n8346.n7670.n8340;
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.temperature;
 //
-// function n1.n7656.n102.n8149.n7837.n8346.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n7837.n8346.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n7837.n8346.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n7837.n8346.n7670.n9583
-//   input n1.n7656.n102.n8149.n7837.n8346.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
 // algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n7837.n8346.n7670.n9583;
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n10111
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1)));
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear
+//   input Real x \"Independent variable of function\";
+//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
+//   output Real y \"= f_nonlinear(x)\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n8551(n3331, 190.0, 647.0, n403, n6343[1:1], n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
-// end n1.n7656.n102.n8149.n8133.n7670.n10111;
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX(p, x, X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n8551
-//   input Real n9469;
-//   input Real n5250;
-//   input Real n5263;
-//   input Real n7786 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9471 n9476;
-//   input Real n9964 = 1e-13;
-//   output Real n9472;
-//   protected constant Real n23 = 1e-15;
-//   protected constant Real n9965 = 1e-10;
-//   protected Real n58;
-//   protected Real n136;
-//   protected Real n768;
-//   protected Real n497;
-//   protected Real n61;
-//   protected Real n403;
-//   protected Real n769;
-//   protected Real n723;
-//   protected Real n770;
-//   protected Real n771;
-//   protected Real n772;
-//   protected Real n773;
-//   protected Boolean n774 = false;
-//   protected Real n9966 = n5250 - n9965;
-//   protected Real n9967 = n5263 + n9965;
-//   protected Real n130 = n9966;
-//   protected Real n490 = n9967;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output f_nonlinear_Data res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.solve
+//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
+//   input Real x_min \"Minimum value of x\";
+//   input Real x_max \"Maximum value of x\";
+//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
+//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
+//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f_nonlinear(a) - y_zero\";
+//   protected Real fb \"= f_nonlinear(b) - y_zero\";
+//   protected Real fc;
+//   protected Boolean found = false;
+//   protected Real x_min2 = x_min - x_eps;
+//   protected Real x_max2 = x_max + x_eps;
+//   protected Real a = x_min2 \"Current best minimum interval value\";
+//   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
-//   n771 := n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9475(n9966, n7786, n6343, n9476) - n9469;
-//   n772 := n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9475(n9967, n7786, n6343, n9476) - n9469;
-//   n773 := n772;
-//   if n771 > 0.0 and n772 > 0.0 or n771 < 0.0 and n772 < 0.0 then
-//     n1.n11.n681.n682(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
+//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
+//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
 //     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(n9966, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(n9967, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(n9469, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(n771, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(n772, 6, 0, true) + \"
+//       x_min  = \" + String(x_min2, 6, 0, true) + \"
+//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
+//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
+//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
 //     \" + \"fa and fb must have opposite sign which is not the case\");
 //   end if;
-//   n58 := n130;
-//   n773 := n771;
-//   n768 := n490 - n130;
-//   n136 := n768;
-//   while not n774 loop
-//     if abs(n773) < abs(n772) then
-//       n130 := n490;
-//       n490 := n58;
-//       n58 := n130;
-//       n771 := n772;
-//       n772 := n773;
-//       n773 := n771;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
 //     end if;
-//     n770 := 2.0 * n23 * abs(n490) + n9964;
-//     n497 := (n58 - n490) / 2.0;
-//     if abs(n497) <= n770 or n772 == 0.0 then
-//       n774 := true;
-//       n9472 := n490;
+//     tol := 2.0 * eps * abs(b) + x_tol;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       x_zero := b;
 //     else
-//       if abs(n768) < n770 or abs(n771) <= abs(n772) then
-//         n768 := n497;
-//         n136 := n768;
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
 //       else
-//         n61 := n772 / n771;
-//         if n130 == n58 then
-//           n403 := 2.0 * n497 * n61;
-//           n769 := 1.0 - n61;
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
 //         else
-//           n769 := n771 / n773;
-//           n723 := n772 / n773;
-//           n403 := n61 * (2.0 * n497 * n769 * (n769 - n723) - (n490 - n130) * (n723 - 1.0));
-//           n769 := (n769 - 1.0) * (n723 - 1.0) * (n61 - 1.0);
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
 //         end if;
-//         if n403 > 0.0 then
-//           n769 := -n769;
+//         if p > 0.0 then
+//           q := -q;
 //         else
-//           n403 := -n403;
+//           p := -p;
 //         end if;
-//         n61 := n768;
-//         n768 := n136;
-//         if 2.0 * n403 < 3.0 * n497 * n769 - abs(n770 * n769) and n403 < abs(0.5 * n61 * n769) then
-//           n136 := n403 / n769;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
 //         else
-//           n768 := n497;
-//           n136 := n768;
+//           e := m;
+//           d := e;
 //         end if;
 //       end if;
-//       n130 := n490;
-//       n771 := n772;
-//       n490 := n490 + (if abs(n136) > n770 then n136 else if n497 > 0.0 then n770 else -n770);
-//       n772 := n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9475(n490, n7786, n6343, n9476) - n9469;
-//       if n772 > 0.0 and n773 > 0.0 or n772 < 0.0 and n773 < 0.0 then
-//         n58 := n130;
-//         n773 := n771;
-//         n768 := n490 - n130;
-//         n136 := n768;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
 //       end if;
 //     end if;
 //   end while;
-// end n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n8551;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX.Internal.solve;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9471 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9471\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n9471 res;
-// end n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9471;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9475
-//   input Real n637;
-//   input Real n403 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9471 n9476;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n159 := n1.n7656.n102.n8149.n8133.n7670.n10138(n403, n637, n6343);
-// end n1.n7656.n102.n8149.n8133.n7670.n10111.n12.n9475;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n8133.n7670.n10117;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n8133.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n8133.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n8133.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n8133.n7670.n11.n10129(n1.n7656.n102.n8149.n8133.n7670.n10117(n7827), n1.n7656.n102.n8149.n8133.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n8133.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n8133.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n8133.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n8133.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n8133.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n8133.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n8133.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10138
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n8133.n7670.n8562(n217);
-//   n10108 := min(n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110) * (1.0 - n6343[1]), 1.0);
-//   n10105 := max(n6343[1] - n10108, 0.0);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n3331 := n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) * n10106 + n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) * n10107 + n1.n7656.n102.n8149.n8133.n7670.n10136(n217) * n10105;
-// end n1.n7656.n102.n8149.n8133.n7670.n10138;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n8133.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n8133.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n8133.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n8133.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n8133.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n8133.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n8133.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n8133.n7670.n11.n10129;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n8133.n7670.n11.n10145;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
-// algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n8133.n7670.n11.n10146;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n8133.n7670.n11.n8436;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
+//   end if;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction_der;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n523
-//   input n1.n7656.n102.n8149.n8133.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n8133.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n8133.n7670.n523;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n7785
-//   input n1.n7656.n102.n8149.n8133.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
 // algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n8133.n7670.n7785;
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater_der;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n7955
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n8133.n7670.n7785(n1.n7656.n102.n8149.n8133.n7670.n8338(n403, n3331, n6343));
-// end n1.n7656.n102.n8149.n8133.n7670.n7955;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(T);
+//   X_sat := min(p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat) * (1.0 - X[1]), 1.0);
+//   X_liquid := max(X[1] - X_sat, 0.0);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   h := Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) * X_steam + Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) * X_air + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater(T) * X_liquid;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n7957
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
 // algorithm
-//   n3331 := n1.n7656.n102.n8149.n8133.n7670.n8732(n1.n7656.n102.n8149.n8133.n7670.n8396(n403, n217, n6343));
-// end n1.n7656.n102.n8149.n8133.n7670.n7957;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX_der;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n8338
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n8133.n7670.n8367 n865;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
 // algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n8133.n7670.n8367(n403, n1.n7656.n102.n8149.n8133.n7670.n10111(n403, n3331, n6343), n6343) else n1.n7656.n102.n8149.n8133.n7670.n8367(n403, n1.n7656.n102.n8149.n8133.n7670.n10111(n403, n3331, n6343), cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n8133.n7670.n8338;
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8133.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n8133.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n8133.n7670.n8396
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n8133.n7670.n8367 n865;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
 // algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n8133.n7670.n8367(n403, n217, n6343) else n1.n7656.n102.n8149.n8133.n7670.n8367(n403, n217, cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n8133.n7670.n8396;
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
 // algorithm
-//   n7826 := n1.n7656.n102.n8149.n8133.n7670.n11.n8436(n1.n7656.n102.n8149.n8133.n7670.n10117(n7827), n1.n7656.n102.n8149.n8133.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n8133.n7670.n8562;
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid_der;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n8732
-//   input n1.n7656.n102.n8149.n8133.n7670.n8367 n865;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
 // algorithm
-//   n3331 := n1.n7656.n102.n8149.n8133.n7670.n10138(n865.n403, n865.n217, n865.n6343);
-// end n1.n7656.n102.n8149.n8133.n7670.n8732;
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure_der;
 //
-// function n1.n7656.n102.n8149.n8133.n7670.n9583
-//   input n1.n7656.n102.n8149.n8133.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_pTX \"Return thermodynamic state as function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n8133.n7670.n9583;
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState(p, T, X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState(p, T, cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_pTX;
 //
-// function n1.n7656.n102.n8149.n8133.n7988.n7670.n7785
-//   input n1.n7656.n102.n8149.n8133.n7988.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_phX \"Return thermodynamic state as function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState state \"Thermodynamic state\";
 // algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n8133.n7988.n7670.n7785;
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX(p, h, X), X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.T_phX(p, h, X), cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_phX;
 //
-// function n1.n7656.n102.n8149.n8133.n7988.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8133.n7988.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n8133.n7988.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   output Real n8479;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n8487;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8498;
-//   protected Real n1201;
-//   protected Real n1202;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy \"Return specific enthalpy of moist air as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
 // algorithm
-//   if n8478 >= 0.0 then
-//     n5456 := n8443;
-//     n457 := n8445;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.h_pTX(state.p, state.T, state.X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX \"Return specific enthalpy from p, T, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_pTX(p, T, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
+// algorithm
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
+// algorithm
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.sublimationPressureIce_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.temperature_phX \"Return temperature from p, h, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.temperature(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_phX(p, h, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.temperature_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
+// algorithm
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.density;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.dynamicViscosity \"Return dynamic viscosity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
+// algorithm
+//   eta := 1e-06 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, Modelica.SIunits.Conversions.to_degC(state.T));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.dynamicViscosity;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+// algorithm
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.gasConstant;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+// algorithm
+//   p := state.p;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.pressure;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric \"Calculate mass flow rate as function of pressure drop due to friction\"
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") \"Inner cross section area\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   output Real dm_flow_ddp_fric \"Derivative of mass flow rate with dp_fric\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real dRe_ddp \"dRe/ddp\";
+//   protected Real aux1;
+//   protected Real aux2;
+// algorithm
+//   if dp_fric >= 0.0 then
+//     rho := rho_a;
+//     mu := mu_a;
 //   else
-//     n5456 := n8444;
-//     n457 := n8446;
+//     rho := rho_b;
+//     mu := mu_b;
 //   end if;
-//   n8487 := abs(n8478) * 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 * n457);
-//   n1201 := 2.0 * n6099 ^ 3.0 * n5456 / (n2194 * n457 ^ 2.0);
-//   n2800 := n8487 / 64.0;
-//   n8498 := n1201 / 64.0;
-//   if n2800 > n8474 then
-//     n2800 := -2.0 * sqrt(n8487) * log10(2.51 / sqrt(n8487) + 0.27 * n3083);
-//     n1202 := sqrt(n1201 * abs(n8478));
-//     n8498 := 0.4342944819032518 * ((-2.0 * log(2.51 / n1202 + 0.27 * n3083) * n1201 / (2.0 * n1202)) + 5.02 / (2.0 * abs(n8478) * (2.51 / n1202 + 0.27 * n3083)));
-//     if n2800 < n8475 then
-//       (n2800, n8498) := n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476.n8497(n8487, n8474, n8475, n3083, n8478);
+//   lambda2 := abs(dp_fric) * 2.0 * diameter ^ 3.0 * rho / (length * mu * mu) \"Known as lambda2=f(dp)\";
+//   aux1 := 2.0 * diameter ^ 3.0 * rho / (length * mu ^ 2.0);
+//   Re := lambda2 / 64.0 \"Hagen-Poiseuille\";
+//   dRe_ddp := aux1 / 64.0 \"Hagen-Poiseuille\";
+//   if Re > Re1 then
+//     Re := -2.0 * sqrt(lambda2) * log10(2.51 / sqrt(lambda2) + 0.27 * Delta) \"Colebrook-White\";
+//     aux2 := sqrt(aux1 * abs(dp_fric));
+//     dRe_ddp := 0.4342944819032518 * ((-2.0 * log(2.51 / aux2 + 0.27 * Delta) * aux1 / (2.0 * aux2)) + 5.02 / (2.0 * abs(dp_fric) * (2.51 / aux2 + 0.27 * Delta)));
+//     if Re < Re2 then
+//       (Re, dRe_ddp) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative(lambda2, Re1, Re2, Delta, dp_fric);
 //     end if;
 //   end if;
-//   n7744 := n7704 / n6099 * n457 * (if n8478 >= 0.0 then n2800 else -n2800);
-//   n8479 := n7704 / n6099 * n457 * n8498;
-// end n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476;
+//   m_flow := crossArea / diameter * mu * (if dp_fric >= 0.0 then Re else -Re);
+//   dm_flow_ddp_fric := crossArea / diameter * mu * dRe_ddp;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric;
 //
-// function n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476.n8497
-//   input Real n8487;
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083(min = 0.0);
-//   input Real n8478(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   output Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   output Real n8498;
-//   protected Real n703 = log10(64.0 * n8474);
-//   protected Real n233 = log10(n8474);
-//   protected Real n8499 = 1.0;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n637 = log10(n8487);
-//   protected Real n159;
-//   protected Real n8501;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n704 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n231 = log10(n8492);
-//   protected Real n8500 = 0.5 + 1.090079149577162 / (n8492 * n8491);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative \"Interpolation in log-log space using a cubic Hermite polynomial, where x=log10(lambda2), y=log10(Re)\"
+//   input Real lambda2 \"Known independent variable\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   output Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Unknown return variable\";
+//   output Real dRe_ddp \"Derivative of return value\";
+//   protected Real x1 = log10(64.0 * Re1);
+//   protected Real y1 = log10(Re1);
+//   protected Real y1d = 1.0;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x = log10(lambda2);
+//   protected Real y;
+//   protected Real dy_dx \"Derivative in transformed space\";
+//   protected Real aux3 = log10(aux2);
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real x2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real y2 = log10(aux5);
+//   protected Real y2d = 0.5 + 1.090079149577162 / (aux5 * aux4);
 // algorithm
-//   (n159, n8501) := n1.n7656.n11.n8483(n637, n703, n704, n233, n231, n8499, n8500);
-//   n2800 := 10.0 ^ n159;
-//   n8498 := n2800 / abs(n8478) * n8501;
-// end n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476.n8497;
+//   (y, dy_dx) := Modelica.Fluid.Utilities.cubicHermite_withDerivative(x, x1, x2, y1, y2, y1d, y2d);
+//   Re := 10.0 ^ y;
+//   dRe_ddp := Re / abs(dp_fric) * dy_dx;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative;
 //
-// function n1.n7656.n102.n8149.n8133.n8346.n7663.n8412
-//   input Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n7750(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   protected Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8487;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083), n8328);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.massFlowRate_dp_staticHead \"Return mass flow rate m_flow as function of pressure loss dp, i.e., m_flow = f(dp), due to wall friction and static head\"
+//   input Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real g_times_height_ab(unit = \"m2/s2\") \"Gravity times (Height(port_b) - Height(port_a))\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real dp_small(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0 \"Regularization of zero flow if |dp| < dp_small (dummy if use_dp_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Boundary between transition and turbulent regime\";
+//   protected Real dp_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Upper end of regularization domain of the m_flow(dp) relation\";
+//   protected Real dp_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Lower end of regularization domain of the m_flow(dp) relation\";
+//   protected Real m_flow_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at upper end of regularization domain\";
+//   protected Real m_flow_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at lower end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at upper end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at lower end of regularization domain\";
+//   protected Real dp_grav_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_a \"Static head if mass flows in design direction (a to b)\";
+//   protected Real dp_grav_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_b \"Static head if mass flows against design direction (b to a)\";
+//   protected Real m_flow_zero(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
+//   protected Real dm_flow_ddp_fric_zero;
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta)) ^ 0.97, Re_turbulent) \"Boundary between laminar regime and transition\";
+//   protected Real dp_zero(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (dp_grav_a + dp_grav_b) / 2.0;
 // algorithm
-//   n5456 := if n7744 >= 0.0 then n8443 else n8444;
-//   n457 := if n7744 >= 0.0 then n8445 else n8446;
-//   n2800 := n6099 * abs(n7744) / (n7704 * n457);
-//   n8487 := if n2800 <= n8474 then 64.0 * n2800 else if n2800 >= n8475 then 0.25 * (n2800 / log10(n3083 / 3.7 + 5.74 / n2800 ^ 0.9)) ^ 2.0 else n1.n7656.n102.n8149.n8133.n8346.n7663.n8412.n8488(n2800, n8474, n8475, n3083);
-//   n4510 := n2194 * n457 * n457 / (2.0 * n5456 * n6099 * n6099 * n6099) * (if n7744 >= 0.0 then n8487 else -n8487);
-// end n1.n7656.n102.n8149.n8133.n8346.n7663.n8412;
-//
-// function n1.n7656.n102.n8149.n8133.n8346.n7663.n8412.n8488
-//   input Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   input Real n3083;
-//   output Real n8487;
-//   protected Real n703 = log10(n8474);
-//   protected Real n233 = log10(64.0 * n8474);
-//   protected Real n8489 = 1.0;
-//   protected Real n1201 = 1.121782646756099;
-//   protected Real n1202 = n3083 / 3.7 + 5.74 / n8475 ^ 0.9;
-//   protected Real n704 = log10(n8475);
-//   protected Real n8496;
-//   protected Real n8490 = log10(n1202);
-//   protected Real n8494 = n704 - n703;
-//   protected Real n1581 = 0.25 * (n8475 / n8490) ^ 2.0;
-//   protected Real n8493 = 2.0 + 4.0 * n1201 / (n1202 * n8490 * n8475 ^ 0.9);
-//   protected Real n8491 = 2.51 / sqrt(n1581) + 0.27 * n3083;
-//   protected Real n231 = log10(n1581);
-//   protected Real n8492 = -2.0 * sqrt(n1581) * log10(n8491);
-//   protected Real n497 = (n231 - n233) / n8494;
-//   protected Real n43 = (3.0 * n497 - 2.0 * n8489 - n8493) / n8494;
-//   protected Real n45 = (n8489 + n8493 - 2.0 * n497) / (n8494 * n8494);
-// algorithm
-//   n8496 := log10(n2800 / n8474);
-//   n8487 := 64.0 * n8474 * (n2800 / n8474) ^ (1.0 + n8496 * (n43 + n8496 * n45));
-// end n1.n7656.n102.n8149.n8133.n8346.n7663.n8412.n8488;
-//
-// function n1.n7656.n102.n8149.n8133.n8346.n7663.n8415
-//   input Real n4510(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n8443(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8444(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n8445(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n8446(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n2194(quantity = \"Length\", unit = \"m\");
-//   input Real n6099(quantity = \"Length\", unit = \"m\", min = 0.0);
-//   input Real n8447(unit = \"m2/s2\");
-//   input Real n7704(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * n6099 ^ 2.0 / 4.0;
-//   input Real n8234(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05;
-//   input Real n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0;
-//   input Real n8328(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
-//   output Real n7744(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n3083(min = 0.0) = n8234 / n6099;
-//   protected Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
-//   protected Real n8475(quantity = \"ReynoldsNumber\", unit = \"1\") = n8328;
-//   protected Real n8455(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8456(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   protected Real n8457(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8458(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8453(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8454(quantity = \"MassFlowRate\", unit = \"kg/s\");
-//   protected Real n8451(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8443;
-//   protected Real n8452(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = n8447 * n8444;
-//   protected Real n8459(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
-//   protected Real n8461;
-//   protected Real n8474(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if n3083 <= 0.0065 then 1.0 else 0.0065 / n3083)) ^ 0.97, n8328);
-//   protected Real n8460(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (n8451 + n8452) / 2.0;
-// algorithm
-//   n8455 := max(n8451, n8452) + n8308;
-//   n8456 := min(n8451, n8452) - n8308;
-//   if n4510 >= n8455 then
-//     n7744 := n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476(n4510 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
-//   elseif n4510 <= n8456 then
-//     n7744 := n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476(n4510 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083)[1];
+//   dp_a := max(dp_grav_a, dp_grav_b) + dp_small;
+//   dp_b := min(dp_grav_a, dp_grav_b) - dp_small;
+//   if dp >= dp_a then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
+//   elseif dp <= dp_b then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
 //   else
-//     (n8457, n8453) := n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476(n8455 - n8451, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n8458, n8454) := n1.n7656.n102.n8149.n8133.n8346.n7663.n12.n8476(n8456 - n8452, n8443, n8444, n8445, n8446, n2194, n6099, n7704, n8474, n8475, n3083);
-//     (n7744, n8461) := n1.n7656.n11.n8462(n8460, n8456, n8455, n8458, n8457, n8454, n8453);
-//     if n4510 > n8460 then
-//       n7744 := n1.n7656.n11.n8462(n4510, n8460, n8455, n8459, n8457, n8461, n8453)[1];
+//     (m_flow_a, dm_flow_ddp_fric_a) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_a - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow_b, dm_flow_ddp_fric_b) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_b - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow, dm_flow_ddp_fric_zero) := Modelica.Fluid.Utilities.regFun3(dp_zero, dp_b, dp_a, m_flow_b, m_flow_a, dm_flow_ddp_fric_b, dm_flow_ddp_fric_a);
+//     if dp > dp_zero then
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_zero, dp_a, m_flow_zero, m_flow_a, dm_flow_ddp_fric_zero, dm_flow_ddp_fric_a)[1];
 //     else
-//       n7744 := n1.n7656.n11.n8462(n4510, n8456, n8460, n8458, n8459, n8454, n8461)[1];
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_b, dp_zero, m_flow_b, m_flow_zero, dm_flow_ddp_fric_b, dm_flow_ddp_fric_zero)[1];
 //     end if;
 //   end if;
-// end n1.n7656.n102.n8149.n8133.n8346.n7663.n8415;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.massFlowRate_dp_staticHead;
 //
-// function n1.n7656.n102.n8149.n8133.n8346.n7670.n523
-//   input n1.n7656.n102.n8149.n8133.n8346.n7670.n8367 n865;
-//   output Real n136(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow \"Return pressure loss dp as function of mass flow rate m_flow, i.e., dp = f(m_flow), due to wall friction\"
+//   input Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01 \"Regularization of zero flow if |m_flow| < m_flow_small (dummy if use_m_flow_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Re entering turbulent curve\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta), Re_turbulent) \"Re leaving laminar curve\";
 // algorithm
-//   n136 := n865.n403 / (n1.n7656.n102.n8149.n8133.n8346.n7670.n9583(n865) * n865.n217);
-// end n1.n7656.n102.n8149.n8133.n8346.n7670.n523;
+//   rho := if m_flow >= 0.0 then rho_a else rho_b;
+//   mu := if m_flow >= 0.0 then mu_a else mu_b;
+//   Re := diameter * abs(m_flow) / (crossArea * mu);
+//   lambda2 := if Re <= Re1 then 64.0 * Re else if Re >= Re2 then 0.25 * (Re / log10(Delta / 3.7 + 5.74 / Re ^ 0.9)) ^ 2.0 else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2(Re, Re1, Re2, Delta);
+//   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow;
 //
-// function n1.n7656.n102.n8149.n8133.n8346.n7670.n7786
-//   input n1.n7656.n102.n8149.n8133.n8346.n7670.n8367 n865;
-//   output Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Delta;
+//   output Real lambda2;
+//   protected Real x1 = log10(Re1);
+//   protected Real y1 = log10(64.0 * Re1);
+//   protected Real yd1 = 1.0;
+//   protected Real aux1 = 1.121782646756099;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x2 = log10(Re2);
+//   protected Real dx;
+//   protected Real aux3 = log10(aux2);
+//   protected Real diff_x = x2 - x1;
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real y2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real m = (y2 - y1) / diff_x;
+//   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
+//   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
 // algorithm
-//   n403 := n865.n403;
-// end n1.n7656.n102.n8149.n8133.n8346.n7670.n7786;
+//   dx := log10(Re / Re1);
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
 //
-// function n1.n7656.n102.n8149.n8133.n8346.n7670.n8340
-//   input n1.n7656.n102.n8149.n8133.n8346.n7670.n8367 n865;
-//   output Real n4890(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n4890 := 1e-06 * n1.n7671.n8128.n9970.n9971.n9972({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, n1.n101.n946.n949(n865.n217));
-// end n1.n7656.n102.n8149.n8133.n8346.n7670.n8340;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n8133.n8346.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8133.n8346.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n8133.n8346.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n8133.n8346.n7670.n9583
-//   input n1.n7656.n102.n8149.n8133.n8346.n7670.n8367 n865;
-//   output Real n344(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n344 := 287.0512249529787 * (1.0 - n865.n6343[1]) + 461.5233290850878 * n865.n6343[1];
-// end n1.n7656.n102.n8149.n8133.n8346.n7670.n9583;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n10111
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1)));
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n8551(n3331, 190.0, 647.0, n403, n6343[1:1], n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
-// end n1.n7656.n102.n8149.n8153.n7670.n10111;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
+//   else
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
+//   end if;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n8551
-//   input Real n9469;
-//   input Real n5250;
-//   input Real n5263;
-//   input Real n7786 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9471 n9476;
-//   input Real n9964 = 1e-13;
-//   output Real n9472;
-//   protected constant Real n23 = 1e-15;
-//   protected constant Real n9965 = 1e-10;
-//   protected Real n58;
-//   protected Real n136;
-//   protected Real n768;
-//   protected Real n497;
-//   protected Real n61;
-//   protected Real n403;
-//   protected Real n769;
-//   protected Real n723;
-//   protected Real n770;
-//   protected Real n771;
-//   protected Real n772;
-//   protected Real n773;
-//   protected Boolean n774 = false;
-//   protected Real n9966 = n5250 - n9965;
-//   protected Real n9967 = n5263 + n9965;
-//   protected Real n130 = n9966;
-//   protected Real n490 = n9967;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n771 := n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9475(n9966, n7786, n6343, n9476) - n9469;
-//   n772 := n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9475(n9967, n7786, n6343, n9476) - n9469;
-//   n773 := n772;
-//   if n771 > 0.0 and n772 > 0.0 or n771 < 0.0 and n772 < 0.0 then
-//     n1.n11.n681.n682(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
+//   else
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
+//   end if;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
+//   end if;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
+// algorithm
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.density;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.dynamicViscosity \"Return dynamic viscosity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
+// algorithm
+//   eta := 1e-06 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, Modelica.SIunits.Conversions.to_degC(state.T));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.dynamicViscosity;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+// algorithm
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+// algorithm
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.gasConstant;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
+// algorithm
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.h_pTX_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.prandtlNumber \"Return the Prandtl number\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real Pr(quantity = \"PrandtlNumber\", unit = \"1\", min = 0.001, max = 100000.0, nominal = 1.0) \"Prandtl number\";
+// algorithm
+//   Pr := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.dynamicViscosity(state) * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.specificHeatCapacityCp(state) / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.thermalConductivity(state);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.prandtlNumber;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
+// algorithm
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressure;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
+// algorithm
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
+// algorithm
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
+// algorithm
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.saturationPressure_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.specificHeatCapacityCp \"Return specific heat capacity at constant pressure as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real cp(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\", min = 0.0, max = 10000000.0, start = 1000.0, nominal = 1000.0) \"Specific heat capacity at constant pressure\";
+//   protected Real dT(unit = \"s/K\") = 1.0;
+// algorithm
+//   cp := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.h_pTX_der(state.p, state.T, state.X, 0.0, 1.0, {0.0, 0.0}) * dT \"Definition of cp: dh/dT @ constant p\";
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.specificHeatCapacityCp;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
+// algorithm
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
+// algorithm
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.sublimationPressureIce_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.thermalConductivity \"Return thermal conductivity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real lambda(quantity = \"ThermalConductivity\", unit = \"W/(m.K)\", min = 0.0, max = 500.0, start = 1.0, nominal = 1.0) \"Thermal conductivity\";
+// algorithm
+//   lambda := 0.001 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({6.569147081771781e-15, -3.402596192305051e-11, 5.327928484630316e-08, -4.534083928921947e-05, 0.07612967530903766, 24.16948108809705}, -150.0, 1000.0, Modelica.SIunits.Conversions.to_degC(state.T));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.thermalConductivity;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear
+//   input Real x \"Independent variable of function\";
+//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
+//   output Real y \"= f_nonlinear(x)\";
+// algorithm
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX(p, x, X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output f_nonlinear_Data res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.solve
+//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
+//   input Real x_min \"Minimum value of x\";
+//   input Real x_max \"Maximum value of x\";
+//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
+//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
+//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f_nonlinear(a) - y_zero\";
+//   protected Real fb \"= f_nonlinear(b) - y_zero\";
+//   protected Real fc;
+//   protected Boolean found = false;
+//   protected Real x_min2 = x_min - x_eps;
+//   protected Real x_max2 = x_max + x_eps;
+//   protected Real a = x_min2 \"Current best minimum interval value\";
+//   protected Real b = x_max2 \"Current best maximum interval value\";
+// algorithm
+//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
+//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
 //     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(n9966, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(n9967, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(n9469, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(n771, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(n772, 6, 0, true) + \"
+//       x_min  = \" + String(x_min2, 6, 0, true) + \"
+//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
+//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
+//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
 //     \" + \"fa and fb must have opposite sign which is not the case\");
 //   end if;
-//   n58 := n130;
-//   n773 := n771;
-//   n768 := n490 - n130;
-//   n136 := n768;
-//   while not n774 loop
-//     if abs(n773) < abs(n772) then
-//       n130 := n490;
-//       n490 := n58;
-//       n58 := n130;
-//       n771 := n772;
-//       n772 := n773;
-//       n773 := n771;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
 //     end if;
-//     n770 := 2.0 * n23 * abs(n490) + n9964;
-//     n497 := (n58 - n490) / 2.0;
-//     if abs(n497) <= n770 or n772 == 0.0 then
-//       n774 := true;
-//       n9472 := n490;
+//     tol := 2.0 * eps * abs(b) + x_tol;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       x_zero := b;
 //     else
-//       if abs(n768) < n770 or abs(n771) <= abs(n772) then
-//         n768 := n497;
-//         n136 := n768;
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
 //       else
-//         n61 := n772 / n771;
-//         if n130 == n58 then
-//           n403 := 2.0 * n497 * n61;
-//           n769 := 1.0 - n61;
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
 //         else
-//           n769 := n771 / n773;
-//           n723 := n772 / n773;
-//           n403 := n61 * (2.0 * n497 * n769 * (n769 - n723) - (n490 - n130) * (n723 - 1.0));
-//           n769 := (n769 - 1.0) * (n723 - 1.0) * (n61 - 1.0);
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
 //         end if;
-//         if n403 > 0.0 then
-//           n769 := -n769;
+//         if p > 0.0 then
+//           q := -q;
 //         else
-//           n403 := -n403;
+//           p := -p;
 //         end if;
-//         n61 := n768;
-//         n768 := n136;
-//         if 2.0 * n403 < 3.0 * n497 * n769 - abs(n770 * n769) and n403 < abs(0.5 * n61 * n769) then
-//           n136 := n403 / n769;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
 //         else
-//           n768 := n497;
-//           n136 := n768;
+//           e := m;
+//           d := e;
 //         end if;
 //       end if;
-//       n130 := n490;
-//       n771 := n772;
-//       n490 := n490 + (if abs(n136) > n770 then n136 else if n497 > 0.0 then n770 else -n770);
-//       n772 := n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9475(n490, n7786, n6343, n9476) - n9469;
-//       if n772 > 0.0 and n773 > 0.0 or n772 < 0.0 and n773 < 0.0 then
-//         n58 := n130;
-//         n773 := n771;
-//         n768 := n490 - n130;
-//         n136 := n768;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
 //       end if;
 //     end if;
 //   end while;
-// end n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n8551;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX.Internal.solve;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9471 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9471\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n9471 res;
-// end n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9471;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9475
-//   input Real n637;
-//   input Real n403 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9471 n9476;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n159 := n1.n7656.n102.n8149.n8153.n7670.n10138(n403, n637, n6343);
-// end n1.n7656.n102.n8149.n8153.n7670.n10111.n12.n9475;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n8153.n7670.n10117;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n8153.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n8153.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n8153.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n8153.n7670.n11.n10129(n1.n7656.n102.n8149.n8153.n7670.n10117(n7827), n1.n7656.n102.n8149.n8153.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n8153.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n8153.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n8153.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n8153.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n8153.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n8153.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n8153.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10138
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n8153.n7670.n8562(n217);
-//   n10108 := min(n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110) * (1.0 - n6343[1]), 1.0);
-//   n10105 := max(n6343[1] - n10108, 0.0);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n3331 := n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) * n10106 + n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) * n10107 + n1.n7656.n102.n8149.n8153.n7670.n10136(n217) * n10105;
-// end n1.n7656.n102.n8149.n8153.n7670.n10138;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n8153.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n8153.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n8153.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n8153.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n8153.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n8153.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n8153.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n8153.n7670.n11.n10129;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n8153.n7670.n11.n10145;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
-// algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n8153.n7670.n11.n10146;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n8153.n7670.n11.n8436;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
+//   end if;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction_der;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n7785
-//   input n1.n7656.n102.n8149.n8153.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
 // algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n8153.n7670.n7785;
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.density;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n7955
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n8153.n7670.n7785(n1.n7656.n102.n8149.n8153.n7670.n8338(n403, n3331, n6343));
-// end n1.n7656.n102.n8149.n8153.n7670.n7955;
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n7957
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
 // algorithm
-//   n3331 := n1.n7656.n102.n8149.n8153.n7670.n8732(n1.n7656.n102.n8149.n8153.n7670.n8396(n403, n217, n6343));
-// end n1.n7656.n102.n8149.n8153.n7670.n7957;
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater_der;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n8338
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n8153.n7670.n8367 n865;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
 // algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n8153.n7670.n8367(n403, n1.n7656.n102.n8149.n8153.n7670.n10111(n403, n3331, n6343), n6343) else n1.n7656.n102.n8149.n8153.n7670.n8367(n403, n1.n7656.n102.n8149.n8153.n7670.n10111(n403, n3331, n6343), cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n8153.n7670.n8338;
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.gasConstant;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8153.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n8153.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n8153.n7670.n8396
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n8153.n7670.n8367 n865;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
 // algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n8153.n7670.n8367(n403, n217, n6343) else n1.n7656.n102.n8149.n8153.n7670.n8367(n403, n217, cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n8153.n7670.n8396;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(T);
+//   X_sat := min(p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat) * (1.0 - X[1]), 1.0);
+//   X_liquid := max(X[1] - X_sat, 0.0);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   h := Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) * X_steam + Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) * X_air + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater(T) * X_liquid;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
 // algorithm
-//   n7826 := n1.n7656.n102.n8149.n8153.n7670.n11.n8436(n1.n7656.n102.n8149.n8153.n7670.n10117(n7827), n1.n7656.n102.n8149.n8153.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n8153.n7670.n8562;
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX_der;
 //
-// function n1.n7656.n102.n8149.n8153.n7670.n8732
-//   input n1.n7656.n102.n8149.n8153.n7670.n8367 n865;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
 // algorithm
-//   n3331 := n1.n7656.n102.n8149.n8153.n7670.n10138(n865.n403, n865.n217, n865.n6343);
-// end n1.n7656.n102.n8149.n8153.n7670.n8732;
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n10111
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1)));
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
 // algorithm
-//   n217 := n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n8551(n3331, 190.0, 647.0, n403, n6343[1:1], n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
-// end n1.n7656.n102.n8149.n8155.n7670.n10111;
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n8551
-//   input Real n9469;
-//   input Real n5250;
-//   input Real n5263;
-//   input Real n7786 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9471 n9476;
-//   input Real n9964 = 1e-13;
-//   output Real n9472;
-//   protected constant Real n23 = 1e-15;
-//   protected constant Real n9965 = 1e-10;
-//   protected Real n58;
-//   protected Real n136;
-//   protected Real n768;
-//   protected Real n497;
-//   protected Real n61;
-//   protected Real n403;
-//   protected Real n769;
-//   protected Real n723;
-//   protected Real n770;
-//   protected Real n771;
-//   protected Real n772;
-//   protected Real n773;
-//   protected Boolean n774 = false;
-//   protected Real n9966 = n5250 - n9965;
-//   protected Real n9967 = n5263 + n9965;
-//   protected Real n130 = n9966;
-//   protected Real n490 = n9967;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
 // algorithm
-//   n771 := n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9475(n9966, n7786, n6343, n9476) - n9469;
-//   n772 := n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9475(n9967, n7786, n6343, n9476) - n9469;
-//   n773 := n772;
-//   if n771 > 0.0 and n772 > 0.0 or n771 < 0.0 and n772 < 0.0 then
-//     n1.n11.n681.n682(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
+// algorithm
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_pTX \"Return thermodynamic state as function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state\";
+// algorithm
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState(p, T, X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState(p, T, cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_phX \"Return thermodynamic state as function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state\";
+// algorithm
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX(p, h, X), X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.T_phX(p, h, X), cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy \"Return specific enthalpy of moist air as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.h_pTX(state.p, state.T, state.X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX \"Return specific enthalpy from p, T, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_pTX(p, T, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
+// algorithm
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
+// algorithm
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.sublimationPressureIce_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.temperature_phX \"Return temperature from p, h, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.temperature(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_phX(p, h, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.temperature_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
+// algorithm
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.density;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.dynamicViscosity \"Return dynamic viscosity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
+// algorithm
+//   eta := 1e-06 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, Modelica.SIunits.Conversions.to_degC(state.T));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.dynamicViscosity;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+// algorithm
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.gasConstant;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+// algorithm
+//   p := state.p;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.pressure;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric \"Calculate mass flow rate as function of pressure drop due to friction\"
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") \"Inner cross section area\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   output Real dm_flow_ddp_fric \"Derivative of mass flow rate with dp_fric\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real dRe_ddp \"dRe/ddp\";
+//   protected Real aux1;
+//   protected Real aux2;
+// algorithm
+//   if dp_fric >= 0.0 then
+//     rho := rho_a;
+//     mu := mu_a;
+//   else
+//     rho := rho_b;
+//     mu := mu_b;
+//   end if;
+//   lambda2 := abs(dp_fric) * 2.0 * diameter ^ 3.0 * rho / (length * mu * mu) \"Known as lambda2=f(dp)\";
+//   aux1 := 2.0 * diameter ^ 3.0 * rho / (length * mu ^ 2.0);
+//   Re := lambda2 / 64.0 \"Hagen-Poiseuille\";
+//   dRe_ddp := aux1 / 64.0 \"Hagen-Poiseuille\";
+//   if Re > Re1 then
+//     Re := -2.0 * sqrt(lambda2) * log10(2.51 / sqrt(lambda2) + 0.27 * Delta) \"Colebrook-White\";
+//     aux2 := sqrt(aux1 * abs(dp_fric));
+//     dRe_ddp := 0.4342944819032518 * ((-2.0 * log(2.51 / aux2 + 0.27 * Delta) * aux1 / (2.0 * aux2)) + 5.02 / (2.0 * abs(dp_fric) * (2.51 / aux2 + 0.27 * Delta)));
+//     if Re < Re2 then
+//       (Re, dRe_ddp) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative(lambda2, Re1, Re2, Delta, dp_fric);
+//     end if;
+//   end if;
+//   m_flow := crossArea / diameter * mu * (if dp_fric >= 0.0 then Re else -Re);
+//   dm_flow_ddp_fric := crossArea / diameter * mu * dRe_ddp;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative \"Interpolation in log-log space using a cubic Hermite polynomial, where x=log10(lambda2), y=log10(Re)\"
+//   input Real lambda2 \"Known independent variable\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   output Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Unknown return variable\";
+//   output Real dRe_ddp \"Derivative of return value\";
+//   protected Real x1 = log10(64.0 * Re1);
+//   protected Real y1 = log10(Re1);
+//   protected Real y1d = 1.0;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x = log10(lambda2);
+//   protected Real y;
+//   protected Real dy_dx \"Derivative in transformed space\";
+//   protected Real aux3 = log10(aux2);
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real x2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real y2 = log10(aux5);
+//   protected Real y2d = 0.5 + 1.090079149577162 / (aux5 * aux4);
+// algorithm
+//   (y, dy_dx) := Modelica.Fluid.Utilities.cubicHermite_withDerivative(x, x1, x2, y1, y2, y1d, y2d);
+//   Re := 10.0 ^ y;
+//   dRe_ddp := Re / abs(dp_fric) * dy_dx;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.massFlowRate_dp_staticHead \"Return mass flow rate m_flow as function of pressure loss dp, i.e., m_flow = f(dp), due to wall friction and static head\"
+//   input Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real g_times_height_ab(unit = \"m2/s2\") \"Gravity times (Height(port_b) - Height(port_a))\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real dp_small(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0 \"Regularization of zero flow if |dp| < dp_small (dummy if use_dp_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Boundary between transition and turbulent regime\";
+//   protected Real dp_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Upper end of regularization domain of the m_flow(dp) relation\";
+//   protected Real dp_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Lower end of regularization domain of the m_flow(dp) relation\";
+//   protected Real m_flow_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at upper end of regularization domain\";
+//   protected Real m_flow_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at lower end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at upper end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at lower end of regularization domain\";
+//   protected Real dp_grav_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_a \"Static head if mass flows in design direction (a to b)\";
+//   protected Real dp_grav_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_b \"Static head if mass flows against design direction (b to a)\";
+//   protected Real m_flow_zero(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
+//   protected Real dm_flow_ddp_fric_zero;
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta)) ^ 0.97, Re_turbulent) \"Boundary between laminar regime and transition\";
+//   protected Real dp_zero(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (dp_grav_a + dp_grav_b) / 2.0;
+// algorithm
+//   dp_a := max(dp_grav_a, dp_grav_b) + dp_small;
+//   dp_b := min(dp_grav_a, dp_grav_b) - dp_small;
+//   if dp >= dp_a then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
+//   elseif dp <= dp_b then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
+//   else
+//     (m_flow_a, dm_flow_ddp_fric_a) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_a - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow_b, dm_flow_ddp_fric_b) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_b - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow, dm_flow_ddp_fric_zero) := Modelica.Fluid.Utilities.regFun3(dp_zero, dp_b, dp_a, m_flow_b, m_flow_a, dm_flow_ddp_fric_b, dm_flow_ddp_fric_a);
+//     if dp > dp_zero then
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_zero, dp_a, m_flow_zero, m_flow_a, dm_flow_ddp_fric_zero, dm_flow_ddp_fric_a)[1];
+//     else
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_b, dp_zero, m_flow_b, m_flow_zero, dm_flow_ddp_fric_b, dm_flow_ddp_fric_zero)[1];
+//     end if;
+//   end if;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.massFlowRate_dp_staticHead;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow \"Return pressure loss dp as function of mass flow rate m_flow, i.e., dp = f(m_flow), due to wall friction\"
+//   input Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01 \"Regularization of zero flow if |m_flow| < m_flow_small (dummy if use_m_flow_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Re entering turbulent curve\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta), Re_turbulent) \"Re leaving laminar curve\";
+// algorithm
+//   rho := if m_flow >= 0.0 then rho_a else rho_b;
+//   mu := if m_flow >= 0.0 then mu_a else mu_b;
+//   Re := diameter * abs(m_flow) / (crossArea * mu);
+//   lambda2 := if Re <= Re1 then 64.0 * Re else if Re >= Re2 then 0.25 * (Re / log10(Delta / 3.7 + 5.74 / Re ^ 0.9)) ^ 2.0 else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2(Re, Re1, Re2, Delta);
+//   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Delta;
+//   output Real lambda2;
+//   protected Real x1 = log10(Re1);
+//   protected Real y1 = log10(64.0 * Re1);
+//   protected Real yd1 = 1.0;
+//   protected Real aux1 = 1.121782646756099;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x2 = log10(Re2);
+//   protected Real dx;
+//   protected Real aux3 = log10(aux2);
+//   protected Real diff_x = x2 - x1;
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real y2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real m = (y2 - y1) / diff_x;
+//   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
+//   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
+// algorithm
+//   dx := log10(Re / Re1);
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX \"Return temperature as a function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) \"Mass fractions of composition\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.solve(h, 190.0, 647.0, p, X[1:1], Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), 1e-13);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear
+//   input Real x \"Independent variable of function\";
+//   input Real p = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (her always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for the function\";
+//   output Real y \"= f_nonlinear(x)\";
+// algorithm
+//   y := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX(p, x, X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output f_nonlinear_Data res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.solve
+//   input Real y_zero \"Determine x_zero, such that f_nonlinear(x_zero) = y_zero\";
+//   input Real x_min \"Minimum value of x\";
+//   input Real x_max \"Maximum value of x\";
+//   input Real pressure = 0.0 \"Disregarded variables (here always used for pressure)\";
+//   input Real[:] X = {} \"Disregarded variables (here always used for composition)\";
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear_Data f_nonlinear_data \"Additional data for function f_nonlinear\";
+//   input Real x_tol = 1e-13 \"Relative tolerance of the result\";
+//   output Real x_zero \"f_nonlinear(x_zero) = y_zero\";
+//   protected constant Real eps = 1e-15 \"Machine epsilon\";
+//   protected constant Real x_eps = 1e-10 \"Slight modification of x_min, x_max, since x_min, x_max are usually exactly at the borders T_min/h_min and then small numeric noise may make the interval invalid\";
+//   protected Real c \"Intermediate point a <= c <= b\";
+//   protected Real d;
+//   protected Real e \"b - a\";
+//   protected Real m;
+//   protected Real s;
+//   protected Real p;
+//   protected Real q;
+//   protected Real r;
+//   protected Real tol;
+//   protected Real fa \"= f_nonlinear(a) - y_zero\";
+//   protected Real fb \"= f_nonlinear(b) - y_zero\";
+//   protected Real fc;
+//   protected Boolean found = false;
+//   protected Real x_min2 = x_min - x_eps;
+//   protected Real x_max2 = x_max + x_eps;
+//   protected Real a = x_min2 \"Current best minimum interval value\";
+//   protected Real b = x_max2 \"Current best maximum interval value\";
+// algorithm
+//   fa := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear(x_min2, pressure, X, f_nonlinear_data) - y_zero;
+//   fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear(x_max2, pressure, X, f_nonlinear_data) - y_zero;
+//   fc := fb;
+//   if fa > 0.0 and fb > 0.0 or fa < 0.0 and fb < 0.0 then
+//     Modelica.Utilities.Streams.error(\"The arguments x_min and x_max to OneNonLinearEquation.solve(..)
 //     do not bracket the root of the single non-linear equation:
-//       x_min  = \" + String(n9966, 6, 0, true) + \"
-//     \" + \"  x_max  = \" + String(n9967, 6, 0, true) + \"
-//     \" + \"  y_zero = \" + String(n9469, 6, 0, true) + \"
-//     \" + \"  fa = f(x_min) - y_zero = \" + String(n771, 6, 0, true) + \"
-//     \" + \"  fb = f(x_max) - y_zero = \" + String(n772, 6, 0, true) + \"
+//       x_min  = \" + String(x_min2, 6, 0, true) + \"
+//     \" + \"  x_max  = \" + String(x_max2, 6, 0, true) + \"
+//     \" + \"  y_zero = \" + String(y_zero, 6, 0, true) + \"
+//     \" + \"  fa = f(x_min) - y_zero = \" + String(fa, 6, 0, true) + \"
+//     \" + \"  fb = f(x_max) - y_zero = \" + String(fb, 6, 0, true) + \"
 //     \" + \"fa and fb must have opposite sign which is not the case\");
 //   end if;
-//   n58 := n130;
-//   n773 := n771;
-//   n768 := n490 - n130;
-//   n136 := n768;
-//   while not n774 loop
-//     if abs(n773) < abs(n772) then
-//       n130 := n490;
-//       n490 := n58;
-//       n58 := n130;
-//       n771 := n772;
-//       n772 := n773;
-//       n773 := n771;
+//   c := a;
+//   fc := fa;
+//   e := b - a;
+//   d := e;
+//   while not found loop
+//     if abs(fc) < abs(fb) then
+//       a := b;
+//       b := c;
+//       c := a;
+//       fa := fb;
+//       fb := fc;
+//       fc := fa;
 //     end if;
-//     n770 := 2.0 * n23 * abs(n490) + n9964;
-//     n497 := (n58 - n490) / 2.0;
-//     if abs(n497) <= n770 or n772 == 0.0 then
-//       n774 := true;
-//       n9472 := n490;
+//     tol := 2.0 * eps * abs(b) + x_tol;
+//     m := (c - b) / 2.0;
+//     if abs(m) <= tol or fb == 0.0 then
+//       found := true;
+//       x_zero := b;
 //     else
-//       if abs(n768) < n770 or abs(n771) <= abs(n772) then
-//         n768 := n497;
-//         n136 := n768;
+//       if abs(e) < tol or abs(fa) <= abs(fb) then
+//         e := m;
+//         d := e;
 //       else
-//         n61 := n772 / n771;
-//         if n130 == n58 then
-//           n403 := 2.0 * n497 * n61;
-//           n769 := 1.0 - n61;
+//         s := fb / fa;
+//         if a == c then
+//           p := 2.0 * m * s;
+//           q := 1.0 - s;
 //         else
-//           n769 := n771 / n773;
-//           n723 := n772 / n773;
-//           n403 := n61 * (2.0 * n497 * n769 * (n769 - n723) - (n490 - n130) * (n723 - 1.0));
-//           n769 := (n769 - 1.0) * (n723 - 1.0) * (n61 - 1.0);
+//           q := fa / fc;
+//           r := fb / fc;
+//           p := s * (2.0 * m * q * (q - r) - (b - a) * (r - 1.0));
+//           q := (q - 1.0) * (r - 1.0) * (s - 1.0);
 //         end if;
-//         if n403 > 0.0 then
-//           n769 := -n769;
+//         if p > 0.0 then
+//           q := -q;
 //         else
-//           n403 := -n403;
+//           p := -p;
 //         end if;
-//         n61 := n768;
-//         n768 := n136;
-//         if 2.0 * n403 < 3.0 * n497 * n769 - abs(n770 * n769) and n403 < abs(0.5 * n61 * n769) then
-//           n136 := n403 / n769;
+//         s := e;
+//         e := d;
+//         if 2.0 * p < 3.0 * m * q - abs(tol * q) and p < abs(0.5 * s * q) then
+//           d := p / q;
 //         else
-//           n768 := n497;
-//           n136 := n768;
+//           e := m;
+//           d := e;
 //         end if;
 //       end if;
-//       n130 := n490;
-//       n771 := n772;
-//       n490 := n490 + (if abs(n136) > n770 then n136 else if n497 > 0.0 then n770 else -n770);
-//       n772 := n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9475(n490, n7786, n6343, n9476) - n9469;
-//       if n772 > 0.0 and n773 > 0.0 or n772 < 0.0 and n773 < 0.0 then
-//         n58 := n130;
-//         n773 := n771;
-//         n768 := n490 - n130;
-//         n136 := n768;
+//       a := b;
+//       fa := fb;
+//       b := b + (if abs(d) > tol then d else if m > 0.0 then tol else -tol);
+//       fb := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.f_nonlinear(b, pressure, X, f_nonlinear_data) - y_zero;
+//       if fb > 0.0 and fc > 0.0 or fb < 0.0 and fc < 0.0 then
+//         c := a;
+//         fc := fa;
+//         e := b - a;
+//         d := e;
 //       end if;
 //     end if;
 //   end while;
-// end n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n8551;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX.Internal.solve;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9471 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9471\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n9471 res;
-// end n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9471;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9475
-//   input Real n637;
-//   input Real n403 = 0.0;
-//   input Real[:] n6343 = {};
-//   input n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9471 n9476;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.smoothMax
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   output Real y \"Result of smooth max operator\";
 // algorithm
-//   n159 := n1.n7656.n102.n8149.n8155.n7670.n10138(n403, n637, n6343);
-// end n1.n7656.n102.n8149.n8155.n7670.n10111.n12.n9475;
+//   y := max(x1, x2) + log(exp(4.0 / dx * (x1 - max(x1, x2))) + exp(4.0 / dx * (x2 - max(x1, x2)))) / (4.0 / dx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.smoothMax;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n10117
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.smoothMax_der
+//   input Real x1 \"First argument of smooth max operator\";
+//   input Real x2 \"Second argument of smooth max operator\";
+//   input Real dx \"Approximate difference between x1 and x2, below which regularization starts\";
+//   input Real dx1;
+//   input Real dx2;
+//   input Real ddx;
+//   output Real dy \"Derivative of smooth max operator\";
 // algorithm
-//   n7826 := exp((n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6]) * n10118 / n7827) * n10119;
-// end n1.n7656.n102.n8149.n8155.n7670.n10117;
+//   dy := (if x1 > x2 then dx1 else dx2) + 0.25 * (((4.0 * (dx1 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x1 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x1 - max(x1, x2)) / dx) + (4.0 * (dx2 - (if x1 > x2 then dx1 else dx2)) / dx - 4.0 * (x2 - max(x1, x2)) * ddx / dx ^ 2.0) * exp(4.0 * (x2 - max(x1, x2)) / dx)) * dx / (exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) + log(exp(4.0 * (x1 - max(x1, x2)) / dx) + exp(4.0 * (x2 - max(x1, x2)) / dx)) * ddx);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.smoothMax_der;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n10120
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10118(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096;
-//   protected Real n10119(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0;
-//   protected Real[:] n130 = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502};
-//   protected Real[:] n228 = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5};
-//   protected Real n1968 = 1.0 - n7827 / n10118;
-//   protected Real n10123 = -1.0 / n10118 * n10121;
-//   protected Real n1969 = n130[1] * n1968 ^ n228[1] + n130[2] * n1968 ^ n228[2] + n130[3] * n1968 ^ n228[3] + n130[4] * n1968 ^ n228[4] + n130[5] * n1968 ^ n228[5] + n130[6] * n1968 ^ n228[6];
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n10122 := exp(n1969 * n10118 / n7827) * n10119 * ((n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123 + n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123 + n130[3] * n1968 ^ (n228[3] - 1.0) * n228[3] * n10123 + n130[4] * n1968 ^ (n228[4] - 1.0) * n228[4] * n10123 + n130[5] * n1968 ^ (n228[5] - 1.0) * n228[5] * n10123 + n130[6] * n1968 ^ (n228[6] - 1.0) * n228[6] * n10123) * n10118 / n7827 - n1969 * n10118 * n10121 / n7827 ^ 2.0);
-// end n1.n7656.n102.n8149.n8155.n7670.n10120;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10124
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-// algorithm
-//   n7826 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126;
-// end n1.n7656.n102.n8149.n8155.n7670.n10124;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10127
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-//   protected Real n10125(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16;
-//   protected Real n10126(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657;
-//   protected Real[:] n130 = {-13.928169, 34.7078238};
-//   protected Real[:] n228 = {-1.5, -1.25};
-//   protected Real n1968 = n7827 / n10125;
-//   protected Real n10123 = n10121 / n10125;
-// algorithm
-//   n10122 := exp(n130[1] - n130[1] * n1968 ^ n228[1] + n130[2] - n130[2] * n1968 ^ n228[2]) * n10126 * ((-n130[1] * n1968 ^ (n228[1] - 1.0) * n228[1] * n10123) - n130[2] * n1968 ^ (n228[2] - 1.0) * n228[2] * n10123);
-// end n1.n7656.n102.n8149.n8155.n7670.n10127;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10128
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real n10121(unit = \"K/s\");
-//   output Real n10122(unit = \"Pa/s\");
-// algorithm
-//   n10122 := n1.n7656.n102.n8149.n8155.n7670.n11.n10129(n1.n7656.n102.n8149.n8155.n7670.n10117(n7827), n1.n7656.n102.n8149.n8155.n7670.n10124(n7827), n7827 - 273.16, 1.0, n1.n7656.n102.n8149.n8155.n7670.n10120(n7827, n10121), n1.n7656.n102.n8149.n8155.n7670.n10127(n7827, n10121), n10121, 0.0);
-// end n1.n7656.n102.n8149.n8155.n7670.n10128;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10136
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n8155.n7670.n11.n8436(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1);
-// end n1.n7656.n102.n8149.n8155.n7670.n10136;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10137
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197(unit = \"K/s\");
-//   output Real n9441(unit = \"J/(kg.s)\");
-// algorithm
-//   n9441 := n1.n7656.n102.n8149.n8155.n7670.n11.n10129(4200.0 * (n217 - 273.15), 2050.0 * (n217 - 273.15) - 333000.0, n217 - 273.16, 0.1, 4200.0 * n8197, 2050.0 * n8197, n8197, 0.0);
-// end n1.n7656.n102.n8149.n8155.n7670.n10137;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10138
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n8155.n7670.n8562(n217);
-//   n10108 := min(n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110) * (1.0 - n6343[1]), 1.0);
-//   n10105 := max(n6343[1] - n10108, 0.0);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n3331 := n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) * n10106 + n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) * n10107 + n1.n7656.n102.n8149.n8155.n7670.n10136(n217) * n10105;
-// end n1.n7656.n102.n8149.n8155.n7670.n10138;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n10139
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\");
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"1\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)));
-//   input Real n4510(unit = \"Pa/s\");
-//   input Real n8197(unit = \"K/s\");
-//   input Real[:] n10140(unit = \"1/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-//   protected Real n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0);
-//   protected Real n10108(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10105(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10106(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10107(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10109(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0);
-//   protected Real n10141(unit = \"1/s\");
-//   protected Real n10142(unit = \"1/s\");
-//   protected Real n10143(unit = \"1/s\");
-//   protected Real n9875(unit = \"Pa/s\");
-//   protected Real n10144(unit = \"1/s\");
-// algorithm
-//   n10110 := n1.n7656.n102.n8149.n8155.n7670.n8562(n217);
-//   n10109 := n10110 * 0.6219647130774989 / max(1e-13, n403 - n10110);
-//   n10108 := min(n10109 * (1.0 - n6343[1]), 1.0);
-//   n10105 := n1.n7656.n102.n8149.n8155.n7670.n11.n10145(n6343[1] - n10108, 0.0, 1e-05);
-//   n10106 := n6343[1] - n10105;
-//   n10107 := 1.0 - n6343[1];
-//   n10142 := -n10140[1];
-//   n9875 := n1.n7656.n102.n8149.n8155.n7670.n10128(n217, n8197);
-//   n10144 := 0.6219647130774989 * (n9875 * (n403 - n10110) - n10110 * (n4510 - n9875)) / (n403 - n10110) / (n403 - n10110);
-//   n10143 := n1.n7656.n102.n8149.n8155.n7670.n11.n10146(n6343[1] - n10108, 0.0, 1e-05, (1.0 + n10109) * n10140[1] - (1.0 - n6343[1]) * n10144, 0.0, 0.0);
-//   n10141 := n10140[1] - n10143;
-//   n10059 := n10106 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319, n8197) + n10141 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), n217, true, n1.n7671.n365.n8633.n9642.n9645, 2547494.319) + n10107 * n1.n7671.n9351.n9473.n885.n10147(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684, n8197) + n10142 * n1.n7671.n9351.n9473.n885.n10135(n1.n7671.n9351.n9473.n10104(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), n217, true, n1.n7671.n365.n8633.n9642.n9645, 25104.684) + n10105 * n1.n7656.n102.n8149.n8155.n7670.n10137(n217, n8197) + n10143 * n1.n7656.n102.n8149.n8155.n7670.n10136(n217);
-// end n1.n7656.n102.n8149.n8155.n7670.n10139;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7656.n102.n8149.n8155.n7670.n11.n10129;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction;
 //
-// function n1.n7656.n102.n8149.n8155.n7670.n11.n10145
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   output Real n159;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := max(n703, n704) + log(exp(4.0 / n8496 * (n703 - max(n703, n704))) + exp(4.0 / n8496 * (n704 - max(n703, n704)))) / (4.0 / n8496);
-// end n1.n7656.n102.n8149.n8155.n7670.n11.n10145;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n11.n10146
-//   input Real n703;
-//   input Real n704;
-//   input Real n8496;
-//   input Real n10165;
-//   input Real n10166;
-//   input Real n9804;
-//   output Real n7276;
-// algorithm
-//   n7276 := (if n703 > n704 then n10165 else n10166) + 0.25 * (((4.0 * (n10165 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n703 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n703 - max(n703, n704)) / n8496) + (4.0 * (n10166 - (if n703 > n704 then n10165 else n10166)) / n8496 - 4.0 * (n704 - max(n703, n704)) * n9804 / n8496 ^ 2.0) * exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n8496 / (exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) + log(exp(4.0 * (n703 - max(n703, n704)) / n8496) + exp(4.0 * (n704 - max(n703, n704)) / n8496)) * n9804);
-// end n1.n7656.n102.n8149.n8155.n7670.n11.n10146;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
 //   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
 //   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7656.n102.n8149.n8155.n7670.n11.n8436;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n7785
-//   input n1.n7656.n102.n8149.n8155.n7670.n8367 n865;
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n865.n217;
-// end n1.n7656.n102.n8149.n8155.n7670.n7785;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n7955
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-// algorithm
-//   n217 := n1.n7656.n102.n8149.n8155.n7670.n7785(n1.n7656.n102.n8149.n8155.n7670.n8338(n403, n3331, n6343));
-// end n1.n7656.n102.n8149.n8155.n7670.n7955;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n7957
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n8155.n7670.n8732(n1.n7656.n102.n8149.n8155.n7670.n8396(n403, n217, n6343));
-// end n1.n7656.n102.n8149.n8155.n7670.n7957;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n8338
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n8155.n7670.n8367 n865;
-// algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n8155.n7670.n8367(n403, n1.n7656.n102.n8149.n8155.n7670.n10111(n403, n3331, n6343), n6343) else n1.n7656.n102.n8149.n8155.n7670.n8367(n403, n1.n7656.n102.n8149.n8155.n7670.n10111(n403, n3331, n6343), cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n8155.n7670.n8338;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n8367 \"Automatically generated record constructor for n1.n7656.n102.n8149.n8155.n7670.n8367\"
-//   input Real n403;
-//   input Real n217;
-//   input Real[2] n6343;
-//   output n8367 res;
-// end n1.n7656.n102.n8149.n8155.n7670.n8367;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n8396
-//   input Real n403(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   input Real[:] n6343(quantity = fill(\"MassFraction\", size(n6343, 1)), unit = fill(\"kg/kg\", size(n6343, 1)), min = fill(0.0, size(n6343, 1)), max = fill(1.0, size(n6343, 1)), nominal = fill(0.1, size(n6343, 1))) = {0.01, 0.99};
-//   output n1.n7656.n102.n8149.n8155.n7670.n8367 n865;
-// algorithm
-//   n865 := if size(n6343, 1) == 2 then n1.n7656.n102.n8149.n8155.n7670.n8367(n403, n217, n6343) else n1.n7656.n102.n8149.n8155.n7670.n8367(n403, n217, cat(1, n6343, {1.0 - sum(n6343)}));
-// end n1.n7656.n102.n8149.n8155.n7670.n8396;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n8562
-//   input Real n7827(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0);
-//   output Real n7826(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
-// algorithm
-//   n7826 := n1.n7656.n102.n8149.n8155.n7670.n11.n8436(n1.n7656.n102.n8149.n8155.n7670.n10117(n7827), n1.n7656.n102.n8149.n8155.n7670.n10124(n7827), n7827 - 273.16, 1.0);
-// end n1.n7656.n102.n8149.n8155.n7670.n8562;
-//
-// function n1.n7656.n102.n8149.n8155.n7670.n8732
-//   input n1.n7656.n102.n8149.n8155.n7670.n8367 n865;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
-// algorithm
-//   n3331 := n1.n7656.n102.n8149.n8155.n7670.n10138(n865.n403, n865.n217, n865.n6343);
-// end n1.n7656.n102.n8149.n8155.n7670.n8732;
-//
-// function n1.n7656.n11.n8462
-//   input Real n637;
-//   input Real n1050;
-//   input Real n703;
-//   input Real n287;
-//   input Real n233;
-//   input Real n9302;
-//   input Real n8499;
-//   output Real n159;
-//   output Real n58;
-//   protected Real n9304;
-//   protected Real n9305;
-//   protected Real n9306;
-//   protected Real n457;
-//   protected Real n4890;
-//   protected Real n3481;
-//   protected Real n5456;
-//   protected Real n9307;
-//   protected Real n9308;
-//   protected Real n9309;
-//   protected Real n9310;
-//   protected Real n9311;
-//   protected Real n1120;
-//   protected Real n2374;
-//   protected Real n9312;
-//   protected Real n9313;
-//   protected Real n9314;
-//   protected Real n9315;
-//   protected Boolean n9316 = false;
-// algorithm
-//   assert(n1050 < n703, \"assert message 8766466662519165273\");
-//   if n9302 * n8499 >= 0.0 then
-//   else
-//     assert(abs(n9302) < 1e-15 or abs(n8499) < 1e-15, \"assert message 1884851029044619375\");
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
 //   end if;
-//   n9304 := n703 - n1050;
-//   n9305 := (n233 - n287) / n9304;
-//   if abs(n9305) <= 0.0 then
-//     n159 := n287 + n9305 * (n637 - n1050);
-//     n58 := 0.0;
-//   elseif abs(n8499 + n9302 - 2.0 * n9305) < 1e-13 then
-//     n159 := n287 + (n637 - n1050) * (n9302 + (n637 - n1050) / n9304 * ((-2.0 * n9302) - n8499 + 3.0 * n9305 + (n637 - n1050) * (n9302 + n8499 - 2.0 * n9305) / n9304));
-//     n9314 := (n1050 + n703) / 2.0;
-//     n58 := 3.0 * (n9302 + n8499 - 2.0 * n9305) * (n9314 - n1050) ^ 2.0 / n9304 ^ 2.0 + 2.0 * ((-2.0 * n9302) - n8499 + 3.0 * n9305) * (n9314 - n1050) / n9304 + n9302;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
+// algorithm
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.density;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater \"Computes specific enthalpy of water (solid/liquid) near atmospheric pressure from temperature T\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy of water\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater_der \"Derivative function of enthalpyOfWater\"
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT(unit = \"K/s\") \"Time derivative of temperature\";
+//   output Real dh(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+// algorithm
+//   dh := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction_der(4200.0 * (T - 273.15), 2050.0 * (T - 273.15) - 333000.0, T - 273.16, 0.1, 4200.0 * dT, 2050.0 * dT, dT, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+// algorithm
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.gasConstant;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX \"Return specific enthalpy of moist air as a function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at p, T, X\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+// algorithm
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(T);
+//   X_sat := min(p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat) * (1.0 - X[1]), 1.0);
+//   X_liquid := max(X[1] - X_sat, 0.0);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   h := Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) * X_steam + Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) * X_air + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater(T) * X_liquid;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX_der \"Derivative function of h_pTX\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"1\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1))) \"Mass fractions of moist air\";
+//   input Real dp(unit = \"Pa/s\") \"Pressure derivative\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   input Real[:] dX(unit = \"1/s\") \"Composition derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Time derivative of specific enthalpy\";
+//   protected Real p_steam_sat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"partial saturation pressure of steam\";
+//   protected Real X_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of moist air\";
+//   protected Real X_liquid(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of liquid water\";
+//   protected Real X_steam(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of steam water\";
+//   protected Real X_air(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Mass fraction of air\";
+//   protected Real x_sat(quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0) \"Absolute humidity per unit mass of dry air at saturation\";
+//   protected Real dX_steam(unit = \"1/s\") \"Time derivative of steam mass fraction\";
+//   protected Real dX_air(unit = \"1/s\") \"Time derivative of dry air mass fraction\";
+//   protected Real dX_liq(unit = \"1/s\") \"Time derivative of liquid/solid water mass fraction\";
+//   protected Real dps(unit = \"Pa/s\") \"Time derivative of saturation pressure\";
+//   protected Real dx_sat(unit = \"1/s\") \"Time derivative of absolute humidity per unit mass of dry air\";
+// algorithm
+//   p_steam_sat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(T);
+//   x_sat := p_steam_sat * 0.6219647130774989 / max(1e-13, p - p_steam_sat);
+//   X_sat := min(x_sat * (1.0 - X[1]), 1.0);
+//   X_liquid := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.smoothMax(X[1] - X_sat, 0.0, 1e-05);
+//   X_steam := X[1] - X_liquid;
+//   X_air := 1.0 - X[1];
+//   dX_air := -dX[1];
+//   dps := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure_der(T, dT);
+//   dx_sat := 0.6219647130774989 * (dps * (p - p_steam_sat) - p_steam_sat * (dp - dps)) / (p - p_steam_sat) / (p - p_steam_sat);
+//   dX_liq := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.smoothMax_der(X[1] - X_sat, 0.0, 1e-05, (1.0 + x_sat) * dX[1] - (1.0 - X[1]) * dx_sat, 0.0, 0.0);
+//   dX_steam := dX[1] - dX_liq;
+//   h_der := X_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319, dT) + dX_steam * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"H2O\", 0.01801528, -13423382.81725291, 549760.6476280135, 1000.0, {-39479.6083, 575.5731019999999, 0.931782653, 0.00722271286, -7.34255737e-06, 4.95504349e-09, -1.336933246e-12}, {-33039.7431, 17.24205775}, {1034972.096, -2412.698562, 4.64611078, 0.002291998307, -6.836830479999999e-07, 9.426468930000001e-11, -4.82238053e-15}, {-13842.86509, -7.97814851}, 461.5233290850878), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 2547494.319) + X_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow_der(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684, dT) + dX_air * Modelica.Media.IdealGases.Common.Functions.h_Tlow(Modelica.Media.IdealGases.Common.DataRecord(\"Air\", 0.0289651159, -4333.833858403446, 298609.6803431054, 1000.0, {10099.5016, -196.827561, 5.00915511, -0.00576101373, 1.06685993e-05, -7.94029797e-09, 2.18523191e-12}, {-176.796731, -3.921504225}, {241521.443, -1257.8746, 5.14455867, -0.000213854179, 7.06522784e-08, -1.07148349e-11, 6.57780015e-16}, {6462.26319, -8.147411905}, 287.0512249529787), T, true, Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined, 25104.684) + X_liquid * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater_der(T, dT) + dX_liq * Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.enthalpyOfWater(T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure \"Return saturation pressure of water as a function of temperature T between 190 and 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Saturation pressure\";
+// algorithm
+//   psat := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid \"Return saturation pressure of water as a function of temperature T in the range of 273.16 to 647.096 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Saturation pressure\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression\";
+// algorithm
+//   psat := exp((a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6]) * Tcritical / Tsat) * pcritical;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid_der \"Derivative function for 'saturationPressureLiquid'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Saturation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure derivative\";
+//   protected Real Tcritical(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 647.096 \"Critical temperature\";
+//   protected Real pcritical(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 22064000.0 \"Critical pressure\";
+//   protected Real[:] a = {-7.85951783, 1.84408259, -11.7866497, 22.6807411, -15.9618719, 1.80122502} \"Coefficients a[:]\";
+//   protected Real[:] n = {1.0, 1.5, 3.0, 3.5, 4.0, 7.5} \"Coefficients n[:]\";
+//   protected Real r1 = 1.0 - Tsat / Tcritical \"Common subexpression 1\";
+//   protected Real r1_der = -1.0 / Tcritical * dTsat \"Derivative of common subexpression 1\";
+//   protected Real r2 = a[1] * r1 ^ n[1] + a[2] * r1 ^ n[2] + a[3] * r1 ^ n[3] + a[4] * r1 ^ n[4] + a[5] * r1 ^ n[5] + a[6] * r1 ^ n[6] \"Common subexpression 2\";
+// algorithm
+//   psat_der := exp(r2 * Tcritical / Tsat) * pcritical * ((a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der + a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der + a[3] * r1 ^ (n[3] - 1.0) * n[3] * r1_der + a[4] * r1 ^ (n[4] - 1.0) * n[4] * r1_der + a[5] * r1 ^ (n[5] - 1.0) * n[5] * r1_der + a[6] * r1 ^ (n[6] - 1.0) * n[6] * r1_der) * Tcritical / Tsat - r2 * Tcritical * dTsat / Tsat ^ 2.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure_der \"Derivative function for 'saturationPressure'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Saturation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Time derivative of saturation temperature\";
+//   output Real psat_der(unit = \"Pa/s\") \"Saturation pressure\";
+// algorithm
+//   psat_der := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.Utilities.spliceFunction_der(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid(Tsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce(Tsat), Tsat - 273.16, 1.0, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressureLiquid_der(Tsat, dTsat), Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce_der(Tsat, dTsat), dTsat, 0.0);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_pTX \"Return thermodynamic state as function of pressure p, temperature T and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state\";
+// algorithm
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState(p, T, X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState(p, T, cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_phX \"Return thermodynamic state as function of pressure p, specific enthalpy h and composition X\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state\";
+// algorithm
+//   state := if size(X, 1) == 2 then Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX(p, h, X), X) else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState(p, Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.T_phX(p, h, X), cat(1, X, {1.0 - sum(X)}));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy \"Return specific enthalpy of moist air as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.h_pTX(state.p, state.T, state.X);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX \"Return specific enthalpy from p, T, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+// algorithm
+//   h := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_pTX(p, T, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce \"Return sublimation pressure of water as a function of temperature T between 190 and 273.16 K\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   output Real psat(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) \"Sublimation pressure\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression\";
+// algorithm
+//   psat := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce_der \"Derivative function for 'sublimationPressureIce'\"
+//   input Real Tsat(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Sublimation temperature\";
+//   input Real dTsat(unit = \"K/s\") \"Sublimation temperature derivative\";
+//   output Real psat_der(unit = \"Pa/s\") \"Sublimation pressure derivative\";
+//   protected Real Ttriple(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 273.16 \"Triple point temperature\";
+//   protected Real ptriple(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 611.657 \"Triple point pressure\";
+//   protected Real[:] a = {-13.928169, 34.7078238} \"Coefficients a[:]\";
+//   protected Real[:] n = {-1.5, -1.25} \"Coefficients n[:]\";
+//   protected Real r1 = Tsat / Ttriple \"Common subexpression 1\";
+//   protected Real r1_der = dTsat / Ttriple \"Derivative of common subexpression 1\";
+// algorithm
+//   psat_der := exp(a[1] - a[1] * r1 ^ n[1] + a[2] - a[2] * r1 ^ n[2]) * ptriple * ((-a[1] * r1 ^ (n[1] - 1.0) * n[1] * r1_der) - a[2] * r1 ^ (n[2] - 1.0) * n[2] * r1_der);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.sublimationPressureIce_der;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.temperature;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.temperature_phX \"Return temperature from p, h, and X or Xi\"
+//   input Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+//   input Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) \"Specific enthalpy\";
+//   input Real[:] X(quantity = fill(\"MassFraction\", size(X, 1)), unit = fill(\"kg/kg\", size(X, 1)), min = fill(0.0, size(X, 1)), max = fill(1.0, size(X, 1)), nominal = fill(0.1, size(X, 1))) = {0.01, 0.99} \"Mass fractions\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.temperature(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_phX(p, h, X));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.temperature_phX;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.density \"Returns density of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real d(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0, max = 100000.0, start = 1.0, nominal = 1.0) \"Density\";
+// algorithm
+//   d := state.p / (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.gasConstant(state) * state.T);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.density;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.dynamicViscosity \"Return dynamic viscosity as a function of the thermodynamic state record, valid from 123.15 K to 1273.15 K\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real eta(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0, max = 100000000.0, start = 0.001, nominal = 0.001) \"Dynamic viscosity\";
+// algorithm
+//   eta := 1e-06 * Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange({9.739110288630587e-15, -3.135372487033391e-11, 4.300487659564222e-08, -3.822801629175824e-05, 0.05042787436718076, 17.23926013924253}, -150.0, 1000.0, Modelica.SIunits.Conversions.to_degC(state.T));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.dynamicViscosity;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.gasConstant \"Return ideal gas constant as a function from thermodynamic state, only valid for phi<1\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState state \"Thermodynamic state\";
+//   output Real R(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Mixture gas constant\";
+// algorithm
+//   R := 287.0512249529787 * (1.0 - state.X[1]) + 461.5233290850878 * state.X[1];
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.gasConstant;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.pressure \"Returns pressure of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) \"Pressure\";
+// algorithm
+//   p := state.p;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.pressure;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric \"Calculate mass flow rate as function of pressure drop due to friction\"
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") \"Inner cross section area\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   output Real dm_flow_ddp_fric \"Derivative of mass flow rate with dp_fric\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real dRe_ddp \"dRe/ddp\";
+//   protected Real aux1;
+//   protected Real aux2;
+// algorithm
+//   if dp_fric >= 0.0 then
+//     rho := rho_a;
+//     mu := mu_a;
 //   else
-//     n9306 := 0.3333333333333333 * ((-3.0 * n1050 * n9302) - 3.0 * n1050 * n8499 + 6.0 * n1050 * n9305 - 2.0 * n9304 * n9302 - n9304 * n8499 + 3.0 * n9304 * n9305) / ((-n9302) - n8499 + 2.0 * n9305);
-//     n457 := n9306 - n1050;
-//     n4890 := n703 - n9306;
-//     n3481 := 3.0 * (n9302 + n8499 - 2.0 * n9305) * (n9306 - n1050) ^ 2.0 / n9304 ^ 2.0 + 2.0 * ((-2.0 * n9302) - n8499 + 3.0 * n9305) * (n9306 - n1050) / n9304 + n9302;
-//     n9314 := 0.25 * /*Real*/(sign(n9305)) * min(abs(n3481), abs(n9305));
-//     if abs(n9302 - n8499) <= 1e-13 then
-//       n9315 := n9302;
-//       if n233 > n287 + n9302 * (n703 - n1050) then
-//         n9316 := true;
-//       end if;
-//     elseif abs(n8499 + n9302 - 2.0 * n9305) < 1e-13 then
-//       n9315 := (6.0 * n9305 * (n8499 + n9302 - 1.5 * n9305) - n8499 * n9302 - n8499 ^ 2.0 - n9302 ^ 2.0) * (if n8499 + n9302 - 2.0 * n9305 >= 0.0 then 1.0 else -1.0) * 9.999999999999999e+59;
-//     else
-//       n9315 := (6.0 * n9305 * (n8499 + n9302 - 1.5 * n9305) - n8499 * n9302 - n8499 ^ 2.0 - n9302 ^ 2.0) / (3.0 * (n8499 + n9302 - 2.0 * n9305));
-//     end if;
-//     if (n457 > 0.0 and n4890 < n9304 and n9305 * n3481 <= 0.0 or abs(n9314) < abs(n9315) and n9315 * n9305 >= 0.0 or abs(n9314) < abs(0.1 * n9305)) and not n9316 then
-//       n58 := n9314;
-//       if abs(n58) < abs(n9315) and n9315 * n9305 >= 0.0 then
-//         n58 := n9315;
-//       end if;
-//       if abs(n58) < abs(0.1 * n9305) then
-//         n58 := 0.1 * n9305;
-//       end if;
-//       n9307 := (n9302 * n457 + n8499 * n4890) / n9304;
-//       if abs(n9307 - n58) < 1e-06 then
-//         n58 := 0.999999 * n9307;
-//       end if;
-//       n5456 := 3.0 * (n9305 - n58) / (n9307 - n58);
-//       n9308 := n5456 * n457;
-//       n9309 := n5456 * n4890;
-//       n9310 := n1050 + n9308;
-//       n9311 := n703 - n9309;
-//       n1120 := (n9302 - n58) / max(n9308 ^ 2.0, 1e-13);
-//       n2374 := (n8499 - n58) / max(n9309 ^ 2.0, 1e-13);
-//       n9312 := n287 - n1120 / 3.0 * (n1050 - n9310) ^ 3.0 - n58 * n1050;
-//       n9313 := n233 - n2374 / 3.0 * (n703 - n9311) ^ 3.0 - n58 * n703;
-//       if n637 < n9310 then
-//         n159 := n1120 / 3.0 * (n637 - n9310) ^ 3.0 + n58 * n637 + n9312;
-//       elseif n637 < n9311 then
-//         n159 := n58 * n637 + n9312;
-//       else
-//         n159 := n2374 / 3.0 * (n637 - n9311) ^ 3.0 + n58 * n637 + n9313;
-//       end if;
-//     else
-//       n159 := n287 + (n637 - n1050) * (n9302 + (n637 - n1050) / n9304 * ((-2.0 * n9302) - n8499 + 3.0 * n9305 + (n637 - n1050) * (n9302 + n8499 - 2.0 * n9305) / n9304));
-//       n9314 := (n1050 + n703) / 2.0;
-//       n58 := 3.0 * (n9302 + n8499 - 2.0 * n9305) * (n9314 - n1050) ^ 2.0 / n9304 ^ 2.0 + 2.0 * ((-2.0 * n9302) - n8499 + 3.0 * n9305) * (n9314 - n1050) / n9304 + n9302;
+//     rho := rho_b;
+//     mu := mu_b;
+//   end if;
+//   lambda2 := abs(dp_fric) * 2.0 * diameter ^ 3.0 * rho / (length * mu * mu) \"Known as lambda2=f(dp)\";
+//   aux1 := 2.0 * diameter ^ 3.0 * rho / (length * mu ^ 2.0);
+//   Re := lambda2 / 64.0 \"Hagen-Poiseuille\";
+//   dRe_ddp := aux1 / 64.0 \"Hagen-Poiseuille\";
+//   if Re > Re1 then
+//     Re := -2.0 * sqrt(lambda2) * log10(2.51 / sqrt(lambda2) + 0.27 * Delta) \"Colebrook-White\";
+//     aux2 := sqrt(aux1 * abs(dp_fric));
+//     dRe_ddp := 0.4342944819032518 * ((-2.0 * log(2.51 / aux2 + 0.27 * Delta) * aux1 / (2.0 * aux2)) + 5.02 / (2.0 * abs(dp_fric) * (2.51 / aux2 + 0.27 * Delta)));
+//     if Re < Re2 then
+//       (Re, dRe_ddp) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative(lambda2, Re1, Re2, Delta, dp_fric);
 //     end if;
 //   end if;
-// end n1.n7656.n11.n8462;
+//   m_flow := crossArea / diameter * mu * (if dp_fric >= 0.0 then Re else -Re);
+//   dm_flow_ddp_fric := crossArea / diameter * mu * dRe_ddp;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric;
 //
-// function n1.n7656.n11.n8483
-//   input Real n637;
-//   input Real n703;
-//   input Real n704;
-//   input Real n233;
-//   input Real n231;
-//   input Real n8499;
-//   input Real n8500;
-//   output Real n159;
-//   output Real n8501;
-//   protected Real n3331;
-//   protected Real n1548;
-//   protected Real n9318;
-//   protected Real n9319;
-//   protected Real n9320;
-//   protected Real n9321;
-//   protected Real n9322;
-//   protected Real n9323;
-//   protected Real n9324;
-//   protected Real n9325;
-//   protected Real n8490;
-//   protected Real n1202;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative \"Interpolation in log-log space using a cubic Hermite polynomial, where x=log10(lambda2), y=log10(Re)\"
+//   input Real lambda2 \"Known independent variable\";
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between laminar regime and transition\";
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") \"Boundary between transition and turbulent regime\";
+//   input Real Delta(min = 0.0) \"Relative roughness\";
+//   input Real dp_fric(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss due to friction (dp = port_a.p - port_b.p)\";
+//   output Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Unknown return variable\";
+//   output Real dRe_ddp \"Derivative of return value\";
+//   protected Real x1 = log10(64.0 * Re1);
+//   protected Real y1 = log10(Re1);
+//   protected Real y1d = 1.0;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x = log10(lambda2);
+//   protected Real y;
+//   protected Real dy_dx \"Derivative in transformed space\";
+//   protected Real aux3 = log10(aux2);
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real x2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real y2 = log10(aux5);
+//   protected Real y2d = 0.5 + 1.090079149577162 / (aux5 * aux4);
 // algorithm
-//   n3331 := n704 - n703;
-//   if abs(n3331) > 0.0 then
-//     n1548 := (n637 - n703) / n3331;
-//     n8490 := n1548 ^ 3.0;
-//     n1202 := n1548 ^ 2.0;
-//     n9318 := 2.0 * n8490 - 3.0 * n1202 + 1.0;
-//     n9319 := n8490 - 2.0 * n1202 + n1548;
-//     n9320 := (-2.0 * n8490) + 3.0 * n1202;
-//     n9321 := n8490 - n1202;
-//     n9322 := 6.0 * (n1202 - n1548);
-//     n9323 := 3.0 * n1202 - 4.0 * n1548 + 1.0;
-//     n9324 := 6.0 * (n1548 - n1202);
-//     n9325 := 3.0 * n1202 - 2.0 * n1548;
-//     n159 := n233 * n9318 + n3331 * n8499 * n9319 + n231 * n9320 + n3331 * n8500 * n9321;
-//     n8501 := n233 * n9322 / n3331 + n8499 * n9323 + n231 * n9324 / n3331 + n8500 * n9325;
+//   (y, dy_dx) := Modelica.Fluid.Utilities.cubicHermite_withDerivative(x, x1, x2, y1, y2, y1d, y2d);
+//   Re := 10.0 ^ y;
+//   dRe_ddp := Re / abs(dp_fric) * dy_dx;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric.interpolateInRegion2_withDerivative;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.massFlowRate_dp_staticHead \"Return mass flow rate m_flow as function of pressure loss dp, i.e., m_flow = f(dp), due to wall friction and static head\"
+//   input Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real g_times_height_ab(unit = \"m2/s2\") \"Gravity times (Height(port_b) - Height(port_a))\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real dp_small(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 1.0 \"Regularization of zero flow if |dp| < dp_small (dummy if use_dp_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Boundary between transition and turbulent regime\";
+//   protected Real dp_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Upper end of regularization domain of the m_flow(dp) relation\";
+//   protected Real dp_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Lower end of regularization domain of the m_flow(dp) relation\";
+//   protected Real m_flow_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at upper end of regularization domain\";
+//   protected Real m_flow_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Value at lower end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_a(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at upper end of regularization domain\";
+//   protected Real dm_flow_ddp_fric_b(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Derivative at lower end of regularization domain\";
+//   protected Real dp_grav_a(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_a \"Static head if mass flows in design direction (a to b)\";
+//   protected Real dp_grav_b(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = g_times_height_ab * rho_b \"Static head if mass flows against design direction (b to a)\";
+//   protected Real m_flow_zero(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
+//   protected Real dm_flow_ddp_fric_zero;
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min((745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta)) ^ 0.97, Re_turbulent) \"Boundary between laminar regime and transition\";
+//   protected Real dp_zero(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") = (dp_grav_a + dp_grav_b) / 2.0;
+// algorithm
+//   dp_a := max(dp_grav_a, dp_grav_b) + dp_small;
+//   dp_b := min(dp_grav_a, dp_grav_b) - dp_small;
+//   if dp >= dp_a then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
+//   elseif dp <= dp_b then
+//     m_flow := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta)[1];
 //   else
-//     n159 := (n233 + n231) / 2.0;
-//     n8501 := /*Real*/(sign(n231 - n233)) * 9.999999999999999e+59;
+//     (m_flow_a, dm_flow_ddp_fric_a) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_a - dp_grav_a, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow_b, dm_flow_ddp_fric_b) := Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.Internal.m_flow_of_dp_fric(dp_b - dp_grav_b, rho_a, rho_b, mu_a, mu_b, length, diameter, crossArea, Re1, Re2, Delta);
+//     (m_flow, dm_flow_ddp_fric_zero) := Modelica.Fluid.Utilities.regFun3(dp_zero, dp_b, dp_a, m_flow_b, m_flow_a, dm_flow_ddp_fric_b, dm_flow_ddp_fric_a);
+//     if dp > dp_zero then
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_zero, dp_a, m_flow_zero, m_flow_a, dm_flow_ddp_fric_zero, dm_flow_ddp_fric_a)[1];
+//     else
+//       m_flow := Modelica.Fluid.Utilities.regFun3(dp, dp_b, dp_zero, m_flow_b, m_flow_zero, dm_flow_ddp_fric_b, dm_flow_ddp_fric_zero)[1];
+//     end if;
 //   end if;
-// end n1.n7656.n11.n8483;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.massFlowRate_dp_staticHead;
 //
-// function n1.n7656.n11.n8727
-//   input String n8726;
-//   input String[:] n8724;
-//   input Boolean n7994;
-//   input Boolean n9288;
-//   input Real[:] n9289;
-//   input String n9290 = \"??? boundary ???\";
-//   protected Integer n7958 = size(n9289, 1);
-//   protected String n9291;
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow \"Return pressure loss dp as function of mass flow rate m_flow, i.e., dp = f(m_flow), due to wall friction\"
+//   input Real m_flow(quantity = \"MassFlowRate\", unit = \"kg/s\") \"Mass flow rate from port_a to port_b\";
+//   input Real rho_a(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_a\";
+//   input Real rho_b(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Density at port_b\";
+//   input Real mu_a(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_a (dummy if use_mu = false)\";
+//   input Real mu_b(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic viscosity at port_b (dummy if use_mu = false)\";
+//   input Real length(quantity = \"Length\", unit = \"m\") \"Length of pipe\";
+//   input Real diameter(quantity = \"Length\", unit = \"m\", min = 0.0) \"Inner (hydraulic) diameter of pipe\";
+//   input Real crossArea(quantity = \"Area\", unit = \"m2\") = 3.141592653589793 * diameter ^ 2.0 / 4.0 \"Inner cross section area\";
+//   input Real roughness(quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0) = 2.5e-05 \"Absolute roughness of pipe, with a default for a smooth steel pipe (dummy if use_roughness = false)\";
+//   input Real m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.01 \"Regularization of zero flow if |m_flow| < m_flow_small (dummy if use_m_flow_small = false)\";
+//   input Real Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0 \"Turbulent flow if Re >= Re_turbulent (dummy if use_Re_turbulent = false)\";
+//   output Real dp(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pressure loss (dp = port_a.p - port_b.p)\";
+//   protected Real Delta(min = 0.0) = roughness / diameter \"Relative roughness\";
+//   protected Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\") = Re_turbulent \"Re entering turbulent curve\";
+//   protected Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Upstream viscosity\";
+//   protected Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Upstream density\";
+//   protected Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+//   protected Real lambda2 \"Modified friction coefficient (= lambda*Re^2)\";
+//   protected Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\") = min(745.0 * exp(if Delta <= 0.0065 then 1.0 else 0.0065 / Delta), Re_turbulent) \"Re leaving laminar curve\";
 // algorithm
-//   assert(not n7994 or n7994 and n9288, \"assert message 405342961918706907\");
-//   for n49 in 1:n7958 loop
-//     assert(n9289[n49] >= 0.0, \"assert message 837991791729573288\");
+//   rho := if m_flow >= 0.0 then rho_a else rho_b;
+//   mu := if m_flow >= 0.0 then mu_a else mu_b;
+//   Re := diameter * abs(m_flow) / (crossArea * mu);
+//   lambda2 := if Re <= Re1 then 64.0 * Re else if Re >= Re2 then 0.25 * (Re / log10(Delta / 3.7 + 5.74 / Re ^ 0.9)) ^ 2.0 else Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2(Re, Re1, Re2, Delta);
+//   dp := length * mu * mu / (2.0 * rho * diameter * diameter * diameter) * (if m_flow >= 0.0 then lambda2 else -lambda2);
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2
+//   input Real Re(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re1(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Re2(quantity = \"ReynoldsNumber\", unit = \"1\");
+//   input Real Delta;
+//   output Real lambda2;
+//   protected Real x1 = log10(Re1);
+//   protected Real y1 = log10(64.0 * Re1);
+//   protected Real yd1 = 1.0;
+//   protected Real aux1 = 1.121782646756099;
+//   protected Real aux2 = Delta / 3.7 + 5.74 / Re2 ^ 0.9;
+//   protected Real x2 = log10(Re2);
+//   protected Real dx;
+//   protected Real aux3 = log10(aux2);
+//   protected Real diff_x = x2 - x1;
+//   protected Real L2 = 0.25 * (Re2 / aux3) ^ 2.0;
+//   protected Real yd2 = 2.0 + 4.0 * aux1 / (aux2 * aux3 * Re2 ^ 0.9);
+//   protected Real aux4 = 2.51 / sqrt(L2) + 0.27 * Delta;
+//   protected Real y2 = log10(L2);
+//   protected Real aux5 = -2.0 * sqrt(L2) * log10(aux4);
+//   protected Real m = (y2 - y1) / diff_x;
+//   protected Real c2 = (3.0 * m - 2.0 * yd1 - yd2) / diff_x;
+//   protected Real c3 = (yd1 + yd2 - 2.0 * m) / (diff_x * diff_x);
+// algorithm
+//   dx := log10(Re / Re1);
+//   lambda2 := 64.0 * Re1 * (Re / Re1) ^ (1.0 + dx * (c2 + dx * c3));
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow.interpolateInRegion2;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.ThermodynamicState \"Automatically generated record constructor for Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.ThermodynamicState\"
+//   input Real p;
+//   input Real T;
+//   input Real[2] X;
+//   output ThermodynamicState res;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.ThermodynamicState;
+//
+// function Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.temperature \"Return temperature of ideal gas as a function of the thermodynamic state record\"
+//   input Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.ThermodynamicState state \"Thermodynamic state record\";
+//   output Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) \"Temperature\";
+// algorithm
+//   T := state.T;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.temperature;
+//
+// function Modelica.Fluid.Pipes.BaseClasses.CharacteristicNumbers.NusseltNumber \"Return Nusselt number\"
+//   input Real alpha(quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\") \"Coefficient of heat transfer\";
+//   input Real D(quantity = \"Length\", unit = \"m\") \"Characteristic dimension\";
+//   input Real lambda(quantity = \"ThermalConductivity\", unit = \"W/(m.K)\") \"Thermal conductivity\";
+//   output Real Nu(quantity = \"NusseltNumber\", unit = \"1\") \"Nusselt number\";
+// algorithm
+//   Nu := alpha * D / lambda;
+// end Modelica.Fluid.Pipes.BaseClasses.CharacteristicNumbers.NusseltNumber;
+//
+// function Modelica.Fluid.Pipes.BaseClasses.CharacteristicNumbers.ReynoldsNumber \"Return Reynolds number from v, rho, mu, D\"
+//   input Real v(quantity = \"Velocity\", unit = \"m/s\") \"Mean velocity of fluid flow\";
+//   input Real rho(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) \"Fluid density\";
+//   input Real mu(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) \"Dynamic (absolute) viscosity\";
+//   input Real D(quantity = \"Length\", unit = \"m\") \"Characteristic dimension (hydraulic diameter of pipes)\";
+//   output Real Re(quantity = \"ReynoldsNumber\", unit = \"1\") \"Reynolds number\";
+// algorithm
+//   Re := abs(v) * rho * D / mu;
+// end Modelica.Fluid.Pipes.BaseClasses.CharacteristicNumbers.ReynoldsNumber;
+//
+// function Modelica.Fluid.Utilities.checkBoundary \"Check whether boundary definition is correct\"
+//   input String mediumName;
+//   input String[:] substanceNames \"Names of substances\";
+//   input Boolean singleState;
+//   input Boolean define_p;
+//   input Real[:] X_boundary;
+//   input String modelName = \"??? boundary ???\";
+//   protected Integer nX = size(X_boundary, 1);
+//   protected String X_str;
+// algorithm
+//   assert(not singleState or singleState and define_p, \"
+//   Wrong value of parameter define_p (= false) in model \\\"\" + modelName + \"\\\":
+//   The selected medium \\\"\" + mediumName + \"\\\" has Medium.singleState=true.
+//   Therefore, an boundary density cannot be defined and
+//   define_p = true is required.
+//   \");
+//   for i in 1:nX loop
+//     assert(X_boundary[i] >= 0.0, \"
+//     Wrong boundary mass fractions in medium \\\"\" + mediumName + \"\\\" in model \\\"\" + modelName + \"\\\":
+//     The boundary value X_boundary(\" + String(i, 0, true) + \") = \" + String(X_boundary[i], 6, 0, true) + \"
+//     is negative. It must be positive.
+//     \");
 //   end for;
-//   if n7958 > 0 and abs(sum(n9289) - 1.0) > 1e-10 then
-//     n9291 := \"\";
-//     for n49 in 1:n7958 loop
-//       n9291 := n9291 + \"   X_boundary[\" + String(n49, 0, true) + \"] = \" + String(n9289[n49], 6, 0, true) + \" \\\"\" + n8724[n49] + \"\\\"
+//   if nX > 0 and abs(sum(X_boundary) - 1.0) > 1e-10 then
+//     X_str := \"\";
+//     for i in 1:nX loop
+//       X_str := X_str + \"   X_boundary[\" + String(i, 0, true) + \"] = \" + String(X_boundary[i], 6, 0, true) + \" \\\"\" + substanceNames[i] + \"\\\"
 //       \";
 //     end for;
-//     n1.n11.n681.n682(\"The boundary mass fractions in medium \\\"\" + n8726 + \"\\\" in model \\\"\" + n9290 + \"\\\"
-//     \" + \"do not sum up to 1. Instead, sum(X_boundary) = \" + String(sum(n9289), 6, 0, true) + \":
-//     \" + n9291);
+//     Modelica.Utilities.Streams.error(\"The boundary mass fractions in medium \\\"\" + mediumName + \"\\\" in model \\\"\" + modelName + \"\\\"
+//     \" + \"do not sum up to 1. Instead, sum(X_boundary) = \" + String(sum(X_boundary), 6, 0, true) + \":
+//     \" + X_str);
 //   end if;
-// end n1.n7656.n11.n8727;
+// end Modelica.Fluid.Utilities.checkBoundary;
 //
-// function n1.n7656.n7680.n5984.n8393.n8329
-//   input Real n213(quantity = \"Velocity\", unit = \"m/s\");
-//   input Real n5456(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0);
-//   input Real n457(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0);
-//   input Real n640(quantity = \"Length\", unit = \"m\");
-//   output Real n2800(quantity = \"ReynoldsNumber\", unit = \"1\");
+// function Modelica.Fluid.Utilities.cubicHermite_withDerivative \"Evaluate a cubic Hermite spline, return value and derivative\"
+//   input Real x \"Abscissa value\";
+//   input Real x1 \"Lower abscissa value\";
+//   input Real x2 \"Upper abscissa value\";
+//   input Real y1 \"Lower ordinate value\";
+//   input Real y2 \"Upper ordinate value\";
+//   input Real y1d \"Lower gradient\";
+//   input Real y2d \"Upper gradient\";
+//   output Real y \"Interpolated ordinate value\";
+//   output Real dy_dx \"Derivative dy/dx at abscissa value x\";
+//   protected Real h \"Distance between x1 and x2\";
+//   protected Real t \"abscissa scaled with h, i.e., t=[0..1] within x=[x1..x2]\";
+//   protected Real h00 \"Basis function 00 of cubic Hermite spline\";
+//   protected Real h10 \"Basis function 10 of cubic Hermite spline\";
+//   protected Real h01 \"Basis function 01 of cubic Hermite spline\";
+//   protected Real h11 \"Basis function 11 of cubic Hermite spline\";
+//   protected Real h00d \"d/dt h00\";
+//   protected Real h10d \"d/dt h10\";
+//   protected Real h01d \"d/dt h01\";
+//   protected Real h11d \"d/dt h11\";
+//   protected Real aux3 \"t cube\";
+//   protected Real aux2 \"t square\";
 // algorithm
-//   n2800 := abs(n213) * n5456 * n640 / n457;
-// end n1.n7656.n7680.n5984.n8393.n8329;
+//   h := x2 - x1;
+//   if abs(h) > 0.0 then
+//     t := (x - x1) / h;
+//     aux3 := t ^ 3.0;
+//     aux2 := t ^ 2.0;
+//     h00 := 2.0 * aux3 - 3.0 * aux2 + 1.0;
+//     h10 := aux3 - 2.0 * aux2 + t;
+//     h01 := (-2.0 * aux3) + 3.0 * aux2;
+//     h11 := aux3 - aux2;
+//     h00d := 6.0 * (aux2 - t);
+//     h10d := 3.0 * aux2 - 4.0 * t + 1.0;
+//     h01d := 6.0 * (t - aux2);
+//     h11d := 3.0 * aux2 - 2.0 * t;
+//     y := y1 * h00 + h * y1d * h10 + y2 * h01 + h * y2d * h11;
+//     dy_dx := y1 * h00d / h + y1d * h10d + y2 * h01d / h + y2d * h11d;
+//   else
+//     y := (y1 + y2) / 2.0;
+//     dy_dx := /*Real*/(sign(y2 - y1)) * 9.999999999999999e+59;
+//   end if;
+// end Modelica.Fluid.Utilities.cubicHermite_withDerivative;
 //
-// function n1.n7656.n7680.n5984.n8393.n8430
-//   input Real n712(quantity = \"CoefficientOfHeatTransfer\", unit = \"W/(m2.K)\");
-//   input Real n640(quantity = \"Length\", unit = \"m\");
-//   input Real n474(quantity = \"ThermalConductivity\", unit = \"W/(m.K)\");
-//   output Real n8438(quantity = \"NusseltNumber\", unit = \"1\");
+// function Modelica.Fluid.Utilities.regFun3 \"Co-monotonic and C1 smooth regularization function\"
+//   input Real x \"Abscissa value\";
+//   input Real x0 \"Lower abscissa value\";
+//   input Real x1 \"Upper abscissa value\";
+//   input Real y0 \"Ordinate value at lower abscissa value\";
+//   input Real y1 \"Ordinate value at upper abscissa value\";
+//   input Real y0d \"Derivative at lower abscissa value\";
+//   input Real y1d \"Derivative at upper abscissa value\";
+//   output Real y \"Ordinate value\";
+//   output Real c \"Slope of linear section between two cubic polynomials or dummy linear section slope if single cubic is used\";
+//   protected Real h0 \"Width of interval i=0\";
+//   protected Real Delta0 \"Slope of secant on interval i=0\";
+//   protected Real xstar \"Inflection point of cubic polynomial S0\";
+//   protected Real mu \"Distance of inflection point and left limit x0\";
+//   protected Real eta \"Distance of right limit x1 and inflection point\";
+//   protected Real omega \"Slope of cubic polynomial S0 at inflection point\";
+//   protected Real rho \"Weighting factor of eta and eta_tilde, mu and mu_tilde\";
+//   protected Real theta0 \"Slope metric\";
+//   protected Real mu_tilde \"Distance of start of linear section and left limit x0\";
+//   protected Real eta_tilde \"Distance of right limit x1 and end of linear section\";
+//   protected Real xi1 \"Start of linear section\";
+//   protected Real xi2 \"End of linear section\";
+//   protected Real a1 \"Leading coefficient of cubic on the left\";
+//   protected Real a2 \"Leading coefficient of cubic on the right\";
+//   protected Real const12 \"Integration constant of left cubic, linear section\";
+//   protected Real const3 \"Integration constant of right cubic\";
+//   protected Real aux01;
+//   protected Real aux02;
+//   protected Boolean useSingleCubicPolynomial = false \"Indicate to override further logic and use single cubic\";
 // algorithm
-//   n8438 := n712 * n640 / n474;
-// end n1.n7656.n7680.n5984.n8393.n8430;
+//   assert(x0 < x1, \"regFun3(): Data points not sorted appropriately (x0 = \" + String(x0, 6, 0, true) + \" > x1 = \" + String(x1, 6, 0, true) + \"). Please flip arguments.\");
+//   if y0d * y1d >= 0.0 then
+//   else
+//     assert(abs(y0d) < 1e-15 or abs(y1d) < 1e-15, \"regFun3(): Derivatives at data points do not allow co-monotone interpolation, as both are non-zero, of opposite sign and have an absolute value larger than machine eps (y0d = \" + String(y0d, 6, 0, true) + \", y1d = \" + String(y1d, 6, 0, true) + \"). Please correct arguments.\");
+//   end if;
+//   h0 := x1 - x0;
+//   Delta0 := (y1 - y0) / h0;
+//   if abs(Delta0) <= 0.0 then
+//     y := y0 + Delta0 * (x - x0);
+//     c := 0.0;
+//   elseif abs(y1d + y0d - 2.0 * Delta0) < 1e-13 then
+//     y := y0 + (x - x0) * (y0d + (x - x0) / h0 * ((-2.0 * y0d) - y1d + 3.0 * Delta0 + (x - x0) * (y0d + y1d - 2.0 * Delta0) / h0));
+//     aux01 := (x0 + x1) / 2.0;
+//     c := 3.0 * (y0d + y1d - 2.0 * Delta0) * (aux01 - x0) ^ 2.0 / h0 ^ 2.0 + 2.0 * ((-2.0 * y0d) - y1d + 3.0 * Delta0) * (aux01 - x0) / h0 + y0d;
+//   else
+//     xstar := 0.3333333333333333 * ((-3.0 * x0 * y0d) - 3.0 * x0 * y1d + 6.0 * x0 * Delta0 - 2.0 * h0 * y0d - h0 * y1d + 3.0 * h0 * Delta0) / ((-y0d) - y1d + 2.0 * Delta0);
+//     mu := xstar - x0;
+//     eta := x1 - xstar;
+//     omega := 3.0 * (y0d + y1d - 2.0 * Delta0) * (xstar - x0) ^ 2.0 / h0 ^ 2.0 + 2.0 * ((-2.0 * y0d) - y1d + 3.0 * Delta0) * (xstar - x0) / h0 + y0d;
+//     aux01 := 0.25 * /*Real*/(sign(Delta0)) * min(abs(omega), abs(Delta0)) \"Slope c if not using plain cubic S0\";
+//     if abs(y0d - y1d) <= 1e-13 then
+//       aux02 := y0d;
+//       if y1 > y0 + y0d * (x1 - x0) then
+//         useSingleCubicPolynomial := true;
+//       end if;
+//     elseif abs(y1d + y0d - 2.0 * Delta0) < 1e-13 then
+//       aux02 := (6.0 * Delta0 * (y1d + y0d - 1.5 * Delta0) - y1d * y0d - y1d ^ 2.0 - y0d ^ 2.0) * (if y1d + y0d - 2.0 * Delta0 >= 0.0 then 1.0 else -1.0) * 9.999999999999999e+59;
+//     else
+//       aux02 := (6.0 * Delta0 * (y1d + y0d - 1.5 * Delta0) - y1d * y0d - y1d ^ 2.0 - y0d ^ 2.0) / (3.0 * (y1d + y0d - 2.0 * Delta0));
+//     end if;
+//     if (mu > 0.0 and eta < h0 and Delta0 * omega <= 0.0 or abs(aux01) < abs(aux02) and aux02 * Delta0 >= 0.0 or abs(aux01) < abs(0.1 * Delta0)) and not useSingleCubicPolynomial then
+//       c := aux01;
+//       if abs(c) < abs(aux02) and aux02 * Delta0 >= 0.0 then
+//         c := aux02;
+//       end if;
+//       if abs(c) < abs(0.1 * Delta0) then
+//         c := 0.1 * Delta0;
+//       end if;
+//       theta0 := (y0d * mu + y1d * eta) / h0;
+//       if abs(theta0 - c) < 1e-06 then
+//         c := 0.999999 * theta0;
+//       end if;
+//       rho := 3.0 * (Delta0 - c) / (theta0 - c);
+//       mu_tilde := rho * mu;
+//       eta_tilde := rho * eta;
+//       xi1 := x0 + mu_tilde;
+//       xi2 := x1 - eta_tilde;
+//       a1 := (y0d - c) / max(mu_tilde ^ 2.0, 1e-13);
+//       a2 := (y1d - c) / max(eta_tilde ^ 2.0, 1e-13);
+//       const12 := y0 - a1 / 3.0 * (x0 - xi1) ^ 3.0 - c * x0;
+//       const3 := y1 - a2 / 3.0 * (x1 - xi2) ^ 3.0 - c * x1;
+//       if x < xi1 then
+//         y := a1 / 3.0 * (x - xi1) ^ 3.0 + c * x + const12;
+//       elseif x < xi2 then
+//         y := c * x + const12;
+//       else
+//         y := a2 / 3.0 * (x - xi2) ^ 3.0 + c * x + const3;
+//       end if;
+//     else
+//       y := y0 + (x - x0) * (y0d + (x - x0) / h0 * ((-2.0 * y0d) - y1d + 3.0 * Delta0 + (x - x0) * (y0d + y1d - 2.0 * Delta0) / h0));
+//       aux01 := (x0 + x1) / 2.0;
+//       c := 3.0 * (y0d + y1d - 2.0 * Delta0) * (aux01 - x0) ^ 2.0 / h0 ^ 2.0 + 2.0 * ((-2.0 * y0d) - y1d + 3.0 * Delta0) * (aux01 - x0) / h0 + y0d;
+//     end if;
+//   end if;
+// end Modelica.Fluid.Utilities.regFun3;
 //
-// function n1.n7671.n8128.n9970.n9971.n10036
-//   input Real[:] n403;
-//   input Real n122;
-//   output Real n159;
+// function Modelica.Media.Air.MoistAir.Utilities.spliceFunction \"Spline interpolation of two functions\"
+//   input Real pos \"Returned value for x-deltax >= 0\";
+//   input Real neg \"Returned value for x+deltax <= 0\";
+//   input Real x \"Function argument\";
+//   input Real deltax = 1.0 \"Region around x with spline interpolation\";
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real y;
 // algorithm
-//   n159 := n403[1];
-//   for n752 in 2:size(n403, 1) loop
-//     n159 := n403[n752] + n122 * n159;
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   if scaledX1 <= -0.999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.999999999 then
+//     y := 1.0;
+//   else
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
+//   end if;
+//   out := pos * y + (1.0 - y) * neg;
+// end Modelica.Media.Air.MoistAir.Utilities.spliceFunction;
+//
+// function Modelica.Media.Air.MoistAir.Utilities.spliceFunction_der \"Derivative of spliceFunction\"
+//   input Real pos;
+//   input Real neg;
+//   input Real x;
+//   input Real deltax = 1.0;
+//   input Real dpos;
+//   input Real dneg;
+//   input Real dx;
+//   input Real ddeltax = 0.0;
+//   output Real out;
+//   protected Real scaledX;
+//   protected Real scaledX1;
+//   protected Real dscaledX1;
+//   protected Real y;
+// algorithm
+//   scaledX1 := x / deltax;
+//   scaledX := scaledX1 * 1.570796326794897;
+//   dscaledX1 := (dx - scaledX1 * ddeltax) / deltax;
+//   if scaledX1 <= -0.99999999999 then
+//     y := 0.0;
+//   elseif scaledX1 >= 0.9999999999 then
+//     y := 1.0;
+//   else
+//     y := (tanh(tan(scaledX)) + 1.0) / 2.0;
+//   end if;
+//   out := dpos * y + (1.0 - y) * dneg;
+//   if abs(scaledX1) < 1.0 then
+//     out := out + (pos - neg) * dscaledX1 * 1.570796326794897 / 2.0 / (cosh(tan(scaledX)) * cos(scaledX)) ^ 2.0;
+//   end if;
+// end Modelica.Media.Air.MoistAir.Utilities.spliceFunction_der;
+//
+// function Modelica.Media.IdealGases.Common.DataRecord \"Automatically generated record constructor for Modelica.Media.IdealGases.Common.DataRecord\"
+//   input String name;
+//   input Real MM;
+//   input Real Hf;
+//   input Real H0;
+//   input Real Tlimit;
+//   input Real[7] alow;
+//   input Real[2] blow;
+//   input Real[7] ahigh;
+//   input Real[2] bhigh;
+//   input Real R;
+//   output DataRecord res;
+// end Modelica.Media.IdealGases.Common.DataRecord;
+//
+// function Modelica.Media.IdealGases.Common.Functions.cp_Tlow \"Compute specific heat capacity at constant pressure, low T region\"
+//   input Modelica.Media.IdealGases.Common.DataRecord data \"Ideal gas data\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   output Real cp(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\") \"Specific heat capacity at temperature T\";
+// algorithm
+//   cp := data.R * 1.0 / (T * T) * (data.alow[1] + T * (data.alow[2] + T * (data.alow[3] + T * (data.alow[4] + T * (data.alow[5] + T * (data.alow[6] + data.alow[7] * T))))));
+// end Modelica.Media.IdealGases.Common.Functions.cp_Tlow;
+//
+// function Modelica.Media.IdealGases.Common.Functions.cp_Tlow_der \"Compute specific heat capacity at constant pressure, low T region\"
+//   input Modelica.Media.IdealGases.Common.DataRecord data \"Ideal gas data\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Real dT \"Temperature derivative\";
+//   output Real cp_der \"Derivative of specific heat capacity\";
+// algorithm
+//   cp_der := dT * data.R / (T * T * T) * ((-2.0 * data.alow[1]) + T * ((-data.alow[2]) + T * T * (data.alow[4] + T * (2.0 * data.alow[5] + T * (3.0 * data.alow[6] + 4.0 * data.alow[7] * T)))));
+// end Modelica.Media.IdealGases.Common.Functions.cp_Tlow_der;
+//
+// function Modelica.Media.IdealGases.Common.Functions.h_Tlow \"Compute specific enthalpy, low T region; reference is decided by the
+//     refChoice input, or by the referenceChoice package constant by default\"
+//   input Modelica.Media.IdealGases.Common.DataRecord data \"Ideal gas data\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Boolean exclEnthForm = true \"If true, enthalpy of formation Hf is not included in specific enthalpy h\";
+//   input enumeration(ZeroAt0K, ZeroAt25C, UserDefined) refChoice = Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.ZeroAt0K \"Choice of reference enthalpy\";
+//   input Real h_off(quantity = \"SpecificEnergy\", unit = \"J/kg\") = 0.0 \"User defined offset for reference enthalpy, if referenceChoice = UserDefined\";
+//   output Real h(quantity = \"SpecificEnergy\", unit = \"J/kg\") \"Specific enthalpy at temperature T\";
+// algorithm
+//   h := data.R * ((-data.alow[1]) + T * (data.blow[1] + data.alow[2] * log(T) + T * (data.alow[3] + T * (0.5 * data.alow[4] + T * (0.3333333333333333 * data.alow[5] + T * (0.25 * data.alow[6] + 0.2 * data.alow[7] * T)))))) / T + (if exclEnthForm then -data.Hf else 0.0) + (if refChoice == Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.ZeroAt0K then data.H0 else 0.0) + (if refChoice == Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.UserDefined then h_off else 0.0);
+// end Modelica.Media.IdealGases.Common.Functions.h_Tlow;
+//
+// function Modelica.Media.IdealGases.Common.Functions.h_Tlow_der \"Compute specific enthalpy, low T region; reference is decided by the
+//     refChoice input, or by the referenceChoice package constant by default\"
+//   input Modelica.Media.IdealGases.Common.DataRecord data \"Ideal gas data\";
+//   input Real T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Temperature\";
+//   input Boolean exclEnthForm = true \"If true, enthalpy of formation Hf is not included in specific enthalpy h\";
+//   input enumeration(ZeroAt0K, ZeroAt25C, UserDefined) refChoice = Modelica.Media.Interfaces.Choices.ReferenceEnthalpy.ZeroAt0K \"Choice of reference enthalpy\";
+//   input Real h_off(quantity = \"SpecificEnergy\", unit = \"J/kg\") = 0.0 \"User defined offset for reference enthalpy, if referenceChoice = UserDefined\";
+//   input Real dT(unit = \"K/s\") \"Temperature derivative\";
+//   output Real h_der(unit = \"J/(kg.s)\") \"Derivative of specific enthalpy at temperature T\";
+// algorithm
+//   h_der := dT * Modelica.Media.IdealGases.Common.Functions.cp_Tlow(data, T);
+// end Modelica.Media.IdealGases.Common.Functions.h_Tlow_der;
+//
+// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate \"Evaluate polynomial at a given abscissa value\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real u \"Abscissa value\";
+//   output Real y \"Value of polynomial at u\";
+// algorithm
+//   y := p[1];
+//   for j in 2:size(p, 1) loop
+//     y := p[j] + u * y;
 //   end for;
-// end n1.n7671.n8128.n9970.n9971.n10036;
+// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate;
 //
-// function n1.n7671.n8128.n9970.n9971.n11662
-//   input Real[:] n403;
-//   input Real n122;
-//   input Real n11673;
-//   output Real n7276;
-//   protected Integer n228 = size(n403, 1);
+// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange \"Evaluate polynomial at a given abscissa value with linear extrapolation outside of the defined range\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real uMin \"Polynomial valid in the range uMin .. uMax\";
+//   input Real uMax \"Polynomial valid in the range uMin .. uMax\";
+//   input Real u \"Abscissa value\";
+//   output Real y \"Value of polynomial at u. Outside of uMin,uMax, linear extrapolation is used\";
 // algorithm
-//   n7276 := n403[1] * /*Real*/(n228 - 1);
-//   for n752 in 2:size(n403, 1) - 1 loop
-//     n7276 := n403[n752] * /*Real*/(n228 - n752) + n122 * n7276;
+//   if u < uMin then
+//     y := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(p, uMin) - Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMin, uMin - u);
+//   elseif u > uMax then
+//     y := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(p, uMax) + Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMax, u - uMax);
+//   else
+//     y := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(p, u);
+//   end if;
+// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange;
+//
+// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange_der \"Evaluate derivative of polynomial at a given abscissa value with extrapolation outside of the defined range\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real uMin \"Polynomial valid in the range uMin .. uMax\";
+//   input Real uMax \"Polynomial valid in the range uMin .. uMax\";
+//   input Real u \"Abscissa value\";
+//   input Real du \"Delta of abscissa value\";
+//   output Real dy \"Value of derivative of polynomial at u\";
+// algorithm
+//   if u < uMin then
+//     dy := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMin, du);
+//   elseif u > uMax then
+//     dy := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, uMax, du);
+//   else
+//     dy := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der(p, u, du);
+//   end if;
+// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluateWithRange_der;
+//
+// function Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der \"Evaluate derivative of polynomial at a given abscissa value\"
+//   input Real[:] p \"Polynomial coefficients (p[1] is coefficient of highest power)\";
+//   input Real u \"Abscissa value\";
+//   input Real du \"Delta of abscissa value\";
+//   output Real dy \"Value of derivative of polynomial at u\";
+//   protected Integer n = size(p, 1);
+// algorithm
+//   dy := p[1] * /*Real*/(n - 1);
+//   for j in 2:size(p, 1) - 1 loop
+//     dy := p[j] * /*Real*/(n - j) + u * dy;
 //   end for;
-//   n7276 := n7276 * n11673;
-// end n1.n7671.n8128.n9970.n9971.n11662;
+//   dy := dy * du;
+// end Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate_der;
 //
-// function n1.n7671.n8128.n9970.n9971.n11663
-//   input Real[:] n403;
-//   input Real n675;
-//   input Real n674;
-//   input Real n122;
-//   input Real n11673;
-//   output Real n7276;
+// function Modelica.SIunits.Conversions.to_bar \"Convert from Pascal to bar\"
+//   input Real Pa(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\") \"Pascal value\";
+//   output Real bar(quantity = \"Pressure\", unit = \"bar\") \"bar value\";
 // algorithm
-//   if n122 < n675 then
-//     n7276 := n1.n7671.n8128.n9970.n9971.n11662(n403, n675, n11673);
-//   elseif n122 > n674 then
-//     n7276 := n1.n7671.n8128.n9970.n9971.n11662(n403, n674, n11673);
-//   else
-//     n7276 := n1.n7671.n8128.n9970.n9971.n11662(n403, n122, n11673);
-//   end if;
-// end n1.n7671.n8128.n9970.n9971.n11663;
+//   bar := Pa / 100000.0;
+// end Modelica.SIunits.Conversions.to_bar;
 //
-// function n1.n7671.n8128.n9970.n9971.n9972
-//   input Real[:] n403;
-//   input Real n675;
-//   input Real n674;
-//   input Real n122;
-//   output Real n159;
+// function Modelica.SIunits.Conversions.to_degC \"Convert from Kelvin to degCelsius\"
+//   input Real Kelvin(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) \"Kelvin value\";
+//   output Real Celsius(quantity = \"ThermodynamicTemperature\", unit = \"degC\") \"Celsius value\";
 // algorithm
-//   if n122 < n675 then
-//     n159 := n1.n7671.n8128.n9970.n9971.n10036(n403, n675) - n1.n7671.n8128.n9970.n9971.n11662(n403, n675, n675 - n122);
-//   elseif n122 > n674 then
-//     n159 := n1.n7671.n8128.n9970.n9971.n10036(n403, n674) + n1.n7671.n8128.n9970.n9971.n11662(n403, n674, n122 - n674);
-//   else
-//     n159 := n1.n7671.n8128.n9970.n9971.n10036(n403, n122);
-//   end if;
-// end n1.n7671.n8128.n9970.n9971.n9972;
+//   Celsius := Kelvin - 273.15;
+// end Modelica.SIunits.Conversions.to_degC;
 //
-// function n1.n7671.n8150.n8151.n11.n10129
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   input Real n10161;
-//   input Real n10162;
-//   input Real n8496;
-//   input Real n10163 = 0.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n10164;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   n10164 := (n8496 - n10160 * n10163) / n9237;
-//   if n10160 <= -0.99999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.9999999999 then
-//     n159 := 1.0;
-//   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
-//   end if;
-//   n1629 := n10161 * n159 + (1.0 - n159) * n10162;
-//   if abs(n10160) < 1.0 then
-//     n1629 := n1629 + (n8602 - n10158) * n10164 * 1.570796326794897 / 2.0 / (cosh(tan(n10159)) * cos(n10159)) ^ 2.0;
-//   end if;
-// end n1.n7671.n8150.n8151.n11.n10129;
+// function Modelica.Utilities.Streams.error \"Print error message and cancel all actions - in case of an unrecoverable error\"
+//   input String string \"String to be printed to error message window\";
 //
-// function n1.n7671.n8150.n8151.n11.n8436
-//   input Real n8602;
-//   input Real n10158;
-//   input Real n637;
-//   input Real n9237 = 1.0;
-//   output Real n1629;
-//   protected Real n10159;
-//   protected Real n10160;
-//   protected Real n159;
-// algorithm
-//   n10160 := n637 / n9237;
-//   n10159 := n10160 * 1.570796326794897;
-//   if n10160 <= -0.999999999 then
-//     n159 := 0.0;
-//   elseif n10160 >= 0.999999999 then
-//     n159 := 1.0;
-//   else
-//     n159 := (tanh(tan(n10159)) + 1.0) / 2.0;
-//   end if;
-//   n1629 := n8602 * n159 + (1.0 - n159) * n10158;
-// end n1.n7671.n8150.n8151.n11.n8436;
+//   external \"C\" ModelicaError(string);
+// end Modelica.Utilities.Streams.error;
 //
-// function n1.n7671.n9351.n9473.n10104 \"Automatically generated record constructor for n1.n7671.n9351.n9473.n10104\"
-//   input String n59;
-//   input Real n9229;
-//   input Real n9787;
-//   input Real n5519;
-//   input Real n10373;
-//   input Real[7] n10374;
-//   input Real[2] n10375;
-//   input Real[7] n10376;
-//   input Real[2] n10377;
-//   input Real n344;
-//   output n10104 res;
-// end n1.n7671.n9351.n9473.n10104;
-//
-// function n1.n7671.n9351.n9473.n885.n10135
-//   input n1.n7671.n9351.n9473.n10104 n2501;
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Boolean n10385 = true;
-//   input enumeration(n9643, n9644, n9645) n10134 = n1.n7671.n365.n8633.n9642.n9643;
-//   input Real n9933(quantity = \"SpecificEnergy\", unit = \"J/kg\") = 0.0;
-//   output Real n3331(quantity = \"SpecificEnergy\", unit = \"J/kg\");
-// algorithm
-//   n3331 := n2501.n344 * ((-n2501.n10374[1]) + n217 * (n2501.n10375[1] + n2501.n10374[2] * log(n217) + n217 * (n2501.n10374[3] + n217 * (0.5 * n2501.n10374[4] + n217 * (0.3333333333333333 * n2501.n10374[5] + n217 * (0.25 * n2501.n10374[6] + 0.2 * n2501.n10374[7] * n217)))))) / n217 + (if n10385 then -n2501.n9787 else 0.0) + (if n10134 == n1.n7671.n365.n8633.n9642.n9643 then n2501.n5519 else 0.0) + (if n10134 == n1.n7671.n365.n8633.n9642.n9645 then n9933 else 0.0);
-// end n1.n7671.n9351.n9473.n885.n10135;
-//
-// function n1.n7671.n9351.n9473.n885.n10147
-//   input n1.n7671.n9351.n9473.n10104 n2501;
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Boolean n10385 = true;
-//   input enumeration(n9643, n9644, n9645) n10134 = n1.n7671.n365.n8633.n9642.n9643;
-//   input Real n9933(quantity = \"SpecificEnergy\", unit = \"J/kg\") = 0.0;
-//   input Real n8197(unit = \"K/s\");
-//   output Real n10059(unit = \"J/(kg.s)\");
-// algorithm
-//   n10059 := n8197 * n1.n7671.n9351.n9473.n885.n10153(n2501, n217);
-// end n1.n7671.n9351.n9473.n885.n10147;
-//
-// function n1.n7671.n9351.n9473.n885.n10153
-//   input n1.n7671.n9351.n9473.n10104 n2501;
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   output Real n4554(quantity = \"SpecificHeatCapacity\", unit = \"J/(kg.K)\");
-// algorithm
-//   n4554 := n2501.n344 * 1.0 / (n217 * n217) * (n2501.n10374[1] + n217 * (n2501.n10374[2] + n217 * (n2501.n10374[3] + n217 * (n2501.n10374[4] + n217 * (n2501.n10374[5] + n217 * (n2501.n10374[6] + n2501.n10374[7] * n217))))));
-// end n1.n7671.n9351.n9473.n885.n10153;
-//
-// function n1.n7671.n9351.n9473.n885.n10383
-//   input n1.n7671.n9351.n9473.n10104 n2501;
-//   input Real n217(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
-//   input Real n8197;
-//   output Real n10384;
-// algorithm
-//   n10384 := n8197 * n2501.n344 / (n217 * n217 * n217) * ((-2.0 * n2501.n10374[1]) + n217 * ((-n2501.n10374[2]) + n217 * n217 * (n2501.n10374[4] + n217 * (2.0 * n2501.n10374[5] + n217 * (3.0 * n2501.n10374[6] + 4.0 * n2501.n10374[7] * n217)))));
-// end n1.n7671.n9351.n9473.n885.n10383;
-//
-// class n1.n7656.n102.n8149
+// class Modelica.Fluid.Examples.BranchingDynamicPipes \"Multi-way connections of pipes with dynamic momentum balance, pressure wave and flow reversal\"
 //   parameter Real system.p_ambient(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = 101325.0;
 //   parameter Real system.T_ambient(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = 293.15;
 //   parameter Real system.g(quantity = \"Acceleration\", unit = \"m/s2\") = 9.806649999999999;
 //   final parameter Boolean system.allowFlowReversal = true;
-//   final parameter enumeration(n8305, n7697, n7751, n117) system.energyDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) system.massDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) system.substanceDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) system.traceDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) system.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) system.energyDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) system.massDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) system.substanceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) system.traceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) system.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   parameter Real system.m_flow_start(quantity = \"MassFlowRate\", unit = \"kg/s\") = 0.0;
 //   parameter Real system.p_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = system.p_ambient;
 //   parameter Real system.T_start(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0) = system.T_ambient;
@@ -4015,21 +4026,21 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real boundary1.medium.state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean boundary1.medium.preferredMediumStates = false;
 //   final parameter Boolean boundary1.medium.standardOrderComponents = true;
-//   Real boundary1.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(boundary1.medium.T);
-//   Real boundary1.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(boundary1.medium.p);
+//   Real boundary1.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(boundary1.medium.T);
+//   Real boundary1.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(boundary1.medium.p);
 //   Real boundary1.medium.x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real boundary1.medium.phi;
-//   protected Real n8153.n7931.n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8153.n7931.n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8153.n7931.n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8153.n7931.n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8153.n7931.n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8153.n7931.n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real boundary1.medium.$n1(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary1.medium.$n2(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary1.medium.$n3(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary1.medium.$n4(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary1.medium.$n5(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary1.medium.$n6(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real boundary1.ports[1].m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 9.999999999999999e+59);
 //   Real boundary1.ports[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real boundary1.ports[1].h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
 //   Real boundary1.ports[1].Xi_outflow[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected final parameter enumeration(n8710, n8711, n8714) n8153.n8745 = n1.n7656.n31.n8708.n8714;
+//   protected final parameter enumeration(Entering, Leaving, Bidirectional) boundary1.$n7 = Modelica.Fluid.Types.PortFlowDirection.Bidirectional;
 //   final parameter Boolean boundary1.use_p_in = false;
 //   final parameter Boolean boundary1.use_T_in = false;
 //   final parameter Boolean boundary1.use_X_in = false;
@@ -4038,10 +4049,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real boundary1.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = 293.15;
 //   parameter Real boundary1.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01;
 //   parameter Real boundary1.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99;
-//   protected Real n8153.n8735;
-//   protected Real n8153.n8736;
-//   protected Real n8153.n8737[1];
-//   protected Real n8153.n8737[2];
+//   protected Real boundary1.$n8;
+//   protected Real boundary1.$n9;
+//   protected Real boundary1.$n10[1];
+//   protected Real boundary1.$n10[2];
 //   final parameter Boolean pipe1.allowFlowReversal = true;
 //   Real pipe1.port_a.m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0);
 //   Real pipe1.port_a.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
@@ -4051,9 +4062,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.port_b.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe1.port_b.h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
 //   Real pipe1.port_b.Xi_outflow[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected final parameter Boolean n7835.n7805 = false;
-//   protected final parameter Boolean n7835.n7806 = false;
-//   protected parameter Boolean n7835.n8767 = true;
+//   protected final parameter Boolean pipe1.$n11 = false;
+//   protected final parameter Boolean pipe1.$n12 = false;
+//   protected parameter Boolean pipe1.$n13 = true;
 //   parameter Real pipe1.nParallel(min = 1.0) = 1.0;
 //   final parameter Real pipe1.length(quantity = \"Length\", unit = \"m\") = 50.0;
 //   parameter Boolean pipe1.isCircular = true;
@@ -4069,10 +4080,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.fluidVolumes[3](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe1.fluidVolumes[4](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe1.fluidVolumes[5](quantity = \"Volume\", unit = \"m3\");
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe1.energyDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe1.massDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe1.substanceDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe1.traceDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.energyDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.massDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.substanceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.traceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   parameter Real pipe1.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 150000.0;
 //   parameter Real pipe1.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 130000.0;
 //   final parameter Real pipe1.ps_start[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe1.p_a_start;
@@ -4082,7 +4093,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe1.ps_start[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe1.p_a_start + (pipe1.p_b_start - pipe1.p_a_start) * 4.0 / 4.0;
 //   final parameter Boolean pipe1.use_T_start = true;
 //   parameter Real pipe1.T_start(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = system.T_start;
-//   parameter Real pipe1.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = n1.n7656.n102.n8149.n7835.n7670.n7957((pipe1.p_a_start + pipe1.p_b_start) / 2.0, pipe1.T_start, pipe1.X_start);
+//   parameter Real pipe1.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX((pipe1.p_a_start + pipe1.p_b_start) / 2.0, pipe1.T_start, pipe1.X_start);
 //   parameter Real pipe1.X_start[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01;
 //   parameter Real pipe1.X_start[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99;
 //   Real pipe1.Us[1](quantity = \"Energy\", unit = \"J\");
@@ -4116,16 +4127,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe1.mediums[1].preferredMediumStates = true;
 //   final parameter Boolean pipe1.mediums[1].standardOrderComponents = true;
-//   Real pipe1.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe1.mediums[1].T);
-//   Real pipe1.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe1.mediums[1].p);
+//   Real pipe1.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[1].T);
+//   Real pipe1.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[1].p);
 //   Real pipe1.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe1.mediums[1].phi;
-//   protected Real n7835.n8256[1].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[1].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[1].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[1].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[1].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[1].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe1.mediums[1].$n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[1].$n15(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[1].$n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[1].$n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[1].$n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[1].$n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe1.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[2], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start);
@@ -4142,16 +4153,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe1.mediums[2].preferredMediumStates = true;
 //   final parameter Boolean pipe1.mediums[2].standardOrderComponents = true;
-//   Real pipe1.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe1.mediums[2].T);
-//   Real pipe1.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe1.mediums[2].p);
+//   Real pipe1.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[2].T);
+//   Real pipe1.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[2].p);
 //   Real pipe1.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe1.mediums[2].phi;
-//   protected Real n7835.n8256[2].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[2].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[2].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[2].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[2].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[2].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe1.mediums[2].$n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[2].$n15(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[2].$n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[2].$n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[2].$n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[2].$n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe1.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[3], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start);
@@ -4168,16 +4179,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe1.mediums[3].preferredMediumStates = true;
 //   final parameter Boolean pipe1.mediums[3].standardOrderComponents = true;
-//   Real pipe1.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe1.mediums[3].T);
-//   Real pipe1.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe1.mediums[3].p);
+//   Real pipe1.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[3].T);
+//   Real pipe1.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[3].p);
 //   Real pipe1.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe1.mediums[3].phi;
-//   protected Real n7835.n8256[3].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[3].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[3].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[3].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[3].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[3].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe1.mediums[3].$n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[3].$n15(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[3].$n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[3].$n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[3].$n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[3].$n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe1.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[4], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start);
@@ -4194,16 +4205,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe1.mediums[4].preferredMediumStates = true;
 //   final parameter Boolean pipe1.mediums[4].standardOrderComponents = true;
-//   Real pipe1.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe1.mediums[4].T);
-//   Real pipe1.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe1.mediums[4].p);
+//   Real pipe1.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[4].T);
+//   Real pipe1.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[4].p);
 //   Real pipe1.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe1.mediums[4].phi;
-//   protected Real n7835.n8256[4].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[4].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[4].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[4].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[4].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[4].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe1.mediums[4].$n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[4].$n15(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[4].$n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[4].$n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[4].$n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[4].$n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe1.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe1.ps_start[5], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe1.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe1.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe1.h_start);
@@ -4220,16 +4231,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe1.mediums[5].preferredMediumStates = true;
 //   final parameter Boolean pipe1.mediums[5].standardOrderComponents = true;
-//   Real pipe1.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe1.mediums[5].T);
-//   Real pipe1.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe1.mediums[5].p);
+//   Real pipe1.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe1.mediums[5].T);
+//   Real pipe1.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe1.mediums[5].p);
 //   Real pipe1.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe1.mediums[5].phi;
-//   protected Real n7835.n8256[5].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[5].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[5].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[5].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[5].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7835.n8256[5].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe1.mediums[5].$n14(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[5].$n15(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[5].$n16(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[5].$n17(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[5].$n18(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe1.mediums[5].$n19(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe1.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe1.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe1.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
@@ -4255,7 +4266,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.Wb_flows[3](quantity = \"Power\", unit = \"W\");
 //   Real pipe1.Wb_flows[4](quantity = \"Power\", unit = \"W\");
 //   Real pipe1.Wb_flows[5](quantity = \"Power\", unit = \"W\");
-//   protected final parameter Boolean n7835.n8082 = true;
+//   protected final parameter Boolean pipe1.$n20 = true;
 //   final parameter Real pipe1.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe1.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe1.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0;
@@ -4281,10 +4292,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe1.dheights[3](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe1.dheights[4](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe1.dheights[5](quantity = \"Length\", unit = \"m\") = 10.0;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe1.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe1.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.02;
 //   final parameter Integer pipe1.nNodes(min = 1) = 5;
-//   final parameter enumeration(n8127, n7761, n8187, n8189) pipe1.modelStructure = n1.n7656.n31.n7760.n7761;
+//   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe1.modelStructure = Modelica.Fluid.Types.ModelStructure.a_v_b;
 //   final parameter Boolean pipe1.useLumpedPressure = false;
 //   final parameter Integer pipe1.nFM = 6;
 //   final parameter Integer pipe1.nFMDistributed = 6;
@@ -4394,7 +4405,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe1.flowModel.dheights[6](quantity = \"Length\", unit = \"m\");
 //   final parameter Real pipe1.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g;
 //   final parameter Boolean pipe1.flowModel.allowFlowReversal = true;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe1.flowModel.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe1.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe1.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.02;
 //   final parameter Real pipe1.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe1.p_a_start;
 //   final parameter Real pipe1.flowModel.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe1.p_b_start;
@@ -4471,10 +4482,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe1.flowModel.p_a_start - pipe1.flowModel.p_b_start) / 6.0);
 //   final parameter Real pipe1.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
 //   final parameter Boolean pipe1.flowModel.show_Res = false;
-//   protected final parameter Boolean n7835.n8346.n8385 = false;
-//   protected parameter Real n7835.n8346.n8135(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
-//   protected final parameter Boolean n7835.n8346.n8389 = false;
-//   protected parameter Real n7835.n8346.n8390(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
+//   protected final parameter Boolean pipe1.flowModel.$n21 = false;
+//   protected parameter Real pipe1.flowModel.$n22(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
+//   protected final parameter Boolean pipe1.flowModel.$n23 = false;
+//   protected parameter Real pipe1.flowModel.$n24(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
 //   Real pipe1.flowModel.pathLengths_internal[1](quantity = \"Length\", unit = \"m\");
 //   Real pipe1.flowModel.pathLengths_internal[2](quantity = \"Length\", unit = \"m\");
 //   Real pipe1.flowModel.pathLengths_internal[3](quantity = \"Length\", unit = \"m\");
@@ -4490,16 +4501,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe1.flowModel.dp_nominal(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
 //   parameter Real pipe1.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe1.flowModel.m_flow_small;
 //   parameter Real pipe1.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small;
-//   protected parameter Real n7835.n8346.n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
-//   protected final parameter Boolean n7835.n8346.n8407 = false;
-//   protected final parameter Boolean n7835.n8346.n8409 = false;
-//   protected Real n7835.n8346.n8410[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8346.n8410[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8346.n8410[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8346.n8410[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8346.n8410[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8346.n8410[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8346.n8411(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = n1.n7656.n102.n8149.n7835.n8346.n7663.n8412(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, n7835.n8346.n8135, n7835.n8346.n8135, n7835.n8346.n8390, n7835.n8346.n8390, pipe1.flowModel.pathLengths_internal[1], n7835.n8346.n8410[1], (pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[1]) + n1.n7656.n102.n8149.n7835.n8346.n7663.n8412(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, n7835.n8346.n8135, n7835.n8346.n8135, n7835.n8346.n8390, n7835.n8346.n8390, pipe1.flowModel.pathLengths_internal[2], n7835.n8346.n8410[2], (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[2]) + n1.n7656.n102.n8149.n7835.n8346.n7663.n8412(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, n7835.n8346.n8135, n7835.n8346.n8135, n7835.n8346.n8390, n7835.n8346.n8390, pipe1.flowModel.pathLengths_internal[3], n7835.n8346.n8410[3], (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[3]) + n1.n7656.n102.n8149.n7835.n8346.n7663.n8412(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, n7835.n8346.n8135, n7835.n8346.n8135, n7835.n8346.n8390, n7835.n8346.n8390, pipe1.flowModel.pathLengths_internal[4], n7835.n8346.n8410[4], (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[4]) + n1.n7656.n102.n8149.n7835.n8346.n7663.n8412(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, n7835.n8346.n8135, n7835.n8346.n8135, n7835.n8346.n8390, n7835.n8346.n8390, pipe1.flowModel.pathLengths_internal[5], n7835.n8346.n8410[5], (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[5]) + n1.n7656.n102.n8149.n7835.n8346.n7663.n8412(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, n7835.n8346.n8135, n7835.n8346.n8135, n7835.n8346.n8390, n7835.n8346.n8390, pipe1.flowModel.pathLengths_internal[6], n7835.n8346.n8410[6], (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[6]);
+//   protected parameter Real pipe1.flowModel.$n25(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
+//   protected final parameter Boolean pipe1.flowModel.$n26 = false;
+//   protected final parameter Boolean pipe1.flowModel.$n27 = false;
+//   protected Real pipe1.flowModel.$n28[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.flowModel.$n28[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.flowModel.$n28[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.flowModel.$n28[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.flowModel.$n28[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.flowModel.$n28[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.flowModel.$n29(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.$n22, pipe1.flowModel.$n22, pipe1.flowModel.$n24, pipe1.flowModel.$n24, pipe1.flowModel.pathLengths_internal[1], pipe1.flowModel.$n28[1], (pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.$n22, pipe1.flowModel.$n22, pipe1.flowModel.$n24, pipe1.flowModel.$n24, pipe1.flowModel.pathLengths_internal[2], pipe1.flowModel.$n28[2], (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.$n22, pipe1.flowModel.$n22, pipe1.flowModel.$n24, pipe1.flowModel.$n24, pipe1.flowModel.pathLengths_internal[3], pipe1.flowModel.$n28[3], (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.$n22, pipe1.flowModel.$n22, pipe1.flowModel.$n24, pipe1.flowModel.$n24, pipe1.flowModel.pathLengths_internal[4], pipe1.flowModel.$n28[4], (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.$n22, pipe1.flowModel.$n22, pipe1.flowModel.$n24, pipe1.flowModel.$n24, pipe1.flowModel.pathLengths_internal[5], pipe1.flowModel.$n28[5], (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.pressureLoss_m_flow(pipe1.flowModel.m_flow_nominal / pipe1.flowModel.nParallel, pipe1.flowModel.$n22, pipe1.flowModel.$n22, pipe1.flowModel.$n24, pipe1.flowModel.$n24, pipe1.flowModel.pathLengths_internal[6], pipe1.flowModel.$n28[6], (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0, pipe1.flowModel.m_flow_small / pipe1.flowModel.nParallel, pipe1.flowModel.Res_turbulent_internal[6]);
 //   Real pipe1.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.02);
 //   Real pipe1.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.02);
 //   Real pipe1.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.02);
@@ -4523,46 +4534,46 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe1.vs[3](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe1.vs[4](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe1.vs[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8348[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8348[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8348[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8348[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8348[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8348[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8373[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8373[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8373[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8373[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8373[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8373[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8370[1](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8370[2](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8370[3](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8370[4](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8370[5](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8370[6](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8370[7](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7835.n8369[1](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8369[2](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8369[3](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8369[4](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8369[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8369[6](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8369[7](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7835.n8371[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8371[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8371[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8371[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8371[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8371[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8371[7](quantity = \"Length\", unit = \"m\");
-//   protected Real n7835.n8372[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7835.n8372[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7835.n8372[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7835.n8372[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7835.n8372[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7835.n8372[6](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7835.n8372[7](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n30[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n30[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n30[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n30[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n30[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n30[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n31[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n31[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n31[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n31[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n31[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n31[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n32[1](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n32[2](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n32[3](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n32[4](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n32[5](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n32[6](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n32[7](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe1.$n33[1](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n33[2](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n33[3](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n33[4](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n33[5](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n33[6](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n33[7](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe1.$n34[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n34[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n34[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n34[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n34[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n34[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n34[7](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe1.$n35[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n35[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n35[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n35[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n35[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n35[6](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe1.$n35[7](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
 //   final parameter Boolean pipe1.use_HeatTransfer = false;
 //   final parameter Integer pipe1.heatTransfer.n = 5;
 //   final Real pipe1.heatTransfer.states[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe1.mediums[1].state.p;
@@ -4648,9 +4659,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.port_b.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe2.port_b.h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
 //   Real pipe2.port_b.Xi_outflow[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected final parameter Boolean n7836.n7805 = true;
-//   protected final parameter Boolean n7836.n7806 = true;
-//   protected parameter Boolean n7836.n8767 = true;
+//   protected final parameter Boolean pipe2.$n36 = true;
+//   protected final parameter Boolean pipe2.$n37 = true;
+//   protected parameter Boolean pipe2.$n38 = true;
 //   parameter Real pipe2.nParallel(min = 1.0) = 1.0;
 //   final parameter Real pipe2.length(quantity = \"Length\", unit = \"m\") = 50.0;
 //   parameter Boolean pipe2.isCircular = true;
@@ -4666,10 +4677,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.fluidVolumes[3](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe2.fluidVolumes[4](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe2.fluidVolumes[5](quantity = \"Volume\", unit = \"m3\");
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe2.energyDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe2.massDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe2.substanceDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe2.traceDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.energyDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.massDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.substanceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.traceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   parameter Real pipe2.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 130000.0;
 //   parameter Real pipe2.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 120000.0;
 //   final parameter Real pipe2.ps_start[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe2.p_a_start;
@@ -4679,7 +4690,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe2.ps_start[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe2.p_a_start + (pipe2.p_b_start - pipe2.p_a_start) * 4.0 / 4.0;
 //   final parameter Boolean pipe2.use_T_start = true;
 //   parameter Real pipe2.T_start(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = system.T_start;
-//   parameter Real pipe2.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = n1.n7656.n102.n8149.n7836.n7670.n7957((pipe2.p_a_start + pipe2.p_b_start) / 2.0, pipe2.T_start, pipe2.X_start);
+//   parameter Real pipe2.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX((pipe2.p_a_start + pipe2.p_b_start) / 2.0, pipe2.T_start, pipe2.X_start);
 //   parameter Real pipe2.X_start[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01;
 //   parameter Real pipe2.X_start[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99;
 //   Real pipe2.Us[1](quantity = \"Energy\", unit = \"J\");
@@ -4713,16 +4724,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe2.mediums[1].preferredMediumStates = true;
 //   final parameter Boolean pipe2.mediums[1].standardOrderComponents = true;
-//   Real pipe2.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe2.mediums[1].T);
-//   Real pipe2.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe2.mediums[1].p);
+//   Real pipe2.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[1].T);
+//   Real pipe2.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[1].p);
 //   Real pipe2.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe2.mediums[1].phi;
-//   protected Real n7836.n8256[1].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[1].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[1].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[1].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[1].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[1].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe2.mediums[1].$n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[1].$n40(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[1].$n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[1].$n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[1].$n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[1].$n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe2.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[2], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start);
@@ -4739,16 +4750,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe2.mediums[2].preferredMediumStates = true;
 //   final parameter Boolean pipe2.mediums[2].standardOrderComponents = true;
-//   Real pipe2.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe2.mediums[2].T);
-//   Real pipe2.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe2.mediums[2].p);
+//   Real pipe2.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[2].T);
+//   Real pipe2.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[2].p);
 //   Real pipe2.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe2.mediums[2].phi;
-//   protected Real n7836.n8256[2].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[2].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[2].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[2].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[2].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[2].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe2.mediums[2].$n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[2].$n40(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[2].$n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[2].$n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[2].$n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[2].$n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe2.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[3], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start);
@@ -4765,16 +4776,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe2.mediums[3].preferredMediumStates = true;
 //   final parameter Boolean pipe2.mediums[3].standardOrderComponents = true;
-//   Real pipe2.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe2.mediums[3].T);
-//   Real pipe2.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe2.mediums[3].p);
+//   Real pipe2.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[3].T);
+//   Real pipe2.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[3].p);
 //   Real pipe2.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe2.mediums[3].phi;
-//   protected Real n7836.n8256[3].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[3].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[3].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[3].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[3].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[3].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe2.mediums[3].$n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[3].$n40(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[3].$n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[3].$n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[3].$n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[3].$n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe2.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[4], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start);
@@ -4791,16 +4802,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe2.mediums[4].preferredMediumStates = true;
 //   final parameter Boolean pipe2.mediums[4].standardOrderComponents = true;
-//   Real pipe2.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe2.mediums[4].T);
-//   Real pipe2.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe2.mediums[4].p);
+//   Real pipe2.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[4].T);
+//   Real pipe2.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[4].p);
 //   Real pipe2.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe2.mediums[4].phi;
-//   protected Real n7836.n8256[4].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[4].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[4].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[4].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[4].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[4].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe2.mediums[4].$n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[4].$n40(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[4].$n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[4].$n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[4].$n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[4].$n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe2.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe2.ps_start[5], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe2.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe2.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe2.h_start);
@@ -4817,16 +4828,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe2.mediums[5].preferredMediumStates = true;
 //   final parameter Boolean pipe2.mediums[5].standardOrderComponents = true;
-//   Real pipe2.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe2.mediums[5].T);
-//   Real pipe2.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe2.mediums[5].p);
+//   Real pipe2.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe2.mediums[5].T);
+//   Real pipe2.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe2.mediums[5].p);
 //   Real pipe2.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe2.mediums[5].phi;
-//   protected Real n7836.n8256[5].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[5].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[5].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[5].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[5].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7836.n8256[5].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe2.mediums[5].$n39(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[5].$n40(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[5].$n41(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[5].$n42(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[5].$n43(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe2.mediums[5].$n44(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe2.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe2.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe2.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
@@ -4852,7 +4863,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.Wb_flows[3](quantity = \"Power\", unit = \"W\");
 //   Real pipe2.Wb_flows[4](quantity = \"Power\", unit = \"W\");
 //   Real pipe2.Wb_flows[5](quantity = \"Power\", unit = \"W\");
-//   protected final parameter Boolean n7836.n8082 = true;
+//   protected final parameter Boolean pipe2.$n45 = true;
 //   final parameter Real pipe2.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe2.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe2.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0;
@@ -4878,10 +4889,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe2.dheights[3](quantity = \"Length\", unit = \"m\") = 5.0;
 //   final parameter Real pipe2.dheights[4](quantity = \"Length\", unit = \"m\") = 5.0;
 //   final parameter Real pipe2.dheights[5](quantity = \"Length\", unit = \"m\") = 5.0;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe2.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe2.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.01;
 //   final parameter Integer pipe2.nNodes(min = 1) = 5;
-//   final parameter enumeration(n8127, n7761, n8187, n8189) pipe2.modelStructure = n1.n7656.n31.n7760.n8127;
+//   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe2.modelStructure = Modelica.Fluid.Types.ModelStructure.av_vb;
 //   final parameter Boolean pipe2.useLumpedPressure = false;
 //   final parameter Integer pipe2.nFM = 4;
 //   final parameter Integer pipe2.nFMDistributed = 4;
@@ -4965,7 +4976,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe2.flowModel.dheights[4](quantity = \"Length\", unit = \"m\");
 //   final parameter Real pipe2.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g;
 //   final parameter Boolean pipe2.flowModel.allowFlowReversal = true;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe2.flowModel.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe2.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe2.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.01;
 //   final parameter Real pipe2.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe2.p_a_start;
 //   final parameter Real pipe2.flowModel.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe2.p_b_start;
@@ -5020,10 +5031,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.flowModel.dps_fg[4](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe2.flowModel.p_a_start - pipe2.flowModel.p_b_start) / 4.0);
 //   final parameter Real pipe2.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
 //   final parameter Boolean pipe2.flowModel.show_Res = false;
-//   protected final parameter Boolean n7836.n8346.n8385 = false;
-//   protected parameter Real n7836.n8346.n8135(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
-//   protected final parameter Boolean n7836.n8346.n8389 = false;
-//   protected parameter Real n7836.n8346.n8390(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
+//   protected final parameter Boolean pipe2.flowModel.$n46 = false;
+//   protected parameter Real pipe2.flowModel.$n47(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
+//   protected final parameter Boolean pipe2.flowModel.$n48 = false;
+//   protected parameter Real pipe2.flowModel.$n49(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
 //   Real pipe2.flowModel.pathLengths_internal[1](quantity = \"Length\", unit = \"m\");
 //   Real pipe2.flowModel.pathLengths_internal[2](quantity = \"Length\", unit = \"m\");
 //   Real pipe2.flowModel.pathLengths_internal[3](quantity = \"Length\", unit = \"m\");
@@ -5035,14 +5046,14 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe2.flowModel.dp_nominal(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
 //   parameter Real pipe2.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe2.flowModel.m_flow_small;
 //   parameter Real pipe2.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small;
-//   protected parameter Real n7836.n8346.n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
-//   protected final parameter Boolean n7836.n8346.n8407 = false;
-//   protected final parameter Boolean n7836.n8346.n8409 = false;
-//   protected Real n7836.n8346.n8410[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8346.n8410[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8346.n8410[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8346.n8410[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8346.n8411(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = n1.n7656.n102.n8149.n7836.n8346.n7663.n8412(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, n7836.n8346.n8135, n7836.n8346.n8135, n7836.n8346.n8390, n7836.n8346.n8390, pipe2.flowModel.pathLengths_internal[1], n7836.n8346.n8410[1], (pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[1]) + n1.n7656.n102.n8149.n7836.n8346.n7663.n8412(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, n7836.n8346.n8135, n7836.n8346.n8135, n7836.n8346.n8390, n7836.n8346.n8390, pipe2.flowModel.pathLengths_internal[2], n7836.n8346.n8410[2], (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[2]) + n1.n7656.n102.n8149.n7836.n8346.n7663.n8412(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, n7836.n8346.n8135, n7836.n8346.n8135, n7836.n8346.n8390, n7836.n8346.n8390, pipe2.flowModel.pathLengths_internal[3], n7836.n8346.n8410[3], (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[3]) + n1.n7656.n102.n8149.n7836.n8346.n7663.n8412(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, n7836.n8346.n8135, n7836.n8346.n8135, n7836.n8346.n8390, n7836.n8346.n8390, pipe2.flowModel.pathLengths_internal[4], n7836.n8346.n8410[4], (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[4]);
+//   protected parameter Real pipe2.flowModel.$n50(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
+//   protected final parameter Boolean pipe2.flowModel.$n51 = false;
+//   protected final parameter Boolean pipe2.flowModel.$n52 = false;
+//   protected Real pipe2.flowModel.$n53[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.flowModel.$n53[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.flowModel.$n53[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.flowModel.$n53[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.flowModel.$n54(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.$n47, pipe2.flowModel.$n47, pipe2.flowModel.$n49, pipe2.flowModel.$n49, pipe2.flowModel.pathLengths_internal[1], pipe2.flowModel.$n53[1], (pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.$n47, pipe2.flowModel.$n47, pipe2.flowModel.$n49, pipe2.flowModel.$n49, pipe2.flowModel.pathLengths_internal[2], pipe2.flowModel.$n53[2], (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.$n47, pipe2.flowModel.$n47, pipe2.flowModel.$n49, pipe2.flowModel.$n49, pipe2.flowModel.pathLengths_internal[3], pipe2.flowModel.$n53[3], (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.pressureLoss_m_flow(pipe2.flowModel.m_flow_nominal / pipe2.flowModel.nParallel, pipe2.flowModel.$n47, pipe2.flowModel.$n47, pipe2.flowModel.$n49, pipe2.flowModel.$n49, pipe2.flowModel.pathLengths_internal[4], pipe2.flowModel.$n53[4], (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0, pipe2.flowModel.m_flow_small / pipe2.flowModel.nParallel, pipe2.flowModel.Res_turbulent_internal[4]);
 //   Real pipe2.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.01);
 //   Real pipe2.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.01);
 //   Real pipe2.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.01);
@@ -5066,34 +5077,34 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.vs[3](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe2.vs[4](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe2.vs[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7836.n8348[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8348[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8348[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8348[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8373[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8373[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8373[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8373[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8370[1](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7836.n8370[2](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7836.n8370[3](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7836.n8370[4](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7836.n8370[5](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7836.n8369[1](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7836.n8369[2](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7836.n8369[3](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7836.n8369[4](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7836.n8369[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7836.n8371[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8371[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8371[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8371[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8371[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n8372[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7836.n8372[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7836.n8372[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7836.n8372[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7836.n8372[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe2.$n55[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n55[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n55[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n55[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n56[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n56[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n56[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n56[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n57[1](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe2.$n57[2](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe2.$n57[3](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe2.$n57[4](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe2.$n57[5](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe2.$n58[1](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe2.$n58[2](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe2.$n58[3](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe2.$n58[4](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe2.$n58[5](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe2.$n59[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n59[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n59[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n59[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n59[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe2.$n60[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe2.$n60[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe2.$n60[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe2.$n60[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe2.$n60[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
 //   final parameter Boolean pipe2.use_HeatTransfer = true;
 //   Real pipe2.heatPorts[1].T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
 //   Real pipe2.heatPorts[1].Q_flow(quantity = \"Power\", unit = \"W\");
@@ -5216,27 +5227,27 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe2.heatTransfer.diameters[3](quantity = \"Length\", unit = \"m\");
 //   Real pipe2.heatTransfer.diameters[4](quantity = \"Length\", unit = \"m\");
 //   Real pipe2.heatTransfer.diameters[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7836.n7988.n8431[1];
-//   protected Real n7836.n7988.n8431[2];
-//   protected Real n7836.n7988.n8431[3];
-//   protected Real n7836.n7988.n8431[4];
-//   protected Real n7836.n7988.n8431[5];
-//   protected Real n7836.n7988.n8432[1];
-//   protected Real n7836.n7988.n8432[2];
-//   protected Real n7836.n7988.n8432[3];
-//   protected Real n7836.n7988.n8432[4];
-//   protected Real n7836.n7988.n8432[5];
-//   protected Real n7836.n7988.n8433;
-//   protected Real n7836.n7988.n8434[1];
-//   protected Real n7836.n7988.n8434[2];
-//   protected Real n7836.n7988.n8434[3];
-//   protected Real n7836.n7988.n8434[4];
-//   protected Real n7836.n7988.n8434[5];
-//   protected Real n7836.n7988.n8435[1];
-//   protected Real n7836.n7988.n8435[2];
-//   protected Real n7836.n7988.n8435[3];
-//   protected Real n7836.n7988.n8435[4];
-//   protected Real n7836.n7988.n8435[5];
+//   protected Real pipe2.heatTransfer.$n61[1];
+//   protected Real pipe2.heatTransfer.$n61[2];
+//   protected Real pipe2.heatTransfer.$n61[3];
+//   protected Real pipe2.heatTransfer.$n61[4];
+//   protected Real pipe2.heatTransfer.$n61[5];
+//   protected Real pipe2.heatTransfer.$n62[1];
+//   protected Real pipe2.heatTransfer.$n62[2];
+//   protected Real pipe2.heatTransfer.$n62[3];
+//   protected Real pipe2.heatTransfer.$n62[4];
+//   protected Real pipe2.heatTransfer.$n62[5];
+//   protected Real pipe2.heatTransfer.$n63;
+//   protected Real pipe2.heatTransfer.$n64[1];
+//   protected Real pipe2.heatTransfer.$n64[2];
+//   protected Real pipe2.heatTransfer.$n64[3];
+//   protected Real pipe2.heatTransfer.$n64[4];
+//   protected Real pipe2.heatTransfer.$n64[5];
+//   protected Real pipe2.heatTransfer.$n65[1];
+//   protected Real pipe2.heatTransfer.$n65[2];
+//   protected Real pipe2.heatTransfer.$n65[3];
+//   protected Real pipe2.heatTransfer.$n65[4];
+//   protected Real pipe2.heatTransfer.$n65[5];
 //   final parameter Real pipe2.dxs[1] = 0.2;
 //   final parameter Real pipe2.dxs[2] = 0.2;
 //   final parameter Real pipe2.dxs[3] = 0.2;
@@ -5251,9 +5262,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.port_b.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe3.port_b.h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
 //   Real pipe3.port_b.Xi_outflow[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected final parameter Boolean n7837.n7805 = false;
-//   protected final parameter Boolean n7837.n7806 = false;
-//   protected parameter Boolean n7837.n8767 = true;
+//   protected final parameter Boolean pipe3.$n66 = false;
+//   protected final parameter Boolean pipe3.$n67 = false;
+//   protected parameter Boolean pipe3.$n68 = true;
 //   parameter Real pipe3.nParallel(min = 1.0) = 1.0;
 //   final parameter Real pipe3.length(quantity = \"Length\", unit = \"m\") = 25.0;
 //   parameter Boolean pipe3.isCircular = true;
@@ -5269,10 +5280,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.fluidVolumes[3](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe3.fluidVolumes[4](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe3.fluidVolumes[5](quantity = \"Volume\", unit = \"m3\");
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe3.energyDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe3.massDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe3.substanceDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe3.traceDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.energyDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.massDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.substanceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.traceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   parameter Real pipe3.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 130000.0;
 //   parameter Real pipe3.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 120000.0;
 //   final parameter Real pipe3.ps_start[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe3.p_a_start;
@@ -5282,7 +5293,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe3.ps_start[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe3.p_a_start + (pipe3.p_b_start - pipe3.p_a_start) * 4.0 / 4.0;
 //   final parameter Boolean pipe3.use_T_start = true;
 //   parameter Real pipe3.T_start(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = system.T_start;
-//   parameter Real pipe3.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = n1.n7656.n102.n8149.n7837.n7670.n7957((pipe3.p_a_start + pipe3.p_b_start) / 2.0, pipe3.T_start, pipe3.X_start);
+//   parameter Real pipe3.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX((pipe3.p_a_start + pipe3.p_b_start) / 2.0, pipe3.T_start, pipe3.X_start);
 //   parameter Real pipe3.X_start[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01;
 //   parameter Real pipe3.X_start[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99;
 //   Real pipe3.Us[1](quantity = \"Energy\", unit = \"J\");
@@ -5316,16 +5327,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe3.mediums[1].preferredMediumStates = true;
 //   final parameter Boolean pipe3.mediums[1].standardOrderComponents = true;
-//   Real pipe3.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe3.mediums[1].T);
-//   Real pipe3.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe3.mediums[1].p);
+//   Real pipe3.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[1].T);
+//   Real pipe3.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[1].p);
 //   Real pipe3.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe3.mediums[1].phi;
-//   protected Real n7837.n8256[1].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[1].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[1].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[1].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[1].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[1].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe3.mediums[1].$n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[1].$n70(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[1].$n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[1].$n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[1].$n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[1].$n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe3.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[2], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start);
@@ -5342,16 +5353,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe3.mediums[2].preferredMediumStates = true;
 //   final parameter Boolean pipe3.mediums[2].standardOrderComponents = true;
-//   Real pipe3.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe3.mediums[2].T);
-//   Real pipe3.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe3.mediums[2].p);
+//   Real pipe3.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[2].T);
+//   Real pipe3.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[2].p);
 //   Real pipe3.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe3.mediums[2].phi;
-//   protected Real n7837.n8256[2].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[2].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[2].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[2].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[2].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[2].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe3.mediums[2].$n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[2].$n70(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[2].$n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[2].$n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[2].$n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[2].$n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe3.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[3], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start);
@@ -5368,16 +5379,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe3.mediums[3].preferredMediumStates = true;
 //   final parameter Boolean pipe3.mediums[3].standardOrderComponents = true;
-//   Real pipe3.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe3.mediums[3].T);
-//   Real pipe3.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe3.mediums[3].p);
+//   Real pipe3.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[3].T);
+//   Real pipe3.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[3].p);
 //   Real pipe3.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe3.mediums[3].phi;
-//   protected Real n7837.n8256[3].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[3].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[3].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[3].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[3].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[3].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe3.mediums[3].$n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[3].$n70(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[3].$n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[3].$n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[3].$n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[3].$n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe3.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[4], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start);
@@ -5394,16 +5405,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe3.mediums[4].preferredMediumStates = true;
 //   final parameter Boolean pipe3.mediums[4].standardOrderComponents = true;
-//   Real pipe3.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe3.mediums[4].T);
-//   Real pipe3.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe3.mediums[4].p);
+//   Real pipe3.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[4].T);
+//   Real pipe3.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[4].p);
 //   Real pipe3.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe3.mediums[4].phi;
-//   protected Real n7837.n8256[4].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[4].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[4].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[4].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[4].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[4].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe3.mediums[4].$n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[4].$n70(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[4].$n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[4].$n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[4].$n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[4].$n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe3.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe3.ps_start[5], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe3.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe3.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe3.h_start);
@@ -5420,16 +5431,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe3.mediums[5].preferredMediumStates = true;
 //   final parameter Boolean pipe3.mediums[5].standardOrderComponents = true;
-//   Real pipe3.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe3.mediums[5].T);
-//   Real pipe3.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe3.mediums[5].p);
+//   Real pipe3.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe3.mediums[5].T);
+//   Real pipe3.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe3.mediums[5].p);
 //   Real pipe3.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe3.mediums[5].phi;
-//   protected Real n7837.n8256[5].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[5].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[5].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[5].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[5].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n7837.n8256[5].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe3.mediums[5].$n69(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[5].$n70(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[5].$n71(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[5].$n72(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[5].$n73(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe3.mediums[5].$n74(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe3.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe3.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe3.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
@@ -5455,7 +5466,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.Wb_flows[3](quantity = \"Power\", unit = \"W\");
 //   Real pipe3.Wb_flows[4](quantity = \"Power\", unit = \"W\");
 //   Real pipe3.Wb_flows[5](quantity = \"Power\", unit = \"W\");
-//   protected final parameter Boolean n7837.n8082 = true;
+//   protected final parameter Boolean pipe3.$n75 = true;
 //   final parameter Real pipe3.lengths[1](quantity = \"Length\", unit = \"m\") = 5.0;
 //   final parameter Real pipe3.lengths[2](quantity = \"Length\", unit = \"m\") = 5.0;
 //   final parameter Real pipe3.lengths[3](quantity = \"Length\", unit = \"m\") = 5.0;
@@ -5481,10 +5492,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe3.dheights[3](quantity = \"Length\", unit = \"m\") = 5.0;
 //   final parameter Real pipe3.dheights[4](quantity = \"Length\", unit = \"m\") = 5.0;
 //   final parameter Real pipe3.dheights[5](quantity = \"Length\", unit = \"m\") = 5.0;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe3.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe3.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.01;
 //   final parameter Integer pipe3.nNodes(min = 1) = 5;
-//   final parameter enumeration(n8127, n7761, n8187, n8189) pipe3.modelStructure = n1.n7656.n31.n7760.n7761;
+//   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe3.modelStructure = Modelica.Fluid.Types.ModelStructure.a_v_b;
 //   final parameter Boolean pipe3.useLumpedPressure = false;
 //   final parameter Integer pipe3.nFM = 6;
 //   final parameter Integer pipe3.nFMDistributed = 6;
@@ -5594,7 +5605,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe3.flowModel.dheights[6](quantity = \"Length\", unit = \"m\");
 //   final parameter Real pipe3.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g;
 //   final parameter Boolean pipe3.flowModel.allowFlowReversal = true;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe3.flowModel.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe3.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe3.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.01;
 //   final parameter Real pipe3.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe3.p_a_start;
 //   final parameter Real pipe3.flowModel.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe3.p_b_start;
@@ -5671,10 +5682,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe3.flowModel.p_a_start - pipe3.flowModel.p_b_start) / 6.0);
 //   final parameter Real pipe3.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
 //   final parameter Boolean pipe3.flowModel.show_Res = false;
-//   protected final parameter Boolean n7837.n8346.n8385 = false;
-//   protected parameter Real n7837.n8346.n8135(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
-//   protected final parameter Boolean n7837.n8346.n8389 = false;
-//   protected parameter Real n7837.n8346.n8390(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
+//   protected final parameter Boolean pipe3.flowModel.$n76 = false;
+//   protected parameter Real pipe3.flowModel.$n77(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
+//   protected final parameter Boolean pipe3.flowModel.$n78 = false;
+//   protected parameter Real pipe3.flowModel.$n79(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
 //   Real pipe3.flowModel.pathLengths_internal[1](quantity = \"Length\", unit = \"m\");
 //   Real pipe3.flowModel.pathLengths_internal[2](quantity = \"Length\", unit = \"m\");
 //   Real pipe3.flowModel.pathLengths_internal[3](quantity = \"Length\", unit = \"m\");
@@ -5690,16 +5701,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe3.flowModel.dp_nominal(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
 //   parameter Real pipe3.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe3.flowModel.m_flow_small;
 //   parameter Real pipe3.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small;
-//   protected parameter Real n7837.n8346.n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
-//   protected final parameter Boolean n7837.n8346.n8407 = false;
-//   protected final parameter Boolean n7837.n8346.n8409 = false;
-//   protected Real n7837.n8346.n8410[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8346.n8410[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8346.n8410[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8346.n8410[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8346.n8410[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8346.n8410[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8346.n8411(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = n1.n7656.n102.n8149.n7837.n8346.n7663.n8412(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, n7837.n8346.n8135, n7837.n8346.n8135, n7837.n8346.n8390, n7837.n8346.n8390, pipe3.flowModel.pathLengths_internal[1], n7837.n8346.n8410[1], (pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[1]) + n1.n7656.n102.n8149.n7837.n8346.n7663.n8412(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, n7837.n8346.n8135, n7837.n8346.n8135, n7837.n8346.n8390, n7837.n8346.n8390, pipe3.flowModel.pathLengths_internal[2], n7837.n8346.n8410[2], (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[2]) + n1.n7656.n102.n8149.n7837.n8346.n7663.n8412(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, n7837.n8346.n8135, n7837.n8346.n8135, n7837.n8346.n8390, n7837.n8346.n8390, pipe3.flowModel.pathLengths_internal[3], n7837.n8346.n8410[3], (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[3]) + n1.n7656.n102.n8149.n7837.n8346.n7663.n8412(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, n7837.n8346.n8135, n7837.n8346.n8135, n7837.n8346.n8390, n7837.n8346.n8390, pipe3.flowModel.pathLengths_internal[4], n7837.n8346.n8410[4], (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[4]) + n1.n7656.n102.n8149.n7837.n8346.n7663.n8412(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, n7837.n8346.n8135, n7837.n8346.n8135, n7837.n8346.n8390, n7837.n8346.n8390, pipe3.flowModel.pathLengths_internal[5], n7837.n8346.n8410[5], (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[5]) + n1.n7656.n102.n8149.n7837.n8346.n7663.n8412(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, n7837.n8346.n8135, n7837.n8346.n8135, n7837.n8346.n8390, n7837.n8346.n8390, pipe3.flowModel.pathLengths_internal[6], n7837.n8346.n8410[6], (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[6]);
+//   protected parameter Real pipe3.flowModel.$n80(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
+//   protected final parameter Boolean pipe3.flowModel.$n81 = false;
+//   protected final parameter Boolean pipe3.flowModel.$n82 = false;
+//   protected Real pipe3.flowModel.$n83[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.flowModel.$n83[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.flowModel.$n83[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.flowModel.$n83[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.flowModel.$n83[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.flowModel.$n83[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.flowModel.$n84(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.$n77, pipe3.flowModel.$n77, pipe3.flowModel.$n79, pipe3.flowModel.$n79, pipe3.flowModel.pathLengths_internal[1], pipe3.flowModel.$n83[1], (pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.$n77, pipe3.flowModel.$n77, pipe3.flowModel.$n79, pipe3.flowModel.$n79, pipe3.flowModel.pathLengths_internal[2], pipe3.flowModel.$n83[2], (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.$n77, pipe3.flowModel.$n77, pipe3.flowModel.$n79, pipe3.flowModel.$n79, pipe3.flowModel.pathLengths_internal[3], pipe3.flowModel.$n83[3], (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.$n77, pipe3.flowModel.$n77, pipe3.flowModel.$n79, pipe3.flowModel.$n79, pipe3.flowModel.pathLengths_internal[4], pipe3.flowModel.$n83[4], (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.$n77, pipe3.flowModel.$n77, pipe3.flowModel.$n79, pipe3.flowModel.$n79, pipe3.flowModel.pathLengths_internal[5], pipe3.flowModel.$n83[5], (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.pressureLoss_m_flow(pipe3.flowModel.m_flow_nominal / pipe3.flowModel.nParallel, pipe3.flowModel.$n77, pipe3.flowModel.$n77, pipe3.flowModel.$n79, pipe3.flowModel.$n79, pipe3.flowModel.pathLengths_internal[6], pipe3.flowModel.$n83[6], (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0, pipe3.flowModel.m_flow_small / pipe3.flowModel.nParallel, pipe3.flowModel.Res_turbulent_internal[6]);
 //   Real pipe3.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.01);
 //   Real pipe3.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.01);
 //   Real pipe3.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.01);
@@ -5723,46 +5734,46 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe3.vs[3](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe3.vs[4](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe3.vs[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8348[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8348[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8348[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8348[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8348[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8348[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8373[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8373[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8373[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8373[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8373[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8373[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8370[1](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8370[2](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8370[3](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8370[4](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8370[5](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8370[6](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8370[7](quantity = \"Area\", unit = \"m2\");
-//   protected Real n7837.n8369[1](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8369[2](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8369[3](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8369[4](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8369[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8369[6](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8369[7](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n7837.n8371[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8371[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8371[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8371[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8371[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8371[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8371[7](quantity = \"Length\", unit = \"m\");
-//   protected Real n7837.n8372[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7837.n8372[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7837.n8372[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7837.n8372[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7837.n8372[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7837.n8372[6](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n7837.n8372[7](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n85[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n85[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n85[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n85[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n85[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n85[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n86[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n86[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n86[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n86[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n86[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n86[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n87[1](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n87[2](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n87[3](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n87[4](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n87[5](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n87[6](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n87[7](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe3.$n88[1](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n88[2](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n88[3](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n88[4](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n88[5](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n88[6](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n88[7](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe3.$n89[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n89[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n89[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n89[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n89[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n89[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n89[7](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe3.$n90[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n90[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n90[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n90[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n90[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n90[6](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe3.$n90[7](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
 //   final parameter Boolean pipe3.use_HeatTransfer = false;
 //   final parameter Integer pipe3.heatTransfer.n = 5;
 //   final Real pipe3.heatTransfer.states[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe3.mediums[1].state.p;
@@ -5848,9 +5859,9 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.port_b.p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe4.port_b.h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
 //   Real pipe4.port_b.Xi_outflow[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected final parameter Boolean n8133.n7805 = false;
-//   protected final parameter Boolean n8133.n7806 = false;
-//   protected parameter Boolean n8133.n8767 = true;
+//   protected final parameter Boolean pipe4.$n91 = false;
+//   protected final parameter Boolean pipe4.$n92 = false;
+//   protected parameter Boolean pipe4.$n93 = true;
 //   parameter Real pipe4.nParallel(min = 1.0) = 1.0;
 //   final parameter Real pipe4.length(quantity = \"Length\", unit = \"m\") = 50.0;
 //   parameter Boolean pipe4.isCircular = true;
@@ -5866,10 +5877,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.fluidVolumes[3](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe4.fluidVolumes[4](quantity = \"Volume\", unit = \"m3\");
 //   final Real pipe4.fluidVolumes[5](quantity = \"Volume\", unit = \"m3\");
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe4.energyDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe4.massDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe4.substanceDynamics = n1.n7656.n31.n7696.n7751;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe4.traceDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.energyDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.massDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.substanceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.traceDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   parameter Real pipe4.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 120000.0;
 //   parameter Real pipe4.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = 100000.0;
 //   final parameter Real pipe4.ps_start[1](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe4.p_a_start;
@@ -5879,7 +5890,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe4.ps_start[5](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe4.p_a_start + (pipe4.p_b_start - pipe4.p_a_start) * 4.0 / 4.0;
 //   final parameter Boolean pipe4.use_T_start = true;
 //   parameter Real pipe4.T_start(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 190.0, max = 647.0, start = 288.15, nominal = 300.0) = system.T_start;
-//   parameter Real pipe4.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = n1.n7656.n102.n8149.n8133.n7670.n7957((pipe4.p_a_start + pipe4.p_b_start) / 2.0, pipe4.T_start, pipe4.X_start);
+//   parameter Real pipe4.h_start(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX((pipe4.p_a_start + pipe4.p_b_start) / 2.0, pipe4.T_start, pipe4.X_start);
 //   parameter Real pipe4.X_start[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01;
 //   parameter Real pipe4.X_start[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99;
 //   Real pipe4.Us[1](quantity = \"Energy\", unit = \"J\");
@@ -5913,16 +5924,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[1].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe4.mediums[1].preferredMediumStates = true;
 //   final parameter Boolean pipe4.mediums[1].standardOrderComponents = true;
-//   Real pipe4.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe4.mediums[1].T);
-//   Real pipe4.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe4.mediums[1].p);
+//   Real pipe4.mediums[1].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[1].T);
+//   Real pipe4.mediums[1].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[1].p);
 //   Real pipe4.mediums[1].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe4.mediums[1].phi;
-//   protected Real n8133.n8256[1].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[1].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[1].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[1].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[1].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[1].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe4.mediums[1].$n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[1].$n95(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[1].$n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[1].$n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[1].$n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[1].$n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe4.mediums[2].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[2], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[2].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[2].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start);
@@ -5939,16 +5950,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[2].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe4.mediums[2].preferredMediumStates = true;
 //   final parameter Boolean pipe4.mediums[2].standardOrderComponents = true;
-//   Real pipe4.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe4.mediums[2].T);
-//   Real pipe4.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe4.mediums[2].p);
+//   Real pipe4.mediums[2].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[2].T);
+//   Real pipe4.mediums[2].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[2].p);
 //   Real pipe4.mediums[2].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe4.mediums[2].phi;
-//   protected Real n8133.n8256[2].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[2].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[2].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[2].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[2].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[2].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe4.mediums[2].$n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[2].$n95(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[2].$n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[2].$n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[2].$n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[2].$n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe4.mediums[3].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[3], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[3].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[3].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start);
@@ -5965,16 +5976,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[3].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe4.mediums[3].preferredMediumStates = true;
 //   final parameter Boolean pipe4.mediums[3].standardOrderComponents = true;
-//   Real pipe4.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe4.mediums[3].T);
-//   Real pipe4.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe4.mediums[3].p);
+//   Real pipe4.mediums[3].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[3].T);
+//   Real pipe4.mediums[3].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[3].p);
 //   Real pipe4.mediums[3].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe4.mediums[3].phi;
-//   protected Real n8133.n8256[3].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[3].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[3].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[3].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[3].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[3].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe4.mediums[3].$n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[3].$n95(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[3].$n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[3].$n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[3].$n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[3].$n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe4.mediums[4].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[4], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[4].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[4].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start);
@@ -5991,16 +6002,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[4].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe4.mediums[4].preferredMediumStates = true;
 //   final parameter Boolean pipe4.mediums[4].standardOrderComponents = true;
-//   Real pipe4.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe4.mediums[4].T);
-//   Real pipe4.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe4.mediums[4].p);
+//   Real pipe4.mediums[4].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[4].T);
+//   Real pipe4.mediums[4].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[4].p);
 //   Real pipe4.mediums[4].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe4.mediums[4].phi;
-//   protected Real n8133.n8256[4].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[4].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[4].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[4].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[4].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[4].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe4.mediums[4].$n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[4].$n95(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[4].$n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[4].$n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[4].$n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[4].$n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe4.mediums[5].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = pipe4.ps_start[5], nominal = 100000.0, stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[5].Xi[1](quantity = \"MassFraction\", unit = \"1\", min = 0.0, max = 1.0, start = pipe4.X_start[1], stateSelect = StateSelect.prefer);
 //   Real pipe4.mediums[5].h(quantity = \"SpecificEnergy\", unit = \"J/kg\", start = pipe4.h_start);
@@ -6017,16 +6028,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.mediums[5].state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean pipe4.mediums[5].preferredMediumStates = true;
 //   final parameter Boolean pipe4.mediums[5].standardOrderComponents = true;
-//   Real pipe4.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(pipe4.mediums[5].T);
-//   Real pipe4.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(pipe4.mediums[5].p);
+//   Real pipe4.mediums[5].T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(pipe4.mediums[5].T);
+//   Real pipe4.mediums[5].p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(pipe4.mediums[5].p);
 //   Real pipe4.mediums[5].x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real pipe4.mediums[5].phi;
-//   protected Real n8133.n8256[5].n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[5].n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[5].n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[5].n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[5].n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8133.n8256[5].n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real pipe4.mediums[5].$n94(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[5].$n95(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[5].$n96(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[5].$n97(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[5].$n98(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real pipe4.mediums[5].$n99(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real pipe4.mb_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe4.mb_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
 //   Real pipe4.mb_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0);
@@ -6052,7 +6063,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.Wb_flows[3](quantity = \"Power\", unit = \"W\");
 //   Real pipe4.Wb_flows[4](quantity = \"Power\", unit = \"W\");
 //   Real pipe4.Wb_flows[5](quantity = \"Power\", unit = \"W\");
-//   protected final parameter Boolean n8133.n8082 = true;
+//   protected final parameter Boolean pipe4.$n100 = true;
 //   final parameter Real pipe4.lengths[1](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe4.lengths[2](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe4.lengths[3](quantity = \"Length\", unit = \"m\") = 10.0;
@@ -6078,10 +6089,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final parameter Real pipe4.dheights[3](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe4.dheights[4](quantity = \"Length\", unit = \"m\") = 10.0;
 //   final parameter Real pipe4.dheights[5](quantity = \"Length\", unit = \"m\") = 10.0;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe4.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe4.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.02;
 //   final parameter Integer pipe4.nNodes(min = 1) = 5;
-//   final parameter enumeration(n8127, n7761, n8187, n8189) pipe4.modelStructure = n1.n7656.n31.n7760.n7761;
+//   final parameter enumeration(av_vb, a_v_b, av_b, a_vb) pipe4.modelStructure = Modelica.Fluid.Types.ModelStructure.a_v_b;
 //   final parameter Boolean pipe4.useLumpedPressure = false;
 //   final parameter Integer pipe4.nFM = 6;
 //   final parameter Integer pipe4.nFMDistributed = 6;
@@ -6191,7 +6202,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   final Real pipe4.flowModel.dheights[6](quantity = \"Length\", unit = \"m\");
 //   final parameter Real pipe4.flowModel.g(quantity = \"Acceleration\", unit = \"m/s2\") = system.g;
 //   final parameter Boolean pipe4.flowModel.allowFlowReversal = true;
-//   final parameter enumeration(n8305, n7697, n7751, n117) pipe4.flowModel.momentumDynamics = n1.n7656.n31.n7696.n7751;
+//   final parameter enumeration(DynamicFreeInitial, FixedInitial, SteadyStateInitial, SteadyState) pipe4.flowModel.momentumDynamics = Modelica.Fluid.Types.Dynamics.SteadyStateInitial;
 //   final parameter Real pipe4.flowModel.m_flow_start(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -100000.0, max = 100000.0) = 0.02;
 //   final parameter Real pipe4.flowModel.p_a_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe4.p_a_start;
 //   final parameter Real pipe4.flowModel.p_b_start(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe4.p_b_start;
@@ -6268,10 +6279,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.flowModel.dps_fg[6](quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", start = (pipe4.flowModel.p_a_start - pipe4.flowModel.p_b_start) / 6.0);
 //   final parameter Real pipe4.flowModel.Re_turbulent(quantity = \"ReynoldsNumber\", unit = \"1\") = 4000.0;
 //   final parameter Boolean pipe4.flowModel.show_Res = false;
-//   protected final parameter Boolean n8133.n8346.n8385 = false;
-//   protected parameter Real n8133.n8346.n8135(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
-//   protected final parameter Boolean n8133.n8346.n8389 = false;
-//   protected parameter Real n8133.n8346.n8390(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
+//   protected final parameter Boolean pipe4.flowModel.$n101 = false;
+//   protected parameter Real pipe4.flowModel.$n102(quantity = \"Density\", unit = \"kg/m3\", displayUnit = \"g/cm3\", min = 0.0) = 1.196838693581092;
+//   protected final parameter Boolean pipe4.flowModel.$n103 = false;
+//   protected parameter Real pipe4.flowModel.$n104(quantity = \"DynamicViscosity\", unit = \"Pa.s\", min = 0.0) = 1.823286547365138e-05;
 //   Real pipe4.flowModel.pathLengths_internal[1](quantity = \"Length\", unit = \"m\");
 //   Real pipe4.flowModel.pathLengths_internal[2](quantity = \"Length\", unit = \"m\");
 //   Real pipe4.flowModel.pathLengths_internal[3](quantity = \"Length\", unit = \"m\");
@@ -6287,16 +6298,16 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real pipe4.flowModel.dp_nominal(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
 //   parameter Real pipe4.flowModel.m_flow_nominal(quantity = \"MassFlowRate\", unit = \"kg/s\") = 100.0 * pipe4.flowModel.m_flow_small;
 //   parameter Real pipe4.flowModel.m_flow_small(quantity = \"MassFlowRate\", unit = \"kg/s\") = system.m_flow_small;
-//   protected parameter Real n8133.n8346.n8308(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
-//   protected final parameter Boolean n8133.n8346.n8407 = false;
-//   protected final parameter Boolean n8133.n8346.n8409 = false;
-//   protected Real n8133.n8346.n8410[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8346.n8410[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8346.n8410[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8346.n8410[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8346.n8410[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8346.n8410[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8346.n8411(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = n1.n7656.n102.n8149.n8133.n8346.n7663.n8412(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, n8133.n8346.n8135, n8133.n8346.n8135, n8133.n8346.n8390, n8133.n8346.n8390, pipe4.flowModel.pathLengths_internal[1], n8133.n8346.n8410[1], (pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[1]) + n1.n7656.n102.n8149.n8133.n8346.n7663.n8412(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, n8133.n8346.n8135, n8133.n8346.n8135, n8133.n8346.n8390, n8133.n8346.n8390, pipe4.flowModel.pathLengths_internal[2], n8133.n8346.n8410[2], (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[2]) + n1.n7656.n102.n8149.n8133.n8346.n7663.n8412(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, n8133.n8346.n8135, n8133.n8346.n8135, n8133.n8346.n8390, n8133.n8346.n8390, pipe4.flowModel.pathLengths_internal[3], n8133.n8346.n8410[3], (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[3]) + n1.n7656.n102.n8149.n8133.n8346.n7663.n8412(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, n8133.n8346.n8135, n8133.n8346.n8135, n8133.n8346.n8390, n8133.n8346.n8390, pipe4.flowModel.pathLengths_internal[4], n8133.n8346.n8410[4], (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[4]) + n1.n7656.n102.n8149.n8133.n8346.n7663.n8412(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, n8133.n8346.n8135, n8133.n8346.n8135, n8133.n8346.n8390, n8133.n8346.n8390, pipe4.flowModel.pathLengths_internal[5], n8133.n8346.n8410[5], (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[5]) + n1.n7656.n102.n8149.n8133.n8346.n7663.n8412(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, n8133.n8346.n8135, n8133.n8346.n8135, n8133.n8346.n8390, n8133.n8346.n8390, pipe4.flowModel.pathLengths_internal[6], n8133.n8346.n8410[6], (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[6]);
+//   protected parameter Real pipe4.flowModel.$n105(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, start = 1.0, fixed = false, nominal = 100000.0);
+//   protected final parameter Boolean pipe4.flowModel.$n106 = false;
+//   protected final parameter Boolean pipe4.flowModel.$n107 = false;
+//   protected Real pipe4.flowModel.$n108[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.flowModel.$n108[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.flowModel.$n108[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.flowModel.$n108[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.flowModel.$n108[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.flowModel.$n108[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.flowModel.$n109(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, nominal = 100000.0) = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.$n102, pipe4.flowModel.$n102, pipe4.flowModel.$n104, pipe4.flowModel.$n104, pipe4.flowModel.pathLengths_internal[1], pipe4.flowModel.$n108[1], (pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[1]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.$n102, pipe4.flowModel.$n102, pipe4.flowModel.$n104, pipe4.flowModel.$n104, pipe4.flowModel.pathLengths_internal[2], pipe4.flowModel.$n108[2], (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[2]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.$n102, pipe4.flowModel.$n102, pipe4.flowModel.$n104, pipe4.flowModel.$n104, pipe4.flowModel.pathLengths_internal[3], pipe4.flowModel.$n108[3], (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[3]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.$n102, pipe4.flowModel.$n102, pipe4.flowModel.$n104, pipe4.flowModel.$n104, pipe4.flowModel.pathLengths_internal[4], pipe4.flowModel.$n108[4], (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[4]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.$n102, pipe4.flowModel.$n102, pipe4.flowModel.$n104, pipe4.flowModel.$n104, pipe4.flowModel.pathLengths_internal[5], pipe4.flowModel.$n108[5], (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[5]) + Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.pressureLoss_m_flow(pipe4.flowModel.m_flow_nominal / pipe4.flowModel.nParallel, pipe4.flowModel.$n102, pipe4.flowModel.$n102, pipe4.flowModel.$n104, pipe4.flowModel.$n104, pipe4.flowModel.pathLengths_internal[6], pipe4.flowModel.$n108[6], (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0, pipe4.flowModel.m_flow_small / pipe4.flowModel.nParallel, pipe4.flowModel.Res_turbulent_internal[6]);
 //   Real pipe4.m_flows[1](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.02);
 //   Real pipe4.m_flows[2](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.02);
 //   Real pipe4.m_flows[3](quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 100000.0, start = 0.02);
@@ -6320,46 +6331,46 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real pipe4.vs[3](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe4.vs[4](quantity = \"Velocity\", unit = \"m/s\");
 //   Real pipe4.vs[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8348[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8348[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8348[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8348[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8348[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8348[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8373[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8373[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8373[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8373[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8373[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8373[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8370[1](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8370[2](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8370[3](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8370[4](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8370[5](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8370[6](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8370[7](quantity = \"Area\", unit = \"m2\");
-//   protected Real n8133.n8369[1](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8369[2](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8369[3](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8369[4](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8369[5](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8369[6](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8369[7](quantity = \"Velocity\", unit = \"m/s\");
-//   protected Real n8133.n8371[1](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8371[2](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8371[3](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8371[4](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8371[5](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8371[6](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8371[7](quantity = \"Length\", unit = \"m\");
-//   protected Real n8133.n8372[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n8133.n8372[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n8133.n8372[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n8133.n8372[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n8133.n8372[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n8133.n8372[6](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
-//   protected Real n8133.n8372[7](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n110[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n110[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n110[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n110[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n110[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n110[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n111[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n111[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n111[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n111[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n111[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n111[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n112[1](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n112[2](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n112[3](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n112[4](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n112[5](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n112[6](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n112[7](quantity = \"Area\", unit = \"m2\");
+//   protected Real pipe4.$n113[1](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n113[2](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n113[3](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n113[4](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n113[5](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n113[6](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n113[7](quantity = \"Velocity\", unit = \"m/s\");
+//   protected Real pipe4.$n114[1](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n114[2](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n114[3](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n114[4](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n114[5](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n114[6](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n114[7](quantity = \"Length\", unit = \"m\");
+//   protected Real pipe4.$n115[1](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n115[2](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n115[3](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n115[4](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n115[5](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n115[6](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
+//   protected Real pipe4.$n115[7](quantity = \"Length\", unit = \"m\", displayUnit = \"mm\", min = 0.0);
 //   final parameter Boolean pipe4.use_HeatTransfer = false;
 //   final parameter Integer pipe4.heatTransfer.n = 5;
 //   final Real pipe4.heatTransfer.states[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0) = pipe4.mediums[1].state.p;
@@ -6453,21 +6464,21 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real boundary4.medium.state.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, start = 0.99, nominal = 0.1);
 //   final parameter Boolean boundary4.medium.preferredMediumStates = false;
 //   final parameter Boolean boundary4.medium.standardOrderComponents = true;
-//   Real boundary4.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = n1.n101.n946.n949(boundary4.medium.T);
-//   Real boundary4.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = n1.n101.n946.n993(boundary4.medium.p);
+//   Real boundary4.medium.T_degC(quantity = \"ThermodynamicTemperature\", unit = \"degC\") = Modelica.SIunits.Conversions.to_degC(boundary4.medium.T);
+//   Real boundary4.medium.p_bar(quantity = \"Pressure\", unit = \"bar\") = Modelica.SIunits.Conversions.to_bar(boundary4.medium.p);
 //   Real boundary4.medium.x_water(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
 //   Real boundary4.medium.phi;
-//   protected Real n8155.n7931.n10105(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8155.n7931.n10106(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8155.n7931.n10107(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8155.n7931.n10108(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8155.n7931.n10109(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected Real n8155.n7931.n10110(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
+//   protected Real boundary4.medium.$n116(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary4.medium.$n117(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary4.medium.$n118(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary4.medium.$n119(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary4.medium.$n120(quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
+//   protected Real boundary4.medium.$n121(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real boundary4.ports[1].m_flow(quantity = \"MassFlowRate.Moist air\", unit = \"kg/s\", min = -9.999999999999999e+59, max = 9.999999999999999e+59);
 //   Real boundary4.ports[1].p(quantity = \"Pressure\", unit = \"Pa\", displayUnit = \"bar\", min = 0.0, max = 100000000.0, start = 100000.0, nominal = 100000.0);
 //   Real boundary4.ports[1].h_outflow(quantity = \"SpecificEnergy\", unit = \"J/kg\", min = -10000000000.0, max = 10000000000.0, nominal = 1000000.0);
 //   Real boundary4.ports[1].Xi_outflow[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1);
-//   protected final parameter enumeration(n8710, n8711, n8714) n8155.n8745 = n1.n7656.n31.n8708.n8714;
+//   protected final parameter enumeration(Entering, Leaving, Bidirectional) boundary4.$n122 = Modelica.Fluid.Types.PortFlowDirection.Bidirectional;
 //   final parameter Boolean boundary4.use_p_in = true;
 //   final parameter Boolean boundary4.use_T_in = false;
 //   final parameter Boolean boundary4.use_X_in = false;
@@ -6477,10 +6488,10 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   parameter Real boundary4.X[1](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.01;
 //   parameter Real boundary4.X[2](quantity = \"MassFraction\", unit = \"kg/kg\", min = 0.0, max = 1.0, nominal = 0.1) = 0.99;
 //   Real boundary4.p_in;
-//   protected Real n8155.n8735;
-//   protected Real n8155.n8736;
-//   protected Real n8155.n8737[1];
-//   protected Real n8155.n8737[2];
+//   protected Real boundary4.$n123;
+//   protected Real boundary4.$n124;
+//   protected Real boundary4.$n125[1];
+//   protected Real boundary4.$n125[2];
 //   parameter Real ramp1.height = 100000.0;
 //   parameter Real ramp1.duration(quantity = \"Time\", unit = \"s\", min = 0.0, start = 2.0) = 0.0;
 //   Real ramp1.y;
@@ -6512,8 +6523,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   Real heat2[5].port.T(quantity = \"ThermodynamicTemperature\", unit = \"K\", displayUnit = \"degC\", min = 0.0, start = 288.15, nominal = 300.0);
 //   Real heat2[5].port.Q_flow(quantity = \"Power\", unit = \"W\");
 // initial equation
-//   pipe1.flowModel.dp_nominal = 1000.0 * n7835.n8346.n8308;
-//   n7835.n8346.n8308 = system.dp_small;
+//   pipe1.flowModel.dp_nominal = 1000.0 * pipe1.flowModel.$n25;
+//   pipe1.flowModel.$n25 = system.dp_small;
 //   der(pipe1.flowModel.m_flows[1]) = 0.0;
 //   der(pipe1.flowModel.m_flows[2]) = 0.0;
 //   der(pipe1.flowModel.m_flows[3]) = 0.0;
@@ -6535,8 +6546,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe1.mediums[3].Xi[1]) = 0.0;
 //   der(pipe1.mediums[4].Xi[1]) = 0.0;
 //   der(pipe1.mediums[5].Xi[1]) = 0.0;
-//   pipe2.flowModel.dp_nominal = 1000.0 * n7836.n8346.n8308;
-//   n7836.n8346.n8308 = system.dp_small;
+//   pipe2.flowModel.dp_nominal = 1000.0 * pipe2.flowModel.$n50;
+//   pipe2.flowModel.$n50 = system.dp_small;
 //   der(pipe2.flowModel.m_flows[1]) = 0.0;
 //   der(pipe2.flowModel.m_flows[2]) = 0.0;
 //   der(pipe2.flowModel.m_flows[3]) = 0.0;
@@ -6556,8 +6567,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe2.mediums[3].Xi[1]) = 0.0;
 //   der(pipe2.mediums[4].Xi[1]) = 0.0;
 //   der(pipe2.mediums[5].Xi[1]) = 0.0;
-//   pipe3.flowModel.dp_nominal = 1000.0 * n7837.n8346.n8308;
-//   n7837.n8346.n8308 = system.dp_small;
+//   pipe3.flowModel.dp_nominal = 1000.0 * pipe3.flowModel.$n80;
+//   pipe3.flowModel.$n80 = system.dp_small;
 //   der(pipe3.flowModel.m_flows[1]) = 0.0;
 //   der(pipe3.flowModel.m_flows[2]) = 0.0;
 //   der(pipe3.flowModel.m_flows[3]) = 0.0;
@@ -6579,8 +6590,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe3.mediums[3].Xi[1]) = 0.0;
 //   der(pipe3.mediums[4].Xi[1]) = 0.0;
 //   der(pipe3.mediums[5].Xi[1]) = 0.0;
-//   pipe4.flowModel.dp_nominal = 1000.0 * n8133.n8346.n8308;
-//   n8133.n8346.n8308 = system.dp_small;
+//   pipe4.flowModel.dp_nominal = 1000.0 * pipe4.flowModel.$n105;
+//   pipe4.flowModel.$n105 = system.dp_small;
 //   der(pipe4.flowModel.m_flows[1]) = 0.0;
 //   der(pipe4.flowModel.m_flows[2]) = 0.0;
 //   der(pipe4.flowModel.m_flows[3]) = 0.0;
@@ -6613,7 +6624,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.heatTransfer.heatPorts[4].Q_flow - pipe2.heatPorts[4].Q_flow = 0.0;
 //   pipe2.heatPorts[5].T = pipe2.heatTransfer.heatPorts[5].T;
 //   pipe2.heatTransfer.heatPorts[5].Q_flow - pipe2.heatPorts[5].Q_flow = 0.0;
-//   boundary4.p_in = n8155.n8735;
+//   boundary4.p_in = boundary4.$n123;
 //   ramp1.y = boundary4.p_in;
 //   boundary1.ports[1].p = pipe1.port_a.p;
 //   pipe1.port_b.p = pipe3.port_a.p;
@@ -6650,156 +6661,192 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   heat2[3].port.Q_flow + pipe2.heatPorts[3].Q_flow = 0.0;
 //   heat2[4].port.Q_flow + pipe2.heatPorts[4].Q_flow = 0.0;
 //   heat2[5].port.Q_flow + pipe2.heatPorts[5].Q_flow = 0.0;
-//   assert(boundary1.medium.T >= 190.0 and boundary1.medium.T <= 647.0, \"assert message 315810245365667762\");
+//   assert(boundary1.medium.T >= 190.0 and boundary1.medium.T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(boundary1.medium.T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   boundary1.medium.MM = 1.0 / (boundary1.medium.Xi[1] / 0.01801528 + (1.0 - boundary1.medium.Xi[1]) / 0.0289651159);
-//   n8153.n7931.n10110 = min(n1.n7656.n102.n8149.n8153.n7670.n8562(boundary1.medium.T), 0.999 * boundary1.medium.p);
-//   n8153.n7931.n10108 = min(n8153.n7931.n10110 * 0.6219647130774989 / max(1e-13, boundary1.medium.p - n8153.n7931.n10110) * (1.0 - boundary1.medium.Xi[1]), 1.0);
-//   n8153.n7931.n10105 = max(boundary1.medium.Xi[1] - n8153.n7931.n10108, 0.0);
-//   n8153.n7931.n10106 = boundary1.medium.Xi[1] - n8153.n7931.n10105;
-//   n8153.n7931.n10107 = 1.0 - boundary1.medium.Xi[1];
-//   boundary1.medium.h = n1.n7656.n102.n8149.n8153.n7670.n7957(boundary1.medium.p, boundary1.medium.T, boundary1.medium.Xi);
-//   boundary1.medium.R = 287.0512249529787 * n8153.n7931.n10107 / (1.0 - n8153.n7931.n10105) + 461.5233290850878 * n8153.n7931.n10106 / (1.0 - n8153.n7931.n10105);
+//   boundary1.medium.$n6 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.saturationPressure(boundary1.medium.T), 0.999 * boundary1.medium.p);
+//   boundary1.medium.$n4 = min(boundary1.medium.$n6 * 0.6219647130774989 / max(1e-13, boundary1.medium.p - boundary1.medium.$n6) * (1.0 - boundary1.medium.Xi[1]), 1.0);
+//   boundary1.medium.$n1 = max(boundary1.medium.Xi[1] - boundary1.medium.$n4, 0.0);
+//   boundary1.medium.$n2 = boundary1.medium.Xi[1] - boundary1.medium.$n1;
+//   boundary1.medium.$n3 = 1.0 - boundary1.medium.Xi[1];
+//   boundary1.medium.h = Modelica.Fluid.Examples.BranchingDynamicPipes.boundary1.Medium.specificEnthalpy_pTX(boundary1.medium.p, boundary1.medium.T, boundary1.medium.Xi);
+//   boundary1.medium.R = 287.0512249529787 * boundary1.medium.$n3 / (1.0 - boundary1.medium.$n1) + 461.5233290850878 * boundary1.medium.$n2 / (1.0 - boundary1.medium.$n1);
 //   boundary1.medium.u = boundary1.medium.h - boundary1.medium.R * boundary1.medium.T;
 //   boundary1.medium.d = boundary1.medium.p / (boundary1.medium.R * boundary1.medium.T);
 //   boundary1.medium.state.p = boundary1.medium.p;
 //   boundary1.medium.state.T = boundary1.medium.T;
 //   boundary1.medium.state.X[1] = boundary1.medium.X[1];
 //   boundary1.medium.state.X[2] = boundary1.medium.X[2];
-//   n8153.n7931.n10109 = 0.6219647130774989 * n8153.n7931.n10110 / max(1e-13, boundary1.medium.p - n8153.n7931.n10110);
-//   boundary1.medium.x_water = boundary1.medium.Xi[1] / max(n8153.n7931.n10107, 1e-13);
-//   boundary1.medium.phi = boundary1.medium.p / n8153.n7931.n10110 * boundary1.medium.Xi[1] / (boundary1.medium.Xi[1] + 0.6219647130774989 * n8153.n7931.n10107);
+//   boundary1.medium.$n5 = 0.6219647130774989 * boundary1.medium.$n6 / max(1e-13, boundary1.medium.p - boundary1.medium.$n6);
+//   boundary1.medium.x_water = boundary1.medium.Xi[1] / max(boundary1.medium.$n3, 1e-13);
+//   boundary1.medium.phi = boundary1.medium.p / boundary1.medium.$n6 * boundary1.medium.Xi[1] / (boundary1.medium.Xi[1] + 0.6219647130774989 * boundary1.medium.$n3);
 //   boundary1.medium.Xi[1] = boundary1.medium.X[1];
 //   boundary1.medium.X[2] = 1.0 - boundary1.medium.Xi[1];
-//   assert(boundary1.medium.X[1] >= -1e-05 and boundary1.medium.X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(boundary1.medium.X[2] >= -1e-05 and boundary1.medium.X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(boundary1.medium.p >= 0.0, \"assert message 2590312994638120201\");
-//   n1.n7656.n11.n8727(\"Moist air\", {\"water\", \"air\"}, false, true, n8153.n8737, \"Boundary_pT\");
-//   n8153.n8735 = boundary1.p;
-//   n8153.n8736 = boundary1.T;
-//   n8153.n8737[1] = boundary1.X[1];
-//   n8153.n8737[2] = boundary1.X[2];
-//   boundary1.medium.p = n8153.n8735;
-//   boundary1.medium.T = n8153.n8736;
-//   boundary1.medium.Xi[1] = n8153.n8737[1];
+//   assert(boundary1.medium.X[1] >= -1e-05 and boundary1.medium.X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(boundary1.medium.X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(boundary1.medium.X[2] >= -1e-05 and boundary1.medium.X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(boundary1.medium.X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(boundary1.medium.p >= 0.0, \"Pressure (= \" + String(boundary1.medium.p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(boundary1.medium.T, 6, 0, true) + \" K)\");
+//   Modelica.Fluid.Utilities.checkBoundary(\"Moist air\", {\"water\", \"air\"}, false, true, boundary1.$n10, \"Boundary_pT\");
+//   boundary1.$n8 = boundary1.p;
+//   boundary1.$n9 = boundary1.T;
+//   boundary1.$n10[1] = boundary1.X[1];
+//   boundary1.$n10[2] = boundary1.X[2];
+//   boundary1.medium.p = boundary1.$n8;
+//   boundary1.medium.T = boundary1.$n9;
+//   boundary1.medium.Xi[1] = boundary1.$n10[1];
 //   boundary1.ports[1].p = boundary1.medium.p;
 //   boundary1.ports[1].h_outflow = boundary1.medium.h;
 //   boundary1.ports[1].Xi_outflow[1] = boundary1.medium.Xi[1];
-//   pipe1.fluidVolumes = array(pipe1.crossAreas[i] * {10.0, 10.0, 10.0, 10.0, 10.0}[i] for n49 in 1:5) * pipe1.nParallel;
-//   assert(pipe1.mediums[1].T >= 190.0 and pipe1.mediums[1].T <= 647.0, \"assert message 315810245365667762\");
+//   pipe1.fluidVolumes = array(pipe1.crossAreas[i] * {10.0, 10.0, 10.0, 10.0, 10.0}[i] for i in 1:5) * pipe1.nParallel;
+//   assert(pipe1.mediums[1].T >= 190.0 and pipe1.mediums[1].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe1.mediums[1].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe1.mediums[1].MM = 1.0 / (pipe1.mediums[1].Xi[1] / 0.01801528 + (1.0 - pipe1.mediums[1].Xi[1]) / 0.0289651159);
-//   n7835.n8256[1].n10110 = min(n1.n7656.n102.n8149.n7835.n7670.n8562(pipe1.mediums[1].T), 0.999 * pipe1.mediums[1].p);
-//   n7835.n8256[1].n10108 = min(n7835.n8256[1].n10110 * 0.6219647130774989 / max(1e-13, pipe1.mediums[1].p - n7835.n8256[1].n10110) * (1.0 - pipe1.mediums[1].Xi[1]), 1.0);
-//   n7835.n8256[1].n10105 = max(pipe1.mediums[1].Xi[1] - n7835.n8256[1].n10108, 0.0);
-//   n7835.n8256[1].n10106 = pipe1.mediums[1].Xi[1] - n7835.n8256[1].n10105;
-//   n7835.n8256[1].n10107 = 1.0 - pipe1.mediums[1].Xi[1];
-//   pipe1.mediums[1].h = n1.n7656.n102.n8149.n7835.n7670.n7957(pipe1.mediums[1].p, pipe1.mediums[1].T, pipe1.mediums[1].Xi);
-//   pipe1.mediums[1].R = 287.0512249529787 * n7835.n8256[1].n10107 / (1.0 - n7835.n8256[1].n10105) + 461.5233290850878 * n7835.n8256[1].n10106 / (1.0 - n7835.n8256[1].n10105);
+//   pipe1.mediums[1].$n19 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(pipe1.mediums[1].T), 0.999 * pipe1.mediums[1].p);
+//   pipe1.mediums[1].$n17 = min(pipe1.mediums[1].$n19 * 0.6219647130774989 / max(1e-13, pipe1.mediums[1].p - pipe1.mediums[1].$n19) * (1.0 - pipe1.mediums[1].Xi[1]), 1.0);
+//   pipe1.mediums[1].$n14 = max(pipe1.mediums[1].Xi[1] - pipe1.mediums[1].$n17, 0.0);
+//   pipe1.mediums[1].$n15 = pipe1.mediums[1].Xi[1] - pipe1.mediums[1].$n14;
+//   pipe1.mediums[1].$n16 = 1.0 - pipe1.mediums[1].Xi[1];
+//   pipe1.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[1].p, pipe1.mediums[1].T, pipe1.mediums[1].Xi);
+//   pipe1.mediums[1].R = 287.0512249529787 * pipe1.mediums[1].$n16 / (1.0 - pipe1.mediums[1].$n14) + 461.5233290850878 * pipe1.mediums[1].$n15 / (1.0 - pipe1.mediums[1].$n14);
 //   pipe1.mediums[1].u = pipe1.mediums[1].h - pipe1.mediums[1].R * pipe1.mediums[1].T;
 //   pipe1.mediums[1].d = pipe1.mediums[1].p / (pipe1.mediums[1].R * pipe1.mediums[1].T);
 //   pipe1.mediums[1].state.p = pipe1.mediums[1].p;
 //   pipe1.mediums[1].state.T = pipe1.mediums[1].T;
 //   pipe1.mediums[1].state.X[1] = pipe1.mediums[1].X[1];
 //   pipe1.mediums[1].state.X[2] = pipe1.mediums[1].X[2];
-//   n7835.n8256[1].n10109 = 0.6219647130774989 * n7835.n8256[1].n10110 / max(1e-13, pipe1.mediums[1].p - n7835.n8256[1].n10110);
-//   pipe1.mediums[1].x_water = pipe1.mediums[1].Xi[1] / max(n7835.n8256[1].n10107, 1e-13);
-//   pipe1.mediums[1].phi = pipe1.mediums[1].p / n7835.n8256[1].n10110 * pipe1.mediums[1].Xi[1] / (pipe1.mediums[1].Xi[1] + 0.6219647130774989 * n7835.n8256[1].n10107);
+//   pipe1.mediums[1].$n18 = 0.6219647130774989 * pipe1.mediums[1].$n19 / max(1e-13, pipe1.mediums[1].p - pipe1.mediums[1].$n19);
+//   pipe1.mediums[1].x_water = pipe1.mediums[1].Xi[1] / max(pipe1.mediums[1].$n16, 1e-13);
+//   pipe1.mediums[1].phi = pipe1.mediums[1].p / pipe1.mediums[1].$n19 * pipe1.mediums[1].Xi[1] / (pipe1.mediums[1].Xi[1] + 0.6219647130774989 * pipe1.mediums[1].$n16);
 //   pipe1.mediums[1].Xi[1] = pipe1.mediums[1].X[1];
 //   pipe1.mediums[1].X[2] = 1.0 - pipe1.mediums[1].Xi[1];
-//   assert(pipe1.mediums[1].X[1] >= -1e-05 and pipe1.mediums[1].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[1].X[2] >= -1e-05 and pipe1.mediums[1].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[1].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe1.mediums[2].T >= 190.0 and pipe1.mediums[2].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe1.mediums[1].X[1] >= -1e-05 and pipe1.mediums[1].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe1.mediums[1].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[1].X[2] >= -1e-05 and pipe1.mediums[1].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe1.mediums[1].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[1].p >= 0.0, \"Pressure (= \" + String(pipe1.mediums[1].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe1.mediums[1].T, 6, 0, true) + \" K)\");
+//   assert(pipe1.mediums[2].T >= 190.0 and pipe1.mediums[2].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe1.mediums[2].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe1.mediums[2].MM = 1.0 / (pipe1.mediums[2].Xi[1] / 0.01801528 + (1.0 - pipe1.mediums[2].Xi[1]) / 0.0289651159);
-//   n7835.n8256[2].n10110 = min(n1.n7656.n102.n8149.n7835.n7670.n8562(pipe1.mediums[2].T), 0.999 * pipe1.mediums[2].p);
-//   n7835.n8256[2].n10108 = min(n7835.n8256[2].n10110 * 0.6219647130774989 / max(1e-13, pipe1.mediums[2].p - n7835.n8256[2].n10110) * (1.0 - pipe1.mediums[2].Xi[1]), 1.0);
-//   n7835.n8256[2].n10105 = max(pipe1.mediums[2].Xi[1] - n7835.n8256[2].n10108, 0.0);
-//   n7835.n8256[2].n10106 = pipe1.mediums[2].Xi[1] - n7835.n8256[2].n10105;
-//   n7835.n8256[2].n10107 = 1.0 - pipe1.mediums[2].Xi[1];
-//   pipe1.mediums[2].h = n1.n7656.n102.n8149.n7835.n7670.n7957(pipe1.mediums[2].p, pipe1.mediums[2].T, pipe1.mediums[2].Xi);
-//   pipe1.mediums[2].R = 287.0512249529787 * n7835.n8256[2].n10107 / (1.0 - n7835.n8256[2].n10105) + 461.5233290850878 * n7835.n8256[2].n10106 / (1.0 - n7835.n8256[2].n10105);
+//   pipe1.mediums[2].$n19 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(pipe1.mediums[2].T), 0.999 * pipe1.mediums[2].p);
+//   pipe1.mediums[2].$n17 = min(pipe1.mediums[2].$n19 * 0.6219647130774989 / max(1e-13, pipe1.mediums[2].p - pipe1.mediums[2].$n19) * (1.0 - pipe1.mediums[2].Xi[1]), 1.0);
+//   pipe1.mediums[2].$n14 = max(pipe1.mediums[2].Xi[1] - pipe1.mediums[2].$n17, 0.0);
+//   pipe1.mediums[2].$n15 = pipe1.mediums[2].Xi[1] - pipe1.mediums[2].$n14;
+//   pipe1.mediums[2].$n16 = 1.0 - pipe1.mediums[2].Xi[1];
+//   pipe1.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[2].p, pipe1.mediums[2].T, pipe1.mediums[2].Xi);
+//   pipe1.mediums[2].R = 287.0512249529787 * pipe1.mediums[2].$n16 / (1.0 - pipe1.mediums[2].$n14) + 461.5233290850878 * pipe1.mediums[2].$n15 / (1.0 - pipe1.mediums[2].$n14);
 //   pipe1.mediums[2].u = pipe1.mediums[2].h - pipe1.mediums[2].R * pipe1.mediums[2].T;
 //   pipe1.mediums[2].d = pipe1.mediums[2].p / (pipe1.mediums[2].R * pipe1.mediums[2].T);
 //   pipe1.mediums[2].state.p = pipe1.mediums[2].p;
 //   pipe1.mediums[2].state.T = pipe1.mediums[2].T;
 //   pipe1.mediums[2].state.X[1] = pipe1.mediums[2].X[1];
 //   pipe1.mediums[2].state.X[2] = pipe1.mediums[2].X[2];
-//   n7835.n8256[2].n10109 = 0.6219647130774989 * n7835.n8256[2].n10110 / max(1e-13, pipe1.mediums[2].p - n7835.n8256[2].n10110);
-//   pipe1.mediums[2].x_water = pipe1.mediums[2].Xi[1] / max(n7835.n8256[2].n10107, 1e-13);
-//   pipe1.mediums[2].phi = pipe1.mediums[2].p / n7835.n8256[2].n10110 * pipe1.mediums[2].Xi[1] / (pipe1.mediums[2].Xi[1] + 0.6219647130774989 * n7835.n8256[2].n10107);
+//   pipe1.mediums[2].$n18 = 0.6219647130774989 * pipe1.mediums[2].$n19 / max(1e-13, pipe1.mediums[2].p - pipe1.mediums[2].$n19);
+//   pipe1.mediums[2].x_water = pipe1.mediums[2].Xi[1] / max(pipe1.mediums[2].$n16, 1e-13);
+//   pipe1.mediums[2].phi = pipe1.mediums[2].p / pipe1.mediums[2].$n19 * pipe1.mediums[2].Xi[1] / (pipe1.mediums[2].Xi[1] + 0.6219647130774989 * pipe1.mediums[2].$n16);
 //   pipe1.mediums[2].Xi[1] = pipe1.mediums[2].X[1];
 //   pipe1.mediums[2].X[2] = 1.0 - pipe1.mediums[2].Xi[1];
-//   assert(pipe1.mediums[2].X[1] >= -1e-05 and pipe1.mediums[2].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[2].X[2] >= -1e-05 and pipe1.mediums[2].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[2].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe1.mediums[3].T >= 190.0 and pipe1.mediums[3].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe1.mediums[2].X[1] >= -1e-05 and pipe1.mediums[2].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe1.mediums[2].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[2].X[2] >= -1e-05 and pipe1.mediums[2].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe1.mediums[2].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[2].p >= 0.0, \"Pressure (= \" + String(pipe1.mediums[2].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe1.mediums[2].T, 6, 0, true) + \" K)\");
+//   assert(pipe1.mediums[3].T >= 190.0 and pipe1.mediums[3].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe1.mediums[3].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe1.mediums[3].MM = 1.0 / (pipe1.mediums[3].Xi[1] / 0.01801528 + (1.0 - pipe1.mediums[3].Xi[1]) / 0.0289651159);
-//   n7835.n8256[3].n10110 = min(n1.n7656.n102.n8149.n7835.n7670.n8562(pipe1.mediums[3].T), 0.999 * pipe1.mediums[3].p);
-//   n7835.n8256[3].n10108 = min(n7835.n8256[3].n10110 * 0.6219647130774989 / max(1e-13, pipe1.mediums[3].p - n7835.n8256[3].n10110) * (1.0 - pipe1.mediums[3].Xi[1]), 1.0);
-//   n7835.n8256[3].n10105 = max(pipe1.mediums[3].Xi[1] - n7835.n8256[3].n10108, 0.0);
-//   n7835.n8256[3].n10106 = pipe1.mediums[3].Xi[1] - n7835.n8256[3].n10105;
-//   n7835.n8256[3].n10107 = 1.0 - pipe1.mediums[3].Xi[1];
-//   pipe1.mediums[3].h = n1.n7656.n102.n8149.n7835.n7670.n7957(pipe1.mediums[3].p, pipe1.mediums[3].T, pipe1.mediums[3].Xi);
-//   pipe1.mediums[3].R = 287.0512249529787 * n7835.n8256[3].n10107 / (1.0 - n7835.n8256[3].n10105) + 461.5233290850878 * n7835.n8256[3].n10106 / (1.0 - n7835.n8256[3].n10105);
+//   pipe1.mediums[3].$n19 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(pipe1.mediums[3].T), 0.999 * pipe1.mediums[3].p);
+//   pipe1.mediums[3].$n17 = min(pipe1.mediums[3].$n19 * 0.6219647130774989 / max(1e-13, pipe1.mediums[3].p - pipe1.mediums[3].$n19) * (1.0 - pipe1.mediums[3].Xi[1]), 1.0);
+//   pipe1.mediums[3].$n14 = max(pipe1.mediums[3].Xi[1] - pipe1.mediums[3].$n17, 0.0);
+//   pipe1.mediums[3].$n15 = pipe1.mediums[3].Xi[1] - pipe1.mediums[3].$n14;
+//   pipe1.mediums[3].$n16 = 1.0 - pipe1.mediums[3].Xi[1];
+//   pipe1.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[3].p, pipe1.mediums[3].T, pipe1.mediums[3].Xi);
+//   pipe1.mediums[3].R = 287.0512249529787 * pipe1.mediums[3].$n16 / (1.0 - pipe1.mediums[3].$n14) + 461.5233290850878 * pipe1.mediums[3].$n15 / (1.0 - pipe1.mediums[3].$n14);
 //   pipe1.mediums[3].u = pipe1.mediums[3].h - pipe1.mediums[3].R * pipe1.mediums[3].T;
 //   pipe1.mediums[3].d = pipe1.mediums[3].p / (pipe1.mediums[3].R * pipe1.mediums[3].T);
 //   pipe1.mediums[3].state.p = pipe1.mediums[3].p;
 //   pipe1.mediums[3].state.T = pipe1.mediums[3].T;
 //   pipe1.mediums[3].state.X[1] = pipe1.mediums[3].X[1];
 //   pipe1.mediums[3].state.X[2] = pipe1.mediums[3].X[2];
-//   n7835.n8256[3].n10109 = 0.6219647130774989 * n7835.n8256[3].n10110 / max(1e-13, pipe1.mediums[3].p - n7835.n8256[3].n10110);
-//   pipe1.mediums[3].x_water = pipe1.mediums[3].Xi[1] / max(n7835.n8256[3].n10107, 1e-13);
-//   pipe1.mediums[3].phi = pipe1.mediums[3].p / n7835.n8256[3].n10110 * pipe1.mediums[3].Xi[1] / (pipe1.mediums[3].Xi[1] + 0.6219647130774989 * n7835.n8256[3].n10107);
+//   pipe1.mediums[3].$n18 = 0.6219647130774989 * pipe1.mediums[3].$n19 / max(1e-13, pipe1.mediums[3].p - pipe1.mediums[3].$n19);
+//   pipe1.mediums[3].x_water = pipe1.mediums[3].Xi[1] / max(pipe1.mediums[3].$n16, 1e-13);
+//   pipe1.mediums[3].phi = pipe1.mediums[3].p / pipe1.mediums[3].$n19 * pipe1.mediums[3].Xi[1] / (pipe1.mediums[3].Xi[1] + 0.6219647130774989 * pipe1.mediums[3].$n16);
 //   pipe1.mediums[3].Xi[1] = pipe1.mediums[3].X[1];
 //   pipe1.mediums[3].X[2] = 1.0 - pipe1.mediums[3].Xi[1];
-//   assert(pipe1.mediums[3].X[1] >= -1e-05 and pipe1.mediums[3].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[3].X[2] >= -1e-05 and pipe1.mediums[3].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[3].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe1.mediums[4].T >= 190.0 and pipe1.mediums[4].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe1.mediums[3].X[1] >= -1e-05 and pipe1.mediums[3].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe1.mediums[3].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[3].X[2] >= -1e-05 and pipe1.mediums[3].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe1.mediums[3].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[3].p >= 0.0, \"Pressure (= \" + String(pipe1.mediums[3].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe1.mediums[3].T, 6, 0, true) + \" K)\");
+//   assert(pipe1.mediums[4].T >= 190.0 and pipe1.mediums[4].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe1.mediums[4].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe1.mediums[4].MM = 1.0 / (pipe1.mediums[4].Xi[1] / 0.01801528 + (1.0 - pipe1.mediums[4].Xi[1]) / 0.0289651159);
-//   n7835.n8256[4].n10110 = min(n1.n7656.n102.n8149.n7835.n7670.n8562(pipe1.mediums[4].T), 0.999 * pipe1.mediums[4].p);
-//   n7835.n8256[4].n10108 = min(n7835.n8256[4].n10110 * 0.6219647130774989 / max(1e-13, pipe1.mediums[4].p - n7835.n8256[4].n10110) * (1.0 - pipe1.mediums[4].Xi[1]), 1.0);
-//   n7835.n8256[4].n10105 = max(pipe1.mediums[4].Xi[1] - n7835.n8256[4].n10108, 0.0);
-//   n7835.n8256[4].n10106 = pipe1.mediums[4].Xi[1] - n7835.n8256[4].n10105;
-//   n7835.n8256[4].n10107 = 1.0 - pipe1.mediums[4].Xi[1];
-//   pipe1.mediums[4].h = n1.n7656.n102.n8149.n7835.n7670.n7957(pipe1.mediums[4].p, pipe1.mediums[4].T, pipe1.mediums[4].Xi);
-//   pipe1.mediums[4].R = 287.0512249529787 * n7835.n8256[4].n10107 / (1.0 - n7835.n8256[4].n10105) + 461.5233290850878 * n7835.n8256[4].n10106 / (1.0 - n7835.n8256[4].n10105);
+//   pipe1.mediums[4].$n19 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(pipe1.mediums[4].T), 0.999 * pipe1.mediums[4].p);
+//   pipe1.mediums[4].$n17 = min(pipe1.mediums[4].$n19 * 0.6219647130774989 / max(1e-13, pipe1.mediums[4].p - pipe1.mediums[4].$n19) * (1.0 - pipe1.mediums[4].Xi[1]), 1.0);
+//   pipe1.mediums[4].$n14 = max(pipe1.mediums[4].Xi[1] - pipe1.mediums[4].$n17, 0.0);
+//   pipe1.mediums[4].$n15 = pipe1.mediums[4].Xi[1] - pipe1.mediums[4].$n14;
+//   pipe1.mediums[4].$n16 = 1.0 - pipe1.mediums[4].Xi[1];
+//   pipe1.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[4].p, pipe1.mediums[4].T, pipe1.mediums[4].Xi);
+//   pipe1.mediums[4].R = 287.0512249529787 * pipe1.mediums[4].$n16 / (1.0 - pipe1.mediums[4].$n14) + 461.5233290850878 * pipe1.mediums[4].$n15 / (1.0 - pipe1.mediums[4].$n14);
 //   pipe1.mediums[4].u = pipe1.mediums[4].h - pipe1.mediums[4].R * pipe1.mediums[4].T;
 //   pipe1.mediums[4].d = pipe1.mediums[4].p / (pipe1.mediums[4].R * pipe1.mediums[4].T);
 //   pipe1.mediums[4].state.p = pipe1.mediums[4].p;
 //   pipe1.mediums[4].state.T = pipe1.mediums[4].T;
 //   pipe1.mediums[4].state.X[1] = pipe1.mediums[4].X[1];
 //   pipe1.mediums[4].state.X[2] = pipe1.mediums[4].X[2];
-//   n7835.n8256[4].n10109 = 0.6219647130774989 * n7835.n8256[4].n10110 / max(1e-13, pipe1.mediums[4].p - n7835.n8256[4].n10110);
-//   pipe1.mediums[4].x_water = pipe1.mediums[4].Xi[1] / max(n7835.n8256[4].n10107, 1e-13);
-//   pipe1.mediums[4].phi = pipe1.mediums[4].p / n7835.n8256[4].n10110 * pipe1.mediums[4].Xi[1] / (pipe1.mediums[4].Xi[1] + 0.6219647130774989 * n7835.n8256[4].n10107);
+//   pipe1.mediums[4].$n18 = 0.6219647130774989 * pipe1.mediums[4].$n19 / max(1e-13, pipe1.mediums[4].p - pipe1.mediums[4].$n19);
+//   pipe1.mediums[4].x_water = pipe1.mediums[4].Xi[1] / max(pipe1.mediums[4].$n16, 1e-13);
+//   pipe1.mediums[4].phi = pipe1.mediums[4].p / pipe1.mediums[4].$n19 * pipe1.mediums[4].Xi[1] / (pipe1.mediums[4].Xi[1] + 0.6219647130774989 * pipe1.mediums[4].$n16);
 //   pipe1.mediums[4].Xi[1] = pipe1.mediums[4].X[1];
 //   pipe1.mediums[4].X[2] = 1.0 - pipe1.mediums[4].Xi[1];
-//   assert(pipe1.mediums[4].X[1] >= -1e-05 and pipe1.mediums[4].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[4].X[2] >= -1e-05 and pipe1.mediums[4].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[4].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe1.mediums[5].T >= 190.0 and pipe1.mediums[5].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe1.mediums[4].X[1] >= -1e-05 and pipe1.mediums[4].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe1.mediums[4].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[4].X[2] >= -1e-05 and pipe1.mediums[4].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe1.mediums[4].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[4].p >= 0.0, \"Pressure (= \" + String(pipe1.mediums[4].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe1.mediums[4].T, 6, 0, true) + \" K)\");
+//   assert(pipe1.mediums[5].T >= 190.0 and pipe1.mediums[5].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe1.mediums[5].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe1.mediums[5].MM = 1.0 / (pipe1.mediums[5].Xi[1] / 0.01801528 + (1.0 - pipe1.mediums[5].Xi[1]) / 0.0289651159);
-//   n7835.n8256[5].n10110 = min(n1.n7656.n102.n8149.n7835.n7670.n8562(pipe1.mediums[5].T), 0.999 * pipe1.mediums[5].p);
-//   n7835.n8256[5].n10108 = min(n7835.n8256[5].n10110 * 0.6219647130774989 / max(1e-13, pipe1.mediums[5].p - n7835.n8256[5].n10110) * (1.0 - pipe1.mediums[5].Xi[1]), 1.0);
-//   n7835.n8256[5].n10105 = max(pipe1.mediums[5].Xi[1] - n7835.n8256[5].n10108, 0.0);
-//   n7835.n8256[5].n10106 = pipe1.mediums[5].Xi[1] - n7835.n8256[5].n10105;
-//   n7835.n8256[5].n10107 = 1.0 - pipe1.mediums[5].Xi[1];
-//   pipe1.mediums[5].h = n1.n7656.n102.n8149.n7835.n7670.n7957(pipe1.mediums[5].p, pipe1.mediums[5].T, pipe1.mediums[5].Xi);
-//   pipe1.mediums[5].R = 287.0512249529787 * n7835.n8256[5].n10107 / (1.0 - n7835.n8256[5].n10105) + 461.5233290850878 * n7835.n8256[5].n10106 / (1.0 - n7835.n8256[5].n10105);
+//   pipe1.mediums[5].$n19 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.saturationPressure(pipe1.mediums[5].T), 0.999 * pipe1.mediums[5].p);
+//   pipe1.mediums[5].$n17 = min(pipe1.mediums[5].$n19 * 0.6219647130774989 / max(1e-13, pipe1.mediums[5].p - pipe1.mediums[5].$n19) * (1.0 - pipe1.mediums[5].Xi[1]), 1.0);
+//   pipe1.mediums[5].$n14 = max(pipe1.mediums[5].Xi[1] - pipe1.mediums[5].$n17, 0.0);
+//   pipe1.mediums[5].$n15 = pipe1.mediums[5].Xi[1] - pipe1.mediums[5].$n14;
+//   pipe1.mediums[5].$n16 = 1.0 - pipe1.mediums[5].Xi[1];
+//   pipe1.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.specificEnthalpy_pTX(pipe1.mediums[5].p, pipe1.mediums[5].T, pipe1.mediums[5].Xi);
+//   pipe1.mediums[5].R = 287.0512249529787 * pipe1.mediums[5].$n16 / (1.0 - pipe1.mediums[5].$n14) + 461.5233290850878 * pipe1.mediums[5].$n15 / (1.0 - pipe1.mediums[5].$n14);
 //   pipe1.mediums[5].u = pipe1.mediums[5].h - pipe1.mediums[5].R * pipe1.mediums[5].T;
 //   pipe1.mediums[5].d = pipe1.mediums[5].p / (pipe1.mediums[5].R * pipe1.mediums[5].T);
 //   pipe1.mediums[5].state.p = pipe1.mediums[5].p;
 //   pipe1.mediums[5].state.T = pipe1.mediums[5].T;
 //   pipe1.mediums[5].state.X[1] = pipe1.mediums[5].X[1];
 //   pipe1.mediums[5].state.X[2] = pipe1.mediums[5].X[2];
-//   n7835.n8256[5].n10109 = 0.6219647130774989 * n7835.n8256[5].n10110 / max(1e-13, pipe1.mediums[5].p - n7835.n8256[5].n10110);
-//   pipe1.mediums[5].x_water = pipe1.mediums[5].Xi[1] / max(n7835.n8256[5].n10107, 1e-13);
-//   pipe1.mediums[5].phi = pipe1.mediums[5].p / n7835.n8256[5].n10110 * pipe1.mediums[5].Xi[1] / (pipe1.mediums[5].Xi[1] + 0.6219647130774989 * n7835.n8256[5].n10107);
+//   pipe1.mediums[5].$n18 = 0.6219647130774989 * pipe1.mediums[5].$n19 / max(1e-13, pipe1.mediums[5].p - pipe1.mediums[5].$n19);
+//   pipe1.mediums[5].x_water = pipe1.mediums[5].Xi[1] / max(pipe1.mediums[5].$n16, 1e-13);
+//   pipe1.mediums[5].phi = pipe1.mediums[5].p / pipe1.mediums[5].$n19 * pipe1.mediums[5].Xi[1] / (pipe1.mediums[5].Xi[1] + 0.6219647130774989 * pipe1.mediums[5].$n16);
 //   pipe1.mediums[5].Xi[1] = pipe1.mediums[5].X[1];
 //   pipe1.mediums[5].X[2] = 1.0 - pipe1.mediums[5].Xi[1];
-//   assert(pipe1.mediums[5].X[1] >= -1e-05 and pipe1.mediums[5].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[5].X[2] >= -1e-05 and pipe1.mediums[5].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe1.mediums[5].p >= 0.0, \"assert message 2590312994638120201\");
+//   assert(pipe1.mediums[5].X[1] >= -1e-05 and pipe1.mediums[5].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe1.mediums[5].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[5].X[2] >= -1e-05 and pipe1.mediums[5].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe1.mediums[5].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe1.mediums[5].p >= 0.0, \"Pressure (= \" + String(pipe1.mediums[5].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe1.mediums[5].T, 6, 0, true) + \" K)\");
 //   pipe1.flowModel.states[1].X = pipe1.statesFM[1].X;
 //   pipe1.flowModel.states[2].X = pipe1.statesFM[2].X;
 //   pipe1.flowModel.states[3].X = pipe1.statesFM[3].X;
@@ -6807,18 +6854,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.flowModel.states[5].X = pipe1.statesFM[5].X;
 //   pipe1.flowModel.states[6].X = pipe1.statesFM[6].X;
 //   pipe1.flowModel.states[7].X = pipe1.statesFM[7].X;
-//   pipe1.flowModel.vs = n7835.n8369;
-//   pipe1.flowModel.crossAreas = n7835.n8370;
-//   pipe1.flowModel.dimensions = n7835.n8371;
-//   pipe1.flowModel.roughnesses = n7835.n8372;
-//   pipe1.flowModel.dheights = n7835.n8373;
-//   pipe1.flowModel.pathLengths = n7835.n8348;
-//   pipe1.flowModel.rhos = array(n1.n7656.n102.n8149.n7835.n8346.n7670.n523(pipe1.flowModel.states[$i1]) for $i1 in 1:7);
-//   pipe1.flowModel.mus = array(n1.n7656.n102.n8149.n7835.n8346.n7670.n8340(pipe1.flowModel.states[$i1]) for $i1 in 1:7);
+//   pipe1.flowModel.vs = pipe1.$n33;
+//   pipe1.flowModel.crossAreas = pipe1.$n32;
+//   pipe1.flowModel.dimensions = pipe1.$n34;
+//   pipe1.flowModel.roughnesses = pipe1.$n35;
+//   pipe1.flowModel.dheights = pipe1.$n31;
+//   pipe1.flowModel.pathLengths = pipe1.$n30;
+//   pipe1.flowModel.rhos = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.density(pipe1.flowModel.states[$i1]) for $i1 in 1:7);
+//   pipe1.flowModel.mus = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.dynamicViscosity(pipe1.flowModel.states[$i1]) for $i1 in 1:7);
 //   pipe1.flowModel.pathLengths_internal = pipe1.flowModel.pathLengths;
 //   pipe1.flowModel.Res_turbulent_internal = {pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent, pipe1.flowModel.Re_turbulent};
-//   n7835.n8346.n8410 = {0.5 * (pipe1.flowModel.dimensions[1] + pipe1.flowModel.dimensions[2]), 0.5 * (pipe1.flowModel.dimensions[2] + pipe1.flowModel.dimensions[3]), 0.5 * (pipe1.flowModel.dimensions[3] + pipe1.flowModel.dimensions[4]), 0.5 * (pipe1.flowModel.dimensions[4] + pipe1.flowModel.dimensions[5]), 0.5 * (pipe1.flowModel.dimensions[5] + pipe1.flowModel.dimensions[6]), 0.5 * (pipe1.flowModel.dimensions[6] + pipe1.flowModel.dimensions[7])};
-//   pipe1.flowModel.m_flows = array(homotopy((array(n1.n7656.n102.n8149.n7835.n8346.n7663.n8415(pipe1.flowModel.dps_fg[$i1], pipe1.flowModel.rhos[(1:6)[$i1]], pipe1.flowModel.rhos[(2:7)[$i1]], pipe1.flowModel.mus[(1:6)[$i1]], pipe1.flowModel.mus[(2:7)[$i1]], pipe1.flowModel.pathLengths_internal[$i1], n7835.n8346.n8410[$i1], {pipe1.flowModel.g * pipe1.flowModel.dheights[1], pipe1.flowModel.g * pipe1.flowModel.dheights[2], pipe1.flowModel.g * pipe1.flowModel.dheights[3], pipe1.flowModel.g * pipe1.flowModel.dheights[4], pipe1.flowModel.g * pipe1.flowModel.dheights[5], pipe1.flowModel.g * pipe1.flowModel.dheights[6]}[$i1], {(pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0}[$i1], {(pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0}[$i1], n7835.n8346.n8308 / 6.0, pipe1.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:6) * pipe1.flowModel.nParallel)[$i1], {pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[1] - pipe1.flowModel.g * pipe1.flowModel.dheights[1] * n7835.n8346.n8135), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[2] - pipe1.flowModel.g * pipe1.flowModel.dheights[2] * n7835.n8346.n8135), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[3] - pipe1.flowModel.g * pipe1.flowModel.dheights[3] * n7835.n8346.n8135), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[4] - pipe1.flowModel.g * pipe1.flowModel.dheights[4] * n7835.n8346.n8135), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[5] - pipe1.flowModel.g * pipe1.flowModel.dheights[5] * n7835.n8346.n8135), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[6] - pipe1.flowModel.g * pipe1.flowModel.dheights[6] * n7835.n8346.n8135)}[$i1]) for $i1 in 1:6);
+//   pipe1.flowModel.$n28 = {0.5 * (pipe1.flowModel.dimensions[1] + pipe1.flowModel.dimensions[2]), 0.5 * (pipe1.flowModel.dimensions[2] + pipe1.flowModel.dimensions[3]), 0.5 * (pipe1.flowModel.dimensions[3] + pipe1.flowModel.dimensions[4]), 0.5 * (pipe1.flowModel.dimensions[4] + pipe1.flowModel.dimensions[5]), 0.5 * (pipe1.flowModel.dimensions[5] + pipe1.flowModel.dimensions[6]), 0.5 * (pipe1.flowModel.dimensions[6] + pipe1.flowModel.dimensions[7])};
+//   pipe1.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe1.flowModel.dps_fg[$i1], pipe1.flowModel.rhos[(1:6)[$i1]], pipe1.flowModel.rhos[(2:7)[$i1]], pipe1.flowModel.mus[(1:6)[$i1]], pipe1.flowModel.mus[(2:7)[$i1]], pipe1.flowModel.pathLengths_internal[$i1], pipe1.flowModel.$n28[$i1], {pipe1.flowModel.g * pipe1.flowModel.dheights[1], pipe1.flowModel.g * pipe1.flowModel.dheights[2], pipe1.flowModel.g * pipe1.flowModel.dheights[3], pipe1.flowModel.g * pipe1.flowModel.dheights[4], pipe1.flowModel.g * pipe1.flowModel.dheights[5], pipe1.flowModel.g * pipe1.flowModel.dheights[6]}[$i1], {(pipe1.flowModel.crossAreas[1] + pipe1.flowModel.crossAreas[2]) / 2.0, (pipe1.flowModel.crossAreas[2] + pipe1.flowModel.crossAreas[3]) / 2.0, (pipe1.flowModel.crossAreas[3] + pipe1.flowModel.crossAreas[4]) / 2.0, (pipe1.flowModel.crossAreas[4] + pipe1.flowModel.crossAreas[5]) / 2.0, (pipe1.flowModel.crossAreas[5] + pipe1.flowModel.crossAreas[6]) / 2.0, (pipe1.flowModel.crossAreas[6] + pipe1.flowModel.crossAreas[7]) / 2.0}[$i1], {(pipe1.flowModel.roughnesses[1] + pipe1.flowModel.roughnesses[2]) / 2.0, (pipe1.flowModel.roughnesses[2] + pipe1.flowModel.roughnesses[3]) / 2.0, (pipe1.flowModel.roughnesses[3] + pipe1.flowModel.roughnesses[4]) / 2.0, (pipe1.flowModel.roughnesses[4] + pipe1.flowModel.roughnesses[5]) / 2.0, (pipe1.flowModel.roughnesses[5] + pipe1.flowModel.roughnesses[6]) / 2.0, (pipe1.flowModel.roughnesses[6] + pipe1.flowModel.roughnesses[7]) / 2.0}[$i1], pipe1.flowModel.$n25 / 6.0, pipe1.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:6) * pipe1.flowModel.nParallel)[$i1], {pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[1] - pipe1.flowModel.g * pipe1.flowModel.dheights[1] * pipe1.flowModel.$n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[2] - pipe1.flowModel.g * pipe1.flowModel.dheights[2] * pipe1.flowModel.$n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[3] - pipe1.flowModel.g * pipe1.flowModel.dheights[3] * pipe1.flowModel.$n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[4] - pipe1.flowModel.g * pipe1.flowModel.dheights[4] * pipe1.flowModel.$n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[5] - pipe1.flowModel.g * pipe1.flowModel.dheights[5] * pipe1.flowModel.$n22), pipe1.flowModel.m_flow_nominal / pipe1.flowModel.dp_nominal * (pipe1.flowModel.dps_fg[6] - pipe1.flowModel.g * pipe1.flowModel.dheights[6] * pipe1.flowModel.$n22)}[$i1]) for $i1 in 1:6);
 //   pipe1.flowModel.rhos_act[1] = noEvent(if pipe1.flowModel.m_flows[1] > 0.0 then pipe1.flowModel.rhos[1] else pipe1.flowModel.rhos[2]);
 //   pipe1.flowModel.mus_act[1] = noEvent(if pipe1.flowModel.m_flows[1] > 0.0 then pipe1.flowModel.mus[1] else pipe1.flowModel.mus[2]);
 //   pipe1.flowModel.rhos_act[2] = noEvent(if pipe1.flowModel.m_flows[2] > 0.0 then pipe1.flowModel.rhos[2] else pipe1.flowModel.rhos[3]);
@@ -6831,24 +6878,24 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.flowModel.mus_act[5] = noEvent(if pipe1.flowModel.m_flows[5] > 0.0 then pipe1.flowModel.mus[5] else pipe1.flowModel.mus[6]);
 //   pipe1.flowModel.rhos_act[6] = noEvent(if pipe1.flowModel.m_flows[6] > 0.0 then pipe1.flowModel.rhos[6] else pipe1.flowModel.rhos[7]);
 //   pipe1.flowModel.mus_act[6] = noEvent(if pipe1.flowModel.m_flows[6] > 0.0 then pipe1.flowModel.mus[6] else pipe1.flowModel.mus[7]);
-//   pipe1.flowModel.Ib_flows = array(pipe1.flowModel.rhos[i] * pipe1.flowModel.vs[i] * pipe1.flowModel.vs[i] * pipe1.flowModel.crossAreas[i] - pipe1.flowModel.rhos[i + 1] * pipe1.flowModel.vs[i + 1] * pipe1.flowModel.vs[i + 1] * pipe1.flowModel.crossAreas[i + 1] for n49 in 1:6) * pipe1.flowModel.nParallel;
-//   pipe1.flowModel.Fs_p = array(0.5 * (pipe1.flowModel.crossAreas[i] + pipe1.flowModel.crossAreas[i + 1]) * (n1.n7656.n102.n8149.n7835.n8346.n7670.n7786(pipe1.flowModel.states[i + 1]) - n1.n7656.n102.n8149.n7835.n8346.n7670.n7786(pipe1.flowModel.states[i])) for n49 in 1:6) * pipe1.flowModel.nParallel;
-//   pipe1.flowModel.dps_fg = array(pipe1.flowModel.Fs_fg[i] / pipe1.flowModel.nParallel * 2.0 / (pipe1.flowModel.crossAreas[i] + pipe1.flowModel.crossAreas[i + 1]) for n49 in 1:6);
-//   pipe1.flowModel.Is = array(pipe1.flowModel.m_flows[i] * pipe1.flowModel.pathLengths[i] for n49 in 1:6);
+//   pipe1.flowModel.Ib_flows = array(pipe1.flowModel.rhos[i] * pipe1.flowModel.vs[i] * pipe1.flowModel.vs[i] * pipe1.flowModel.crossAreas[i] - pipe1.flowModel.rhos[i + 1] * pipe1.flowModel.vs[i + 1] * pipe1.flowModel.vs[i + 1] * pipe1.flowModel.crossAreas[i + 1] for i in 1:6) * pipe1.flowModel.nParallel;
+//   pipe1.flowModel.Fs_p = array(0.5 * (pipe1.flowModel.crossAreas[i] + pipe1.flowModel.crossAreas[i + 1]) * (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.pressure(pipe1.flowModel.states[i + 1]) - Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.flowModel.Medium.pressure(pipe1.flowModel.states[i])) for i in 1:6) * pipe1.flowModel.nParallel;
+//   pipe1.flowModel.dps_fg = array(pipe1.flowModel.Fs_fg[i] / pipe1.flowModel.nParallel * 2.0 / (pipe1.flowModel.crossAreas[i] + pipe1.flowModel.crossAreas[i + 1]) for i in 1:6);
+//   pipe1.flowModel.Is = array(pipe1.flowModel.m_flows[i] * pipe1.flowModel.pathLengths[i] for i in 1:6);
 //   der(pipe1.flowModel.Is[1]) = pipe1.flowModel.Ib_flows[1] - pipe1.flowModel.Fs_p[1] - pipe1.flowModel.Fs_fg[1];
 //   der(pipe1.flowModel.Is[2]) = pipe1.flowModel.Ib_flows[2] - pipe1.flowModel.Fs_p[2] - pipe1.flowModel.Fs_fg[2];
 //   der(pipe1.flowModel.Is[3]) = pipe1.flowModel.Ib_flows[3] - pipe1.flowModel.Fs_p[3] - pipe1.flowModel.Fs_fg[3];
 //   der(pipe1.flowModel.Is[4]) = pipe1.flowModel.Ib_flows[4] - pipe1.flowModel.Fs_p[4] - pipe1.flowModel.Fs_fg[4];
 //   der(pipe1.flowModel.Is[5]) = pipe1.flowModel.Ib_flows[5] - pipe1.flowModel.Fs_p[5] - pipe1.flowModel.Fs_fg[5];
 //   der(pipe1.flowModel.Is[6]) = pipe1.flowModel.Ib_flows[6] - pipe1.flowModel.Fs_p[6] - pipe1.flowModel.Fs_fg[6];
-//   pipe1.vs = array(0.5 * (pipe1.m_flows[i] + pipe1.m_flows[i + 1]) / pipe1.mediums[i].d / pipe1.crossAreas[i] for n49 in 1:5) / pipe1.nParallel;
+//   pipe1.vs = array(0.5 * (pipe1.m_flows[i] + pipe1.m_flows[i + 1]) / pipe1.mediums[i].d / pipe1.crossAreas[i] for i in 1:5) / pipe1.nParallel;
 //   pipe1.heatTransfer.states[1].X = pipe1.mediums[1].state.X;
 //   pipe1.heatTransfer.states[2].X = pipe1.mediums[2].state.X;
 //   pipe1.heatTransfer.states[3].X = pipe1.mediums[3].state.X;
 //   pipe1.heatTransfer.states[4].X = pipe1.mediums[4].state.X;
 //   pipe1.heatTransfer.states[5].X = pipe1.mediums[5].state.X;
 //   pipe1.heatTransfer.surfaceAreas = {pipe1.perimeter * 10.0, pipe1.perimeter * 10.0, pipe1.perimeter * 10.0, pipe1.perimeter * 10.0, pipe1.perimeter * 10.0};
-//   pipe1.heatTransfer.Ts = array(n1.n7656.n102.n8149.n7835.n7988.n7670.n7785(pipe1.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe1.heatTransfer.Ts = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.heatTransfer.Medium.temperature(pipe1.heatTransfer.states[$i1]) for $i1 in 1:5);
 //   pipe1.heatTransfer.vs = pipe1.vs;
 //   pipe1.heatTransfer.lengths = {10.0, 10.0, 10.0, 10.0, 10.0};
 //   pipe1.heatTransfer.dimensions = pipe1.dimensions;
@@ -6868,42 +6915,42 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.Qb_flows[3] = pipe1.heatTransfer.Q_flows[3];
 //   pipe1.Qb_flows[4] = pipe1.heatTransfer.Q_flows[4];
 //   pipe1.Qb_flows[5] = pipe1.heatTransfer.Q_flows[5];
-//   pipe1.Wb_flows[2:4] = array(pipe1.vs[i] * pipe1.crossAreas[i] * ((pipe1.mediums[i + 1].p - pipe1.mediums[i - 1].p) / 2.0 + (pipe1.flowModel.dps_fg[i] + pipe1.flowModel.dps_fg[i + 1]) / 2.0 - system.g * {10.0, 10.0, 10.0, 10.0, 10.0}[i] * pipe1.mediums[i].d) for n49 in 2:4) * pipe1.nParallel;
+//   pipe1.Wb_flows[2:4] = array(pipe1.vs[i] * pipe1.crossAreas[i] * ((pipe1.mediums[i + 1].p - pipe1.mediums[i - 1].p) / 2.0 + (pipe1.flowModel.dps_fg[i] + pipe1.flowModel.dps_fg[i + 1]) / 2.0 - system.g * {10.0, 10.0, 10.0, 10.0, 10.0}[i] * pipe1.mediums[i].d) for i in 2:4) * pipe1.nParallel;
 //   pipe1.Wb_flows[1] = pipe1.vs[1] * pipe1.crossAreas[1] * ((pipe1.mediums[2].p - pipe1.port_a.p) / 1.5 + pipe1.flowModel.dps_fg[1] + pipe1.flowModel.dps_fg[2] / 2.0 - system.g * 10.0 * pipe1.mediums[1].d) * pipe1.nParallel;
 //   pipe1.Wb_flows[5] = pipe1.vs[5] * pipe1.crossAreas[5] * ((pipe1.port_b.p - pipe1.mediums[4].p) / 1.5 + pipe1.flowModel.dps_fg[5] / 2.0 + pipe1.flowModel.dps_fg[6] - system.g * 10.0 * pipe1.mediums[5].d) * pipe1.nParallel;
-//   n7835.n8348[1] = 5.0;
-//   n7835.n8348[2] = 10.0;
-//   n7835.n8348[3] = 10.0;
-//   n7835.n8348[4] = 10.0;
-//   n7835.n8348[5] = 10.0;
-//   n7835.n8348[6] = 5.0;
-//   n7835.n8373[1] = 5.0;
-//   n7835.n8373[2] = 10.0;
-//   n7835.n8373[3] = 10.0;
-//   n7835.n8373[4] = 10.0;
-//   n7835.n8373[5] = 10.0;
-//   n7835.n8373[6] = 5.0;
-//   n7835.n8370[1] = pipe1.crossAreas[1];
-//   n7835.n8370[2] = pipe1.crossAreas[1];
-//   n7835.n8370[3] = pipe1.crossAreas[2];
-//   n7835.n8370[4] = pipe1.crossAreas[3];
-//   n7835.n8370[5] = pipe1.crossAreas[4];
-//   n7835.n8370[6] = pipe1.crossAreas[5];
-//   n7835.n8370[7] = pipe1.crossAreas[5];
-//   n7835.n8371[1] = pipe1.dimensions[1];
-//   n7835.n8371[2] = pipe1.dimensions[1];
-//   n7835.n8371[3] = pipe1.dimensions[2];
-//   n7835.n8371[4] = pipe1.dimensions[3];
-//   n7835.n8371[5] = pipe1.dimensions[4];
-//   n7835.n8371[6] = pipe1.dimensions[5];
-//   n7835.n8371[7] = pipe1.dimensions[5];
-//   n7835.n8372[1] = pipe1.roughnesses[1];
-//   n7835.n8372[2] = pipe1.roughnesses[1];
-//   n7835.n8372[3] = pipe1.roughnesses[2];
-//   n7835.n8372[4] = pipe1.roughnesses[3];
-//   n7835.n8372[5] = pipe1.roughnesses[4];
-//   n7835.n8372[6] = pipe1.roughnesses[5];
-//   n7835.n8372[7] = pipe1.roughnesses[5];
+//   pipe1.$n30[1] = 5.0;
+//   pipe1.$n30[2] = 10.0;
+//   pipe1.$n30[3] = 10.0;
+//   pipe1.$n30[4] = 10.0;
+//   pipe1.$n30[5] = 10.0;
+//   pipe1.$n30[6] = 5.0;
+//   pipe1.$n31[1] = 5.0;
+//   pipe1.$n31[2] = 10.0;
+//   pipe1.$n31[3] = 10.0;
+//   pipe1.$n31[4] = 10.0;
+//   pipe1.$n31[5] = 10.0;
+//   pipe1.$n31[6] = 5.0;
+//   pipe1.$n32[1] = pipe1.crossAreas[1];
+//   pipe1.$n32[2] = pipe1.crossAreas[1];
+//   pipe1.$n32[3] = pipe1.crossAreas[2];
+//   pipe1.$n32[4] = pipe1.crossAreas[3];
+//   pipe1.$n32[5] = pipe1.crossAreas[4];
+//   pipe1.$n32[6] = pipe1.crossAreas[5];
+//   pipe1.$n32[7] = pipe1.crossAreas[5];
+//   pipe1.$n34[1] = pipe1.dimensions[1];
+//   pipe1.$n34[2] = pipe1.dimensions[1];
+//   pipe1.$n34[3] = pipe1.dimensions[2];
+//   pipe1.$n34[4] = pipe1.dimensions[3];
+//   pipe1.$n34[5] = pipe1.dimensions[4];
+//   pipe1.$n34[6] = pipe1.dimensions[5];
+//   pipe1.$n34[7] = pipe1.dimensions[5];
+//   pipe1.$n35[1] = pipe1.roughnesses[1];
+//   pipe1.$n35[2] = pipe1.roughnesses[1];
+//   pipe1.$n35[3] = pipe1.roughnesses[2];
+//   pipe1.$n35[4] = pipe1.roughnesses[3];
+//   pipe1.$n35[5] = pipe1.roughnesses[4];
+//   pipe1.$n35[6] = pipe1.roughnesses[5];
+//   pipe1.$n35[7] = pipe1.roughnesses[5];
 //   pipe1.mb_flows[1] = pipe1.m_flows[1] - pipe1.m_flows[2];
 //   pipe1.mbXi_flows[1,1] = pipe1.mXi_flows[1,1] - pipe1.mXi_flows[2,1];
 //   pipe1.Hb_flows[1] = pipe1.H_flows[1] - pipe1.H_flows[2];
@@ -6937,8 +6984,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.port_b.h_outflow = pipe1.mediums[5].h;
 //   pipe1.port_a.Xi_outflow[1] = pipe1.mediums[1].Xi[1];
 //   pipe1.port_b.Xi_outflow[1] = pipe1.mediums[5].Xi[1];
-//   pipe1.state_a = n1.n7656.n102.n8149.n7835.n7670.n8338(pipe1.port_a.p, boundary1.ports[1].h_outflow, {boundary1.ports[1].Xi_outflow[1]});
-//   pipe1.state_b = n1.n7656.n102.n8149.n7835.n7670.n8338(pipe1.port_b.p, ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.h_outflow + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.h_outflow) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07))});
+//   pipe1.state_a = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_phX(pipe1.port_a.p, boundary1.ports[1].h_outflow, {boundary1.ports[1].Xi_outflow[1]});
+//   pipe1.state_b = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.setState_phX(pipe1.port_b.p, ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.h_outflow + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.h_outflow) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07))});
 //   pipe1.statesFM[1] = pipe1.state_a;
 //   pipe1.statesFM[2] = pipe1.mediums[1].state;
 //   pipe1.statesFM[3] = pipe1.mediums[2].state;
@@ -6952,13 +6999,13 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe1.m_flows[4] = pipe1.flowModel.m_flows[4];
 //   pipe1.m_flows[5] = pipe1.flowModel.m_flows[5];
 //   pipe1.m_flows[6] = pipe1.flowModel.m_flows[6];
-//   n7835.n8369[1] = pipe1.m_flows[1] / n1.n7656.n102.n8149.n7835.n7670.n523(pipe1.state_a) / pipe1.crossAreas[1] / pipe1.nParallel;
-//   n7835.n8369[2] = pipe1.vs[1];
-//   n7835.n8369[3] = pipe1.vs[2];
-//   n7835.n8369[4] = pipe1.vs[3];
-//   n7835.n8369[5] = pipe1.vs[4];
-//   n7835.n8369[6] = pipe1.vs[5];
-//   n7835.n8369[7] = pipe1.m_flows[6] / n1.n7656.n102.n8149.n7835.n7670.n523(pipe1.state_b) / pipe1.crossAreas[5] / pipe1.nParallel;
+//   pipe1.$n33[1] = pipe1.m_flows[1] / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.density(pipe1.state_a) / pipe1.crossAreas[1] / pipe1.nParallel;
+//   pipe1.$n33[2] = pipe1.vs[1];
+//   pipe1.$n33[3] = pipe1.vs[2];
+//   pipe1.$n33[4] = pipe1.vs[3];
+//   pipe1.$n33[5] = pipe1.vs[4];
+//   pipe1.$n33[6] = pipe1.vs[5];
+//   pipe1.$n33[7] = pipe1.m_flows[6] / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe1.Medium.density(pipe1.state_b) / pipe1.crossAreas[5] / pipe1.nParallel;
 //   pipe1.ms[1] = pipe1.fluidVolumes[1] * pipe1.mediums[1].d;
 //   pipe1.mXis[1,1] = pipe1.ms[1] * pipe1.mediums[1].Xi[1];
 //   pipe1.Us[1] = pipe1.ms[1] * pipe1.mediums[1].u;
@@ -6989,139 +7036,169 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe1.mXis[3,1]) = pipe1.mbXi_flows[3,1];
 //   der(pipe1.mXis[4,1]) = pipe1.mbXi_flows[4,1];
 //   der(pipe1.mXis[5,1]) = pipe1.mbXi_flows[5,1];
-//   pipe2.fluidVolumes = array(pipe2.crossAreas[i] * {10.0, 10.0, 10.0, 10.0, 10.0}[i] for n49 in 1:5) * pipe2.nParallel;
-//   assert(pipe2.mediums[1].T >= 190.0 and pipe2.mediums[1].T <= 647.0, \"assert message 315810245365667762\");
+//   pipe2.fluidVolumes = array(pipe2.crossAreas[i] * {10.0, 10.0, 10.0, 10.0, 10.0}[i] for i in 1:5) * pipe2.nParallel;
+//   assert(pipe2.mediums[1].T >= 190.0 and pipe2.mediums[1].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe2.mediums[1].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe2.mediums[1].MM = 1.0 / (pipe2.mediums[1].Xi[1] / 0.01801528 + (1.0 - pipe2.mediums[1].Xi[1]) / 0.0289651159);
-//   n7836.n8256[1].n10110 = min(n1.n7656.n102.n8149.n7836.n7670.n8562(pipe2.mediums[1].T), 0.999 * pipe2.mediums[1].p);
-//   n7836.n8256[1].n10108 = min(n7836.n8256[1].n10110 * 0.6219647130774989 / max(1e-13, pipe2.mediums[1].p - n7836.n8256[1].n10110) * (1.0 - pipe2.mediums[1].Xi[1]), 1.0);
-//   n7836.n8256[1].n10105 = max(pipe2.mediums[1].Xi[1] - n7836.n8256[1].n10108, 0.0);
-//   n7836.n8256[1].n10106 = pipe2.mediums[1].Xi[1] - n7836.n8256[1].n10105;
-//   n7836.n8256[1].n10107 = 1.0 - pipe2.mediums[1].Xi[1];
-//   pipe2.mediums[1].h = n1.n7656.n102.n8149.n7836.n7670.n7957(pipe2.mediums[1].p, pipe2.mediums[1].T, pipe2.mediums[1].Xi);
-//   pipe2.mediums[1].R = 287.0512249529787 * n7836.n8256[1].n10107 / (1.0 - n7836.n8256[1].n10105) + 461.5233290850878 * n7836.n8256[1].n10106 / (1.0 - n7836.n8256[1].n10105);
+//   pipe2.mediums[1].$n44 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(pipe2.mediums[1].T), 0.999 * pipe2.mediums[1].p);
+//   pipe2.mediums[1].$n42 = min(pipe2.mediums[1].$n44 * 0.6219647130774989 / max(1e-13, pipe2.mediums[1].p - pipe2.mediums[1].$n44) * (1.0 - pipe2.mediums[1].Xi[1]), 1.0);
+//   pipe2.mediums[1].$n39 = max(pipe2.mediums[1].Xi[1] - pipe2.mediums[1].$n42, 0.0);
+//   pipe2.mediums[1].$n40 = pipe2.mediums[1].Xi[1] - pipe2.mediums[1].$n39;
+//   pipe2.mediums[1].$n41 = 1.0 - pipe2.mediums[1].Xi[1];
+//   pipe2.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[1].p, pipe2.mediums[1].T, pipe2.mediums[1].Xi);
+//   pipe2.mediums[1].R = 287.0512249529787 * pipe2.mediums[1].$n41 / (1.0 - pipe2.mediums[1].$n39) + 461.5233290850878 * pipe2.mediums[1].$n40 / (1.0 - pipe2.mediums[1].$n39);
 //   pipe2.mediums[1].u = pipe2.mediums[1].h - pipe2.mediums[1].R * pipe2.mediums[1].T;
 //   pipe2.mediums[1].d = pipe2.mediums[1].p / (pipe2.mediums[1].R * pipe2.mediums[1].T);
 //   pipe2.mediums[1].state.p = pipe2.mediums[1].p;
 //   pipe2.mediums[1].state.T = pipe2.mediums[1].T;
 //   pipe2.mediums[1].state.X[1] = pipe2.mediums[1].X[1];
 //   pipe2.mediums[1].state.X[2] = pipe2.mediums[1].X[2];
-//   n7836.n8256[1].n10109 = 0.6219647130774989 * n7836.n8256[1].n10110 / max(1e-13, pipe2.mediums[1].p - n7836.n8256[1].n10110);
-//   pipe2.mediums[1].x_water = pipe2.mediums[1].Xi[1] / max(n7836.n8256[1].n10107, 1e-13);
-//   pipe2.mediums[1].phi = pipe2.mediums[1].p / n7836.n8256[1].n10110 * pipe2.mediums[1].Xi[1] / (pipe2.mediums[1].Xi[1] + 0.6219647130774989 * n7836.n8256[1].n10107);
+//   pipe2.mediums[1].$n43 = 0.6219647130774989 * pipe2.mediums[1].$n44 / max(1e-13, pipe2.mediums[1].p - pipe2.mediums[1].$n44);
+//   pipe2.mediums[1].x_water = pipe2.mediums[1].Xi[1] / max(pipe2.mediums[1].$n41, 1e-13);
+//   pipe2.mediums[1].phi = pipe2.mediums[1].p / pipe2.mediums[1].$n44 * pipe2.mediums[1].Xi[1] / (pipe2.mediums[1].Xi[1] + 0.6219647130774989 * pipe2.mediums[1].$n41);
 //   pipe2.mediums[1].Xi[1] = pipe2.mediums[1].X[1];
 //   pipe2.mediums[1].X[2] = 1.0 - pipe2.mediums[1].Xi[1];
-//   assert(pipe2.mediums[1].X[1] >= -1e-05 and pipe2.mediums[1].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[1].X[2] >= -1e-05 and pipe2.mediums[1].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[1].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe2.mediums[2].T >= 190.0 and pipe2.mediums[2].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe2.mediums[1].X[1] >= -1e-05 and pipe2.mediums[1].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe2.mediums[1].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[1].X[2] >= -1e-05 and pipe2.mediums[1].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe2.mediums[1].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[1].p >= 0.0, \"Pressure (= \" + String(pipe2.mediums[1].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe2.mediums[1].T, 6, 0, true) + \" K)\");
+//   assert(pipe2.mediums[2].T >= 190.0 and pipe2.mediums[2].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe2.mediums[2].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe2.mediums[2].MM = 1.0 / (pipe2.mediums[2].Xi[1] / 0.01801528 + (1.0 - pipe2.mediums[2].Xi[1]) / 0.0289651159);
-//   n7836.n8256[2].n10110 = min(n1.n7656.n102.n8149.n7836.n7670.n8562(pipe2.mediums[2].T), 0.999 * pipe2.mediums[2].p);
-//   n7836.n8256[2].n10108 = min(n7836.n8256[2].n10110 * 0.6219647130774989 / max(1e-13, pipe2.mediums[2].p - n7836.n8256[2].n10110) * (1.0 - pipe2.mediums[2].Xi[1]), 1.0);
-//   n7836.n8256[2].n10105 = max(pipe2.mediums[2].Xi[1] - n7836.n8256[2].n10108, 0.0);
-//   n7836.n8256[2].n10106 = pipe2.mediums[2].Xi[1] - n7836.n8256[2].n10105;
-//   n7836.n8256[2].n10107 = 1.0 - pipe2.mediums[2].Xi[1];
-//   pipe2.mediums[2].h = n1.n7656.n102.n8149.n7836.n7670.n7957(pipe2.mediums[2].p, pipe2.mediums[2].T, pipe2.mediums[2].Xi);
-//   pipe2.mediums[2].R = 287.0512249529787 * n7836.n8256[2].n10107 / (1.0 - n7836.n8256[2].n10105) + 461.5233290850878 * n7836.n8256[2].n10106 / (1.0 - n7836.n8256[2].n10105);
+//   pipe2.mediums[2].$n44 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(pipe2.mediums[2].T), 0.999 * pipe2.mediums[2].p);
+//   pipe2.mediums[2].$n42 = min(pipe2.mediums[2].$n44 * 0.6219647130774989 / max(1e-13, pipe2.mediums[2].p - pipe2.mediums[2].$n44) * (1.0 - pipe2.mediums[2].Xi[1]), 1.0);
+//   pipe2.mediums[2].$n39 = max(pipe2.mediums[2].Xi[1] - pipe2.mediums[2].$n42, 0.0);
+//   pipe2.mediums[2].$n40 = pipe2.mediums[2].Xi[1] - pipe2.mediums[2].$n39;
+//   pipe2.mediums[2].$n41 = 1.0 - pipe2.mediums[2].Xi[1];
+//   pipe2.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[2].p, pipe2.mediums[2].T, pipe2.mediums[2].Xi);
+//   pipe2.mediums[2].R = 287.0512249529787 * pipe2.mediums[2].$n41 / (1.0 - pipe2.mediums[2].$n39) + 461.5233290850878 * pipe2.mediums[2].$n40 / (1.0 - pipe2.mediums[2].$n39);
 //   pipe2.mediums[2].u = pipe2.mediums[2].h - pipe2.mediums[2].R * pipe2.mediums[2].T;
 //   pipe2.mediums[2].d = pipe2.mediums[2].p / (pipe2.mediums[2].R * pipe2.mediums[2].T);
 //   pipe2.mediums[2].state.p = pipe2.mediums[2].p;
 //   pipe2.mediums[2].state.T = pipe2.mediums[2].T;
 //   pipe2.mediums[2].state.X[1] = pipe2.mediums[2].X[1];
 //   pipe2.mediums[2].state.X[2] = pipe2.mediums[2].X[2];
-//   n7836.n8256[2].n10109 = 0.6219647130774989 * n7836.n8256[2].n10110 / max(1e-13, pipe2.mediums[2].p - n7836.n8256[2].n10110);
-//   pipe2.mediums[2].x_water = pipe2.mediums[2].Xi[1] / max(n7836.n8256[2].n10107, 1e-13);
-//   pipe2.mediums[2].phi = pipe2.mediums[2].p / n7836.n8256[2].n10110 * pipe2.mediums[2].Xi[1] / (pipe2.mediums[2].Xi[1] + 0.6219647130774989 * n7836.n8256[2].n10107);
+//   pipe2.mediums[2].$n43 = 0.6219647130774989 * pipe2.mediums[2].$n44 / max(1e-13, pipe2.mediums[2].p - pipe2.mediums[2].$n44);
+//   pipe2.mediums[2].x_water = pipe2.mediums[2].Xi[1] / max(pipe2.mediums[2].$n41, 1e-13);
+//   pipe2.mediums[2].phi = pipe2.mediums[2].p / pipe2.mediums[2].$n44 * pipe2.mediums[2].Xi[1] / (pipe2.mediums[2].Xi[1] + 0.6219647130774989 * pipe2.mediums[2].$n41);
 //   pipe2.mediums[2].Xi[1] = pipe2.mediums[2].X[1];
 //   pipe2.mediums[2].X[2] = 1.0 - pipe2.mediums[2].Xi[1];
-//   assert(pipe2.mediums[2].X[1] >= -1e-05 and pipe2.mediums[2].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[2].X[2] >= -1e-05 and pipe2.mediums[2].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[2].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe2.mediums[3].T >= 190.0 and pipe2.mediums[3].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe2.mediums[2].X[1] >= -1e-05 and pipe2.mediums[2].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe2.mediums[2].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[2].X[2] >= -1e-05 and pipe2.mediums[2].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe2.mediums[2].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[2].p >= 0.0, \"Pressure (= \" + String(pipe2.mediums[2].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe2.mediums[2].T, 6, 0, true) + \" K)\");
+//   assert(pipe2.mediums[3].T >= 190.0 and pipe2.mediums[3].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe2.mediums[3].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe2.mediums[3].MM = 1.0 / (pipe2.mediums[3].Xi[1] / 0.01801528 + (1.0 - pipe2.mediums[3].Xi[1]) / 0.0289651159);
-//   n7836.n8256[3].n10110 = min(n1.n7656.n102.n8149.n7836.n7670.n8562(pipe2.mediums[3].T), 0.999 * pipe2.mediums[3].p);
-//   n7836.n8256[3].n10108 = min(n7836.n8256[3].n10110 * 0.6219647130774989 / max(1e-13, pipe2.mediums[3].p - n7836.n8256[3].n10110) * (1.0 - pipe2.mediums[3].Xi[1]), 1.0);
-//   n7836.n8256[3].n10105 = max(pipe2.mediums[3].Xi[1] - n7836.n8256[3].n10108, 0.0);
-//   n7836.n8256[3].n10106 = pipe2.mediums[3].Xi[1] - n7836.n8256[3].n10105;
-//   n7836.n8256[3].n10107 = 1.0 - pipe2.mediums[3].Xi[1];
-//   pipe2.mediums[3].h = n1.n7656.n102.n8149.n7836.n7670.n7957(pipe2.mediums[3].p, pipe2.mediums[3].T, pipe2.mediums[3].Xi);
-//   pipe2.mediums[3].R = 287.0512249529787 * n7836.n8256[3].n10107 / (1.0 - n7836.n8256[3].n10105) + 461.5233290850878 * n7836.n8256[3].n10106 / (1.0 - n7836.n8256[3].n10105);
+//   pipe2.mediums[3].$n44 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(pipe2.mediums[3].T), 0.999 * pipe2.mediums[3].p);
+//   pipe2.mediums[3].$n42 = min(pipe2.mediums[3].$n44 * 0.6219647130774989 / max(1e-13, pipe2.mediums[3].p - pipe2.mediums[3].$n44) * (1.0 - pipe2.mediums[3].Xi[1]), 1.0);
+//   pipe2.mediums[3].$n39 = max(pipe2.mediums[3].Xi[1] - pipe2.mediums[3].$n42, 0.0);
+//   pipe2.mediums[3].$n40 = pipe2.mediums[3].Xi[1] - pipe2.mediums[3].$n39;
+//   pipe2.mediums[3].$n41 = 1.0 - pipe2.mediums[3].Xi[1];
+//   pipe2.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[3].p, pipe2.mediums[3].T, pipe2.mediums[3].Xi);
+//   pipe2.mediums[3].R = 287.0512249529787 * pipe2.mediums[3].$n41 / (1.0 - pipe2.mediums[3].$n39) + 461.5233290850878 * pipe2.mediums[3].$n40 / (1.0 - pipe2.mediums[3].$n39);
 //   pipe2.mediums[3].u = pipe2.mediums[3].h - pipe2.mediums[3].R * pipe2.mediums[3].T;
 //   pipe2.mediums[3].d = pipe2.mediums[3].p / (pipe2.mediums[3].R * pipe2.mediums[3].T);
 //   pipe2.mediums[3].state.p = pipe2.mediums[3].p;
 //   pipe2.mediums[3].state.T = pipe2.mediums[3].T;
 //   pipe2.mediums[3].state.X[1] = pipe2.mediums[3].X[1];
 //   pipe2.mediums[3].state.X[2] = pipe2.mediums[3].X[2];
-//   n7836.n8256[3].n10109 = 0.6219647130774989 * n7836.n8256[3].n10110 / max(1e-13, pipe2.mediums[3].p - n7836.n8256[3].n10110);
-//   pipe2.mediums[3].x_water = pipe2.mediums[3].Xi[1] / max(n7836.n8256[3].n10107, 1e-13);
-//   pipe2.mediums[3].phi = pipe2.mediums[3].p / n7836.n8256[3].n10110 * pipe2.mediums[3].Xi[1] / (pipe2.mediums[3].Xi[1] + 0.6219647130774989 * n7836.n8256[3].n10107);
+//   pipe2.mediums[3].$n43 = 0.6219647130774989 * pipe2.mediums[3].$n44 / max(1e-13, pipe2.mediums[3].p - pipe2.mediums[3].$n44);
+//   pipe2.mediums[3].x_water = pipe2.mediums[3].Xi[1] / max(pipe2.mediums[3].$n41, 1e-13);
+//   pipe2.mediums[3].phi = pipe2.mediums[3].p / pipe2.mediums[3].$n44 * pipe2.mediums[3].Xi[1] / (pipe2.mediums[3].Xi[1] + 0.6219647130774989 * pipe2.mediums[3].$n41);
 //   pipe2.mediums[3].Xi[1] = pipe2.mediums[3].X[1];
 //   pipe2.mediums[3].X[2] = 1.0 - pipe2.mediums[3].Xi[1];
-//   assert(pipe2.mediums[3].X[1] >= -1e-05 and pipe2.mediums[3].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[3].X[2] >= -1e-05 and pipe2.mediums[3].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[3].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe2.mediums[4].T >= 190.0 and pipe2.mediums[4].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe2.mediums[3].X[1] >= -1e-05 and pipe2.mediums[3].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe2.mediums[3].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[3].X[2] >= -1e-05 and pipe2.mediums[3].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe2.mediums[3].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[3].p >= 0.0, \"Pressure (= \" + String(pipe2.mediums[3].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe2.mediums[3].T, 6, 0, true) + \" K)\");
+//   assert(pipe2.mediums[4].T >= 190.0 and pipe2.mediums[4].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe2.mediums[4].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe2.mediums[4].MM = 1.0 / (pipe2.mediums[4].Xi[1] / 0.01801528 + (1.0 - pipe2.mediums[4].Xi[1]) / 0.0289651159);
-//   n7836.n8256[4].n10110 = min(n1.n7656.n102.n8149.n7836.n7670.n8562(pipe2.mediums[4].T), 0.999 * pipe2.mediums[4].p);
-//   n7836.n8256[4].n10108 = min(n7836.n8256[4].n10110 * 0.6219647130774989 / max(1e-13, pipe2.mediums[4].p - n7836.n8256[4].n10110) * (1.0 - pipe2.mediums[4].Xi[1]), 1.0);
-//   n7836.n8256[4].n10105 = max(pipe2.mediums[4].Xi[1] - n7836.n8256[4].n10108, 0.0);
-//   n7836.n8256[4].n10106 = pipe2.mediums[4].Xi[1] - n7836.n8256[4].n10105;
-//   n7836.n8256[4].n10107 = 1.0 - pipe2.mediums[4].Xi[1];
-//   pipe2.mediums[4].h = n1.n7656.n102.n8149.n7836.n7670.n7957(pipe2.mediums[4].p, pipe2.mediums[4].T, pipe2.mediums[4].Xi);
-//   pipe2.mediums[4].R = 287.0512249529787 * n7836.n8256[4].n10107 / (1.0 - n7836.n8256[4].n10105) + 461.5233290850878 * n7836.n8256[4].n10106 / (1.0 - n7836.n8256[4].n10105);
+//   pipe2.mediums[4].$n44 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(pipe2.mediums[4].T), 0.999 * pipe2.mediums[4].p);
+//   pipe2.mediums[4].$n42 = min(pipe2.mediums[4].$n44 * 0.6219647130774989 / max(1e-13, pipe2.mediums[4].p - pipe2.mediums[4].$n44) * (1.0 - pipe2.mediums[4].Xi[1]), 1.0);
+//   pipe2.mediums[4].$n39 = max(pipe2.mediums[4].Xi[1] - pipe2.mediums[4].$n42, 0.0);
+//   pipe2.mediums[4].$n40 = pipe2.mediums[4].Xi[1] - pipe2.mediums[4].$n39;
+//   pipe2.mediums[4].$n41 = 1.0 - pipe2.mediums[4].Xi[1];
+//   pipe2.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[4].p, pipe2.mediums[4].T, pipe2.mediums[4].Xi);
+//   pipe2.mediums[4].R = 287.0512249529787 * pipe2.mediums[4].$n41 / (1.0 - pipe2.mediums[4].$n39) + 461.5233290850878 * pipe2.mediums[4].$n40 / (1.0 - pipe2.mediums[4].$n39);
 //   pipe2.mediums[4].u = pipe2.mediums[4].h - pipe2.mediums[4].R * pipe2.mediums[4].T;
 //   pipe2.mediums[4].d = pipe2.mediums[4].p / (pipe2.mediums[4].R * pipe2.mediums[4].T);
 //   pipe2.mediums[4].state.p = pipe2.mediums[4].p;
 //   pipe2.mediums[4].state.T = pipe2.mediums[4].T;
 //   pipe2.mediums[4].state.X[1] = pipe2.mediums[4].X[1];
 //   pipe2.mediums[4].state.X[2] = pipe2.mediums[4].X[2];
-//   n7836.n8256[4].n10109 = 0.6219647130774989 * n7836.n8256[4].n10110 / max(1e-13, pipe2.mediums[4].p - n7836.n8256[4].n10110);
-//   pipe2.mediums[4].x_water = pipe2.mediums[4].Xi[1] / max(n7836.n8256[4].n10107, 1e-13);
-//   pipe2.mediums[4].phi = pipe2.mediums[4].p / n7836.n8256[4].n10110 * pipe2.mediums[4].Xi[1] / (pipe2.mediums[4].Xi[1] + 0.6219647130774989 * n7836.n8256[4].n10107);
+//   pipe2.mediums[4].$n43 = 0.6219647130774989 * pipe2.mediums[4].$n44 / max(1e-13, pipe2.mediums[4].p - pipe2.mediums[4].$n44);
+//   pipe2.mediums[4].x_water = pipe2.mediums[4].Xi[1] / max(pipe2.mediums[4].$n41, 1e-13);
+//   pipe2.mediums[4].phi = pipe2.mediums[4].p / pipe2.mediums[4].$n44 * pipe2.mediums[4].Xi[1] / (pipe2.mediums[4].Xi[1] + 0.6219647130774989 * pipe2.mediums[4].$n41);
 //   pipe2.mediums[4].Xi[1] = pipe2.mediums[4].X[1];
 //   pipe2.mediums[4].X[2] = 1.0 - pipe2.mediums[4].Xi[1];
-//   assert(pipe2.mediums[4].X[1] >= -1e-05 and pipe2.mediums[4].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[4].X[2] >= -1e-05 and pipe2.mediums[4].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[4].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe2.mediums[5].T >= 190.0 and pipe2.mediums[5].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe2.mediums[4].X[1] >= -1e-05 and pipe2.mediums[4].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe2.mediums[4].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[4].X[2] >= -1e-05 and pipe2.mediums[4].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe2.mediums[4].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[4].p >= 0.0, \"Pressure (= \" + String(pipe2.mediums[4].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe2.mediums[4].T, 6, 0, true) + \" K)\");
+//   assert(pipe2.mediums[5].T >= 190.0 and pipe2.mediums[5].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe2.mediums[5].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe2.mediums[5].MM = 1.0 / (pipe2.mediums[5].Xi[1] / 0.01801528 + (1.0 - pipe2.mediums[5].Xi[1]) / 0.0289651159);
-//   n7836.n8256[5].n10110 = min(n1.n7656.n102.n8149.n7836.n7670.n8562(pipe2.mediums[5].T), 0.999 * pipe2.mediums[5].p);
-//   n7836.n8256[5].n10108 = min(n7836.n8256[5].n10110 * 0.6219647130774989 / max(1e-13, pipe2.mediums[5].p - n7836.n8256[5].n10110) * (1.0 - pipe2.mediums[5].Xi[1]), 1.0);
-//   n7836.n8256[5].n10105 = max(pipe2.mediums[5].Xi[1] - n7836.n8256[5].n10108, 0.0);
-//   n7836.n8256[5].n10106 = pipe2.mediums[5].Xi[1] - n7836.n8256[5].n10105;
-//   n7836.n8256[5].n10107 = 1.0 - pipe2.mediums[5].Xi[1];
-//   pipe2.mediums[5].h = n1.n7656.n102.n8149.n7836.n7670.n7957(pipe2.mediums[5].p, pipe2.mediums[5].T, pipe2.mediums[5].Xi);
-//   pipe2.mediums[5].R = 287.0512249529787 * n7836.n8256[5].n10107 / (1.0 - n7836.n8256[5].n10105) + 461.5233290850878 * n7836.n8256[5].n10106 / (1.0 - n7836.n8256[5].n10105);
+//   pipe2.mediums[5].$n44 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.saturationPressure(pipe2.mediums[5].T), 0.999 * pipe2.mediums[5].p);
+//   pipe2.mediums[5].$n42 = min(pipe2.mediums[5].$n44 * 0.6219647130774989 / max(1e-13, pipe2.mediums[5].p - pipe2.mediums[5].$n44) * (1.0 - pipe2.mediums[5].Xi[1]), 1.0);
+//   pipe2.mediums[5].$n39 = max(pipe2.mediums[5].Xi[1] - pipe2.mediums[5].$n42, 0.0);
+//   pipe2.mediums[5].$n40 = pipe2.mediums[5].Xi[1] - pipe2.mediums[5].$n39;
+//   pipe2.mediums[5].$n41 = 1.0 - pipe2.mediums[5].Xi[1];
+//   pipe2.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.specificEnthalpy_pTX(pipe2.mediums[5].p, pipe2.mediums[5].T, pipe2.mediums[5].Xi);
+//   pipe2.mediums[5].R = 287.0512249529787 * pipe2.mediums[5].$n41 / (1.0 - pipe2.mediums[5].$n39) + 461.5233290850878 * pipe2.mediums[5].$n40 / (1.0 - pipe2.mediums[5].$n39);
 //   pipe2.mediums[5].u = pipe2.mediums[5].h - pipe2.mediums[5].R * pipe2.mediums[5].T;
 //   pipe2.mediums[5].d = pipe2.mediums[5].p / (pipe2.mediums[5].R * pipe2.mediums[5].T);
 //   pipe2.mediums[5].state.p = pipe2.mediums[5].p;
 //   pipe2.mediums[5].state.T = pipe2.mediums[5].T;
 //   pipe2.mediums[5].state.X[1] = pipe2.mediums[5].X[1];
 //   pipe2.mediums[5].state.X[2] = pipe2.mediums[5].X[2];
-//   n7836.n8256[5].n10109 = 0.6219647130774989 * n7836.n8256[5].n10110 / max(1e-13, pipe2.mediums[5].p - n7836.n8256[5].n10110);
-//   pipe2.mediums[5].x_water = pipe2.mediums[5].Xi[1] / max(n7836.n8256[5].n10107, 1e-13);
-//   pipe2.mediums[5].phi = pipe2.mediums[5].p / n7836.n8256[5].n10110 * pipe2.mediums[5].Xi[1] / (pipe2.mediums[5].Xi[1] + 0.6219647130774989 * n7836.n8256[5].n10107);
+//   pipe2.mediums[5].$n43 = 0.6219647130774989 * pipe2.mediums[5].$n44 / max(1e-13, pipe2.mediums[5].p - pipe2.mediums[5].$n44);
+//   pipe2.mediums[5].x_water = pipe2.mediums[5].Xi[1] / max(pipe2.mediums[5].$n41, 1e-13);
+//   pipe2.mediums[5].phi = pipe2.mediums[5].p / pipe2.mediums[5].$n44 * pipe2.mediums[5].Xi[1] / (pipe2.mediums[5].Xi[1] + 0.6219647130774989 * pipe2.mediums[5].$n41);
 //   pipe2.mediums[5].Xi[1] = pipe2.mediums[5].X[1];
 //   pipe2.mediums[5].X[2] = 1.0 - pipe2.mediums[5].Xi[1];
-//   assert(pipe2.mediums[5].X[1] >= -1e-05 and pipe2.mediums[5].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[5].X[2] >= -1e-05 and pipe2.mediums[5].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe2.mediums[5].p >= 0.0, \"assert message 2590312994638120201\");
+//   assert(pipe2.mediums[5].X[1] >= -1e-05 and pipe2.mediums[5].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe2.mediums[5].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[5].X[2] >= -1e-05 and pipe2.mediums[5].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe2.mediums[5].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe2.mediums[5].p >= 0.0, \"Pressure (= \" + String(pipe2.mediums[5].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe2.mediums[5].T, 6, 0, true) + \" K)\");
 //   pipe2.flowModel.states[1].X = pipe2.statesFM[1].X;
 //   pipe2.flowModel.states[2].X = pipe2.statesFM[2].X;
 //   pipe2.flowModel.states[3].X = pipe2.statesFM[3].X;
 //   pipe2.flowModel.states[4].X = pipe2.statesFM[4].X;
 //   pipe2.flowModel.states[5].X = pipe2.statesFM[5].X;
-//   pipe2.flowModel.vs = n7836.n8369;
-//   pipe2.flowModel.crossAreas = n7836.n8370;
-//   pipe2.flowModel.dimensions = n7836.n8371;
-//   pipe2.flowModel.roughnesses = n7836.n8372;
-//   pipe2.flowModel.dheights = n7836.n8373;
-//   pipe2.flowModel.pathLengths = n7836.n8348;
-//   pipe2.flowModel.rhos = array(n1.n7656.n102.n8149.n7836.n8346.n7670.n523(pipe2.flowModel.states[$i1]) for $i1 in 1:5);
-//   pipe2.flowModel.mus = array(n1.n7656.n102.n8149.n7836.n8346.n7670.n8340(pipe2.flowModel.states[$i1]) for $i1 in 1:5);
+//   pipe2.flowModel.vs = pipe2.$n58;
+//   pipe2.flowModel.crossAreas = pipe2.$n57;
+//   pipe2.flowModel.dimensions = pipe2.$n59;
+//   pipe2.flowModel.roughnesses = pipe2.$n60;
+//   pipe2.flowModel.dheights = pipe2.$n56;
+//   pipe2.flowModel.pathLengths = pipe2.$n55;
+//   pipe2.flowModel.rhos = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.density(pipe2.flowModel.states[$i1]) for $i1 in 1:5);
+//   pipe2.flowModel.mus = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.dynamicViscosity(pipe2.flowModel.states[$i1]) for $i1 in 1:5);
 //   pipe2.flowModel.pathLengths_internal = pipe2.flowModel.pathLengths;
 //   pipe2.flowModel.Res_turbulent_internal = {pipe2.flowModel.Re_turbulent, pipe2.flowModel.Re_turbulent, pipe2.flowModel.Re_turbulent, pipe2.flowModel.Re_turbulent};
-//   n7836.n8346.n8410 = {0.5 * (pipe2.flowModel.dimensions[1] + pipe2.flowModel.dimensions[2]), 0.5 * (pipe2.flowModel.dimensions[2] + pipe2.flowModel.dimensions[3]), 0.5 * (pipe2.flowModel.dimensions[3] + pipe2.flowModel.dimensions[4]), 0.5 * (pipe2.flowModel.dimensions[4] + pipe2.flowModel.dimensions[5])};
-//   pipe2.flowModel.m_flows = array(homotopy((array(n1.n7656.n102.n8149.n7836.n8346.n7663.n8415(pipe2.flowModel.dps_fg[$i1], pipe2.flowModel.rhos[(1:4)[$i1]], pipe2.flowModel.rhos[(2:5)[$i1]], pipe2.flowModel.mus[(1:4)[$i1]], pipe2.flowModel.mus[(2:5)[$i1]], pipe2.flowModel.pathLengths_internal[$i1], n7836.n8346.n8410[$i1], {pipe2.flowModel.g * pipe2.flowModel.dheights[1], pipe2.flowModel.g * pipe2.flowModel.dheights[2], pipe2.flowModel.g * pipe2.flowModel.dheights[3], pipe2.flowModel.g * pipe2.flowModel.dheights[4]}[$i1], {(pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0}[$i1], {(pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0}[$i1], n7836.n8346.n8308 / 4.0, pipe2.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:4) * pipe2.flowModel.nParallel)[$i1], {pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[1] - pipe2.flowModel.g * pipe2.flowModel.dheights[1] * n7836.n8346.n8135), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[2] - pipe2.flowModel.g * pipe2.flowModel.dheights[2] * n7836.n8346.n8135), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[3] - pipe2.flowModel.g * pipe2.flowModel.dheights[3] * n7836.n8346.n8135), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[4] - pipe2.flowModel.g * pipe2.flowModel.dheights[4] * n7836.n8346.n8135)}[$i1]) for $i1 in 1:4);
+//   pipe2.flowModel.$n53 = {0.5 * (pipe2.flowModel.dimensions[1] + pipe2.flowModel.dimensions[2]), 0.5 * (pipe2.flowModel.dimensions[2] + pipe2.flowModel.dimensions[3]), 0.5 * (pipe2.flowModel.dimensions[3] + pipe2.flowModel.dimensions[4]), 0.5 * (pipe2.flowModel.dimensions[4] + pipe2.flowModel.dimensions[5])};
+//   pipe2.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe2.flowModel.dps_fg[$i1], pipe2.flowModel.rhos[(1:4)[$i1]], pipe2.flowModel.rhos[(2:5)[$i1]], pipe2.flowModel.mus[(1:4)[$i1]], pipe2.flowModel.mus[(2:5)[$i1]], pipe2.flowModel.pathLengths_internal[$i1], pipe2.flowModel.$n53[$i1], {pipe2.flowModel.g * pipe2.flowModel.dheights[1], pipe2.flowModel.g * pipe2.flowModel.dheights[2], pipe2.flowModel.g * pipe2.flowModel.dheights[3], pipe2.flowModel.g * pipe2.flowModel.dheights[4]}[$i1], {(pipe2.flowModel.crossAreas[1] + pipe2.flowModel.crossAreas[2]) / 2.0, (pipe2.flowModel.crossAreas[2] + pipe2.flowModel.crossAreas[3]) / 2.0, (pipe2.flowModel.crossAreas[3] + pipe2.flowModel.crossAreas[4]) / 2.0, (pipe2.flowModel.crossAreas[4] + pipe2.flowModel.crossAreas[5]) / 2.0}[$i1], {(pipe2.flowModel.roughnesses[1] + pipe2.flowModel.roughnesses[2]) / 2.0, (pipe2.flowModel.roughnesses[2] + pipe2.flowModel.roughnesses[3]) / 2.0, (pipe2.flowModel.roughnesses[3] + pipe2.flowModel.roughnesses[4]) / 2.0, (pipe2.flowModel.roughnesses[4] + pipe2.flowModel.roughnesses[5]) / 2.0}[$i1], pipe2.flowModel.$n50 / 4.0, pipe2.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:4) * pipe2.flowModel.nParallel)[$i1], {pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[1] - pipe2.flowModel.g * pipe2.flowModel.dheights[1] * pipe2.flowModel.$n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[2] - pipe2.flowModel.g * pipe2.flowModel.dheights[2] * pipe2.flowModel.$n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[3] - pipe2.flowModel.g * pipe2.flowModel.dheights[3] * pipe2.flowModel.$n47), pipe2.flowModel.m_flow_nominal / pipe2.flowModel.dp_nominal * (pipe2.flowModel.dps_fg[4] - pipe2.flowModel.g * pipe2.flowModel.dheights[4] * pipe2.flowModel.$n47)}[$i1]) for $i1 in 1:4);
 //   pipe2.flowModel.rhos_act[1] = noEvent(if pipe2.flowModel.m_flows[1] > 0.0 then pipe2.flowModel.rhos[1] else pipe2.flowModel.rhos[2]);
 //   pipe2.flowModel.mus_act[1] = noEvent(if pipe2.flowModel.m_flows[1] > 0.0 then pipe2.flowModel.mus[1] else pipe2.flowModel.mus[2]);
 //   pipe2.flowModel.rhos_act[2] = noEvent(if pipe2.flowModel.m_flows[2] > 0.0 then pipe2.flowModel.rhos[2] else pipe2.flowModel.rhos[3]);
@@ -7130,92 +7207,92 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.flowModel.mus_act[3] = noEvent(if pipe2.flowModel.m_flows[3] > 0.0 then pipe2.flowModel.mus[3] else pipe2.flowModel.mus[4]);
 //   pipe2.flowModel.rhos_act[4] = noEvent(if pipe2.flowModel.m_flows[4] > 0.0 then pipe2.flowModel.rhos[4] else pipe2.flowModel.rhos[5]);
 //   pipe2.flowModel.mus_act[4] = noEvent(if pipe2.flowModel.m_flows[4] > 0.0 then pipe2.flowModel.mus[4] else pipe2.flowModel.mus[5]);
-//   pipe2.flowModel.Ib_flows = array(pipe2.flowModel.rhos[i] * pipe2.flowModel.vs[i] * pipe2.flowModel.vs[i] * pipe2.flowModel.crossAreas[i] - pipe2.flowModel.rhos[i + 1] * pipe2.flowModel.vs[i + 1] * pipe2.flowModel.vs[i + 1] * pipe2.flowModel.crossAreas[i + 1] for n49 in 1:4) * pipe2.flowModel.nParallel;
-//   pipe2.flowModel.Fs_p = array(0.5 * (pipe2.flowModel.crossAreas[i] + pipe2.flowModel.crossAreas[i + 1]) * (n1.n7656.n102.n8149.n7836.n8346.n7670.n7786(pipe2.flowModel.states[i + 1]) - n1.n7656.n102.n8149.n7836.n8346.n7670.n7786(pipe2.flowModel.states[i])) for n49 in 1:4) * pipe2.flowModel.nParallel;
-//   pipe2.flowModel.dps_fg = array(pipe2.flowModel.Fs_fg[i] / pipe2.flowModel.nParallel * 2.0 / (pipe2.flowModel.crossAreas[i] + pipe2.flowModel.crossAreas[i + 1]) for n49 in 1:4);
-//   pipe2.flowModel.Is = array(pipe2.flowModel.m_flows[i] * pipe2.flowModel.pathLengths[i] for n49 in 1:4);
+//   pipe2.flowModel.Ib_flows = array(pipe2.flowModel.rhos[i] * pipe2.flowModel.vs[i] * pipe2.flowModel.vs[i] * pipe2.flowModel.crossAreas[i] - pipe2.flowModel.rhos[i + 1] * pipe2.flowModel.vs[i + 1] * pipe2.flowModel.vs[i + 1] * pipe2.flowModel.crossAreas[i + 1] for i in 1:4) * pipe2.flowModel.nParallel;
+//   pipe2.flowModel.Fs_p = array(0.5 * (pipe2.flowModel.crossAreas[i] + pipe2.flowModel.crossAreas[i + 1]) * (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.pressure(pipe2.flowModel.states[i + 1]) - Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.flowModel.Medium.pressure(pipe2.flowModel.states[i])) for i in 1:4) * pipe2.flowModel.nParallel;
+//   pipe2.flowModel.dps_fg = array(pipe2.flowModel.Fs_fg[i] / pipe2.flowModel.nParallel * 2.0 / (pipe2.flowModel.crossAreas[i] + pipe2.flowModel.crossAreas[i + 1]) for i in 1:4);
+//   pipe2.flowModel.Is = array(pipe2.flowModel.m_flows[i] * pipe2.flowModel.pathLengths[i] for i in 1:4);
 //   der(pipe2.flowModel.Is[1]) = pipe2.flowModel.Ib_flows[1] - pipe2.flowModel.Fs_p[1] - pipe2.flowModel.Fs_fg[1];
 //   der(pipe2.flowModel.Is[2]) = pipe2.flowModel.Ib_flows[2] - pipe2.flowModel.Fs_p[2] - pipe2.flowModel.Fs_fg[2];
 //   der(pipe2.flowModel.Is[3]) = pipe2.flowModel.Ib_flows[3] - pipe2.flowModel.Fs_p[3] - pipe2.flowModel.Fs_fg[3];
 //   der(pipe2.flowModel.Is[4]) = pipe2.flowModel.Ib_flows[4] - pipe2.flowModel.Fs_p[4] - pipe2.flowModel.Fs_fg[4];
-//   pipe2.vs = array(0.5 * (pipe2.m_flows[i] + pipe2.m_flows[i + 1]) / pipe2.mediums[i].d / pipe2.crossAreas[i] for n49 in 1:5) / pipe2.nParallel;
+//   pipe2.vs = array(0.5 * (pipe2.m_flows[i] + pipe2.m_flows[i + 1]) / pipe2.mediums[i].d / pipe2.crossAreas[i] for i in 1:5) / pipe2.nParallel;
 //   pipe2.heatTransfer.states[1].X = pipe2.mediums[1].state.X;
 //   pipe2.heatTransfer.states[2].X = pipe2.mediums[2].state.X;
 //   pipe2.heatTransfer.states[3].X = pipe2.mediums[3].state.X;
 //   pipe2.heatTransfer.states[4].X = pipe2.mediums[4].state.X;
 //   pipe2.heatTransfer.states[5].X = pipe2.mediums[5].state.X;
 //   pipe2.heatTransfer.surfaceAreas = {pipe2.perimeter * 10.0, pipe2.perimeter * 10.0, pipe2.perimeter * 10.0, pipe2.perimeter * 10.0, pipe2.perimeter * 10.0};
-//   pipe2.heatTransfer.Ts = array(n1.n7656.n102.n8149.n7836.n7988.n7670.n7785(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.Ts = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.temperature(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
 //   pipe2.heatTransfer.vs = pipe2.vs;
 //   pipe2.heatTransfer.lengths = {10.0, 10.0, 10.0, 10.0, 10.0};
 //   pipe2.heatTransfer.dimensions = pipe2.dimensions;
 //   pipe2.heatTransfer.roughnesses = pipe2.roughnesses;
 //   pipe2.heatTransfer.diameters = pipe2.heatTransfer.dimensions;
-//   n7836.n7988.n8433 = 3.66;
-//   n7836.n7988.n8431[1] = smooth(0, n7836.n7988.n8435[1] / 8.0 * abs(pipe2.heatTransfer.Res[1]) * pipe2.heatTransfer.Prs[1] / (1.0 + 12.7 * (n7836.n7988.n8435[1] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[1] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[1] / pipe2.heatTransfer.lengths[1] / (if pipe2.heatTransfer.vs[1] >= 0.0 then 0.5 else 4.5)) ^ 0.6666666666666666));
-//   n7836.n7988.n8435[1] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[1])) - 1.5) ^ (-2.0);
-//   n7836.n7988.n8432[1] = (n7836.n7988.n8433 ^ 3.0 + 0.3429999999999999 + (n7836.n7988.n8434[1] - 0.7) ^ 3.0) ^ 0.3333333333333333;
-//   n7836.n7988.n8434[1] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[1]) * pipe2.heatTransfer.Prs[1] * pipe2.heatTransfer.diameters[1] / pipe2.heatTransfer.lengths[1] / (if pipe2.heatTransfer.vs[1] >= 0.0 then 0.5 else 4.5)) ^ 0.3333333333333333);
-//   pipe2.heatTransfer.Nus[1] = n1.n7671.n8150.n8151.n11.n8436(n7836.n7988.n8431[1], n7836.n7988.n8432[1], pipe2.heatTransfer.Res[1] - 6150.0, 3850.0);
-//   n7836.n7988.n8431[2] = smooth(0, n7836.n7988.n8435[2] / 8.0 * abs(pipe2.heatTransfer.Res[2]) * pipe2.heatTransfer.Prs[2] / (1.0 + 12.7 * (n7836.n7988.n8435[2] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[2] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[2] / pipe2.heatTransfer.lengths[2] / (if pipe2.heatTransfer.vs[2] >= 0.0 then 1.5 else 3.5)) ^ 0.6666666666666666));
-//   n7836.n7988.n8435[2] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[2])) - 1.5) ^ (-2.0);
-//   n7836.n7988.n8432[2] = (n7836.n7988.n8433 ^ 3.0 + 0.3429999999999999 + (n7836.n7988.n8434[2] - 0.7) ^ 3.0) ^ 0.3333333333333333;
-//   n7836.n7988.n8434[2] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[2]) * pipe2.heatTransfer.Prs[2] * pipe2.heatTransfer.diameters[2] / pipe2.heatTransfer.lengths[2] / (if pipe2.heatTransfer.vs[2] >= 0.0 then 1.5 else 3.5)) ^ 0.3333333333333333);
-//   pipe2.heatTransfer.Nus[2] = n1.n7671.n8150.n8151.n11.n8436(n7836.n7988.n8431[2], n7836.n7988.n8432[2], pipe2.heatTransfer.Res[2] - 6150.0, 3850.0);
-//   n7836.n7988.n8431[3] = smooth(0, n7836.n7988.n8435[3] / 8.0 * abs(pipe2.heatTransfer.Res[3]) * pipe2.heatTransfer.Prs[3] / (1.0 + 12.7 * (n7836.n7988.n8435[3] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[3] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[3] / pipe2.heatTransfer.lengths[3] / 2.5) ^ 0.6666666666666666));
-//   n7836.n7988.n8435[3] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[3])) - 1.5) ^ (-2.0);
-//   n7836.n7988.n8432[3] = (n7836.n7988.n8433 ^ 3.0 + 0.3429999999999999 + (n7836.n7988.n8434[3] - 0.7) ^ 3.0) ^ 0.3333333333333333;
-//   n7836.n7988.n8434[3] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[3]) * pipe2.heatTransfer.Prs[3] * pipe2.heatTransfer.diameters[3] / pipe2.heatTransfer.lengths[3] / 2.5) ^ 0.3333333333333333);
-//   pipe2.heatTransfer.Nus[3] = n1.n7671.n8150.n8151.n11.n8436(n7836.n7988.n8431[3], n7836.n7988.n8432[3], pipe2.heatTransfer.Res[3] - 6150.0, 3850.0);
-//   n7836.n7988.n8431[4] = smooth(0, n7836.n7988.n8435[4] / 8.0 * abs(pipe2.heatTransfer.Res[4]) * pipe2.heatTransfer.Prs[4] / (1.0 + 12.7 * (n7836.n7988.n8435[4] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[4] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[4] / pipe2.heatTransfer.lengths[4] / (if pipe2.heatTransfer.vs[4] >= 0.0 then 3.5 else 1.5)) ^ 0.6666666666666666));
-//   n7836.n7988.n8435[4] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[4])) - 1.5) ^ (-2.0);
-//   n7836.n7988.n8432[4] = (n7836.n7988.n8433 ^ 3.0 + 0.3429999999999999 + (n7836.n7988.n8434[4] - 0.7) ^ 3.0) ^ 0.3333333333333333;
-//   n7836.n7988.n8434[4] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[4]) * pipe2.heatTransfer.Prs[4] * pipe2.heatTransfer.diameters[4] / pipe2.heatTransfer.lengths[4] / (if pipe2.heatTransfer.vs[4] >= 0.0 then 3.5 else 1.5)) ^ 0.3333333333333333);
-//   pipe2.heatTransfer.Nus[4] = n1.n7671.n8150.n8151.n11.n8436(n7836.n7988.n8431[4], n7836.n7988.n8432[4], pipe2.heatTransfer.Res[4] - 6150.0, 3850.0);
-//   n7836.n7988.n8431[5] = smooth(0, n7836.n7988.n8435[5] / 8.0 * abs(pipe2.heatTransfer.Res[5]) * pipe2.heatTransfer.Prs[5] / (1.0 + 12.7 * (n7836.n7988.n8435[5] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[5] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[5] / pipe2.heatTransfer.lengths[5] / (if pipe2.heatTransfer.vs[5] >= 0.0 then 4.5 else 0.5)) ^ 0.6666666666666666));
-//   n7836.n7988.n8435[5] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[5])) - 1.5) ^ (-2.0);
-//   n7836.n7988.n8432[5] = (n7836.n7988.n8433 ^ 3.0 + 0.3429999999999999 + (n7836.n7988.n8434[5] - 0.7) ^ 3.0) ^ 0.3333333333333333;
-//   n7836.n7988.n8434[5] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[5]) * pipe2.heatTransfer.Prs[5] * pipe2.heatTransfer.diameters[5] / pipe2.heatTransfer.lengths[5] / (if pipe2.heatTransfer.vs[5] >= 0.0 then 4.5 else 0.5)) ^ 0.3333333333333333);
-//   pipe2.heatTransfer.Nus[5] = n1.n7671.n8150.n8151.n11.n8436(n7836.n7988.n8431[5], n7836.n7988.n8432[5], pipe2.heatTransfer.Res[5] - 6150.0, 3850.0);
-//   pipe2.heatTransfer.ds = array(n1.n7656.n102.n8149.n7836.n7988.n7670.n523(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
-//   pipe2.heatTransfer.mus = array(n1.n7656.n102.n8149.n7836.n7988.n7670.n8340(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
-//   pipe2.heatTransfer.lambdas = array(n1.n7656.n102.n8149.n7836.n7988.n7670.n8428(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
-//   pipe2.heatTransfer.Prs = array(n1.n7656.n102.n8149.n7836.n7988.n7670.n8429(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
-//   pipe2.heatTransfer.Res = array(n1.n7656.n7680.n5984.n8393.n8329(pipe2.heatTransfer.vs[$i1], pipe2.heatTransfer.ds[$i1], pipe2.heatTransfer.mus[$i1], pipe2.heatTransfer.diameters[$i1]) for $i1 in 1:5);
-//   pipe2.heatTransfer.Nus = array(n1.n7656.n7680.n5984.n8393.n8430(pipe2.heatTransfer.alphas[$i1], pipe2.heatTransfer.diameters[$i1], pipe2.heatTransfer.lambdas[$i1]) for $i1 in 1:5);
-//   pipe2.heatTransfer.Q_flows = array(pipe2.heatTransfer.alphas[i] * pipe2.heatTransfer.surfaceAreas[i] * (pipe2.heatTransfer.heatPorts[i].T - pipe2.heatTransfer.Ts[i]) * pipe2.heatTransfer.nParallel for n49 in 1:5);
-//   pipe2.heatTransfer.Q_flows = {pipe2.heatTransfer.heatPorts[1].Q_flow, pipe2.heatTransfer.heatPorts[2].Q_flow, pipe2.heatTransfer.heatPorts[3].Q_flow, pipe2.heatTransfer.heatPorts[4].Q_flow, pipe2.heatTransfer.heatPorts[5].Q_flow} + array(0.0 for n49 in 1:5);
+//   pipe2.heatTransfer.$n63 = 3.66;
+//   pipe2.heatTransfer.$n61[1] = smooth(0, pipe2.heatTransfer.$n65[1] / 8.0 * abs(pipe2.heatTransfer.Res[1]) * pipe2.heatTransfer.Prs[1] / (1.0 + 12.7 * (pipe2.heatTransfer.$n65[1] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[1] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[1] / pipe2.heatTransfer.lengths[1] / (if pipe2.heatTransfer.vs[1] >= 0.0 then 0.5 else 4.5)) ^ 0.6666666666666666));
+//   pipe2.heatTransfer.$n65[1] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[1])) - 1.5) ^ (-2.0);
+//   pipe2.heatTransfer.$n62[1] = (pipe2.heatTransfer.$n63 ^ 3.0 + 0.3429999999999999 + (pipe2.heatTransfer.$n64[1] - 0.7) ^ 3.0) ^ 0.3333333333333333;
+//   pipe2.heatTransfer.$n64[1] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[1]) * pipe2.heatTransfer.Prs[1] * pipe2.heatTransfer.diameters[1] / pipe2.heatTransfer.lengths[1] / (if pipe2.heatTransfer.vs[1] >= 0.0 then 0.5 else 4.5)) ^ 0.3333333333333333);
+//   pipe2.heatTransfer.Nus[1] = Modelica.Media.Air.MoistAir.Utilities.spliceFunction(pipe2.heatTransfer.$n61[1], pipe2.heatTransfer.$n62[1], pipe2.heatTransfer.Res[1] - 6150.0, 3850.0);
+//   pipe2.heatTransfer.$n61[2] = smooth(0, pipe2.heatTransfer.$n65[2] / 8.0 * abs(pipe2.heatTransfer.Res[2]) * pipe2.heatTransfer.Prs[2] / (1.0 + 12.7 * (pipe2.heatTransfer.$n65[2] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[2] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[2] / pipe2.heatTransfer.lengths[2] / (if pipe2.heatTransfer.vs[2] >= 0.0 then 1.5 else 3.5)) ^ 0.6666666666666666));
+//   pipe2.heatTransfer.$n65[2] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[2])) - 1.5) ^ (-2.0);
+//   pipe2.heatTransfer.$n62[2] = (pipe2.heatTransfer.$n63 ^ 3.0 + 0.3429999999999999 + (pipe2.heatTransfer.$n64[2] - 0.7) ^ 3.0) ^ 0.3333333333333333;
+//   pipe2.heatTransfer.$n64[2] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[2]) * pipe2.heatTransfer.Prs[2] * pipe2.heatTransfer.diameters[2] / pipe2.heatTransfer.lengths[2] / (if pipe2.heatTransfer.vs[2] >= 0.0 then 1.5 else 3.5)) ^ 0.3333333333333333);
+//   pipe2.heatTransfer.Nus[2] = Modelica.Media.Air.MoistAir.Utilities.spliceFunction(pipe2.heatTransfer.$n61[2], pipe2.heatTransfer.$n62[2], pipe2.heatTransfer.Res[2] - 6150.0, 3850.0);
+//   pipe2.heatTransfer.$n61[3] = smooth(0, pipe2.heatTransfer.$n65[3] / 8.0 * abs(pipe2.heatTransfer.Res[3]) * pipe2.heatTransfer.Prs[3] / (1.0 + 12.7 * (pipe2.heatTransfer.$n65[3] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[3] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[3] / pipe2.heatTransfer.lengths[3] / 2.5) ^ 0.6666666666666666));
+//   pipe2.heatTransfer.$n65[3] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[3])) - 1.5) ^ (-2.0);
+//   pipe2.heatTransfer.$n62[3] = (pipe2.heatTransfer.$n63 ^ 3.0 + 0.3429999999999999 + (pipe2.heatTransfer.$n64[3] - 0.7) ^ 3.0) ^ 0.3333333333333333;
+//   pipe2.heatTransfer.$n64[3] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[3]) * pipe2.heatTransfer.Prs[3] * pipe2.heatTransfer.diameters[3] / pipe2.heatTransfer.lengths[3] / 2.5) ^ 0.3333333333333333);
+//   pipe2.heatTransfer.Nus[3] = Modelica.Media.Air.MoistAir.Utilities.spliceFunction(pipe2.heatTransfer.$n61[3], pipe2.heatTransfer.$n62[3], pipe2.heatTransfer.Res[3] - 6150.0, 3850.0);
+//   pipe2.heatTransfer.$n61[4] = smooth(0, pipe2.heatTransfer.$n65[4] / 8.0 * abs(pipe2.heatTransfer.Res[4]) * pipe2.heatTransfer.Prs[4] / (1.0 + 12.7 * (pipe2.heatTransfer.$n65[4] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[4] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[4] / pipe2.heatTransfer.lengths[4] / (if pipe2.heatTransfer.vs[4] >= 0.0 then 3.5 else 1.5)) ^ 0.6666666666666666));
+//   pipe2.heatTransfer.$n65[4] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[4])) - 1.5) ^ (-2.0);
+//   pipe2.heatTransfer.$n62[4] = (pipe2.heatTransfer.$n63 ^ 3.0 + 0.3429999999999999 + (pipe2.heatTransfer.$n64[4] - 0.7) ^ 3.0) ^ 0.3333333333333333;
+//   pipe2.heatTransfer.$n64[4] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[4]) * pipe2.heatTransfer.Prs[4] * pipe2.heatTransfer.diameters[4] / pipe2.heatTransfer.lengths[4] / (if pipe2.heatTransfer.vs[4] >= 0.0 then 3.5 else 1.5)) ^ 0.3333333333333333);
+//   pipe2.heatTransfer.Nus[4] = Modelica.Media.Air.MoistAir.Utilities.spliceFunction(pipe2.heatTransfer.$n61[4], pipe2.heatTransfer.$n62[4], pipe2.heatTransfer.Res[4] - 6150.0, 3850.0);
+//   pipe2.heatTransfer.$n61[5] = smooth(0, pipe2.heatTransfer.$n65[5] / 8.0 * abs(pipe2.heatTransfer.Res[5]) * pipe2.heatTransfer.Prs[5] / (1.0 + 12.7 * (pipe2.heatTransfer.$n65[5] / 8.0) ^ 0.5 * (pipe2.heatTransfer.Prs[5] ^ 0.6666666666666666 - 1.0)) * (1.0 + 0.3333333333333333 * (pipe2.heatTransfer.diameters[5] / pipe2.heatTransfer.lengths[5] / (if pipe2.heatTransfer.vs[5] >= 0.0 then 4.5 else 0.5)) ^ 0.6666666666666666));
+//   pipe2.heatTransfer.$n65[5] = (1.8 * log10(max(1e-10, pipe2.heatTransfer.Res[5])) - 1.5) ^ (-2.0);
+//   pipe2.heatTransfer.$n62[5] = (pipe2.heatTransfer.$n63 ^ 3.0 + 0.3429999999999999 + (pipe2.heatTransfer.$n64[5] - 0.7) ^ 3.0) ^ 0.3333333333333333;
+//   pipe2.heatTransfer.$n64[5] = smooth(0, 1.077 * (abs(pipe2.heatTransfer.Res[5]) * pipe2.heatTransfer.Prs[5] * pipe2.heatTransfer.diameters[5] / pipe2.heatTransfer.lengths[5] / (if pipe2.heatTransfer.vs[5] >= 0.0 then 4.5 else 0.5)) ^ 0.3333333333333333);
+//   pipe2.heatTransfer.Nus[5] = Modelica.Media.Air.MoistAir.Utilities.spliceFunction(pipe2.heatTransfer.$n61[5], pipe2.heatTransfer.$n62[5], pipe2.heatTransfer.Res[5] - 6150.0, 3850.0);
+//   pipe2.heatTransfer.ds = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.density(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.mus = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.dynamicViscosity(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.lambdas = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.thermalConductivity(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.Prs = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.heatTransfer.Medium.prandtlNumber(pipe2.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.Res = array(Modelica.Fluid.Pipes.BaseClasses.CharacteristicNumbers.ReynoldsNumber(pipe2.heatTransfer.vs[$i1], pipe2.heatTransfer.ds[$i1], pipe2.heatTransfer.mus[$i1], pipe2.heatTransfer.diameters[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.Nus = array(Modelica.Fluid.Pipes.BaseClasses.CharacteristicNumbers.NusseltNumber(pipe2.heatTransfer.alphas[$i1], pipe2.heatTransfer.diameters[$i1], pipe2.heatTransfer.lambdas[$i1]) for $i1 in 1:5);
+//   pipe2.heatTransfer.Q_flows = array(pipe2.heatTransfer.alphas[i] * pipe2.heatTransfer.surfaceAreas[i] * (pipe2.heatTransfer.heatPorts[i].T - pipe2.heatTransfer.Ts[i]) * pipe2.heatTransfer.nParallel for i in 1:5);
+//   pipe2.heatTransfer.Q_flows = {pipe2.heatTransfer.heatPorts[1].Q_flow, pipe2.heatTransfer.heatPorts[2].Q_flow, pipe2.heatTransfer.heatPorts[3].Q_flow, pipe2.heatTransfer.heatPorts[4].Q_flow, pipe2.heatTransfer.heatPorts[5].Q_flow} + array(0.0 for i in 1:5);
 //   pipe2.Qb_flows[1] = pipe2.heatTransfer.Q_flows[1];
 //   pipe2.Qb_flows[2] = pipe2.heatTransfer.Q_flows[2];
 //   pipe2.Qb_flows[3] = pipe2.heatTransfer.Q_flows[3];
 //   pipe2.Qb_flows[4] = pipe2.heatTransfer.Q_flows[4];
 //   pipe2.Qb_flows[5] = pipe2.heatTransfer.Q_flows[5];
-//   pipe2.Wb_flows[2:4] = array(pipe2.vs[i] * pipe2.crossAreas[i] * ((pipe2.mediums[i + 1].p - pipe2.mediums[i - 1].p) / 2.0 + (pipe2.flowModel.dps_fg[i - 1] + pipe2.flowModel.dps_fg[i]) / 2.0 - system.g * {5.0, 5.0, 5.0, 5.0, 5.0}[i] * pipe2.mediums[i].d) for n49 in 2:4) * pipe2.nParallel;
+//   pipe2.Wb_flows[2:4] = array(pipe2.vs[i] * pipe2.crossAreas[i] * ((pipe2.mediums[i + 1].p - pipe2.mediums[i - 1].p) / 2.0 + (pipe2.flowModel.dps_fg[i - 1] + pipe2.flowModel.dps_fg[i]) / 2.0 - system.g * {5.0, 5.0, 5.0, 5.0, 5.0}[i] * pipe2.mediums[i].d) for i in 2:4) * pipe2.nParallel;
 //   pipe2.Wb_flows[1] = pipe2.vs[1] * pipe2.crossAreas[1] * ((pipe2.mediums[2].p - pipe2.mediums[1].p) / 2.0 + pipe2.flowModel.dps_fg[1] / 2.0 - system.g * 5.0 * pipe2.mediums[1].d) * pipe2.nParallel;
 //   pipe2.Wb_flows[5] = pipe2.vs[5] * pipe2.crossAreas[5] * ((pipe2.mediums[5].p - pipe2.mediums[4].p) / 2.0 + pipe2.flowModel.dps_fg[4] / 2.0 - system.g * 5.0 * pipe2.mediums[5].d) * pipe2.nParallel;
-//   n7836.n8348[1] = 15.0;
-//   n7836.n8348[2] = 10.0;
-//   n7836.n8348[3] = 10.0;
-//   n7836.n8348[4] = 15.0;
-//   n7836.n8373[1] = 7.5;
-//   n7836.n8373[2] = 5.0;
-//   n7836.n8373[3] = 5.0;
-//   n7836.n8373[4] = 7.5;
-//   n7836.n8370[1] = pipe2.crossAreas[1];
-//   n7836.n8370[2] = pipe2.crossAreas[2];
-//   n7836.n8370[3] = pipe2.crossAreas[3];
-//   n7836.n8370[4] = pipe2.crossAreas[4];
-//   n7836.n8370[5] = pipe2.crossAreas[5];
-//   n7836.n8371[1] = pipe2.dimensions[1];
-//   n7836.n8371[2] = pipe2.dimensions[2];
-//   n7836.n8371[3] = pipe2.dimensions[3];
-//   n7836.n8371[4] = pipe2.dimensions[4];
-//   n7836.n8371[5] = pipe2.dimensions[5];
-//   n7836.n8372[1] = pipe2.roughnesses[1];
-//   n7836.n8372[2] = pipe2.roughnesses[2];
-//   n7836.n8372[3] = pipe2.roughnesses[3];
-//   n7836.n8372[4] = pipe2.roughnesses[4];
-//   n7836.n8372[5] = pipe2.roughnesses[5];
+//   pipe2.$n55[1] = 15.0;
+//   pipe2.$n55[2] = 10.0;
+//   pipe2.$n55[3] = 10.0;
+//   pipe2.$n55[4] = 15.0;
+//   pipe2.$n56[1] = 7.5;
+//   pipe2.$n56[2] = 5.0;
+//   pipe2.$n56[3] = 5.0;
+//   pipe2.$n56[4] = 7.5;
+//   pipe2.$n57[1] = pipe2.crossAreas[1];
+//   pipe2.$n57[2] = pipe2.crossAreas[2];
+//   pipe2.$n57[3] = pipe2.crossAreas[3];
+//   pipe2.$n57[4] = pipe2.crossAreas[4];
+//   pipe2.$n57[5] = pipe2.crossAreas[5];
+//   pipe2.$n59[1] = pipe2.dimensions[1];
+//   pipe2.$n59[2] = pipe2.dimensions[2];
+//   pipe2.$n59[3] = pipe2.dimensions[3];
+//   pipe2.$n59[4] = pipe2.dimensions[4];
+//   pipe2.$n59[5] = pipe2.dimensions[5];
+//   pipe2.$n60[1] = pipe2.roughnesses[1];
+//   pipe2.$n60[2] = pipe2.roughnesses[2];
+//   pipe2.$n60[3] = pipe2.roughnesses[3];
+//   pipe2.$n60[4] = pipe2.roughnesses[4];
+//   pipe2.$n60[5] = pipe2.roughnesses[5];
 //   pipe2.mb_flows[1] = pipe2.m_flows[1] - pipe2.m_flows[2];
 //   pipe2.mbXi_flows[1,1] = pipe2.mXi_flows[1,1] - pipe2.mXi_flows[2,1];
 //   pipe2.Hb_flows[1] = pipe2.H_flows[1] - pipe2.H_flows[2];
@@ -7249,8 +7326,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.port_b.h_outflow = pipe2.mediums[5].h;
 //   pipe2.port_a.Xi_outflow[1] = pipe2.mediums[1].Xi[1];
 //   pipe2.port_b.Xi_outflow[1] = pipe2.mediums[5].Xi[1];
-//   pipe2.state_a = n1.n7656.n102.n8149.n7836.n7670.n8338(pipe2.port_a.p, ($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.h_outflow + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.h_outflow) / ($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07))});
-//   pipe2.state_b = n1.n7656.n102.n8149.n7836.n7670.n8338(pipe2.port_b.p, ($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.h_outflow + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.h_outflow) / ($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07))});
+//   pipe2.state_a = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_phX(pipe2.port_a.p, ($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.h_outflow + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.h_outflow) / ($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) * pipe3.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe3.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07))});
+//   pipe2.state_b = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe2.Medium.setState_phX(pipe2.port_b.p, ($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.h_outflow + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.h_outflow) / ($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07))});
 //   pipe2.statesFM[1] = pipe2.mediums[1].state;
 //   pipe2.statesFM[2] = pipe2.mediums[2].state;
 //   pipe2.statesFM[3] = pipe2.mediums[3].state;
@@ -7260,11 +7337,11 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe2.m_flows[3] = pipe2.flowModel.m_flows[2];
 //   pipe2.m_flows[4] = pipe2.flowModel.m_flows[3];
 //   pipe2.m_flows[5] = pipe2.flowModel.m_flows[4];
-//   n7836.n8369[1] = pipe2.vs[1];
-//   n7836.n8369[2] = pipe2.vs[2];
-//   n7836.n8369[3] = pipe2.vs[3];
-//   n7836.n8369[4] = pipe2.vs[4];
-//   n7836.n8369[5] = pipe2.vs[5];
+//   pipe2.$n58[1] = pipe2.vs[1];
+//   pipe2.$n58[2] = pipe2.vs[2];
+//   pipe2.$n58[3] = pipe2.vs[3];
+//   pipe2.$n58[4] = pipe2.vs[4];
+//   pipe2.$n58[5] = pipe2.vs[5];
 //   pipe2.port_a.p = pipe2.mediums[1].p;
 //   pipe2.port_b.p = pipe2.mediums[5].p;
 //   pipe2.ms[1] = pipe2.fluidVolumes[1] * pipe2.mediums[1].d;
@@ -7297,122 +7374,152 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe2.mXis[3,1]) = pipe2.mbXi_flows[3,1];
 //   der(pipe2.mXis[4,1]) = pipe2.mbXi_flows[4,1];
 //   der(pipe2.mXis[5,1]) = pipe2.mbXi_flows[5,1];
-//   pipe3.fluidVolumes = array(pipe3.crossAreas[i] * {5.0, 5.0, 5.0, 5.0, 5.0}[i] for n49 in 1:5) * pipe3.nParallel;
-//   assert(pipe3.mediums[1].T >= 190.0 and pipe3.mediums[1].T <= 647.0, \"assert message 315810245365667762\");
+//   pipe3.fluidVolumes = array(pipe3.crossAreas[i] * {5.0, 5.0, 5.0, 5.0, 5.0}[i] for i in 1:5) * pipe3.nParallel;
+//   assert(pipe3.mediums[1].T >= 190.0 and pipe3.mediums[1].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe3.mediums[1].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe3.mediums[1].MM = 1.0 / (pipe3.mediums[1].Xi[1] / 0.01801528 + (1.0 - pipe3.mediums[1].Xi[1]) / 0.0289651159);
-//   n7837.n8256[1].n10110 = min(n1.n7656.n102.n8149.n7837.n7670.n8562(pipe3.mediums[1].T), 0.999 * pipe3.mediums[1].p);
-//   n7837.n8256[1].n10108 = min(n7837.n8256[1].n10110 * 0.6219647130774989 / max(1e-13, pipe3.mediums[1].p - n7837.n8256[1].n10110) * (1.0 - pipe3.mediums[1].Xi[1]), 1.0);
-//   n7837.n8256[1].n10105 = max(pipe3.mediums[1].Xi[1] - n7837.n8256[1].n10108, 0.0);
-//   n7837.n8256[1].n10106 = pipe3.mediums[1].Xi[1] - n7837.n8256[1].n10105;
-//   n7837.n8256[1].n10107 = 1.0 - pipe3.mediums[1].Xi[1];
-//   pipe3.mediums[1].h = n1.n7656.n102.n8149.n7837.n7670.n7957(pipe3.mediums[1].p, pipe3.mediums[1].T, pipe3.mediums[1].Xi);
-//   pipe3.mediums[1].R = 287.0512249529787 * n7837.n8256[1].n10107 / (1.0 - n7837.n8256[1].n10105) + 461.5233290850878 * n7837.n8256[1].n10106 / (1.0 - n7837.n8256[1].n10105);
+//   pipe3.mediums[1].$n74 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(pipe3.mediums[1].T), 0.999 * pipe3.mediums[1].p);
+//   pipe3.mediums[1].$n72 = min(pipe3.mediums[1].$n74 * 0.6219647130774989 / max(1e-13, pipe3.mediums[1].p - pipe3.mediums[1].$n74) * (1.0 - pipe3.mediums[1].Xi[1]), 1.0);
+//   pipe3.mediums[1].$n69 = max(pipe3.mediums[1].Xi[1] - pipe3.mediums[1].$n72, 0.0);
+//   pipe3.mediums[1].$n70 = pipe3.mediums[1].Xi[1] - pipe3.mediums[1].$n69;
+//   pipe3.mediums[1].$n71 = 1.0 - pipe3.mediums[1].Xi[1];
+//   pipe3.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[1].p, pipe3.mediums[1].T, pipe3.mediums[1].Xi);
+//   pipe3.mediums[1].R = 287.0512249529787 * pipe3.mediums[1].$n71 / (1.0 - pipe3.mediums[1].$n69) + 461.5233290850878 * pipe3.mediums[1].$n70 / (1.0 - pipe3.mediums[1].$n69);
 //   pipe3.mediums[1].u = pipe3.mediums[1].h - pipe3.mediums[1].R * pipe3.mediums[1].T;
 //   pipe3.mediums[1].d = pipe3.mediums[1].p / (pipe3.mediums[1].R * pipe3.mediums[1].T);
 //   pipe3.mediums[1].state.p = pipe3.mediums[1].p;
 //   pipe3.mediums[1].state.T = pipe3.mediums[1].T;
 //   pipe3.mediums[1].state.X[1] = pipe3.mediums[1].X[1];
 //   pipe3.mediums[1].state.X[2] = pipe3.mediums[1].X[2];
-//   n7837.n8256[1].n10109 = 0.6219647130774989 * n7837.n8256[1].n10110 / max(1e-13, pipe3.mediums[1].p - n7837.n8256[1].n10110);
-//   pipe3.mediums[1].x_water = pipe3.mediums[1].Xi[1] / max(n7837.n8256[1].n10107, 1e-13);
-//   pipe3.mediums[1].phi = pipe3.mediums[1].p / n7837.n8256[1].n10110 * pipe3.mediums[1].Xi[1] / (pipe3.mediums[1].Xi[1] + 0.6219647130774989 * n7837.n8256[1].n10107);
+//   pipe3.mediums[1].$n73 = 0.6219647130774989 * pipe3.mediums[1].$n74 / max(1e-13, pipe3.mediums[1].p - pipe3.mediums[1].$n74);
+//   pipe3.mediums[1].x_water = pipe3.mediums[1].Xi[1] / max(pipe3.mediums[1].$n71, 1e-13);
+//   pipe3.mediums[1].phi = pipe3.mediums[1].p / pipe3.mediums[1].$n74 * pipe3.mediums[1].Xi[1] / (pipe3.mediums[1].Xi[1] + 0.6219647130774989 * pipe3.mediums[1].$n71);
 //   pipe3.mediums[1].Xi[1] = pipe3.mediums[1].X[1];
 //   pipe3.mediums[1].X[2] = 1.0 - pipe3.mediums[1].Xi[1];
-//   assert(pipe3.mediums[1].X[1] >= -1e-05 and pipe3.mediums[1].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[1].X[2] >= -1e-05 and pipe3.mediums[1].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[1].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe3.mediums[2].T >= 190.0 and pipe3.mediums[2].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe3.mediums[1].X[1] >= -1e-05 and pipe3.mediums[1].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe3.mediums[1].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[1].X[2] >= -1e-05 and pipe3.mediums[1].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe3.mediums[1].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[1].p >= 0.0, \"Pressure (= \" + String(pipe3.mediums[1].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe3.mediums[1].T, 6, 0, true) + \" K)\");
+//   assert(pipe3.mediums[2].T >= 190.0 and pipe3.mediums[2].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe3.mediums[2].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe3.mediums[2].MM = 1.0 / (pipe3.mediums[2].Xi[1] / 0.01801528 + (1.0 - pipe3.mediums[2].Xi[1]) / 0.0289651159);
-//   n7837.n8256[2].n10110 = min(n1.n7656.n102.n8149.n7837.n7670.n8562(pipe3.mediums[2].T), 0.999 * pipe3.mediums[2].p);
-//   n7837.n8256[2].n10108 = min(n7837.n8256[2].n10110 * 0.6219647130774989 / max(1e-13, pipe3.mediums[2].p - n7837.n8256[2].n10110) * (1.0 - pipe3.mediums[2].Xi[1]), 1.0);
-//   n7837.n8256[2].n10105 = max(pipe3.mediums[2].Xi[1] - n7837.n8256[2].n10108, 0.0);
-//   n7837.n8256[2].n10106 = pipe3.mediums[2].Xi[1] - n7837.n8256[2].n10105;
-//   n7837.n8256[2].n10107 = 1.0 - pipe3.mediums[2].Xi[1];
-//   pipe3.mediums[2].h = n1.n7656.n102.n8149.n7837.n7670.n7957(pipe3.mediums[2].p, pipe3.mediums[2].T, pipe3.mediums[2].Xi);
-//   pipe3.mediums[2].R = 287.0512249529787 * n7837.n8256[2].n10107 / (1.0 - n7837.n8256[2].n10105) + 461.5233290850878 * n7837.n8256[2].n10106 / (1.0 - n7837.n8256[2].n10105);
+//   pipe3.mediums[2].$n74 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(pipe3.mediums[2].T), 0.999 * pipe3.mediums[2].p);
+//   pipe3.mediums[2].$n72 = min(pipe3.mediums[2].$n74 * 0.6219647130774989 / max(1e-13, pipe3.mediums[2].p - pipe3.mediums[2].$n74) * (1.0 - pipe3.mediums[2].Xi[1]), 1.0);
+//   pipe3.mediums[2].$n69 = max(pipe3.mediums[2].Xi[1] - pipe3.mediums[2].$n72, 0.0);
+//   pipe3.mediums[2].$n70 = pipe3.mediums[2].Xi[1] - pipe3.mediums[2].$n69;
+//   pipe3.mediums[2].$n71 = 1.0 - pipe3.mediums[2].Xi[1];
+//   pipe3.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[2].p, pipe3.mediums[2].T, pipe3.mediums[2].Xi);
+//   pipe3.mediums[2].R = 287.0512249529787 * pipe3.mediums[2].$n71 / (1.0 - pipe3.mediums[2].$n69) + 461.5233290850878 * pipe3.mediums[2].$n70 / (1.0 - pipe3.mediums[2].$n69);
 //   pipe3.mediums[2].u = pipe3.mediums[2].h - pipe3.mediums[2].R * pipe3.mediums[2].T;
 //   pipe3.mediums[2].d = pipe3.mediums[2].p / (pipe3.mediums[2].R * pipe3.mediums[2].T);
 //   pipe3.mediums[2].state.p = pipe3.mediums[2].p;
 //   pipe3.mediums[2].state.T = pipe3.mediums[2].T;
 //   pipe3.mediums[2].state.X[1] = pipe3.mediums[2].X[1];
 //   pipe3.mediums[2].state.X[2] = pipe3.mediums[2].X[2];
-//   n7837.n8256[2].n10109 = 0.6219647130774989 * n7837.n8256[2].n10110 / max(1e-13, pipe3.mediums[2].p - n7837.n8256[2].n10110);
-//   pipe3.mediums[2].x_water = pipe3.mediums[2].Xi[1] / max(n7837.n8256[2].n10107, 1e-13);
-//   pipe3.mediums[2].phi = pipe3.mediums[2].p / n7837.n8256[2].n10110 * pipe3.mediums[2].Xi[1] / (pipe3.mediums[2].Xi[1] + 0.6219647130774989 * n7837.n8256[2].n10107);
+//   pipe3.mediums[2].$n73 = 0.6219647130774989 * pipe3.mediums[2].$n74 / max(1e-13, pipe3.mediums[2].p - pipe3.mediums[2].$n74);
+//   pipe3.mediums[2].x_water = pipe3.mediums[2].Xi[1] / max(pipe3.mediums[2].$n71, 1e-13);
+//   pipe3.mediums[2].phi = pipe3.mediums[2].p / pipe3.mediums[2].$n74 * pipe3.mediums[2].Xi[1] / (pipe3.mediums[2].Xi[1] + 0.6219647130774989 * pipe3.mediums[2].$n71);
 //   pipe3.mediums[2].Xi[1] = pipe3.mediums[2].X[1];
 //   pipe3.mediums[2].X[2] = 1.0 - pipe3.mediums[2].Xi[1];
-//   assert(pipe3.mediums[2].X[1] >= -1e-05 and pipe3.mediums[2].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[2].X[2] >= -1e-05 and pipe3.mediums[2].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[2].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe3.mediums[3].T >= 190.0 and pipe3.mediums[3].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe3.mediums[2].X[1] >= -1e-05 and pipe3.mediums[2].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe3.mediums[2].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[2].X[2] >= -1e-05 and pipe3.mediums[2].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe3.mediums[2].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[2].p >= 0.0, \"Pressure (= \" + String(pipe3.mediums[2].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe3.mediums[2].T, 6, 0, true) + \" K)\");
+//   assert(pipe3.mediums[3].T >= 190.0 and pipe3.mediums[3].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe3.mediums[3].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe3.mediums[3].MM = 1.0 / (pipe3.mediums[3].Xi[1] / 0.01801528 + (1.0 - pipe3.mediums[3].Xi[1]) / 0.0289651159);
-//   n7837.n8256[3].n10110 = min(n1.n7656.n102.n8149.n7837.n7670.n8562(pipe3.mediums[3].T), 0.999 * pipe3.mediums[3].p);
-//   n7837.n8256[3].n10108 = min(n7837.n8256[3].n10110 * 0.6219647130774989 / max(1e-13, pipe3.mediums[3].p - n7837.n8256[3].n10110) * (1.0 - pipe3.mediums[3].Xi[1]), 1.0);
-//   n7837.n8256[3].n10105 = max(pipe3.mediums[3].Xi[1] - n7837.n8256[3].n10108, 0.0);
-//   n7837.n8256[3].n10106 = pipe3.mediums[3].Xi[1] - n7837.n8256[3].n10105;
-//   n7837.n8256[3].n10107 = 1.0 - pipe3.mediums[3].Xi[1];
-//   pipe3.mediums[3].h = n1.n7656.n102.n8149.n7837.n7670.n7957(pipe3.mediums[3].p, pipe3.mediums[3].T, pipe3.mediums[3].Xi);
-//   pipe3.mediums[3].R = 287.0512249529787 * n7837.n8256[3].n10107 / (1.0 - n7837.n8256[3].n10105) + 461.5233290850878 * n7837.n8256[3].n10106 / (1.0 - n7837.n8256[3].n10105);
+//   pipe3.mediums[3].$n74 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(pipe3.mediums[3].T), 0.999 * pipe3.mediums[3].p);
+//   pipe3.mediums[3].$n72 = min(pipe3.mediums[3].$n74 * 0.6219647130774989 / max(1e-13, pipe3.mediums[3].p - pipe3.mediums[3].$n74) * (1.0 - pipe3.mediums[3].Xi[1]), 1.0);
+//   pipe3.mediums[3].$n69 = max(pipe3.mediums[3].Xi[1] - pipe3.mediums[3].$n72, 0.0);
+//   pipe3.mediums[3].$n70 = pipe3.mediums[3].Xi[1] - pipe3.mediums[3].$n69;
+//   pipe3.mediums[3].$n71 = 1.0 - pipe3.mediums[3].Xi[1];
+//   pipe3.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[3].p, pipe3.mediums[3].T, pipe3.mediums[3].Xi);
+//   pipe3.mediums[3].R = 287.0512249529787 * pipe3.mediums[3].$n71 / (1.0 - pipe3.mediums[3].$n69) + 461.5233290850878 * pipe3.mediums[3].$n70 / (1.0 - pipe3.mediums[3].$n69);
 //   pipe3.mediums[3].u = pipe3.mediums[3].h - pipe3.mediums[3].R * pipe3.mediums[3].T;
 //   pipe3.mediums[3].d = pipe3.mediums[3].p / (pipe3.mediums[3].R * pipe3.mediums[3].T);
 //   pipe3.mediums[3].state.p = pipe3.mediums[3].p;
 //   pipe3.mediums[3].state.T = pipe3.mediums[3].T;
 //   pipe3.mediums[3].state.X[1] = pipe3.mediums[3].X[1];
 //   pipe3.mediums[3].state.X[2] = pipe3.mediums[3].X[2];
-//   n7837.n8256[3].n10109 = 0.6219647130774989 * n7837.n8256[3].n10110 / max(1e-13, pipe3.mediums[3].p - n7837.n8256[3].n10110);
-//   pipe3.mediums[3].x_water = pipe3.mediums[3].Xi[1] / max(n7837.n8256[3].n10107, 1e-13);
-//   pipe3.mediums[3].phi = pipe3.mediums[3].p / n7837.n8256[3].n10110 * pipe3.mediums[3].Xi[1] / (pipe3.mediums[3].Xi[1] + 0.6219647130774989 * n7837.n8256[3].n10107);
+//   pipe3.mediums[3].$n73 = 0.6219647130774989 * pipe3.mediums[3].$n74 / max(1e-13, pipe3.mediums[3].p - pipe3.mediums[3].$n74);
+//   pipe3.mediums[3].x_water = pipe3.mediums[3].Xi[1] / max(pipe3.mediums[3].$n71, 1e-13);
+//   pipe3.mediums[3].phi = pipe3.mediums[3].p / pipe3.mediums[3].$n74 * pipe3.mediums[3].Xi[1] / (pipe3.mediums[3].Xi[1] + 0.6219647130774989 * pipe3.mediums[3].$n71);
 //   pipe3.mediums[3].Xi[1] = pipe3.mediums[3].X[1];
 //   pipe3.mediums[3].X[2] = 1.0 - pipe3.mediums[3].Xi[1];
-//   assert(pipe3.mediums[3].X[1] >= -1e-05 and pipe3.mediums[3].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[3].X[2] >= -1e-05 and pipe3.mediums[3].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[3].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe3.mediums[4].T >= 190.0 and pipe3.mediums[4].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe3.mediums[3].X[1] >= -1e-05 and pipe3.mediums[3].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe3.mediums[3].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[3].X[2] >= -1e-05 and pipe3.mediums[3].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe3.mediums[3].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[3].p >= 0.0, \"Pressure (= \" + String(pipe3.mediums[3].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe3.mediums[3].T, 6, 0, true) + \" K)\");
+//   assert(pipe3.mediums[4].T >= 190.0 and pipe3.mediums[4].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe3.mediums[4].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe3.mediums[4].MM = 1.0 / (pipe3.mediums[4].Xi[1] / 0.01801528 + (1.0 - pipe3.mediums[4].Xi[1]) / 0.0289651159);
-//   n7837.n8256[4].n10110 = min(n1.n7656.n102.n8149.n7837.n7670.n8562(pipe3.mediums[4].T), 0.999 * pipe3.mediums[4].p);
-//   n7837.n8256[4].n10108 = min(n7837.n8256[4].n10110 * 0.6219647130774989 / max(1e-13, pipe3.mediums[4].p - n7837.n8256[4].n10110) * (1.0 - pipe3.mediums[4].Xi[1]), 1.0);
-//   n7837.n8256[4].n10105 = max(pipe3.mediums[4].Xi[1] - n7837.n8256[4].n10108, 0.0);
-//   n7837.n8256[4].n10106 = pipe3.mediums[4].Xi[1] - n7837.n8256[4].n10105;
-//   n7837.n8256[4].n10107 = 1.0 - pipe3.mediums[4].Xi[1];
-//   pipe3.mediums[4].h = n1.n7656.n102.n8149.n7837.n7670.n7957(pipe3.mediums[4].p, pipe3.mediums[4].T, pipe3.mediums[4].Xi);
-//   pipe3.mediums[4].R = 287.0512249529787 * n7837.n8256[4].n10107 / (1.0 - n7837.n8256[4].n10105) + 461.5233290850878 * n7837.n8256[4].n10106 / (1.0 - n7837.n8256[4].n10105);
+//   pipe3.mediums[4].$n74 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(pipe3.mediums[4].T), 0.999 * pipe3.mediums[4].p);
+//   pipe3.mediums[4].$n72 = min(pipe3.mediums[4].$n74 * 0.6219647130774989 / max(1e-13, pipe3.mediums[4].p - pipe3.mediums[4].$n74) * (1.0 - pipe3.mediums[4].Xi[1]), 1.0);
+//   pipe3.mediums[4].$n69 = max(pipe3.mediums[4].Xi[1] - pipe3.mediums[4].$n72, 0.0);
+//   pipe3.mediums[4].$n70 = pipe3.mediums[4].Xi[1] - pipe3.mediums[4].$n69;
+//   pipe3.mediums[4].$n71 = 1.0 - pipe3.mediums[4].Xi[1];
+//   pipe3.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[4].p, pipe3.mediums[4].T, pipe3.mediums[4].Xi);
+//   pipe3.mediums[4].R = 287.0512249529787 * pipe3.mediums[4].$n71 / (1.0 - pipe3.mediums[4].$n69) + 461.5233290850878 * pipe3.mediums[4].$n70 / (1.0 - pipe3.mediums[4].$n69);
 //   pipe3.mediums[4].u = pipe3.mediums[4].h - pipe3.mediums[4].R * pipe3.mediums[4].T;
 //   pipe3.mediums[4].d = pipe3.mediums[4].p / (pipe3.mediums[4].R * pipe3.mediums[4].T);
 //   pipe3.mediums[4].state.p = pipe3.mediums[4].p;
 //   pipe3.mediums[4].state.T = pipe3.mediums[4].T;
 //   pipe3.mediums[4].state.X[1] = pipe3.mediums[4].X[1];
 //   pipe3.mediums[4].state.X[2] = pipe3.mediums[4].X[2];
-//   n7837.n8256[4].n10109 = 0.6219647130774989 * n7837.n8256[4].n10110 / max(1e-13, pipe3.mediums[4].p - n7837.n8256[4].n10110);
-//   pipe3.mediums[4].x_water = pipe3.mediums[4].Xi[1] / max(n7837.n8256[4].n10107, 1e-13);
-//   pipe3.mediums[4].phi = pipe3.mediums[4].p / n7837.n8256[4].n10110 * pipe3.mediums[4].Xi[1] / (pipe3.mediums[4].Xi[1] + 0.6219647130774989 * n7837.n8256[4].n10107);
+//   pipe3.mediums[4].$n73 = 0.6219647130774989 * pipe3.mediums[4].$n74 / max(1e-13, pipe3.mediums[4].p - pipe3.mediums[4].$n74);
+//   pipe3.mediums[4].x_water = pipe3.mediums[4].Xi[1] / max(pipe3.mediums[4].$n71, 1e-13);
+//   pipe3.mediums[4].phi = pipe3.mediums[4].p / pipe3.mediums[4].$n74 * pipe3.mediums[4].Xi[1] / (pipe3.mediums[4].Xi[1] + 0.6219647130774989 * pipe3.mediums[4].$n71);
 //   pipe3.mediums[4].Xi[1] = pipe3.mediums[4].X[1];
 //   pipe3.mediums[4].X[2] = 1.0 - pipe3.mediums[4].Xi[1];
-//   assert(pipe3.mediums[4].X[1] >= -1e-05 and pipe3.mediums[4].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[4].X[2] >= -1e-05 and pipe3.mediums[4].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[4].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe3.mediums[5].T >= 190.0 and pipe3.mediums[5].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe3.mediums[4].X[1] >= -1e-05 and pipe3.mediums[4].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe3.mediums[4].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[4].X[2] >= -1e-05 and pipe3.mediums[4].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe3.mediums[4].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[4].p >= 0.0, \"Pressure (= \" + String(pipe3.mediums[4].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe3.mediums[4].T, 6, 0, true) + \" K)\");
+//   assert(pipe3.mediums[5].T >= 190.0 and pipe3.mediums[5].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe3.mediums[5].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe3.mediums[5].MM = 1.0 / (pipe3.mediums[5].Xi[1] / 0.01801528 + (1.0 - pipe3.mediums[5].Xi[1]) / 0.0289651159);
-//   n7837.n8256[5].n10110 = min(n1.n7656.n102.n8149.n7837.n7670.n8562(pipe3.mediums[5].T), 0.999 * pipe3.mediums[5].p);
-//   n7837.n8256[5].n10108 = min(n7837.n8256[5].n10110 * 0.6219647130774989 / max(1e-13, pipe3.mediums[5].p - n7837.n8256[5].n10110) * (1.0 - pipe3.mediums[5].Xi[1]), 1.0);
-//   n7837.n8256[5].n10105 = max(pipe3.mediums[5].Xi[1] - n7837.n8256[5].n10108, 0.0);
-//   n7837.n8256[5].n10106 = pipe3.mediums[5].Xi[1] - n7837.n8256[5].n10105;
-//   n7837.n8256[5].n10107 = 1.0 - pipe3.mediums[5].Xi[1];
-//   pipe3.mediums[5].h = n1.n7656.n102.n8149.n7837.n7670.n7957(pipe3.mediums[5].p, pipe3.mediums[5].T, pipe3.mediums[5].Xi);
-//   pipe3.mediums[5].R = 287.0512249529787 * n7837.n8256[5].n10107 / (1.0 - n7837.n8256[5].n10105) + 461.5233290850878 * n7837.n8256[5].n10106 / (1.0 - n7837.n8256[5].n10105);
+//   pipe3.mediums[5].$n74 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.saturationPressure(pipe3.mediums[5].T), 0.999 * pipe3.mediums[5].p);
+//   pipe3.mediums[5].$n72 = min(pipe3.mediums[5].$n74 * 0.6219647130774989 / max(1e-13, pipe3.mediums[5].p - pipe3.mediums[5].$n74) * (1.0 - pipe3.mediums[5].Xi[1]), 1.0);
+//   pipe3.mediums[5].$n69 = max(pipe3.mediums[5].Xi[1] - pipe3.mediums[5].$n72, 0.0);
+//   pipe3.mediums[5].$n70 = pipe3.mediums[5].Xi[1] - pipe3.mediums[5].$n69;
+//   pipe3.mediums[5].$n71 = 1.0 - pipe3.mediums[5].Xi[1];
+//   pipe3.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.specificEnthalpy_pTX(pipe3.mediums[5].p, pipe3.mediums[5].T, pipe3.mediums[5].Xi);
+//   pipe3.mediums[5].R = 287.0512249529787 * pipe3.mediums[5].$n71 / (1.0 - pipe3.mediums[5].$n69) + 461.5233290850878 * pipe3.mediums[5].$n70 / (1.0 - pipe3.mediums[5].$n69);
 //   pipe3.mediums[5].u = pipe3.mediums[5].h - pipe3.mediums[5].R * pipe3.mediums[5].T;
 //   pipe3.mediums[5].d = pipe3.mediums[5].p / (pipe3.mediums[5].R * pipe3.mediums[5].T);
 //   pipe3.mediums[5].state.p = pipe3.mediums[5].p;
 //   pipe3.mediums[5].state.T = pipe3.mediums[5].T;
 //   pipe3.mediums[5].state.X[1] = pipe3.mediums[5].X[1];
 //   pipe3.mediums[5].state.X[2] = pipe3.mediums[5].X[2];
-//   n7837.n8256[5].n10109 = 0.6219647130774989 * n7837.n8256[5].n10110 / max(1e-13, pipe3.mediums[5].p - n7837.n8256[5].n10110);
-//   pipe3.mediums[5].x_water = pipe3.mediums[5].Xi[1] / max(n7837.n8256[5].n10107, 1e-13);
-//   pipe3.mediums[5].phi = pipe3.mediums[5].p / n7837.n8256[5].n10110 * pipe3.mediums[5].Xi[1] / (pipe3.mediums[5].Xi[1] + 0.6219647130774989 * n7837.n8256[5].n10107);
+//   pipe3.mediums[5].$n73 = 0.6219647130774989 * pipe3.mediums[5].$n74 / max(1e-13, pipe3.mediums[5].p - pipe3.mediums[5].$n74);
+//   pipe3.mediums[5].x_water = pipe3.mediums[5].Xi[1] / max(pipe3.mediums[5].$n71, 1e-13);
+//   pipe3.mediums[5].phi = pipe3.mediums[5].p / pipe3.mediums[5].$n74 * pipe3.mediums[5].Xi[1] / (pipe3.mediums[5].Xi[1] + 0.6219647130774989 * pipe3.mediums[5].$n71);
 //   pipe3.mediums[5].Xi[1] = pipe3.mediums[5].X[1];
 //   pipe3.mediums[5].X[2] = 1.0 - pipe3.mediums[5].Xi[1];
-//   assert(pipe3.mediums[5].X[1] >= -1e-05 and pipe3.mediums[5].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[5].X[2] >= -1e-05 and pipe3.mediums[5].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe3.mediums[5].p >= 0.0, \"assert message 2590312994638120201\");
+//   assert(pipe3.mediums[5].X[1] >= -1e-05 and pipe3.mediums[5].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe3.mediums[5].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[5].X[2] >= -1e-05 and pipe3.mediums[5].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe3.mediums[5].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe3.mediums[5].p >= 0.0, \"Pressure (= \" + String(pipe3.mediums[5].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe3.mediums[5].T, 6, 0, true) + \" K)\");
 //   pipe3.flowModel.states[1].X = pipe3.statesFM[1].X;
 //   pipe3.flowModel.states[2].X = pipe3.statesFM[2].X;
 //   pipe3.flowModel.states[3].X = pipe3.statesFM[3].X;
@@ -7420,18 +7527,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.flowModel.states[5].X = pipe3.statesFM[5].X;
 //   pipe3.flowModel.states[6].X = pipe3.statesFM[6].X;
 //   pipe3.flowModel.states[7].X = pipe3.statesFM[7].X;
-//   pipe3.flowModel.vs = n7837.n8369;
-//   pipe3.flowModel.crossAreas = n7837.n8370;
-//   pipe3.flowModel.dimensions = n7837.n8371;
-//   pipe3.flowModel.roughnesses = n7837.n8372;
-//   pipe3.flowModel.dheights = n7837.n8373;
-//   pipe3.flowModel.pathLengths = n7837.n8348;
-//   pipe3.flowModel.rhos = array(n1.n7656.n102.n8149.n7837.n8346.n7670.n523(pipe3.flowModel.states[$i1]) for $i1 in 1:7);
-//   pipe3.flowModel.mus = array(n1.n7656.n102.n8149.n7837.n8346.n7670.n8340(pipe3.flowModel.states[$i1]) for $i1 in 1:7);
+//   pipe3.flowModel.vs = pipe3.$n88;
+//   pipe3.flowModel.crossAreas = pipe3.$n87;
+//   pipe3.flowModel.dimensions = pipe3.$n89;
+//   pipe3.flowModel.roughnesses = pipe3.$n90;
+//   pipe3.flowModel.dheights = pipe3.$n86;
+//   pipe3.flowModel.pathLengths = pipe3.$n85;
+//   pipe3.flowModel.rhos = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.density(pipe3.flowModel.states[$i1]) for $i1 in 1:7);
+//   pipe3.flowModel.mus = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.dynamicViscosity(pipe3.flowModel.states[$i1]) for $i1 in 1:7);
 //   pipe3.flowModel.pathLengths_internal = pipe3.flowModel.pathLengths;
 //   pipe3.flowModel.Res_turbulent_internal = {pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent, pipe3.flowModel.Re_turbulent};
-//   n7837.n8346.n8410 = {0.5 * (pipe3.flowModel.dimensions[1] + pipe3.flowModel.dimensions[2]), 0.5 * (pipe3.flowModel.dimensions[2] + pipe3.flowModel.dimensions[3]), 0.5 * (pipe3.flowModel.dimensions[3] + pipe3.flowModel.dimensions[4]), 0.5 * (pipe3.flowModel.dimensions[4] + pipe3.flowModel.dimensions[5]), 0.5 * (pipe3.flowModel.dimensions[5] + pipe3.flowModel.dimensions[6]), 0.5 * (pipe3.flowModel.dimensions[6] + pipe3.flowModel.dimensions[7])};
-//   pipe3.flowModel.m_flows = array(homotopy((array(n1.n7656.n102.n8149.n7837.n8346.n7663.n8415(pipe3.flowModel.dps_fg[$i1], pipe3.flowModel.rhos[(1:6)[$i1]], pipe3.flowModel.rhos[(2:7)[$i1]], pipe3.flowModel.mus[(1:6)[$i1]], pipe3.flowModel.mus[(2:7)[$i1]], pipe3.flowModel.pathLengths_internal[$i1], n7837.n8346.n8410[$i1], {pipe3.flowModel.g * pipe3.flowModel.dheights[1], pipe3.flowModel.g * pipe3.flowModel.dheights[2], pipe3.flowModel.g * pipe3.flowModel.dheights[3], pipe3.flowModel.g * pipe3.flowModel.dheights[4], pipe3.flowModel.g * pipe3.flowModel.dheights[5], pipe3.flowModel.g * pipe3.flowModel.dheights[6]}[$i1], {(pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0}[$i1], {(pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0}[$i1], n7837.n8346.n8308 / 6.0, pipe3.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:6) * pipe3.flowModel.nParallel)[$i1], {pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[1] - pipe3.flowModel.g * pipe3.flowModel.dheights[1] * n7837.n8346.n8135), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[2] - pipe3.flowModel.g * pipe3.flowModel.dheights[2] * n7837.n8346.n8135), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[3] - pipe3.flowModel.g * pipe3.flowModel.dheights[3] * n7837.n8346.n8135), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[4] - pipe3.flowModel.g * pipe3.flowModel.dheights[4] * n7837.n8346.n8135), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[5] - pipe3.flowModel.g * pipe3.flowModel.dheights[5] * n7837.n8346.n8135), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[6] - pipe3.flowModel.g * pipe3.flowModel.dheights[6] * n7837.n8346.n8135)}[$i1]) for $i1 in 1:6);
+//   pipe3.flowModel.$n83 = {0.5 * (pipe3.flowModel.dimensions[1] + pipe3.flowModel.dimensions[2]), 0.5 * (pipe3.flowModel.dimensions[2] + pipe3.flowModel.dimensions[3]), 0.5 * (pipe3.flowModel.dimensions[3] + pipe3.flowModel.dimensions[4]), 0.5 * (pipe3.flowModel.dimensions[4] + pipe3.flowModel.dimensions[5]), 0.5 * (pipe3.flowModel.dimensions[5] + pipe3.flowModel.dimensions[6]), 0.5 * (pipe3.flowModel.dimensions[6] + pipe3.flowModel.dimensions[7])};
+//   pipe3.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe3.flowModel.dps_fg[$i1], pipe3.flowModel.rhos[(1:6)[$i1]], pipe3.flowModel.rhos[(2:7)[$i1]], pipe3.flowModel.mus[(1:6)[$i1]], pipe3.flowModel.mus[(2:7)[$i1]], pipe3.flowModel.pathLengths_internal[$i1], pipe3.flowModel.$n83[$i1], {pipe3.flowModel.g * pipe3.flowModel.dheights[1], pipe3.flowModel.g * pipe3.flowModel.dheights[2], pipe3.flowModel.g * pipe3.flowModel.dheights[3], pipe3.flowModel.g * pipe3.flowModel.dheights[4], pipe3.flowModel.g * pipe3.flowModel.dheights[5], pipe3.flowModel.g * pipe3.flowModel.dheights[6]}[$i1], {(pipe3.flowModel.crossAreas[1] + pipe3.flowModel.crossAreas[2]) / 2.0, (pipe3.flowModel.crossAreas[2] + pipe3.flowModel.crossAreas[3]) / 2.0, (pipe3.flowModel.crossAreas[3] + pipe3.flowModel.crossAreas[4]) / 2.0, (pipe3.flowModel.crossAreas[4] + pipe3.flowModel.crossAreas[5]) / 2.0, (pipe3.flowModel.crossAreas[5] + pipe3.flowModel.crossAreas[6]) / 2.0, (pipe3.flowModel.crossAreas[6] + pipe3.flowModel.crossAreas[7]) / 2.0}[$i1], {(pipe3.flowModel.roughnesses[1] + pipe3.flowModel.roughnesses[2]) / 2.0, (pipe3.flowModel.roughnesses[2] + pipe3.flowModel.roughnesses[3]) / 2.0, (pipe3.flowModel.roughnesses[3] + pipe3.flowModel.roughnesses[4]) / 2.0, (pipe3.flowModel.roughnesses[4] + pipe3.flowModel.roughnesses[5]) / 2.0, (pipe3.flowModel.roughnesses[5] + pipe3.flowModel.roughnesses[6]) / 2.0, (pipe3.flowModel.roughnesses[6] + pipe3.flowModel.roughnesses[7]) / 2.0}[$i1], pipe3.flowModel.$n80 / 6.0, pipe3.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:6) * pipe3.flowModel.nParallel)[$i1], {pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[1] - pipe3.flowModel.g * pipe3.flowModel.dheights[1] * pipe3.flowModel.$n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[2] - pipe3.flowModel.g * pipe3.flowModel.dheights[2] * pipe3.flowModel.$n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[3] - pipe3.flowModel.g * pipe3.flowModel.dheights[3] * pipe3.flowModel.$n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[4] - pipe3.flowModel.g * pipe3.flowModel.dheights[4] * pipe3.flowModel.$n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[5] - pipe3.flowModel.g * pipe3.flowModel.dheights[5] * pipe3.flowModel.$n77), pipe3.flowModel.m_flow_nominal / pipe3.flowModel.dp_nominal * (pipe3.flowModel.dps_fg[6] - pipe3.flowModel.g * pipe3.flowModel.dheights[6] * pipe3.flowModel.$n77)}[$i1]) for $i1 in 1:6);
 //   pipe3.flowModel.rhos_act[1] = noEvent(if pipe3.flowModel.m_flows[1] > 0.0 then pipe3.flowModel.rhos[1] else pipe3.flowModel.rhos[2]);
 //   pipe3.flowModel.mus_act[1] = noEvent(if pipe3.flowModel.m_flows[1] > 0.0 then pipe3.flowModel.mus[1] else pipe3.flowModel.mus[2]);
 //   pipe3.flowModel.rhos_act[2] = noEvent(if pipe3.flowModel.m_flows[2] > 0.0 then pipe3.flowModel.rhos[2] else pipe3.flowModel.rhos[3]);
@@ -7444,24 +7551,24 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.flowModel.mus_act[5] = noEvent(if pipe3.flowModel.m_flows[5] > 0.0 then pipe3.flowModel.mus[5] else pipe3.flowModel.mus[6]);
 //   pipe3.flowModel.rhos_act[6] = noEvent(if pipe3.flowModel.m_flows[6] > 0.0 then pipe3.flowModel.rhos[6] else pipe3.flowModel.rhos[7]);
 //   pipe3.flowModel.mus_act[6] = noEvent(if pipe3.flowModel.m_flows[6] > 0.0 then pipe3.flowModel.mus[6] else pipe3.flowModel.mus[7]);
-//   pipe3.flowModel.Ib_flows = array(pipe3.flowModel.rhos[i] * pipe3.flowModel.vs[i] * pipe3.flowModel.vs[i] * pipe3.flowModel.crossAreas[i] - pipe3.flowModel.rhos[i + 1] * pipe3.flowModel.vs[i + 1] * pipe3.flowModel.vs[i + 1] * pipe3.flowModel.crossAreas[i + 1] for n49 in 1:6) * pipe3.flowModel.nParallel;
-//   pipe3.flowModel.Fs_p = array(0.5 * (pipe3.flowModel.crossAreas[i] + pipe3.flowModel.crossAreas[i + 1]) * (n1.n7656.n102.n8149.n7837.n8346.n7670.n7786(pipe3.flowModel.states[i + 1]) - n1.n7656.n102.n8149.n7837.n8346.n7670.n7786(pipe3.flowModel.states[i])) for n49 in 1:6) * pipe3.flowModel.nParallel;
-//   pipe3.flowModel.dps_fg = array(pipe3.flowModel.Fs_fg[i] / pipe3.flowModel.nParallel * 2.0 / (pipe3.flowModel.crossAreas[i] + pipe3.flowModel.crossAreas[i + 1]) for n49 in 1:6);
-//   pipe3.flowModel.Is = array(pipe3.flowModel.m_flows[i] * pipe3.flowModel.pathLengths[i] for n49 in 1:6);
+//   pipe3.flowModel.Ib_flows = array(pipe3.flowModel.rhos[i] * pipe3.flowModel.vs[i] * pipe3.flowModel.vs[i] * pipe3.flowModel.crossAreas[i] - pipe3.flowModel.rhos[i + 1] * pipe3.flowModel.vs[i + 1] * pipe3.flowModel.vs[i + 1] * pipe3.flowModel.crossAreas[i + 1] for i in 1:6) * pipe3.flowModel.nParallel;
+//   pipe3.flowModel.Fs_p = array(0.5 * (pipe3.flowModel.crossAreas[i] + pipe3.flowModel.crossAreas[i + 1]) * (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.pressure(pipe3.flowModel.states[i + 1]) - Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.flowModel.Medium.pressure(pipe3.flowModel.states[i])) for i in 1:6) * pipe3.flowModel.nParallel;
+//   pipe3.flowModel.dps_fg = array(pipe3.flowModel.Fs_fg[i] / pipe3.flowModel.nParallel * 2.0 / (pipe3.flowModel.crossAreas[i] + pipe3.flowModel.crossAreas[i + 1]) for i in 1:6);
+//   pipe3.flowModel.Is = array(pipe3.flowModel.m_flows[i] * pipe3.flowModel.pathLengths[i] for i in 1:6);
 //   der(pipe3.flowModel.Is[1]) = pipe3.flowModel.Ib_flows[1] - pipe3.flowModel.Fs_p[1] - pipe3.flowModel.Fs_fg[1];
 //   der(pipe3.flowModel.Is[2]) = pipe3.flowModel.Ib_flows[2] - pipe3.flowModel.Fs_p[2] - pipe3.flowModel.Fs_fg[2];
 //   der(pipe3.flowModel.Is[3]) = pipe3.flowModel.Ib_flows[3] - pipe3.flowModel.Fs_p[3] - pipe3.flowModel.Fs_fg[3];
 //   der(pipe3.flowModel.Is[4]) = pipe3.flowModel.Ib_flows[4] - pipe3.flowModel.Fs_p[4] - pipe3.flowModel.Fs_fg[4];
 //   der(pipe3.flowModel.Is[5]) = pipe3.flowModel.Ib_flows[5] - pipe3.flowModel.Fs_p[5] - pipe3.flowModel.Fs_fg[5];
 //   der(pipe3.flowModel.Is[6]) = pipe3.flowModel.Ib_flows[6] - pipe3.flowModel.Fs_p[6] - pipe3.flowModel.Fs_fg[6];
-//   pipe3.vs = array(0.5 * (pipe3.m_flows[i] + pipe3.m_flows[i + 1]) / pipe3.mediums[i].d / pipe3.crossAreas[i] for n49 in 1:5) / pipe3.nParallel;
+//   pipe3.vs = array(0.5 * (pipe3.m_flows[i] + pipe3.m_flows[i + 1]) / pipe3.mediums[i].d / pipe3.crossAreas[i] for i in 1:5) / pipe3.nParallel;
 //   pipe3.heatTransfer.states[1].X = pipe3.mediums[1].state.X;
 //   pipe3.heatTransfer.states[2].X = pipe3.mediums[2].state.X;
 //   pipe3.heatTransfer.states[3].X = pipe3.mediums[3].state.X;
 //   pipe3.heatTransfer.states[4].X = pipe3.mediums[4].state.X;
 //   pipe3.heatTransfer.states[5].X = pipe3.mediums[5].state.X;
 //   pipe3.heatTransfer.surfaceAreas = {pipe3.perimeter * 5.0, pipe3.perimeter * 5.0, pipe3.perimeter * 5.0, pipe3.perimeter * 5.0, pipe3.perimeter * 5.0};
-//   pipe3.heatTransfer.Ts = array(n1.n7656.n102.n8149.n7837.n7988.n7670.n7785(pipe3.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe3.heatTransfer.Ts = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.heatTransfer.Medium.temperature(pipe3.heatTransfer.states[$i1]) for $i1 in 1:5);
 //   pipe3.heatTransfer.vs = pipe3.vs;
 //   pipe3.heatTransfer.lengths = {5.0, 5.0, 5.0, 5.0, 5.0};
 //   pipe3.heatTransfer.dimensions = pipe3.dimensions;
@@ -7481,42 +7588,42 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.Qb_flows[3] = pipe3.heatTransfer.Q_flows[3];
 //   pipe3.Qb_flows[4] = pipe3.heatTransfer.Q_flows[4];
 //   pipe3.Qb_flows[5] = pipe3.heatTransfer.Q_flows[5];
-//   pipe3.Wb_flows[2:4] = array(pipe3.vs[i] * pipe3.crossAreas[i] * ((pipe3.mediums[i + 1].p - pipe3.mediums[i - 1].p) / 2.0 + (pipe3.flowModel.dps_fg[i] + pipe3.flowModel.dps_fg[i + 1]) / 2.0 - system.g * {5.0, 5.0, 5.0, 5.0, 5.0}[i] * pipe3.mediums[i].d) for n49 in 2:4) * pipe3.nParallel;
+//   pipe3.Wb_flows[2:4] = array(pipe3.vs[i] * pipe3.crossAreas[i] * ((pipe3.mediums[i + 1].p - pipe3.mediums[i - 1].p) / 2.0 + (pipe3.flowModel.dps_fg[i] + pipe3.flowModel.dps_fg[i + 1]) / 2.0 - system.g * {5.0, 5.0, 5.0, 5.0, 5.0}[i] * pipe3.mediums[i].d) for i in 2:4) * pipe3.nParallel;
 //   pipe3.Wb_flows[1] = pipe3.vs[1] * pipe3.crossAreas[1] * ((pipe3.mediums[2].p - pipe3.port_a.p) / 1.5 + pipe3.flowModel.dps_fg[1] + pipe3.flowModel.dps_fg[2] / 2.0 - system.g * 5.0 * pipe3.mediums[1].d) * pipe3.nParallel;
 //   pipe3.Wb_flows[5] = pipe3.vs[5] * pipe3.crossAreas[5] * ((pipe3.port_b.p - pipe3.mediums[4].p) / 1.5 + pipe3.flowModel.dps_fg[5] / 2.0 + pipe3.flowModel.dps_fg[6] - system.g * 5.0 * pipe3.mediums[5].d) * pipe3.nParallel;
-//   n7837.n8348[1] = 2.5;
-//   n7837.n8348[2] = 5.0;
-//   n7837.n8348[3] = 5.0;
-//   n7837.n8348[4] = 5.0;
-//   n7837.n8348[5] = 5.0;
-//   n7837.n8348[6] = 2.5;
-//   n7837.n8373[1] = 2.5;
-//   n7837.n8373[2] = 5.0;
-//   n7837.n8373[3] = 5.0;
-//   n7837.n8373[4] = 5.0;
-//   n7837.n8373[5] = 5.0;
-//   n7837.n8373[6] = 2.5;
-//   n7837.n8370[1] = pipe3.crossAreas[1];
-//   n7837.n8370[2] = pipe3.crossAreas[1];
-//   n7837.n8370[3] = pipe3.crossAreas[2];
-//   n7837.n8370[4] = pipe3.crossAreas[3];
-//   n7837.n8370[5] = pipe3.crossAreas[4];
-//   n7837.n8370[6] = pipe3.crossAreas[5];
-//   n7837.n8370[7] = pipe3.crossAreas[5];
-//   n7837.n8371[1] = pipe3.dimensions[1];
-//   n7837.n8371[2] = pipe3.dimensions[1];
-//   n7837.n8371[3] = pipe3.dimensions[2];
-//   n7837.n8371[4] = pipe3.dimensions[3];
-//   n7837.n8371[5] = pipe3.dimensions[4];
-//   n7837.n8371[6] = pipe3.dimensions[5];
-//   n7837.n8371[7] = pipe3.dimensions[5];
-//   n7837.n8372[1] = pipe3.roughnesses[1];
-//   n7837.n8372[2] = pipe3.roughnesses[1];
-//   n7837.n8372[3] = pipe3.roughnesses[2];
-//   n7837.n8372[4] = pipe3.roughnesses[3];
-//   n7837.n8372[5] = pipe3.roughnesses[4];
-//   n7837.n8372[6] = pipe3.roughnesses[5];
-//   n7837.n8372[7] = pipe3.roughnesses[5];
+//   pipe3.$n85[1] = 2.5;
+//   pipe3.$n85[2] = 5.0;
+//   pipe3.$n85[3] = 5.0;
+//   pipe3.$n85[4] = 5.0;
+//   pipe3.$n85[5] = 5.0;
+//   pipe3.$n85[6] = 2.5;
+//   pipe3.$n86[1] = 2.5;
+//   pipe3.$n86[2] = 5.0;
+//   pipe3.$n86[3] = 5.0;
+//   pipe3.$n86[4] = 5.0;
+//   pipe3.$n86[5] = 5.0;
+//   pipe3.$n86[6] = 2.5;
+//   pipe3.$n87[1] = pipe3.crossAreas[1];
+//   pipe3.$n87[2] = pipe3.crossAreas[1];
+//   pipe3.$n87[3] = pipe3.crossAreas[2];
+//   pipe3.$n87[4] = pipe3.crossAreas[3];
+//   pipe3.$n87[5] = pipe3.crossAreas[4];
+//   pipe3.$n87[6] = pipe3.crossAreas[5];
+//   pipe3.$n87[7] = pipe3.crossAreas[5];
+//   pipe3.$n89[1] = pipe3.dimensions[1];
+//   pipe3.$n89[2] = pipe3.dimensions[1];
+//   pipe3.$n89[3] = pipe3.dimensions[2];
+//   pipe3.$n89[4] = pipe3.dimensions[3];
+//   pipe3.$n89[5] = pipe3.dimensions[4];
+//   pipe3.$n89[6] = pipe3.dimensions[5];
+//   pipe3.$n89[7] = pipe3.dimensions[5];
+//   pipe3.$n90[1] = pipe3.roughnesses[1];
+//   pipe3.$n90[2] = pipe3.roughnesses[1];
+//   pipe3.$n90[3] = pipe3.roughnesses[2];
+//   pipe3.$n90[4] = pipe3.roughnesses[3];
+//   pipe3.$n90[5] = pipe3.roughnesses[4];
+//   pipe3.$n90[6] = pipe3.roughnesses[5];
+//   pipe3.$n90[7] = pipe3.roughnesses[5];
 //   pipe3.mb_flows[1] = pipe3.m_flows[1] - pipe3.m_flows[2];
 //   pipe3.mbXi_flows[1,1] = pipe3.mXi_flows[1,1] - pipe3.mXi_flows[2,1];
 //   pipe3.Hb_flows[1] = pipe3.H_flows[1] - pipe3.H_flows[2];
@@ -7550,8 +7657,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.port_b.h_outflow = pipe3.mediums[5].h;
 //   pipe3.port_a.Xi_outflow[1] = pipe3.mediums[1].Xi[1];
 //   pipe3.port_b.Xi_outflow[1] = pipe3.mediums[5].Xi[1];
-//   pipe3.state_a = n1.n7656.n102.n8149.n7837.n7670.n8338(pipe3.port_a.p, ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.h_outflow + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.h_outflow) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07))});
-//   pipe3.state_b = n1.n7656.n102.n8149.n7837.n7670.n8338(pipe3.port_b.p, ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.h_outflow + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.h_outflow) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.Xi_outflow[1] + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07))});
+//   pipe3.state_a = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_phX(pipe3.port_a.p, ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.h_outflow + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.h_outflow) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) * pipe2.port_a.Xi_outflow[1] + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07) * pipe1.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_a.m_flow, 1e-07) + $OMC$PositiveMax(-pipe1.port_b.m_flow, 1e-07))});
+//   pipe3.state_b = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.setState_phX(pipe3.port_b.p, ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.h_outflow + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.h_outflow) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.Xi_outflow[1] + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07) * pipe4.port_a.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe4.port_a.m_flow, 1e-07))});
 //   pipe3.statesFM[1] = pipe3.state_a;
 //   pipe3.statesFM[2] = pipe3.mediums[1].state;
 //   pipe3.statesFM[3] = pipe3.mediums[2].state;
@@ -7565,13 +7672,13 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe3.m_flows[4] = pipe3.flowModel.m_flows[4];
 //   pipe3.m_flows[5] = pipe3.flowModel.m_flows[5];
 //   pipe3.m_flows[6] = pipe3.flowModel.m_flows[6];
-//   n7837.n8369[1] = pipe3.m_flows[1] / n1.n7656.n102.n8149.n7837.n7670.n523(pipe3.state_a) / pipe3.crossAreas[1] / pipe3.nParallel;
-//   n7837.n8369[2] = pipe3.vs[1];
-//   n7837.n8369[3] = pipe3.vs[2];
-//   n7837.n8369[4] = pipe3.vs[3];
-//   n7837.n8369[5] = pipe3.vs[4];
-//   n7837.n8369[6] = pipe3.vs[5];
-//   n7837.n8369[7] = pipe3.m_flows[6] / n1.n7656.n102.n8149.n7837.n7670.n523(pipe3.state_b) / pipe3.crossAreas[5] / pipe3.nParallel;
+//   pipe3.$n88[1] = pipe3.m_flows[1] / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.density(pipe3.state_a) / pipe3.crossAreas[1] / pipe3.nParallel;
+//   pipe3.$n88[2] = pipe3.vs[1];
+//   pipe3.$n88[3] = pipe3.vs[2];
+//   pipe3.$n88[4] = pipe3.vs[3];
+//   pipe3.$n88[5] = pipe3.vs[4];
+//   pipe3.$n88[6] = pipe3.vs[5];
+//   pipe3.$n88[7] = pipe3.m_flows[6] / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe3.Medium.density(pipe3.state_b) / pipe3.crossAreas[5] / pipe3.nParallel;
 //   pipe3.ms[1] = pipe3.fluidVolumes[1] * pipe3.mediums[1].d;
 //   pipe3.mXis[1,1] = pipe3.ms[1] * pipe3.mediums[1].Xi[1];
 //   pipe3.Us[1] = pipe3.ms[1] * pipe3.mediums[1].u;
@@ -7602,122 +7709,152 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe3.mXis[3,1]) = pipe3.mbXi_flows[3,1];
 //   der(pipe3.mXis[4,1]) = pipe3.mbXi_flows[4,1];
 //   der(pipe3.mXis[5,1]) = pipe3.mbXi_flows[5,1];
-//   pipe4.fluidVolumes = array(pipe4.crossAreas[i] * {10.0, 10.0, 10.0, 10.0, 10.0}[i] for n49 in 1:5) * pipe4.nParallel;
-//   assert(pipe4.mediums[1].T >= 190.0 and pipe4.mediums[1].T <= 647.0, \"assert message 315810245365667762\");
+//   pipe4.fluidVolumes = array(pipe4.crossAreas[i] * {10.0, 10.0, 10.0, 10.0, 10.0}[i] for i in 1:5) * pipe4.nParallel;
+//   assert(pipe4.mediums[1].T >= 190.0 and pipe4.mediums[1].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe4.mediums[1].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe4.mediums[1].MM = 1.0 / (pipe4.mediums[1].Xi[1] / 0.01801528 + (1.0 - pipe4.mediums[1].Xi[1]) / 0.0289651159);
-//   n8133.n8256[1].n10110 = min(n1.n7656.n102.n8149.n8133.n7670.n8562(pipe4.mediums[1].T), 0.999 * pipe4.mediums[1].p);
-//   n8133.n8256[1].n10108 = min(n8133.n8256[1].n10110 * 0.6219647130774989 / max(1e-13, pipe4.mediums[1].p - n8133.n8256[1].n10110) * (1.0 - pipe4.mediums[1].Xi[1]), 1.0);
-//   n8133.n8256[1].n10105 = max(pipe4.mediums[1].Xi[1] - n8133.n8256[1].n10108, 0.0);
-//   n8133.n8256[1].n10106 = pipe4.mediums[1].Xi[1] - n8133.n8256[1].n10105;
-//   n8133.n8256[1].n10107 = 1.0 - pipe4.mediums[1].Xi[1];
-//   pipe4.mediums[1].h = n1.n7656.n102.n8149.n8133.n7670.n7957(pipe4.mediums[1].p, pipe4.mediums[1].T, pipe4.mediums[1].Xi);
-//   pipe4.mediums[1].R = 287.0512249529787 * n8133.n8256[1].n10107 / (1.0 - n8133.n8256[1].n10105) + 461.5233290850878 * n8133.n8256[1].n10106 / (1.0 - n8133.n8256[1].n10105);
+//   pipe4.mediums[1].$n99 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(pipe4.mediums[1].T), 0.999 * pipe4.mediums[1].p);
+//   pipe4.mediums[1].$n97 = min(pipe4.mediums[1].$n99 * 0.6219647130774989 / max(1e-13, pipe4.mediums[1].p - pipe4.mediums[1].$n99) * (1.0 - pipe4.mediums[1].Xi[1]), 1.0);
+//   pipe4.mediums[1].$n94 = max(pipe4.mediums[1].Xi[1] - pipe4.mediums[1].$n97, 0.0);
+//   pipe4.mediums[1].$n95 = pipe4.mediums[1].Xi[1] - pipe4.mediums[1].$n94;
+//   pipe4.mediums[1].$n96 = 1.0 - pipe4.mediums[1].Xi[1];
+//   pipe4.mediums[1].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[1].p, pipe4.mediums[1].T, pipe4.mediums[1].Xi);
+//   pipe4.mediums[1].R = 287.0512249529787 * pipe4.mediums[1].$n96 / (1.0 - pipe4.mediums[1].$n94) + 461.5233290850878 * pipe4.mediums[1].$n95 / (1.0 - pipe4.mediums[1].$n94);
 //   pipe4.mediums[1].u = pipe4.mediums[1].h - pipe4.mediums[1].R * pipe4.mediums[1].T;
 //   pipe4.mediums[1].d = pipe4.mediums[1].p / (pipe4.mediums[1].R * pipe4.mediums[1].T);
 //   pipe4.mediums[1].state.p = pipe4.mediums[1].p;
 //   pipe4.mediums[1].state.T = pipe4.mediums[1].T;
 //   pipe4.mediums[1].state.X[1] = pipe4.mediums[1].X[1];
 //   pipe4.mediums[1].state.X[2] = pipe4.mediums[1].X[2];
-//   n8133.n8256[1].n10109 = 0.6219647130774989 * n8133.n8256[1].n10110 / max(1e-13, pipe4.mediums[1].p - n8133.n8256[1].n10110);
-//   pipe4.mediums[1].x_water = pipe4.mediums[1].Xi[1] / max(n8133.n8256[1].n10107, 1e-13);
-//   pipe4.mediums[1].phi = pipe4.mediums[1].p / n8133.n8256[1].n10110 * pipe4.mediums[1].Xi[1] / (pipe4.mediums[1].Xi[1] + 0.6219647130774989 * n8133.n8256[1].n10107);
+//   pipe4.mediums[1].$n98 = 0.6219647130774989 * pipe4.mediums[1].$n99 / max(1e-13, pipe4.mediums[1].p - pipe4.mediums[1].$n99);
+//   pipe4.mediums[1].x_water = pipe4.mediums[1].Xi[1] / max(pipe4.mediums[1].$n96, 1e-13);
+//   pipe4.mediums[1].phi = pipe4.mediums[1].p / pipe4.mediums[1].$n99 * pipe4.mediums[1].Xi[1] / (pipe4.mediums[1].Xi[1] + 0.6219647130774989 * pipe4.mediums[1].$n96);
 //   pipe4.mediums[1].Xi[1] = pipe4.mediums[1].X[1];
 //   pipe4.mediums[1].X[2] = 1.0 - pipe4.mediums[1].Xi[1];
-//   assert(pipe4.mediums[1].X[1] >= -1e-05 and pipe4.mediums[1].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[1].X[2] >= -1e-05 and pipe4.mediums[1].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[1].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe4.mediums[2].T >= 190.0 and pipe4.mediums[2].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe4.mediums[1].X[1] >= -1e-05 and pipe4.mediums[1].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe4.mediums[1].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[1].X[2] >= -1e-05 and pipe4.mediums[1].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe4.mediums[1].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[1].p >= 0.0, \"Pressure (= \" + String(pipe4.mediums[1].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe4.mediums[1].T, 6, 0, true) + \" K)\");
+//   assert(pipe4.mediums[2].T >= 190.0 and pipe4.mediums[2].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe4.mediums[2].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe4.mediums[2].MM = 1.0 / (pipe4.mediums[2].Xi[1] / 0.01801528 + (1.0 - pipe4.mediums[2].Xi[1]) / 0.0289651159);
-//   n8133.n8256[2].n10110 = min(n1.n7656.n102.n8149.n8133.n7670.n8562(pipe4.mediums[2].T), 0.999 * pipe4.mediums[2].p);
-//   n8133.n8256[2].n10108 = min(n8133.n8256[2].n10110 * 0.6219647130774989 / max(1e-13, pipe4.mediums[2].p - n8133.n8256[2].n10110) * (1.0 - pipe4.mediums[2].Xi[1]), 1.0);
-//   n8133.n8256[2].n10105 = max(pipe4.mediums[2].Xi[1] - n8133.n8256[2].n10108, 0.0);
-//   n8133.n8256[2].n10106 = pipe4.mediums[2].Xi[1] - n8133.n8256[2].n10105;
-//   n8133.n8256[2].n10107 = 1.0 - pipe4.mediums[2].Xi[1];
-//   pipe4.mediums[2].h = n1.n7656.n102.n8149.n8133.n7670.n7957(pipe4.mediums[2].p, pipe4.mediums[2].T, pipe4.mediums[2].Xi);
-//   pipe4.mediums[2].R = 287.0512249529787 * n8133.n8256[2].n10107 / (1.0 - n8133.n8256[2].n10105) + 461.5233290850878 * n8133.n8256[2].n10106 / (1.0 - n8133.n8256[2].n10105);
+//   pipe4.mediums[2].$n99 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(pipe4.mediums[2].T), 0.999 * pipe4.mediums[2].p);
+//   pipe4.mediums[2].$n97 = min(pipe4.mediums[2].$n99 * 0.6219647130774989 / max(1e-13, pipe4.mediums[2].p - pipe4.mediums[2].$n99) * (1.0 - pipe4.mediums[2].Xi[1]), 1.0);
+//   pipe4.mediums[2].$n94 = max(pipe4.mediums[2].Xi[1] - pipe4.mediums[2].$n97, 0.0);
+//   pipe4.mediums[2].$n95 = pipe4.mediums[2].Xi[1] - pipe4.mediums[2].$n94;
+//   pipe4.mediums[2].$n96 = 1.0 - pipe4.mediums[2].Xi[1];
+//   pipe4.mediums[2].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[2].p, pipe4.mediums[2].T, pipe4.mediums[2].Xi);
+//   pipe4.mediums[2].R = 287.0512249529787 * pipe4.mediums[2].$n96 / (1.0 - pipe4.mediums[2].$n94) + 461.5233290850878 * pipe4.mediums[2].$n95 / (1.0 - pipe4.mediums[2].$n94);
 //   pipe4.mediums[2].u = pipe4.mediums[2].h - pipe4.mediums[2].R * pipe4.mediums[2].T;
 //   pipe4.mediums[2].d = pipe4.mediums[2].p / (pipe4.mediums[2].R * pipe4.mediums[2].T);
 //   pipe4.mediums[2].state.p = pipe4.mediums[2].p;
 //   pipe4.mediums[2].state.T = pipe4.mediums[2].T;
 //   pipe4.mediums[2].state.X[1] = pipe4.mediums[2].X[1];
 //   pipe4.mediums[2].state.X[2] = pipe4.mediums[2].X[2];
-//   n8133.n8256[2].n10109 = 0.6219647130774989 * n8133.n8256[2].n10110 / max(1e-13, pipe4.mediums[2].p - n8133.n8256[2].n10110);
-//   pipe4.mediums[2].x_water = pipe4.mediums[2].Xi[1] / max(n8133.n8256[2].n10107, 1e-13);
-//   pipe4.mediums[2].phi = pipe4.mediums[2].p / n8133.n8256[2].n10110 * pipe4.mediums[2].Xi[1] / (pipe4.mediums[2].Xi[1] + 0.6219647130774989 * n8133.n8256[2].n10107);
+//   pipe4.mediums[2].$n98 = 0.6219647130774989 * pipe4.mediums[2].$n99 / max(1e-13, pipe4.mediums[2].p - pipe4.mediums[2].$n99);
+//   pipe4.mediums[2].x_water = pipe4.mediums[2].Xi[1] / max(pipe4.mediums[2].$n96, 1e-13);
+//   pipe4.mediums[2].phi = pipe4.mediums[2].p / pipe4.mediums[2].$n99 * pipe4.mediums[2].Xi[1] / (pipe4.mediums[2].Xi[1] + 0.6219647130774989 * pipe4.mediums[2].$n96);
 //   pipe4.mediums[2].Xi[1] = pipe4.mediums[2].X[1];
 //   pipe4.mediums[2].X[2] = 1.0 - pipe4.mediums[2].Xi[1];
-//   assert(pipe4.mediums[2].X[1] >= -1e-05 and pipe4.mediums[2].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[2].X[2] >= -1e-05 and pipe4.mediums[2].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[2].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe4.mediums[3].T >= 190.0 and pipe4.mediums[3].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe4.mediums[2].X[1] >= -1e-05 and pipe4.mediums[2].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe4.mediums[2].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[2].X[2] >= -1e-05 and pipe4.mediums[2].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe4.mediums[2].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[2].p >= 0.0, \"Pressure (= \" + String(pipe4.mediums[2].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe4.mediums[2].T, 6, 0, true) + \" K)\");
+//   assert(pipe4.mediums[3].T >= 190.0 and pipe4.mediums[3].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe4.mediums[3].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe4.mediums[3].MM = 1.0 / (pipe4.mediums[3].Xi[1] / 0.01801528 + (1.0 - pipe4.mediums[3].Xi[1]) / 0.0289651159);
-//   n8133.n8256[3].n10110 = min(n1.n7656.n102.n8149.n8133.n7670.n8562(pipe4.mediums[3].T), 0.999 * pipe4.mediums[3].p);
-//   n8133.n8256[3].n10108 = min(n8133.n8256[3].n10110 * 0.6219647130774989 / max(1e-13, pipe4.mediums[3].p - n8133.n8256[3].n10110) * (1.0 - pipe4.mediums[3].Xi[1]), 1.0);
-//   n8133.n8256[3].n10105 = max(pipe4.mediums[3].Xi[1] - n8133.n8256[3].n10108, 0.0);
-//   n8133.n8256[3].n10106 = pipe4.mediums[3].Xi[1] - n8133.n8256[3].n10105;
-//   n8133.n8256[3].n10107 = 1.0 - pipe4.mediums[3].Xi[1];
-//   pipe4.mediums[3].h = n1.n7656.n102.n8149.n8133.n7670.n7957(pipe4.mediums[3].p, pipe4.mediums[3].T, pipe4.mediums[3].Xi);
-//   pipe4.mediums[3].R = 287.0512249529787 * n8133.n8256[3].n10107 / (1.0 - n8133.n8256[3].n10105) + 461.5233290850878 * n8133.n8256[3].n10106 / (1.0 - n8133.n8256[3].n10105);
+//   pipe4.mediums[3].$n99 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(pipe4.mediums[3].T), 0.999 * pipe4.mediums[3].p);
+//   pipe4.mediums[3].$n97 = min(pipe4.mediums[3].$n99 * 0.6219647130774989 / max(1e-13, pipe4.mediums[3].p - pipe4.mediums[3].$n99) * (1.0 - pipe4.mediums[3].Xi[1]), 1.0);
+//   pipe4.mediums[3].$n94 = max(pipe4.mediums[3].Xi[1] - pipe4.mediums[3].$n97, 0.0);
+//   pipe4.mediums[3].$n95 = pipe4.mediums[3].Xi[1] - pipe4.mediums[3].$n94;
+//   pipe4.mediums[3].$n96 = 1.0 - pipe4.mediums[3].Xi[1];
+//   pipe4.mediums[3].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[3].p, pipe4.mediums[3].T, pipe4.mediums[3].Xi);
+//   pipe4.mediums[3].R = 287.0512249529787 * pipe4.mediums[3].$n96 / (1.0 - pipe4.mediums[3].$n94) + 461.5233290850878 * pipe4.mediums[3].$n95 / (1.0 - pipe4.mediums[3].$n94);
 //   pipe4.mediums[3].u = pipe4.mediums[3].h - pipe4.mediums[3].R * pipe4.mediums[3].T;
 //   pipe4.mediums[3].d = pipe4.mediums[3].p / (pipe4.mediums[3].R * pipe4.mediums[3].T);
 //   pipe4.mediums[3].state.p = pipe4.mediums[3].p;
 //   pipe4.mediums[3].state.T = pipe4.mediums[3].T;
 //   pipe4.mediums[3].state.X[1] = pipe4.mediums[3].X[1];
 //   pipe4.mediums[3].state.X[2] = pipe4.mediums[3].X[2];
-//   n8133.n8256[3].n10109 = 0.6219647130774989 * n8133.n8256[3].n10110 / max(1e-13, pipe4.mediums[3].p - n8133.n8256[3].n10110);
-//   pipe4.mediums[3].x_water = pipe4.mediums[3].Xi[1] / max(n8133.n8256[3].n10107, 1e-13);
-//   pipe4.mediums[3].phi = pipe4.mediums[3].p / n8133.n8256[3].n10110 * pipe4.mediums[3].Xi[1] / (pipe4.mediums[3].Xi[1] + 0.6219647130774989 * n8133.n8256[3].n10107);
+//   pipe4.mediums[3].$n98 = 0.6219647130774989 * pipe4.mediums[3].$n99 / max(1e-13, pipe4.mediums[3].p - pipe4.mediums[3].$n99);
+//   pipe4.mediums[3].x_water = pipe4.mediums[3].Xi[1] / max(pipe4.mediums[3].$n96, 1e-13);
+//   pipe4.mediums[3].phi = pipe4.mediums[3].p / pipe4.mediums[3].$n99 * pipe4.mediums[3].Xi[1] / (pipe4.mediums[3].Xi[1] + 0.6219647130774989 * pipe4.mediums[3].$n96);
 //   pipe4.mediums[3].Xi[1] = pipe4.mediums[3].X[1];
 //   pipe4.mediums[3].X[2] = 1.0 - pipe4.mediums[3].Xi[1];
-//   assert(pipe4.mediums[3].X[1] >= -1e-05 and pipe4.mediums[3].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[3].X[2] >= -1e-05 and pipe4.mediums[3].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[3].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe4.mediums[4].T >= 190.0 and pipe4.mediums[4].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe4.mediums[3].X[1] >= -1e-05 and pipe4.mediums[3].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe4.mediums[3].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[3].X[2] >= -1e-05 and pipe4.mediums[3].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe4.mediums[3].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[3].p >= 0.0, \"Pressure (= \" + String(pipe4.mediums[3].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe4.mediums[3].T, 6, 0, true) + \" K)\");
+//   assert(pipe4.mediums[4].T >= 190.0 and pipe4.mediums[4].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe4.mediums[4].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe4.mediums[4].MM = 1.0 / (pipe4.mediums[4].Xi[1] / 0.01801528 + (1.0 - pipe4.mediums[4].Xi[1]) / 0.0289651159);
-//   n8133.n8256[4].n10110 = min(n1.n7656.n102.n8149.n8133.n7670.n8562(pipe4.mediums[4].T), 0.999 * pipe4.mediums[4].p);
-//   n8133.n8256[4].n10108 = min(n8133.n8256[4].n10110 * 0.6219647130774989 / max(1e-13, pipe4.mediums[4].p - n8133.n8256[4].n10110) * (1.0 - pipe4.mediums[4].Xi[1]), 1.0);
-//   n8133.n8256[4].n10105 = max(pipe4.mediums[4].Xi[1] - n8133.n8256[4].n10108, 0.0);
-//   n8133.n8256[4].n10106 = pipe4.mediums[4].Xi[1] - n8133.n8256[4].n10105;
-//   n8133.n8256[4].n10107 = 1.0 - pipe4.mediums[4].Xi[1];
-//   pipe4.mediums[4].h = n1.n7656.n102.n8149.n8133.n7670.n7957(pipe4.mediums[4].p, pipe4.mediums[4].T, pipe4.mediums[4].Xi);
-//   pipe4.mediums[4].R = 287.0512249529787 * n8133.n8256[4].n10107 / (1.0 - n8133.n8256[4].n10105) + 461.5233290850878 * n8133.n8256[4].n10106 / (1.0 - n8133.n8256[4].n10105);
+//   pipe4.mediums[4].$n99 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(pipe4.mediums[4].T), 0.999 * pipe4.mediums[4].p);
+//   pipe4.mediums[4].$n97 = min(pipe4.mediums[4].$n99 * 0.6219647130774989 / max(1e-13, pipe4.mediums[4].p - pipe4.mediums[4].$n99) * (1.0 - pipe4.mediums[4].Xi[1]), 1.0);
+//   pipe4.mediums[4].$n94 = max(pipe4.mediums[4].Xi[1] - pipe4.mediums[4].$n97, 0.0);
+//   pipe4.mediums[4].$n95 = pipe4.mediums[4].Xi[1] - pipe4.mediums[4].$n94;
+//   pipe4.mediums[4].$n96 = 1.0 - pipe4.mediums[4].Xi[1];
+//   pipe4.mediums[4].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[4].p, pipe4.mediums[4].T, pipe4.mediums[4].Xi);
+//   pipe4.mediums[4].R = 287.0512249529787 * pipe4.mediums[4].$n96 / (1.0 - pipe4.mediums[4].$n94) + 461.5233290850878 * pipe4.mediums[4].$n95 / (1.0 - pipe4.mediums[4].$n94);
 //   pipe4.mediums[4].u = pipe4.mediums[4].h - pipe4.mediums[4].R * pipe4.mediums[4].T;
 //   pipe4.mediums[4].d = pipe4.mediums[4].p / (pipe4.mediums[4].R * pipe4.mediums[4].T);
 //   pipe4.mediums[4].state.p = pipe4.mediums[4].p;
 //   pipe4.mediums[4].state.T = pipe4.mediums[4].T;
 //   pipe4.mediums[4].state.X[1] = pipe4.mediums[4].X[1];
 //   pipe4.mediums[4].state.X[2] = pipe4.mediums[4].X[2];
-//   n8133.n8256[4].n10109 = 0.6219647130774989 * n8133.n8256[4].n10110 / max(1e-13, pipe4.mediums[4].p - n8133.n8256[4].n10110);
-//   pipe4.mediums[4].x_water = pipe4.mediums[4].Xi[1] / max(n8133.n8256[4].n10107, 1e-13);
-//   pipe4.mediums[4].phi = pipe4.mediums[4].p / n8133.n8256[4].n10110 * pipe4.mediums[4].Xi[1] / (pipe4.mediums[4].Xi[1] + 0.6219647130774989 * n8133.n8256[4].n10107);
+//   pipe4.mediums[4].$n98 = 0.6219647130774989 * pipe4.mediums[4].$n99 / max(1e-13, pipe4.mediums[4].p - pipe4.mediums[4].$n99);
+//   pipe4.mediums[4].x_water = pipe4.mediums[4].Xi[1] / max(pipe4.mediums[4].$n96, 1e-13);
+//   pipe4.mediums[4].phi = pipe4.mediums[4].p / pipe4.mediums[4].$n99 * pipe4.mediums[4].Xi[1] / (pipe4.mediums[4].Xi[1] + 0.6219647130774989 * pipe4.mediums[4].$n96);
 //   pipe4.mediums[4].Xi[1] = pipe4.mediums[4].X[1];
 //   pipe4.mediums[4].X[2] = 1.0 - pipe4.mediums[4].Xi[1];
-//   assert(pipe4.mediums[4].X[1] >= -1e-05 and pipe4.mediums[4].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[4].X[2] >= -1e-05 and pipe4.mediums[4].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[4].p >= 0.0, \"assert message 2590312994638120201\");
-//   assert(pipe4.mediums[5].T >= 190.0 and pipe4.mediums[5].T <= 647.0, \"assert message 315810245365667762\");
+//   assert(pipe4.mediums[4].X[1] >= -1e-05 and pipe4.mediums[4].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe4.mediums[4].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[4].X[2] >= -1e-05 and pipe4.mediums[4].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe4.mediums[4].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[4].p >= 0.0, \"Pressure (= \" + String(pipe4.mediums[4].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe4.mediums[4].T, 6, 0, true) + \" K)\");
+//   assert(pipe4.mediums[5].T >= 190.0 and pipe4.mediums[5].T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(pipe4.mediums[5].T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   pipe4.mediums[5].MM = 1.0 / (pipe4.mediums[5].Xi[1] / 0.01801528 + (1.0 - pipe4.mediums[5].Xi[1]) / 0.0289651159);
-//   n8133.n8256[5].n10110 = min(n1.n7656.n102.n8149.n8133.n7670.n8562(pipe4.mediums[5].T), 0.999 * pipe4.mediums[5].p);
-//   n8133.n8256[5].n10108 = min(n8133.n8256[5].n10110 * 0.6219647130774989 / max(1e-13, pipe4.mediums[5].p - n8133.n8256[5].n10110) * (1.0 - pipe4.mediums[5].Xi[1]), 1.0);
-//   n8133.n8256[5].n10105 = max(pipe4.mediums[5].Xi[1] - n8133.n8256[5].n10108, 0.0);
-//   n8133.n8256[5].n10106 = pipe4.mediums[5].Xi[1] - n8133.n8256[5].n10105;
-//   n8133.n8256[5].n10107 = 1.0 - pipe4.mediums[5].Xi[1];
-//   pipe4.mediums[5].h = n1.n7656.n102.n8149.n8133.n7670.n7957(pipe4.mediums[5].p, pipe4.mediums[5].T, pipe4.mediums[5].Xi);
-//   pipe4.mediums[5].R = 287.0512249529787 * n8133.n8256[5].n10107 / (1.0 - n8133.n8256[5].n10105) + 461.5233290850878 * n8133.n8256[5].n10106 / (1.0 - n8133.n8256[5].n10105);
+//   pipe4.mediums[5].$n99 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.saturationPressure(pipe4.mediums[5].T), 0.999 * pipe4.mediums[5].p);
+//   pipe4.mediums[5].$n97 = min(pipe4.mediums[5].$n99 * 0.6219647130774989 / max(1e-13, pipe4.mediums[5].p - pipe4.mediums[5].$n99) * (1.0 - pipe4.mediums[5].Xi[1]), 1.0);
+//   pipe4.mediums[5].$n94 = max(pipe4.mediums[5].Xi[1] - pipe4.mediums[5].$n97, 0.0);
+//   pipe4.mediums[5].$n95 = pipe4.mediums[5].Xi[1] - pipe4.mediums[5].$n94;
+//   pipe4.mediums[5].$n96 = 1.0 - pipe4.mediums[5].Xi[1];
+//   pipe4.mediums[5].h = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.specificEnthalpy_pTX(pipe4.mediums[5].p, pipe4.mediums[5].T, pipe4.mediums[5].Xi);
+//   pipe4.mediums[5].R = 287.0512249529787 * pipe4.mediums[5].$n96 / (1.0 - pipe4.mediums[5].$n94) + 461.5233290850878 * pipe4.mediums[5].$n95 / (1.0 - pipe4.mediums[5].$n94);
 //   pipe4.mediums[5].u = pipe4.mediums[5].h - pipe4.mediums[5].R * pipe4.mediums[5].T;
 //   pipe4.mediums[5].d = pipe4.mediums[5].p / (pipe4.mediums[5].R * pipe4.mediums[5].T);
 //   pipe4.mediums[5].state.p = pipe4.mediums[5].p;
 //   pipe4.mediums[5].state.T = pipe4.mediums[5].T;
 //   pipe4.mediums[5].state.X[1] = pipe4.mediums[5].X[1];
 //   pipe4.mediums[5].state.X[2] = pipe4.mediums[5].X[2];
-//   n8133.n8256[5].n10109 = 0.6219647130774989 * n8133.n8256[5].n10110 / max(1e-13, pipe4.mediums[5].p - n8133.n8256[5].n10110);
-//   pipe4.mediums[5].x_water = pipe4.mediums[5].Xi[1] / max(n8133.n8256[5].n10107, 1e-13);
-//   pipe4.mediums[5].phi = pipe4.mediums[5].p / n8133.n8256[5].n10110 * pipe4.mediums[5].Xi[1] / (pipe4.mediums[5].Xi[1] + 0.6219647130774989 * n8133.n8256[5].n10107);
+//   pipe4.mediums[5].$n98 = 0.6219647130774989 * pipe4.mediums[5].$n99 / max(1e-13, pipe4.mediums[5].p - pipe4.mediums[5].$n99);
+//   pipe4.mediums[5].x_water = pipe4.mediums[5].Xi[1] / max(pipe4.mediums[5].$n96, 1e-13);
+//   pipe4.mediums[5].phi = pipe4.mediums[5].p / pipe4.mediums[5].$n99 * pipe4.mediums[5].Xi[1] / (pipe4.mediums[5].Xi[1] + 0.6219647130774989 * pipe4.mediums[5].$n96);
 //   pipe4.mediums[5].Xi[1] = pipe4.mediums[5].X[1];
 //   pipe4.mediums[5].X[2] = 1.0 - pipe4.mediums[5].Xi[1];
-//   assert(pipe4.mediums[5].X[1] >= -1e-05 and pipe4.mediums[5].X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[5].X[2] >= -1e-05 and pipe4.mediums[5].X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(pipe4.mediums[5].p >= 0.0, \"assert message 2590312994638120201\");
+//   assert(pipe4.mediums[5].X[1] >= -1e-05 and pipe4.mediums[5].X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(pipe4.mediums[5].X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[5].X[2] >= -1e-05 and pipe4.mediums[5].X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(pipe4.mediums[5].X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(pipe4.mediums[5].p >= 0.0, \"Pressure (= \" + String(pipe4.mediums[5].p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(pipe4.mediums[5].T, 6, 0, true) + \" K)\");
 //   pipe4.flowModel.states[1].X = pipe4.statesFM[1].X;
 //   pipe4.flowModel.states[2].X = pipe4.statesFM[2].X;
 //   pipe4.flowModel.states[3].X = pipe4.statesFM[3].X;
@@ -7725,18 +7862,18 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.flowModel.states[5].X = pipe4.statesFM[5].X;
 //   pipe4.flowModel.states[6].X = pipe4.statesFM[6].X;
 //   pipe4.flowModel.states[7].X = pipe4.statesFM[7].X;
-//   pipe4.flowModel.vs = n8133.n8369;
-//   pipe4.flowModel.crossAreas = n8133.n8370;
-//   pipe4.flowModel.dimensions = n8133.n8371;
-//   pipe4.flowModel.roughnesses = n8133.n8372;
-//   pipe4.flowModel.dheights = n8133.n8373;
-//   pipe4.flowModel.pathLengths = n8133.n8348;
-//   pipe4.flowModel.rhos = array(n1.n7656.n102.n8149.n8133.n8346.n7670.n523(pipe4.flowModel.states[$i1]) for $i1 in 1:7);
-//   pipe4.flowModel.mus = array(n1.n7656.n102.n8149.n8133.n8346.n7670.n8340(pipe4.flowModel.states[$i1]) for $i1 in 1:7);
+//   pipe4.flowModel.vs = pipe4.$n113;
+//   pipe4.flowModel.crossAreas = pipe4.$n112;
+//   pipe4.flowModel.dimensions = pipe4.$n114;
+//   pipe4.flowModel.roughnesses = pipe4.$n115;
+//   pipe4.flowModel.dheights = pipe4.$n111;
+//   pipe4.flowModel.pathLengths = pipe4.$n110;
+//   pipe4.flowModel.rhos = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.density(pipe4.flowModel.states[$i1]) for $i1 in 1:7);
+//   pipe4.flowModel.mus = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.dynamicViscosity(pipe4.flowModel.states[$i1]) for $i1 in 1:7);
 //   pipe4.flowModel.pathLengths_internal = pipe4.flowModel.pathLengths;
 //   pipe4.flowModel.Res_turbulent_internal = {pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent, pipe4.flowModel.Re_turbulent};
-//   n8133.n8346.n8410 = {0.5 * (pipe4.flowModel.dimensions[1] + pipe4.flowModel.dimensions[2]), 0.5 * (pipe4.flowModel.dimensions[2] + pipe4.flowModel.dimensions[3]), 0.5 * (pipe4.flowModel.dimensions[3] + pipe4.flowModel.dimensions[4]), 0.5 * (pipe4.flowModel.dimensions[4] + pipe4.flowModel.dimensions[5]), 0.5 * (pipe4.flowModel.dimensions[5] + pipe4.flowModel.dimensions[6]), 0.5 * (pipe4.flowModel.dimensions[6] + pipe4.flowModel.dimensions[7])};
-//   pipe4.flowModel.m_flows = array(homotopy((array(n1.n7656.n102.n8149.n8133.n8346.n7663.n8415(pipe4.flowModel.dps_fg[$i1], pipe4.flowModel.rhos[(1:6)[$i1]], pipe4.flowModel.rhos[(2:7)[$i1]], pipe4.flowModel.mus[(1:6)[$i1]], pipe4.flowModel.mus[(2:7)[$i1]], pipe4.flowModel.pathLengths_internal[$i1], n8133.n8346.n8410[$i1], {pipe4.flowModel.g * pipe4.flowModel.dheights[1], pipe4.flowModel.g * pipe4.flowModel.dheights[2], pipe4.flowModel.g * pipe4.flowModel.dheights[3], pipe4.flowModel.g * pipe4.flowModel.dheights[4], pipe4.flowModel.g * pipe4.flowModel.dheights[5], pipe4.flowModel.g * pipe4.flowModel.dheights[6]}[$i1], {(pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0}[$i1], {(pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0}[$i1], n8133.n8346.n8308 / 6.0, pipe4.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:6) * pipe4.flowModel.nParallel)[$i1], {pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[1] - pipe4.flowModel.g * pipe4.flowModel.dheights[1] * n8133.n8346.n8135), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[2] - pipe4.flowModel.g * pipe4.flowModel.dheights[2] * n8133.n8346.n8135), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[3] - pipe4.flowModel.g * pipe4.flowModel.dheights[3] * n8133.n8346.n8135), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[4] - pipe4.flowModel.g * pipe4.flowModel.dheights[4] * n8133.n8346.n8135), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[5] - pipe4.flowModel.g * pipe4.flowModel.dheights[5] * n8133.n8346.n8135), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[6] - pipe4.flowModel.g * pipe4.flowModel.dheights[6] * n8133.n8346.n8135)}[$i1]) for $i1 in 1:6);
+//   pipe4.flowModel.$n108 = {0.5 * (pipe4.flowModel.dimensions[1] + pipe4.flowModel.dimensions[2]), 0.5 * (pipe4.flowModel.dimensions[2] + pipe4.flowModel.dimensions[3]), 0.5 * (pipe4.flowModel.dimensions[3] + pipe4.flowModel.dimensions[4]), 0.5 * (pipe4.flowModel.dimensions[4] + pipe4.flowModel.dimensions[5]), 0.5 * (pipe4.flowModel.dimensions[5] + pipe4.flowModel.dimensions[6]), 0.5 * (pipe4.flowModel.dimensions[6] + pipe4.flowModel.dimensions[7])};
+//   pipe4.flowModel.m_flows = array(homotopy((array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.WallFriction.massFlowRate_dp_staticHead(pipe4.flowModel.dps_fg[$i1], pipe4.flowModel.rhos[(1:6)[$i1]], pipe4.flowModel.rhos[(2:7)[$i1]], pipe4.flowModel.mus[(1:6)[$i1]], pipe4.flowModel.mus[(2:7)[$i1]], pipe4.flowModel.pathLengths_internal[$i1], pipe4.flowModel.$n108[$i1], {pipe4.flowModel.g * pipe4.flowModel.dheights[1], pipe4.flowModel.g * pipe4.flowModel.dheights[2], pipe4.flowModel.g * pipe4.flowModel.dheights[3], pipe4.flowModel.g * pipe4.flowModel.dheights[4], pipe4.flowModel.g * pipe4.flowModel.dheights[5], pipe4.flowModel.g * pipe4.flowModel.dheights[6]}[$i1], {(pipe4.flowModel.crossAreas[1] + pipe4.flowModel.crossAreas[2]) / 2.0, (pipe4.flowModel.crossAreas[2] + pipe4.flowModel.crossAreas[3]) / 2.0, (pipe4.flowModel.crossAreas[3] + pipe4.flowModel.crossAreas[4]) / 2.0, (pipe4.flowModel.crossAreas[4] + pipe4.flowModel.crossAreas[5]) / 2.0, (pipe4.flowModel.crossAreas[5] + pipe4.flowModel.crossAreas[6]) / 2.0, (pipe4.flowModel.crossAreas[6] + pipe4.flowModel.crossAreas[7]) / 2.0}[$i1], {(pipe4.flowModel.roughnesses[1] + pipe4.flowModel.roughnesses[2]) / 2.0, (pipe4.flowModel.roughnesses[2] + pipe4.flowModel.roughnesses[3]) / 2.0, (pipe4.flowModel.roughnesses[3] + pipe4.flowModel.roughnesses[4]) / 2.0, (pipe4.flowModel.roughnesses[4] + pipe4.flowModel.roughnesses[5]) / 2.0, (pipe4.flowModel.roughnesses[5] + pipe4.flowModel.roughnesses[6]) / 2.0, (pipe4.flowModel.roughnesses[6] + pipe4.flowModel.roughnesses[7]) / 2.0}[$i1], pipe4.flowModel.$n105 / 6.0, pipe4.flowModel.Res_turbulent_internal[$i1]) for $i1 in 1:6) * pipe4.flowModel.nParallel)[$i1], {pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[1] - pipe4.flowModel.g * pipe4.flowModel.dheights[1] * pipe4.flowModel.$n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[2] - pipe4.flowModel.g * pipe4.flowModel.dheights[2] * pipe4.flowModel.$n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[3] - pipe4.flowModel.g * pipe4.flowModel.dheights[3] * pipe4.flowModel.$n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[4] - pipe4.flowModel.g * pipe4.flowModel.dheights[4] * pipe4.flowModel.$n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[5] - pipe4.flowModel.g * pipe4.flowModel.dheights[5] * pipe4.flowModel.$n102), pipe4.flowModel.m_flow_nominal / pipe4.flowModel.dp_nominal * (pipe4.flowModel.dps_fg[6] - pipe4.flowModel.g * pipe4.flowModel.dheights[6] * pipe4.flowModel.$n102)}[$i1]) for $i1 in 1:6);
 //   pipe4.flowModel.rhos_act[1] = noEvent(if pipe4.flowModel.m_flows[1] > 0.0 then pipe4.flowModel.rhos[1] else pipe4.flowModel.rhos[2]);
 //   pipe4.flowModel.mus_act[1] = noEvent(if pipe4.flowModel.m_flows[1] > 0.0 then pipe4.flowModel.mus[1] else pipe4.flowModel.mus[2]);
 //   pipe4.flowModel.rhos_act[2] = noEvent(if pipe4.flowModel.m_flows[2] > 0.0 then pipe4.flowModel.rhos[2] else pipe4.flowModel.rhos[3]);
@@ -7749,24 +7886,24 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.flowModel.mus_act[5] = noEvent(if pipe4.flowModel.m_flows[5] > 0.0 then pipe4.flowModel.mus[5] else pipe4.flowModel.mus[6]);
 //   pipe4.flowModel.rhos_act[6] = noEvent(if pipe4.flowModel.m_flows[6] > 0.0 then pipe4.flowModel.rhos[6] else pipe4.flowModel.rhos[7]);
 //   pipe4.flowModel.mus_act[6] = noEvent(if pipe4.flowModel.m_flows[6] > 0.0 then pipe4.flowModel.mus[6] else pipe4.flowModel.mus[7]);
-//   pipe4.flowModel.Ib_flows = array(pipe4.flowModel.rhos[i] * pipe4.flowModel.vs[i] * pipe4.flowModel.vs[i] * pipe4.flowModel.crossAreas[i] - pipe4.flowModel.rhos[i + 1] * pipe4.flowModel.vs[i + 1] * pipe4.flowModel.vs[i + 1] * pipe4.flowModel.crossAreas[i + 1] for n49 in 1:6) * pipe4.flowModel.nParallel;
-//   pipe4.flowModel.Fs_p = array(0.5 * (pipe4.flowModel.crossAreas[i] + pipe4.flowModel.crossAreas[i + 1]) * (n1.n7656.n102.n8149.n8133.n8346.n7670.n7786(pipe4.flowModel.states[i + 1]) - n1.n7656.n102.n8149.n8133.n8346.n7670.n7786(pipe4.flowModel.states[i])) for n49 in 1:6) * pipe4.flowModel.nParallel;
-//   pipe4.flowModel.dps_fg = array(pipe4.flowModel.Fs_fg[i] / pipe4.flowModel.nParallel * 2.0 / (pipe4.flowModel.crossAreas[i] + pipe4.flowModel.crossAreas[i + 1]) for n49 in 1:6);
-//   pipe4.flowModel.Is = array(pipe4.flowModel.m_flows[i] * pipe4.flowModel.pathLengths[i] for n49 in 1:6);
+//   pipe4.flowModel.Ib_flows = array(pipe4.flowModel.rhos[i] * pipe4.flowModel.vs[i] * pipe4.flowModel.vs[i] * pipe4.flowModel.crossAreas[i] - pipe4.flowModel.rhos[i + 1] * pipe4.flowModel.vs[i + 1] * pipe4.flowModel.vs[i + 1] * pipe4.flowModel.crossAreas[i + 1] for i in 1:6) * pipe4.flowModel.nParallel;
+//   pipe4.flowModel.Fs_p = array(0.5 * (pipe4.flowModel.crossAreas[i] + pipe4.flowModel.crossAreas[i + 1]) * (Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.pressure(pipe4.flowModel.states[i + 1]) - Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.flowModel.Medium.pressure(pipe4.flowModel.states[i])) for i in 1:6) * pipe4.flowModel.nParallel;
+//   pipe4.flowModel.dps_fg = array(pipe4.flowModel.Fs_fg[i] / pipe4.flowModel.nParallel * 2.0 / (pipe4.flowModel.crossAreas[i] + pipe4.flowModel.crossAreas[i + 1]) for i in 1:6);
+//   pipe4.flowModel.Is = array(pipe4.flowModel.m_flows[i] * pipe4.flowModel.pathLengths[i] for i in 1:6);
 //   der(pipe4.flowModel.Is[1]) = pipe4.flowModel.Ib_flows[1] - pipe4.flowModel.Fs_p[1] - pipe4.flowModel.Fs_fg[1];
 //   der(pipe4.flowModel.Is[2]) = pipe4.flowModel.Ib_flows[2] - pipe4.flowModel.Fs_p[2] - pipe4.flowModel.Fs_fg[2];
 //   der(pipe4.flowModel.Is[3]) = pipe4.flowModel.Ib_flows[3] - pipe4.flowModel.Fs_p[3] - pipe4.flowModel.Fs_fg[3];
 //   der(pipe4.flowModel.Is[4]) = pipe4.flowModel.Ib_flows[4] - pipe4.flowModel.Fs_p[4] - pipe4.flowModel.Fs_fg[4];
 //   der(pipe4.flowModel.Is[5]) = pipe4.flowModel.Ib_flows[5] - pipe4.flowModel.Fs_p[5] - pipe4.flowModel.Fs_fg[5];
 //   der(pipe4.flowModel.Is[6]) = pipe4.flowModel.Ib_flows[6] - pipe4.flowModel.Fs_p[6] - pipe4.flowModel.Fs_fg[6];
-//   pipe4.vs = array(0.5 * (pipe4.m_flows[i] + pipe4.m_flows[i + 1]) / pipe4.mediums[i].d / pipe4.crossAreas[i] for n49 in 1:5) / pipe4.nParallel;
+//   pipe4.vs = array(0.5 * (pipe4.m_flows[i] + pipe4.m_flows[i + 1]) / pipe4.mediums[i].d / pipe4.crossAreas[i] for i in 1:5) / pipe4.nParallel;
 //   pipe4.heatTransfer.states[1].X = pipe4.mediums[1].state.X;
 //   pipe4.heatTransfer.states[2].X = pipe4.mediums[2].state.X;
 //   pipe4.heatTransfer.states[3].X = pipe4.mediums[3].state.X;
 //   pipe4.heatTransfer.states[4].X = pipe4.mediums[4].state.X;
 //   pipe4.heatTransfer.states[5].X = pipe4.mediums[5].state.X;
 //   pipe4.heatTransfer.surfaceAreas = {pipe4.perimeter * 10.0, pipe4.perimeter * 10.0, pipe4.perimeter * 10.0, pipe4.perimeter * 10.0, pipe4.perimeter * 10.0};
-//   pipe4.heatTransfer.Ts = array(n1.n7656.n102.n8149.n8133.n7988.n7670.n7785(pipe4.heatTransfer.states[$i1]) for $i1 in 1:5);
+//   pipe4.heatTransfer.Ts = array(Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.heatTransfer.Medium.temperature(pipe4.heatTransfer.states[$i1]) for $i1 in 1:5);
 //   pipe4.heatTransfer.vs = pipe4.vs;
 //   pipe4.heatTransfer.lengths = {10.0, 10.0, 10.0, 10.0, 10.0};
 //   pipe4.heatTransfer.dimensions = pipe4.dimensions;
@@ -7786,42 +7923,42 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.Qb_flows[3] = pipe4.heatTransfer.Q_flows[3];
 //   pipe4.Qb_flows[4] = pipe4.heatTransfer.Q_flows[4];
 //   pipe4.Qb_flows[5] = pipe4.heatTransfer.Q_flows[5];
-//   pipe4.Wb_flows[2:4] = array(pipe4.vs[i] * pipe4.crossAreas[i] * ((pipe4.mediums[i + 1].p - pipe4.mediums[i - 1].p) / 2.0 + (pipe4.flowModel.dps_fg[i] + pipe4.flowModel.dps_fg[i + 1]) / 2.0 - system.g * {10.0, 10.0, 10.0, 10.0, 10.0}[i] * pipe4.mediums[i].d) for n49 in 2:4) * pipe4.nParallel;
+//   pipe4.Wb_flows[2:4] = array(pipe4.vs[i] * pipe4.crossAreas[i] * ((pipe4.mediums[i + 1].p - pipe4.mediums[i - 1].p) / 2.0 + (pipe4.flowModel.dps_fg[i] + pipe4.flowModel.dps_fg[i + 1]) / 2.0 - system.g * {10.0, 10.0, 10.0, 10.0, 10.0}[i] * pipe4.mediums[i].d) for i in 2:4) * pipe4.nParallel;
 //   pipe4.Wb_flows[1] = pipe4.vs[1] * pipe4.crossAreas[1] * ((pipe4.mediums[2].p - pipe4.port_a.p) / 1.5 + pipe4.flowModel.dps_fg[1] + pipe4.flowModel.dps_fg[2] / 2.0 - system.g * 10.0 * pipe4.mediums[1].d) * pipe4.nParallel;
 //   pipe4.Wb_flows[5] = pipe4.vs[5] * pipe4.crossAreas[5] * ((pipe4.port_b.p - pipe4.mediums[4].p) / 1.5 + pipe4.flowModel.dps_fg[5] / 2.0 + pipe4.flowModel.dps_fg[6] - system.g * 10.0 * pipe4.mediums[5].d) * pipe4.nParallel;
-//   n8133.n8348[1] = 5.0;
-//   n8133.n8348[2] = 10.0;
-//   n8133.n8348[3] = 10.0;
-//   n8133.n8348[4] = 10.0;
-//   n8133.n8348[5] = 10.0;
-//   n8133.n8348[6] = 5.0;
-//   n8133.n8373[1] = 5.0;
-//   n8133.n8373[2] = 10.0;
-//   n8133.n8373[3] = 10.0;
-//   n8133.n8373[4] = 10.0;
-//   n8133.n8373[5] = 10.0;
-//   n8133.n8373[6] = 5.0;
-//   n8133.n8370[1] = pipe4.crossAreas[1];
-//   n8133.n8370[2] = pipe4.crossAreas[1];
-//   n8133.n8370[3] = pipe4.crossAreas[2];
-//   n8133.n8370[4] = pipe4.crossAreas[3];
-//   n8133.n8370[5] = pipe4.crossAreas[4];
-//   n8133.n8370[6] = pipe4.crossAreas[5];
-//   n8133.n8370[7] = pipe4.crossAreas[5];
-//   n8133.n8371[1] = pipe4.dimensions[1];
-//   n8133.n8371[2] = pipe4.dimensions[1];
-//   n8133.n8371[3] = pipe4.dimensions[2];
-//   n8133.n8371[4] = pipe4.dimensions[3];
-//   n8133.n8371[5] = pipe4.dimensions[4];
-//   n8133.n8371[6] = pipe4.dimensions[5];
-//   n8133.n8371[7] = pipe4.dimensions[5];
-//   n8133.n8372[1] = pipe4.roughnesses[1];
-//   n8133.n8372[2] = pipe4.roughnesses[1];
-//   n8133.n8372[3] = pipe4.roughnesses[2];
-//   n8133.n8372[4] = pipe4.roughnesses[3];
-//   n8133.n8372[5] = pipe4.roughnesses[4];
-//   n8133.n8372[6] = pipe4.roughnesses[5];
-//   n8133.n8372[7] = pipe4.roughnesses[5];
+//   pipe4.$n110[1] = 5.0;
+//   pipe4.$n110[2] = 10.0;
+//   pipe4.$n110[3] = 10.0;
+//   pipe4.$n110[4] = 10.0;
+//   pipe4.$n110[5] = 10.0;
+//   pipe4.$n110[6] = 5.0;
+//   pipe4.$n111[1] = 5.0;
+//   pipe4.$n111[2] = 10.0;
+//   pipe4.$n111[3] = 10.0;
+//   pipe4.$n111[4] = 10.0;
+//   pipe4.$n111[5] = 10.0;
+//   pipe4.$n111[6] = 5.0;
+//   pipe4.$n112[1] = pipe4.crossAreas[1];
+//   pipe4.$n112[2] = pipe4.crossAreas[1];
+//   pipe4.$n112[3] = pipe4.crossAreas[2];
+//   pipe4.$n112[4] = pipe4.crossAreas[3];
+//   pipe4.$n112[5] = pipe4.crossAreas[4];
+//   pipe4.$n112[6] = pipe4.crossAreas[5];
+//   pipe4.$n112[7] = pipe4.crossAreas[5];
+//   pipe4.$n114[1] = pipe4.dimensions[1];
+//   pipe4.$n114[2] = pipe4.dimensions[1];
+//   pipe4.$n114[3] = pipe4.dimensions[2];
+//   pipe4.$n114[4] = pipe4.dimensions[3];
+//   pipe4.$n114[5] = pipe4.dimensions[4];
+//   pipe4.$n114[6] = pipe4.dimensions[5];
+//   pipe4.$n114[7] = pipe4.dimensions[5];
+//   pipe4.$n115[1] = pipe4.roughnesses[1];
+//   pipe4.$n115[2] = pipe4.roughnesses[1];
+//   pipe4.$n115[3] = pipe4.roughnesses[2];
+//   pipe4.$n115[4] = pipe4.roughnesses[3];
+//   pipe4.$n115[5] = pipe4.roughnesses[4];
+//   pipe4.$n115[6] = pipe4.roughnesses[5];
+//   pipe4.$n115[7] = pipe4.roughnesses[5];
 //   pipe4.mb_flows[1] = pipe4.m_flows[1] - pipe4.m_flows[2];
 //   pipe4.mbXi_flows[1,1] = pipe4.mXi_flows[1,1] - pipe4.mXi_flows[2,1];
 //   pipe4.Hb_flows[1] = pipe4.H_flows[1] - pipe4.H_flows[2];
@@ -7855,8 +7992,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.port_b.h_outflow = pipe4.mediums[5].h;
 //   pipe4.port_a.Xi_outflow[1] = pipe4.mediums[1].Xi[1];
 //   pipe4.port_b.Xi_outflow[1] = pipe4.mediums[5].Xi[1];
-//   pipe4.state_a = n1.n7656.n102.n8149.n8133.n7670.n8338(pipe4.port_a.p, ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.h_outflow + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.h_outflow) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.Xi_outflow[1] + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07))});
-//   pipe4.state_b = n1.n7656.n102.n8149.n8133.n7670.n8338(pipe4.port_b.p, boundary4.ports[1].h_outflow, {boundary4.ports[1].Xi_outflow[1]});
+//   pipe4.state_a = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_phX(pipe4.port_a.p, ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.h_outflow + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.h_outflow) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07)), {($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) * pipe2.port_b.Xi_outflow[1] + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07) * pipe3.port_b.Xi_outflow[1]) / ($OMC$PositiveMax(-pipe2.port_b.m_flow, 1e-07) + $OMC$PositiveMax(-pipe3.port_b.m_flow, 1e-07))});
+//   pipe4.state_b = Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.setState_phX(pipe4.port_b.p, boundary4.ports[1].h_outflow, {boundary4.ports[1].Xi_outflow[1]});
 //   pipe4.statesFM[1] = pipe4.state_a;
 //   pipe4.statesFM[2] = pipe4.mediums[1].state;
 //   pipe4.statesFM[3] = pipe4.mediums[2].state;
@@ -7870,13 +8007,13 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   pipe4.m_flows[4] = pipe4.flowModel.m_flows[4];
 //   pipe4.m_flows[5] = pipe4.flowModel.m_flows[5];
 //   pipe4.m_flows[6] = pipe4.flowModel.m_flows[6];
-//   n8133.n8369[1] = pipe4.m_flows[1] / n1.n7656.n102.n8149.n8133.n7670.n523(pipe4.state_a) / pipe4.crossAreas[1] / pipe4.nParallel;
-//   n8133.n8369[2] = pipe4.vs[1];
-//   n8133.n8369[3] = pipe4.vs[2];
-//   n8133.n8369[4] = pipe4.vs[3];
-//   n8133.n8369[5] = pipe4.vs[4];
-//   n8133.n8369[6] = pipe4.vs[5];
-//   n8133.n8369[7] = pipe4.m_flows[6] / n1.n7656.n102.n8149.n8133.n7670.n523(pipe4.state_b) / pipe4.crossAreas[5] / pipe4.nParallel;
+//   pipe4.$n113[1] = pipe4.m_flows[1] / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.density(pipe4.state_a) / pipe4.crossAreas[1] / pipe4.nParallel;
+//   pipe4.$n113[2] = pipe4.vs[1];
+//   pipe4.$n113[3] = pipe4.vs[2];
+//   pipe4.$n113[4] = pipe4.vs[3];
+//   pipe4.$n113[5] = pipe4.vs[4];
+//   pipe4.$n113[6] = pipe4.vs[5];
+//   pipe4.$n113[7] = pipe4.m_flows[6] / Modelica.Fluid.Examples.BranchingDynamicPipes.pipe4.Medium.density(pipe4.state_b) / pipe4.crossAreas[5] / pipe4.nParallel;
 //   pipe4.ms[1] = pipe4.fluidVolumes[1] * pipe4.mediums[1].d;
 //   pipe4.mXis[1,1] = pipe4.ms[1] * pipe4.mediums[1].Xi[1];
 //   pipe4.Us[1] = pipe4.ms[1] * pipe4.mediums[1].u;
@@ -7907,36 +8044,42 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   der(pipe4.mXis[3,1]) = pipe4.mbXi_flows[3,1];
 //   der(pipe4.mXis[4,1]) = pipe4.mbXi_flows[4,1];
 //   der(pipe4.mXis[5,1]) = pipe4.mbXi_flows[5,1];
-//   assert(boundary4.medium.T >= 190.0 and boundary4.medium.T <= 647.0, \"assert message 315810245365667762\");
+//   assert(boundary4.medium.T >= 190.0 and boundary4.medium.T <= 647.0, \"
+//   Temperature T is not in the allowed range
+//   190.0 K <= (T =\" + String(boundary4.medium.T, 6, 0, true) + \" K) <= 647.0 K
+//   required from medium model \\\"\" + \"Moist air\" + \"\\\".\");
 //   boundary4.medium.MM = 1.0 / (boundary4.medium.Xi[1] / 0.01801528 + (1.0 - boundary4.medium.Xi[1]) / 0.0289651159);
-//   n8155.n7931.n10110 = min(n1.n7656.n102.n8149.n8155.n7670.n8562(boundary4.medium.T), 0.999 * boundary4.medium.p);
-//   n8155.n7931.n10108 = min(n8155.n7931.n10110 * 0.6219647130774989 / max(1e-13, boundary4.medium.p - n8155.n7931.n10110) * (1.0 - boundary4.medium.Xi[1]), 1.0);
-//   n8155.n7931.n10105 = max(boundary4.medium.Xi[1] - n8155.n7931.n10108, 0.0);
-//   n8155.n7931.n10106 = boundary4.medium.Xi[1] - n8155.n7931.n10105;
-//   n8155.n7931.n10107 = 1.0 - boundary4.medium.Xi[1];
-//   boundary4.medium.h = n1.n7656.n102.n8149.n8155.n7670.n7957(boundary4.medium.p, boundary4.medium.T, boundary4.medium.Xi);
-//   boundary4.medium.R = 287.0512249529787 * n8155.n7931.n10107 / (1.0 - n8155.n7931.n10105) + 461.5233290850878 * n8155.n7931.n10106 / (1.0 - n8155.n7931.n10105);
+//   boundary4.medium.$n121 = min(Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.saturationPressure(boundary4.medium.T), 0.999 * boundary4.medium.p);
+//   boundary4.medium.$n119 = min(boundary4.medium.$n121 * 0.6219647130774989 / max(1e-13, boundary4.medium.p - boundary4.medium.$n121) * (1.0 - boundary4.medium.Xi[1]), 1.0);
+//   boundary4.medium.$n116 = max(boundary4.medium.Xi[1] - boundary4.medium.$n119, 0.0);
+//   boundary4.medium.$n117 = boundary4.medium.Xi[1] - boundary4.medium.$n116;
+//   boundary4.medium.$n118 = 1.0 - boundary4.medium.Xi[1];
+//   boundary4.medium.h = Modelica.Fluid.Examples.BranchingDynamicPipes.boundary4.Medium.specificEnthalpy_pTX(boundary4.medium.p, boundary4.medium.T, boundary4.medium.Xi);
+//   boundary4.medium.R = 287.0512249529787 * boundary4.medium.$n118 / (1.0 - boundary4.medium.$n116) + 461.5233290850878 * boundary4.medium.$n117 / (1.0 - boundary4.medium.$n116);
 //   boundary4.medium.u = boundary4.medium.h - boundary4.medium.R * boundary4.medium.T;
 //   boundary4.medium.d = boundary4.medium.p / (boundary4.medium.R * boundary4.medium.T);
 //   boundary4.medium.state.p = boundary4.medium.p;
 //   boundary4.medium.state.T = boundary4.medium.T;
 //   boundary4.medium.state.X[1] = boundary4.medium.X[1];
 //   boundary4.medium.state.X[2] = boundary4.medium.X[2];
-//   n8155.n7931.n10109 = 0.6219647130774989 * n8155.n7931.n10110 / max(1e-13, boundary4.medium.p - n8155.n7931.n10110);
-//   boundary4.medium.x_water = boundary4.medium.Xi[1] / max(n8155.n7931.n10107, 1e-13);
-//   boundary4.medium.phi = boundary4.medium.p / n8155.n7931.n10110 * boundary4.medium.Xi[1] / (boundary4.medium.Xi[1] + 0.6219647130774989 * n8155.n7931.n10107);
+//   boundary4.medium.$n120 = 0.6219647130774989 * boundary4.medium.$n121 / max(1e-13, boundary4.medium.p - boundary4.medium.$n121);
+//   boundary4.medium.x_water = boundary4.medium.Xi[1] / max(boundary4.medium.$n118, 1e-13);
+//   boundary4.medium.phi = boundary4.medium.p / boundary4.medium.$n121 * boundary4.medium.Xi[1] / (boundary4.medium.Xi[1] + 0.6219647130774989 * boundary4.medium.$n118);
 //   boundary4.medium.Xi[1] = boundary4.medium.X[1];
 //   boundary4.medium.X[2] = 1.0 - boundary4.medium.Xi[1];
-//   assert(boundary4.medium.X[1] >= -1e-05 and boundary4.medium.X[1] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(boundary4.medium.X[2] >= -1e-05 and boundary4.medium.X[2] <= 1.00001, \"assert message 1370699107527140891\");
-//   assert(boundary4.medium.p >= 0.0, \"assert message 2590312994638120201\");
-//   n1.n7656.n11.n8727(\"Moist air\", {\"water\", \"air\"}, false, true, n8155.n8737, \"Boundary_pT\");
-//   n8155.n8736 = boundary4.T;
-//   n8155.n8737[1] = boundary4.X[1];
-//   n8155.n8737[2] = boundary4.X[2];
-//   boundary4.medium.p = n8155.n8735;
-//   boundary4.medium.T = n8155.n8736;
-//   boundary4.medium.Xi[1] = n8155.n8737[1];
+//   assert(boundary4.medium.X[1] >= -1e-05 and boundary4.medium.X[1] <= 1.00001, \"Mass fraction X[\" + String(1, 0, true) + \"] = \" + String(boundary4.medium.X[1], 6, 0, true) + \"of substance \" + \"water\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(boundary4.medium.X[2] >= -1e-05 and boundary4.medium.X[2] <= 1.00001, \"Mass fraction X[\" + String(2, 0, true) + \"] = \" + String(boundary4.medium.X[2], 6, 0, true) + \"of substance \" + \"air\" + \"
+//   of medium \" + \"Moist air\" + \" is not in the range 0..1\");
+//   assert(boundary4.medium.p >= 0.0, \"Pressure (= \" + String(boundary4.medium.p, 6, 0, true) + \" Pa) of medium \\\"\" + \"Moist air\" + \"\\\" is negative
+//   (Temperature = \" + String(boundary4.medium.T, 6, 0, true) + \" K)\");
+//   Modelica.Fluid.Utilities.checkBoundary(\"Moist air\", {\"water\", \"air\"}, false, true, boundary4.$n125, \"Boundary_pT\");
+//   boundary4.$n124 = boundary4.T;
+//   boundary4.$n125[1] = boundary4.X[1];
+//   boundary4.$n125[2] = boundary4.X[2];
+//   boundary4.medium.p = boundary4.$n123;
+//   boundary4.medium.T = boundary4.$n124;
+//   boundary4.medium.Xi[1] = boundary4.$n125[1];
 //   boundary4.ports[1].p = boundary4.medium.p;
 //   boundary4.ports[1].h_outflow = boundary4.medium.h;
 //   boundary4.ports[1].Xi_outflow[1] = boundary4.medium.Xi[1];
@@ -7946,7 +8089,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   heat2[3].port.Q_flow = -heat2[3].Q_flow * (1.0 + heat2[3].alpha * (heat2[3].port.T - heat2[3].T_ref));
 //   heat2[4].port.Q_flow = -heat2[4].Q_flow * (1.0 + heat2[4].alpha * (heat2[4].port.T - heat2[4].T_ref));
 //   heat2[5].port.Q_flow = -heat2[5].Q_flow * (1.0 + heat2[5].alpha * (heat2[5].port.T - heat2[5].T_ref));
-// end n1.n7656.n102.n8149;
+// end Modelica.Fluid.Examples.BranchingDynamicPipes;
 // "
 // ""
 // endResult


### PR DESCRIPTION
- Implement new obfuscation method that obfuscates protected variables (with `--obfuscate=protected`) or only encrypted protected variables (with `--obfuscate=encrypted`) that replaces the old non-working method of obfuscating protected variables.
- Enable `--obfuscate=encrypted` automatically when the AST contains any encrypted classes.
- Add scopes to all equations and algorithms, to allow the obfuscation to look up names in annotations.