### PR TITLE
Fix error handling in OMShell

### DIFF
--- a/OMShell/OMShell/OMShellGUI/omcinteractiveenvironment.cpp
+++ b/OMShell/OMShell/OMShellGUI/omcinteractiveenvironment.cpp
@@ -177,10 +177,8 @@ namespace IAEX
     if( error_.size() > 2 ) {
       if (error_.contains("Error:")) {
         severity = 2;
-        error_ = QString( "OMC-ERROR: \n" ) + error_;
       } else if (error_.contains("Warning:")) {
         severity = 1;
-        error_ = QString( "OMC-WARNING: \n" ) + error_;
       } else {
         severity = 0;
       }

--- a/OMShell/OMShell/OMShellGUI/oms.cpp
+++ b/OMShell/OMShell/OMShellGUI/oms.cpp
@@ -525,25 +525,15 @@ void OMS::returnPressed()
       cursor_.insertText( "\n" + res + "\n", textFormat_ );
 
     // get Error text
-    try
+    QString error = delegate_->getError();
+    if(error.size() > 2)
     {
-      QString getErrorString = "getErrorString()";
-      delegate_->evalExpression(getErrorString);
-    }
-    catch( exception &e )
-    {
-      exceptionInEval(e);
-      return;
-    }
-    QString error = delegate_->getResult();
-    if( error.size() > 2 )
-    {
-      cursor_.insertText( error.mid( 1, error.size() - 2 ) );
+      cursor_.insertText(error);
     }
   }
   else
   {
-    cursor_.insertText("[ERROR] No OMC serer started - unable to restart OMC\n" );
+    cursor_.insertText("[ERROR] No OMC server started - unable to restart OMC\n" );
   }
 
   // add new command line

--- a/OMShell/mosh/src/mosh.cpp
+++ b/OMShell/mosh/src/mosh.cpp
@@ -135,7 +135,11 @@ void doOMCCommunication(const string *scriptname)
       if (!done) add_history(line);
       env->evalExpression(line);
       string res = env->getResult();
-      cout << res << endl;
+      cout << res;
+      string error = env->getError();
+      if (error.size() > 3) {
+        cout << error;
+      }
     }
     free(line);
   }

--- a/OMShell/mosh/src/omcinteractiveenvironment.cpp
+++ b/OMShell/mosh/src/omcinteractiveenvironment.cpp
@@ -162,10 +162,8 @@ static bool contains(std::string s1, std::string s2);
     if( error_.size() > 2 ) {
       if (contains(error_,"Error:")) {
         severity = 2;
-        error_ = "OMC-ERROR: \n" + error_;
       } else if (contains(error_,"Warning:")) {
         severity = 1;
-        error_ = "OMC-WARNING: \n" + error_;
       } else {
         severity = 0;
       }


### PR DESCRIPTION
- Show the stored error message from the expression evaluator instead of calling `getErrorString` again, otherwise the error message is lost.

Fixes #10324