### PR TITLE
fix matlab code for linearization

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -5224,9 +5224,9 @@ template functionlinearmodelMatlab(ModelInfo modelInfo, String modelNamePrefix) 
       <%matrixB%>
       <%matrixC%>
       <%matrixD%>
-      "  stateVars  = {<%getVarNameMatlab(vars.stateVars, "x0")%>}\n"
-      "  inputVars  = {<%getVarNameMatlab(vars.inputVars, "u0")%>}\n"
-      "  outputVars = {<%getVarNameMatlab(vars.outputVars, "y0")%>}\n"
+      "  stateVars  = {<%getVarNameMatlab(vars.stateVars, "x0")%>};\n"
+      "  inputVars  = {<%getVarNameMatlab(vars.inputVars, "u0")%>};\n"
+      "  outputVars = {<%getVarNameMatlab(vars.outputVars, "y0")%>};\n"
       "  Ts = %g; %% stop time\n\n"
       "end";
     }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -5212,7 +5212,7 @@ template functionlinearmodelMatlab(ModelInfo modelInfo, String modelNamePrefix) 
     <<
     const char *<%symbolName(modelNamePrefix,"linear_model_frame")%>()
     {
-      return "function [sys, x0, u0, n, m, p, Ts] = linearized_model()\n"
+      return "function [A, B, C, D, stateVars, inputVars, outputVars] = linearized_model()\n"
       "%% <%modelNamePrefix%>\n"
       "%% der(x) = A * x + B * u\n%% y = C * x + D * u\n"
       "  n = <%varInfo.numStateVars%>; %% number of states\n  m = <%varInfo.numInVars%>; %% number of inputs\n  p = <%varInfo.numOutVars%>; %% number of outputs\n"
@@ -5224,9 +5224,10 @@ template functionlinearmodelMatlab(ModelInfo modelInfo, String modelNamePrefix) 
       <%matrixB%>
       <%matrixC%>
       <%matrixD%>
+      "  stateVars  = {<%getVarNameMatlab(vars.stateVars, "x0")%>}\n"
+      "  inputVars  = {<%getVarNameMatlab(vars.inputVars, "u0")%>}\n"
+      "  outputVars = {<%getVarNameMatlab(vars.outputVars, "y0")%>}\n"
       "  Ts = %g; %% stop time\n\n"
-      "  %% The Control System Toolbox is required for this. Alternatively just return the matrices A,B,C,D instead.\n"
-      "  sys = ss(A,B,C,D,'StateName',{<%getVarNameMatlab(vars.stateVars, "x")%>}, 'InputName',{<%getVarNameMatlab(vars.inputVars, "u")%>}, 'OutputName', {<%getVarNameMatlab(vars.outputVars, "y")%>});\n"
       "end";
     }
     const char *<%symbolName(modelNamePrefix,"linear_model_datarecovery_frame")%>()
@@ -5334,7 +5335,7 @@ template getVarNameMatlab(list<SimVar> simVars, String arrayName) "template getV
 <<
 <%simVars |> var hasindex arrindex fromindex 1 => (match var
     case SIMVAR(__) then
-      <<'<%arrayName%>_<%crefStrMatlabSafe(name)%>'>>
+      <<'<%crefStrMatlabSafe(name)%>'>>
     end match) ;separator=","%>
 >>
 end getVarNameMatlab;

--- a/testsuite/openmodelica/linearization/test_dump_languages.mos
+++ b/testsuite/openmodelica/linearization/test_dump_languages.mos
@@ -88,7 +88,7 @@ readFile("linearized_model.py"); getErrorString();
 // end SimulationResult;
 // "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
-// "function [sys, x0, u0, n, m, p, Ts] = linearized_model()
+// "function [A, B, C, D, stateVars, inputVars, outputVars] = linearized_model()
 // % simple_test
 // % der(x) = A * x + B * u
 // % y = C * x + D * u
@@ -109,10 +109,11 @@ readFile("linearized_model.py"); getErrorString();
 //
 //   D =	[4.007476581092785];
 //
+//   stateVars  = {'num_x(1)','num_x(2)'}
+//   inputVars  = {'u'}
+//   outputVars = {'y'}
 //   Ts = 0.5; % stop time
 //
-//   % The Control System Toolbox is required for this. Alternatively just return the matrices A,B,C,D instead.
-//   sys = ss(A,B,C,D,'StateName',{'x_num_x(1)','x_num_x(2)'}, 'InputName',{'u_u'}, 'OutputName', {'y_y'});
 // end"
 // ""
 // true

--- a/testsuite/openmodelica/linearization/test_dump_languages.mos
+++ b/testsuite/openmodelica/linearization/test_dump_languages.mos
@@ -109,9 +109,9 @@ readFile("linearized_model.py"); getErrorString();
 //
 //   D =	[4.007476581092785];
 //
-//   stateVars  = {'num_x(1)','num_x(2)'}
-//   inputVars  = {'u'}
-//   outputVars = {'y'}
+//   stateVars  = {'num_x(1)','num_x(2)'};
+//   inputVars  = {'u'};
+//   outputVars = {'y'};
 //   Ts = 0.5; % stop time
 //
 // end"


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMMatlab/issues/26

### Purpose
This PR fixes the matlab code generation for linearization and the generated matlab code will be used to directly fetch `matrix A, B, C and D` to speed up the linearization process


