### PR TITLE
Fix scope for constrainedby annotation

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1234,7 +1234,7 @@ function dumpJSONComponent
   input InstanceTree cls;
   output JSON json = JSON.makeNull();
 protected
-  InstNode node;
+  InstNode node, scope;
   Component comp;
   SCode.Element elem;
   Boolean is_constant;
@@ -1251,6 +1251,7 @@ algorithm
 
   comp := InstNode.component(node);
   elem := InstNode.definition(node);
+  scope := InstNode.parent(node);
 
   () := match (comp, elem)
     case (Component.TYPED_COMPONENT(), SCode.Element.COMPONENT())
@@ -1261,8 +1262,8 @@ algorithm
         json := JSON.addPair("type", dumpJSONComponentType(cls, node, comp.ty, isDeleted = true), json);
         json := dumpJSONSCodeMod(elem.modifications, json);
         json := JSON.addPair("condition", JSON.makeBoolean(false), json);
-        json := JSON.addPairNotNull("prefixes", dumpJSONAttributes(elem.attributes, elem.prefixes, node), json);
-        json := dumpJSONCommentOpt(SOME(elem.comment), InstNode.parent(node), json);
+        json := JSON.addPairNotNull("prefixes", dumpJSONAttributes(elem.attributes, elem.prefixes, scope), json);
+        json := dumpJSONCommentOpt(SOME(elem.comment), scope, json);
       then
         ();
 
@@ -1288,8 +1289,8 @@ algorithm
           json := JSON.addPair("condition", dumpJSONBinding(comp.condition), json);
         end if;
 
-        json := JSON.addPairNotNull("prefixes", dumpJSONAttributes(elem.attributes, elem.prefixes, node), json);
-        json := dumpJSONCommentOpt(comp.comment, InstNode.parent(node), json);
+        json := JSON.addPairNotNull("prefixes", dumpJSONAttributes(elem.attributes, elem.prefixes, scope), json);
+        json := dumpJSONCommentOpt(comp.comment, scope, json);
       then
         ();
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation7.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation7.mos
@@ -1,0 +1,108 @@
+// name: GetModelInstanceAnnotation7
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  record R
+  end R;
+
+  model A
+    parameter Integer x = 1;
+    replaceable R r constrainedby R annotation(Dialog(enable=x > 1));
+  end A;
+
+  model M
+    A a;
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"a\",
+//       \"type\": {
+//         \"name\": \"A\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"x\",
+//             \"type\": \"Integer\",
+//             \"modifiers\": \"1\",
+//             \"value\": {
+//               \"binding\": 1
+//             },
+//             \"prefixes\": {
+//               \"variability\": \"parameter\"
+//             }
+//           },
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"r\",
+//             \"type\": {
+//               \"name\": \"R\",
+//               \"restriction\": \"record\",
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 2,
+//                 \"columnStart\": 3,
+//                 \"lineEnd\": 3,
+//                 \"columnEnd\": 8
+//               }
+//             },
+//             \"prefixes\": {
+//               \"replaceable\": {
+//                 \"constrainedby\": \"R\",
+//                 \"annotation\": {
+//                   \"Dialog\": {
+//                     \"enable\": {
+//                       \"$kind\": \"binary_op\",
+//                       \"lhs\": {
+//                         \"$kind\": \"cref\",
+//                         \"parts\": [
+//                           {
+//                             \"name\": \"a\"
+//                           },
+//                           {
+//                             \"name\": \"x\"
+//                           }
+//                         ]
+//                       },
+//                       \"op\": \">\",
+//                       \"rhs\": 1
+//                     }
+//                   }
+//                 }
+//               }
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 5,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 8,
+//           \"columnEnd\": 8
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 10,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 12,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -7,6 +7,7 @@ GetModelInstanceAnnotation3.mos \
 GetModelInstanceAnnotation4.mos \
 GetModelInstanceAnnotation5.mos \
 GetModelInstanceAnnotation6.mos \
+GetModelInstanceAnnotation7.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \


### PR DESCRIPTION
- Use the parent of the component rather than the component itself when instantiating expressions in constrainedby annotations.

Fixes #10210