### PR TITLE
Omitt Jacobian calculation for scaling issues

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
@@ -485,7 +485,7 @@ NLS_SOLVER_STATUS solveNLS_gb(DATA *data, threadData_t *threadData, NONLINEAR_SY
     // Get kinsol data object
     NLS_KINSOL_DATA* kin_mem = ((NLS_KINSOL_DATA*)solverData->ordinaryData)->kinsolMemory;
 
-    set_kinsol_parameters(kin_mem, nlsData->size * 4, SUNFALSE, 10);
+    set_kinsol_parameters(kin_mem, nlsData->size * 4, SUNTRUE, 10);
     solved = solveNLS(data, threadData, nlsData);
     if (ACTIVE_STREAM(LOG_GBODE_NLS)) get_kinsol_statistics(kin_mem);
   } else {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
@@ -78,6 +78,36 @@ void setJacElementSundialsSparse(int row, int column, int nth, double value, voi
   SM_DATA_S(A)[nth] = value;
 }
 
+/**
+ * @brief             Scaling of a sparse matrix column-wise by a vector
+ *
+ * @param A           Sparse matrix in CSC.
+ * @param vScale      Vector for scaling
+ * @return *SUNMatrix Returns the scaled sparse matrix
+ */
+SUNMatrix _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale)
+{
+  sunindextype i, j;
+  char *matrixtype;
+  char *indexname;
+  realtype *vScaling = N_VGetArrayPointer(vScale), value;
+  SUNMatrix B = SUNMatClone_Sparse(A);
+  SUNMatCopy_Sparse(A, B);
+
+   /* should not be called unless A is a sparse matrix in CSC format;
+     otherwise return immediately */
+  if (SUNMatGetID(A) != SUNMATRIX_SPARSE || SM_SPARSETYPE_S(A) == CSR_MAT)
+    return(A);
+
+  for (j=0; j<SM_NP_S(A); j++) {
+    for (i=(SM_INDEXPTRS_S(A))[j]; i<(SM_INDEXPTRS_S(A))[j+1]; i++) {
+      value = (SM_DATA_S(A))[i]/vScaling[(SM_INDEXVALS_S(A))[i]];
+      (SM_DATA_S(B))[i] = (SM_DATA_S(A))[i]/vScaling[(SM_INDEXVALS_S(A))[i]];
+    }
+  }
+
+  return(B);
+}
 
 /**
  * @brief Calculates A+c*I and stores the result in A.

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
@@ -83,7 +83,7 @@ void setJacElementSundialsSparse(int row, int column, int nth, double value, voi
  *
  * @param A           Sparse matrix in CSC.
  * @param vScale      Vector for scaling
- * @return *SUNMatrix Returns the scaled sparse matrix
+ * @return SUNMatrix  Returns the scaled sparse matrix
  */
 SUNMatrix _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale)
 {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
@@ -87,21 +87,21 @@ void setJacElementSundialsSparse(int row, int column, int nth, double value, voi
  */
 SUNMatrix _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale)
 {
-  sunindextype i, j;
-  char *matrixtype;
-  char *indexname;
-  realtype *vScaling = N_VGetArrayPointer(vScale), value;
-  SUNMatrix B = SUNMatClone_Sparse(A);
-  SUNMatCopy_Sparse(A, B);
 
-   /* should not be called unless A is a sparse matrix in CSC format;
-     otherwise return immediately */
+  /* should not be called unless A is a sparse matrix in CSC format;
+    otherwise return immediately */
   if (SUNMatGetID(A) != SUNMATRIX_SPARSE || SM_SPARSETYPE_S(A) == CSR_MAT)
     return(A);
 
+  sunindextype i, j;
+  char *matrixtype;
+  char *indexname;
+  realtype *vScaling = N_VGetArrayPointer(vScale);
+  SUNMatrix B = SUNMatClone_Sparse(A);
+  SUNMatCopy_Sparse(A, B);
+
   for (j=0; j<SM_NP_S(A); j++) {
     for (i=(SM_INDEXPTRS_S(A))[j]; i<(SM_INDEXPTRS_S(A))[j+1]; i++) {
-      value = (SM_DATA_S(A))[i]/vScaling[(SM_INDEXVALS_S(A))[i]];
       (SM_DATA_S(B))[i] = (SM_DATA_S(A))[i]/vScaling[(SM_INDEXVALS_S(A))[i]];
     }
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
@@ -52,6 +52,7 @@ extern "C" {
 
 void setJacElementSundialsSparse(int row, int column, int nth, double value, void* Jac, int nRows);
 int _omc_SUNMatScaleIAdd_Sparse(realtype c, SUNMatrix A);
+SUNMatrix _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale);
 
 #endif /* WITH_SUNDIALS */
 


### PR DESCRIPTION
### Related Issues

#10287 

### Purpose

Improve Jacobian calculation in GBODE (only update, if necessary). By default the Jacobian has been calculated each time a/the nonlinear system has to be solved. This happened at least at each integration time step. 

### Approach

Reuse the already calculated Jacobian stored in the kinsol data.
