### PR TITLE
[OMEdit] Apply specular coefficient of material

### DIFF
--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp
@@ -290,17 +290,19 @@ void ViewerWidget::showVisualizerPickContextMenu(const QPoint& pos)
   QAction action1(QIcon(":/Resources/icons/transparency.svg"), tr("Change Transparency"), this);
   QAction action2(QIcon(":/Resources/icons/invisible.svg"), tr("Make Visualizer Invisible"), this);
   QAction action3(QIcon(":/Resources/icons/changeColor.svg"), tr("Change Color"), this);
-  QAction action4(QIcon(":/Resources/icons/checkered.svg"), tr("Apply Checker Texture"), this);
-  QAction action5(QIcon(":/Resources/icons/texture.svg"), tr("Apply Custom Texture"), this);
-  QAction action6(QIcon(":/Resources/icons/undo.svg"), tr("Remove Texture"), this);
+  QAction action4(QIcon(":/Resources/icons/specularity.svg"), tr("Change Specularity"), this);
+  QAction action5(QIcon(":/Resources/icons/checkered.svg"), tr("Apply Checker Texture"), this);
+  QAction action6(QIcon(":/Resources/icons/texture.svg"), tr("Apply Custom Texture"), this);
+  QAction action7(QIcon(":/Resources/icons/undo.svg"), tr("Remove Texture"), this);
 
   connect(&action0, SIGNAL(triggered()), this, SLOT(resetVisualPropertiesForAllVisualizers()));
   connect(&action1, SIGNAL(triggered()), this, SLOT(changeVisualizerTransparency()));
   connect(&action2, SIGNAL(triggered()), this, SLOT(makeVisualizerInvisible()));
   connect(&action3, SIGNAL(triggered()), this, SLOT(changeVisualizerColor()));
-  connect(&action4, SIGNAL(triggered()), this, SLOT(applyCheckerTexture()));
-  connect(&action5, SIGNAL(triggered()), this, SLOT(applyCustomTexture()));
-  connect(&action6, SIGNAL(triggered()), this, SLOT(removeTexture()));
+  connect(&action4, SIGNAL(triggered()), this, SLOT(changeVisualizerSpec()));
+  connect(&action5, SIGNAL(triggered()), this, SLOT(applyCheckerTexture()));
+  connect(&action6, SIGNAL(triggered()), this, SLOT(applyCustomTexture()));
+  connect(&action7, SIGNAL(triggered()), this, SLOT(removeTexture()));
 
   // If a visualizer is picked, one can change its properties
   if (mpSelectedVisualizer) {
@@ -313,10 +315,11 @@ void ViewerWidget::showVisualizerPickContextMenu(const QPoint& pos)
   visualizerMenu.addAction(&action2);
   visualizerMenu.addSeparator();
   visualizerMenu.addAction(&action3);
-  visualizerMenu.addSeparator();
   visualizerMenu.addAction(&action4);
+  visualizerMenu.addSeparator();
   visualizerMenu.addAction(&action5);
   visualizerMenu.addAction(&action6);
+  visualizerMenu.addAction(&action7);
 
   contextMenu.exec(this->mapToGlobal(pos));
 }
@@ -365,6 +368,26 @@ void ViewerWidget::changeVisualizerColor()
     const QColor color = QColorDialog::getColor(currentColor, this, Helper::chooseColor);
     if (color.isValid()) { // Picked color is invalid if the user cancels the dialog
       mpSelectedVisualizer->getVisualProperties()->getColor().set(color);
+      mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
+    }
+    mpSelectedVisualizer = nullptr;
+  }
+}
+
+/*!
+ * \brief ViewerWidget::changeVisualizerSpec
+ * opens a number dialog and selects a new specular coefficient for the visualizer
+ */
+void ViewerWidget::changeVisualizerSpec()
+{
+  if (mpSelectedVisualizer) {
+    bool ok;
+    const int min = 0, max = 100, step = 1; // Unit: [%]
+    const int currentSpecular = mpSelectedVisualizer->getVisualProperties()->getSpecular().get() * (max - min) + min;
+    const int specular = QInputDialog::getInt(this, Helper::chooseSpecularity, Helper::percentageLabel,
+                                              currentSpecular, min, max, step, &ok);
+    if (ok) { // Picked specular coefficient is not OK if the user cancels the dialog
+      mpSelectedVisualizer->getVisualProperties()->getSpecular().set((float) (specular - min) / (max - min));
       mpAnimationWidget->getVisualization()->getBaseData()->modifyVisualizer(mpSelectedVisualizer);
     }
     mpSelectedVisualizer = nullptr;

--- a/OMEdit/OMEditLIB/Animation/ViewerWidget.h
+++ b/OMEdit/OMEditLIB/Animation/ViewerWidget.h
@@ -106,6 +106,7 @@ public slots:
   void changeVisualizerTransparency();
   void makeVisualizerInvisible();
   void changeVisualizerColor();
+  void changeVisualizerSpec();
   void applyCheckerTexture();
   void applyCustomTexture();
   void removeTexture();

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1565,12 +1565,13 @@ void UpdateVisitor::apply(osg::Geode& node)
 
     AbstractVisualProperties* visualProperties = _visualizer->getVisualProperties();
     QColor      color            = visualProperties->getColor().get();
+    float       specular         = visualProperties->getSpecular().get();
     float       transparency     = visualProperties->getTransparency().get();
     std::string textureImagePath = visualProperties->getTextureImagePath().get();
 
     if (changeMaterial) {
-      //set color
-      changeColorOfMaterial(ss, mode, color);
+      //set color and specular coefficient
+      changeColorOfMaterial(ss, mode, color, specular);
 
       //set transparency
       changeTransparencyOfMaterial(ss, transparency);
@@ -1662,15 +1663,17 @@ void UpdateVisitor::applyTexture(osg::StateSet* ss, const std::string& imagePath
  * \brief UpdateVisitor::changeColorOfMaterial
  * changes color of a material
  */
-void UpdateVisitor::changeColorOfMaterial(osg::StateSet* ss, const osg::Material::ColorMode mode, const QColor color)
+void UpdateVisitor::changeColorOfMaterial(osg::StateSet* ss, const osg::Material::ColorMode mode, const QColor color, const float specular)
 {
   if (ss)
   {
     osg::ref_ptr<osg::Material> material = dynamic_cast<osg::Material*>(ss->getAttribute(osg::StateAttribute::MATERIAL));
     if (!material.valid()) material = new osg::Material();
     material->setColorMode(mode);
-    material->setAmbient(osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
-    material->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
+    material->setAmbient  (osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
+    material->setDiffuse  (osg::Material::FRONT_AND_BACK, osg::Vec4f(color.redF(), color.greenF(), color.blueF(), color.alphaF()));
+    material->setSpecular (osg::Material::FRONT_AND_BACK, osg::Vec4f(specular, specular, specular, 1.0));
+    material->setShininess(osg::Material::FRONT_AND_BACK, 8.0); // Material shininess in range [0., 128.]
     ss->setAttributeAndModes(material.get(), osg::StateAttribute::ON | osg::StateAttribute::OVERRIDE);
   }
 }

--- a/OMEdit/OMEditLIB/Animation/Visualization.h
+++ b/OMEdit/OMEditLIB/Animation/Visualization.h
@@ -97,7 +97,7 @@ public:
   virtual void apply(osg::MatrixTransform& node) override;
   osg::Image* convertImage(const QImage& iImage);
   void applyTexture(osg::StateSet* ss, const std::string& imagePath);
-  void changeColorOfMaterial(osg::StateSet* ss, const osg::Material::ColorMode mode, const QColor color);
+  void changeColorOfMaterial(osg::StateSet* ss, const osg::Material::ColorMode mode, const QColor color, const float specular);
   void changeTransparencyOfMaterial(osg::StateSet* ss, const float transparency);
   void changeTransparencyOfGeometry(osg::Geode& geode, const float transparency);
 public:

--- a/OMEdit/OMEditLIB/Resources/icons/specularity.svg
+++ b/OMEdit/OMEditLIB/Resources/icons/specularity.svg
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg3913"
+   sodipodi:version="0.32"
+   inkscape:version="0.44"
+   version="1.0"
+   sodipodi:docbase="E:\E MES IMAGES\SVG"
+   sodipodi:docname="City_locator_23.svg"
+   inkscape:export-filename="E:\E MES IMAGES\SVG\City_locator_23.png"
+   inkscape:export-xdpi="899.99408"
+   inkscape:export-ydpi="899.99408">
+  <defs
+     id="defs3915">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#fc0000;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         id="stop4577"
+         offset="0"
+         style="stop-color:#bd185f;stop-opacity:0.87450981;" />
+      <stop
+         id="stop4575"
+         offset="0"
+         style="stop-color:#fcfcf5;stop-opacity:0.74901962;" />
+      <stop
+         id="stop4571"
+         offset="0.75"
+         style="stop-color:#fc0000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#f52300;stop-opacity:0.24705882;"
+         offset="0.875"
+         id="stop4573" />
+      <stop
+         style="stop-color:#fc0000;stop-opacity:0;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <radialGradient
+       id="id24"
+       gradientUnits="userSpaceOnUse"
+       cx="69270"
+       cy="206932"
+       r="4608"
+       fx="69270"
+       fy="206932">
+      <stop
+         offset="0"
+         style="stop-color:white;stop-opacity:1;"
+         id="stop131" />
+      <stop
+         offset="0.21176501"
+         style="stop-color:#f3f516;stop-opacity:1;"
+         id="stop133" />
+      <stop
+         id="stop2789"
+         style="stop-color:#f7e00e;stop-opacity:0.92000002;"
+         offset="0.321569" />
+      <stop
+         offset="0.431373"
+         style="stop-color:#FCCE00"
+         id="stop135" />
+      <stop
+         offset="1"
+         style="stop-color:#663333"
+         id="stop137" />
+    </radialGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#id24"
+       id="radialGradient2787"
+       cx="69660.258"
+       cy="207312.27"
+       fx="69660.258"
+       fy="207312.27"
+       r="3951.2668"
+       gradientTransform="matrix(1,0,0,1.167794,0,-34984.94)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3678"
+       id="radialGradient3684"
+       cx="5.4643841"
+       cy="6.1165833"
+       fx="5.4643841"
+       fy="6.1165833"
+       r="8.0103531"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.139054,-6.506896e-3,6.50701e-3,1.139074,-0.853061,-0.851841)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="18.850604"
+     inkscape:cx="10.000066"
+     inkscape:cy="9.9996796"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="1024"
+     inkscape:window-height="708"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     showgrid="true" />
+  <metadata
+     id="metadata3918">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-368.0202,-524.5148)">
+    <ellipse
+       style="fill:url(#radialGradient2787);fill-opacity:1;fill-rule:evenodd;stroke:black;stroke-width:12.35446262;stroke-miterlimit:4;stroke-dasharray:none"
+       sodipodi:ry="4608"
+       sodipodi:rx="3945"
+       sodipodi:cy="208499"
+       sodipodi:cx="71084"
+       id="ellipse201"
+       ry="4608"
+       rx="3945"
+       cy="208499"
+       cx="71084"
+       class="fil2 str0"
+       transform="matrix(1.505093e-3,0,0,1.288531e-3,269.0323,263.8574)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#radialGradient3684);fill-opacity:1;stroke-width:0.023;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path2791"
+       sodipodi:cx="8.0103531"
+       sodipodi:cy="7.989594"
+       sodipodi:rx="8.0103531"
+       sodipodi:ry="8.0103531"
+       d="M 16.020706 7.989594 A 8.0103531 8.0103531 0 1 1  0,7.989594 A 8.0103531 8.0103531 0 1 1  16.020706 7.989594 z"
+       transform="matrix(0.749031,0,0,0.749031,370.0202,526.5304)" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke-width:0.023;stroke-miterlimit:4;stroke-dasharray:none;stroke:none"
+       id="rect4579"
+       width="16"
+       height="16"
+       x="368.0202"
+       y="524.51483" />
+  </g>
+</svg>

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -151,6 +151,7 @@ QString Helper::close;
 QString Helper::error;
 QString Helper::percentageLabel;
 QString Helper::chooseTransparency;
+QString Helper::chooseSpecularity;
 QString Helper::chooseColor;
 QString Helper::chooseFile;
 QString Helper::chooseFiles;
@@ -457,6 +458,7 @@ void Helper::initHelperVariables()
   Helper::error = tr("Error");
   Helper::percentageLabel = tr("Percentage:");
   Helper::chooseTransparency = tr("Choose Transparency");
+  Helper::chooseSpecularity = tr("Choose Specularity");
   Helper::chooseColor = tr("Choose Color");
   Helper::chooseFile = tr("Choose File");
   Helper::chooseFiles = tr("Choose File(s)");

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -157,6 +157,7 @@ public:
   static QString error;
   static QString percentageLabel;
   static QString chooseTransparency;
+  static QString chooseSpecularity;
   static QString chooseColor;
   static QString chooseFile;
   static QString chooseFiles;

--- a/OMEdit/OMEditLIB/resource_omedit.qrc
+++ b/OMEdit/OMEditLIB/resource_omedit.qrc
@@ -178,6 +178,7 @@
         <file>Resources/icons/checkered.svg</file>
         <file>Resources/icons/texture.svg</file>
         <file>Resources/icons/changeColor.svg</file>
+        <file>Resources/icons/specularity.svg</file>
         <file>Resources/bitmaps/check.png</file>
         <file>Resources/icons/traceability.svg</file>
         <file>Resources/icons/interaction.svg</file>


### PR DESCRIPTION
References:
- https://learnopengl.com/Lighting/Materials
§4: "The specular material vector sets the color of the specular highlight on the surface (or possibly even reflect a surface-specific color). Lastly, the shininess impacts the scattering/radius of the specular highlight."
- https://people.inf.ethz.ch/fcellier/Lect/MMPS/Refs/Dymola5Manual.pdf
p.167: "Specular is a coefficient defining white specular reflection."
- https://www.maplesoft.com/documentation_center/online_manuals/modelica/Modelica_UsersGuide_ReleaseNotes.html#Modelica.UsersGuide.ReleaseNotes.Version_2_2_1
Modelica.Mechanics.MultiBody.all models: "All components with animation information have a new variable specularCoefficient to define the reflection of ambient light. The default value is world.defaultSpecularCoefficient which has a default of 0.7. By changing world.defaultSpecularCoefficient, the specularCoefficient of all components is changed that are not explicitly set differently."
- https://github.com/modelica/ModelicaStandardLibrary/blob/2308ab206ffa874188d24b64962fa42dfeb3c81f/Modelica/Mechanics/MultiBody/Types/SpecularCoefficient.mo
l.3: "Reflection of ambient light (= 0: light is completely absorbed)"