### PR TITLE
Fixing fmiFlags=s:euler for CMake FMUs

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4052,7 +4052,7 @@ algorithm
   end if;
 
   // Check flag fmiFlags if we need additional 3rdParty runtime libs and files
-  needs3rdPartyLibs := SimCodeUtil.cvodeFmiFlagIsSet();
+  needs3rdPartyLibs := SimCodeUtil.cvodeFmiFlagIsSet(SimCodeUtil.createFMISimulationFlags(false));
 
   // Use CMake on Windows when cross-compiling with docker
   _ := match (Flags.getConfigString(Flags.FMU_CMAKE_BUILD), needs3rdPartyLibs)

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4052,12 +4052,7 @@ algorithm
   end if;
 
   // Check flag fmiFlags if we need additional 3rdParty runtime libs and files
-  fmiFlagsList := Flags.getConfigStringList(Flags.FMI_FLAGS);
-  if listLength(fmiFlagsList) >= 1 and not stringEqual(List.first(fmiFlagsList), "none") then
-    needs3rdPartyLibs := true;
-  else
-    needs3rdPartyLibs := false;
-  end if;
+  needs3rdPartyLibs := SimCodeUtil.cvodeFmiFlagIsSet();
 
   // Use CMake on Windows when cross-compiling with docker
   _ := match (Flags.getConfigString(Flags.FMU_CMAKE_BUILD), needs3rdPartyLibs)

--- a/OMCompiler/Compiler/SimCode/SimCode.mo
+++ b/OMCompiler/Compiler/SimCode/SimCode.mo
@@ -715,7 +715,7 @@ public uniontype FmiSimulationFlags
   end FMI_SIMULATION_FLAGS_FILE;
 end FmiSimulationFlags;
 
-constant FmiSimulationFlags defaultFmiSimulationFlags = FMI_SIMULATION_FLAGS({("solver","euler")});
+constant FmiSimulationFlags defaultFmiSimulationFlags = FMI_SIMULATION_FLAGS({("s","euler")});
 
 annotation(__OpenModelica_Interface="backend");
 end SimCode;

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -924,13 +924,9 @@ algorithm
             Error.addCompilerError("Unsupported value " + Flags.getConfigString(Flags.FMU_RUNTIME_DEPENDS) + "for compiler flag 'fmuRuntimeDepends'.");
             then();
         end match;
-        if isSome(simCode.fmiSimulationFlags) then
-          cmakelistsStr := System.stringReplace(cmakelistsStr, "@WITH_SUNDIALS@", ";WITH_SUNDIALS");
-        else
-          cmakelistsStr := System.stringReplace(cmakelistsStr, "@WITH_SUNDIALS@", "");
-        end if;
 
         // Add external libraries and includes
+        cmakelistsStr := System.stringReplace(cmakelistsStr, "@NEED_CVODE@", SimCodeUtil.getCmakeSundialsLinkCode());
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_LIBS@", SimCodeUtil.getCmakeLinkLibrariesCode(simCode.makefileParams.libs));
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_INCLUDES@", SimCodeUtil.make2CMakeInclude(simCode.makefileParams.includes));
 

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -845,9 +845,8 @@ algorithm
           cminpack_sources := {};
         end if;
 
-        // Check if the sundials files are needed. Shouldn't this actually check what the flags are
-        // instead of just checking if flags are set only?
-        if isSome(simCode.fmiSimulationFlags) then
+        // Check if the sundials files are needed
+        if SimCodeUtil.cvodeFmiFlagIsSet(simCode.fmiSimulationFlags) then
           // The sundials headers are in the include directory.
           copyFiles(RuntimeSources.sundials_headers, source=install_include_omc_dir, destination=fmu_tmp_sources_dir);
           copyFiles(RuntimeSources.simrt_c_sundials_sources, source=install_fmu_sources_dir, destination=fmu_tmp_sources_dir);
@@ -926,7 +925,7 @@ algorithm
         end match;
 
         // Add external libraries and includes
-        cmakelistsStr := System.stringReplace(cmakelistsStr, "@NEED_CVODE@", SimCodeUtil.getCmakeSundialsLinkCode());
+        cmakelistsStr := System.stringReplace(cmakelistsStr, "@NEED_CVODE@", SimCodeUtil.getCmakeSundialsLinkCode(simCode.fmiSimulationFlags));
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_LIBS@", SimCodeUtil.getCmakeLinkLibrariesCode(simCode.makefileParams.libs));
         cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_ADDITIONAL_INCLUDES@", SimCodeUtil.make2CMakeInclude(simCode.makefileParams.includes));
 

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15604,6 +15604,36 @@ algorithm
   end for;
 end getCmakeLinkLibrariesCode;
 
+public function getCmakeSundialsLinkCode
+  "Code for FMU CMakeLists.txt to specify if CVODE is needed."
+  output String code = "";
+algorithm
+  if not cvodeFmiFlagIsSet() then
+    code := "set(NEED_CVODE FALSE)";
+  else
+    code := "set(NEED_CVODE TRUE)\n" +
+            "set(CVODE_DIRECTORY \"" +  Settings.getInstallationDirectoryPath() + "/lib/omc\")";
+  end if;
+end getCmakeSundialsLinkCode;
+
+public function cvodeFmiFlagIsSet
+  "Checks if s:cvode is part of FMI_FLAGS."
+  output Boolean needsCvode = false;
+protected
+  list<String> fmiFlagsList;
+algorithm
+  fmiFlagsList := Flags.getConfigStringList(Flags.FMI_FLAGS);
+  if listLength(fmiFlagsList) >= 1 then
+    for flag in fmiFlagsList loop
+      if stringEqual(flag, "s:cvode") then
+        needsCvode := true;
+        return;
+      end if;
+    end for;
+  end if;
+  return;
+end cvodeFmiFlagIsSet;
+
 public function make2CMakeInclude
   "Convert makefile include directories to CMake include directories"
   input list<String> includes;

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1305,7 +1305,6 @@ template settingsfile(SimCode simCode)
   #define OMC_MODEL_PREFIX "<%modelNamePrefix(simCode)%>"
   #define OMC_MINIMAL_RUNTIME 1
   #define OMC_FMI_RUNTIME 1
-  <%if isSome(fmiSimulationFlags) then "#define WITH_SUNDIALS 1"%>
   #endif
  >>
 end settingsfile;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_error.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_error.c
@@ -949,15 +949,4 @@ void kinsolInfoHandlerFunction(const char *module, const char *function,
   throwStreamPrint(NULL, "No sundials/kinsol support activated.");
 }
 
-/**
- * @brief  Function not supported without WITH_SUNDIALS
- *
- * @param A
- * @param name
- * @param logLevel
- */
-void sundialsPrintSparseMatrix(SUNMatrix A, const char* name, const int logLevel) {
-  throwStreamPrint(NULL, "No sundials/kinsol support activated.");
-}
-
 #endif /* WITH_SUNDIALS */

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -5,6 +5,9 @@ set(FMU_NAME @FMU_NAME_IN@)
 
 project(${FMU_NAME})
 
+# CVODE needed
+@NEED_CVODE@
+
 # Test if RUNTIME_DEPENDENCIES is needed and available
 set(RUNTIME_DEPENDENCIES_LEVEL @RUNTIME_DEPENDENCIES_LEVEL@)
 if(${CMAKE_VERSION} VERSION_LESS "3.21" AND NOT ${RUNTIME_DEPENDENCIES_LEVEL} STREQUAL "none")
@@ -36,7 +39,10 @@ file(GLOB_RECURSE FMU_RUNTIME_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/external_solve
                                       ${CMAKE_CURRENT_SOURCE_DIR}/meta/*.c
                                       ${CMAKE_CURRENT_SOURCE_DIR}/simulation/*.c
                                       ${CMAKE_CURRENT_SOURCE_DIR}/util/*.c)
-
+if (NOT ${NEED_CVODE})
+  list(REMOVE_ITEM FMU_RUNTIME_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/simulation/solver/sundials_error.c
+                                       ${CMAKE_CURRENT_SOURCE_DIR}/simulation/solver/cvode_solver.c)
+endif()
 file(GLOB FMU_GENERATED_MODEL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
@@ -78,12 +84,26 @@ if(NOT ${CMAKE_VERSION} VERSION_LESS "3.13")
 endif()
 target_link_libraries(${FMU_NAME} PRIVATE m Threads::Threads)
 @FMU_ADDITIONAL_LIBS@
+if(${NEED_CVODE})
+  find_library(SUNDIALS_CVODE_LIBRARY sundials_cvode
+               PATHS ${CVODE_DIRECTORY}
+               NO_DEFAULT_PATH)
+  find_library(SUNDIALS_NVSERIAL_LIBRARY sundials_nvecserial
+               PATHS ${CVODE_DIRECTORY}
+               NO_DEFAULT_PATH)
+  target_link_libraries(${FMU_NAME} PRIVATE ${SUNDIALS_CVODE_LIBRARY} ${SUNDIALS_NVSERIAL_LIBRARY})
+  target_include_directories(${FMU_NAME} PRIVATE sundials)
+  set(WITH_SUNDIALS ";WITH_SUNDIALS")
+  message(STATUS "CVODE: ${SUNDIALS_CVODE_LIBRARY} ${SUNDIALS_NVSERIAL_LIBRARY}")
+else()
+  message(STATUS "CVODE: Not linked")
+endif()
 
 target_include_directories(${FMU_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(${FMU_NAME} PRIVATE ${FMI_INTERFACE_HEADER_FILES_DIRECTORY}
                                                sundials@FMU_ADDITIONAL_INCLUDES@)
 
-target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL)
+target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL${WITH_SUNDIALS})
 
 if(RUNTIME_DEPENDENCIES_LEVEL STREQUAL "all")
   install(TARGETS ${FMU_NAME}

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/FmuExportFlags.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/FmuExportFlags.mos
@@ -86,6 +86,7 @@ val(v, 1.0, "BouncingBallFMI20_res.mat"); getErrorString();
 // "BouncingBallFMI20.fmu"
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
+// caution: filename not matched:  resources/BouncingBallFMI20_flags.json
 // 11
 // ""
 // true

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/FmuExportFlags.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/FmuExportFlags.mos
@@ -86,7 +86,6 @@ val(v, 1.0, "BouncingBallFMI20_res.mat"); getErrorString();
 // "BouncingBallFMI20.fmu"
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// caution: filename not matched:  resources/BouncingBallFMI20_flags.json
 // 11
 // ""
 // true
@@ -97,7 +96,7 @@ val(v, 1.0, "BouncingBallFMI20_res.mat"); getErrorString();
 // 0
 // ""
 // "{
-//   \"solver\" : \"euler\"
+//   \"s\" : \"euler\"
 // }"
 // ""
 // true


### PR DESCRIPTION


### Related Issues

Fix for https://github.com/OpenModelica/OpenModelica/issues/9635.

### Purpose

Make it possible to use all combinations of `fmiFlags` and FMU build system (CMake, Makefile):
  - `--fmiFlags=s:euler --fmuCMakeBuild=false`
  - `--fmiFlags=s:cvode--fmuCMakeBuild=false`
  - `--fmuCMakeBuild=false`
  - -`-fmiFlags=s:euler --fmuCMakeBuild=true`
  - `--fmiFlags=s:cvode --fmuCMakeBuild=true`
  - `--fmuCMakeBuild=true`

### Changes

- CMakeLists.txt.in:
   - Won't include C source files for CVODE unless needed
   - CMake will define WITH_SUNDIALS if needed
   - Link to sundials_cvode and sundials_nvecserial 
- Removed #define WITH_SUNDIALS from template
