### PR TITLE
Add initial CMake support for OMEdit Testsuite.

### DIFF
--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -6,6 +6,7 @@ project(OMEdit)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omedit)
 
 omc_option(OM_OMEDIT_INSTALL_RUNTIME_DLLS "Install the required runtime dll dependency DLLs to the binary directory. Valid only for Windows builds." ON)
+omc_option(OM_OMEDIT_ENABLE_TESTS "Enable building of OMEdit Testsuite tests." OFF)
 
 ## Set the C++ standard to use. OMEdit uses C++14
 set(CMAKE_CXX_STANDARD 14)
@@ -29,3 +30,6 @@ target_include_directories(omedit_config INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 omc_add_subdirectory(OMEditLIB)
 omc_add_subdirectory(OMEditGUI)
 
+if(OM_OMEDIT_ENABLE_TESTS)
+  omc_add_subdirectory(Testsuite)
+endif()

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -326,4 +326,4 @@ if(MINGW)
   target_link_libraries(OMEditLib PUBLIC zlib)
 endif()
 
-target_include_directories(OMEditLib PRIVATE ${OMCompiler_SOURCE_DIR}/Compiler/Script)
+target_include_directories(OMEditLib PUBLIC ${OMCompiler_SOURCE_DIR}/Compiler/Script)

--- a/OMEdit/Testsuite/CMakeLists.txt
+++ b/OMEdit/Testsuite/CMakeLists.txt
@@ -1,0 +1,63 @@
+find_package(Qt5Test REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+# Enable testing in this directory. This means you need to be in
+# <build_dir>/OMEdit/Testsuite/ folder to run ctest.
+# If you want to run the tests while in another directory (ctest > 3.22) you
+# have to specify --test-dir (e.g., --test-dir <build_dir>/OMEdit/Testsuite)
+enable_testing()
+
+add_library(OMEditTestSuiteUtil STATIC Util/Util.cpp)
+add_library(omedit::testsuite::util ALIAS OMEditTestSuiteUtil)
+
+target_link_libraries(OMEditTestSuiteUtil PUBLIC Qt5::Test)
+target_link_libraries(OMEditTestSuiteUtil PUBLIC OMEditLib)
+
+target_include_directories(OMEditTestSuiteUtil PUBLIC Util/)
+
+
+# This macro takes two arguments. The test executable name to be created (which will
+# also be the name of the test instance right now) and a list of source files to build
+# the test executable.
+# Note that you have to quote the list you send into this macro. See below for examples.
+# This is the ugly part of CMake script syntax.
+macro(add_omedit_test test_name test_source_files)
+  add_executable(${test_name} ${test_source_files})
+  target_link_libraries(${test_name} PUBLIC omedit::testsuite::util)
+
+  add_test(NAME ${test_name}
+         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/RunOMEditTest.sh $<TARGET_FILE:${test_name}>)
+
+  # Label the tests (does not matter just now but it will of more types of tests are added.).
+  set_tests_properties(${TEST_FILE_NAME} PROPERTIES LABELS "OMEditTestsuite")
+
+  message(STATUS "Added OMEdit test ${test_name}.")
+endmacro()
+
+
+set(OMEDIT_TEST_BROWSEMSL_SOURCES BrowseMSL/BrowseMSL.cpp
+                                  BrowseMSL/BrowseMSL.cpp)
+add_omedit_test(BrowseMSL "${OMEDIT_TEST_BROWSEMSL_SOURCES}")
+
+set(OMEDIT_TEST_DIAGRAM_SOURCES Diagram/Diagram.cpp
+                                Diagram/Diagram.h)
+add_omedit_test(Diagram "${OMEDIT_TEST_DIAGRAM_SOURCES}")
+
+set(OMEDIT_TEST_TRANSFORMATION_SOURCES Transformation/TransformationTest.cpp
+                                       Transformation/TransformationTest.h)
+add_omedit_test(Transformation "${OMEDIT_TEST_TRANSFORMATION_SOURCES}")
+
+set(OMEDIT_TEST_HOMOTOPY_SOURCES Homotopy/HomotopyTest.cpp
+                                 Homotopy/HomotopyTest.h)
+add_omedit_test(Homotopy "${OMEDIT_TEST_HOMOTOPY_SOURCES}")
+
+set(OMEDIT_TEST_EXPRESSION_SOURCES Expression/ExpressionTest.cpp
+                                   Expression/ExpressionTest.h)
+add_omedit_test(Expression "${OMEDIT_TEST_EXPRESSION_SOURCES}")
+
+set(OMEDIT_TEST_MODELINSTANCE_SOURCES ModelInstance/ModelInstanceTest.cpp
+                                      ModelInstance/ModelInstanceTest.h)
+add_omedit_test(ModelInstance "${OMEDIT_TEST_MODELINSTANCE_SOURCES}")

--- a/OMEdit/Testsuite/Makefile.unix.in
+++ b/OMEdit/Testsuite/Makefile.unix.in
@@ -5,6 +5,7 @@ QMAKE=@QMAKE@
 install: build
 	cp -p ../bin/tests/* @OMBUILDDIR@/bin
 	cp -p RunOMEditTestsuite.sh @OMBUILDDIR@/bin
+	cp -p RunOMEditTest.sh @OMBUILDDIR@/bin
 
 build: Makefile OMEditGUI.unix.config.pri
 	$(MAKE) -f Makefile

--- a/OMEdit/Testsuite/RunOMEditTest.sh
+++ b/OMEdit/Testsuite/RunOMEditTest.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# If number of arguments less then 1; print usage and exit
+if [ $# -lt 1 ]; then
+    printf "Usage: $0 <test_file>\n"
+    exit 1
+fi
+
+testexe="$1" # The test executable name.
+
+echo "Running testcase "$testexe
+ORIGINAL_TEMP=$TEMP
+ORIGINAL_TMP=$TMP
+ORIGINAL_TMPDIR=$TMPDIR
+NEW_TEMP=$OMEditTestResults/$testexe
+NEW_TMP=$OMEditTestResults/$testexe
+NEW_TMPDIR=$OMEditTestResults/$testexe
+export TEMP=$NEW_TEMP
+export TMP=$NEW_TMP
+export TMPDIR=$NEW_TMPDIR
+$testexe || $testexe || $testexe || $testexe || $testexe
+export TEMP=$ORIGINAL_TEMP
+export TMP=$ORIGINAL_TMP
+export TMPDIR=$ORIGINAL_TMPDIR

--- a/OMEdit/Testsuite/RunOMEditTestsuite.sh
+++ b/OMEdit/Testsuite/RunOMEditTestsuite.sh
@@ -4,21 +4,8 @@ set -e
 testcases=( "BrowseMSL" "Diagram" "Transformation" "Homotopy" "Expression" "ModelInstance" )
 OMEditTestResults="$PWD/OMEditTestResult"
 
-for i in "${testcases[@]}"
+for testcase in "${testcases[@]}"
 do
-  echo "Running testcase "$i
-  ORIGINAL_TEMP=$TMP
-  ORIGINAL_TMP=$TMP
-  ORIGINAL_TMPDIR=$TMPDIR
-  NEW_TEMP=$OMEditTestResults/$i
-  NEW_TMP=$OMEditTestResults/$i
-  NEW_TMPDIR=$OMEditTestResults/$i
-  export TEMP=$NEW_TEMP
-  export TMP=$NEW_TMP
-  export TMPDIR=$NEW_TMPDIR
-  ./$i || ./$i || ./$i || ./$i || ./$i
-  export TEMP=$ORIGINAL_TEMP
-  export TMP=$ORIGINAL_TMP
-  export TMPDIR=$ORIGINAL_TMPDIR
+  ./RunOMEditTest.sh ./$testcase
 done
 rm -rf $OMEditTestResults

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -188,6 +188,7 @@ OM_OMC_ENABLE_CPP_RUNTIME=ON
 OM_OMC_ENABLE_FORTRAN=ON
 OM_OMC_ENABLE_IPOPT=ON
 OM_OMEDIT_INSTALL_RUNTIME_DLLS=ON
+OM_OMEDIT_ENABLE_TESTS=OFF
 OM_OMSHELL_ENABLE_TERMINAL=ON
 ```
 ### 4.1.1. OpenModelica Options
@@ -203,6 +204,9 @@ OM_OMSHELL_ENABLE_TERMINAL=ON
 `OM_OMC_ENABLE_IPOPT` allows you to enable/disable support for dynamic optimization support with Ipopt. Enabling this requires having a working Fortran compiler.
 
 ### 4.1.3. OpenModelica/OMEdit Options
+OM_OMEDIT_ENABLE_TESTS
+`OM_OMEDIT_ENABLE_TESTS` Enable testing and build the OMEdit Testsuite.
+
 `OM_OMEDIT_INSTALL_RUNTIME_DLLS` allows you to enable/disable the installation of the required runtime DLLs for MSYS/MinGW builds.
 
 You should disable this if you are either


### PR DESCRIPTION
[Split the OMEdit Testsuite runner.](https://github.com/OpenModelica/OpenModelica/commit/6b1dd1dabdf2a1d1d4b1842db0888da9147ea1b8) 

  - This allows us to run each test case individually.
 
[Add initial CMake support for OMEdit Testsuite.](https://github.com/OpenModelica/OpenModelica/commit/4dc8ad10830f15a4190b728cbd07fe2a885b8d02) 

  - Building these tests is disabled by default for now. It can be enabled by specifying `OM_OMEDIT_ENABLE_TESTS=ON` while configuring OpenModelica.

  - The tests do not actually run successfully yet because they (like omc) want to be in a directory called bin to run. We can work around this afterwards.

  - The testsuite can only be run from inside `<build_dir>/OMEdit/Testsuite` directory.
    Or if you have recent ctest (3.22) you can specify the test dir from anywhere by specifying `test-dir` to ctest, e.g.,
    `ctest --test-dir <build_dir>/OMEdit/Testsuite`.

    Remember they do not pass yet.