### PR TITLE
Add cmake config for building with encryption support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ omc_add_to_report(CMAKE_LIBRARY_ARCHITECTURE)
 
 ## OPTIONS #################################################################################################
 omc_option(OM_ENABLE_GUI_CLIENTS "Enable, build, and install the qt based GUI clients." ON)
+
+omc_option(OM_ENABLE_ENCRYPTION "Enable and build the OpenModelica Encryption support module. " OFF)
+
 ## Use ccache to speedup compilation! It is important to use ccache if you can.
 ## You get almost no op compilations (for unmodified files) at the cost of some memory.
 ## This is usefull, for example, in cases where you change branches often or need to clean
@@ -140,6 +143,11 @@ set(CMAKE_INSTALL_MESSAGE LAZY)
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "unknown-install-component")
 
 ## Subdirectories ##########################################################################################
+# If asked for encryption support, add and configure the OMEncryption directory.
+if(OM_ENABLE_ENCRYPTION)
+  omc_add_subdirectory(OMEncryption)
+endif()
+
 omc_add_subdirectory(OMCompiler)
 
 if(OM_ENABLE_GUI_CLIENTS)

--- a/OMCompiler/Parser/CMakeLists.txt
+++ b/OMCompiler/Parser/CMakeLists.txt
@@ -39,3 +39,8 @@ target_link_libraries(omparse PUBLIC omc::3rd::omantlr3)
 # To find the generated antlr headers. SYSTEM to disable warnings on the generated code.
 target_include_directories(omparse SYSTEM PRIVATE ${GNERATED_DIRECTORY})
 target_include_directories(omparse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(OM_ENABLE_ENCRYPTION)
+  target_compile_definitions(omparse PUBLIC OM_ENABLE_ENCRYPTION)
+  target_link_libraries(omparse PUBLIC om::encrypt::libtool)
+endif()

--- a/README.cmake.md
+++ b/README.cmake.md
@@ -181,6 +181,7 @@ The main ones (with their default values) are
 ```cmake
 OM_USE_CCACHE=ON
 OM_ENABLE_GUI_CLIENTS=ON
+OM_ENABLE_ENCRYPTION=OFF
 OM_OMC_ENABLE_CPP_RUNTIME=ON
 OM_OMC_ENABLE_FORTRAN=ON
 OM_OMC_ENABLE_IPOPT=ON
@@ -192,6 +193,8 @@ OM_OMSHELL_ENABLE_TERMINAL=ON
 `OM_USE_CCACHE` option is for enabling/disabling ccache support as explained in [2. ccache](#2-ccache). It is recommended that you install ccache and set this to ON.
 
 `OM_ENABLE_GUI_CLIENTS` allows you to enable/disable the configuration and build of the qt based GUI clients and their dependencies. These include: OMEdit, OMNotebook, OMParser, OMPlot, OMShell. You will need to install and make available the necessary packages (and their dependencies) such as the Qt libs, OpenSceneGraph, OpenThreads ...
+
+`OM_ENABLE_ENCRYPTION` allows you to enable/disable building OpenModelica with library encryption support. Note that, for this to work, you need an additional module which is not distributed in the default OpenModelcia source repository. Contact the OpenModelica team if you need encryption support.
 
 ### 4.1.2. OpenModelica/OMCompiler Options
 `OM_OMC_ENABLE_CPP_RUNTIME` allows you to enable/disable the building of the C++ based simulation runtime. This requires multiple Boost library components (file_system, program_options, ...)


### PR DESCRIPTION
  - OpenModelica with encryption support can now be built using CMake. The support is disabled by default and can be enabled by specifying

    `cmake .... -DOM_ENABLE_ENCRYPTION=ON ....`
