### PR TITLE
Improve getAllSubtypeOf

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstContext.mo
@@ -38,30 +38,31 @@ encapsulated package NFInstContext
   constant Type NO_CONTEXT      = 0;
   constant Type RELAXED         = intBitLShift(1,  0); // Relaxed instantiation, used by e.g. checkModel.
   constant Type INSTANCE_API    = intBitLShift(1,  1); // Instantiation for the model instance API.
-  constant Type CLASS           = intBitLShift(1,  2); // In class.
-  constant Type FUNCTION        = intBitLShift(1,  3); // In function.
-  constant Type REDECLARED      = intBitLShift(1,  4); // In an element that will be replaced with a redeclare.
-  constant Type ALGORITHM       = intBitLShift(1,  5); // In algorithm section.
-  constant Type EQUATION        = intBitLShift(1,  6); // In equation section.
-  constant Type INITIAL         = intBitLShift(1,  7); // In initial section.
-  constant Type LHS             = intBitLShift(1,  8); // On left hand side of equality/assignment.
-  constant Type RHS             = intBitLShift(1,  9); // On right hand side of equality/assignment.
-  constant Type WHEN            = intBitLShift(1, 10); // In when equation/statement.
-  constant Type CLOCKED         = intBitLShift(1, 11); // Part of a clocked when equation.
-  constant Type FOR             = intBitLShift(1, 12); // In a for loop.
-  constant Type IF              = intBitLShift(1, 13); // In an if equation/statement.
-  constant Type WHILE           = intBitLShift(1, 14); // In a while loop.
-  constant Type NONEXPANDABLE   = intBitLShift(1, 15); // In non-parameter if/for.
-  constant Type ITERATION_RANGE = intBitLShift(1, 16); // In range used for iteration.
-  constant Type DIMENSION       = intBitLShift(1, 17); // In dimension.
-  constant Type BINDING         = intBitLShift(1, 18); // In binding.
-  constant Type CONDITION       = intBitLShift(1, 19); // In conditional expression.
-  constant Type SUBSCRIPT       = intBitLShift(1, 20); // In subscript.
-  constant Type SUBEXPRESSION   = intBitLShift(1, 21); // Part of a larger expression.
-  constant Type CONNECT         = intBitLShift(1, 22); // Part of connect argument.
-  constant Type NOEVENT         = intBitLShift(1, 23); // Part of noEvent argument.
-  constant Type ASSERT          = intBitLShift(1, 24); // Part of assert argument.
-  constant Type ANNOTATION      = intBitLShift(1, 25); // Part of an annotation.
+  constant Type FAST_LOOKUP     = intBitLShift(1,  2); // Only expand packages when doing lookup.
+  constant Type CLASS           = intBitLShift(1,  3); // In class.
+  constant Type FUNCTION        = intBitLShift(1,  4); // In function.
+  constant Type REDECLARED      = intBitLShift(1,  5); // In an element that will be replaced with a redeclare.
+  constant Type ALGORITHM       = intBitLShift(1,  6); // In algorithm section.
+  constant Type EQUATION        = intBitLShift(1,  7); // In equation section.
+  constant Type INITIAL         = intBitLShift(1,  8); // In initial section.
+  constant Type LHS             = intBitLShift(1,  9); // On left hand side of equality/assignment.
+  constant Type RHS             = intBitLShift(1, 10); // On right hand side of equality/assignment.
+  constant Type WHEN            = intBitLShift(1, 11); // In when equation/statement.
+  constant Type CLOCKED         = intBitLShift(1, 12); // Part of a clocked when equation.
+  constant Type FOR             = intBitLShift(1, 13); // In a for loop.
+  constant Type IF              = intBitLShift(1, 14); // In an if equation/statement.
+  constant Type WHILE           = intBitLShift(1, 15); // In a while loop.
+  constant Type NONEXPANDABLE   = intBitLShift(1, 16); // In non-parameter if/for.
+  constant Type ITERATION_RANGE = intBitLShift(1, 17); // In range used for iteration.
+  constant Type DIMENSION       = intBitLShift(1, 18); // In dimension.
+  constant Type BINDING         = intBitLShift(1, 19); // In binding.
+  constant Type CONDITION       = intBitLShift(1, 20); // In conditional expression.
+  constant Type SUBSCRIPT       = intBitLShift(1, 21); // In subscript.
+  constant Type SUBEXPRESSION   = intBitLShift(1, 22); // Part of a larger expression.
+  constant Type CONNECT         = intBitLShift(1, 23); // Part of connect argument.
+  constant Type NOEVENT         = intBitLShift(1, 24); // Part of noEvent argument.
+  constant Type ASSERT          = intBitLShift(1, 25); // Part of assert argument.
+  constant Type ANNOTATION      = intBitLShift(1, 26); // Part of an annotation.
 
   // Combined flags:
   constant Type EQ_SUBEXPRESSION = intBitOr(EQUATION, SUBEXPRESSION);
@@ -104,6 +105,11 @@ encapsulated package NFInstContext
     input Type context;
     output Boolean res = intBitAnd(context, INSTANCE_API) > 0;
   end inInstanceAPI;
+
+  function inFastLookup
+    input Type context;
+    output Boolean res = intBitAnd(context, FAST_LOOKUP) > 0;
+  end inFastLookup;
 
   function inClass
     input Type context;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -504,6 +504,7 @@ protected
   SCode.Program program;
   String name, id1, id2;
   Boolean b, s;
+  InstContext.Type context;
 algorithm
   // do some quick checks
   // classPath is already fully qualified
@@ -526,11 +527,13 @@ algorithm
     // run the front-end front
     (program, name, expanded_cls) := frontEndLookup(absynProgram, classPath);
 
+    context := InstContext.set(NFInstContext.RELAXED, NFInstContext.FAST_LOOKUP);
+
     // if is derived qualify in the parent
     if InstNode.isDerivedClass(expanded_cls) then
-      cls := Lookup.lookupClassName(pathToQualify, InstNode.classParent(expanded_cls), NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
+      cls := Lookup.lookupClassName(pathToQualify, InstNode.classParent(expanded_cls), context, AbsynUtil.dummyInfo, checkAccessViolations = false);
     else // qualify in the class
-      cls := Lookup.lookupClassName(pathToQualify, expanded_cls, NFInstContext.RELAXED, AbsynUtil.dummyInfo, checkAccessViolations = false);
+      cls := Lookup.lookupClassName(pathToQualify, expanded_cls, context, AbsynUtil.dummyInfo, checkAccessViolations = false);
     end if;
 
     qualPath := InstNode.fullPath(cls);
@@ -794,7 +797,7 @@ algorithm
   name := AbsynUtil.pathString(classPath);
 
   (program, top) := mkTop(absynProgram, name);
-  cls := Inst.lookupRootClass(classPath, top, NFInstContext.RELAXED);
+  cls := Inst.lookupRootClass(classPath, top, InstContext.set(NFInstContext.RELAXED, NFInstContext.FAST_LOOKUP));
 
   // Expand the class.
   expanded_cls := NFInst.expand(cls);


### PR DESCRIPTION
- Only expand packages when doing lookup for getAllSubtypeOf, since fully instantiating them is unnecessary and slow in that context.

Fixes #10273