### PR TITLE
[OMEdit] Fix DXF shapes coloring

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1549,12 +1549,13 @@ void UpdateVisitor::apply(osg::Geode& node)
   }//end switch action
 
   if (_changeMaterialProperties) {
-    //set color
-    if (!_visualizer->isShape() or _visualizer->asShape()->_type.compare("dxf") != 0)
+    if (!_visualizer->isShape() or _visualizer->asShape()->_type.compare("dxf") != 0) {
+      //set color
       changeColor(node.getOrCreateStateSet(), _visualizer->getColor());
 
-    //set transparency
-    changeTransparency(node.getOrCreateStateSet(), _visualizer->getTransparency());
+      //set transparency
+      changeTransparency(node.getOrCreateStateSet(), _visualizer->getTransparency());
+    }
   }
 
   traverse(node);


### PR DESCRIPTION
### Related Issues

Fixes #10144.

### Purpose

Fix coloring shape visualizers of DXF type.

### Approach

Previously the change of transparency was already outside the condition on DXF shapes: https://github.com/OpenModelica/OpenModelica/blob/ff8602fe029812835dc37c16d66b2639f215e3b4/OMEdit/OMEditLIB/Animation/Visualizer.cpp#L555-L560

However there was an additional check at the beginning of the method (i.e., nothing was done for opaque shapes):
https://github.com/OpenModelica/OpenModelica/blob/ff8602fe029812835dc37c16d66b2639f215e3b4/OMEdit/OMEditLIB/Animation/Visualizer.cpp#L651-L653

This was working because the visualizer picker currently disallows changing the transparency of DXF shapes:
https://github.com/OpenModelica/OpenModelica/blob/d85e7290b4f2a49afa640256db15473e6eda1a49/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp#L326-L336

Later I refactored the code to properly handle the case of switching from transparent to opaque shapes:
https://github.com/OpenModelica/OpenModelica/blob/d85e7290b4f2a49afa640256db15473e6eda1a49/OMEdit/OMEditLIB/Animation/Visualization.cpp#L1293-L1300

But this means that a material was always added on top of the geode's geometry:
https://github.com/OpenModelica/OpenModelica/blob/d85e7290b4f2a49afa640256db15473e6eda1a49/OMEdit/OMEditLIB/Animation/Visualization.cpp#L1395-L1405

Indeed, DXF shapes are the only ones that are created without a material so that the color is taken from the underlying geometry:
https://github.com/OpenModelica/OpenModelica/blob/d85e7290b4f2a49afa640256db15473e6eda1a49/OMEdit/OMEditLIB/Animation/Visualization.cpp#L1027-L1037

A possible solution is to set the color mode to GL_DIFFUSE on the material so that the diffuse color is taken from the geometry:
https://github.com/openscenegraph/OpenSceneGraph/blob/OpenSceneGraph-3.2/include/osg/Material#L105-L114

Note that this would make it possible to change both the color and the transparency of DXF shapes, but this would require a bit more work to set up.

The fix for now is to avoid changing the transparency of DXF shapes.