### PR TITLE
Fix intString/stringInt on 64-bit Windows

### DIFF
--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -49,7 +49,7 @@ metamodelica_string intString(modelica_integer i)
   void *res;
   if (i>=0 && i<=9) /* Small integers are used so much it makes sense to cache them */
     return mmc_strings_len1['0'+i];
-  sprintf(buffer, "%ld", (long) i);
+  snprintf(buffer, 22, "%" PRINT_MMC_SINT_T, i);
   res = mmc_mk_scon(buffer);
   MMC_CHECK_STRING(res);
   return res;
@@ -80,16 +80,20 @@ metamodelica_string nobox_intStringChar(threadData_t *threadData,modelica_intege
 
 modelica_integer nobox_stringInt(threadData_t *threadData,metamodelica_string s)
 {
-  long res;
+  modelica_integer res;
   char *endptr,*str=MMC_STRINGDATA(s);
   MMC_CHECK_STRING(s);
   errno = 0;
+#if defined(_WIN64) || defined(__MINGW64__)
+  res = strtoll(str,&endptr,10);
+#else
   res = strtol(str,&endptr,10);
+#endif
   if (errno != 0 || str == endptr)
     MMC_THROW_INTERNAL();
   if (*endptr != '\0')
     MMC_THROW_INTERNAL();
-  if (res > INT_MAX || res < INT_MIN)
+  if (res > MODELICA_INT_MAX || res < MODELICA_INT_MIN)
     MMC_THROW_INTERNAL();
   return res;
 }

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -48,8 +48,8 @@ extern "C" {
 #define PRINT_MMC_UINT_T "lu"
 typedef unsigned long mmc_uint_t;
 typedef long mmc_sint_t;
-#define MODELICA_INT_MIN LONG_MIN;
-#define MODELICA_INT_MAX LONG_MAX;
+#define MODELICA_INT_MIN LONG_MIN
+#define MODELICA_INT_MAX LONG_MAX
 
 #elif defined(_LLP64) || defined(_WIN64) || defined(__MINGW64__) /* windows 64bit */
 
@@ -66,8 +66,8 @@ typedef long mmc_sint_t;
 #define PRINT_MMC_UINT_T PRIu64
 typedef unsigned long long mmc_uint_t;
 typedef long long mmc_sint_t;
-#define MODELICA_INT_MIN LONG_MIN;
-#define MODELICA_INT_MAX LONG_MAX;
+#define MODELICA_INT_MIN LONG_MIN
+#define MODELICA_INT_MAX LONG_MAX
 
 #else /* 32bit platforms */
 
@@ -78,8 +78,8 @@ typedef long long mmc_sint_t;
 #define PRINT_MMC_UINT_T "u"
 typedef unsigned int mmc_uint_t;
 typedef int mmc_sint_t;
-#define MODELICA_INT_MIN INT_MIN;
-#define MODELICA_INT_MAX INT_MAX;
+#define MODELICA_INT_MIN INT_MIN
+#define MODELICA_INT_MAX INT_MAX
 
 #endif
 


### PR DESCRIPTION
- Change intString to use the `PRINT_MMC_SINT_T` macro for the format string instead of assuming it's a `long`, and change to snprintf just to be safe.
- Change `stringInt` to use `modelica_integer` instead of `long`, and use `MODELICA_INT_MIN/MAX` instead of `INT_MIN/MAX`.