### PR TITLE
Change behaviour of arrayConnect flag

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -327,8 +327,7 @@ algorithm
   execStat(getInstanceName());
   InstUtil.dumpFlatModelDebug("flatten", flatModel);
 
-  if settings.arrayConnect and
-     FlatModel.hasArrayConnections(flatModel, Flags.getConfigInt(Flags.ARRAY_CONNECT_MIN_SIZE)) then
+  if settings.arrayConnect then
     flatModel := resolveArrayConnections(flatModel);
   else
     flatModel := resolveConnections(flatModel, deleted_vars, settings);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -240,7 +240,6 @@ function resetGlobalFlags
 algorithm
   if Flags.getConfigBool(Flags.NEW_BACKEND) then
     FlagsUtil.set(Flags.NF_SCALARIZE, false);
-    FlagsUtil.set(Flags.ARRAY_CONNECT, true);
   end if;
 
   // gather here all the flags to disable expansion

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1451,11 +1451,6 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
-constant ConfigFlag ARRAY_CONNECT_MIN_SIZE = CONFIG_FLAG(155, "arrayConnectMinSize",
-  NONE(), EXTERNAL(), INT_FLAG(100), NONE(),
-  Gettext.gettext("The minimum size of array connections for -d=arrayConnect to have effect"));
-
-
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."
   input Boolean initialize = true;

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -409,8 +409,7 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.SIMULATION,
   Flags.OBFUSCATE,
   Flags.FMU_RUNTIME_DEPENDS,
-  Flags.FRONTEND_INLINE,
-  Flags.ARRAY_CONNECT_MIN_SIZE
+  Flags.FRONTEND_INLINE
 };
 
 public function new

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect1.mo
@@ -1,7 +1,7 @@
 // name: ArrayConnect1
 // keywords:
 // status: correct
-// cflags: -d=newInst,arrayConnect,-nfScalarize --arrayConnectMinSize=10
+// cflags: -d=newInst,arrayConnect,-nfScalarize
 //
 
 connector C

--- a/testsuite/openmodelica/flatmodelica/SD.mo
+++ b/testsuite/openmodelica/flatmodelica/SD.mo
@@ -1,7 +1,7 @@
 // name: SD
 // keywords:
 // status: correct
-// cflags: -d=newInst,-nfScalarize,arrayConnect,combineSubscripts -f --arrayConnectMinSize=3
+// cflags: -d=newInst,-nfScalarize,arrayConnect,combineSubscripts -f
 //
 
 connector C


### PR DESCRIPTION
- Don't enable `arrayConnect` flag for new backend by default.
- Always use the array connection handling if the `arrayConnect` flag is enabled.
- Remove the `arrayConnectMinSize` flag since it no longer has any purpose.