### PR TITLE
Fix derived modifiers in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -835,14 +835,27 @@ uniontype InstNode
 
   function getDerivedNode
     input InstNode node;
+    input Boolean recursive = true;
     output InstNode derived;
   algorithm
     derived := match node
-      case CLASS_NODE(nodeType = InstNodeType.BASE_CLASS(parent = derived))
-        then getDerivedNode(derived);
+      case CLASS_NODE() then getDerivedNode2(node, node.nodeType, recursive);
       else node;
     end match;
   end getDerivedNode;
+
+  function getDerivedNode2
+    input InstNode node;
+    input InstNodeType ty;
+    input Boolean recursive;
+    output InstNode derived;
+  algorithm
+    derived := match ty
+      case InstNodeType.BASE_CLASS() then if recursive then getDerivedNode(ty.parent) else ty.parent;
+      case InstNodeType.DERIVED_CLASS() then getDerivedNode2(node, ty.ty, recursive);
+      else node;
+    end match;
+  end getDerivedNode2;
 
   function updateClass
     input Class cls;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1088,7 +1088,6 @@ algorithm
   json := JSON.addPairNotNull("dims", dumpJSONClassDims(node, def), json);
   json := JSON.addPair("restriction",
     JSON.makeString(Restriction.toString(InstNode.restriction(node))), json);
-  json := dumpJSONSCodeMod(SCodeUtil.elementMod(def), scope, json);
 
   json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(def, node), json);
 
@@ -1224,13 +1223,14 @@ function dumpJSONExtends
 protected
   InstNode node;
   SCode.Element cls_def, ext_def;
+  SCode.Mod mod;
 algorithm
   InstanceTree.CLASS(node = node) := ext;
   cls_def := InstNode.definition(node);
   ext_def := InstNode.extendsDefinition(node);
 
   json := JSON.addPair("$kind", JSON.makeString("extends"), json);
-  json := dumpJSONSCodeMod(SCodeUtil.elementMod(ext_def), node, json);
+  json := dumpJSONSCodeMod(getExtendsModifier(ext_def, node), node, json);
   json := dumpJSONCommentOpt(SCodeUtil.getElementComment(ext_def), node, json);
 
   if Class.isOnlyBuiltin(InstNode.getClass(node)) then
@@ -1239,6 +1239,18 @@ algorithm
     json := JSON.addPair("baseClass", dumpJSONInstanceTree(ext, node, root = false, isDeleted = isDeleted), json);
   end if;
 end dumpJSONExtends;
+
+function getExtendsModifier
+  input SCode.Element definition;
+  input InstNode node;
+  output SCode.Mod mod;
+algorithm
+  mod := match definition
+    case SCode.EXTENDS() then definition.modifications;
+    case SCode.CLASS() then SCodeUtil.elementMod(InstNode.definition(InstNode.getDerivedNode(node, recursive = false)));
+    else SCode.NOMOD();
+  end match;
+end getExtendsModifier;
 
 function dumpJSONReplaceableClass
   input InstNode cls;

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -20,10 +20,6 @@
       "description": "The class prefixes",
       "$ref": "#/definitions/classPrefixes"
     },
-    "modifiers": {
-      "description": "Modifier from the SCode",
-      "type": "#/definitions/scodeModifier"
-    },
     "comment": {
       "$ref": "#/definitions/comment"
     },

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -39,15 +39,15 @@ getModelInstance(M, prettyPrint = true);
 //       \"type\": {
 //         \"name\": \"Angle\",
 //         \"restriction\": \"type\",
-//         \"modifiers\": {
-//           \"quantity\": {
-//             \"final\": true,
-//             \"$value\": \"\\\"Angle\\\"\"
-//           }
-//         },
 //         \"elements\": [
 //           {
 //             \"$kind\": \"extends\",
+//             \"modifiers\": {
+//               \"quantity\": {
+//                 \"final\": true,
+//                 \"$value\": \"\\\"Angle\\\"\"
+//               }
+//             },
 //             \"baseClass\": \"Real\"
 //           }
 //         ],

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived1.mos
@@ -54,12 +54,12 @@ getErrorString();
 //       \"type\": {
 //         \"name\": \"RealInput2\",
 //         \"restriction\": \"type\",
-//         \"modifiers\": {
-//           \"start\": \"1.0\"
-//         },
 //         \"elements\": [
 //           {
 //             \"$kind\": \"extends\",
+//             \"modifiers\": {
+//               \"start\": \"1.0\"
+//             },
 //             \"baseClass\": {
 //               \"name\": \"RealInput\",
 //               \"restriction\": \"type\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived2.mos
@@ -39,12 +39,12 @@ getModelInstance(RealInput2, prettyPrint = true); getErrorString();
 // "{
 //   \"name\": \"RealInput2\",
 //   \"restriction\": \"type\",
-//   \"modifiers\": {
-//     \"start\": \"1.0\"
-//   },
 //   \"elements\": [
 //     {
 //       \"$kind\": \"extends\",
+//       \"modifiers\": {
+//         \"start\": \"1.0\"
+//       },
 //       \"baseClass\": {
 //         \"name\": \"RealInput\",
 //         \"restriction\": \"type\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived3.mos
@@ -1,0 +1,87 @@
+// name: GetModelInstanceDerived3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    type ThermodynamicTemperature = Real(final quantity = \"ThermodynamicTemperature\");
+    type Temperature = ThermodynamicTemperature(start = 1);
+    parameter Temperature T_ref = 300.15;
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true); getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"T_ref\",
+//       \"type\": {
+//         \"name\": \"Temperature\",
+//         \"restriction\": \"type\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"extends\",
+//             \"modifiers\": {
+//               \"start\": \"1\"
+//             },
+//             \"baseClass\": {
+//               \"name\": \"ThermodynamicTemperature\",
+//               \"restriction\": \"type\",
+//               \"elements\": [
+//                 {
+//                   \"$kind\": \"extends\",
+//                   \"modifiers\": {
+//                     \"quantity\": {
+//                       \"final\": true,
+//                       \"$value\": \"\\\"ThermodynamicTemperature\\\"\"
+//                     }
+//                   },
+//                   \"baseClass\": \"Real\"
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 3,
+//                 \"columnStart\": 5,
+//                 \"lineEnd\": 3,
+//                 \"columnEnd\": 86
+//               }
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 4,
+//           \"columnStart\": 5,
+//           \"lineEnd\": 4,
+//           \"columnEnd\": 59
+//         }
+//       },
+//       \"modifiers\": \"300.15\",
+//       \"value\": {
+//         \"binding\": 300.15
+//       },
+//       \"prefixes\": {
+//         \"variability\": \"parameter\"
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 6,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExtends3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExtends3.mos
@@ -7,11 +7,11 @@
 
 loadString("
   type MyReal
-    extends Real;
+    extends Real(start = 1.0);
   end MyReal;
 
   model M
-    MyReal x;
+    MyReal x(unit = \"m\");
   end M;
 ");
 getErrorString();
@@ -34,6 +34,9 @@ getModelInstance(M, prettyPrint=true);
 //         \"elements\": [
 //           {
 //             \"$kind\": \"extends\",
+//             \"modifiers\": {
+//               \"start\": \"1.0\"
+//             },
 //             \"baseClass\": \"Real\"
 //           }
 //         ],
@@ -44,6 +47,9 @@ getModelInstance(M, prettyPrint=true);
 //           \"lineEnd\": 4,
 //           \"columnEnd\": 13
 //         }
+//       },
+//       \"modifiers\": {
+//         \"unit\": \"\\\"m\\\"\"
 //       }
 //     }
 //   ],

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -23,6 +23,7 @@ GetModelInstanceConnection1.mos \
 GetModelInstanceConnection2.mos \
 GetModelInstanceDerived1.mos \
 GetModelInstanceDerived2.mos \
+GetModelInstanceDerived3.mos \
 GetModelInstanceDuplicate1.mos \
 GetModelInstanceEnum1.mos \
 GetModelInstanceEnum2.mos \


### PR DESCRIPTION
- Dump the modifier of a short class definition on the extends element instead of on the class itself, so that short and long class definitions are dumped in the same way.

Fixes #9519