### PR TITLE
Use libraries.openmodelica.org mirror for package manager (#9704)

### DIFF
--- a/OMCompiler/Compiler/Util/Curl.mo
+++ b/OMCompiler/Compiler/Util/Curl.mo
@@ -34,7 +34,7 @@ encapsulated package Curl
 import Config;
 
 function multiDownload
-  input list<tuple<String,String>> urlFileList;
+  input list<tuple<list<String>,String>> urlFileList;
   input Integer maxParallel = Config.noProc();
   output Boolean success;
   external "C" success = om_curl_multi_download(urlFileList, maxParallel);

--- a/OMCompiler/Compiler/runtime/om_curl.c
+++ b/OMCompiler/Compiler/runtime/om_curl.c
@@ -12,7 +12,9 @@
 
 typedef struct {
   const char *url;
-  const char *filename;
+  void *filename;
+  void *tmpFilename;
+  void *nextTry;
   FILE *fout;
 } pair;
 
@@ -21,7 +23,7 @@ static size_t writeDataCallback(char *data, size_t n, size_t l, void *fout)
   return fwrite(data, n, l, (FILE*) fout);
 }
 
-static void* addTransfer(CURLM *cm, void *urlPathList, int *result)
+static void* addTransfer(CURLM *cm, void *urlPathList, int *result, int n)
 {
   if (listEmpty(urlPathList)) {
     return urlPathList;
@@ -29,8 +31,9 @@ static void* addTransfer(CURLM *cm, void *urlPathList, int *result)
   CURL *eh = curl_easy_init();
   void *first = MMC_CAR(urlPathList);
   void *rest = MMC_CDR(urlPathList);
-  const char *url = MMC_STRINGDATA(MMC_CAR(first));
-  const char *file = MMC_STRINGDATA(MMC_CDR(first));
+  const char *url = MMC_STRINGDATA(MMC_CAR(MMC_CAR(first)));
+  void *tmpFilename = stringAppend(MMC_CDR(first), stringAppend(mmc_mk_scon(".tmp"), intString(n)));
+  const char *file = MMC_STRINGDATA(tmpFilename);
   FILE *fout = omc_fopen(file, "wb");
 
   if (fout == NULL) {
@@ -41,9 +44,10 @@ static void* addTransfer(CURLM *cm, void *urlPathList, int *result)
 
   pair *p = (pair*) malloc(sizeof(pair));
   p->url = url;
+  p->nextTry = MMC_CDR(MMC_CAR(first));
   p->fout = fout;
-  p->filename = file;
-
+  p->filename = MMC_CDR(first);
+  p->tmpFilename = tmpFilename;
 #if defined(__MINGW32__)
   {
     /* mingw/windows horror, let's find the curl CA bundle! */
@@ -92,13 +96,14 @@ int om_curl_multi_download(void *urlPathList, int maxParallel)
   int msgs_left = -1;
   int still_alive = 1;
   int result = 1;
+  int transferNumber = 1;
   curl_global_init(CURL_GLOBAL_ALL);
   cm = curl_multi_init();
 
   curl_multi_setopt(cm, CURLMOPT_MAXCONNECTS, maxParallel);
 
   for (transfers = 0; transfers < maxParallel; transfers++) {
-    urlPathList = addTransfer(cm, urlPathList, &result);
+    urlPathList = addTransfer(cm, urlPathList, &result, transferNumber++);
   }
 
   do {
@@ -112,13 +117,26 @@ int om_curl_multi_download(void *urlPathList, int maxParallel)
       const char *url = p->url;
 
       if (msg->msg == CURLMSG_DONE) {
-        fclose(fout);
-        urlPathList = addTransfer(cm, urlPathList, &result);
         if (msg->data.result != CURLE_OK) {
+          fclose(fout);
           const char *msgs[2] = {curl_easy_strerror(msg->data.result), url};
-          c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Curl error for URL %s: %s", msgs, 2);
-          omc_unlink(p->filename);
-          result = 0;
+          omc_unlink(MMC_STRINGDATA(p->tmpFilename));
+          if (listEmpty(p->nextTry)) {
+            c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Curl error for URL %s: %s", msgs, 2);
+            result = 0;
+            urlPathList = addTransfer(cm, urlPathList, &result, transferNumber++);
+          } else {
+            c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Will try another mirror due to curl error for URL %s: %s", msgs, 2);
+            urlPathList = addTransfer(cm, mmc_mk_cons(mmc_mk_cons(p->nextTry, p->filename), urlPathList), &result, transferNumber++);
+            still_alive = 1;
+          }
+        } else {
+          fclose(fout);
+          if (rename(MMC_STRINGDATA(p->tmpFilename), MMC_STRINGDATA(p->filename))) {
+            const char *msgs[3] = {strerror(errno), MMC_STRINGDATA(p->filename), MMC_STRINGDATA(p->tmpFilename)};
+            c_add_message(NULL, -1, ErrorType_runtime,ErrorLevel_error, "Failed to rename file after downloading with curl %s %s: %s", msgs, 3);
+          }
+          urlPathList = addTransfer(cm, urlPathList, &result, transferNumber++);
         }
         curl_multi_remove_handle(cm, e);
         curl_easy_cleanup(e);

--- a/libraries/index.json
+++ b/libraries/index.json
@@ -443,5 +443,8 @@
         }
       }
     }
-  }
+  },
+  "mirrors": [
+    "https://libraries.openmodelica.org/cache/"
+  ]
 }

--- a/libraries/install-index.json
+++ b/libraries/install-index.json
@@ -111,5 +111,8 @@
         }
       }
     }
-  }
+  },
+  "mirrors": [
+    "https://libraries.openmodelica.org/cache/"
+  ]
 }

--- a/libraries/update.py
+++ b/libraries/update.py
@@ -134,6 +134,6 @@ end if;
   fout.write('system("touch .openmodelica/%s")' % stamp)
 
 with open(args.filenameprefix + "index.json", "w") as fout:
-  fout.write(json.dumps({"libs":newdata}, indent=2))
+  fout.write(json.dumps({"libs":newdata,"mirrors":["https://libraries.openmodelica.org/cache/"]}, indent=2))
 with open("Makefile.version", "w") as fout:
   fout.write('STAMP=%s' % stamp)


### PR DESCRIPTION
Also use this mirror for the install and testing libraries.

When downloading packages, now use a tmp-file instead of a zip-file and rename the file when done. This fixes an unfinished download when omc is forced to close.