### PR TITLE
Improve unknown dimension deduction

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5541,7 +5541,12 @@ public
         algorithm
           subs := list(s for s guard not filterSplitIndices2(s, node) in subs);
         then
-          applySubscripts(subs, exp.exp);
+          if listEmpty(subs) then
+            exp.exp
+          elseif Type.isUnknown(exp.ty) then
+            SUBSCRIPTED_EXP(exp.exp, subs, exp.ty, List.any(subs, Subscript.isSplit))
+          else
+            applySubscripts(subs, exp.exp);
 
       else exp;
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -1223,6 +1223,17 @@ public
     end match;
   end first;
 
+  function isSplit
+    input Subscript sub;
+    output Boolean res;
+  algorithm
+    res := match sub
+      case SPLIT_PROXY() then true;
+      case SPLIT_INDEX() then true;
+      else false;
+    end match;
+  end isSplit;
+
   function isSplitIndex
     input Subscript sub;
     output Boolean res;

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown10.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown10.mo
@@ -1,0 +1,25 @@
+// name: DimUnknown10
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+model A
+  Real [:, 2] x;
+end A;
+
+model DimUnknown10
+  A a(x(start = [1, 1; 1, 1; 1, 1]));
+end DimUnknown10;
+
+// Result:
+// class DimUnknown10
+//   Real a.x[1,1](start = 1.0);
+//   Real a.x[1,2](start = 1.0);
+//   Real a.x[2,1](start = 1.0);
+//   Real a.x[2,2](start = 1.0);
+//   Real a.x[3,1](start = 1.0);
+//   Real a.x[3,2](start = 1.0);
+// end DimUnknown10;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown11.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown11.mo
@@ -1,0 +1,25 @@
+// name: DimUnknown11
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+model A
+  Real [:, 2] x;
+end A;
+
+model DimUnknown11
+  A a(x(start = {{1, 1}, {1, 1}, {1, 1}}));
+end DimUnknown11;
+
+// Result:
+// class DimUnknown11
+//   Real a.x[1,1](start = 1.0);
+//   Real a.x[1,2](start = 1.0);
+//   Real a.x[2,1](start = 1.0);
+//   Real a.x[2,2](start = 1.0);
+//   Real a.x[3,1](start = 1.0);
+//   Real a.x[3,2](start = 1.0);
+// end DimUnknown11;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -343,6 +343,8 @@ DimUnknown6.mo \
 DimUnknown7.mo \
 DimUnknown8.mo \
 DimUnknown9.mo \
+DimUnknown10.mo \
+DimUnknown11.mo \
 dim1.mo \
 dim13.mo \
 dim16.mo \


### PR DESCRIPTION
- Fix Expression.filterSplitIndices so that it also works on untyped expressions, which is used by Typing.typeDimension when deducing the size of an unknown dimension from a component's start attribute.

Fixes #9510