### PR TITLE
Change unary minus to negative values earlier

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -6105,5 +6105,19 @@ public
     end match;
   end repairOperator;
 
+  function makeUnary
+    input Operator op;
+    input Expression exp;
+    output Expression unaryExp;
+  algorithm
+    if op.op == NFOperator.Op.ADD then
+      unaryExp := exp;
+    elseif op.op == NFOperator.Op.UMINUS then
+      unaryExp := negate(exp);
+    else
+      unaryExp := UNARY(op, exp);
+    end if;
+  end makeUnary;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFExpression;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2488,7 +2488,7 @@ algorithm
         e1 := instExp(absynExp.exp, scope, context, info);
         op := Operator.fromAbsyn(absynExp.op);
       then
-        Expression.UNARY(op, e1);
+        Expression.makeUnary(op, e1);
 
     case Absyn.Exp.LBINARY()
       algorithm


### PR DESCRIPTION
- Change negative numbers which are parsed as unary expressions to negative Integer/Real expressions during the instantiation, to simplify them as early as possible.