### PR TITLE
Improve function inlining in the frontend

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStatement.mo
@@ -139,6 +139,16 @@ public
     annotation(__OpenModelica_EarlyInline=true);
   end makeAssignment;
 
+  function isAssignment
+    input Statement stmt;
+    output Boolean res;
+  algorithm
+    res := match stmt
+      case ASSIGNMENT() then true;
+      else false;
+    end match;
+  end isAssignment;
+
   function makeIf
     input list<tuple<Expression, list<Statement>>> branches;
     input DAE.ElementSource src;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -79,6 +79,7 @@ import Component = NFComponent;
 import InstContext = NFInstContext;
 import NFInstNode.InstNodeType;
 import Array;
+import Inline = NFInline;
 
 public
 type MatchKind = enumeration(
@@ -230,6 +231,8 @@ algorithm
     (outExp, outType) := matchOverloadedBinaryOperator(
       exp1, type1, var1, op, exp2, type2, var2, candidates, info);
   end if;
+
+  outExp := Inline.inlineCallExp(outExp);
 end checkOverloadedBinaryOperator;
 
 function matchOverloadedBinaryOperator
@@ -1345,6 +1348,8 @@ algorithm
        Function.candidateFuncListString(list(mfn.func for mfn in matchedFunctions))}, info);
     fail();
   end if;
+
+  outExp := Inline.inlineCallExp(outExp);
 end checkOverloadedUnaryOperator;
 
 function checkLogicalBinaryOperation

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1447,6 +1447,10 @@ constant ConfigFlag FMU_RUNTIME_DEPENDS = CONFIG_FLAG(153, "fmuRuntimeDepends",
     })),
   Gettext.gettext("Defines if runtime library dependencies are included in the FMU. Only used when compiler flag fmuCMakeBuild=true."));
 
+constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Gettext.gettext("Enables inlining of functions in the frontend."));
+
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -408,7 +408,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.DUMP_FLAT_MODEL,
   Flags.SIMULATION,
   Flags.OBFUSCATE,
-  Flags.FMU_RUNTIME_DEPENDS
+  Flags.FMU_RUNTIME_DEPENDS,
+  Flags.FRONTEND_INLINE
 };
 
 public function new

--- a/testsuite/flattening/modelica/scodeinst/Inline3.mo
+++ b/testsuite/flattening/modelica/scodeinst/Inline3.mo
@@ -1,0 +1,24 @@
+// name: Inline3
+// keywords:
+// status: correct
+// cflags: -d=newInst --frontendInline
+//
+
+function f
+  input Real x[3];
+  input Real y[3];
+  output Real z;
+algorithm
+  z := x * y;
+  annotation(Inline = true);
+end f;
+
+model Inline3
+  Real x = f({1, 2, 3}, {time, time, time});
+end Inline3;
+
+// Result:
+// class Inline3
+//   Real x = time + 2.0 * time + 3.0 * time;
+// end Inline3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -727,6 +727,7 @@ ImportUnqualified3.mo \
 ImpureCall1.mo \
 Inline1.mo \
 Inline2.mo \
+Inline3.mo \
 InnerOuter1.mo \
 InnerOuter2.mo \
 InnerOuter3.mo \


### PR DESCRIPTION
- Add flag `--frontendInline` to enable inlining of normal functions with annotation `Inline = true`.
- Handle inlining of functions with no body by constructing a body from the output parameter's binding.
- Handle references to record fields when inlining component references.
- Inline operator functions after operator overloading if applicable.