### PR TITLE
[OMNotebook] set default open/save path to user's documents folder

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/application.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/application.h
@@ -62,7 +62,7 @@ namespace IAEX
       virtual void addToPasteboard(Cell *cell) = 0;
       virtual void clearPasteboard() = 0;
       virtual vector<Cell *> pasteboard() = 0;
-      virtual void open(const QString filename, int readmode = READMODE_NORMAL) = 0;
+      virtual void open(const QString filename, int readmode = READMODE_NORMAL, int isDrModelica = 0) = 0;
     virtual void removeTempFiles(QString filename) = 0;    // Added 2006-01-16 AF
     virtual vector<DocumentView *> documentViewList() = 0;  // Added 2006-01-27 AF
     virtual void removeDocumentView(DocumentView *view) = 0;  // Added 2006-01-27 AF

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
@@ -250,27 +250,14 @@ namespace IAEX
           //QString drmodelica = OmcInteractiveEnvironment::OpenModelicaHome() + "/share/omnotebook/drmodelica/QuickTour/HelloWorld.onb";
 
           if( dir.exists( drmodelica ))
-            open(drmodelica);
+            open(drmodelica, READMODE_NORMAL, 1);
           else if( dir.exists( "DrModelica/DrModelica.onb" ))
-            open( "DrModelica/DrModelica.onb" );
+            open( "DrModelica/DrModelica.onb", READMODE_NORMAL, 1);
           else
           {
             cout << "Unable to find (1): " << drmodelica.toStdString() << endl;
             cout << "Unable to find (2): DrModelica/DrModelica.onb" << endl;
-
-            // NB
-            drmodelica = OmcInteractiveEnvironment::OpenModelicaHome() + "/share/omnotebook/drmodelica/DrModelica.onb";
-
-            if( dir.exists( drmodelica ))
-              open(drmodelica);
-            else if( dir.exists( "DrModelica/DrModelica.nb" ))
-              open( "DrModelica/DrModelica.nb" );
-            else
-            {
-              cout << "Unable to find (3): " << drmodelica.toStdString() << endl;
-              cout << "Unable to find (4): DrModelica/DrModelica.nb" << endl;
-              open(QString());
-            }
+            open(QString());
           }
         }
       }
@@ -404,7 +391,7 @@ namespace IAEX
    * all operations are done on the window.
    * 2006-05-03 AF, during open, stop highlighter
    */
-  void CellApplication::open( const QString filename, int readmode )
+  void CellApplication::open( const QString filename, int readmode, int isDrModelica )
   {
     // 2005-12-01 AF, Added try-catch
     try
@@ -415,7 +402,7 @@ namespace IAEX
 
       //2. Create a new View.
       // 2005-09-22 AF: Added 'filename' in NotebookWindow() call
-      DocumentView *v = new NotebookWindow(d, filename);
+      DocumentView *v = new NotebookWindow(d, filename, isDrModelica);
       add(v);
 
       // 2006-01-31 AF, Open window minimized instead of normal

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.h
@@ -86,7 +86,7 @@ namespace IAEX
     void add(Document *doc);
     void add(DocumentView *view);
 
-    void open(const QString filename, int readmode = READMODE_NORMAL );
+    void open(const QString filename, int readmode = READMODE_NORMAL, int isDrModelica=0);
     void removeTempFiles(QString filename);      // Added 2006-01-16 AF
     vector<DocumentView *> documentViewList();    // Added 2006-01-27 AF
     void removeDocumentView( DocumentView *view );  // Added 2006-01-27 AF

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
@@ -128,7 +128,7 @@ QString NotebookWindow::linkDir_ = QString();
   * Also made som other updates /AF
   */
 NotebookWindow::NotebookWindow(Document *subject,
-                               const QString filename, QWidget *parent)
+                               const QString filename, int isDrModelica, QWidget *parent)
   : DocumentView(parent),
     subject_(subject),
     filename_(filename),
@@ -136,8 +136,17 @@ NotebookWindow::NotebookWindow(Document *subject,
     app_( subject->application() ), //AF
     findForm_( 0 )          //AF
 {
-  if( !filename_.isNull() )
-    qDebug( "%s", filename_.toStdString().c_str() );
+  if(!isDrModelica && !filename_.isNull() ) {
+    saveDir_ = openDir_ = QFileInfo( filename_ ).absolutePath();
+  } else {
+    QString documentsDir = QFileInfo( QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) ).absoluteFilePath();
+    if (saveDir_.isNull()) {
+      saveDir_ = documentsDir;
+    }
+    if (openDir_.isNull()) {
+      openDir_ = documentsDir;
+    }
+  }
 
   //    subject_->attach(this);
   //    setMinimumSize( 150, 220 );    //AF

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.h
@@ -74,7 +74,7 @@ class NotebookWindow : public DocumentView
   Q_OBJECT
 
 public:
-  NotebookWindow(Document *subject, const QString filename=0,
+  NotebookWindow(Document *subject, const QString filename=0, int isDrModelica=0,
                  QWidget *parent=0);
   virtual ~NotebookWindow();
 


### PR DESCRIPTION
### Purpose

Old location was a temporary folder, so that some models got lost if the location was not set correctly before saving the notebook.

### Approach

Set file requester default path according to latest opened folder, or user's documents folder if new notebook is opened or DrModelica is loaded.
