### PR TITLE
Clean up solverstats array

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/cvode_solver.c
@@ -780,10 +780,10 @@ int cvode_solver_deinitial(CVODE_SOLVER *cvodeData)
  * If flag LOG_SOLVER_V is provided even more statistics will be collected.
  *
  * @param cvode_mem         Pointer to CVODE memory block.
- * @param solverStatsTmp    Pointer to solverStatsTmp of solverInfo.
+ * @param solverStats       Pointer to solverStats of solverInfo.
  * @param threadData        Thread data for error handling.
  */
-void cvode_save_statistics(void *cvode_mem, unsigned int *solverStatsTmp, threadData_t *threadData)
+void cvode_save_statistics(void *cvode_mem, SOLVERSTATS *solverStats, threadData_t *threadData)
 {
   /* Variables */
   long int tmp1, tmp2;
@@ -794,32 +794,32 @@ void cvode_save_statistics(void *cvode_mem, unsigned int *solverStatsTmp, thread
   tmp1 = 0;
   flag = CVodeGetNumSteps(cvode_mem, &tmp1);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_CV_FLAG, "CVodeGetNumSteps");
-  solverStatsTmp[0] = tmp1;
+  solverStats->nStepsTaken = tmp1;
 
   /* Get number of right hand side evaluations */
   /* TODO: Is it okay to count number of rhs evaluations instead of residual evaluations? */
   tmp1 = 0;
   flag = CVodeGetNumRhsEvals(cvode_mem, &tmp1);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_CV_FLAG, "CVodeGetNumRhsEvals");
-  solverStatsTmp[1] = tmp1;
+  solverStats->nCallsODE = tmp1;
 
   /* Get number of Jacobian evaluations */
   tmp1 = 0;
   flag = CVodeGetNumJacEvals(cvode_mem, &tmp1);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_CVLS_FLAG, "CVodeGetNumJacEvals");
-  solverStatsTmp[2] = tmp1;
+  solverStats->nCallsJacobian = tmp1;
 
   /* Get number of local error test failures */
   tmp1 = 0;
   flag = CVodeGetNumErrTestFails(cvode_mem, &tmp1);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_CV_FLAG, "CVodeGetNumErrTestFails");
-  solverStatsTmp[3] = tmp1;
+  solverStats->nErrorTestFailures = tmp1;
 
   /* Get number of nonlinear convergence failures */
   tmp1 = 0;
   flag = CVodeGetNumNonlinSolvConvFails(cvode_mem, &tmp1);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_CV_FLAG, "CVodeGetNumNonlinSolvConvFails");
-  solverStatsTmp[4] = tmp1;
+  solverStats->nConvergenveTestFailures = tmp1;
 
   /* Get even more statistics */
   if (useStream[LOG_SOLVER_V])
@@ -979,7 +979,7 @@ int cvode_solver_step(DATA *data, threadData_t *threadData, SOLVER_INFO *solverI
   }
 
   /* Save statistics */
-  cvode_save_statistics(cvodeData->cvode_mem, solverInfo->solverStatsTmp, threadData);
+  cvode_save_statistics(cvodeData->cvode_mem, &solverInfo->solverStatsTmp, threadData);
 
   infoStreamPrint(LOG_SOLVER, 0, "##CVODE## Finished Integrator step.");
   /* Measure time */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/dassl.c
@@ -708,6 +708,14 @@ int dassl_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
   }
 
 
+  /* save dassl stats */
+  // TODO: Who thought this is an acceptable way to log stats in iwork? Never heard of structs?
+  solverInfo->solverStatsTmp.nStepsTaken              = dasslData->iwork[10];
+  solverInfo->solverStatsTmp.nCallsODE                = dasslData->iwork[11];
+  solverInfo->solverStatsTmp.nCallsJacobian           = dasslData->iwork[12];
+  solverInfo->solverStatsTmp.nErrorTestFailures       = dasslData->iwork[13];
+  solverInfo->solverStatsTmp.nConvergenveTestFailures = dasslData->iwork[14];
+
   if(ACTIVE_STREAM(LOG_DASSL))
   {
     infoStreamPrint(LOG_DASSL, 1, "dassl call statistics: ");
@@ -718,19 +726,12 @@ int dassl_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo)
     infoStreamPrint(LOG_DASSL, 0, "step size used on last successful step: %0.4g", dasslData->rwork[6]);
     infoStreamPrint(LOG_DASSL, 0, "the order of the method used on the last step: %d", dasslData->iwork[7]);
     infoStreamPrint(LOG_DASSL, 0, "the order of the method to be attempted on the next step: %d", dasslData->iwork[8]);
-    infoStreamPrint(LOG_DASSL, 0, "number of steps taken so far: %d", (int)dasslData->iwork[10]);
-    infoStreamPrint(LOG_DASSL, 0, "number of calls of functionODE() : %d", (int)dasslData->iwork[11]);
-    infoStreamPrint(LOG_DASSL, 0, "number of calculation of jacobian : %d", (int)dasslData->iwork[12]);
-    infoStreamPrint(LOG_DASSL, 0, "total number of convergence test failures: %d", (int)dasslData->iwork[13]);
-    infoStreamPrint(LOG_DASSL, 0, "total number of error test failures: %d", (int)dasslData->iwork[14]);
+    infoStreamPrint(LOG_DASSL, 0, "number of steps taken so far: %d", solverInfo->solverStatsTmp.nStepsTaken);
+    infoStreamPrint(LOG_DASSL, 0, "number of calls of functionODE() : %d", solverInfo->solverStatsTmp.nCallsODE);
+    infoStreamPrint(LOG_DASSL, 0, "number of calculation of jacobian : %d", solverInfo->solverStatsTmp.nCallsJacobian);
+    infoStreamPrint(LOG_DASSL, 0, "total number of convergence test failures: %d", solverInfo->solverStatsTmp.nErrorTestFailures);
+    infoStreamPrint(LOG_DASSL, 0, "total number of error test failures: %d", solverInfo->solverStatsTmp.nConvergenveTestFailures);
     messageClose(LOG_DASSL);
-  }
-
-  /* save dassl stats */
-  for(ui = 0; ui < numStatistics; ui++)
-  {
-    assert(10 + ui < dasslData->liw);
-    solverInfo->solverStatsTmp[ui] = dasslData->iwork[10 + ui];
   }
 
   infoStreamPrint(LOG_DASSL, 0, "Finished DASSL step.");

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -931,11 +931,7 @@ int gbodef_main(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo, d
       memcpy(gbfData->yOld, sData->realVars, gbData->nStates * sizeof(double));
 
       /* write statistics to the solverInfo data structure */
-      solverInfo->solverStatsTmp[0] = gbfData->stats.nStepsTaken;
-      solverInfo->solverStatsTmp[1] = gbfData->stats.nCallsODE;
-      solverInfo->solverStatsTmp[2] = gbfData->stats.nCallsJacobian;
-      solverInfo->solverStatsTmp[3] = gbfData->stats.nErrorTestFailures;
-      solverInfo->solverStatsTmp[4] = gbfData->stats.nConvergenveTestFailures;
+      memcpy(&solverInfo->solverStatsTmp, &gbfData->stats, sizeof(SOLVERSTATS));
 
       // log the emitted result
       if (ACTIVE_STREAM(LOG_GBODE)){
@@ -1421,7 +1417,7 @@ int gbode_birate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
         memcpy(gbData->gbfData->yOld, sData->realVars, nStates * sizeof(double));
 
         /* write statistics to the solverInfo data structure */
-        setSolverStats(solverInfo->solverStatsTmp, &gbData->stats);
+        memcpy(&solverInfo->solverStatsTmp, &gbData->stats, sizeof(SOLVERSTATS));
 
         // log the emitted result
         if (ACTIVE_STREAM(LOG_GBODE)){
@@ -1542,7 +1538,7 @@ int gbode_birate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverInfo)
   }
   /* Write statistics to the solverInfo data structure */
   logSolverStats(LOG_SOLVER_V, "gb_singlerate", solverInfo->currentTime, gbData->time, gbData->stepSize, &gbData->stats);
-  setSolverStats(solverInfo->solverStatsTmp, &gbData->stats);
+  memcpy(&solverInfo->solverStatsTmp, &gbData->stats, sizeof(SOLVERSTATS));
 
   messageClose(LOG_SOLVER);
   return 0;
@@ -1790,7 +1786,7 @@ int gbode_singlerate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverIn
         memcpy(gbData->yOld, sData->realVars, gbData->nStates * sizeof(double));
 
         /* write statistics to the solverInfo data structure */
-        setSolverStats(solverInfo->solverStatsTmp, &gbData->stats);
+        memcpy(&solverInfo->solverStatsTmp, &gbData->stats, sizeof(SOLVERSTATS));
 
         // log the emitted result
         if (ACTIVE_STREAM(LOG_GBODE)){
@@ -1909,7 +1905,7 @@ int gbode_singlerate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverIn
   }
   /* Write statistics to the solverInfo data structure */
   logSolverStats(LOG_SOLVER_V, "gb_singlerate", solverInfo->currentTime, gbData->time, gbData->stepSize, &gbData->stats);
-  setSolverStats(solverInfo->solverStatsTmp, &gbData->stats);
+  memcpy(&solverInfo->solverStatsTmp, &gbData->stats, sizeof(SOLVERSTATS));
 
   messageClose(LOG_SOLVER);
   return 0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.c
@@ -728,33 +728,6 @@ void logSolverStats(enum LOG_STREAM stream, const char* name, double timeValue, 
 }
 
 /**
- * @brief Set solver stats.
- *
- * @param solverStats   Pointer to solverStats to set.
- * @param stats         Values to set in solverStats.
- */
-void setSolverStats(unsigned int* solverStats, SOLVERSTATS* stats) {
-  solverStats[0] = stats->nStepsTaken;
-  solverStats[1] = stats->nCallsODE;
-  solverStats[2] = stats->nCallsJacobian;
-  solverStats[3] = stats->nErrorTestFailures;
-  solverStats[4] = stats->nConvergenveTestFailures;
-}
-
-/**
- * @brief Set all solver stats to zero.
- *
- * @param stats   Pointer to solver stats.
- */
-void resetSolverStats(SOLVERSTATS* stats) {
-  stats->nStepsTaken = 0;
-  stats->nCallsODE = 0;
-  stats->nCallsJacobian = 0;
-  stats->nErrorTestFailures = 0;
-  stats->nConvergenveTestFailures = 0;
-}
-
-/**
  * @brief Info message for GBODE replacement.
  *
  * Dumps simulation flags to use to LOG_STDOUT.

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_util.h
@@ -74,8 +74,6 @@ void dumpFastStates_gbf(DATA_GBODE *gbData, double time, int rejectedType);
 modelica_boolean checkFastStatesChange(DATA_GBODE* gbData);
 
 void logSolverStats(enum LOG_STREAM stream, const char* name, double timeValue, double integratorTime, double stepSize, SOLVERSTATS* stats);
-void setSolverStats(unsigned int* solverStats, SOLVERSTATS* stats);
-void resetSolverStats(SOLVERSTATS* stats);
 
 void deprecationWarningGBODE(enum SOLVER_METHOD method);
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/ida_solver.c
@@ -1050,34 +1050,32 @@ int ida_solver_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInf
   /* steps */
   tmp = 0;
   flag = IDAGetNumSteps(idaData->ida_mem, &tmp);
-  if (flag == IDA_SUCCESS)
-  {
-    solverInfo->solverStatsTmp[0] = tmp;
-  }
+  checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDAGetNumSteps");
+  solverInfo->solverStatsTmp.nStepsTaken = tmp;
 
   /* functionODE evaluations */
   tmp = 0;
   flag = IDAGetNumResEvals(idaData->ida_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDAGetNumResEvals");
-  solverInfo->solverStatsTmp[1] = tmp;
+  solverInfo->solverStatsTmp.nCallsODE = tmp;
 
   /* Jacobians evaluations */
   tmp = 0;
   flag = IDAGetNumJacEvals(idaData->ida_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDAGetNumJacEvals");
-  solverInfo->solverStatsTmp[2] = tmp;
+  solverInfo->solverStatsTmp.nCallsJacobian = tmp;
 
   /* local error test failures */
   tmp = 0;
   flag = IDAGetNumErrTestFails(idaData->ida_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDAGetNumErrTestFails");
-  solverInfo->solverStatsTmp[3] = tmp;
+  solverInfo->solverStatsTmp.nErrorTestFailures = tmp;
 
   /* local error test failures */
   tmp = 0;
   flag = IDAGetNumNonlinSolvConvFails(idaData->ida_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_IDA_FLAG, "IDAGetNumNonlinSolvConvFails");
-  solverInfo->solverStatsTmp[4] = tmp;
+  solverInfo->solverStatsTmp.nConvergenveTestFailures = tmp;
 
   /* get more statistics */
   if (useStream[LOG_SOLVER_V])

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/irksco.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/irksco.c
@@ -578,9 +578,9 @@ int irksco_midpoint_rule(DATA* data, threadData_t* threadData, SOLVER_INFO* solv
   }
 
   /* write stats */
-  solverInfo->solverStatsTmp[0] = userdata->stepsDone;
-  solverInfo->solverStatsTmp[1] = userdata->evalFunctionODE;
-  solverInfo->solverStatsTmp[2] = userdata->evalJacobians;
+  solverInfo->solverStatsTmp.nStepsTaken = userdata->stepsDone;
+  solverInfo->solverStatsTmp.nCallsODE = userdata->evalFunctionODE;
+  solverInfo->solverStatsTmp.nCallsJacobian = userdata->evalJacobians;
 
   infoStreamPrint(LOG_SOLVER, 0, "Finished irksco step.");
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -368,10 +368,7 @@ static void saveIntegratorStats(SOLVER_INFO* solverInfo)
   int ui;
   if (!(omc_flag[FLAG_NO_RESTART] && solverInfo->solverMethod==S_DASSL) && solverInfo->didEventStep)
   {
-    for(ui=0; ui<numStatistics; ui++)
-    {
-      solverInfo->solverStats[ui] += solverInfo->solverStatsTmp[ui];
-    }
+    addSolverStats(&solverInfo->solverStats, &solverInfo->solverStatsTmp);
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/radau.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/radau.c
@@ -525,22 +525,22 @@ int kinsolOde(SOLVER_INFO* solverInfo)  /* TODO: Unify this function with nlsKin
 
   /* Update statistics */
   /* TODO: Statistics are incomplete: If you retry you need to count that as well */
-  solverInfo->solverStatsTmp[0] += 1;                 /* Number of steps */
+  solverInfo->solverStatsTmp.nStepsTaken += 1;                 /* Number of steps */
 
   tmp = 0;
   flag = KINGetNumFuncEvals(kData->kin_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINGetNumFuncEvals");
-  solverInfo->solverStatsTmp[1] += tmp;               /* functionODE evaluations */
+  solverInfo->solverStatsTmp.nCallsODE += tmp;               /* functionODE evaluations */
 
   tmp = 0;
   flag = KINGetNumJacEvals(kData->kin_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINGetNumJacEvals");
-  solverInfo->solverStatsTmp[2] += tmp;               /* Jacobians evaluations */
+  solverInfo->solverStatsTmp.nCallsJacobian += tmp;               /* Jacobians evaluations */
 
   tmp = 0;
   flag = KINGetNumBetaCondFails(kData->kin_mem, &tmp);
   checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINSpilsGetNumJtimesEvals");
-  solverInfo->solverStatsTmp[4] += tmp;               /* beta-condition failures evaluations */
+  solverInfo->solverStatsTmp.nErrorTestFailures += tmp;               /* beta-condition failures evaluations */
 
   if (solvedSuccessfully != 0) {
     infoStreamPrint(LOG_SOLVER, 0, "##IMPRK## Integration step finished unsuccessful.");

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -111,14 +111,14 @@ int solver_main_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
   case S_EULER:
     retVal = euler_ex_step(data, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
   case S_HEUN:
   case S_RUNGEKUTTA:
     retVal = rungekutta_step(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
 
@@ -126,7 +126,7 @@ int solver_main_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
   case S_DASSL:
     retVal = dassl_step(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
 #endif
@@ -140,7 +140,7 @@ int solver_main_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
       retVal = euler_ex_step(data, solverInfo);
     }
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
 #endif
@@ -150,47 +150,47 @@ int solver_main_step(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
   case S_IMPRUNGEKUTTA:
     retVal = radau_lobatto_step(data, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
   case S_IDA:
     retVal = ida_solver_step(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
   case S_CVODE:
     retVal = cvode_solver_step(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
 #endif
   case S_ERKSSC:
     retVal = rungekutta_step_ssc(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     TRACE_POP
     return retVal;
   case S_SYM_SOLVER:
     retVal = sym_solver_step(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     return retVal;
   case S_SYM_SOLVER_SSC:
     retVal = sym_solver_ssc_step(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     return retVal;
   case S_IRKSCO:
     retVal = irksco_midpoint_rule(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     return retVal;
   case S_GBODE:
     retVal = gbode_main(data, threadData, solverInfo);
     if(omc_flag[FLAG_SOLVER_STEPS])
-      data->simulationInfo->solverSteps = solverInfo->solverStats[0] + solverInfo->solverStatsTmp[0];
+      data->simulationInfo->solverSteps = solverInfo->solverStats.nStepsTaken + solverInfo->solverStatsTmp.nStepsTaken;
     return retVal;
   default:
     throwStreamPrint(threadData, "Unhandled case in solver_main_step.");
@@ -225,8 +225,8 @@ int initializeSolverData(DATA* data, threadData_t *threadData, SOLVER_INFO* solv
   solverInfo->didEventStep = 0;
   solverInfo->stateEvents = 0;
   solverInfo->sampleEvents = 0;
-  solverInfo->solverStats = (unsigned int*) calloc(numStatistics, sizeof(unsigned int));
-  solverInfo->solverStatsTmp = (unsigned int*) calloc(numStatistics, sizeof(unsigned int));
+  resetSolverStats(&solverInfo->solverStats);
+  resetSolverStats(&solverInfo->solverStatsTmp);
 
   /* if FLAG_NOEQUIDISTANT_GRID is set, choose integrator step method */
   if (omc_flag[FLAG_NOEQUIDISTANT_GRID])
@@ -391,9 +391,6 @@ int freeSolverData(DATA* data, SOLVER_INFO* solverInfo)
   int i;
 
   freeList(solverInfo->eventLst);
-  /* free solver statistics */
-  free(solverInfo->solverStats);
-  free(solverInfo->solverStatsTmp);
   /* deintialize solver related workspace */
   switch (solverInfo->solverMethod)
   {
@@ -618,15 +615,14 @@ int finishSimulation(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
     else
     {
       /* save stats before print */
-      for(ui=0; ui<numStatistics; ui++)
-        solverInfo->solverStats[ui] += solverInfo->solverStatsTmp[ui];
+      addSolverStats(&solverInfo->solverStats, &solverInfo->solverStatsTmp);
 
       infoStreamPrint(LOG_STATS, 1, "solver: %s", SOLVER_METHOD_NAME[solverInfo->solverMethod]);
-      infoStreamPrint(LOG_STATS, 0, "%5d steps taken", solverInfo->solverStats[0]);
-      infoStreamPrint(LOG_STATS, 0, "%5d calls of functionODE", solverInfo->solverStats[1]);
-      infoStreamPrint(LOG_STATS, 0, "%5d evaluations of jacobian", solverInfo->solverStats[2]);
-      infoStreamPrint(LOG_STATS, 0, "%5d error test failures", solverInfo->solverStats[3]);
-      infoStreamPrint(LOG_STATS, 0, "%5d convergence test failures", solverInfo->solverStats[4]);
+      infoStreamPrint(LOG_STATS, 0, "%5d steps taken", solverInfo->solverStats.nStepsTaken);
+      infoStreamPrint(LOG_STATS, 0, "%5d calls of functionODE", solverInfo->solverStats.nCallsODE);
+      infoStreamPrint(LOG_STATS, 0, "%5d evaluations of jacobian", solverInfo->solverStats.nCallsJacobian);
+      infoStreamPrint(LOG_STATS, 0, "%5d error test failures", solverInfo->solverStats.nErrorTestFailures);
+      infoStreamPrint(LOG_STATS, 0, "%5d convergence test failures", solverInfo->solverStats.nConvergenveTestFailures);
       infoStreamPrint(LOG_STATS, 0, "%gs time of jacobian evaluation", rt_accumulated(SIM_TIMER_JACOBIAN));
 #ifdef USE_PARJAC
       infoStreamPrint(LOG_STATS, 0, "%i OpenMP-threads used for jacobian evaluation", omc_get_max_threads());
@@ -911,9 +907,9 @@ static int euler_ex_step(DATA* data, SOLVER_INFO* solverInfo)
 
   /* save stats */
   /* steps */
-  solverInfo->solverStatsTmp[0] += 1;
+  solverInfo->solverStatsTmp.nStepsTaken += 1;
   /* function ODE evaluation is done directly after this function */
-  solverInfo->solverStatsTmp[1] += 1;
+  solverInfo->solverStatsTmp.nCallsODE += 1;
 
   if (measure_time_flag) rt_accumulate(SIM_TIMER_SOLVER);
 
@@ -1015,9 +1011,9 @@ static int rungekutta_step_ssc(DATA* data, threadData_t *threadData, SOLVER_INFO
 
     /* save stats */
     /* steps */
-    solverInfo->solverStatsTmp[0] += 1;
+    solverInfo->solverStatsTmp.nStepsTaken += 1;
     /* function ODE evaluation is done directly after this */
-    solverInfo->solverStatsTmp[1] += 4;
+    solverInfo->solverStatsTmp.nCallsODE += 4;
 
 
     //stepsize
@@ -1085,9 +1081,9 @@ static int sym_solver_step(DATA* data, threadData_t *threadData, SOLVER_INFO* so
 
     /* save stats */
     /* steps */
-    solverInfo->solverStatsTmp[0] += 1;
+    solverInfo->solverStatsTmp.nStepsTaken += 1;
     /* function ODE evaluation is done directly after this */
-    solverInfo->solverStatsTmp[1] += 1;
+    solverInfo->solverStatsTmp.nCallsODE += 1;
   }
   else
   /* in case desired step size is too small */
@@ -1157,9 +1153,9 @@ static int rungekutta_step(DATA* data, threadData_t *threadData, SOLVER_INFO* so
 
   /* save stats */
   /* steps */
-  solverInfo->solverStatsTmp[0] += 1;
+  solverInfo->solverStatsTmp.nStepsTaken += 1;
   /* function ODE evaluation is done directly after this */
-  solverInfo->solverStatsTmp[1] += rk->work_states_ndims+1;
+  solverInfo->solverStatsTmp.nCallsODE += rk->work_states_ndims+1;
   if (measure_time_flag) rt_accumulate(SIM_TIMER_SOLVER);
 
   return 0;
@@ -1267,4 +1263,34 @@ static void writeOutputVars(char* names, DATA* data)
     p = strtok(NULL, "!");
   }
   fprintf(stdout, "\n"); fflush(stdout);
+}
+
+/**
+ * @brief Set all solver stats to zero.
+ *
+ * @param stats   Pointer to solver stats.
+ */
+void resetSolverStats(SOLVERSTATS* stats) {
+  stats->nStepsTaken = 0;
+  stats->nCallsODE = 0;
+  stats->nCallsJacobian = 0;
+  stats->nErrorTestFailures = 0;
+  stats->nConvergenveTestFailures = 0;
+}
+
+/**
+ * @brief Add two solver statistics.
+ *
+ * destStats += addStats
+ *
+ * @param destStats   Pointer to solver stats to add stats to.
+ *                    On return has result of addition.
+ * @param addStats    Pointer to solver stats to add.
+ */
+void addSolverStats(SOLVERSTATS* destStats, SOLVERSTATS* addStats) {
+  destStats->nStepsTaken              += addStats->nStepsTaken;
+  destStats->nCallsODE                += addStats->nCallsODE;
+  destStats->nCallsJacobian           += addStats->nCallsJacobian;
+  destStats->nErrorTestFailures       += addStats->nErrorTestFailures;
+  destStats->nConvergenveTestFailures += addStats->nConvergenveTestFailures;
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
@@ -42,8 +42,6 @@
 #include "../../util/list.h"
 #include "../../util/simulation_options.h"
 
-static const unsigned int numStatistics = 5;
-
 /**
  * @brief Solver statistics.
  */
@@ -80,9 +78,8 @@ typedef struct SOLVER_INFO
   unsigned long stateEvents;
   unsigned long sampleEvents;
   /* integrator stats */
-  /* TODO: Change to SOLVERSTATS!!!! */
-  unsigned int* solverStats;          /* Statistic for integrator */
-  unsigned int* solverStatsTmp;       /* tmp solver stats to update solverStats with */
+  SOLVERSTATS solverStats;            /* Statistic for integrator */
+  SOLVERSTATS solverStatsTmp;         /* tmp solver stats to update solverStats with */
 
   /* further options */
   int integratorSteps;              /* 1 => stepSizeControl; 0 => equidistant grid */
@@ -113,6 +110,9 @@ extern int solver_main_step(DATA* data, threadData_t *threadData, SOLVER_INFO* s
 void checkTermination(DATA* data);
 
 extern int stateSelection(DATA *data, threadData_t *threadData, char reportError, int switchStates);
+
+void resetSolverStats(SOLVERSTATS* stats);
+void addSolverStats(SOLVERSTATS* destStats, SOLVERSTATS* addStats);
 
 #ifdef __cplusplus
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sym_solver_ssc.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sym_solver_ssc.c
@@ -458,8 +458,8 @@ int generateTwoApproximationsOfDifferentOrder(DATA* data, threadData_t *threadDa
     data->callback->symbolicInlineSystems(data, threadData);
 
 
-    solverInfo->solverStatsTmp[0] += 1;
-    solverInfo->solverStatsTmp[1] += 2;
+    solverInfo->solverStatsTmp.nStepsTaken += 1;
+    solverInfo->solverStatsTmp.nCallsODE += 2;
 
     /* save values in y2 */
     memcpy(userdata->y2, sData->realVars, data->modelData->nStates*sizeof(double));
@@ -522,8 +522,8 @@ int generateTwoApproximationsOfDifferentOrder(DATA* data, threadData_t *threadDa
     data->callback->symbolicInlineSystems(data, threadData);
 
 
-    solverInfo->solverStatsTmp[0] += 1;
-    solverInfo->solverStatsTmp[1] += 2;
+    solverInfo->solverStatsTmp.nStepsTaken += 1;
+    solverInfo->solverStatsTmp.nCallsODE += 2;
 
     /* save values in y2 */
     memcpy(userdata->y2, sData->realVars, data->modelData->nStates*sizeof(double));

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.c.inc
@@ -168,8 +168,6 @@ int FMI2CS_initializeSolverData(ModelInstance* comp)
   solverInfo->didEventStep = 0;
   solverInfo->stateEvents = 0;
   solverInfo->sampleEvents = 0;
-  solverInfo->solverStats = NULL;
-  solverInfo->solverStatsTmp = NULL;
 
   /* read fmu flags from flags.json */
   char* flags_filename = functions->allocateMemory(strlen(comp->fmuData->modelData->resourcesDir) + strlen(comp->fmuData->modelData->modelFilePrefix) + 20, sizeof(char));


### PR DESCRIPTION
### Related Issues

The ODE solver statistics are saved in an totally obscure int array of length 5.

### Purpose

I mean it's super obvious what is happening in

```C
  for(ui = 0; ui < numStatistics; ui++)
  {
    assert(10 + ui < dasslData->liw);
    solverInfo->solverStatsTmp[ui] = dasslData->iwork[10 + ui];
  }
```

and what solverStatsTmp[0] represents (sarcasm).


### Approach

Fixed this nightmare:

  - Use struct instead of int array to save solver statistics.
