### PR TITLE
Add modifier argument to getModelInstance

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4405,6 +4405,7 @@ end convertPackageToLibrary;
 function getModelInstance
   "Dumps a model instance as a JSON string."
   input TypeName className;
+  input String modifier = "";
   input Boolean prettyPrint = false;
   output String result;
 external "builtin";

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -2155,10 +2155,10 @@ algorithm
       then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Element")),{},NONE(), false);
 
     case Absyn.C_EXPRESSION()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Expression")),{},NONE(), false);
+      then DAE.T_CODE(DAE.C_EXPRESSION_OR_MODIFICATION());
 
     case Absyn.C_MODIFICATION()
-      then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Modification")),{},NONE(), false);
+      then DAE.T_CODE(DAE.C_EXPRESSION_OR_MODIFICATION());
   end match;
 end elabCodeType;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -315,8 +315,9 @@ end lookupRootClass;
 function instantiateRootClass
   input output InstNode clsNode;
   input InstContext.Type context;
+  input Modifier mod = Modifier.NOMOD();
 algorithm
-  clsNode := instantiate(clsNode, context = context);
+  clsNode := instantiate(clsNode, mod, context = context);
   checkPartialClass(clsNode, context);
 
   insertGeneratedInners(clsNode, InstNode.topScope(clsNode), context);
@@ -324,6 +325,7 @@ end instantiateRootClass;
 
 function instantiate
   input output InstNode node;
+  input Modifier mod = Modifier.NOMOD();
   input InstNode parent = InstNode.EMPTY_NODE();
   input InstContext.Type context;
   input Boolean instPartial = false "Whether to instantiate a partial class or not.";
@@ -331,7 +333,7 @@ algorithm
   node := expand(node);
 
   if instPartial or not InstNode.isPartial(node) or InstContext.inRelaxed(context) then
-    node := instClass(node, Modifier.NOMOD(), NFAttributes.DEFAULT_ATTR, true, 0, parent, context);
+    node := instClass(node, mod, NFAttributes.DEFAULT_ATTR, true, 0, parent, context);
   end if;
 end instantiate;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4658,6 +4658,7 @@ end convertPackageToLibrary;
 function getModelInstance
   "Dumps a model instance as a JSON string."
   input TypeName className;
+  input String modifier = "";
   input Boolean prettyPrint = false;
   output String result;
 external "builtin";

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3085,8 +3085,8 @@ algorithm
     case ("convertPackageToLibrary", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.CODE(Absyn.C_TYPENAME(path)), Values.STRING(str)})
       then convertPackageToLibrary(classpath, path, str);
 
-    case ("getModelInstance", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.BOOL(b)})
-      then NFApi.getModelInstance(classpath, b);
+    case ("getModelInstance", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(str), Values.BOOL(b)})
+      then NFApi.getModelInstance(classpath, str, b);
 
     case ("getModelInstanceIcon", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.BOOL(b)})
       then NFApi.getModelInstanceIcon(classpath, b);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3417,10 +3417,10 @@ QJsonObject OMCProxy::getModelInstance(const QString &className, bool prettyPrin
       } else {
         getErrorString();
       }
-      modelInstanceJson = mpOMCInterface->getModelInstance(className, prettyPrint);
+      modelInstanceJson = mpOMCInterface->getModelInstance(className, QString(), prettyPrint);
     }
   } else {
-    modelInstanceJson = mpOMCInterface->getModelInstance(className, prettyPrint);
+    modelInstanceJson = mpOMCInterface->getModelInstance(className, QString(), prettyPrint);
   }
   printMessagesStringInternal();
   if (!modelInstanceJson.isEmpty()) {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
@@ -15,7 +15,7 @@ loadString("
   end M;
 ");
 
-getModelInstance(M, true);
+getModelInstance(M, prettyPrint = true);
 getErrorString();
 
 // Result:

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
@@ -10,8 +10,8 @@ loadString("
   type RealInput2 = RealInput(start = 1.0);
 ");
 
-getModelInstance(RealInput, true); getErrorString();
-getModelInstance(RealInput2, true); getErrorString();
+getModelInstance(RealInput, prettyPrint = true); getErrorString();
+getModelInstance(RealInput2, prettyPrint = true); getErrorString();
 
 // Result:
 // true

--- a/testsuite/openmodelica/instance-API/GetModelInstanceMod4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceMod4.mos
@@ -1,0 +1,105 @@
+// name: GetModelInstanceMod4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  type MyReal = Real;
+
+  model A
+    Real x;
+    replaceable Real y;
+  end A;
+
+  model M
+    A a(x = 1, y = 2);
+    Real z;
+  end M;
+");
+
+getModelInstance(M, modifier = "(a(redeclare MyReal y = 4, x = 3), z = 5)", prettyPrint = true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"a\",
+//       \"type\": {
+//         \"name\": \"A\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"x\",
+//             \"type\": \"Real\",
+//             \"value\": {
+//               \"binding\": 3
+//             }
+//           },
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"y\",
+//             \"type\": {
+//               \"name\": \"MyReal\",
+//               \"restriction\": \"type\",
+//               \"elements\": [
+//                 {
+//                   \"$kind\": \"extends\",
+//                   \"baseClass\": \"Real\"
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 2,
+//                 \"columnStart\": 3,
+//                 \"lineEnd\": 2,
+//                 \"columnEnd\": 21
+//               }
+//             },
+//             \"value\": {
+//               \"binding\": 4
+//             },
+//             \"prefixes\": {
+//               \"replaceable\": true
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 4,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 7,
+//           \"columnEnd\": 8
+//         }
+//       },
+//       \"modifiers\": {
+//         \"x\": \"1\",
+//         \"y\": \"2\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"z\",
+//       \"type\": \"Real\",
+//       \"value\": {
+//         \"binding\": 5
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 9,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 12,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -41,6 +41,7 @@ GetModelInstanceMissingClass2.mos \
 GetModelInstanceMod1.mos \
 GetModelInstanceMod2.mos \
 GetModelInstanceMod3.mos \
+GetModelInstanceMod4.mos \
 GetModelInstanceReplaceable1.mos \
 GetModelInstanceReplaceable2.mos \
 GetModelInstanceReplaceable3.mos \


### PR DESCRIPTION
- Add an argument to getModelInstance that makes it possible to supply a modifier to use when instantiating the model.
- Fix Static.elabCodeType to make it possible to use modifiers and expressions as default arguments in ModelicaBuiltin.

Fixes #10349