### PR TITLE
Handle incorrect models better in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -904,7 +904,7 @@ function lookupCrefInNode
   input InstContext.Type context;
 protected
   InstNode scope;
-  InstNode n;
+  InstNode n, cls_node;
   String name;
   Class cls;
   Boolean is_import;
@@ -929,7 +929,14 @@ algorithm
   end if;
 
   name := AbsynUtil.crefFirstIdent(cref);
-  cls := InstNode.getClass(scope);
+  cls_node := InstNode.classScope(scope);
+
+  if InstNode.isEmpty(cls_node) then
+    foundCref := ComponentRef.fromAbsynCref(cref, foundCref);
+    return;
+  end if;
+
+  cls := InstNode.getClass(cls_node);
 
   try
     (n, is_import) := Class.lookupElement(name, cls);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -433,7 +433,11 @@ algorithm
         typeDimensions(c.dimensions, node, c.binding, context, c.info);
 
         // Construct the type of the component and update the node with it.
-        ty := typeClassType(c.classInst, c.binding, context, component);
+        if InstNode.isEmpty(c.classInst) then
+          ty := Type.UNKNOWN();
+        else
+          ty := typeClassType(c.classInst, c.binding, context, component);
+        end if;
         ty := Type.liftArrayLeftList(ty, arrayList(c.dimensions));
 
         if Binding.isBound(c.condition) then
@@ -447,7 +451,7 @@ algorithm
           c_typed := Component.setType(ty, c);
           InstNode.updateComponent(c_typed, node);
 
-          if not is_deleted then
+          if not is_deleted and not InstNode.isEmpty(c.classInst) then
             // Check that flow/stream variables are Real.
             checkComponentStreamAttribute(c.attributes.connectorType, ty, component);
 
@@ -943,7 +947,8 @@ algorithm
         try
           binding := typeBinding(binding, InstContext.set(context, NFInstContext.BINDING));
 
-          if not (InstContext.inAnnotation(context) and stringEq(name, "graphics")) then
+          if not (InstContext.inAnnotation(context) and stringEq(name, "graphics") or
+                  InstNode.isEmpty(c.classInst)) then
             binding := TypeCheck.matchBinding(binding, c.ty, name, node, context);
           end if;
 
@@ -967,7 +972,7 @@ algorithm
 
         InstNode.updateComponent(c, node);
 
-        if typeChildren then
+        if typeChildren and not InstNode.isEmpty(c.classInst) then
           typeBindings(c.classInst, context);
         end if;
       then
@@ -981,7 +986,7 @@ algorithm
           checkComponentBindingVariability(InstNode.name(component), c, c.binding, context);
         end if;
 
-        if typeChildren then
+        if typeChildren and not InstNode.isEmpty(c.classInst) then
           typeBindings(c.classInst, context);
         end if;
       then

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -214,6 +214,18 @@
                 {
                   "description": "Builtin type",
                   "type": "string"
+                },
+                {
+                  "description": "Missing type",
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "missing": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               ]
             },

--- a/testsuite/openmodelica/instance-API/GetModelInstanceMissingClass1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceMissingClass1.mos
@@ -1,0 +1,72 @@
+// name: GetModelInstanceMissingClass1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    MissingClass x = 1.0;
+    AlsoMissing y[:] = {1, 2, 3};
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"x\",
+//       \"type\": {
+//         \"name\": \"MissingClass\",
+//         \"missing\": true
+//       },
+//       \"modifiers\": \"1.0\",
+//       \"value\": {
+//         \"binding\": 1
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"y\",
+//       \"type\": {
+//         \"name\": \"AlsoMissing\",
+//         \"missing\": true
+//       },
+//       \"dims\": {
+//         \"absyn\": [
+//           \":\"
+//         ],
+//         \"typed\": [
+//           \"3\"
+//         ]
+//       },
+//       \"modifiers\": \"{1, 2, 3}\",
+//       \"value\": {
+//         \"binding\": [
+//           1,
+//           2,
+//           3
+//         ]
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 5,
+//     \"columnEnd\": 8
+//   }
+// }"
+// "[<interactive>:3:5-3:25:writable] Error: Class MissingClass not found in scope M.
+// [<interactive>:4:5-4:33:writable] Error: Class AlsoMissing not found in scope M.
+// "
+// endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceMissingClass2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceMissingClass2.mos
@@ -1,0 +1,165 @@
+// name: GetModelInstanceMissingClass2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  connector C
+    Real e;
+    flow Real f;
+  end C;
+
+  model M
+    MissingConnector c1, c2;
+    MissingClass m;
+    C c;
+  equation
+    connect(c1, c2);
+    connect(m.c, c);
+    connect(c1.c, c2.c);
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"c1\",
+//       \"type\": {
+//         \"name\": \"MissingConnector\",
+//         \"missing\": true
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"c2\",
+//       \"type\": {
+//         \"name\": \"MissingConnector\",
+//         \"missing\": true
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"m\",
+//       \"type\": {
+//         \"name\": \"MissingClass\",
+//         \"missing\": true
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"c\",
+//       \"type\": {
+//         \"name\": \"C\",
+//         \"restriction\": \"connector\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"e\",
+//             \"type\": \"Real\"
+//           },
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"f\",
+//             \"type\": \"Real\",
+//             \"prefixes\": {
+//               \"connector\": \"flow\"
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 5,
+//           \"columnEnd\": 8
+//         }
+//       }
+//     }
+//   ],
+//   \"connections\": [
+//     {
+//       \"lhs\": {
+//         \"$kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c1\"
+//           }
+//         ]
+//       },
+//       \"rhs\": {
+//         \"$kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c2\"
+//           }
+//         ]
+//       }
+//     },
+//     {
+//       \"lhs\": {
+//         \"$kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"m\"
+//           },
+//           {
+//             \"name\": \"c\"
+//           }
+//         ]
+//       },
+//       \"rhs\": {
+//         \"$kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c\"
+//           }
+//         ]
+//       }
+//     },
+//     {
+//       \"lhs\": {
+//         \"$kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c1\"
+//           },
+//           {
+//             \"name\": \"c\"
+//           }
+//         ]
+//       },
+//       \"rhs\": {
+//         \"$kind\": \"cref\",
+//         \"parts\": [
+//           {
+//             \"name\": \"c2\"
+//           },
+//           {
+//             \"name\": \"c\"
+//           }
+//         ]
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 7,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 15,
+//     \"columnEnd\": 8
+//   }
+// }"
+// "[<interactive>:8:5-8:28:writable] Error: Class MissingConnector not found in scope M.
+// [<interactive>:9:5-9:19:writable] Error: Class MissingClass not found in scope M.
+// "
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -35,6 +35,8 @@ GetModelInstanceIcon4.mos \
 GetModelInstanceInnerOuter1.mos \
 GetModelInstanceInnerOuter2.mos \
 GetModelInstanceInnerOuter3.mos \
+GetModelInstanceMissingClass1.mos \
+GetModelInstanceMissingClass2.mos \
 GetModelInstanceMod1.mos \
 GetModelInstanceMod2.mos \
 GetModelInstanceReplaceable1.mos \


### PR DESCRIPTION
- Try to ignore missing types.
- Treat connectors where part of the name can't be found like expandable connectors, to allow connectors referring to elements inside missing types.