### PR TITLE
Do not overwrite parameter values to compute attribute values.

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1477,22 +1477,13 @@ algorithm
     ((uniqueEqIndex, startValueEquations, _)) := BackendDAEUtil.foldEqSystem(inInitDAE, SimCodeUtil.createStartValueEquations, (uniqueEqIndex, {}, inBackendDAE.shared.globalKnownVars));
     if debug then ExecStat.execStat("simCode: createStartValueEquations"); end if;
 
-    nominalValueEquations := {};
-    minValueEquations := {};
-    maxValueEquations := {};
-    // For now, disable traversal of globalknownvars for creation of nominal, min, and max assignments (if we are not doing
-    // dynamic optimizations).
-    // We need to revise how we handle these assignments for parameters with regard to maintaining the binding values
-    // for those that we end up generating these assignments. See #9825 for discussions.
-    // If you change these remember to change the coresponding code for ode mode simulation in SimCodeUtil.mo.
-    if (Config.acceptOptimicaGrammar() or Flags.getConfigBool(Flags.GENERATE_DYN_OPTIMIZATION_PROBLEM)) then
-      ((uniqueEqIndex, nominalValueEquations)) := SimCodeUtil.createValueEquationsShared(inBackendDAE.shared, SimCodeUtil.createInitialAssignmentsFromNominal, (uniqueEqIndex, nominalValueEquations));
-      if debug then ExecStat.execStat("simCode: createNominalValueEquationsShared"); end if;
-      ((uniqueEqIndex, minValueEquations)) := SimCodeUtil.createValueEquationsShared(inBackendDAE.shared, SimCodeUtil.createInitialAssignmentsFromMin, (uniqueEqIndex, minValueEquations));
-      if debug then ExecStat.execStat("simCode: createMinValueEquationsShared"); end if;
-      ((uniqueEqIndex, maxValueEquations)) := SimCodeUtil.createValueEquationsShared(inBackendDAE.shared, SimCodeUtil.createInitialAssignmentsFromMax, (uniqueEqIndex, maxValueEquations));
-      if debug then ExecStat.execStat("simCode: createMaxValueEquationsShared"); end if;
-    end if;
+
+    ((uniqueEqIndex, nominalValueEquations)) := SimCodeUtil.createValueEquationsShared(inBackendDAE.shared, SimCodeUtil.createInitialAssignmentsFromNominal, (uniqueEqIndex, nominalValueEquations));
+    if debug then ExecStat.execStat("simCode: createNominalValueEquationsShared"); end if;
+    ((uniqueEqIndex, minValueEquations)) := SimCodeUtil.createValueEquationsShared(inBackendDAE.shared, SimCodeUtil.createInitialAssignmentsFromMin, (uniqueEqIndex, minValueEquations));
+    if debug then ExecStat.execStat("simCode: createMinValueEquationsShared"); end if;
+    ((uniqueEqIndex, maxValueEquations)) := SimCodeUtil.createValueEquationsShared(inBackendDAE.shared, SimCodeUtil.createInitialAssignmentsFromMax, (uniqueEqIndex, maxValueEquations));
+    if debug then ExecStat.execStat("simCode: createMaxValueEquationsShared"); end if;
 
     ((uniqueEqIndex, nominalValueEquations)) := BackendDAEUtil.foldEqSystem(inBackendDAE, SimCodeUtil.createNominalValueEquations, (uniqueEqIndex, nominalValueEquations));
     if debug then ExecStat.execStat("simCode: createNominalValueEquations"); end if;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -444,19 +444,13 @@ algorithm
     ((uniqueEqIndex, startValueEquations, _)) := BackendDAEUtil.foldEqSystem(dlow, createStartValueEquations, (uniqueEqIndex, {}, globalKnownVars));
     if debug then execStat("simCode: createStartValueEquations"); end if;
 
-    // For now, disable traversal of globalknownvars for creation of nominal, min, and max assignments (if we are not doing
-    // dynamic optimizations).
-    // We need to revise how we handle these assignments for parameters with regard to maintaining the binding values
-    // for those that we end up generating these assignments. See #9825 for discussions.
-    // If you change these remember to change the coresponding code for daemode in SimCodeMain.mo.
-    if (Config.acceptOptimicaGrammar() or Flags.getConfigBool(Flags.GENERATE_DYN_OPTIMIZATION_PROBLEM)) then
-      ((uniqueEqIndex, nominalValueEquations)) := createValueEquationsShared(dlow.shared, createInitialAssignmentsFromNominal, (uniqueEqIndex, nominalValueEquations));
-      if debug then execStat("simCode: createNominalValueEquationsShared"); end if;
-      ((uniqueEqIndex, minValueEquations)) := createValueEquationsShared(dlow.shared, createInitialAssignmentsFromMin, (uniqueEqIndex, minValueEquations));
-      if debug then execStat("simCode: createMinValueEquationsShared"); end if;
-      ((uniqueEqIndex, maxValueEquations)) := createValueEquationsShared(dlow.shared, createInitialAssignmentsFromMax, (uniqueEqIndex, maxValueEquations));
-      if debug then execStat("simCode: createMaxValueEquationsShared"); end if;
-    end if;
+
+    ((uniqueEqIndex, nominalValueEquations)) := createValueEquationsShared(dlow.shared, createInitialAssignmentsFromNominal, (uniqueEqIndex, nominalValueEquations));
+    if debug then execStat("simCode: createNominalValueEquationsShared"); end if;
+    ((uniqueEqIndex, minValueEquations)) := createValueEquationsShared(dlow.shared, createInitialAssignmentsFromMin, (uniqueEqIndex, minValueEquations));
+    if debug then execStat("simCode: createMinValueEquationsShared"); end if;
+    ((uniqueEqIndex, maxValueEquations)) := createValueEquationsShared(dlow.shared, createInitialAssignmentsFromMax, (uniqueEqIndex, maxValueEquations));
+    if debug then execStat("simCode: createMaxValueEquationsShared"); end if;
 
     ((uniqueEqIndex, nominalValueEquations)) := BackendDAEUtil.foldEqSystem(dlow, createNominalValueEquations, (uniqueEqIndex, nominalValueEquations));
     if debug then execStat("simCode: createNominalValueEquations"); end if;

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3445,10 +3445,10 @@ template functionUpdateBoundVariableAttributes(SimCode simCode, list<SimEqSystem
 ::=
 let &sub = buffer ""
   <<
-  <%(startValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => equation_impl2(-1, -1, eq, contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ true, /* Initial? */ true) ; separator="\n")%>
-  <%(nominalValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => functionUpdateBoundVariableAttributesFunctions(eq, "nominal", contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ true) ; separator="\n") %>
-  <%(minValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => functionUpdateBoundVariableAttributesFunctions(eq, "min", contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ true) ; separator="\n") %>
-  <%(maxValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => functionUpdateBoundVariableAttributesFunctions(eq, "max", contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ true) ; separator="\n") %>
+  <%(startValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => equation_impl2(-1, -1, eq, contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ false, /* Initial? */ true) ; separator="\n")%>
+  <%(nominalValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => functionUpdateBoundVariableAttributesFunctions(eq, "nominal", contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ false) ; separator="\n") %>
+  <%(minValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => functionUpdateBoundVariableAttributesFunctions(eq, "min", contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ false) ; separator="\n") %>
+  <%(maxValueEquations |> eq as SES_SIMPLE_ASSIGN(__) => functionUpdateBoundVariableAttributesFunctions(eq, "max", contextOther, modelNamePrefix, /* Static? */ true, /* No optimization */ false) ; separator="\n") %>
   OMC_DISABLE_OPT
   int <%symbolName(modelNamePrefix,"updateBoundVariableAttributes")%>(DATA *data, threadData_t *threadData)
   {


### PR DESCRIPTION
Do not overwrite values to compute attribute values.

  - The previous implementation used the parameter itself to temporarily
    store and return the computed attribute values. It then used this value
    to update the actual attribute value and resetted the parameter to its
    start value. This does not always work (I think) because the value of
    the parameter is different from the start value (which is saved in the
    init.xml file) if the value is not a constant (?)

    On top of that it was quite confusing to read and understand. So modify
    the codegen to treat this case specifically and generate in-place
    updates to these non-constant min, max, nominal attribute values.

Do not disable optimization of some functions.

  - These are static functions and are marked for no optimization. I am
    not sure what the effect of the no-optimization attribute is in this
    case. Do not try to disable optimization for them anyway because they
    should be optimized if possible.
 
Reenable default extraction of min, max nominal assignments for params.

  - This reverts https://github.com/OpenModelica/OpenModelica/pull/9853 (#44dc29024c038c040e2e240d1c265ddec3dcad5e)

  - It was disabled because of https://github.com/OpenModelica/OpenModelica/issues/9825.

  - The handling has been improved now so it can be re-enabled.

Fixes #9825.