### PR TITLE
[OMEdit] Fix STL shapes picking

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1286,7 +1286,14 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(shape._fileName);
       if (node.valid())
       {
-        node->setName(shape._id);
+        osg::ref_ptr<osg::Group> group = node->asGroup();
+        if (group.valid()) {
+          for (unsigned int i = 0; i < group->getNumChildren(); i++) {
+            group->getChild(i)->setName(shape._id);
+          }
+        } else { // Should never occur
+          node->setName(shape._id);
+        }
 
         osg::ref_ptr<osg::Material> material = new osg::Material();
         material->setDiffuse(osg::Material::FRONT, osg::Vec4f(0.0, 0.0, 0.0, 0.0));


### PR DESCRIPTION
### Related Issues

### Purpose

Fix picking shape visualizers of STL type.

### Approach

Previously the name of the visualizer was set each time its related geode was traversed for updating/modifying: https://github.com/OpenModelica/OpenModelica/blob/ff8602fe029812835dc37c16d66b2639f215e3b4/OMEdit/OMEditLIB/Animation/Visualizer.cpp#L485-L489

Later I refactored the code to set the name only once at the creation of the node graph: https://github.com/OpenModelica/OpenModelica/blob/d85e7290b4f2a49afa640256db15473e6eda1a49/OMEdit/OMEditLIB/Animation/Visualization.cpp#L1013-L1016

However, STL files are loaded by an OSG plugin that encapsulates possibly multiple geodes inside a group: https://github.com/openscenegraph/OpenSceneGraph/blob/OpenSceneGraph-3.2/src/osgPlugins/stl/ReaderWriterSTL.cpp#L439-L443

Hence I was actually setting the name on the group rather than on the geode itself, the latter being the "end node" when computing intersections for picking a visualizer: https://github.com/OpenModelica/OpenModelica/blob/c05a31de40049217677597fd65d69a16e653be4d/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp#L262-L266

Therefore the fix is to loop over the group's children (i.e., the geodes) and set the name on them.