### PR TITLE
[OMEdit] Fix OSG override warning

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -44,6 +44,7 @@
 #include <QImage>
 #include <QOpenGLContext> // must be included before OSG headers
 
+#include <osg/Version>
 #include <osg/Transform>
 #include <osg/AutoTransform>
 #include <osg/MatrixTransform>
@@ -87,11 +88,10 @@ public:
   UpdateVisitor& operator=(const UpdateVisitor& uv) = delete;
   virtual void apply(osg::Geode& node) override;
   virtual void apply(osg::Transform& node) override;
-  // Work-around for osg::NodeVisitor::apply(osg::AutoTransform&) (see OSG commit a4b0dc7)
-#ifdef Q_OS_WIN
+#if OSG_MIN_VERSION_REQUIRED(3, 6, 0)
   virtual void apply(osg::AutoTransform& node) override;
 #else
-  virtual void apply(osg::AutoTransform& node);
+  virtual void apply(osg::AutoTransform& node); // Work-around for osg::NodeVisitor::apply(osg::AutoTransform&) (see OSG commit a4b0dc7)
 #endif
   virtual void apply(osg::MatrixTransform& node) override;
   osg::Image* convertImage(const QImage& iImage);


### PR DESCRIPTION
### Related Issues

Improves PR #9703

### Purpose

Fix a compiler warning about method overriding, due to a workaround introduced [here](https://github.com/OpenModelica/OpenModelica/pull/9389/files#diff-d4f189122e389920b341c4ebd1676037774a662f6ad9f66fa62149ec25d8d768R90) and tentatively fixed [here](https://github.com/OpenModelica/OpenModelica/commit/e6c7e5575e1eacc65b4408c8db5ef4322bf037c2#diff-d4f189122e389920b341c4ebd1676037774a662f6ad9f66fa62149ec25d8d768) (for Windows only), which is needed for backwards compatibility with versions of OSG older than [this commit](https://github.com/openscenegraph/OpenSceneGraph/commit/a4b0dc7426ccc2023f28fba9a4d2ccf01b423744).

### Approach

Instead of checking the OS, simply check the OSG version to decide whether to override the method.