### PR TITLE
Do not remove the element modifiers

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -1874,8 +1874,6 @@ void ElementParameters::updateElementParameters()
     }
     // if valueChanged is true then put the change in the undo stack.
     if (valueChanged) {
-      // remove all the modifiers of a component.
-      pOMCProxy->removeComponentModifiers(className, mpElement->getName());
       // apply the new Component modifiers if any
       QMap<QString, QString>::iterator newElementModifier;
       for (newElementModifier = elementModifiersMap.begin(); newElementModifier != elementModifiersMap.end(); ++newElementModifier) {


### PR DESCRIPTION
### Related Issues

Fixes #10148, fixes #10149
Also linked to #10190

### Purpose

Make sure modifiers are set properly and retained.

### Approach

Since we only update the modified modifiers so there is no point in removing all existing modifiers