### PR TITLE
[OMEdit] Faster loading of STL files

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -47,6 +47,7 @@
 #include <osg/ShapeDrawable>
 #include <osg/StateAttribute>
 #include <osg/Texture2D>
+#include <osgDB/Options>
 #include <osgDB/ReadFile>
 #include <osgGA/OrbitManipulator>
 #include <osgUtil/CullVisitor>
@@ -1284,7 +1285,9 @@ void OSGScene::setUpScene(std::vector<ShapeObject>& shapes)
     if (shape._type.compare("stl") == 0)
     { //cad node
       //std::cout<<"It's a stl and the filename is "<<shape._fileName<<std::endl;
-      osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(shape._fileName);
+      // Disable mesh optimization because it is too expensive (see OSG commit a082b57)
+      osg::ref_ptr<osgDB::Options> options = new osgDB::Options("noTriStripPolygons");
+      osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(shape._fileName, options.get());
       if (node.valid())
       {
         osg::ref_ptr<osg::Material> material = new osg::Material();


### PR DESCRIPTION
### Related Issues

Addendum to #10165.

### Purpose

STL files take a very long time to load (at least [this model](https://github.com/OpenModelica/OpenModelica/files/10664594/stl.zip)) with OSG >= 3.6.1.
The culprit is OSG commit [`a082b57`](https://github.com/openscenegraph/OpenSceneGraph/commit/a082b57c3fc137cf31f22d50eb1fe4ca4e2e9932) (along with [`7bda808`](https://github.com/openscenegraph/OpenSceneGraph/commit/7bda8083fb0ef6897925679ad7462875d8e60bca)) which changed the mesh optimization method.

### Approach

Disable mesh optimization of STL shapes.

[Here](https://github.com/openscenegraph/OpenSceneGraph/blob/7bda8083fb0ef6897925679ad7462875d8e60bca/src/osgPlugins/stl/ReaderWriterSTL.cpp#L184-L186) is the call to optimize the mesh in [this function](https://github.com/openscenegraph/OpenSceneGraph/blob/7bda8083fb0ef6897925679ad7462875d8e60bca/include/osgUtil/MeshOptimizers#L125-L138).
Executing `export OSG_NOTIFY_LEVEL=DEBUG` (or `set OSG_NOTIFY_LEVEL=DEBUG` on Windows) before running OMEdit reveals that [this line](https://github.com/openscenegraph/OpenSceneGraph/blob/7bda8083fb0ef6897925679ad7462875d8e60bca/src/osgUtil/MeshOptimizers.cpp#L811) is called a great number of times.
The solution is to [pass an option](https://github.com/openscenegraph/OpenSceneGraph/blob/7bda8083fb0ef6897925679ad7462875d8e60bca/src/osgPlugins/stl/ReaderWriterSTL.cpp#L82-L85) in order to disable this expensive mesh optimization.
