### PR TITLE
Copy external libraries into Docker volume for FMU compilation

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3735,7 +3735,6 @@ protected function configureFMU
   input String platform;
   input String fmutmp;
   input String logfile;
-  input list<String> externalLibLocations;
   input Boolean isWindows;
   input Boolean needs3rdPartyLibs;
 protected
@@ -3994,7 +3993,6 @@ protected
   String fmuTargetName;
   GlobalScript.SimulationOptions defaulSimOpt;
   SimCode.SimulationSettings simSettings;
-  SimCode.SimCode simCode;
   list<String> libs;
   Boolean isWindows;
   Boolean useCrossCompileCmake = false;
@@ -4118,7 +4116,7 @@ algorithm
     if useCrossCompileCmake then
       configureFMU_cmake(platform, fmutmp, filenameprefix, configureLogFile, libs, isWindows);
     else
-      configureFMU(platform, fmutmp, configureLogFile, libs, isWindows, needs3rdPartyLibs);
+      configureFMU(platform, fmutmp, configureLogFile, isWindows, needs3rdPartyLibs);
     end if;
     if Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_BLACKBOX or Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_PROTECTED then
       System.removeFile(configureLogFile);

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15662,14 +15662,14 @@ public function getCmakeLinkLibrariesCode
 protected
   list<String> locations;
   list<String> libraries;
-  function addQuotationMarks
+  function addDockerVol
     input String istring;
-    output String ostring = "\""+istring+"\"";
-  end addQuotationMarks;
+    output String ostring = "\"${DOCKER_VOL_DIR}"+istring+"\"";
+  end addDockerVol;
 algorithm
   (locations, libraries) := getDirectoriesForDLLsFromLinkLibs(libs);
   locations := listAppend({Settings.getInstallationDirectoryPath() + "/bin"}, locations);   // pthread located in OpenModelica/bin/ on Windows
-  locations := List.map(locations, addQuotationMarks);
+  locations := List.map(locations, addDockerVol);
   // Use target_link_directories when CMake 3.13 is available and skip the find_library part
   cmakecode := cmakecode + "set(EXTERNAL_LIBDIRECTORIES " + stringDelimitList(locations, "\n                            ") + ")\n";
   for lib in libraries loop

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15625,7 +15625,7 @@ algorithm
   end matchcontinue;
 end generateRunnerBatScript;
 
-protected function getDirectoriesForDLLsFromLinkLibs
+function getDirectoriesForDLLsFromLinkLibs
   " Parse the makefileParams.libs and extract the necessary directories
    to be added to the PATH for finding dependenncy libraries (DLLs on Windows).
    NOTE: this function expects the 'link command' as the second argument. This will


### PR DESCRIPTION
### Related Issues

Fixes #10279.

### Purpose

Fix compilation of CMake FMUs using Docker that have external (C) libraries used.

### Approach

Copy all external C library locations into Docker volume using `docker cp` and update the CMakeLists.txt to search in the Docker volume in `/fmu`.

To really use this feature one needs a Docker image with a newer CMake version to use
```
setCommandLineOptions("--fmuRuntimeDepends=all"); getErrorString();
```
to copy the dependencies into the FMU. multiarch/crossbuild uses cmake version 3.7.2 and is not really suitable.
