### PR TITLE
Build qwt as a static library.

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
+++ b/OMPlot/OMPlot/OMPlotGUI/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(OMPlotLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(OMPlotLib PUBLIC Qt5::Widgets)
 target_link_libraries(OMPlotLib PUBLIC Qt5::PrintSupport)
-target_link_libraries(OMPlotLib PUBLIC qwt)
+target_link_libraries(OMPlotLib PUBLIC omqwt)
 target_link_libraries(OMPlotLib PUBLIC omc::simrt::runtime)
 
 

--- a/OMPlot/qwt/CMakeLists.txt
+++ b/OMPlot/qwt/CMakeLists.txt
@@ -2,7 +2,7 @@
 # qwt 6.1.5 and OpenModelica
 
 cmake_minimum_required (VERSION 3.14)
-project (qwt VERSION 6.1.5 LANGUAGES CXX)
+project (omqwt VERSION 6.1.5 LANGUAGES CXX)
 
 option (QWT_WITH_PLOT "Whether to build plot" ON)
 option (QWT_WITH_SVG "Whether to build svg" ON)

--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -214,22 +214,22 @@ if (QWT_WITH_WIDGETS)
     qwt_wheel.cpp)
 endif ()
 
-add_library(qwt SHARED ${QWT_HEADERS} ${QWT_SOURCES})
+add_library(omqwt STATIC ${QWT_HEADERS} ${QWT_SOURCES})
 
-target_compile_definitions(qwt
+target_compile_definitions(omqwt
 	PUBLIC
 		$<$<BOOL:MSVC>:QWT_DLL>
 	PRIVATE
 		$<$<BOOL:MSVC>:QWT_MAKEDLL>
 )
 
-target_include_directories(qwt
+target_include_directories(omqwt
   PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include>)
 
 if (USE_QT6)
-  target_link_libraries(qwt
+  target_link_libraries(omqwt
     PUBLIC
       Qt6::Core
       Qt6::OpenGL
@@ -239,7 +239,7 @@ if (USE_QT6)
       Qt6::PrintSupport
       Qt6::Svg)
 else ()
-    target_link_libraries(qwt
+    target_link_libraries(omqwt
     PUBLIC
       Qt5::Core
       Qt5::OpenGL
@@ -249,10 +249,8 @@ else ()
       Qt5::Svg)
 endif ()
 
-set_target_properties(qwt PROPERTIES
+set_target_properties(omqwt PROPERTIES
   VERSION ${QWT_VERSION}
   SOVERSION ${QWT_VER_MAJ}
   AUTOMOC ON)
-target_compile_definitions(qwt PRIVATE QWT_MOC_INCLUDE)
-
-install (TARGETS qwt)
+target_compile_definitions(omqwt PRIVATE QWT_MOC_INCLUDE)


### PR DESCRIPTION
  - As it turns out there is no need to have it as a shared library and install it as long as `libOMPlotLib` is a shared lib.

  - It is also renamed to `omqwt` just to be consistent with the Makefiles build.

  - Fixes #9925.

### Related Issues

#9925

