### PR TITLE
Adjust configuration and use of OMEncryption libraries.

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -4146,7 +4146,7 @@ algorithm
     ext := if Autoconf.os == "Windows_NT" then ".exe" else "";
     if encrypt then
       // create the path till packagetool
-      packageTool := stringAppendList({omhome,pd,"lib",pd,"omc",pd,"SEMLA",pd,"packagetool",ext});
+      packageTool := stringAppendList({omhome,pd,"bin",pd,"omc-semla",pd,"packagetool",ext});
       if System.regularFileExists(packageTool) then
         // create the list of arguments for packagetool
         packageToolArgs := "-librarypath \"" + System.dirname(fileName) + "\" -version \"1.0\" -language \"3.2\" -encrypt \"" + boolString(encrypt) + "\"";

--- a/OMCompiler/Compiler/boot/Makefile.in
+++ b/OMCompiler/Compiler/boot/Makefile.in
@@ -15,7 +15,7 @@ OM_ENABLE_ENCRYPTION=@OM_ENABLE_ENCRYPTION@
 LIB_OMC=lib/@host_short@/omc
 
 ifeq ($(OM_ENABLE_ENCRYPTION),yes)
-OMENCRYPTIONLIBS=-L$(OMBUILDDIR)/lib/omc/SEMLA -ltool -lssl -lcrypto
+OMENCRYPTIONLIBS=../../../OMEncryption/3rdParty/SEMLA/build/libtool.a ../../../OMEncryption/3rdParty/SEMLA/build/openssl/lib/libcrypto.a ../../../OMEncryption/3rdParty/SEMLA/build/openssl/lib/libssl.a
 else
 OMENCRYPTIONLIBS=
 endif

--- a/OMCompiler/Compiler/boot/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/boot/Makefile.omdev.mingw
@@ -32,7 +32,7 @@ endif
 TOP_DIR=../../
 OMHOME=$(OMBUILDDIR)
 ifeq ($(OM_ENABLE_ENCRYPTION),yes)
-OMENCRYPTIONLIBS=-L$(OMBUILDDIR)/lib/omc/SEMLA -ltool
+OMENCRYPTIONLIBS=../../../OMEncryption/3rdParty/SEMLA/build/libtool.a
 else
 OMENCRYPTIONLIBS=
 endif

--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -73,18 +73,24 @@ ifeq ($(OM_ENABLE_ENCRYPTION),yes)
 semla:
 	mkdir -p ../OMEncryption/3rdParty/SEMLA/build
 	# Build SEMLA
-	(cd ../OMEncryption/3rdParty/SEMLA/build && test -f Makefile || $(CMAKE) -DCMAKE_COLOR_MAKEFILE:Bool=OFF -DTOOL_PRIVATE_KEY_DIRECTORY:String=`pwd`/../src/openssl_keys -DLVE_KEYS_DIRECTORY:String=`pwd`/../src/openssl_keys -DTOOLS_PUBLIC_KEYS_DIRECTORY:String=`pwd`/../src/openssl_keys -DLICENSE_MANAGER:String=testingdummy -DDECRYPTOR:String=default -DOBFUSCATOR:String=dummy -DCMAKE_INSTALL_PREFIX:String=../install ../src -G $(CMAKE_TARGET))
+	(cd ../OMEncryption/3rdParty/SEMLA/build && test -f Makefile || \
+	  $(CMAKE) -DCMAKE_COLOR_MAKEFILE:Bool=OFF \
+	   -DTOOL_PRIVATE_KEY_DIRECTORY:String=`pwd`/../src/openssl_keys \
+	   -DLVE_KEYS_DIRECTORY:String=`pwd`/../src/openssl_keys \
+	   -DTOOLS_PUBLIC_KEYS_DIRECTORY:String=`pwd`/../src/openssl_keys \
+	   -DLICENSE_MANAGER:String=testingdummy \
+	   -DDECRYPTOR:String=default \
+	   -DOBFUSCATOR:String=dummy \
+	   -DCMAKE_INSTALL_PREFIX="$(top_builddir)" \
+	   -DCMAKE_INSTALL_BINDIR="$(builddir_bin)" \
+	   ../src -G $(CMAKE_TARGET))
+
 	$(MAKE) -C ../OMEncryption/3rdParty/SEMLA/build install
-	mkdir -p $(builddir_lib)/omc/SEMLA/LVE
-	cp -pPR ../OMEncryption/3rdParty/SEMLA/install/bin/* $(builddir_lib)/omc/SEMLA
-	cp -pPR ../OMEncryption/3rdParty/SEMLA/install/lib/libtool.a $(builddir_lib)/omc/SEMLA
-	cp -pPR ../OMEncryption/3rdParty/SEMLA/install/lib/libcrypto.a $(builddir_lib)/omc/SEMLA/libcrypto_semla.a
-	cp -pPR ../OMEncryption/3rdParty/SEMLA/install/lib/libssl.a $(builddir_lib)/omc/SEMLA/libssl_semla.a
 
 semla-clean:
 	rm -rf ../OMEncryption/3rdParty/SEMLA/build
 	rm -rf ../OMEncryption/3rdParty/SEMLA/install
-	rm -rf $(builddir_lib)/omc/SEMLA
+	rm -rf $(builddir_bin)/omc-semla
 endif # end of OM_ENABLE_ENCRYPTION
 
 release: omc


### PR DESCRIPTION
  - The semla libraries built are no longer installed. There is no need to distribute them. The libraries/exes who want to link to them can link to them directly from their build directory.

  - The executables/tools needed for encryption support are now installed to `bin/omc-semla/` instead of `lib/omc/SEMLA`.
