### PR TITLE
fix #9776 correct typo: % instead of &

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1003,7 +1003,7 @@ QString LineAnnotation::getShapeAnnotation()
   }
   // get the line pattern
   if (mLinePattern.isDynamicSelectExpression() || mLinePattern.toQString().compare(QStringLiteral("LinePattern.LineSolid")) != 0) {
-    annotationString.append(QString("pattern=&1").arg(mLinePattern.toQString()));
+    annotationString.append(QString("pattern=%1").arg(mLinePattern.toQString()));
   }
   // get the thickness
   if (mLineThickness.isDynamicSelectExpression() || mLineThickness.toQString().compare(QStringLiteral("0.25")) != 0) {


### PR DESCRIPTION
Fix bug introduced in PR https://github.com/OpenModelica/OpenModelica/pull/9750, use % instead of &.
We should maybe log the errors we get from OMC when sendExpression doesn't get the expected result.