### PR TITLE
Fix scoping when instantiating annotations

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -874,7 +874,7 @@ algorithm
   Typing.typeComponents(cls_node, context);
   Typing.typeBindings(cls_node, context);
 
-  json := dumpJSONInstanceTree(inst_tree);
+  json := dumpJSONInstanceTree(inst_tree, cls_node);
   res := Values.STRING(JSON.toString(json, prettyPrint));
 end getModelInstance;
 
@@ -957,6 +957,7 @@ end buildInstanceTreeComponent;
 
 function dumpJSONInstanceTree
   input InstanceTree tree;
+  input InstNode scope;
   input Boolean root = true;
   input Boolean isDeleted = false;
   output JSON json = JSON.emptyObject();
@@ -986,7 +987,7 @@ algorithm
     json := JSON.addPair("extends", dumpJSONExtendsList(exts, isDeleted), json);
   end if;
 
-  json := dumpJSONCommentOpt(cmt, node, json);
+  json := dumpJSONCommentOpt(cmt, scope, json);
 
   if not isDeleted then
     if not listEmpty(comps) then
@@ -1109,7 +1110,7 @@ algorithm
   if Class.isOnlyBuiltin(InstNode.getClass(node)) then
     json := JSON.addPair("baseClass", JSON.makeString(InstNode.name(node)), json);
   else
-    json := JSON.addPair("baseClass", dumpJSONInstanceTree(ext, root = false, isDeleted = isDeleted), json);
+    json := JSON.addPair("baseClass", dumpJSONInstanceTree(ext, node, root = false, isDeleted = isDeleted), json);
   end if;
 end dumpJSONExtends;
 
@@ -1216,7 +1217,7 @@ function dumpJSONComponentType
 algorithm
   json := match (cls, ty)
     case (_, Type.ENUMERATION()) then dumpJSONEnumType(node);
-    case (InstanceTree.CLASS(), _) then dumpJSONInstanceTree(cls, isDeleted = isDeleted);
+    case (InstanceTree.CLASS(), _) then dumpJSONInstanceTree(cls, node, isDeleted = isDeleted);
     else dumpJSONTypeName(ty);
   end match;
 end dumpJSONComponentType;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation6.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation6.mos
@@ -1,0 +1,152 @@
+// name: GetModelInstanceAnnotation6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    block To_deg
+      Real y;
+    end To_deg;
+
+    model RotatingRect
+      To_deg to_deg;
+    equation
+      annotation(Icon(graphics = {Rectangle(extent = {{0, 0}, {1, 1}}, rotation = DynamicSelect(-5, to_deg.y))}));
+    end RotatingRect;
+
+    RotatingRect rotatingRect;
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"components\": [
+//     {
+//       \"name\": \"rotatingRect\",
+//       \"type\": {
+//         \"name\": \"RotatingRect\",
+//         \"restriction\": \"model\",
+//         \"annotation\": {
+//           \"Icon\": {
+//             \"graphics\": [
+//               {
+//                 \"$kind\": \"record\",
+//                 \"name\": \"Rectangle\",
+//                 \"elements\": [
+//                   true,
+//                   [
+//                     0,
+//                     0
+//                   ],
+//                   {
+//                     \"$kind\": \"call\",
+//                     \"name\": \"DynamicSelect\",
+//                     \"arguments\": [
+//                       -5,
+//                       {
+//                         \"$kind\": \"cref\",
+//                         \"parts\": [
+//                           {
+//                             \"name\": \"rotatingRect\"
+//                           },
+//                           {
+//                             \"name\": \"to_deg\"
+//                           },
+//                           {
+//                             \"name\": \"y\"
+//                           }
+//                         ]
+//                       }
+//                     ]
+//                   },
+//                   [
+//                     0,
+//                     0,
+//                     0
+//                   ],
+//                   [
+//                     0,
+//                     0,
+//                     0
+//                   ],
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"LinePattern.Solid\",
+//                     \"index\": 2
+//                   },
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"FillPattern.None\",
+//                     \"index\": 1
+//                   },
+//                   0.25,
+//                   {
+//                     \"$kind\": \"enum\",
+//                     \"name\": \"BorderPattern.None\",
+//                     \"index\": 1
+//                   },
+//                   [
+//                     [
+//                       0,
+//                       0
+//                     ],
+//                     [
+//                       1,
+//                       1
+//                     ]
+//                   ],
+//                   0
+//                 ]
+//               }
+//             ]
+//           }
+//         },
+//         \"components\": [
+//           {
+//             \"name\": \"to_deg\",
+//             \"type\": {
+//               \"name\": \"To_deg\",
+//               \"restriction\": \"block\",
+//               \"components\": [
+//                 {
+//                   \"name\": \"y\",
+//                   \"type\": \"Real\"
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 3,
+//                 \"columnStart\": 5,
+//                 \"lineEnd\": 5,
+//                 \"columnEnd\": 15
+//               }
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 7,
+//           \"columnStart\": 5,
+//           \"lineEnd\": 11,
+//           \"columnEnd\": 21
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 14,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -6,6 +6,7 @@ GetModelInstanceAnnotation2.mos \
 GetModelInstanceAnnotation3.mos \
 GetModelInstanceAnnotation4.mos \
 GetModelInstanceAnnotation5.mos \
+GetModelInstanceAnnotation6.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \


### PR DESCRIPTION
- Pass the scope as an argument to `dumpJSONInstanceTree` instead of using the node in the given instance tree node, since they're not always the same (such as when dumping the type of a component, where the scope should be the component rather than the type).

Fixes #10175