### PR TITLE
Work around non-scalarized connector lookup issue

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -1023,6 +1023,10 @@ algorithm
   ovar := UnorderedMap.get(varName, variables);
 
   if isNone(ovar) then
+    ovar := UnorderedMap.get(ComponentRef.stripSubscriptsAll(varName), variables);
+  end if;
+
+  if isNone(ovar) then
     Error.addInternalError(getInstanceName() + " could not find the variable " +
       ComponentRef.toString(varName) + "\n", sourceInfo());
   end if;


### PR DESCRIPTION
- If the lookup in ConnectEquations.lookupVarAttr fails, try again without subscripts in case lookup table only contains the non-scalarized variable.