### PR TITLE
Show the parameters in the correct tab and group

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1852,7 +1852,8 @@ void ExpandableConnectorTreeModel::createExpandableConnectorTreeItem(ModelInstan
   if (pModelComponent->getModel()) {
     restriction = StringHandler::getModelicaClassType(pModelComponent->getModel()->getRestriction());
   }
-  ExpandableConnectorTreeItem *pExpandableConnectorTreeItem = new ExpandableConnectorTreeItem(pModelComponent->getName(), pModelComponent->isArray(), pModelComponent->getTypedDimensions(),
+  ExpandableConnectorTreeItem *pExpandableConnectorTreeItem = new ExpandableConnectorTreeItem(pModelComponent->getName(), pModelComponent->getDimensions().isArray(),
+                                                                                              pModelComponent->getDimensions().getTypedDimensions(),
                                                                                               restriction, false, pParentExpandableConnectorTreeItem);
   int row = pParentExpandableConnectorTreeItem->getChildren().size();
   QModelIndex index = expandableConnectorTreeItemIndex(pParentExpandableConnectorTreeItem);

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1487,7 +1487,7 @@ bool Element::isExpandableConnector() const
 bool Element::isArray() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelComponent->isArray();
+    return mpModelComponent->getDimensions().isArray();
   } else {
     return (mpElementInfo && mpElementInfo->isArray());
   }
@@ -1501,7 +1501,7 @@ bool Element::isArray() const
 QStringList Element::getAbsynArrayIndexes() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelComponent->getAbsynDimensions();
+    return mpModelComponent->getDimensions().getAbsynDimensions();
   } else if (mpElementInfo) {
     return QStringList() << mpElementInfo->getArrayIndex();
   } else {
@@ -1517,7 +1517,7 @@ QStringList Element::getAbsynArrayIndexes() const
 QStringList Element::getTypedArrayIndexes() const
 {
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    return mpModelComponent->getTypedDimensions();
+    return mpModelComponent->getDimensions().getTypedDimensions();
   } else if (mpElementInfo) {
     return QStringList() << mpElementInfo->getArrayIndex();
   } else {
@@ -1554,7 +1554,7 @@ bool Element::isConnectorSizing()
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
     if (isArray()) {
       // connectorSizing is only done on the single dimensional array.
-      QString parameter = mpModelComponent->getAbsynDimensions().at(0);
+      QString parameter = mpModelComponent->getDimensions().getAbsynDimensions().at(0);
       bool ok;
       parameter.toInt(&ok);
       // if the array index is not a number then look for parameter
@@ -2719,7 +2719,7 @@ void Element::createClassShapes()
       } else if (ModelInstance::Text *pText = dynamic_cast<ModelInstance::Text*>(shape)) {
         mShapesList.append(new TextAnnotation(pText, this));
       } else if (ModelInstance::Bitmap *pBitmap = dynamic_cast<ModelInstance::Bitmap*>(shape)) {
-        mShapesList.append(new BitmapAnnotation(pBitmap, mpModel->getFileName(), this));
+        mShapesList.append(new BitmapAnnotation(pBitmap, mpModel->getSource().getFileName(), this));
       }
     }
   } else {

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -664,6 +664,29 @@ namespace ModelInstance
     }
   }
 
+  Dimensions::Dimensions()
+  {
+    mAbsynDims.clear();
+    mTypedDims.clear();
+  }
+
+  void Dimensions::deserialize(const QJsonObject &jsonObject)
+  {
+    if (jsonObject.contains("absyn")) {
+      QJsonArray absynDimsArray = jsonObject.value("absyn").toArray();
+      foreach (auto absynDim, absynDimsArray) {
+        mAbsynDims.append(absynDim.toString());
+      }
+    }
+
+    if (jsonObject.contains("typed")) {
+      QJsonArray typedDimsArray = jsonObject.value("typed").toArray();
+      foreach (auto typedDim, typedDimsArray) {
+        mTypedDims.append(typedDim.toString());
+      }
+    }
+  }
+
   Modifier::Modifier()
   {
     mName = "";
@@ -725,15 +748,13 @@ namespace ModelInstance
   Replaceable::Replaceable(Model *pParentModel)
   {
     mpParentModel = pParentModel;
-    mIsReplaceable = false;
     mConstrainedby = "";
-    mpAnnotation = std::make_unique<Annotation>(pParentModel);
+    mComment = "";
   }
 
   void Replaceable::deserialize(const QJsonValue &jsonValue)
   {
     if (jsonValue.isObject()) {
-      mIsReplaceable = true;
       QJsonObject replaceableObject = jsonValue.toObject();
       mConstrainedby = replaceableObject.value("constrainedby").toString();
 
@@ -746,10 +767,109 @@ namespace ModelInstance
       }
 
       if (replaceableObject.contains("annotation")) {
+        mpAnnotation = std::make_unique<Annotation>(mpParentModel);
         mpAnnotation->deserialize(replaceableObject.value("annotation").toObject());
       }
-    } else {
-      mIsReplaceable = jsonValue.toBool();
+    }
+  }
+
+  Prefixes::Prefixes(Model *pParentModel)
+  {
+    mpParentModel = pParentModel;
+    mPublic = true;
+    mFinal = false;
+    mInner = false;
+    mOuter = false;
+    mRedeclare = false;
+    mPartial = false;
+    mEncapsulated = false;
+    mConnector = "";
+    mVariability = "";
+    mDirection = "";
+  }
+
+  void Prefixes::deserialize(const QJsonObject &jsonObject)
+  {
+    if (jsonObject.contains("public")) {
+      mPublic = jsonObject.value("public").toBool();
+    }
+
+    if (jsonObject.contains("final")) {
+      mFinal = jsonObject.value("final").toBool();
+    }
+
+    if (jsonObject.contains("inner")) {
+      mInner = jsonObject.value("inner").toBool();
+    }
+
+    if (jsonObject.contains("outer")) {
+      mOuter = jsonObject.value("outer").toBool();
+    }
+
+    if (jsonObject.contains("replaceable")) {
+      mpReplaceable = std::make_unique<Replaceable>(mpParentModel);
+      mpReplaceable->deserialize(jsonObject.value("replaceable"));
+    }
+
+    if (jsonObject.contains("redeclare")) {
+      mRedeclare = jsonObject.value("redeclare").toBool();
+    }
+
+    if (jsonObject.contains("partial")) {
+      mPartial = jsonObject.value("partial").toBool();
+    }
+
+    if (jsonObject.contains("encapsulated")) {
+      mEncapsulated = jsonObject.value("encapsulated").toBool();
+    }
+
+    if (jsonObject.contains("connector")) {
+      mConnector = jsonObject.value("connector").toString();
+    }
+
+    if (jsonObject.contains("variability")) {
+      mVariability = jsonObject.value("variability").toString();
+    }
+
+    if (jsonObject.contains("direction")) {
+      mDirection = jsonObject.value("direction").toString();
+    }
+  }
+
+  Source::Source()
+  {
+    mFileName = "";
+    mLineStart = 0;
+    mColumnStart = 0;
+    mLineEnd = 0;
+    mColumnEnd = 0;
+    mReadonly = false;
+  }
+
+  void Source::deserialize(const QJsonObject &jsonObject)
+  {
+    if (jsonObject.contains("filename")) {
+      mFileName = jsonObject.value("filename").toString();
+    }
+
+    if (jsonObject.contains("lineStart")) {
+      mLineStart = jsonObject.value("lineStart").toInt();
+    }
+
+    if (jsonObject.contains("columnStart")) {
+      mColumnStart = jsonObject.value("columnStart").toInt();
+    }
+
+    if (jsonObject.contains("lineEnd")) {
+      mLineEnd = jsonObject.value("lineEnd").toInt();
+    }
+
+    if (jsonObject.contains("columnEnd")) {
+      mColumnEnd = jsonObject.value("columnEnd").toInt();
+    }
+
+    if (jsonObject.contains("readonly")) {
+      mReadonly = jsonObject.value("readonly").toBool();
     }
   }
 
@@ -783,14 +903,7 @@ namespace ModelInstance
     }
 
     if (mModelJson.contains("dims")) {
-      QJsonObject dims = mModelJson.value("dims").toObject();
-
-      if (dims.contains("absyn")) {
-        QJsonArray dimsAbsynArray = dims.value("absyn").toArray();
-        foreach (auto dim, dimsAbsynArray) {
-          mDims.append(dim.toString());
-        }
-      }
+      mDims.deserialize(mModelJson.value("dims").toObject());
     }
 
     if (mModelJson.contains("restriction")) {
@@ -803,46 +916,7 @@ namespace ModelInstance
     }
 
     if (mModelJson.contains("prefixes")) {
-      QJsonObject prefixes = mModelJson.value("prefixes").toObject();
-
-      if (prefixes.contains("public")) {
-        mPublic = prefixes.value("public").toBool();
-      }
-
-      if (prefixes.contains("final")) {
-        mFinal = prefixes.value("final").toBool();
-      }
-
-      if (prefixes.contains("inner")) {
-        mInner = prefixes.value("inner").toBool();
-      }
-
-      if (prefixes.contains("outer")) {
-        mOuter = prefixes.value("outer").toBool();
-      }
-
-      if (prefixes.contains("replaceable")) {
-        auto replaceable = prefixes.value("replaceble");
-
-        if (replaceable.isObject()) {
-          mReplaceable = true;
-          // constrainedby stuff goes here
-        } else {
-          mReplaceable = replaceable.toBool();
-        }
-      }
-
-      if (prefixes.contains("redeclare")) {
-        mRedeclare = prefixes.value("redeclare").toBool();
-      }
-
-      if (prefixes.contains("partial")) {
-        mPartial = prefixes.value("partial").toBool();
-      }
-
-      if (prefixes.contains("encapsulated")) {
-        mEncapsulated = prefixes.value("encapsulated").toBool();
-      }
+      mpPrefixes->deserialize(mModelJson.value("prefixes").toObject());
     }
 
     QJsonArray elements = mModelJson.value("elements").toArray();
@@ -851,10 +925,12 @@ namespace ModelInstance
       QJsonObject elementObject = element.toObject();
       QString kind = elementObject.value("$kind").toString();
 
-      if (kind == "extends") {
+      if (kind.compare(QStringLiteral("extends")) == 0) {
         mElements.append(new Extend(this, elementObject));
-      } else if (kind == "component") {
+      } else if (kind.compare(QStringLiteral("component")) == 0) {
         mElements.append(new Component(this, elementObject));
+      } else if (kind.compare(QStringLiteral("class")) == 0) {
+        mElements.append(new ReplaceableClass(this, elementObject));
       } else {
         qDebug() << "Unhandled kind of element" << kind;
       }
@@ -883,34 +959,6 @@ namespace ModelInstance
 
     if (!mpAnnotation->getDiagramAnnotation()->mMergedCoOrdinateSystem.isComplete()) {
       readCoordinateSystemFromExtendsClass(&mpAnnotation->getDiagramAnnotation()->mMergedCoOrdinateSystem, false);
-    }
-
-    if (mModelJson.contains("source")) {
-      QJsonObject source = mModelJson.value("source").toObject();
-
-      if (source.contains("filename")) {
-        mFileName = source.value("filename").toString();
-      }
-
-      if (source.contains("lineStart")) {
-        mLineStart = source.value("lineStart").toInt();
-      }
-
-      if (source.contains("columnStart")) {
-        mColumnStart = source.value("columnStart").toInt();
-      }
-
-      if (source.contains("lineEnd")) {
-        mLineEnd = source.value("lineEnd").toInt();
-      }
-
-      if (source.contains("columnEnd")) {
-        mColumnEnd = source.value("columnEnd").toInt();
-      }
-
-      if (source.contains("readonly")) {
-        mReadonly = source.value("readonly").toBool();
-      }
     }
 
     if (mModelJson.contains("connections")) {
@@ -947,6 +995,10 @@ namespace ModelInstance
           mInitialStates.append(pInitialState);
         }
       }
+    }
+
+    if (mModelJson.contains("source")) {
+      mSource.deserialize(mModelJson.value("source").toObject());
     }
   }
 
@@ -1107,25 +1159,11 @@ namespace ModelInstance
   void Model::initialize()
   {
     mModelJson = QJsonObject();
-    mDims.clear();
     mRestriction = "";
-    mPublic = false;
-    mFinal = false;
-    mInner = false;
-    mOuter = false;
-    mReplaceable = false;
-    mRedeclare = false;
-    mPartial = false;
-    mEncapsulated = false;
+    mpPrefixes = std::make_unique<Prefixes>(this);
     mComment = "";
     mpAnnotation = std::make_unique<Annotation>(this);
     mElements.clear();
-    mFileName = "";
-    mLineStart = 0;
-    mColumnStart = 0;
-    mLineEnd = 0;
-    mColumnEnd = 0;
-    mReadonly = false;
     mConnections.clear();
     mTransitions.clear();
     mInitialStates.clear();
@@ -1300,6 +1338,42 @@ namespace ModelInstance
     }
   }
 
+  Extend::Extend(Model *pParentModel, const QJsonObject &jsonObject)
+    : Element(pParentModel)
+  {
+    mpExtendsAnnotation = std::make_unique<Annotation>(pParentModel);
+    deserialize(jsonObject);
+  }
+
+  void Extend::deserialize(const QJsonObject &jsonObject)
+  {
+    if (jsonObject.contains("modifiers")) {
+      mExtendsModifier.deserialize(jsonObject.value("modifiers"));
+    }
+
+    if (jsonObject.contains("annotation")) {
+      mpExtendsAnnotation->deserialize(jsonObject.value("annotation").toObject());
+    }
+
+    if (jsonObject.contains("baseClass")) {
+      mpModel = new Model(jsonObject.value("baseClass").toObject(), this);
+    }
+  }
+
+  /*!
+   * \brief Extend::getQualifiedName
+   * Returns the qualified name of component.
+   * \return
+   */
+  QString Extend::getQualifiedName() const
+  {
+    if (mpParentModel && mpParentModel->getParentElement()) {
+      return mpParentModel->getParentElement()->getQualifiedName();
+    } else {
+      return "";
+    }
+  }
+
   Component::Component(Model *pParentModel)
     : Element(pParentModel)
   {
@@ -1322,17 +1396,7 @@ namespace ModelInstance
       delete mpModel;
     }
     mpModel = 0;
-    mAbsynDims.clear();
-    mTypedDims.clear();
-    mPublic = true;
-    mFinal = false;
-    mInner = false;
-    mOuter = false;
-    mpReplaceable = std::make_unique<Replaceable>(mpParentModel);
-    mRedeclare = false;
-    mConnector = "";
-    mVariability = "";
-    mDirection = "";
+    mpPrefixes = std::make_unique<Prefixes>(mpParentModel);
     mComment = "";
     mpAnnotation = std::make_unique<Annotation>(mpParentModel);
   }
@@ -1383,62 +1447,11 @@ namespace ModelInstance
     }
 
     if (jsonObject.contains("dims")) {
-      QJsonObject dims = jsonObject.value("dims").toObject();
-
-      if (dims.contains("absyn")) {
-        QJsonArray absynDimsArray = dims.value("absyn").toArray();
-        foreach (auto absynDim, absynDimsArray) {
-          mAbsynDims.append(absynDim.toString());
-        }
-      }
-
-      if (dims.contains("typed")) {
-        QJsonArray typedDimsArray = dims.value("typed").toArray();
-        foreach (auto typedDim, typedDimsArray) {
-          mTypedDims.append(typedDim.toString());
-        }
-      }
+      mDims.deserialize(jsonObject.value("dims").toObject());
     }
 
     if (jsonObject.contains("prefixes")) {
-      QJsonObject prefixes = jsonObject.value("prefixes").toObject();
-
-      if (prefixes.contains("public")) {
-        mPublic = prefixes.value("public").toBool();
-      }
-
-      if (prefixes.contains("final")) {
-        mFinal = prefixes.value("final").toBool();
-      }
-
-      if (prefixes.contains("inner")) {
-        mInner = prefixes.value("inner").toBool();
-      }
-
-      if (prefixes.contains("outer")) {
-        mOuter = prefixes.value("outer").toBool();
-      }
-
-      if (prefixes.contains("replaceable")) {
-        mpReplaceable->deserialize(prefixes.value("replaceable"));
-      }
-
-      if (prefixes.contains("redeclare")) {
-        mRedeclare = prefixes.value("redeclare").toBool();
-      }
-
-      if (prefixes.contains("connector")) {
-        mConnector = prefixes.value("connector").toString();
-      }
-
-      if (prefixes.contains("variability")) {
-        mVariability = prefixes.value("variability").toString();
-      }
-
-      if (prefixes.contains("direction")) {
-        mDirection = prefixes.value("direction").toString();
-      }
-
+      mpPrefixes->deserialize(jsonObject.value("prefixes").toObject());
     }
 
     if (jsonObject.contains("comment")) {
@@ -1467,6 +1480,36 @@ namespace ModelInstance
       }
     }
     return modifierValue;
+  }
+
+  /*!
+   * \brief Component::getComment
+   * Returns the Component comment.
+   * Prefer the comment given in replaceable part.
+   * \return
+   */
+  QString Component::getComment() const
+  {
+    if (mpPrefixes->getReplaceable() && !mpPrefixes->getReplaceable()->getComment().isEmpty()) {
+      return mpPrefixes->getReplaceable()->getComment();
+    } else {
+      return mComment;
+    }
+  }
+
+  /*!
+   * \brief Component::getAnnotation
+   * Returns the Component Annotation.
+   * Prefer the annotation given in replaceable part.
+   * \return
+   */
+  Annotation *Component::getAnnotation() const
+  {
+    if (mpPrefixes->getReplaceable() && mpPrefixes->getReplaceable()->getAnnotation()) {
+      return mpPrefixes->getReplaceable()->getAnnotation();
+    } else {
+      return mpAnnotation.get();
+    }
   }
 
   QString Component::getModifierValueFromInheritedType(Model *pModel, QStringList modifierNames)
@@ -1500,39 +1543,49 @@ namespace ModelInstance
     }
   }
 
-  Extend::Extend(Model *pParentModel, const QJsonObject &jsonObject)
+  ReplaceableClass::ReplaceableClass(Model *pParentModel, const QJsonObject &jsonObject)
     : Element(pParentModel)
   {
-    mpExtendsAnnotation = std::make_unique<Annotation>(pParentModel);
+    mpParentModel = pParentModel;
+    mName = "";
+    mpPrefixes = std::make_unique<Prefixes>(mpParentModel);
+    mBaseClass = "";
     deserialize(jsonObject);
   }
 
-  void Extend::deserialize(const QJsonObject &jsonObject)
+  void ReplaceableClass::deserialize(const QJsonObject &jsonObject)
   {
-    if (jsonObject.contains("modifiers")) {
-      mExtendsModifier.deserialize(jsonObject.value("modifiers"));
+    if (jsonObject.contains("name")) {
+      mName = jsonObject.value("name").toString();
     }
 
-    if (jsonObject.contains("annotation")) {
-      mpExtendsAnnotation->deserialize(jsonObject.value("annotation").toObject());
+    if (jsonObject.contains("prefixes")) {
+      mpPrefixes->deserialize(jsonObject.value("prefixes").toObject());
     }
 
     if (jsonObject.contains("baseClass")) {
-      mpModel = new Model(jsonObject.value("baseClass").toObject(), this);
+      mBaseClass = jsonObject.value("baseClass").toString();
+    }
+
+    if (jsonObject.contains("dims")) {
+      mDims.deserialize(jsonObject.value("dims").toObject());
+    }
+
+    if (jsonObject.contains("modifiers")) {
+      mModifier.deserialize(jsonObject.value("modifiers"));
+    }
+
+    if (jsonObject.contains("source")) {
+      mSource.deserialize(jsonObject.value("source").toObject());
     }
   }
 
-  /*!
-   * \brief Extend::getQualifiedName
-   * Returns the qualified name of component.
-   * \return
-   */
-  QString Extend::getQualifiedName() const
+  QString ReplaceableClass::getQualifiedName() const
   {
     if (mpParentModel && mpParentModel->getParentElement()) {
-      return mpParentModel->getParentElement()->getQualifiedName();
+      return mpParentModel->getParentElement()->getQualifiedName() % "." % mName;
     } else {
-      return "";
+      return mName;
     }
   }
 

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -450,7 +450,7 @@ void GraphicsView::drawElements(ModelInstance::Model *pModelInstance, bool inher
                   pIconGraphicsView->addItem(pIconElement->getOriginItem());
                   pIconGraphicsView->addElementToList(pIconElement);
                   pIconGraphicsView->deleteElementFromOutOfSceneList(pIconElement);
-                  pIconElement->setVisible(pModelInstanceComponent->isPublic());
+                  pIconElement->setVisible(pModelInstanceComponent->getPrefixes()->isPublic());
                 }
               }
             }
@@ -1047,7 +1047,7 @@ void GraphicsView::addElementToView(ModelInstance::Component *pComponent, bool i
       pIconGraphicsView->addElementToList(pIconElement);
     }
     // hide the element if it is connector and is protected
-    pIconElement->setVisible(pComponent->isPublic());
+    pIconElement->setVisible(pComponent->getPrefixes()->isPublic());
   }
 
   if (pDiagramElement->mTransformation.isValid() && pDiagramElement->mTransformation.getVisible()) {


### PR DESCRIPTION
### Related Issues

Fixes #10214

### Purpose

The parameters should appear in the correct tab and group.

### Approach

For replaceable use the annotation defined in the constrainedBy.
