### PR TITLE
Fix memor leaks in C runtime lists

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -425,7 +425,7 @@ static const char* readFunction(const char *str, FUNCTION_INFO *xml, int i, cons
   str=skipValue(str, fileName);
   xml->id = i;
   len = str-str2;
-  name = malloc(len);
+  name = malloc(len);         // TODO AHeu: This leaks memory!
   memcpy(name, str2, len-1);
   name[len-1] = '\0';
   xml->name = name;

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_info_json.c
@@ -425,7 +425,7 @@ static const char* readFunction(const char *str, FUNCTION_INFO *xml, int i, cons
   str=skipValue(str, fileName);
   xml->id = i;
   len = str-str2;
-  name = malloc(len);         // TODO AHeu: This leaks memory!
+  name = malloc(len);
   memcpy(name, str2, len-1);
   name[len-1] = '\0';
   xml->name = name;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/events.c
@@ -295,7 +295,7 @@ double findRoot(DATA* data, threadData_t* threadData, LIST* eventList, double ti
 
   LIST_NODE* it;
   fortran_integer i=0;
-  LIST *tmpEventList = allocList(sizeof(long));
+  LIST *tmpEventList = allocList(eventListAlloc, eventListFree, eventListCopy);
 
   /* static work arrays */
   double *states_left = data->simulationInfo->states_left;
@@ -494,6 +494,37 @@ void saveZeroCrossingsAfterEvent(DATA *data, threadData_t *threadData)
   TRACE_POP
 }
 
+/**
+ * @brief Allocate memory for eventList elements.
+ *
+ * @param data      Unused.
+ * @return void*    Allocated memory for LIST_NODE data.
+ */
+void* eventListAlloc(const void* data) {
+  void* newElem = malloc(sizeof(long));
+  assertStreamPrint(NULL, newElem != NULL, "eventListAlloc: Out of memory");
+  return newElem;
+}
+
+/**
+ * @brief Free memory allocated with eventListAlloc.
+ *
+ * @param data      Void pointer, representing index for new list element.
+ */
+void eventListFree(void* data) {
+  free(data);
+}
+
+/**
+ * @brief Copy data of eventList elements.
+ *
+ * @param dest    Void pointer of destination data, representing long index.
+ * @param src     Void pointer of source data, representing long index.
+ */
+void eventListCopy(void* dest, const void* src) {
+  long* dest_event = (long*) dest;
+  *dest_event = *((long*) src);
+}
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/events.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/events.h
@@ -53,6 +53,9 @@ void handleEvents(DATA* data, threadData_t *threadData, LIST* eventLst, double *
 double findRoot(DATA* data, threadData_t* threadData, LIST* eventList, double time_left, double* states_left, double time_right, double* states_right);
 int checkZeroCrossings(DATA *data, LIST *tmpEventList, LIST *eventList);
 
+void* eventListAlloc(const void* data);
+void eventListFree(void* data);
+void eventListCopy(void* dest, const void* src);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
@@ -164,7 +164,7 @@ double findRoot_gb(DATA* data, threadData_t* threadData, SOLVER_INFO* solverInfo
 
   LIST_NODE* it;
   fortran_integer i=0;
-  LIST *tmpEventList = allocList(sizeof(long));
+  LIST *tmpEventList = allocList(eventListAlloc, eventListFree, eventListCopy);
 
   /* static work arrays */
   double *states_left = data->simulationInfo->states_left;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -57,6 +57,11 @@
   #include <omp.h>
 #endif
 
+/* Private function prototypes */
+void* syncTimerListAlloc(const void* data);
+void syncTimerListFree(void* data);
+void syncTimerListCopy(void* dest, const void* src);
+
 int maxEventIterations = 20;
 double linearSparseSolverMaxDensity = DEFAULT_FLAG_LSS_MAX_DENSITY;
 int linearSparseSolverMinSize = DEFAULT_FLAG_LSS_MIN_SIZE;
@@ -1045,7 +1050,7 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
 
   if (data->modelData->nBaseClocks > 0) {
     data->simulationInfo->baseClocks = (BASECLOCK_DATA*) calloc(data->modelData->nBaseClocks, sizeof(BASECLOCK_DATA));
-    data->simulationInfo->intvlTimers = allocList(sizeof(SYNC_TIMER));
+    data->simulationInfo->intvlTimers = allocList(syncTimerListAlloc, syncTimerListFree, syncTimerListCopy);
   } else {
     data->simulationInfo->baseClocks = NULL;
     data->simulationInfo->intvlTimers = NULL;
@@ -1616,5 +1621,38 @@ modelica_real _event_div_real(modelica_real x1, modelica_real x2, modelica_integ
   return trunc(value1/value2);
 #endif
 }
+
+
+/**
+ * @brief Allocate memory for syncTimerList elements.
+ *
+ * @param data      Unused.
+ * @return void*    Allocated memory for LIST_NODE data.
+ */
+void* syncTimerListAlloc(const void* data) {
+  void* newElem = malloc(sizeof(SYNC_TIMER));
+  assertStreamPrint(NULL, newElem != NULL, "syncTimerListAlloc: Out of memory");
+  return newElem;
+}
+
+/**
+ * @brief Free memory allocated with syncTimerListAlloc.
+ *
+ * @param data      Void pointer, representing SYNC_TIMER.
+ */
+void syncTimerListFree(void* data) {
+  free(data);
+}
+
+/**
+ * @brief Copy data of syncTimerList elements.
+ *
+ * @param dest    Void pointer of destination data, representing SYNC_TIMER.
+ * @param src     Void pointer of source data, representing SYNC_TIMER.
+ */
+void syncTimerListCopy(void* dest, const void* src) {
+  memcpy(dest, src, sizeof(SYNC_TIMER));
+}
+
 
 int measure_time_flag=0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -425,7 +425,7 @@ void initializeNonlinearSystemData(DATA *data, threadData_t *threadData, NONLINE
   nonlinsys->resValues = (double*) malloc(size*sizeof(double));
 
   /* allocate value list*/
-  nonlinsys->oldValueList = (void*) allocValueList(1);
+  nonlinsys->oldValueList = allocValueList(1, nonlinsys->size);
 
   nonlinsys->lastTimeSolved = 0.0;
 
@@ -870,9 +870,9 @@ void printNonLinearFinishInfo(int logName, DATA* data, NONLINEAR_SYSTEM_DATA *no
 int getInitialGuess(NONLINEAR_SYSTEM_DATA *nonlinsys, double time)
 {
   /* value extrapolation */
-  printValuesListTimes((VALUES_LIST*)nonlinsys->oldValueList);
+  printValuesListTimes(nonlinsys->oldValueList->valueList);
   /* if list is empty use current start values */
-  if (listLen(((VALUES_LIST*)nonlinsys->oldValueList)->valueList)==0)
+  if (listLen(nonlinsys->oldValueList->valueList)==0)
   {
     /* use old value if no values are stored in the list */
     memcpy(nonlinsys->nlsx, nonlinsys->nlsxOld, nonlinsys->size*(sizeof(double)));
@@ -880,7 +880,7 @@ int getInitialGuess(NONLINEAR_SYSTEM_DATA *nonlinsys, double time)
   else
   {
     /* get extrapolated values */
-    getValues((VALUES_LIST*)nonlinsys->oldValueList, time, nonlinsys->nlsxExtrapolation, nonlinsys->nlsxOld);
+    getValues(nonlinsys->oldValueList->valueList, time, nonlinsys->nlsxExtrapolation, nonlinsys->nlsxOld);
     memcpy(nonlinsys->nlsx, nonlinsys->nlsxOld, nonlinsys->size*(sizeof(double)));
   }
 
@@ -898,27 +898,34 @@ int getInitialGuess(NONLINEAR_SYSTEM_DATA *nonlinsys, double time)
  */
 int updateInitialGuessDB(NONLINEAR_SYSTEM_DATA *nonlinsys, double time, EVAL_CONTEXT context)
 {
+  /* Variables */
+  VALUE* tmpNode;
+
   /* write solution to oldValue list for extrapolation */
   if (nonlinsys->solved == NLS_SOLVED)
   {
     /* do not use solution of jacobian for next extrapolation */
     if (context == CONTEXT_ODE || context == CONTEXT_ALGEBRAIC || context == CONTEXT_EVENTS)
     {
-      addListElement((VALUES_LIST*)nonlinsys->oldValueList,
-                     createValueElement(nonlinsys->size, time, nonlinsys->nlsx));
+      tmpNode = createValueElement(nonlinsys->size, time, nonlinsys->nlsx);
+      addListElement(nonlinsys->oldValueList->valueList,
+                     tmpNode);
+      freeValue(tmpNode);
     }
   }
   else if (nonlinsys->solved == NLS_SOLVED_LESS_ACCURACY)
   {
-    if (listLen(((VALUES_LIST*)nonlinsys->oldValueList)->valueList)>0)
+    if (listLen((nonlinsys->oldValueList)->valueList)>0)
     {
-      cleanValueList((VALUES_LIST*)nonlinsys->oldValueList, NULL);
+      cleanValueList(nonlinsys->oldValueList->valueList, NULL);
     }
     /* do not use solution of jacobian for next extrapolation */
     if (context == CONTEXT_ODE || context == CONTEXT_ALGEBRAIC || context == CONTEXT_EVENTS)
     {
-      addListElement((VALUES_LIST*)nonlinsys->oldValueList,
-                     createValueElement(nonlinsys->size, time, nonlinsys->nlsx));
+      tmpNode = createValueElement(nonlinsys->size, time, nonlinsys->nlsx);
+      addListElement(nonlinsys->oldValueList->valueList,
+                     tmpNode);
+      freeValue(tmpNode);
     }
   }
   return 0;
@@ -1484,7 +1491,7 @@ void cleanUpOldValueListAfterEvent(DATA *data, double time)
   NONLINEAR_SYSTEM_DATA* nonlinsys = data->simulationInfo->nonlinearSystemData;
 
   for(i=0; i<data->modelData->nNonLinearSystems; ++i) {
-    cleanValueListbyTime(nonlinsys[i].oldValueList, time);
+    cleanValueListbyTime(nonlinsys[i].oldValueList->valueList, time);
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearValuesList.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearValuesList.c
@@ -322,8 +322,8 @@ void getValues(LIST* valuesList, double time, double* extrapolatedValues, double
   if (old2 == NULL)
   {
     oldValues = (VALUE*) listNodeData(old);
-    memcpy(extrapolatedValues, oldValues->values, oldValues->size*sizeof(double));    // TODO AHeu: Invalid read!
-    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));             // TODO AHeu: Invalid read?
+    memcpy(extrapolatedValues, oldValues->values, oldValues->size*sizeof(double));
+    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "take just old values.");
   }
   else
@@ -336,9 +336,9 @@ void getValues(LIST* valuesList, double time, double* extrapolatedValues, double
     printValueElement(old2Values);
     for(i = 0; i < oldValues->size; ++i)
     {
-      extrapolatedValues[i] = extrapolateValues(time, oldValues->values[i], oldValues->time, old2Values->values[i], old2Values->time);    // TODO AHeu: Invalid read!
+      extrapolatedValues[i] = extrapolateValues(time, oldValues->values[i], oldValues->time, old2Values->values[i], old2Values->time);
     }
-    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));     // TODO AHeu: Invalid read!
+    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));
   }
   messageClose(LOG_NLS_EXTRAPOLATE);
   return;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearValuesList.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearValuesList.c
@@ -47,36 +47,43 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define UNUSED(x) (void)(x)
+
 /* Forward extrapolate function definition */
 double extrapolateValues(const double, const double, const double, const double, const double);
 
-VALUES_LIST* allocValueList(unsigned int numberOfList)
+/**
+ * @brief Allocate value lists.
+ *
+ * @param numberOfList    Number of lists to allocate.
+ * @param valueSize       Length of array double* values
+ * @return VALUES_LIST*   Array of value lists.
+ */
+VALUES_LIST* allocValueList(unsigned int numberOfList, unsigned int valueSize)
 {
   unsigned int i = 0;
   VALUES_LIST* valueList = (VALUES_LIST*) malloc(numberOfList*sizeof(VALUES_LIST));
 
-  for(i=0; i<numberOfList; ++i){
-    (valueList+i)->valueList = allocList(sizeof(VALUE));
+  unsigned int itemSize = sizeof(VALUE) + valueSize*sizeof(double);
+  for(i=0; i<numberOfList; i++) {
+    valueList[i].valueList = allocList(itemSize);
   }
 
   return valueList;
 }
 
-void freeValueList(VALUES_LIST *valueList, unsigned int numberOfList)
+/**
+ * @brief Free array of value lists.
+ *
+ * @param valueList       Array of value lists.
+ * @param numberOfList    Length of array valueList.
+ */
+void freeValueList(VALUES_LIST* valueList, unsigned int numberOfList)
 {
-  VALUE* elem;
-  VALUES_LIST *tmpList;
+  unsigned int i = 0;
 
-  int i,j;
-  for(j = 0; j < numberOfList; ++j)
-  {
-    tmpList = valueList+j;
-    for(i = 0; i < listLen(tmpList->valueList); ++i)
-    {
-      elem = (VALUE*) listFirstData(tmpList->valueList);
-      listRemoveFront(tmpList->valueList);
-    }
-    freeList(tmpList->valueList);
+  for(i=0; i<numberOfList; i++) {
+    freeList(valueList[i].valueList);
   }
   free(valueList);
 }
@@ -88,25 +95,14 @@ void freeValueList(VALUES_LIST *valueList, unsigned int numberOfList)
  * @param valueList    Pointer to value list
  * @param startNode    Pointer to list node, following nodes will be deleted
  */
-void cleanValueList(VALUES_LIST *valueList, LIST_NODE *startNode)
+void cleanValueList(LIST* valueList, LIST_NODE *startNode)
 {
   int len;
   if(startNode)
   {
-    /* clean list from next node */
-    len = listLen(valueList->valueList);
-    infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "cleanValueList length: %d", len);
-    LIST_NODE *node = updateNodeNext(valueList->valueList, startNode, NULL);
-    while(node)
-    {
-      LIST_NODE *tmpNode = listNextNode(node);
-      freeNode(node);
-      node = tmpNode;
-      len--;
-    }
-    updatelistLength(valueList->valueList, len);
+    listClearAfterNode(valueList, startNode);
   }
-  else listClear(valueList->valueList);
+  else listClear(valueList);
 }
 
 /**
@@ -115,20 +111,21 @@ void cleanValueList(VALUES_LIST *valueList, LIST_NODE *startNode)
  * @param valueList    Pointer to value list
  * @param time         time
  */
-void cleanValueListbyTime(VALUES_LIST *valueList, double time)
+void cleanValueListbyTime(LIST *valueList, double time)
 {
   LIST_NODE *next, *it;
   VALUE* elem;
 
   printValuesListTimes(valueList);
   // need to get first node at each iteration since head is removed
-  for(it = listFirstNode(valueList->valueList); it; it = listFirstNode(valueList->valueList))
+  for(it = listFirstNode(valueList); it; it = listFirstNode(valueList))
   {
+    assert(it != NULL);
     elem = (VALUE*)listNodeData(it);
     if (elem->time <= time)
     {
       cleanValueList(valueList, it);
-      infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "New list length %d: ", listLen(valueList->valueList));
+      infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "New list length %d: ", listLen(valueList));
       printValuesListTimes(valueList);
       infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "Done!");
       break;
@@ -137,54 +134,64 @@ void cleanValueListbyTime(VALUES_LIST *valueList, double time)
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "cleanValueListbyTime %g check element: ", time);
     printValueElement(elem);
 
-    listRemoveFront(valueList->valueList);
+    listRemoveFront(valueList);
   }
 }
 
 /**
- * @brief Creates a new value element for a value list.
+ * @brief Create new value element for value list.
  *
- * @param size      size of values array
- * @param time      time
- * @param values    array of values
+ * @param size      Length of values array.
+ * @param time      Time
+ * @param values    Array of values
  */
 VALUE* createValueElement(unsigned int size, double time, double* values)
 {
-  VALUE* elem = (VALUE*) malloc(sizeof(VALUE));
-  elem->values = (double*) malloc(size*sizeof(double));
+  VALUE* elem = calloc(1, sizeof(VALUE));
+  elem->values = calloc(size, sizeof(double));
   elem->time = time;
   elem->size = size;
 
   memcpy(elem->values, values, size*sizeof(double));
 
   /* debug output */
-  infoStreamPrint(LOG_NLS_EXTRAPOLATE, 1, "Create Element");
-  messageClose(LOG_NLS_EXTRAPOLATE);
+  infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "Create Element");
 
   return elem;
 }
 
+/**
+ * @brief Free value element allocated with createValueElement
+ *
+ * @param elem    Value element to free.
+ */
 void freeValue(VALUE* elem)
 {
   free(elem->values);
   free(elem);
 }
 
-void addListElement(VALUES_LIST* valuesList, VALUE* newElem)
+/**
+ * @brief Adds copy of new element to list.
+ *
+ * @param valuesList    List
+ * @param newElem       New element to add to list.
+ */
+void addListElement(LIST* valuesList, VALUE* newElem)
 {
   LIST_NODE *node, *next;
   VALUE* elem;
   int replace = 0, i = 0;
 
   /* debug output */
-  infoStreamPrint(LOG_NLS_EXTRAPOLATE, 1, "Adding element in a list of size %d", listLen(valuesList->valueList));
+  infoStreamPrint(LOG_NLS_EXTRAPOLATE, 1, "Adding element in a list of size %d", listLen(valuesList));
   printValueElement(newElem);
 
-  /*  if it's empty, just push in  */
-  if (listLen(valuesList->valueList) == 0)
+  /*  if it's empty, just push it in */
+  if (listLen(valuesList) == 0)
   {
-    infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "List is empty add just.");
-    listPushFront(valuesList->valueList, (void*) newElem);
+    infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "List is empty add new element.");
+    listPushFront(valuesList, (void*) newElem);
 
     messageClose(LOG_NLS_EXTRAPOLATE);
     return;
@@ -193,13 +200,13 @@ void addListElement(VALUES_LIST* valuesList, VALUE* newElem)
   /*  if the element at begin is earlier than current
    *  push the element just in front and if the end element
    *  is later than current push it just back.*/
-  node = listFirstNode(valuesList->valueList);
+  node = listFirstNode(valuesList);
   if ( fabs( ((VALUE*)listNodeData(node))->time - newElem->time ) > MINIMAL_STEP_SIZE )
   {
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "First Value list element is:");
     printValueElement(((VALUE*)listNodeData(node)));
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "so new element is added before.");
-    listPushFront(valuesList->valueList, (void*) newElem);
+    listPushFront(valuesList, (void*) newElem);
 
     messageClose(LOG_NLS_EXTRAPOLATE);
     return;
@@ -241,15 +248,15 @@ void addListElement(VALUES_LIST* valuesList, VALUE* newElem)
   /* add element before currect node */
   if (!replace){
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "Insert element before last output element.");
-    listInsert(valuesList->valueList, node, (void*) newElem);
+    listInsert(valuesList, node, (void*) newElem);
   }
   else
   {
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "replace element.");
-    updateNodeData(valuesList->valueList, next, (void*) newElem);
+    updateNodeData(valuesList, next, (void*) newElem);
   }
   /*  clean list if too full */
-  if (i < 3 && listLen(valuesList->valueList)>10)
+  if (i < 3 && listLen(valuesList)>10)
   {
     while(i < 4)
     {
@@ -271,17 +278,17 @@ void addListElement(VALUES_LIST* valuesList, VALUE* newElem)
  * @param extrapolatedValues    values extrapolated (overwritten)
  * @param oldOutput             old values just before time
  */
-void getValues(VALUES_LIST* valuesList, double time, double* extrapolatedValues, double* oldOutput)
+void getValues(LIST* valuesList, double time, double* extrapolatedValues, double* oldOutput)
 {
   LIST_NODE *it;
   LIST_NODE *old = NULL;
   LIST_NODE *old2 = NULL;
   VALUE *oldValues, *old2Values, *elem;
 
-  infoStreamPrint(LOG_NLS_EXTRAPOLATE, 1, "Get values for time %g in a list of size %d", time, listLen(valuesList->valueList));
+  infoStreamPrint(LOG_NLS_EXTRAPOLATE, 1, "Get values for time %g in a list of size %d", time, listLen(valuesList));
 
   /* find corresponding values */
-  for(it = listFirstNode(valuesList->valueList); it; it = listNextNode(it))
+  for(it = listFirstNode(valuesList); it; it = listNextNode(it))
   {
     elem = (VALUE*)listNodeData(it);
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "Searching current element:");
@@ -313,8 +320,8 @@ void getValues(VALUES_LIST* valuesList, double time, double* extrapolatedValues,
   if (old2 == NULL)
   {
     oldValues = (VALUE*) listNodeData(old);
-    memcpy(extrapolatedValues, oldValues->values, oldValues->size*sizeof(double));
-    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));
+    memcpy(extrapolatedValues, oldValues->values, oldValues->size*sizeof(double));    // TODO AHeu: Invalid read!
+    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));             // TODO AHeu: Invalid read?
     infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "take just old values.");
   }
   else
@@ -327,9 +334,9 @@ void getValues(VALUES_LIST* valuesList, double time, double* extrapolatedValues,
     printValueElement(old2Values);
     for(i = 0; i < oldValues->size; ++i)
     {
-      extrapolatedValues[i] = extrapolateValues(time, oldValues->values[i], oldValues->time, old2Values->values[i], old2Values->time);
+      extrapolatedValues[i] = extrapolateValues(time, oldValues->values[i], oldValues->time, old2Values->values[i], old2Values->time);    // TODO AHeu: Invalid read!
     }
-    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));
+    memcpy(oldOutput, oldValues->values, oldValues->size*sizeof(double));     // TODO AHeu: Invalid read!
   }
   messageClose(LOG_NLS_EXTRAPOLATE);
   return;
@@ -349,31 +356,30 @@ void printValueElement(VALUE* elem)
   }
 }
 
-void printValuesListTimes(VALUES_LIST* list)
-{
-  /* debug output */
-  if(ACTIVE_STREAM(LOG_NLS_EXTRAPOLATE))
-  {
-    int i;
-    LIST_NODE *it;
-    VALUE *elem;
+/**
+ * @brief Print function for printValuesListTimes
+ *
+ * @param data      Data of node of type VALUE*
+ * @param stream    Stream to output to.
+ * @param unused    Unused
+ */
+static void printElemTimes(void* data, int stream, void* unused) {
+  UNUSED(unused);
+  VALUE* elem = (VALUE*) data;
 
-    infoStreamPrint(LOG_NLS_EXTRAPOLATE, 1, "Print all elements");
-    it = listFirstNode(list->valueList);
-    if(!it)
-    {
-      infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "List is empty!");
-    }
-    else
-    {
-      /* go though the list */
-      for(i = 0; it; it = listNextNode(it)) {
-        elem = (VALUE*)listNodeData(it);
-        infoStreamPrint(LOG_NLS_EXTRAPOLATE, 0, "Element %d at time %g", i++, elem->time);
-      }
-    }
-    messageClose(LOG_NLS_EXTRAPOLATE);
+  unsigned int i;
+  for(i=0; i<elem->size; i++) {
+    infoStreamPrint(stream, 0, "Element %d at time %g", i, elem->time);
   }
+}
+
+/**
+ * @brief Print value times of value list.
+ *
+ * @param list    Value list.
+ */
+void printValuesListTimes(LIST* list) {
+  printList(list, LOG_NLS_EXTRAPOLATE, printElemTimes);
 }
 
 /*! \fn extraPolateValues

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearValuesList.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearValuesList.h
@@ -39,36 +39,29 @@
 
 #include "../../util/list.h"
 
-typedef struct VALUES_LIST
-{
+typedef struct VALUES_LIST {
   LIST* valueList;
 } VALUES_LIST;
 
-typedef struct VALUE
-{
-  double time;
-  unsigned int size;
-  double *values;
+typedef struct VALUE {
+  double time;            /* Time value */
+  unsigned int size;      /* Length of array values */
+  double *values;         /* Array with values */
 } VALUE;
 
-
-VALUES_LIST *allocValueList(const unsigned int numberOfLists);
-void freeValueList(VALUES_LIST *valueList, unsigned int numberOfLists);
+VALUES_LIST* allocValueList(unsigned int numberOfList, unsigned int valueSize);
+void freeValueList(VALUES_LIST* valueList, unsigned int numberOfLists);
 
 VALUE* createValueElement(unsigned int size, double time, double* values);
 void freeValue(VALUE* elem);
-void cleanValueList(VALUES_LIST *valueListm, LIST_NODE* next);
-void cleanValueListbyTime(VALUES_LIST *valueList, double time);
+void cleanValueList(LIST* valueList, LIST_NODE *startNode);
+void cleanValueListbyTime(LIST *valueList, double time);
 void removeListNodes(LIST* list, LIST_NODE *node);
 
-void addListElement(VALUES_LIST* valueList, VALUE* elem);
-void getValues(VALUES_LIST* valueList, double time, double* values, double* oldOutput);
+void addListElement(LIST* valueList, VALUE* elem);
+void getValues(LIST* valueList, double time, double* values, double* oldOutput);
 
 void printValueElement(VALUE* elem);
-void printValuesListTimes(VALUES_LIST* list);
-
-
+void printValuesListTimes(LIST* list);
 
 #endif
-
-

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/perform_simulation.c.inc
@@ -365,10 +365,9 @@ static void retrySimulationStep(DATA* data, threadData_t *threadData, SOLVER_INF
 
 static void saveIntegratorStats(SOLVER_INFO* solverInfo)
 {
-  int ui;
   if (!(omc_flag[FLAG_NO_RESTART] && solverInfo->solverMethod==S_DASSL) && solverInfo->didEventStep)
   {
-    addSolverStats(&solverInfo->solverStats, &solverInfo->solverStatsTmp);
+    addSolverStats(&(solverInfo->solverStats), &(solverInfo->solverStatsTmp));
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -615,7 +615,7 @@ int finishSimulation(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
     else
     {
       /* save stats before print */
-      addSolverStats(&solverInfo->solverStats, &solverInfo->solverStatsTmp);
+      addSolverStats(&(solverInfo->solverStats), &(solverInfo->solverStatsTmp));
 
       infoStreamPrint(LOG_STATS, 1, "solver: %s", SOLVER_METHOD_NAME[solverInfo->solverMethod]);
       infoStreamPrint(LOG_STATS, 0, "%5d steps taken", solverInfo->solverStats.nStepsTaken);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -221,7 +221,7 @@ int initializeSolverData(DATA* data, threadData_t *threadData, SOLVER_INFO* solv
   solverInfo->solverRootFinding = 0;
   solverInfo->solverNoEquidistantGrid = 0;
   solverInfo->lastdesiredStep = solverInfo->currentTime + solverInfo->currentStepSize;
-  solverInfo->eventLst = allocList(sizeof(long));
+  solverInfo->eventLst = allocList(eventListAlloc, eventListFree, eventListCopy);
   solverInfo->didEventStep = 0;
   solverInfo->stateEvents = 0;
   solverInfo->sampleEvents = 0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.h
@@ -70,7 +70,7 @@ typedef struct SOLVER_INFO
   double lastdesiredStep;
 
   /* events */
-  LIST* eventLst;
+  LIST* eventLst;         /* List with long indices from data->simulationInfo->zeroCrossingIndex */
   int didEventStep;       /* Boolean stating if during the last step an event was encountered,
                            * Used to reinitialize ODE/DAE solver after event iteration */
 

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -65,6 +65,7 @@
 /* Forward declarations */
 struct DATA;
 typedef struct DATA DATA;
+typedef struct VALUES_LIST VALUES_LIST;
 
 /* Model info structures */
 typedef struct VAR_INFO
@@ -327,7 +328,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
   modelica_real *nlsxOld;              /* previous x */
   modelica_real *nlsxExtrapolation;    /* extrapolated values for x from old and old2 - used as initial guess */
 
-  void *oldValueList;                  /* old values organized in a sorted list for extrapolation and interpolate, respectively */
+  VALUES_LIST *oldValueList;           /* old values organized in a sorted list for extrapolation and interpolate, respectively */
   modelica_real *resValues;            /* memory space for evaluated residual values */
 
   NLS_SOLVER_STATUS solved;            /* Specifiex if the NLS could be solved (with less accuracy) or failed */

--- a/OMCompiler/SimulationRuntime/c/util/list.c
+++ b/OMCompiler/SimulationRuntime/c/util/list.c
@@ -115,7 +115,7 @@ void listPushFront(LIST *list, const void *data)
   tmpNode->data = malloc(list->itemSize);
   assertStreamPrint(NULL, 0 != tmpNode->data, "out of memory");
 
-  memcpy(tmpNode->data, data, list->itemSize);
+  memcpy(tmpNode->data, data, list->itemSize);      // TODO AHeu: Invalid read, size doesn't match createValueElement?
   tmpNode->next = list->first;
   ++(list->length);
 
@@ -173,7 +173,7 @@ void listPushBack(LIST *list, const void *data)
 }
 
 /**
- * @brief Copies data into new tmpNode and inserts tmpNode into list after prevNode
+ * @brief Copies data into new node and inserts it into list after prevNode
  *
  * @param list       Pointer to list
  * @param prevNode   Pointer to previous node
@@ -300,6 +300,31 @@ void listClear(LIST *list)
 }
 
 /**
+ * @brief Remove all nodes after startNode from list.
+ *
+ * Checks if startNode is part of list.
+ *
+ * @param list        List to remove elements from.
+ * @param startNode   Node to remove after. startNode won't be removed.
+ */
+void listClearAfterNode(LIST *list, LIST_NODE *startNode) {
+  assertStreamPrint(NULL, 0 != list, "invalid list-pointer");
+  assertStreamPrint(NULL, 0 != startNode, "invalid list-node");
+
+  assertStreamPrint(NULL, listIsIn(list, startNode), "listClearAfterNode: start node not in list!");
+
+  LIST_NODE* delNode = startNode->next;
+  while (delNode) {
+    LIST_NODE* nextNode = delNode->next;
+    freeNode(delNode);
+    list->length--;
+    delNode = nextNode;
+  }
+  startNode->next = NULL;
+  list->last = startNode;
+}
+
+/**
  * @brief Retruns first node of list
  *
  * @param list    Pointer to list
@@ -324,7 +349,30 @@ LIST_NODE *listNextNode(LIST_NODE *node)
 }
 
 /**
- * @brief Returns node data
+ * @brief Test if node is in list
+ *
+ * @param list                  Pointer to List.
+ * @param node                  Node to test if in list.
+ * @return modelica_boolean     True if node is in list, false otherwise.
+ */
+modelica_boolean listIsIn(LIST *list, LIST_NODE *node) {
+  assertStreamPrint(NULL, 0 != list, "invalid list-pointer");
+  assertStreamPrint(NULL, 0 != node, "invalid list-node");
+
+  modelica_boolean isIn = FALSE;
+  LIST_NODE* tmpNode = list->first;
+  while (tmpNode) {
+    if (node == tmpNode) {
+      return TRUE;
+    }
+    tmpNode = tmpNode->next;
+  }
+
+  return FALSE;
+}
+
+/**
+ * @brief Returns node data.
  *
  * @param node    Pointer to node
  * @return        Pointer to data
@@ -336,7 +384,13 @@ void *listNodeData(LIST_NODE *node)
   return node->data;
 }
 
-/* not sure about this, looks dangerous */
+/**
+ * @brief Copy content of data into node data.
+ *
+ * @param list    List containing node.
+ * @param node    Node to update.
+ * @param data    Data to copy into node data.
+ */
 void updateNodeData(LIST *list, LIST_NODE *node, const void *data)
 {
   assertStreamPrint(NULL, 0 != list, "invalid list-pointer");
@@ -344,31 +398,6 @@ void updateNodeData(LIST *list, LIST_NODE *node, const void *data)
   assertStreamPrint(NULL, 0 != node->data, "invalid list-data");
   memcpy(node->data, data, list->itemSize);
   return;
-}
-
-/* not sure about this, looks dangerous */
-LIST_NODE* updateNodeNext(LIST *list, LIST_NODE *node, LIST_NODE *newNext)
-{
-  assertStreamPrint(NULL, 0 != list, "invalid list-pointer");
-  assertStreamPrint(NULL, 0 != node, "invalid list-node");
-  LIST_NODE *next = node->next;
-  node->next = newNext;
-  return next;
-}
-
-/* not sure about this, looks dangerous */
-void updatelistFirst(LIST* list, LIST_NODE *node)
-{
-  assertStreamPrint(NULL, 0 != list, "invalid list-pointer");
-  assertStreamPrint(NULL, 0 != node, "invalid list-node");
-  list->first = node;
-}
-
-/* not sure about this, looks dangerous */
-void updatelistLength(LIST* list, unsigned int newLength)
-{
-  assertStreamPrint(NULL, 0 != list, "invalid list-pointer");
-  list->length = newLength;
 }
 
 /**

--- a/OMCompiler/SimulationRuntime/c/util/list.c
+++ b/OMCompiler/SimulationRuntime/c/util/list.c
@@ -40,6 +40,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Private function prototypes */
+modelica_boolean listIsIn(LIST *list, LIST_NODE *node);
+
 struct LIST_NODE
 {
   void *data;         /* Data of list element.

--- a/OMCompiler/SimulationRuntime/c/util/list.h
+++ b/OMCompiler/SimulationRuntime/c/util/list.h
@@ -37,7 +37,7 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
-#include "openmodelica_types.h"
+#include "../openmodelica_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/OMCompiler/SimulationRuntime/c/util/list.h
+++ b/OMCompiler/SimulationRuntime/c/util/list.h
@@ -50,7 +50,12 @@ extern "C" {
   struct LIST;
   typedef struct LIST LIST;
 
-  LIST *allocList(unsigned int itemSize);
+
+  typedef void*(allocListNodeDataFunc_t)(const void* data);
+  typedef void(freeListNodeDataFunc_t)(void* data);
+  typedef void(copyListNodeDataFunc_t)(void* dest, const void* src);
+
+  LIST *allocList(allocListNodeDataFunc_t* allocListNodeFunc, freeListNodeDataFunc_t* freeListNodeFunc, copyListNodeDataFunc_t* copyListNodeDataFunc);
   void freeList(LIST *list);
 
   void listPushFront(LIST *list, const void *data);
@@ -68,7 +73,7 @@ extern "C" {
 
   void listClear(LIST *list);
   void listClearAfterNode(LIST *list, LIST_NODE *startNode);
-  void freeNode(LIST_NODE *node);
+  void freeNode(LIST *list, LIST_NODE *node);
 
   LIST_NODE *listFirstNode(LIST *list);
   LIST_NODE *listNextNode(LIST_NODE *node);

--- a/OMCompiler/SimulationRuntime/c/util/list.h
+++ b/OMCompiler/SimulationRuntime/c/util/list.h
@@ -37,8 +37,6 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
-#include "../openmodelica_types.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,7 +75,6 @@ extern "C" {
 
   LIST_NODE *listFirstNode(LIST *list);
   LIST_NODE *listNextNode(LIST_NODE *node);
-  modelica_boolean listIsIn(LIST *list, LIST_NODE *node);
 
   void *listNodeData(LIST_NODE *node);
   void updateNodeData(LIST *list, LIST_NODE *node, const void *data);

--- a/OMCompiler/SimulationRuntime/c/util/list.h
+++ b/OMCompiler/SimulationRuntime/c/util/list.h
@@ -37,6 +37,8 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
+#include "openmodelica_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -65,16 +67,15 @@ extern "C" {
   void listRemoveFront(LIST *list);
 
   void listClear(LIST *list);
+  void listClearAfterNode(LIST *list, LIST_NODE *startNode);
   void freeNode(LIST_NODE *node);
 
   LIST_NODE *listFirstNode(LIST *list);
   LIST_NODE *listNextNode(LIST_NODE *node);
+  modelica_boolean listIsIn(LIST *list, LIST_NODE *node);
 
   void *listNodeData(LIST_NODE *node);
   void updateNodeData(LIST *list, LIST_NODE *node, const void *data);
-  LIST_NODE* updateNodeNext(LIST *list, LIST_NODE *node, LIST_NODE *newNext);
-  void updatelistFirst(LIST* list, LIST_NODE *node);
-  void updatelistLength(LIST* list, unsigned int newLength);
   void printList(LIST* list, int stream, void (*printDataFunc)(void*,int,void*));
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Related Issues

Fixes #9442.

### Purpose

Fix memory leaks in list handling from updateInitialGuessDB.

### Approach

  - Rework Lists completely.
    - All lists need functions for memory allocation, memory freeing and copying of list elements data.
    - Improve code quality of some list functions
    - Removed "dangerous" list functions that can easily leak memory
