### PR TITLE
[OMEdit] Set material on both front & back faces

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1634,7 +1634,7 @@ void UpdateVisitor::changeColor(osg::StateSet* ss, const QColor color)
   {
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
     if (!material.valid()) material = new osg::Material();
-    material->setDiffuse(osg::Material::FRONT, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
+    material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
     ss->setAttribute(material.get());
   }
 }


### PR DESCRIPTION
No reason to set a different color (gray by default) on the back face (if any).