### PR TITLE
Make incompatible pointer types an error.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -701,7 +701,7 @@ pipeline {
             stash name: 'cross-fmu-results-armhf', includes: 'testsuite/special/FmuExportCrossCompile/*.csv, testsuite/special/FmuExportCrossCompile/Test_FMUs/**'
           }
         }
-        stage('clang-qt5') {
+        stage('clang-qt5-omedit-testsuite') {
           agent {
             docker {
               image 'docker.openmodelica.org/build-deps:v1.16.3'

--- a/OMCompiler/CMakeLists.txt
+++ b/OMCompiler/CMakeLists.txt
@@ -54,7 +54,8 @@ omc_add_subdirectory(3rdParty)
 # We do this after 3rdParty is added!! because some libs in FMILib use implicit function declaration
 # because of missing #defines due to bad configuration for now.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
+  add_compile_options($<$<COMPILE_LANGUAGE:C>:-Werror=incompatible-pointer-types>)
 endif()
 
 omc_add_subdirectory(SimulationRuntime)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.c
@@ -651,7 +651,7 @@ void dumpFastStates_gb(DATA_GBODE* gbData, modelica_boolean event, double time, 
  *                    -1  <= step is preliminary accepted but needs refinement
  */
 void dumpFastStates_gbf(DATA_GBODE* gbData, double time, int rejectedType) {
-  char fastStates_row[4096];
+  char fastStates_row[40960];
   unsigned int bufSize = 40960;
   unsigned int ct;
   int i, ii;

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
@@ -313,7 +313,7 @@ int omc_dladdr(void *addr, Dl_info *info)
 {
   HANDLE hProcess;
   DWORD dwModuleBase;
-  DWORD displacement;
+  DWORD64 displacement;
   char sModuleName[MAX_PATH + 1];
   sModuleName[MAX_PATH] = '\0';
 


### PR DESCRIPTION
  - For anything we build inside OMCompiler/, excluding OMCompiler/3rdParty, for the incompatible pointer types warning to error.

  - Fix unmatched buffer size in `gbode_util.c`

  - Rename the `clang-qt5` stage to `clang-qt5-omedit-testsuite`