### PR TITLE
Show correct time unit in the plot tooltip (#10107)

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/Plot.cpp
@@ -300,6 +300,8 @@ void Plot::replot()
   mpParentPlotWindow->setCanUseYPrefixUnits(canUseYPrefixUnits);
   mpYScaleDraw->invalidateCache();
 
+  QwtPlot::replot();
+
   // Now we need to again loop through curves to set the color and title.
   for (int i = 0 ; i < mPlotCurvesList.length() ; i++) {
     // if user has set the custom color for the curve then dont get automatic color for it
@@ -335,8 +337,6 @@ void Plot::replot()
   } else {
     setAxisTitle(QwtPlot::yLeft, mpParentPlotWindow->getYCustomLabel());
   }
-
-  QwtPlot::replot();
 }
 
 } // namespace OMPlot

--- a/OMPlot/OMPlot/OMPlotGUI/PlotPicker.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotPicker.cpp
@@ -173,7 +173,7 @@ QwtText PlotPicker::trackerText(const QPoint &pos) const
     if (mpPlot->getParentPlotWindow()->getPlotType() != PlotWindow::PLOTPARAMETRIC
         && mpPlot->getParentPlotWindow()->getPlotType() != PlotWindow::PLOTARRAYPARAMETRIC
         && !mpPlot->getParentPlotWindow()->getTimeUnit().isEmpty()) {
-      timeUnit = QString("%1").arg(mpPlot->getParentPlotWindow()->getTimeUnit());
+      timeUnit = QString("%1%2").arg(mpPlot->getXScaleDraw()->getUnitPrefix(), mpPlot->getParentPlotWindow()->getTimeUnit());
     }
     QString toolTip;
     for (int i = 0 ; i < plotCurves.size() ; i++) {

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -2291,7 +2291,6 @@ void SetupDialog::applySetup()
     mpPlotWindow->setYRange(mpYMinimumTextBox->text().toDouble(), mpYMaximumTextBox->text().toDouble());
   }
   // replot
-  mpPlotWindow->getPlot()->updateLayout();
   mpPlotWindow->getPlot()->replot();
   if (requiresFitInView) {
     mpPlotWindow->fitInView();

--- a/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/ScaleDraw.cpp
@@ -114,6 +114,8 @@ QwtText ScaleDraw::label(double value) const
         }
       }
       value = value / qPow(10, mExponent);
+    } else {
+      mExponent = 0;
     }
   }
   return QLocale().toString(value, 'g', 4);


### PR DESCRIPTION
Fixes #9950
Update the legend when unit prefix is enabled/disabled Use correct exponent value