### PR TITLE
support building the simulation code as a dyamic link library

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1183,17 +1183,6 @@ void communicateMsg(char id, unsigned int size, const char *data)
  * if this is a good idea. However, I am leaving it as it was for now.
  */
 int _main_initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *threadData) {
-#if defined(__MINGW32__) || defined(_MSC_VER)
-  /* Support for non-ASCII characters
-   * Read the unicode command line arguments and replace the normal arguments with it.
-   */
-  wchar_t** wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
-  for (int i = 0; i < argc; i++) {
-    char* buf = omc_wchar_to_multibyte_str(wargv[i]);
-    strcpy(argv[i], buf);
-    free(buf);
-  }
-#endif
 
   if (initRuntimeAndSimulation(argc, argv, data, threadData)) //initRuntimeAndSimulation returns 1 if an error occurs
     return 1;


### PR DESCRIPTION
### Purpose

Add code and a `Model.makefile` target (`omc_dll_target`) to be able to build dynamic link libraries from the simulation code.

DO NOT merge yet, this is WIP some code needs to be moved from the template to the SimulationRuntime/c.

Made a PR so I can build a release from it.