### PR TITLE
Delete loop connections

### DIFF
--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -9546,7 +9546,8 @@ protected function deleteEquationInEqlist
 algorithm
   outAbsynEquationItemLst := match (inAbsynEquationItemLst1,inComponentRef2,inComponentRef3)
     local
-      list<Absyn.EquationItem> res,xs;
+      list<Absyn.EquationItem> res,xs,loopRes,forEqList;
+      Absyn.ForIterators forIterator;
       Absyn.ComponentRef cn1,cn2,c1,c2;
       Absyn.EquationItem x;
 
@@ -9556,6 +9557,16 @@ algorithm
         AbsynUtil.crefEqual(c1,cn1) and AbsynUtil.crefEqual(c2,cn2)
       then
         deleteEquationInEqlist(xs, c1, c2);
+    case ((Absyn.EQUATIONITEM(equation_ = Absyn.EQ_FOR(forEquations = forEqList, iterators = forIterator)) :: xs),c1,c2)
+      equation
+        res = deleteEquationInEqlist(xs, c1, c2);
+        loopRes = deleteEquationInEqlist(forEqList, c1, c2);
+
+        if listLength(loopRes) > 0 then
+          loopRes = { Absyn.EQUATIONITEM(Absyn.EQ_FOR(forIterator, loopRes), NONE(), AbsynUtil.dummyInfo) };
+        end if;
+      then
+        listAppend(loopRes, res);
     case ((x :: xs),c1,c2)
       equation
         res = deleteEquationInEqlist(xs, c1, c2);

--- a/testsuite/openmodelica/interactive-API/DeleteConnection.mos
+++ b/testsuite/openmodelica/interactive-API/DeleteConnection.mos
@@ -3,16 +3,44 @@
 // cflags: -d=-newInst
 
 loadString("
-model M
-equation
-  connect(c1[1],c2);
-  connect(c1,c2);
-end M;
+  model M
+  equation
+    connect(c1[1],c2);
+    connect(c1,c2);
+  end M;
 ");
 deleteConnection(c1[1],c2,M);
 list();
 deleteConnection(c1,c2,M);
 list();
+
+deleteClass(M); getErrorString();
+
+loadString("
+  model M
+  equation
+    connect(c1[1],c2);
+    for i in 1:n-1 loop
+      connect(c3[i],c4[i+1]);
+      for j in n*2:n loop
+        connect(c5[j],c6[i+1]);
+      end for;
+      connect(c2[i],c3[i+1]);
+    end for;
+    connect(c1,c2);
+  end M;
+");
+deleteConnection(c1[1],c2,M);
+list();
+deleteConnection(c3[i],c4[i+1],M);
+list();
+deleteConnection(c5[j],c6[i+1],M);
+list();
+deleteConnection(c1,c2,M);
+list();
+deleteConnection(c2[i],c3[i + 1],M);
+list();
+
 
 // Result:
 // true
@@ -20,6 +48,52 @@ list();
 // "model M
 // equation
 //   connect(c1, c2);
+// end M;"
+// Ok
+// "model M
+// equation
+// 
+// end M;"
+// true
+// ""
+// true
+// Ok
+// "model M
+// equation
+//   for i in 1:n - 1 loop
+//     connect(c3[i], c4[i + 1]);
+//     for j in n*2:n loop
+//       connect(c5[j], c6[i + 1]);
+//     end for;
+//     connect(c2[i], c3[i + 1]);
+//   end for;
+//   connect(c1, c2);
+// end M;"
+// Ok
+// "model M
+// equation
+//   for i in 1:n - 1 loop
+//     for j in n*2:n loop
+//       connect(c5[j], c6[i + 1]);
+//     end for;
+//     connect(c2[i], c3[i + 1]);
+//   end for;
+//   connect(c1, c2);
+// end M;"
+// Ok
+// "model M
+// equation
+//   for i in 1:n - 1 loop
+//     connect(c2[i], c3[i + 1]);
+//   end for;
+//   connect(c1, c2);
+// end M;"
+// Ok
+// "model M
+// equation
+//   for i in 1:n - 1 loop
+//     connect(c2[i], c3[i + 1]);
+//   end for;
 // end M;"
 // Ok
 // "model M


### PR DESCRIPTION
### Purpose

The current `deleteConnection` API doesn't delete any connect equation within a loop structure, although it reports an `Ok` status.

### Approach

Update the current API to also go into loops and recur for the equation list within it.
