### PR TITLE
Fix some uninitialized variable uses.

### DIFF
--- a/OMCompiler/Compiler/Util/BaseHashSet.mo
+++ b/OMCompiler/Compiler/Util/BaseHashSet.mo
@@ -347,7 +347,7 @@ protected function get2
   input Key key;
   input list<tuple<Key,Integer>> keyIndices;
   input FuncEq keyEqual;
-  output Integer index;
+  output Integer index = -1;
   output Boolean found = true;
 protected
   Key key2;

--- a/OMCompiler/Compiler/runtime/matching.c
+++ b/OMCompiler/Compiler/runtime/matching.c
@@ -1246,8 +1246,8 @@ void match_pr_fifo_fair(int* col_ptrs, int* col_ids, int* row_ptrs, int* row_ids
 }
 
 void matching(int* col_ptrs, int* col_ids, int* match, int* row_match, int n, int m, int matching_id, int cheap_id, double relabel_period, int clear_match) {
-  int* row_ptrs;
-  int* row_ids;
+  int* row_ptrs = NULL;
+  int* row_ids = NULL;
   int i;
 
   if (clear_match==1)


### PR DESCRIPTION
  - These variables were being accessed at runtime without being intialized.
