### PR TITLE
Clear the generated inner cache in NFApi

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1971,6 +1971,16 @@ uniontype InstNode
       else Type.isDiscrete(Class.getType(cls, base_node));
     end match;
   end isDiscreteClass;
+
+  function clearGeneratedInners
+    input InstNode node;
+  protected
+    InstNode top;
+    UnorderedMap<String, InstNode> inners;
+  algorithm
+    InstNodeType.TOP_SCOPE(generatedInners = inners) := nodeType(InstNode.topScope(node));
+    UnorderedMap.clear(inners);
+  end clearGeneratedInners;
 end InstNode;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -614,6 +614,7 @@ algorithm
     // if absyn is the same, all fine, reuse
     if referenceEq(absynProgram, Util.tuple21(listHead(cache))) then
       (program, top) := Util.tuple22(listHead(cache));
+      InstNode.clearGeneratedInners(top);
       update := false;
     else
       update := true;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter3.mos
@@ -1,0 +1,54 @@
+// name: GetModelInstanceInnerOuter2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package P
+    model M
+      outer Real x;
+    end M;
+
+    type RealInput = input Real;
+  end P;
+");
+
+getModelInstance(P.M, prettyPrint=true);
+getModelInstance(P.RealInput, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"P.M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 3,
+//     \"columnStart\": 5,
+//     \"lineEnd\": 5,
+//     \"columnEnd\": 10
+//   }
+// }"
+// "{
+//   \"name\": \"P.RealInput\",
+//   \"restriction\": \"type\",
+//   \"prefixes\": {
+//     \"direction\": \"input\"
+//   },
+//   \"extends\": {
+//     \"baseClass\": \"Real\"
+//   },
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 7,
+//     \"columnStart\": 5,
+//     \"lineEnd\": 7,
+//     \"columnEnd\": 32
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -21,6 +21,7 @@ GetModelInstanceIcon1.mos \
 GetModelInstanceIcon2.mos \
 GetModelInstanceInnerOuter1.mos \
 GetModelInstanceInnerOuter2.mos \
+GetModelInstanceInnerOuter3.mos \
 GetModelInstanceMod1.mos \
 GetModelInstanceMod2.mos \
 GetModelInstanceReplaceable1.mos \


### PR DESCRIPTION
- Clear the generated inner cache between calls to the NFApi, otherwise they'll be added to every subsequent model that's instantiated and cause issues.