### PR TITLE
Fix OMShell-terminal on Windows and add a CMake Windows job.

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -510,6 +510,15 @@ def shouldWeDisableAllCMakeBuilds() {
   return params.DISABLE_ALL_CMAKE_BUILDS
 }
 
+def shouldWeEnableMinGWCMakeBuild() {
+  if (isPR()) {
+    if (pullRequest.labels.contains("CI/CMake/Enable/MinGW")) {
+      return true
+    }
+  }
+  return params.ENABLE_MINGW_CMAKE_BUILD
+}
+
 def shouldWeEnableMacOSCMakeBuild() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/CMake/Enable/macOS")) {

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -74,7 +74,8 @@ RUNTIMESIMULATION_HEADERS = ./simulation/modelinfo.h \
 ./simulation/simulation_input_xml.h \
 ./simulation/simulation_omc_assert.h \
 ./simulation/simulation_runtime.h \
-./simulation/omc_simulation_util.h
+./simulation/omc_simulation_util.h \
+./simulation/socket.h
 
 RUNTIMESIMRESULTS_HEADERS = ./simulation/results/simulation_result.h
 

--- a/OMShell/mosh/src/mosh.cpp
+++ b/OMShell/mosh/src/mosh.cpp
@@ -42,7 +42,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/unistd.h>
 #include <sys/stat.h>
 
@@ -50,6 +49,7 @@
 #include <sys/param.h> /* MAXPATHLEN */
 #include "options.h"
 #include "omcinteractiveenvironment.h"
+#include "simulation/socket.h"
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
 #else


### PR DESCRIPTION
  - There is now a PR CI job that can build OpenModelica with CMake on Windows. This is disabled by default and can be enabled by setting the label (on the PR): 
   `CI/CMake/Enable/MinGW`

  - Note that this does not build anything with MSVC, so it is not a replacement for the normal Windows build (`CI/Build MinGW` label) 

  - OMShell-terminal: use `simulation/socket.h` from our runtime code instead of directly including `sys/socket.h`. OMShell-terminal can now be compiled on Windows and seems to work just fine.
