### PR TITLE
check for output vars of type REAL()

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1792,7 +1792,7 @@ algorithm
   daeVarsLst := {};
   newEqnlst := {};
   for var in BackendVariable.varList(currentSystem.orderedVars) loop
-    if BackendVariable.isOutputVar(var) then
+    if BackendVariable.isOutputVar(var) and BackendVariable.isRealVar(var) then
       newCref := ComponentReference.appendStringLastIdent("_der", var.varName); // append _der
       newCref := ComponentReference.prependStringCref("$", newCref); // prepend $
       daeVarsLst := BackendVariable.makeVar(newCref) :: daeVarsLst;

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/Makefile
@@ -7,6 +7,7 @@ ExportCvodeFmu_static.mos \
 fmi_interpolation_01.mos \
 FmuExportFlags.mos \
 simpleStiffFMU.mos \
+issue10523.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/issue10523.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/issue10523.mos
@@ -1,0 +1,19 @@
+// name: issue10523.mos
+// keywords: FMI 2.0 export
+// status: correct
+// teardown_command: rm -rf Modelica.Blocks.Sources.IntegerConstant.fmu Modelica_Blocks_Sources_IntegerConstant.log Modelica_Blocks_Sources_IntegerConstant_info.json
+
+loadModel(Modelica);
+getErrorString();
+
+buildModelFMU(Modelica.Blocks.Sources.IntegerConstant, version="2.0", fmuType="cs");
+getErrorString();
+
+
+// Result:
+// true
+// ""
+// "Modelica.Blocks.Sources.IntegerConstant.fmu"
+// "[Modelica 4.0.0+maint.om/Blocks/Sources.mo:2236:5-2236:57:writable] Warning: Parameter k has no value, and is fixed during initialization (fixed=true), using available start value (start=1) as default value.
+// "
+// endResult


### PR DESCRIPTION
### Related Issues
https://github.com/OpenModelica/OpenModelica/issues/10523

### Purpose
This PR fixes the Backend `preOptModule = introduceOutputRealDerivatives`  to check for `Output Vars of type REAL()`
