### PR TITLE
Adding clear filter button in Library Browser.

### DIFF
--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -69,6 +69,7 @@ TreeSearchFilters::TreeSearchFilters(QWidget *pParent)
   // create the filter text box
   mpFilterTextBox = new QLineEdit;
   mpFilterTextBox->installEventFilter(this);
+  mpFilterTextBox->setClearButtonEnabled(true);
   connect(this, SIGNAL(clearFilter(QString)), mpFilterTextBox, SIGNAL(textEdited(QString)));
   // filter timer
   mpFilterTimer = new QTimer(this);


### PR DESCRIPTION

### Related Issues

none 

### Purpose

The Library Browser widget filter line edit gets a standard Qt clear button enabled, making mouse users a quicker way to restore full library tree view back.

### Approach

One-liner to enable built-in button for clearing line edit widgets.
