### PR TITLE
Copy RunOMEditTest to the bin folder.

### DIFF
--- a/OMEdit/Testsuite/Makefile.omdev.mingw
+++ b/OMEdit/Testsuite/Makefile.omdev.mingw
@@ -23,6 +23,7 @@ mkbuilddirs:
 install: build
 	cp -p ../bin/tests/*$(EXE) $(builddir_bin)
 	cp -p RunOMEditTestsuite.sh $(builddir_bin)
+	cp -p RunOMEditTest.sh $(builddir_bin)
 
 build: Makefile
 	$(MAKE) -f Makefile


### PR DESCRIPTION
  - This new file was forgotten and not copied on Windows. It is needed by the `Makefiles` based handling of `OMEditTestsuite` on Windows.

