### PR TITLE
Build and upload productbuild packages.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -40,6 +40,26 @@ pipeline {
                                           + " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
                                       )
                 sh "build/bin/omc --version"
+                // Create a product build package
+                sh '''
+                cd build_cmake
+                cpack -G productbuild
+                du -sh _packages/*
+                '''
+                sshPublisher (
+                  failOnError: true,
+                  publishers: [
+                    sshPublisherDesc(
+                      configName: 'cmake-macos-packages',
+                      transfers: [
+                        sshTransfer(
+                          remoteDirectory: 'pkg/arm64/nightly/',
+                          sourceFiles: 'build_cmake/_packages/*.pkg',
+                          removePrefix: 'build_cmake/_packages/')
+                      ]
+                    )
+                  ]
+                )
               }
             }
           }

--- a/cmake/omc_git_revision.cmake
+++ b/cmake/omc_git_revision.cmake
@@ -12,3 +12,5 @@ if(Git_FOUND)
 else()
   set(SOURCE_REVISION "unknown-cmake")
 endif()
+
+omc_add_to_report(SOURCE_REVISION)

--- a/cmake/packaging/productbuild.cmake
+++ b/cmake/packaging/productbuild.cmake
@@ -1,1 +1,2 @@
 # Options and settings that are specific to macOS productbuild packages.
+set(CPACK_PRODUCTBUILD_IDENTIFIER "org.openmodelica")


### PR DESCRIPTION
  - The packages built by this job will be uploaded at https://build.openmodelica.org/mac/pkg/arm64/nightly/

  - Set identifier "openmodelica.org" for our pkgbuild packages.

  - Report OpenModelica git revision at CMake configure time.

