### PR TITLE
Don't translate in DAE mode with Cpp runtime

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3471,8 +3471,15 @@ protected function callTranslateModel
   output list<String> outStringLst;
   output String outFileDir;
   output list<tuple<String,Values.Value>> resultValues;
+protected
+  Boolean daeMode;
 algorithm
-  if Flags.getConfigBool(Flags.DAE_MODE) then
+  daeMode := Flags.getConfigBool(Flags.DAE_MODE);
+  if daeMode and Config.simCodeTarget() == "Cpp" then
+    Error.addMessage(Error.DAE_MODE_NOT_SUPPORTED_CPP, {});
+    daeMode := false;
+  end if;
+  if daeMode then
     (outCache, outStringLst, outFileDir, resultValues) :=
     SimCodeMain.translateModelDAEMode(inCache,inEnv,className,inFileNamePrefix,
     inSimSettingsOpt,Absyn.FUNCTIONARGS({},{}));

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -1270,6 +1270,8 @@ public constant ErrorTypes.Message DUPLICATE_VARIABLE_ERROR = ErrorTypes.MESSAGE
   Gettext.gettext("Duplicate elements:\n %s."));
 public constant ErrorTypes.Message ENCRYPTION_NOT_SUPPORTED = ErrorTypes.MESSAGE(7026, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("File not Found: %s. Compile OpenModelica with Encryption support."));
+public constant ErrorTypes.Message DAE_MODE_NOT_SUPPORTED_CPP = ErrorTypes.MESSAGE(7027, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  Gettext.gettext("DAE mode is not supported with Cpp target. Generating ODE instead."));
 
 constant SourceInfo dummyInfo = SOURCEINFO("",false,0,0,0,0,0.0);
 


### PR DESCRIPTION
The function `SimCodeMain.translateModelDAEMode` leaves variable mappings for C++ uninitialized, leading to many translation errors of the form:
```
  Internal error GetVarIndexListByMapping: No Element for machine.lambdaDPu found!
```

See e.g. `PowerGrids.Electrical.Test.SynchronousMachine4WindingsPowerSwing` defining the annotation
```
   __OpenModelica_commandLineOptions = "--daeMode -d=initialization,evaluateAllParameters"
```
that cannot be changed if loaded in OMEdit as system library.

### Related Issues

Similar treatment with warning for the unsupported FMU for cosimulation. 