### PR TITLE
Fix dumping visualizers with identical cref parts

### DIFF
--- a/OMCompiler/Compiler/BackEnd/VisualXML.mo
+++ b/OMCompiler/Compiler/BackEnd/VisualXML.mo
@@ -419,14 +419,14 @@ algorithm
   (crefOut, wasCut) := matchcontinue(crefIn, crefCut)
     local
       DAE.ComponentRef crefCut1, crefIn1;
-
+/* Issue #5953
     case(DAE.CREF_QUAL(componentRef=crefIn1),DAE.CREF_QUAL())
       algorithm
         // the crefs are not equal, check the next cref in crefIn
         true := not ComponentReference.crefFirstCrefEqual(crefIn,crefCut);
       then
         splitCrefAfter(crefIn1,crefCut);
-
+*/
     case(DAE.CREF_QUAL(componentRef=crefIn1),DAE.CREF_QUAL(componentRef=crefCut1))
       algorithm
         // the crefs are equal, continue checking
@@ -471,8 +471,8 @@ algorithm
     case (BackendDAE.VAR(varName=cref), (vars, vis as SHAPE(ident=ident)))
       algorithm
         //this var belongs to the visualization object
-        //crefIdent := makeCrefQualFromString(ident); // make a qualified cref out of the shape ident
-        (cref1,true) := splitCrefAfter(cref,ident); // check if this occures in the qualified var cref
+        //crefIdent := makeCrefQualFromString(ident); // make a qualified cref out of the visualizer ident
+        (cref1,true) := splitCrefAfter(cref,ident); // check if this occurs in the qualified var cref
         filled_vis := fillShapeObject(cref1,varIn,storeProtectedCrefs,program,vis);
       then
         (vars, filled_vis);
@@ -480,8 +480,8 @@ algorithm
     case (BackendDAE.VAR(varName=cref), (vars, vis as VECTOR(ident=ident)))
       algorithm
         //this var belongs to the visualization object
-        //crefIdent := makeCrefQualFromString(ident); // make a qualified cref out of the shape ident
-        (cref1,true) := splitCrefAfter(cref,ident); // check if this occures in the qualified var cref
+        //crefIdent := makeCrefQualFromString(ident); // make a qualified cref out of the visualizer ident
+        (cref1,true) := splitCrefAfter(cref,ident); // check if this occurs in the qualified var cref
         filled_vis := fillVectorObject(cref1,varIn,storeProtectedCrefs,program,vis);
       then
         (vars, filled_vis);
@@ -489,8 +489,8 @@ algorithm
     case (BackendDAE.VAR(varName=cref), (vars, vis as SURFACE(ident=ident)))
       algorithm
         //this var belongs to the visualization object
-        //crefIdent := makeCrefQualFromString(ident); // make a qualified cref out of the shape ident
-        (cref1,true) := splitCrefAfter(cref,ident); // check if this occures in the qualified var cref
+        //crefIdent := makeCrefQualFromString(ident); // make a qualified cref out of the visualizer ident
+        (cref1,true) := splitCrefAfter(cref,ident); // check if this occurs in the qualified var cref
         filled_vis := fillSurfaceObject(cref1,varIn,storeProtectedCrefs,program,vis);
       then
         (vars, filled_vis);


### PR DESCRIPTION
### Related Issues

Fixes #5953.

### Purpose

Generation of `<model>_visual.xml` file led to mismatched component references in case a qualified cref was contained as part of another qualified cref.

### Approach

Check that the cref _begins_ exactly with the identifier to be matched.

@adeas31 & @vwaurich What do you think? Do you see a particular case that would break the proposed fix?
(I'm not really aware of how crefs are generated and how they should be matched.)

By the way, this combinatorial operation looks highly inefficient, i.e., checking all model variables against each component identifier.
Don't you have a more straightforward way to associate variables with each component, e.g., not losing this association in the first place?