### PR TITLE
Enable, build and install the OMShell-terminal.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -33,11 +33,11 @@ pipeline {
               echo "Running on: ${env.NODE_NAME}"
               withEnv (["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
                 sh "echo PATH: $PATH"
-                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release" +
-                                          " -DCMAKE_INSTALL_PREFIX=build" +
-                                          " -DOM_OMC_ENABLE_FORTRAN=OFF" +
-                                          " -DOM_OMC_ENABLE_IPOPT=OFF" +
-                                          " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
+                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
+                                          + " -DCMAKE_INSTALL_PREFIX=build"
+                                          + " -DOM_OMC_ENABLE_FORTRAN=OFF"
+                                          + " -DOM_OMC_ENABLE_IPOPT=OFF"
+                                          + " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
                                       )
                 sh "build/bin/omc --version"
               }

--- a/.CI/cmake/Jenkinsfile.cmake.omdev.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.omdev.gcc
@@ -2,7 +2,7 @@ def common
 pipeline {
   agent none
   options {
-    buildDiscarder(logRotator(numToKeepStr: "5", artifactNumToKeepStr: "2"))
+    buildDiscarder(logRotator(numToKeepStr: "15", artifactNumToKeepStr: "5"))
   }
   stages {
     stage('Environment') {
@@ -36,7 +36,11 @@ pipeline {
             script {
               withEnv (["PATH=C:\\OMDev\\tools\\msys\\usr\\bin;C:\\Program Files\\TortoiseSVN\\bin;c:\\bin\\jdk\\bin;c:\\bin\\nsis\\;${env.PATH};c:\\bin\\git\\bin;"]) {
                 bat "echo PATH: %PATH%"
-                common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOM_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build -G "MSYS Makefiles"')
+                common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release'
+                                        + ' -DOM_USE_CCACHE=OFF'
+                                        + ' -DCMAKE_INSTALL_PREFIX=build'
+                                        + ' -G "MSYS Makefiles"'
+                                      )
               }
             }
           }

--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -2,7 +2,7 @@ def common
 pipeline {
   agent none
   options {
-    buildDiscarder(logRotator(numToKeepStr: "5", artifactNumToKeepStr: "2"))
+    buildDiscarder(logRotator(numToKeepStr: "15", artifactNumToKeepStr: "5"))
   }
   stages {
     stage('Environment') {
@@ -49,7 +49,11 @@ pipeline {
           }
           steps {
             script {
-              common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOM_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build -DSUNDIALS_BUILD_SHARED_LIBS=ON', '/opt/cmake-3.17.2/bin/cmake')
+              common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
+                                        + " -DOM_USE_CCACHE=OFF"
+                                        + " -DCMAKE_INSTALL_PREFIX=build"
+                                        + " -DSUNDIALS_BUILD_SHARED_LIBS=ON"
+                                    , '/opt/cmake-3.17.2/bin/cmake')
               sh "build/bin/omc --version"
             }
             stash name: 'omc-cmake-gcc', includes: 'build/**'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,10 @@ pipeline {
           steps {
             script {
               echo "Running on: ${env.NODE_NAME}"
-              common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release -DOM_USE_CCACHE=OFF -DCMAKE_INSTALL_PREFIX=build', '/opt/cmake-3.17.2/bin/cmake')
+              common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
+                                        + " -DOM_USE_CCACHE=OFF"
+                                        + " -DCMAKE_INSTALL_PREFIX=build"
+                                    , "/opt/cmake-3.17.2/bin/cmake")
               sh "build/bin/omc --version"
             }
             // stash name: 'omc-cmake-gcc', includes: 'OMCompiler/build_cmake/install_cmake/bin/**'
@@ -152,12 +155,12 @@ pipeline {
               echo "Running on: ${env.NODE_NAME}"
               withEnv (["PATH=/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"]) {
                 sh "echo PATH: $PATH"
-                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release" +
-                                          " -DOM_USE_CCACHE=OFF" +
-                                          " -DCMAKE_INSTALL_PREFIX=build" +
-                                          " -DOM_OMC_ENABLE_FORTRAN=OFF" +
-                                          " -DOM_OMC_ENABLE_IPOPT=OFF" +
-                                          " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
+                common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
+                                          + " -DOM_USE_CCACHE=OFF"
+                                          + " -DCMAKE_INSTALL_PREFIX=build"
+                                          + " -DOM_OMC_ENABLE_FORTRAN=OFF"
+                                          + " -DOM_OMC_ENABLE_IPOPT=OFF"
+                                          + " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
                                       )
                 sh "build/bin/omc --version"
               }

--- a/OMShell/CMakeLists.txt
+++ b/OMShell/CMakeLists.txt
@@ -1,14 +1,13 @@
 cmake_minimum_required (VERSION 3.14)
-set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME gui)
-
 
 project(OMShell)
 
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
-
-
-find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml REQUIRED)
+## The autotools/Makefiles based OpenModelica build skips omshell-terminal on Windows.
+## So we make it default-enabled optional component here as well. In case it needs to be disabled in some cases.
+option(OM_OMSHELL_ENABLE_TERMINAL "Enable building the OMShell REPL terminal (in addition to the OMSell GUI)" ON)
 
 omc_add_subdirectory(OMShell/OMShellGUI)
+
+if(OM_OMSHELL_ENABLE_TERMINAL)
+  omc_add_subdirectory(mosh)
+endif()

--- a/OMShell/OMShell/OMShellGUI/CMakeLists.txt
+++ b/OMShell/OMShell/OMShellGUI/CMakeLists.txt
@@ -1,5 +1,13 @@
 
 
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME gui)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml REQUIRED)
+
 set(OMSHELLLIB_SOURCES commandcompletion.cpp
                        omcinteractiveenvironment.cpp
                        oms.cpp
@@ -11,14 +19,12 @@ set(OMSHELLLIB_HEADERS commandcompletion.h
 
 
 add_library(OMShellLib STATIC ${OMSHELLLIB_SOURCES} ${OMSHELLLIB_HEADERS})
-target_compile_definitions(OMShellLib PRIVATE OMSHELLLIB_MOC_INCLUDE)
 
+target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
 target_link_libraries(OMShellLib PUBLIC Qt5::Xml)
 target_link_libraries(OMShellLib PUBLIC Qt5::Widgets)
 target_link_libraries(OMShellLib PUBLIC Qt5::PrintSupport)
 target_link_libraries(OMShellLib PUBLIC Qt5::WebKitWidgets)
-target_link_libraries(OMShellLib PUBLIC OpenModelicaCompiler)
-
 
 
 if(APPLE)

--- a/OMShell/mosh/CMakeLists.txt
+++ b/OMShell/mosh/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+
+
+# We have our own module for this. CMake does not provide one yet.
+find_package(Readline REQUIRED)
+
+set(OMSHELL_TERMINAL_SOURCES src/mosh.cpp
+                             src/omcinteractiveenvironment.cpp
+                             src/options.cpp)
+
+add_executable(OMShell-terminal ${OMSHELL_TERMINAL_SOURCES})
+
+target_link_libraries(OMShell-terminal PRIVATE OpenModelicaCompiler)
+target_link_libraries(OMShell-terminal PRIVATE Readline::Readline)
+
+install(TARGETS OMShell-terminal)

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -12,10 +12,11 @@
     - [4.1.1. OpenModelica Options](#411-openmodelica-options)
     - [4.1.2. OpenModelica/OMCompiler Options](#412-openmodelicaomcompiler-options)
     - [4.1.3. OpenModelica/OMEdit Options](#413-openmodelicaomedit-options)
-    - [4.1.4. Other Options](#414-other-options)
-  - [4.2. Selecting a Compiler.](#42-selecting-a-compiler)
-  - [4.3. Disabling Colors for Makefile Generators](#43-disabling-colors-for-makefile-generators)
-  - [4.4. Enabling Verbose Output](#44-enabling-verbose-output)
+    - [4.1.4. OpenModelica/OMShell Options](#414-openmodelicaomshell-options)
+    - [4.1.4. Other OpenModleica specific Options](#414-other-openmodleica-specific-options)
+  - [4.2. Useful CMake Configuration Options](#42-useful-cmake-configuration-options)
+    - [4.2.1. Disabling Colors for Makefile Generators](#421-disabling-colors-for-makefile-generators)
+    - [4.2.2 Enabling Verbose Output](#422-enabling-verbose-output)
 - [5. Integration with Editors/Tools](#5-integration-with-editorstools)
 - [6. Running Tests (rtest)](#6-running-tests-rtest)
 
@@ -187,6 +188,7 @@ OM_OMC_ENABLE_CPP_RUNTIME=ON
 OM_OMC_ENABLE_FORTRAN=ON
 OM_OMC_ENABLE_IPOPT=ON
 OM_OMEDIT_INSTALL_RUNTIME_DLLS=ON
+OM_OMSHELL_ENABLE_TERMINAL=ON
 ```
 ### 4.1.1. OpenModelica Options
 `OM_USE_CCACHE` option is for enabling/disabling ccache support as explained in [2. ccache](#2-ccache). It is recommended that you install ccache and set this to ON.
@@ -194,9 +196,9 @@ OM_OMEDIT_INSTALL_RUNTIME_DLLS=ON
 `OM_ENABLE_GUI_CLIENTS` allows you to enable/disable the configuration and build of the qt based GUI clients and their dependencies. These include: OMEdit, OMNotebook, OMParser, OMPlot, OMShell. You will need to install and make available the necessary packages (and their dependencies) such as the Qt libs, OpenSceneGraph, OpenThreads ...
 
 ### 4.1.2. OpenModelica/OMCompiler Options
-`OM_OMC_ENABLE_CPP_RUNTIME` allows you to enable/disable the building of the C++ based simulation runtime. This will require multiple Boost library components (file_system, program_options, ...)
+`OM_OMC_ENABLE_CPP_RUNTIME` allows you to enable/disable the building of the C++ based simulation runtime. This requires multiple Boost library components (file_system, program_options, ...)
 
-`OM_OMC_ENABLE_FORTRAN` allows you to enable/disable Fortran support. If your system does not have a Fortran compile you can disable this. Fortran is required if you enable IPOPT support (`OM_OMC_ENABLE_IPOPT`).
+`OM_OMC_ENABLE_FORTRAN` allows you to enable/disable Fortran support. If your system does not have a Fortran compiler you can disable this. Fortran is required if you enable IPOPT support (`OM_OMC_ENABLE_IPOPT`).
 
 `OM_OMC_ENABLE_IPOPT` allows you to enable/disable support for dynamic optimization support with Ipopt. Enabling this requires having a working Fortran compiler.
 
@@ -209,7 +211,10 @@ You should disable this if you are either
 
   - Using OMDev or other MSYS/MinGW setup and have specified the MSYS/MinGW system directories as your CMake install directory.
 
-### 4.1.4. Other Options
+### 4.1.4. OpenModelica/OMShell Options
+`OM_OMSHELL_ENABLE_TERMINAL` allows you to enable/disable the building of the OMShell-terminal command-line REPL application. This requires the GNU readline library. Note that this is different from the Qt based OMShell GUI application.
+
+### 4.1.4. Other OpenModleica specific Options
 There are also some additional options that are kept as a migration step to maintain the similarity with the `autotools` build system.
 
 
@@ -220,19 +225,8 @@ OM_OMC_USE_LAPACK=ON
 
 These options are not guaranteed to work properly if they are changed from their default values as of now.
 
-## 4.2. Selecting a Compiler.
-If you, for example, want to use clang instead of GCC, you can do so by modifying `CMAKE_<LANG>_COMPILER`
-```sh
-cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-```
-
-CMake picks up the default compiler by checking for CC/CXX in your environment. This means you can also achieve the same thing by modifying the environment just for the current CMake invocation:
-
-```sh
-CC=clang CXX=clang++ cmake ..
-```
-
-## 4.3. Disabling Colors for Makefile Generators
+## 4.2. Useful CMake Configuration Options
+### 4.2.1. Disabling Colors for Makefile Generators
 If you do not like colors you can disable them.
 ```sh
 cmake .. -DCMAKE_COLOR_MAKEFILE=OFF
@@ -240,7 +234,7 @@ cmake .. -DCMAKE_COLOR_MAKEFILE=OFF
 
 This can be useful if you want to redirect output to a file for example.
 
-## 4.4. Enabling Verbose Output
+### 4.2.2 Enabling Verbose Output
 Sometimes you might want to get a verbose output to see what CMake is actually doing and what exact commands it is issuing.
 
 If you are using CMake itself to issue builds (recommended) instead of invoking the generator directly, you can specify `-v` to the build command

--- a/cmake/modules/FindReadline.cmake
+++ b/cmake/modules/FindReadline.cmake
@@ -1,0 +1,63 @@
+## This is not fully tested.
+## It is used only by the optional (default disabled) OMShell-terminal right now.
+
+## readline needs curses. If you switch to static versions of readline enable this
+## and explicitly add the target_link_libraries down below.
+# find_package(Curses REQUIRED)
+
+# Try finding with PkgConfig to get some hints
+find_package(PkgConfig)
+pkg_check_modules(PC_Readline QUIET readline)
+
+# message(STATUS "PC_Readline_LIBRARIES: ${PC_Readline_LIBRARIES}")
+# message(STATUS "PC_Readline_INCLUDE_DIRS: ${PC_Readline_INCLUDE_DIRS}")
+# message(STATUS "PC_Readline_LIBRARY_DIRS: ${PC_Readline_LIBRARY_DIRS}")
+# message(STATUS "PC_Readline_LDFLAGS: ${PC_Readline_LDFLAGS}")
+
+## Find and set the Readline_INCLUDE_DIR using the info from PkgConfig
+find_path(Readline_INCLUDE_DIR
+  NAMES readline.h
+  PATHS ${PC_Readline_INCLUDE_DIRS}
+  PATH_SUFFIXES readline
+)
+
+## Find and set the Readline_LIBRARY using the info from PkgConfig
+find_library(Readline_LIBRARY
+  NAMES readline
+  PATHS ${PC_Readline_LIBRARY_DIRS}
+)
+
+# message(STATUS "Readline_LIBRARY: ${Readline_LIBRARY}")
+# message(STATUS "Readline_VERSION: ${Readline_VERSION}")
+
+## Handle the standard CMake arguments, e.g REQUIRED, VERSION ...
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Readline
+  FOUND_VAR Readline_FOUND
+  REQUIRED_VARS
+    Readline_LIBRARY
+    Readline_INCLUDE_DIR
+  VERSION_VAR Readline_VERSION
+)
+
+## Add an imported target for the library so we would not have to
+## deal with specifying include directories and additional flags manually.
+if(Readline_FOUND AND NOT TARGET Readline::Readline)
+  add_library(Readline::Readline UNKNOWN IMPORTED)
+  set_target_properties(Readline::Readline PROPERTIES
+    IMPORTED_LOCATION "${Readline_LIBRARY}"
+    INTERFACE_COMPILE_OPTIONS "${PC_Readline_CFLAGS_OTHER}"
+    INTERFACE_INCLUDE_DIRECTORIES "${Readline_INCLUDE_DIR}"
+  )
+#   target_link_libraries(Readline::Readline INTERFACE ${CURSES_LIBRARIES})
+endif()
+
+## compatibility variables
+set(Readline_VERSION_STRING ${Readline_VERSION})
+
+## Hide some of the variables by default in user interfaces.
+## They are just noise most of the time.
+mark_as_advanced(
+  Readline_INCLUDE_DIR
+  Readline_LIBRARY
+)


### PR DESCRIPTION
  - This offers it as a default-enabled optional component. It can be disabled by specifying

```cmake
OM_OMSHELL_ENABLE_TERMINAL=OFF
```
to the CMake configure command.

