### PR TITLE
Fix for diff algorithm in function_arguments

### DIFF
--- a/testsuite/openmodelica/diff/Makefile
+++ b/testsuite/openmodelica/diff/Makefile
@@ -13,10 +13,12 @@ ClosedDoors.mos \
 LargeFileChange.mos \
 LimPID.mos \
 ListFile.mos \
+MoistAirUnsaturated.mos \
 MoveComment.mos \
 MoveComponent.mos \
 MoveConnection.mos \
 multipoleFluidTemperature.mos \
+PartialCoolingCapacity.mos \
 Pipe.mos \
 removeComponentModifiers.mos \
 RLC.mos \

--- a/testsuite/openmodelica/diff/MoistAirUnsaturated.mos
+++ b/testsuite/openmodelica/diff/MoistAirUnsaturated.mos
@@ -1,0 +1,29 @@
+// depends: MoistAirUnsaturatedBefore.mo
+// status: correct
+
+before:=readFile("MoistAirUnsaturatedBefore.mo");getErrorString();
+loadFile("MoistAirUnsaturatedAfter.mo");getErrorString();
+res:=diffModelicaFileListings(before,list(),OpenModelica.Scripting.DiffFormat.color);getErrorString();
+
+// Result:
+// "within;
+// package MoistAirUnsaturated
+// redeclare function extends thermalConductivity
+// algorithm
+//   lambda := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(Modelica.SIunits.Conversions.to_degC(state.T));
+// end thermalConductivity;
+// end MoistAirUnsaturated;
+// "
+// ""
+// true
+// ""
+// "within;
+// package MoistAirUnsaturated
+// redeclare function extends thermalConductivity
+// algorithm
+//   lambda := [9;31mModelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(Modelica.SIunits.Conversions.to_degC(state.T))[0m[4;32mModelica.Math.Polynomials.evaluate(Modelica.Units.Conversions.to_degC(state.T))[0m;
+// end thermalConductivity;
+// end MoistAirUnsaturated;
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/diff/MoistAirUnsaturatedAfter.mo
+++ b/testsuite/openmodelica/diff/MoistAirUnsaturatedAfter.mo
@@ -1,0 +1,9 @@
+within;
+
+package MoistAirUnsaturated
+  redeclare function extends thermalConductivity
+    algorithm
+      lambda := Modelica.Math.Polynomials.evaluate(Modelica.Units.Conversions.to_degC(state.T));
+  end thermalConductivity;
+
+end MoistAirUnsaturated;

--- a/testsuite/openmodelica/diff/MoistAirUnsaturatedBefore.mo
+++ b/testsuite/openmodelica/diff/MoistAirUnsaturatedBefore.mo
@@ -1,0 +1,7 @@
+within;
+package MoistAirUnsaturated
+redeclare function extends thermalConductivity
+algorithm
+  lambda := Modelica.Media.Incompressible.TableBased.Polynomials_Temp.evaluate(Modelica.SIunits.Conversions.to_degC(state.T));
+end thermalConductivity;
+end MoistAirUnsaturated;

--- a/testsuite/openmodelica/diff/PartialCoolingCapacity.mos
+++ b/testsuite/openmodelica/diff/PartialCoolingCapacity.mos
@@ -1,0 +1,29 @@
+// depends: PartialCoolingCapacityBefore.mo
+// status: correct
+
+before:=readFile("PartialCoolingCapacityBefore.mo");getErrorString();
+loadFile("PartialCoolingCapacityAfter.mo");getErrorString();
+res:=diffModelicaFileListings(before,list(),OpenModelica.Scripting.DiffFormat.color);getErrorString();
+
+// Result:
+// "within;
+// partial block PartialCoolingCapacity
+// algorithm
+//        biquadratic(
+//          x1=B,
+//          x2=B);
+// end PartialCoolingCapacity;
+// "
+// ""
+// true
+// ""
+// "within;
+// partial block PartialCoolingCapacity
+// algorithm
+//        biquadratic(
+//          x1=[4;32mA[0m,
+//          x2=[4;32mA[0m);
+// end PartialCoolingCapacity;
+// "
+// ""
+// endResult

--- a/testsuite/openmodelica/diff/PartialCoolingCapacityAfter.mo
+++ b/testsuite/openmodelica/diff/PartialCoolingCapacityAfter.mo
@@ -1,0 +1,7 @@
+within;
+partial block PartialCoolingCapacity
+algorithm
+       biquadratic(
+         x1=A,
+         x2=A);
+end PartialCoolingCapacity;

--- a/testsuite/openmodelica/diff/PartialCoolingCapacityBefore.mo
+++ b/testsuite/openmodelica/diff/PartialCoolingCapacityBefore.mo
@@ -1,0 +1,7 @@
+within;
+partial block PartialCoolingCapacity
+algorithm
+       biquadratic(
+         x1=B,
+         x2=B);
+end PartialCoolingCapacity;


### PR DESCRIPTION
If the function_arguments started with whitespace, this was previously not handled correctly (replacing all arguments with the new formatting).