### PR TITLE
[cmake] install OMNotebookHelp.onb

### DIFF
--- a/OMNotebook/CMakeLists.txt
+++ b/OMNotebook/CMakeLists.txt
@@ -20,3 +20,5 @@ install(DIRECTORY
 	DrModelica/
 	DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omnotebook/drmodelica/
     FILES_MATCHING PATTERN "*.onb")
+install(FILES OMNotebookHelp.onb
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/omnotebook/)


### PR DESCRIPTION
### Purpose

OMNotebook help file is missing for cmake build