### PR TITLE
Fix `-d=evalOutputOnly`

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -7627,7 +7627,6 @@ algorithm
   end if;
 
   if Flags.isSet(Flags.EVAL_OUTPUT_ONLY) then
-    // prepare the equations
     dae := BackendDAEOptimize.evaluateOutputsOnly(dae);
   end if;
 

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -491,7 +491,7 @@ algorithm
     // create inline equations if present
     if isSome(inInlineData) then
       SOME(inlineData) := inInlineData;
-      (uniqueEqIndex, inlineEquationsTemp, _, _, , _, tempvars, _, _, _, _) :=
+      (uniqueEqIndex, inlineEquationsTemp, _, _, _, _, tempvars, _, _, _, _) :=
             createEquationsForSystems(inlineData.inlineSystems,
                                       shared, uniqueEqIndex, {}, tempvars, uniqueEqIndex,
                                       SimCode.NO_MAPPING(), false);
@@ -1550,7 +1550,7 @@ algorithm
     oequationsForZeroCrossings := Dangerous.listReverseInPlace(oequationsForZeroCrossings);
     ((ouniqueEqIndex, olocalKnownVars)) := BackendVariable.traverseBackendDAEVars(shared.localKnownVars, traverseKnVarsToSimEqSystem, (ouniqueEqIndex, {}));
   else
-    Error.addInternalError("createEquationsForSystems failed", sourceInfo());
+    Error.addInternalError(getInstanceName() + " failed", sourceInfo());
     fail();
   end try;
 end createEquationsForSystems;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -430,7 +430,7 @@ constant DebugFlag DUMP_RTEARING = DEBUG_FLAG(128, "dumpRecursiveTearing", false
 constant DebugFlag DIS_SYMJAC_FMI20 = DEBUG_FLAG(129, "disableDirectionalDerivatives", true,
   Gettext.gettext("For FMI 2.0 only dependecy analysis will be perform."));
 constant DebugFlag EVAL_OUTPUT_ONLY = DEBUG_FLAG(130, "evalOutputOnly", false,
-  Gettext.gettext("Generates equations to calculate outputs only."));
+  Gettext.gettext("Generates equations to calculate top level outputs only."));
 constant DebugFlag HARDCODED_START_VALUES = DEBUG_FLAG(131, "hardcodedStartValues", false,
   Gettext.gettext("Embed the start values of variables and parameters into the c++ code and do not read it from xml file."));
 constant DebugFlag DUMP_FUNCTIONS = DEBUG_FLAG(132, "dumpFunctions", false,

--- a/testsuite/simulation/modelica/linear_system/Ticket3926.mos
+++ b/testsuite/simulation/modelica/linear_system/Ticket3926.mos
@@ -18,10 +18,10 @@ end foo;
 ");getErrorString();
 
 setCommandLineOptions("--initOptModules-=calculateStrongComponentJacobians");
-simulate(foo);getErrorString(); 
+simulate(foo);getErrorString();
 
-val(p1, 0.0);getErrorString(); 
-val(p2, 0.0);getErrorString(); 
+val(p1, 0.0);getErrorString();
+val(p2, 0.0);getErrorString();
 val(p3, 0.0);getErrorString();
 val(p4, 0.0);getErrorString();
 val(q1, 0.0);getErrorString();
@@ -54,7 +54,7 @@ val(q2, 0.0);getErrorString();
 // "Error: A torn linear system has no symbolic jacobian and currently there are no means to solve that numerically. Please compile with the module \"calculateStrongComponentJacobians\" to provide symbolic jacobians for torn linear systems.
 // [SimCode/SimCodeUtil.mo:0:0-0:0:writable] Error: Internal error function createOdeSystem failed for component torn linear Equationsystem{{{1:1}},
 // {2:2} Size: 1
-// [SimCode/SimCodeUtil.mo:0:0-0:0:writable] Error: Internal error createEquationsForSystems failed
+// [SimCode/SimCodeUtil.mo:0:0-0:0:writable] Error: Internal error SimCodeUtil.createEquationsForSystems failed
 // [SimCode/SimCodeUtil.mo:0:0-0:0:writable] Error: Internal error function createSimCode failed [Transformation from optimised DAE to simulation code structure failed]
 // "
 //

--- a/testsuite/simulation/modelica/others/EngineV6_output.mos
+++ b/testsuite/simulation/modelica/others/EngineV6_output.mos
@@ -8,7 +8,7 @@ loadFile("EngineV6_output.mo");getErrorString();
 setDebugFlags("evalOutputOnly"); getErrorString();
 setCommandLineOptions("--maxSizeLineartearing=4000"); getErrorString();
 simulate(EngineV6_output); getErrorString();
-  
+
 val(crankshaftSpeed,1.0); getErrorString();
 
 // Result:
@@ -19,7 +19,6 @@ val(crankshaftSpeed,1.0); getErrorString();
 // ""
 // true
 // ""
-// There have been 1345 SCCs and now there are 686 SCCs.
 // record SimulationResult
 //     resultFile = "EngineV6_output_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.01, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'EngineV6_output', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",

--- a/testsuite/simulation/modelica/parameters/Engine1a_output.mos
+++ b/testsuite/simulation/modelica/parameters/Engine1a_output.mos
@@ -13,7 +13,6 @@ simulate(Engine1a_output); getErrorString();
 // ""
 // true
 // ""
-// There have been 175 SCCs and now there are 66 SCCs.
 // record SimulationResult
 //     resultFile = "Engine1a_output_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 5.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Engine1a_output', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
@@ -21,8 +20,5 @@ simulate(Engine1a_output); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: No output variables in this system (2/4)
-// Notification: No output variables in this system (3/4)
-// Notification: No output variables in this system (4/4)
-// "
+// ""
 // endResult


### PR DESCRIPTION
### Related Issues

#8271


### Purpose

- The flag removes all equations that are unneeded for calculating all top level outputs.