### PR TITLE
Classify .tpl as Susan files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.mo linguist-language=Modelica
+*.tpl linguist-language=Susan


### PR DESCRIPTION
### Related Issues

Susan files are classified as Smarty files, see the linguist file used by GitHub: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml#L6394-L6403

### Purpose

Classify `.tpl` files as Susan files instead of Smarty files.
See http://dx.doi.org/10.3384/ecp09430124 for a description of Susan.

### Changes
Susan is not a known language for linguist, so this will disable the (wrong) syntax highlighting on GitHub for .tpl files.
