### PR TITLE
fixing compilation issue

### DIFF
--- a/OMEdit/OMEditLIB/Animation/ExtraShapes.cpp
+++ b/OMEdit/OMEditLIB/Animation/ExtraShapes.cpp
@@ -37,6 +37,8 @@
 #endif
 #include <cmath>
 
+#include <QOpenGLContext> // must be included before OSG headers
+
 #include <osg/LightModel>
 #include <osg/StateAttribute>
 #include <osg/StateSet>


### PR DESCRIPTION
### Related Issues

#9145 

### Purpose

QOpenGLContext header missing for OMEdit/OMEditLIB/Animation/ExtraShapes.cpp


### Approach

added the missing include
