### PR TITLE
Use enclosing scope for extends in replaceable classes

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1173,6 +1173,11 @@ function dumpJSONNodePath
   output JSON json = dumpJSONPath(InstNode.scopePath(node, ignoreBaseClass = true));
 end dumpJSONNodePath;
 
+function dumpJSONNodeEnclosingPath
+  input InstNode node;
+  output JSON json = dumpJSONPath(InstNode.enclosingScopePath(node, ignoreRedeclare = true));
+end dumpJSONNodeEnclosingPath;
+
 function dumpJSONPath
   input Absyn.Path path;
   output JSON json = JSON.makeString(AbsynUtil.pathString(path));
@@ -1258,7 +1263,7 @@ algorithm
       algorithm
         try
           derivedNode := Lookup.lookupName(path, scope, NFInstContext.RELAXED, false);
-          json := JSON.addPair("baseClass", dumpJSONNodePath(derivedNode), json);
+          json := JSON.addPair("baseClass", dumpJSONNodeEnclosingPath(derivedNode), json);
         else
         end try;
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
@@ -135,7 +135,7 @@ getModelInstance(M, prettyPrint = true);
 //                 }
 //               }
 //             },
-//             \"baseClass\": \"C\",
+//             \"baseClass\": \"A.C\",
 //             \"source\": {
 //               \"filename\": \"<interactive>\",
 //               \"lineStart\": 13,

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable4.mos
@@ -1,0 +1,107 @@
+// name: GetModelInstanceReplaceable4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package P
+    model A
+      replaceable model B
+        Real x;
+      end B;
+
+      replaceable model C
+        Real y;
+      end C;
+
+      replaceable model D = C constrainedby C;
+    end A;
+
+    model M
+      A a;
+    end M;
+  end P;
+");
+
+getModelInstance(P.M, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"P.M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"a\",
+//       \"type\": {
+//         \"name\": \"P.A\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"class\",
+//             \"name\": \"B\",
+//             \"prefixes\": {
+//               \"replaceable\": true
+//             },
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 4,
+//               \"columnStart\": 19,
+//               \"lineEnd\": 6,
+//               \"columnEnd\": 12
+//             }
+//           },
+//           {
+//             \"$kind\": \"class\",
+//             \"name\": \"C\",
+//             \"prefixes\": {
+//               \"replaceable\": true
+//             },
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 8,
+//               \"columnStart\": 19,
+//               \"lineEnd\": 10,
+//               \"columnEnd\": 12
+//             }
+//           },
+//           {
+//             \"$kind\": \"class\",
+//             \"name\": \"D\",
+//             \"prefixes\": {
+//               \"replaceable\": {
+//                 \"constrainedby\": \"C\"
+//               }
+//             },
+//             \"baseClass\": \"P.A.C\",
+//             \"source\": {
+//               \"filename\": \"<interactive>\",
+//               \"lineStart\": 12,
+//               \"columnStart\": 19,
+//               \"lineEnd\": 12,
+//               \"columnEnd\": 31
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 3,
+//           \"columnStart\": 5,
+//           \"lineEnd\": 13,
+//           \"columnEnd\": 10
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 15,
+//     \"columnStart\": 5,
+//     \"lineEnd\": 17,
+//     \"columnEnd\": 10
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -47,6 +47,7 @@ GetModelInstanceMod4.mos \
 GetModelInstanceReplaceable1.mos \
 GetModelInstanceReplaceable2.mos \
 GetModelInstanceReplaceable3.mos \
+GetModelInstanceReplaceable4.mos \
 GetModelInstanceStateMachine1.mos \
 
 


### PR DESCRIPTION
- Dump the enclosing scope path instead of the instance tree path for extended names in replaceable classes in getModelInstance.