### PR TITLE
Don't print C-comments when obfuscating

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -4045,14 +4045,14 @@ template crefToOMSICStr(ComponentRef cref, HashTableCrefSimVar.HashTable hashTab
       case v as SIMVAR(index=-2) then
         match cref2simvar(componentRef, getSimCode())
           case v as SIMVAR(__) then
-            let c_comment = CodegenUtil.crefCComment(v)
+            let c_comment = CodegenUtil.crefCCommentWithVariability(v)
             let index = getValueReference(v, getSimCode(), false)
             <<
-            this_function->pre_vars-><%crefTypeOMSIC(name)%>[<%index%>]<%c_comment%> /* TODO: Check why pre variable  <%CodegenUtil.escapeCComments(CodegenUtil.crefStrNoUnderscore(v.name))%> is not in local hash table! */
+            this_function->pre_vars-><%crefTypeOMSIC(name)%>[<%index%>]<%c_comment%> /* TODO: Check why pre variable <%CodegenUtil.crefCComment(v, CodegenUtil.crefStrNoUnderscore(v.name))%> is not in local hash table! */
             >>
         end match
       case v as SIMVAR(__) then
-        let c_comment = CodegenUtil.crefCComment(v)
+        let c_comment = CodegenUtil.crefCCommentWithVariability(v)
         let index = getValueReference(v, getSimCode(), false)
         <<
         this_function->pre_vars-><%crefTypeOMSIC(name)%>[<%index%>]<%c_comment%>
@@ -4066,7 +4066,7 @@ template crefToOMSICStr(ComponentRef cref, HashTableCrefSimVar.HashTable hashTab
         match cref2simvar(cref, getSimCode())
           case v as SIMVAR(__) then
           let index = getValueReference(v, getSimCode(), false)
-          let c_comment = CodegenUtil.crefCComment(v)
+          let c_comment = CodegenUtil.crefCCommentWithVariability(v)
            <<
            model_vars_and_params-><%crefTypeOMSIC(name)%>[<%index%>]<%c_comment%>
            >>
@@ -4076,13 +4076,13 @@ template crefToOMSICStr(ComponentRef cref, HashTableCrefSimVar.HashTable hashTab
       case v as SIMVAR(varKind=JAC_VAR(__))
       case v as SIMVAR(varKind=JAC_DIFF_VAR(__))
       case v as SIMVAR(varKind=SEED_VAR(__)) then
-        let c_comment = CodegenUtil.crefCComment(v)
+        let c_comment = CodegenUtil.crefCCommentWithVariability(v)
         <<
         this_function->local_vars-><%crefTypeOMSIC(name)%>[<%v.index%>]<%c_comment%>
         >>
 
       case v as SIMVAR(__) then
-        let c_comment = CodegenUtil.crefCComment(v)
+        let c_comment = CodegenUtil.crefCCommentWithVariability(v)
         let index = getValueReference(v, getSimCode(), false)
         <<
         this_function->function_vars-><%crefTypeOMSIC(name)%>[<%index%>]<%c_comment%>
@@ -4750,9 +4750,9 @@ template jacCrefs(ComponentRef cr, Context context, Integer ix)
  match context
    case JACOBIAN_CONTEXT(jacHT=SOME(jacHT)) then
      match simVarFromHT(cr, jacHT)
-     case v as SIMVAR(varKind=BackendDAE.JAC_VAR()) then 'jacobian->resultVars[<%index%>]<%crefCComment(v)%>'
-     case v as SIMVAR(varKind=BackendDAE.JAC_DIFF_VAR()) then 'jacobian->tmpVars[<%index%>]<%crefCComment(v)%>'
-     case v as SIMVAR(varKind=BackendDAE.SEED_VAR()) then 'jacobian->seedVars[<%index%>]<%crefCComment(v)%>'
+     case v as SIMVAR(varKind=BackendDAE.JAC_VAR()) then 'jacobian->resultVars[<%index%>]<%crefCCommentWithVariability(v)%>'
+     case v as SIMVAR(varKind=BackendDAE.JAC_DIFF_VAR()) then 'jacobian->tmpVars[<%index%>]<%crefCCommentWithVariability(v)%>'
+     case v as SIMVAR(varKind=BackendDAE.SEED_VAR()) then 'jacobian->seedVars[<%index%>]<%crefCCommentWithVariability(v)%>'
      case SIMVAR(index=-2) then crefOld(cr, ix)
 end jacCrefs;
 
@@ -4866,11 +4866,11 @@ template crefToCStr(ComponentRef cr, Integer ix, Boolean isPre, Boolean isStart,
     case SIMVAR(aliasvar=ALIAS(varName=varName)) then crefToCStr(varName, ix, isPre, isStart, &sub)
     case SIMVAR(aliasvar=NEGATEDALIAS(varName=varName), type_=T_BOOL()) then '!(<%crefToCStr(varName, ix, isPre, isStart, &sub)%>)'
     case SIMVAR(aliasvar=NEGATEDALIAS(varName=varName)) then '-(<%crefToCStr(varName, ix, isPre, isStart, &sub)%>)'
-    case v as SIMVAR(varKind=JAC_VAR()) then '(parentJacobian->resultVars[<%index%>])<%&sub%><%crefCComment(v)%>'
-    case v as SIMVAR(varKind=JAC_DIFF_VAR()) then '(parentJacobian->tmpVars[<%index%>])<%&sub%><%crefCComment(v)%>'
-    case v as SIMVAR(varKind=SEED_VAR()) then '(parentJacobian->seedVars[<%index%>])<%&sub%><%crefCComment(v)%>'
-    case v as SIMVAR(varKind=DAE_RESIDUAL_VAR()) then '(data->simulationInfo->daeModeData->residualVars[<%index%>])<%&sub%><%crefCComment(v)%>'
-    case v as SIMVAR(varKind=DAE_AUX_VAR()) then '(data->simulationInfo->daeModeData->auxiliaryVars[<%index%>])<%&sub%><%crefCComment(v)%>'
+    case v as SIMVAR(varKind=JAC_VAR()) then '(parentJacobian->resultVars[<%index%>])<%&sub%><%crefCCommentWithVariability(v)%>'
+    case v as SIMVAR(varKind=JAC_DIFF_VAR()) then '(parentJacobian->tmpVars[<%index%>])<%&sub%><%crefCCommentWithVariability(v)%>'
+    case v as SIMVAR(varKind=SEED_VAR()) then '(parentJacobian->seedVars[<%index%>])<%&sub%><%crefCCommentWithVariability(v)%>'
+    case v as SIMVAR(varKind=DAE_RESIDUAL_VAR()) then '(data->simulationInfo->daeModeData->residualVars[<%index%>])<%&sub%><%crefCCommentWithVariability(v)%>'
+    case v as SIMVAR(varKind=DAE_AUX_VAR()) then '(data->simulationInfo->daeModeData->auxiliaryVars[<%index%>])<%&sub%><%crefCCommentWithVariability(v)%>'
     case SIMVAR(index=-2) then
       (let s = (if isPre then crefNonSimVar(crefPrefixPre(cr)) else crefNonSimVar(cr))
       if intEq(ix,0) then s
@@ -7854,7 +7854,7 @@ template varArrayNameValues(SimVar var, Integer ix, Boolean isPre, Boolean isSta
         case SIMVAR(varKind=EXTOBJ()) then
           "ERROR: Not implemented in varArrayNameValues"
         case SIMVAR(__) then
-          let c_comment = CodegenUtil.crefCComment(var)
+          let c_comment = CodegenUtil.crefCCommentWithVariability(var)
           <<
           <%if isStart then '<%varAttributes(var, &sub)%>.start'
             else if isPre then '(<%arr%>this_function->pre_vars-><%crefTypeOMSIC(name)%>[<%index%>]<%c_comment%>)<%&sub%>'
@@ -7866,11 +7866,11 @@ template varArrayNameValues(SimVar var, Integer ix, Boolean isPre, Boolean isSta
       match var
         case SIMVAR(varKind=PARAM())
         case SIMVAR(varKind=OPT_TGRID()) then
-          '(<%arr%>data->simulationInfo-><%crefShortType(name)%>Parameter[<%index%>]<%crefCComment(var)%>)<%&sub%>'
+          '(<%arr%>data->simulationInfo-><%crefShortType(name)%>Parameter[<%index%>]<%crefCCommentWithVariability(var)%>)<%&sub%>'
         case SIMVAR(varKind=EXTOBJ()) then
           '(<%arr%>data->simulationInfo->extObjs[<%index%>])<%&sub%>'
         case SIMVAR(__) then
-          let c_comment = CodegenUtil.crefCComment(var)
+          let c_comment = CodegenUtil.crefCCommentWithVariability(var)
           '<%if isStart then '<%varAttributes(var, &sub)%>.start'
              else if isPre then '(<%arr%>data->simulationInfo-><%crefShortType(name)%>VarsPre[<%index%>]<%c_comment%>)<%&sub%>'
              else '(<%arr%>data->localData[<%ix%>]-><%crefShortType(name)%>Vars[<%index%>]<%c_comment%>)<%sub%>'%>'
@@ -7889,7 +7889,7 @@ template crefVarInfo(ComponentRef cr)
 ::=
   match cref2simvar(cr, getSimCode())
   case var as SIMVAR(__) then
-  'data->modelData-><%varArrayName(var)%>Data[<%index%>].info /* <%escapeCComments(crefStrNoUnderscore(name))%> */'
+  'data->modelData-><%varArrayName(var)%>Data[<%index%>].info /* <%crefCComment(var, crefStrNoUnderscore(name))%> */'
 end crefVarInfo;
 
 template varAttributes(SimVar var, Text &sub)
@@ -7898,7 +7898,7 @@ template varAttributes(SimVar var, Text &sub)
   match var
   case SIMVAR(index=-1) then crefAttributes(name) // input variable? pass subs!!!
   case SIMVAR(__) then
-  '(<%arr%>data->modelData-><%varArrayName(var)%>Data[<%index%>]<%crefCComment(var)%>)<%sub%>.attribute '
+  '(<%arr%>data->modelData-><%varArrayName(var)%>Data[<%index%>]<%crefCCommentWithVariability(var)%>)<%sub%>.attribute '
 end varAttributes;
 
 template crefAttributes(ComponentRef cr)
@@ -7907,7 +7907,7 @@ template crefAttributes(ComponentRef cr)
   case var as SIMVAR(index=-1, varKind=JAC_VAR()) then "dummyREAL_ATTRIBUTE"
   case var as SIMVAR(__) then
     if intLt(index,0) then error(sourceInfo(), 'varAttributes got negative index=<%index%> for <%crefStr(name)%>') else
-    'data->modelData-><%varArrayName(var)%>Data[<%index%>].attribute /* <%escapeCComments(crefStrNoUnderscore(name))%> */'
+    'data->modelData-><%varArrayName(var)%>Data[<%index%>].attribute /* <%crefCComment(var, crefStrNoUnderscore(name))%> */'
 end crefAttributes;
 
 template typeCastContext(Context context, Type ty)

--- a/OMCompiler/Compiler/Template/CodegenOMSI_common.tpl
+++ b/OMCompiler/Compiler/Template/CodegenOMSI_common.tpl
@@ -69,19 +69,19 @@ template generateEquationsCode (SimCode simCode, String FileNamePrefix)
 
     /* generate file for algebraic systems in simulation problem */
 
-   
-    let modelNamePrefix =   modelNameOMSIC
-    
 
-   
+    let modelNamePrefix =   modelNameOMSIC
+
+
+
     let content = generateOmsiFunctionCode(simulation, modelNamePrefix,"","sim_eqns")
     let () = textFile(content, fullPathPrefix+"/"+fileNamePrefix+"_sim_eqns.c")
-    
+
 
 
     let content = generateOmsiFunctionCode(initialization, modelNamePrefix,"", "init_eqns")
     let () = textFile(content, fullPathPrefix+"/"+fileNamePrefix+"_init_eqns.c")
-    
+
 
   <<>>
 end generateEquationsCode;
@@ -103,14 +103,14 @@ template generateOmsiFunctionCode(OMSIFunction omsiFunction, String FileNamePref
 
   // generate header file
   let &functionPrototypes +='omsi_status <%FileNamePrefix%>_<%omsiName%>_allEqns(omsi_function_t* simulation, omsi_values* model_vars_and_params, void* data);<%\n%>'
-   
+
 
   let headerFileName =     '<%fileNamePrefix%>_<%omsiName%>'
-    
-  
+
+
   let headerFileContent = generateCodeHeader(FileNamePrefix, &includes, headerFileName, &functionPrototypes)
   let () = textFile(headerFileContent, fullPathPrefix+"/"+headerFileName+".h")
-     
+
 
 
   match omsiFunction
@@ -132,7 +132,7 @@ template generateOmsiFunctionCode(OMSIFunction omsiFunction, String FileNamePref
 
     /* Equations evaluation */
     omsi_status <%FileNamePrefix%>_<%omsiName%>_allEqns(omsi_function_t* <%omsiName%>, omsi_values* model_vars_and_params, void* data){
-    
+
 
       /* Variables */
       omsi_status status, new_status;
@@ -581,27 +581,24 @@ template generateOmsiIndexTypeInitialization (list<SimVar> variables, String Str
         "OMSI_TYPE_UNKNOWN"
     )
 
-    let &stringName = buffer""
+    let &stringName = buffer ""
     let &stringIndex = buffer ""
-    let &stringVarKind = buffer ""
     let _ = (match variable
       case var as SIMVAR(varKind=JAC_VAR(__))
       case var as SIMVAR(varKind=JAC_DIFF_VAR(__))
       case var as SIMVAR(varKind=SEED_VAR(__)) then
-      let &stringName += '<%CodegenUtil.escapeCComments(CodegenUtil.crefStrNoUnderscore(var.name))%>'
+      let &stringName += '<%CodegenUtil.crefCCommentWithVariability(var)%>'
       let &stringIndex += var.index
-      let &stringVarKind += CodegenUtil.variabilityString(var.varKind)
       <<>>
       case var as SIMVAR(__) then
-      let &stringName += '<%CodegenUtil.escapeCComments(CodegenUtil.crefStrNoUnderscore(var.name))%>'
+      let &stringName += '<%CodegenUtil.crefCCommentWithVariability(var)%>'
       let &stringIndex += getValueReference(var, getSimCode(), false)
-      let &stringVarKind += CodegenUtil.variabilityString(var.varKind)
       <<>>
     )
 
     <<
     <%omsiFuncName%>[<%i0%>].type  = <%stringType%>;
-    <%omsiFuncName%>[<%i0%>].index = <%stringIndex%>;    /* <%stringName%> <%stringVarKind%> */
+    <%omsiFuncName%>[<%i0%>].index = <%stringIndex%>;   <%stringName%>
     >>
   ;separator="\n")
 
@@ -637,10 +634,10 @@ template generateInitalizationOMSIFunction (OMSIFunction omsiFunction, String fu
 
     <<
 
-   
+
     omsi_status <%FileNamePrefix%>_<%omsiName%>_instantiate_<%functionName%>_OMSIFunc (omsi_function_t* omsi_function) {
-    
-   
+
+
 
       filtered_base_logger(global_logCategories, log_all, omsi_ok,
           "fmi2Instantiate: Instantiate omsi_function <%functionName%>.");

--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -65,7 +65,6 @@ template replaceDotAndUnderscore(String str)
 end replaceDotAndUnderscore;
 
 template getGeneralTarget(String str)
- "Replace _ with __ and dot in identifiers with _"
 ::=
   match str
   case "msvc10"
@@ -160,7 +159,6 @@ template subscriptStr(Subscript subscript)
   else "UNKNOWN_SUBSCRIPT"
 end subscriptStr;
 
-
 /*********************** Comments ************************/
 
 template escapeCComments(String stringWithCComments)
@@ -168,8 +166,22 @@ template escapeCComments(String stringWithCComments)
 ::= '<%System.stringReplace(System.stringReplace(stringWithCComments, "/*", "(*"), "*/", "*)")%>'
 end escapeCComments;
 
-template crefCComment(SimVar v)
+template crefCComment(SimVar v, String vName)
 "write the C comment for a cref, if it is not to be obfuscated"
+::=
+  match v
+  case SIMVAR(isProtected = true) then
+    if stringEq(getConfigString(OBFUSCATE), "none")
+    then '<%escapeCComments(vName)%>'
+    else 'OBFUSCATED'
+  case SIMVAR(__) then
+    if not stringEq(getConfigString(OBFUSCATE), "full")
+    then '<%escapeCComments(vName)%>'
+    else 'OBFUSCATED'
+end crefCComment;
+
+template crefCCommentWithVariability(SimVar v)
+"write the C comment for a cref with variability"
 ::=
   match v
   case SIMVAR(isProtected = true) then
@@ -178,10 +190,9 @@ template crefCComment(SimVar v)
   case SIMVAR(__) then
     if not stringEq(getConfigString(OBFUSCATE), "full")
     then ' /* <%escapeCComments(crefStrNoUnderscore(name))%> <%variabilityString(varKind)%> */'
-end crefCComment;
+end crefCCommentWithVariability;
 
 /*********************************************************/
-
 
 template initDefaultValXml(DAE.Type type_)
 ::=

--- a/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
@@ -112,6 +112,11 @@ template equationIndexAlternativeTearing(SimEqSystem eq)
 end equationIndexAlternativeTearing;
 
 template dumpEqs(list<SimEqSystem> eqs)
+::= match getConfigString(OBFUSCATE)
+  case "none" then dumpEqsWork(eqs)
+end dumpEqs;
+
+template dumpEqsWork(list<SimEqSystem> eqs)
 ::= eqs |> eq hasindex i0 =>
   match eq
     case e as SES_RESIDUAL(__) then
@@ -275,10 +280,10 @@ template dumpEqs(list<SimEqSystem> eqs)
       <<
       unknown equation
       >>
-end dumpEqs;
+end dumpEqsWork;
 
 
-template dumpAlgSystemOps (Option<DerivativeMatrix> derivativeMatrix)
+template dumpAlgSystemOps(Option<DerivativeMatrix> derivativeMatrix)
 "dumps description of eqations of algebraic system.
  Helper function for dumpEqs."
 ::=
@@ -298,7 +303,7 @@ template dumpAlgSystemOps (Option<DerivativeMatrix> derivativeMatrix)
   >>
 end dumpAlgSystemOps;
 
-template dumpAlgSystemColumn (OMSIFunction column ,Text &columnBuffer, Text &varsBuffer)
+template dumpAlgSystemColumn(OMSIFunction column ,Text &columnBuffer, Text &varsBuffer)
 "dumps equation description for one OMSIFunction"
 ::=
 
@@ -363,6 +368,11 @@ template dumpWhenOps(list<BackendDAE.WhenOperator> whenOps)
 end dumpWhenOps;
 
 template dumpEqsAlternativeTearing(list<SimEqSystem> eqs)
+::= match getConfigString(OBFUSCATE)
+  case "none" then dumpEqsAlternativeTearingWork(eqs)
+end dumpEqsAlternativeTearing;
+
+template dumpEqsAlternativeTearingWork(list<SimEqSystem> eqs)
 ::= eqs |> eq hasindex i0 =>
   match eq
     case e as SES_LINEAR(alternativeTearing=SOME(at as LINEARSYSTEM(__))) then
@@ -416,7 +426,7 @@ template dumpEqsAlternativeTearing(list<SimEqSystem> eqs)
       <<
       unknown equation
       >>
-end dumpEqsAlternativeTearing;
+end dumpEqsAlternativeTearingWork;
 
 annotation(__OpenModelica_Interface="backend");
 end CodegenUtilSimulation;


### PR DESCRIPTION
### Related Issues

- See #9119
- Continuation of #9672 and #9880

### Purpose

- Hide more occurrences of variable names in comments.
- Also skip printing equation information when obfuscating.