### PR TITLE
Remove modulo from hashing functions

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -231,14 +231,14 @@ algorithm
   // 1. Collect all possible record types from equations and globalKnownVars
   // (the frontend does not keep correct types at the variables so they have to be grabbed from eqns beforehand
   // I don't like it but thats how it is).
-  map := UnorderedMap.new<DAE.Type>(ComponentReference.hashComponentRefMod, ComponentReference.crefEqual);
+  map := UnorderedMap.new<DAE.Type>(ComponentReference.hashComponentRef, ComponentReference.crefEqual);
   collectRecordTypesVarLst(map, globalKnownVarLst);
   eqns  := List.map(eqns, function collectRecordTypesEqn(map = map));
   reqns := List.map(reqns, function collectRecordTypesEqn(map = map));
   ieqns := List.map(ieqns, function collectRecordTypesEqn(map = map));
 
   // 2. Collect bindings from variables and update in types
-  arrayMap := UnorderedMap.new<ArrayBindingList>(ComponentReference.hashComponentRefMod, ComponentReference.crefEqual);
+  arrayMap := UnorderedMap.new<ArrayBindingList>(ComponentReference.hashComponentRef, ComponentReference.crefEqual);
 
   _ := List.map(varlst, function collectRecordElementBindings(map = map, arrayMap = arrayMap));
   _ := List.map(globalKnownVarLst, function collectRecordElementBindings(map = map, arrayMap = arrayMap));

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -2856,7 +2856,7 @@ protected
 algorithm
   BackendDAE.VARIABLES(indices, arr, buckets, num_vars) := inVariables;
   (arr, outVar as BackendDAE.VAR(varName = cr)) := vararrayDelete(arr, inIndex);
-  hash_idx := ComponentReference.hashComponentRefMod(cr, buckets) + 1;
+  hash_idx := intMod(ComponentReference.hashComponentRef(cr), buckets) + 1;
   cr_indices := indices[hash_idx];
   cr_indices := List.deleteMemberOnTrue(BackendDAE.CREFINDEX(cr, inIndex - 1), cr_indices, removeVar2);
   arrayUpdate(indices, hash_idx, cr_indices);
@@ -3041,7 +3041,7 @@ protected
   Integer hash_idx, arr_idx;
   list<BackendDAE.CrefIndex> indices;
 algorithm
-  hash_idx := ComponentReference.hashComponentRefMod(inVar.varName, inVariables.bucketSize) + 1;
+  hash_idx := intMod(ComponentReference.hashComponentRef(inVar.varName), inVariables.bucketSize) + 1;
   indices := arrayGet(inVariables.crefIndices, hash_idx);
 
   try
@@ -3086,7 +3086,7 @@ protected
   list<BackendDAE.CrefIndex> indices;
 algorithm
   BackendDAE.VARIABLES(hashvec, varr, bsize, num_vars) := inVariables;
-  idx := ComponentReference.hashComponentRefMod(inVar.varName, bsize) + 1;
+  idx := intMod(ComponentReference.hashComponentRef(inVar.varName), bsize) + 1;
   varr := vararrayAdd(varr, inVar);
   indices := hashvec[idx];
   arrayUpdate(hashvec, idx, (BackendDAE.CREFINDEX(inVar.varName, num_vars)::indices));
@@ -3493,7 +3493,7 @@ protected
   DAE.ComponentRef cr;
 algorithm
   BackendDAE.VARIABLES(crefIndices=indices, varArr=arr, bucketSize=buckets) := inVariables;
-  hash_idx := ComponentReference.hashComponentRefMod(inCref, buckets) + 1;
+  hash_idx := intMod(ComponentReference.hashComponentRef(inCref), buckets) + 1;
   cr_indices := indices[hash_idx];
   BackendDAE.CREFINDEX(index=outIndex) := List.getMemberOnTrue(inCref, cr_indices, crefIndexEqualCref);
   outIndex := outIndex + 1;

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -4429,7 +4429,7 @@ uniontype LinearJacobian
 
     /* Loop over all equations and create residual expression. */
     for loopEq in loopEqs loop
-      row := UnorderedMap.new<Real>(intMod, intEq);
+      row := UnorderedMap.new<Real>(Util.id, intEq);
       (eqn, index) := loopEq;
       res := BackendEquation.createResidualExp(eqn);
       /* Loop over all variables and differentiate residual expression for each. */

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1245,19 +1245,14 @@ algorithm
   end match;
 end pathCompareNoQual;
 
-public function pathHashMod "Hashes a path."
+public function pathHash "Hashes a path."
   input Absyn.Path path;
-  input Integer mod;
   output Integer hash;
 algorithm
-// hash := valueHashMod(path,mod);
-// print(pathString(path) + " => " + intString(hash) + "\n");
-// hash := stringHashDjb2Mod(pathString(path),mod);
-// TODO: stringHashDjb2 is missing a default value for the seed; add this once we bootstrapped omc so we can use that function instead of our own hack
-  hash := intAbs(intMod(pathHashModWork(path,5381),mod));
-end pathHashMod;
+  hash := pathHashWork(path,5381);
+end pathHash;
 
-public function pathHashModWork "Hashes a path."
+public function pathHashWork "Hashes a path."
   input Absyn.Path path;
   input Integer acc;
   output Integer hash;
@@ -1267,11 +1262,11 @@ algorithm
       Absyn.Path p;
       String s;
       Integer i,i2;
-    case (Absyn.FULLYQUALIFIED(p),_) then pathHashModWork(p, acc*31 + 46 /* '.' */);
-    case (Absyn.QUALIFIED(s,p),_) equation i = stringHashDjb2(s); i2 = acc*31+46; then pathHashModWork(p, i2*31 + i);
+    case (Absyn.FULLYQUALIFIED(p),_) then pathHashWork(p, acc*31 + 46 /* '.' */);
+    case (Absyn.QUALIFIED(s,p),_) equation i = stringHashDjb2(s); i2 = acc*31+46; then pathHashWork(p, i2*31 + i);
     case (Absyn.IDENT(s),_) equation i = stringHashDjb2(s); i2 = acc*31+46; then i2*31 + i;
   end match;
-end pathHashModWork;
+end pathHashWork;
 
 public function optPathString "Returns a path converted to string or an empty string if nothing exist"
   input Option<Absyn.Path> inPathOption;

--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -63,25 +63,6 @@ protected import Util;
 // do not make this public. instead use the function below.
 protected constant DAE.ComponentRef dummyCref = DAE.CREF_IDENT("dummy", DAE.T_UNKNOWN_DEFAULT, {});
 
-public function hashComponentRefMod "
-  author: PA
-
-  Calculates a hash value for DAE.ComponentRef, by hashing each individual part separately and summing the values, and then apply
-  intMod to it, to return a value in range [0,mod-1].
-  Also hashes subscripts in a clever way avoiding [1,2] and [2,1] to hash to the same value. This is done by investigating array type
-  to find dimension of array.
-"
-  input DAE.ComponentRef cr;
-  input Integer mod;
-  output Integer res;
-protected
-  Integer h;
-algorithm
-   // hash might overflow => force positive
-   h := intAbs(hashComponentRef(cr));
-   res := intMod(h,mod);
-end hashComponentRefMod;
-
 public function hashComponentRef "new hashing that properly deals with subscripts so [1,2] and [2,1] hash to different values"
   input DAE.ComponentRef cr;
   output Integer hash;

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -11069,16 +11069,6 @@ algorithm
   end match;
 end promoteExp3;
 
-public function hashExpMod "
-author: PA
-hash expression to value in range [0,mod-1]"
-  input DAE.Exp e;
-  input Integer mod;
-  output Integer hash;
-algorithm
-  hash := intMod(intAbs(hashExp(e)),mod);
-end hashExpMod;
-
 public function hashExp "help function to hashExpMod"
   input DAE.Exp e;
   output Integer hash;

--- a/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
+++ b/OMCompiler/Compiler/FrontEnd/ExpressionSimplify.mo
@@ -3179,7 +3179,7 @@ algorithm
 
     // general case, this is O(n) but has a small overhead
     else algorithm
-      coeff_map := UnorderedMap.new<Real>(Expression.hashExpMod, Expression.expEqual, listLength(inTplExpRealLst));
+      coeff_map := UnorderedMap.new<Real>(Expression.hashExp, Expression.expEqual, listLength(inTplExpRealLst));
       for tpl in inTplExpRealLst loop
         (exp1, coeff1) := tpl;
         // set the coefficient of exp1 to coeff1, add the previous coefficient if exp1 is already in the map

--- a/OMCompiler/Compiler/FrontEnd/FHashTableCrToUnit.mo
+++ b/OMCompiler/Compiler/FrontEnd/FHashTableCrToUnit.mo
@@ -72,7 +72,6 @@ public type HashTable = tuple<
 
 partial function FuncHashKey
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashKey;
 
@@ -110,7 +109,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size, (ComponentReference.hashComponentRefMod, ComponentReference.crefEqual, ComponentReference.printComponentRefStr, FUnit.unit2string));
+  hashTable := BaseHashTable.emptyHashTableWork(size, (ComponentReference.hashComponentRef, ComponentReference.crefEqual, ComponentReference.printComponentRefStr, FUnit.unit2string));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/FrontEnd/FHashTableStringToUnit.mo
+++ b/OMCompiler/Compiler/FrontEnd/FHashTableStringToUnit.mo
@@ -70,7 +70,6 @@ public type HashTable = tuple<
 
 partial function FuncHashKey
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashKey;
 
@@ -108,7 +107,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size, (stringHashDjb2Mod, stringEq, Util.id, FUnit.unit2string));
+  hashTable := BaseHashTable.emptyHashTableWork(size, (stringHashDjb2, stringEq, Util.id, FUnit.unit2string));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/FrontEnd/FHashTableUnitToString.mo
+++ b/OMCompiler/Compiler/FrontEnd/FHashTableUnitToString.mo
@@ -69,7 +69,6 @@ public type HashTable = tuple<
 
 partial function FuncHashKey
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashKey;
 
@@ -114,7 +113,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(FUnit.hashUnitMod,FUnit.unitEqual,FUnit.unit2string,id));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(FUnit.hashUnit,FUnit.unitEqual,FUnit.unit2string,id));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/FrontEnd/FUnit.mo
+++ b/OMCompiler/Compiler/FrontEnd/FUnit.mo
@@ -173,16 +173,15 @@ algorithm
   end match;
 end isUnit;
 
-public function hashUnitMod
+public function hashUnit
   input Unit inKey;
-  input Integer inMod;
   output Integer outHash;
 protected
   String str;
 algorithm
   str := unit2string(inKey);
-  outHash := stringHashDjb2Mod(str, inMod);
-end hashUnitMod;
+  outHash := stringHashDjb2(str);
+end hashUnit;
 
 public function unitEqual
   input Unit inKey;

--- a/OMCompiler/Compiler/FrontEnd/InstHashTable.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstHashTable.mo
@@ -197,7 +197,6 @@ protected type HashTable = tuple<
 
 protected partial function FuncHashKey
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashKey;
 
@@ -238,7 +237,7 @@ protected function emptyInstHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(AbsynUtil.pathHashMod,AbsynUtil.pathEqual,AbsynUtil.pathStringDefault,opaqVal));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(AbsynUtil.pathHash,AbsynUtil.pathEqual,AbsynUtil.pathStringDefault,opaqVal));
 end emptyInstHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/MidCode/HashTableMidVar.mo
+++ b/OMCompiler/Compiler/MidCode/HashTableMidVar.mo
@@ -56,7 +56,6 @@ public type HashTable = tuple<array<list<tuple<Key, Integer>>>,
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -92,7 +91,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,MidCode.varString));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,MidCode.varString));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="backend");

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -620,8 +620,7 @@ public
     function hash
       "only hashes the name"
       input Pointer<Equation> eqn;
-      input Integer mod;
-      output Integer i = Variable.hash(Pointer.access(getResidualVar(eqn)), mod);
+      output Integer i = Variable.hash(Pointer.access(getResidualVar(eqn)));
     end hash;
 
     function equalName

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
@@ -85,8 +85,7 @@ public
 
     function hash
       input AliasInfo info;
-      input Integer mod;
-      output Integer i = intMod(System.systemTypeInteger(info.systemType) + info.partitionIndex*13 + info.componentIndex*31, mod);
+      output Integer i = System.systemTypeInteger(info.systemType) + info.partitionIndex*13 + info.componentIndex*31;
     end hash;
 
     function isEqual
@@ -217,17 +216,16 @@ public
   function hash
     "only hashes basic types, isEqual is used to differ between sliced/entwined loops"
     input StrongComponent comp;
-    input Integer mod;
     output Integer i;
   algorithm
     i := match comp
-      case SINGLE_COMPONENT()   then intMod(BVariable.hash(comp.var, mod) + Equation.hash(comp.eqn, mod), mod);
-      case MULTI_COMPONENT()    then intMod(Equation.hash(comp.eqn, mod), mod);
-      case SLICED_COMPONENT()   then intMod(ComponentRef.hash(comp.var_cref, mod) + Equation.hash(Slice.getT(comp.eqn), mod), mod);
-      case GENERIC_COMPONENT()  then Equation.hash(Slice.getT(comp.eqn), mod);
-      case ENTWINED_COMPONENT() then intMod(sum(hash(sub_comp, mod) for sub_comp in comp.entwined_slices), mod);
-      case ALGEBRAIC_LOOP()     then intMod(Tearing.hash(comp.strict, mod), mod);
-      case ALIAS()              then AliasInfo.hash(comp.aliasInfo, mod);
+      case SINGLE_COMPONENT()   then BVariable.hash(comp.var) + Equation.hash(comp.eqn);
+      case MULTI_COMPONENT()    then Equation.hash(comp.eqn);
+      case SLICED_COMPONENT()   then ComponentRef.hash(comp.var_cref) + Equation.hash(Slice.getT(comp.eqn));
+      case GENERIC_COMPONENT()  then Equation.hash(Slice.getT(comp.eqn));
+      case ENTWINED_COMPONENT() then sum(hash(sub_comp) for sub_comp in comp.entwined_slices);
+      case ALGEBRAIC_LOOP()     then Tearing.hash(comp.strict);
+      case ALIAS()              then AliasInfo.hash(comp.aliasInfo);
     end match;
   end hash;
 
@@ -344,8 +342,8 @@ public
     input list<SuperNode> nodes;
     output StrongComponent entwined;
   protected
-    UnorderedMap<Integer, Slice.IntLst> elem_map = UnorderedMap.new<Slice.IntLst>(intMod, intEq);
-    UnorderedMap<Integer, ComponentRef> cref_map = UnorderedMap.new<ComponentRef>(intMod, intEq);
+    UnorderedMap<Integer, Slice.IntLst> elem_map = UnorderedMap.new<Slice.IntLst>(Util.id, intEq);
+    UnorderedMap<Integer, ComponentRef> cref_map = UnorderedMap.new<ComponentRef>(Util.id, intEq);
     list<tuple<Integer, Slice.IntLst>> flat_map;
     Integer arr_idx;
     Slice.IntLst scal_indices;
@@ -749,8 +747,8 @@ protected
     list<Integer> idx_lst;
     Pointer<Variable> var;
     Pointer<Equation> eqn;
-    UnorderedMap<Integer, Slice.IntLst> var_map = UnorderedMap.new<Slice.IntLst>(intMod, intEq, listLength(comp_indices));
-    UnorderedMap<Integer, Slice.IntLst> eqn_map = UnorderedMap.new<Slice.IntLst>(intMod, intEq, listLength(comp_indices));
+    UnorderedMap<Integer, Slice.IntLst> var_map = UnorderedMap.new<Slice.IntLst>(Util.id, intEq, listLength(comp_indices));
+    UnorderedMap<Integer, Slice.IntLst> eqn_map = UnorderedMap.new<Slice.IntLst>(Util.id, intEq, listLength(comp_indices));
   algorithm
     // store all component var and eqn indices in maps
     for eqn_idx in comp_indices loop

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -118,8 +118,7 @@ public
 
   function hash
     input Pointer<Variable> var_ptr;
-    input Integer mod;
-    output Integer i = Variable.hash(Pointer.access(var_ptr), mod);
+    output Integer i = Variable.hash(Pointer.access(var_ptr));
   end hash;
 
   function equalName

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
@@ -556,13 +556,12 @@ protected
     "returns the hash value of an edge tpl
      (a, b) == (b, a) -> same hash!"
     input EdgeTpl tpl;
-    input Integer mod;
     output Integer hash;
   protected
     Integer l, r;
   algorithm
     (l, r) := tpl;
-    hash := intMod(intBitXor(l,r), mod);
+    hash := intBitXor(l,r);
   end hashEdgeTpl;
 
   function eqEdgeTpl

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBSorting.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBSorting.mo
@@ -68,11 +68,10 @@ public
 
     function hash
       input PseudoBucketKey key   "the key to hash";
-      input Integer modulo        "modulo value";
       input Integer shift         "has to be statically provided while creating the PseudoBucket.";
       output Integer val          "the hash value";
     algorithm
-      val := mod(key.mode*shift*shift + key.eqn_arr_idx*shift + key.eqn_start_idx, modulo);
+      val := key.mode*shift*shift + key.eqn_arr_idx*shift + key.eqn_start_idx;
     end hash;
 
     function equal
@@ -377,7 +376,7 @@ public
       PseudoBucketValue val;
       Integer index, shift;
       list<Integer> var_lst;
-      UnorderedSet<Integer> alg_loop_set = UnorderedSet.new(intMod, intEq) "the set of indices appearing in algebraic loops";
+      UnorderedSet<Integer> alg_loop_set = UnorderedSet.new(Util.id, intEq) "the set of indices appearing in algebraic loops";
     algorithm
       phase2_adj := match (phase2_adj, phase2_matching)
         case (Adjacency.PSEUDO_ARRAY_ADJACENCY_MATRIX(), Matching.SCALAR_MATCHING()) algorithm

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -78,7 +78,6 @@ public
 
   function hash
     input Tearing tearing;
-    input Integer mod;
     output Integer i = -1;
   algorithm
     // ToDo!

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -757,7 +757,7 @@ public
         // interface map. If the map contains a variable it has a zero derivative
         // if the value is "true" it has to be stripped from the interface
         // (it is possible that a variable has a zero derivative, but still appears in the interface)
-        UnorderedMap<String, Boolean> interface_map = UnorderedMap.new<Boolean>(stringHashDjb2Mod, stringEqual);
+        UnorderedMap<String, Boolean> interface_map = UnorderedMap.new<Boolean>(stringHashDjb2, stringEqual);
 
       // builtin functions
       case Expression.CALL(call = call as Call.TYPED_CALL()) guard(Function.isBuiltin(call.fn)) algorithm

--- a/OMCompiler/Compiler/NBackEnd/Util/NBGraphUtil.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBGraphUtil.mo
@@ -68,8 +68,7 @@ public
 
     function hash
       input SetVertex v;
-      input Integer mod;
-      output Integer i = Variable.hash(Pointer.access(v.name), mod);
+      output Integer i = Variable.hash(Pointer.access(v.name));
     end hash;
 
     function isEqual
@@ -149,8 +148,7 @@ public
 
     function hash
       input SetEdge e;
-      input Integer mod;
-      output Integer i = stringHashDjb2Mod(e.name, mod);
+      output Integer i = stringHashDjb2(e.name);
     end hash;
 
     function isEqual

--- a/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
@@ -133,7 +133,7 @@ public
     (flatModel, conns) := collect(flatModel);
 
     graph := IncidenceList.new(SetVertex.isEqual, SetEdge.isEqual, SetVertex.toString, SetEdge.toString);
-    nmv_table := UnorderedMap.new<SBMultiInterval>(stringHashDjb2Mod, stringEq);
+    nmv_table := UnorderedMap.new<SBMultiInterval>(stringHashDjb2, stringEq);
     createGraph(flatModel.variables, conns, graph, v_count, e_count, nmv_table);
 
     if Flags.isSet(Flags.DUMP_SET_BASED_GRAPHS) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFCardinalityTable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCardinalityTable.mo
@@ -44,7 +44,7 @@ encapsulated package NFCardinalityTable
     input Integer size;
     output Table table;
   algorithm
-    table := UnorderedMap.new<Integer>(stringHashDjb2Mod, stringEq, size);
+    table := UnorderedMap.new<Integer>(stringHashDjb2, stringEq, size);
   end emptyCardinalityTable;
 
   function fromConnections

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1265,15 +1265,13 @@ public
 
   function hash
     input ComponentRef cref;
-    input Integer mod;
-    output Integer hash = stringHashDjb2Mod(toString(cref), mod);
+    output Integer hash = stringHashDjb2(toString(cref));
   end hash;
 
   function hashStrip
     "hashes the cref without subscripts. used for non expanded variables"
     input ComponentRef cref;
-    input Integer mod;
-    output Integer hash = stringHashDjb2Mod(toString(stripSubscriptsAll(cref)), mod);
+    output Integer hash = stringHashDjb2(toString(stripSubscriptsAll(cref)));
   end hashStrip;
 
   function toPath

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectionSets.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectionSets.mo
@@ -47,7 +47,7 @@ package ConnectionSets
 
   redeclare function extends EntryHash
   algorithm
-    hash := Connector.hash(entry, mod);
+    hash := Connector.hash(entry);
   end EntryHash;
 
   redeclare function extends EntryEqual

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnector.mo
@@ -221,16 +221,14 @@ public
 
   function hash
     input Connector conn;
-    input Integer mod;
-    output Integer hash = ComponentRef.hash(conn.name, mod);
+    output Integer hash = ComponentRef.hash(conn.name);
   end hash;
 
   function hashNoSubs
     input Connector conn;
-    input Integer mod;
     output Integer hash;
   algorithm
-    hash := ComponentRef.hashStrip(conn.name, mod);
+    hash := ComponentRef.hashStrip(conn.name);
   end hashNoSubs;
 
   function split

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -583,7 +583,7 @@ protected
   UnorderedMap<String, Expression> arg_map;
   list<Expression> args;
 algorithm
-  arg_map := UnorderedMap.new<Expression>(stringHashDjb2Mod, stringEq);
+  arg_map := UnorderedMap.new<Expression>(stringHashDjb2, stringEq);
 
   // Add default arguments from the slots.
   for s in newFn.slots loop

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandableConnectors.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandableConnectors.mo
@@ -485,10 +485,9 @@ end updatePotentiallyPresentVariable;
 
 function hashConnector
   input Connector conn;
-  input Integer mod;
   output Integer res;
 algorithm
-  res := stringHashDjb2Mod(ComponentRef.firstName(conn.name), mod);
+  res := stringHashDjb2(ComponentRef.firstName(conn.name));
 end hashConnector;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -284,7 +284,7 @@ public
   protected
     TypeMap types;
   algorithm
-    types := UnorderedMap.new<Type>(AbsynUtil.pathHashMod, AbsynUtil.pathEqual);
+    types := UnorderedMap.new<Type>(AbsynUtil.pathHash, AbsynUtil.pathEqual);
     List.map1_0(flatModel.variables, collectVariableFlatTypes, types);
     List.map1_0(flatModel.equations, collectEquationFlatTypes, types);
     List.map1_0(flatModel.initialEquations, collectEquationFlatTypes, types);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -321,7 +321,7 @@ algorithm
     SCode.COMMENT(NONE(), NONE()), AbsynUtil.dummyInfo);
 
   // Make an InstNode for the top scope, to use as the parent of the top level elements.
-  generated_inners := UnorderedMap.new<InstNode>(System.stringHashDjb2Mod, stringEq);
+  generated_inners := UnorderedMap.new<InstNode>(System.stringHashDjb2, stringEq);
   node_ty := InstNodeType.TOP_SCOPE(InstNode.EMPTY_NODE(), generated_inners);
   topNode := InstNode.newClass(cls_elem, InstNode.EMPTY_NODE(), node_ty);
 
@@ -2173,7 +2173,7 @@ function makeRecordComplexType
   output ComplexType ty;
 protected
   InstNode cls_node;
-  UnorderedMap<String, Integer> indexMap = UnorderedMap.new<Integer>(stringHashDjb2Mod, stringEq);
+  UnorderedMap<String, Integer> indexMap = UnorderedMap.new<Integer>(stringHashDjb2, stringEq);
 algorithm
   cls_node := if SCodeUtil.isOperatorRecord(InstNode.definition(node))
     then InstNode.classScope(node) else InstNode.classScope(InstNode.getDerivedNode(node));

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1932,8 +1932,7 @@ uniontype InstNode
   function hash
     "Returns the hash of an InstNode's name."
     input InstNode node;
-    input Integer mod;
-    output Integer hash = stringHashDjb2Mod(name(node), mod);
+    output Integer hash = stringHashDjb2(name(node));
   end hash;
 
   function dimensionCount

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstUtil.mo
@@ -365,7 +365,7 @@ public
   algorithm
     // Find the groups of mergeable component.
     (mergeable, outElements) := makeMergeMap(elements);
-    outNameMap := UnorderedMap.new<Absyn.ComponentRef>(stringHashDjb2Mod, stringEq);
+    outNameMap := UnorderedMap.new<Absyn.ComponentRef>(stringHashDjb2, stringEq);
 
     // Merge each group of mergeable components.
     for el in mergeable loop
@@ -406,7 +406,7 @@ public
       newValue := elem :: newValue;
     end append_merge;
   algorithm
-    merge_map := UnorderedMap.new<ElementList>(stringHashDjb2Mod, stringEq);
+    merge_map := UnorderedMap.new<ElementList>(stringHashDjb2, stringEq);
 
     // Group the components by their signature if they fulfill the requirements
     // for being considered mergeable.
@@ -659,7 +659,7 @@ public
     // Make a name => binding map.
     binding_map := UnorderedMap.fromLists<Absyn.Exp>(names,
       listReverse(Absyn.Exp.ARRAY(b) for b in bindings),
-      AbsynUtil.pathHashMod, AbsynUtil.pathEqual);
+      AbsynUtil.pathHash, AbsynUtil.pathEqual);
 
     // Use one the modifiers as a template and replace the bindings in it with
     // the merged bindings, in order to preserve 'each' and 'final'.

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -280,7 +280,7 @@ algorithm
   tree := Class.classTree(InstNode.getClass(recNode));
   field_lst := ClassTree.foldComponents(tree, collectRecordField, {});
   fields := listArray(listReverseInPlace(field_lst));
-  indexMap := UnorderedMap.new<Integer>(stringHashDjb2Mod, stringEq, arrayLength(fields));
+  indexMap := UnorderedMap.new<Integer>(stringHashDjb2, stringEq, arrayLength(fields));
   Type.updateRecordFieldsIndexMap(fields, indexMap);
 end collectRecordFields;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -1282,13 +1282,12 @@ public
 
   function hash
     input Subscript sub;
-    input Integer mod;
     output Integer hash;
   algorithm
     hash := match sub
-      case SPLIT_PROXY() then intMod(InstNode.hash(sub.origin, 1) + InstNode.hash(sub.parent, 1), mod);
-      case SPLIT_INDEX() then intMod(InstNode.hash(sub.node, 1) + sub.dimIndex, mod);
-      else stringHashDjb2Mod(toString(sub), mod);
+      case SPLIT_PROXY() then InstNode.hash(sub.origin) + InstNode.hash(sub.parent);
+      case SPLIT_INDEX() then InstNode.hash(sub.node) + sub.dimIndex;
+      else stringHashDjb2(toString(sub));
     end match;
   end hash;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1217,7 +1217,7 @@ public
         array<Record.Field> fields = listArray(field_lst);
 
       case COMPLEX(complexTy = ComplexType.RECORD(constructor = rec_node)) algorithm
-        indexMap := UnorderedMap.new<Integer>(stringHashDjb2Mod, stringEq, arrayLength(fields));
+        indexMap := UnorderedMap.new<Integer>(stringHashDjb2, stringEq, arrayLength(fields));
         updateRecordFieldsIndexMap(fields, indexMap);
       then COMPLEX(recordType.cls, ComplexType.RECORD(rec_node, fields, indexMap));
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
@@ -149,7 +149,7 @@ protected
   String s;
   Unit ut;
 algorithm
-  outKnownUnits := UnorderedMap.new<Unit>(stringHashDjb2Mod, stringEq);
+  outKnownUnits := UnorderedMap.new<Unit>(stringHashDjb2, stringEq);
 
   for unit in LU_COMPLEXUNITS loop
     (s, ut) := unit;
@@ -163,7 +163,7 @@ protected
   String s;
   Unit ut;
 algorithm
-  outKnownUnitsInverse := UnorderedMap.new<String>(hashUnitMod, unitEqual);
+  outKnownUnitsInverse := UnorderedMap.new<String>(hashUnit, unitEqual);
 
   for unit in LU_COMPLEXUNITS loop
     (s, ut) := unit;
@@ -198,16 +198,15 @@ algorithm
   end match;
 end isMaster;
 
-public function hashUnitMod
+public function hashUnit
   input Unit inKey;
-  input Integer inMod;
   output Integer outHash;
 protected
   String str;
 algorithm
   str := unit2string(inKey);
-  outHash := stringHashDjb2Mod(str, inMod);
-end hashUnitMod;
+  outHash := stringHashDjb2(str);
+end hashUnit;
 
 public function unitEqual
   input Unit inKey;

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
@@ -61,7 +61,7 @@ algorithm
     htCr2U1 := Unit.newCrefUnitTable(Util.nextPrime(integer(10 + 1.4*listLength(flatModel.variables))));
     htS2U := Unit.getKnownUnits();
     htU2S := Unit.getKnownUnitsInverse();
-    fn_cache := UnorderedMap.new<Functionargs>(stringHashDjb2Mod, stringEq);
+    fn_cache := UnorderedMap.new<Functionargs>(stringHashDjb2, stringEq);
 
     for v in flatModel.variables loop
       convertUnitStringToUnit(v, htCr2U1, htS2U, htU2S);

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -105,8 +105,7 @@ public
 
   function hash
     input Variable var;
-    input Integer mod;
-    output Integer i = ComponentRef.hash(var.name, mod);
+    output Integer i = ComponentRef.hash(var.name);
   end hash;
 
   function equalName

--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -78,7 +78,7 @@ end POP_INDENT;
 function emptyObject
   output JSON obj;
 algorithm
-  obj := OBJECT(UnorderedMap.new<JSON>(stringHashDjb2Mod, stringEq));
+  obj := OBJECT(UnorderedMap.new<JSON>(stringHashDjb2, stringEq));
 end emptyObject;
 
 function fromPair
@@ -616,7 +616,7 @@ protected
   String key;
   Boolean cont;
 algorithm
-  values := UnorderedMap.new<JSON>(stringHashDjb2Mod, stringEq);
+  values := UnorderedMap.new<JSON>(stringHashDjb2, stringEq);
   tokens := parse_expected_token(tokens, TokenId.OBJECTBEGIN);
   cont := peek_id(tokens) <> TokenId.ARRAYEND;
   while cont loop

--- a/OMCompiler/Compiler/Script/Conversion.mo
+++ b/OMCompiler/Compiler/Script/Conversion.mo
@@ -86,7 +86,7 @@ protected
     function newNode
       output ConversionRules node;
     algorithm
-      node := CONVERSION_RULES(UnorderedMap.new<ConversionRules>(System.stringHashDjb2Mod, stringEq), {});
+      node := CONVERSION_RULES(UnorderedMap.new<ConversionRules>(System.stringHashDjb2, stringEq), {});
     end newNode;
   end ConversionRules;
 
@@ -702,13 +702,13 @@ protected
   function newRuleTable
     output RuleTable table;
   algorithm
-    table := UnorderedMap.new<RuleList>(System.stringHashDjb2Mod, stringEq);
+    table := UnorderedMap.new<RuleList>(System.stringHashDjb2, stringEq);
   end newRuleTable;
 
   function newTypeTable
     output TypeTable table;
   algorithm
-    table := UnorderedMap.new<Absyn.Path>(System.stringHashDjb2Mod, stringEq);
+    table := UnorderedMap.new<Absyn.Path>(System.stringHashDjb2, stringEq);
   end newTypeTable;
 
   function newEnv
@@ -1191,7 +1191,7 @@ protected
   protected
     type OptExp = Option<Absyn.Exp>;
   algorithm
-    placeholders := UnorderedMap.new<OptExp>(System.stringHashDjb2Mod, stringEq);
+    placeholders := UnorderedMap.new<OptExp>(System.stringHashDjb2, stringEq);
 
     for arg in args loop
       UnorderedMap.add(AbsynUtil.pathString(AbsynUtil.elementArgName(arg)),
@@ -1575,7 +1575,7 @@ protected
   protected
     UnorderedSet<Absyn.Path> imports;
   algorithm
-    imports := UnorderedSet.new(AbsynUtil.pathHashMod, AbsynUtil.pathEqual, 1);
+    imports := UnorderedSet.new(AbsynUtil.pathHash, AbsynUtil.pathEqual, 1);
     outElements := list(e for e guard not importExists(e, imports) in elements);
   end filterDuplicateImports;
 

--- a/OMCompiler/Compiler/Script/Obfuscate.mo
+++ b/OMCompiler/Compiler/Script/Obfuscate.mo
@@ -81,7 +81,7 @@ encapsulated package Obfuscate
   algorithm
     // The mapping table is used to keep track of which obfuscated name each
     // original name is mapped to.
-    mapping := UnorderedMap.new<String>(stringHashDjb2Mod, stringEqual);
+    mapping := UnorderedMap.new<String>(stringHashDjb2, stringEqual);
     // We don't want to obfuscate builtin names, so we keep track of them in a
     // separate table.
     builtins := makeBuiltins();
@@ -103,7 +103,7 @@ encapsulated package Obfuscate
     SCode.Program builtin_scode;
     ElementType etype;
   algorithm
-    builtins := UnorderedMap.new<ElementType>(stringHashDjb2Mod, stringEqual);
+    builtins := UnorderedMap.new<ElementType>(stringHashDjb2, stringEqual);
 
     (_, builtin_scode) := FBuiltin.getInitialFunctions();
 

--- a/OMCompiler/Compiler/Script/TotalModelDebug.mo
+++ b/OMCompiler/Compiler/Script/TotalModelDebug.mo
@@ -55,7 +55,7 @@ public
     Integer prev_size = 0;
   algorithm
     // Create a new table and add each identifier in the path of the class.
-    used := UnorderedSet.new(stringHashDjb2Mod, stringEq);
+    used := UnorderedSet.new(stringHashDjb2, stringEq);
     analysePath(classPath, used);
 
     // Add some identifiers which can be implicitly used.

--- a/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeFunctionUtil.mo
@@ -485,7 +485,7 @@ protected
   list<tuple<SimCodeFunction.RecordDeclaration,list<SimCodeFunction.RecordDeclaration>>> g;
   UnorderedMap<String, SimCodeFunction.RecordDeclaration> recDeclsMap;
 algorithm
-  recDeclsMap := UnorderedMap.new<SimCodeFunction.RecordDeclaration>(stringHashDjb2Mod, stringEq);
+  recDeclsMap := UnorderedMap.new<SimCodeFunction.RecordDeclaration>(stringHashDjb2, stringEq);
   (functions, outIncludes, includeDirs, libs, libpaths) := elaborateFunctions2(program, daeElements, {}, includes, {}, {}, {}, recDeclsMap);
 
   collectRecDeclsFromMetaRecCallExps(literals, recDeclsMap);

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -147,25 +147,24 @@ algorithm
   // ((i, ht, literals)) := BackendDAEUtil.traverseBackendDAEExpsNoCopyWithUpdate(dae, findLiteralsHelper, (i, ht, literals));
 end simulationFindLiterals;
 
-public function hashEqSystemMod
+public function hashEqSystem
   input SimCode.SimEqSystem eq;
-  input Integer mod;
   output Integer hash;
 algorithm
   hash := match eq
     local
       DAE.Statement stmt;
-    case SimCode.SES_RESIDUAL() then Expression.hashExpMod(eq.exp, mod);
-    case SimCode.SES_FOR_RESIDUAL() then Expression.hashExpMod(eq.exp, mod); // also hash the indices?
-    case SimCode.SES_GENERIC_RESIDUAL() then Expression.hashExpMod(eq.exp, mod); // also hash the indices?
-    case SimCode.SES_SIMPLE_ASSIGN() then intMod(ComponentReference.hashComponentRefMod(eq.cref,mod)+7*Expression.hashExpMod(eq.exp, mod), mod);
-    case SimCode.SES_SIMPLE_ASSIGN_CONSTRAINTS() then intMod(ComponentReference.hashComponentRefMod(eq.cref,mod)+7*Expression.hashExpMod(eq.exp, mod), mod);
-    case SimCode.SES_ARRAY_CALL_ASSIGN() then intMod(Expression.hashExpMod(eq.lhs, mod)+7*Expression.hashExpMod(eq.exp, mod), mod);
-    case SimCode.SES_ALGORITHM(statements={stmt as DAE.STMT_ASSERT()}) then intMod(Expression.hashExpMod(stmt.cond, mod)+7*Expression.hashExpMod(stmt.msg, mod)+49*Expression.hashExpMod(stmt.level, mod), mod);
+    case SimCode.SES_RESIDUAL() then Expression.hashExp(eq.exp);
+    case SimCode.SES_FOR_RESIDUAL() then Expression.hashExp(eq.exp); // also hash the indices?
+    case SimCode.SES_GENERIC_RESIDUAL() then Expression.hashExp(eq.exp); // also hash the indices?
+    case SimCode.SES_SIMPLE_ASSIGN() then ComponentReference.hashComponentRef(eq.cref)+7*Expression.hashExp(eq.exp);
+    case SimCode.SES_SIMPLE_ASSIGN_CONSTRAINTS() then ComponentReference.hashComponentRef(eq.cref)+7*Expression.hashExp(eq.exp);
+    case SimCode.SES_ARRAY_CALL_ASSIGN() then Expression.hashExp(eq.lhs)+7*Expression.hashExp(eq.exp);
+    case SimCode.SES_ALGORITHM(statements={stmt as DAE.STMT_ASSERT()}) then Expression.hashExp(stmt.cond)+7*Expression.hashExp(stmt.msg)+49*Expression.hashExp(stmt.level);
     // Whatever; we're not caching these values anyway
-    else intMod(valueConstructor(eq), mod);
+    else valueConstructor(eq);
   end match;
-end hashEqSystemMod;
+end hashEqSystem;
 
 public function compareEqSystemsEquality "Is true if the equations are the same except the index. If false they might still be the same."
   input SimCode.SimEqSystem eq1;

--- a/OMCompiler/Compiler/Util/BaseHashSet.mo
+++ b/OMCompiler/Compiler/Util/BaseHashSet.mo
@@ -82,7 +82,7 @@ type HashSet = tuple<HashVector, ValueArray, Integer, Integer, FuncsTuple>;
 type HashVector = array<list<tuple<Key,Integer>>>;
 type ValueArray = tuple<Integer,Integer,array<Option<Key>>>;
 type FuncsTuple = tuple<FuncHash,FuncEq,FuncKeyString>;
-partial function FuncHash input Key key; input Integer mod; output Integer hash; end FuncHash;
+partial function FuncHash input Key key; output Integer hash; end FuncHash;
 partial function FuncEq input Key key1; input Key key2; output Boolean b; end FuncEq;
 partial function FuncKeyString input Key key; output String str; end FuncKeyString;
 
@@ -143,7 +143,7 @@ algorithm
           //print("adding when present, indx =" );print(intString(indx));print("\n");
           varr = valueArraySetnth(varr, indx, key);
         else
-          indx = hashFunc(key, bsize);
+          indx = intMod(hashFunc(key), bsize);
           newpos = valueArrayLength(varr);
           varr = valueArrayAdd(varr, key);
           indexes = hashvec[indx + 1];
@@ -160,7 +160,7 @@ algorithm
         print(" key: ");
         s = keystrFunc(key);
         print(s + " Hash: ");
-        hval = hashFunc(key,bsize);
+        hval = intMod(hashFunc(key),bsize);
         print(intString(hval));
         print("\n");
       then
@@ -190,7 +190,7 @@ algorithm
     // Adding when not existing previously
     case (key,(hashvec,varr,bsize,_,fntpl as (hashFunc,_,_)))
       equation
-        indx = hashFunc(key, bsize);
+        indx = intMod(hashFunc(key), bsize);
         newpos = valueArrayLength(varr);
         varr_1 = valueArrayAdd(varr, key);
         indexes = hashvec[indx + 1];
@@ -225,7 +225,7 @@ algorithm
     case (_,
         ((hashvec, varr, bsize, _, fntpl as (hashFunc, _, _)))) guard not has(key, hashSet)
       equation
-        indx = hashFunc(key, bsize);
+        indx = intMod(hashFunc(key), bsize);
         newpos = valueArrayLength(varr);
         varr_1 = valueArrayAdd(varr, key);
         indexes = hashvec[indx + 1];
@@ -332,7 +332,7 @@ algorithm
 
     case (_,(hashvec,varr,bsize,_,(hashFunc,keyEqual,_)))
       equation
-        hashindx = hashFunc(key, bsize);
+        hashindx = intMod(hashFunc(key), bsize);
         indexes = hashvec[hashindx + 1];
         (indx,b) = get2(key, indexes, keyEqual);
         k = if b then valueArrayNthT(varr, indx) else NONE();

--- a/OMCompiler/Compiler/Util/BaseHashTable.mo
+++ b/OMCompiler/Compiler/Util/BaseHashTable.mo
@@ -91,7 +91,7 @@ type HashVector = array<HashNode>;
 type ValueArray = tuple<Integer, Integer, array<Option<HashEntry>>>;
 type FuncsTuple = tuple<FuncHash, FuncEq, FuncKeyString, FuncValString>;
 
-partial function FuncHash input Key key; input Integer mod; output Integer hash; end FuncHash;
+partial function FuncHash input Key key; output Integer hash; end FuncHash;
 partial function FuncEq input Key key1; input Key key2; output Boolean b; end FuncEq;
 partial function FuncKeyString input Key key; output String str; end FuncKeyString;
 partial function FuncValString input Value val; output String str; end FuncValString;
@@ -141,7 +141,7 @@ algorithm
   (key, _) := entry;
   (hashvec, varr, bsize, fntpl as (hashFunc, keyEqual, _, _)) := hashTable;
 
-  hash_idx := hashFunc(key, bsize) + 1;
+  hash_idx := intMod(hashFunc(key), bsize) + 1;
   indices := hashvec[hash_idx];
 
   for i in indices loop
@@ -202,7 +202,7 @@ algorithm
     case ((v as (key, _)),
        (hashvec, varr, bsize, fntpl as (hashFunc, _, _, _)))
       equation
-        indx = hashFunc(key, bsize)+1;
+        indx = intMod(hashFunc(key), bsize)+1;
         (varr,newpos) = valueArrayAdd(varr, v);
         indexes = hashvec[indx];
         hashvec = arrayUpdate(hashvec, indx, ((key, newpos) :: indexes));
@@ -236,7 +236,7 @@ algorithm
   (key, _) := entry;
   (hashvec, varr, bsize, fntpl as (hashFunc, _, _, _)) := hashTable;
   failure((_) := get(key, hashTable));
-  indx := hashFunc(key, bsize)+1;
+  indx := intMod(hashFunc(key), bsize)+1;
   (varr, newpos) := valueArrayAdd(varr, entry);
   indexes := hashvec[indx];
   hashvec := arrayUpdate(hashvec, indx, ((key, newpos) :: indexes));
@@ -344,7 +344,7 @@ protected
   FuncHash hashFunc;
 algorithm
   (hashvec, _, bsize, (hashFunc, keyEqual, _, _)) := hashTable;
-  hashindx := hashFunc(key, bsize) + 1;
+  hashindx := intMod(hashFunc(key), bsize) + 1;
   indexes := hashvec[hashindx];
   indx := hasKeyIndex2(key, indexes, keyEqual);
 end hasKeyIndex;
@@ -687,7 +687,7 @@ algorithm
     _ := match arrayGet(vae, i)
       case SOME((key,_))
         algorithm
-          hash_idx := hashFunc(key, bs) + 1;
+          hash_idx := intMod(hashFunc(key), bs) + 1;
           arrayUpdate(hv, hash_idx, {});
           arrayUpdate(vae, i, NONE());
         then ();
@@ -716,7 +716,7 @@ algorithm
       case SOME((key,_))
         algorithm
           if not workaroundForBug then
-            hash_idx := hashFunc(key, bs) + 1;
+            hash_idx := intMod(hashFunc(key), bs) + 1;
             arrayUpdate(hv, hash_idx, {});
           end if;
           arrayUpdate(vae, i, NONE());

--- a/OMCompiler/Compiler/Util/DisjointSets.mo
+++ b/OMCompiler/Compiler/Util/DisjointSets.mo
@@ -42,7 +42,6 @@ replaceable type Entry = Integer;
 
 replaceable partial function EntryHash
   input Entry entry;
-  input Integer mod;
   output Integer hash;
 end EntryHash;
 

--- a/OMCompiler/Compiler/Util/HashSet.mo
+++ b/OMCompiler/Compiler/Util/HashSet.mo
@@ -56,7 +56,6 @@ public type HashSet = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -87,7 +86,7 @@ public function emptyHashSetSized
   input Integer size;
   output HashSet hashSet;
 algorithm
-  hashSet := BaseHashSet.emptyHashSetWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr));
+  hashSet := BaseHashSet.emptyHashSetWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr));
 end emptyHashSetSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashSetExp.mo
+++ b/OMCompiler/Compiler/Util/HashSetExp.mo
@@ -57,7 +57,6 @@ public type HashSet = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -88,7 +87,7 @@ public function emptyHashSetSized
   input Integer size;
   output HashSet hashSet;
 algorithm
-  hashSet := BaseHashSet.emptyHashSetWork(size,(Expression.hashExpMod,Expression.expEqual,ExpressionDump.printExpStr));
+  hashSet := BaseHashSet.emptyHashSetWork(size,(Expression.hashExp,Expression.expEqual,ExpressionDump.printExpStr));
 end emptyHashSetSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashSetString.mo
+++ b/OMCompiler/Compiler/Util/HashSetString.mo
@@ -56,7 +56,6 @@ public type HashSet = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -87,7 +86,7 @@ public function emptyHashSetSized
   input Integer size;
   output HashSet hashSet;
 algorithm
-  hashSet := BaseHashSet.emptyHashSetWork(size,(stringHashDjb2Mod,stringEq,Util.id));
+  hashSet := BaseHashSet.emptyHashSetWork(size,(stringHashDjb2,stringEq,Util.id));
 end emptyHashSetSized;
 
 annotation(__OpenModelica_Interface="util");

--- a/OMCompiler/Compiler/Util/HashTable.mo
+++ b/OMCompiler/Compiler/Util/HashTable.mo
@@ -56,7 +56,6 @@ public type HashTable = tuple<array<list<tuple<Key, Integer>>>,
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -92,7 +91,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,intString));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,intString));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTable2.mo
+++ b/OMCompiler/Compiler/Util/HashTable2.mo
@@ -59,7 +59,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -95,7 +94,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ExpressionDump.printExpStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ExpressionDump.printExpStr));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTable3.mo
+++ b/OMCompiler/Compiler/Util/HashTable3.mo
@@ -58,7 +58,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -94,7 +93,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ComponentReference.printComponentRefListStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ComponentReference.printComponentRefListStr));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTable5.mo
+++ b/OMCompiler/Compiler/Util/HashTable5.mo
@@ -59,7 +59,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -82,13 +81,12 @@ end FuncExpStr;
 protected function hashFunc
 "Calculates a hash value for Key"
   input Key cr;
-  input Integer mod;
   output Integer res;
 protected
   String crstr;
 algorithm
   crstr := Dump.printComponentRefStr(cr);
-  res := stringHashDjb2Mod(crstr,mod);
+  res := stringHashDjb2(crstr);
 end hashFunc;
 
 public function emptyHashTable

--- a/OMCompiler/Compiler/Util/HashTableCG.mo
+++ b/OMCompiler/Compiler/Util/HashTableCG.mo
@@ -58,7 +58,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -96,7 +95,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ComponentReference.printComponentRefStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ComponentReference.printComponentRefStr));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTableCrIListArray.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrIListArray.mo
@@ -59,7 +59,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -95,7 +94,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printIntListArrayStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printIntListArrayStr));
 end emptyHashTableSized;
 
 public function printIntListArrayStr

--- a/OMCompiler/Compiler/Util/HashTableCrILst.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrILst.mo
@@ -59,7 +59,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -95,7 +94,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printIntListStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printIntListStr));
 end emptyHashTableSized;
 
 public function printIntListStr

--- a/OMCompiler/Compiler/Util/HashTableCrIntToExp.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrIntToExp.mo
@@ -60,7 +60,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -83,10 +82,9 @@ end FuncExpStr;
 protected function hashFunc
 "Calculates a hash value for Key"
   input Key tpl;
-  input Integer mod;
   output Integer res;
 algorithm
-  res := intMod(intAbs(ComponentReference.hashComponentRef(Util.tuple21(tpl)) + Util.tuple22(tpl)),mod);
+  res := ComponentReference.hashComponentRef(Util.tuple21(tpl)) + Util.tuple22(tpl);
 end hashFunc;
 
 protected function keyEqual

--- a/OMCompiler/Compiler/Util/HashTableCrToCrEqLst.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrToCrEqLst.mo
@@ -61,7 +61,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -97,7 +96,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printTupleComponentRefEqListStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printTupleComponentRefEqListStr));
 end emptyHashTableSized;
 
 public function printTupleComponentRefEqListStr

--- a/OMCompiler/Compiler/Util/HashTableCrToExp.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrToExp.mo
@@ -58,7 +58,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -96,17 +95,8 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ExpressionDump.printExpStr));
-  //hashTable := BaseHashTable.emptyHashTableWork(size,(calcHashValue,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ExpressionDump.printExpStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ExpressionDump.printExpStr));
 end emptyHashTableSized;
-
-protected function calcHashValue
-  input DAE.ComponentRef cr;
-  input Integer imod;
-  output Integer value;
-algorithm
-  value := stringHashDjb2Mod(ComponentReference.printComponentRefStr(cr),imod);
-end calcHashValue;
 
 annotation(__OpenModelica_Interface="frontend");
 end HashTableCrToExp;

--- a/OMCompiler/Compiler/Util/HashTableCrToExpOption.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrToExpOption.mo
@@ -58,7 +58,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -96,8 +95,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printExpOtionStr));
-  //hashTable := BaseHashTable.emptyHashTableWork(size,(calcHashValue,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,ExpressionDump.printExpStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printExpOtionStr));
 end emptyHashTableSized;
 
 protected function printExpOtionStr
@@ -111,14 +109,6 @@ algorithm
     else "NONE()";
   end match;
 end printExpOtionStr;
-
-protected function calcHashValue
-  input DAE.ComponentRef cr;
-  input Integer imod;
-  output Integer value;
-algorithm
-  value := stringHashDjb2Mod(ComponentReference.printComponentRefStr(cr),imod);
-end calcHashValue;
 
 annotation(__OpenModelica_Interface="frontend");
 end HashTableCrToExpOption;

--- a/OMCompiler/Compiler/Util/HashTableCrToExpSourceTpl.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrToExpSourceTpl.mo
@@ -71,7 +71,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -107,7 +106,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printExpSourceTplStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,printExpSourceTplStr));
 end emptyHashTableSized;
 
 public function printExpSourceTplStr

--- a/OMCompiler/Compiler/Util/HashTableCrefSimVar.mo
+++ b/OMCompiler/Compiler/Util/HashTableCrefSimVar.mo
@@ -65,7 +65,6 @@ type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -101,7 +100,7 @@ function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,opaqueStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,opaqueStr));
 end emptyHashTableSized;
 
 protected

--- a/OMCompiler/Compiler/Util/HashTableExpToExp.mo
+++ b/OMCompiler/Compiler/Util/HashTableExpToExp.mo
@@ -71,7 +71,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -109,7 +108,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(Expression.hashExpMod,Expression.expEqual,ExpressionDump.printExpStr,ExpressionDump.printExpStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(Expression.hashExp,Expression.expEqual,ExpressionDump.printExpStr,ExpressionDump.printExpStr));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTableExpToIndex.mo
+++ b/OMCompiler/Compiler/Util/HashTableExpToIndex.mo
@@ -59,7 +59,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -97,7 +96,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(Expression.hashExpMod,Expression.expEqual,ExpressionDump.printExpStr,intString));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(Expression.hashExp,Expression.expEqual,ExpressionDump.printExpStr,intString));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTableSM1.mo
+++ b/OMCompiler/Compiler/Util/HashTableSM1.mo
@@ -50,7 +50,6 @@ public type HashTable = tuple<array<list<tuple<Key, Integer>>>,
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -86,7 +85,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRefMod,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,modeStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(ComponentReference.hashComponentRef,ComponentReference.crefEqual,ComponentReference.printComponentRefStr,modeStr));
 end emptyHashTableSized;
 
 public function modeStr

--- a/OMCompiler/Compiler/Util/HashTableSimCodeEqCache.mo
+++ b/OMCompiler/Compiler/Util/HashTableSimCodeEqCache.mo
@@ -63,7 +63,6 @@ type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -101,7 +100,7 @@ function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(SimCodeUtil.hashEqSystemMod,SimCodeUtil.compareEqSystemsEquality,SimCodeUtil.simEqSystemString,intString));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(SimCodeUtil.hashEqSystem,SimCodeUtil.compareEqSystemsEquality,SimCodeUtil.simEqSystemString,intString));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="backend");

--- a/OMCompiler/Compiler/Util/HashTableStringToPath.mo
+++ b/OMCompiler/Compiler/Util/HashTableStringToPath.mo
@@ -59,7 +59,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -97,7 +96,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2Mod,stringEq,Util.id,AbsynUtil.pathStringDefault));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2,stringEq,Util.id,AbsynUtil.pathStringDefault));
 end emptyHashTableSized;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/Util/HashTableStringToProgram.mo
+++ b/OMCompiler/Compiler/Util/HashTableStringToProgram.mo
@@ -58,7 +58,6 @@ public type HashTable = tuple<
 
 partial function FuncHashCref
   input Key cr;
-  input Integer mod;
   output Integer res;
 end FuncHashCref;
 
@@ -96,7 +95,7 @@ public function emptyHashTableSized
   input Integer size;
   output HashTable hashTable;
 algorithm
-  hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2Mod, stringEq, Util.id, dummyStr));
+  hashTable := BaseHashTable.emptyHashTableWork(size,(stringHashDjb2, stringEq, Util.id, dummyStr));
 end emptyHashTableSized;
 
 protected

--- a/OMCompiler/Compiler/Util/SBAtomicSet.mo
+++ b/OMCompiler/Compiler/Util/SBAtomicSet.mo
@@ -145,8 +145,7 @@ public
 
   function hash
     input SBAtomicSet set1;
-    input Integer mod;
-    output Integer hash = SBMultiInterval.hash(set1.aset, mod);
+    output Integer hash = SBMultiInterval.hash(set1.aset);
   end hash;
 
   function toString

--- a/OMCompiler/Compiler/Util/SBInterval.mo
+++ b/OMCompiler/Compiler/Util/SBInterval.mo
@@ -313,8 +313,7 @@ public
 
   function hash
     input SBInterval int;
-    input Integer mod;
-    output Integer hash = intMod(int.lo, mod);
+    output Integer hash = int.lo;
   end hash;
 
   function toString

--- a/OMCompiler/Compiler/Util/SBMultiInterval.mo
+++ b/OMCompiler/Compiler/Util/SBMultiInterval.mo
@@ -268,10 +268,9 @@ public
 
   function hash
     input SBMultiInterval mi;
-    input Integer mod;
     output Integer res;
   algorithm
-    res := intMod(arrayLength(mi.intervals), mod);
+    res := arrayLength(mi.intervals);
   end hash;
 
   function size

--- a/OMCompiler/Compiler/Util/SBSet.mo
+++ b/OMCompiler/Compiler/Util/SBSet.mo
@@ -280,8 +280,7 @@ public
 
   function hash
     input SBSet set;
-    input Integer mod;
-    output Integer hash = intMod(UnorderedSet.size(set.asets), mod);
+    output Integer hash = UnorderedSet.size(set.asets);
   end hash;
 
   function toString

--- a/OMCompiler/Compiler/Util/UnorderedMap.mo
+++ b/OMCompiler/Compiler/Util/UnorderedMap.mo
@@ -47,7 +47,6 @@ protected
 public
   partial function Hash
     input K key;
-    input Integer mod;
     output Integer hash;
   end Hash;
 
@@ -178,7 +177,7 @@ public
     Hash hashfn = map.hashFn;
     Integer hash;
   algorithm
-    hash := hashfn(key, Vector.size(map.buckets));
+    hash := intMod(hashfn(key), Vector.size(map.buckets));
     addEntry(key, value, hash, map);
   end addNew;
 
@@ -645,7 +644,7 @@ public
 
     // Rehash all the keys and refill the buckets.
     for i in 1:Vector.size(map.keys) loop
-      bucket_id := hashfn(Vector.get(keys, i), bucket_count) + 1;
+      bucket_id := intMod(hashfn(Vector.get(keys, i)), bucket_count) + 1;
       Vector.updateNoBounds(buckets, bucket_id, i :: Vector.getNoBounds(buckets, bucket_id));
     end for;
   end rehash;
@@ -738,7 +737,7 @@ protected
     list<Integer> bucket;
   algorithm
     if Vector.size(map.buckets) > 0 then
-      hash := hashfn(key, Vector.size(map.buckets));
+      hash := intMod(hashfn(key), Vector.size(map.buckets));
 
       bucket := Vector.get(map.buckets, hash + 1);
       for i in bucket loop
@@ -760,8 +759,6 @@ protected
     input UnorderedMap<K, V> map;
   protected
     Vector<list<Integer>> buckets = map.buckets;
-    Integer h;
-    Hash hashfn;
   algorithm
     // Add the key/value to the key/value arrays.
     Vector.push(map.keys, key);

--- a/OMCompiler/Compiler/Util/UnorderedSet.mo
+++ b/OMCompiler/Compiler/Util/UnorderedSet.mo
@@ -46,7 +46,6 @@ protected
 public
   partial function Hash
     input T key;
-    input Integer mod;
     output Integer hash;
   end Hash;
 
@@ -133,7 +132,7 @@ public
     Hash hashfn = set.hashFn;
     Integer hash, pos;
   algorithm
-    hash := hashfn(key, arrayLength(Mutable.access(set.buckets)));
+    hash := intMod(hashfn(key), arrayLength(Mutable.access(set.buckets)));
     addKey(key, hash, set);
   end addNew;
 
@@ -167,7 +166,7 @@ public
     list<T> bucket;
     Option<T> okey;
   algorithm
-    hash := hashfn(key, arrayLength(buckets));
+    hash := intMod(hashfn(key), arrayLength(buckets));
     bucket := arrayGet(buckets, hash + 1);
 
     (bucket, okey) := List.deleteMemberOnTrue(key, bucket, eqfn);
@@ -357,7 +356,7 @@ public
       for k in b loop
         // Apply the function to the key
         newKey := fn(k);
-        hash := hashfn(newKey, bucket_count);
+        hash := intMod(hashfn(newKey), bucket_count);
         bucket := arrayGet(new_buckets, hash + 1);
 
         // check if we have a duplicate
@@ -511,7 +510,7 @@ public
     // Rehash all the keys in the old buckets and add them to the new.
     for b in old_buckets loop
       for k in b loop
-        hash := hashfn(k, bucket_count);
+        hash := intMod(hashfn(k), bucket_count);
         arrayUpdate(new_buckets, hash + 1, k :: arrayGet(new_buckets, hash + 1));
       end for;
     end for;
@@ -562,7 +561,7 @@ protected
     array<list<T>> buckets = Mutable.access(set.buckets);
     list<T> bucket;
   algorithm
-    hash := hashfn(key, arrayLength(buckets));
+    hash := intMod(hashfn(key), arrayLength(buckets));
     bucket := arrayGet(buckets, hash + 1);
 
     for k in bucket loop
@@ -590,7 +589,7 @@ protected
       buckets := Mutable.access(set.buckets);
       // The bucket count has changed so we need to rehash the key we're going
       // to add too.
-      h := hashfn(key, arrayLength(buckets));
+      h := intMod(hashfn(key), arrayLength(buckets));
     else
       buckets := Mutable.access(set.buckets);
       h := hash;


### PR DESCRIPTION
- Change all hash table/set implementations to do the modulo of the hash value themselves instead of having the hash function do it, it's an implementation detail that the user should neither have to care about nor be trusted with.