### PR TITLE
Use same expression if fail to find the variable binding expression

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/DynamicAnnotation.cpp
@@ -93,7 +93,12 @@ void DynamicAnnotation::evaluate(ModelInstance::Model *pModel)
               auto vname = QString::fromStdString(name);
               // the instance api returns the qualified cref
               vname = StringHandler::getLastWordAfterDot(vname);
-              return pModel->getVariableBinding(vname);
+              FlatModelica::Expression exp = pModel->getVariableBinding(vname);
+              if (exp.isNull()) {
+                return mExp;
+              } else {
+                return exp;
+              }
             }));
   } catch (const std::exception &e) {
     qDebug() << "Failed to evaluate expression.";


### PR DESCRIPTION
@perost we might fail to parse the variable binding expression in that case just use the same expression as it is. This avoids the crash of null pointer expression.