### PR TITLE
Use compareFilesAndMove instead of system(mv ...).

### DIFF
--- a/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
+++ b/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
@@ -5,7 +5,7 @@ if bool then
   setCommandLineOptions("-g=MetaModelica");
   bool := loadFile("OpenModelicaScriptingAPI.tmp.mo");
   if bool then
-    bool := 0 == system("mv OpenModelicaScriptingAPI.tmp.mo OpenModelicaScriptingAPI.mo");
+    bool := OpenModelica.Scripting.compareFilesAndMove("OpenModelicaScriptingAPI.tmp.mo", "OpenModelicaScriptingAPI.mo");
   else
     exit(1);
   end if;

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/MEC_standalone_2.8.cmake
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/MEC_standalone_2.8.cmake
@@ -14,8 +14,8 @@ project(OMModelicaExternalC)
 link_directories(${CMAKE_INSTALL_LIBDIR} ${CMAKE_INSTALL_BINDIR})
 
 # Set the rpath to the one dir up as the destination of the libs
-# when installing is an 'ffi' directory in the lib directory.
-# See the install commnad at the end of this file. If that is
+# when installing there is an 'ffi' directory in the lib directory.
+# See the install command at the end of this file. If that is
 # changed make sure to adjust this as well.
 if(APPLE)
   set(CMAKE_INSTALL_RPATH "@loader_path/../../${CMAKE_INSTALL_LIBDIR}")

--- a/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp
@@ -111,7 +111,7 @@ void OMModel::load_ODE_system() {
 }
 
 inline void check_tag(int index, const std::string& tag) {
-    if (tag == "dummy" or tag == "assign" or tag == "residual" or tag == "tornsystem" or tag == "system" or
+    if (tag == "dummy" || tag == "assign" || tag == "residual" || tag == "tornsystem" || tag == "system" ||
         tag == "algorithm")
         return;
     else {
@@ -120,7 +120,7 @@ inline void check_tag(int index, const std::string& tag) {
 }
 
 inline void check_container_dispaly(int index, const std::string& disp) {
-    if (disp == "linear" or disp == "non-linear")
+    if (disp == "linear" || disp == "non-linear")
         return;
     else {
         utility::eq_index_fatal(index, "container with unknown disp : " + disp);


### PR DESCRIPTION
  - Use `compareFilesAndMove` instead of `system(mv ...)`.  
    - The first one is more portable.

  - Misc.
    - Change `or` in C++ code to `||`. I must have come straight from Python when I wrote this.

