### PR TITLE
Read the CoordinateSystem recursively

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -609,10 +609,10 @@ QList<QPointF> ShapeAnnotation::getExtentsForInheritedShapeFromIconDiagramMap(Gr
     ModelInstance::Extend *pExtend = dynamic_cast<ModelInstance::Extend*>(getParentModel());
     if (pExtend) {
       if (pGraphicsView->getViewType() == StringHandler::Icon) {
-        extent = pExtend->getAnnotation()->getIconMap().getExtent();
+        extent = pExtend->getExtendsAnnotation()->getIconMap().getExtent();
         preserveAspectRatio = pExtend->getAnnotation()->getIconAnnotation()->mMergedCoOrdinateSystem.getPreserveAspectRatio();
       } else {
-        extent = pExtend->getAnnotation()->getDiagramMap().getExtent();
+        extent = pExtend->getExtendsAnnotation()->getDiagramMap().getExtent();
         preserveAspectRatio = pExtend->getAnnotation()->getDiagramAnnotation()->mMergedCoOrdinateSystem.getPreserveAspectRatio();
       }
     }

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -507,7 +507,7 @@ private:
     QList<Extend *> getExtends() const {return mExtends;}
     QString getComment() const {return mComment;}
     Annotation *getAnnotation() const {return mpAnnotation.get();}
-    void readCoordinateSystemFromExtendsClass(bool isIcon);
+    void readCoordinateSystemFromExtendsClass(CoordinateSystem *pCoordinateSystem, bool isIcon);
     void addElement(Element *pElement) {mElements.append(pElement);}
     QList<Element *> getElements() const {return mElements;}
     QString getFileName() const {return mFileName;}
@@ -709,10 +709,10 @@ private:
     Extend();
     void deserialize(const QJsonObject &jsonObject);
 
-    Annotation *getAnnotation() const {return mpAnnotation.get();}
+    Annotation *getExtendsAnnotation() const {return mpExtendsAnnotation.get();}
     Modifier getExtendsModifier() const {return mExtendsModifier;}
   private:
-    std::unique_ptr<Annotation> mpAnnotation;
+    std::unique_ptr<Annotation> mpExtendsAnnotation;
     Modifier mExtendsModifier;
   };
 

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -338,11 +338,11 @@ void GraphicsView::drawShapes(ModelInstance::Model *pModelInstance, bool inherti
     pExtendModel = dynamic_cast<ModelInstance::Extend*>(pModelInstance);
   }
   if (mViewType == StringHandler::Icon && mpModelWidget->getLibraryTreeItem()->getAccess() >= LibraryTreeItem::icon) {
-    if (!(pExtendModel && !pExtendModel->getAnnotation()->getIconMap().getprimitivesVisible())) {
+    if (!(pExtendModel && !pExtendModel->getExtendsAnnotation()->getIconMap().getprimitivesVisible())) {
       shapes = pModelInstance->getAnnotation()->getIconAnnotation()->getGraphics();
     }
   } else if (mViewType == StringHandler::Diagram && mpModelWidget->getLibraryTreeItem()->getAccess() >= LibraryTreeItem::diagram) {
-    if (!(pExtendModel && !pExtendModel->getAnnotation()->getDiagramMap().getprimitivesVisible())) {
+    if (!(pExtendModel && !pExtendModel->getExtendsAnnotation()->getDiagramMap().getprimitivesVisible())) {
       shapes = pModelInstance->getAnnotation()->getDiagramAnnotation()->getGraphics();
     }
   }


### PR DESCRIPTION
### Related Issues

Fixes #10152

### Purpose

When extending a model, OMEdit appears to ignore the Diagram and Icon size of the extended class.

### Approach

Read the coordinate system extent and preserveAspectRatio recursively.
