### PR TITLE
Fix Call.toArrayConstructor

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2045,7 +2045,7 @@ public
         Option<Expression> step;
 
       case TYPED_CALL() then match AbsynUtil.pathString(Function.nameConsiderBuiltin(iCall.fn))
-        case "fill" algorithm
+        case "fill" guard listLength(iCall.arguments) == 2 algorithm
           {body, stop}  := iCall.arguments;
           start         := Expression.INTEGER(1);
           step          := NONE();


### PR DESCRIPTION
- Don't fail on `fill`-calls that don't have exactly two arguments.