### PR TITLE
Update meta_modelica_segv.c

### DIFF
--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_segv.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_segv.c
@@ -253,7 +253,7 @@ void init_metamodelica_segv_handler()
 
 void mmc_init_stackoverflow(threadData_t *threadData)
 {
-  threadData->stackBottom = 0x1; /* Dummy until Windows detects the stack bottom */
+  threadData->stackBottom = (void *)0x1; /* Dummy until Windows detects the stack bottom */
 }
 #endif
 


### PR DESCRIPTION
### Related Issues

None I'm aware of.

### Purpose

Clang 15 wants an explicit cast to pointer to void. Detected on fairly recent FreeBSD/amd64 14.0-CURRENT.

### Approach

Enable successful compilation.
