### PR TITLE
Update the underlying expression when connection points are updated

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1085,15 +1085,15 @@ void LineAnnotation::updateStartPoint(QPointF point)
   }
   /* update the 1st point */
   if (mPoints.size() > 0) {
-    mPoints[0] = point;
+    mPoints.setPoint(0, point);
     updateCornerItem(0);
   }
   /* update the 2nd point */
   if (mPoints.size() > 1) {
     if (mGeometries[0] == ShapeAnnotation::HorizontalLine) {
-      mPoints[1] = QPointF(mPoints[1].x(), mPoints[1].y() + dy);
+      mPoints.setPoint(1, QPointF(mPoints[1].x(), mPoints[1].y() + dy));
     } else if (mGeometries[0] == ShapeAnnotation::VerticalLine) {
-      mPoints[1] = QPointF(mPoints[1].x() + dx, mPoints[1].y());
+      mPoints.setPoint(1, QPointF(mPoints[1].x() + dx, mPoints[1].y()));
     }
     updateCornerItem(1);
   }
@@ -1134,14 +1134,14 @@ void LineAnnotation::updateEndPoint(QPointF point)
     }
     /* update the last point */
     if (mPoints.size() > 1) {
-      mPoints.last() = point;
+      mPoints.setPoint(mPoints.size() - 1, point);
       updateCornerItem(lastIndex);
       /* update the 2nd point */
       if (secondLastIndex < mGeometries.size()) {
         if (mGeometries.at(secondLastIndex) == ShapeAnnotation::HorizontalLine) {
-          mPoints[secondLastIndex] = QPointF(mPoints.at(secondLastIndex).x(), mPoints.at(secondLastIndex).y() + dy);
+          mPoints.setPoint(secondLastIndex, QPointF(mPoints.at(secondLastIndex).x(), mPoints.at(secondLastIndex).y() + dy));
         } else if (mGeometries.at(secondLastIndex) == ShapeAnnotation::VerticalLine) {
-          mPoints[secondLastIndex] = QPointF(mPoints.at(secondLastIndex).x() + dx, mPoints.at(secondLastIndex).y());
+          mPoints.setPoint(secondLastIndex, QPointF(mPoints.at(secondLastIndex).x() + dx, mPoints.at(secondLastIndex).y()));
         }
         updateCornerItem(secondLastIndex);
       }
@@ -1150,7 +1150,7 @@ void LineAnnotation::updateEndPoint(QPointF point)
       removeRedundantPointsGeometriesAndCornerItems();
     }
   } else {
-    mPoints.last() = point;
+    mPoints.setPoint(mPoints.size() - 1, point);
   }
 }
 
@@ -1167,9 +1167,9 @@ void LineAnnotation::updateTransitionTextPosition()
   if (mpTextAnnotation) {
     if (mPoints.size() > 0) {
       if (mImmediate) {
-        mpTextAnnotation->setPos(mPoints.last());
+        mpTextAnnotation->setPos(mPoints.at(mPoints.size() - 1));
       } else {
-        mpTextAnnotation->setPos(mPoints.first());
+        mpTextAnnotation->setPos(mPoints.at(0));
       }
     }
   }
@@ -1370,7 +1370,7 @@ void LineAnnotation::handleComponentMoved(bool positionChanged)
     if (mpStartElement) {
       QPointF offset = mpStartElement->mapToScene(mpStartElement->boundingRect().center()) - mPoints[0];
       for (int i = 0 ; i < mPoints.size() ; i++) {
-        mPoints[i] = QPointF(mPoints[i].x() + offset.x(), mPoints[i].y() + offset.y());
+        mPoints.setPoint(i, QPointF(mPoints[i].x() + offset.x(), mPoints[i].y() + offset.y()));
         updateCornerItem(i);
       }
     }

--- a/OMEdit/OMEditLIB/Annotations/PointArrayAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PointArrayAnnotation.cpp
@@ -51,9 +51,15 @@ PointArrayAnnotation& PointArrayAnnotation::operator= (const QVector<QPointF> &v
   return *this;
 }
 
-QPointF &PointArrayAnnotation::operator[](int i)
+const QPointF &PointArrayAnnotation::operator[](int i) const
 {
   return mValue[i];
+}
+
+void PointArrayAnnotation::setPoint(int i, const QPointF &value)
+{
+  mValue[i] = value;
+  setExp();
 }
 
 bool PointArrayAnnotation::operator==(const PointArrayAnnotation &pointArray) const

--- a/OMEdit/OMEditLIB/Annotations/PointArrayAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/PointArrayAnnotation.h
@@ -47,7 +47,8 @@ class PointArrayAnnotation : public DynamicAnnotation
 
     operator const QVector<QPointF>&() const { return mValue; }
     PointArrayAnnotation& operator= (const QVector<QPointF> &value);
-    QPointF& operator[] (int i);
+    const QPointF& operator[] (int i) const;
+    void setPoint(int i, const QPointF &value);
     bool operator== (const PointArrayAnnotation &pointArray) const;
 
     void append(const QPointF &value) { mValue.append(value); setExp(); }
@@ -57,8 +58,6 @@ class PointArrayAnnotation : public DynamicAnnotation
     int size() const { return mValue.size(); }
     void replace(int i, const QPointF &value) { mValue.replace(i, value); setExp(); }
 
-    QPointF& first()       { return mValue.first(); }
-    QPointF& last()       { return mValue.last(); }
     auto begin()       { return mValue.begin(); }
     auto begin() const { return mValue.begin(); }
     auto end()         { return mValue.end(); }

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
@@ -125,14 +125,14 @@ void PolygonAnnotation::parseShapeAnnotation(QString annotation)
   mPoints.parse(list.at(8));
   /* The polygon is automatically closed, if the first and the last points are not identical. */
   if (mPoints.size() == 1) {
-    mPoints.append(mPoints.first());
-    mPoints.append(mPoints.first());
+    mPoints.append(mPoints.at(0));
+    mPoints.append(mPoints.at(0));
   } else if (mPoints.size() == 2) {
-    mPoints.append(mPoints.first());
+    mPoints.append(mPoints.at(0));
   }
   if (mPoints.size() > 0) {
-    if (mPoints.first() != mPoints.last()) {
-      mPoints.append(mPoints.first());
+    if (mPoints.at(0) != mPoints.at(mPoints.size() - 1)) {
+      mPoints.append(mPoints.at(0));
     }
   }
   // 10th item of the list is smooth.
@@ -147,14 +147,14 @@ void PolygonAnnotation::parseShapeAnnotation()
   mPoints = mpPolygon->getPoints();
   /* The polygon is automatically closed, if the first and the last points are not identical. */
   if (mPoints.size() == 1) {
-    mPoints.append(mPoints.first());
-    mPoints.append(mPoints.first());
+    mPoints.append(mPoints.at(0));
+    mPoints.append(mPoints.at(0));
   } else if (mPoints.size() == 2) {
-    mPoints.append(mPoints.first());
+    mPoints.append(mPoints.at(0));
   }
   if (mPoints.size() > 0) {
-    if (mPoints.first() != mPoints.last()) {
-      mPoints.append(mPoints.first());
+    if (mPoints.at(0) != mPoints.at(mPoints.size() - 1)) {
+      mPoints.append(mPoints.at(0));
     }
   }
   mPoints.evaluate(mpPolygon->getParentModel());
@@ -287,7 +287,7 @@ void PolygonAnnotation::addPoint(QPointF point)
 {
   prepareGeometryChange();
   mPoints.append(point);
-  mPoints.last() = mPoints.first();
+  mPoints.setPoint(mPoints.size() - 1, mPoints.at(0));
 }
 
 void PolygonAnnotation::removePoint(int index)

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -1634,15 +1634,15 @@ void ShapeAnnotation::updateCornerItemPoint(int index, QPointF point)
         mPoints.replace(index, point);
         // update previous point
         if (mGeometries.size() > index - 1 && mGeometries[index - 1] == ShapeAnnotation::HorizontalLine && mPoints.size() > index - 1) {
-          mPoints[index - 1] = QPointF(mPoints[index - 1].x(), mPoints[index - 1].y() +  dy);
+          mPoints.setPoint(index - 1, QPointF(mPoints[index - 1].x(), mPoints[index - 1].y() +  dy));
         } else if (mGeometries.size() > index - 1 && mGeometries[index - 1] == ShapeAnnotation::VerticalLine && mPoints.size() > index - 1) {
-          mPoints[index - 1] = QPointF(mPoints[index - 1].x() + dx, mPoints[index - 1].y());
+          mPoints.setPoint(index - 1, QPointF(mPoints[index - 1].x() + dx, mPoints[index - 1].y()));
         }
         // update next point
         if (mGeometries.size() > index && mGeometries[index] == ShapeAnnotation::HorizontalLine && mPoints.size() > index + 1) {
-          mPoints[index + 1] = QPointF(mPoints[index + 1].x(), mPoints[index + 1].y() +  dy);
+          mPoints.setPoint(index + 1, QPointF(mPoints[index + 1].x(), mPoints[index + 1].y() +  dy));
         } else if (mGeometries.size() > index && mGeometries[index] == ShapeAnnotation::VerticalLine && mPoints.size() > index + 1) {
-          mPoints[index + 1] = QPointF(mPoints[index + 1].x() + dx, mPoints[index + 1].y());
+          mPoints.setPoint(index + 1, QPointF(mPoints[index + 1].x() + dx, mPoints[index + 1].y()));
         }
       }
     } else {
@@ -1654,9 +1654,9 @@ void ShapeAnnotation::updateCornerItemPoint(int index, QPointF point)
     mPoints.replace(index, point);
     /* if first point */
     if (index == 0) {
-      mPoints.last() = point;
+      mPoints.setPoint(mPoints.size() - 1, point);
     } else if (index == mPoints.size() - 1) { /* if last point */
-      mPoints.first() = point;
+      mPoints.setPoint(0, point);
     }
     applyTransformation();
   } else {

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -150,9 +150,9 @@ TextAnnotation::TextAnnotation(QString annotation, LineAnnotation *pLineAnnotati
    */
   if (pLineAnnotation->getPoints().size() > 0) {
     if (pLineAnnotation->getImmediate()) {
-      setPos(pLineAnnotation->getPoints().last());
+      setPos(pLineAnnotation->getPoints().at(mPoints.size() - 1));
     } else {
-      setPos(pLineAnnotation->getPoints().first());
+      setPos(pLineAnnotation->getPoints().at(0));
     }
   }
 }
@@ -175,9 +175,9 @@ TextAnnotation::TextAnnotation(ModelInstance::Text *pText, LineAnnotation *pLine
    */
   if (pLineAnnotation->getPoints().size() > 0) {
     if (pLineAnnotation->getImmediate()) {
-      setPos(pLineAnnotation->getPoints().last());
+      setPos(pLineAnnotation->getPoints().at(mPoints.size() - 1));
     } else {
-      setPos(pLineAnnotation->getPoints().first());
+      setPos(pLineAnnotation->getPoints().at(0));
     }
   }
 }

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -822,7 +822,7 @@ void UpdateConnectionCommand::undo()
 
 void UpdateConnectionCommand::redrawConnectionWithAnnotation(QString const& annotation)
 {
-  auto updateFunction = std::bind(&LineAnnotation::updateConnectionAnnotation ,mpConnectionLineAnnotation);
+  auto updateFunction = std::bind(&LineAnnotation::updateConnectionAnnotation, mpConnectionLineAnnotation);
   mpConnectionLineAnnotation->redraw(annotation, updateFunction);
 }
 


### PR DESCRIPTION
### Related Issues

Fixes #10053

### Purpose

Move the connection according to the position of the component.

### Approach

When the connection points are updated then we should update the underlying expression.
