### PR TITLE
OMEdit: Use splitCommand for terminal args

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -2747,13 +2747,17 @@ void MainWindow::openTerminal()
     return;
   }
   QString arguments = OptionsDialog::instance()->getGeneralSettingsPage()->getTerminalCommandArguments();
-  QStringList args = arguments.split(" ");
   QDetachableProcess process;
   process.setWorkingDirectory(OptionsDialog::instance()->getGeneralSettingsPage()->getWorkingDirectory());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+  const QStringList args(QProcess::splitCommand(arguments));
   process.start(terminalCommand, args);
+#else
+  process.start(terminalCommand + " " + arguments);
+#endif
   if (process.error() == QProcess::FailedToStart) {
     QString errorString = tr("Unable to run terminal command <b>%1</b> with arguments <b>%2</b>. Process failed with error <b>%3</b>")
-                          .arg(terminalCommand, args.join(" "), process.errorString());
+                          .arg(terminalCommand, arguments, process.errorString());
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, errorString, Helper::scriptingKind, Helper::errorLevel));
   }
 }

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -439,6 +439,22 @@ void QDetachableProcess::start(const QString &program, const QStringList &argume
   setProcessState(QProcess::NotRunning);
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+/*!
+ * \brief QDetachableProcess::start
+ * Starts a process and detaches from it.
+ * \param command
+ * \param mode
+ */
+void QDetachableProcess::start(const QString &command, QIODevice::OpenMode mode)
+{
+  QProcess::start(command, mode);
+  waitForStarted();
+  setProcessState(QProcess::NotRunning);
+}
+#endif
+
+
 JsonDocument::JsonDocument(QObject *pParent)
   : QObject(pParent)
 {

--- a/OMEdit/OMEditLIB/Util/Utilities.h
+++ b/OMEdit/OMEditLIB/Util/Utilities.h
@@ -417,7 +417,11 @@ class QDetachableProcess : public QProcess
   Q_OBJECT
 public:
   QDetachableProcess(QObject *pParent = 0);
+
   void start(const QString &program, const QStringList &arguments, OpenMode mode = ReadWrite);
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+  void start(const QString &command, OpenMode mode = ReadWrite);
+#endif
 };
 
 class JsonDocument : public QObject


### PR DESCRIPTION
Use `QProcess::splitCommand` instead of `QString::split(" ")`, which allows to use quotes, as seen in #9606

cc @adeas31 
