### PR TITLE
Dump replaceable classes better in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -102,6 +102,7 @@ uniontype InstNodeType
   record REDECLARED_CLASS
     InstNode parent;
     InstNodeType originalType;
+    Option<InstNode> originalNode;
   end REDECLARED_CLASS;
 
   record GENERATED_INNER
@@ -1568,6 +1569,16 @@ uniontype InstNode
       else false;
     end match;
   end isRedeclared;
+
+  function getRedeclaredNode
+    input InstNode node;
+    output InstNode outNode;
+  algorithm
+    outNode := match node
+      case InstNode.CLASS_NODE(nodeType = InstNodeType.REDECLARED_CLASS(originalNode = SOME(outNode))) then outNode;
+      else node;
+    end match;
+  end getRedeclaredNode;
 
   function isReplaceable
     input InstNode node;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1196,10 +1196,11 @@ protected
   Option<list<Absyn.Subscript>> odims;
   SCode.Comment cmt;
 algorithm
-  elem := InstNode.definition(cls);
+  node := InstNode.getRedeclaredNode(cls);
+  elem := InstNode.definition(node);
 
   json := JSON.addPair("$kind", JSON.makeString("class"), json);
-  json := JSON.addPair("name", JSON.makeString(InstNode.name(cls)), json);
+  json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
   json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(elem, scope), json);
 
   SCode.Element.CLASS(classDef = cdef, cmt = cmt) := elem;
@@ -1232,7 +1233,7 @@ algorithm
 
   json := dumpJSONCommentAnnotation(SOME(cmt), scope, json,
     {"Dialog", "choices", "choicesAllMatching"});
-  json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(cls)), json);
+  json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(node)), json);
 end dumpJSONReplaceableClass;
 
 function dumpJSONComponent

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
@@ -21,11 +21,11 @@ loadString("
   end A;
 
   model M
-    extends A(redeclare model B = B, redeclare model C = C(y = 2.0));
+    extends A(redeclare model B = MB, redeclare model C = C(y = 2.0));
 
-    model B
+    model MB
       Real x = 2.0;
-    end B;
+    end MB;
   end M;
 ");
 
@@ -41,7 +41,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"extends\",
 //       \"modifiers\": {
 //         \"B\": {
-//           \"$value\": \"redeclare model B = B\"
+//           \"$value\": \"redeclare model B = MB\"
 //         },
 //         \"C\": {
 //           \"$value\": \"redeclare model C = C(y = 2.0)\"
@@ -64,7 +64,7 @@ getModelInstance(M, prettyPrint = true);
 //                 {
 //                   \"$kind\": \"extends\",
 //                   \"baseClass\": {
-//                     \"name\": \"B\",
+//                     \"name\": \"MB\",
 //                     \"restriction\": \"model\",
 //                     \"elements\": [
 //                       {
@@ -82,7 +82,7 @@ getModelInstance(M, prettyPrint = true);
 //                       \"lineStart\": 19,
 //                       \"columnStart\": 5,
 //                       \"lineEnd\": 21,
-//                       \"columnEnd\": 10
+//                       \"columnEnd\": 11
 //                     }
 //                   }
 //                 }
@@ -92,18 +92,21 @@ getModelInstance(M, prettyPrint = true);
 //                 \"lineStart\": 17,
 //                 \"columnStart\": 25,
 //                 \"lineEnd\": 17,
-//                 \"columnEnd\": 36
+//                 \"columnEnd\": 37
 //               }
 //             }
 //           },
 //           {
 //             \"$kind\": \"class\",
 //             \"name\": \"B\",
+//             \"prefixes\": {
+//               \"replaceable\": true
+//             },
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
-//               \"lineStart\": 19,
-//               \"columnStart\": 5,
-//               \"lineEnd\": 21,
+//               \"lineStart\": 5,
+//               \"columnStart\": 17,
+//               \"lineEnd\": 7,
 //               \"columnEnd\": 10
 //             }
 //           },
@@ -111,18 +114,14 @@ getModelInstance(M, prettyPrint = true);
 //             \"$kind\": \"class\",
 //             \"name\": \"C\",
 //             \"prefixes\": {
-//               \"redeclare\": true
-//             },
-//             \"baseClass\": \"C\",
-//             \"modifiers\": {
-//               \"y\": \"2.0\"
+//               \"replaceable\": true
 //             },
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
-//               \"lineStart\": 17,
-//               \"columnStart\": 48,
-//               \"lineEnd\": 17,
-//               \"columnEnd\": 68
+//               \"lineStart\": 9,
+//               \"columnStart\": 17,
+//               \"lineEnd\": 11,
+//               \"columnEnd\": 10
 //             }
 //           },
 //           {
@@ -151,7 +150,7 @@ getModelInstance(M, prettyPrint = true);
 //           \"lineStart\": 17,
 //           \"columnStart\": 5,
 //           \"lineEnd\": 17,
-//           \"columnEnd\": 69
+//           \"columnEnd\": 70
 //         }
 //       }
 //     }


### PR DESCRIPTION
- Dump the replaceable classes themselves instead of the classes that replace them in case of existing redeclares.