### PR TITLE
Enable ccache on Windows CI jobs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,7 +187,6 @@ pipeline {
               withEnv (["PATH=C:\\OMDev\\tools\\msys\\usr\\bin;C:\\Program Files\\TortoiseSVN\\bin;c:\\bin\\jdk\\bin;c:\\bin\\nsis\\;${env.PATH};c:\\bin\\git\\bin;"]) {
                 bat "echo PATH: %PATH%"
                 common.buildOMC_CMake('-DCMAKE_BUILD_TYPE=Release'
-                                        + ' -DOM_USE_CCACHE=OFF'
                                         + ' -DCMAKE_INSTALL_PREFIX=build'
                                         + ' -G "MSYS Makefiles"'
                                       )


### PR DESCRIPTION
  - ccache is now available in OMDev. Enable it when compiling OpenModelica with OMDev. This should make checking builds on Windows a bit faster once we have the initial ccache on each Windows runner.

    The nightly Windows job still builds without ccache. So, in the extreme case of something going amiss due to ccache, we will still catch it the next day.

