### PR TITLE
Fix Windows CMake build.

### DIFF
--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -216,12 +216,13 @@ endif ()
 
 add_library(omqwt STATIC ${QWT_HEADERS} ${QWT_SOURCES})
 
-target_compile_definitions(omqwt
-	PUBLIC
-		$<$<BOOL:MSVC>:QWT_DLL>
-	PRIVATE
-		$<$<BOOL:MSVC>:QWT_MAKEDLL>
-)
+## We build it as a static library now. Disable dllimport/export attributes.
+# target_compile_definitions(omqwt
+# 	PUBLIC
+# 		$<$<BOOL:MSVC>:QWT_DLL>
+# 	PRIVATE
+# 		$<$<BOOL:MSVC>:QWT_MAKEDLL>
+# )
 
 target_include_directories(omqwt
   PUBLIC


### PR DESCRIPTION
  - We now build `libqwt` as a static library. There should be no `dllimport` or `dllexport` attributes added.

