### PR TITLE
Minor documentation fixes.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.macos.gcc
+++ b/.CI/cmake/Jenkinsfile.cmake.macos.gcc
@@ -74,7 +74,7 @@ pipeline {
                           removePrefix: "build_cmake/_packages/",
                           // Make a symbolic link to the latest package.
                           // Unfortunatelly, relative paths do not seem to work. Use full path to the files.
-                          execCommand: "ln -s ${full_remote_dir}/${pkg_filename} ${full_remote_dir}/OpenModelica-latest.pkg")
+                          execCommand: "ln -sf ${full_remote_dir}/${pkg_filename} ${full_remote_dir}/OpenModelica-latest.pkg")
                       ]
                     )
                   ]

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -82,9 +82,6 @@ Once XCode and macports are installed, you need to install the dependencies for 
 
 Optionally, You can also install `gfortran` if you plan to use OpenModelica for dynamic optimization purposes.
 > **Note**
-> `gfortran` is not available for M1 macs through macports.
-
-> **Note**
 > If you install and use `gfortran`, it is recommended that you also use `gcc` and `g++` (instead of `clang` and `clang++`).
 
 If you cannot or do not want to use `gfortran`, then you should disable Fortran support by adding  ```-DOM_OMC_ENABLE_FORTRAN=OFF -DOM_OMC_ENABLE_IPOPT=OFF``` to the CMake configuration command.
@@ -204,7 +201,6 @@ OM_OMSHELL_ENABLE_TERMINAL=ON
 `OM_OMC_ENABLE_IPOPT` allows you to enable/disable support for dynamic optimization support with Ipopt. Enabling this requires having a working Fortran compiler.
 
 ### 4.1.3. OpenModelica/OMEdit Options
-OM_OMEDIT_ENABLE_TESTS
 `OM_OMEDIT_ENABLE_TESTS` Enable testing and build the OMEdit Testsuite.
 
 `OM_OMEDIT_INSTALL_RUNTIME_DLLS` allows you to enable/disable the installation of the required runtime DLLs for MSYS/MinGW builds.


### PR DESCRIPTION
  - `gfortran` is available in `maports` as part of the `gcc` port.

  - Overwrite symbolic link when submitting macOS packages. It was failing if one exists already (which it does all the time now).
