### PR TITLE
Use only one list for elements

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -276,12 +276,9 @@ void BitmapAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
   ShapeAnnotation::setDefaults(pShapeAnnotation);
 }
 
-ModelInstance::Model *BitmapAnnotation::getParentModel() const
+ModelInstance::Extend *BitmapAnnotation::getExtend() const
 {
-  if (mpBitmap) {
-    return mpBitmap->getParentModel();
-  }
-  return 0;
+  return mpBitmap->getParentExtend();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.h
@@ -63,7 +63,7 @@ public:
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
-  ModelInstance::Model *getParentModel() const override;
+  ModelInstance::Extend *getExtend() const override;
   void setBitmap(ModelInstance::Bitmap *pBitmap) {mpBitmap = pBitmap;}
 private:
   ModelInstance::Bitmap *mpBitmap;

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
@@ -248,12 +248,9 @@ void EllipseAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
   ShapeAnnotation::setDefaults(pShapeAnnotation);
 }
 
-ModelInstance::Model *EllipseAnnotation::getParentModel() const
+ModelInstance::Extend *EllipseAnnotation::getExtend() const
 {
-  if (mpEllipse) {
-    return mpEllipse->getParentModel();
-  }
-  return 0;
+  return mpEllipse->getParentExtend();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.h
@@ -61,7 +61,7 @@ public:
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
-  ModelInstance::Model *getParentModel() const override;
+  ModelInstance::Extend *getExtend() const override;
   void setEllipse(ModelInstance::Ellipse *pEllipse) {mpEllipse = pEllipse;}
 private:
   ModelInstance::Ellipse *mpEllipse;

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -142,7 +142,7 @@ public:
   bool isActiveState() {return mActiveState;}
   void setShapeFlags(bool enable) override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
-  ModelInstance::Model *getParentModel() const override;
+  ModelInstance::Extend *getExtend() const override;
   void setAligned(bool aligned);
   void updateOMSConnection();
   void updateToolTip();
@@ -251,7 +251,7 @@ public:
   Qt::ItemFlags flags(const QModelIndex &index) const override;
   QModelIndex findFirstEnabledItem(ExpandableConnectorTreeItem *pExpandableConnectorTreeItem);
   QModelIndex expandableConnectorTreeItemIndex(const ExpandableConnectorTreeItem *pExpandableConnectorTreeItem) const;
-  void createExpandableConnectorTreeItem(ModelInstance::Element *pModelElement, ExpandableConnectorTreeItem *pParentExpandableConnectorTreeItem);
+  void createExpandableConnectorTreeItem(ModelInstance::Component *pModelComponent, ExpandableConnectorTreeItem *pParentExpandableConnectorTreeItem);
   void createExpandableConnectorTreeItem(Element *pElement, ExpandableConnectorTreeItem *pParentExpandableConnectorTreeItem);
 private:
   CreateConnectionDialog *mpCreateConnectionDialog;

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
@@ -320,12 +320,9 @@ void PolygonAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
   ShapeAnnotation::setDefaults(pShapeAnnotation);
 }
 
-ModelInstance::Model *PolygonAnnotation::getParentModel() const
+ModelInstance::Extend *PolygonAnnotation::getExtend() const
 {
-  if (mpPolygon) {
-    return mpPolygon->getParentModel();
-  }
-  return 0;
+  return mpPolygon->getParentExtend();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.h
@@ -67,7 +67,7 @@ public:
   void clearPoints() override;
   void updateEndPoint(QPointF point);
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
-  ModelInstance::Model *getParentModel() const override;
+  ModelInstance::Extend *getExtend() const override;
   void setPolygon(ModelInstance::Polygon *pPolygon) {mpPolygon = pPolygon;}
 private:
   ModelInstance::Polygon *mpPolygon;

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
@@ -275,12 +275,9 @@ void RectangleAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
   ShapeAnnotation::setDefaults(pShapeAnnotation);
 }
 
-ModelInstance::Model *RectangleAnnotation::getParentModel() const
+ModelInstance::Extend *RectangleAnnotation::getExtend() const
 {
-  if (mpRectangle) {
-    return mpRectangle->getParentModel();
-  }
-  return 0;
+  return mpRectangle->getParentExtend();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.h
@@ -64,7 +64,7 @@ public:
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
-  ModelInstance::Model *getParentModel() const override;
+  ModelInstance::Extend *getExtend() const override;
   void setRectangle(ModelInstance::Rectangle *pRectangle) {mpRectangle = pRectangle;}
 private:
   ModelInstance::Rectangle *mpRectangle;

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -606,14 +606,14 @@ QList<QPointF> ShapeAnnotation::getExtentsForInheritedShapeFromIconDiagramMap(Gr
   bool preserveAspectRatio = false;
 
   if (MainWindow::instance()->isNewApi()) {
-    ModelInstance::Extend *pExtend = dynamic_cast<ModelInstance::Extend*>(getParentModel());
+    ModelInstance::Extend *pExtend = dynamic_cast<ModelInstance::Extend*>(getExtend());
     if (pExtend) {
       if (pGraphicsView->getViewType() == StringHandler::Icon) {
         extent = pExtend->getExtendsAnnotation()->getIconMap().getExtent();
-        preserveAspectRatio = pExtend->getAnnotation()->getIconAnnotation()->mMergedCoOrdinateSystem.getPreserveAspectRatio();
+        preserveAspectRatio = pExtend->getModel()->getAnnotation()->getIconAnnotation()->mMergedCoOrdinateSystem.getPreserveAspectRatio();
       } else {
         extent = pExtend->getExtendsAnnotation()->getDiagramMap().getExtent();
-        preserveAspectRatio = pExtend->getAnnotation()->getDiagramAnnotation()->mMergedCoOrdinateSystem.getPreserveAspectRatio();
+        preserveAspectRatio = pExtend->getModel()->getAnnotation()->getDiagramAnnotation()->mMergedCoOrdinateSystem.getPreserveAspectRatio();
       }
     }
   } else {

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
@@ -215,7 +215,7 @@ public:
   void moveShape(const qreal dx, const qreal dy);
   virtual void setShapeFlags(bool enable);
   virtual void updateShape(ShapeAnnotation *pShapeAnnotation) = 0;
-  virtual ModelInstance::Model* getParentModel() const = 0;
+  virtual ModelInstance::Extend* getExtend() const = 0;
   void emitAdded() {emit added();}
   void emitChanged() {emit changed();}
   void emitDeleted() {emit deleted();}

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -530,12 +530,9 @@ void TextAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
   ShapeAnnotation::setDefaults(pShapeAnnotation);
 }
 
-ModelInstance::Model *TextAnnotation::getParentModel() const
+ModelInstance::Extend *TextAnnotation::getExtend() const
 {
-  if (mpText) {
-    return mpText->getParentModel();
-  }
-  return 0;
+  return mpText->getParentExtend();
 }
 
 void TextAnnotation::initUpdateTextString()
@@ -571,13 +568,13 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
           QString unit = mpElement->getRootParentElement()->getParameterModifierValue(variable, "unit");
           QString displayUnit = mpElement->getRootParentElement()->getParameterModifierValue(variable, "displayUnit");
           if (MainWindow::instance()->isNewApi()) {
-            ModelInstance::Element* pModelElement = Element::getModelElementByName(mpElement->getRootParentElement()->getModel(), variable);
-            if (pModelElement) {
+            ModelInstance::Component* pModelComponent = Element::getModelComponentByName(mpElement->getRootParentElement()->getModel(), variable);
+            if (pModelComponent) {
               if (displayUnit.isEmpty()) {
-                displayUnit = pModelElement->getModifierValueFromType(QStringList() << "displayUnit");
+                displayUnit = pModelComponent->getModifierValueFromType(QStringList() << "displayUnit");
               }
               if (unit.isEmpty()) {
-                unit = pModelElement->getModifierValueFromType(QStringList() << "unit");
+                unit = pModelComponent->getModifierValueFromType(QStringList() << "unit");
               }
             }
           } else {

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
@@ -68,7 +68,7 @@ public:
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;
   void updateShape(ShapeAnnotation *pShapeAnnotation) override;
-  ModelInstance::Model *getParentModel() const override;
+  ModelInstance::Extend *getExtend() const override;
   void setText(ModelInstance::Text *pText) {mpText = pText;}
 private:
   Element *mpElement;

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -606,14 +606,14 @@ bool ElementInfo::isModiferClassRecord(QString modifierName, Element *pElement)
   return result;
 }
 
-Element::Element(ModelInstance::Element *pModelElement, bool inherited, GraphicsView *pGraphicsView, bool createTransformation, QPointF position)
+Element::Element(ModelInstance::Component *pModelCompnent, bool inherited, GraphicsView *pGraphicsView, bool createTransformation, QPointF position)
   : QGraphicsItem(0), mpReferenceElement(0), mpParentElement(0)
 {
   setZValue(2000);
-  mpModelElement = pModelElement;
-  mpModel = pModelElement->getModel();
-  mName = mpModelElement->getName();
-  mClassName = mpModelElement->getType();
+  mpModelComponent = pModelCompnent;
+  mpModel = pModelCompnent->getModel();
+  mName = mpModelComponent->getName();
+  mClassName = mpModelComponent->getType();
   mpLibraryTreeItem = 0;
   mpElementInfo = 0;
   mpGraphicsView = pGraphicsView;
@@ -655,7 +655,7 @@ Element::Element(ModelInstance::Element *pModelElement, bool inherited, Graphics
     mTransformation.setExtent(extent);
     mTransformation.setRotateAngle(0.0);
   } else {
-    mTransformation.parseTransformation(mpModelElement->getAnnotation()->getPlacementAnnotation(), getCoOrdinateSystemNew());
+    mTransformation.parseTransformation(mpModelComponent->getAnnotation()->getPlacementAnnotation(), getCoOrdinateSystemNew());
   }
   setTransform(mTransformation.getTransformationMatrix());
   setDialogAnnotation(QStringList());
@@ -686,10 +686,10 @@ Element::Element(ModelInstance::Model *pModel, Element *pParentElement)
    * Use same ModelElement as parent
    * Creating a new ModelElement here for inherited classes gives wrong display of text names.
    */
-  mpModelElement = mpParentElement->getModelElement();
+  mpModelComponent = mpParentElement->getModelComponent();
   mpModel = pModel;
-  mName = mpModelElement->getName();
-  mClassName = mpModelElement->getType();
+  mName = mpModelComponent->getName();
+  mClassName = mpModelComponent->getType();
   mpLibraryTreeItem = 0;
   mpElementInfo = 0;
   mpGraphicsView = mpParentElement->getGraphicsView();
@@ -718,13 +718,13 @@ Element::Element(ModelInstance::Model *pModel, Element *pParentElement)
   connect(mpGraphicsView, SIGNAL(resetDynamicSelect()), this, SLOT(resetDynamicSelect()));
 }
 
-Element::Element(ModelInstance::Element *pModelElement, Element *pParentElement, Element *pRootParentElement)
+Element::Element(ModelInstance::Component *pModelComponent, Element *pParentElement, Element *pRootParentElement)
   : QGraphicsItem(pRootParentElement), mpReferenceElement(0), mpParentElement(pParentElement)
 {
-  mpModelElement = pModelElement;
-  mpModel = pModelElement->getModel();
-  mName = mpModelElement->getName();
-  mClassName = mpModelElement->getType();
+  mpModelComponent = pModelComponent;
+  mpModel = pModelComponent->getModel();
+  mName = mpModelComponent->getName();
+  mClassName = mpModelComponent->getType();
   mpLibraryTreeItem = 0;
   mpElementInfo = 0;
   mIsInheritedElement = mpParentElement->isInheritedElement();
@@ -745,7 +745,7 @@ Element::Element(ModelInstance::Element *pModelElement, Element *pParentElement,
   mpBusComponent = 0;
   drawInheritedElementsAndShapes();
   mTransformation = Transformation(StringHandler::Icon, this);
-  mTransformation.parseTransformation(mpModelElement->getAnnotation()->getPlacementAnnotation(), getCoOrdinateSystemNew());
+  mTransformation.parseTransformation(mpModelComponent->getAnnotation()->getPlacementAnnotation(), getCoOrdinateSystemNew());
   setTransform(mTransformation.getTransformationMatrix());
   mpOriginItem = 0;
   mpBottomLeftResizerItem = 0;
@@ -1216,7 +1216,7 @@ QString Element::getClassName() const
 QString Element::getComment() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelElement->getComment();
+    return mpModelComponent->getComment();
   } else {
     return mpElementInfo->getComment();
   }
@@ -1230,7 +1230,7 @@ QString Element::getComment() const
 bool Element::isCondition() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelElement->getCondition();
+    return mpModelComponent->getCondition();
   } else {
     return true;
   }
@@ -1487,7 +1487,7 @@ bool Element::isExpandableConnector() const
 bool Element::isArray() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelElement->isArray();
+    return mpModelComponent->isArray();
   } else {
     return (mpElementInfo && mpElementInfo->isArray());
   }
@@ -1501,7 +1501,7 @@ bool Element::isArray() const
 QStringList Element::getAbsynArrayIndexes() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelElement->getAbsynDimensions();
+    return mpModelComponent->getAbsynDimensions();
   } else if (mpElementInfo) {
     return QStringList() << mpElementInfo->getArrayIndex();
   } else {
@@ -1517,7 +1517,7 @@ QStringList Element::getAbsynArrayIndexes() const
 QStringList Element::getTypedArrayIndexes() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelElement->getTypedDimensions();
+    return mpModelComponent->getTypedDimensions();
   } else if (mpElementInfo) {
     return QStringList() << mpElementInfo->getArrayIndex();
   } else {
@@ -1554,7 +1554,7 @@ bool Element::isConnectorSizing()
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
     if (isArray()) {
       // connectorSizing is only done on the single dimensional array.
-      QString parameter = mpModelElement->getAbsynDimensions().at(0);
+      QString parameter = mpModelComponent->getAbsynDimensions().at(0);
       bool ok;
       parameter.toInt(&ok);
       // if the array index is not a number then look for parameter
@@ -1607,11 +1607,14 @@ bool Element::isParameterConnectorSizing(ModelInstance::Model *pModel, QString p
       return true;
     }
     // Look in class inheritance
-    QList<ModelInstance::Extend*> extends = pModel->getExtends();
-    foreach (auto pExtend, extends) {
-      result = Element::isParameterConnectorSizing(pExtend, parameter);
-      if (result) {
-        return result;
+    QList<ModelInstance::Element*> elements = pModel->getElements();
+    foreach (auto pElement, elements) {
+      if (pElement->isExtend() && pElement->getModel()) {
+        auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+        result = Element::isParameterConnectorSizing(pExtend->getModel(), parameter);
+        if (result) {
+          return result;
+        }
       }
     }
   }
@@ -1654,8 +1657,11 @@ void Element::createClassElements()
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
     QList<ModelInstance::Element*> elements = mpModel->getElements();
     foreach (auto pElement, elements) {
-      if (pElement->getModel() && pElement->getModel()->isConnector()) {
-        mElementsList.append(new Element(pElement, this, getRootParentElement()));
+      if (pElement->isComponent()) {
+        auto pComponent = dynamic_cast<ModelInstance::Component*>(pElement);
+        if (pComponent->getModel() && pComponent->getModel()->isConnector()) {
+          mElementsList.append(new Element(pComponent, this, getRootParentElement()));
+        }
       }
     }
   } else {
@@ -1816,9 +1822,9 @@ void Element::removeChildrenNew()
 void Element::reDrawElementNew()
 {
   removeChildrenNew();
-  mpModel = mpModelElement->getModel();
-  mName = mpModelElement->getName();
-  mClassName = mpModelElement->getType();
+  mpModel = mpModelComponent->getModel();
+  mName = mpModelComponent->getName();
+  mClassName = mpModelComponent->getType();
   // delete if state element and then check if we need to create a state element
   if (mpStateElementRectangle) {
     delete mpStateElementRectangle;
@@ -1917,7 +1923,7 @@ QString Element::getParameterDisplayString(QString parameterName)
   /* case 1 */
   if (displayString.isEmpty()) {
     if (mpGraphicsView->getModelWidget()->isNewApi()) {
-      displayString = mpModelElement->getModifier().getModifierValue(QStringList() << parameterName);
+      displayString = mpModelComponent->getModifier().getModifierValue(QStringList() << parameterName);
     } else {
       displayString = mpElementInfo->getModifiersMap(pOMCProxy, className, this).value(parameterName, "");
     }
@@ -1975,7 +1981,7 @@ QString Element::getParameterModifierValue(const QString &parameterName, const Q
   QString modifierValue = "";
   /* case 1 */
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    modifierValue = mpModelElement->getModifierValueFromType(QStringList() << parameterName << modifier);
+    modifierValue = mpModelComponent->getModifierValueFromType(QStringList() << parameterName << modifier);
   } else {
     OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
     QString className = mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure();
@@ -2290,32 +2296,33 @@ Element* Element::getElementByName(const QString &elementName)
 }
 
 /*!
- * \brief Element::getModelElementByName
- * Get the ModelInstance::Element by name.
- * \param elementName
+ * \brief Element::getModelComponentByName
+ * Get the ModelInstance::Component by name.
+ * \param name
  * \return
  */
-ModelInstance::Element* Element::getModelElementByName(ModelInstance::Model *pModel, const QString &elementName)
+ModelInstance::Component* Element::getModelComponentByName(ModelInstance::Model *pModel, const QString &name)
 {
-  ModelInstance::Element *pModelElementFound = 0;
+  ModelInstance::Component *pModelComponentFound = 0;
   if (pModel) {
     QList<ModelInstance::Element*> elements = pModel->getElements();
     foreach (auto pElement, elements) {
-      if (pElement->getName().compare(elementName) == 0) {
-        pModelElementFound = pElement;
-        return pModelElementFound;
-      }
-    }
-    /* if is not found in elements list then look into the inheritance. */
-    QList<ModelInstance::Extend*> extends = pModel->getExtends();
-    foreach (auto pExtend, extends) {
-      pModelElementFound = Element::getModelElementByName(pExtend, elementName);
-      if (pModelElementFound) {
-        return pModelElementFound;
+      if (pElement->isComponent()) {
+        auto pComponent = dynamic_cast<ModelInstance::Component*>(pElement);
+        if (pComponent->getName().compare(name) == 0) {
+          pModelComponentFound = pComponent;
+          return pModelComponentFound;
+        }
+      } else if (pElement->isExtend() && pElement->getModel()) {
+        auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+        pModelComponentFound = Element::getModelComponentByName(pExtend->getModel(), name);
+        if (pModelComponentFound) {
+          return pModelComponentFound;
+        }
       }
     }
   }
-  return pModelElementFound;
+  return pModelComponentFound;
 }
 
 /*!
@@ -2660,9 +2667,12 @@ void Element::showNonExistingOrDefaultElementIfNeeded()
 void Element::createClassInheritedElements()
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    QList<ModelInstance::Extend*> extends = mpModel->getExtends();
-    foreach (auto pExtend, extends) {
-      mInheritedElementsList.append(new Element(pExtend, this));
+    QList<ModelInstance::Element*> elements = mpModel->getElements();
+    foreach (auto pElement, elements) {
+      if (pElement->isExtend() && pElement->getModel()) {
+        auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+        mInheritedElementsList.append(new Element(pExtend->getModel(), this));
+      }
     }
   } else {
     if (!mpLibraryTreeItem->isNonExisting()) {
@@ -3047,19 +3057,22 @@ QString Element::getParameterDisplayStringFromExtendsParameters(ModelInstance::M
   QString displayString = modifierString;
   QString typeName = "";
 
-  QList<ModelInstance::Extend*> extends = pModel->getExtends();
-  foreach (auto pExtend, extends) {
-    QString value = pExtend->getParameterValue(parameterName, typeName);
-    if (displayString.isEmpty()) {
-      displayString = value;
-    }
-    Element::checkEnumerationDisplayString(displayString, typeName);
-    if (!(displayString.isEmpty() || typeName.isEmpty())) {
-      return displayString;
-    }
-    displayString = Element::getParameterDisplayStringFromExtendsParameters(pExtend, parameterName, displayString);
-    if (!(displayString.isEmpty() || typeName.isEmpty())) {
-      return displayString;
+  QList<ModelInstance::Element*> elements = pModel->getElements();
+  foreach (auto pElement, elements) {
+    if (pElement->isExtend() && pElement->getModel()) {
+      auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+      QString value = pExtend->getModel()->getParameterValue(parameterName, typeName);
+      if (displayString.isEmpty()) {
+        displayString = value;
+      }
+      Element::checkEnumerationDisplayString(displayString, typeName);
+      if (!(displayString.isEmpty() || typeName.isEmpty())) {
+        return displayString;
+      }
+      displayString = Element::getParameterDisplayStringFromExtendsParameters(pExtend->getModel(), parameterName, displayString);
+      if (!(displayString.isEmpty() || typeName.isEmpty())) {
+        return displayString;
+      }
     }
   }
   return displayString;
@@ -3087,7 +3100,7 @@ bool Element::checkEnumerationDisplayString(QString &displayString, const QStrin
 void Element::updateToolTip()
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    QString comment = mpModelElement->getComment().replace("\\\"", "\"");
+    QString comment = mpModelComponent->getComment().replace("\\\"", "\"");
     OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
     comment = pOMCProxy->makeDocumentationUriToFileName(comment);
     // since tooltips can't handle file:// scheme so we have to remove it in order to display images and make links work.
@@ -3099,10 +3112,10 @@ void Element::updateToolTip()
 
     if ((mIsInheritedElement || mElementType == Element::Port) && mpParentElement && !mpGraphicsView->isVisualizationView()) {
       setToolTip(tr("<b>%1</b> %2<br/>%3<br /><br />Element declared in %4").arg(mpModel->getName())
-                 .arg(mpModelElement->getName()).arg(comment)
+                 .arg(mpModelComponent->getName()).arg(comment)
                  .arg(mpParentElement->getModel()->getName()));
     } else {
-      setToolTip(tr("<b>%1</b> %2<br/>%3").arg(mpModel->getName()).arg(mpModelElement->getName()).arg(comment));
+      setToolTip(tr("<b>%1</b> %2<br/>%3").arg(mpModel->getName()).arg(mpModelComponent->getName()).arg(comment));
     }
   } else {
     if (mpLibraryTreeItem && mpLibraryTreeItem->getLibraryType() == LibraryTreeItem::OMS) {

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -196,9 +196,9 @@ public:
     Port  /* Port Element. */
   };
 
-  Element(ModelInstance::Element *pModelElement, bool inherited, GraphicsView *pGraphicsView, bool createTransformation, QPointF position);
+  Element(ModelInstance::Component *pModelCompnent, bool inherited, GraphicsView *pGraphicsView, bool createTransformation, QPointF position);
   Element(ModelInstance::Model *pModel, Element *pParentElement);
-  Element(ModelInstance::Element *pModelElement, Element *pParentElement, Element *pRootParentElement);
+  Element(ModelInstance::Component *pModelComponent, Element *pParentElement, Element *pRootParentElement);
 
   Element(QString name, LibraryTreeItem *pLibraryTreeItem, QString annotation, QPointF position, ElementInfo *pElementInfo, GraphicsView *pGraphicsView);
   Element(LibraryTreeItem *pLibraryTreeItem, Element *pParentElement);
@@ -213,8 +213,8 @@ public:
   QRectF itemsBoundingRect();
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
   ModelInstance::Model *getModel() const {return mpModel;}
-  ModelInstance::Element *getModelElement() const {return mpModelElement;}
-  void setModelElement(ModelInstance::Element *pModelElement) {mpModelElement = pModelElement;}
+  ModelInstance::Component *getModelComponent() const {return mpModelComponent;}
+  void setModelComponent(ModelInstance::Component *pModelComponent) {mpModelComponent = pModelComponent;}
   LibraryTreeItem* getLibraryTreeItem() {return mpLibraryTreeItem;}
   QString getName() const;
   QString getClassName() const;
@@ -305,12 +305,12 @@ public:
   void setBusComponent(Element *pBusComponent);
   Element* getBusComponent() {return mpBusComponent;}
   Element* getElementByName(const QString &elementName);
-  static ModelInstance::Element* getModelElementByName(ModelInstance::Model *pModel, const QString &elementName);
+  static ModelInstance::Component *getModelComponentByName(ModelInstance::Model *pModel, const QString &name);
 
   Transformation mTransformation;
   Transformation mOldTransformation;
 private:
-  ModelInstance::Element *mpModelElement;
+  ModelInstance::Component *mpModelComponent;
   ModelInstance::Model *mpModel;
   QString mName;
   QString mClassName;

--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -64,7 +64,7 @@
 Parameter::Parameter(Element *pElement, bool showStartAttribute, QString tab, QString groupBox)
 {
   mpElement = pElement;
-  mpModelInstanceElement = 0;
+  mpModelInstanceComponent = 0;
   mTab = tab;
   mGroupBox = groupBox;
   mShowStartAttribute = showStartAttribute;
@@ -143,12 +143,12 @@ Parameter::Parameter(Element *pElement, bool showStartAttribute, QString tab, QS
   mpCommentLabel = new Label(mpElement->getElementInfo()->getComment());
 }
 
-Parameter::Parameter(ModelInstance::Element *pElement, ElementParameters *pElementParameters)
+Parameter::Parameter(ModelInstance::Component *pComponent, ElementParameters *pElementParameters)
 {
   mpElement = 0;
-  mpModelInstanceElement = pElement;
+  mpModelInstanceComponent = pComponent;
   mpElementParameters = pElementParameters;
-  const ModelInstance::DialogAnnotation dialogAnnotation = mpModelInstanceElement->getAnnotation()->getDialogAnnotation();
+  const ModelInstance::DialogAnnotation dialogAnnotation = mpModelInstanceComponent->getAnnotation()->getDialogAnnotation();
   mTab = dialogAnnotation.getTab();
   mGroupBox = dialogAnnotation.getGroup();
   mGroupBoxDefined = !mGroupBox.isEmpty();
@@ -168,18 +168,18 @@ Parameter::Parameter(ModelInstance::Element *pElement, ElementParameters *pEleme
   mConnectorSizing = dialogAnnotation.isConnectorSizing();
 
   QString start = "", fixed = "";
-  bool isParameter = (mpModelInstanceElement->getVariability().compare(QStringLiteral("parameter")) == 0);
+  bool isParameter = (mpModelInstanceComponent->getVariability().compare(QStringLiteral("parameter")) == 0);
   // If not a parameter then check for start and fixed bindings. See Modelica.Electrical.Analog.Basic.Resistor parameter R.
   if (!isParameter && !mShowStartAttribute) {
-    start = mpModelInstanceElement->getModifier().getModifierValue(QStringList() << "start");
-    fixed = mpModelInstanceElement->getModifier().getModifierValue(QStringList() << "fixed");
+    start = mpModelInstanceComponent->getModifier().getModifierValue(QStringList() << "start");
+    fixed = mpModelInstanceComponent->getModifier().getModifierValue(QStringList() << "fixed");
     mShowStartAttribute = (!start.isEmpty() || !fixed.isEmpty()) ? true : false;
   }
 
   // if showStartAttribute true and group name is empty or Parameters then we should make group name Initialization
   if (mShowStartAttribute && mGroupBox.isEmpty()) {
     mGroupBox = "Initialization";
-  } else if (mGroupBox.isEmpty() && (isParameter || mpModelInstanceElement->getAnnotation()->hasDialogAnnotation() || mpModelInstanceElement->getReplaceable()->isReplaceable())) {
+  } else if (mGroupBox.isEmpty() && (isParameter || mpModelInstanceComponent->getAnnotation()->hasDialogAnnotation() || mpModelInstanceComponent->getReplaceable()->isReplaceable())) {
     mGroupBox = "Parameters";
   }
 
@@ -188,22 +188,22 @@ Parameter::Parameter(ModelInstance::Element *pElement, ElementParameters *pEleme
   connect(mpFixedCheckBox, SIGNAL(clicked()), SLOT(showFixedMenu()));
   setFixedState("false", true);
   // set the value type based on element type.
-  if (mpModelInstanceElement->getType().compare(QStringLiteral("Boolean")) == 0) {
-    if (mpModelInstanceElement->getAnnotation()->getChoices().isCheckBox() || mpModelInstanceElement->getAnnotation()-> getChoices().isDymolaCheckBox()) {
+  if (mpModelInstanceComponent->getType().compare(QStringLiteral("Boolean")) == 0) {
+    if (mpModelInstanceComponent->getAnnotation()->getChoices().isCheckBox() || mpModelInstanceComponent->getAnnotation()-> getChoices().isDymolaCheckBox()) {
       mValueType = Parameter::CheckBox;
     } else {
       mValueType = Parameter::Boolean;
     }
-  } else if (mpModelInstanceElement->getModel() && mpModelInstanceElement->getModel()->isEnumeration()) {
+  } else if (mpModelInstanceComponent->getModel() && mpModelInstanceComponent->getModel()->isEnumeration()) {
     mValueType = Parameter::Enumeration;
-  } else if (OptionsDialog::instance()->getGeneralSettingsPage()->getReplaceableSupport() && mpModelInstanceElement->getReplaceable()->isReplaceable()) {
+  } else if (OptionsDialog::instance()->getGeneralSettingsPage()->getReplaceableSupport() && mpModelInstanceComponent->getReplaceable()->isReplaceable()) {
     // replaceable component or short element definition
-    if (mpModelInstanceElement->getModel() && mpModelInstanceElement->getModel()->isType()) {
+    if (mpModelInstanceComponent->getModel() && mpModelInstanceComponent->getModel()->isType()) {
       mValueType = Parameter::ReplaceableClass;
     } else {
       mValueType = Parameter::ReplaceableComponent;
     }
-  } else if (!mpModelInstanceElement->getAnnotation()->getChoices().getChoices().isEmpty()) {
+  } else if (!mpModelInstanceComponent->getAnnotation()->getChoices().getChoices().isEmpty()) {
     mValueType = Parameter::Choices;
   } else {
     mValueType = Parameter::Normal;
@@ -216,9 +216,9 @@ Parameter::Parameter(ModelInstance::Element *pElement, ElementParameters *pEleme
   connect(mpFileSelectorButton, SIGNAL(clicked()), SLOT(fileSelectorButtonClicked()));
   createValueWidget();
   // Get unit value
-  mUnit = mpModelInstanceElement->getModifierValueFromType(QStringList() << "unit");
+  mUnit = mpModelInstanceComponent->getModifierValueFromType(QStringList() << "unit");
   // Get displayUnit value
-  QString displayUnit = mpModelInstanceElement->getModifierValueFromType(QStringList() << "displayUnit");
+  QString displayUnit = mpModelInstanceComponent->getModifierValueFromType(QStringList() << "displayUnit");
   if (displayUnit.isEmpty()) {
     displayUnit = mUnit;
   }
@@ -252,19 +252,19 @@ Parameter::Parameter(ModelInstance::Element *pElement, ElementParameters *pEleme
     mpUnitComboBox->setCurrentIndex(1);
   }
   connect(mpUnitComboBox, SIGNAL(currentIndexChanged(int)), SLOT(unitComboBoxChanged(int)));
-  QString comment = mpModelInstanceElement->getReplaceable()->getComment();
+  QString comment = mpModelInstanceComponent->getReplaceable()->getComment();
   if (comment.isEmpty()) {
-    comment = mpModelInstanceElement->getComment();
+    comment = mpModelInstanceComponent->getComment();
   }
   mpCommentLabel = new Label(comment);
 
   if (mValueType == Parameter::ReplaceableClass) {
-    QString className = mpModelInstanceElement->getModel()->getName();
+    QString className = mpModelInstanceComponent->getModel()->getName();
     setValueWidget(comment.isEmpty() ? className : QString("%1 - %2").arg(className, comment), true, mUnit);
   } else if (mValueType == Parameter::ReplaceableComponent) {
-    setValueWidget(QString("replaceable %1 %2").arg(mpModelInstanceElement->getParentModel()->getName(), mpModelInstanceElement->getName()), true, mUnit);
+    setValueWidget(QString("replaceable %1 %2").arg(mpModelInstanceComponent->getParentModel()->getName(), mpModelInstanceComponent->getName()), true, mUnit);
   } else {
-    setValueWidget(mpModelInstanceElement->getModifier().getValue(), true, mUnit);
+    setValueWidget(mpModelInstanceComponent->getModifier().getValue(), true, mUnit);
   }
   if (mShowStartAttribute) {
     setValueWidget(start, true, mUnit);
@@ -280,7 +280,7 @@ Parameter::Parameter(ModelInstance::Element *pElement, ElementParameters *pEleme
 void Parameter::updateNameLabel()
 {
   if (MainWindow::instance()->isNewApi()) {
-    mpNameLabel->setText(mpModelInstanceElement->getName() + (mShowStartAttribute ? ".start" : ""));
+    mpNameLabel->setText(mpModelInstanceComponent->getName() + (mShowStartAttribute ? ".start" : ""));
   } else {
     mpNameLabel->setText(mpElement->getName() + (mShowStartAttribute ? ".start" : ""));
   }
@@ -495,7 +495,7 @@ void Parameter::setEnabled(bool enable)
  */
 void Parameter::update()
 {
-  mEnable.evaluate(mpModelInstanceElement->getParentModel());
+  mEnable.evaluate(mpModelInstanceComponent->getParentModel());
   setEnabled(mEnable);
 }
 
@@ -505,7 +505,7 @@ void Parameter::createValueWidget()
   OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
   QString className;
   if (MainWindow::instance()->isNewApi()) {
-    className = mpModelInstanceElement->getType();
+    className = mpModelInstanceComponent->getType();
   } else {
     className = mpElement->getElementInfo()->getClassName();
   }
@@ -530,9 +530,12 @@ void Parameter::createValueWidget()
       // add an empty item to comments list to get correct tooltip
       enumerationLiteralsComments.append("");
       if (MainWindow::instance()->isNewApi()) {
-        foreach (auto pModelInstanceElement, mpModelInstanceElement->getModel()->getElements()) {
-          enumerationLiterals.append(pModelInstanceElement->getName());
-          enumerationLiteralsComments.append(pModelInstanceElement->getComment());
+        foreach (auto pModelInstanceElement, mpModelInstanceComponent->getModel()->getElements()) {
+          if (pModelInstanceElement->isComponent()) {
+            auto pModelInstanceComponent = dynamic_cast<ModelInstance::Component*>(pModelInstanceElement);
+            enumerationLiterals.append(pModelInstanceComponent->getName());
+            enumerationLiteralsComments.append(pModelInstanceComponent->getComment());
+          }
         }
       } else {
         enumerationLiterals = pOMCProxy->getEnumerationLiterals(className);
@@ -541,7 +544,7 @@ void Parameter::createValueWidget()
         mpValueComboBox->addItem(enumerationLiterals[i], className + "." + enumerationLiterals[i]);
       }
       if (MainWindow::instance()->isNewApi()) {
-        Utilities::setToolTip(mpValueComboBox, mpModelInstanceElement->getModel()->getName(), enumerationLiteralsComments);
+        Utilities::setToolTip(mpValueComboBox, mpModelInstanceComponent->getModel()->getName(), enumerationLiteralsComments);
       }
       connect(mpValueComboBox, SIGNAL(currentIndexChanged(int)), SLOT(valueComboBoxChanged(int)));
       break;
@@ -554,18 +557,18 @@ void Parameter::createValueWidget()
     case Parameter::ReplaceableComponent:
     case Parameter::ReplaceableClass:
       if (MainWindow::instance()->isNewApi()) {
-        constrainedByClassName = mpModelInstanceElement->getReplaceable()->getConstrainedby();
+        constrainedByClassName = mpModelInstanceComponent->getReplaceable()->getConstrainedby();
         if (constrainedByClassName.isEmpty()) {
-          constrainedByClassName = mpModelInstanceElement->getType();
+          constrainedByClassName = mpModelInstanceComponent->getType();
         }
-        choices = mpModelInstanceElement->getAnnotation()->getChoices().getChoices();
-        parentClassName = mpModelInstanceElement->getParentModel()->getName();
-        if (mpModelInstanceElement->getModel()) {
-          restriction = mpModelInstanceElement->getModel()->getRestriction();
+        choices = mpModelInstanceComponent->getAnnotation()->getChoices().getChoices();
+        parentClassName = mpModelInstanceComponent->getParentModel()->getName();
+        if (mpModelInstanceComponent->getModel()) {
+          restriction = mpModelInstanceComponent->getModel()->getRestriction();
         } else {
-          restriction = mpModelInstanceElement->getType();
+          restriction = mpModelInstanceComponent->getType();
         }
-        elementName = mpModelInstanceElement->getName();
+        elementName = mpModelInstanceComponent->getName();
       } else {
         constrainedByClassName = mpElement->getElementInfo()->getConstrainedByClassName();
         if (mpElement->hasChoices()) {
@@ -621,7 +624,7 @@ void Parameter::createValueWidget()
       mpValueComboBox = new QComboBox;
       mpValueComboBox->setEditable(true);
       mpValueComboBox->addItem("", "");
-      foreach (QString choice, mpModelInstanceElement->getAnnotation()->getChoices().getChoices()) {
+      foreach (QString choice, mpModelInstanceComponent->getAnnotation()->getChoices().getChoices()) {
         mpValueComboBox->addItem(choice, choice);
       }
       connect(mpValueComboBox, SIGNAL(currentIndexChanged(int)), SLOT(valueComboBoxChanged(int)));
@@ -675,7 +678,7 @@ void Parameter::updateValueBinding(const FlatModelica::Expression expression)
 {
   if (MainWindow::instance()->isNewApi()) {
     // update the binding with the new value
-    mpModelInstanceElement->setBinding(expression);
+    mpModelInstanceComponent->setBinding(expression);
     mpElementParameters->updateParameters();
   }
 }
@@ -1389,9 +1392,12 @@ void ElementParameters::createTabsGroupBoxesAndParametersHelper(LibraryTreeItem 
 
 void ElementParameters::createTabsGroupBoxesAndParameters(ModelInstance::Model *pModelInstance)
 {
-  foreach (auto pExtend, pModelInstance->getExtends()) {
-    createTabsGroupBoxesAndParameters(pExtend);
-    createTabsGroupBoxesAndParametersHelper(pExtend);
+  foreach (auto pElement, pModelInstance->getElements()) {
+    if (pElement->isExtend() && pElement->getModel()) {
+      auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+      createTabsGroupBoxesAndParameters(pExtend->getModel());
+      createTabsGroupBoxesAndParametersHelper(pExtend->getModel());
+    }
   }
 }
 
@@ -1399,48 +1405,51 @@ void ElementParameters::createTabsGroupBoxesAndParametersHelper(ModelInstance::M
 {
   int insertIndex = 0;
   foreach (auto pElement, pModelInstance->getElements()) {
-    // if we already have the parameter from one of the inherited class then just skip this one.
-    if (findParameter(pElement->getName())) {
-      continue;
-    }
-    /* Ticket #2531
-     * Do not show the protected & final parameters.
-     */
-    if (!pElement->isPublic() || pElement->isFinal()) {
-      continue;
-    }
-    // if connectorSizing is present then don't show the parameter
-    if (pElement->getAnnotation()->getDialogAnnotation().isConnectorSizing()) {
-      continue;
-    }
-    // create the Parameter
-    Parameter *pParameter = new Parameter(pElement, this);
-
-    if (!mTabsMap.contains(pParameter->getTab())) {
-      ParametersScrollArea *pParametersScrollArea = new ParametersScrollArea;
-      GroupBox *pGroupBox = new GroupBox(pParameter->getGroupBox());
-      // set the group image
-      pGroupBox->setGroupImage(pParameter->getGroupImage());
-      pParametersScrollArea->addGroupBox(pGroupBox);
-      mTabsMap.insert(pParameter->getTab(), mpParametersTabWidget->addTab(pParametersScrollArea, pParameter->getTab()));
-    } else {
-      ParametersScrollArea *pParametersScrollArea;
-      pParametersScrollArea = qobject_cast<ParametersScrollArea*>(mpParametersTabWidget->widget(mTabsMap.value(pParameter->getTab())));
-      GroupBox *pGroupBox = pParametersScrollArea->getGroupBox(pParameter->getGroupBox());
-      if (pParametersScrollArea && !pGroupBox) {
-        pGroupBox = new GroupBox(pParameter->getGroupBox());
-        pParametersScrollArea->addGroupBox(pGroupBox);
+    if (pElement->isComponent()) {
+      auto pComponent = dynamic_cast<ModelInstance::Component*>(pElement);
+      // if we already have the parameter from one of the inherited class then just skip this one.
+      if (findParameter(pComponent->getName())) {
+        continue;
       }
-      // set the group image
-      pGroupBox->setGroupImage(pParameter->getGroupImage());
-    }
+      /* Ticket #2531
+       * Do not show the protected & final parameters.
+       */
+      if (!pComponent->isPublic() || pComponent->isFinal()) {
+        continue;
+      }
+      // if connectorSizing is present then don't show the parameter
+      if (pComponent->getAnnotation()->getDialogAnnotation().isConnectorSizing()) {
+        continue;
+      }
+      // create the Parameter
+      Parameter *pParameter = new Parameter(pComponent, this);
 
-    if (useInsert) {
-      mParametersList.insert(insertIndex, pParameter);
-    } else {
-      mParametersList.append(pParameter);
+      if (!mTabsMap.contains(pParameter->getTab())) {
+        ParametersScrollArea *pParametersScrollArea = new ParametersScrollArea;
+        GroupBox *pGroupBox = new GroupBox(pParameter->getGroupBox());
+        // set the group image
+        pGroupBox->setGroupImage(pParameter->getGroupImage());
+        pParametersScrollArea->addGroupBox(pGroupBox);
+        mTabsMap.insert(pParameter->getTab(), mpParametersTabWidget->addTab(pParametersScrollArea, pParameter->getTab()));
+      } else {
+        ParametersScrollArea *pParametersScrollArea;
+        pParametersScrollArea = qobject_cast<ParametersScrollArea*>(mpParametersTabWidget->widget(mTabsMap.value(pParameter->getTab())));
+        GroupBox *pGroupBox = pParametersScrollArea->getGroupBox(pParameter->getGroupBox());
+        if (pParametersScrollArea && !pGroupBox) {
+          pGroupBox = new GroupBox(pParameter->getGroupBox());
+          pParametersScrollArea->addGroupBox(pGroupBox);
+        }
+        // set the group image
+        pGroupBox->setGroupImage(pParameter->getGroupImage());
+      }
+
+      if (useInsert) {
+        mParametersList.insert(insertIndex, pParameter);
+      } else {
+        mParametersList.append(pParameter);
+      }
+      insertIndex++;
     }
-    insertIndex++;
   }
 }
 
@@ -1451,55 +1460,58 @@ void ElementParameters::createTabsGroupBoxesAndParametersHelper(ModelInstance::M
  */
 void ElementParameters::fetchElementExtendsModifiers(ModelInstance::Model *pModelInstance)
 {
-  foreach (auto pExtend, pModelInstance->getExtends()) {
-    foreach (auto modifier, pExtend->getExtendsModifier().getModifiers()) {
-      Parameter *pParameter = findParameter(modifier.getName());
-      if (pParameter) {
-        /* Ticket #2531
+  foreach (auto pElement, pModelInstance->getElements()) {
+    if (pElement->isExtend() && pElement->getModel()) {
+      auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+      foreach (auto modifier, pExtend->getExtendsModifier().getModifiers()) {
+        Parameter *pParameter = findParameter(modifier.getName());
+        if (pParameter) {
+          /* Ticket #2531
          * Check if parameter is marked final in the extends modifier.
          */
-        if (modifier.isFinal()) {
-          mParametersList.removeOne(pParameter);
-          delete pParameter;
-          continue;
-        }
-        pParameter->setValueWidget(modifier.getValue(), true, pParameter->getUnit());
-        foreach (auto subModifier, modifier.getModifiers()) {
-          if (subModifier.getName().compare(QStringLiteral("start")) == 0 || subModifier.getName().compare(QStringLiteral("fixed")) == 0) {
-            QString startOrFixed = subModifier.getValueWithoutQuotes();
-            if (!startOrFixed.isEmpty()) {
-              if (!pParameter->isGroupBoxDefined()) {
-                pParameter->setGroupBox("Initialization");
+          if (modifier.isFinal()) {
+            mParametersList.removeOne(pParameter);
+            delete pParameter;
+            continue;
+          }
+          pParameter->setValueWidget(modifier.getValue(), true, pParameter->getUnit());
+          foreach (auto subModifier, modifier.getModifiers()) {
+            if (subModifier.getName().compare(QStringLiteral("start")) == 0 || subModifier.getName().compare(QStringLiteral("fixed")) == 0) {
+              QString startOrFixed = subModifier.getValueWithoutQuotes();
+              if (!startOrFixed.isEmpty()) {
+                if (!pParameter->isGroupBoxDefined()) {
+                  pParameter->setGroupBox("Initialization");
+                }
+                pParameter->setShowStartAttribute(true);
+                if (subModifier.getName().compare(QStringLiteral("start")) == 0) {
+                  pParameter->setValueWidget(startOrFixed, true, pParameter->getUnit());
+                } else { // fixed modifier
+                  pParameter->setFixedState(startOrFixed, true);
+                }
               }
-              pParameter->setShowStartAttribute(true);
-              if (subModifier.getName().compare(QStringLiteral("start")) == 0) {
-                pParameter->setValueWidget(startOrFixed, true, pParameter->getUnit());
-              } else { // fixed modifier
-                pParameter->setFixedState(startOrFixed, true);
+            } else if (subModifier.getName().compare(QStringLiteral("displayUnit")) == 0) {
+              QString displayUnit = subModifier.getValueWithoutQuotes();
+              int index = pParameter->getUnitComboBox()->findData(displayUnit);
+              if (index < 0) {
+                // add extends modifier as additional display unit if compatible
+                index = pParameter->getUnitComboBox()->count() - 1;
+                OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
+                if (index > -1 &&
+                    (pOMCProxy->convertUnits(pParameter->getUnitComboBox()->itemData(0).toString(), displayUnit)).unitsCompatible) {
+                  pParameter->getUnitComboBox()->addItem(Utilities::convertUnitToSymbol(displayUnit), displayUnit);
+                  index ++;
+                }
               }
-            }
-          } else if (subModifier.getName().compare(QStringLiteral("displayUnit")) == 0) {
-            QString displayUnit = subModifier.getValueWithoutQuotes();
-            int index = pParameter->getUnitComboBox()->findData(displayUnit);
-            if (index < 0) {
-              // add extends modifier as additional display unit if compatible
-              index = pParameter->getUnitComboBox()->count() - 1;
-              OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
-              if (index > -1 &&
-                  (pOMCProxy->convertUnits(pParameter->getUnitComboBox()->itemData(0).toString(), displayUnit)).unitsCompatible) {
-                pParameter->getUnitComboBox()->addItem(Utilities::convertUnitToSymbol(displayUnit), displayUnit);
-                index ++;
+              if (index > -1) {
+                pParameter->getUnitComboBox()->setCurrentIndex(index);
+                pParameter->setDisplayUnit(displayUnit);
               }
-            }
-            if (index > -1) {
-              pParameter->getUnitComboBox()->setCurrentIndex(index);
-              pParameter->setDisplayUnit(displayUnit);
             }
           }
         }
       }
+      fetchElementExtendsModifiers(pExtend->getModel());
     }
-    fetchElementExtendsModifiers(pExtend);
   }
 }
 
@@ -1577,7 +1589,7 @@ void ElementParameters::fetchElementExtendsModifiers()
 void ElementParameters::fetchElementModifiers()
 {
   if (MainWindow::instance()->isNewApi()) {
-    foreach (auto modifier, mpElement->getModelElement()->getModifier().getModifiers()) {
+    foreach (auto modifier, mpElement->getModelComponent()->getModifier().getModifiers()) {
       Parameter *pParameter = findParameter(modifier.getName());
       if (pParameter) {
         pParameter->setValueWidget(modifier.getValue(), mpElement->isInheritedElement(), pParameter->getUnit());
@@ -1681,56 +1693,59 @@ void ElementParameters::fetchElementModifiers()
 void ElementParameters::fetchClassExtendsModifiers()
 {
   ModelInstance::Model *pClassModelInstance = mpElement->getGraphicsView()->getModelWidget()->getModelInstance();
-  QList<ModelInstance::Extend*> extends = pClassModelInstance->getExtends();
-  foreach (auto pExtend, extends) {
-    if (pExtend->getName().compare(mpElement->getModelElement()->getParentModel()->getName()) == 0) {
-      foreach (auto modifier, pExtend->getExtendsModifier().getModifiers()) {
-        if (modifier.getName().compare(mpElement->getName()) == 0) {
-          foreach (auto subModifier, modifier.getModifiers()) {
-            Parameter *pParameter = findParameter(subModifier.getName());
-            if (pParameter) {
-              pParameter->setValueWidget(subModifier.getValue(), false, pParameter->getUnit());
-              foreach (auto subSubModifier, subModifier.getModifiers()) {
-                if (subSubModifier.getName().compare(QStringLiteral("start")) == 0 || subSubModifier.getName().compare(QStringLiteral("fixed")) == 0) {
-                  QString startOrFixed = subSubModifier.getValueWithoutQuotes();
-                  if (!startOrFixed.isEmpty()) {
-                    if (!pParameter->isGroupBoxDefined()) {
-                      pParameter->setGroupBox("Initialization");
+  QList<ModelInstance::Element*> elements = pClassModelInstance->getElements();
+  foreach (auto pElement, elements) {
+    if (pElement->isExtend() && pElement->getModel()) {
+      auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+      if (pExtend->getModel()->getName().compare(mpElement->getModelComponent()->getParentModel()->getName()) == 0) {
+        foreach (auto modifier, pExtend->getExtendsModifier().getModifiers()) {
+          if (modifier.getName().compare(mpElement->getName()) == 0) {
+            foreach (auto subModifier, modifier.getModifiers()) {
+              Parameter *pParameter = findParameter(subModifier.getName());
+              if (pParameter) {
+                pParameter->setValueWidget(subModifier.getValue(), false, pParameter->getUnit());
+                foreach (auto subSubModifier, subModifier.getModifiers()) {
+                  if (subSubModifier.getName().compare(QStringLiteral("start")) == 0 || subSubModifier.getName().compare(QStringLiteral("fixed")) == 0) {
+                    QString startOrFixed = subSubModifier.getValueWithoutQuotes();
+                    if (!startOrFixed.isEmpty()) {
+                      if (!pParameter->isGroupBoxDefined()) {
+                        pParameter->setGroupBox("Initialization");
+                      }
+                      pParameter->setShowStartAttribute(true);
+                      if (subSubModifier.getName().compare(QStringLiteral("start")) == 0) {
+                        pParameter->setValueWidget(startOrFixed, false, pParameter->getUnit());
+                      } else { // fixed modifier
+                        pParameter->setFixedState(startOrFixed, false);
+                      }
                     }
-                    pParameter->setShowStartAttribute(true);
-                    if (subSubModifier.getName().compare(QStringLiteral("start")) == 0) {
-                      pParameter->setValueWidget(startOrFixed, false, pParameter->getUnit());
-                    } else { // fixed modifier
-                      pParameter->setFixedState(startOrFixed, false);
+                  } else if (subSubModifier.getName().compare(QStringLiteral("displayUnit")) == 0) {
+                    QString displayUnit = subSubModifier.getValueWithoutQuotes();
+                    int index = pParameter->getUnitComboBox()->findData(displayUnit);
+                    if (index < 0) {
+                      // add extends modifier as additional display unit if compatible
+                      index = pParameter->getUnitComboBox()->count() - 1;
+                      OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
+                      if (index > -1 &&
+                          (pOMCProxy->convertUnits(pParameter->getUnitComboBox()->itemData(0).toString(), displayUnit)).unitsCompatible) {
+                        pParameter->getUnitComboBox()->addItem(Utilities::convertUnitToSymbol(displayUnit), displayUnit);
+                        index ++;
+                      }
                     }
-                  }
-                } else if (subSubModifier.getName().compare(QStringLiteral("displayUnit")) == 0) {
-                  QString displayUnit = subSubModifier.getValueWithoutQuotes();
-                  int index = pParameter->getUnitComboBox()->findData(displayUnit);
-                  if (index < 0) {
-                    // add extends modifier as additional display unit if compatible
-                    index = pParameter->getUnitComboBox()->count() - 1;
-                    OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
-                    if (index > -1 &&
-                        (pOMCProxy->convertUnits(pParameter->getUnitComboBox()->itemData(0).toString(), displayUnit)).unitsCompatible) {
-                      pParameter->getUnitComboBox()->addItem(Utilities::convertUnitToSymbol(displayUnit), displayUnit);
-                      index ++;
+                    if (index > -1) {
+                      pParameter->getUnitComboBox()->setCurrentIndex(index);
+                      pParameter->setDisplayUnit(displayUnit);
                     }
+                  } else {
+                    pParameter->setValueWidget(modifier.getValueWithoutQuotes(), false, pParameter->getUnit());
                   }
-                  if (index > -1) {
-                    pParameter->getUnitComboBox()->setCurrentIndex(index);
-                    pParameter->setDisplayUnit(displayUnit);
-                  }
-                } else {
-                  pParameter->setValueWidget(modifier.getValueWithoutQuotes(), false, pParameter->getUnit());
                 }
               }
             }
+            break;
           }
-          break;
         }
+        break;
       }
-      break;
     }
   }
 }
@@ -1765,7 +1780,7 @@ Parameter* ElementParameters::findParameter(const QString &parameter, Qt::CaseSe
 {
   foreach (Parameter *pParameter, mParametersList) {
     if (MainWindow::instance()->isNewApi()) {
-      if (pParameter->getModelInstanceElement()->getName().compare(parameter, caseSensitivity) == 0) {
+      if (pParameter->getModelInstanceComponent()->getName().compare(parameter, caseSensitivity) == 0) {
         return pParameter;
       }
     } else {
@@ -1881,7 +1896,7 @@ void ElementParameters::updateElementParameters()
         QString modifierKey = QString(mpElement->getName() % "." % newElementModifier.key());
         // if the element is inherited then add the modifier value into the extends.
         if (mpElement->isInheritedElement()) {
-          pOMCProxy->setExtendsModifierValue(className, mpElement->getModelElement()->getParentModel()->getName(), modifierKey, modifierValue);
+          pOMCProxy->setExtendsModifierValue(className, mpElement->getModelComponent()->getParentModel()->getName(), modifierKey, modifierValue);
         } else {
           pOMCProxy->setComponentModifierValue(className, modifierKey, modifierValue);
         }
@@ -2012,7 +2027,7 @@ void ElementParameters::reject()
     foreach (Parameter *pParameter, mParametersList) {
       // reset any changed parameter binding
       if (pParameter->isValueModified()) {
-        pParameter->getModelInstanceElement()->resetBinding();
+        pParameter->getModelInstanceComponent()->resetBinding();
       }
     }
   }
@@ -2155,18 +2170,18 @@ void ElementAttributes::initializeDialog()
 {
   if (MainWindow::instance()->isNewApi()) {
     // get Class Name
-    mpNameTextBox->setText(mpElement->getModelElement()->getName());
+    mpNameTextBox->setText(mpElement->getModelComponent()->getName());
     mpNameTextBox->setCursorPosition(0);
     // get dimensions
-    QString dimensions = mpElement->getModelElement()->getAbsynDimensionsString();
+    QString dimensions = mpElement->getModelComponent()->getAbsynDimensionsString();
     mpDimensionsTextBox->setText(QString("[%1]").arg(dimensions));
     // get Comment
-    mpCommentTextBox->setText(mpElement->getModelElement()->getComment());
+    mpCommentTextBox->setText(mpElement->getModelComponent()->getComment());
     mpCommentTextBox->setCursorPosition(0);
     // get classname
-    mpPathTextBox->setText(mpElement->getModelElement()->getType());
+    mpPathTextBox->setText(mpElement->getModelComponent()->getType());
     // get Variability
-    const QString variability = mpElement->getModelElement()->getVariability();
+    const QString variability = mpElement->getModelComponent()->getVariability();
     if (variability.compare(QStringLiteral("constant")) == 0) {
       mpConstantRadio->setChecked(true);
     } else if (variability.compare(QStringLiteral("parameter")) == 0) {
@@ -2177,11 +2192,11 @@ void ElementAttributes::initializeDialog()
       mpDefaultRadio->setChecked(true);
     }
     // get Properties
-    mpFinalCheckBox->setChecked(mpElement->getModelElement()->isFinal());
-    mpProtectedCheckBox->setChecked(!mpElement->getModelElement()->isPublic());
-    mpReplaceAbleCheckBox->setChecked(mpElement->getModelElement()->getReplaceable()->isReplaceable());
+    mpFinalCheckBox->setChecked(mpElement->getModelComponent()->isFinal());
+    mpProtectedCheckBox->setChecked(!mpElement->getModelComponent()->isPublic());
+    mpReplaceAbleCheckBox->setChecked(mpElement->getModelComponent()->getReplaceable()->isReplaceable());
     // get Casuality
-    const QString direction = mpElement->getModelElement()->getDirection();
+    const QString direction = mpElement->getModelComponent()->getDirection();
     if (direction.compare(QStringLiteral("input")) == 0) {
       mpInputRadio->setChecked(true);
     } else if (direction.compare(QStringLiteral("output")) == 0) {
@@ -2190,8 +2205,8 @@ void ElementAttributes::initializeDialog()
       mpNoneRadio->setChecked(true);
     }
     // get InnerOuter
-    mpInnerCheckBox->setChecked(mpElement->getModelElement()->isInner());
-    mpOuterCheckBox->setChecked(mpElement->getModelElement()->isOuter());
+    mpInnerCheckBox->setChecked(mpElement->getModelComponent()->isInner());
+    mpOuterCheckBox->setChecked(mpElement->getModelComponent()->isOuter());
   } else {
     // get Class Name
     mpNameTextBox->setText(mpElement->getElementInfo()->getName());
@@ -2293,16 +2308,16 @@ void ElementAttributes::updateElementAttributes()
     OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
     QString modelName = pModelWidget->getLibraryTreeItem()->getNameStructure();
     bool attributesChanged = false;
-    attributesChanged |= mpElement->getModelElement()->isFinal() != mpFinalCheckBox->isChecked();
-    attributesChanged |= !mpElement->getModelElement()->isPublic() != mpProtectedCheckBox->isChecked();
-    attributesChanged |= mpElement->getModelElement()->getReplaceable()->isReplaceable() != mpReplaceAbleCheckBox->isChecked();
-    attributesChanged |= mpElement->getModelElement()->getVariability().compare(variability) != 0;
-    attributesChanged |= mpElement->getModelElement()->isInner() != mpInnerCheckBox->isChecked();
-    attributesChanged |= mpElement->getModelElement()->isOuter() != mpOuterCheckBox->isChecked();
-    attributesChanged |= mpElement->getModelElement()->getDirection().compare(causality) != 0;
+    attributesChanged |= mpElement->getModelComponent()->isFinal() != mpFinalCheckBox->isChecked();
+    attributesChanged |= !mpElement->getModelComponent()->isPublic() != mpProtectedCheckBox->isChecked();
+    attributesChanged |= mpElement->getModelComponent()->getReplaceable()->isReplaceable() != mpReplaceAbleCheckBox->isChecked();
+    attributesChanged |= mpElement->getModelComponent()->getVariability().compare(variability) != 0;
+    attributesChanged |= mpElement->getModelComponent()->isInner() != mpInnerCheckBox->isChecked();
+    attributesChanged |= mpElement->getModelComponent()->isOuter() != mpOuterCheckBox->isChecked();
+    attributesChanged |= mpElement->getModelComponent()->getDirection().compare(causality) != 0;
 
     QString isFinal = mpFinalCheckBox->isChecked() ? "true" : "false";
-    QString flow = (mpElement->getModelElement()->getConnector().compare(QStringLiteral("flow")) == 0) ? "true" : "false";
+    QString flow = (mpElement->getModelComponent()->getConnector().compare(QStringLiteral("flow")) == 0) ? "true" : "false";
     QString isProtected = mpProtectedCheckBox->isChecked() ? "true" : "false";
     QString isReplaceAble = mpReplaceAbleCheckBox->isChecked() ? "true" : "false";
     QString isInner = mpInnerCheckBox->isChecked() ? "true" : "false";
@@ -2317,7 +2332,7 @@ void ElementAttributes::updateElementAttributes()
     }
 
     // update the element comment only if its changed.
-    if (mpElement->getModelElement()->getComment().compare(mpCommentTextBox->text()) != 0) {
+    if (mpElement->getModelComponent()->getComment().compare(mpCommentTextBox->text()) != 0) {
       QString comment = StringHandler::escapeString(mpCommentTextBox->text());
       if (pOMCProxy->setComponentComment(modelName, mpElement->getName(), comment)) {
         attributesChanged = true;
@@ -2328,7 +2343,7 @@ void ElementAttributes::updateElementAttributes()
     }
     // update the element dimensions
     const QString dimensions = StringHandler::removeFirstLastSquareBrackets(mpDimensionsTextBox->text());
-    if (mpElement->getModelElement()->getAbsynDimensionsString().compare(dimensions) != 0) {
+    if (mpElement->getModelComponent()->getAbsynDimensionsString().compare(dimensions) != 0) {
       const QString arrayIndex = QString("{%1}").arg(dimensions);
       if (pOMCProxy->setComponentDimensions(modelName, mpElement->getName(), arrayIndex)) {
         attributesChanged = true;

--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -54,9 +54,9 @@ public:
     Choices
   };
   Parameter(Element *pElement, bool showStartAttribute, QString tab, QString groupBox);
-  Parameter(ModelInstance::Element *pElement, ElementParameters *pElementParameters);
+  Parameter(ModelInstance::Component *pComponent, ElementParameters *pElementParameters);
   Element* getElement() {return mpElement;}
-  ModelInstance::Element* getModelInstanceElement() {return mpModelInstanceElement;}
+  ModelInstance::Component* getModelInstanceComponent() {return mpModelInstanceComponent;}
   void setTab(QString tab) {mTab = tab;}
   StringAnnotation getTab() {return mTab;}
   void setGroupBox(QString groupBox) {mGroupBox = groupBox;}
@@ -96,7 +96,7 @@ public:
   void update();
 private:
   Element *mpElement;
-  ModelInstance::Element *mpModelInstanceElement;
+  ModelInstance::Component *mpModelInstanceComponent;
   ElementParameters *mpElementParameters = 0;
   StringAnnotation mTab;
   StringAnnotation mGroupBox;

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -251,6 +251,14 @@ namespace ModelInstance
     mpParentModel = pParentModel;
   }
 
+  Extend *Shape::getParentExtend() const
+  {
+    if (mpParentModel && mpParentModel->getParentElement() && mpParentModel->getParentElement()->isExtend()) {
+      return dynamic_cast<ModelInstance::Extend*>(mpParentModel->getParentElement());
+    }
+    return 0;
+  }
+
   Shape::~Shape() = default;
 
   Line::Line(Model *pParentModel)
@@ -745,13 +753,9 @@ namespace ModelInstance
     }
   }
 
-  Model::Model()
+  Model::Model(const QJsonObject &jsonObject, Element *pParentElement)
   {
-    initialize();
-  }
-
-  Model::Model(const QJsonObject &jsonObject)
-  {
+    mpParentElement = pParentElement;
     initialize();
     mModelJson = jsonObject;
     deserialize();
@@ -759,9 +763,6 @@ namespace ModelInstance
 
   Model::~Model()
   {
-    qDeleteAll(mExtends);
-    mExtends.clear();
-
     qDeleteAll(mElements);
     mElements.clear();
 
@@ -851,9 +852,11 @@ namespace ModelInstance
       QString kind = elementObject.value("$kind").toString();
 
       if (kind == "extends") {
-        mExtends.append(new Extend(elementObject));
+        mElements.append(new Extend(this, elementObject));
       } else if (kind == "component") {
-        mElements.append(new Element(this, elementObject));
+        mElements.append(new Component(this, elementObject));
+      } else {
+        qDebug() << "Unhandled kind of element" << kind;
       }
     }
 
@@ -981,33 +984,39 @@ namespace ModelInstance
      *
      * Following is the second case.
      */
-    foreach (auto pExtend, mExtends) {
-      ModelInstance::CoordinateSystem coordinateSystem;
-      if (isIcon) {
-        coordinateSystem = pExtend->getAnnotation()->getIconAnnotation()->mCoordinateSystem;
-      } else {
-        coordinateSystem = pExtend->getAnnotation()->getDiagramAnnotation()->mCoordinateSystem;
-      }
+    foreach (auto pElement, mElements) {
+      if (pElement->isExtend() && pElement->getModel()) {
+        auto pExtend = dynamic_cast<Extend*>(pElement);
+        ModelInstance::CoordinateSystem coordinateSystem;
+        if (isIcon) {
+          coordinateSystem = pExtend->getModel()->getAnnotation()->getIconAnnotation()->mCoordinateSystem;
+        } else {
+          coordinateSystem = pExtend->getModel()->getAnnotation()->getDiagramAnnotation()->mCoordinateSystem;
+        }
 
-      if (!pCoordinateSystem->hasExtent() && coordinateSystem.hasExtent()) {
-        pCoordinateSystem->setExtent(coordinateSystem.getExtent());
-      }
-      if (!pCoordinateSystem->hasPreserveAspectRatio() && coordinateSystem.hasPreserveAspectRatio()) {
-        pCoordinateSystem->setPreserveAspectRatio(coordinateSystem.getPreserveAspectRatio());
-      }
+        if (!pCoordinateSystem->hasExtent() && coordinateSystem.hasExtent()) {
+          pCoordinateSystem->setExtent(coordinateSystem.getExtent());
+        }
+        if (!pCoordinateSystem->hasPreserveAspectRatio() && coordinateSystem.hasPreserveAspectRatio()) {
+          pCoordinateSystem->setPreserveAspectRatio(coordinateSystem.getPreserveAspectRatio());
+        }
 
-      if (!pCoordinateSystem->isComplete()) {
-        pExtend->readCoordinateSystemFromExtendsClass(pCoordinateSystem, isIcon);
+        if (!pCoordinateSystem->isComplete()) {
+          pExtend->getModel()->readCoordinateSystemFromExtendsClass(pCoordinateSystem, isIcon);
+        }
+        break; // we only check coordinate system of first inherited class. See the comment in start of function i.e., "The coordinate systems of the first base-class ..."
       }
-      break; // we only check coordinate system of first inherited class. See the comment in start of function i.e., "The coordinate systems of the first base-class ..."
     }
   }
 
   bool Model::isParameterConnectorSizing(const QString &parameter)
   {
-    foreach (auto pModelElement, mElements) {
-      if (pModelElement->getName().compare(parameter) == 0) {
-        return pModelElement->getAnnotation()->getDialogAnnotation().isConnectorSizing();
+    foreach (auto pElement, mElements) {
+      if (pElement->isComponent()) {
+        auto pComponent = dynamic_cast<Component*>(pElement);
+        if (pComponent->getName().compare(parameter) == 0) {
+          return pComponent->getAnnotation()->getDialogAnnotation().isConnectorSizing();
+        }
       }
     }
     return false;
@@ -1017,14 +1026,17 @@ namespace ModelInstance
   {
     QString value = "";
     foreach (auto pElement, mElements) {
-      if (pElement->getName().compare(StringHandler::getFirstWordBeforeDot(parameter)) == 0) {
-        value = pElement->getModifier().getValueWithoutQuotes();
-        // Fixes issue #7493. Handles the case where value is from instance name e.g., %instanceName.parameterName
-        if (value.isEmpty() && pElement->getModel()) {
-          value = pElement->getModel()->getParameterValue(StringHandler::getLastWordAfterDot(parameter), typeName);
+      if (pElement->isComponent()) {
+        auto pComponent = dynamic_cast<Component*>(pElement);
+        if (pComponent->getName().compare(StringHandler::getFirstWordBeforeDot(parameter)) == 0) {
+          value = pComponent->getModifier().getValueWithoutQuotes();
+          // Fixes issue #7493. Handles the case where value is from instance name e.g., %instanceName.parameterName
+          if (value.isEmpty() && pComponent->getModel()) {
+            value = pComponent->getModel()->getParameterValue(StringHandler::getLastWordAfterDot(parameter), typeName);
+          }
+          typeName = pComponent->getType();
+          break;
         }
-        typeName = pElement->getType();
-        break;
       }
     }
     return value;
@@ -1033,18 +1045,19 @@ namespace ModelInstance
   QString Model::getParameterValueFromExtendsModifiers(const QString &parameter)
   {
     QString value = "";
-    foreach (auto pExtend, mExtends) {
-      value = pExtend->getExtendsModifier().getModifierValue(QStringList() << parameter);
-      if (!value.isEmpty()) {
-        return value;
-      }
-    }
-
-    if (value.isEmpty()) {
-      foreach (auto pExtend, mExtends) {
-        value = pExtend->getParameterValueFromExtendsModifiers(parameter);
+    foreach (auto pElement, mElements) {
+      if (pElement->isExtend()) {
+        auto pExtend = dynamic_cast<Extend*>(pElement);
+        value = pExtend->getExtendsModifier().getModifierValue(QStringList() << parameter);
         if (!value.isEmpty()) {
           return value;
+        } else {
+          if (pExtend->getModel()) {
+            value = pExtend->getModel()->getParameterValueFromExtendsModifiers(parameter);
+            if (!value.isEmpty()) {
+              return value;
+            }
+          }
         }
       }
     }
@@ -1054,17 +1067,19 @@ namespace ModelInstance
 
   FlatModelica::Expression Model::getVariableBinding(const QString &variableName)
   {
-    foreach (auto pElement, mElements) {
-      if (pElement->getName().compare(variableName) == 0) {
-        return pElement->getBinding();
-      }
-    }
-
     FlatModelica::Expression expression;
-    foreach (auto pExtend, mExtends) {
-      expression = pExtend->getVariableBinding(variableName);
-      if (!expression.isNull()) {
-        return expression;
+    foreach (auto pElement, mElements) {
+      if (pElement->isComponent()) {
+        auto pComponent = dynamic_cast<Component*>(pElement);
+        if (pComponent->getName().compare(variableName) == 0) {
+          return pComponent->getBinding();
+        }
+      } else if (pElement->isExtend() && pElement->getModel()) {
+        auto pExtend = dynamic_cast<Extend*>(pElement);
+        expression = pExtend->getModel()->getVariableBinding(variableName);
+        if (!expression.isNull()) {
+          return expression;
+        }
       }
     }
 
@@ -1084,7 +1099,6 @@ namespace ModelInstance
     mRedeclare = false;
     mPartial = false;
     mEncapsulated = false;
-    mExtends.clear();
     mComment = "";
     mpAnnotation = std::make_unique<Annotation>(this);
     mElements.clear();
@@ -1259,14 +1273,6 @@ namespace ModelInstance
   Element::Element(Model *pParentModel)
   {
     mpParentModel = pParentModel;
-    mpModel = 0;
-    initialize();
-  }
-
-  Element::Element(Model *pParentModel, const QJsonObject &jsonObject)
-    : Element(pParentModel)
-  {
-    deserialize(jsonObject);
   }
 
   Element::~Element()
@@ -1276,8 +1282,22 @@ namespace ModelInstance
     }
   }
 
-  void Element::initialize()
+  Component::Component(Model *pParentModel)
+    : Element(pParentModel)
   {
+    initialize();
+  }
+
+  Component::Component(Model *pParentModel, const QJsonObject &jsonObject)
+    : Element(pParentModel)
+  {
+    initialize();
+    deserialize(jsonObject);
+  }
+
+  void Component::initialize()
+  {
+    mKind = "";
     mName = "";
     mCondition = true;
     mType = "";
@@ -1300,8 +1320,12 @@ namespace ModelInstance
     mpAnnotation = std::make_unique<Annotation>(mpParentModel);
   }
 
-  void Element::deserialize(const QJsonObject &jsonObject)
+  void Component::deserialize(const QJsonObject &jsonObject)
   {
+    if (jsonObject.contains("$kind")) {
+      mKind = jsonObject.value("$kind").toString();
+    }
+
     if (jsonObject.contains("name")) {
       mName = jsonObject.value("name").toString();
     }
@@ -1314,7 +1338,7 @@ namespace ModelInstance
       if (jsonObject.value("type").isString()) {
         mType = jsonObject.value("type").toString();
       } else if (jsonObject.value("type").isObject()) {
-        mpModel = new Model(jsonObject.value("type").toObject());
+        mpModel = new Model(jsonObject.value("type").toObject(), this);
         mType = mpModel->getName();
       }
     }
@@ -1413,7 +1437,7 @@ namespace ModelInstance
     }
   }
 
-  QString Element::getModifierValueFromType(QStringList modifierNames)
+  QString Component::getModifierValueFromType(QStringList modifierNames)
   {
     /* 1. First check if unit is defined with in the component modifier.
      * 2. If no unit is found then check it in the derived class modifier value.
@@ -1426,24 +1450,64 @@ namespace ModelInstance
       modifierValue = mpModel->getModifier().getModifierValue(modifierNames);
       // Case 3
       if (modifierValue.isEmpty()) {
-        modifierValue = Element::getModifierValueFromInheritedType(mpModel, modifierNames);
+        modifierValue = Component::getModifierValueFromInheritedType(mpModel, modifierNames);
       }
     }
     return modifierValue;
   }
 
-  QString Element::getModifierValueFromInheritedType(Model *pModel, QStringList modifierNames)
+  QString Component::getModifierValueFromInheritedType(Model *pModel, QStringList modifierNames)
   {
     QString modifierValue = "";
-    foreach (auto pExtend, pModel->getExtends()) {
-      modifierValue = pExtend->getModifier().getModifierValue(modifierNames);
-      if (modifierValue.isEmpty()) {
-        modifierValue = Element::getModifierValueFromInheritedType(pExtend, modifierNames);
-      } else {
-        return modifierValue;
+    foreach (auto pElement, pModel->getElements()) {
+      if (pElement->isExtend() && pElement->getModel()) {
+        auto pExtend = dynamic_cast<Extend*>(pElement);
+        modifierValue = pExtend->getModel()->getModifier().getModifierValue(modifierNames);
+        if (modifierValue.isEmpty()) {
+          modifierValue = Component::getModifierValueFromInheritedType(pExtend->getModel(), modifierNames);
+        } else {
+          return modifierValue;
+        }
       }
     }
     return modifierValue;
+  }
+
+  bool Component::isComponent() const
+  {
+    return mKind.compare(QStringLiteral("component")) == 0;
+  }
+
+  Extend::Extend(Model *pParentModel, const QJsonObject &jsonObject)
+    : Element(pParentModel)
+  {
+    mKind = "";
+    mpExtendsAnnotation = std::make_unique<Annotation>(pParentModel);
+    deserialize(jsonObject);
+  }
+
+  void Extend::deserialize(const QJsonObject &jsonObject)
+  {
+    if (jsonObject.contains("$kind")) {
+      mKind = jsonObject.value("$kind").toString();
+    }
+
+    if (jsonObject.contains("modifiers")) {
+      mExtendsModifier.deserialize(jsonObject.value("modifiers"));
+    }
+
+    if (jsonObject.contains("annotation")) {
+      mpExtendsAnnotation->deserialize(jsonObject.value("annotation").toObject());
+    }
+
+    if (jsonObject.contains("baseClass")) {
+      mpModel = new Model(jsonObject.value("baseClass").toObject(), this);
+    }
+  }
+
+  bool Extend::isExtend() const
+  {
+    return mKind.compare(QStringLiteral("extends")) == 0;
   }
 
   Part::Part()
@@ -1634,34 +1698,6 @@ namespace ModelInstance
 
     if (jsonObject.contains("primitivesVisible")) {
       mPrimitivesVisible.deserialize(jsonObject.value("primitivesVisible"));
-    }
-  }
-
-  Extend::Extend()
-    : Model()
-  {
-    mpExtendsAnnotation = std::make_unique<Annotation>(this);
-  }
-
-  Extend::Extend(const QJsonObject &jsonObject)
-    : Extend()
-  {
-    deserialize(jsonObject);
-  }
-
-  void Extend::deserialize(const QJsonObject &jsonObject)
-  {
-    if (jsonObject.contains("modifiers")) {
-      mExtendsModifier.deserialize(jsonObject.value("modifiers"));
-    }
-
-    if (jsonObject.contains("annotation")) {
-      mpExtendsAnnotation->deserialize(jsonObject.value("annotation").toObject());
-    }
-
-    if (jsonObject.contains("baseClass")) {
-      Model::setModelJson(jsonObject.value("baseClass").toObject());
-      Model::deserialize();
     }
   }
 

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -133,6 +133,8 @@ private:
     RealAnnotation mLineThickness;
   };
 
+  class Model;
+  class Extend;
   class Shape : public GraphicItem, public FilledShape
   {
   public:
@@ -140,6 +142,7 @@ private:
     virtual ~Shape();
 
     Model *getParentModel() const {return mpParentModel;}
+    Extend *getParentExtend() const;
   private:
     Model *mpParentModel;
   };
@@ -475,7 +478,6 @@ private:
     std::unique_ptr<Annotation> mpAnnotation;
   };
 
-  class Extend;
   class Element;
   class Connection;
   class Transition;
@@ -483,10 +485,11 @@ private:
   class Model
   {
   public:
-    Model();
-    Model(const QJsonObject &jsonObject);
+    Model(const QJsonObject &jsonObject, Element *pParentElement = 0);
     virtual ~Model();
     void deserialize();
+
+    Element *getParentElement() const {return mpParentElement;}
     QJsonObject getModelJson() const {return mModelJson;}
     void setModelJson(const QJsonObject &modelJson) {mModelJson = modelJson;}
     QString getName() const {return mName;}
@@ -505,7 +508,6 @@ private:
     bool isRedeclare() const {return mRedeclare;}
     bool isPartial() const {return mPartial;}
     bool isEncapsulated() const {return mEncapsulated;}
-    QList<Extend *> getExtends() const {return mExtends;}
     QString getComment() const {return mComment;}
     Annotation *getAnnotation() const {return mpAnnotation.get();}
     void readCoordinateSystemFromExtendsClass(CoordinateSystem *pCoordinateSystem, bool isIcon);
@@ -529,6 +531,7 @@ private:
   private:
     void initialize();
 
+    Element *mpParentElement;
     QJsonObject mModelJson;
     QString mName;
     QStringList mDims;
@@ -542,7 +545,6 @@ private:
     bool mRedeclare;
     bool mPartial;
     bool mEncapsulated;
-    QList<Extend*> mExtends;
     QString mComment;
     std::unique_ptr<Annotation> mpAnnotation;
     QList<Element*> mElements;
@@ -561,19 +563,32 @@ private:
   {
   public:
     Element(Model *pParentModel);
-    Element(Model *pParentModel, const QJsonObject &jsonObject);
-    ~Element();
+    virtual ~Element();
+
+    Model *getParentModel() const {return mpParentModel;}
+    void setModel(Model *pModel) {mpModel = pModel;}
+    Model *getModel() const {return mpModel;}
+
+    virtual bool isComponent() const = 0;
+    virtual bool isExtend() const = 0;
+  protected:
+    Model *mpParentModel;
+    Model *mpModel = 0;
+  };
+
+  class Component : public Element
+  {
+  public:
+    Component(Model *pParentModel);
+    Component(Model *pParentModel, const QJsonObject &jsonObject);
     void initialize();
     void deserialize(const QJsonObject &jsonObject);
 
-    Model *getParentModel() const {return mpParentModel;}
     void setName(const QString &name) {mName = name;}
     QString getName() const {return mName;}
     bool getCondition() const {return mCondition;}
     void setType(const QString &type) {mType = type;}
     QString getType() const {return mType;}
-    void setModel(Model *pModel) {mpModel = pModel;}
-    Model *getModel() const {return mpModel;}
     Modifier getModifier() const {return mModifier;}
     FlatModelica::Expression getBinding() const {return mBinding;}
     void setBinding(const FlatModelica::Expression expression) {mBinding = expression;}
@@ -595,11 +610,11 @@ private:
     QString getComment() const {return mComment;}
     Annotation *getAnnotation() const {return mpAnnotation.get();}
   private:
-    Model *mpParentModel;
+    QString mKind;
     QString mName;
     bool mCondition;
     QString mType;
-    Model *mpModel;
+
     Modifier mModifier;
     FlatModelica::Expression mBinding;
     FlatModelica::Expression mBindingForReset;
@@ -618,6 +633,28 @@ private:
     std::unique_ptr<Annotation> mpAnnotation;
 
     static QString getModifierValueFromInheritedType(Model *pModel, QStringList modifierName);
+    // Element interface
+  public:
+    virtual bool isComponent() const override;
+    virtual bool isExtend() const override {return false;}
+  };
+
+  class Extend : public Element
+  {
+  public:
+    Extend(Model *pParentModel, const QJsonObject &jsonObject);
+    void deserialize(const QJsonObject &jsonObject);
+
+    Annotation *getExtendsAnnotation() const {return mpExtendsAnnotation.get();}
+    Modifier getExtendsModifier() const {return mExtendsModifier;}
+  private:
+    QString mKind;
+    std::unique_ptr<Annotation> mpExtendsAnnotation;
+    Modifier mExtendsModifier;
+    // Element interface
+  public:
+    virtual bool isComponent() const override {return false;}
+    virtual bool isExtend() const override;
   };
 
   class Part
@@ -705,20 +742,6 @@ private:
     Model *mpParentModel;
     std::unique_ptr<Connector> mpStartConnector;
     std::unique_ptr<Annotation> mpAnnotation;
-  };
-
-  class Extend : public Model
-  {
-  public:
-    Extend();
-    Extend(const QJsonObject &jsonObject);
-    void deserialize(const QJsonObject &jsonObject);
-
-    Annotation *getExtendsAnnotation() const {return mpExtendsAnnotation.get();}
-    Modifier getExtendsModifier() const {return mExtendsModifier;}
-  private:
-    std::unique_ptr<Annotation> mpExtendsAnnotation;
-    Modifier mExtendsModifier;
   };
 
 }

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -420,36 +420,37 @@ void GraphicsView::drawElements(ModelInstance::Model *pModelInstance, bool inher
     int elementIndex = -1, connectorIndex = -1;
     for (int i = 0; i < elements.size(); ++i) {
       auto pModelInstanceElement = elements.at(i);
-      if (pModelInstanceElement->getModel()) {
+      if (pModelInstanceElement->isComponent() && pModelInstanceElement->getModel()) {
+        auto pModelInstanceComponent = dynamic_cast<ModelInstance::Component*>(pModelInstanceElement);
         elementIndex++;
-        mpModelWidget->addDependsOnModel(pModelInstanceElement->getModel()->getName());
-        if (pModelInstanceElement->getModel()->isConnector()) {
+        mpModelWidget->addDependsOnModel(pModelInstanceComponent->getModel()->getName());
+        if (pModelInstanceComponent->getModel()->isConnector()) {
           connectorIndex++;
         }
         if (modelInfo.mDiagramElementsList.isEmpty() || inherited) {
-          addElementToView(pModelInstanceElement, inherited, false, false, QPointF(0, 0));
+          addElementToView(pModelInstanceComponent, inherited, false, false, QPointF(0, 0));
         } else { // update case
           GraphicsView *pIconGraphicsView = mpModelWidget->getIconGraphicsView();
           GraphicsView *pDiagramGraphicsView = mpModelWidget->getDiagramGraphicsView();
           if (elementIndex < modelInfo.mDiagramElementsList.size()) {
             Element *pDiagramElement = modelInfo.mDiagramElementsList.at(elementIndex);
             if (pDiagramElement) {
-              pDiagramElement->setModelElement(pModelInstanceElement);
+              pDiagramElement->setModelComponent(pModelInstanceComponent);
               pDiagramElement->reDrawElementNew();
               pDiagramGraphicsView->addItem(pDiagramElement);
               pDiagramGraphicsView->addItem(pDiagramElement->getOriginItem());
               pDiagramGraphicsView->addElementToList(pDiagramElement);
               pDiagramGraphicsView->deleteElementFromOutOfSceneList(pDiagramElement);
-              if (pModelInstanceElement->getModel()->isConnector() && connectorIndex < modelInfo.mIconElementsList.size()) {
+              if (pModelInstanceComponent->getModel()->isConnector() && connectorIndex < modelInfo.mIconElementsList.size()) {
                 Element *pIconElement = modelInfo.mIconElementsList.at(connectorIndex);
                 if (pIconElement) {
-                  pIconElement->setModelElement(pModelInstanceElement);
+                  pIconElement->setModelComponent(pModelInstanceComponent);
                   pIconElement->reDrawElementNew();
                   pIconGraphicsView->addItem(pIconElement);
                   pIconGraphicsView->addItem(pIconElement->getOriginItem());
                   pIconGraphicsView->addElementToList(pIconElement);
                   pIconGraphicsView->deleteElementFromOutOfSceneList(pIconElement);
-                  pIconElement->setVisible(pModelInstanceElement->isPublic());
+                  pIconElement->setVisible(pModelInstanceComponent->isPublic());
                 }
               }
             }
@@ -498,7 +499,7 @@ void GraphicsView::drawConnections(ModelInstance::Model *pModelInstance, bool in
           // if a element type is connector then we only get one item in startElementList
           // check the startElementlist
           // if conditional connector and condition is false then connect with the red cross box
-          if (startElementList.size() < 2 || pStartElement->isExpandableConnector() || !pStartElement->getModelElement()->getCondition()) {
+          if (startElementList.size() < 2 || pStartElement->isExpandableConnector() || !pStartElement->getModelComponent()->getCondition()) {
             pStartConnectorElement = pStartElement;
           } else {
             // look for port from the parent element
@@ -530,7 +531,7 @@ void GraphicsView::drawConnections(ModelInstance::Model *pModelInstance, bool in
           // if a element type is connector then we only get one item in endElementList
           // check the endElementList
           // if conditional connector and condition is false then connect with the red cross box
-          if (endElementList.size() < 2 || pEndElement->isExpandableConnector() || !pEndElement->getModelElement()->getCondition()) {
+          if (endElementList.size() < 2 || pEndElement->isExpandableConnector() || !pEndElement->getModelComponent()->getCondition()) {
             pEndConnectorElement = pEndElement;
           } else {
             QString endElementName = endElementList.at(1);
@@ -953,13 +954,13 @@ bool GraphicsView::addComponent(QString className, QPointF position)
           || (mViewType == StringHandler::Icon && (type == StringHandler::Connector || type == StringHandler::ExpandableConnector))) {
         if (mpModelWidget->isNewApi()) {
           ModelInstance::Model *pModelInstance = mpModelWidget->getModelInstance();
-          ModelInstance::Element *pElement = new ModelInstance::Element(pModelInstance);
-          pElement->setName(name);
-          pElement->setType(pLibraryTreeItem->getNameStructure());
-          pElement->setModel(new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(pLibraryTreeItem->getNameStructure())));
-          pModelInstance->addElement(pElement);
+          ModelInstance::Component *pComponent = new ModelInstance::Component(pModelInstance);
+          pComponent->setName(name);
+          pComponent->setType(pLibraryTreeItem->getNameStructure());
+          pComponent->setModel(new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(pLibraryTreeItem->getNameStructure())));
+          pModelInstance->addElement(pComponent);
           ModelInfo oldModelInfo = mpModelWidget->createModelInfo();
-          addElementToView(pElement, false, true, true, position);
+          addElementToView(pComponent, false, true, true, position);
           ModelInfo newModelInfo = mpModelWidget->createModelInfo();
           mpModelWidget->getUndoStack()->push(new OMCUndoCommand(mpModelWidget->getLibraryTreeItem(), oldModelInfo, newModelInfo, "Add Element"));
           mpModelWidget->updateModelText();
@@ -1013,13 +1014,13 @@ void GraphicsView::addComponentToView(QString name, LibraryTreeItem *pLibraryTre
 /*!
  * \brief GraphicsView::addElementToView
  * Adds the Element to the view and also to OMC.
- * \param pElement
+ * \param pComponent
  * \param inherited
  * \param addElementToOMC
  * \param createTransformation
  * \param position
  */
-void GraphicsView::addElementToView(ModelInstance::Element *pElement, bool inherited, bool addElementToOMC, bool createTransformation, QPointF position)
+void GraphicsView::addElementToView(ModelInstance::Component *pComponent, bool inherited, bool addElementToOMC, bool createTransformation, QPointF position)
 {
   Element *pIconElement = 0;
   Element *pDiagramElement = 0;
@@ -1027,14 +1028,14 @@ void GraphicsView::addElementToView(ModelInstance::Element *pElement, bool inher
   GraphicsView *pDiagramGraphicsView = mpModelWidget->getDiagramGraphicsView();
 
   // if element is of connector type.
-  if (pElement && pElement->getModel()->isConnector()) {
+  if (pComponent && pComponent->getModel()->isConnector()) {
     // Connector type elements exists on icon view as well
-    pIconElement = new Element(pElement, inherited, pIconGraphicsView, createTransformation, position);
+    pIconElement = new Element(pComponent, inherited, pIconGraphicsView, createTransformation, position);
   }
-  pDiagramElement = new Element(pElement, inherited, pDiagramGraphicsView, createTransformation, position);
+  pDiagramElement = new Element(pComponent, inherited, pDiagramGraphicsView, createTransformation, position);
 
   // if element is of connector type && containing class is Modelica type.
-  if (pIconElement && pElement->getModel()->isConnector()) {
+  if (pIconElement && pComponent->getModel()->isConnector()) {
     // Connector type elements exists on icon view as well
     if (pIconElement->mTransformation.isValid() && pIconElement->mTransformation.getVisible()) {
       pIconGraphicsView->addItem(pIconElement);
@@ -1046,7 +1047,7 @@ void GraphicsView::addElementToView(ModelInstance::Element *pElement, bool inher
       pIconGraphicsView->addElementToList(pIconElement);
     }
     // hide the element if it is connector and is protected
-    pIconElement->setVisible(pElement->isPublic());
+    pIconElement->setVisible(pComponent->isPublic());
   }
 
   if (pDiagramElement->mTransformation.isValid() && pDiagramElement->mTransformation.getVisible()) {
@@ -5778,10 +5779,13 @@ void ModelWidget::drawModel(const ModelInfo &modelInfo)
 
 void ModelWidget::drawModelIconDiagram(ModelInstance::Model *pModelInstance, bool inherited, const ModelInfo &modelInfo)
 {
-  QList<ModelInstance::Extend*> extends = pModelInstance->getExtends();
-  foreach (auto pExtend, extends) {
-    addDependsOnModel(pExtend->getName());
-    drawModelIconDiagram(pExtend, true, modelInfo);
+  QList<ModelInstance::Element*> elements = pModelInstance->getElements();
+  foreach (auto pElement, elements) {
+    if (pElement->isExtend() && pElement->getModel()) {
+      auto pExtend = dynamic_cast<ModelInstance::Extend*>(pElement);
+      addDependsOnModel(pExtend->getModel()->getName());
+      drawModelIconDiagram(pExtend->getModel(), true, modelInfo);
+    }
   }
 
   mpIconGraphicsView->drawShapes(pModelInstance, inherited, modelInfo.mName.isEmpty());
@@ -5908,11 +5912,15 @@ void ModelWidget::detectMultipleDeclarations()
           j++;
           continue;
         }
-        if (elements[i]->getName().compare(elements[j]->getName()) == 0) {
-          MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica,
-                                                                GUIMessages::getMessage(GUIMessages::MULTIPLE_DECLARATIONS_COMPONENT).arg(elements[i]->getName()),
-                                                                Helper::scriptingKind, Helper::errorLevel));
-          return;
+        if (elements[i]->isComponent() && elements[j]->isComponent()) {
+          auto pComponent1 = dynamic_cast<ModelInstance::Component*>(elements[i]);
+          auto pComponent2 = dynamic_cast<ModelInstance::Component*>(elements[j]);
+          if (pComponent1->getName().compare(pComponent2->getName()) == 0) {
+            MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica,
+                                                                  GUIMessages::getMessage(GUIMessages::MULTIPLE_DECLARATIONS_COMPONENT).arg(pComponent1->getName()),
+                                                                  Helper::scriptingKind, Helper::errorLevel));
+            return;
+          }
         }
       }
     }

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -247,7 +247,7 @@ public:
   bool addComponent(QString className, QPointF position);
   void addComponentToView(QString name, LibraryTreeItem *pLibraryTreeItem, QString annotation, QPointF position,
                           ElementInfo *pComponentInfo, bool addObject, bool openingClass, bool emitComponentAdded);
-  void addElementToView(ModelInstance::Element *pElement, bool inherited, bool addElementToOMC, bool createTransformation, QPointF position);
+  void addElementToView(ModelInstance::Component *pComponent, bool inherited, bool addElementToOMC, bool createTransformation, QPointF position);
   void addElementToList(Element *pElement) {mElementsList.append(pElement);}
   void addElementToOutOfSceneList(Element *pElement) {mOutOfSceneElementsList.append(pElement);}
   void addInheritedElementToList(Element *pElement) {mInheritedElementsList.append(pElement);}

--- a/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.cpp
+++ b/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.cpp
@@ -66,10 +66,10 @@ void ModelInstanceTest::classAnnotations()
   }
 }
 
-void ModelInstanceTest::classComponents()
+void ModelInstanceTest::classElements()
 {
   if (mpModelInstance->getElements().isEmpty()) {
-    QFAIL("Failed to read the class components.");
+    QFAIL("Failed to read the class elements.");
   }
 }
 
@@ -77,13 +77,6 @@ void ModelInstanceTest::classConnections()
 {
   if (mpModelInstance->getConnections().isEmpty()) {
     QFAIL("Failed to read the class connections.");
-  }
-}
-
-void ModelInstanceTest::classExtends()
-{
-  if (mpModelInstance->getExtends().isEmpty()) {
-    QFAIL("Failed to read the class extends.");
   }
 }
 

--- a/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.h
+++ b/OMEdit/Testsuite/ModelInstance/ModelInstanceTest.h
@@ -59,16 +59,15 @@ private slots:
    */
   void classAnnotations();
   /*!
-   * \brief classComponents
-   * Tests the class components.
+   * \brief classElements
+   * Tests the class elements.
    */
-  void classComponents();
+  void classElements();
   /*!
    * \brief classConnections
    * Tests the class connections.
    */
   void classConnections();
-  void classExtends();
   void cleanupTestCase();
 };
 


### PR DESCRIPTION
Everything in a Model is an element which can be a component or extend Use composition in Extend class instead of inheriting it from Model.