### PR TITLE
Check for __linux__ instead of linux.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_segv.h
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_segv.h
@@ -57,7 +57,7 @@ static inline void mmc_init_stackoverflow(threadData_t *threadData)
 void mmc_init_stackoverflow(threadData_t *threadData);
 #endif
 
-#if defined(linux)
+#if defined(__linux__)
 static inline void mmc_init_stackoverflow_fast(threadData_t *threadData, threadData_t *oldThreadData)
 {
   if (oldThreadData)


### PR DESCRIPTION
  - This check decided whether omc would refetch the stack base or whether it would use what was already saved in the threadData. Refetching the stack base is quite expensive on Linux.

    The macro `linux` seems to be defined somewhere for the autoconf build system. For CMake build, however, it is not defined. Instead the macro `__linux__` is defined. Use this macro since it should work for both build systems.

   - This was making OMEdit startup quite slow because OMEdit was making a lot of calls to omc that cause the stackbase to be refetched on each call (e.g. inside `OMCProxy::sendCommand`).

  - There are still remaining uses of `linux` macro in the rest of the OpenModelica source code. They should also be fixed.

  - We should probably check if the issue occurs on `macOS` as well. If it does maybe we should cover all `unix` systems instead of just `linux`.