### PR TITLE
implemented prototype for FMU serialization

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMU2.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU2.tpl
@@ -146,7 +146,7 @@ case SIMCODE(__) then
     canBeInstantiatedOnlyOncePerProcess="false"
     canNotUseMemoryManagementFunctions="false"
     <% if Flags.isSet(FMU_EXPERIMENTAL) then 'canGetAndSetFMUstate="true"' else 'canGetAndSetFMUstate="false"'%>
-    canSerializeFMUstate="false"
+    <% if Flags.isSet(FMU_EXPERIMENTAL) then 'canSerializeFMUstate="true"' else 'canSerializeFMUstate="false"'%>
     <% if Flags.isSet(FMU_EXPERIMENTAL) then 'providesDirectionalDerivative="true"' else 'providesDirectionalDerivative="false"'%>>
     <%SourceFiles(sourceFiles)%>
   </CoSimulation>

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -440,7 +440,7 @@ constant DebugFlag DEBUG_DIFFERENTIATION = DEBUG_FLAG(133, "debugDifferentiation
 constant DebugFlag DEBUG_DIFFERENTIATION_VERBOSE = DEBUG_FLAG(134, "debugDifferentiationVerbose", false,
   Gettext.gettext("Dumps verbose debug output for the differentiation process."));
 constant DebugFlag FMU_EXPERIMENTAL = DEBUG_FLAG(135, "fmuExperimental", false,
-  Gettext.gettext("Adds features to the FMI export that are considered experimental as of now: fmi2GetSpecificDerivatives, canGetSetFMUState"));
+  Gettext.gettext("Adds features to the FMI export that are considered experimental as of now: fmi2GetSpecificDerivatives, canGetSetFMUState, canSerializeFMUstate"));
 constant DebugFlag DUMP_DGESV = DEBUG_FLAG(136, "dumpdgesv", false,
   Gettext.gettext("Enables dumping of the information whether DGESV is used to solve linear systems."));
 constant DebugFlag MULTIRATE_PARTITION = DEBUG_FLAG(137, "multirate", false,

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -381,6 +381,39 @@ fmi2Status internalEventIteration(fmi2Component c, fmi2EventInfo *eventInfo)
   return status;
 }
 
+/********************************************************************
+ * Private helpers for (modelica_)string array handling             *
+ ********************************************************************/
+
+  /* size of array of strings is not known at compile-time!      */
+  /* figure out total size by repeatedly scanning with strlen(). */
+  /* this code relies on the assumption of 1 char = 1 byte.      */
+
+size_t getStringArraySize(char *stringArray, int elements) {
+    size_t totalSize = 0;
+    char *currStr = stringArray;
+    int currStrLen;
+    for (int j = 0; j < elements; j++) {
+        currStrLen = strlen(currStr) + 1;
+        currStr   += currStrLen;
+        totalSize += currStrLen;
+    }
+    return totalSize;
+}
+
+size_t copyStringArray(char* destination, char *stringArray, int elements) {
+    size_t copiedBytes = 0;
+    char *currStr = stringArray;
+    int currStrLen;
+    for (int j = 0; j < elements; j++) {
+        currStrLen = strlen(currStr) + 1;
+        memcpy(destination, currStr, currStrLen);
+        currStr     += currStrLen;
+        copiedBytes += currStrLen;
+    }
+    return copiedBytes;
+}
+
 /**
  * @brief Helper function for fmi2GetXXX to update the component if needed.
  *
@@ -579,7 +612,6 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
   if (fmuResourceLocation) {
     comp->fmuData->modelData->resourcesDir = functions->allocateMemory(1 + strlen(fmuResourceLocation), sizeof(char));
     strcpy(comp->fmuData->modelData->resourcesDir, fmuResourceLocation);
-    free(fmuResourceLocation);
   } else {
     FILTERED_LOG(comp, fmi2OK, LOG_STATUSWARNING, "fmi2Instantiate: Ignoring unknown resource URI: %s", fmuResourceLocation)
   }
@@ -1405,17 +1437,175 @@ fmi2Status fmi2FreeFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
 
 fmi2Status fmi2SerializedFMUstateSize(fmi2Component c, fmi2FMUstate FMUstate, size_t *size)
 {
-  return unsupportedFunction((ModelInstance *)c, "fmi2SerializedFMUstateSize");
+  /* portable serialization is tricky. for now only x86_64 tested!          */
+  /* TODO: make serialization format architecture- & endianness-independent */
+
+  ModelInstance *comp = (ModelInstance *) c;
+  DATA *fmudata = (DATA *) comp->fmuData;
+  INTERNAL_FMU_STATE *internal_state = (INTERNAL_FMU_STATE *) FMUstate;
+
+  size_t stateSize = 0;
+
+  /* space for ringbuffer / simulation data contents */
+  stateSize += ringBufferLength(internal_state->simulationData)    /* timeValue */
+                   * sizeof(modelica_real);
+  stateSize += ringBufferLength(internal_state->simulationData)    /* realVars */
+                   * fmudata->modelData->nVariablesReal
+                   * sizeof(modelica_real);
+  stateSize += ringBufferLength(internal_state->simulationData)    /* integerVars */
+                   * fmudata->modelData->nVariablesInteger
+                   * sizeof(modelica_integer);
+  stateSize += ringBufferLength(internal_state->simulationData)    /* booleanVars */
+                   * fmudata->modelData->nVariablesBoolean
+                   * sizeof(modelica_boolean);
+                                                            /* stringVars */
+  for (int i = 0; i < ringBufferLength(internal_state->simulationData); i++) {
+    SIMULATION_DATA *sdata = (SIMULATION_DATA *)getRingData(internal_state->simulationData, i);
+    stateSize += getStringArraySize((char *)(sdata->stringVars), 
+                                    fmudata->modelData->nVariablesString);
+  }
+
+  /* space for model parameters */
+  stateSize += fmudata->modelData->nParametersReal * sizeof(modelica_real);
+  stateSize += fmudata->modelData->nParametersInteger * sizeof(modelica_integer);
+  stateSize += fmudata->modelData->nParametersBoolean * sizeof(modelica_boolean);
+  stateSize += getStringArraySize((char *)(internal_state->stringParameter), 
+                                  fmudata->modelData->nParametersString);
+  
+  *size = stateSize;
+  return fmi2OK;
 }
 
 fmi2Status fmi2SerializeFMUstate(fmi2Component c, fmi2FMUstate FMUstate, fmi2Byte serializedState[], size_t size)
 {
-  return unsupportedFunction((ModelInstance *)c, "fmi2SerializeFMUstate");
+  /* portable serialization is tricky. for now only x86_64 tested!          */
+  /* TODO: make serialization format architecture- & endianness-independent */
+
+  ModelInstance *comp = (ModelInstance *) c;
+  fmi2CallbackFunctions *functions = (fmi2CallbackFunctions *) comp->functions;
+  DATA *fmudata = (DATA *) comp->fmuData;
+  INTERNAL_FMU_STATE *internal_state = (INTERNAL_FMU_STATE *) FMUstate;
+
+  /* assumption sizeof(fmi2Byte) == sizeof(char) */
+  /* probably true for most modern platforms     */
+  fmi2Byte *serialVec = serializedState;
+
+  fmi2Byte *currElement = serialVec;
+  char *currStr;
+  int currStrLen;
+  for (int i = 0; i < ringBufferLength(internal_state->simulationData); i++) {
+    SIMULATION_DATA *sdata = 
+                        (SIMULATION_DATA *)getRingData(internal_state->simulationData, i);
+    memcpy(currElement, &(sdata->timeValue), sizeof(modelica_real));
+    currElement += sizeof(modelica_real);
+    memcpy(currElement, sdata->realVars, 
+                        sizeof(modelica_real)*fmudata->modelData->nVariablesReal);
+    currElement += sizeof(modelica_real)*fmudata->modelData->nVariablesReal;
+    memcpy(currElement, sdata->integerVars, 
+                        sizeof(modelica_integer)*fmudata->modelData->nVariablesInteger);
+    currElement += sizeof(modelica_integer)*fmudata->modelData->nVariablesInteger;
+    memcpy(currElement, sdata->booleanVars,
+                        sizeof(modelica_boolean)*fmudata->modelData->nVariablesBoolean);
+    currElement += sizeof(modelica_boolean)*fmudata->modelData->nVariablesBoolean;
+
+    currElement += copyStringArray( (char *)currElement, (char *)(sdata->stringVars), 
+                                    fmudata->modelData->nVariablesString);
+  }
+  memcpy(currElement, internal_state->realParameter, 
+                      sizeof(modelica_real)*fmudata->modelData->nParametersReal);
+  currElement += sizeof(modelica_real)*fmudata->modelData->nParametersReal;
+  memcpy(currElement, internal_state->integerParameter,
+                      sizeof(modelica_integer)*fmudata->modelData->nParametersInteger);
+  currElement += sizeof(modelica_integer)*fmudata->modelData->nParametersInteger;
+  memcpy(currElement, internal_state->booleanParameter,
+                      sizeof(modelica_boolean)*fmudata->modelData->nParametersBoolean);
+  currElement += sizeof(modelica_boolean)*fmudata->modelData->nParametersBoolean;
+  currElement += copyStringArray( (char *)currElement, (char *)(internal_state->stringParameter),
+                                  fmudata->modelData->nParametersString);
+
+  return fmi2OK;
 }
 
 fmi2Status fmi2DeSerializeFMUstate(fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate)
 {
-  return unsupportedFunction((ModelInstance *)c, "fmi2DeSerializeFMUstate");
+  /* portable serialization is tricky. for now only x86_64 tested!          */
+  /* TODO: make serialization format architecture- & endianness-independent */
+
+  ModelInstance *comp = (ModelInstance *) c;
+  fmi2CallbackFunctions* functions = (fmi2CallbackFunctions *) comp->functions;
+  INTERNAL_FMU_STATE *internal_state = 
+            (INTERNAL_FMU_STATE *) functions->allocateMemory(1, sizeof(INTERNAL_FMU_STATE));
+  internal_state->simulationData = allocRingBuffer(SIZERINGBUFFER, sizeof(SIMULATION_DATA));
+  DATA *fmudata = (DATA *) comp->fmuData;
+
+  fmi2Byte *currElement = (fmi2Byte *) serializedState;
+
+  SIMULATION_DATA tmpSimData = {0};
+  for (int i = 0; i < ringBufferLength(fmudata->simulationData); i++) {
+
+    /* timeValue */
+    memcpy(&(tmpSimData.timeValue), currElement, sizeof(modelica_real));
+    currElement += sizeof(modelica_real);
+
+    /* realVars */
+    tmpSimData.realVars = (modelica_real *) functions->
+                    allocateMemory(fmudata->modelData->nVariablesReal, sizeof(modelica_real));
+    memcpy(tmpSimData.realVars, currElement, 
+                                sizeof(modelica_real)*fmudata->modelData->nVariablesReal);
+    currElement += sizeof(modelica_real)*fmudata->modelData->nVariablesReal;
+
+    /* integerVars */
+    tmpSimData.integerVars = (modelica_integer *) functions->
+                    allocateMemory(fmudata->modelData->nVariablesInteger, sizeof(modelica_integer));
+    memcpy(tmpSimData.integerVars, currElement,
+                                   sizeof(modelica_integer)*fmudata->modelData->nVariablesInteger);
+    currElement += sizeof(modelica_integer)*fmudata->modelData->nVariablesInteger;
+
+    /* booleanVars */
+    tmpSimData.booleanVars = (modelica_boolean *) functions->
+                    allocateMemory(fmudata->modelData->nVariablesBoolean, sizeof(modelica_boolean));
+    memcpy(tmpSimData.booleanVars, currElement, 
+                                   sizeof(modelica_boolean)*fmudata->modelData->nVariablesBoolean);
+    currElement += sizeof(modelica_boolean)*fmudata->modelData->nVariablesBoolean;
+
+    /* stringVars */
+    size_t strArraySize = getStringArraySize(currElement, fmudata->modelData->nVariablesString);
+    tmpSimData.stringVars = (modelica_string *) functions->allocateMemory(1, strArraySize);
+    memcpy(tmpSimData.stringVars, currElement, strArraySize);
+    currElement += strArraySize;
+
+    appendRingData(internal_state->simulationData, &tmpSimData);
+  }
+
+  /* realParameter */
+  internal_state->realParameter = (modelica_real *) functions->
+                    allocateMemory(fmudata->modelData->nParametersReal, sizeof(modelica_real));
+  memcpy(internal_state->realParameter, currElement, 
+                                        sizeof(modelica_real)*fmudata->modelData->nParametersReal);
+  currElement += sizeof(modelica_real)*fmudata->modelData->nParametersReal;
+
+  /* integerParameter */
+  internal_state->integerParameter = (modelica_integer *) functions->
+                  allocateMemory(fmudata->modelData->nParametersInteger, sizeof(modelica_integer));
+  memcpy(internal_state->integerParameter, currElement,
+                                   sizeof(modelica_integer)*fmudata->modelData->nParametersInteger);
+  currElement += sizeof(modelica_integer)*fmudata->modelData->nParametersInteger;
+
+  /* booleanParameter */
+  internal_state->booleanParameter = (modelica_boolean *) functions->
+                  allocateMemory(fmudata->modelData->nParametersBoolean, sizeof(modelica_boolean));
+  memcpy(internal_state->booleanParameter, currElement,
+                                   sizeof(modelica_boolean)*fmudata->modelData->nParametersBoolean);
+  currElement += sizeof(modelica_boolean)*fmudata->modelData->nParametersBoolean;
+
+  /* stringParameter */
+  size_t strArraySize = getStringArraySize(currElement, fmudata->modelData->nParametersString);
+  internal_state->stringParameter = (modelica_string *) functions->allocateMemory(1, strArraySize);
+  memcpy(internal_state->stringParameter, currElement, strArraySize);
+  currElement += strArraySize;
+
+  *FMUstate = (fmi2FMUstate) internal_state;
+  return fmi2OK;
 }
 
 fmi2Status fmi2GetDirectionalDerivativeForInitialization(fmi2Component c,


### PR DESCRIPTION
### Related Issues
#9991 

### Purpose
As described in issue #9991 this is a prototypical implementation for FMU de-/serialization.

### Approach
Concatenate(/de-concatenate) all FMU state variables and parameters to binary vector on serialization(/de-serialization)
Attention: This implementation of serialization and de-serialization is platform dependent (type size and endianness). It does NOT guarantee binary compatibility between various compute platforms (e.g. x86_64, ARM, RISC-V, ...)
