### PR TITLE
Define OPENMODELICA_H_ for external includes of libraries

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -289,13 +289,17 @@ end commonHeader;
 
 /* public */ template externalFunctionIncludes(list<String> includes)
  "Generates external includes part in function files.
-  used in Compiler/Template/CodegenFMU.tpl"
+  used in Compiler/Template/CodegenFMU.tpl.
+  Include openmodelica.h, because some Modelica libraries test if some tool depedent variable is set, e.g. TILMedia."
 ::=
   if includes then
   <<
   #ifdef __cplusplus
   extern "C" {
   #endif
+  #include "openmodelica.h"       // Defines OPENMODELICA_H_ for libraris to test if called from OpenModelica.
+  #include "ModelicaUtilities.h"  // Make Modelica C util functions available for external includes.
+
   <% (includes ;separator="\n") %>
   #ifdef __cplusplus
   }


### PR DESCRIPTION
### Related Issues

#9249

### Purpose

  - Make it possible for external includes from Modelica library to figure out if OpenModelica is the Modelica tool. E.g. TILMedia checks for some tools and can now also check if OpenModelica is used.
  - Make Modelica C util functions available for external includes. E.g. TILMedia uses `ModelicaFormatMessage`.

### Approach

  - Include `openmodelica.h` to have `OPENMODELICA_H_` defined.
    ```C
    #if defined(OPENMODELICA_H_)
    /* OpenModelica specific function prototype */ 
    #endif
    ```
