### PR TITLE
Improve connection handling

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCheckModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCheckModel.mo
@@ -57,7 +57,7 @@ algorithm
     (variables, equations) := countVariableSize(v, variables, equations);
   end for;
 
-  equations := equations + countEquationListSize(flatModel.equations);
+  equations := equations + Equation.sizeOfList(flatModel.equations);
 
   for a in flatModel.algorithms loop
     equations := equations + countAlgorithmSize(a);
@@ -89,44 +89,6 @@ algorithm
 
   equations := equations + Type.sizeOf(Binding.getType(binding));
 end countVariableSize;
-
-function countEquationListSize
-  input list<Equation> eqs;
-  output Integer equations = 0;
-algorithm
-  for e in eqs loop
-    equations := equations + countEquationSize(e);
-  end for;
-end countEquationListSize;
-
-function countEquationSize
-  input Equation eq;
-  output Integer equations;
-algorithm
-  equations := match eq
-    case Equation.EQUALITY() then Type.sizeOf(eq.ty);
-    case Equation.ARRAY_EQUALITY() then Type.sizeOf(eq.ty);
-    case Equation.FOR() then countEquationListSize(eq.body);
-    case Equation.IF() then countEquationBranchSize(listHead(eq.branches));
-    case Equation.WHEN() then countEquationBranchSize(listHead(eq.branches));
-    else 0;
-  end match;
-end countEquationSize;
-
-function countEquationBranchSize
-  input Equation.Branch branch;
-  output Integer equations;
-algorithm
-  equations := match branch
-    case Equation.Branch.BRANCH() then countEquationListSize(branch.body);
-
-    else
-      algorithm
-        Error.assertion(false, getInstanceName() + " got invalid branch", sourceInfo());
-      then
-        fail();
-  end match;
-end countEquationBranchSize;
 
 function countAlgorithmSize
   input Algorithm alg;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -298,6 +298,20 @@ public
     end match;
   end firstName;
 
+  function first
+    input output ComponentRef cref;
+  algorithm
+    () := match cref
+      case CREF()
+        algorithm
+          cref.restCref := EMPTY();
+        then
+          ();
+
+      else ();
+    end match;
+  end first;
+
   function rest
     input ComponentRef cref;
     output ComponentRef restCref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectionSets.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectionSets.mo
@@ -70,19 +70,12 @@ package ConnectionSets
       listLength(connections.connections) + listLength(connections.flows));
 
     // Add flow variable to the sets, unless disabled by flag.
-    // Do this here if NF_SCALARIZE to use fast addList for scalarized flows.
-    if not Flags.isSet(Flags.DISABLE_SINGLE_FLOW_EQ) and Flags.isSet(Flags.NF_SCALARIZE) then
-      sets := List.fold(connections.flows, addConnector, sets);
+    if not Flags.isSet(Flags.DISABLE_SINGLE_FLOW_EQ) then
+      sets := List.fold(connections.flows, addSingleConnector, sets);
     end if;
 
     // Add the connections.
     sets := List.fold1(connections.connections, addConnection, connections.broken, sets);
-
-    // Add remaining flow variables to the sets, unless disabled by flag.
-    // Do this after addConnection if not NF_SCALARIZE to get array dims right.
-    if not Flags.isSet(Flags.DISABLE_SINGLE_FLOW_EQ) and not Flags.isSet(Flags.NF_SCALARIZE) then
-      sets := List.fold(connections.flows, addSingleConnector, sets);
-    end if;
   end fromConnections;
 
   function addScalarConnector
@@ -97,7 +90,7 @@ package ConnectionSets
     input Connector conn;
     input output ConnectionSets.Sets sets;
   algorithm
-    sets := addList(Connector.split(conn), sets);
+    sets := addList(Connector.scalarize(conn), sets);
   end addConnector;
 
   function addSingleConnector
@@ -105,9 +98,7 @@ package ConnectionSets
     input Connector conn;
     input output ConnectionSets.Sets sets;
   algorithm
-    for c in Connector.split(conn) loop
-      sets := find(c, sets);
-    end for;
+    sets := find(conn, sets);
   end addSingleConnector;
 
   function addConnection
@@ -119,17 +110,13 @@ package ConnectionSets
   protected
     list<Connection> conns;
   algorithm
-    conns := Connection.split(connection);
-
-    if not listEmpty(broken) then
-      conns := list(c for c guard not isBroken(c.lhs, c.rhs, broken) in conns);
+    if not listEmpty(broken) and isBroken(connection.lhs, connection.rhs, broken) then
+      return;
     end if;
 
     // TODO: Check variability of connectors. It's an error if either
     //       connector is constant/parameter while the other isn't.
-    for conn in conns loop
-      sets := merge(conn.lhs, conn.rhs, sets);
-    end for;
+    sets := merge(connection.lhs, connection.rhs, sets);
   end addConnection;
 
   function isBroken

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -202,6 +202,20 @@ public
     end if;
   end makeConnectors;
 
+  function split
+    input output Connections conns;
+  algorithm
+    conns.flows := List.mapFlat(conns.flows, Connector.split);
+    conns.connections := List.mapFlat(conns.connections, Connection.split);
+  end split;
+
+  function scalarize
+    input output Connections conns;
+  algorithm
+    conns.flows := List.mapFlat(conns.flows, Connector.scalarize);
+    conns.connections := List.mapFlat(conns.connections, Connection.scalarize);
+  end scalarize;
+
   function toString
     input Connections conns;
     output String str;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
@@ -37,7 +37,6 @@ encapsulated uniontype NFConnector
   import NFPrefixes.ConnectorType;
   import NFPrefixes.Variability;
   import DAE;
-  import Flags;
 
 protected
   import Origin = NFComponentRef.Origin;
@@ -51,6 +50,7 @@ protected
   import ComplexType = NFComplexType;
   import Dimension = NFDimension;
   import MetaModelica.Dangerous.arrayGetNoBoundsChecking;
+  import MetaModelica.Dangerous.listReverseInPlace;
 
 public
   type Face = enumeration(INSIDE, OUTSIDE);
@@ -191,6 +191,11 @@ public
     output Boolean isExpandable = ConnectorType.isExpandable(conn.cty);
   end isExpandable;
 
+  function isArray
+    input Connector conn;
+    output Boolean isArray = Type.isArray(conn.ty);
+  end isArray;
+
   function name
     input Connector conn;
     output ComponentRef name = conn.name;
@@ -212,21 +217,70 @@ public
     output Integer hash = ComponentRef.hash(conn.name, mod);
   end hash;
 
-  type ScalarizeSetting = enumeration(
-    NONE    "a[2].b[2] => {a[2].b[2]}",
-    PREFIX  "a[2].b[2] => {a[1].b[2], a[2].b[2]}",
-    ALL     "a[2].b[2] => {a[1].b[1], a[1].b[2], a[2].b[1], a[2].b[2]}"
-  );
-
   function split
-    "Splits a connector into its primitive components."
+    "Splits a connector into its primitive components, while keeping arrays as
+     they are.
+       split(c) => {c.e, c.f, c.s}"
     input Connector conn;
-    input ScalarizeSetting scalarize = if Flags.isSet(Flags.NF_SCALARIZE) then
-                                         ScalarizeSetting.ALL else ScalarizeSetting.NONE;
     output list<Connector> connl;
   algorithm
-    connl := splitImpl(conn.name, conn.ty, conn.face, conn.source, conn.cty, scalarize);
+    connl := splitImpl(conn.name, conn.ty, conn.face, conn.source, conn.cty);
+    connl := listReverseInPlace(connl);
   end split;
+
+  function scalarize
+    "Splits a connector into scalar elements.
+      scalarize(a/*Real[2]*/.b/*Real[2]*/) => {a[1].b[1], a[1].b[2], a[2].b[1], a[2].b[2]}"
+    input Connector conn;
+    output list<Connector> connl = {};
+  protected
+    ComponentRef name;
+    Type ty;
+    Face face;
+    DAE.ElementSource source;
+    ConnectorType.Type cty;
+    list<ComponentRef> names;
+  algorithm
+    CONNECTOR(name, ty, face, cty, source) := conn;
+    names := ComponentRef.scalarizeAll(name);
+    ty := Type.arrayElementType(ty);
+
+    for n in names loop
+      connl := CONNECTOR(n, ty, face, cty, source) :: connl;
+    end for;
+  end scalarize;
+
+  function scalarizePrefix
+    "Splits the prefix of a connector into scalar elements.
+       scalarizePrefix(a/*Real[2]*/.b/*Real[2]*/) => {a[1].b, a[2].b}"
+    input Connector conn;
+    output list<Connector> connl = {};
+  protected
+    ComponentRef name, prefix;
+    Type ty;
+    Face face;
+    DAE.ElementSource source;
+    ConnectorType.Type cty;
+    list<ComponentRef> prefixes;
+  algorithm
+    CONNECTOR(name, ty, face, cty, source) := conn;
+    prefix := ComponentRef.rest(name);
+
+    if ComponentRef.isEmpty(prefix) then
+      connl := {conn};
+      return;
+    end if;
+
+    prefixes := ComponentRef.scalarizeAll(prefix);
+    ty := ComponentRef.getSubscriptedType(ComponentRef.first(name));
+
+    for p in prefixes loop
+      name := ComponentRef.prepend(p, name);
+      connl := CONNECTOR(name, ty, face, cty, source) :: connl;
+    end for;
+
+    connl := listReverseInPlace(connl);
+  end scalarizePrefix;
 
 protected
   function crefFace
@@ -251,58 +305,37 @@ protected
     input Face face;
     input DAE.ElementSource source;
     input ConnectorType.Type cty;
-    input ScalarizeSetting scalarize;
+    input list<Dimension> dims = {};
     input output list<Connector> conns = {};
-    input list<Dimension> dims = {} "accumulated dimensions if splitArrays = false";
+  protected
+    ComplexType ct;
+    ClassTree tree;
   algorithm
     conns := match ty
-      local
-        Type ety;
-        ComplexType ct;
-        ClassTree tree;
-
+      // A connector, split into connector elements.
       case Type.COMPLEX(complexTy = ct as ComplexType.CONNECTOR())
         algorithm
-          conns := splitImpl2(name, face, source, ct.potentials, scalarize, conns, dims);
-          conns := splitImpl2(name, face, source, ct.flows, scalarize, conns, dims);
-          conns := splitImpl2(name, face, source, ct.streams, scalarize, conns, dims);
+          conns := splitImpl2(name, face, source, ct.potentials, dims, conns);
+          conns := splitImpl2(name, face, source, ct.flows, dims, conns);
+          conns := splitImpl2(name, face, source, ct.streams, dims, conns);
         then
           conns;
 
+      // An external object, don't split.
       case Type.COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT())
         then CONNECTOR(name, Type.liftArrayLeftList(ty, dims), face, cty, source) :: conns;
 
+      // A record, split into record elements.
       case Type.COMPLEX()
         algorithm
           tree := Class.classTree(InstNode.getClass(ty.cls));
-          conns := splitImpl2(name, face, source,
-            arrayList(ClassTree.getComponents(tree)), scalarize, conns, dims);
+          conns := splitImpl2(name, face, source, arrayList(ClassTree.getComponents(tree)), dims, conns);
         then
           conns;
 
-      case Type.ARRAY(elementType = ety as Type.COMPLEX())
-        guard scalarize >= ScalarizeSetting.PREFIX
-        algorithm
-          for c in ComponentRef.scalarize(name) loop
-            conns := splitImpl(c, ety, face, source, cty, scalarize, conns, dims);
-          end for;
-        then
-          conns;
-
-      case Type.ARRAY(elementType = ety)
-        algorithm
-          if scalarize == ScalarizeSetting.ALL then
-            for c in ComponentRef.scalarize(name) loop
-              conns := splitImpl(c, ety, face, source, cty, scalarize, conns, dims);
-            end for;
-          else
-            if not Type.isEmptyArray(ty) then
-              conns := splitImpl(name, ety, face, source, cty, scalarize, conns,
-                                 listAppend(dims, ty.dimensions));
-            end if;
-          end if;
-        then
-          conns;
+      // An array, split according to the element type.
+      case Type.ARRAY()
+        then splitImpl(name, ty.elementType, face, source, cty, listAppend(dims, ty.dimensions), conns);
 
       else CONNECTOR(name, Type.liftArrayLeftList(ty, dims), face, cty, source) :: conns;
     end match;
@@ -313,9 +346,8 @@ protected
     input Face face;
     input DAE.ElementSource source;
     input list<InstNode> comps;
-    input ScalarizeSetting scalarize;
-    input output list<Connector> conns;
     input list<Dimension> dims;
+    input output list<Connector> conns;
   protected
     Component c;
     ComponentRef cref;
@@ -329,7 +361,7 @@ protected
 
       if not ConnectorType.isPotentiallyPresent(cty) then
         cref := ComponentRef.append(ComponentRef.fromNode(comp, ty), name);
-        conns := splitImpl(cref, ty, face, source, cty, scalarize, conns, dims);
+        conns := splitImpl(cref, ty, face, source, cty, dims, conns);
       end if;
     end for;
   end splitImpl2;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -1005,5 +1005,20 @@ public
     end match;
   end obfuscateAbsynCref2;
 
+  function hasArrayConnections
+    input FlatModel flatModel;
+    input Integer minSize = 100;
+    output Boolean hasArrays = false;
+  protected
+    Type ty;
+  algorithm
+    for eq in flatModel.equations loop
+      if Equation.contains(eq, Equation.isConnect) and Equation.sizeOf(eq) >= minSize then
+        hasArrays := true;
+        return;
+      end if;
+    end for;
+  end hasArrayConnections;
+
   annotation(__OpenModelica_Interface="frontend");
 end NFFlatModel;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -327,10 +327,11 @@ algorithm
   execStat(getInstanceName());
   InstUtil.dumpFlatModelDebug("flatten", flatModel);
 
-  if settings.arrayConnect then
+  if settings.arrayConnect and
+     FlatModel.hasArrayConnections(flatModel, Flags.getConfigInt(Flags.ARRAY_CONNECT_MIN_SIZE)) then
     flatModel := resolveArrayConnections(flatModel);
   else
-    flatModel := resolveConnections(flatModel, deleted_vars);
+    flatModel := resolveConnections(flatModel, deleted_vars, settings);
   end if;
   InstUtil.dumpFlatModelDebug("connections", flatModel);
 end flatten;
@@ -1512,13 +1513,10 @@ algorithm
 
     case Equation.FOR()
       algorithm
-        if settings.arrayConnect then
-          eq.body := flattenEquations(eq.body, EMPTY_PREFIX, settings);
-          eql := eq :: equations;
-        elseif not settings.scalarize then
-          eql := splitForLoop(eq, prefix, equations, settings);
-        else
+        if settings.scalarize then
           eql := unrollForLoop(eq, prefix, equations, settings);
+        else
+          eql := splitForLoop(eq, prefix, equations, settings);
         end if;
       then eql;
 
@@ -1742,6 +1740,7 @@ algorithm
   (connects, non_connects) := splitForLoop2(body);
 
   if not listEmpty(connects) then
+    range := Ceval.evalExpOpt(range, Ceval.EvalTarget.RANGE(Equation.info(forLoop)));
     eq := Equation.FOR(iter, range, connects, scope, src);
 
     if settings.arrayConnect then
@@ -1966,6 +1965,7 @@ function resolveConnections
 "Generates the connect equations and adds them to the equation list"
   input output FlatModel flatModel;
   input UnorderedSet<ComponentRef> deletedVars;
+  input FlattenSettings settings;
 protected
   Connections conns;
   list<Equation> conn_eql, ec_eql;
@@ -1985,9 +1985,11 @@ algorithm
   // get the connections from the model
   (flatModel, conns) := Connections.collect(flatModel,
     function isDeletedConnector(deletedVars = deletedVars));
+  ctable := CardinalityTable.fromConnections(conns);
 
   // Elaborate expandable connectors.
   (flatModel, conns) := ExpandableConnectors.elaborate(flatModel, conns);
+
   // handle overconstrained connections
   // - build the graph
   // - evaluate the Connections.* operators
@@ -2000,6 +2002,12 @@ algorithm
   // add the broken connections
   conns := Connections.addBroken(broken, conns);
   // build the sets, check the broken connects
+  conns := Connections.split(conns);
+
+  if settings.scalarize or settings.newBackend then
+    conns := Connections.scalarize(conns);
+  end if;
+
   csets := ConnectionSets.fromConnections(conns);
   csets_array := ConnectionSets.extractSets(csets);
   // generate the equations
@@ -2014,8 +2022,6 @@ algorithm
   // add the equations to the flat model
   flatModel.equations := listAppend(conn_eql, flatModel.equations);
   flatModel.variables := list(v for v guard Variable.isPresent(v) in flatModel.variables);
-
-  ctable := CardinalityTable.fromConnections(conns);
 
   // Evaluate any connection operators if they're used.
   if  System.getHasStreamConnectors() or System.getUsesCardinality() then

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -286,38 +286,40 @@ algorithm
   conns := NFConnections.makeConnections(clhs, lhs_ty, crhs, rhs_ty, source, isDeleted);
 
   for c in conns loop
-    for conn in Connection.split(c) loop
-      lhs := Connector.name(conn.lhs);
-      rhs := Connector.name(conn.rhs);
+    for sconn in Connection.split(c) loop
+      for conn in Connection.scalarizePrefix(sconn) loop
+        lhs := Connector.name(conn.lhs);
+        rhs := Connector.name(conn.rhs);
 
-      if isOverconstrainedCref(lhs) and isOverconstrainedCref(rhs) then
-        lhs := getOverconstrainedCref(lhs);
-        rhs := getOverconstrainedCref(rhs);
+        if isOverconstrainedCref(lhs) and isOverconstrainedCref(rhs) then
+          lhs := getOverconstrainedCref(lhs);
+          rhs := getOverconstrainedCref(rhs);
 
-        lhsArr := ComponentRef.stripSubscripts(lhs);
-        rhsArr := ComponentRef.stripSubscripts(rhs);
+          lhsArr := ComponentRef.stripSubscripts(lhs);
+          rhsArr := ComponentRef.stripSubscripts(rhs);
 
-        ty1 := ComponentRef.getComponentType(lhsArr);
-        ty2 := ComponentRef.getComponentType(rhsArr);
+          ty1 := ComponentRef.getComponentType(lhsArr);
+          ty2 := ComponentRef.getComponentType(rhsArr);
 
-        fcref_rhs := Function.lookupFunctionSimple("equalityConstraint", InstNode.classScope(ComponentRef.node(lhs)), context);
-        (fcref_rhs, fn_node_rhs, _) := Function.instFunctionRef(fcref_rhs, context, ElementSource.getInfo(source));
-        expRHS := Expression.CALL(Call.UNTYPED_CALL(fcref_rhs, {Expression.CREF(ty1, lhsArr), Expression.CREF(ty2, rhsArr)}, {}, fn_node_rhs));
+          fcref_rhs := Function.lookupFunctionSimple("equalityConstraint", InstNode.classScope(ComponentRef.node(lhs)), context);
+          (fcref_rhs, fn_node_rhs, _) := Function.instFunctionRef(fcref_rhs, context, ElementSource.getInfo(source));
+          expRHS := Expression.CALL(Call.UNTYPED_CALL(fcref_rhs, {Expression.CREF(ty1, lhsArr), Expression.CREF(ty2, rhsArr)}, {}, fn_node_rhs));
 
-        (expRHS, ty, var) := Typing.typeExp(expRHS, context, ElementSource.getInfo(source));
+          (expRHS, ty, var) := Typing.typeExp(expRHS, context, ElementSource.getInfo(source));
 
-        fcref_lhs := Function.lookupFunctionSimple("fill", InstNode.topScope(ComponentRef.node(clhs)), context);
-        (fcref_lhs, fn_node_lhs, _) := Function.instFunctionRef(fcref_lhs, context, ElementSource.getInfo(source));
-        expLHS := Expression.CALL(Call.UNTYPED_CALL(fcref_lhs, Expression.REAL(0.0)::List.map(Type.arrayDims(ty), Dimension.sizeExp), {}, fn_node_lhs));
+          fcref_lhs := Function.lookupFunctionSimple("fill", InstNode.topScope(ComponentRef.node(lhs)), context);
+          (fcref_lhs, fn_node_lhs, _) := Function.instFunctionRef(fcref_lhs, context, ElementSource.getInfo(source));
+          expLHS := Expression.CALL(Call.UNTYPED_CALL(fcref_lhs, Expression.REAL(0.0)::List.map(Type.arrayDims(ty), Dimension.sizeExp), {}, fn_node_lhs));
 
-        (expLHS, ty, var) := Typing.typeExp(expLHS, context, ElementSource.getInfo(source));
+          (expLHS, ty, var) := Typing.typeExp(expLHS, context, ElementSource.getInfo(source));
 
-        replaceEq := Equation.EQUALITY(expRHS, expLHS, ty, InstNode.EMPTY_NODE(), source);
+          replaceEq := Equation.EQUALITY(expRHS, expLHS, ty, InstNode.EMPTY_NODE(), source);
 
-        eqsEqualityConstraint := {replaceEq};
+          eqsEqualityConstraint := {replaceEq};
 
-        return;
-      end if;
+          return;
+        end if;
+      end for;
     end for;
   end for;
 end generateEqualityConstraintEquation;
@@ -336,7 +338,8 @@ function getOverconstrainedCrefs
 protected
   list<Connector> conns;
 algorithm
-  conns := Connector.split(conn, scalarize = NFConnector.ScalarizeSetting.PREFIX);
+  conns := Connector.split(conn);
+  conns := List.mapFlat(conns, Connector.scalarizePrefix);
   crefs := list(getOverconstrainedCref(c.name) for c
     guard not isDeleted(c.name) and isOverconstrainedCref(c.name) in conns);
   crefs := List.uniqueOnTrue(crefs, ComponentRef.isEqual);

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1451,6 +1451,10 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
+constant ConfigFlag ARRAY_CONNECT_MIN_SIZE = CONFIG_FLAG(155, "arrayConnectMinSize",
+  NONE(), EXTERNAL(), INT_FLAG(100), NONE(),
+  Gettext.gettext("The minimum size of array connections for -d=arrayConnect to have effect"));
+
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -409,7 +409,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.SIMULATION,
   Flags.OBFUSCATE,
   Flags.FMU_RUNTIME_DEPENDS,
-  Flags.FRONTEND_INLINE
+  Flags.FRONTEND_INLINE,
+  Flags.ARRAY_CONNECT_MIN_SIZE
 };
 
 public function new

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect1.mo
@@ -1,7 +1,7 @@
 // name: ArrayConnect1
 // keywords:
 // status: correct
-// cflags: -d=newInst,arrayConnect,-nfScalarize
+// cflags: -d=newInst,arrayConnect,-nfScalarize --arrayConnectMinSize=10
 //
 
 connector C

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect3.mo
@@ -83,13 +83,13 @@ end ArrayConnect3;
 //     cells[$i1,100].r.f + cells[$i1,1].l.f = 0.0;
 //   end for;
 //   for $i2 in 1:100 loop
-//     cells[1000,$i2].d.e = S.n.e;
-//   end for;
-//   sum(cells[1000,:].d.f) + S.n.f = 0.0;
-//   for $i2 in 1:100 loop
 //     cells[1,$i2].u.e = S.p.e;
 //   end for;
 //   sum(cells[1,:].u.f) + S.p.f = 0.0;
+//   for $i2 in 1:100 loop
+//     cells[1000,$i2].d.e = S.n.e;
+//   end for;
+//   sum(cells[1000,:].d.f) + S.n.f = 0.0;
 //   for $i1 in 1:999 loop
 //     cells[$i1,100].d.f = 0.0;
 //   end for;

--- a/testsuite/openmodelica/cppruntime/VectorizedSolarSystem.mo
+++ b/testsuite/openmodelica/cppruntime/VectorizedSolarSystem.mo
@@ -39,6 +39,7 @@ package Vectorized
     connect(plant.term, grid.terms);
   end SolarSystem;
 
+  annotation(uses(Modelica(version="3.2.3")));
 end Vectorized;
 
 model VectorizedSolarSystemTest = Vectorized.SolarSystem;

--- a/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
@@ -171,9 +171,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // Equations (13, 13)
 // ========================================
 // 1/1 (3): busBar1.terminal_n.v = fixedLoad1.terminal.v   [dynamic |0|0|0|0|]
-// 2/4 (3): busBar1.terminal_n.i + fixedLoad1.terminal.i = 0.0   [dynamic |0|0|0|0|]
-// 3/7 (1): fixedVoltageSource1.terminal.v = busBar1.terminal_p.v   [dynamic |0|0|0|0|]
-// 4/8 (1): fixedVoltageSource1.terminal.i + busBar1.terminal_p.i = 0.0   [dynamic |0|0|0|0|]
+// 2/4 (1): fixedVoltageSource1.terminal.v = busBar1.terminal_p.v   [dynamic |0|0|0|0|]
+// 3/5 (1): busBar1.terminal_p.i + fixedVoltageSource1.terminal.i = 0.0   [dynamic |0|0|0|0|]
+// 4/6 (3): busBar1.terminal_n.i + fixedLoad1.terminal.i = 0.0   [dynamic |0|0|0|0|]
 // 5/9 (1): fixedVoltageSource1.p = {fixedVoltageSource1.terminal.v * fixedVoltageSource1.terminal.i}   [dynamic |0|0|0|0|]
 // 6/10 (1): fixedVoltageSource1.terminal.v = {fixedVoltageSource1.V}   [dynamic |0|0|0|0|]
 // 7/11 (3): for $i1 in 1 : 3 loop
@@ -417,9 +417,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // Equations (13, 13)
 // ========================================
 // 1/1 (3): busBar1.terminal_n.v = fixedLoad1.terminal.v   [dynamic |0|0|0|0|]
-// 2/4 (3): busBar1.terminal_n.i + fixedLoad1.terminal.i = 0.0   [dynamic |0|0|0|0|]
-// 3/7 (1): fixedVoltageSource1.terminal.v = busBar1.terminal_p.v   [dynamic |0|0|0|0|]
-// 4/8 (1): fixedVoltageSource1.terminal.i + busBar1.terminal_p.i = 0.0   [dynamic |0|0|0|0|]
+// 2/4 (1): fixedVoltageSource1.terminal.v = busBar1.terminal_p.v   [dynamic |0|0|0|0|]
+// 3/5 (1): busBar1.terminal_p.i + fixedVoltageSource1.terminal.i = 0.0   [dynamic |0|0|0|0|]
+// 4/6 (3): busBar1.terminal_n.i + fixedLoad1.terminal.i = 0.0   [dynamic |0|0|0|0|]
 // 5/9 (1): fixedVoltageSource1.p = {fixedVoltageSource1.terminal.v * fixedVoltageSource1.terminal.i}   [dynamic |0|0|0|0|]
 // 6/10 (1): fixedVoltageSource1.terminal.v = {fixedVoltageSource1.V}   [dynamic |0|0|0|0|]
 // 7/11 (3): for $i1 in 1 : 3 loop
@@ -442,14 +442,14 @@ val(fixedVoltageSource1.p[1], 1.0);
 // var 2 is solved in eqn 10
 // var 3 is solved in eqn 9
 // var 4 is solved in eqn 13
-// var 5 is solved in eqn 2
+// var 5 is solved in eqn 4
 // var 6 is solved in eqn 12
-// var 7 is solved in eqn 3
+// var 7 is solved in eqn 2
 // var 8 is solved in eqn 1
 // var 9 is solved in eqn 8
 // var 10 is solved in eqn 7
 // var 11 is solved in eqn 5
-// var 12 is solved in eqn 4
+// var 12 is solved in eqn 3
 // var 13 is solved in eqn 6
 //
 //
@@ -458,15 +458,15 @@ val(fixedVoltageSource1.p[1], 1.0);
 // {12:6}
 // Array  {{10:2}}
 // Array  {{6:13}}
-// Array  {{4:12}}
+// Array  {{3:12}}
 // Array  {{5:11}}
-// Array  {{3:7}}
+// Array  {{2:7}}
 // Array  {{9:3}}
 // Array  {{11:1}}
 // {13:4}
 // Array  {{1:8}}
 // {8:9}
-// Array  {{2:5}}
+// Array  {{4:5}}
 // {7:10}
 //
 //

--- a/testsuite/openmodelica/cppruntime/testVectorizedSolarSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedSolarSystem.mos
@@ -52,7 +52,7 @@ val(grid.P_grid, 0.0);
 // Equations (7, 7)
 // ========================================
 // 1/1 (1000): plant.term.v = grid.terms.v   [dynamic |0|0|0|0|]
-// 2/1001 (1000): plant.term.i + grid.terms.i = 0.0   [dynamic |0|0|0|0|]
+// 2/1001 (1000): grid.terms.i + plant.term.i = 0.0   [dynamic |0|0|0|0|]
 // 3/2001 (1000): for $i1 in 1 : 1000 loop
 //     plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0; end for;    [dynamic |0|0|0|0|]
 // 4/3001 (1000): for i in 1 : 1000 loop
@@ -100,7 +100,7 @@ val(grid.P_grid, 0.0);
 // Equations (7, 7)
 // ========================================
 // 1/1 (1000): plant.term.v = grid.terms.v   [dynamic |0|0|0|0|]
-// 2/1001 (1000): plant.term.i + grid.terms.i = 0.0   [dynamic |0|0|0|0|]
+// 2/1001 (1000): grid.terms.i + plant.term.i = 0.0   [dynamic |0|0|0|0|]
 // 3/2001 (1000): for $i1 in 1 : 1000 loop
 //     plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0; end for;    [dynamic |0|0|0|0|]
 // 4/3001 (1000): for i in 1 : 1000 loop

--- a/testsuite/openmodelica/flatmodelica/SD.mo
+++ b/testsuite/openmodelica/flatmodelica/SD.mo
@@ -1,7 +1,7 @@
 // name: SD
 // keywords:
 // status: correct
-// cflags: -d=newInst,-nfScalarize,arrayConnect,combineSubscripts -f
+// cflags: -d=newInst,-nfScalarize,arrayConnect,combineSubscripts -f --arrayConnectMinSize=3
 //
 
 connector C

--- a/testsuite/simulation/modelica/NBackend/array_handling/exemplary.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/exemplary.mos
@@ -48,11 +48,11 @@ val(x[4,2],1);
 // BLOCK: Sliced Component (status = Solve.UNPROCESSED)
 // ----------------------------------------
 // ### Variable:
-// 	x[3, j]
+// 	y[j]
 // ### Equation:
 // 	[FOR-] (22) ($RES_SIM_0)
 // 	[----] for j in 1:22 loop
-// 	[----]   [SCAL] (1) x[3, j] = CAST(Real, j) * cos(time)
+// 	[----]   [SCAL] (1) y[j] = CAST(Real, j) * sin(time)
 // 	[----] end for;
 // 	 slice: {21, 20, 19, 18, 17, 16, 15, 14, 13, 12, ...}
 //
@@ -63,7 +63,7 @@ val(x[4,2],1);
 // ### Equation:
 // 	[FOR-] (22) ($RES_SIM_0)
 // 	[----] for j in 1:22 loop
-// 	[----]   [SCAL] (1) x[3, j] = CAST(Real, j) * cos(time)
+// 	[----]   [SCAL] (1) y[j] = CAST(Real, j) * sin(time)
 // 	[----] end for;
 // 	 slice: {21, 20, 19, 18, 17, 16, 15, 14, 13, 12, ...}
 //
@@ -72,11 +72,11 @@ val(x[4,2],1);
 // BLOCK: Sliced Component (status = Solve.UNPROCESSED)
 // ----------------------------------------
 // ### Variable:
-// 	y[j]
+// 	x[3, j]
 // ### Equation:
 // 	[FOR-] (22) ($RES_SIM_1)
 // 	[----] for j in 1:22 loop
-// 	[----]   [SCAL] (1) y[j] = CAST(Real, j) * sin(time)
+// 	[----]   [SCAL] (1) x[3, j] = CAST(Real, j) * cos(time)
 // 	[----] end for;
 // 	 slice: {21, 20, 19, 18, 17, 16, 15, 14, 13, 12, ...}
 //
@@ -87,7 +87,7 @@ val(x[4,2],1);
 // ### Equation:
 // 	[FOR-] (22) ($RES_SIM_1)
 // 	[----] for j in 1:22 loop
-// 	[----]   [SCAL] (1) y[j] = CAST(Real, j) * sin(time)
+// 	[----]   [SCAL] (1) x[3, j] = CAST(Real, j) * cos(time)
 // 	[----] end for;
 // 	 slice: {21, 20, 19, 18, 17, 16, 15, 14, 13, 12, ...}
 //


### PR DESCRIPTION
- Only use the array connection handling on models that contain large array connections.
- Split the splitting and scalarization of connectors into two separate phases, to allow better control over the scalarization.