### PR TITLE
[BE] fix output filter module

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -5752,7 +5752,7 @@ author: Waurich TUD 09/2015"
 protected
   Integer size, nVars, nEqs;
   array<Integer> ass1,ass2, varVisited;
-  list<Integer> outputVarIndxs, allVarIndxs, stateIndxs, stateTasks, stateTasks1 , outputTasks, predecessors, tasks, varIdcs, eqIdcs, stateDerIdcs;
+  list<Integer> outputVarIndxs, stateIndxs, stateTasks, stateTasks1 , outputTasks, predecessors, tasks, varIdcs, eqIdcs, stateDerIdcs;
   list<BackendDAE.StrongComponent> comps, compsNew, addComps;
   BackendDAE.StrongComponent comp;
   BackendDAE.EqSystem syst;
@@ -5802,7 +5802,6 @@ algorithm
     //get output variables
     BackendDAE.EQSYSTEM(orderedVars = vars) := syst;
     varLst := BackendVariable.varList(vars);
-    allVarIndxs := BackendVariable.getVarIndexFromVars(varLst,vars);
     varLst := List.filterOnTrue(varLst,BackendVariable.isVarOnTopLevelAndOutput);
 
     if not listEmpty(varLst) then
@@ -5865,13 +5864,10 @@ algorithm
         eqIndexLst := listAppend(eqIndLst,eqIndexLst);
       end for;
 
-      // find new and unneeded vars and equations
+      // causalize again
       syst.orderedVars := BackendVariable.listVar1(listReverse(varLstNew));
       syst.orderedEqs := BackendEquation.listEquation(listReverse(eqLstNew));
-      vars := BackendVariable.deleteVars(syst.orderedVars, vars);
-      eqs := BackendEquation.deleteList(eqs, eqIndexLst);
 
-      // causalize again
       syst.m := NONE();
       syst.mT := NONE();
       syst.matching := BackendDAE.NO_MATCHING();
@@ -5893,6 +5889,10 @@ algorithm
       syst.removedEqs := BackendEquation.emptyEqns();
 
       systsNew := syst::systsNew;
+
+      // find unneeded vars and equations
+      vars := BackendVariable.deleteVars(syst.orderedVars, vars);
+      eqs := BackendEquation.deleteList(eqs, eqIndexLst);
     else
       if debug then print("No output variables in this system ("+intString(systemNumber)+"/"+intString(numberOfSystems)+")\n"); end if;
     end if;

--- a/OMCompiler/Compiler/BackEnd/BackendEquation.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendEquation.mo
@@ -1914,10 +1914,32 @@ algorithm
     case BackendDAE.COMPLEX_EQUATION(attr=BackendDAE.EQUATION_ATTRIBUTES(kind=kind)) then kind;
     case BackendDAE.IF_EQUATION(attr=BackendDAE.EQUATION_ATTRIBUTES(kind=kind)) then kind;
     else equation
-      Error.addInternalError("BackendEquation.equationKind failed!", sourceInfo());
+      Error.addInternalError(getInstanceName() + " failed!", sourceInfo());
     then fail();
   end match;
 end equationKind;
+
+public function setEquationKind
+  input output BackendDAE.Equation eq;
+  input output BackendDAE.EquationKind k;
+algorithm
+  eq := match eq
+    local
+      BackendDAE.EquationAttributes a;
+    case BackendDAE.EQUATION(attr=a)          algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.ARRAY_EQUATION(attr=a)    algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.FOR_EQUATION(attr=a)      algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.SOLVED_EQUATION(attr=a)   algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.RESIDUAL_EQUATION(attr=a) algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.WHEN_EQUATION(attr=a)     algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.ALGORITHM(attr=a)         algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.COMPLEX_EQUATION(attr=a)  algorithm a.kind := k; eq.attr := a; then eq;
+    case BackendDAE.IF_EQUATION(attr=a)       algorithm a.kind := k; eq.attr := a; then eq;
+    else algorithm
+      Error.addInternalError(getInstanceName() + " failed!", sourceInfo());
+    then fail();
+  end match;
+end setEquationKind;
 
 public function setEvalStageDynamic
   input output BackendDAE.EvaluationStages evalStage;

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -1248,6 +1248,15 @@ algorithm
   var.varKind := BackendDAE.PARAM();
 end makeParam;
 
+public function makeParamFixed
+  "Change variable to parameter"
+  input output BackendDAE.Var var;
+  input output Boolean fixed; // also output for traversing
+algorithm
+  var.varKind := BackendDAE.PARAM();
+  var := setVarFixed(var, fixed);
+end makeParamFixed;
+
 public function isParamOrConstant
 "Return true if variable is parameter or constant"
   input BackendDAE.Var invar;


### PR DESCRIPTION
 - the initial system might be causalized differently, therefore:
   - add all removed variables to parameters
   - add all remved equations to initial equations
 - ToDo: if the variables and equations are also not needed for intialization, the could be removed entirely

### Related Issues

 - fixes ticket #8271
