### PR TITLE
Fatal error when input variable is differentiated.

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -9367,6 +9367,7 @@ algorithm
 end setFunctionTree;
 
 public function setEqSystEqs
+  "Set ordered equations of input equation system to given equations."
   input BackendDAE.EqSystem inSyst;
   input BackendDAE.EquationArray inEqs;
   output BackendDAE.EqSystem syst = inSyst;

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -465,7 +465,7 @@ protected function inputDerivativesUsedWork "author: Frenkel TUD 2012-10"
   output BackendDAE.Shared outShared = inShared "unused";
   output Boolean outChanged;
 algorithm
-  (osyst, outChanged) := matchcontinue(isyst)
+  (osyst, outChanged) := match(isyst)
     local
       BackendDAE.EquationArray orderedEqs;
       list<DAE.Exp> explst;
@@ -474,10 +474,10 @@ algorithm
       ((_, explst as _::_)) = BackendDAEUtil.traverseBackendDAEExpsEqns(orderedEqs, traverserinputDerivativesUsed, (BackendVariable.daeGlobalKnownVars(inShared), {}));
       s = stringDelimitList(List.map(explst, ExpressionDump.printExpStr), "\n");
       Error.addMessage(Error.DERIVATIVE_INPUT, {s});
-    then (BackendDAEUtil.setEqSystEqs(isyst, orderedEqs), true);
+    then fail();
 
     else (isyst, inChanged);
-  end matchcontinue;
+  end match;
 end inputDerivativesUsedWork;
 
 protected function traverserinputDerivativesUsed "author: Frenkel TUD 2012-10"


### PR DESCRIPTION
### Related Issues

Fixes #9802.

### Purpose

  - Stop if input variables need to be differentiated.

### Approach

  - Error was not fatal before and the compiler didn't stop.
