### PR TITLE
Handle string record members mapping to external records.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -729,7 +729,13 @@ case var as VARIABLE(__) then
 
   match ty
     case ty as T_ARRAY(__) then
-      let &varCopies += 'assert("0, Copying of array record members to/from external functions is not yet supported.");<%\n%>'
+      let &varCopies += 'omc_assert(NULL, omc_dummyFileInfo, "Copying of array record members to/from external functions is not yet supported.");<%\n%>'
+      ""
+    case ty as T_STRING(__) then
+      let &varCopies += if copy_to then
+                          '<%dstName%> = MMC_STRINGDATA(<%srcName%>);<%\n%>'
+                        else
+                          'omc_assert(NULL, omc_dummyFileInfo, "Copying of string record members from external functions is not yet supported.");<%\n%>'
       ""
     case ty as T_COMPLEX(complexClassType=RECORD(__)) then
       let recType = expTypeShort(ty)

--- a/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.c
+++ b/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.c
@@ -1,5 +1,10 @@
+#include <stdio.h>
 #include "ExternalCFuncInputOnly.h"
 
-void WriteDataC(Data* data) {
-
+void  WriteDataC(Data* data)
+{
+    if (data->value)
+    {
+      printf("received name: %s\n",data->name);
+    }
 }

--- a/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.h
+++ b/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.h
@@ -1,5 +1,10 @@
-typedef struct {
-  int value;
+
+typedef struct
+{
+
+    int value;
+    const char* name;
+
 } Data;
 
 void WriteDataC(Data* data);

--- a/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mo
+++ b/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mo
@@ -1,12 +1,13 @@
 encapsulated package ExternalCFuncInputOnly
   model Component
-    parameter Data data(value=true);
+    parameter Data data(value=true,name= "Component");
   initial equation
     WriteData(data=data);
   end Component;
 
   record Data
     parameter Boolean value = false;
+    parameter String name = "unknown";
   end Data;
 
   function WriteData

--- a/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mos
+++ b/testsuite/simulation/modelica/external_functions/ExternalCFuncInputOnly.mos
@@ -8,6 +8,7 @@
 // depends: ExternalCFuncInputOnly.h
 //
 //  Checks that a record passed to external function is marked for the extra conversion code generation.
+//  Checks that a string type record member variable is mapped correctly to an external record.
 //
 
 loadFile("ExternalCFuncInputOnly.mo");
@@ -22,7 +23,8 @@ getErrorString();
 // record SimulationResult
 //     resultFile = "ExternalCFuncInputOnly.Component_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ExternalCFuncInputOnly.Component', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+//     messages = "received name: Component
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
  - Record member variables of String type are now properly handled when mapped from a Modelica record to the C record.

    This mimics what is done for normal String variables (non record member) passed to external functions. Both solutions do not make deep copy right now!. If this needs to be changed then it should be changed for both cases.

  - The reverse operation (receiving string data from external record) is still disabled until we are sure what more is needed or we get a MWE.


### Related Issues
- Fixes #9980 
