### PR TITLE
Print errors to stderr

### DIFF
--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -329,11 +329,15 @@ protected function showErrors
   input String errorMessages;
 algorithm
   if errorString <> "" then
-    print(errorString); print("\n");
+    System.fflush();
+    System.fputs(errorString, System.StreamType.STDERR);
+    System.fputs("\n", System.StreamType.STDERR);
   end if;
 
   if errorMessages <> "" then
-    print(errorMessages); print("\n");
+    System.fflush();
+    System.fputs(errorMessages, System.StreamType.STDERR);
+    System.fputs("\n", System.StreamType.STDERR);
   end if;
 end showErrors;
 

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1316,5 +1316,16 @@ Includes constant data and handles cycles.
 </html>"));
 end getSizeOfData;
 
+type StreamType = enumeration(STDOUT, STDERR);
+
+function fputs
+  input String str;
+  input StreamType streamType;
+  output Integer res "Nonnegative on success, EOF on error";
+  external "C" res=SystemImpl__fputs(str, streamType) annotation(Library = "omcruntime", Documentation(info="<html>
+Outputs a string using the C function fputs.
+</html>"));
+end fputs;
+
 annotation(__OpenModelica_Interface="util");
 end System;

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -3326,6 +3326,16 @@ int SystemImpl__relocateFunctions(const char *fileName, void *names)
 }
 #endif
 
+int SystemImpl__fputs(const char *str, int stream)
+{
+  switch (stream) {
+    case 1: return fputs(str, stdout); break;
+    case 2: return fputs(str, stderr); break;
+  }
+
+  return -1;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Change `Main.showErrors` to print error messages to stderr instead of stdout.

Fixes #10327