### PR TITLE
Cleanup/Fixup installation components.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,11 @@ endif()
 ## Do not print unnecessary install messages when nothing has actually changed.
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
-
+# Set a 'catch-all' install component "unknown-install-component". If you see some install component under this
+# id, then you know that something has not set an install component either explicily on the install() command
+# or at higher level using 'set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME <id>)' to cover all install() commands
+# issues after it.
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "unknown-install-component")
 
 ## Subdirectories ##########################################################################################
 omc_add_subdirectory(OMCompiler)

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(OMCompiler C CXX)
 
+# For now, unless explicitly specified otherwise, we set install component simrt
+# for everything installed from the OMCompiler directory. There are some places that
+# modify this explictly, e.g., the omc compiler ('COMPONENT omc'), the cpp runtime (simrt-cpp),
+# and FMU realted installtions (COMPONENT fmu)
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME simrt)
+
 ## OPTIONS #################################################################################################
 
 omc_option(OM_OMC_ENABLE_FORTRAN "Enable Fortran support. Fortran is required if you enable IPOPT support." ON)

--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -262,22 +262,22 @@ endif()
 # They are part of "compiler" installation component. This means that you can
 # install just the files in this component by specifying its name.
 install(TARGETS omc OpenModelicaCompiler
-            COMPONENT compiler)
+            COMPONENT omc)
 
 # Install the *ModelicaBuiltin files to <library_dir>/omc/ that is where omc.exe expects them to be.
 # They are also part of "compiler" installation component.
 install(FILES NFFrontEnd/NFModelicaBuiltin.mo
             DESTINATION lib/omc
-            COMPONENT compiler)
+            COMPONENT omc)
 install(FILES FrontEnd/ModelicaBuiltin.mo
             DESTINATION lib/omc
-            COMPONENT compiler)
+            COMPONENT omc)
 install(FILES FrontEnd/MetaModelicaBuiltin.mo
             DESTINATION lib/omc
-            COMPONENT compiler)
+            COMPONENT omc)
 install(FILES FrontEnd/PDEModelicaBuiltin.mo
             DESTINATION lib/omc
-            COMPONENT compiler)
+            COMPONENT omc)
 
 # Install the scripts to 'share' dir.
 install(DIRECTORY scripts

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 # OMC will overflow the stack (at least on Windows old OMDev) on very deep recursive calls.
 # E.g., try translating the CodegenCpp* tpl files to mo files with
-# an omc not compiled without large stack size. The tpl parser is quite recursive and will
+# an omc compiled without large stack size. The tpl parser is quite recursive and will
 # overflow on parsing comments with very long lines ~300. *CPP tpl files have lines longer
 # than that.
 if(MINGW)

--- a/OMCompiler/Compiler/runtime/CMakeLists.txt
+++ b/OMCompiler/Compiler/runtime/CMakeLists.txt
@@ -13,9 +13,6 @@ if(OM_OMC_USE_LAPACK)
   set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_OLD})
 endif()
 
-
-# find_package(ZLIB REQUIRED) # Not needed. We use the minizip lib from 3rdParty/FMIL instead
-
 # On Win32 we use system UUID lib which is one of the default libs that cmake adds to any target on Win32. On non Win32
 # systems we need to link explicitly to uuid. However, there is no FindUUID yet. We can add one later. Instead we use
 # find library for now. It should be okay for now since I am guessing uuid headers should be in the default include dirs

--- a/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake/source_code_fmu_config.cmake
@@ -61,7 +61,9 @@ set(SOURCE_FMU_COMMON_FILES_LIST ./gc/memory_pool.c
 foreach(source_file ${SOURCE_FMU_COMMON_FILES_LIST})
   list(APPEND SOURCE_FMU_COMMON_FILES_LIST_QUOTED \"${source_file}\")
   get_filename_component(DEST_DIR ${source_file} DIRECTORY)
-  install(FILES ${source_file} DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR})
+  install(FILES ${source_file}
+          DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}
+          COMPONENT fmu)
 endforeach()
 string(REPLACE ";" ",\n                                         " SOURCE_FMU_COMMON_FILES "${SOURCE_FMU_COMMON_FILES_LIST_QUOTED}")
 
@@ -175,6 +177,7 @@ file(GLOB_RECURSE 3RD_DGESV_HEADERS ${OMCompiler_3rdParty_SOURCE_DIR}/dgesv/incl
 install(FILES ${3RD_DGESV_HEADERS}
               ${3RD_DGESV_FILES}
         DESTINATION ${SOURCE_FMU_SOURCES_DIR}/external_solvers
+        COMPONENT fmu
 )
 
 foreach(source_file_full_path ${3RD_DGESV_FILES})
@@ -192,7 +195,9 @@ set(SOURCE_FMU_NLS_FILES_LIST simulation/solver/nonlinearSolverHomotopy.c simula
 foreach(source_file ${SOURCE_FMU_NLS_FILES_LIST})
   list(APPEND SOURCE_FMU_NLS_FILES_LIST_QUOTED \"${source_file}\")
   get_filename_component(DEST_DIR ${source_file} DIRECTORY)
-  install(FILES ${source_file} DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR})
+  install(FILES ${source_file}
+          DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}
+          COMPONENT fmu)
 endforeach()
 string(REPLACE ";" "," SOURCE_FMU_NLS_FILES "${SOURCE_FMU_NLS_FILES_LIST_QUOTED}")
 
@@ -215,6 +220,7 @@ set(3RD_CMINPACK_HEADERS  ${OMCompiler_3rdParty_SOURCE_DIR}/CMinpack/cminpack.h
 install(FILES ${3RD_CMINPACK_HEADERS}
               ${3RD_CMINPACK_FMU_FILES}
         DESTINATION ${SOURCE_FMU_SOURCES_DIR}/external_solvers
+        COMPONENT fmu
 )
 
 foreach(source_file_full_path ${3RD_CMINPACK_FMU_FILES})
@@ -232,7 +238,9 @@ set(SOURCE_FMU_LS_FILES_LIST simulation/solver/linearSystem.c simulation/solver/
 foreach(source_file ${SOURCE_FMU_LS_FILES_LIST})
   list(APPEND SOURCE_FMU_LS_FILES_LIST_QUOTED \"${source_file}\")
   get_filename_component(DEST_DIR ${source_file} DIRECTORY)
-  install(FILES ${source_file} DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR})
+  install(FILES ${source_file}
+          DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}
+          COMPONENT fmu)
 endforeach()
 string(REPLACE ";" "," SOURCE_FMU_LS_FILES "${SOURCE_FMU_LS_FILES_LIST_QUOTED}")
 
@@ -244,7 +252,9 @@ set(SOURCE_FMU_MIXED_FILES_LIST simulation/solver/mixedSearchSolver.c simulation
 foreach(source_file ${SOURCE_FMU_MIXED_FILES_LIST})
   list(APPEND SOURCE_FMU_MIXED_FILES_LIST_QUOTED \"${source_file}\")
   get_filename_component(DEST_DIR ${source_file} DIRECTORY)
-  install(FILES ${source_file} DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR})
+  install(FILES ${source_file}
+          DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}
+          COMPONENT fmu)
 endforeach()
 string(REPLACE ";" "," SOURCE_FMU_MIXED_FILES "${SOURCE_FMU_MIXED_FILES_LIST_QUOTED}")
 
@@ -257,7 +267,9 @@ set(SOURCE_FMU_CVODE_RUNTIME_FILES_LIST simulation/solver/cvode_solver.c simulat
 foreach(source_file ${SOURCE_FMU_CVODE_RUNTIME_FILES_LIST})
   list(APPEND SOURCE_FMU_CVODE_RUNTIME_FILES_LIST_QUOTED \"${source_file}\")
   get_filename_component(DEST_DIR ${source_file} DIRECTORY)
-  install(FILES ${source_file} DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR})
+  install(FILES ${source_file}
+          DESTINATION ${SOURCE_FMU_SOURCES_DIR}/${DEST_DIR}
+          COMPONENT fmu)
 endforeach()
 string(REPLACE ";" "," SOURCE_FMU_CVODE_RUNTIME_FILES "${SOURCE_FMU_CVODE_RUNTIME_FILES_LIST_QUOTED}")
 
@@ -283,7 +295,8 @@ target_include_directories(SimulationRuntimeFMI PUBLIC ${CMAKE_CURRENT_SOURCE_DI
 
 target_link_libraries(SimulationRuntimeFMI PUBLIC OMCPThreads::OMCPThreads)
 
-install(TARGETS SimulationRuntimeFMI)
+install(TARGETS SimulationRuntimeFMI
+        COMPONENT fmu)
 
 
 # ######################################################################################################################
@@ -300,4 +313,5 @@ target_sources(OpenModelicaFMIRuntimeC PRIVATE ${OMC_SIMRT_FMI_SOURCES})
 # target_link_libraries(OpenModelicaFMIRuntimeC_base PUBLIC omc::config)
 target_link_libraries(OpenModelicaFMIRuntimeC PUBLIC omc::3rd::fmilib)
 
-install(TARGETS OpenModelicaFMIRuntimeC)
+install(TARGETS OpenModelicaFMIRuntimeC
+        COMPONENT fmu)

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -54,7 +54,8 @@ elseif(MSVC)
   set_target_properties(OpenModelicaRuntimeC PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
 endif()
 
-install(TARGETS OpenModelicaRuntimeC)
+install(TARGETS OpenModelicaRuntimeC
+        COMPONENT omc)
 
 
 # ######################################################################################################################

--- a/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/cpp/cmake_3.14.cmake
@@ -9,6 +9,8 @@ set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_LIBDIR})
 # CPP headers are installed in include/omc/cpp for now.
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/cpp)
 
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME simrt-cpp)
+
 
 
 # Boost and a threading library are required for the CPP-runtime.

--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.14)
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME gui)
 
 project(OMEdit)
 

--- a/OMNotebook/CMakeLists.txt
+++ b/OMNotebook/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.14)
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME gui)
 
 project(OMNotebook)
 

--- a/OMPlot/CMakeLists.txt
+++ b/OMPlot/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.14)
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME gui)
 
 project(OMPlot)
 

--- a/OMShell/CMakeLists.txt
+++ b/OMShell/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required (VERSION 3.14)
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME gui)
+
 
 project(OMShell)
 

--- a/omsimulator.cmake
+++ b/omsimulator.cmake
@@ -1,4 +1,6 @@
 
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omsimulator)
+
 
 include(ExternalProject)
 include(ProcessorCount)


### PR DESCRIPTION
For now, there are six install components 
  
  - `omc`: the core omc compiler without any simulation runtime, i.e., omc executable and shared libs needed to run it (`libOpenModelicaRuntimeC` and `omcgc`).

  - `simrt`: everything needed to run a simulation using omc. This includes

      - anything installed from `3rdParty` (technically not needed to be distributed but
        we need to clean that later.) EXCEPT `omcgc` (see `omc`).
      - Everything we install from SimulationRuntime/c EXCEPT `libOpenModelicaRuntimeC` (see `omc`)

  - `simrt-cpp`: Everything we install from `SimulationRuntime/cpp`

  - `fmu`: Everything needed to compile an FMU (normal or source FMU) including the simulation runtime source files needed for creating Source-Code FMUs.

  - `gui`: All the gui clients, i.e., anything installed from `OMEdit`, `OMPlot`, `OMShell` and `OMNotebook`. This can be split up later if needed.

  - `omsimulator`: The `OMSimulator` executable and libraries. This should probably be handled in its own repo and added as a dependency here.

