### PR TITLE
[OMEdit] Set ambient color of material as well

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1634,6 +1634,7 @@ void UpdateVisitor::changeColor(osg::StateSet* ss, const QColor color)
   {
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
     if (!material.valid()) material = new osg::Material();
+    material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
     material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
     ss->setAttribute(material.get());
   }


### PR DESCRIPTION
References:
- https://learnopengl.com/Lighting/Materials
§4: "The ambient material vector defines what color the surface reflects under ambient lighting; this is usually the same as the surface's color. The diffuse material vector defines the color of the surface under diffuse lighting. The diffuse color is (just like ambient lighting) set to the desired surface's color."
- https://people.inf.ethz.ch/fcellier/Lect/MMPS/Refs/Dymola5Manual.pdf
p.167: "{r,g,b} affects the color of diffuse and ambient reflected light."