### PR TITLE
Measure the time performance of instance api

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -132,8 +132,9 @@ void signalHandler(int signalNumber)
 void printOMEditUsage()
 {
   printf("Usage: OMEdit --Debug=true|false] [files]\n");
-  printf("    --Debug=[true|false]        Enables the debugging features like QUndoView, diffModelicaFileListings view. Default is false.\n");
-  printf("    --NAPI=[true|false]         Enables the use of new json based api.\n");
+  printf("    --Debug=[true|false]            Enables the debugging features like QUndoView, diffModelicaFileListings view. Default is false.\n");
+  printf("    --NAPI=[true|false]             Enables the use of new json based api.\n");
+  printf("    --NAPIProfiling=[true|false]    Enables the profiling of new json based api.\n");
   printf("    files                       List of Modelica files(*.mo) to open.\n");
 }
 

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -108,6 +108,8 @@ public:
   void setNewApi(bool newApi) {mNewApi = newApi;}
   bool isNewApiCommandLine() const {return mNewApiCommandLine;}
   void setNewApiCommandLine(bool newApiCommandLine) {mNewApiCommandLine = newApiCommandLine;}
+  bool isNewApiProfiling() const {return mNewApiProfiling;}
+  void setNewApiProfiling(bool newApiProfiling) {mNewApiProfiling = newApiProfiling;}
   bool isTestsuiteRunning() const {return mTestsuiteRunning;}
   void setTestsuiteRunning(bool testsuiteRunning) {mTestsuiteRunning = testsuiteRunning;}
   OMCProxy* getOMCProxy() {return mpOMCProxy;}
@@ -266,6 +268,7 @@ private:
   bool mDebug;
   bool mNewApi;
   bool mNewApiCommandLine;
+  bool mNewApiProfiling;
   bool mTestsuiteRunning;
   OMCProxy *mpOMCProxy;
   bool mExitApplicationStatus;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -956,7 +956,10 @@ bool GraphicsView::addComponent(QString className, QPointF position)
           ModelInstance::Component *pComponent = new ModelInstance::Component(pModelInstance);
           pComponent->setName(name);
           pComponent->setType(pLibraryTreeItem->getNameStructure());
-          pComponent->setModel(new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(pLibraryTreeItem->getNameStructure())));
+          /* We use getModelInstanceIcon here for bettter performance
+           * This model will be updated right after this so it doesn't matter if the Component has complete model or not.
+           */
+          pComponent->setModel(new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(pLibraryTreeItem->getNameStructure(), false, true)));
           pModelInstance->addElement(pComponent);
           ModelInfo oldModelInfo = mpModelWidget->createModelInfo();
           addElementToView(pComponent, false, true, true, position);
@@ -5810,9 +5813,24 @@ void ModelWidget::loadModelInstance(bool icon, const ModelInfo &modelInfo)
 {
   // save the current ModelInstance pointer so we can delete it later.
   ModelInstance::Model *pOldModelInstance = mpModelInstance;
+  // call getModelInstance
+  const QJsonObject jsonObject = MainWindow::instance()->getOMCProxy()->getModelInstance(mpLibraryTreeItem->getNameStructure(), false, icon);
+
+  QElapsedTimer timer;
+  timer.start();
   // set the new ModelInstance
-  mpModelInstance = new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(mpLibraryTreeItem->getNameStructure(), false, icon));
+  mpModelInstance = new ModelInstance::Model(jsonObject);
+  if (MainWindow::instance()->isNewApiProfiling()) {
+    qDebug() << "Time for parsing JSON" << (double)timer.elapsed() / 1000.0 << "secs";
+  }
+
+  timer.restart();
+  // drawing
   drawModel(modelInfo);
+  if (MainWindow::instance()->isNewApiProfiling()) {
+    qDebug() << "Time for drawing graphical objects" << (double)timer.elapsed() / 1000.0 << "secs";
+  }
+
   // delete the old ModelInstance
   if (pOldModelInstance) {
     delete pOldModelInstance;

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -109,6 +109,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   // if user has requested to open the file by passing it in argument then,
   bool debug = false;
   bool newApi = false;
+  bool newApiProfiling = false;
   bool newApiCommandLine = false;
   QString fileName = "";
   QStringList fileNames, invalidFlags;
@@ -126,6 +127,12 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
         napiArg.remove("--NAPI=");
         if (0 == strcmp("true", napiArg.toUtf8().constData())) {
           newApi = true;
+        }
+      } else if (strncmp(arguments().at(i).toUtf8().constData(), "--NAPIProfiling=",16) == 0) {
+        QString napiProfilingArg = arguments().at(i);
+        napiProfilingArg.remove("--NAPIProfiling=");
+        if (0 == strcmp("true", napiProfilingArg.toUtf8().constData())) {
+          newApiProfiling = true;
         }
       } else {
         fileName = arguments().at(i);
@@ -151,6 +158,7 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
   pMainwindow->setDebug(debug);
   pMainwindow->setNewApi(newApi);
   pMainwindow->setNewApiCommandLine(newApiCommandLine);
+  pMainwindow->setNewApiProfiling(newApiProfiling);
   pMainwindow->setTestsuiteRunning(testsuiteRunning);
   pMainwindow->setUpMainWindow(threadData);
   if (pMainwindow->getExitApplicationStatus()) {        // if there is some issue in running the application.


### PR DESCRIPTION
Added a command line argument `--NAPIProfiling=true`
Prints the time measurement to the console for each call to `getModelInstance`