### PR TITLE
[NewAPI] Show the connection if conditional connector is false

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -612,6 +612,10 @@ void LineAnnotation::parseShapeAnnotation(QString annotation)
   }
   mPoints.clear();
   mPoints.parse(list.at(3));
+  // add geometries for points
+  for (int i = 0 ; i < mPoints.size() ; i++) {
+    addGeometry();
+  }
   // 5th item of list contains the color.
   mLineColor.parse(list.at(4));
   // 6th item of list contains the Line Pattern.
@@ -635,6 +639,10 @@ void LineAnnotation::parseShapeAnnotation()
   GraphicItem::parseShapeAnnotation(mpLine);
 
   mPoints = mpLine->getPoints();
+  // add geometries for points
+  for (int i = 0 ; i < mPoints.size() ; i++) {
+    addGeometry();
+  }
   mPoints.evaluate(mpLine->getParentModel());
   mLineColor = mpLine->getColor();
   mLineColor.evaluate(mpLine->getParentModel());
@@ -1017,6 +1025,11 @@ void LineAnnotation::addPoint(QPointF point)
 {
   prepareGeometryChange();
   mPoints.append(point);
+  addGeometry();
+}
+
+void LineAnnotation::addGeometry()
+{
   if (mPoints.size() > 1) {
     if (mGeometries.size() == 0) {
       QPointF currentPoint = mPoints[mPoints.size() - 1];

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -97,6 +97,7 @@ public:
   QString getShapeAnnotation() override;
   QString getCompositeModelShapeAnnotation();
   void addPoint(QPointF point) override;
+  void addGeometry();
   void removePoint(int index);
   void clearPoints() override;
   void updateStartPoint(QPointF point);

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1156,7 +1156,7 @@ void Element::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
   Q_UNUSED(option);
   Q_UNUSED(widget);
   if (mTransformation.isValid()) {
-    setVisible(mTransformation.getVisible());
+    setVisible(mTransformation.getVisible() && isCondition());
     if (mpStateElementRectangle) {
       if (isVisible()) {
         if (mHasTransition && mIsInitialState) {
@@ -1219,6 +1219,20 @@ QString Element::getComment() const
     return mpModelElement->getComment();
   } else {
     return mpElementInfo->getComment();
+  }
+}
+
+/*!
+ * \brief Element::isCondition
+ * Returns the element condition.
+ * \return
+ */
+bool Element::isCondition() const
+{
+  if (mpGraphicsView->getModelWidget()->isNewApi()) {
+    return mpModelElement->getCondition();
+  } else {
+    return true;
   }
 }
 

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -219,6 +219,7 @@ public:
   QString getName() const;
   QString getClassName() const;
   QString getComment() const;
+  bool isCondition() const;
   GraphicsView* getGraphicsView() {return mpGraphicsView;}
   Element *getReferenceElement() {return mpReferenceElement;}
   Element* getParentElement() {return mpParentElement;}

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -100,7 +100,7 @@ namespace ModelInstance
   class GraphicItem
   {
   public:
-    GraphicItem() {}
+    GraphicItem();
     BooleanAnnotation getVisible() const {return mVisible;}
     PointAnnotation getOrigin() const {return mOrigin;}
     RealAnnotation getRotation() const {return mRotation;}


### PR DESCRIPTION
### Related Issues

Fixes #9534

### Purpose

Keep the connection of conditional connector if it is not enabled.

### Approach

Draw the conditional connector but keep it hidden. This is needed so we can keep the connection and move the it around. Set default values for graphical primitives.
