### PR TITLE
Improve connection graph handling for new backend

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2065,6 +2065,17 @@ public
     end match;
   end toArrayConstructor;
 
+  function isConnectionsOperator
+    input Call call;
+    output Boolean isOp;
+  algorithm
+    isOp := match call
+      case TYPED_CALL()
+        then Function.isBuiltin(call.fn) and functionNameFirst(call) == "Connections";
+      else false;
+    end match;
+  end isConnectionsOperator;
+
 protected
   function instNormalCall
     input Absyn.ComponentRef functionName;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1435,6 +1435,28 @@ public
     end match;
   end stripSubscriptsExceptModel;
 
+  function stripIteratorSubscripts
+    input output ComponentRef cref;
+  protected
+    list<Subscript> subs;
+  algorithm
+    () := match cref
+      case CREF()
+        algorithm
+          if not listEmpty(cref.subscripts) and Subscript.isIterator(List.last(cref.subscripts)) then
+            subs := listReverse(cref.subscripts);
+            subs := List.trim(subs, Subscript.isIterator);
+            cref.subscripts := listReverseInPlace(subs);
+          end if;
+
+          cref.restCref := stripIteratorSubscripts(cref.restCref);
+        then
+          ();
+
+      else ();
+    end match;
+  end stripIteratorSubscripts;
+
   function simplifySubscripts
     input output ComponentRef cref;
     input Boolean trim = false;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1082,6 +1082,12 @@ algorithm
           rhs := Expression.CREF(ty, rhs.cref);
         then Equation.ARRAY_EQUALITY(lhs, rhs, ty, eq.scope, eq.source) :: equations;
 
+      // Pass Connections.* operators as they are and let the connection
+      // handling deal with them.
+      case Equation.NORETCALL(exp = lhs as Expression.CALL())
+        guard Call.isConnectionsOperator(lhs.call)
+        then eq :: equations;
+
       // wrap general equation into for loop
       else
         algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -260,7 +260,7 @@ public
     end match;
   end isScalarLiteral;
 
-  function isIterator
+  function equalsIterator
     input Subscript sub;
     input InstNode iterator;
     output Boolean res;
@@ -274,6 +274,19 @@ public
       case INDEX(index = Expression.CREF(cref = cref))
         then InstNode.refEqual(iterator, ComponentRef.node(cref));
 
+      else false;
+    end match;
+  end equalsIterator;
+
+  function isIterator
+    input Subscript sub;
+    output Boolean res;
+  protected
+    ComponentRef cref;
+  algorithm
+    res := match sub
+      case UNTYPED() then Expression.isIterator(sub.exp);
+      case INDEX() then Expression.isIterator(sub.index);
       else false;
     end match;
   end isIterator;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -3714,7 +3714,7 @@ algorithm
           index := 1;
 
           for sub in subs loop
-            if Subscript.isIterator(sub, iterator) then
+            if Subscript.equalsIterator(sub, iterator) then
               crefs := (cref, index) :: crefs;
             end if;
 


### PR DESCRIPTION
- Try to avoid wrapping Connections.* operators in for-loops, since it's not needed and messes up the connection graph handling.
- Remove iterator subscripts when looking up edges or roots in the connection graph, since those operators might sometimes be wrapped anyway.
- Fix formatting.
- Rename `Subscript.isIterator` to `Subscript.equalsIterator` and implement a new `Subscript.isIterator` that just checks if a subscript is an iterator rather than a specific iterator.