### PR TITLE
Allow using the existing result file for DynamicSelect animation

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.h
@@ -233,7 +233,7 @@ public:
   void reSimulate(bool showSetup);
   void interactiveReSimulation(QString modelName);
   void updateInitXmlFile(SimulationOptions simulationOptions);
-  void initializeVisualization(SimulationOptions simulationOptions);
+  void initializeVisualization();
   double readVariableValue(QString variable, double time);
   void closeResultFile();
 private:
@@ -261,7 +261,7 @@ private:
   csv_data *mpCSVData;
   QFile mPlotFileReader;
   void selectInteractivePlotWindow(VariablesTreeItem *pVariablesTreeItem);
-  void openResultFile();
+  void openResultFile(double &startTime, double &stopTime);
   void updateVisualization();
   void checkVariable(const QModelIndex &index, bool checkState);
   void unCheckVariableAndErrorMessage(const QModelIndex &index, const QString &errorMessage);


### PR DESCRIPTION
Fixes #9652
Does not set the result file active when its opened. Use the context menu to set it active.