### PR TITLE
Only simplify builtin call when scalarizing

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -201,16 +201,6 @@ algorithm
 
     case Expression.IF() then evaluateIfExp(exp, info);
 
-    // TODO: The return type of calls can have dimensions that reference
-    //       function parameters, and thus can't be evaluated. This should be
-    //       fixed so that the return type reference the input arguments instead.
-    case Expression.CALL()
-      algorithm
-        (outExp, outChanged) := Expression.mapFoldShallow(exp,
-          function evaluateExpTraverser(info = info), false);
-      then
-        (outExp, outChanged);
-
     // Only evaluate the index for size expressions.
     case Expression.SIZE()
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1477,6 +1477,9 @@ function expandProxySubscripts
 protected
   Integer dim_count;
   Expression cr_exp;
+  Type ty;
+  list<Dimension> dims;
+  Dimension dim;
 algorithm
   for s in subscripts loop
     outSubscripts := match s
@@ -1504,10 +1507,18 @@ algorithm
 
             // Add size expressions to the list of fill dimensions.
             if dim_count > 0 then
-              cr_exp := Expression.fromCref(ComponentRef.fromNode(s.parent, InstNode.getType(s.parent)));
+              ty := InstNode.getType(s.parent);
+              cr_exp := Expression.fromCref(ComponentRef.fromNode(s.parent, ty));
+              dims := Type.arrayDims(ty);
 
               for i in 1:dim_count loop
-                fillDimensions := Expression.SIZE(cr_exp, SOME(Expression.INTEGER(i))) :: fillDimensions;
+                dim :: dims := dims;
+
+                if Dimension.isKnown(dim, allowExp = true) then
+                  fillDimensions := Dimension.sizeExp(dim) :: fillDimensions;
+                else
+                  fillDimensions := Expression.SIZE(cr_exp, SOME(Expression.INTEGER(i))) :: fillDimensions;
+                end if;
               end for;
             end if;
           end if;

--- a/testsuite/flattening/modelica/scodeinst/MergeComponents5.mo
+++ b/testsuite/flattening/modelica/scodeinst/MergeComponents5.mo
@@ -21,6 +21,6 @@ end MergeComponents5;
 // Result:
 // class MergeComponents5
 //   Real[3, 3] $A31.y = {{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}, {7.0, 8.0, 9.0}};
-//   Real[3, 3] $A31.x = {{1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}, {1.0, 2.0, 3.0}};
+//   Real[3, 3] $A31.x = fill({1.0, 2.0, 3.0}, 3);
 // end MergeComponents5;
 // endResult

--- a/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
@@ -153,19 +153,19 @@ val(fixedVoltageSource1.p[1], 1.0);
 //
 // Variables (13)
 // ========================================
-// 1: busBar1.p:VARIABLE(unit = {"W"} )  type: Real[1] [1]
-// 2: busBar1.i:VARIABLE(start = busBar1.i_start unit = {"A"} nominal = {1.0} )  type: Real[1] [1]
-// 3: busBar1.v:VARIABLE(start = busBar1.v_start unit = {"V"} nominal = {1000.0} )  type: Real[1] [1]
-// 4: busBar1.terminal_n.v:VARIABLE(flow=false unit = fill({"V"}, 3) nominal = fill({1000.0}, 3) )  "voltage vector" type: Real[3, 1] [3,1]
-// 5: busBar1.terminal_n.i:VARIABLE(flow=true unit = fill({"A"}, 3) nominal = fill({1.0}, 3) )  "current vector" type: Real[3, 1] [3,1]
-// 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = {"A"} nominal = {1.0} )  "current vector" type: Real[1] [1]
-// 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = {"V"} nominal = {1000.0} )  "voltage vector" type: Real[1] [1]
-// 8: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = fill({"V"}, 3) nominal = fill({1000.0}, 3) )  "voltage vector" type: Real[3, 1] [3,1]
-// 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = fill({"A"}, 3) nominal = fill({1.0}, 3) )  "current vector" type: Real[3, 1] [3,1]
-// 10: fixedLoad1.p:VARIABLE(unit = fill({"W"}, 3) )  type: Real[3, 1] [3,1]
-// 11: fixedVoltageSource1.p:VARIABLE(unit = {"W"} )  type: Real[1] [1]
-// 12: fixedVoltageSource1.terminal.i:VARIABLE(flow=true unit = {"A"} nominal = {1.0} )  "current vector" type: Real[1] [1]
-// 13: fixedVoltageSource1.terminal.v:VARIABLE(flow=false unit = {"V"} nominal = {1000.0} )  "voltage vector" type: Real[1] [1]
+// 1: busBar1.p:VARIABLE(unit = fill("W", 1) )  type: Real[1] [1]
+// 2: busBar1.i:VARIABLE(start = busBar1.i_start unit = fill("A", 1) nominal = fill(1.0, 1) )  type: Real[1] [1]
+// 3: busBar1.v:VARIABLE(start = busBar1.v_start unit = fill("V", 1) nominal = fill(1000.0, 1) )  type: Real[1] [1]
+// 4: busBar1.terminal_n.v:VARIABLE(flow=false unit = fill(fill("V", 1), 3) nominal = fill(fill(1000.0, 1), 3) )  "voltage vector" type: Real[3, 1] [3,1]
+// 5: busBar1.terminal_n.i:VARIABLE(flow=true unit = fill(fill("A", 1), 3) nominal = fill(fill(1.0, 1), 3) )  "current vector" type: Real[3, 1] [3,1]
+// 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = fill("A", 1) nominal = fill(1.0, 1) )  "current vector" type: Real[1] [1]
+// 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = fill("V", 1) nominal = fill(1000.0, 1) )  "voltage vector" type: Real[1] [1]
+// 8: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = fill(fill("V", 1), 3) nominal = fill(fill(1000.0, 1), 3) )  "voltage vector" type: Real[3, 1] [3,1]
+// 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = fill(fill("A", 1), 3) nominal = fill(fill(1.0, 1), 3) )  "current vector" type: Real[3, 1] [3,1]
+// 10: fixedLoad1.p:VARIABLE(unit = fill(fill("W", 1), 3) )  type: Real[3, 1] [3,1]
+// 11: fixedVoltageSource1.p:VARIABLE(unit = fill("W", 1) )  type: Real[1] [1]
+// 12: fixedVoltageSource1.terminal.i:VARIABLE(flow=true unit = fill("A", 1) nominal = fill(1.0, 1) )  "current vector" type: Real[1] [1]
+// 13: fixedVoltageSource1.terminal.v:VARIABLE(flow=false unit = fill("V", 1) nominal = fill(1000.0, 1) )  "voltage vector" type: Real[1] [1]
 //
 //
 // Equations (13, 13)
@@ -263,9 +263,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // Known variables only depending on parameters and constants - globalKnownVars (20)
 // ========================================
 // 1: busBar1.n_n:PARAM(final = true )  = 3  type: Integer
-// 2: busBar1.i_start:PARAM(unit = {"A"} nominal = {1.0} )  = {0.0}  "Start value for current" type: Real[1] [1]
-// 3: busBar1.v_start:PARAM(unit = {"V"} nominal = {1000.0} )  = {0.0}  "Start value for voltage drop" type: Real[1] [1]
-// 4: fixedLoad1.v_start:PARAM(unit = fill({"V"}, 3) nominal = fill({1000.0}, 3) )  = {{1.0}, {1.0}, {1.0}}  "Start value for voltage drop" type: Real[3, 1] [3,1]
+// 2: busBar1.i_start:PARAM(unit = fill("A", 1) nominal = fill(1.0, 1) )  = {0.0}  "Start value for current" type: Real[1] [1]
+// 3: busBar1.v_start:PARAM(unit = fill("V", 1) nominal = fill(1000.0, 1) )  = {0.0}  "Start value for voltage drop" type: Real[1] [1]
+// 4: fixedLoad1.v_start:PARAM(unit = fill(fill("V", 1), 3) nominal = fill(fill(1000.0, 1), 3) )  = {{1.0}, {1.0}, {1.0}}  "Start value for voltage drop" type: Real[3, 1] [3,1]
 // 5: fixedLoad1.P:PARAM(unit = fill("W", 3) )  = 1000000.0:1000000.0:3000000.0  "rms value of constant active power" type: Real[3] [3]
 // 6: fixedLoad1.phi:PARAM(unit = fill("rad", 3) )  = 0.1:0.1:0.3  "phase angle" type: Real[3] [3]
 // 7: system.synRef:PARAM(final = true )  = true  type: Boolean
@@ -274,7 +274,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 10: system.dynType:PARAM(min = PowerSystems.Types.Dynamics.FreeInitial max = PowerSystems.Types.Dynamics.SteadyState final = true )  = PowerSystems.Types.Dynamics.SteadyInitial  "transient or steady-state model" type: enumeration(FreeInitial, FixedInitial, SteadyInitial, SteadyState)
 // 11: system.refType:PARAM(min = PowerSystems.Types.ReferenceFrame.Synchron max = PowerSystems.Types.ReferenceFrame.Inertial final = true )  = PowerSystems.Types.ReferenceFrame.Synchron  "reference frame (3-phase)" type: enumeration(Synchron, Inertial)
 // 12: system.alpha0:PARAM(unit = "rad" final = true )  = 0.0  "phase angle" type: Real
-// 13: system.f_lim:PARAM(unit = {"Hz", "Hz"} final = true )  = {25.0, 100.0}  "limit frequencies (for supervision of average frequency)" type: Real[2] [2]
+// 13: system.f_lim:PARAM(unit = fill("Hz", 2) final = true )  = {25.0, 100.0}  "limit frequencies (for supervision of average frequency)" type: Real[2] [2]
 // 14: system.f_nom:PARAM(unit = "Hz" final = true )  = 50.0  "nominal frequency" type: Real
 // 15: system.f:PARAM(unit = "Hz" final = true )  = 50.0  "frequency if type is parameter, else initial frequency" type: Real
 // 16: system.fType:PARAM(min = PowerSystems.Types.SystemFrequency.Parameter max = PowerSystems.Types.SystemFrequency.Average final = true )  = PowerSystems.Types.SystemFrequency.Parameter  "system frequency type" type: enumeration(Parameter, Signal, Average)


### PR DESCRIPTION
- Turn off simplification of builtin calls when scalarization is turned off, to avoid e.g. `fill` from being expanded.
- Improve Typing.expandProxySubscripts so we use the actual dimension if it's available instead of creating unnecessary `size` calls.
- Remove deprecated workaround for function calls in EvalConstants.evaluateExp, that issue was fixed some time ago and not evaluating the return type of e.g. `fill` can cause issues.