### PR TITLE
[OMEdit] Fix CAD shapes scaling

### DIFF
--- a/OMEdit/OMEditLIB/Animation/ExtraShapes.cpp
+++ b/OMEdit/OMEditLIB/Animation/ExtraShapes.cpp
@@ -963,3 +963,88 @@ DXFile::DXFile(std::string filename)
     ss->setAttributeAndModes(lightModel.get(), osg::StateAttribute::ON | osg::StateAttribute::OVERRIDE | osg::StateAttribute::PROTECTED);
   }
 }
+
+
+/*!
+ * \brief CADFile constructor
+ * \param osg::Node* subgraph
+ */
+CADFile::CADFile(osg::Node* subgraph)
+  : osg::Group()
+{
+  addChild(subgraph);
+  CADVisitor visitor(this);
+  subgraph->accept(visitor);
+}
+
+/*!
+ * \brief CADFile::scaleVertices
+ * \param osg::Geode& geode
+ * \param bool scaling
+ * \param float scaleX
+ * \param float scaleY
+ * \param float scaleZ
+ */
+void CADFile::scaleVertices(osg::Geode& geode, bool scaling, float scaleX, float scaleY, float scaleZ)
+{
+  if (!scaling) {
+    scaleX = scaleY = scaleZ = 1;
+  }
+  unsigned int num = geode.getNumDrawables();
+  for (unsigned int i = 0; i < num; i++) {
+    osg::Drawable* drawable = geode.getDrawable(i);
+    if (drawable) {
+      osg::Geometry* geometry = drawable->asGeometry();
+      if (geometry) {
+        osg::Vec3Array* vertices = dynamic_cast<osg::Vec3Array*>(geometry->getVertexArray());
+        if (vertices) {
+          osg::Vec3Array* unscaledVertices = unscaledGeometryVertices[geometry];
+          if (unscaledVertices) {
+            osg::Vec3Array::size_type size = unscaledVertices->size();
+            for (osg::Vec3Array::size_type j = 0; j < size; j++) {
+              osg::Vec3& unscaledVertex = unscaledVertices->at(j);
+              osg::Vec3& vertex = vertices->at(j);
+              vertex.x() = unscaledVertex.x() * scaleX;
+              vertex.y() = unscaledVertex.y() * scaleY;
+              vertex.z() = unscaledVertex.z() * scaleZ;
+            }
+            vertices->dirty();
+            drawable->dirtyBound();
+            drawable->dirtyDisplayList();
+          }
+        }
+      }
+    }
+  }
+}
+
+/*!
+ * \brief CADVisitor constructor
+ * \param CADFile* cadFile
+ */
+CADVisitor::CADVisitor(CADFile* cadFile)
+  : osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN)
+{
+  this->cadFile = cadFile;
+}
+
+/*!
+ * \brief CADVisitor::apply
+ * \param osg::Geode& geode
+ */
+void CADVisitor::apply(osg::Geode& geode)
+{
+  unsigned int num = geode.getNumDrawables();
+  for (unsigned int i = 0; i < num; i++) {
+    osg::Drawable* drawable = geode.getDrawable(i);
+    if (drawable) {
+      osg::Geometry* geometry = drawable->asGeometry();
+      if (geometry) {
+        osg::Vec3Array* vertices = dynamic_cast<osg::Vec3Array*>(geometry->getVertexArray());
+        if (vertices) {
+          cadFile->unscaledGeometryVertices[geometry] = dynamic_cast<osg::Vec3Array*>(vertices->clone(osg::CopyOp::DEEP_COPY_ARRAYS));
+        }
+      }
+    }
+  }
+}

--- a/OMEdit/OMEditLIB/Animation/ExtraShapes.h
+++ b/OMEdit/OMEditLIB/Animation/ExtraShapes.h
@@ -87,9 +87,9 @@ class DXF3dFace
 public:
   DXF3dFace();
   ~DXF3dFace();
-  QString fill3dFace(QTextStream* stream);
   void dumpDXF3DFace();
-  osg::Vec3f calcNormals();
+  QString fill3dFace(QTextStream* stream);
+  osg::Vec3f calcNormal();
 
 public:
   osg::Vec3 vec1;
@@ -103,16 +103,12 @@ public:
 
 class DXFile : public osg::Geometry
 {
- public:
-    /*-----------------------------------------
-     * CONSTRUCTORS
-     *---------------------------------------*/
-   DXFile(std::string filename);
-     ~DXFile() = default;
-
-  //members
 public:
-    std::string fileName;
+  DXFile(std::string filename);
+  ~DXFile() = default;
+
+public:
+  std::string fileName;
 };
 
 #endif //end EXTRASHAPES_H

--- a/OMEdit/OMEditLIB/Animation/ExtraShapes.h
+++ b/OMEdit/OMEditLIB/Animation/ExtraShapes.h
@@ -48,6 +48,8 @@
 #include <QTextStream>
 #include <QFile>
 
+#include <unordered_map>
+
 // TODO: Support is missing for the following shape types:
 //  - beam,
 //  - gearwheel.
@@ -109,6 +111,35 @@ public:
 
 public:
   std::string fileName;
+};
+
+template<typename T>
+struct std::hash<const osg::ref_ptr<T>> {
+  std::size_t operator()(const osg::ref_ptr<T>& ref) const {
+    return reinterpret_cast<std::uintptr_t>(ref.get());
+  }
+};
+
+class CADFile : public osg::Group
+{
+public:
+  CADFile(osg::Node* subgraph);
+  ~CADFile() = default;
+  void scaleVertices(osg::Geode& geode, bool scaling, float scaleX, float scaleY, float scaleZ);
+
+public:
+  std::unordered_map<const osg::ref_ptr<osg::Geometry>, osg::ref_ptr<osg::Vec3Array>> unscaledGeometryVertices;
+};
+
+class CADVisitor : public osg::NodeVisitor
+{
+public:
+  CADVisitor(CADFile* cadFile);
+  ~CADVisitor() {cadFile.release();}
+  void apply(osg::Geode& geode) override;
+
+private:
+  osg::ref_ptr<CADFile> cadFile;
 };
 
 #endif //end EXTRASHAPES_H


### PR DESCRIPTION
### Related Issues

Fixes #5593

### Purpose

[MSL documentation](https://build.openmodelica.org/Documentation/Modelica.Mechanics.MultiBody.Visualizers.Advanced.Shape.html) states that external shapes (i.e., shapes loaded from CAD files) must be scaled with `length`, `width`, `height` of the Modelica component if `extra` is enabled.
This was missing not only for DXF but also for STL files.

### Approach

Scale vertex coordinates with `length`, `width`, `height` if `extra` is not zero.
Because those are not parameters but time-varying inputs, scaling must be applied each time the visualizer is updated.
Original (unscaled) vertices are stored for each geometry in the subgraph just after loading the CAD file.

### Testing

- Run the [`EngineV6_analytic`](https://build.openmodelica.org/Documentation/Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_analytic.html) example.
- For dynamic scaling, `EngineV6_analytic` has been adapted to `dxf` below so you can play around with these settings:
```modelica
  Modelica.Mechanics.MultiBody.Examples.Loops.Utilities.EngineV6_analytic engine(redeclare model Cylinder =
      Modelica.Mechanics.MultiBody.Examples.Loops.Utilities.Cylinder_analytic_CAD(crankShape(
        length = Modelica.Math.cos(2*Modelica.Constants.pi*time)*0.5-0.3,
         width = Modelica.Math.cos(2*Modelica.Constants.pi*time)*0.5-0.3,
        height = Modelica.Math.cos(2*Modelica.Constants.pi*time)*0.5-0.3,
        extra = if time < 0.1 or time > 0.2 then 1 else 0
      ))
    )
```

<details><summary>Click to expand</summary>

```modelica
model dxf
  "V6 engine with 6 cylinders, 6 planar loops, 1 degree-of-freedom and analytic handling of kinematic loops"

  extends Modelica.Icons.Example;
  parameter Boolean animation=true "= true, if animation shall be enabled";
  output Modelica.Units.NonSI.AngularVelocity_rpm
    engineSpeed_rpm=
         Modelica.Units.Conversions.to_rpm(load.w) "Engine speed";
  output Modelica.Units.SI.Torque engineTorque = filter.u
    "Torque generated by engine";
  output Modelica.Units.SI.Torque filteredEngineTorque = filter.y
    "Filtered torque generated by engine";

  inner Modelica.Mechanics.MultiBody.World world(animateWorld=false,
      animateGravity =                                                              false)
    annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
  Modelica.Mechanics.MultiBody.Examples.Loops.Utilities.EngineV6_analytic engine(redeclare model Cylinder =
      Modelica.Mechanics.MultiBody.Examples.Loops.Utilities.Cylinder_analytic_CAD(crankShape(
        length = Modelica.Math.cos(2*Modelica.Constants.pi*time)*0.5-0.3,
         width = Modelica.Math.cos(2*Modelica.Constants.pi*time)*0.5-0.3,
        height = Modelica.Math.cos(2*Modelica.Constants.pi*time)*0.5-0.3,
        extra = if time < 0.1 or time > 0.2 then 1 else 0
      ))
    )
    annotation (Placement(transformation(extent={{-40,0},{0,40}})));
  Modelica.Mechanics.Rotational.Components.Inertia load(
                                             phi(
      start=0,
      fixed=true), w(
      start=10,
      fixed=true),
    stateSelect=StateSelect.always,
    J=1) annotation (Placement(transformation(
          extent={{40,10},{60,30}})));
  Modelica.Mechanics.Rotational.Sources.QuadraticSpeedDependentTorque load2(
                                                 tau_nominal=-100, w_nominal=
        200,
    useSupport=false)
             annotation (Placement(transformation(extent={{90,10},{70,30}})));
  Modelica.Mechanics.Rotational.Sensors.TorqueSensor torqueSensor
    annotation (Placement(transformation(extent={{10,10},{30,30}})));
  Modelica.Blocks.Continuous.CriticalDamping filter(
    n=2,
    initType=Modelica.Blocks.Types.Init.SteadyState,
    f=5) annotation (Placement(transformation(extent={{30,-20},{50,0}})));
equation

  connect(world.frame_b, engine.frame_a)
    annotation (Line(
      points={{-60,-10},{-20,-10},{-20,-0.2}},
      color={95,95,95},
      thickness=0.5));
  connect(load2.flange, load.flange_b)
    annotation (Line(points={{70,20},{60,20}}));
  connect(torqueSensor.flange_a, engine.flange_b)
    annotation (Line(points={{10,20},{2,20}}));
  connect(torqueSensor.flange_b, load.flange_a)
    annotation (Line(points={{30,20},{40,20}}));
  connect(torqueSensor.tau, filter.u) annotation (Line(points={{12,9},{12,-10},{28,-10}},
                     color={0,0,127}));
  annotation (
    Documentation(info="<html>
<p>
This is a similar model as the example \"EngineV6\". However, the cylinders
have been built up with component Modelica.Mechanics.MultiBody.Joints.Assemblies.JointRRR that
solves the non-linear system of equations in an aggregation of 3 revolution
joints <strong>analytically</strong> and only one body is used that holds the total
mass of the crank shaft:
</p>

<p>
<img src=\"modelica://Modelica/Resources/Images/Mechanics/MultiBody/Examples/Loops/EngineV6_CAD_small.png\">
</p>

<p>
This model is about 20 times faster as the EngineV6 example and <strong>no</strong> linear or
non-linear system of equations occur. In contrast, the \"EngineV6\" example
leads to 6 systems of nonlinear equations (every system has dimension = 5, with
Evaluate=false and dimension=1 with Evaluate=true) and a linear system of equations
of about 40. This shows the power of the analytic loop handling.
</p>

<p>
Simulate for 3 s with about 50000 output intervals, and plot the variables <strong>engineSpeed_rpm</strong>,
<strong>engineTorque</strong>, and <strong>filteredEngineTorque</strong>. Note, the result file has
a size of about 240 Mbyte in this case. The default setting of StopTime = 1.01 s (with the default setting of the tool for the number of output points), in order that (automatic) regression testing does not have to cope with a large result file.
</p>

</html>"), experiment(StopTime=1.01));
end dxf;
```
</details>