### PR TITLE
Dump original bindings in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -794,5 +794,17 @@ public
     binding := FLAT_BINDING(exp, var, source);
   end makeFlat;
 
+  function isEvaluated
+    input Binding binding;
+    output Boolean evaluated;
+  algorithm
+    evaluated := match binding
+      case TYPED_BINDING()
+        then Mutable.access(binding.evalState) == EvalState.EVALUATED;
+      case CEVAL_BINDING() then true;
+      else false;
+    end match;
+  end isEvaluated;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFBinding;


### PR DESCRIPTION
- Keep references to the original bindings for components in getModelInstance, so they can be dumped also for components whose bindings are evaluated and overwritten by the frontend.

Fixes #10188