### PR TITLE
Set appropriate method-specific defaults for gbode solver

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.c
@@ -260,6 +260,31 @@ double getGBRatio() {
 }
 
 /**
+ * @brief Get information on richardson extrapolation.
+ *
+ * Read flag FLAG_ERR to get percentage.
+ * Defaults to 0.
+ *
+ * @return int  0: default, depending on the RK method
+ *              1: richardson extrapolation
+ *              2: embedded scheme
+ **/
+int getGBErr(enum _FLAG flag) {
+  double richardson;
+  const char *flag_value = omc_flagValue[flag];
+
+  if (flag_value) {
+    richardson = atof(omc_flagValue[flag]);
+    if (richardson != 0 && richardson != 1 && richardson != 2) {
+      throwStreamPrint(NULL, "Flag -gberr and -gbferr has to be 0, 1 or 2.");
+    }
+  } else {
+    richardson = 0;
+  }
+  return (int) richardson;
+}
+
+/**
  * @brief Dump available flag options to stdout.
  *
  * @param flagName    Name of flag

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.c
@@ -176,7 +176,13 @@ enum GB_CTRL_METHOD getControllerMethod(enum _FLAG flag) {
     dumOptions(FLAG_NAME[flag], flag_value, GB_CTRL_METHOD_NAME, GB_CTRL_MAX);
     return GB_CTRL_UNKNOWN;
   } else {
-    return GB_CTRL_I;
+    // Default value
+    if (flag == FLAG_MR_CTRL) {
+      return getControllerMethod(FLAG_SR_CTRL);
+    } else {
+      infoStreamPrint(LOG_SOLVER, 0, "Chosen gbode step size control: i [default]");
+      return GB_CTRL_I;
+    }
   }
 }
 
@@ -205,7 +211,7 @@ enum GB_INTERPOL_METHOD getInterpolationMethod(enum _FLAG flag) {
       if (strcmp(flag_value, GB_INTERPOL_METHOD_NAME[method]) == 0) {
         if (flag == FLAG_MR_INT && (method == GB_INTERPOL_HERMITE_ERRCTRL || method == GB_DENSE_OUTPUT_ERRCTRL)) {
           warningStreamPrint(LOG_SOLVER, 0, "Chosen gbode interpolation method %s not supported for fast state integration", GB_INTERPOL_METHOD_NAME[method]);
-          method = GB_INTERPOL_HERMITE;
+          method = GB_DENSE_OUTPUT;
         }
         infoStreamPrint(LOG_SOLVER, 0, "Chosen gbode interpolation method: %s", GB_INTERPOL_METHOD_NAME[method]);
         return method;
@@ -214,7 +220,19 @@ enum GB_INTERPOL_METHOD getInterpolationMethod(enum _FLAG flag) {
     dumOptions(FLAG_NAME[flag], flag_value, GB_INTERPOL_METHOD_NAME, GB_INTERPOL_MAX);
     return GB_INTERPOL_UNKNOWN;
   } else {
-    return GB_INTERPOL_HERMITE;
+    // Default value
+    if (flag == FLAG_MR_INT) {
+      method = getInterpolationMethod(FLAG_SR_INT);
+      if (method == GB_INTERPOL_HERMITE_ERRCTRL || method == GB_DENSE_OUTPUT_ERRCTRL) {
+        warningStreamPrint(LOG_SOLVER, 0, "Chosen gbode interpolation method %s not supported for fast state integration", GB_INTERPOL_METHOD_NAME[method]);
+        infoStreamPrint(LOG_SOLVER, 0, "Chosen gbode interpolation method: dense_output [default]");
+        method = GB_DENSE_OUTPUT;
+      }
+      return method;
+    } else {
+      infoStreamPrint(LOG_SOLVER, 0, "Chosen gbode interpolation method: dense_output [default]");
+      return GB_DENSE_OUTPUT;
+    }
   }
 }
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.c
@@ -260,28 +260,41 @@ double getGBRatio() {
 }
 
 /**
- * @brief Get information on richardson extrapolation.
+ * @brief Get extrapolation method from user flag.
  *
- * Read flag FLAG_ERR to get percentage.
- * Defaults to 0.
+ * Reads flag FLAG_SR_ERR, FLAG_MR_ERR.
+ * Defaults to GB_EXT_DEFAULT.
  *
- * @return int  0: default, depending on the RK method
- *              1: richardson extrapolation
- *              2: embedded scheme
- **/
-int getGBErr(enum _FLAG flag) {
-  double richardson;
+ * @param flag                      Flag specifying error estimation.
+ *                                  Allowed values: FLAG_SR_ERR, FLAG_MR_ERR
+ * @return enum GB_EXTRAPOL_METHOD  Extrapolation method.
+ */
+enum GB_EXTRAPOL_METHOD getGBErr(enum _FLAG flag) {
+  assertStreamPrint(NULL, flag==FLAG_SR_ERR || flag==FLAG_MR_ERR, "Illegal input 'flag' to getGBErr!");
+
+  enum GB_EXTRAPOL_METHOD extrapolationMethod;
   const char *flag_value = omc_flagValue[flag];
 
-  if (flag_value) {
-    richardson = atof(omc_flagValue[flag]);
-    if (richardson != 0 && richardson != 1 && richardson != 2) {
-      throwStreamPrint(NULL, "Flag -gberr and -gbferr has to be 0, 1 or 2.");
+  if (flag_value != NULL) {
+    if (strcmp(flag_value, "default")==0) {
+      extrapolationMethod = GB_EXT_DEFAULT;
+    } else if (strcmp(flag_value, "richardson")==0) {
+      extrapolationMethod = GB_EXT_RICHARDSON;
+    } else if (strcmp(flag_value, "embedded")==0) {
+      extrapolationMethod = GB_EXT_EMBEDDED;
+    } else {
+      errorStreamPrint(LOG_STDOUT, 0, "Illegal value '%s' for flag -%s", flag_value, FLAG_NAME[flag]);
+      infoStreamPrint(LOG_STDOUT, 1, "Allowed values are:");
+      infoStreamPrint(LOG_STDOUT, 0, "default");
+      infoStreamPrint(LOG_STDOUT, 0, "richardson");
+      infoStreamPrint(LOG_STDOUT, 0, "embedded");
+      messageClose(LOG_STDOUT);
+      omc_throw(NULL);
     }
   } else {
-    richardson = 0;
+    extrapolationMethod = GB_EXT_DEFAULT;
   }
-  return (int) richardson;
+  return extrapolationMethod;
 }
 
 /**

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.h
@@ -40,12 +40,23 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Extrapolation method for single-rate / multi-rate error estimation.
+ */
+enum GB_EXTRAPOL_METHOD{
+  GB_EXT_UNKNOWN = 0,    /* Unknown method */
+
+  GB_EXT_DEFAULT,        /* Default, depending on the Runge-Kutta method */
+  GB_EXT_RICHARDSON,     /* Richardson extrapolation*/
+  GB_EXT_EMBEDDED        /* Embedded scheme */
+};
+
 enum GB_METHOD getGB_method(enum _FLAG flag);
 enum GB_INTERPOL_METHOD getInterpolationMethod(enum _FLAG flag);
 enum GB_CTRL_METHOD getControllerMethod(enum _FLAG flag);
 enum GB_NLS_METHOD getGB_NLS_method(enum _FLAG flag);
 double getGBRatio();
-int getGBErr(enum _FLAG flag);
+enum GB_EXTRAPOL_METHOD getGBErr(enum _FLAG flag);
 
 #ifdef __cplusplus
 };

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_conf.h
@@ -45,6 +45,7 @@ enum GB_INTERPOL_METHOD getInterpolationMethod(enum _FLAG flag);
 enum GB_CTRL_METHOD getControllerMethod(enum _FLAG flag);
 enum GB_NLS_METHOD getGB_NLS_method(enum _FLAG flag);
 double getGBRatio();
+int getGBErr(enum _FLAG flag);
 
 #ifdef __cplusplus
 };

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -264,7 +264,7 @@ int gbodef_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solve
     break;
   case GB_DENSE_OUTPUT:
   case GB_DENSE_OUTPUT_ERRCTRL:
-    infoStreamPrint(LOG_SOLVER, 0, "If available, dense output is used for emitting results, otherwise hermite");
+    infoStreamPrint(LOG_SOLVER, 0, "Dense output is used for emitting results");
     break;
   default:
     throwStreamPrint(NULL, "Unhandled interpolation case.");
@@ -478,7 +478,7 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
     break;
   case GB_DENSE_OUTPUT:
   case GB_DENSE_OUTPUT_ERRCTRL:
-    infoStreamPrint(LOG_SOLVER, 0, "If available, dense output is used  for emitting results%s", buffer);
+    infoStreamPrint(LOG_SOLVER, 0, "Dense output is used  for emitting results%s", buffer);
     break;
   default:
     throwStreamPrint(NULL, "Unhandled interpolation case.");

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -438,7 +438,7 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
   }
 
   gbData->percentage = getGBRatio();
-  gbData->multi_rate = gbData->percentage > 0;
+  gbData->multi_rate = gbData->percentage > 0 && gbData->percentage < 1;
 
   gbData->fastStatesIdx   = malloc(sizeof(int) * gbData->nStates);
   gbData->slowStatesIdx   = malloc(sizeof(int) * gbData->nStates);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -452,7 +452,13 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
     gbData->sortedStatesIdx[i] = i;
   }
 
-  gbData->interpolation = getInterpolationMethod(FLAG_SR_INT);
+
+  if (gbData->multi_rate && omc_flagValue[FLAG_SR_INT]==NULL) {
+    gbData->interpolation = GB_DENSE_OUTPUT_ERRCTRL;
+  } else {
+    gbData->interpolation = getInterpolationMethod(FLAG_SR_INT);
+  }
+
   if (!gbData->tableau->withDenseOutput) {
     if (gbData->interpolation == GB_DENSE_OUTPUT) gbData->interpolation = GB_INTERPOL_HERMITE;
     if (gbData->interpolation == GB_DENSE_OUTPUT_ERRCTRL) gbData->interpolation = GB_INTERPOL_HERMITE_ERRCTRL;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_tableau.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_tableau.c
@@ -34,6 +34,7 @@
  */
 
 #include "gbode_tableau.h"
+#include "gbode_conf.h"
 
 #include <string.h>
 
@@ -1398,11 +1399,10 @@ void analyseButcherTableau(BUTCHER_TABLEAU* tableau, int nStates, unsigned int* 
  */
 BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD GM_method, enum _FLAG FLAG_ERR) {
   BUTCHER_TABLEAU* tableau = (BUTCHER_TABLEAU*) malloc(sizeof(BUTCHER_TABLEAU));
-  const char* flag_value = omc_flagValue[FLAG_ERR];
-  int richardson = 0;
+  int richardson;
 
-  if (flag_value != NULL) richardson = atoi(flag_value);
-  if (richardson) {
+  richardson = getGBErr(FLAG_ERR);
+  if (richardson == 1) {
     tableau->richardson = TRUE;
     infoStreamPrint(LOG_SOLVER, 0, "Richardson extrapolation is used for step size control");
   } else {
@@ -1493,54 +1493,71 @@ BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD GM_method, enum _FLAG FLAG_ER
       getButcherTableau_ESDIRK4(tableau);
       break;
     case RK_RADAU_IA_2:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IA_2(tableau);
       break;
     case RK_RADAU_IA_3:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IA_3(tableau);
       break;
     case RK_RADAU_IA_4:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IA_4(tableau);
       break;
     case RK_RADAU_IIA_2:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IIA_2(tableau);
       break;
     case RK_RADAU_IIA_3:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IIA_3(tableau);
       break;
     case RK_RADAU_IIA_4:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IIA_4(tableau);
       break;
     case RK_LOBA_IIIA_3:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIA_3(tableau);
       break;
     case RK_LOBA_IIIA_4:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIA_4(tableau);
       break;
     case RK_LOBA_IIIB_3:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIB_3(tableau);
       break;
     case RK_LOBA_IIIB_4:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIB_4(tableau);
       break;
     case RK_LOBA_IIIC_3:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIC_3(tableau);
       break;
     case RK_LOBA_IIIC_4:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIC_4(tableau);
       break;
     case RK_GAUSS2:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_GAUSS2(tableau);
       break;
     case RK_GAUSS3:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_GAUSS3(tableau);
       break;
     case RK_GAUSS4:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_GAUSS4(tableau);
       break;
     case RK_GAUSS5:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_GAUSS5(tableau);
       break;
     case RK_GAUSS6:
+      if (richardson == 0) tableau->richardson = TRUE;
       getButcherTableau_GAUSS6(tableau);
       break;
     default:

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_tableau.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_tableau.c
@@ -1394,22 +1394,26 @@ void analyseButcherTableau(BUTCHER_TABLEAU* tableau, int nStates, unsigned int* 
 /**
  * @brief Allocate memory and initialize Butcher tableau for given method.
  *
- * @param GM_method           Runge-Kutta method.
+ * @param method              Runge-Kutta method.
+ * @param flag                Flag specifying error estimation.
+ *                            Allowed values: FLAG_SR_ERR, FLAG_MR_ERR
  * @return BUTCHER_TABLEAU*   Return pointer to Butcher tableau on success, NULL on failure.
  */
-BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD GM_method, enum _FLAG FLAG_ERR) {
+BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD method, enum _FLAG flag) {
   BUTCHER_TABLEAU* tableau = (BUTCHER_TABLEAU*) malloc(sizeof(BUTCHER_TABLEAU));
-  int richardson;
+  enum GB_EXTRAPOL_METHOD extrapolMethod;
 
-  richardson = getGBErr(FLAG_ERR);
-  if (richardson == 1) {
+  assertStreamPrint(NULL, flag==FLAG_SR_ERR || flag==FLAG_MR_ERR, "Illegal input 'flag' to initButcherTableau!");
+
+  extrapolMethod = getGBErr(flag);
+  if (extrapolMethod == GB_EXT_RICHARDSON) {
     tableau->richardson = TRUE;
     infoStreamPrint(LOG_SOLVER, 0, "Richardson extrapolation is used for step size control");
   } else {
     tableau->richardson = FALSE;
   }
 
-  switch(GM_method)
+  switch(method)
   {
     case MS_ADAMS_MOULTON:
       getButcherTableau_MS(tableau);
@@ -1493,75 +1497,75 @@ BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD GM_method, enum _FLAG FLAG_ER
       getButcherTableau_ESDIRK4(tableau);
       break;
     case RK_RADAU_IA_2:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IA_2(tableau);
       break;
     case RK_RADAU_IA_3:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IA_3(tableau);
       break;
     case RK_RADAU_IA_4:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IA_4(tableau);
       break;
     case RK_RADAU_IIA_2:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IIA_2(tableau);
       break;
     case RK_RADAU_IIA_3:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IIA_3(tableau);
       break;
     case RK_RADAU_IIA_4:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_RADAU_IIA_4(tableau);
       break;
     case RK_LOBA_IIIA_3:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIA_3(tableau);
       break;
     case RK_LOBA_IIIA_4:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIA_4(tableau);
       break;
     case RK_LOBA_IIIB_3:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIB_3(tableau);
       break;
     case RK_LOBA_IIIB_4:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIB_4(tableau);
       break;
     case RK_LOBA_IIIC_3:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIC_3(tableau);
       break;
     case RK_LOBA_IIIC_4:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_LOBATTO_IIIC_4(tableau);
       break;
     case RK_GAUSS2:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_GAUSS2(tableau);
       break;
     case RK_GAUSS3:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_GAUSS3(tableau);
       break;
     case RK_GAUSS4:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_GAUSS4(tableau);
       break;
     case RK_GAUSS5:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_GAUSS5(tableau);
       break;
     case RK_GAUSS6:
-      if (richardson == 0) tableau->richardson = TRUE;
+      if (extrapolMethod == GB_EXT_DEFAULT) tableau->richardson = TRUE;
       getButcherTableau_GAUSS6(tableau);
       break;
     default:
-      throwStreamPrint(NULL, "Error: Unknown Runge Kutta method %i.", GM_method);
+      throwStreamPrint(NULL, "Error: Unknown Runge Kutta method %i.", method);
   }
 
   return tableau;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_tableau.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_tableau.h
@@ -99,7 +99,7 @@ enum GM_TYPE {
 
 /* Function prototypes */
 
-BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD GM_method, enum _FLAG FLAG_ERR);
+BUTCHER_TABLEAU* initButcherTableau(enum GB_METHOD method, enum _FLAG flag);
 void freeButcherTableau(BUTCHER_TABLEAU* tableau);
 
 void analyseButcherTableau(BUTCHER_TABLEAU* tableau, int nStates, unsigned int* nlSystemSize, enum GM_TYPE* expl);

--- a/OMCompiler/SimulationRuntime/c/util/simulation_options.c
+++ b/OMCompiler/SimulationRuntime/c/util/simulation_options.c
@@ -273,12 +273,12 @@ const char *FLAG_DESC[FLAG_MAX+1] = {
   /* FLAG_DATA_RECONCILE_STATE */         "Run the State Estimation numerical computation algorithm for constrained equations",
   /* FLAG_SR */                           "Value specifies the chosen solver of solver gbode (single-rate, slow states integrator)",
   /* FLAG_SR_CTRL */                      "Step size control of solver gbode (single-rate, slow states integrator)",
-  /* FLAG_SR_ERR */                       "Error estimation done by Richardson extrapolation  (-gberr=1) of solver gbode (single-rate, slow states integrator)",
+  /* FLAG_SR_ERR */                       "Error estimation method for solver gbode (single-rate, slow states integrator).",
   /* FLAG_SR_INT */                       "Interpolation method of solver gbode (single-rate, slow states integrator)",
   /* FLAG_SR_NLS */                       "Non-linear solver method of solver gbode (single-rate, slow states integrator)",
   /* FLAG_MR */                           "Value specifies the chosen solver of solver gbode (multi-rate, fast states integrator)",
   /* FLAG_MR_CTRL */                      "Step size control of solver gbode (multi-rate, fast states integrator)",
-  /* FLAG_MR_ERR */                       "Error estimation done by Richardson extrapolation  (-gberr=1) of solver gbode (multi-rate, fast states integrator)",
+  /* FLAG_MR_ERR */                       "Error estimation method for gbode solver (multi-rate, fast states integrator).",
   /* FLAG_MR_INT */                       "Interpolation method of solver gbode (multi-rate, fast states integrator)",
   /* FLAG_MR_NLS */                       "Non-linear solver method of solver gbode (multi-rate, fast states integrator)",
   /* FLAG_MR_PAR */                       "Define percentage of states for the fast states selection of solver gbode",
@@ -579,8 +579,11 @@ const char *FLAG_DETAILED_DESC[FLAG_MAX+1] = {
   /* FLAG_SR_CTRL */
   "  Step size control of solver gbode (single-rate, slow states integrator).",
   /* FLAG_SR_ERR */
-  "  Error estimation done by Richardson extrapolation (-gberr=1) of solver gbode\n"
-  "  (single-rate, slow states integrator).",
+  "  Error estimation method for solver gbode (single-rate, slow states integrator)\n"
+  "  Possible values:\n\n"
+  "    * default    - depending on the Runge-Kutta method\n"
+  "    * richardson - Richardson extrapolation\n"
+  "    * embedded   - Embedded scheme\n",
   /* FLAG_SR_INT */
   "  Interpolation method of solver gbode (single-rate, slow states integrator).",
   /* FLAG_SR_NLS */
@@ -591,8 +594,11 @@ const char *FLAG_DETAILED_DESC[FLAG_MAX+1] = {
   /* FLAG_MR_CTRL */
   "  Step size control of solver gbode (multi-rate, fast states integrator).",
   /* FLAG_MR_ERR */
-  "  Error estimation done by Richardson extrapolation  (-gberr=1) of solver gbode\n"
-  "  (multi-rate, fast states integrator).",
+  "  Error estimation method for solver gbode (multi-rate, fast states integrator)\n"
+  "  Possible values:\n\n"
+  "    * default    - depending on the Runge-Kutta method\n"
+  "    * richardson - Richardson extrapolation\n"
+  "    * embedded   - Embedded scheme\n",
   /* FLAG_MR_INT */
   "  Interpolation method of solver gbode (multi-rate, fast states integrator).",
   /* FLAG_MR_NLS */

--- a/doc/UsersGuide/source/solving.rst
+++ b/doc/UsersGuide/source/solving.rst
@@ -138,7 +138,7 @@ adjust the behavior of the solver for specific simulation problems:
 :ref:`gbfctrl <simflag-gbctrl>`,
 :ref:`gbfnls <simflag-gbnls>`,
 :ref:`gbfint <simflag-gbint>`,
-:ref:`gbferr <simflag-gberr>`.
+:ref:`gbferr <simflag-gbferr>`.
 
 This solver will replace obsolete and no longer maintained solvers providing a
 lot more using the following simulation flags:


### PR DESCRIPTION
### Purpose

Configure default settings of GBODE:
Chosen interpolation scheme is dense output, if available. Otherwise hermite.
-gbfint, -gbfctrl, -gbfnls, if not specified, gets the same values as -gbint, -gbctrl, -gbnls

