### PR TITLE
KINSOL: Error if no Jacobian sparsity pattern available

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -56,6 +56,8 @@
 
 /* Function prototypes */
 static int nlsKinsolResiduals(N_Vector x, N_Vector f, void* userData);
+static int nlsJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
+                  void *userData, N_Vector tmp1, N_Vector tmp2);
 static int nlsSparseJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
                         void* userData, N_Vector tmp1, N_Vector tmp2);
 int nlsSparseSymJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
@@ -170,23 +172,20 @@ void resetKinsolMemory(NLS_KINSOL_DATA *kinsolData) {
       kinsolData->linearSolverMethod == NLS_LS_TOTALPIVOT) {
     kinsolData->linSol = SUNLinSol_Dense(kinsolData->y, kinsolData->J);
     if (kinsolData->linSol == NULL) {
-      errorStreamPrint(LOG_STDOUT, 0,
-                       "KINSOL: In function SUNLinSol_Dense: Input incompatible.");
+      throwStreamPrint(NULL, "KINSOL: In function SUNLinSol_Dense: Input incompatible.");
     }
   } else if (kinsolData->linearSolverMethod == NLS_LS_LAPACK) {
     kinsolData->linSol = SUNLinSol_LapackDense(kinsolData->y, kinsolData->J);
     if (kinsolData->linSol == NULL) {
-      errorStreamPrint(LOG_STDOUT, 0,
-                       "KINSOL: In function SUNLinSol_LapackDense: Input incompatible.");
+      throwStreamPrint(NULL, "KINSOL: In function SUNLinSol_LapackDense: Input incompatible.");
     }
   } else if (kinsolData->linearSolverMethod == NLS_LS_KLU) {
     kinsolData->linSol = SUNLinSol_KLU(kinsolData->y, kinsolData->J);
     if (kinsolData->linSol == NULL) {
-      errorStreamPrint(LOG_STDOUT, 0,
-                       "KINSOL: In function SUNLinSol_KLU: Input incompatible.");
+      throwStreamPrint(NULL, "KINSOL: In function SUNLinSol_KLU: Input incompatible.");
     }
   } else {
-    errorStreamPrint(LOG_STDOUT, 0, "KINSOL: Unknown linear solver method.");
+    throwStreamPrint(NULL, "KINSOL: Unknown linear solver method.");
   }
   /* Log used solver */
   infoStreamPrint(LOG_NLS, 0, "KINSOL: Using linear solver method %s", NLS_LS_METHOD[kinsolData->linearSolverMethod]);
@@ -203,7 +202,7 @@ void resetKinsolMemory(NLS_KINSOL_DATA *kinsolData) {
     } else if (sparsePattern != NULL) {
       flag = KINSetJacFn(kinsolData->kinsolMemory, nlsSparseJac); /* Use numeric Jacobian with sparsity pattern */
     } else {
-      flag = KINSetJacFn(kinsolData->kinsolMemory, NULL); /* Use internal difference quotient for Jacobian */
+      throwStreamPrint(NULL, "KINSOL: In function resetKinsolMemory: Sparse linear solver KLU needs sparse Jacobian, but no sparsity pattern is available. Use a dense non-linear solver instead of KINSOL.");
     }
     checkReturnFlag_SUNDIALS(flag, SUNDIALS_KINLS_FLAG, "KINSetJacFn");
   }
@@ -222,7 +221,7 @@ void resetKinsolMemory(NLS_KINSOL_DATA *kinsolData) {
  */
 NLS_KINSOL_DATA* nlsKinsolAllocate(int size, NLS_USERDATA* userData, modelica_boolean attemptRetry) {
   /* Allocate system data */
-  NLS_KINSOL_DATA *kinsolData = (NLS_KINSOL_DATA *)malloc(sizeof(NLS_KINSOL_DATA));
+  NLS_KINSOL_DATA *kinsolData = (NLS_KINSOL_DATA *)calloc(1, sizeof(NLS_KINSOL_DATA));
 
   kinsolData->size = size;
   kinsolData->linearSolverMethod = userData->nlsData->nlsLinearSolver;
@@ -398,11 +397,13 @@ static int nlsDenseJac(long int N,
 /**
  * @brief Set element of jacobian saved in CSC SUNMatrix.
  *
- * @param row
- * @param col
- * @param value
- * @param nth
- * @param A
+ * @param row     Index of row.
+ * @param col     Index of column
+ * @param value   Value to set in (row, column).
+ * @param nth     Index of row indices in A.indexvals.
+ *                indexvals - pointer to a contiguous block of int variables (of length NNZ),
+ *                containing the row indices of each nonzero matrix entry held in data
+ * @param A       Sparse CSC Matrix
  */
 static void setJacElementKluSparse(int row, int col, double value, int nth,
                                    SUNMatrix A) {
@@ -1065,17 +1066,20 @@ static modelica_boolean nlsKinsolErrorHandler(int errorCode, DATA *data,
     return errorCode;
   case KIN_LSETUP_FAIL:
     /* In case something goes wrong with the symbolic jacobian try the numerical */
-    if (kinsolData->linearSolverMethod == NLS_LS_KLU &&
-        nlsData->isPatternAvailable &&
-        nlsData->analyticalJacobianColumn != NULL) {
-      warningStreamPrint(LOG_NLS_V, 0,
-                         "KINSOL: The kinls setup routine (lsetup) encountered an error. "
-                         "Retry with numerical Jacobian.\n");
-      flag = KINSetJacFn(kinsolData->kinsolMemory, nlsSparseJac);
-      checkReturnFlag_SUNDIALS(flag, SUNDIALS_KINLS_FLAG, "KINSetJacFn");
-    }
-    if (flag < 0) {
-      return FALSE;
+    warningStreamPrint(LOG_NLS_V, 0,
+                       "KINSOL: The kinls setup routine (lsetup) encountered an error. "
+                       "Retry with numerical Jacobian.\n");
+    if (kinsolData->linearSolverMethod == NLS_LS_KLU) {
+      if (nlsData->isPatternAvailable && nlsData->analyticalJacobianColumn != NULL) {
+        flag = KINSetJacFn(kinsolData->kinsolMemory, nlsSparseJac);
+        checkReturnFlag_SUNDIALS(flag, SUNDIALS_KINLS_FLAG, "KINSetJacFn");
+        if (flag < 0) {
+          return FALSE;
+        }
+      } else {
+        errorStreamPrint(LOG_STDOUT, 0, "KINSOL: Trying to switch to numeric Jacobian for sparse solver KLU, but no sparsity pattern is available.");
+        return FALSE;
+      }
     }
     break;
   case KIN_LINESEARCH_BCFAIL:

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -56,8 +56,6 @@
 
 /* Function prototypes */
 static int nlsKinsolResiduals(N_Vector x, N_Vector f, void* userData);
-static int nlsJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
-                  void *userData, N_Vector tmp1, N_Vector tmp2);
 static int nlsSparseJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,
                         void* userData, N_Vector tmp1, N_Vector tmp2);
 int nlsSparseSymJac(N_Vector vecX, N_Vector vecFX, SUNMatrix Jac,


### PR DESCRIPTION
### Related Issues

This won't fix #10034, but gives a better error message.

### Purpose

KINSOL with KLU uses Sparse Jacobian matrix. We cam't use the internal difference quotient for Jacobians in the sparse case since it needs a dense Jacobian structure.

### Approach

Throw an error in that case:

```
$ ./DistributionSystemModelicaIndividual_N_10_M_10 -nls=kinsol
assert            | debug   | KINSOL: In function resetKinsolMemory: Sparse linear solver KLU needs sparse Jacobian, but no sparsity pattern is available. Use a dense non-linear solver instead of KINSOL.
Execution failed!
```
