### PR TITLE
Pass record inputs to external functions by reference in Cpp runtime

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -4817,10 +4817,11 @@ template extArg(SimExtArg extArg, Text &preExp, Text &varDecls, Text &inputAssig
 
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=0, type_=t) then
     let cr = '<%contextCref2(c,contextFunction)%>'
+    let byref = match t case T_COMPLEX(__) then '&'
     if acceptMetaModelicaGrammar() then
       (match t case T_STRING(__) then 'MMC_STRINGDATA(<%cr%>)' else '<%cr%>_ext')
     else
-      '<%cr%><%match t case T_STRING(__) then ".c_str()" else "_ext"%>'
+      '<%byref%><%cr%><%match t case T_STRING(__) then ".c_str()" else "_ext"%>'
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=oi, type_=t) then
     let extName = extVarName2(c)
     let &outputAssign += '<%contextCref2(c,contextFunction)%> = <%extName%>;<%\n%>'

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -4817,7 +4817,7 @@ template extArg(SimExtArg extArg, Text &preExp, Text &varDecls, Text &inputAssig
 
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=0, type_=t) then
     let cr = '<%contextCref2(c,contextFunction)%>'
-    let byref = match t case T_COMPLEX(__) then '&'
+    let byref = match t case T_COMPLEX(complexClassType=RECORD(__)) then '&'
     if acceptMetaModelicaGrammar() then
       (match t case T_STRING(__) then 'MMC_STRINGDATA(<%cr%>)' else '<%cr%>_ext')
     else

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -5047,10 +5047,11 @@ template extArg(SimExtArg extArg, Text &preExp, Text &varDecls, Text &inputAssig
 
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=0, type_=t) then
     let cr = '<%contextCref2(c,contextFunction)%>'
+    let byref = match t case T_COMPLEX(__) then '&'
     if acceptMetaModelicaGrammar() then
       (match t case T_STRING(__) then 'MMC_STRINGDATA(<%cr%>)' else '<%cr%>_ext')
     else
-      '<%cr%><%match t case T_STRING(__) then ".c_str()" else "_ext"%>'
+      '<%byref%><%cr%><%match t case T_STRING(__) then ".c_str()" else "_ext"%>'
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=oi, type_=t) then
     let extName = extVarName2(c)
     let &outputAssign += '<%contextCref2(c,contextFunction)%> = <%extName%>;<%\n%>'

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -5047,7 +5047,7 @@ template extArg(SimExtArg extArg, Text &preExp, Text &varDecls, Text &inputAssig
 
   case SIMEXTARG(cref=c, isInput=ii, outputIndex=0, type_=t) then
     let cr = '<%contextCref2(c,contextFunction)%>'
-    let byref = match t case T_COMPLEX(__) then '&'
+    let byref = match t case T_COMPLEX(complexClassType=RECORD(__)) then '&'
     if acceptMetaModelicaGrammar() then
       (match t case T_STRING(__) then 'MMC_STRINGDATA(<%cr%>)' else '<%cr%>_ext')
     else

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -16,6 +16,7 @@ clockedSolverTest.mos \
 clockedTypesTest.mos \
 clockedTest.mos \
 externalArrayInputTest.mos \
+externalRecordTest.mos \
 mathFunctionsTest.mos \
 mslDistributionsTest.mos \
 mslElectricalMachinesTest.mos \

--- a/testsuite/openmodelica/cppruntime/externalRecordTest.mos
+++ b/testsuite/openmodelica/cppruntime/externalRecordTest.mos
@@ -1,0 +1,60 @@
+// name: externalRecordTest
+// keywords: external function with record input and output
+// status: correct
+// teardown_command: rm -f *ExternalRecord.Test*
+// cflags: -d=-newInst
+
+setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+
+loadString("
+package ExternalRecord
+  record R
+    Real a;
+    Real b;
+  end R;
+  function f
+    input R r1;
+    output R r2;
+    external \"C\" f_ext(r1, r2);
+    annotation(Include=\"
+      void f_ext(const void *x, void *y) {
+        ((double *)y)[0] = ((double *)x)[1];
+        ((double *)y)[1] = ((double *)x)[0];
+      }\");
+  end f;
+  model Test
+    R r1(a = 1, b = 2);
+    R r2;
+  algorithm
+    r2 := f(r1);
+  end Test;
+end ExternalRecord;
+"); getErrorString();
+
+simulate(ExternalRecord.Test); getErrorString();
+
+val(r1.a, 0);
+val(r1.b, 0);
+val(r2.a, 0);
+val(r2.b, 0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+// resultFile = "ExternalRecord.Test_res.mat",
+// simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'ExternalRecord.Test', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+// messages = ""
+// end SimulationResult;
+// ""
+// 1.0
+// 2.0
+// 2.0
+// 1.0
+// endResult


### PR DESCRIPTION
So far only outputs of external functions have been passed by reference.

See e.g. `ExternalMedia.Media.CoolPropMedium.setBubbleState` passing `SaturationProperties` as input and receiving `ThermodynamicState` as output. Called from `ExternalMedia.Test.CoolProp.Pentane_hs`
