### PR TITLE
Do not generate the element name same as class name

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -3564,7 +3564,7 @@ void Element::duplicate()
       return;
     }
   } else {
-    name = mpGraphicsView->getUniqueElementName(StringHandler::toCamelCase(getName()));
+    name = mpGraphicsView->getUniqueElementName(getClassName(), StringHandler::toCamelCase(getName()));
   }
   QPointF gridStep(mpGraphicsView->mMergedCoOrdinateSystem.getHorizontalGridStep() * 5, mpGraphicsView->mMergedCoOrdinateSystem.getVerticalGridStep() * 5);
   // add component

--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -2206,7 +2206,7 @@ void ElementAttributes::updateElementAttributes()
   ModelWidget *pModelWidget = mpElement->getGraphicsView()->getModelWidget();
   /* Check the same element name problem before setting any attributes. */
   if (mpElement->getName().compare(mpNameTextBox->text()) != 0) {
-    if (!mpElement->getGraphicsView()->checkElementName(mpNameTextBox->text())) {
+    if (!mpElement->getGraphicsView()->checkElementName(mpElement->getClassName(), mpNameTextBox->text())) {
       QMessageBox::information(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName, Helper::information),
                                GUIMessages::getMessage(GUIMessages::SAME_COMPONENT_NAME).arg(mpNameTextBox->text()), Helper::ok);
       return;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -259,8 +259,8 @@ public:
   void deleteInheritedElementFromList(Element *pElement) {mInheritedElementsList.removeOne(pElement);}
   Element* getElementObject(QString elementName);
   QString getUniqueElementName(const QString &nameStructure, const QString &name, QString *defaultName);
-  QString getUniqueElementName(QString elementName, int number = 0);
-  bool checkElementName(QString elementName);
+  QString getUniqueElementName(const QString &nameStructure, QString elementName, int number = 0);
+  bool checkElementName(const QString &nameStructure, QString elementName);
   QList<Element*> getElementsList() {return mElementsList;}
   QList<Element*> getInheritedElementsList() {return mInheritedElementsList;}
   QList<LineAnnotation*> getConnectionsList() {return mConnectionsList;}

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.cpp
@@ -2384,7 +2384,7 @@ void RenameItemDialog::renameItem()
  * \param pGraphicsView
  * \param pParent
  */
-ComponentNameDialog::ComponentNameDialog(QString name, GraphicsView *pGraphicsView, QWidget *pParent)
+ComponentNameDialog::ComponentNameDialog(const QString &nameStructure, QString name, GraphicsView *pGraphicsView, QWidget *pParent)
   : QDialog(pParent), mpGraphicsView(pGraphicsView)
 {
   setWindowTitle(tr("%1 - Enter Component Name").arg(Helper::applicationName));
@@ -2392,6 +2392,7 @@ ComponentNameDialog::ComponentNameDialog(QString name, GraphicsView *pGraphicsVi
   Label *pNoteLabel = new Label(tr("Please choose a meaningful name for this component, to improve the readability of simulation results."));
   pNoteLabel->setElideMode(Qt::ElideMiddle);
   // Create the name label and text box
+  mNameStructure = nameStructure;
   mpNameLabel = new Label(Helper::name);
   mpNameTextBox = new QLineEdit(name);
   mpNameTextBox->selectAll();
@@ -2447,7 +2448,7 @@ void ComponentNameDialog::updateComponentName()
     return;
   }
   // check for existing component name
-  if (!mpGraphicsView->checkElementName(mpNameTextBox->text())) {
+  if (!mpGraphicsView->checkElementName(mNameStructure, mpNameTextBox->text())) {
     QMessageBox::information(MainWindow::instance(), QString("%1 - %2").arg(Helper::applicationName).arg(Helper::information),
                              GUIMessages::getMessage(GUIMessages::SAME_COMPONENT_NAME).arg(mpNameTextBox->text()), Helper::ok);
     return;

--- a/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelicaClassDialog.h
@@ -384,10 +384,11 @@ class ComponentNameDialog : public QDialog
 {
   Q_OBJECT
 public:
-  ComponentNameDialog(QString name, GraphicsView *pGraphicsView, QWidget *pParent = 0);
+  ComponentNameDialog(const QString &nameStructure, QString name, GraphicsView *pGraphicsView, QWidget *pParent = 0);
   QString getComponentName() {return mpNameTextBox->text();}
 private:
   GraphicsView *mpGraphicsView;
+  QString mNameStructure;
   Label *mpNameLabel;
   QLineEdit *mpNameTextBox;
   QCheckBox *mpDontShowThisMessageAgainCheckBox;


### PR DESCRIPTION
### Related Issues

Fixes #10065

### Purpose

Avoid creating invalid model code.

### Approach

Check if the auto generate element name is same as class name.
