### PR TITLE
Add initial CMake packaging support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 
 cmake_minimum_required(VERSION 3.14)
-project(OpenModelica C CXX)
+project(OpenModelica
+        VERSION 1.19.3
+        HOMEPAGE_URL "https://openmodelica.org/"
+        LANGUAGES C CXX)
 
 # Any custom Find* modules should be placed here.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
@@ -158,6 +161,8 @@ if(OM_ENABLE_GUI_CLIENTS)
 endif()
 
 omc_add_subdirectory(testsuite)
+
+include(cmake/packaging/common.cmake)
 
 
 ## Report some status info.

--- a/cmake/packaging/common.cmake
+++ b/cmake/packaging/common.cmake
@@ -1,0 +1,78 @@
+# Common variables for most package generators.
+
+set(CPACK_VERBATIM_VARIABLES ON)
+
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set(CPACK_PACKAGE_VENDOR "Open Source Modelica Consoritum")
+
+set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
+SET(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_BINARY_DIR}/_packages")
+
+set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/omc")
+
+set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+
+set(CPACK_PACKAGE_CONTACT "build@openmodelica.org")
+
+set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/OSMC-License.txt")
+# set(CPACK_RESOURCE_FILE_README "${PROJECT_SOURCE_DIR}/README.md")
+
+# Generator specific variables go in their own files.
+include(cmake/packaging/debian.cmake)
+include(cmake/packaging/productbuild.cmake)
+
+# Now that the options/settings variables have been set include CPack and add the components.
+include(CPack)
+
+cpack_add_component(omc
+                    DISPLAY_NAME "OpenModelica core compiler(omc)"
+                    # For graphical multi-component installers, set this to required.
+                    REQUIRED
+                    DESCRIPTION "The OpenModelica Compiler without any of the simulation support.
+You can use this package to translate Modelica or MetaModelica files. If you
+are intending to simulate models you should install the simrt package as well."
+                    )
+
+cpack_add_component(simrt
+                    DISPLAY_NAME "Simulation Runtime"
+                    DEPENDS omc
+                    DESCRIPTION "The OpenModelica simulation runtime and tools.
+This is the core of the OpenModelica simulation infrastructure and is required if you intend to simulate
+Modelica models with OpenModelica.
+It is recommended to use it together with an OpenModelica client,
+such as OMShell (textual interface), OMNotebook (for teaching purposes)
+or OMEdit (graphical modeling) which are available in the openmodelica-gui package."
+                    )
+
+cpack_add_component(simrt-cpp
+                    DISPLAY_NAME "CPP Simulation Runtime"
+                    DEPENDS simrt
+                    DESCRIPTION "The C++ simulation runtime for OpenModelica. This is required
+if you plan to generate C++ code and simulate models, .i.e., use the --simCodeTarget=Cpp translation option."
+                    )
+
+cpack_add_component(fmu
+                    DISPLAY_NAME "FMU Support"
+                    DEPENDS simrt
+                    DESCRIPTION "The libaries and files needed to compile an OpenModelica
+FMU (normal or Source-Code FMU) including the simulation runtime source files needed for creating Source-Code FMUs."
+                    )
+
+cpack_add_component(omsimulator
+                    DISPLAY_NAME "OMSimulator"
+                    DESCRIPTION "The OpenModelica FMI & SSP-based co-simulation environment."
+                    )
+
+cpack_add_component(gui
+                    DISPLAY_NAME "GUI Clients"
+                    DEPENDS simrt omsimulator
+                    DESCRIPTION "The OpenModelica Graphical User Interface clients. These include OMEdit (graphical modeling),
+OMNotebook (for teaching purposes), OMShell (textual interface) and OMPlot (a plotting tool used by the other clients)."
+                    )
+
+
+
+
+

--- a/cmake/packaging/debian.cmake
+++ b/cmake/packaging/debian.cmake
@@ -1,0 +1,18 @@
+# Options and settings that are specific to debian packages.
+
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "OpenModelica Build System <${CPACK_PACKAGE_CONTACT}>")
+
+# Enable component based packaging (openmodelica-compiler, openmodelica-gui, ...)
+set(CPACK_DEB_COMPONENT_INSTALL ON)
+
+# use dpkg-shlibdeps to generate better package dependency list.
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+# Allow setting our own inter-component dependencies
+set(CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS ON)
+
+# Set the section control field
+# https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+set(CPACK_DEBIAN_PACKAGE_SECTION "math")

--- a/cmake/packaging/productbuild.cmake
+++ b/cmake/packaging/productbuild.cmake
@@ -1,0 +1,1 @@
+# Options and settings that are specific to macOS productbuild packages.


### PR DESCRIPTION
  - This is experimental and far from enough. The idea is to use this to enable creating `productbuild` based installers for macOS.

    For now, the testing is done on debian since that is what is available.  We can use that as a starting point to create the macOS packages.

