### PR TITLE
Add the libs-for-testing target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ if(OM_ENABLE_GUI_CLIENTS)
   omc_add_subdirectory(OMSens_Qt)
 endif()
 
+omc_add_subdirectory(libraries)
 omc_add_subdirectory(testsuite)
 
 include(cmake/packaging/common.cmake)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,14 +1,32 @@
 
 
-set(STAMP 20200610130629.stamp)
+set(STAMP 20221102135323.stamp)
 
 # Note that omc needs to be built and INSTALLED before you can add the libs for testing.
-# The reason being omc needs to be ina folder **/bin to work. Otherwise it will refuse to run
+# The reason being omc needs to be in a folder **/bin to work. Otherwise it will refuse to run
 # Plus it needs to know where find the shared libs it needs. That is structured to work for install.
+set(LIBS_DIR_FOR_TESTING ${CMAKE_CURRENT_SOURCE_DIR}/.openmodelica/libraries)
 add_custom_target(libs-for-testing
-            COMMAND ${CMAKE_COMMAND} -E remove_directory .openmodelica/libraries
-            COMMAND ${CMAKE_COMMAND} -E make_directory .openmodelica/libraries
+            COMMAND ${CMAKE_COMMAND} -E remove_directory ${LIBS_DIR_FOR_TESTING}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBS_DIR_FOR_TESTING}
+            COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/index.json ${LIBS_DIR_FOR_TESTING}
             COMMAND ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/omc index.mos
 
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         )
+
+
+## Disabled until we figure out how to properly handle this for packaging.
+
+# # Note that omc needs to be built and INSTALLED before you can add the libs for testing.
+# # The reason being omc needs to be in a folder **/bin to work. Otherwise it will refuse to run
+# # Plus it needs to know where find the shared libs it needs. That is structured to work for install.
+# set(LIBS_DIR_FOR_INSTALLER ${CMAKE_CURRENT_SOURCE_DIR}/.openmodelica/libraries)
+# add_custom_target(libs-for-installer
+#             COMMAND ${CMAKE_COMMAND} -E remove_directory ${LIBS_DIR_FOR_INSTALLER}
+#             COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBS_DIR_FOR_INSTALLER}
+#             COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/install-index.json ${LIBS_DIR_FOR_INSTALLER}
+#             COMMAND ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/omc ../index.mos
+
+#             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/installing
+#         )

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -3,4 +3,5 @@ omc_add_subdirectory(ReferenceFiles)
 
 add_custom_target(testsuite-depends
                     DEPENDS omc-diff
+                    DEPENDS libs-for-testing
                     DEPENDS reference-files)


### PR DESCRIPTION
  - This target was removed temporarily while we were adjusting how libraries are cached for installers.

  - The target installs libraries needed for running the OpenModelica testsuite. It is also implied by the target `testsuite-depends`
