### PR TITLE
Fix extends of builtin type in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -926,7 +926,7 @@ algorithm
 
     case (_, ClassTree.INSTANTIATED_TREE(exts = ext_nodes))
       algorithm
-        exts := list(buildInstanceTree(e) for e in ext_nodes);
+        exts := list(buildInstanceTree(e, isDerived = true) for e in ext_nodes);
         components := list(buildInstanceTreeComponent(arrayGet(cls_tree.components, i))
                            for i in cls_tree.localComponents);
       then

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends3.mos
@@ -1,0 +1,56 @@
+// name: GetModelInstanceExtends3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  type MyReal
+    extends Real;
+  end MyReal;
+
+  model M
+    MyReal x;
+  end M;
+");
+getErrorString();
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// ""
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//     {
+//       \"name\": \"x\",
+//       \"type\": {
+//         \"name\": \"MyReal\",
+//         \"restriction\": \"type\",
+//         \"extends\": [
+//           {
+//             \"baseClass\": \"Real\"
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 4,
+//           \"columnEnd\": 13
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 6,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 8,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -22,6 +22,7 @@ GetModelInstanceEvaluate1.mos \
 GetModelInstanceExp1.mos \
 GetModelInstanceExtends1.mos \
 GetModelInstanceExtends2.mos \
+GetModelInstanceExtends3.mos \
 GetModelInstanceIcon1.mos \
 GetModelInstanceIcon2.mos \
 GetModelInstanceInnerOuter1.mos \


### PR DESCRIPTION
- Set the `isDerived` class to `true` when building instance trees for extends, otherwise extends of builtin types are incorrectly optimized away and cause issues later on.

Fixes #10069