### PR TITLE
Disable shared version of OMParser's antlr4.

### DIFF
--- a/OMParser/3rdParty/antlr4/runtime/Cpp/CMakeLists.txt
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/CMakeLists.txt
@@ -207,16 +207,16 @@ if (ANTLR4_INSTALL)
 
 endif(ANTLR4_INSTALL)
 
-if(EXISTS LICENSE.txt)
-install(FILES LICENSE.txt
-        DESTINATION "share/doc/libantlr4")
-elseif(EXISTS ../../LICENSE.txt)
-install(FILES ../../LICENSE.txt
-    DESTINATION "share/doc/libantlr4")
-endif()
+# if(EXISTS LICENSE.txt)
+# install(FILES LICENSE.txt
+#         DESTINATION "share/doc/libantlr4")
+# elseif(EXISTS ../../LICENSE.txt)
+# install(FILES ../../LICENSE.txt
+#     DESTINATION "share/doc/libantlr4")
+# endif()
 
-install(FILES README.md VERSION
-    DESTINATION "share/doc/libantlr4")
+# install(FILES README.md VERSION
+#     DESTINATION "share/doc/libantlr4")
 
 set(CPACK_PACKAGE_CONTACT "antlr-discussion@googlegroups.com")
 set(CPACK_PACKAGE_VERSION ${ANTLR_VERSION})

--- a/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
+++ b/OMParser/3rdParty/antlr4/runtime/Cpp/runtime/CMakeLists.txt
@@ -23,7 +23,7 @@ file(GLOB libantlrcpp_SRC
   "${PROJECT_SOURCE_DIR}/runtime/src/tree/xpath/*.cpp"
 )
 
-add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
+# add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
 add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 
 # This are needed for transitive include dirs. Ideally all include dirs should be specified
@@ -31,17 +31,17 @@ add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 target_include_directories(antlr4_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(antlr4_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-target_include_directories(antlr4_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_include_directories(antlr4_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+# target_include_directories(antlr4_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+# target_include_directories(antlr4_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 # Anything that links to the static lib should use the ANTLR4CPP_STATIC define as well.
 target_compile_definitions(antlr4_static PUBLIC ANTLR4CPP_STATIC)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  target_link_libraries(antlr4_shared ${UUID_LIBRARIES})
+  # target_link_libraries(antlr4_shared ${UUID_LIBRARIES})
   target_link_libraries(antlr4_static ${UUID_LIBRARIES})
 elseif(APPLE)
-  target_link_libraries(antlr4_shared ${COREFOUNDATION_LIBRARY})
+  # target_link_libraries(antlr4_shared ${COREFOUNDATION_LIBRARY})
   target_link_libraries(antlr4_static ${COREFOUNDATION_LIBRARY})
 endif()
 
@@ -66,10 +66,10 @@ if(WIN32)
 endif(WIN32)
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   if(WITH_STATIC_CRT)
-    target_compile_options(antlr4_shared PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+    # target_compile_options(antlr4_shared PRIVATE "/MT$<$<CONFIG:Debug>:d>")
     target_compile_options(antlr4_static PRIVATE "/MT$<$<CONFIG:Debug>:d>")
   else()
-    target_compile_options(antlr4_shared PRIVATE "/MD$<$<CONFIG:Debug>:d>")
+    # target_compile_options(antlr4_shared PRIVATE "/MD$<$<CONFIG:Debug>:d>")
     target_compile_options(antlr4_static PRIVATE "/MD$<$<CONFIG:Debug>:d>")
   endif()
 endif()
@@ -84,22 +84,22 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   set(extra_static_compile_flags "-DANTLR4CPP_STATIC -MP")
 endif()
 
-set_target_properties(antlr4_shared
-                      PROPERTIES VERSION   ${ANTLR_VERSION}
-                                 SOVERSION ${ANTLR_VERSION}
-                                 OUTPUT_NAME antlr4-runtime
-                                 COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
+# set_target_properties(antlr4_shared
+#                       PROPERTIES VERSION   ${ANTLR_VERSION}
+#                                  SOVERSION ${ANTLR_VERSION}
+#                                  OUTPUT_NAME antlr4-runtime
+#                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
 
 set_target_properties(antlr4_static
                       PROPERTIES OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 
-install(TARGETS antlr4_shared antlr4_static
-        EXPORT antlr4-targets
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
+# install(TARGETS antlr4_static
+#         EXPORT antlr4-targets
+#           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+#           LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#           ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#         )
 
 
 # install(DIRECTORY "${PROJECT_SOURCE_DIR}/runtime/src/"

--- a/OMParser/Makefile
+++ b/OMParser/Makefile
@@ -26,7 +26,7 @@ libOMParser.a: $(OBJS)
 	$(AR) -s -r $@ $(OBJS)
 	mkdir -p $(OMBUILDDIR)/lib/$(host_short)/omc/ $(OMBUILDDIR)/include/omc/
 	cp -pR $@ $(OMBUILDDIR)/lib/$(host_short)/omc/
-	cp install/lib/libantlr4-runtime.a $(OMBUILDDIR)/lib/$(host_short)/omc/
+	cp 3rdParty/antlr4/runtime/Cpp/build/runtime/libantlr4-runtime.a $(OMBUILDDIR)/lib/$(host_short)/omc/
 
 $(OBJS): $(CPP_FILES) install/lib/libantlr4-runtime.a
 
@@ -36,8 +36,7 @@ $(OBJS): $(CPP_FILES) install/lib/libantlr4-runtime.a
 install/lib/libantlr4-runtime.a: 3rdParty/antlr4/runtime/Cpp/CMakeLists.txt
 	mkdir -p 3rdParty/antlr4/runtime/Cpp/build
 	$(MAKE) 3rdParty/antlr4/runtime/Cpp/build/Makefile
-	$(MAKE) -C 3rdParty/antlr4/runtime/Cpp/build/ install
-	if test -d "./install/lib64"; then ln -sf ./lib64 ./install/lib; fi
+	$(MAKE) -C 3rdParty/antlr4/runtime/Cpp/build/
 
 $(CPP_FILES): runtool
 


### PR DESCRIPTION
  - We do not need it since we only depend on the static version.

  - Remove installation of antlr4 files and targets since we do not want them installed as well (this affects the CMake OpenModelica build only).