### PR TITLE
Output libOpenModelicaCompiler in a 'bin' or 'lib' directory.

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -191,6 +191,28 @@ add_dependencies(DEPENDENCY_UPDATE DEPENDENCY_SCAN)
 add_library(OpenModelicaCompiler SHARED ${OMC_C_SOURCE_FILES} .cmake/omc_entry_point.c)
 add_dependencies(OpenModelicaCompiler DEPENDENCY_UPDATE)
 
+# output libOpenModelicaCompiler in a directory named 'lib' or 'bin' (on Windows, dll) inside
+# the current binary directory. The reason for this is that omc (using libOpenModelicaCompiler),
+# up on launch, checks where it is located and looks for the things it wants relative to that location.
+# For example it expects ModelicaBuiltin.mo to be in '../lib/omc' relative to the libOpenModelicaCompiler shared
+# library. To achieve this it first checks if libOpenModelicaCompiler is a directory named 'bin' or 'lib'.
+# If it is not it will refuse to run. So output it in a directory named 'lib' or 'bin' and then copy
+# The files it needs in '../lib/omc' relative to it.
+set_target_properties(OpenModelicaCompiler
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+
+# It also wants to have these builtin files in ../lib/ relative to its location.
+add_custom_command (
+    TARGET OpenModelicaCompiler
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FrontEnd/ModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/lib/omc/ModelicaBuiltin.mo
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FrontEnd/MetaModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/lib/omc/MetaModelicaBuiltin.mo
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/NFFrontEnd/NFModelicaBuiltin.mo ${CMAKE_CURRENT_BINARY_DIR}/lib/omc/NFModelicaBuiltin.mo
+    COMMENT "Copying (NF/Meta/Modelica)Builtin.mo files for the omc generated in the build tree (not installed yet).")
+
+
 target_compile_definitions(OpenModelicaCompiler PRIVATE ADD_METARECORD_DEFINITIONS=)
 
 # Silence warnings about extra parenthesized equality checks. if((a==b))


### PR DESCRIPTION
  - And copy the Builtin Modelica files for it (e.g. ModelicaBuiltin.mo).

  - This is needed so that we can use `omc` (-> `libOpenModelicaCompiler`) for some internal purposes before we install it.

  - There are two such uses right now.

    - Downloading libraries: we have to use `omc` itself as a package manager to download and install Modelica packages. This change means we can do that without having to install omc first.

    - Running `OMEdit` tests: These tests are mini OMEdits themselves. Which means they need to link to `libOpenModelicaCompiler`. If we want them to work as part of the build and test flow, we need to make sure `omc` and `libOpenModelicaCompiler` are usable from the build tree.

  - An alternative solution is to start relying on `OPENMODELICAHOME` env variable as an override value for `getInstallationDirectory()` purposes. If this is defined, use it instead of trying to figure out if where `libOpenModelicaCompiler` is located, i.e., instead of checking if it is a `lib` or `bin` dir and failing if it is not.
