### PR TITLE
Fix new backend implicit flags

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -229,6 +229,11 @@ end instClassInProgram;
 function resetGlobalFlags
   "Resets the global flags that the frontend uses."
 algorithm
+  if Flags.getConfigBool(Flags.NEW_BACKEND) then
+    FlagsUtil.set(Flags.NF_SCALARIZE, false);
+    FlagsUtil.set(Flags.ARRAY_CONNECT, true);
+  end if;
+
   // gather here all the flags to disable expansion
   // and scalarization if -d=-nfScalarize is on
   if not Flags.isSet(Flags.NF_SCALARIZE) then

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1044,10 +1044,6 @@ algorithm
     // new backend - also activates new frontend by default
     case (graph, filenameprefix) guard(Flags.getConfigBool(Flags.NEW_BACKEND))
       algorithm
-        // set implied flags to true
-        FlagsUtil.enableDebug(Flags.SCODE_INST);
-        FlagsUtil.enableDebug(Flags.ARRAY_CONNECT);
-        FlagsUtil.disableDebug(Flags.NF_SCALARIZE);
         // ToDo: set permanently matching -> SBGraphs
 
         // ================================


### PR DESCRIPTION
- Move the setting of the implicit flags for the new backend from SimCodeMain to the frontend so they're always set even if not going through the `translateModel` path.