### PR TITLE
Utilize simulation flag -noRootFinding in GBODE

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
@@ -275,8 +275,13 @@ double checkForEvents(DATA* data, threadData_t* threadData, SOLVER_INFO* solverI
   *foundEvent = checkForStateEvent(data, solverInfo->eventLst);
 
   if (*foundEvent) {
-    eventTime = findRoot_gb(data, threadData, solverInfo, solverInfo->eventLst, timeLeft, leftValues, timeRight, rightValues, isInnerIntegration);
-    infoStreamPrint(LOG_SOLVER, 0, "gbode detected an event at time: %20.16g", eventTime);
+     if(omc_flag[FLAG_NO_ROOTFINDING]) {
+       eventTime = timeRight;
+       infoStreamPrint(LOG_SOLVER, 0, "gbode detected an event at time: %20.16g (rootfinding is disabled)", eventTime);
+     } else {
+       eventTime = findRoot_gb(data, threadData, solverInfo, solverInfo->eventLst, timeLeft, leftValues, timeRight, rightValues, isInnerIntegration);
+       infoStreamPrint(LOG_SOLVER, 0, "gbode detected an event at time: %20.16g", eventTime);
+    }
   }
 
   // re-store the pre values of the zeroCrossings for comparison

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
@@ -283,7 +283,6 @@ double checkForEvents(DATA* data, threadData_t* threadData, SOLVER_INFO* solverI
        infoStreamPrint(LOG_SOLVER, 0, "gbode detected an event at time: %20.16g", eventTime);
     }
   }
-
   // re-store the pre values of the zeroCrossings for comparison
   memcpy(data->simulationInfo->zeroCrossings, data->simulationInfo->zeroCrossingsPre, data->modelData->nZeroCrossings * sizeof(modelica_real));
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_events.c
@@ -275,7 +275,7 @@ double checkForEvents(DATA* data, threadData_t* threadData, SOLVER_INFO* solverI
   *foundEvent = checkForStateEvent(data, solverInfo->eventLst);
 
   if (*foundEvent) {
-     if(omc_flag[FLAG_NO_ROOTFINDING]) {
+     if (omc_flag[FLAG_NO_ROOTFINDING]) {
        eventTime = timeRight;
        infoStreamPrint(LOG_SOLVER, 0, "gbode detected an event at time: %20.16g (rootfinding is disabled)", eventTime);
      } else {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -1843,7 +1843,6 @@ int gbode_singlerate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverIn
         }
         infoStreamPrint(LOG_SOLVER, 0, "Reject step from %10g to %10g, interpolation error %10g, new stepsize %10g",
                         gbData->time, gbData->time + gbData->lastStepSize, gbData->err_int, gbData->stepSize);
-
         // count failed steps and output information on the solver status
         // gbData->errorTestFailures++;
         continue;


### PR DESCRIPTION
### Related Issues

#10341

### Purpose

Utilize simulation flag -noRootFinding in GBODE for single-rate and bi-rate mode