### PR TITLE
Fixes for Windows build with new MSYS2

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -52,9 +52,6 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__MINGW32__)
-#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L /* for ctime_r in time.h */
-#endif
 #include <time.h>
 #include <math.h>
 
@@ -3005,7 +3002,7 @@ char* SystemImpl__ctime(double time)
 {
   char buf[64] = {0}; /* needs to be >=26 char */
   time_t t = (time_t) time;
-#if defined(_MSC_VER)
+#if defined(__MINGW32__) || defined(_MSC_VER)
   errno_t e = ctime_s(buf, 64, t);
   assert(e == 0 && "ctime_s returned an error");
   return omc_alloc_interface.malloc_strdup(buf);

--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -48,10 +48,10 @@ CONFIG(release, debug|release) { # release
   # win32 vs. win64
   contains(QT_ARCH, i386) { # 32-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw32/lib/binutils -L$$(OMDEV)/tools/msys/mingw32/bin
-    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
+    INCLUDEPATH += $$(OMDEV)/tools/msys/mingw32/include/binutils
   } else { # 64-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw64/lib/binutils -L$$(OMDEV)/tools/msys/mingw64/bin
-    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
+    INCLUDEPATH += $$(OMDEV)/tools/msys/mingw64/include/binutils
   }
   LIBS += -limagehlp -lbfd -lintl -liberty -llibosg.dll -llibosgViewer.dll -llibOpenThreads.dll -llibosgDB.dll -llibosgGA.dll
 } else { # debug

--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -48,10 +48,10 @@ CONFIG(release, debug|release) { # release
   # win32 vs. win64
   contains(QT_ARCH, i386) { # 32-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw32/lib/binutils -L$$(OMDEV)/tools/msys/mingw32/bin
-    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
+    QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
   } else { # 64-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw64/lib/binutils -L$$(OMDEV)/tools/msys/mingw64/bin
-    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
+    QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
   }
   LIBS += -limagehlp -lbfd -lintl -liberty -llibosg.dll -llibosgViewer.dll -llibOpenThreads.dll -llibosgDB.dll -llibosgGA.dll
 } else { # debug

--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -48,10 +48,10 @@ CONFIG(release, debug|release) { # release
   # win32 vs. win64
   contains(QT_ARCH, i386) { # 32-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw32/lib/binutils -L$$(OMDEV)/tools/msys/mingw32/bin
-    QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
+    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
   } else { # 64-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw64/lib/binutils -L$$(OMDEV)/tools/msys/mingw64/bin
-    QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
+    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
   }
   LIBS += -limagehlp -lbfd -lintl -liberty -llibosg.dll -llibosgViewer.dll -llibOpenThreads.dll -llibosgDB.dll -llibosgGA.dll
 } else { # debug

--- a/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
+++ b/OMEdit/OMEditGUI/OMEditGUI.win.config.pri
@@ -48,8 +48,10 @@ CONFIG(release, debug|release) { # release
   # win32 vs. win64
   contains(QT_ARCH, i386) { # 32-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw32/lib/binutils -L$$(OMDEV)/tools/msys/mingw32/bin
+    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
   } else { # 64-bit
     LIBS += -L$$(OMDEV)/tools/msys/mingw64/lib/binutils -L$$(OMDEV)/tools/msys/mingw64/bin
+    QMAKE_CXXFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
   }
   LIBS += -limagehlp -lbfd -lintl -liberty -llibosg.dll -llibosgViewer.dll -llibOpenThreads.dll -llibosgDB.dll -llibosgGA.dll
 } else { # debug

--- a/OMEdit/OMEditLIB/CrashReport/backtrace.h
+++ b/OMEdit/OMEditLIB/CrashReport/backtrace.h
@@ -18,7 +18,7 @@
 
 #define GCC_VERSION (__GNUC__ * 10000 \
                      + __GNUC_MINOR__ * 100 \
-		     + __GNUC_PATCHLEVEL__)
+                     + __GNUC_PATCHLEVEL__)
 
 #if defined(_WIN32)
 #ifdef __cplusplus
@@ -30,10 +30,8 @@ extern "C" {
 #include <imagehlp.h>
 #if defined(__MINGW32__) && ((GCC_VERSION > 40900) || defined(__clang__))
 #define PACKAGE OMEdit
-#include <binutils/bfd.h>
-#else
-#include <bfd.h>
 #endif
+#include <bfd.h>
 #include <psapi.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -78,9 +78,9 @@ CONFIG(release, debug|release) { # release
 # On older msys the include directory for binutils is in binutils
 # On recent (November 2022) MSYS2 this is no longer needed.
 contains(QT_ARCH, i386) { # 32-bit
-  QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
+  INCLUDEPATH += $$(OMDEV)/tools/msys/mingw32/include/binutils
 } else { # 64-bit
-  QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
+  INCLUDEPATH += $$(OMDEV)/tools/msys/mingw64/include/binutils
 }
 
   OPENMODELICAHOME = $$(OMBUILDDIR)

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -75,6 +75,14 @@ CONFIG(release, debug|release) { # release
   QMAKE_LFLAGS_RELEASE =
 }
 
+# On older msys the include directory for binutils is in binutils
+# On recent (November 2022) MSYS2 this is no longer needed.
+contains(QT_ARCH, i386) { # 32-bit
+  QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw32/include/binutils
+} else { # 64-bit
+  QMAKE_CFLAGS += -I$$(OMDEV)/tools/msys/mingw64/include/binutils
+}
+
   OPENMODELICAHOME = $$(OMBUILDDIR)
   host_short =
 

--- a/cmake/modules/Findbinutils.cmake
+++ b/cmake/modules/Findbinutils.cmake
@@ -10,23 +10,29 @@ if(binutils_FOUND)
 endif()
 
 find_library(LIBBFD_LIBRARY
-              NAMES libbfd.a
-              PATH_SUFFIXES binutils)
+             NAMES libbfd.a
+             PATH_SUFFIXES binutils)
 
 find_library(LIBIBERTY_LIBRARY
-              NAMES libiberty.a
-              PATH_SUFFIXES binutils)
+             NAMES libiberty.a
+             PATH_SUFFIXES binutils)
 
+if(MINGW)
+  find_path(BINUTILS_INCLUDE_DIR
+            bfd.h
+            PATHS include
+            PATH_SUFFIXES binutils)
+endif()
 
 include (FindPackageHandleStandardArgs)
 
 
 # handle the QUIETLY and REQUIRED arguments and set binutils_FOUND to TRUE if all listed variables are TRUE
 find_package_handle_standard_args(binutils
-                                  REQUIRED_VARS LIBBFD_LIBRARY LIBIBERTY_LIBRARY
+                                  REQUIRED_VARS LIBBFD_LIBRARY LIBIBERTY_LIBRARY BINUTILS_INCLUDE_DIR
                                   HANDLE_COMPONENTS)
 
-mark_as_advanced(LIBBFD_LIBRARY LIBIBERTY_LIBRARY)
+mark_as_advanced(LIBBFD_LIBRARY LIBIBERTY_LIBRARY BINUTILS_INCLUDE_DIR)
 
 if(binutils_FOUND)
 
@@ -37,6 +43,7 @@ if(binutils_FOUND)
 
   add_library(binutils::bfd STATIC IMPORTED)
   set_target_properties(binutils::bfd PROPERTIES IMPORTED_LOCATION ${LIBBFD_LIBRARY})
+  set_target_properties(binutils::bfd PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${BINUTILS_INCLUDE_DIR})
 
   target_link_libraries(binutils::bfd INTERFACE binutils::iberty)
   target_link_libraries(binutils::bfd INTERFACE ${Intl_LIBRARIES})


### PR DESCRIPTION
### Related Issues

We might want to use a newer version of msys in OMDev, so @mahge and myslef tried to get OpenModelica compiling on both the newer and the older version from OMDev.

### Purpose

  - Minor changes to CMake and make files
  - Should be possible to build with old an new msys using CMake.
