### PR TITLE
Use 3rdParty/lis on Windows/OMDev.

### DIFF
--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -258,8 +258,6 @@ ifeq (MINGW32,$(findstring MINGW32,$(shell uname)))
 	(cp -puf $(OMDEVMSYS)/lib/omniORB-4.2.0-mingw32/bin/x86_win32/omnithread40_rt.dll $(builddir_lib)/omc/)
 	(cp -puf $(OMDEVMSYS)/lib/3rdParty/Sundials/lib/release/mingw/libsundials_kinsol.a $(builddir_lib)/omc/)
 	(cp -puf $(OMDEVMSYS)/lib/3rdParty/Sundials/lib/release/mingw/libsundials_nvecserial.a $(builddir_lib)/omc/)
-	(cp -puf $(OMDEVMSYS)/lib/lis/liblis.la $(builddir_lib)/omc/)
-	(cp -puf $(OMDEVMSYS)/lib/lis/liblis.a $(builddir_lib)/omc/)
 	test ! -f $(OMDEVMSYS)/tools/msys/mingw32/bin/libnghttp2-14.dll || cp -puf $(OMDEVMSYS)/tools/msys/mingw32/bin/libnghttp2-14.dll $(builddir_bin)/
 	test ! -f $(OMDEVMSYS)/tools/msys/mingw32/bin/libunistring-2.dll || cp -puf $(OMDEVMSYS)/tools/msys/mingw32/bin/libunistring-2.dll $(builddir_bin)/
 else # mingw64
@@ -289,8 +287,6 @@ else # mingw64
 	(cp -puf $(OMDEVMSYS)/lib/omniORB-4.2.0-mingw64/bin/x86_win32/omnithread40_rt.dll $(builddir_lib)/omc/)
 	(cp -puf $(OMDEVMSYS)/lib/3rdParty/Sundials64/lib/release/mingw/libsundials_kinsol.a $(builddir_lib)/omc/)
 	(cp -puf $(OMDEVMSYS)/lib/3rdParty/Sundials64/lib/release/mingw/libsundials_nvecserial.a $(builddir_lib)/omc/)
-	(cp -puf $(OMDEVMSYS)/lib/lis64/liblis.la $(builddir_lib)/omc/)
-	(cp -puf $(OMDEVMSYS)/lib/lis64/liblis.a $(builddir_lib)/omc/)
 	test ! -f $(OMDEVMSYS)/tools/msys/mingw64/bin/libnghttp2-14.dll || cp -puf $(OMDEVMSYS)/tools/msys/mingw64/bin/libnghttp2-14.dll $(builddir_bin)/
 	test ! -f $(OMDEVMSYS)/tools/msys/mingw64/bin/libunistring-2.dll || cp -puf $(OMDEVMSYS)/tools/msys/mingw64/bin/libunistring-2.dll $(builddir_bin)/
 endif
@@ -577,12 +573,12 @@ lis: lis-configure
 	@echo Building Lis from sources
 	$(MAKE) -C 3rdParty/lis-1.4.12/src
 	# Copy the library; not headers (as they are not used by the runtime system)
-	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis*.dll $(OMBUILDDIR)/bin/
-	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis*.dll.a $(OMBUILDDIR)/$(LIB_OMC)/
+	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis.a $(OMBUILDDIR)/$(LIB_OMC)/
+	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis.la $(OMBUILDDIR)/$(LIB_OMC)/
 
 lis-configure:
 	# Configure and build lis
-	if ! test -f 3rdParty/lis-1.4.12/Makefile; then cd 3rdParty/lis-1.4.12 && autoconf && ./configure --enable-shared --disable-static MPICC="false" CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" && $(MAKE) clean; fi
+	if ! test -f 3rdParty/lis-1.4.12/Makefile; then cd 3rdParty/lis-1.4.12 && autoconf && ./configure --enable-static --disable-shared MPICC="false" CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" && $(MAKE) clean; fi
 
 lis-clean:
 	if test -f 3rdParty/lis-1.4.12/Makefile; then $(MAKE) -C 3rdParty/lis-1.4.12 clean; fi

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -573,8 +573,20 @@ omc-bootstrapped:
 	$(MAKE) -f $(defaultMakefileTarget) -C Compiler/boot CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" OMBUILDDIR=$(OMBUILDDIR)
 	$(MAKE) -f $(defaultMakefileTarget) -C Compiler install_scripts CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" OMBUILDDIR=$(OMBUILDDIR)
 
-lis:
+lis: lis-configure
+	@echo Building Lis from sources
+	$(MAKE) -C 3rdParty/lis-1.4.12/src
+	# Copy the library; not headers (as they are not used by the runtime system)
+	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis*.dll $(OMBUILDDIR)/bin/
+	cp -Pp 3rdParty/lis-1.4.12/src/.libs/liblis*.dll.a $(OMBUILDDIR)/$(LIB_OMC)/
+
+lis-configure:
+	# Configure and build lis
+	if ! test -f 3rdParty/lis-1.4.12/Makefile; then cd 3rdParty/lis-1.4.12 && autoconf && ./configure --enable-shared --disable-static MPICC="false" CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" LDFLAGS="$(LDFLAGS)" && $(MAKE) clean; fi
 
 lis-clean:
+	if test -f 3rdParty/lis-1.4.12/Makefile; then $(MAKE) -C 3rdParty/lis-1.4.12 clean; fi
+	rm -f 3rdParty/lis-1.4.12/Makefile
+
 
 .PRECIOUS: Makefile.omdev.mingw


### PR DESCRIPTION
  - We were using the MSYS package managed `lis`. We were using the 3rdParty lis only on non-Windows systems.

    Build it from 3rdParty now. Recent versions of `mingw-lis` require MPI support and we do not want that. Plus, it is more consistent this way.

