### PR TITLE
Enable error suppression for dumpJSONInstanceIcon again

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1049,7 +1049,7 @@ algorithm
   // Instantiate the scope if the annotation contains component references that
   // we need to be able to look up.
   if not annotation_is_literal then
-    //ErrorExt.setCheckpoint(getInstanceName());
+    ErrorExt.setCheckpoint(getInstanceName());
     try
       context := InstContext.set(NFInstContext.CLASS, NFInstContext.RELAXED);
       scope := InstNode.setNodeType(InstNodeType.ROOT_CLASS(InstNode.EMPTY_NODE()), scope);
@@ -1058,7 +1058,7 @@ algorithm
       Inst.instExpressions(scope, context = context);
     else
     end try;
-    //ErrorExt.rollBack(getInstanceName());
+    ErrorExt.rollBack(getInstanceName());
   end if;
 
   json := dumpJSONCommentOpt(cmt, scope, json, failOnError = true);


### PR DESCRIPTION
- Errors where temporarily enabled for debugging, but are not longer needed.