### PR TITLE
Explicitly specify compilers on macOS.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -38,6 +38,10 @@ pipeline {
                                           // Look in /opt/local first to prefer the macports libraries
                                           // over others in the system.
                                           + " -DCMAKE_PREFIX_PATH=/opt/local"
+                                          // Always specify the compilers explicilty for macOS
+                                          + " -DCMAKE_C_COMPILER=gcc"
+                                          + " -DCMAKE_CXX_COMPILER=g++"
+                                          + " -DCMAKE_Fortran_COMPILER=gfortran"
                                       )
                 sh "build/bin/omc --version"
                 // Create a product build package

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,6 +165,10 @@ pipeline {
                                           // Look in /opt/local first to prefer the macports libraries
                                           // over others in the system.
                                           + " -DCMAKE_PREFIX_PATH=/opt/local"
+                                          // Always specify the compilers explicilty for macOS
+                                          + " -DCMAKE_C_COMPILER=gcc"
+                                          + " -DCMAKE_CXX_COMPILER=g++"
+                                          + " -DCMAKE_Fortran_COMPILER=gfortran"
                                       )
                 sh "build/bin/omc --version"
               }


### PR DESCRIPTION
  - There is a difference between the default include directories used by `gcc/g++/clang/clang++` vs the system default compiler targets `(cc/c++`).

    Always specify the compilers explicitly so OpenModelica knows the actual functional compilers to use for simulation code.
