### PR TITLE
Keep on writing to the log file even if display limit is reached

### DIFF
--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.cpp
@@ -502,8 +502,8 @@ void SimulationOutputWidget::writeSimulationMessage(SimulationMessage *pSimulati
   /* append the output */
   /* write the error message */
   if (pSimulationMessage->mText.compare("Reached display limit") == 0) {
-      QString simulationLogFilePath = QString("%1/%2.log").arg(mSimulationOptions.getWorkingDirectory()).arg(mSimulationOptions.getOutputFileName());
-      mpSimulationOutputTextBrowser->insertHtml(QString("Reached display limit. To read the full log open the file <a href=\"file:///%1\">%1</a>\n").arg(simulationLogFilePath));
+    QString simulationLogFilePath = QString("%1/%2.log").arg(mSimulationOptions.getWorkingDirectory()).arg(mSimulationOptions.getOutputFileName());
+    mpSimulationOutputTextBrowser->insertHtml(QString("Reached display limit. To read the full log open the file <a href=\"file:///%1\">%1</a>\n").arg(simulationLogFilePath));
   } else {
     mpSimulationOutputTextBrowser->insertPlainText(text);
   }


### PR DESCRIPTION
Fixes #10428

This was a regression introduce in e6c7e5575e1eacc65b4408c8db5ef4322bf037c2 when we updated the code to use `QXmlStreamReader` instead of deprecated `QXmlDefaultHandler`.