### PR TITLE
Prefer macports libraries when building on macOS.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -35,9 +35,9 @@ pipeline {
                 sh "echo PATH: $PATH"
                 common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
                                           + " -DCMAKE_INSTALL_PREFIX=build"
-                                          + " -DOM_OMC_ENABLE_FORTRAN=OFF"
-                                          + " -DOM_OMC_ENABLE_IPOPT=OFF"
-                                          + " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
+                                          // Look in /opt/local first to prefer the macports libraries
+                                          // over others in the system.
+                                          + " -DCMAKE_PREFIX_PATH=/opt/local"
                                       )
                 sh "build/bin/omc --version"
                 // Create a product build package

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,9 +162,9 @@ pipeline {
                 common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
                                           + " -DOM_USE_CCACHE=OFF"
                                           + " -DCMAKE_INSTALL_PREFIX=build"
-                                          + " -DOM_OMC_ENABLE_FORTRAN=OFF"
-                                          + " -DOM_OMC_ENABLE_IPOPT=OFF"
-                                          + " -DOM_OMC_ENABLE_CPP_RUNTIME=OFF"
+                                          // Look in /opt/local first to prefer the macports libraries
+                                          // over others in the system.
+                                          + " -DCMAKE_PREFIX_PATH=/opt/local"
                                       )
                 sh "build/bin/omc --version"
               }


### PR DESCRIPTION
  - On our macOS CI machine, we have libraries from `XCode`, `homebrew` and `macports`. Add a `/opt/local` to the cmake prefix path so it can pick the `macports` libraries first.

  - Enable building the CPP runtime and `Ipopt` since we now have boost and `gfortran` installed and usable.
