### PR TITLE
Declare DynamicSelect to be impure

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -626,7 +626,7 @@ function size "Returns dimensions of an array"
 </html>"));
 end size;
 
-function DynamicSelect<__Any> "select static or dynamic expressions in the annotations"
+impure function DynamicSelect<__Any> "select static or dynamic expressions in the annotations"
   input __Any static;
   input __Any dynamic;
   output __Any selected;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation5.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation5.mos
@@ -1,0 +1,102 @@
+// name: GetModelInstanceAnnotation5
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    annotation(Icon(graphics = {
+      Rectangle(extent = DynamicSelect({{0, 0}, {20, 20}}, {{0, 0}, {20, 30}}))
+    }));
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"graphics\": [
+//         {
+//           \"$kind\": \"record\",
+//           \"name\": \"Rectangle\",
+//           \"elements\": [
+//             true,
+//             [
+//               0,
+//               0
+//             ],
+//             0,
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"LinePattern.Solid\",
+//               \"index\": 2
+//             },
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"FillPattern.None\",
+//               \"index\": 1
+//             },
+//             0.25,
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"BorderPattern.None\",
+//               \"index\": 1
+//             },
+//             {
+//               \"$kind\": \"call\",
+//               \"name\": \"DynamicSelect\",
+//               \"arguments\": [
+//                 [
+//                   [
+//                     0,
+//                     0
+//                   ],
+//                   [
+//                     20,
+//                     20
+//                   ]
+//                 ],
+//                 [
+//                   [
+//                     0,
+//                     0
+//                   ],
+//                   [
+//                     20,
+//                     30
+//                   ]
+//                 ]
+//               ]
+//             },
+//             0
+//           ]
+//         }
+//       ]
+//     }
+//   },
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 6,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -5,6 +5,7 @@ GetModelInstanceAnnotation1.mos \
 GetModelInstanceAnnotation2.mos \
 GetModelInstanceAnnotation3.mos \
 GetModelInstanceAnnotation4.mos \
+GetModelInstanceAnnotation5.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceComment1.mos \


### PR DESCRIPTION
- Declare DynamicSelect to be impure to make sure the compiler doesn't try to evaluate it.