### PR TITLE
Reduce number of nodes to simplify test case.

### DIFF
--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial.mos
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStateInitial.mos
@@ -20,8 +20,8 @@ buildModel(OverdeterminedInitialization.Fluid.DynamicPipesSeriesLargeNSteadyStat
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
 // Notification: The following initial equation is redundant and consistent due to simplifications in RemoveSimpleEquations and therefore removed from the initialization problem: der(pipe1.mediums[1].p) = 0.0 -> 0.0 = 0.0
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization system:
-//          $DER.pipe1.mediums[50].p = 0.0.
+//          $DER.pipe1.mediums[10].p = 0.0.
 // Warning: The initial conditions are over specified. The following 1 initial equations are redundant, so they are removed from the initialization_lambda0 system:
-//          $DER.pipe1.mediums[50].p = 0.0.
+//          $DER.pipe1.mediums[10].p = 0.0.
 // "
 // endResult

--- a/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.mo
+++ b/testsuite/simulation/modelica/initialization/OverdeterminedInitialization.mo
@@ -278,8 +278,8 @@ The initial equations are consistent however and a tool shall reduce them approp
     model DynamicPipesSeriesLargeNSteadyStateInitial
       "Same as DynamicPipesSeriesSteadyStateInitial but with larger number of nodes"
        extends DynamicPipesSeriesSteadyStateInitial(
-         pipe1(nNodes = 50),
-         pipe2(nNodes = 50));
+         pipe1(nNodes = 10),
+         pipe2(nNodes = 10));
     equation
 
     end DynamicPipesSeriesLargeNSteadyStateInitial;


### PR DESCRIPTION
  - Reduce the number of nodes from 50 to 10 in order to reduce the running time of the simulation.

  - Improves #9799
