### PR TITLE
Double time-out time for curl

### DIFF
--- a/OMCompiler/Compiler/runtime/om_curl.c
+++ b/OMCompiler/Compiler/runtime/om_curl.c
@@ -72,7 +72,7 @@ static void* addTransfer(CURLM *cm, void *urlPathList, int *result)
   curl_easy_setopt(eh, CURLOPT_FOLLOWLOCATION, 1);
   curl_easy_setopt(eh, CURLOPT_WRITEFUNCTION, writeDataCallback);
   curl_easy_setopt(eh, CURLOPT_URL, url);
-  curl_easy_setopt(eh, CURLOPT_CONNECTTIMEOUT, 8L);
+  curl_easy_setopt(eh, CURLOPT_CONNECTTIMEOUT, 16L);
   curl_easy_setopt(eh, CURLOPT_FAILONERROR, 1);
 
   curl_easy_setopt(eh, CURLOPT_PRIVATE, p);


### PR DESCRIPTION
### Related Issues

We get time-outs in Jenkins while downloading Modelica libraries from GitHub.

From [some random test run on Jenkins](https://test.openmodelica.org/jenkins/blue/rest/organizations/jenkins/pipelines/OpenModelica/branches/PR-9677/runs/2/nodes/278/steps/764/log/?start=0):
```
[/var/lib/jenkins1/ws/OpenModelica_PR-9677/libraries/.openmodelica/libraries/Complex 3.2.2+maint.om/package.mo:0:0-0:0:readonly] Notification: Package installed successfully (SHA 9578058eff7a3a3d953a37d190a9bafa4e77092e).
Error: Curl error for URL https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/34fe8cf3c7127ae09ca5f41e26b48fb6044e1e34.zip: Timeout was reached
Makefile:18: recipe for target '.openmodelica/20221102135323.stamp' failed
make[1]: *** [.openmodelica/20221102135323.stamp] Error 1
make[1]: Leaving directory '/var/lib/jenkins1/ws/OpenModelica_PR-9677/libraries'
Makefile:66: recipe for target 'libs-for-testing.skip' failed
make: *** [libs-for-testing.skip] Error 2
make: *** Waiting for unfinished jobs....
```

### Purpose

Wait longer before aborting with a time-out error.

### Approach

Wait 16 instead of 8 seconds.
But if a server can't answer in 8 seconds we might need to re-do the request insead of waiting longer.
