### PR TITLE
[OMEdit] Set visual properties on CAD shapes

### DIFF
--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -99,6 +99,7 @@ public:
   void applyTexture(osg::StateSet* ss, const std::string& imagePath);
   void changeColorOfMaterial(osg::StateSet* ss, const osg::Material::ColorMode mode, const QColor color);
   void changeTransparencyOfMaterial(osg::StateSet* ss, const float transparency);
+  void changeTransparencyOfGeometry(osg::Geode& geode, const float transparency);
 public:
   AbstractVisualizerObject* _visualizer;
   bool _changeMaterialProperties;


### PR DESCRIPTION
Reasons for implementation:
- Material on all visualizers to later apply specular coefficient
- Handle color mode so that it will work also for Surface (multicolored, monochrome, custom color)