### PR TITLE
Added back the command line option for instance api

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -133,6 +133,7 @@ void printOMEditUsage()
 {
   printf("Usage: OMEdit --Debug=true|false] [files]\n");
   printf("    --Debug=[true|false]        Enables the debugging features like QUndoView, diffModelicaFileListings view. Default is false.\n");
+  printf("    --NAPI=[true|false]         Enables the use of new json based api.\n");
   printf("    files                       List of Modelica files(*.mo) to open.\n");
 }
 

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -106,6 +106,8 @@ public:
   void setDebug(bool debug) {mDebug = debug;}
   bool isNewApi() const {return mNewApi;}
   void setNewApi(bool newApi) {mNewApi = newApi;}
+  bool isNewApiCommandLine() const {return mNewApiCommandLine;}
+  void setNewApiCommandLine(bool newApiCommandLine) {mNewApiCommandLine = newApiCommandLine;}
   bool isTestsuiteRunning() const {return mTestsuiteRunning;}
   void setTestsuiteRunning(bool testsuiteRunning) {mTestsuiteRunning = testsuiteRunning;}
   OMCProxy* getOMCProxy() {return mpOMCProxy;}
@@ -263,6 +265,7 @@ public:
 private:
   bool mDebug;
   bool mNewApi;
+  bool mNewApiCommandLine;
   bool mTestsuiteRunning;
   OMCProxy *mpOMCProxy;
   bool mExitApplicationStatus;

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -108,6 +108,8 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   setlocale(LC_NUMERIC, "C");
   // if user has requested to open the file by passing it in argument then,
   bool debug = false;
+  bool newApi = false;
+  bool newApiCommandLine = false;
   QString fileName = "";
   QStringList fileNames, invalidFlags;
   if (arguments().size() > 1 && !testsuiteRunning) {
@@ -117,8 +119,13 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         debugArg.remove("--Debug=");
         if (0 == strcmp("true", debugArg.toUtf8().constData())) {
           debug = true;
-        } else {
-          debug = false;
+        }
+      } else if (strncmp(arguments().at(i).toUtf8().constData(), "--NAPI=",7) == 0) {
+        newApiCommandLine = true;
+        QString napiArg = arguments().at(i);
+        napiArg.remove("--NAPI=");
+        if (0 == strcmp("true", napiArg.toUtf8().constData())) {
+          newApi = true;
         }
       } else {
         fileName = arguments().at(i);
@@ -142,6 +149,8 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   // MainWindow Initialization
   MainWindow *pMainwindow = MainWindow::instance();
   pMainwindow->setDebug(debug);
+  pMainwindow->setNewApi(newApi);
+  pMainwindow->setNewApiCommandLine(newApiCommandLine);
   pMainwindow->setTestsuiteRunning(testsuiteRunning);
   pMainwindow->setUpMainWindow(threadData);
   if (pMainwindow->getExitApplicationStatus()) {        // if there is some issue in running the application.

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -48,6 +48,8 @@
 #include "Simulation/TranslationFlagsWidget.h"
 #include <limits>
 
+#include <QStringBuilder>
+
 /*!
  * \class OptionsDialog
  * \brief Creates an interface with options like Modelica Text, Pen Styles, Libraries etc.
@@ -308,7 +310,9 @@ void OptionsDialog::readGeneralSettings()
   } else {
     mpGeneralSettingsPage->getEnableInstanceAPICheckBox()->setChecked(OptionsDefaults::GeneralSettings::enableInstanceAPI);
   }
-  MainWindow::instance()->setNewApi(mpGeneralSettingsPage->getEnableInstanceAPICheckBox()->isChecked());
+  if (!MainWindow::instance()->isNewApiCommandLine()) {
+    MainWindow::instance()->setNewApi(mpGeneralSettingsPage->getEnableInstanceAPICheckBox()->isChecked());
+  }
 }
 
 //! Reads the Libraries section settings from omedit.ini
@@ -3683,6 +3687,10 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   mpOptionalFeaturesGroupBox = new QGroupBox(tr("Optional Features"));
   // Enable instance api
   mpEnableInstanceAPICheckBox = new QCheckBox(tr("Enable instance API *"));
+  const QString newAPI = MainWindow::instance()->isNewApi() ? "true" : "false";
+  if (MainWindow::instance()->isNewApiCommandLine()) {
+    mpEnableInstanceAPICheckBox->setText(mpEnableInstanceAPICheckBox->text() % " (You are using command line option --NAPI=" % newAPI % " so this option will be ignored.)");
+  }
   mpEnableInstanceAPICheckBox->setChecked(OptionsDefaults::GeneralSettings::enableInstanceAPI);
   // Optional Features Layout
   QGridLayout *pOptionalFeaturesLayout = new QGridLayout;

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1205,7 +1205,8 @@ General Options
 
 -  Optional Features
 
-  -  *Enable instance API* - Enables/disables the instance API support.
+  -  *Enable instance API* - Enables/disables the use of json based instance api. The instance API enables the features
+     like conditional connectors, dialog enable, replaceable etc.
 
 Libraries Options
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The command line option is preferred over the setting in options dialog. If option is used if command line option is not specified.