### PR TITLE
Improve handling of array connections

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/CheckModel.mo
+++ b/OMCompiler/Compiler/FrontEnd/CheckModel.mo
@@ -208,6 +208,22 @@ algorithm
         (_, size, _, _) = List.fold(daeElts, countVarEqnSize, (0, 0, {}, hs));
       then (varSize, eqnSize+size, eqns, hs);
 
+    case DAE.INITIAL_FOR_EQUATION()
+      equation
+        (varSize, eqnSize, eqns, hs) = inArg;
+        (_, size, _, _) = List.fold(element.equations, countVarEqnSize, (0, 0, {}, hs));
+        size = size * Expression.sizeOf(Expression.typeof(element.range));
+      then
+        (varSize, eqnSize+size, eqns, hs);
+
+    case DAE.FOR_EQUATION()
+      equation
+        (varSize, eqnSize, eqns, hs) = inArg;
+        (_, size, _, _) = List.fold(element.equations, countVarEqnSize, (0, 0, {}, hs));
+        size = size * Expression.sizeOf(Expression.typeof(element.range));
+      then
+        (varSize, eqnSize+size, eqns, hs);
+
     // if equation with condition false and no else
     case DAE.IF_EQUATION(condition1 = {DAE.BCONST(false)}, equations3 = {})
        then inArg;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -991,7 +991,21 @@ public
     "strips the subscripts before comparing. Used for non expandend variables"
     input ComponentRef cref1;
     input ComponentRef cref2;
-    output Boolean b = isEqual(stripSubscriptsAll(cref1), stripSubscriptsAll(cref2));
+    output Boolean b;
+  algorithm
+    if referenceEq(cref1, cref2) then
+      b := true;
+      return;
+    end if;
+
+    b := match (cref1, cref2)
+      case (CREF(), CREF()) algorithm
+        then InstNode.name(cref1.node) == InstNode.name(cref2.node) and
+          isEqualStrip(cref1.restCref, cref2.restCref);
+      case (EMPTY(), EMPTY()) then true;
+      case (WILD(), WILD()) then true;
+      else false;
+    end match;
   end isEqualStrip;
 
   function isLess

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -35,6 +35,7 @@ encapsulated uniontype NFConnections
   import FlatModel = NFFlatModel;
   import ComponentRef = NFComponentRef;
   import Equation = NFEquation;
+  import NFPrefixes.ConnectorType;
 
 protected
   import Connections = NFConnections;
@@ -209,12 +210,84 @@ public
     conns.connections := List.mapFlat(conns.connections, Connection.split);
   end split;
 
+  function connectCount
+    input Connector conn;
+    input UnorderedMap<Connector, Integer> connectCounts;
+    output Integer count;
+  algorithm
+    count := UnorderedMap.getOrDefault(conn, connectCounts, 0);
+  end connectCount;
+
   function scalarize
     input output Connections conns;
+    input Boolean keepSingleConnectedArrays;
+  protected
+    UnorderedMap<Connector, Integer> connect_counts;
+    list<Connector> flows = {};
+    list<Connection> connections = {};
+    Integer count;
   algorithm
-    conns.flows := List.mapFlat(conns.flows, Connector.scalarize);
-    conns.connections := List.mapFlat(conns.connections, Connection.scalarize);
+    if keepSingleConnectedArrays then
+      connect_counts := analyseArrayConnections(conns);
+
+      for f in conns.flows loop
+        count := connectCount(f, connect_counts);
+
+        if count == 0 then
+          flows := f :: flows;
+        elseif count > 1 then
+          flows := listAppend(Connector.scalarize(f), flows);
+        end if;
+      end for;
+
+      for c in conns.connections loop
+        if not ConnectorType.isStream(c.lhs.cty) and
+           connectCount(c.lhs, connect_counts) == 1 and connectCount(c.rhs, connect_counts) == 1 then
+          connections := c :: connections;
+        else
+          connections := listAppend(Connection.scalarize(c), connections);
+        end if;
+      end for;
+
+      conns.flows := listReverseInPlace(flows);
+      conns.connections := listReverseInPlace(connections);
+    else
+      conns.flows := List.mapFlat(conns.flows, Connector.scalarize);
+      conns.connections := List.mapFlat(conns.connections, Connection.scalarize);
+    end if;
   end scalarize;
+
+  function analyseArrayConnections
+    input Connections conns;
+    output UnorderedMap<Connector, Integer> connectCounts;
+  algorithm
+    connectCounts := UnorderedMap.new<Integer>(Connector.hashNoSubs, Connector.isEqualNoSubs,
+      listLength(conns.connections));
+
+    for conn in conns.connections loop
+      analyseArrayConnector(conn.lhs, connectCounts);
+      analyseArrayConnector(conn.rhs, connectCounts);
+    end for;
+  end analyseArrayConnections;
+
+  function analyseArrayConnector
+    input Connector conn;
+    input UnorderedMap<Connector, Integer> connectCounts;
+  protected
+    function update
+      input Option<Integer> count;
+      output Integer outCount;
+    algorithm
+      outCount := match count
+        case SOME(outCount) then outCount + 1;
+        else 1;
+      end match;
+    end update;
+  algorithm
+    if Connector.isArray(conn) or ComponentRef.hasSubscripts(conn.name) then
+      UnorderedMap.addUpdate(conn, update, connectCounts);
+    end if;
+  end analyseArrayConnector;
 
   function toString
     input Connections conns;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
@@ -37,6 +37,7 @@ encapsulated uniontype NFConnector
   import NFPrefixes.ConnectorType;
   import NFPrefixes.Variability;
   import DAE;
+  import Subscript = NFSubscript;
 
 protected
   import Origin = NFComponentRef.Origin;
@@ -142,6 +143,13 @@ public
                              conn1.face == conn2.face;
   end isEqual;
 
+  function isEqualNoSubs
+    input Connector conn1;
+    input Connector conn2;
+    output Boolean isEqual = ComponentRef.isEqualStrip(conn1.name, conn2.name) and
+                             conn1.face == conn2.face;
+  end isEqualNoSubs;
+
   function isPrefix
     input Connector conn1;
     input Connector conn2;
@@ -217,6 +225,14 @@ public
     output Integer hash = ComponentRef.hash(conn.name, mod);
   end hash;
 
+  function hashNoSubs
+    input Connector conn;
+    input Integer mod;
+    output Integer hash;
+  algorithm
+    hash := ComponentRef.hashStrip(conn.name, mod);
+  end hashNoSubs;
+
   function split
     "Splits a connector into its primitive components, while keeping arrays as
      they are.
@@ -281,6 +297,14 @@ public
 
     connl := listReverseInPlace(connl);
   end scalarizePrefix;
+
+  function addSubscripts
+    input list<Subscript> subscripts;
+    input output Connector conn;
+  algorithm
+    conn.name := ComponentRef.mergeSubscripts(subscripts, conn.name, true);
+    conn.ty := Type.subscript(conn.ty, subscripts);
+  end addSubscripts;
 
 protected
   function crefFace

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2005,10 +2005,7 @@ algorithm
   conns := Connections.addBroken(broken, conns);
   // build the sets, check the broken connects
   conns := Connections.split(conns);
-
-  if settings.scalarize or settings.newBackend then
-    conns := Connections.scalarize(conns);
-  end if;
+  conns := Connections.scalarize(conns, keepSingleConnectedArrays = not settings.scalarize);
 
   csets := ConnectionSets.fromConnections(conns);
   csets_array := ConnectionSets.extractSets(csets);

--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -737,8 +737,9 @@ protected
     KeyEq eqfn = map.eqFn;
     list<Integer> bucket;
   algorithm
-    hash := hashfn(key, Vector.size(map.buckets));
     if Vector.size(map.buckets) > 0 then
+      hash := hashfn(key, Vector.size(map.buckets));
+
       bucket := Vector.get(map.buckets, hash + 1);
       for i in bucket loop
         if eqfn(key, Vector.getNoBounds(map.keys, i)) then
@@ -746,6 +747,8 @@ protected
           break;
         end if;
       end for;
+    else
+      hash := 0;
     end if;
   end find;
 

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect4.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect4.mo
@@ -1,0 +1,40 @@
+// name: ArrayConnect4
+// keywords:
+// status: correct
+// cflags: -d=newInst,-nfScalarize
+//
+
+connector Port
+  Real v;
+  flow Real i;
+end Port;
+
+model M
+  Port port;
+equation
+  port.v = 10 * port.i;
+end M;
+
+model S
+  parameter Integer N = 3;
+  M m[N];
+equation
+  for i in 1:N-1 loop
+    connect(m[i].port, m[i+1].port);
+  end for;
+end S;
+
+// Result:
+// class S
+//   final parameter Integer N = 3;
+//   Real[3] m.port.i;
+//   Real[3] m.port.v;
+// equation
+//   m[2].port.v = m[3].port.v;
+//   m[2].port.v = m[1].port.v;
+//   m[3].port.i + m[2].port.i + m[1].port.i = 0.0;
+//   for $i1 in 1:3 loop
+//     m[$i1].port.v = 10.0 * m[$i1].port.i;
+//   end for;
+// end S;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect5.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect5.mo
@@ -1,0 +1,42 @@
+// name: ArrayConnect5
+// keywords:
+// status: correct
+// cflags: -d=newInst,-nfScalarize
+//
+
+connector C
+  Real e[2];
+  flow Real f[2];
+end C;
+
+model ArrayConnect5
+  C c1[2], c2[2];
+equation
+  connect(c1, c2);
+end ArrayConnect5;
+
+// Result:
+// class ArrayConnect5
+//   Real[2, 2] c1.f;
+//   Real[2, 2] c1.e;
+//   Real[2, 2] c2.f;
+//   Real[2, 2] c2.e;
+// equation
+//   c1.e = c2.e;
+//   for $i1 in 1:2 loop
+//     for $i2 in 1:2 loop
+//       (-c1[$i1].f[$i2]) - c2[$i1].f[$i2] = 0.0;
+//     end for;
+//   end for;
+//   for $i1 in 1:2 loop
+//     for $i2 in 1:2 loop
+//       c1[$i1].f[$i2] = 0.0;
+//     end for;
+//   end for;
+//   for $i1 in 1:2 loop
+//     for $i2 in 1:2 loop
+//       c2[$i1].f[$i2] = 0.0;
+//     end for;
+//   end for;
+// end ArrayConnect5;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -19,6 +19,8 @@ ArrayBoundsEq1.mo\
 ArrayConnect1.mo \
 ArrayConnect2.mo \
 ArrayConnect3.mo \
+ArrayConnect4.mo \
+ArrayConnect5.mo \
 ArrayConstructorComplex1.mo \
 ArrayConstructorRecord1.mo \
 ArrayConstructorRecord2.mo \

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -31,13 +31,13 @@ testMatrixIO.mos \
 testMatrixState.mos \
 testReduction.mos \
 testVectorizedBlocks.mos \
-testVectorizedPowerSystem.mos \
 testVectorizedSolarSystem.mos \
 trapezoidTest.mos \
 negatedParameter.mos
 
 FAILINGTESTFILES= \
 ClockInterval.mos \
+testVectorizedPowerSystem.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/openmodelica/cppruntime/testVectorizedSolarSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedSolarSystem.mos
@@ -52,7 +52,8 @@ val(grid.P_grid, 0.0);
 // Equations (7, 7)
 // ========================================
 // 1/1 (1000): plant.term.v = grid.terms.v   [dynamic |0|0|0|0|]
-// 2/1001 (1000): grid.terms.i + plant.term.i = 0.0   [dynamic |0|0|0|0|]
+// 2/1001 (1000): for $i1 in 1 : 1000 loop
+//     plant[$i1].term.i + grid.terms[$i1].i = 0.0; end for;    [dynamic |0|0|0|0|]
 // 3/2001 (1000): for $i1 in 1 : 1000 loop
 //     plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0; end for;    [dynamic |0|0|0|0|]
 // 4/3001 (1000): for i in 1 : 1000 loop
@@ -100,7 +101,8 @@ val(grid.P_grid, 0.0);
 // Equations (7, 7)
 // ========================================
 // 1/1 (1000): plant.term.v = grid.terms.v   [dynamic |0|0|0|0|]
-// 2/1001 (1000): grid.terms.i + plant.term.i = 0.0   [dynamic |0|0|0|0|]
+// 2/1001 (1000): for $i1 in 1 : 1000 loop
+//     plant[$i1].term.i + grid.terms[$i1].i = 0.0; end for;    [dynamic |0|0|0|0|]
 // 3/2001 (1000): for $i1 in 1 : 1000 loop
 //     plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0; end for;    [dynamic |0|0|0|0|]
 // 4/3001 (1000): for i in 1 : 1000 loop
@@ -129,7 +131,7 @@ val(grid.P_grid, 0.0);
 // {4:1}
 // Array  {{1:6}}
 // {3:7}
-// Array  {{2:2}}
+// {2:2}
 // {5:3}
 //
 //


### PR DESCRIPTION
- Don't scalarize single-connected connectors when scalarization is turned off.
- Handle array connectors when generating flow equations.
- Implement support for for-equations in checkModel.
- Fix lookup in empty UnorderedMap.
- Disable test case `testVectorizedSolarSystem`, which relied on broken flow equation generation and now instead fails because SimCodeUtil.createEquation can't handle nested for-equations.