### PR TITLE
Set the C++ standards using qmake CONFIGs.

### DIFF
--- a/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -33,6 +33,9 @@ greaterThan(QT_MAJOR_VERSION, 4) {
   QT += printsupport widgets webkitwidgets concurrent
 }
 
+# Set the C++ standard.
+CONFIG += c++14
+
 TARGET = OMEdit
 TEMPLATE = app
 

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -33,6 +33,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
   QT += printsupport widgets webkitwidgets concurrent
 }
 
+# Set the C++ standard.
 CONFIG += c++14
 
 TARGET = OMEdit

--- a/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
@@ -9,6 +9,9 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     QT *= printsupport widgets webkitwidgets
 }
 
+# Set the C++ standard.
+CONFIG += c++14
+
 TRANSLATIONS = Resources/nls/OMNotebook_de_DE.ts
 
 TARGET = OMNotebook

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.pro
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.pro
@@ -9,6 +9,9 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     QT *= printsupport widgets
 }
 
+# Set the C++ standard.
+CONFIG += c++14
+
 TARGET = OMPlot
 TEMPLATE = app
 CONFIG += console

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlotLib.pro
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlotLib.pro
@@ -9,6 +9,9 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     QT *= printsupport widgets
 }
 
+# Set the C++ standard.
+CONFIG += c++14
+
 TARGET = OMPlot
 TEMPLATE = lib
 

--- a/OMShell/OMShell/OMShellGUI/OMShellGUI.pro
+++ b/OMShell/OMShell/OMShellGUI/OMShellGUI.pro
@@ -3,6 +3,9 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     QT *= printsupport widgets webkitwidgets
 }
 
+# Set the C++ standard.
+CONFIG += c++14
+
 TRANSLATIONS = \
   OMShell_de.ts \
   OMShell_sv.ts


### PR DESCRIPTION
  - If these are not specified using the CONFIG setting, `qmake` will add its own standard options. On EL7 for example, it adds `-std=gnu++11`
