### PR TITLE
Fix getModelInstance of derived classes

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -868,6 +868,7 @@ algorithm
   inst_tree := buildInstanceTree(cls_node);
   Inst.instExpressions(cls_node, context = context, settings = inst_settings);
 
+  Typing.typeClassType(cls_node, NFBinding.EMPTY_BINDING, context, cls_node);
   Typing.typeComponents(cls_node, context);
   Typing.typeBindings(cls_node, context);
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
@@ -1,4 +1,4 @@
-// name: GetModelInstanceAnnotation1
+// name: GetModelInstanceDerived1
 // keywords:
 // status: correct
 // cflags: -d=newInst
@@ -17,6 +17,7 @@ loadString("
 
 getModelInstance(M, true);
 getErrorString();
+
 // Result:
 // true
 // "{

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
@@ -1,0 +1,70 @@
+// name: GetModelInstanceDerived2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  type RealInput = input Real;
+  type RealInput2 = RealInput(start = 1.0);
+");
+
+getModelInstance(RealInput, true); getErrorString();
+getModelInstance(RealInput2, true); getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"RealInput\",
+//   \"restriction\": \"type\",
+//   \"prefixes\": {
+//     \"direction\": \"input\"
+//   },
+//   \"extends\": {
+//     \"baseClass\": \"Real\"
+//   },
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 2,
+//     \"columnEnd\": 30
+//   }
+// }"
+// ""
+// "{
+//   \"name\": \"RealInput2\",
+//   \"restriction\": \"type\",
+//   \"modifiers\": {
+//     \"start\": \"1.0\"
+//   },
+//   \"extends\": {
+//     \"baseClass\": {
+//       \"name\": \"RealInput\",
+//       \"restriction\": \"type\",
+//       \"prefixes\": {
+//         \"direction\": \"input\"
+//       },
+//       \"extends\": {
+//         \"baseClass\": \"Real\"
+//       },
+//       \"source\": {
+//         \"filename\": \"<interactive>\",
+//         \"lineStart\": 2,
+//         \"columnStart\": 3,
+//         \"lineEnd\": 2,
+//         \"columnEnd\": 30
+//       }
+//     }
+//   },
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 3,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 3,
+//     \"columnEnd\": 43
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -10,6 +10,7 @@ GetModelInstanceComment1.mos \
 GetModelInstanceConditional1.mos \
 GetModelInstanceConnection1.mos \
 GetModelInstanceDerived1.mos \
+GetModelInstanceDerived2.mos \
 GetModelInstanceDuplicate1.mos \
 GetModelInstanceEnum1.mos \
 GetModelInstanceEnum2.mos \


### PR DESCRIPTION
- Call `Typing.typeClassType` before typing anything else in the class, since derived classes will otherwise be in an invalid state.

Fixes #9701