### PR TITLE
Utilize max and initial step size

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -370,6 +370,21 @@ int gbode_allocateData(DATA *data, threadData_t *threadData, SOLVER_INFO *solver
     gbData->maxStepSize = -1;
     infoStreamPrint(LOG_SOLVER, 0, "maximum step size not set");
   }
+    /* Initial step size */
+  if (omc_flag[FLAG_INITIAL_STEP_SIZE])
+  {
+    gbData->initialStepSize = atof(omc_flagValue[FLAG_INITIAL_STEP_SIZE]);
+    if (gbData->initialStepSize < GB_MINIMAL_STEP_SIZE || gbData->initialStepSize > DBL_MAX/2) {
+      throwStreamPrint(NULL, "initial step size %g is not allowed, minimal step size is %g", gbData->initialStepSize, GB_MINIMAL_STEP_SIZE);
+    } else {
+      infoStreamPrint(LOG_SOLVER, 0, "initial step size %g", gbData->initialStepSize);
+    }
+  }
+  else
+  {
+    gbData->initialStepSize = -1; /* use default */
+    infoStreamPrint(LOG_SOLVER, 0, "initial step size not set");
+  }
   gbData->isFirstStep = TRUE;
 
   /* Allocate internal memory */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
@@ -148,6 +148,7 @@ typedef struct DATA_GBODE{
   double time, timeLeft, timeRight;                 /* actual time values and the time values of the current interpolation interval */
   double stepSize, lastStepSize;                    /* actual and last step size of integration */
   double maxStepSize;                               /* maximal step size of integration */
+  double initialStepSize;                           /* initial step size of integration */
   int act_stage;                                    /* Current stage of Runge-Kutta method. */
   enum GB_CTRL_METHOD ctrl_method;                  /* Step size control algorithm */
   int ringBufferSize;                               /* Buffer size for storing the error, stepSize and last values of states (yv) and their derivatives (kv) */

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.h
@@ -147,6 +147,7 @@ typedef struct DATA_GBODE{
   double percentage, err_threshold;                 /* percentage of fast states and the corresponding error threshold */
   double time, timeLeft, timeRight;                 /* actual time values and the time values of the current interpolation interval */
   double stepSize, lastStepSize;                    /* actual and last step size of integration */
+  double maxStepSize;                               /* maximal step size of integration */
   int act_stage;                                    /* Current stage of Runge-Kutta method. */
   enum GB_CTRL_METHOD ctrl_method;                  /* Step size control algorithm */
   int ringBufferSize;                               /* Buffer size for storing the error, stepSize and last values of states (yv) and their derivatives (kv) */


### PR DESCRIPTION
### Related Issues

#10258

### Purpose

Utilize the simulation flags `-maxStepSize` and `-initialStepSize` for the single-rate and bi-rate mode.
