### PR TITLE
KINSOL needs to have higher accuracy for some MSL models

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_nls.c
@@ -426,7 +426,8 @@ void set_kinsol_parameters(NLS_KINSOL_DATA* kin_mem, int numIter, int jacUpdate,
     checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINSetNoInitSetup");
     flag = KINSetMaxSetupCalls(kin_mem, maxJacUpdate);
     checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINSetMaxSetupCalls");
-
+    flag = KINSetFuncNormTol(kin_mem, 100*DBL_EPSILON);
+    checkReturnFlag_SUNDIALS(flag, SUNDIALS_KIN_FLAG, "KINSetFuncNormTol");
 }
 
 /**


### PR DESCRIPTION
### Purpose

Some models perform rather pure with GBODE, if the accuracy of the KINSOL solver is to low. With the current settings 499 models of the MSL simulate and 473 are verified correctly.

