### PR TITLE
[OMEdit] Fix CAD shapes naming

### DIFF
--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -261,8 +261,9 @@ void ViewerWidget::pickVisualizer(int x, int y)
   if (mpSceneView->computeIntersections(mpSceneView->getCamera(), osgUtil::Intersector::WINDOW, x, y, intersections)) {
     //take the first intersection with a facette only
     osgUtil::LineSegmentIntersector::Intersections::const_iterator hitr = intersections.cbegin();
-    if (!hitr->nodePath.empty() && !hitr->nodePath.back()->getName().empty()) {
-      mpSelectedVisualizer = mpAnimationWidget->getVisualization()->getBaseData()->getVisualizerObjectByID(hitr->nodePath.back()->getName());
+    constexpr osg::NodePath::size_type lvl = 2;
+    if (hitr->nodePath.size() > lvl && !hitr->nodePath.at(lvl)->getName().empty()) {
+      mpSelectedVisualizer = mpAnimationWidget->getVisualization()->getBaseData()->getVisualizerObjectByID(hitr->nodePath.at(lvl)->getName());
       //std::cout<<"Object identified by name "<<mpSelectedVisualizer->_id<<std::endl;
     } else if (hitr->drawable.valid()) {
       mpSelectedVisualizer = mpAnimationWidget->getVisualization()->getBaseData()->getVisualizerObjectByID(hitr->drawable->className());

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1279,6 +1279,7 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
   for (ShapeObject& shape : shapes)
   {
     osg::ref_ptr<osg::MatrixTransform> transf = new osg::MatrixTransform();
+    transf->setName(shape._id);
 
     if (shape._type.compare("stl") == 0)
     { //cad node
@@ -1286,15 +1287,6 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(shape._fileName);
       if (node.valid())
       {
-        osg::ref_ptr<osg::Group> group = node->asGroup();
-        if (group.valid()) {
-          for (unsigned int i = 0; i < group->getNumChildren(); i++) {
-            group->getChild(i)->setName(shape._id);
-          }
-        } else { // Should never occur
-          node->setName(shape._id);
-        }
-
         osg::ref_ptr<osg::Material> material = new osg::Material();
         material->setDiffuse(osg::Material::FRONT, osg::Vec4f(0.0, 0.0, 0.0, 0.0));
 
@@ -1310,7 +1302,6 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       osg::ref_ptr<DXFile> dxfDraw = new DXFile(shape._fileName);
 
       osg::ref_ptr<osg::Geode> geode = new osg::Geode();
-      geode->setName(shape._id);
       geode->addDrawable(dxfDraw.get());
 
       transf->addChild(geode.get());
@@ -1321,7 +1312,6 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
       shapeDraw->setColor(osg::Vec4(1.0, 1.0, 1.0, 1.0));
 
       osg::ref_ptr<osg::Geode> geode = new osg::Geode();
-      geode->setName(shape._id);
       geode->addDrawable(shapeDraw.get());
 
       osg::ref_ptr<osg::Material> material = new osg::Material();
@@ -1344,6 +1334,7 @@ void OSGScene::setUpScene(std::vector<VectorObject>& vectors)
   for (VectorObject& vector : vectors)
   {
     osg::ref_ptr<AutoTransformVisualizer> transf = new AutoTransformVisualizer(&vector);
+    transf->setName(vector._id);
     transf->setAutoRotateMode(osg::AutoTransform::NO_ROTATION);
     transf->setAutoScaleTransitionWidthRatio(0);
     transf->setAutoScaleToScreen(vector.isScaleInvariant());
@@ -1362,7 +1353,6 @@ void OSGScene::setUpScene(std::vector<VectorObject>& vectors)
     shapeDraw2->setColor(osg::Vec4(1.0, 1.0, 1.0, 1.0));
 
     osg::ref_ptr<osg::Geode> geode = new osg::Geode();
-    geode->setName(vector._id);
     geode->addDrawable(shapeDraw0.get());
     geode->addDrawable(shapeDraw1.get());
     geode->addDrawable(shapeDraw2.get());


### PR DESCRIPTION
### Related Issues

PR #10163

### Purpose

Preparing the future: Support CAD files other than DXF & STL, typically OBJ & 3DS, which would have a different node structure when loaded with OSG plugins.
Moreover, some nodes (geodes) are given names taken from within the CAD file, so those should not be overwritten because they can serve for other purposes like searching and debugging.

### Approach

Instead of setting the visualizer's name on the geodes, set it on the topmost transform that is used for positioning the visualizer.
This makes sense as the visualizer is already associated with this transform for one-to-one mapping and retrieving:
https://github.com/OpenModelica/OpenModelica/blob/bb59d23756b63cb736c176af74cd6e2bfb46e05d/OMEdit/OMEditLIB/Animation/Visualization.cpp#L1338

As a consequence, adapt the visualizer picker so that it checks the name of the node which is located at the level of this transform in the intersection path.