### PR TITLE
Improve getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -153,6 +153,14 @@ algorithm
   end match;
 end addElement;
 
+function addElementNotNull
+  input JSON value;
+  input JSON obj;
+  output JSON outObj;
+algorithm
+  outObj := if isNull(value) then obj else addElement(value, obj);
+end addElementNotNull;
+
 function addPair
   "Adds a key-value pair to a JSON object, or returns a new object with the
    key-value pair if the JSON is null."

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -97,6 +97,7 @@ import SCodeUtil;
 import ElementSource;
 import InstSettings = NFInst.InstSettings;
 import Testsuite;
+import MetaModelica.Dangerous.listReverseInPlace;
 
 
 public
@@ -828,10 +829,6 @@ algorithm
   end match;
 end getInheritedClasses;
 
-function instAnnotation
-
-end instAnnotation;
-
 uniontype InstanceTree
   record COMPONENT
     InstNode node;
@@ -840,8 +837,8 @@ uniontype InstanceTree
 
   record CLASS
     InstNode node;
-    list<InstanceTree> exts;
-    list<InstanceTree> components;
+    list<InstanceTree> elements;
+    Boolean isExtends;
   end CLASS;
 
   record EMPTY
@@ -903,12 +900,13 @@ function buildInstanceTree
   input Boolean isDerived = false;
   output InstanceTree tree;
 protected
+  InstNode cls_node;
   Class cls;
   ClassTree cls_tree;
-  list<InstanceTree> exts, components;
-  array<InstNode> ext_nodes;
+  list<InstanceTree> elems;
 algorithm
-  cls := InstNode.getClass(InstNode.resolveInner(node));
+  cls_node := InstNode.resolveInner(node);
+  cls := InstNode.getClass(cls_node);
 
   if not isDerived and Class.isOnlyBuiltin(cls) then
     tree := InstanceTree.EMPTY();
@@ -920,20 +918,18 @@ algorithm
   tree := match (cls, cls_tree)
     case (Class.EXPANDED_DERIVED(), _)
       algorithm
-        exts := {buildInstanceTree(cls.baseClass, isDerived = true)};
+        elems := {buildInstanceTree(cls.baseClass, isDerived = true)};
       then
-        InstanceTree.CLASS(node, exts, {});
+        InstanceTree.CLASS(node, elems, isDerived);
 
-    case (_, ClassTree.INSTANTIATED_TREE(exts = ext_nodes))
+    case (_, ClassTree.INSTANTIATED_TREE())
       algorithm
-        exts := list(buildInstanceTree(e, isDerived = true) for e in ext_nodes);
-        components := list(buildInstanceTreeComponent(arrayGet(cls_tree.components, i))
-                           for i in cls_tree.localComponents);
+        elems := buildInstanceTreeElements(InstNode.definition(cls_node), cls_tree);
       then
-        InstanceTree.CLASS(node, exts, components);
+        InstanceTree.CLASS(node, elems, isDerived);
 
     case (_, ClassTree.FLAT_TREE())
-      then InstanceTree.CLASS(node, {}, {});
+      then InstanceTree.CLASS(node, {}, isDerived);
 
     else
       algorithm
@@ -943,6 +939,64 @@ algorithm
   end match;
 end buildInstanceTree;
 
+function buildInstanceTreeElements
+  input SCode.Element classDefinition;
+  input ClassTree classTree;
+  output list<InstanceTree> elements = {};
+protected
+  list<SCode.Element> scode_elems;
+  array<Mutable<InstNode>> clss, comps;
+  array<InstNode> exts;
+  Integer cls_index = 1, comp_index = 1, ext_index = 1;
+  InstanceTree tree;
+  list<Integer> local_comps;
+algorithm
+  ClassTree.INSTANTIATED_TREE(classes = clss, components = comps, exts = exts,
+    localComponents = local_comps) := classTree;
+  scode_elems := SCodeUtil.getClassElements(classDefinition);
+
+  if not listEmpty(local_comps) then
+    comp_index :: local_comps := local_comps;
+  end if;
+
+  for e in scode_elems loop
+    elements := match e
+      case SCode.Element.EXTENDS()
+        algorithm
+          tree := buildInstanceTree(exts[ext_index], isDerived = true);
+          ext_index := ext_index + 1;
+        then
+          tree :: elements;
+
+      case SCode.Element.CLASS()
+        guard SCodeUtil.isElementReplaceable(e)
+        algorithm
+          while InstNode.name(Mutable.access(clss[cls_index])) <> e.name loop
+            cls_index := cls_index + 1;
+          end while;
+
+          tree := InstanceTree.CLASS(Mutable.access(clss[cls_index]), {}, false);
+          cls_index := cls_index + 1;
+        then
+          tree :: elements;
+
+      case SCode.Element.COMPONENT()
+        algorithm
+          while InstNode.name(Mutable.access(comps[comp_index])) <> e.name loop
+            comp_index :: local_comps := local_comps;
+          end while;
+
+          tree := buildInstanceTreeComponent(comps[comp_index]);
+        then
+          tree :: elements;
+
+      else elements;
+    end match;
+  end for;
+
+  elements := listReverseInPlace(elements);
+end buildInstanceTreeElements;
+
 function buildInstanceTreeComponent
   input Mutable<InstNode> compNode;
   output InstanceTree tree;
@@ -951,7 +1005,7 @@ protected
   InstanceTree cls;
 algorithm
   node := Mutable.access(compNode);
-  cls := buildInstanceTree(InstNode.classScope(node));
+  cls := buildInstanceTree(InstNode.classScope(InstNode.resolveInner(node)));
   tree := InstanceTree.COMPONENT(node, cls);
 end buildInstanceTreeComponent;
 
@@ -963,13 +1017,13 @@ function dumpJSONInstanceTree
   output JSON json = JSON.emptyObject();
 protected
   InstNode node;
-  list<InstanceTree> comps, exts;
+  list<InstanceTree> elems;
   Sections sections;
   Option<SCode.Comment> cmt;
   JSON j;
   SCode.Element def;
 algorithm
-  InstanceTree.CLASS(node = node, exts = exts, components = comps) := tree;
+  InstanceTree.CLASS(node = node, elements = elems) := tree;
   node := InstNode.resolveInner(node);
   def := InstNode.definition(node);
   cmt := SCodeUtil.getElementComment(def);
@@ -983,24 +1037,13 @@ algorithm
 
   json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(def, node), json);
 
-  if not listEmpty(exts) then
-    json := JSON.addPair("extends", dumpJSONExtendsList(exts, isDeleted), json);
-  end if;
-
   json := dumpJSONCommentOpt(cmt, scope, json);
 
-  if not isDeleted then
-    if not listEmpty(comps) then
-      json := JSON.addPair("components", dumpJSONComponents(comps), json);
-    end if;
+  json := JSON.addPairNotNull("elements", dumpJSONElements(elems, node, isDeleted), json);
 
+  if not isDeleted then
     sections := Class.getSections(InstNode.getClass(node));
     json := dumpJSONEquations(sections, node, json);
-  end if;
-
-  if root then
-    j := dumpJSONReplaceableElements(node);
-    json := JSON.addPairNotNull("replaceable", j, json);
   end if;
 
   json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(node)), json);
@@ -1082,15 +1125,36 @@ function dumpJSONPath
   output JSON json = JSON.makeString(AbsynUtil.pathString(path));
 end dumpJSONPath;
 
-function dumpJSONExtendsList
-  input list<InstanceTree> exts;
+function dumpJSONElements
+  input list<InstanceTree> elements;
+  input InstNode scope;
   input Boolean isDeleted;
-  output JSON json = JSON.emptyArray();
+  output JSON json = JSON.makeNull();
+protected
+  JSON j;
 algorithm
-  for ext in exts loop
-    json := JSON.addElement(dumpJSONExtends(ext, isDeleted), json);
-  end for;
-end dumpJSONExtendsList;
+  if isDeleted then
+    for e in elements loop
+      j := match e
+        case InstanceTree.CLASS(isExtends = true) then dumpJSONExtends(e, isDeleted);
+        else JSON.makeNull();
+      end match;
+
+      json := JSON.addElementNotNull(j, json);
+    end for;
+  else
+    for e in elements loop
+      j := match e
+        case InstanceTree.CLASS(isExtends = true) then dumpJSONExtends(e, isDeleted);
+        case InstanceTree.CLASS() then dumpJSONReplaceableClass(e.node, scope);
+        case InstanceTree.COMPONENT() then dumpJSONComponent(e.node, e.cls);
+        else JSON.makeNull();
+      end match;
+
+      json := JSON.addElementNotNull(j, json);
+    end for;
+  end if;
+end dumpJSONElements;
 
 function dumpJSONExtends
   input InstanceTree ext;
@@ -1104,6 +1168,7 @@ algorithm
   cls_def := InstNode.definition(node);
   ext_def := InstNode.extendsDefinition(node);
 
+  json := JSON.addPair("$kind", JSON.makeString("extends"), json);
   json := dumpJSONSCodeMod(SCodeUtil.elementMod(ext_def), json);
   json := dumpJSONCommentOpt(SCodeUtil.getElementComment(ext_def), node, json);
 
@@ -1114,25 +1179,54 @@ algorithm
   end if;
 end dumpJSONExtends;
 
-function dumpJSONComponents
-  input list<InstanceTree> components;
-  output JSON json = JSON.emptyArray();
+function dumpJSONReplaceableClass
+  input InstNode cls;
+  input InstNode scope;
+  output JSON json = JSON.emptyObject();
 protected
-  InstNode node;
-  JSON j;
+  SCode.Element elem;
+  SCode.ClassDef cdef;
+  InstNode node, derivedNode;
+  Absyn.Path path;
+  list<Absyn.Subscript> dims;
 algorithm
-  for comp in components loop
-    InstanceTree.COMPONENT(node = node) := comp;
-    j := dumpJSONComponent(comp);
+  elem := InstNode.definition(cls);
 
-    if not JSON.isNull(j) then
-      json := JSON.addElement(j, json);
-    end if;
-  end for;
-end dumpJSONComponents;
+  json := JSON.addPair("$kind", JSON.makeString("class"), json);
+  json := JSON.addPair("name", JSON.makeString(InstNode.name(cls)), json);
+  json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(elem, scope), json);
+
+  SCode.Element.CLASS(classDef = cdef) := elem;
+
+  () := match cdef
+    case SCode.ClassDef.DERIVED(typeSpec = Absyn.TypeSpec.TPATH(path = path, arrayDim = SOME(dims)))
+      algorithm
+        try
+          derivedNode := Lookup.lookupName(path, scope, NFInstContext.RELAXED, false);
+          json := JSON.addPair("baseClass", dumpJSONNodePath(derivedNode), json);
+        else
+        end try;
+
+        json := JSON.addPairNotNull("dims", dumpJSONDims(dims, {}), json);
+        json := dumpJSONSCodeMod(cdef.modifications, json);
+      then
+        ();
+
+    case SCode.ClassDef.CLASS_EXTENDS()
+      algorithm
+        json := dumpJSONSCodeMod(cdef.modifications, json);
+      then
+        ();
+
+    else ();
+  end match;
+
+  json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(cls)), json);
+end dumpJSONReplaceableClass;
 
 function dumpJSONComponent
-  input InstanceTree component;
+  input InstNode component;
+  input InstanceTree cls;
   output JSON json = JSON.makeNull();
 protected
   InstNode node;
@@ -1141,11 +1235,9 @@ protected
   Boolean is_constant;
   SCode.Comment cmt;
   SCode.Annotation ann;
-  InstanceTree cls;
   JSON j;
 algorithm
-  InstanceTree.COMPONENT(node = node, cls = cls) := component;
-  node := InstNode.resolveInner(node);
+  node := InstNode.resolveInner(component);
 
   // Skip dumping inner elements that were added by the compiler itself.
   if InstNode.isGeneratedInner(node) then
@@ -1159,6 +1251,7 @@ algorithm
     case (Component.TYPED_COMPONENT(), SCode.Element.COMPONENT())
       guard Component.isDeleted(comp)
       algorithm
+        json := JSON.addPair("$kind", JSON.makeString("component"), json);
         json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
         json := JSON.addPair("type", dumpJSONComponentType(cls, node, comp.ty, isDeleted = true), json);
         json := dumpJSONSCodeMod(elem.modifications, json);
@@ -1170,6 +1263,7 @@ algorithm
 
     case (Component.TYPED_COMPONENT(), SCode.Element.COMPONENT())
       algorithm
+        json := JSON.addPair("$kind", JSON.makeString("component"), json);
         json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
         json := JSON.addPair("type", dumpJSONComponentType(cls, node, comp.ty), json);
 
@@ -1180,12 +1274,7 @@ algorithm
 
         json := dumpJSONSCodeMod(elem.modifications, json);
 
-        //if not Type.isComplex(comp.ty) then
-        //  json := dumpJSONBuiltinClassComponents(comp.classInst, elem.modifications, json);
-        //end if;
-
         is_constant := comp.attributes.variability <= Variability.PARAMETER;
-
         if Binding.isExplicitlyBound(comp.binding) then
           json := JSON.addPair("value", dumpJSONBinding(comp.binding, evaluate = is_constant), json);
         end if;
@@ -1292,37 +1381,6 @@ algorithm
   end if;
 end dumpJSONBinding;
 
-function dumpJSONBuiltinClassComponents
-  input InstNode clsNode;
-  input output JSON json;
-protected
-  Class cls;
-  ClassTree cls_tree;
-  Component comp;
-  JSON attr_json = JSON.makeNull();
-algorithm
-  cls := InstNode.getClass(clsNode);
-  cls_tree := Class.classTree(cls);
-
-  for c in ClassTree.getComponents(cls_tree) loop
-    comp := InstNode.component(c);
-
-    () := match comp
-      case Component.TYPE_ATTRIBUTE()
-        guard Modifier.hasBinding(comp.modifier)
-        algorithm
-          attr_json := JSON.addPair(Modifier.name(comp.modifier),
-            dumpJSONBinding(Modifier.binding(comp.modifier)), attr_json);
-        then
-          ();
-
-      else ();
-    end match;
-  end for;
-
-  json := JSON.addPairNotNull("attributes", attr_json, json);
-end dumpJSONBuiltinClassComponents;
-
 function dumpJSONClassDims
   input InstNode node;
   input SCode.Element element;
@@ -1351,7 +1409,7 @@ end dumpJSONClassDims;
 function dumpJSONDims
   input list<Absyn.Subscript> absynDims;
   input list<Dimension> typedDims;
-  output JSON json = JSON.emptyObject();
+  output JSON json = JSON.makeNull();
 protected
   JSON ty_json, absyn_json;
 algorithm
@@ -1360,14 +1418,14 @@ algorithm
     absyn_json := JSON.addElement(JSON.makeString(Dump.printSubscriptStr(d)), absyn_json);
   end for;
 
-  json := JSON.addPair("absyn", absyn_json, json);
+  json := JSON.addPairNotNull("absyn", absyn_json, json);
 
   ty_json := JSON.emptyArray();
   for d in typedDims loop
     ty_json := JSON.addElement(JSON.makeString(Dimension.toString(d)), ty_json);
   end for;
 
-  json := JSON.addPair("typed", ty_json, json);
+  json := JSON.addPairNotNull("typed", ty_json, json);
 end dumpJSONDims;
 
 function dumpJSONAttributes

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -561,6 +561,7 @@ private:
   {
   public:
     Element(Model *pParentModel);
+    Element(Model *pParentModel, const QJsonObject &jsonObject);
     ~Element();
     void initialize();
     void deserialize(const QJsonObject &jsonObject);
@@ -710,6 +711,7 @@ private:
   {
   public:
     Extend();
+    Extend(const QJsonObject &jsonObject);
     void deserialize(const QJsonObject &jsonObject);
 
     Annotation *getExtendsAnnotation() const {return mpExtendsAnnotation.get();}

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -18,45 +18,7 @@
     },
     "prefixes": {
       "description": "The class prefixes",
-      "type": "object",
-      "properties": {
-        "public": {
-          "type": "boolean"
-        },
-        "final": {
-          "type": "boolean"
-        },
-        "inner": {
-          "type": "boolean"
-        },
-        "outer": {
-          "type": "boolean"
-        },
-        "replaceable": {
-          "$ref": "#/definitions/replaceablePrefix"
-        },
-        "redeclare": {
-          "type": "boolean"
-        },
-        "partial": {
-          "type": "boolean"
-        },
-        "encapsulated": {
-          "type": "boolean"
-        },
-        "connector": {
-          "type": "string",
-          "enum": ["flow", "stream"]
-        },
-        "variability": {
-          "type": "string",
-          "enum": ["constant", "parameter", "discrete"]
-        },
-        "direction": {
-          "type": "string",
-          "enum": ["input", "output"]
-        }
-      }
+      "$ref": "#/definitions/classPrefixes"
     },
     "modifiers": {
       "description": "Modifier from the SCode",
@@ -65,18 +27,21 @@
     "comment": {
       "$ref": "#/definitions/comment"
     },
-    "extends": {
-      "description": "The extends clauses in the class instance",
+    "elements": {
+      "description": "The elements in the class instance",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/extends"
-      }
-    },
-    "components": {
-      "description": "The components in the class instance",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/component"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/extends"
+          },
+          {
+            "$ref": "#/definitions/component"
+          },
+          {
+            "$ref": "#/definitions/replaceableClass"
+          }
+        ]
       }
     },
     "connections": {
@@ -149,31 +114,6 @@
         "required": ["arguments"]
       }
     },
-    "replaceable": {
-      "description": "The replaceable elements of the class instance",
-      "type": "array",
-      "items": {
-        "oneOf": [
-          {
-            "type": "object",
-            "properties": {
-              "name": {
-                "description": "The name of a replaceable component",
-                "type": "string"
-              },
-              "type": {
-                "description": "The type of a replaceable component",
-                "type": "string"
-              }
-            }
-          },
-          {
-            "description": "The name of a replaceable class",
-            "type": "string"
-          }
-        ]
-      }
-    },
     "source": {
       "$ref": "#/definitions/source"
     }
@@ -218,6 +158,10 @@
       "description": "An extends clause",
       "type": "object",
       "properties": {
+        "$kind": {
+          "type": "string",
+          "const": "extends"
+        },
         "modifiers": {
           "description": "SCode modifier on the extends clause",
           "type": "#/definitions/scodeModifier"
@@ -239,7 +183,8 @@
             }
           ]
         }
-      }
+      },
+      "required": ["$kind", "baseClass"]
     },
     "component": {
       "type": "object",
@@ -251,6 +196,10 @@
         {
           "description": "Normal component",
           "properties": {
+            "$kind": {
+              "type": "string",
+              "const": "component"
+            },
             "name": {
               "description": "Name of the component",
               "type": "string"
@@ -329,9 +278,85 @@
               "$ref": "#/definitions/annotation"
             }
           },
-          "required": ["name"]
+          "required": ["$kind", "name", "type"]
         }
       ]
+    },
+    "replaceableClass": {
+      "description": "A replaceable class definition",
+      "type": "object",
+      "properties": {
+        "$kind": {
+          "type": "string",
+          "const": "class"
+        },
+        "name": {
+          "description": "Name of the class",
+          "type": "string"
+        },
+        "prefixes": {
+          "description": "The class' prefixes",
+          "$ref": "#/definitions/classPrefixes"
+        },
+        "baseClass": {
+          "description": "The name of the extended class of a short class definition",
+          "type": "string"
+        },
+        "dims": {
+          "description": "The class' dimensions for a short class definition",
+          "$ref": "#/definitions/dimensions"
+        },
+        "modifiers": {
+          "description": "Modifier from the SCode (on short class definitions or class extends)",
+          "$ref": "#/definitions/scodeModifier"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        }
+      },
+      "required": ["$kind", "name"]
+    },
+    "classPrefixes": {
+      "description": "The class prefixes",
+      "type": "object",
+      "properties": {
+        "public": {
+          "type": "boolean"
+        },
+        "final": {
+          "type": "boolean"
+        },
+        "inner": {
+          "type": "boolean"
+        },
+        "outer": {
+          "type": "boolean"
+        },
+        "replaceable": {
+          "$ref": "#/definitions/replaceablePrefix"
+        },
+        "redeclare": {
+          "type": "boolean"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "encapsulated": {
+          "type": "boolean"
+        },
+        "connector": {
+          "type": "string",
+          "enum": ["flow", "stream"]
+        },
+        "variability": {
+          "type": "string",
+          "enum": ["constant", "parameter", "discrete"]
+        },
+        "direction": {
+          "type": "string",
+          "enum": ["input", "output"]
+        }
+      }
     },
     "replaceablePrefix": {
       "oneOf": [

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation3.mos
@@ -18,8 +18,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"annotation\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation4.mos
@@ -100,8 +100,9 @@ getModelInstance(M, prettyPrint=true);
 //       ]
 //     }
 //   },
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"level\",
 //       \"type\": \"Real\",
 //       \"modifiers\": \"20\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation6.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation6.mos
@@ -28,8 +28,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"rotatingRect\",
 //       \"type\": {
 //         \"name\": \"RotatingRect\",
@@ -109,14 +110,16 @@ getModelInstance(M, prettyPrint=true);
 //             ]
 //           }
 //         },
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"to_deg\",
 //             \"type\": {
 //               \"name\": \"To_deg\",
 //               \"restriction\": \"block\",
-//               \"components\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"y\",
 //                   \"type\": \"Real\"
 //                 }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -20,8 +20,9 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"pi\",
 //       \"type\": \"Real\",
 //       \"modifiers\": \"3\",
@@ -33,6 +34,7 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"deg\",
 //       \"type\": {
 //         \"name\": \"Angle\",
@@ -43,8 +45,9 @@ getModelInstance(M, prettyPrint = true);
 //             \"$value\": \"\\\"Angle\\\"\"
 //           }
 //         },
-//         \"extends\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"extends\",
 //             \"baseClass\": \"Real\"
 //           }
 //         ],

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
@@ -35,13 +35,39 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
+//       \"name\": \"x\",
+//       \"type\": \"Real\",
+//       \"prefixes\": {
+//         \"final\": true
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"y\",
+//       \"type\": \"Real\",
+//       \"prefixes\": {
+//         \"direction\": \"input\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"z\",
+//       \"type\": \"Real\",
+//       \"prefixes\": {
+//         \"inner\": true
+//       }
+//     },
+//     {
+//       \"$kind\": \"extends\",
 //       \"baseClass\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"w\",
 //             \"type\": \"Real\",
 //             \"prefixes\": {
@@ -51,6 +77,7 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"z\",
 //             \"type\": \"Real\",
 //             \"prefixes\": {
@@ -66,31 +93,9 @@ getModelInstance(M, prettyPrint = true);
 //           \"columnEnd\": 14
 //         }
 //       }
-//     }
-//   ],
-//   \"components\": [
-//     {
-//       \"name\": \"x\",
-//       \"type\": \"Real\",
-//       \"prefixes\": {
-//         \"final\": true
-//       }
 //     },
 //     {
-//       \"name\": \"y\",
-//       \"type\": \"Real\",
-//       \"prefixes\": {
-//         \"direction\": \"input\"
-//       }
-//     },
-//     {
-//       \"name\": \"z\",
-//       \"type\": \"Real\",
-//       \"prefixes\": {
-//         \"inner\": true
-//       }
-//     },
-//     {
+//       \"$kind\": \"component\",
 //       \"name\": \"w\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {
@@ -100,16 +105,19 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"c\",
 //       \"type\": {
 //         \"name\": \"C\",
 //         \"restriction\": \"connector\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"e\",
 //             \"type\": \"Real\"
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"f\",
 //             \"type\": \"Real\",
 //             \"prefixes\": {
@@ -117,6 +125,7 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"s\",
 //             \"type\": \"Real\",
 //             \"prefixes\": {
@@ -136,12 +145,6 @@ getModelInstance(M, prettyPrint = true);
 //         \"public\": false,
 //         \"variability\": \"parameter\"
 //       }
-//     }
-//   ],
-//   \"replaceable\": [
-//     {
-//       \"name\": \"w\",
-//       \"type\": \"Real\"
 //     }
 //   ],
 //   \"source\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceBinding1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceBinding1.mos
@@ -31,14 +31,16 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"world\",
 //       \"type\": {
 //         \"name\": \"World\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"conf1\",
 //             \"type\": {
 //               \"name\": \"Configuration\",
@@ -56,6 +58,7 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"conf2\",
 //             \"type\": {
 //               \"name\": \"Configuration\",
@@ -107,18 +110,21 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"a\",
 //       \"type\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"world\",
 //             \"type\": {
-//               \"name\": \"world\",
+//               \"name\": \"World\",
 //               \"restriction\": \"model\",
-//               \"components\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"conf1\",
 //                   \"type\": {
 //                     \"name\": \"Configuration\",
@@ -136,6 +142,7 @@ getModelInstance(M, prettyPrint = true);
 //                   }
 //                 },
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"conf2\",
 //                   \"type\": {
 //                     \"name\": \"Configuration\",
@@ -176,10 +183,10 @@ getModelInstance(M, prettyPrint = true);
 //               ],
 //               \"source\": {
 //                 \"filename\": \"<interactive>\",
-//                 \"lineStart\": 15,
-//                 \"columnStart\": 5,
-//                 \"lineEnd\": 15,
-//                 \"columnEnd\": 22
+//                 \"lineStart\": 2,
+//                 \"columnStart\": 3,
+//                 \"lineEnd\": 5,
+//                 \"columnEnd\": 12
 //               }
 //             },
 //             \"prefixes\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceBinding2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceBinding2.mos
@@ -18,8 +18,9 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"dims\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceChoices1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceChoices1.mos
@@ -25,8 +25,9 @@ getErrorString();
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"b\",
 //       \"type\": \"Boolean\",
 //       \"modifiers\": \"true\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceChoices2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceChoices2.mos
@@ -22,8 +22,9 @@ getErrorString();
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {
@@ -41,12 +42,6 @@ getErrorString();
 //           ]
 //         }
 //       }
-//     }
-//   ],
-//   \"replaceable\": [
-//     {
-//       \"name\": \"x\",
-//       \"type\": \"Real\"
 //     }
 //   ],
 //   \"source\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConditional1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConditional1.mos
@@ -18,8 +18,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"condition\": false,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConditional2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConditional2.mos
@@ -27,14 +27,16 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"b\",
 //       \"type\": {
 //         \"name\": \"B\",
 //         \"restriction\": \"model\",
-//         \"extends\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"extends\",
 //             \"baseClass\": {
 //               \"name\": \"A\",
 //               \"restriction\": \"model\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection1.mos
@@ -32,23 +32,27 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"extends\",
 //       \"baseClass\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"c1\",
 //             \"type\": {
 //               \"name\": \"C\",
 //               \"restriction\": \"connector\",
-//               \"components\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"e\",
 //                   \"type\": \"Real\"
 //                 },
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"f\",
 //                   \"type\": \"Real\",
 //                   \"prefixes\": {
@@ -66,16 +70,19 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"c2\",
 //             \"type\": {
 //               \"name\": \"C\",
 //               \"restriction\": \"connector\",
-//               \"components\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"e\",
 //                   \"type\": \"Real\"
 //                 },
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"f\",
 //                   \"type\": \"Real\",
 //                   \"prefixes\": {
@@ -121,20 +128,21 @@ getModelInstance(M, prettyPrint = true);
 //           \"columnEnd\": 14
 //         }
 //       }
-//     }
-//   ],
-//   \"components\": [
+//     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"c3\",
 //       \"type\": {
 //         \"name\": \"C\",
 //         \"restriction\": \"connector\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"e\",
 //             \"type\": \"Real\"
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"f\",
 //             \"type\": \"Real\",
 //             \"prefixes\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
@@ -23,8 +23,9 @@ getErrorString();
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": {
 //         \"name\": \"RealInput\",
@@ -32,8 +33,9 @@ getErrorString();
 //         \"prefixes\": {
 //           \"direction\": \"input\"
 //         },
-//         \"extends\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"extends\",
 //             \"baseClass\": \"Real\"
 //           }
 //         ],
@@ -47,6 +49,7 @@ getErrorString();
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"y\",
 //       \"type\": {
 //         \"name\": \"RealInput2\",
@@ -54,16 +57,18 @@ getErrorString();
 //         \"modifiers\": {
 //           \"start\": \"1.0\"
 //         },
-//         \"extends\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"extends\",
 //             \"baseClass\": {
 //               \"name\": \"RealInput\",
 //               \"restriction\": \"type\",
 //               \"prefixes\": {
 //                 \"direction\": \"input\"
 //               },
-//               \"extends\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"extends\",
 //                   \"baseClass\": \"Real\"
 //                 }
 //               ],

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
@@ -21,8 +21,9 @@ getModelInstance(RealInput2, true); getErrorString();
 //   \"prefixes\": {
 //     \"direction\": \"input\"
 //   },
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"extends\",
 //       \"baseClass\": \"Real\"
 //     }
 //   ],
@@ -41,16 +42,18 @@ getModelInstance(RealInput2, true); getErrorString();
 //   \"modifiers\": {
 //     \"start\": \"1.0\"
 //   },
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"extends\",
 //       \"baseClass\": {
 //         \"name\": \"RealInput\",
 //         \"restriction\": \"type\",
 //         \"prefixes\": {
 //           \"direction\": \"input\"
 //         },
-//         \"extends\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"extends\",
 //             \"baseClass\": \"Real\"
 //           }
 //         ],

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDuplicate1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDuplicate1.mos
@@ -23,13 +23,15 @@ getModelInstance(B, prettyPrint = true);
 // "{
 //   \"name\": \"B\",
 //   \"restriction\": \"model\",
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"extends\",
 //       \"baseClass\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\"
 //           }
@@ -42,10 +44,9 @@ getModelInstance(B, prettyPrint = true);
 //           \"columnEnd\": 14
 //         }
 //       }
-//     }
-//   ],
-//   \"components\": [
+//     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\"
 //     }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum1.mos
@@ -23,8 +23,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"analogFil\",
 //       \"type\": {
 //         \"name\": \"AnalogFilter\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
@@ -20,8 +20,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"e\",
 //       \"type\": {
 //         \"name\": \"E2\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEvaluate1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEvaluate1.mos
@@ -19,8 +19,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"n1\",
 //       \"type\": \"Integer\",
 //       \"modifiers\": \"1\",
@@ -32,6 +33,7 @@ getModelInstance(M, prettyPrint=true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"n2\",
 //       \"type\": \"Integer\",
 //       \"modifiers\": \"n1\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp1.mos
@@ -24,8 +24,9 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"modifiers\": \"2.0\",
@@ -34,12 +35,14 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"a\",
 //       \"type\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"dims\": {
@@ -70,6 +73,7 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
 //       \"modifiers\": \"a.x[1]\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends1.mos
@@ -26,8 +26,14 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
+//       \"name\": \"y\",
+//       \"type\": \"Real\"
+//     },
+//     {
+//       \"$kind\": \"extends\",
 //       \"modifiers\": {
 //         \"x\": \"1\"
 //       },
@@ -48,8 +54,9 @@ getModelInstance(M, prettyPrint=true);
 //       \"baseClass\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"value\": {
@@ -65,14 +72,9 @@ getModelInstance(M, prettyPrint=true);
 //           \"columnEnd\": 78
 //         }
 //       }
-//     }
-//   ],
-//   \"components\": [
-//     {
-//       \"name\": \"y\",
-//       \"type\": \"Real\"
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"z\",
 //       \"type\": \"Real\"
 //     }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends2.mos
@@ -26,8 +26,14 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
+//       \"name\": \"y\",
+//       \"type\": \"Real\"
+//     },
+//     {
+//       \"$kind\": \"extends\",
 //       \"modifiers\": {
 //         \"x\": \"1\"
 //       },
@@ -48,8 +54,9 @@ getModelInstance(M, prettyPrint=true);
 //       \"baseClass\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"value\": {
@@ -65,14 +72,9 @@ getModelInstance(M, prettyPrint=true);
 //           \"columnEnd\": 78
 //         }
 //       }
-//     }
-//   ],
-//   \"components\": [
-//     {
-//       \"name\": \"y\",
-//       \"type\": \"Real\"
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"z\",
 //       \"type\": \"Real\"
 //     }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends3.mos
@@ -24,14 +24,16 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": {
 //         \"name\": \"MyReal\",
 //         \"restriction\": \"type\",
-//         \"extends\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"extends\",
 //             \"baseClass\": \"Real\"
 //           }
 //         ],

--- a/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter1.mos
@@ -23,14 +23,16 @@ getModelInstance(B, prettyPrint=true);
 // "{
 //   \"name\": \"B\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"a\",
 //       \"type\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"prefixes\": {
@@ -48,6 +50,7 @@ getModelInstance(B, prettyPrint=true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter2.mos
@@ -22,9 +22,6 @@ getModelInstance(P.M, prettyPrint=true);
 // "{
 //   \"name\": \"P.M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
-//
-//   ],
 //   \"source\": {
 //     \"filename\": \"<interactive>\",
 //     \"lineStart\": 5,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceInnerOuter3.mos
@@ -23,9 +23,6 @@ getModelInstance(P.RealInput, prettyPrint=true);
 // "{
 //   \"name\": \"P.M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
-//
-//   ],
 //   \"source\": {
 //     \"filename\": \"<interactive>\",
 //     \"lineStart\": 3,
@@ -40,8 +37,9 @@ getModelInstance(P.RealInput, prettyPrint=true);
 //   \"prefixes\": {
 //     \"direction\": \"input\"
 //   },
-//   \"extends\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"extends\",
 //       \"baseClass\": \"Real\"
 //     }
 //   ],

--- a/testsuite/openmodelica/instance-API/GetModelInstanceMod1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceMod1.mos
@@ -34,26 +34,30 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"c\",
 //       \"type\": {
 //         \"name\": \"C\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"b1\",
 //             \"type\": {
 //               \"name\": \"B\",
 //               \"restriction\": \"model\",
-//               \"components\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"a1\",
 //                   \"type\": {
 //                     \"name\": \"A\",
 //                     \"restriction\": \"model\",
-//                     \"components\": [
+//                     \"elements\": [
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"x\",
 //                         \"type\": \"Real\",
 //                         \"value\": {
@@ -61,6 +65,7 @@ getModelInstance(M, prettyPrint = true);
 //                         }
 //                       },
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"y\",
 //                         \"type\": \"Real\",
 //                         \"value\": {
@@ -78,12 +83,14 @@ getModelInstance(M, prettyPrint = true);
 //                   }
 //                 },
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"a2\",
 //                   \"type\": {
 //                     \"name\": \"A\",
 //                     \"restriction\": \"model\",
-//                     \"components\": [
+//                     \"elements\": [
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"x\",
 //                         \"type\": \"Real\",
 //                         \"value\": {
@@ -91,6 +98,7 @@ getModelInstance(M, prettyPrint = true);
 //                         }
 //                       },
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"y\",
 //                         \"type\": \"Real\",
 //                         \"value\": {
@@ -118,18 +126,21 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"b2\",
 //             \"type\": {
 //               \"name\": \"B\",
 //               \"restriction\": \"model\",
-//               \"components\": [
+//               \"elements\": [
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"a1\",
 //                   \"type\": {
 //                     \"name\": \"A\",
 //                     \"restriction\": \"model\",
-//                     \"components\": [
+//                     \"elements\": [
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"x\",
 //                         \"type\": \"Real\",
 //                         \"value\": {
@@ -137,6 +148,7 @@ getModelInstance(M, prettyPrint = true);
 //                         }
 //                       },
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"y\",
 //                         \"type\": \"Real\"
 //                       }
@@ -151,16 +163,19 @@ getModelInstance(M, prettyPrint = true);
 //                   }
 //                 },
 //                 {
+//                   \"$kind\": \"component\",
 //                   \"name\": \"a2\",
 //                   \"type\": {
 //                     \"name\": \"A\",
 //                     \"restriction\": \"model\",
-//                     \"components\": [
+//                     \"elements\": [
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"x\",
 //                         \"type\": \"Real\"
 //                       },
 //                       {
+//                         \"$kind\": \"component\",
 //                         \"name\": \"y\",
 //                         \"type\": \"Real\"
 //                       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceMod2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceMod2.mos
@@ -24,14 +24,16 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"a1\",
 //       \"type\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"value\": {
@@ -42,6 +44,7 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"y\",
 //             \"type\": \"Real\",
 //             \"value\": {
@@ -77,12 +80,14 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"a2\",
 //       \"type\": {
 //         \"name\": \"A\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
 //             \"value\": {
@@ -94,6 +99,7 @@ getModelInstance(M, prettyPrint = true);
 //             }
 //           },
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"y\",
 //             \"type\": \"Real\",
 //             \"value\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
@@ -24,8 +24,9 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"modifiers\": \"1.0\",
@@ -37,6 +38,21 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"class\",
+//       \"name\": \"M\",
+//       \"prefixes\": {
+//         \"replaceable\": true
+//       },
+//       \"source\": {
+//         \"filename\": \"<interactive>\",
+//         \"lineStart\": 5,
+//         \"columnStart\": 17,
+//         \"lineEnd\": 7,
+//         \"columnEnd\": 10
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
 //       \"name\": \"m\",
 //       \"type\": {
 //         \"name\": \"M\",
@@ -44,8 +60,9 @@ getModelInstance(M, prettyPrint = true);
 //         \"prefixes\": {
 //           \"replaceable\": true
 //         },
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\"
 //           }
@@ -59,13 +76,6 @@ getModelInstance(M, prettyPrint = true);
 //         }
 //       }
 //     }
-//   ],
-//   \"replaceable\": [
-//     {
-//       \"name\": \"x\",
-//       \"type\": \"Real\"
-//     },
-//     \"M\"
 //   ],
 //   \"source\": {
 //     \"filename\": \"<interactive>\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable2.mos
@@ -20,8 +20,9 @@ getModelInstance(M, prettyPrint = true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"x\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {
@@ -35,6 +36,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"comment\": \"definition comment\"
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {
@@ -48,6 +50,7 @@ getModelInstance(M, prettyPrint = true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"z\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {
@@ -60,20 +63,6 @@ getModelInstance(M, prettyPrint = true);
 //         }
 //       },
 //       \"comment\": \"definition comment\"
-//     }
-//   ],
-//   \"replaceable\": [
-//     {
-//       \"name\": \"x\",
-//       \"type\": \"Real\"
-//     },
-//     {
-//       \"name\": \"y\",
-//       \"type\": \"Real\"
-//     },
-//     {
-//       \"name\": \"z\",
-//       \"type\": \"Real\"
 //     }
 //   ],
 //   \"source\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
@@ -1,0 +1,162 @@
+// name: GetModelInstanceReplaceable3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model A
+    B b;
+
+    replaceable model B
+      Real x;
+    end B;
+
+    replaceable model C
+      Real y;
+    end C;
+
+    replaceable model D = C constrainedby C(y = 1);
+  end A;
+
+  model M
+    extends A(redeclare model B = B, redeclare model C = C(y = 2.0));
+
+    model B
+      Real x = 2.0;
+    end B;
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"extends\",
+//       \"modifiers\": {
+//         \"B\": {
+//           \"$value\": \"redeclare model B = B\"
+//         },
+//         \"C\": {
+//           \"$value\": \"redeclare model C = C(y = 2.0)\"
+//         }
+//       },
+//       \"baseClass\": {
+//         \"name\": \"A\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"b\",
+//             \"type\": {
+//               \"name\": \"B\",
+//               \"restriction\": \"model\",
+//               \"prefixes\": {
+//                 \"redeclare\": true
+//               },
+//               \"elements\": [
+//                 {
+//                   \"$kind\": \"extends\",
+//                   \"baseClass\": {
+//                     \"name\": \"B\",
+//                     \"restriction\": \"model\",
+//                     \"elements\": [
+//                       {
+//                         \"$kind\": \"component\",
+//                         \"name\": \"x\",
+//                         \"type\": \"Real\",
+//                         \"modifiers\": \"2.0\",
+//                         \"value\": {
+//                           \"binding\": 2
+//                         }
+//                       }
+//                     ],
+//                     \"source\": {
+//                       \"filename\": \"<interactive>\",
+//                       \"lineStart\": 19,
+//                       \"columnStart\": 5,
+//                       \"lineEnd\": 21,
+//                       \"columnEnd\": 10
+//                     }
+//                   }
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 17,
+//                 \"columnStart\": 25,
+//                 \"lineEnd\": 17,
+//                 \"columnEnd\": 36
+//               }
+//             }
+//           },
+//           {
+//             \"$kind\": \"class\",
+//             \"name\": \"B\",
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 19,
+//               \"columnStart\": 5,
+//               \"lineEnd\": 21,
+//               \"columnEnd\": 10
+//             }
+//           },
+//           {
+//             \"$kind\": \"class\",
+//             \"name\": \"C\",
+//             \"prefixes\": {
+//               \"redeclare\": true
+//             },
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 17,
+//               \"columnStart\": 48,
+//               \"lineEnd\": 17,
+//               \"columnEnd\": 68
+//             }
+//           },
+//           {
+//             \"$kind\": \"class\",
+//             \"name\": \"D\",
+//             \"prefixes\": {
+//               \"replaceable\": {
+//                 \"constrainedby\": \"C\",
+//                 \"modifiers\": {
+//                   \"y\": \"1\"
+//                 }
+//               }
+//             },
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 13,
+//               \"columnStart\": 17,
+//               \"lineEnd\": 13,
+//               \"columnEnd\": 29
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 17,
+//           \"columnStart\": 5,
+//           \"lineEnd\": 17,
+//           \"columnEnd\": 69
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 16,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 22,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceStateMachine1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceStateMachine1.mos
@@ -40,8 +40,9 @@ getModelInstance(M, prettyPrint=true);
 // "{
 //   \"name\": \"M\",
 //   \"restriction\": \"model\",
-//   \"components\": [
+//   \"elements\": [
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"y\",
 //       \"type\": \"Real\",
 //       \"prefixes\": {
@@ -49,12 +50,14 @@ getModelInstance(M, prettyPrint=true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"state1\",
 //       \"type\": {
 //         \"name\": \"State1\",
 //         \"restriction\": \"model\",
-//         \"components\": [
+//         \"elements\": [
 //           {
+//             \"$kind\": \"component\",
 //             \"name\": \"i\",
 //             \"type\": \"Integer\",
 //             \"modifiers\": {
@@ -75,6 +78,7 @@ getModelInstance(M, prettyPrint=true);
 //       }
 //     },
 //     {
+//       \"$kind\": \"component\",
 //       \"name\": \"state2\",
 //       \"type\": {
 //         \"name\": \"State2\",

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -38,6 +38,7 @@ GetModelInstanceMod1.mos \
 GetModelInstanceMod2.mos \
 GetModelInstanceReplaceable1.mos \
 GetModelInstanceReplaceable2.mos \
+GetModelInstanceReplaceable3.mos \
 GetModelInstanceStateMachine1.mos \
 
 


### PR DESCRIPTION
- Unify class elements into one array instead of dumping component and extends separately, to get the correct ordering of them.
- Dump information about replaceable class elements.
- Remove the array of replaceable names since it's not used.
- Update OMEdit to handle the new JSON structure.