### PR TITLE
Improve getModelInstanceIcon

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -3148,13 +3148,21 @@ algorithm
     case Absyn.NOMOD() then true;
 
     // search inside, some(exp)
-    case Absyn.EQMOD()
-      algorithm
-        (_, lst::{}) := traverseExpBidir(eqMod.exp, onlyLiteralsInExpEnter, onlyLiteralsInExpExit, {}::{});
-      then
-        listEmpty(lst);
+    case Absyn.EQMOD() then onlyLiteralsInExp(eqMod.exp);
+
   end match;
 end onlyLiteralsInEqMod;
+
+public function onlyLiteralsInExp
+  "Checks if an expression only contains literal expressions."
+  input Absyn.Exp exp;
+  output Boolean onlyLiterals;
+protected
+  list<Absyn.Exp> lst;
+algorithm
+  (_, lst::{}) := traverseExpBidir(exp, onlyLiteralsInExpEnter, onlyLiteralsInExpExit, {}::{});
+  onlyLiterals := listEmpty(lst);
+end onlyLiteralsInExp;
 
 protected function onlyLiteralsInExpEnter
 "@author: adrpo

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -6174,5 +6174,37 @@ function isNonEmptyAlgorithm
   output Boolean res = not listEmpty(alg.statements);
 end isNonEmptyAlgorithm;
 
+function onlyLiteralsInMod
+  "Checks if the bindings in a modifier only contains literal expressions."
+  input SCode.Mod mod;
+  output Boolean onlyLiterals;
+protected
+  list<Absyn.Exp> lst;
+algorithm
+  onlyLiterals := match mod
+    case SCode.Mod.MOD()
+      algorithm
+        if isSome(mod.binding) then
+          onlyLiterals := AbsynUtil.onlyLiteralsInExp(Util.getOption(mod.binding));
+        else
+          onlyLiterals := true;
+        end if;
+
+        if onlyLiterals then
+          for m in mod.subModLst loop
+            onlyLiterals := onlyLiteralsInMod(m.mod);
+
+            if not onlyLiterals then
+              break;
+            end if;
+          end for;
+        end if;
+      then
+        onlyLiterals;
+
+    else true;
+  end match;
+end onlyLiteralsInMod;
+
 annotation(__OpenModelica_Interface="frontend");
 end SCodeUtil;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon3.mos
@@ -1,0 +1,137 @@
+// name: GetModelInstanceIcon3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package Icons
+    partial model Example
+      parameter Boolean visible = true;
+      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
+            Ellipse(visible = visible,
+                    lineColor = {75,138,73},
+                    fillColor={255,255,255},
+                    fillPattern = FillPattern.Solid,
+                    extent = {{-100,-100},{100,100}})}),
+        IconMap(extent = {{0, 0}, {0, 0}}));
+    end Example;
+  end Icons;
+
+  model M
+    extends Icons.Example;
+    annotation (Icon(coordinateSystem(preserveAspectRatio=true)));
+  end M;
+");
+
+getModelInstanceIcon(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"extends\": [
+//     {
+//       \"baseClass\": {
+//         \"name\": \"Icons.Example\",
+//         \"annotation\": {
+//           \"Icon\": {
+//             \"coordinateSystem\": {
+//               \"preserveAspectRatio\": false,
+//               \"extent\": [
+//                 [
+//                   -100,
+//                   -100
+//                 ],
+//                 [
+//                   100,
+//                   100
+//                 ]
+//               ]
+//             },
+//             \"graphics\": [
+//               {
+//                 \"$kind\": \"record\",
+//                 \"name\": \"Ellipse\",
+//                 \"elements\": [
+//                   {
+//                     \"$kind\": \"cref\",
+//                     \"parts\": [
+//                       {
+//                         \"name\": \"visible\"
+//                       }
+//                     ]
+//                   },
+//                   [
+//                     0,
+//                     0
+//                   ],
+//                   0,
+//                   [
+//                     75,
+//                     138,
+//                     73
+//                   ],
+//                   [
+//                     255,
+//                     255,
+//                     255
+//                   ],
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"LinePattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"FillPattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   0.25,
+//                   [
+//                     [
+//                       -100,
+//                       -100
+//                     ],
+//                     [
+//                       100,
+//                       100
+//                     ]
+//                   ],
+//                   0,
+//                   360,
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"EllipseClosure.Chord\",
+//                     \"index\": 2
+//                   }
+//                 ]
+//               }
+//             ]
+//           },
+//           \"IconMap\": {
+//             \"extent\": [
+//               [
+//                 0,
+//                 0
+//               ],
+//               [
+//                 0,
+//                 0
+//               ]
+//             ]
+//           }
+//         }
+//       }
+//     }
+//   ],
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"coordinateSystem\": {
+//         \"preserveAspectRatio\": true
+//       }
+//     }
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -25,6 +25,7 @@ GetModelInstanceExtends2.mos \
 GetModelInstanceExtends3.mos \
 GetModelInstanceIcon1.mos \
 GetModelInstanceIcon2.mos \
+GetModelInstanceIcon3.mos \
 GetModelInstanceInnerOuter1.mos \
 GetModelInstanceInnerOuter2.mos \
 GetModelInstanceInnerOuter3.mos \


### PR DESCRIPTION
- Instantiate the scope of an annotation if the annotation contains component references that we need to be able to look up.