### PR TITLE
Improve instance API Expression handling

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -851,7 +851,8 @@ public
 
       case TYPED_ARRAY_CONSTRUCTOR()
         algorithm
-          json := JSON.addPair("$kind", JSON.makeString("array_constructor"), json);
+          json := JSON.addPair("$kind", JSON.makeString("iterator_call"), json);
+          json := JSON.addPair("name", JSON.makeString("$array"), json);
           json := JSON.addPair("exp", Expression.toJSON(call.exp), json);
           json := JSON.addPair("iterators", iterators_json(call.iters), json);
         then
@@ -860,7 +861,7 @@ public
       case TYPED_REDUCTION()
         algorithm
           path := Function.nameConsiderBuiltin(call.fn);
-          json := JSON.addPair("$kind", JSON.makeString("reduction"), json);
+          json := JSON.addPair("$kind", JSON.makeString("iterator_call"), json);
           json := JSON.addPair("name", JSON.makeString(AbsynUtil.pathString(path)), json);
           json := JSON.addPair("exp", Expression.toJSON(call.exp), json);
           json := JSON.addPair("iterators", iterators_json(call.iters), json);

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5944,11 +5944,14 @@ public
       case Expression.SIZE()
         algorithm
           json := JSON.emptyObject();
-          json := JSON.addPair("$kind", JSON.makeString("size"), json);
-          json := JSON.addPair("exp", toJSON(exp.exp), json);
+          json := JSON.addPair("$kind", JSON.makeString("call"), json);
+          json := JSON.addPair("name", JSON.makeString("size"), json);
 
           if isSome(exp.dimIndex) then
-            json := JSON.addPair("index", toJSON(Util.getOption(exp.dimIndex)), json);
+            JSON.addPair("arguments",
+              JSON.makeArray({toJSON(exp.exp), toJSON(Util.getOption(exp.dimIndex))}), json);
+          else
+            JSON.addPair("arguments", JSON.makeArray({toJSON(exp.exp)}), json);
           end if;
         then
           json;
@@ -6011,30 +6014,9 @@ public
         then
           json;
 
-      case Expression.CAST()
-        algorithm
-          json := JSON.emptyObject();
-          json := JSON.addPair("$kind", JSON.makeString("cast"), json);
-          json := JSON.addPair("type", JSON.makeString(Type.toString(exp.ty)), json);
-          json := JSON.addPair("exp", toJSON(exp.exp), json);
-        then
-          json;
-
-      case Expression.BOX()
-        algorithm
-          json := JSON.emptyObject();
-          json := JSON.addPair("$kind", JSON.makeString("box"), json);
-          json := JSON.addPair("exp", toJSON(exp.exp), json);
-        then
-          json;
-
-      case Expression.UNBOX()
-        algorithm
-          json := JSON.emptyObject();
-          json := JSON.addPair("$kind", JSON.makeString("unbox"), json);
-          json := JSON.addPair("exp", toJSON(exp.exp), json);
-        then
-          json;
+      case Expression.CAST() then toJSON(exp.exp);
+      case Expression.BOX() then toJSON(exp.exp);
+      case Expression.UNBOX() then toJSON(exp.exp);
 
       case Expression.SUBSCRIPTED_EXP()
         algorithm

--- a/OMEdit/Testsuite/Expression/ExpressionTest.cpp
+++ b/OMEdit/Testsuite/Expression/ExpressionTest.cpp
@@ -305,13 +305,16 @@ void ExpressionTest::functions_data()
 void ExpressionTest::parseJSON()
 {
   QFETCH(QJsonValue, jsonValue);
+  QFETCH(QString, string);
 
   try {
     FlatModelica::Expression e;
     e.deserialize(jsonValue);
+    qDebug() << e.toQString();
     //qDebug() << jsonValue;
     //qDebug() << e.serialize();
     QCOMPARE(e.serialize(), jsonValue);
+    QCOMPARE(e.toQString(), string);
   } catch (const std::exception &e) {
     QFAIL(e.what());
   }
@@ -320,28 +323,29 @@ void ExpressionTest::parseJSON()
 void ExpressionTest::parseJSON_data()
 {
   QTest::addColumn<QJsonValue>("jsonValue");
+  QTest::addColumn<QString>("string");
   QJsonValue value;
 
   value = 3;
-  QTest::newRow("json_integer1") << value;
+  QTest::newRow("json_integer1") << value << "3";
 
   value = -52;
-  QTest::newRow("json_integer2") << value;
+  QTest::newRow("json_integer2") << value << "-52";
 
   value = 3.14;
-  QTest::newRow("json_real1") << value;
+  QTest::newRow("json_real1") << value << "3.14";
 
   value = true;
-  QTest::newRow("json_boolean1") << value;
+  QTest::newRow("json_boolean1") << value << "true";
 
   value = false;
-  QTest::newRow("json_boolean2") << value;
+  QTest::newRow("json_boolean2") << value << "false";
 
   value = "string";
-  QTest::newRow("json_string1") << value;
+  QTest::newRow("json_string1") << value << "\"string\"";
 
   value = QJsonArray{1, 2, 3, 4, 5};
-  QTest::newRow("json_array1") << value;
+  QTest::newRow("json_array1") << value << "{1,2,3,4,5}";
 
   //value = QJsonObject{
   //  {"$kind", "cref"},
@@ -366,14 +370,14 @@ void ExpressionTest::parseJSON_data()
     {"name", "TestRecord"},
     {"elements", QJsonArray{4, "test"}}
   };
-  QTest::newRow("json_record1") << value;
+  QTest::newRow("json_record1") << value << "TestRecord(4,\"test\")";
 
   value = QJsonObject{
     {"$kind", "call"},
     {"name", "fill"},
     {"arguments", QJsonArray{1, 2, 3}}
   };
-  QTest::newRow("json_call1") << value;
+  QTest::newRow("json_call1") << value << "fill(1,2,3)";
 
   value = QJsonObject{
     {"$kind", "binary_op"},
@@ -381,14 +385,14 @@ void ExpressionTest::parseJSON_data()
     {"op", ".+"},
     {"rhs", QJsonArray{4, 5, 6}}
   };
-  QTest::newRow("json_binary1") << value;
+  QTest::newRow("json_binary1") << value << "({1,2,3} .+ {4,5,6})";
 
   value = QJsonObject{
     {"$kind", "unary_op"},
     {"op", "not"},
     {"exp", false}
   };
-  QTest::newRow("json_unary1") << value;
+  QTest::newRow("json_unary1") << value << "not false";
 
   value = QJsonObject{
     {"$kind", "if"},
@@ -396,14 +400,47 @@ void ExpressionTest::parseJSON_data()
     {"true", 1},
     {"false", 2}
   };
-  QTest::newRow("json_if1") << value;
+  QTest::newRow("json_if1") << value << "if true then 1 else 2";
 
   value = QJsonObject{
     {"$kind", "enum"},
     {"name", "FillPattern.Solid"},
     {"index", 1}
   };
-  QTest::newRow("json_enum") << value;
+  QTest::newRow("json_enum") << value << "FillPattern.Solid";
+
+  value = QJsonObject{
+    {"$kind", "range"},
+    {"start", 1},
+    {"stop", 4}
+  };
+  QTest::newRow("json_range1") << value << "1:4";
+
+  value = QJsonObject{
+    {"$kind", "range"},
+    {"start", 3},
+    {"step", 2},
+    {"stop", 11}
+  };
+  QTest::newRow("json_range2") << value << "3:2:11";
+
+  value = QJsonObject{
+    {"$kind", "iterator_call"},
+    {"name", "$array"},
+    {"exp", 1},
+    {"iterators", QJsonArray{
+      QJsonObject{
+          {"name", "i"},
+          {"range", QJsonObject{{"$kind", "range"}, {"start", 1}, {"stop", 3}}}
+        },
+      QJsonObject{
+          {"name", "j"},
+          {"range", QJsonObject{{"$kind", "range"}, {"start", 2}, {"stop", 4}}}
+        }
+      }
+    }
+  };
+  QTest::newRow("json_iterator_call1") << value << "{1 for i in 1:3, j in 2:4}";
 }
 
 void ExpressionTest::cleanupTestCase()

--- a/doc/instanceAPI/expression.schema.json
+++ b/doc/instanceAPI/expression.schema.json
@@ -236,46 +236,23 @@
       "required": ["$kind", "name", "arguments"]
     },
     {
-      "description": "Array constructor expression",
+      "description": "Iterator call expression ( fn(x[i] for i in 1:n) )",
       "type": "object",
       "properties": {
         "$kind": {
           "type": "string",
-          "const": "array_constructor"
-        },
-        "exp": {
-          "description": "The expression to be evaluated for each constructed element",
-          "$ref": "#"
-        },
-        "iterators": {
-          "description": "The iterators used to construct the array",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/iterator"
-          },
-          "minItems": 1
-        }
-      },
-      "required": ["$kind", "exp", "iterators"]
-    },
-    {
-      "description": "Reduction expression",
-      "type": "object",
-      "properties": {
-        "$kind": {
-          "type": "string",
-          "const": "reduction"
+          "const": "iterator_call"
         },
         "name": {
-          "description": "Name of the reduction function",
+          "description": "Name of the function ($array for an array constructor)",
           "type": "string"
         },
         "exp": {
-          "description": "The expression of the reduction expression",
+          "description": "The iterated expression",
           "$ref": "#"
         },
         "iterators": {
-          "description": "The iterators of the reduction expression",
+          "description": "The iterators of the call",
           "type": "array",
           "items": {
             "$ref": "#/definitions/iterator"
@@ -284,25 +261,6 @@
         }
       },
       "required": ["$kind", "name", "exp", "iterators"]
-    },
-    {
-      "description": "Size expression",
-      "type": "object",
-      "properties": {
-        "$kind": {
-          "type": "string",
-          "const": "size"
-        },
-        "exp": {
-          "description": "Expression to take the size of",
-          "$ref": "#"
-        },
-        "index": {
-          "description": "Optional dimension index expression",
-          "$ref": "#"
-        }
-      },
-      "required": ["$kind", "exp", "index"]
     },
     {
       "description": "Binary operation expression",
@@ -370,55 +328,6 @@
         }
       },
       "required": ["$kind", "condition", "true", "false"]
-    },
-    {
-      "description": "Type cast expression",
-      "type": "object",
-      "properties": {
-        "$kind": {
-          "type": "string",
-          "const": "cast"
-        },
-        "type": {
-          "description": "Name of the type to cast to",
-          "type": "string"
-        },
-        "exp": {
-          "description": "Expression to type cast",
-          "$ref": "#"
-        }
-      },
-      "required": ["$kind", "type", "exp"]
-    },
-    {
-      "description": "Box expression",
-      "type": "object",
-      "properties": {
-        "$kind": {
-          "type": "string",
-          "const": "box"
-        },
-        "exp": {
-          "description": "Expression to box",
-          "$ref": "#"
-        }
-      },
-      "required": ["$kind", "exp"]
-    },
-    {
-      "description": "Unbox expression",
-      "type": "object",
-      "properties": {
-        "$kind": {
-          "type": "string",
-          "const": "unbox"
-        },
-        "exp": {
-          "description": "Expression to unbox",
-          "$ref": "#"
-        }
-      },
-      "required": ["$kind", "exp"]
     },
     {
       "description": "Subscripted expression",


### PR DESCRIPTION
- Merge `array_constructor` and `reduction` into one `iterator_call` structure, and implement support for it in the OMEdit Expression class.
- Implement support for ranges in the OMEdit Expression class.
- Dump `size()` like a normal function.
- Strip away internal compiler expressions `cast`, `box`, and `unbox` when dumping expressions to JSON.
- Handle `clock` and `typename` expressions like crefs in the OMEdit Expression class.
- Also check the `toQString` results in the Expression test case.