### PR TITLE
Fix variability check during lookup

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
@@ -33,6 +33,7 @@ encapsulated package NFLookupState
 
 import Absyn;
 import AbsynUtil;
+import ComponentRef = NFComponentRef;
 import SCode;
 import NFInstNode.InstNode;
 import InstContext = NFInstContext;
@@ -43,6 +44,7 @@ import Error;
 import SCodeUtil;
 import System;
 import Class = NFClass;
+import Component = NFComponent;
 
 public
 uniontype LookupStateName
@@ -617,6 +619,27 @@ uniontype LookupState
   //  true := SCodeUtil.isValidPackageElement(el);
   //  outEntry := inEntry;
   //end isValidPackageElement;
+
+  function checkCrefVariability
+    "Checks that a variable found in an enclosing scope is a constant, and if
+     not sets the state to an error."
+    input ComponentRef cref;
+    input Boolean inEnclosingScope;
+    input InstContext.Type context;
+    input output LookupState state;
+  algorithm
+    if inEnclosingScope and not InstContext.inRelaxed(context) and
+       isNonConstantComponent(ComponentRef.node(cref)) then
+      state := ERROR(NON_CONSTANT());
+    end if;
+  end checkCrefVariability;
+
+  function isNonConstantComponent
+    input InstNode node;
+    output Boolean res;
+  algorithm
+    res := InstNode.isComponent(node) and not Component.isConst(InstNode.component(node));
+  end isNonConstantComponent;
 end LookupState;
 
 annotation(__OpenModelica_Interface="frontend");

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -889,6 +889,7 @@ PackageConstant1.mo \
 PackageConstant3.mo \
 PackageConstant4.mo \
 PackageConstant5.mo \
+PackageConstant6.mo \
 ParameterBug.mos \
 ParameterDer.mo \
 PartialApplication1.mo \

--- a/testsuite/flattening/modelica/scodeinst/PackageConstant5.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageConstant5.mo
@@ -4,7 +4,7 @@
 // cflags: -d=newInst
 //
 
-model PackageConstant4
+model PackageConstant5
   Real x;
 
   model A
@@ -12,7 +12,7 @@ model PackageConstant4
   end A;
 
   A a;
-end PackageConstant4;
+end PackageConstant5;
 
 // Result:
 // Error processing file: PackageConstant5.mo

--- a/testsuite/flattening/modelica/scodeinst/PackageConstant6.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageConstant6.mo
@@ -1,0 +1,27 @@
+// name: PackageConstant6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model PackageConstant6
+  model A
+    constant Integer n = 2;
+  end A;
+
+  A a;
+
+  model B
+    Real x[a.n];
+  end B;
+
+  B b;
+end PackageConstant6;
+
+// Result:
+// class PackageConstant6
+//   constant Integer a.n = 2;
+//   Real b.x[1];
+//   Real b.x[2];
+// end PackageConstant6;
+// endResult


### PR DESCRIPTION
- Change the check that variables found in an enclosing scope must be a constant so that it checks the last part of a cref instead of the first, since that seems to be the intended behaviour.