### PR TITLE
10263 sp to file

### DIFF
--- a/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
+++ b/OMCompiler/Compiler/.cmake/meta_modelica_source_list.cmake
@@ -415,6 +415,7 @@ set(OMC_MM_BACKEND_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/HpcOmSimCodeMain.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SerializeInitXML.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SerializeModelInfo.mo
+    ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SerializeSparsityPattern.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SerializeTaskSystemInfo.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SimCode.mo
     ${CMAKE_CURRENT_SOURCE_DIR}/SimCode/SimCodeMain.mo

--- a/OMCompiler/Compiler/SimCode/SerializeSparsityPattern.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeSparsityPattern.mo
@@ -1,0 +1,108 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of  MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+encapsulated package SerializeSparsityPattern
+
+//import Absyn;
+//import BackendDAE;
+//import DAE;
+import SimCode;
+
+//protected
+//import Algorithm;
+//import Autoconf;
+//import Config;
+//import DAEDump;
+//import Error;
+//import Expression;
+//import File;
+//import File.Escape.JSON;
+//import writeCref = ComponentReference.writeCref;
+//import expStr = ExpressionDump.printExpStr;
+import List;
+//import PrefixUtil;
+//import SimCodeUtil;
+//import SimCodeFunctionUtil;
+//import SCodeDump;
+import System;
+import Util;
+
+function serialize
+  input SimCode.SimCode code;
+protected
+  array<Integer> columnPointers, rowIndices;
+  String path = code.fileNamePrefix + "_sparsityPatterns/";
+algorithm
+  System.systemCall("mkdir -p '" + path + "'");
+  for jac in code.jacobianMatrices loop
+    columnPointers := listArray(0 :: list(listLength(Util.tuple22(column)) for column in jac.sparsity));
+    rowIndices := listArray(List.flatten(list(Util.tuple22(column) for column in jac.sparsity)));
+    serializeJacobian(path + jac.matrixName + ".bin", arrayLength(columnPointers), arrayLength(rowIndices), columnPointers, rowIndices);
+  end for;
+end serialize;
+
+function serializeJacobian
+  input String name;
+  input Integer numCols;
+  input Integer nnz;
+  input array<Integer> colPtrs;
+  input array<Integer> rowInds;
+protected
+external "C" serializeC(name, numCols, nnz, colPtrs, rowInds) annotation(Include="
+static void serializeC(const char* name, int numCols, int nnz, modelica_metatype colPtrs, modelica_metatype rowInds)
+{
+  FILE * pFile;
+  unsigned int i, j;
+
+  pFile = fopen(name, \"wb\");
+
+  /* compute and write sparsePattern->leadindex */
+  j = 0;
+  for (i = 0; i < numCols; i++) {
+    j += MMC_UNTAGFIXNUM(MMC_STRUCTDATA(colPtrs)[i]);
+    fwrite(&j, sizeof(unsigned int), 1, pFile);
+  }
+
+  /* write sparsePattern->index */
+  for (i = 0; i < nnz; i++) {
+    j = MMC_UNTAGFIXNUM(MMC_STRUCTDATA(rowInds)[i]);
+    fwrite(&j, sizeof(unsigned int), 1, pFile);
+  }
+
+  /* TODO write sparsePattern->colorCols */
+
+  fclose(pFile);
+}
+");
+end serializeJacobian;
+
+annotation(__OpenModelica_Interface="backend");
+end SerializeSparsityPattern;

--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -92,8 +92,9 @@ import HashTableCrILst;
 import HpcOmSimCodeMain;
 import HpcOmTaskGraph;
 import RuntimeSources;
-import SerializeModelInfo;
 import SerializeInitXML;
+import SerializeModelInfo;
+import SerializeSparsityPattern;
 import SimCodeUtil;
 import StackOverflow;
 import StringUtil;
@@ -613,6 +614,7 @@ algorithm
         codegenFuncs := (function runTplWriteFile(func=function CodegenC.simulationFile(in_a_simCode=simCode, in_a_guid=guid, in_a_isModelExchangeFMU=""), file=simCode.fileNamePrefix + ".c")) :: codegenFuncs;
         codegenFuncs := (function runTplWriteFile(func=function CodegenC.simulationFunctionsFile(a_filePrefix=simCode.fileNamePrefix, a_functions=simCode.modelInfo.functions, a_genericCalls=simCode.generic_loop_calls), file=simCode.fileNamePrefix + "_functions.c")) :: codegenFuncs;
 
+        SerializeSparsityPattern.serialize(simCode);
         codegenFuncs := (function runToStr(func=function SerializeModelInfo.serialize(code=simCode, withOperations=Flags.isSet(Flags.INFO_XML_OPERATIONS)))) :: codegenFuncs;
 
         if Flags.getConfigBool(Flags.PARMODAUTO) then
@@ -683,6 +685,7 @@ algorithm
       Tpl.tplNoret(CodegenC.translateModel, simCode);
       SerializeInitXML.simulationInitFile(simCode, guid);
       System.covertTextFileToCLiteral(simCode.fileNamePrefix+"_init.xml",simCode.fileNamePrefix+"_init.c", Config.simulationCodeTarget());
+        SerializeSparsityPattern.serialize(simCode);
       SerializeModelInfo.serialize(simCode, Flags.isSet(Flags.INFO_XML_OPERATIONS));
       Tpl.tplNoret(CodegenJS.markdownFile, simCode);
     then ();
@@ -798,6 +801,7 @@ algorithm
             then();
           end match;
 
+        SerializeSparsityPattern.serialize(simCode);
         SerializeModelInfo.serialize(simCode, Flags.isSet(Flags.INFO_XML_OPERATIONS));
         str := fmutmp + "/sources/" + simCode.fileNamePrefix;
         if FMUVersion == "1.0" then
@@ -961,6 +965,7 @@ algorithm
         end if;
 
         SerializeInitXML.simulationInitFileReturnBool(simCode=simCode, guid=guid);
+        SerializeSparsityPattern.serialize(simCode);
         SerializeModelInfo.serialize(simCode, Flags.isSet(Flags.INFO_XML_OPERATIONS));
 
         runTpl(func = function CodegenOMSI_common.generateFMUModelDescriptionFile(a_simCode=simCode, a_guid=guid, a_FMUVersion=FMUVersion, a_FMUType=FMUType, a_sourceFiles={}, a_fileName=simCode.fullPathPrefix+"/"+"modelDescription.xml"));

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -5656,10 +5656,11 @@ template genSPColors(list<list<Integer>> colorList, String arrayName)
     let ind_name = 'indices_<%index%>'
   <<
   /* color <%index%> with <%length%> columns */
-  const int <%ind_name%>[<%length%>] = {<%(indices |> i_index =>
-    '<%i_index%>' ;separator=", ")%>};
+  unsigned int* <%ind_name%> = malloc(<%length%>*sizeof(unsigned int));
+  fread(<%ind_name%>, sizeof(unsigned int), <%length%>, pFile);
   for(i=0; i<<%length%>; i++)
     <%arrayName%>[<%ind_name%>[i]] = <%index%>;
+  free(<%ind_name%>);
   >>;separator="\n\n")
   <<
   <%colorArray%>

--- a/OMCompiler/Compiler/boot/LoadCompilerSources.mos
+++ b/OMCompiler/Compiler/boot/LoadCompilerSources.mos
@@ -451,6 +451,7 @@ if true then /* Suppress output */
     "../SimCode/HpcOmSimCodeMain.mo",
     "../SimCode/SerializeInitXML.mo",
     "../SimCode/SerializeModelInfo.mo",
+    "../SimCode/SerializeSparsityPattern.mo",
     "../SimCode/SerializeTaskSystemInfo.mo",
     "../SimCode/SimCode.mo",
     "../SimCode/SimCodeMain.mo",

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -180,15 +180,15 @@ typedef struct NONLINEAR_PATTERN
 typedef struct ANALYTIC_JACOBIAN
 {
   JACOBIAN_AVAILABILITY availability;  /* Availability status */
-  unsigned int sizeCols;              /* Number of columns of Jacobian */
-  unsigned int sizeRows;              /* Number of rows of Jacobian */
-  unsigned int sizeTmpVars;           /* Length of vector tmpVars */
-  SPARSE_PATTERN* sparsePattern;      /* Contain sparse pattern including coloring */
-  modelica_real* seedVars;            /* Seed vector for specifying which columns to evaluate */
+  unsigned int sizeCols;               /* Number of columns of Jacobian */
+  unsigned int sizeRows;               /* Number of rows of Jacobian */
+  unsigned int sizeTmpVars;            /* Length of vector tmpVars */
+  SPARSE_PATTERN* sparsePattern;       /* Contain sparse pattern including coloring */
+  modelica_real* seedVars;             /* Seed vector for specifying which columns to evaluate */
   modelica_real* tmpVars;
-  modelica_real* resultVars;          /* Result column for given seed vector */
-  modelica_real dae_cj;               /* Is the scalar in the system Jacobian, proportional to the inverse of the step size. From User Documentation for ida v5.4.0 equation (2.5). */
-  int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian);  /* Constant equations independed of seed vector */
+  modelica_real* resultVars;           /* Result column for given seed vector */
+  modelica_real dae_cj;                /* Is the scalar in the system Jacobian, proportional to the inverse of the step size. From User Documentation for ida v5.4.0 equation (2.5). */
+  int (*constantEqns)(void* data, threadData_t *threadData, void* thisJacobian, void* parentJacobian);  /* Constant equations independend of seed vector */
 } ANALYTIC_JACOBIAN;
 
 /* EXTERNAL_INPUT


### PR DESCRIPTION
### Related Issues

#10263 

### Purpose

Store the sparsity patterns in binary files because it is too large for static memory.