### PR TITLE
Use the pixel ratio when picking the visualizer with mouse

### DIFF
--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -224,6 +224,7 @@ void ViewerWidget::mousePressEvent(QMouseEvent *event)
   // 2 = middle mouse button
   // 3 = right mouse button
   unsigned int button = 0;
+  int pixelRatio = qCeil(qApp->devicePixelRatio());
   switch (event->button()) {
     case Qt::LeftButton:
       button = 1;
@@ -235,7 +236,7 @@ void ViewerWidget::mousePressEvent(QMouseEvent *event)
       button = 3;
       if (event->modifiers() == Qt::ShiftModifier) {
         //qt counts pixels from upper left corner and osg from bottom left corner
-        pickVisualizer(event->x(), this->height() - event->y());
+        pickVisualizer(event->x() * pixelRatio, (this->height() - event->y()) * pixelRatio);
         showVisualizerPickContextMenu(event->pos());
         return;
       }
@@ -243,7 +244,6 @@ void ViewerWidget::mousePressEvent(QMouseEvent *event)
     default:
       break;
   }
-  int pixelRatio = qCeil(qApp->devicePixelRatio());
   getEventQueue()->mouseButtonPress(static_cast<float>(event->x() * pixelRatio), static_cast<float>(event->y() * pixelRatio), button);
 }
 
@@ -255,6 +255,7 @@ void ViewerWidget::mousePressEvent(QMouseEvent *event)
  */
 void ViewerWidget::pickVisualizer(int x, int y)
 {
+  mpSelectedVisualizer = nullptr;
   //std::cout<<"pickVisualizer "<<x<<" and "<<y<<std::endl;
   osgUtil::LineSegmentIntersector::Intersections intersections;
   if (mpSceneView->computeIntersections(mpSceneView->getCamera(), osgUtil::Intersector::WINDOW, x, y, intersections)) {


### PR DESCRIPTION
### Related Issues

Fixes #10089

### Purpose

Show the complete context menu of selected visualizer.

### Approach

Add the pixel ratio to the event position.
