### PR TITLE
Implement getModelInstanceIcon API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4386,11 +4386,21 @@ annotation(preferredView="text",Documentation(info="<html>
 end convertPackageToLibrary;
 
 function getModelInstance
+  "Dumps a model instance as a JSON string."
   input TypeName className;
   input Boolean prettyPrint = false;
   output String result;
 external "builtin";
 end getModelInstance;
+
+function getModelInstanceIcon
+  "Dumps only the Icon and IconMap annotations of a model, using the same JSON
+   format as getModelInstance."
+  input TypeName className;
+  input Boolean prettyPrint = false;
+  output String result;
+external "builtin";
+end getModelInstanceIcon;
 
 function storeAST
   output Integer id;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4638,11 +4638,21 @@ annotation(preferredView="text",Documentation(info="<html>
 end convertPackageToLibrary;
 
 function getModelInstance
+  "Dumps a model instance as a JSON string."
   input TypeName className;
   input Boolean prettyPrint = false;
   output String result;
 external "builtin";
 end getModelInstance;
+
+function getModelInstanceIcon
+  "Dumps only the Icon and IconMap annotations of a model, using the same JSON
+   format as getModelInstance."
+  input TypeName className;
+  input Boolean prettyPrint = false;
+  output String result;
+external "builtin";
+end getModelInstanceIcon;
 
 function storeAST
   output Integer id;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3083,6 +3083,9 @@ algorithm
     case ("getModelInstance", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.BOOL(b)})
       then NFApi.getModelInstance(classpath, b);
 
+    case ("getModelInstanceIcon", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.BOOL(b)})
+      then NFApi.getModelInstanceIcon(classpath, b);
+
     case ("storeAST", {})
       then Values.INTEGER(SymbolTable.storeAST());
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon1.mos
@@ -1,0 +1,78 @@
+// name: GetModelInstanceIcon1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    annotation (
+      Icon(graphics={Rectangle(extent={{-66,78},{70,-56}}, lineColor={28,108,200})}),
+      Diagram(graphics={Ellipse(extent={{-62,68},{56,-60}}, lineColor={28,108,200})}));
+  end M;
+");
+
+getModelInstanceIcon(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"graphics\": [
+//         {
+//           \"$kind\": \"record\",
+//           \"name\": \"Rectangle\",
+//           \"elements\": [
+//             true,
+//             [
+//               0,
+//               0
+//             ],
+//             0,
+//             [
+//               28,
+//               108,
+//               200
+//             ],
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"LinePattern.Solid\",
+//               \"index\": 2
+//             },
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"FillPattern.None\",
+//               \"index\": 1
+//             },
+//             0.25,
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"BorderPattern.None\",
+//               \"index\": 1
+//             },
+//             [
+//               [
+//                 -66,
+//                 78
+//               ],
+//               [
+//                 70,
+//                 -56
+//               ]
+//             ],
+//             0
+//           ]
+//         }
+//       ]
+//     }
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon2.mos
@@ -1,0 +1,126 @@
+// name: GetModelInstanceIcon2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package Icons
+    partial model Example
+      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
+            Ellipse(lineColor = {75,138,73},
+                    fillColor={255,255,255},
+                    fillPattern = FillPattern.Solid,
+                    extent = {{-100,-100},{100,100}})}),
+        IconMap(extent = {{0, 0}, {0, 0}}));
+    end Example;
+  end Icons;
+
+  model M
+    extends Icons.Example;
+    annotation (Icon(coordinateSystem(preserveAspectRatio=true)));
+  end M;
+");
+
+getModelInstanceIcon(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"extends\": [
+//     {
+//       \"name\": \"Icons.Example\",
+//       \"annotation\": {
+//         \"Icon\": {
+//           \"coordinateSystem\": {
+//             \"preserveAspectRatio\": false,
+//             \"extent\": [
+//               [
+//                 -100,
+//                 -100
+//               ],
+//               [
+//                 100,
+//                 100
+//               ]
+//             ]
+//           },
+//           \"graphics\": [
+//             {
+//               \"$kind\": \"record\",
+//               \"name\": \"Ellipse\",
+//               \"elements\": [
+//                 true,
+//                 [
+//                   0,
+//                   0
+//                 ],
+//                 0,
+//                 [
+//                   75,
+//                   138,
+//                   73
+//                 ],
+//                 [
+//                   255,
+//                   255,
+//                   255
+//                 ],
+//                 {
+//                   \"$kind\": \"enum\",
+//                   \"name\": \"LinePattern.Solid\",
+//                   \"index\": 2
+//                 },
+//                 {
+//                   \"$kind\": \"enum\",
+//                   \"name\": \"FillPattern.Solid\",
+//                   \"index\": 2
+//                 },
+//                 0.25,
+//                 [
+//                   [
+//                     -100,
+//                     -100
+//                   ],
+//                   [
+//                     100,
+//                     100
+//                   ]
+//                 ],
+//                 0,
+//                 360,
+//                 {
+//                   \"$kind\": \"enum\",
+//                   \"name\": \"EllipseClosure.Chord\",
+//                   \"index\": 2
+//                 }
+//               ]
+//             }
+//           ]
+//         },
+//         \"IconMap\": {
+//           \"extent\": [
+//             [
+//               0,
+//               0
+//             ],
+//             [
+//               0,
+//               0
+//             ]
+//           ]
+//         }
+//       }
+//     }
+//   ],
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"coordinateSystem\": {
+//         \"preserveAspectRatio\": true
+//       }
+//     }
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -16,6 +16,8 @@ GetModelInstanceEnum2.mos \
 GetModelInstanceExp1.mos \
 GetModelInstanceExtends1.mos \
 GetModelInstanceExtends2.mos \
+GetModelInstanceIcon1.mos \
+GetModelInstanceIcon2.mos \
 GetModelInstanceInnerOuter1.mos \
 GetModelInstanceInnerOuter2.mos \
 GetModelInstanceMod1.mos \


### PR DESCRIPTION
- Implement `getModelInstanceIcon` API that can be used to get the icon annotation of a model without having to use the full `getModelInstance` API.