### PR TITLE
Change error for unassigned outputs to a warning

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -678,7 +678,7 @@ algorithm
   () := match value
     case Expression.EMPTY()
       algorithm
-        Error.addSourceMessage(Error.UNASSIGNED_FUNCTION_OUTPUT,
+        Error.addSourceMessageAsError(Error.UNASSIGNED_FUNCTION_OUTPUT,
           {InstNode.name(outputNode)}, InstNode.info(outputNode));
       then
         fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -2619,6 +2619,7 @@ protected
       return;
     end if;
 
+    // Check if there are variables being used uninitialized.
     unassigned := Vector.new<InstNode>();
     addUnassignedComponents(unassigned, fn.outputs);
     addUnassignedComponents(unassigned, fn.locals);
@@ -2626,17 +2627,19 @@ protected
     body := getBody(fn);
     checkUseBeforeAssign2(unassigned, body);
 
+    // Give a warning for any outputs that were not assigned in the function.
     for var in Vector.toList(unassigned) loop
       if InstNode.isOutput(var) then
         parent := InstNode.InstNode.parent(var);
         sources := {InstNode.info(var)};
 
+        // If the output is inherited then also give the source location of the
+        // derived function, since that's likely where the assignment is missing.
         if InstNode.isBaseClass(parent) then
           sources := InstNode.info(InstNode.getDerivedNode(parent)) :: sources;
         end if;
 
         Error.addMultiSourceMessage(Error.UNASSIGNED_FUNCTION_OUTPUT, {InstNode.name(var)}, sources);
-        fail();
       end if;
     end for;
   end checkUseBeforeAssign;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -740,7 +740,7 @@ public constant ErrorTypes.Message TERMINATE_TRIGGERED = ErrorTypes.MESSAGE(333,
   Gettext.gettext("terminate triggered: %s"));
 public constant ErrorTypes.Message EVAL_RECURSION_LIMIT_REACHED = ErrorTypes.MESSAGE(334, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The recursion limit (--evalRecursionLimit=%s) was exceeded during evaluation of %s."));
-public constant ErrorTypes.Message UNASSIGNED_FUNCTION_OUTPUT = ErrorTypes.MESSAGE(335, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+public constant ErrorTypes.Message UNASSIGNED_FUNCTION_OUTPUT = ErrorTypes.MESSAGE(335, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("Output parameter %s was not assigned a value"));
 public constant ErrorTypes.Message INVALID_WHEN_STATEMENT_CONTEXT = ErrorTypes.MESSAGE(336, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("A when-statement may not be used inside a function or a while, if, or for-clause."));

--- a/testsuite/flattening/modelica/scodeinst/FunctionUnitialized3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionUnitialized3.mo
@@ -1,6 +1,6 @@
 // name: FunctionUnitialized3
 // keywords:
-// status: incorrect
+// status: correct
 // cflags: -d=newInst
 //
 //
@@ -15,11 +15,14 @@ model FunctionUnitialized3
 end FunctionUnitialized3;
 
 // Result:
-// Error processing file: FunctionUnitialized3.mo
-// [flattening/modelica/scodeinst/FunctionUnitialized3.mo:13:5-13:18:writable] Error: Output parameter y was not assigned a value
+// function FunctionUnitialized3.f
+//   input Real x;
+//   output Real y;
+// end FunctionUnitialized3.f;
 //
-// # Error encountered! Exiting...
-// # Please check the error message and the flags.
+// class FunctionUnitialized3
+//   Real y = FunctionUnitialized3.f(time);
+// end FunctionUnitialized3;
+// [flattening/modelica/scodeinst/FunctionUnitialized3.mo:13:5-13:18:writable] Warning: Output parameter y was not assigned a value
 //
-// Execution failed!
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionUnitialized4.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionUnitialized4.mo
@@ -1,6 +1,6 @@
 // name: FunctionUnitialized4
 // keywords:
-// status: incorrect
+// status: correct
 // cflags: -d=newInst
 //
 //
@@ -19,12 +19,15 @@ model FunctionUnitialized4
 end FunctionUnitialized4;
 
 // Result:
-// Error processing file: FunctionUnitialized4.mo
+// function FunctionUnitialized4.f
+//   input Real x;
+//   output Real y;
+// end FunctionUnitialized4.f;
+//
+// class FunctionUnitialized4
+//   Real x = FunctionUnitialized4.f(time);
+// end FunctionUnitialized4;
 // [flattening/modelica/scodeinst/FunctionUnitialized4.mo:14:3-16:8:writable] Notification: From here:
-// [flattening/modelica/scodeinst/FunctionUnitialized4.mo:11:5-11:18:writable] Error: Output parameter y was not assigned a value
+// [flattening/modelica/scodeinst/FunctionUnitialized4.mo:11:5-11:18:writable] Warning: Output parameter y was not assigned a value
 //
-// # Error encountered! Exiting...
-// # Please check the error message and the flags.
-//
-// Execution failed!
 // endResult


### PR DESCRIPTION
- Change the error for outputs that are not assigned in function to a warning instead of a hard error, since there might be such functions that are never actually called.