### PR TITLE
Improve assert message handling and reporting at simulation time.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3131,7 +3131,7 @@ match system
           for (j=0; j<<%listLength(nls.crefs)%>; j++) {
             res[j] = NAN;
           }
-          throwStreamPrintWithEquationIndexes(threadData, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+          throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
           <%if intEq(whichSet, 0) then "return;" else "return 1;"%>
         }
       }
@@ -6090,7 +6090,7 @@ case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = at) th
   /* check if solution process was successful */
   if (retValue > 0){
     const int indexes[2] = {1,<%ls.index%>};
-    throwStreamPrintWithEquationIndexes(threadData, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
+    throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
     <%returnval2%>
   }
   /* write solution */
@@ -6204,7 +6204,7 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       /* check if solution process was successful */
       if (retValue > 0){
         const int indexes[2] = {1,<%nls.index%>};
-        throwStreamPrintWithEquationIndexes(threadData, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+        throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
         <%returnval2%>
       }
       /* write solution */

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1230,7 +1230,6 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
     %>
 
     /* dummy VARINFO and FILEINFO */
-    const FILE_INFO dummyFILE_INFO = omc_dummyFileInfo;
     const VAR_INFO dummyVAR_INFO = omc_dummyVarInfo;
 
     <%functionInput(simCode, modelInfo, modelNamePrefixStr)%>

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -2358,8 +2358,7 @@ template varOutput(Variable var)
       <<
       if (out<%funArgName(var)%>) {
         if (out<%funArgName(var)%>->info == NULL) {
-          FILE_INFO info = omc_dummyFileInfo;
-          omc_assert(threadData, info, "Unknown size parallel array.");
+          omc_assert(threadData, omc_dummyFileInfo, "Unknown size parallel array.");
         }
         else {
           <%expTypeShort(var.ty)%>_array_copy_data(<%funArgName(var)%>, *out<%funArgName(var)%>);
@@ -3502,7 +3501,7 @@ case RANGE(__) then
                     case "1"
                     case "((modelica_integer) 1)"
                     case "((modelica_integer) -1)" then ''
-                    else 'if(!<%stepVar%>) {<%\n%>  FILE_INFO info = omc_dummyFileInfo;<%\n%>  omc_assert<%AddionalFuncName%>(threadData, info, <%eqnsindx%>"assertion range step != 0 failed");<%\n%>} else '
+                    else 'if(!<%stepVar%>) {<%\n%>  omc_assert<%AddionalFuncName%>(threadData, omc_dummyFileInfo, <%eqnsindx%>"assertion range step != 0 failed");<%\n%>} else '
   <<
   <%preExp%>
   <%startVar%> = <%startValue%>; <%stepVar%> = <%stepValue%>; <%stopVar%> = <%stopValue%>;
@@ -4566,8 +4565,7 @@ template assertCommonVar(Text condVar, Text msgVar, Context context, Text &varDe
     <<
     if(!(<%condVar%>))
     {
-      FILE_INFO info = omc_dummyFileInfo;
-      omc_assert(threadData, info, "Common assertion failed");
+      omc_assert(threadData, omc_dummyFileInfo, "Common assertion failed");
     }
     >>
   case FUNCTION_CONTEXT(__) then
@@ -7369,8 +7367,7 @@ template daeExpReduction(Exp exp, Context context, Text &preExp,
       let check =
       <<
       if (<%stepVar%> == 0) {
-        FILE_INFO info = omc_dummyFileInfo;
-        omc_assert(threadData, info, "Range with a step of zero.");
+        omc_assert(threadData, omc_dummyFileInfo, "Range with a step of zero.");
       }<%\n%>
       >>
       match iter.exp

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4595,7 +4595,7 @@ template assertCommonVar(Text condVar, Text msgVar, Context context, Text &varDe
       } else {
         FILE_INFO info = {<%infoArgs(info)%>};
         omc_assert_warning(info, "The following assertion has been violated %sat time %f", initial() ? "during initialization " : "", data->localData[0]->timeValue);
-        throwStreamPrintWithEquationIndexes(threadData, equationIndexes, <%msgVar%>);
+        throwStreamPrintWithEquationIndexes(threadData, info, equationIndexes, <%msgVar%>);
       }
     }
     >>

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4533,8 +4533,7 @@ template assertCommon(Exp condition, list<Exp> messages, Exp level, Context cont
       infoStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, equationIndexes, <%infoTextContext%>);<%rethrow%>
     } else {
       FILE_INFO info = {<%infoArgs(info)%>};
-      omc_assert_warning(info, <%infoTextContext%>);
-      <%omcAssertFunc%>info, equationIndexes, <%msgVar%>);
+      <%omcAssertFunc%>info, equationIndexes, <%infoTextContext%>);
     }
     >>
   let warningTriggered = tempDeclZero("static int", &varDecls)

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4525,7 +4525,8 @@ template assertCommon(Exp condition, list<Exp> messages, Exp level, Context cont
     else
     <<
     if (data->simulationInfo->noThrowAsserts) {
-      infoStreamPrintWithEquationIndexes(LOG_ASSERT, 0, equationIndexes, <%infoTextContext%>);
+      FILE_INFO info = {<%infoArgs(info)%>};
+      infoStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, equationIndexes, <%infoTextContext%>);
       infoStreamPrint(LOG_ASSERT, 0, "%s", <%msgVar%>);<%rethrow%>
     } else {
       FILE_INFO info = {<%infoArgs(info)%>};
@@ -4588,7 +4589,8 @@ template assertCommonVar(Text condVar, Text msgVar, Context context, Text &varDe
     if(!(<%condVar%>))
     {
       if (data->simulationInfo->noThrowAsserts) {
-        infoStreamPrintWithEquationIndexes(LOG_ASSERT, 0, equationIndexes, "The following assertion has been violated %sat time %f", initial() ? "during initialization " : "", data->localData[0]->timeValue);
+        FILE_INFO info = {<%infoArgs(info)%>};
+        infoStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, equationIndexes, "The following assertion has been violated %sat time %f", initial() ? "during initialization " : "", data->localData[0]->timeValue);
         data->simulationInfo->needToReThrow = 1;
       } else {
         FILE_INFO info = {<%infoArgs(info)%>};

--- a/OMCompiler/SimulationRuntime/c/gc/omc_gc.c
+++ b/OMCompiler/SimulationRuntime/c/gc/omc_gc.c
@@ -104,11 +104,10 @@ void mmc_set_current_pos(const char *pos)
 void mmc_do_out_of_memory()
 {
   threadData_t *threadData = (threadData_t*)pthread_getspecific(mmc_thread_data_key);
-  FILE_INFO info = omc_dummyFileInfo;
 #if (defined(OMC_MINIMAL_RUNTIME) || defined(OMC_FMI_RUNTIME))
-  omc_assert(threadData, info, "Out of memory!");
+  omc_assert(threadData, omc_dummyFileInfo, "Out of memory!");
 #else
-  omc_assert_warning(info, "Out of memory! Faking a stack overflow.");
+  omc_assert_warning(omc_dummyFileInfo, "Out of memory! Faking a stack overflow.");
   mmc_do_stackoverflow(threadData);
 #endif
   abort();  // Silence invalid noreturn warning. This is never reached.

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -417,7 +417,6 @@ static const char* readEquations(const char *str, MODEL_DATA_XML *xml)
 
 static const char* readFunction(const char *str, FUNCTION_INFO *xml, int i, const char* fileName)
 {
-  FILE_INFO info = omc_dummyFileInfo;
   size_t len;
   char *name;
   const char *str2;
@@ -430,7 +429,7 @@ static const char* readFunction(const char *str, FUNCTION_INFO *xml, int i, cons
   memcpy(name, str2, len-1);
   name[len-1] = '\0';
   xml->name = name;
-  xml->info = info;
+  xml->info = omc_dummyFileInfo;
   return str;
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_omc_assert.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_omc_assert.c
@@ -76,13 +76,13 @@ static void va_omc_assert_simulation_withEquationIndexes(threadData_t *threadDat
   {
   case ERROR_EVENTSEARCH:
   case ERROR_SIMULATION:
-    va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, 0, indexes, msg, args);
+    va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, indexes, msg, args);
     longjmp(*threadData->simulationJumpBuffer,1);
     break;
   case ERROR_NONLINEARSOLVER:
     if(ACTIVE_STREAM(LOG_NLS))
     {
-      va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, 0, indexes, msg, args);
+      va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, indexes, msg, args);
     }
 #ifndef OMC_EMCC
     longjmp(*threadData->simulationJumpBuffer,1);
@@ -91,17 +91,17 @@ static void va_omc_assert_simulation_withEquationIndexes(threadData_t *threadDat
   case ERROR_INTEGRATOR:
     if(ACTIVE_STREAM(LOG_SOLVER))
     {
-      va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, 0, indexes, msg, args);
+      va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, indexes, msg, args);
     }
     longjmp(*threadData->simulationJumpBuffer,1);
     break;
   case ERROR_EVENTHANDLING:
-    va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, 0, indexes, msg, args);
+    va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, indexes, msg, args);
     longjmp(threadData->globalJumpBuffer ? *threadData->globalJumpBuffer : *threadData->mmc_jumper, 1);
     break;
   case ERROR_OPTIMIZE:
   default:
-    va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, 0, indexes, msg, args);
+    va_errorStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, indexes, msg, args);
     throwStreamPrint(threadData, "Untreated assertion has been detected.");
   }
 }
@@ -127,7 +127,7 @@ void omc_assert_simulation_withEquationIndexes(threadData_t *threadData, FILE_IN
 
 static void va_omc_assert_warning_simulation(FILE_INFO info, const int *indexes, const char *msg, va_list args)
 {
-  va_warningStreamPrintWithEquationIndexes(LOG_ASSERT, 0, indexes, msg, args);
+  va_warningStreamPrintWithEquationIndexes(LOG_ASSERT, info, 0, indexes, msg, args);
 }
 
 void omc_assert_warning_simulation(FILE_INFO info, const char *msg, ...)

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1281,7 +1281,7 @@ static inline void sendXMLTCPIfClosed()
   }
 }
 
-static void messageXMLTCP(int type, int stream, int indentNext, char *msg, int subline, const int *indexes)
+static void messageXMLTCP(int type, int stream, FILE_INFO info, int indentNext, char *msg, int subline, const int *indexes)
 {
   numOpenTags++;
   xmlTcpStream << "<message stream=\"" << LOG_STREAM_NAME[stream] << "\" type=\"" << LOG_TYPE_DESC[type] << "\" text=\"";
@@ -1338,7 +1338,7 @@ static void printEscapedXML(const char *msg)
   }
 }
 
-static void messageXML(int type, int stream, int indentNext, char *msg, int subline, const int *indexes)
+static void messageXML(int type, int stream, FILE_INFO info, int indentNext, char *msg, int subline, const int *indexes)
 {
   printf("<message stream=\"%s\" type=\"%s\" text=\"", LOG_STREAM_NAME[stream], LOG_TYPE_DESC[type]);
   printEscapedXML(msg);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
@@ -100,7 +100,7 @@ int checkForStateEvent(DATA* data, LIST *eventList)
   {
     int *eq_indexes;
     const char *exp_str = data->callback->zeroCrossingDescription(i,&eq_indexes);
-    debugStreamPrintWithEquationIndexes(LOG_EVENTS, 1, eq_indexes, "%s", exp_str);
+    debugStreamPrintWithEquationIndexes(LOG_EVENTS, omc_dummyFileInfo, 1, eq_indexes, "%s", exp_str);
 
     if(sign(data->simulationInfo->zeroCrossings[i]) != sign(data->simulationInfo->zeroCrossingsPre[i]))
     {
@@ -234,7 +234,7 @@ void handleEvents(DATA* data, threadData_t *threadData, LIST* eventLst, double *
         data->simulationInfo->chatteringInfo.messageEmitted = 1;
         if (omc_flag[FLAG_ABORT_SLOW])
         {
-          throwStreamPrintWithEquationIndexes(threadData, eq_indexes, "Aborting simulation due to chattering being detected and the simulation flags requesting we do not continue further.");
+          throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, eq_indexes, "Aborting simulation due to chattering being detected and the simulation flags requesting we do not continue further.");
         }
       }
     }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
@@ -211,7 +211,7 @@ void handleEvents(DATA* data, threadData_t *threadData, LIST* eventLst, double *
         long ix = *((long*) listNodeData(it));
         int *eq_indexes;
         const char *exp_str = data->callback->zeroCrossingDescription(ix,&eq_indexes);
-        infoStreamPrintWithEquationIndexes(LOG_EVENTS, 0, eq_indexes, "[%ld] %s", ix+1, exp_str);
+        infoStreamPrintWithEquationIndexes(LOG_EVENTS, omc_dummyFileInfo, 0, eq_indexes, "[%ld] %s", ix+1, exp_str);
       }
     }
 
@@ -230,7 +230,7 @@ void handleEvents(DATA* data, threadData_t *threadData, LIST* eventLst, double *
         long ix = *((long*) listNodeData(listFirstNode(eventLst)));
         int *eq_indexes;
         const char *exp_str = data->callback->zeroCrossingDescription(ix,&eq_indexes);
-        infoStreamPrintWithEquationIndexes(LOG_STDOUT, 0, eq_indexes, "Chattering detected around time %.12g..%.12g (%d state events in a row with a total time delta less than the step size %.12g). This can be a performance bottleneck. Use -lv LOG_EVENTS for more information. The zero-crossing was: %s", t0, time, numEventLimit, data->simulationInfo->stepSize, exp_str);
+        infoStreamPrintWithEquationIndexes(LOG_STDOUT, omc_dummyFileInfo, 0, eq_indexes, "Chattering detected around time %.12g..%.12g (%d state events in a row with a total time delta less than the step size %.12g). This can be a performance bottleneck. Use -lv LOG_EVENTS for more information. The zero-crossing was: %s", t0, time, numEventLimit, data->simulationInfo->stepSize, exp_str);
         data->simulationInfo->chatteringInfo.messageEmitted = 1;
         if (omc_flag[FLAG_ABORT_SLOW])
         {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -1175,7 +1175,7 @@ NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR
   double *xStart = NV_DATA_S(kinsolData->initialGuess);
   double fNormValue;
 
-  infoStreamPrintWithEquationIndexes(LOG_NLS_V, 1, indexes,
+  infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes,
                                      "Start Kinsol solver at time %g",
                                      data->localData[0]->timeValue);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
@@ -194,7 +194,7 @@ int solveKlu(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
   double tmpJacEvalTime;
   int reuseMatrixJac = (data->simulationInfo->currentContext == CONTEXT_SYM_JACOBIAN && data->simulationInfo->currentJacobianEval > 0);
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Klu Solver",
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Klu Solver",
    eqSystemNumber, (int) systemData->size,
    data->localData[0]->timeValue);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
@@ -185,7 +185,7 @@ int solveLapack(DATA *data, threadData_t *threadData, int sysNumber, double* aux
   double tmpJacEvalTime;
   int reuseMatrixJac = (data->simulationInfo->currentContext == CONTEXT_SYM_JACOBIAN && data->simulationInfo->currentJacobianEval > 0);
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Lapack Solver",
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Lapack Solver",
          eqSystemNumber, (int) systemData->size,
          data->localData[0]->timeValue);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -211,7 +211,7 @@ int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 
   int indexes[2] = {1,eqSystemNumber};
   double tmpJacEvalTime;
-  infoStreamPrintWithEquationIndexes(LOG_LS, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Lis Solver",
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Lis Solver",
          eqSystemNumber, (int) systemData->size,
          data->localData[0]->timeValue);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -410,7 +410,7 @@ int solveTotalPivot(DATA *data, threadData_t *threadData, int sysNumber, double*
   int success = 1;
   double tmpJacEvalTime;
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Total Pivot Solver",
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Total Pivot Solver",
          eqSystemNumber, (int) systemData->size,
          data->localData[0]->timeValue);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -205,7 +205,7 @@ solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
   double tmpJacEvalTime;
   int reuseMatrixJac = (data->simulationInfo->currentContext == CONTEXT_SYM_JACOBIAN && data->simulationInfo->currentJacobianEval > 0);
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, 0, indexes, "Start solving Linear System %d (size %d) at time %g with UMFPACK Solver",
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with UMFPACK Solver",
    eqSystemNumber, (int) systemData->size,
    data->localData[0]->timeValue);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -746,9 +746,9 @@ int check_linear_solution(DATA *data, int printFailingSystems, int sysNumber)
       return 1;
     }
 #ifdef USE_PARJAC
-    warningStreamPrintWithEquationIndexes(LOG_STDOUT, 1, indexes, "Thread %u: Solving linear system %d fails at time %g. For more information use -lv LOG_LS.", omc_get_thread_num(), index, data->localData[0]->timeValue);
+    warningStreamPrintWithEquationIndexes(LOG_STDOUT, omc_dummyFileInfo, 1, indexes, "Thread %u: Solving linear system %d fails at time %g. For more information use -lv LOG_LS.", omc_get_thread_num(), index, data->localData[0]->timeValue);
 #else
-    warningStreamPrintWithEquationIndexes(LOG_STDOUT, 1, indexes, "Solving linear system %d fails at time %g. For more information use -lv LOG_LS.", index, data->localData[0]->timeValue);
+    warningStreamPrintWithEquationIndexes(LOG_STDOUT, omc_dummyFileInfo, 1, indexes, "Solving linear system %d fails at time %g. For more information use -lv LOG_LS.", index, data->localData[0]->timeValue);
 #endif
 
     for(j=0; j<modelInfoGetEquation(&data->modelData->modelDataXml, (linsys[i]).equationIndex).numVar; ++j) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSystem.c
@@ -214,7 +214,7 @@ int initializeLinearSystems(DATA *data, threadData_t *threadData)
       case LSS_DEFAULT:
         {
           int indexes[2] = {1, linsys[i].equationIndex};
-          infoStreamPrintWithEquationIndexes(LOG_STDOUT, 0, indexes, "The simulation runtime does not have access to sparse solvers. Defaulting to a dense linear system solver instead.");
+          infoStreamPrintWithEquationIndexes(LOG_STDOUT, omc_dummyFileInfo, 0, indexes, "The simulation runtime does not have access to sparse solvers. Defaulting to a dense linear system solver instead.");
           linsys[i].useSparseSolver = 0;
           break;
         }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -559,7 +559,7 @@ void printZeroCrossings(DATA *data, int stream)
   {
     int *eq_indexes;
     const char *exp_str = data->callback->zeroCrossingDescription(i,&eq_indexes);
-    infoStreamPrintWithEquationIndexes(stream, 0, eq_indexes, "[%ld] (pre: %2.g) %2.g = %s", i+1, data->simulationInfo->zeroCrossingsPre[i], data->simulationInfo->zeroCrossings[i], exp_str);
+    infoStreamPrintWithEquationIndexes(stream, omc_dummyFileInfo, 0, eq_indexes, "[%ld] (pre: %2.g) %2.g = %s", i+1, data->simulationInfo->zeroCrossingsPre[i], data->simulationInfo->zeroCrossings[i], exp_str);
   }
   messageClose(stream);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -472,7 +472,7 @@ NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYS
   if(ACTIVE_STREAM(LOG_NLS_V))
   {
     int indexes[2] = {1,eqSystemNumber};
-    infoStreamPrintWithEquationIndexes(LOG_NLS_V, 1, indexes, "Start solving non-linear system >>%d<< using Hybrd solver at time %g", eqSystemNumber, data->localData[0]->timeValue);
+    infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes, "Start solving non-linear system >>%d<< using Hybrd solver at time %g", eqSystemNumber, data->localData[0]->timeValue);
     for(i=0; i<hybrdData->n; i++)
     {
       infoStreamPrint(LOG_NLS_V, 1, "%d. %s = %f", i+1, modelInfoGetEquation(&data->modelData->modelDataXml,eqSystemNumber).vars[i], nlsData->nlsx[i]);
@@ -715,7 +715,7 @@ NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYS
       {
         int indexes[2] = {1,eqSystemNumber};
         /* output solution */
-        infoStreamPrintWithEquationIndexes(LOG_NLS_V, 1, indexes, "solution for NLS %d at t=%g", eqSystemNumber, data->localData[0]->timeValue);
+        infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes, "solution for NLS %d at t=%g", eqSystemNumber, data->localData[0]->timeValue);
         for(i=0; i<hybrdData->n; ++i)
         {
           infoStreamPrint(LOG_NLS_V, 0, "[%d] %s = %g", i+1, modelInfoGetEquation(&data->modelData->modelDataXml,eqSystemNumber).vars[i],  hybrdData->x[i]);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverNewton.c
@@ -233,7 +233,7 @@ NLS_SOLVER_STATUS solveNewton(DATA *data, threadData_t *threadData, NONLINEAR_SY
   if(ACTIVE_STREAM(LOG_NLS_V))
   {
     int indexes[2] = {1,eqSystemNumber};
-    infoStreamPrintWithEquationIndexes(LOG_NLS_V, 1, indexes, "Start solving Non-Linear System %d at time %g with Newton Solver",
+    infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes, "Start solving Non-Linear System %d at time %g with Newton Solver",
         eqSystemNumber, data->localData[0]->timeValue);
 
     for(i = 0; i < solverData->n; i++) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -1430,7 +1430,7 @@ int check_nonlinear_solution(DATA *data, int printFailingSystems, int sysNumber)
   {
     int index = nonlinsys[i].equationIndex, indexes[2] = {1,index};
     if (!printFailingSystems) return 1;
-    warningStreamPrintWithEquationIndexes(LOG_NLS, 0, indexes, "nonlinear system %d fails: at t=%g", index, data->localData[0]->timeValue);
+    warningStreamPrintWithEquationIndexes(LOG_NLS, omc_dummyFileInfo, 0, indexes, "nonlinear system %d fails: at t=%g", index, data->localData[0]->timeValue);
     if(data->simulationInfo->initial)
     {
       warningStreamPrint(LOG_INIT, 1, "proper start-values for some of the following iteration variables might help");

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -46,9 +46,9 @@
 #include "util/simulation_options.h"
 #include "util/context.h"
 
-#define omc_dummyVarInfo {-1,-1,"","",omc_dummyFileInfo}
+#define omc_dummyVarInfo {-1,-1,"","",omc_dummyFileInfo_val}
 #define omc_dummyEquationInfo {-1,0,0,-1,NULL}
-#define omc_dummyFunctionInfo {-1,"",omc_dummyFileInfo}
+#define omc_dummyFunctionInfo {-1,"",omc_dummyFileInfo_val}
 #define omc_dummyRealAttribute {NULL,NULL,-DBL_MAX,DBL_MAX,0,0,1.0,0.0}
 
 #define OMC_LINEARIZE_DUMP_LANGUAGE_MODELICA 0

--- a/OMCompiler/SimulationRuntime/c/util/base_array.c
+++ b/OMCompiler/SimulationRuntime/c/util/base_array.c
@@ -388,8 +388,7 @@ size_t calc_base_index_dims_subs(int ndims,...)
     index = 0;
     for(i = 0; i < ndims; ++i) {
         if (subs[i] < 0 || subs[i] >= dims[i]) {
-          FILE_INFO info = omc_dummyFileInfo;
-          omc_assert(NULL, info, "Dimension %d has bounds 1..%d, got array subscript %d", i+1, dims[i], subs[i]+1);
+          omc_assert(NULL, omc_dummyFileInfo, "Dimension %d has bounds 1..%d, got array subscript %d", i+1, dims[i], subs[i]+1);
         }
         index = (index * dims[i]) + subs[i];
     }
@@ -408,8 +407,7 @@ size_t calc_base_index_va(const base_array_t *source, int ndims, va_list ap)
     for(i = 0; i < ndims; ++i) {
         int sub_i = va_arg(ap, _index_t) - 1;
         if (sub_i < 0 || sub_i >= source->dim_size[i]) {
-          FILE_INFO info = omc_dummyFileInfo;
-          omc_assert(NULL, info, "Dimension %d has bounds 1..%d, got array subscript %d", i+1, source->dim_size[i], sub_i+1);
+          omc_assert(NULL, omc_dummyFileInfo, "Dimension %d has bounds 1..%d, got array subscript %d", i+1, source->dim_size[i], sub_i+1);
         }
         index = (index * source->dim_size[i]) + sub_i;
     }

--- a/OMCompiler/SimulationRuntime/c/util/division.c
+++ b/OMCompiler/SimulationRuntime/c/util/division.c
@@ -46,9 +46,9 @@ int valid_number(double a)
 modelica_real division_error_equation_time(threadData_t *threadData, modelica_real a, modelica_real b, const char *msg, const int *indexes, modelica_real time, modelica_boolean noThrow)
 {
   if(noThrow){
-    warningStreamPrintWithEquationIndexes(LOG_UTIL, 0, indexes, "solver will try to handle division by zero at time %.16g: %s", time, msg);
+    warningStreamPrintWithEquationIndexes(LOG_UTIL, omc_dummyFileInfo, 0, indexes, "solver will try to handle division by zero at time %.16g: %s", time, msg);
   } else {
-    throwStreamPrintWithEquationIndexes(threadData, indexes, "division by zero at time %.16g, (a=%.16g) / (b=%.16g), where divisor b expression is: %s", time, a, b, msg);
+    throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "division by zero at time %.16g, (a=%.16g) / (b=%.16g), where divisor b expression is: %s", time, a, b, msg);
   }
   return b;
 }

--- a/OMCompiler/SimulationRuntime/c/util/division.h
+++ b/OMCompiler/SimulationRuntime/c/util/division.h
@@ -64,10 +64,10 @@ static inline modelica_real __OMC_DIV_SIM(threadData_t *threadData, const modeli
 
   if(!valid_number(res)){
     if(noThrowDivZero) {
-      warningStreamPrintWithEquationIndexes(LOG_UTIL, 0, equationIndexes, "division leads to inf or nan at time %g, (a=%g) / (b=%g), where divisor b is: %s", time_, a, b, msg);
+      warningStreamPrintWithEquationIndexes(LOG_UTIL, omc_dummyFileInfo, 0, equationIndexes, "division leads to inf or nan at time %g, (a=%g) / (b=%g), where divisor b is: %s", time_, a, b, msg);
     }
     else {
-      throwStreamPrintWithEquationIndexes(threadData, equationIndexes, "division leads to inf or nan at time %g, (a=%g) / (b=%g), where divisor b is: %s", time_, a, b, msg);
+      throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, equationIndexes, "division leads to inf or nan at time %g, (a=%g) / (b=%g), where divisor b is: %s", time_, a, b, msg);
     }
   }
   return res;

--- a/OMCompiler/SimulationRuntime/c/util/modelica_string.c
+++ b/OMCompiler/SimulationRuntime/c/util/modelica_string.c
@@ -39,12 +39,10 @@
 
 #define FMT_BUFSIZE 400
 
-static const FILE_INFO dummyFILE_INFO = omc_dummyFileInfo;
-
 static inline void checkBufSize(const char *str, int n)
 {
   if (n >= FMT_BUFSIZE) {
-    omc_assert(NULL, dummyFILE_INFO, "Could not parse format string; ran out of buffer size (%d): %s", FMT_BUFSIZE, str);
+    omc_assert(NULL, omc_dummyFileInfo, "Could not parse format string; ran out of buffer size (%d): %s", FMT_BUFSIZE, str);
   }
 }
 
@@ -118,13 +116,13 @@ modelica_string modelica_string_format_to_c_string_format(modelica_string format
   case 'j':
   case 'z':
   case 't':
-    omc_assert(NULL, dummyFILE_INFO, "Length modifiers are not legal in Modelica format strings: %s", str);
+    omc_assert(NULL, omc_dummyFileInfo, "Length modifiers are not legal in Modelica format strings: %s", str);
     break;
   default:
-    omc_assert(NULL, dummyFILE_INFO, "Could not parse format string: invalid conversion specifier: %c in %s", *tmp, str);
+    omc_assert(NULL, omc_dummyFileInfo, "Could not parse format string: invalid conversion specifier: %c in %s", *tmp, str);
   }
   if (*tmp) {
-    omc_assert(NULL, dummyFILE_INFO, "Could not parse format string: trailing data after the format directive", *tmp, str);
+    omc_assert(NULL, omc_dummyFileInfo, "Could not parse format string: trailing data after the format directive", *tmp, str);
   }
   buf[n] = '\0';
   return mmc_mk_scon(buf);
@@ -168,7 +166,7 @@ modelica_string modelica_integer_to_modelica_string_format(modelica_integer i,mo
     break;
   default:
     /* integer values, etc */
-    omc_assert(NULL, dummyFILE_INFO, "Invalid conversion specifier for Real: %c", MMC_STRINGDATA(c_fmt)[MMC_STRLEN(c_fmt)-1]);
+    omc_assert(NULL, omc_dummyFileInfo, "Invalid conversion specifier for Real: %c", MMC_STRINGDATA(c_fmt)[MMC_STRLEN(c_fmt)-1]);
   }
   return res;
 }
@@ -194,7 +192,7 @@ modelica_string modelica_real_to_modelica_string_format(modelica_real r,modelica
     break;
   default:
     /* integer values, etc */
-    omc_assert(NULL, dummyFILE_INFO, "Invalid conversion specifier for Real: %c", MMC_STRINGDATA(c_fmt)[MMC_STRLEN(c_fmt)-1]);
+    omc_assert(NULL, omc_dummyFileInfo, "Invalid conversion specifier for Real: %c", MMC_STRINGDATA(c_fmt)[MMC_STRLEN(c_fmt)-1]);
   }
   return res;
 }

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -34,6 +34,8 @@
 /* For MMC_THROW, so we can end this thing */
 #include "../meta/meta_modelica.h"
 
+const FILE_INFO omc_dummyFileInfo = omc_dummyFileInfo_val;
+
 void (*omc_assert)(threadData_t*,FILE_INFO info,const char *msg,...) __attribute__((noreturn)) = omc_assert_function;
 void (*omc_assert_warning)(FILE_INFO info,const char *msg,...) = omc_assert_warning_function;
 void (*omc_terminate)(FILE_INFO info,const char *msg,...) = omc_terminate_function;

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -306,7 +306,7 @@ void omc_terminate_function(FILE_INFO info, const char *msg, ...)
   MMC_THROW();
 }
 
-void messageText(int type, int stream, int indentNext, char *msg, int subline, const int *indexes)
+void messageText(int type, int stream, FILE_INFO info, int indentNext, char *msg, int subline, const int *indexes)
 {
   int i;
   int len;
@@ -326,7 +326,7 @@ void messageText(int type, int stream, int indentNext, char *msg, int subline, c
       msg[i] = '\0';
       printf("%s\n", msg);
       if (msg[i+1]) {
-        messageText(type, stream, 0, &msg[i+1], 1, indexes);
+        messageText(type, stream, info, 0, &msg[i+1], 1, indexes);
       }
       return;
     }
@@ -355,7 +355,7 @@ static void messageCloseTextWarning(int stream)
   }
 }
 
-void (*messageFunction)(int type, int stream, int indentNext, char *msg, int subline, const int *indexes) = messageText;
+void (*messageFunction)(int type, int stream, FILE_INFO info, int indentNext, char *msg, int subline, const int *indexes) = messageText;
 void (*messageClose)(int stream) = messageCloseText;
 void (*messageCloseWarning)(int stream) = messageCloseTextWarning;
 
@@ -367,7 +367,7 @@ void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list 
   if (useStream[stream]) {
     char logBuffer[SIZE_LOG_BUFFER];
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-    messageFunction(LOG_TYPE_INFO, stream, indentNext, logBuffer, 0, NULL);
+    messageFunction(LOG_TYPE_INFO, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
   }
 }
 
@@ -379,7 +379,7 @@ void infoStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNe
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);
-    messageFunction(LOG_TYPE_INFO, stream, indentNext, logBuffer, 0, indexes);
+    messageFunction(LOG_TYPE_INFO, stream, info, indentNext, logBuffer, 0, indexes);
   }
 }
 
@@ -391,11 +391,11 @@ void infoStreamPrint(int stream, int indentNext, const char *format, ...)
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);
-    messageFunction(LOG_TYPE_INFO, stream, indentNext, logBuffer, 0, NULL);
+    messageFunction(LOG_TYPE_INFO, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
   }
 }
 
-void warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...)
+void warningStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...)
 {
   if (ACTIVE_WARNING_STREAM(stream)) {
     char logBuffer[SIZE_LOG_BUFFER];
@@ -403,7 +403,7 @@ void warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);
-    messageFunction(LOG_TYPE_WARNING, stream, indentNext, logBuffer, 0, indexes);
+    messageFunction(LOG_TYPE_WARNING, stream, info, indentNext, logBuffer, 0, indexes);
   }
 }
 
@@ -415,16 +415,16 @@ void warningStreamPrint(int stream, int indentNext, const char *format, ...)
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);
-    messageFunction(LOG_TYPE_WARNING, stream, indentNext, logBuffer, 0, NULL);
+    messageFunction(LOG_TYPE_WARNING, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
   }
 }
 
-void va_warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, va_list args)
+void va_warningStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, va_list args)
 {
   if (ACTIVE_WARNING_STREAM(stream)) {
     char logBuffer[SIZE_LOG_BUFFER];
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-    messageFunction(LOG_TYPE_WARNING, stream, indentNext, logBuffer, 0, indexes);
+    messageFunction(LOG_TYPE_WARNING, stream, info, indentNext, logBuffer, 0, indexes);
   }
 }
 
@@ -433,7 +433,7 @@ void va_warningStreamPrint(int stream, int indentNext, const char *format, va_li
   if (ACTIVE_WARNING_STREAM(stream)) {
     char logBuffer[SIZE_LOG_BUFFER];
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-    messageFunction(LOG_TYPE_WARNING, stream, indentNext, logBuffer, 0, NULL);
+    messageFunction(LOG_TYPE_WARNING, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
   }
 }
 
@@ -444,22 +444,22 @@ void errorStreamPrint(int stream, int indentNext, const char *format, ...)
   va_start(args, format);
   vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
   va_end(args);
-  messageFunction(LOG_TYPE_ERROR, stream, indentNext, logBuffer, 0, NULL);
+  messageFunction(LOG_TYPE_ERROR, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
 }
 
 void va_errorStreamPrint(int stream, int indentNext, const char *format, va_list args)
 {
   char logBuffer[SIZE_LOG_BUFFER];
   vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-  messageFunction(LOG_TYPE_ERROR, stream, indentNext, logBuffer, 0, NULL);
+  messageFunction(LOG_TYPE_ERROR, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
 }
 
-void va_errorStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, va_list args)
+void va_errorStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, va_list args)
 {
 
   char logBuffer[SIZE_LOG_BUFFER];
   vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-  messageFunction(LOG_TYPE_ERROR, stream, indentNext, logBuffer, 0, indexes);
+  messageFunction(LOG_TYPE_ERROR, stream, info, indentNext, logBuffer, 0, indexes);
 }
 #endif
 
@@ -472,11 +472,11 @@ void debugStreamPrint(int stream, int indentNext, const char *format, ...)
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);
-    messageFunction(LOG_TYPE_DEBUG, stream, indentNext, logBuffer, 0, NULL);
+    messageFunction(LOG_TYPE_DEBUG, stream, omc_dummyFileInfo, indentNext, logBuffer, 0, NULL);
   }
 }
 
-void debugStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...)
+void debugStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...)
 {
   if (useStream[stream]) {
     char logBuffer[SIZE_LOG_BUFFER];
@@ -484,7 +484,7 @@ void debugStreamPrintWithEquationIndexes(int stream, int indentNext, const int *
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);
-    messageFunction(LOG_TYPE_DEBUG, stream, indentNext, logBuffer, 0, indexes);
+    messageFunction(LOG_TYPE_DEBUG, stream, info, indentNext, logBuffer, 0, indexes);
   }
 }
 #endif
@@ -522,7 +522,7 @@ void va_throwStreamPrint(threadData_t *threadData, const char *format, va_list a
 #if !defined(OMC_MINIMAL_LOGGING)
   char logBuffer[SIZE_LOG_BUFFER];
   vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-  messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, 0, logBuffer, 0, NULL);
+  messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, omc_dummyFileInfo, 0, logBuffer, 0, NULL);
 #endif
   threadData = threadData ? threadData : (threadData_t*)pthread_getspecific(mmc_thread_data_key);
   longjmp(*getBestJumpBuffer(threadData), 1);
@@ -541,7 +541,7 @@ void throwStreamPrint(threadData_t *threadData, const char *format, ...)
 #endif
 }
 
-void throwStreamPrintWithEquationIndexes(threadData_t *threadData, const int *indexes, const char *format, ...)
+void throwStreamPrintWithEquationIndexes(threadData_t *threadData, FILE_INFO info, const int *indexes, const char *format, ...)
 {
 #if !defined(OMC_MINIMAL_LOGGING)
   char logBuffer[SIZE_LOG_BUFFER];
@@ -549,7 +549,7 @@ void throwStreamPrintWithEquationIndexes(threadData_t *threadData, const int *in
   va_start(args, format);
   vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
   va_end(args);
-  messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, 0, logBuffer, 0, indexes);
+  messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, info, 0, logBuffer, 0, indexes);
 #endif
   threadData = threadData ? threadData : (threadData_t*)pthread_getspecific(mmc_thread_data_key);
   longjmp(*getBestJumpBuffer(threadData), 1);

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -319,6 +319,15 @@ void messageText(int type, int stream, FILE_INFO info, int indentNext, char *msg
   for(i=0; i<level[stream]; ++i)
       printf("| ");
 
+  if (info.filename && strlen(info.filename) > 0) {
+  // Print to stdout because we are using printf down below as well.
+    printInfo(stdout, info);
+    printf("\n");
+
+    printf("%-17s | ", (subline || (lastStream == stream && level[stream] > 0)) ? "|" : LOG_STREAM_NAME[stream]);
+    printf("%-7s | ", (subline || (lastStream == stream && lastType[stream] == type && level[stream] > 0)) ? "|" : LOG_TYPE_DESC[type]);
+  }
+
   for(i=0; msg[i]; i++)
   {
     if(msg[i] == '\n')

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -320,12 +320,12 @@ void messageText(int type, int stream, FILE_INFO info, int indentNext, char *msg
       printf("| ");
 
   if (info.filename && strlen(info.filename) > 0) {
-  // Print to stdout because we are using printf down below as well.
+    // Print to stdout because we are using printf down below as well.
     printInfo(stdout, info);
     printf("\n");
 
-    printf("%-17s | ", (subline || (lastStream == stream && level[stream] > 0)) ? "|" : LOG_STREAM_NAME[stream]);
-    printf("%-7s | ", (subline || (lastStream == stream && lastType[stream] == type && level[stream] > 0)) ? "|" : LOG_TYPE_DESC[type]);
+    printf("%-17s | ", "|");
+    printf("%-7s | ", "|");
   }
 
   for(i=0; msg[i]; i++)
@@ -335,7 +335,7 @@ void messageText(int type, int stream, FILE_INFO info, int indentNext, char *msg
       msg[i] = '\0';
       printf("%s\n", msg);
       if (msg[i+1]) {
-        messageText(type, stream, info, 0, &msg[i+1], 1, indexes);
+        messageText(type, stream, omc_dummyFileInfo, 0, &msg[i+1], 1, indexes);
       }
       return;
     }

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -371,7 +371,7 @@ void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list 
   }
 }
 
-void infoStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...)
+void infoStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...)
 {
   if (useStream[stream]) {
     char logBuffer[SIZE_LOG_BUFFER];

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.h
@@ -188,7 +188,7 @@ extern void (*messageCloseWarning)(int stream);
 #if !defined(OMC_MINIMAL_LOGGING)
 extern void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list ap);
 extern void infoStreamPrint(int stream, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
-extern void infoStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 4, 5)));
+extern void infoStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 5, 6)));
 extern void warningStreamPrint(int stream, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
 extern void va_warningStreamPrint(int stream, int indentNext, const char *format,va_list ap);
 extern void warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 4, 5)));
@@ -199,7 +199,7 @@ extern void va_errorStreamPrintWithEquationIndexes(int stream, int indentNext, c
 #else
 static inline void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list ap) {}
 static inline void infoStreamPrint(int stream, int indentNext, const char *format, ...) {}
-static inline void infoStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) {}
+static inline void infoStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) {}
 static inline void warningStreamPrint(int stream, int indentNext, const char *format, ...) {}
 static inline void va_warningStreamPrint(int stream, int indentNext, const char *format,va_list ap) {}
 static inline void warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) {}

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.h
@@ -53,7 +53,8 @@ typedef struct _FILE_INFO
   int readonly;
 } FILE_INFO;
 
-#define omc_dummyFileInfo {"",0,0,0,0,0}
+#define omc_dummyFileInfo_val {"",0,0,0,0,0}
+extern const FILE_INFO omc_dummyFileInfo;
 
 DLLExport extern void printInfo(FILE *stream, FILE_INFO info);
 // Defined in omc_error.c

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.h
@@ -181,42 +181,42 @@ extern char logBuffer[2048];
   #define TRACE_POP
 #endif
 
-extern void (*messageFunction)(int type, int stream, int indentNext, char *msg, int subline, const int *indexes);
+extern void (*messageFunction)(int type, int stream, FILE_INFO info, int indentNext, char *msg, int subline, const int *indexes);
 extern void (*messageClose)(int stream);
 extern void (*messageCloseWarning)(int stream);
 
 #if !defined(OMC_MINIMAL_LOGGING)
-extern void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list ap);
 extern void infoStreamPrint(int stream, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+extern void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list ap);
 extern void infoStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 5, 6)));
 extern void warningStreamPrint(int stream, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
 extern void va_warningStreamPrint(int stream, int indentNext, const char *format,va_list ap);
-extern void warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 4, 5)));
-extern void va_warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format,va_list ap);
+extern void warningStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 5, 6)));
+extern void va_warningStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format,va_list ap);
 extern void errorStreamPrint(int stream, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
 extern void va_errorStreamPrint(int stream, int indentNext, const char *format, va_list ap);
-extern void va_errorStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format,va_list ap);
+extern void va_errorStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format,va_list ap);
 #else
-static inline void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list ap) {}
 static inline void infoStreamPrint(int stream, int indentNext, const char *format, ...) {}
+static inline void va_infoStreamPrint(int stream, int indentNext, const char *format, va_list ap) {}
 static inline void infoStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) {}
 static inline void warningStreamPrint(int stream, int indentNext, const char *format, ...) {}
 static inline void va_warningStreamPrint(int stream, int indentNext, const char *format,va_list ap) {}
-static inline void warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) {}
-static inline void va_warningStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format,va_list ap) {}
+static inline void warningStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) {}
+static inline void va_warningStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format,va_list ap) {}
 static inline void errorStreamPrint(int stream, int indentNext, const char *format, ...) {}
 static inline void va_errorStreamPrint(int stream, int indentNext, const char *format, va_list ap) {}
-static inline void va_errorStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format,va_list ap) {}
+static inline void va_errorStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format,va_list ap) {}
 #endif
 
 extern void va_throwStreamPrint(threadData_t *threadData, const char *format, va_list ap) __attribute__ ((noreturn));
 extern void throwStreamPrint(threadData_t *threadData, const char *format, ...) __attribute__ ((format (printf, 2, 3), noreturn));
-extern void throwStreamPrintWithEquationIndexes(threadData_t *threadData, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 3, 4), noreturn));
+extern void throwStreamPrintWithEquationIndexes(threadData_t *threadData, FILE_INFO info, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 4, 5), noreturn));
 #ifdef HAVE_VA_MACROS
 #define assertStreamPrint(threadData, cond, ...) if (!(cond)) {throwStreamPrint((threadData), __VA_ARGS__); assert(0);}
 #else
-static void OMC_INLINE assertStreamPrint(threadData_t *threadData, int cond, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
-static void OMC_INLINE assertStreamPrint(threadData_t *threadData, int cond, const char *format, ...)
+static void OMC_INLINE assertStreamPrint(threadData_t *threadData, FILE_INFO info, int cond, const char *format, ...) __attribute__ ((format (printf, 4, 5)));
+static void OMC_INLINE assertStreamPrint(threadData_t *threadData, FILE_INFO info, int cond, const char *format, ...)
 {
   va_list args;
   if (cond) return;
@@ -241,13 +241,13 @@ static void OMC_INLINE assertStreamPrint(threadData_t *threadData, int cond, con
   }
 
 #ifdef USE_DEBUG_OUTPUT
-void debugStreamPrint(int stream, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
-void debugStreamPrintWithEquationIndexes(int stream, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 4, 5)));
+void debugStreamPrint(int stream, FILE_INFO info, int indentNext, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+void debugStreamPrintWithEquationIndexes(int stream, FILE_INFO info, int indentNext, const int *indexes, const char *format, ...) __attribute__ ((format (printf, 5, 6)));
 #else
 static OMC_INLINE void debugStreamPrint(int stream __attribute__((unused)), int indentNext __attribute__((unused)), const char *format __attribute__((unused)), ...) __attribute__ ((format (printf, 3, 4)));
 static OMC_INLINE void debugStreamPrint(int stream __attribute__((unused)), int indentNext __attribute__((unused)), const char *format __attribute__((unused)), ...) {/* Do nothing */}
-static OMC_INLINE void debugStreamPrintWithEquationIndexes(int stream __attribute__((unused)), int indentNext __attribute__((unused)), const int *indexes __attribute__((unused)), const char *format __attribute__((unused)), ...) __attribute__ ((format (printf, 4, 5)));
-static OMC_INLINE void debugStreamPrintWithEquationIndexes(int stream  __attribute__((unused)), int indentNext __attribute__((unused)), const int *indexes __attribute__((unused)), const char *format __attribute__((unused)), ...)  {/* Do nothing */}
+static OMC_INLINE void debugStreamPrintWithEquationIndexes(int stream __attribute__((unused)), FILE_INFO info, int indentNext __attribute__((unused)), const int *indexes __attribute__((unused)), const char *format __attribute__((unused)), ...) __attribute__ ((format (printf, 5, 6)));
+static OMC_INLINE void debugStreamPrintWithEquationIndexes(int stream  __attribute__((unused)), FILE_INFO info, int indentNext __attribute__((unused)), const int *indexes __attribute__((unused)), const char *format __attribute__((unused)), ...)  {/* Do nothing */}
 #endif
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
@@ -375,8 +375,7 @@ char *realpath(const char *path, char resolved_path[PATH_MAX])
 {
   if (!_fullpath(resolved_path, path, PATH_MAX))
   {
-    FILE_INFO info = omc_dummyFileInfo;
-    omc_assert_warning(info, "System.realpath failed on %s with errno: %d", path, errno);
+    omc_assert_warning(omc_dummyFileInfo, "System.realpath failed on %s with errno: %d", path, errno);
     resolved_path = (char*)path;
   }
   return resolved_path;
@@ -518,8 +517,7 @@ char *realpath(const char *path, char resolved_path[PATH_MAX])
 
   if (return_path == NULL)
   {
-    FILE_INFO info = omc_dummyFileInfo;
-    omc_assert_warning(info, "System.realpath failed on %s with errno: %d", path, errno);
+    omc_assert_warning(omc_dummyFileInfo, "System.realpath failed on %s with errno: %d", path, errno);
     resolved_path = (char*)path;
     return_path = (char*)path;
   }

--- a/OMCompiler/SimulationRuntime/c/util/utility.c
+++ b/OMCompiler/SimulationRuntime/c/util/utility.c
@@ -42,11 +42,10 @@ modelica_real real_int_pow(threadData_t *threadData, modelica_real base, modelic
 {
   modelica_real result = 1.0;
   modelica_integer m = n < 0;
-  FILE_INFO info = omc_dummyFileInfo;
   if(m)
   {
     if(base == 0.0)
-      omc_assert(threadData, info, "Model error. 0^(%i) is not defined", n);
+      omc_assert(threadData, omc_dummyFileInfo, "Model error. 0^(%i) is not defined", n);
     n = -n;
   }
   while(n != 0)
@@ -171,7 +170,6 @@ static int hasDriveLetter(const char* uri)
 
 static modelica_string uriToFilenameRegularPaths(modelica_string uri_om, const char *uri, char buf[PATH_MAX], const char *origUri, const char *resourcesDir)
 {
-  FILE_INFO info = omc_dummyFileInfo;
   omc_stat_t stat_buf;
   size_t len, i, j = 0;
   int uriExists = 0==omc_stat(uri, &stat_buf);
@@ -198,17 +196,17 @@ static modelica_string uriToFilenameRegularPaths(modelica_string uri_om, const c
         return uriToFilenameRegularPaths(NULL, buf, newbuf, origUri, NULL);
       }
     } else {
-      omc_assert_warning(info, "Path longer than PATH_MAX: %s/%s", resourcesDir, uri);
+      omc_assert_warning(omc_dummyFileInfo, "Path longer than PATH_MAX: %s/%s", resourcesDir, uri);
     }
   }
   if (uriExists) {
     if (resourcesDir) {
-      omc_assert_warning(info, PATH_NOT_IN_FMU_RESOURCES, uri);
+      omc_assert_warning(omc_dummyFileInfo, PATH_NOT_IN_FMU_RESOURCES, uri);
     }
     /* This is a file, directory, etc. Can't use open to check this. */
     if (0==realpath(uri, buf)) {
       /* Unexpected; we know the file exists, but realpath failed. Just return the URI */
-      omc_assert_warning(info, "realpath failed for existing path %s: %s", uri, strerror(errno));
+      omc_assert_warning(omc_dummyFileInfo, "realpath failed for existing path %s: %s", uri, strerror(errno));
       return uri_om ? uri_om : mmc_mk_scon(uri);
     }
     /* Use the realpath result */
@@ -218,7 +216,7 @@ static modelica_string uriToFilenameRegularPaths(modelica_string uri_om, const c
       if (buf[len-1]!='/' && origUri[strlen(origUri)-1]=='/') {
         if (len+1 >= PATH_MAX) {
           /* Can't fit the path; just return the original URI */
-          omc_assert_warning(info, "Path longer than PATH_MAX: %s/, returning %s", buf, buf);
+          omc_assert_warning(omc_dummyFileInfo, "Path longer than PATH_MAX: %s/, returning %s", buf, buf);
           return uri_om ? uri_om : mmc_mk_scon(uri);
         }
         strcpy(buf+len, "/");
@@ -233,13 +231,13 @@ static modelica_string uriToFilenameRegularPaths(modelica_string uri_om, const c
   }
   if (0==realpath("./", buf)) {
     /* Failed to resolve ./ */
-    omc_assert_warning(info, "realpath failed to resolve ./");
+    omc_assert_warning(omc_dummyFileInfo, "realpath failed to resolve ./");
     return uri_om ? uri_om : mmc_mk_scon(uri);
   }
   len = strlen(buf);
   if (len+strlen(uri)+1 >= PATH_MAX) {
     /* Can't fit the path; just return the original URI */
-    omc_assert_warning(info, "Path longer than PATH_MAX: %s/%s, returning %s", buf, uri, uri);
+    omc_assert_warning(omc_dummyFileInfo, "Path longer than PATH_MAX: %s/%s, returning %s", buf, uri, uri);
     return uri_om ? uri_om : mmc_mk_scon(uri);
   }
   /* Copy the rest of the URI onto the buffer */
@@ -312,7 +310,6 @@ extern modelica_string OpenModelica_uriToFilename_impl(threadData_t *threadData,
 #define strncasecmp _strnicmp
 #endif
 
-  FILE_INFO info = omc_dummyFileInfo;
   char buf[PATH_MAX];
 
   char* uri = (char*)omc_alloc_interface.malloc_atomic(sizeof(char) * (MMC_STRLEN(uri_om)+1));
@@ -324,24 +321,24 @@ extern modelica_string OpenModelica_uriToFilename_impl(threadData_t *threadData,
     uri += 11;
     getIdent(uri, buf, &uri);
     if (0 == *buf) {
-      omc_assert(threadData, info, "Malformed URI (couldn't get a class name): %s", MMC_STRINGDATA(uri_om));
+      omc_assert(threadData, omc_dummyFileInfo, "Malformed URI (couldn't get a class name): %s", MMC_STRINGDATA(uri_om));
       MMC_THROW();
     }
     dir = lookupDirectoryFromName(buf, threadData->localRoots[LOCAL_ROOT_URI_LOOKUP]);
     if (dir==NULL || MMC_STRLEN(dir)==0) {
-      omc_assert(threadData, info, "Failed to lookup URI (is the package loaded?) %s", MMC_STRINGDATA(uri_om));
+      omc_assert(threadData, omc_dummyFileInfo, "Failed to lookup URI (is the package loaded?) %s", MMC_STRINGDATA(uri_om));
       MMC_THROW();
     }
     if (resourcesDir) {
       if (MMC_STRLEN(dir)+2+strlen(resourcesDir) >= PATH_MAX) {
-        omc_assert_warning(info, "Path longer than PATH_MAX: %s/%s, ignoring the resourcesDir", MMC_STRINGDATA(dir), resourcesDir);
+        omc_assert_warning(omc_dummyFileInfo, "Path longer than PATH_MAX: %s/%s, ignoring the resourcesDir", MMC_STRINGDATA(dir), resourcesDir);
       } else {
         int dirExists = 0==omc_stat(MMC_STRINGDATA(dir), &stat_buf);
         sprintf(buf, "%s/%s", MMC_STRINGDATA(dir), resourcesDir);
         if (!dirExists || 0==omc_stat(buf, &stat_buf)) {
           dir = mmc_mk_scon(buf);
         } else {
-          omc_assert_warning(info, PATH_NOT_IN_FMU_RESOURCES, MMC_STRINGDATA(dir));
+          omc_assert_warning(omc_dummyFileInfo, PATH_NOT_IN_FMU_RESOURCES, MMC_STRINGDATA(dir));
         }
       }
     }
@@ -356,13 +353,13 @@ extern modelica_string OpenModelica_uriToFilename_impl(threadData_t *threadData,
       getIdent(uri, buf, &uri);
       if (0 == *buf) {
         if (*uri == '.') {
-          omc_assert(threadData, info, "Malformed URI (double dot in class name): %s", MMC_STRINGDATA(uri_om));
+          omc_assert(threadData, omc_dummyFileInfo, "Malformed URI (double dot in class name): %s", MMC_STRINGDATA(uri_om));
           MMC_THROW();
         }
         break; /* / or end of string */
       }
       if (MMC_STRLEN(dir)+strlen(buf)+1 >= PATH_MAX) {
-        omc_assert(threadData, info, "Failed to resolve URI; path longer than PATH_MAX(%d): %s", PATH_MAX, MMC_STRINGDATA(uri_om));
+        omc_assert(threadData, omc_dummyFileInfo, "Failed to resolve URI; path longer than PATH_MAX(%d): %s", PATH_MAX, MMC_STRINGDATA(uri_om));
         MMC_THROW();
       }
       /* Move the found ident last in the path */
@@ -392,7 +389,7 @@ extern modelica_string OpenModelica_uriToFilename_impl(threadData_t *threadData,
     return uriToFilenameRegularPaths(NULL, uri+7, buf, MMC_STRINGDATA(uri_om), resourcesDir);
   }
   if (strstr(uri, "://")) {
-    omc_assert(threadData, info, "Unknown URI schema: %s", MMC_STRINGDATA(uri_om));
+    omc_assert(threadData, omc_dummyFileInfo, "Unknown URI schema: %s", MMC_STRINGDATA(uri_om));
     MMC_THROW();
   }
 

--- a/OMCompiler/SimulationRuntime/c/util/varinfo.c
+++ b/OMCompiler/SimulationRuntime/c/util/varinfo.c
@@ -39,19 +39,19 @@ void printErrorEqSyst(EQUATION_SYSTEM_ERROR err, EQUATION_INFO eq, double time)
   switch(err)
   {
   case ERROR_AT_TIME:
-    warningStreamPrintWithEquationIndexes(LOG_NLS, 0, indexes, "Error solving nonlinear system %d at time %g", eq.id, time);
+    warningStreamPrintWithEquationIndexes(LOG_NLS, omc_dummyFileInfo, 0, indexes, "Error solving nonlinear system %d at time %g", eq.id, time);
     break;
   case NO_PROGRESS_START_POINT:
-    warningStreamPrintWithEquationIndexes(LOG_NLS, 0, indexes, "Solving nonlinear system %d: iteration not making progress, trying with different starting points (+%g)", eq.id, time);
+    warningStreamPrintWithEquationIndexes(LOG_NLS, omc_dummyFileInfo, 0, indexes, "Solving nonlinear system %d: iteration not making progress, trying with different starting points (+%g)", eq.id, time);
     break;
   case NO_PROGRESS_FACTOR:
-    warningStreamPrintWithEquationIndexes(LOG_NLS, 0, indexes, "Solving nonlinear system %d: iteration not making progress, trying to decrease factor to %g", eq.id, time);
+    warningStreamPrintWithEquationIndexes(LOG_NLS, omc_dummyFileInfo, 0, indexes, "Solving nonlinear system %d: iteration not making progress, trying to decrease factor to %g", eq.id, time);
     break;
   case IMPROPER_INPUT:
-    warningStreamPrintWithEquationIndexes(LOG_NLS, 0, indexes, "improper input parameters to nonlinear eq. syst: %d at time %g", eq.id, time);
+    warningStreamPrintWithEquationIndexes(LOG_NLS, omc_dummyFileInfo, 0, indexes, "improper input parameters to nonlinear eq. syst: %d at time %g", eq.id, time);
     break;
   default:
-    warningStreamPrintWithEquationIndexes(LOG_NLS, 0, indexes, "Unknown equation system error: %d %d %g", err, eq.id, time);
+    warningStreamPrintWithEquationIndexes(LOG_NLS, omc_dummyFileInfo, 0, indexes, "Unknown equation system error: %d %d %g", err, eq.id, time);
     break;
   }
 }

--- a/testsuite/openmodelica/cruntime/optimization/basic/BRcon2.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/BRcon2.mos
@@ -39,8 +39,7 @@ getErrorString();
 //     resultFile = "nmpcBatchReactorCon2_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'nmpcBatchReactorCon2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $con$2 >= -1e+21 and $con$2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: -1e+21 <= $con$2 <= 0.0, has value: 1
+// |                 | |       | (($con$2 >= -1e+21 and $con$2 <= 0.0)) --> \"Variable violating min/max constraint: -1e+21 <= $con$2 <= 0.0, has value: 1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/BRcon3.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/BRcon3.mos
@@ -41,8 +41,7 @@ getErrorString();
 //     resultFile = "nmpcBatchReactorCon3_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'nmpcBatchReactorCon3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $con$2 >= -1e+21 and $con$2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: -1e+21 <= $con$2 <= 0.0, has value: 1
+// |                 | |       | (($con$2 >= -1e+21 and $con$2 <= 0.0)) --> \"Variable violating min/max constraint: -1e+21 <= $con$2 <= 0.0, has value: 1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/BRcon4.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/BRcon4.mos
@@ -45,8 +45,7 @@ getErrorString();
 //     resultFile = "nmpcBatchReactorCon4_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'nmpcBatchReactorCon4', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $con$cc2 >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= $con$cc2, has value: -1
+// |                 | |       | (($con$cc2 >= 0.0)) --> \"Variable violating min constraint: 0.0 <= $con$cc2, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/BRcon5.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/BRcon5.mos
@@ -48,8 +48,7 @@ getErrorString();
 //     resultFile = "nmpcBatchReactorCon4_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'nmpcBatchReactorCon4', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $con$cc2 >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= $con$cc2, has value: -1
+// |                 | |       | (($con$cc2 >= 0.0)) --> \"Variable violating min constraint: 0.0 <= $con$cc2, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/BReqcon.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/BReqcon.mos
@@ -38,8 +38,7 @@ getErrorString();
 //     resultFile = "nmpcBatchReactorEqCon_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'nmpcBatchReactorEqCon', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $con$1 >= 0.0 and $con$1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $con$1 <= 0.0, has value: -0.5
+// |                 | |       | (($con$1 >= 0.0 and $con$1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $con$1 <= 0.0, has value: -0.5\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFC.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFC.mos
@@ -41,11 +41,9 @@ getErrorString();
 //     resultFile = "testFinalCon_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFC2.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFC2.mos
@@ -43,14 +43,11 @@ getErrorString();
 //     resultFile = "testFinalCon2_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con3 >= 0.0 and $finalCon$final_con3 <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con3 <= 1.0, has value: -15
+// |                 | |       | (($finalCon$final_con3 >= 0.0 and $finalCon$final_con3 <= 1.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con3 <= 1.0, has value: -15\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFC3.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFC3.mos
@@ -41,11 +41,9 @@ getErrorString();
 //     resultFile = "testFinalCon_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-stateFile ReferenceFiles/initStateTCF.csv'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -3
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -2
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -2\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // [0]set x1.start 1

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFC4.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFC4.mos
@@ -52,11 +52,9 @@ getErrorString();
 //     resultFile = "testFinalCon_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-iif ReferenceFiles/testFinalCon3_ref.mat -lv LOG_IPOPT_ERROR -ipopt_max_iter=-1 -ipopt_init FILE -iim none'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFC5.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFC5.mos
@@ -81,11 +81,9 @@ getErrorString();
 //     resultFile = "testFinalCon5__res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon5_', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-optimizerNP=1 -iif=ReferenceFiles/testFinalCon5_ref.mat -ipopt_init=FILE'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -3
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -2
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -2\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables
@@ -119,11 +117,9 @@ getErrorString();
 //     resultFile = "testFinalCon5_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 20, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon5', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-optimizerNP=1'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -3
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -2
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -2\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFC6.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFC6.mos
@@ -59,17 +59,13 @@ getErrorString();
 // |                 | |       | | 1 linear systems
 // LOG_LS            | info    | Start solving Linear System 7 (size 1) at time 0 with Lapack Solver
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con4 >= 0.0 and $finalCon$final_con4 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con4 <= 0.0, has value: -0.589785
+// |                 | |       | (($finalCon$final_con4 >= 0.0 and $finalCon$final_con4 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con4 <= 0.0, has value: -0.589785\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con3 >= 0.0 and $finalCon$final_con3 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con3 <= 0.0, has value: 0.769356
+// |                 | |       | (($finalCon$final_con3 >= 0.0 and $finalCon$final_con3 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con3 <= 0.0, has value: 0.769356\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 10.0 and $finalCon$final_con2 <= 15.0
-// assert            | warning | Variable violating min/max constraint: 10.0 <= $finalCon$final_con2 <= 15.0, has value: -3
+// |                 | |       | (($finalCon$final_con2 >= 10.0 and $finalCon$final_con2 <= 15.0)) --> \"Variable violating min/max constraint: 10.0 <= $finalCon$final_con2 <= 15.0, has value: -3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= -15.0 and $finalCon$final_con1 <= -10.0
-// assert            | warning | Variable violating min/max constraint: -15.0 <= $finalCon$final_con1 <= -10.0, has value: -2
+// |                 | |       | (($finalCon$final_con1 >= -15.0 and $finalCon$final_con1 <= -10.0)) --> \"Variable violating min/max constraint: -15.0 <= $finalCon$final_con1 <= -10.0, has value: -2\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/TFCtestFlag.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/TFCtestFlag.mos
@@ -41,11 +41,9 @@ getErrorString();
 //     resultFile = "testFinalCon_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testFinalCon', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4
+// |                 | |       | (($finalCon$final_con2 >= 0.0 and $finalCon$final_con2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con2 <= 0.0, has value: -4\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1
+// |                 | |       | (($finalCon$final_con1 >= 0.0 and $finalCon$final_con1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$final_con1 <= 0.0, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop1.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop1.mos
@@ -35,11 +35,10 @@ getErrorString();
 //     resultFile = "testAlgLoop1_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testAlgLoop1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 3'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$y >= 0.0 and $EqCon$y <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$y <= 0.0, has value: 0.158529
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | y >= -1.0 and y <= 0.0
-// assert            | warning | Variable violating min/max constraint: -1.0 <= y <= 0.0, has value: 1
+// |                 | |       | (($EqCon$y >= 0.0 and $EqCon$y <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$y <= 0.0, has value: 0.158529\"
+// assert            | warning | [<interactive>:3:3-3:33:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((y >= -1.0 and y <= 0.0)) --> \"Variable violating min/max constraint: -1.0 <= y <= 0.0, has value: 1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop10.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop10.mos
@@ -37,11 +37,9 @@ getErrorString();
 //     resultFile = "testAlgLoop10_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 100, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop10', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 1 -ipopt_max_iter -1 -iif ReferenceFiles/testAlgLoop7_ref.mat -ipopt_init FILE -iim none'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3
+// |                 | |       | (($EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672
+// |                 | |       | (($EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop11.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop11.mos
@@ -37,14 +37,11 @@ getErrorString();
 //     resultFile = "testAlgLoop11_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 100, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop11', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 1 -ipopt_max_iter -1 -iif ReferenceFiles/testAlgLoop7_ref.mat -ipopt_init FILE -iim none'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$y2 >= 0.0 and $EqCon$y2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$y2 <= 0.0, has value: -1
+// |                 | |       | (($EqCon$y2 >= 0.0 and $EqCon$y2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$y2 <= 0.0, has value: -1\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3
+// |                 | |       | (($EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672
+// |                 | |       | (($EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop2.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop2.mos
@@ -35,11 +35,10 @@ getErrorString();
 //     resultFile = "testAlgLoop2_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testAlgLoop2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 3'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$y >= 0.0 and $EqCon$y <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$y <= 0.0, has value: 0.158529
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | y >= 0.0 and y <= 10.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= y <= 10.0, has value: -1
+// |                 | |       | (($EqCon$y >= 0.0 and $EqCon$y <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$y <= 0.0, has value: 0.158529\"
+// assert            | warning | [<interactive>:3:3-3:40:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((y >= 0.0 and y <= 10.0)) --> \"Variable violating min/max constraint: 0.0 <= y <= 10.0, has value: -1\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop4.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop4.mos
@@ -35,9 +35,9 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "testAlgLoop4_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 50, tolerance = 1e-08, method = 'optimization', fileNamePrefix = 'testAlgLoop4', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 3'",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | y >= 5.0
-// assert            | warning | Variable violating min constraint: 5.0 <= y, has value: 0
+//     messages = "assert            | warning | [<interactive>:5:3-5:18:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((y >= 5.0)) --> \"Variable violating min constraint: 5.0 <= y, has value: 0\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop5.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop5.mos
@@ -58,20 +58,15 @@ getErrorString();
 //     resultFile = "testAlgLoop5_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 50, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop5', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 1 -ipopt_init CONST -iit 0.2 -iim=none -iif=ReferenceFiles/testAlgLoop5_ref.mat'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$t1 >= 0.0 and $EqCon$t1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$t1 <= 0.0, has value: -1.66533e-16
+// |                 | |       | (($EqCon$t1 >= 0.0 and $EqCon$t1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$t1 <= 0.0, has value: -1.66533e-16\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$t2 >= 0.0 and $EqCon$t2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$t2 <= 0.0, has value: -0.20139
+// |                 | |       | (($EqCon$t2 >= 0.0 and $EqCon$t2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$t2 <= 0.0, has value: -0.20139\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$$con$con >= 0.0 and $EqCon$$con$con <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$$con$con <= 0.0, has value: 1.11022e-16
+// |                 | |       | (($EqCon$$con$con >= 0.0 and $EqCon$$con$con <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$$con$con <= 0.0, has value: 1.11022e-16\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$fcon3 >= 10.0 and $finalCon$fcon3 <= 10.0
-// assert            | warning | Variable violating min/max constraint: 10.0 <= $finalCon$fcon3 <= 10.0, has value: -13.0063
+// |                 | |       | (($finalCon$fcon3 >= 10.0 and $finalCon$fcon3 <= 10.0)) --> \"Variable violating min/max constraint: 10.0 <= $finalCon$fcon3 <= 10.0, has value: -13.0063\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $finalCon$fcon >= 0.0 and $finalCon$fcon <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $finalCon$fcon <= 0.0, has value: 16
+// |                 | |       | (($finalCon$fcon >= 0.0 and $finalCon$fcon <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $finalCon$fcon <= 0.0, has value: 16\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
@@ -46,11 +46,9 @@ getErrorString();
 //     resultFile = "testAlgLoop6_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 70, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop6', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-optimizerNP 1 -iif=ReferenceFiles/testAlgLoop6_ref.mat -iim=none'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$conDer >= 0.0 and $EqCon$conDer <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$conDer <= 0.0, has value: 0.770042
+// |                 | |       | (($EqCon$conDer >= 0.0 and $EqCon$conDer <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$conDer <= 0.0, has value: 0.770042\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 0.493305
+// |                 | |       | (($EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 0.493305\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop7.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop7.mos
@@ -34,11 +34,9 @@ getErrorString();
 //     resultFile = "testAlgLoop7_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 100, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop7', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 1 -iif ReferenceFiles/testAlgLoop7_ref.mat -iim none -ipopt_init FILE'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3
+// |                 | |       | (($EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672
+// |                 | |       | (($EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop8.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop8.mos
@@ -34,11 +34,9 @@ getErrorString();
 //     resultFile = "testAlgLoop8_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 100, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop8', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 1 -ipopt_max_iter -1 -iif ReferenceFiles/testAlgLoop7_ref.mat -ipopt_init FILE -iim none'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3
+// |                 | |       | (($EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672
+// |                 | |       | (($EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop9.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop9.mos
@@ -34,11 +34,9 @@ getErrorString();
 //     resultFile = "testAlgLoop9_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 100, tolerance = 1e-12, method = 'optimization', fileNamePrefix = 'testAlgLoop9', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv LOG_IPOPT_ERROR -optimizerNP 1 -ipopt_max_iter -1 -iif ReferenceFiles/testAlgLoop7_ref.mat -ipopt_init FILE -iim none'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3
+// |                 | |       | (($EqCon$x2 >= 0.0 and $EqCon$x2 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x2 <= 0.0, has value: 3\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672
+// |                 | |       | (($EqCon$x1 >= 0.0 and $EqCon$x1 <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$x1 <= 0.0, has value: 0.864672\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runDrumBoiler.mos
@@ -32,9 +32,9 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "drumBoiler.optDrumBoiler_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 3600.0, numberOfIntervals = 50, tolerance = 0.0001, method = 'dassl', fileNamePrefix = 'drumBoiler.optDrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_IPOPT_ERROR -optimizerNP 1 -s optimization'",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311
+//     messages = "assert            | warning | [openmodelica/cruntime/optimization/benchmark/DrumBoiler.mo:148:4-148:63:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0)) --> \"Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runExReduceDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runExReduceDrumBoiler.mos
@@ -27,16 +27,16 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "init_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 3600.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'init', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-emit_protected'",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311
+//     messages = "assert            | warning | [openmodelica/cruntime/optimization/benchmark/DrumBoiler.mo:148:4-148:63:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0)) --> \"Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 849.600000
-// |                 | |       | conSigma.con >= conSigma.MinValue and conSigma.con <= conSigma.MaxValue
-// assert            | info    | Variable violating min/max constraint: conSigma.MinValue <= conSigma.con <= conSigma.MaxValue, has value: -150.308
-// assert            | info    | The following assertion has been violated at time 1252.800000
-// |                 | |       | der_V_v >= -0.02 and der_V_v <= 0.025
-// assert            | info    | Variable violating min/max constraint: -0.02 <= der_V_v <= 0.025, has value: 0.0252797
+// assert            | info    | [openmodelica/cruntime/optimization/benchmark/DrumBoiler.mo:163:9-163:92:writable]
+// |                 | |       | The following assertion has been violated at time 849.600000
+// |                 | |       | ((conSigma.con >= conSigma.MinValue and conSigma.con <= conSigma.MaxValue)) --> \"Variable violating min/max constraint: conSigma.MinValue <= conSigma.con <= conSigma.MaxValue, has value: -150.308\"
+// assert            | info    | [openmodelica/cruntime/optimization/benchmark/DrumBoiler.mo:147:4-147:63:writable]
+// |                 | |       | The following assertion has been violated at time 1252.800000
+// |                 | |       | ((der_V_v >= -0.02 and der_V_v <= 0.025)) --> \"Variable violating min/max constraint: -0.02 <= der_V_v <= 0.025, has value: 0.0252797\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -47,11 +47,9 @@ getErrorString();
 //     resultFile = "drumBoiler.optDrumBoiler_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 3600.0, numberOfIntervals = 50, tolerance = 0.0001, method = 'dassl', fileNamePrefix = 'drumBoiler.optDrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_IPOPT_ERROR -optimizerNP 1 -s optimization -iif init_res.mat -ipopt_init FILE -ipopt_max_iter=100'",
 //     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$der_evaporator_p >= 0.0 and $EqCon$der_evaporator_p <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$der_evaporator_p <= 0.0, has value: -1.33747e+06
+// |                 | |       | (($EqCon$der_evaporator_p >= 0.0 and $EqCon$der_evaporator_p <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$der_evaporator_p <= 0.0, has value: -1.33747e+06\"
 // assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | $EqCon$evaporator_V_l >= 0.0 and $EqCon$evaporator_V_l <= 0.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= $EqCon$evaporator_V_l <= 0.0, has value: -0.5
+// |                 | |       | (($EqCon$evaporator_V_l >= 0.0 and $EqCon$evaporator_V_l <= 0.0)) --> \"Variable violating min/max constraint: 0.0 <= $EqCon$evaporator_V_l <= 0.0, has value: -0.5\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runReduceDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runReduceDrumBoiler.mos
@@ -28,9 +28,9 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "drumBoiler.optDrumBoiler_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 3600.0, numberOfIntervals = 50, tolerance = 0.0001, method = 'dassl', fileNamePrefix = 'drumBoiler.optDrumBoiler', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_IPOPT_ERROR -optimizerNP 1 -s optimization'",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311
+//     messages = "assert            | warning | [openmodelica/cruntime/optimization/benchmark/DrumBoiler.mo:148:4-148:63:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((der_evaporator_p >= 0.0 and der_evaporator_p <= 32000.0)) --> \"Variable violating min/max constraint: 0.0 <= der_evaporator_p <= 32000.0, has value: -9.57311\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 //
 // Optimizer Variables

--- a/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump.mos
+++ b/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump.mos
@@ -31,9 +31,9 @@ getEnvironmentVar("REFERENCEFILES")+"/ThermoSysPro/ThermoSysPro.Examples.SimpleE
 //     resultFile = "ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1000.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPump', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 200.000000
-// |                 | |       | StaticCentrifugalPump1.hn >= 0.0
-// assert            | info    | Variable violating min constraint: 0.0 <= StaticCentrifugalPump1.hn, has value: -1.7295e-29
+// assert            | info    | [ThermoSysPro 3.2.0/WaterSteam/Machines/StaticCentrifugalPump.mo:47:3-47:51:writable]
+// |                 | |       | The following assertion has been violated at time 200.000000
+// |                 | |       | ((StaticCentrifugalPump1.hn >= 0.0)) --> \"Variable violating min constraint: 0.0 <= StaticCentrifugalPump1.hn, has value: -1.7295e-29\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution.mos
+++ b/testsuite/simulation/libraries/3rdParty/ThermoSysPro/ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution.mos
@@ -31,9 +31,9 @@ getEnvironmentVar("REFERENCEFILES")+"/ThermoSysPro/ThermoSysPro.Examples.SimpleE
 //     resultFile = "ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1000.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ThermoSysPro.Examples.SimpleExamples.TestStaticCentrifugalPumpWaterSolution', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 200.000000
-// |                 | |       | staticCentrifugalPumpWaterLiBr.deltaP >= 0.0
-// assert            | info    | Variable violating min constraint: 0.0 <= staticCentrifugalPumpWaterLiBr.deltaP, has value: -86.9556
+// assert            | info    | [ThermoSysPro 3.2.0/WaterSolution/Machines/StaticCentrifugalPump.mo:40:3-41:59:writable]
+// |                 | |       | The following assertion has been violated at time 200.000000
+// |                 | |       | ((staticCentrifugalPumpWaterLiBr.deltaP >= 0.0)) --> \"Variable violating min constraint: 0.0 <= staticCentrifugalPumpWaterLiBr.deltaP, has value: -86.9556\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl31/Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b_analytic.mos
+++ b/testsuite/simulation/libraries/msl31/Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b_analytic.mos
@@ -18,9 +18,9 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Mechanics.Multi
 // record SimulationResult
 //     resultFile = "Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b_analytic_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.5, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b_analytic', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | gasForce.T >= 1.0 and gasForce.T <= 6000.0
-// assert            | warning | Variable violating min/max constraint: 1.0 <= gasForce.T <= 6000.0, has value: 407508
+//     messages = "assert            | warning | [Modelica 3.1.0+maint.om/Mechanics/MultiBody/Examples/Loops/Utilities.mo:396:5-396:21:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((gasForce.T >= 1.0 and gasForce.T <= 6000.0)) --> \"Variable violating min/max constraint: 1.0 <= gasForce.T <= 6000.0, has value: 407508\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.MoistAir.mos
@@ -19,9 +19,9 @@ simulate(Modelica.Media.Examples.MoistAir);
 //     resultFile = "Modelica.Media.Examples.MoistAir_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.MoistAir', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.952000
-// |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00448
+// assert            | info    | [Modelica 3.1.0+maint.om/Media/Air.mo:131:7-132:80:writable]
+// |                 | |       | The following assertion has been violated at time 0.952000
+// |                 | |       | ((medium.x_sat >= 0.0 and medium.x_sat <= 1.0)) --> \"Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00448\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
+++ b/testsuite/simulation/libraries/msl31/media/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
@@ -18,19 +18,19 @@ simulate(Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates);
 // record SimulationResult
 //     resultFile = "Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 22.0, numberOfIntervals = 2500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | medium.p >= 2000.0 and medium.p <= 100000000.0
-// assert            | warning | Variable violating min/max constraint: 2000.0 <= medium.p <= 100000000.0, has value: 700
+//     messages = "assert            | warning | [Modelica 3.1.0+maint.om/Media/package.mo:4092:7-4092:60:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((medium.p >= 2000.0 and medium.p <= 100000000.0)) --> \"Variable violating min/max constraint: 2000.0 <= medium.p <= 100000000.0, has value: 700\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 20.080589
-// |                 | |       | medium.x >= 0.0 and medium.x <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1
-// assert            | info    | The following assertion has been violated at time 21.964800
-// |                 | |       | medium.cp_d >= 0.0 and medium.cp_d <= 1000000.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.cp_d <= 1000000.0, has value: 1.08101e+06
-// assert            | info    | The following assertion has been violated at time 21.991200
-// |                 | |       | medium.cp_b >= 0.0 and medium.cp_b <= 1000000.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.cp_b <= 1000000.0, has value: 1.01516e+06
+// assert            | info    | [Modelica 3.1.0+maint.om/Media/package.mo:2452:7-2452:43:writable]
+// |                 | |       | The following assertion has been violated at time 20.080589
+// |                 | |       | ((medium.x >= 0.0 and medium.x <= 1.0)) --> \"Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1\"
+// assert            | info    | [Modelica 3.1.0+maint.om/Media/package.mo:2441:7-2441:66:writable]
+// |                 | |       | The following assertion has been violated at time 21.964800
+// |                 | |       | ((medium.cp_d >= 0.0 and medium.cp_d <= 1000000.0)) --> \"Variable violating min/max constraint: 0.0 <= medium.cp_d <= 1000000.0, has value: 1.08101e+06\"
+// assert            | info    | [Modelica 3.1.0+maint.om/Media/package.mo:2442:7-2442:69:writable]
+// |                 | |       | The following assertion has been violated at time 21.991200
+// |                 | |       | ((medium.cp_b >= 0.0 and medium.cp_b <= 1000000.0)) --> \"Variable violating min/max constraint: 0.0 <= medium.cp_b <= 1000000.0, has value: 1.01516e+06\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.HeatingSystem.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.HeatingSystem.mos
@@ -41,9 +41,9 @@ runScript(modelTesting);getErrorString();
 // {"heater.mediums[1].h","heater.mediums[1].p","pipe.mediums[1].h","pipe.mediums[2].h","pipe.mediums[2].p","radiator.mediums[1].h","radiator.mediums[1].p","tank.level","tank.medium.h"}
 // Simulation options: startTime = 0.0, stopTime = 600.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.HeatingSystem', options = '', outputFormat = 'mat', variableFilter = 'time|heater.mediums.1..h|heater.mediums.1..p|pipe.mediums.1..h|pipe.mediums.2..h|pipe.mediums.2..p|radiator.mediums.1..h|radiator.mediums.1..p|tank.level|tank.medium.h', cflags = '', simflags = ' -abortSlowSimulation -alarm=600 -emit_protected'
 // Result file: Modelica.Fluid.Examples.HeatingSystem_res.mat
-// Messages: assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | pump.delta_head_init >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= pump.delta_head_init, has value: -2.0431
+// Messages: assert            | warning | [Modelica 3.2.1+maint.om/Fluid/Machines.mo:317:5-318:51:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((pump.delta_head_init >= 0.0)) --> "Variable violating min constraint: 0.0 <= pump.delta_head_init, has value: -2.0431"
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.InverseParameterization.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.InverseParameterization.mos
@@ -38,9 +38,9 @@ runScript(modelTesting);getErrorString();
 // {"source.ports[1].m_flow","source.ports[1].p","source.ports[1].h_outflow","sink.ports[1].m_flow","sink.ports[1].p","sink.ports[1].h_outflow","sink1.ports[1].m_flow","sink1.ports[1].p","sink1.ports[1].h_outflow","sink2.ports[1].m_flow","sink2.ports[1].p","sink2.ports[1].h_outflow"}
 // Simulation options: startTime = 0.0, stopTime = 10.0, numberOfIntervals = 10000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.InverseParameterization', options = '', outputFormat = 'mat', variableFilter = 'time|source.ports.1..m_flow|source.ports.1..p|source.ports.1..h_outflow|sink.ports.1..m_flow|sink.ports.1..p|sink.ports.1..h_outflow|sink1.ports.1..m_flow|sink1.ports.1..p|sink1.ports.1..h_outflow|sink2.ports.1..m_flow|sink2.ports.1..p|sink2.ports.1..h_outflow', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Fluid.Examples.InverseParameterization_res.mat
-// Messages: assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | pump.delta_head_init >= 0.0
-// assert | warning | Variable violating min constraint: 0.0 <= pump.delta_head_init, has value: -2.45172
+// Messages: assert            | warning | [Modelica 3.2.1+maint.om/Fluid/Machines.mo:317:5-318:51:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((pump.delta_head_init >= 0.0)) --> "Variable violating min constraint: 0.0 <= pump.delta_head_init, has value: -2.45172"
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.Tanks.EmptyTanks.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.Tanks.EmptyTanks.mos
@@ -43,12 +43,12 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 50.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.Tanks.EmptyTanks', options = '', outputFormat = 'mat', variableFilter = 'time|tank1.level|tank1.medium.T|tank2.level|tank2.medium.T|tank2.traceDynamics|tank2.substanceDynamics|tank2.massDynamics|tank2.energyDynamics|tank1.traceDynamics|tank1.substanceDynamics|tank1.massDynamics|tank1.energyDynamics|system.traceDynamics|system.substanceDynamics|system.massDynamics|system.energyDynamics', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Fluid.Examples.Tanks.EmptyTanks_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
-// assert            | info    | The following assertion has been violated at time 35.406941
-// |                 | |       | tank1.m >= 0.0
-// assert            | info    | Variable violating min constraint: 0.0 <= tank1.m, has value: -9.95589e-08
-// assert            | info    | The following assertion has been violated at time 35.406941
-// |                 | |       | tank1.level >= 0.0
-// assert            | info    | Variable violating min constraint: 0.0 <= tank1.level, has value: -1e-10
+// assert            | info    | [Modelica 3.2.1+maint.om/Fluid/Interfaces.mo:580:7-580:32:writable]
+// |                 | |       | The following assertion has been violated at time 35.406941
+// |                 | |       | ((tank1.m >= 0.0)) --> "Variable violating min constraint: 0.0 <= tank1.m, has value: -9.95589e-08"
+// assert            | info    | [Modelica 3.2.1+maint.om/Fluid/Vessels.mo:53:3-54:29:writable]
+// |                 | |       | The following assertion has been violated at time 35.406941
+// |                 | |       | ((tank1.level >= 0.0)) --> "Variable violating min constraint: 0.0 <= tank1.level, has value: -1e-10"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.Tanks.TanksWithOverflow.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Fluid.Examples.Tanks.TanksWithOverflow.mos
@@ -30,9 +30,9 @@ runScript(modelTesting);getErrorString();
 // {"upperTank.level","upperTank.medium.h","lowerTank.level","lowerTank.medium.h"}
 // Simulation options: startTime = 0.0, stopTime = 25000.0, numberOfIntervals = 5000, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Fluid.Examples.Tanks.TanksWithOverflow', options = '', outputFormat = 'mat', variableFilter = 'time|upperTank.level|upperTank.medium.h|lowerTank.level|lowerTank.medium.h', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Fluid.Examples.Tanks.TanksWithOverflow_res.mat
-// Messages: assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | overflow.flowModel.states[1].p >= 0.0 and overflow.flowModel.states[1].p <= 100000000.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= overflow.flowModel.states[1].p <= 100000000.0, has value: -93465.5
+// Messages: assert            | warning | [Modelica 3.2.1+maint.om/Media/package.mo:5259:7-5259:55:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((overflow.flowModel.states[1].p >= 0.0 and overflow.flowModel.states[1].p <= 100000000.0)) --> "Variable violating min/max constraint: 0.0 <= overflow.flowModel.states[1].p <= 100000000.0, has value: -93465.5"
 // LOG_SUCCESS       | info    | The initialization finished successfully with 3 homotopy steps.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Elementary.Surfaces.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Mechanics.MultiBody.Examples.Elementary.Surfaces.mos
@@ -28,9 +28,9 @@ runScript(modelTesting);getErrorString();
 // {"prismatic.v","position.s"}
 // Simulation options: startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Mechanics.MultiBody.Examples.Elementary.Surfaces', options = '', outputFormat = 'mat', variableFilter = 'time|prismatic.v|position.s', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Mechanics.MultiBody.Examples.Elementary.Surfaces_res.mat
-// Messages: assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | wheel.ri >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= wheel.ri, has value: -0.05
+// Messages: assert            | warning | [Modelica 3.2.1+maint.om/Mechanics/MultiBody/Visualizers.mo:999:5-999:50:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((wheel.ri >= 0.0)) --> "Variable violating min constraint: 0.0 <= wheel.ri, has value: -0.05"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.MoistAir.mos
@@ -29,9 +29,9 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.MoistAir', options = '', outputFormat = 'mat', variableFilter = 'time|medium.p|medium.T', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.MoistAir_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.954000
-// |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00869
+// assert            | info    | [Modelica 3.2.1+maint.om/Media/Air/MoistAir.mo:59:7-60:78:writable]
+// |                 | |       | The following assertion has been violated at time 0.954000
+// |                 | |       | ((medium.x_sat >= 0.0 and medium.x_sat <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.00869"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir.mos
@@ -31,12 +31,12 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.ReferenceAir.MoistAir', options = '', outputFormat = 'mat', variableFilter = 'time|medium.p|medium.T|der_p|der_T', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.ReferenceAir.MoistAir_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.448000
-// |                 | |       | medium.X_liquid >= 0.0 and medium.X_liquid <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869
-// assert            | info    | The following assertion has been violated at time 0.954000
-// |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089
+// assert            | info    | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.448000
+// |                 | |       | ((medium.X_liquid >= 0.0 and medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869"
+// assert            | info    | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:63:5-64:78:writable]
+// |                 | |       | The following assertion has been violated at time 0.954000
+// |                 | |       | ((medium.x_sat >= 0.0 and medium.x_sat <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir1.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir1.mos
@@ -33,15 +33,15 @@ runScript(modelTesting);getErrorString();
 // {"volume.medium.p","volume.medium.T","volume.medium.X[1]","volume.medium.X[2]","volume.medium.Xi[1]","fixedMassFlowRate.port.p","ambient.port.m_flow"}
 // Simulation options: startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.ReferenceAir.MoistAir1', options = '', outputFormat = 'mat', variableFilter = 'time|volume.medium.p|volume.medium.T|volume.medium.X.1.|volume.medium.X.2.|volume.medium.Xi.1.|fixedMassFlowRate.port.p|ambient.port.m_flow', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.ReferenceAir.MoistAir1_res.mat
-// Messages: assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | volume.medium.X_liquid >= 0.0 and volume.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= volume.medium.X_liquid <= 1.0, has value: -0.00448846
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | fixedMassFlowRate.medium.X_liquid >= 0.0 and fixedMassFlowRate.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= fixedMassFlowRate.medium.X_liquid <= 1.0, has value: -0.325633
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | ambient.medium.X_liquid >= 0.0 and ambient.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= ambient.medium.X_liquid <= 1.0, has value: -0.00448846
+// Messages: assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((volume.medium.X_liquid >= 0.0 and volume.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= volume.medium.X_liquid <= 1.0, has value: -0.00448846"
+// assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((fixedMassFlowRate.medium.X_liquid >= 0.0 and fixedMassFlowRate.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= fixedMassFlowRate.medium.X_liquid <= 1.0, has value: -0.325633"
+// assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((ambient.medium.X_liquid >= 0.0 and ambient.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= ambient.medium.X_liquid <= 1.0, has value: -0.00448846"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir2.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.ReferenceAir.MoistAir2.mos
@@ -38,21 +38,21 @@ runScript(modelTesting);getErrorString();
 // {"volume.medium.p","volume.medium.T","volume.medium.X[1]","volume.medium.X[2]","volume.medium.Xi[1]","volume1.medium.p","volume1.medium.T","volume1.medium.X[1]","volume1.medium.X[2]","volume1.medium.Xi[1]","fixedMassFlowRate.port.p","ambient.port.m_flow"}
 // Simulation options: startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.ReferenceAir.MoistAir2', options = '', outputFormat = 'mat', variableFilter = 'time|volume.medium.p|volume.medium.T|volume.medium.X.1.|volume.medium.X.2.|volume.medium.Xi.1.|volume1.medium.p|volume1.medium.T|volume1.medium.X.1.|volume1.medium.X.2.|volume1.medium.Xi.1.|fixedMassFlowRate.port.p|ambient.port.m_flow', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.ReferenceAir.MoistAir2_res.mat
-// Messages: assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | volume.medium.X_liquid >= 0.0 and volume.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= volume.medium.X_liquid <= 1.0, has value: -0.0122993
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | fixedMassFlowRate.medium.X_liquid >= 0.0 and fixedMassFlowRate.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= fixedMassFlowRate.medium.X_liquid <= 1.0, has value: -0.500787
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | fixedMassFlowRate.medium.x_sat >= 0.0 and fixedMassFlowRate.medium.x_sat <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= fixedMassFlowRate.medium.x_sat <= 1.0, has value: 1.02342
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | volume1.medium.X_liquid >= 0.0 and volume1.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= volume1.medium.X_liquid <= 1.0, has value: -0.0122993
-// assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | ambient.medium.X_liquid >= 0.0 and ambient.medium.X_liquid <= 1.0
-// assert            | warning | Variable violating min/max constraint: 0.0 <= ambient.medium.X_liquid <= 1.0, has value: -0.0122993
+// Messages: assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((volume.medium.X_liquid >= 0.0 and volume.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= volume.medium.X_liquid <= 1.0, has value: -0.0122993"
+// assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((fixedMassFlowRate.medium.X_liquid >= 0.0 and fixedMassFlowRate.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= fixedMassFlowRate.medium.X_liquid <= 1.0, has value: -0.500787"
+// assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:63:5-64:78:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((fixedMassFlowRate.medium.x_sat >= 0.0 and fixedMassFlowRate.medium.x_sat <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= fixedMassFlowRate.medium.x_sat <= 1.0, has value: 1.02342"
+// assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((volume1.medium.X_liquid >= 0.0 and volume1.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= volume1.medium.X_liquid <= 1.0, has value: -0.0122993"
+// assert            | warning | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((ambient.medium.X_liquid >= 0.0 and ambient.medium.X_liquid <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= ambient.medium.X_liquid <= 1.0, has value: -0.0122993"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //

--- a/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
+++ b/testsuite/simulation/libraries/msl32/Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates.mos
@@ -29,9 +29,9 @@ runScript(modelTesting);getErrorString();
 // Simulation options: startTime = 0.0, stopTime = 22.0, numberOfIntervals = 2200, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates', options = '', outputFormat = 'mat', variableFilter = 'time|medium.p|medium.h', cflags = '', simflags = ' -abortSlowSimulation -alarm=360 -emit_protected'
 // Result file: Modelica.Media.Examples.TwoPhaseWater.TestTwoPhaseStates_res.mat
 // Messages: LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 20.080014
-// |                 | |       | medium.x >= 0.0 and medium.x <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1
+// assert            | info    | [Modelica 3.2.1+maint.om/Media/package.mo:2592:7-2592:43:writable]
+// |                 | |       | The following assertion has been violated at time 20.080014
+// |                 | |       | ((medium.x >= 0.0 and medium.x <= 1.0)) --> "Variable violating min/max constraint: 0.0 <= medium.x <= 1.0, has value: 1"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 //
 // Files Equal!

--- a/testsuite/simulation/modelica/asserts/AssertTest.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest.mos
@@ -28,9 +28,9 @@ getErrorString();
 //     resultFile = "",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 4, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'AssertTestInst', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: AssertTestInst
-// assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | 7.0 >= assertTest.lowlimit and 7.0 <= assertTest.highlimit
-// assert            | error   | Variable x out of limit
+// assert            | error   | [simulation/modelica/asserts/AssertTest.mo:14:3-14:70:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((7.0 >= assertTest.lowlimit and 7.0 <= assertTest.highlimit)) --> \"Variable x out of limit\"
 // assert            | info    | simulation terminated by an assertion at initialization
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/asserts/AssertTest1.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest1.mos
@@ -17,9 +17,9 @@ getErrorString();
 //     resultFile = "",
 //     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Test1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: Test1
-// assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | 10.0 >= assertTest.lowlimit and 10.0 <= assertTest.highlimit
-// assert            | error   | Variable x out of limit
+// assert            | error   | [simulation/modelica/asserts/AssertTest1.mo:14:3-14:70:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((10.0 >= assertTest.lowlimit and 10.0 <= assertTest.highlimit)) --> \"Variable x out of limit\"
 // assert            | info    | simulation terminated by an assertion at initialization
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/asserts/AssertTest2.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest2.mos
@@ -18,9 +18,9 @@ getErrorString(); // simulation failed, check error string.
 //     resultFile = "",
 //     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Test2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: Test2
-// assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | 5.0 >= assertTest.lowlimit and 5.0 <= assertTest.highlimit
-// assert            | error   | Variable x out of limit
+// assert            | error   | [simulation/modelica/asserts/AssertTest2.mo:14:3-14:70:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((5.0 >= assertTest.lowlimit and 5.0 <= assertTest.highlimit)) --> \"Variable x out of limit\"
 // assert            | info    | simulation terminated by an assertion at initialization
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/asserts/AssertTest4.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest4.mos
@@ -26,9 +26,9 @@ getErrorString();
 // Value of x(=0.666667)
 // Value of x(=0.555556)
 // Value of x(=0.444444)
-// assert            | info    | The following assertion has been violated at time 0.555556
-// |                 | |       | assertTest.x >= 0.5
-// assert            | info    | Variable x(=0.444444) out of limit
+// assert            | info    | [simulation/modelica/asserts/AssertTest4.mo:26:3-26:65:writable]
+// |                 | |       | The following assertion has been violated at time 0.555556
+// |                 | |       | ((assertTest.x >= 0.5)) --> \"Variable x(=0.444444) out of limit\"
 // assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/asserts/AssertTest5.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest5.mos
@@ -26,9 +26,9 @@ getErrorString();
 // Value of x(=0.666667)
 // Value of x(=0.555556)
 // Value of x(=0.444444)
-// assert            | info    | The following assertion has been violated at time 0.555556
-// |                 | |       | assertTest.x >= 0.5
-// assert            | info    | Variable x(=0.444444) out of limit
+// assert            | info    | [simulation/modelica/asserts/AssertTest5.mo:26:3-26:65:writable]
+// |                 | |       | The following assertion has been violated at time 0.555556
+// |                 | |       | ((assertTest.x >= 0.5)) --> \"Variable x(=0.444444) out of limit\"
 // assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/asserts/AssertTest8.mos
+++ b/testsuite/simulation/modelica/asserts/AssertTest8.mos
@@ -29,9 +29,9 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "AssertTest_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'AssertTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | x >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= x, has value: -0.5
+//     messages = "assert            | warning | [<interactive>:3:3-3:29:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((x >= 0.0)) --> \"Variable violating min constraint: 0.0 <= x, has value: -0.5\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/asserts/Makefile
+++ b/testsuite/simulation/modelica/asserts/Makefile
@@ -16,7 +16,7 @@ powAssert1.mos \
 powAssert2.mos \
 powAssert3.mos \
 
-# test that currently fail. Move up when fixed. 
+# test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=  \
 
@@ -25,7 +25,7 @@ FAILINGTESTFILES=  \
 DEPENDENCIES = \
 *.mo \
 *.mos \
-Makefile 
+Makefile
 
 
 
@@ -39,8 +39,8 @@ test:
 	@echo
 	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
 	@$(TEST) $(TESTFILES)
-	
-# Cleans all files that are not listed as dependencies 
+
+# Cleans all files that are not listed as dependencies
 clean :
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
 	@rm -f $(CLEAN)
@@ -49,11 +49,11 @@ clean :
 # do it after cleaning and updating the folder
 # then you can get a list of file names (which must be dependencies
 # since you got them from repository + your own new files)
-# then add them to the DEPENDENCIES. You can find the 
-# list in deps.txt 
-getdeps: 
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
 	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
-	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt	
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
 	@echo Dependency list saved in deps.txt.
 	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
 

--- a/testsuite/simulation/modelica/asserts/TestAssert.mos
+++ b/testsuite/simulation/modelica/asserts/TestAssert.mos
@@ -75,12 +75,12 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 // record SimulationResult
 //     resultFile = "TestAssert.TestWarningConstant_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestWarningConstant', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | false
-// assert            | warning | Variable x is probably too big
-// assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | false
-// assert            | warning | Variable x is probably too big
+//     messages = "assert            | warning | [<interactive>:7:5-7:76:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((false)) --> \"Variable x is probably too big\"
+// assert            | warning | [<interactive>:7:5-7:76:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((false)) --> \"Variable x is probably too big\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -91,9 +91,9 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     resultFile = "TestAssert.TestWarningVariable_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestWarningVariable', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.834000
-// |                 | |       | m3.x < 5.0
-// assert            | info    | Variable x is probably too big
+// assert            | info    | [<interactive>:7:5-7:76:writable]
+// |                 | |       | The following assertion has been violated at time 0.834000
+// |                 | |       | ((m3.x < 5.0)) --> \"Variable x is probably too big\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -102,9 +102,9 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     resultFile = "TestAssert.TestWarningRecurring_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestWarningRecurring', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.158000
-// |                 | |       | m3.x < 5.0
-// assert            | info    | Variable x is probably too big
+// assert            | info    | [<interactive>:7:5-7:76:writable]
+// |                 | |       | The following assertion has been violated at time 0.158000
+// |                 | |       | ((m3.x < 5.0)) --> \"Variable x is probably too big\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -113,9 +113,9 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     resultFile = "",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestErrorConstant', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: TestAssert.TestErrorConstant
-// assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | false
-// assert            | error   | Variable x is too big
+// assert            | error   | [<interactive>:6:5-6:44:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((false)) --> \"Variable x is too big\"
 // assert            | info    | simulation terminated by an assertion at initialization
 // "
 // end SimulationResult;
@@ -125,12 +125,12 @@ simulate(TestAssert.TestErrorVariable); getErrorString();
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestAssert.TestErrorVariable', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: TestAssert.TestErrorVariable
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.250000
-// |                 | |       | m2.x < 5.0
-// assert            | info    | Variable x is probably too big
-// assert            | info    | The following assertion has been violated at time 0.500000
-// |                 | |       | m2.x < 10.0
-// assert            | info    | Variable x is too big
+// assert            | info    | [<interactive>:7:5-7:76:writable]
+// |                 | |       | The following assertion has been violated at time 0.250000
+// |                 | |       | ((m2.x < 5.0)) --> \"Variable x is probably too big\"
+// assert            | info    | [<interactive>:6:5-6:44:writable]
+// |                 | |       | The following assertion has been violated at time 0.500000
+// |                 | |       | ((m2.x < 10.0)) --> \"Variable x is too big\"
 // assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/events/whenTest2.mos
+++ b/testsuite/simulation/modelica/events/whenTest2.mos
@@ -57,12 +57,12 @@ val(x, 0.9);
 // x : 1.28938
 // Time : 0.5
 // x : 1.22416
-// assert            | info    | The following assertion has been violated at time 0.573517
-// |                 | |       | time < 0.5
-// assert            | info    | Assert does trigger.
-// assert            | info    | The following assertion has been violated at time 0.591693
-// |                 | |       | time < 0.55
-// assert            | info    | Assert does triggered again .
+// assert            | info    | [<interactive>:19:7-19:71:writable]
+// |                 | |       | The following assertion has been violated at time 0.573517
+// |                 | |       | ((time < 0.5)) --> \"Assert does trigger.\"
+// assert            | info    | [<interactive>:21:7-21:81:writable]
+// |                 | |       | The following assertion has been violated at time 0.591693
+// |                 | |       | ((time < 0.55)) --> \"Assert does triggered again .\"
 // Time : 0.6
 // x : 1.24662
 // Time : 0.7

--- a/testsuite/simulation/modelica/functions_eval/MoistAir.mos
+++ b/testsuite/simulation/modelica/functions_eval/MoistAir.mos
@@ -20,12 +20,12 @@ getErrorString();
 //     resultFile = "Modelica.Media.Examples.ReferenceAir.MoistAir_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Modelica.Media.Examples.ReferenceAir.MoistAir', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.448000
-// |                 | |       | medium.X_liquid >= 0.0 and medium.X_liquid <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869
-// assert            | info    | The following assertion has been violated at time 0.954000
-// |                 | |       | medium.x_sat >= 0.0 and medium.x_sat <= 1.0
-// assert            | info    | Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089
+// assert            | info    | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:58:5-58:67:writable]
+// |                 | |       | The following assertion has been violated at time 0.448000
+// |                 | |       | ((medium.X_liquid >= 0.0 and medium.X_liquid <= 1.0)) --> \"Variable violating min/max constraint: 0.0 <= medium.X_liquid <= 1.0, has value: -0.00037869\"
+// assert            | info    | [Modelica 3.2.1+maint.om/Media/Air/ReferenceMoistAir.mo:63:5-64:78:writable]
+// |                 | |       | The following assertion has been violated at time 0.954000
+// |                 | |       | ((medium.x_sat >= 0.0 and medium.x_sat <= 1.0)) --> \"Variable violating min/max constraint: 0.0 <= medium.x_sat <= 1.0, has value: 1.0089\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/initialization/bug_4718.mos
+++ b/testsuite/simulation/modelica/initialization/bug_4718.mos
@@ -19,7 +19,8 @@ simulate(InitialAssert);getErrorString();
 //     resultFile = "",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'InitialAssert', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: InitialAssert
-// assert            | error   | abc
+// assert            | error   | [<interactive>:6:5-6:25:writable]
+// |                 | |       | abc
 // assert            | info    | simulation terminated by an assertion at initialization
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/initialization/testIfAssert.mos
+++ b/testsuite/simulation/modelica/initialization/testIfAssert.mos
@@ -35,9 +35,10 @@ getErrorString();
 //     resultFile = "",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'A', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: A
-// assert            | warning | The following assertion has been violated during initialization at time 0.000000
-// |                 | |       | if x < lb then $DER.x < 49.0 else true
-// assert            | error   | Call lb assert
+// assert            | error   | [<interactive>:11:5-11:42:writable]
+// |                 | |       | The following assertion has been violated during initialization at time 0.000000
+// |                 | |       | ((if x < lb then $DER.x < 49.0 else true)) --> \"Call lb assert
+// |                 | |       | \"
 // assert            | info    | simulation terminated by an assertion at initialization
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/msl22/InitTest.mos
+++ b/testsuite/simulation/modelica/msl22/InitTest.mos
@@ -19,9 +19,9 @@ val(slidingMass1.s,3.9540);
 // record SimulationResult
 //     resultFile = "Inittest_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 10.0, numberOfIntervals = 50, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'Inittest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | springDamper1.s_rel >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= springDamper1.s_rel, has value: -0.005
+//     messages = "assert            | warning | [Modelica 2.2.2+maint.om/Mechanics/Translational.mo:1364:7-1364:72:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((springDamper1.s_rel >= 0.0)) --> \"Variable violating min constraint: 0.0 <= springDamper1.s_rel, has value: -0.005\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/others/Bug1687.mos
+++ b/testsuite/simulation/modelica/others/Bug1687.mos
@@ -21,9 +21,9 @@ val(mass.v,0.06);
 // record SimulationResult
 //     resultFile = "ActuatorMechanics_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 0.1, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ActuatorMechanics', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "assert            | warning | The following assertion has been violated at time 0.000000
-// |                 | |       | spring.s_rel >= 0.0
-// assert            | warning | Variable violating min constraint: 0.0 <= spring.s_rel, has value: -0.01
+//     messages = "assert            | warning | [simulation/modelica/others/Bug1687.mo:985:11-986:58:writable]
+// |                 | |       | The following assertion has been violated at time 0.000000
+// |                 | |       | ((spring.s_rel >= 0.0)) --> \"Variable violating min constraint: 0.0 <= spring.s_rel, has value: -0.01\"
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "

--- a/testsuite/simulation/modelica/others/StringTest.mos
+++ b/testsuite/simulation/modelica/others/StringTest.mos
@@ -17,9 +17,9 @@ simulate(STest1, tolerance=1e-5, numberOfIntervals=100);
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 100, tolerance = 1e-05, method = 'dassl', fileNamePrefix = 'STest1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "Simulation execution failed for model: STest1
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert            | info    | The following assertion has been violated at time 0.110000
-// |                 | |       | x < 0.1
-// assert            | info    | x reached 0.11 at time 0.11 b =true i =     66
+// assert            | info    | [simulation/modelica/others/StringTest.mo:8:1-14:56:writable]
+// |                 | |       | The following assertion has been violated at time 0.110000
+// |                 | |       | ((x < 0.1)) --> \"x reached 0.11 at time 0.11 b =true i =     66\"
 // assert            | error   | No event found, but assert was triggered. Throwing now!
 // "
 // end SimulationResult;

--- a/testsuite/simulation/modelica/parallel/ParallelPRV.mos
+++ b/testsuite/simulation/modelica/parallel/ParallelPRV.mos
@@ -22,9 +22,9 @@ val(hydr.left.p,1.01);
 //     resultFile = "PRVSystem_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.2, numberOfIntervals = 119999, tolerance = 1e-06, method = 'rungekutta', fileNamePrefix = 'PRVSystem', options = '', outputFormat = 'mat', variableFilter = 'hydr.left.p|hydr.x', cflags = '', simflags = '-noEventEmit'",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
-// assert | info    | The following assertion has been violated at time 1.000058
-// | | |       | hydr.x >= 0.0 and hydr.x <= 0.015
-// assert | info    | Variable violating min/max constraint: 0.0 <= hydr.x <= 0.015, has value: -3.85812e-24
+// assert            | info    | [simulation/modelica/parallel/ParallelPRV.mo:55:3-55:47:writable]
+// |                 | |       | The following assertion has been violated at time 1.000058
+// |                 | |       | ((hydr.x >= 0.0 and hydr.x <= 0.015)) --> \"Variable violating min/max constraint: 0.0 <= hydr.x <= 0.015, has value: -3.85812e-24\"
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
- Most assert messages now report info regarding the source location of the assert.
- Some assert messages deemed redundant are removed or reformatted.

- The current look and format of assert messages is not final and can be changed as we wish.
- There are still some assert types that do not report source info. They will be improved after this.  


------------------------------------------------------------------------
Changes

[Make `omc_dummyFileInfo` a variable instead of a value.](https://github.com/OpenModelica/OpenModelica/commit/04bd40fe15efd08d3cb1c217734d6e16f0d73a3a) 

 
[Add FILE_INFO to `infoStreamPrintWithEquationIndexes()`](https://github.com/OpenModelica/OpenModelica/commit/416c03bd43700ebab3d9c1819b2dcef10b172b36)



[Add FILE_INFO to `messageFunction` functions.](https://github.com/OpenModelica/OpenModelica/commit/98ce732a57c3a464e0ef7fcb5a24d921972e582c) 

  - the `messageFunction`s `messageText` now takes a FILE_INFO parameter.
    - This required `messageXML` and `messageXMLTCP` functions to take the
      additional parameter too because they need to match.

    - All the functions that call one of these functions now pass FILE_INFO
      argument.

    - For now, all the *`WithEquationIndexes` functions are changed to accept
      a FILE_INFO parameter which they pass on to the `messageFunctions `(e.g.
      `messageText`).

      Other functions that call the `messageFunction`'s just pass an
      `omc_dummyFileInfo` instead. They will be updated if needed.
 
[Print the FILE_INFO if it points to a file.](https://github.com/OpenModelica/OpenModelica/commit/2421192a3331d53f9954ad9a32f032bbf52463f2) 

  - If it is a `dummyFileInfo`, i.e., filename is empty, skip it to not
    generate unnecessary output.
 
[Improve formatting of some messages.](https://github.com/OpenModelica/OpenModelica/commit/88f9d8a67c4eee9cede2cbed883c501a5f77fc17) 

  - Remove redundant message which adds unnecessary `assert`, `warning` ...
    for sub-messages. The message functions split multiline strings sent
    to them. So instead of calling them multiple times give them a multiline
    string.

  - Do not print FILE_INFO for sub-messages.
 
[Remove another redundant assert function call.](https://github.com/OpenModelica/OpenModelica/commit/c80489f436236c1b43602acafd31b7e816aa3a5d) 

  - Instead of calling `omc_assert_warning` and then `omc_assert_withEquationIndexes`
    just call `omc_assert_withEquationIndexes` with the relevant info.

    This might have some consequences though. We will see.
 
[Expected output](https://github.com/OpenModelica/OpenModelica/commit/d8ca9900703f1e57e6430b879f8c28bc439735ad)



















































































































