### PR TITLE
Fix CMake error replace for empty argument

### DIFF
--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -26,7 +26,10 @@ install(TARGETS OMEdit
 if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
 
   # Escape the environment variable path
-  string(REPLACE "\\" "/" OMDEV_ESCAPED "$ENV{OMDev}")
+  if(NOT DEFINED ENV{OMDEV})
+    message(FATAL_ERROR "Environment variable \"OMDEV\" is not set.")
+  endif()
+  string(REPLACE "\\" "/" OMDEV_ESCAPED "$ENV{OMDEV}")
 
   # Check if 64 bit
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/OMEdit/OMEditGUI/CMakeLists.txt
+++ b/OMEdit/OMEditGUI/CMakeLists.txt
@@ -26,7 +26,7 @@ install(TARGETS OMEdit
 if(OM_OMEDIT_INSTALL_RUNTIME_DLLS AND MINGW)
 
   # Escape the environment variable path
-  string(REPLACE "\\" "/" OMDEV_ESCAPED $ENV{OMDev})
+  string(REPLACE "\\" "/" OMDEV_ESCAPED "$ENV{OMDev}")
 
   # Check if 64 bit
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
### Related Issues

I got an error on Windows when compiling with CMake
```bash
STRING sub-command REPLACE requires at least four arguments.
```

because on my system environment variable `OMDev` is not set.

### Purpose

-  Fix CMake error.

### Approach

  - Use quotes around last argument for string(REPLACE) in case last argument is empty.
