### PR TITLE
Change OMCppOMCFactory to static library.

### DIFF
--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/CMakeLists.txt
@@ -4,7 +4,7 @@
 # OMCppOMCFactory
 set(OMC_SIMRT_CPP_SIMCOREFACTORY_OMCFACTORY_SOURCES OMCFactory/OMCFactory.cpp)
 
-add_library(OMCppOMCFactory SHARED)
+add_library(OMCppOMCFactory STATIC)
 add_library(omc::simrt::cpp::simcorefactory::omcfactory ALIAS OMCppOMCFactory)
 
 target_sources(OMCppOMCFactory PRIVATE ${OMC_SIMRT_CPP_SIMCOREFACTORY_OMCFACTORY_SOURCES})


### PR DESCRIPTION
  - This was overlooked and made different from the other build system (the original CMake build for CPP runtime used by the OpenModelica autoconf build.)

  - Normally for Linux, macOS and MinGW this was insignificant. However, for MSVC it matters because the library does not export any symbols. For MSVC, when built as DLL, this implies that the library is not supposed to be linked directly (it will only be loaded). So it will not generate the import lib for it.
