### PR TITLE
Obfuscate comments when flag is set to encrypted

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -172,8 +172,8 @@ template crefCComment(SimVar v)
 "write the C comment for a cref, if it is not to be obfuscated"
 ::=
   match v
-  case SIMVAR(isProtected = true, source = SOURCE(info = SOURCEINFO(fileName = fileName))) then
-    if not boolOr(boolOr(stringEq(getConfigString(OBFUSCATE), "protected"), stringEq(getConfigString(OBFUSCATE), "full")), stringEq(getConfigString(OBFUSCATE), "encrypted"))
+  case SIMVAR(isProtected = true) then
+    if stringEq(getConfigString(OBFUSCATE), "none")
     then ' /* <%escapeCComments(crefStrNoUnderscore(name))%> <%variabilityString(varKind)%> */'
   case SIMVAR(__) then
     if not stringEq(getConfigString(OBFUSCATE), "full")

--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -173,8 +173,7 @@ template crefCComment(SimVar v)
 ::=
   match v
   case SIMVAR(isProtected = true, source = SOURCE(info = SOURCEINFO(fileName = fileName))) then
-    if not boolOr(boolOr(stringEq(getConfigString(OBFUSCATE), "protected"), stringEq(getConfigString(OBFUSCATE), "full")),
-                  boolAnd(stringEq(getConfigString(OBFUSCATE), "encrypted"), Util.endsWith(fileName, ".moc")))
+    if not boolOr(boolOr(stringEq(getConfigString(OBFUSCATE), "protected"), stringEq(getConfigString(OBFUSCATE), "full")), stringEq(getConfigString(OBFUSCATE), "encrypted"))
     then ' /* <%escapeCComments(crefStrNoUnderscore(name))%> <%variabilityString(varKind)%> */'
   case SIMVAR(__) then
     if not stringEq(getConfigString(OBFUSCATE), "full")


### PR DESCRIPTION
Do not check the file extension since the simulating class can be non encrypted.

### Related Issues

#9119