### PR TITLE
Fix scoping in dumpJSONInstanceIcon

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1053,7 +1053,7 @@ algorithm
     try
       context := InstContext.set(NFInstContext.CLASS, NFInstContext.RELAXED);
       scope := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), scope);
-      scope := Inst.instantiate(scope, InstNode.parent(scope), context, true);
+      scope := Inst.instantiate(scope, context = context, instPartial = true);
       Inst.insertGeneratedInners(scope, InstNode.topScope(scope), context);
       Inst.instExpressions(scope, context = context);
     else

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon4.mos
@@ -1,0 +1,152 @@
+// name: GetModelInstanceIcon4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package Icons
+    model A
+      parameter Boolean b;
+    end A;
+
+    partial model Example
+      extends A(b = visible);
+
+      parameter Boolean visible = true;
+      annotation (Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}), graphics={
+            Ellipse(visible = visible,
+                    lineColor = {75,138,73},
+                    fillColor={255,255,255},
+                    fillPattern = FillPattern.Solid,
+                    extent = {{-100,-100},{100,100}})}),
+        IconMap(extent = {{0, 0}, {0, 0}}));
+    end Example;
+  end Icons;
+
+  model M
+    extends Icons.Example;
+    annotation (Icon(coordinateSystem(preserveAspectRatio=true)));
+  end M;
+");
+
+getModelInstanceIcon(M, prettyPrint=true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"extends\": [
+//     {
+//       \"baseClass\": {
+//         \"name\": \"Icons.Example\",
+//         \"extends\": [
+//           {
+//             \"baseClass\": {
+//               \"name\": \"Icons.A\"
+//             }
+//           }
+//         ],
+//         \"annotation\": {
+//           \"Icon\": {
+//             \"coordinateSystem\": {
+//               \"preserveAspectRatio\": false,
+//               \"extent\": [
+//                 [
+//                   -100,
+//                   -100
+//                 ],
+//                 [
+//                   100,
+//                   100
+//                 ]
+//               ]
+//             },
+//             \"graphics\": [
+//               {
+//                 \"$kind\": \"record\",
+//                 \"name\": \"Ellipse\",
+//                 \"elements\": [
+//                   {
+//                     \"$kind\": \"cref\",
+//                     \"parts\": [
+//                       {
+//                         \"name\": \"visible\"
+//                       }
+//                     ]
+//                   },
+//                   [
+//                     0,
+//                     0
+//                   ],
+//                   0,
+//                   [
+//                     75,
+//                     138,
+//                     73
+//                   ],
+//                   [
+//                     255,
+//                     255,
+//                     255
+//                   ],
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"LinePattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"FillPattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   0.25,
+//                   [
+//                     [
+//                       -100,
+//                       -100
+//                     ],
+//                     [
+//                       100,
+//                       100
+//                     ]
+//                   ],
+//                   0,
+//                   360,
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"EllipseClosure.Chord\",
+//                     \"index\": 2
+//                   }
+//                 ]
+//               }
+//             ]
+//           },
+//           \"IconMap\": {
+//             \"extent\": [
+//               [
+//                 0,
+//                 0
+//               ],
+//               [
+//                 0,
+//                 0
+//               ]
+//             ]
+//           }
+//         }
+//       }
+//     }
+//   ],
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"coordinateSystem\": {
+//         \"preserveAspectRatio\": true
+//       }
+//     }
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -28,6 +28,7 @@ GetModelInstanceExtends3.mos \
 GetModelInstanceIcon1.mos \
 GetModelInstanceIcon2.mos \
 GetModelInstanceIcon3.mos \
+GetModelInstanceIcon4.mos \
 GetModelInstanceInnerOuter1.mos \
 GetModelInstanceInnerOuter2.mos \
 GetModelInstanceInnerOuter3.mos \


### PR DESCRIPTION
- Don't try to provide a parent when instantiating the scope in dumpJSONInstanceIcon, the correct parent is generated by the instantiation and shouldn't be provided by the caller in this case.