### PR TITLE
Improve uninitialized output error message

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -2611,6 +2611,8 @@ protected
   protected
     Vector<InstNode> unassigned;
     list<Statement> body;
+    InstNode parent;
+    list<SourceInfo> sources;
   algorithm
     // Skip external and builtin functions.
     if isExternal(fn) or isBuiltin(fn) then
@@ -2626,7 +2628,14 @@ protected
 
     for var in Vector.toList(unassigned) loop
       if InstNode.isOutput(var) then
-        Error.addSourceMessage(Error.UNASSIGNED_FUNCTION_OUTPUT, {InstNode.name(var)}, InstNode.info(var));
+        parent := InstNode.InstNode.parent(var);
+        sources := {InstNode.info(var)};
+
+        if InstNode.isBaseClass(parent) then
+          sources := InstNode.info(InstNode.getDerivedNode(parent)) :: sources;
+        end if;
+
+        Error.addMultiSourceMessage(Error.UNASSIGNED_FUNCTION_OUTPUT, {InstNode.name(var)}, sources);
         fail();
       end if;
     end for;

--- a/testsuite/flattening/modelica/scodeinst/FunctionUnitialized4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionUnitialized4.mo
@@ -1,0 +1,30 @@
+// name: FunctionUnitialized4
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+model FunctionUnitialized4
+  partial function pf
+    input Real x;
+    output Real y;
+  end pf;
+
+  function f
+    extends pf;
+  end f;
+
+  Real x = f(time);
+end FunctionUnitialized4;
+
+// Result:
+// Error processing file: FunctionUnitialized4.mo
+// [flattening/modelica/scodeinst/FunctionUnitialized4.mo:14:3-16:8:writable] Notification: From here:
+// [flattening/modelica/scodeinst/FunctionUnitialized4.mo:11:5-11:18:writable] Error: Output parameter y was not assigned a value
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -665,6 +665,7 @@ FunctionStreamPrefix.mo \
 FunctionUnitialized1.mo \
 FunctionUnitialized2.mo \
 FunctionUnitialized3.mo \
+FunctionUnitialized4.mo \
 IfConnect1.mo \
 IfConnect2.mo \
 IfConnect3.mo \


### PR DESCRIPTION
- Also print the source info for the derived function when the uninitialized output comes from an extends, to give a better clue about where the assignment might be missing.