### PR TITLE
Source-Code FMUs with FMI2_FUNCTION_PREFIX in C sources

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3730,7 +3730,7 @@ algorithm
   LDFLAGS := ("-L"+dquote+Settings.getInstallationDirectoryPath()+"/lib/"+Autoconf.triple+"/omc"+dquote+" "+
               "-Wl,-rpath,"+dquote+Settings.getInstallationDirectoryPath()+"/lib/"+Autoconf.triple+"/omc"+dquote+" "+
               System.getLDFlags()+" ");
-  CPPFLAGS := "-I. -I" + includeDefaultFmi + " -DOMC_FMI_RUNTIME=1";
+  CPPFLAGS := "-I. -I" + includeDefaultFmi + " -DOMC_FMI_RUNTIME=1 -DFMI2_OVERRIDE_FUNCTION_PREFIX";
   if Flags.isSet(Flags.GEN_DEBUG_SYMBOLS) then
     CPPFLAGS := CPPFLAGS + " -O0 -g ";
   end if;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3730,7 +3730,7 @@ algorithm
   LDFLAGS := ("-L"+dquote+Settings.getInstallationDirectoryPath()+"/lib/"+Autoconf.triple+"/omc"+dquote+" "+
               "-Wl,-rpath,"+dquote+Settings.getInstallationDirectoryPath()+"/lib/"+Autoconf.triple+"/omc"+dquote+" "+
               System.getLDFlags()+" ");
-  CPPFLAGS := "-I. -I" + includeDefaultFmi + " -DOMC_FMI_RUNTIME=1 -DFMI2_OVERRIDE_FUNCTION_PREFIX";
+  CPPFLAGS := "-I. -I" + includeDefaultFmi + " -DOMC_FMI_RUNTIME=1";
   if Flags.isSet(Flags.GEN_DEBUG_SYMBOLS) then
     CPPFLAGS := CPPFLAGS + " -O0 -g ";
   end if;

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -1443,6 +1443,7 @@ template fmuMakefile(String target, SimCode simCode, String FMUVersion, list<Str
       FMIPLATFORM=@FMIPLATFORM@
       # Note: Simulation of the fmu with dymola does not work with -finline-small-functions (enabled by most optimization levels)
       CPPFLAGS=@CPPFLAGS@
+      override CPPFLAGS += -DFMI2_OVERRIDE_FUNCTION_PREFIX
 
       override CPPFLAGS += <%makefileParams.includes ; separator=" "%>
 

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -254,11 +254,16 @@ case SIMCODE(__) then
   #include "simulation/solver/events.h"
   <%if isFMIVersion20(FMUVersion) then
   <<
+  #define FMI2_FUNCTION_PREFIX <%modelNamePrefix(simCode)%>_
+  #include "fmi2Functions.h"
   #include "fmi-export/fmu2_model_interface.h"
   #include "fmi-export/fmu_read_flags.h"
   >>
   else
-  '#include "fmi-export/fmu1_model_interface.h"'%>
+  <<
+  #include "fmi2Functions.h"
+  #include "fmi-export/fmu1_model_interface.h"
+  >>%>
 
   #ifdef __cplusplus
   extern "C" {

--- a/OMCompiler/Compiler/Template/CodegenOMSIC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenOMSIC.tpl
@@ -453,6 +453,7 @@ template createMakefileIn(SimCode simCode, String target, String FileNamePrefix,
         OMC_NDELAY_EXPRESSIONS=<%maxDelayedIndex%>
         OMC_NVAR_STRING=<%varInfo.numStringAlgVars%>
 
+        override CPPFLAGS += -DFMI2_OVERRIDE_FUNCTION_PREFIX
         override CPPFLAGS += -Iinclude/ -Iinclude/fmi<%if isFMIVersion20(FMUVersion) then "2" else "1"%> -I. <%makefileParams.includes ; separator=" "%> <% if Flags.isSet(Flags.FMU_EXPERIMENTAL) then '-DFMU_EXPERIMENTAL'%>  -DOMC_MODEL_PREFIX=<%CodegenUtilSimulation.modelNamePrefix(simCode)%> -DOMC_NUM_MIXED_SYSTEMS=<%varInfo.numMixedSystems%> -DOMC_NUM_LINEAR_SYSTEMS=<%varInfo.numLinearSystems%> -DOMC_NUM_NONLINEAR_SYSTEMS=<%varInfo.numNonLinearSystems%> -DOMC_NDELAY_EXPRESSIONS=<%maxDelayedIndex%> -DOMC_NVAR_STRING=<%varInfo.numStringAlgVars%>
 
         <%common%>

--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/FMU2/fmi2FunctionTypes.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/FMU2/fmi2FunctionTypes.h
@@ -8,9 +8,12 @@
 #include "fmi2TypesPlatform.h"
 
 /* This header file must be utilized when compiling an FMU or an FMI master.
-   It declares data and function types for FMI 2.0
+   It declares data and function types for FMI 2.0.4
 
    Revisions:
+   - Sep. 30, 2019: License changed to 2-clause BSD License (without extensions)
+   - Jul.  5, 2019: Remove const modifier from fields of fmi2CallbackFunctions  (#216)
+   - Sep.  6, 2018: Parameter names added to function prototypes
    - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Apr.  3, 2014: Added #include <stddef.h> for size_t definition
    - Mar. 27, 2014: Added #include "fmiTypesPlatform.h" (#179)
@@ -50,11 +53,12 @@
    - Nov. 14, 2011: First public Version
 
 
-   Copyright © 2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -62,12 +66,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -81,13 +83,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 #ifdef __cplusplus
@@ -104,8 +99,7 @@ extern "C" {
 
 
 /* Type definitions */
-typedef enum
-{
+typedef enum {
     fmi2OK,
     fmi2Warning,
     fmi2Discard,
@@ -114,42 +108,44 @@ typedef enum
     fmi2Pending
 } fmi2Status;
 
-typedef enum
-{
+typedef enum {
     fmi2ModelExchange,
     fmi2CoSimulation
 } fmi2Type;
 
-typedef enum
-{
+typedef enum {
     fmi2DoStepStatus,
     fmi2PendingStatus,
     fmi2LastSuccessfulTime,
     fmi2Terminated
 } fmi2StatusKind;
 
-typedef void (*fmi2CallbackLogger)(fmi2ComponentEnvironment, fmi2String, fmi2Status, fmi2String, fmi2String, ...);
-typedef void* (*fmi2CallbackAllocateMemory)(size_t, size_t);
-typedef void (*fmi2CallbackFreeMemory)(void*);
-typedef void (*fmi2StepFinished)(fmi2ComponentEnvironment, fmi2Status);
+typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment componentEnvironment,
+                                                fmi2String instanceName,
+                                                fmi2Status status,
+                                                fmi2String category,
+                                                fmi2String message,
+                                                ...);
+typedef void*     (*fmi2CallbackAllocateMemory)(size_t nobj, size_t size);
+typedef void      (*fmi2CallbackFreeMemory)    (void* obj);
+typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment componentEnvironment,
+                                                fmi2Status status);
 
-typedef struct
-{
-    const fmi2CallbackLogger logger;
-    const fmi2CallbackAllocateMemory allocateMemory;
-    const fmi2CallbackFreeMemory freeMemory;
-    const fmi2StepFinished stepFinished;
-    const fmi2ComponentEnvironment componentEnvironment;
+typedef struct {
+   fmi2CallbackLogger         logger;
+   fmi2CallbackAllocateMemory allocateMemory;
+   fmi2CallbackFreeMemory     freeMemory;
+   fmi2StepFinished           stepFinished;
+   fmi2ComponentEnvironment   componentEnvironment;
 } fmi2CallbackFunctions;
 
-typedef struct
-{
-    fmi2Boolean newDiscreteStatesNeeded;
-    fmi2Boolean terminateSimulation;
-    fmi2Boolean nominalsOfContinuousStatesChanged;
-    fmi2Boolean valuesOfContinuousStatesChanged;
-    fmi2Boolean nextEventTimeDefined;
-    fmi2Real nextEventTime;
+typedef struct {
+   fmi2Boolean newDiscreteStatesNeeded;
+   fmi2Boolean terminateSimulation;
+   fmi2Boolean nominalsOfContinuousStatesChanged;
+   fmi2Boolean valuesOfContinuousStatesChanged;
+   fmi2Boolean nextEventTimeDefined;
+   fmi2Real    nextEventTime;
 } fmi2EventInfo;
 
 
@@ -166,65 +162,83 @@ Types for Common Functions
 ****************************************************/
 
 /* Inquire version numbers of header files and setting logging status */
-typedef const char* fmi2GetTypesPlatformTYPE(void);
-typedef const char* fmi2GetVersionTYPE(void);
-typedef fmi2Status fmi2SetDebugLoggingTYPE(fmi2Component, fmi2Boolean, size_t, const fmi2String []);
+    typedef const char* fmi2GetTypesPlatformTYPE(void);
+    typedef const char* fmi2GetVersionTYPE(void);
+    typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component c,
+                                                fmi2Boolean loggingOn,
+                                                size_t nCategories,
+                                                const fmi2String categories[]);
 
 /* Creation and destruction of FMU instances and setting debug status */
-typedef fmi2Component fmi2InstantiateTYPE(fmi2String, fmi2Type, fmi2String, fmi2String, const fmi2CallbackFunctions*,
-                                          fmi2Boolean, fmi2Boolean);
-typedef void fmi2FreeInstanceTYPE(fmi2Component);
+    typedef fmi2Component fmi2InstantiateTYPE(fmi2String instanceName,
+                                              fmi2Type fmuType,
+                                              fmi2String fmuGUID,
+                                              fmi2String fmuResourceLocation,
+                                              const fmi2CallbackFunctions* functions,
+                                              fmi2Boolean visible,
+                                              fmi2Boolean loggingOn);
+   typedef void          fmi2FreeInstanceTYPE(fmi2Component c);
 
 /* Enter and exit initialization mode, terminate and reset */
-typedef fmi2Status fmi2SetupExperimentTYPE(fmi2Component, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
-typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component);
-typedef fmi2Status fmi2ExitInitializationModeTYPE(fmi2Component);
-typedef fmi2Status fmi2TerminateTYPE(fmi2Component);
-typedef fmi2Status fmi2ResetTYPE(fmi2Component);
+    typedef fmi2Status fmi2SetupExperimentTYPE       (fmi2Component c,
+                                                      fmi2Boolean toleranceDefined,
+                                                      fmi2Real tolerance,
+                                                      fmi2Real startTime,
+                                                      fmi2Boolean stopTimeDefined,
+                                                      fmi2Real stopTime);
+   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component c);
+   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component c);
+   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component c);
+   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component c);
 
 /* Getting and setting variable values */
-typedef fmi2Status fmi2GetRealTYPE(fmi2Component, const fmi2ValueReference [], size_t, fmi2Real []);
-typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component, const fmi2ValueReference [], size_t, fmi2Integer []);
-typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component, const fmi2ValueReference [], size_t, fmi2Boolean []);
-typedef fmi2Status fmi2GetStringTYPE(fmi2Component, const fmi2ValueReference [], size_t, fmi2String []);
+   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real    value[]);
+   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[]);
+   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[]);
+   typedef fmi2Status fmi2GetStringTYPE (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String  value[]);
 
-typedef fmi2Status fmi2SetRealTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Real []);
-typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer []);
-typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Boolean []);
-typedef fmi2Status fmi2SetStringTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2String []);
+   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real    value[]);
+   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]);
+   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
+   typedef fmi2Status fmi2SetStringTYPE (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String  value[]);
 
 /* Getting and setting the internal FMU state */
-typedef fmi2Status fmi2GetFMUstateTYPE(fmi2Component, fmi2FMUstate*);
-typedef fmi2Status fmi2SetFMUstateTYPE(fmi2Component, fmi2FMUstate);
-typedef fmi2Status fmi2FreeFMUstateTYPE(fmi2Component, fmi2FMUstate*);
-typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component, fmi2FMUstate, size_t*);
-typedef fmi2Status fmi2SerializeFMUstateTYPE(fmi2Component, fmi2FMUstate, fmi2Byte [], size_t);
-typedef fmi2Status fmi2DeSerializeFMUstateTYPE(fmi2Component, const fmi2Byte [], size_t, fmi2FMUstate*);
+   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component c, fmi2FMUstate* FMUstate);
+   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component c, fmi2FMUstate  FMUstate);
+   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component c, fmi2FMUstate* FMUstate);
+   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component c, fmi2FMUstate  FMUstate, size_t* size);
+   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component c, fmi2FMUstate  FMUstate, fmi2Byte serializedState[], size_t size);
+   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate);
 
 /* Getting partial derivatives */
-typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component, const fmi2ValueReference [], size_t,
-                                                    const fmi2ValueReference [], size_t,
-                                                    const fmi2Real [], fmi2Real []);
+    typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component c,
+                                                        const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
+                                                        const fmi2ValueReference vKnown_ref[],   size_t nKnown,
+                                                        const fmi2Real dvKnown[],
+                                                        fmi2Real dvUnknown[]);
 
 /***************************************************
 Types for Functions for FMI2 for Model Exchange
 ****************************************************/
 
 /* Enter and exit the different modes */
-typedef fmi2Status fmi2EnterEventModeTYPE(fmi2Component);
-typedef fmi2Status fmi2NewDiscreteStatesTYPE(fmi2Component, fmi2EventInfo*);
-typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component);
-typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component c);
+   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component c, fmi2EventInfo* fmi2eventInfo);
+   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component c);
+   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component c,
+                                                      fmi2Boolean   noSetFMUStatePriorToCurrentPoint,
+                                                      fmi2Boolean*  enterEventMode,
+                                                      fmi2Boolean*  terminateSimulation);
 
 /* Providing independent variables and re-initialization of caching */
-typedef fmi2Status fmi2SetTimeTYPE(fmi2Component, fmi2Real);
-typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component, const fmi2Real [], size_t);
+   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component c, fmi2Real time);
+   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component c, const fmi2Real x[], size_t nx);
 
 /* Evaluation of the model equations */
-typedef fmi2Status fmi2GetDerivativesTYPE(fmi2Component, fmi2Real [], size_t);
-typedef fmi2Status fmi2GetEventIndicatorsTYPE(fmi2Component, fmi2Real [], size_t);
-typedef fmi2Status fmi2GetContinuousStatesTYPE(fmi2Component, fmi2Real [], size_t);
-typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component, fmi2Real [], size_t);
+   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component c, fmi2Real derivatives[],     size_t nx);
+   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component c, fmi2Real eventIndicators[], size_t ni);
+   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component c, fmi2Real x[],               size_t nx);
+   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component c, fmi2Real x_nominal[],       size_t nx);
 
 
 /***************************************************
@@ -232,25 +246,32 @@ Types for Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-typedef fmi2Status fmi2SetRealInputDerivativesTYPE(fmi2Component, const fmi2ValueReference [], size_t,
-                                                   const fmi2Integer [], const fmi2Real []);
-typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component, const fmi2ValueReference [], size_t,
-                                                    const fmi2Integer [], fmi2Real []);
-
-typedef fmi2Status fmi2DoStepTYPE(fmi2Component, fmi2Real, fmi2Real, fmi2Boolean);
-typedef fmi2Status fmi2CancelStepTYPE(fmi2Component);
+    typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component c,
+                                                        const fmi2ValueReference vr[], size_t nvr,
+                                                        const fmi2Integer order[],
+                                                        const fmi2Real value[]);
+    typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component c,
+                                                        const fmi2ValueReference vr[], size_t nvr,
+                                                        const fmi2Integer order[],
+                                                        fmi2Real value[]);
+    typedef fmi2Status fmi2DoStepTYPE   (fmi2Component c,
+                                         fmi2Real      currentCommunicationPoint,
+                                         fmi2Real      communicationStepSize,
+                                         fmi2Boolean   noSetFMUStatePriorToCurrentPoint);
+   typedef fmi2Status fmi2CancelStepTYPE(fmi2Component c);
 
 /* Inquire slave status */
-typedef fmi2Status fmi2GetStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Status*);
-typedef fmi2Status fmi2GetRealStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Real*);
-typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Integer*);
-typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Boolean*);
-typedef fmi2Status fmi2GetStringStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2String*);
+   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component c, const fmi2StatusKind s, fmi2Status*  value);
+   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component c, const fmi2StatusKind s, fmi2Real*    value);
+   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value);
+   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value);
+   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component c, const fmi2StatusKind s, fmi2String*  value);
 
 
 #ifdef __cplusplus
-} /* end of extern "C" { */
+}  /* end of extern "C" { */
 #endif
 
 #endif /* fmi2FunctionTypes_h */
+
 /** @} */ // end of fmu2

--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/FMU2/fmi2Functions.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/FMU2/fmi2Functions.h
@@ -7,7 +7,7 @@
 
 /* This header file must be utilized when compiling a FMU.
    It defines all functions of the
-         FMI 2.0 Model Exchange and Co-Simulation Interface.
+         FMI 2.0.4 Model Exchange and Co-Simulation Interface.
 
    In order to have unique function names even if several FMUs
    are compiled together (e.g. for embedded systems), every "real" function name
@@ -25,7 +25,9 @@
    names are used and "FMI2_FUNCTION_PREFIX" must not be defined.
 
    Revisions:
-   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Sep. 13, 2022: Provide FMI2_OVERRIDE_FUNCTION_PREFIX functionality
+   - Sep. 29, 2019: License changed to 2-clause BSD License (without extensions)
+   - Apr.  9, 2014: All prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Mar. 26, 2014: FMI_Export set to empty value if FMI_Export and FMI_FUNCTION_PREFIX
                     are not defined (#173)
    - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
@@ -104,11 +106,13 @@
                     meeting with additional improvements (by Martin Otter, DLR).
    - Dec. 3 , 2008: First version by Martin Otter (DLR) and Hans Olsson (Dynasim).
 
-   Copyright © 2008-2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -116,12 +120,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -135,13 +137,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 #ifdef __cplusplus
@@ -152,6 +147,15 @@ extern "C" {
 #include "fmi2FunctionTypes.h"
 #include <stdlib.h>
 
+/*
+Allow override of FMI2_FUNCTION_PREFIX: If FMI2_OVERRIDE_FUNCTION_PREFIX
+is defined, then FMI2_ACTUAL_FUNCTION_PREFIX will be used, if defined,
+or no prefix if undefined. Otherwise FMI2_FUNCTION_PREFIX will be used,
+if defined.
+*/
+#if !defined(FMI2_OVERRIDE_FUNCTION_PREFIX) && defined(FMI2_FUNCTION_PREFIX)
+  #define FMI2_ACTUAL_FUNCTION_PREFIX FMI2_FUNCTION_PREFIX
+#endif
 
 /*
   Export FMI2 API functions on Windows and under GCC.
@@ -160,30 +164,30 @@ extern "C" {
   it may be set to __declspec(dllimport).
 */
 #if !defined(FMI2_Export)
-#if !defined(FMI2_FUNCTION_PREFIX)
-#if defined _WIN32 || defined __CYGWIN__
-/* Note: both gcc & MSVC on Windows support this syntax. */
-#define FMI2_Export __declspec(dllexport)
-#else
-#if __GNUC__ >= 4
+  #if !defined(FMI2_ACTUAL_FUNCTION_PREFIX)
+    #if defined _WIN32 || defined __CYGWIN__
+     /* Note: both gcc & MSVC on Windows support this syntax. */
+        #define FMI2_Export __declspec(dllexport)
+    #else
+      #if __GNUC__ >= 4
         #define FMI2_Export __attribute__ ((visibility ("default")))
-#else
+      #else
         #define FMI2_Export
-#endif
-#endif
-#else
+      #endif
+    #endif
+  #else
     #define FMI2_Export
-#endif
+  #endif
 #endif
 
 /* Macros to construct the real function name
    (prepend function name by FMI2_FUNCTION_PREFIX) */
-#if defined(FMI2_FUNCTION_PREFIX)
+#if defined(FMI2_ACTUAL_FUNCTION_PREFIX)
   #define fmi2Paste(a,b)     a ## b
   #define fmi2PasteB(a,b)    fmi2Paste(a,b)
-  #define fmi2FullName(name) fmi2PasteB(FMI2_FUNCTION_PREFIX, name)
+  #define fmi2FullName(name) fmi2PasteB(FMI2_ACTUAL_FUNCTION_PREFIX, name)
 #else
-#define fmi2FullName(name) name
+  #define fmi2FullName(name) name
 #endif
 
 /***************************************************
@@ -253,42 +257,42 @@ Common Functions
 ****************************************************/
 
 /* Inquire version numbers of header files */
-FMI2_Export fmi2GetTypesPlatformTYPE fmi2GetTypesPlatform;
-FMI2_Export fmi2GetVersionTYPE fmi2GetVersion;
-FMI2_Export fmi2SetDebugLoggingTYPE fmi2SetDebugLogging;
+   FMI2_Export fmi2GetTypesPlatformTYPE fmi2GetTypesPlatform;
+   FMI2_Export fmi2GetVersionTYPE       fmi2GetVersion;
+   FMI2_Export fmi2SetDebugLoggingTYPE  fmi2SetDebugLogging;
 
 /* Creation and destruction of FMU instances */
-FMI2_Export fmi2InstantiateTYPE fmi2Instantiate;
-FMI2_Export fmi2FreeInstanceTYPE fmi2FreeInstance;
+   FMI2_Export fmi2InstantiateTYPE  fmi2Instantiate;
+   FMI2_Export fmi2FreeInstanceTYPE fmi2FreeInstance;
 
 /* Enter and exit initialization mode, terminate and reset */
-FMI2_Export fmi2SetupExperimentTYPE fmi2SetupExperiment;
-FMI2_Export fmi2EnterInitializationModeTYPE fmi2EnterInitializationMode;
-FMI2_Export fmi2ExitInitializationModeTYPE fmi2ExitInitializationMode;
-FMI2_Export fmi2TerminateTYPE fmi2Terminate;
-FMI2_Export fmi2ResetTYPE fmi2Reset;
+   FMI2_Export fmi2SetupExperimentTYPE         fmi2SetupExperiment;
+   FMI2_Export fmi2EnterInitializationModeTYPE fmi2EnterInitializationMode;
+   FMI2_Export fmi2ExitInitializationModeTYPE  fmi2ExitInitializationMode;
+   FMI2_Export fmi2TerminateTYPE               fmi2Terminate;
+   FMI2_Export fmi2ResetTYPE                   fmi2Reset;
 
 /* Getting and setting variables values */
-FMI2_Export fmi2GetRealTYPE fmi2GetReal;
-FMI2_Export fmi2GetIntegerTYPE fmi2GetInteger;
-FMI2_Export fmi2GetBooleanTYPE fmi2GetBoolean;
-FMI2_Export fmi2GetStringTYPE fmi2GetString;
+   FMI2_Export fmi2GetRealTYPE    fmi2GetReal;
+   FMI2_Export fmi2GetIntegerTYPE fmi2GetInteger;
+   FMI2_Export fmi2GetBooleanTYPE fmi2GetBoolean;
+   FMI2_Export fmi2GetStringTYPE  fmi2GetString;
 
-FMI2_Export fmi2SetRealTYPE fmi2SetReal;
-FMI2_Export fmi2SetIntegerTYPE fmi2SetInteger;
-FMI2_Export fmi2SetBooleanTYPE fmi2SetBoolean;
-FMI2_Export fmi2SetStringTYPE fmi2SetString;
+   FMI2_Export fmi2SetRealTYPE    fmi2SetReal;
+   FMI2_Export fmi2SetIntegerTYPE fmi2SetInteger;
+   FMI2_Export fmi2SetBooleanTYPE fmi2SetBoolean;
+   FMI2_Export fmi2SetStringTYPE  fmi2SetString;
 
 /* Getting and setting the internal FMU state */
-FMI2_Export fmi2GetFMUstateTYPE fmi2GetFMUstate;
-FMI2_Export fmi2SetFMUstateTYPE fmi2SetFMUstate;
-FMI2_Export fmi2FreeFMUstateTYPE fmi2FreeFMUstate;
-FMI2_Export fmi2SerializedFMUstateSizeTYPE fmi2SerializedFMUstateSize;
-FMI2_Export fmi2SerializeFMUstateTYPE fmi2SerializeFMUstate;
-FMI2_Export fmi2DeSerializeFMUstateTYPE fmi2DeSerializeFMUstate;
+   FMI2_Export fmi2GetFMUstateTYPE            fmi2GetFMUstate;
+   FMI2_Export fmi2SetFMUstateTYPE            fmi2SetFMUstate;
+   FMI2_Export fmi2FreeFMUstateTYPE           fmi2FreeFMUstate;
+   FMI2_Export fmi2SerializedFMUstateSizeTYPE fmi2SerializedFMUstateSize;
+   FMI2_Export fmi2SerializeFMUstateTYPE      fmi2SerializeFMUstate;
+   FMI2_Export fmi2DeSerializeFMUstateTYPE    fmi2DeSerializeFMUstate;
 
 /* Getting partial derivatives */
-FMI2_Export fmi2GetDirectionalDerivativeTYPE fmi2GetDirectionalDerivative;
+   FMI2_Export fmi2GetDirectionalDerivativeTYPE fmi2GetDirectionalDerivative;
 
 
 /***************************************************
@@ -296,20 +300,20 @@ Functions for FMI2 for Model Exchange
 ****************************************************/
 
 /* Enter and exit the different modes */
-FMI2_Export fmi2EnterEventModeTYPE fmi2EnterEventMode;
-FMI2_Export fmi2NewDiscreteStatesTYPE fmi2NewDiscreteStates;
-FMI2_Export fmi2EnterContinuousTimeModeTYPE fmi2EnterContinuousTimeMode;
-FMI2_Export fmi2CompletedIntegratorStepTYPE fmi2CompletedIntegratorStep;
+   FMI2_Export fmi2EnterEventModeTYPE               fmi2EnterEventMode;
+   FMI2_Export fmi2NewDiscreteStatesTYPE            fmi2NewDiscreteStates;
+   FMI2_Export fmi2EnterContinuousTimeModeTYPE      fmi2EnterContinuousTimeMode;
+   FMI2_Export fmi2CompletedIntegratorStepTYPE      fmi2CompletedIntegratorStep;
 
 /* Providing independent variables and re-initialization of caching */
-FMI2_Export fmi2SetTimeTYPE fmi2SetTime;
-FMI2_Export fmi2SetContinuousStatesTYPE fmi2SetContinuousStates;
+   FMI2_Export fmi2SetTimeTYPE             fmi2SetTime;
+   FMI2_Export fmi2SetContinuousStatesTYPE fmi2SetContinuousStates;
 
 /* Evaluation of the model equations */
-FMI2_Export fmi2GetDerivativesTYPE fmi2GetDerivatives;
-FMI2_Export fmi2GetEventIndicatorsTYPE fmi2GetEventIndicators;
-FMI2_Export fmi2GetContinuousStatesTYPE fmi2GetContinuousStates;
-FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;
+   FMI2_Export fmi2GetDerivativesTYPE                fmi2GetDerivatives;
+   FMI2_Export fmi2GetEventIndicatorsTYPE            fmi2GetEventIndicators;
+   FMI2_Export fmi2GetContinuousStatesTYPE           fmi2GetContinuousStates;
+   FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;
 
 
 /***************************************************
@@ -317,21 +321,21 @@ Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-FMI2_Export fmi2SetRealInputDerivativesTYPE fmi2SetRealInputDerivatives;
-FMI2_Export fmi2GetRealOutputDerivativesTYPE fmi2GetRealOutputDerivatives;
+   FMI2_Export fmi2SetRealInputDerivativesTYPE  fmi2SetRealInputDerivatives;
+   FMI2_Export fmi2GetRealOutputDerivativesTYPE fmi2GetRealOutputDerivatives;
 
-FMI2_Export fmi2DoStepTYPE fmi2DoStep;
-FMI2_Export fmi2CancelStepTYPE fmi2CancelStep;
+   FMI2_Export fmi2DoStepTYPE     fmi2DoStep;
+   FMI2_Export fmi2CancelStepTYPE fmi2CancelStep;
 
 /* Inquire slave status */
-FMI2_Export fmi2GetStatusTYPE fmi2GetStatus;
-FMI2_Export fmi2GetRealStatusTYPE fmi2GetRealStatus;
-FMI2_Export fmi2GetIntegerStatusTYPE fmi2GetIntegerStatus;
-FMI2_Export fmi2GetBooleanStatusTYPE fmi2GetBooleanStatus;
-FMI2_Export fmi2GetStringStatusTYPE fmi2GetStringStatus;
+   FMI2_Export fmi2GetStatusTYPE        fmi2GetStatus;
+   FMI2_Export fmi2GetRealStatusTYPE    fmi2GetRealStatus;
+   FMI2_Export fmi2GetIntegerStatusTYPE fmi2GetIntegerStatus;
+   FMI2_Export fmi2GetBooleanStatusTYPE fmi2GetBooleanStatus;
+   FMI2_Export fmi2GetStringStatusTYPE  fmi2GetStringStatus;
 
 #ifdef __cplusplus
-} /* end of extern "C" { */
+}  /* end of extern "C" { */
 #endif
 
 #endif /* fmi2Functions_h */

--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/FMU2/fmi2TypesPlatform.h
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/include/FMU2/fmi2TypesPlatform.h
@@ -6,12 +6,13 @@
 #define fmi2TypesPlatform_h
 
 /* Standard header file to define the argument types of the
-   functions of the Functional Mock-up Interface 2.0.
+   functions of the Functional Mock-up Interface 2.0.4
    This header file must be utilized both by the model and
    by the simulation engine.
 
    Revisions:
-   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Sep. 29, 2019:  License changed to 2-clause BSD License (without extensions)
+   - Apr.  9, 2014:  All prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Mar   31, 2014: New datatype fmiChar introduced.
    - Feb.  17, 2013: Changed fmiTypesPlatform from "standard32" to "default".
                      Removed fmiUndefinedValueReference since no longer needed
@@ -42,11 +43,12 @@
                      Hans Olsson (Dynasim).
 
 
-   Copyright © 2008-2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -54,12 +56,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -73,13 +73,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 /* Platform (unique identification of this header file) */
@@ -100,16 +93,16 @@
                              ('\0' terminated, UTF8 encoded)
    fmi2Byte                : smallest addressable unit of the machine, typically one byte.
 */
-typedef void* fmi2Component; /* Pointer to FMU instance       */
-typedef void* fmi2ComponentEnvironment; /* Pointer to FMU environment    */
-typedef void* fmi2FMUstate; /* Pointer to internal FMU state */
-typedef unsigned int fmi2ValueReference;
-typedef double fmi2Real;
-typedef int fmi2Integer;
-typedef int fmi2Boolean;
-typedef char fmi2Char;
-typedef const fmi2Char* fmi2String;
-typedef char fmi2Byte;
+   typedef void*           fmi2Component;               /* Pointer to FMU instance       */
+   typedef void*           fmi2ComponentEnvironment;    /* Pointer to FMU environment    */
+   typedef void*           fmi2FMUstate;                /* Pointer to internal FMU state */
+   typedef unsigned int    fmi2ValueReference;
+   typedef double          fmi2Real   ;
+   typedef int             fmi2Integer;
+   typedef int             fmi2Boolean;
+   typedef char            fmi2Char;
+   typedef const fmi2Char* fmi2String;
+   typedef char            fmi2Byte;
 
 /* Values for fmi2Boolean  */
 #define fmi2True  1

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -475,7 +475,7 @@ void warningStreamPrintWithLimit(int stream, int indentNext, unsigned long nDisp
     va_warningStreamPrint(stream, indentNext, format, args);
   }
   if (nDisplayed == maxWarnDisplays) {
-    infoStreamPrint(stream, indentNext, "Too many warnings, reached display limit of %u. "
+    infoStreamPrint(stream, indentNext, "Too many warnings, reached display limit of %lu. "
                                         "Suppressing further warning messages of the same type.", maxWarnDisplays);
     infoStreamPrint(stream, indentNext, "Change limit with simulation flag -%s=<newLimit>", FLAG_NAME[FLAG_LV_MAX_WARN]);
     messageClose(stream);

--- a/OMCompiler/SimulationRuntime/cpp/FMU2/fmi2FunctionTypes.h
+++ b/OMCompiler/SimulationRuntime/cpp/FMU2/fmi2FunctionTypes.h
@@ -8,9 +8,12 @@
 #include "fmi2TypesPlatform.h"
 
 /* This header file must be utilized when compiling an FMU or an FMI master.
-   It declares data and function types for FMI 2.0
+   It declares data and function types for FMI 2.0.4
 
    Revisions:
+   - Sep. 30, 2019: License changed to 2-clause BSD License (without extensions)
+   - Jul.  5, 2019: Remove const modifier from fields of fmi2CallbackFunctions  (#216)
+   - Sep.  6, 2018: Parameter names added to function prototypes
    - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Apr.  3, 2014: Added #include <stddef.h> for size_t definition
    - Mar. 27, 2014: Added #include "fmiTypesPlatform.h" (#179)
@@ -50,11 +53,12 @@
    - Nov. 14, 2011: First public Version
 
 
-   Copyright © 2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -62,12 +66,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -81,13 +83,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 #ifdef __cplusplus
@@ -125,17 +120,23 @@ typedef enum {
     fmi2Terminated
 } fmi2StatusKind;
 
-typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment, fmi2String, fmi2Status, fmi2String, fmi2String, ...);
-typedef void*     (*fmi2CallbackAllocateMemory)(size_t, size_t);
-typedef void      (*fmi2CallbackFreeMemory)    (void*);
-typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment, fmi2Status);
+typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment componentEnvironment,
+                                                fmi2String instanceName,
+                                                fmi2Status status,
+                                                fmi2String category,
+                                                fmi2String message,
+                                                ...);
+typedef void*     (*fmi2CallbackAllocateMemory)(size_t nobj, size_t size);
+typedef void      (*fmi2CallbackFreeMemory)    (void* obj);
+typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment componentEnvironment,
+                                                fmi2Status status);
 
 typedef struct {
-   const fmi2CallbackLogger         logger;
-   const fmi2CallbackAllocateMemory allocateMemory;
-   const fmi2CallbackFreeMemory     freeMemory;
-   const fmi2StepFinished           stepFinished;
-   const fmi2ComponentEnvironment   componentEnvironment;
+   fmi2CallbackLogger         logger;
+   fmi2CallbackAllocateMemory allocateMemory;
+   fmi2CallbackFreeMemory     freeMemory;
+   fmi2StepFinished           stepFinished;
+   fmi2ComponentEnvironment   componentEnvironment;
 } fmi2CallbackFunctions;
 
 typedef struct {
@@ -161,64 +162,83 @@ Types for Common Functions
 ****************************************************/
 
 /* Inquire version numbers of header files and setting logging status */
-   typedef const char* fmi2GetTypesPlatformTYPE(void);
-   typedef const char* fmi2GetVersionTYPE(void);
-   typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component, fmi2Boolean, size_t, const fmi2String[]);
+    typedef const char* fmi2GetTypesPlatformTYPE(void);
+    typedef const char* fmi2GetVersionTYPE(void);
+    typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component c,
+                                                fmi2Boolean loggingOn,
+                                                size_t nCategories,
+                                                const fmi2String categories[]);
 
 /* Creation and destruction of FMU instances and setting debug status */
-   typedef fmi2Component fmi2InstantiateTYPE (fmi2String, fmi2Type, fmi2String, fmi2String, const fmi2CallbackFunctions*, fmi2Boolean, fmi2Boolean);
-   typedef void          fmi2FreeInstanceTYPE(fmi2Component);
+    typedef fmi2Component fmi2InstantiateTYPE(fmi2String instanceName,
+                                              fmi2Type fmuType,
+                                              fmi2String fmuGUID,
+                                              fmi2String fmuResourceLocation,
+                                              const fmi2CallbackFunctions* functions,
+                                              fmi2Boolean visible,
+                                              fmi2Boolean loggingOn);
+   typedef void          fmi2FreeInstanceTYPE(fmi2Component c);
 
 /* Enter and exit initialization mode, terminate and reset */
-   typedef fmi2Status fmi2SetupExperimentTYPE        (fmi2Component, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
-   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component);
-   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component);
-   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component);
-   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component);
+    typedef fmi2Status fmi2SetupExperimentTYPE       (fmi2Component c,
+                                                      fmi2Boolean toleranceDefined,
+                                                      fmi2Real tolerance,
+                                                      fmi2Real startTime,
+                                                      fmi2Boolean stopTimeDefined,
+                                                      fmi2Real stopTime);
+   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component c);
+   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component c);
+   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component c);
+   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component c);
 
 /* Getting and setting variable values */
-   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, fmi2Real   []);
-   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Integer[]);
-   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Boolean[]);
-   typedef fmi2Status fmi2GetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, fmi2String []);
+   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real    value[]);
+   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[]);
+   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[]);
+   typedef fmi2Status fmi2GetStringTYPE (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String  value[]);
 
-   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, const fmi2Real   []);
-   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Integer[]);
-   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
-   typedef fmi2Status fmi2SetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, const fmi2String []);
+   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real    value[]);
+   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]);
+   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
+   typedef fmi2Status fmi2SetStringTYPE (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String  value[]);
 
 /* Getting and setting the internal FMU state */
-   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component, fmi2FMUstate*);
-   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component, fmi2FMUstate);
-   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component, fmi2FMUstate*);
-   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component, fmi2FMUstate, size_t*);
-   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component, fmi2FMUstate, fmi2Byte[], size_t);
-   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component, const fmi2Byte[], size_t, fmi2FMUstate*);
+   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component c, fmi2FMUstate* FMUstate);
+   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component c, fmi2FMUstate  FMUstate);
+   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component c, fmi2FMUstate* FMUstate);
+   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component c, fmi2FMUstate  FMUstate, size_t* size);
+   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component c, fmi2FMUstate  FMUstate, fmi2Byte serializedState[], size_t size);
+   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate);
 
 /* Getting partial derivatives */
-   typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component, const fmi2ValueReference[], size_t,
-                                                                   const fmi2ValueReference[], size_t,
-                                                                   const fmi2Real[], fmi2Real[]);
+    typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component c,
+                                                        const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
+                                                        const fmi2ValueReference vKnown_ref[],   size_t nKnown,
+                                                        const fmi2Real dvKnown[],
+                                                        fmi2Real dvUnknown[]);
 
 /***************************************************
 Types for Functions for FMI2 for Model Exchange
 ****************************************************/
 
 /* Enter and exit the different modes */
-   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component);
-   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component, fmi2EventInfo*);
-   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component);
-   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component c);
+   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component c, fmi2EventInfo* fmi2eventInfo);
+   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component c);
+   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component c,
+                                                      fmi2Boolean   noSetFMUStatePriorToCurrentPoint,
+                                                      fmi2Boolean*  enterEventMode,
+                                                      fmi2Boolean*  terminateSimulation);
 
 /* Providing independent variables and re-initialization of caching */
-   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component, fmi2Real);
-   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component, const fmi2Real[], size_t);
+   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component c, fmi2Real time);
+   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component c, const fmi2Real x[], size_t nx);
 
 /* Evaluation of the model equations */
-   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component, fmi2Real[], size_t);
-   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component, fmi2Real[], size_t);
-   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component, fmi2Real[], size_t);
-   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component c, fmi2Real derivatives[],     size_t nx);
+   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component c, fmi2Real eventIndicators[], size_t ni);
+   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component c, fmi2Real x[],               size_t nx);
+   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component c, fmi2Real x_nominal[],       size_t nx);
 
 
 /***************************************************
@@ -226,18 +246,26 @@ Types for Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-   typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], const fmi2Real []);
-   typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], fmi2Real []);
-
-   typedef fmi2Status fmi2DoStepTYPE     (fmi2Component, fmi2Real, fmi2Real, fmi2Boolean);
-   typedef fmi2Status fmi2CancelStepTYPE (fmi2Component);
+    typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component c,
+                                                        const fmi2ValueReference vr[], size_t nvr,
+                                                        const fmi2Integer order[],
+                                                        const fmi2Real value[]);
+    typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component c,
+                                                        const fmi2ValueReference vr[], size_t nvr,
+                                                        const fmi2Integer order[],
+                                                        fmi2Real value[]);
+    typedef fmi2Status fmi2DoStepTYPE   (fmi2Component c,
+                                         fmi2Real      currentCommunicationPoint,
+                                         fmi2Real      communicationStepSize,
+                                         fmi2Boolean   noSetFMUStatePriorToCurrentPoint);
+   typedef fmi2Status fmi2CancelStepTYPE(fmi2Component c);
 
 /* Inquire slave status */
-   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component, const fmi2StatusKind, fmi2Status* );
-   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component, const fmi2StatusKind, fmi2Real*   );
-   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Integer*);
-   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Boolean*);
-   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component, const fmi2StatusKind, fmi2String* );
+   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component c, const fmi2StatusKind s, fmi2Status*  value);
+   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component c, const fmi2StatusKind s, fmi2Real*    value);
+   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value);
+   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value);
+   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component c, const fmi2StatusKind s, fmi2String*  value);
 
 
 #ifdef __cplusplus
@@ -245,4 +273,5 @@ Types for Functions for FMI2 for Co-Simulation
 #endif
 
 #endif /* fmi2FunctionTypes_h */
+
 /** @} */ // end of fmu2

--- a/OMCompiler/SimulationRuntime/cpp/FMU2/fmi2Functions.h
+++ b/OMCompiler/SimulationRuntime/cpp/FMU2/fmi2Functions.h
@@ -7,7 +7,7 @@
 
 /* This header file must be utilized when compiling a FMU.
    It defines all functions of the
-         FMI 2.0 Model Exchange and Co-Simulation Interface.
+         FMI 2.0.4 Model Exchange and Co-Simulation Interface.
 
    In order to have unique function names even if several FMUs
    are compiled together (e.g. for embedded systems), every "real" function name
@@ -25,7 +25,9 @@
    names are used and "FMI2_FUNCTION_PREFIX" must not be defined.
 
    Revisions:
-   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Sep. 13, 2022: Provide FMI2_OVERRIDE_FUNCTION_PREFIX functionality
+   - Sep. 29, 2019: License changed to 2-clause BSD License (without extensions)
+   - Apr.  9, 2014: All prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Mar. 26, 2014: FMI_Export set to empty value if FMI_Export and FMI_FUNCTION_PREFIX
                     are not defined (#173)
    - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
@@ -104,11 +106,13 @@
                     meeting with additional improvements (by Martin Otter, DLR).
    - Dec. 3 , 2008: First version by Martin Otter (DLR) and Hans Olsson (Dynasim).
 
-   Copyright © 2008-2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -116,12 +120,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -135,13 +137,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 #ifdef __cplusplus
@@ -152,6 +147,15 @@ extern "C" {
 #include "fmi2FunctionTypes.h"
 #include <stdlib.h>
 
+/*
+Allow override of FMI2_FUNCTION_PREFIX: If FMI2_OVERRIDE_FUNCTION_PREFIX
+is defined, then FMI2_ACTUAL_FUNCTION_PREFIX will be used, if defined,
+or no prefix if undefined. Otherwise FMI2_FUNCTION_PREFIX will be used,
+if defined.
+*/
+#if !defined(FMI2_OVERRIDE_FUNCTION_PREFIX) && defined(FMI2_FUNCTION_PREFIX)
+  #define FMI2_ACTUAL_FUNCTION_PREFIX FMI2_FUNCTION_PREFIX
+#endif
 
 /*
   Export FMI2 API functions on Windows and under GCC.
@@ -160,7 +164,7 @@ extern "C" {
   it may be set to __declspec(dllimport).
 */
 #if !defined(FMI2_Export)
-  #if !defined(FMI2_FUNCTION_PREFIX)
+  #if !defined(FMI2_ACTUAL_FUNCTION_PREFIX)
     #if defined _WIN32 || defined __CYGWIN__
      /* Note: both gcc & MSVC on Windows support this syntax. */
         #define FMI2_Export __declspec(dllexport)
@@ -178,10 +182,10 @@ extern "C" {
 
 /* Macros to construct the real function name
    (prepend function name by FMI2_FUNCTION_PREFIX) */
-#if defined(FMI2_FUNCTION_PREFIX)
+#if defined(FMI2_ACTUAL_FUNCTION_PREFIX)
   #define fmi2Paste(a,b)     a ## b
   #define fmi2PasteB(a,b)    fmi2Paste(a,b)
-  #define fmi2FullName(name) fmi2PasteB(FMI2_FUNCTION_PREFIX, name)
+  #define fmi2FullName(name) fmi2PasteB(FMI2_ACTUAL_FUNCTION_PREFIX, name)
 #else
   #define fmi2FullName(name) name
 #endif

--- a/OMCompiler/SimulationRuntime/cpp/FMU2/fmi2TypesPlatform.h
+++ b/OMCompiler/SimulationRuntime/cpp/FMU2/fmi2TypesPlatform.h
@@ -6,12 +6,13 @@
 #define fmi2TypesPlatform_h
 
 /* Standard header file to define the argument types of the
-   functions of the Functional Mock-up Interface 2.0.
+   functions of the Functional Mock-up Interface 2.0.4
    This header file must be utilized both by the model and
    by the simulation engine.
 
    Revisions:
-   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Sep. 29, 2019:  License changed to 2-clause BSD License (without extensions)
+   - Apr.  9, 2014:  All prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Mar   31, 2014: New datatype fmiChar introduced.
    - Feb.  17, 2013: Changed fmiTypesPlatform from "standard32" to "default".
                      Removed fmiUndefinedValueReference since no longer needed
@@ -42,11 +43,12 @@
                      Hans Olsson (Dynasim).
 
 
-   Copyright © 2008-2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -54,12 +56,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -73,13 +73,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 /* Platform (unique identification of this header file) */

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -146,9 +146,12 @@ target_include_directories(${FMU_NAME} PRIVATE ${FMI_INTERFACE_HEADER_FILES_DIRE
 
 # Set compiler definitions
 target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL${WITH_SUNDIALS})
-if(NOT BUILD_SHARED_LIBS)
-  # Define FMI2_FUNCTION_PREFIX if FMU compiled statically
-  target_compile_definitions(${FMU_NAME} PRIVATE FMI2_FUNCTION_PREFIX=${FMU_NAME}_)
+if(BUILD_SHARED_LIBS)
+  # Override FMI2_FUNCTION_PREFIX if FMU compiled dynmically
+  target_compile_definitions(${FMU_NAME} PRIVATE FMI2_OVERRIDE_FUNCTION_PREFIX)
+  message(STATUS "Not using FMI2_FUNCTION_PREFIX")
+else()
+  message(STATUS "Using FMI2_FUNCTION_PREFIX")
 endif()
 
 # Install target

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -147,7 +147,7 @@ target_include_directories(${FMU_NAME} PRIVATE ${FMI_INTERFACE_HEADER_FILES_DIRE
 # Set compiler definitions
 target_compile_definitions(${FMU_NAME} PRIVATE OMC_MINIMAL_RUNTIME=1;OMC_FMI_RUNTIME=1;CMINPACK_NO_DLL${WITH_SUNDIALS})
 if(BUILD_SHARED_LIBS)
-  # Override FMI2_FUNCTION_PREFIX if FMU compiled dynmically
+  # Override FMI2_FUNCTION_PREFIX if FMU compiled dynamically
   target_compile_definitions(${FMU_NAME} PRIVATE FMI2_OVERRIDE_FUNCTION_PREFIX)
   message(STATUS "Not using FMI2_FUNCTION_PREFIX")
 else()

--- a/OMCompiler/SimulationRuntime/fmi/export/fmi/fmi2FunctionTypes.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/fmi/fmi2FunctionTypes.h
@@ -4,9 +4,12 @@
 #include "fmi2TypesPlatform.h"
 
 /* This header file must be utilized when compiling an FMU or an FMI master.
-   It declares data and function types for FMI 2.0
+   It declares data and function types for FMI 2.0.4
 
    Revisions:
+   - Sep. 30, 2019: License changed to 2-clause BSD License (without extensions)
+   - Jul.  5, 2019: Remove const modifier from fields of fmi2CallbackFunctions  (#216)
+   - Sep.  6, 2018: Parameter names added to function prototypes
    - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Apr.  3, 2014: Added #include <stddef.h> for size_t definition
    - Mar. 27, 2014: Added #include "fmiTypesPlatform.h" (#179)
@@ -46,11 +49,12 @@
    - Nov. 14, 2011: First public Version
 
 
-   Copyright (C) 2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+   Copyright (C) 2008-2011 MODELISAR consortium,
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -58,12 +62,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -77,13 +79,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 #ifdef __cplusplus
@@ -121,17 +116,23 @@ typedef enum {
     fmi2Terminated
 } fmi2StatusKind;
 
-typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment, fmi2String, fmi2Status, fmi2String, fmi2String, ...);
-typedef void*     (*fmi2CallbackAllocateMemory)(size_t, size_t);
-typedef void      (*fmi2CallbackFreeMemory)    (void*);
-typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment, fmi2Status);
+typedef void      (*fmi2CallbackLogger)        (fmi2ComponentEnvironment componentEnvironment,
+                                                fmi2String instanceName,
+                                                fmi2Status status,
+                                                fmi2String category,
+                                                fmi2String message,
+                                                ...);
+typedef void*     (*fmi2CallbackAllocateMemory)(size_t nobj, size_t size);
+typedef void      (*fmi2CallbackFreeMemory)    (void* obj);
+typedef void      (*fmi2StepFinished)          (fmi2ComponentEnvironment componentEnvironment,
+                                                fmi2Status status);
 
 typedef struct {
-   const fmi2CallbackLogger         logger;
-   const fmi2CallbackAllocateMemory allocateMemory;
-   const fmi2CallbackFreeMemory     freeMemory;
-   const fmi2StepFinished           stepFinished;
-   const fmi2ComponentEnvironment   componentEnvironment;
+   fmi2CallbackLogger         logger;
+   fmi2CallbackAllocateMemory allocateMemory;
+   fmi2CallbackFreeMemory     freeMemory;
+   fmi2StepFinished           stepFinished;
+   fmi2ComponentEnvironment   componentEnvironment;
 } fmi2CallbackFunctions;
 
 typedef struct {
@@ -157,68 +158,83 @@ Types for Common Functions
 ****************************************************/
 
 /* Inquire version numbers of header files and setting logging status */
-   typedef const char* fmi2GetTypesPlatformTYPE(void);
-   typedef const char* fmi2GetVersionTYPE(void);
-   typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component, fmi2Boolean, size_t, const fmi2String[]);
+    typedef const char* fmi2GetTypesPlatformTYPE(void);
+    typedef const char* fmi2GetVersionTYPE(void);
+    typedef fmi2Status  fmi2SetDebugLoggingTYPE(fmi2Component c,
+                                                fmi2Boolean loggingOn,
+                                                size_t nCategories,
+                                                const fmi2String categories[]);
 
 /* Creation and destruction of FMU instances and setting debug status */
-   typedef fmi2Component fmi2InstantiateTYPE (fmi2String, fmi2Type, fmi2String, fmi2String, const fmi2CallbackFunctions*, fmi2Boolean, fmi2Boolean);
-   typedef void          fmi2FreeInstanceTYPE(fmi2Component);
+    typedef fmi2Component fmi2InstantiateTYPE(fmi2String instanceName,
+                                              fmi2Type fmuType,
+                                              fmi2String fmuGUID,
+                                              fmi2String fmuResourceLocation,
+                                              const fmi2CallbackFunctions* functions,
+                                              fmi2Boolean visible,
+                                              fmi2Boolean loggingOn);
+   typedef void          fmi2FreeInstanceTYPE(fmi2Component c);
 
 /* Enter and exit initialization mode, terminate and reset */
-   typedef fmi2Status fmi2SetupExperimentTYPE        (fmi2Component, fmi2Boolean, fmi2Real, fmi2Real, fmi2Boolean, fmi2Real);
-   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component);
-   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component);
-   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component);
-   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component);
+    typedef fmi2Status fmi2SetupExperimentTYPE       (fmi2Component c,
+                                                      fmi2Boolean toleranceDefined,
+                                                      fmi2Real tolerance,
+                                                      fmi2Real startTime,
+                                                      fmi2Boolean stopTimeDefined,
+                                                      fmi2Real stopTime);
+   typedef fmi2Status fmi2EnterInitializationModeTYPE(fmi2Component c);
+   typedef fmi2Status fmi2ExitInitializationModeTYPE (fmi2Component c);
+   typedef fmi2Status fmi2TerminateTYPE              (fmi2Component c);
+   typedef fmi2Status fmi2ResetTYPE                  (fmi2Component c);
 
 /* Getting and setting variable values */
-   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, fmi2Real   []);
-   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Integer[]);
-   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, fmi2Boolean[]);
-   typedef fmi2Status fmi2GetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, fmi2String []);
+   typedef fmi2Status fmi2GetRealTYPE   (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Real    value[]);
+   typedef fmi2Status fmi2GetIntegerTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Integer value[]);
+   typedef fmi2Status fmi2GetBooleanTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2Boolean value[]);
+   typedef fmi2Status fmi2GetStringTYPE (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, fmi2String  value[]);
 
-   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component, const fmi2ValueReference[], size_t, const fmi2Real   []);
-   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Integer[]);
-   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component, const fmi2ValueReference[], size_t, const fmi2Boolean[]);
-   typedef fmi2Status fmi2SetStringTYPE (fmi2Component, const fmi2ValueReference[], size_t, const fmi2String []);
+   typedef fmi2Status fmi2SetRealTYPE   (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Real    value[]);
+   typedef fmi2Status fmi2SetIntegerTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Integer value[]);
+   typedef fmi2Status fmi2SetBooleanTYPE(fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2Boolean value[]);
+   typedef fmi2Status fmi2SetStringTYPE (fmi2Component c, const fmi2ValueReference vr[], size_t nvr, const fmi2String  value[]);
 
 /* Getting and setting the internal FMU state */
-   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component, fmi2FMUstate*);
-   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component, fmi2FMUstate);
-   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component, fmi2FMUstate*);
-   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component, fmi2FMUstate, size_t*);
-   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component, fmi2FMUstate, fmi2Byte[], size_t);
-   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component, const fmi2Byte[], size_t, fmi2FMUstate*);
+   typedef fmi2Status fmi2GetFMUstateTYPE           (fmi2Component c, fmi2FMUstate* FMUstate);
+   typedef fmi2Status fmi2SetFMUstateTYPE           (fmi2Component c, fmi2FMUstate  FMUstate);
+   typedef fmi2Status fmi2FreeFMUstateTYPE          (fmi2Component c, fmi2FMUstate* FMUstate);
+   typedef fmi2Status fmi2SerializedFMUstateSizeTYPE(fmi2Component c, fmi2FMUstate  FMUstate, size_t* size);
+   typedef fmi2Status fmi2SerializeFMUstateTYPE     (fmi2Component c, fmi2FMUstate  FMUstate, fmi2Byte serializedState[], size_t size);
+   typedef fmi2Status fmi2DeSerializeFMUstateTYPE   (fmi2Component c, const fmi2Byte serializedState[], size_t size, fmi2FMUstate* FMUstate);
 
 /* Getting partial derivatives */
-   typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component, const fmi2ValueReference[], size_t,
-                                                                   const fmi2ValueReference[], size_t,
-                                                                   const fmi2Real[], fmi2Real[]);
+    typedef fmi2Status fmi2GetDirectionalDerivativeTYPE(fmi2Component c,
+                                                        const fmi2ValueReference vUnknown_ref[], size_t nUnknown,
+                                                        const fmi2ValueReference vKnown_ref[],   size_t nKnown,
+                                                        const fmi2Real dvKnown[],
+                                                        fmi2Real dvUnknown[]);
 
 /***************************************************
 Types for Functions for FMI2 for Model Exchange
 ****************************************************/
 
 /* Enter and exit the different modes */
-   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component);
-   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component, fmi2EventInfo*);
-   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component);
-   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component, fmi2Boolean, fmi2Boolean*, fmi2Boolean*);
+   typedef fmi2Status fmi2EnterEventModeTYPE         (fmi2Component c);
+   typedef fmi2Status fmi2NewDiscreteStatesTYPE      (fmi2Component c, fmi2EventInfo* fmi2eventInfo);
+   typedef fmi2Status fmi2EnterContinuousTimeModeTYPE(fmi2Component c);
+   typedef fmi2Status fmi2CompletedIntegratorStepTYPE(fmi2Component c,
+                                                      fmi2Boolean   noSetFMUStatePriorToCurrentPoint,
+                                                      fmi2Boolean*  enterEventMode,
+                                                      fmi2Boolean*  terminateSimulation);
 
 /* Providing independent variables and re-initialization of caching */
-   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component, fmi2Real);
-   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component, const fmi2Real[], size_t);
+   typedef fmi2Status fmi2SetTimeTYPE            (fmi2Component c, fmi2Real time);
+   typedef fmi2Status fmi2SetContinuousStatesTYPE(fmi2Component c, const fmi2Real x[], size_t nx);
 
 /* Evaluation of the model equations */
-   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component, fmi2Real[], size_t);
-#ifdef FMU_EXPERIMENTAL
-   typedef fmi2Status fmi2GetSpecificDerivativesTYPE       (fmi2Component, fmi2Real[], const fmi2ValueReference [], size_t);
-#endif
-
-   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component, fmi2Real[], size_t);
-   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component, fmi2Real[], size_t);
-   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component, fmi2Real[], size_t);
+   typedef fmi2Status fmi2GetDerivativesTYPE               (fmi2Component c, fmi2Real derivatives[],     size_t nx);
+   typedef fmi2Status fmi2GetEventIndicatorsTYPE           (fmi2Component c, fmi2Real eventIndicators[], size_t ni);
+   typedef fmi2Status fmi2GetContinuousStatesTYPE          (fmi2Component c, fmi2Real x[],               size_t nx);
+   typedef fmi2Status fmi2GetNominalsOfContinuousStatesTYPE(fmi2Component c, fmi2Real x_nominal[],       size_t nx);
 
 
 /***************************************************
@@ -226,18 +242,26 @@ Types for Functions for FMI2 for Co-Simulation
 ****************************************************/
 
 /* Simulating the slave */
-   typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], const fmi2Real []);
-   typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component, const fmi2ValueReference [], size_t, const fmi2Integer [], fmi2Real []);
-
-   typedef fmi2Status fmi2DoStepTYPE     (fmi2Component, fmi2Real, fmi2Real, fmi2Boolean);
-   typedef fmi2Status fmi2CancelStepTYPE (fmi2Component);
+    typedef fmi2Status fmi2SetRealInputDerivativesTYPE (fmi2Component c,
+                                                        const fmi2ValueReference vr[], size_t nvr,
+                                                        const fmi2Integer order[],
+                                                        const fmi2Real value[]);
+    typedef fmi2Status fmi2GetRealOutputDerivativesTYPE(fmi2Component c,
+                                                        const fmi2ValueReference vr[], size_t nvr,
+                                                        const fmi2Integer order[],
+                                                        fmi2Real value[]);
+    typedef fmi2Status fmi2DoStepTYPE   (fmi2Component c,
+                                         fmi2Real      currentCommunicationPoint,
+                                         fmi2Real      communicationStepSize,
+                                         fmi2Boolean   noSetFMUStatePriorToCurrentPoint);
+   typedef fmi2Status fmi2CancelStepTYPE(fmi2Component c);
 
 /* Inquire slave status */
-   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component, const fmi2StatusKind, fmi2Status* );
-   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component, const fmi2StatusKind, fmi2Real*   );
-   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Integer*);
-   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component, const fmi2StatusKind, fmi2Boolean*);
-   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component, const fmi2StatusKind, fmi2String* );
+   typedef fmi2Status fmi2GetStatusTYPE       (fmi2Component c, const fmi2StatusKind s, fmi2Status*  value);
+   typedef fmi2Status fmi2GetRealStatusTYPE   (fmi2Component c, const fmi2StatusKind s, fmi2Real*    value);
+   typedef fmi2Status fmi2GetIntegerStatusTYPE(fmi2Component c, const fmi2StatusKind s, fmi2Integer* value);
+   typedef fmi2Status fmi2GetBooleanStatusTYPE(fmi2Component c, const fmi2StatusKind s, fmi2Boolean* value);
+   typedef fmi2Status fmi2GetStringStatusTYPE (fmi2Component c, const fmi2StatusKind s, fmi2String*  value);
 
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/fmi/export/fmi/fmi2Functions.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/fmi/fmi2Functions.h
@@ -3,7 +3,7 @@
 
 /* This header file must be utilized when compiling a FMU.
    It defines all functions of the
-         FMI 2.0 Model Exchange and Co-Simulation Interface.
+         FMI 2.0.4 Model Exchange and Co-Simulation Interface.
 
    In order to have unique function names even if several FMUs
    are compiled together (e.g. for embedded systems), every "real" function name
@@ -21,7 +21,9 @@
    names are used and "FMI2_FUNCTION_PREFIX" must not be defined.
 
    Revisions:
-   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Sep. 13, 2022: Provide FMI2_OVERRIDE_FUNCTION_PREFIX functionality
+   - Sep. 29, 2019: License changed to 2-clause BSD License (without extensions)
+   - Apr.  9, 2014: All prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Mar. 26, 2014: FMI_Export set to empty value if FMI_Export and FMI_FUNCTION_PREFIX
                     are not defined (#173)
    - Oct. 11, 2013: Functions of ModelExchange and CoSimulation merged:
@@ -100,11 +102,13 @@
                     meeting with additional improvements (by Martin Otter, DLR).
    - Dec. 3 , 2008: First version by Martin Otter (DLR) and Hans Olsson (Dynasim).
 
+
    Copyright (C) 2008-2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -112,12 +116,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -131,13 +133,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 #ifdef __cplusplus
@@ -148,6 +143,15 @@ extern "C" {
 #include "fmi2FunctionTypes.h"
 #include <stdlib.h>
 
+/*
+Allow override of FMI2_FUNCTION_PREFIX: If FMI2_OVERRIDE_FUNCTION_PREFIX
+is defined, then FMI2_ACTUAL_FUNCTION_PREFIX will be used, if defined,
+or no prefix if undefined. Otherwise FMI2_FUNCTION_PREFIX will be used,
+if defined.
+*/
+#if !defined(FMI2_OVERRIDE_FUNCTION_PREFIX) && defined(FMI2_FUNCTION_PREFIX)
+  #define FMI2_ACTUAL_FUNCTION_PREFIX FMI2_FUNCTION_PREFIX
+#endif
 
 /*
   Export FMI2 API functions on Windows and under GCC.
@@ -156,7 +160,7 @@ extern "C" {
   it may be set to __declspec(dllimport).
 */
 #if !defined(FMI2_Export)
-  #if !defined(FMI2_FUNCTION_PREFIX)
+  #if !defined(FMI2_ACTUAL_FUNCTION_PREFIX)
     #if defined _WIN32 || defined __CYGWIN__
      /* Note: both gcc & MSVC on Windows support this syntax. */
         #define FMI2_Export __declspec(dllexport)
@@ -174,10 +178,10 @@ extern "C" {
 
 /* Macros to construct the real function name
    (prepend function name by FMI2_FUNCTION_PREFIX) */
-#if defined(FMI2_FUNCTION_PREFIX)
+#if defined(FMI2_ACTUAL_FUNCTION_PREFIX)
   #define fmi2Paste(a,b)     a ## b
   #define fmi2PasteB(a,b)    fmi2Paste(a,b)
-  #define fmi2FullName(name) fmi2PasteB(FMI2_FUNCTION_PREFIX, name)
+  #define fmi2FullName(name) fmi2PasteB(FMI2_ACTUAL_FUNCTION_PREFIX, name)
 #else
   #define fmi2FullName(name) name
 #endif
@@ -222,9 +226,6 @@ Functions for FMI2 for Model Exchange
 #define fmi2SetTime                       fmi2FullName(fmi2SetTime)
 #define fmi2SetContinuousStates           fmi2FullName(fmi2SetContinuousStates)
 #define fmi2GetDerivatives                fmi2FullName(fmi2GetDerivatives)
-#ifdef FMU_EXPERIMENTAL
-#define fmi2GetSpecificDerivatives        fmi2FullName(fmi2GetSpecificDerivatives)
-#endif
 #define fmi2GetEventIndicators            fmi2FullName(fmi2GetEventIndicators)
 #define fmi2GetContinuousStates           fmi2FullName(fmi2GetContinuousStates)
 #define fmi2GetNominalsOfContinuousStates fmi2FullName(fmi2GetNominalsOfContinuousStates)
@@ -306,9 +307,6 @@ Functions for FMI2 for Model Exchange
 
 /* Evaluation of the model equations */
    FMI2_Export fmi2GetDerivativesTYPE                fmi2GetDerivatives;
-#ifdef FMU_EXPERIMENTAL
-   FMI2_Export fmi2GetSpecificDerivativesTYPE        fmi2GetSpecificDerivatives;
-#endif
    FMI2_Export fmi2GetEventIndicatorsTYPE            fmi2GetEventIndicators;
    FMI2_Export fmi2GetContinuousStatesTYPE           fmi2GetContinuousStates;
    FMI2_Export fmi2GetNominalsOfContinuousStatesTYPE fmi2GetNominalsOfContinuousStates;

--- a/OMCompiler/SimulationRuntime/fmi/export/fmi/fmi2TypesPlatform.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/fmi/fmi2TypesPlatform.h
@@ -2,12 +2,13 @@
 #define fmi2TypesPlatform_h
 
 /* Standard header file to define the argument types of the
-   functions of the Functional Mock-up Interface 2.0.
+   functions of the Functional Mock-up Interface 2.0.4
    This header file must be utilized both by the model and
    by the simulation engine.
 
    Revisions:
-   - Apr.  9, 2014: all prefixes "fmi" renamed to "fmi2" (decision from April 8)
+   - Sep. 29, 2019:  License changed to 2-clause BSD License (without extensions)
+   - Apr.  9, 2014:  All prefixes "fmi" renamed to "fmi2" (decision from April 8)
    - Mar   31, 2014: New datatype fmiChar introduced.
    - Feb.  17, 2013: Changed fmiTypesPlatform from "standard32" to "default".
                      Removed fmiUndefinedValueReference since no longer needed
@@ -39,10 +40,11 @@
 
 
    Copyright (C) 2008-2011 MODELISAR consortium,
-               2012-2013 Modelica Association Project "FMI"
-               All rights reserved.
-   This file is licensed by the copyright holders under the BSD 2-Clause License
-   (http://www.opensource.org/licenses/bsd-license.html):
+                 2012-2022 Modelica Association Project "FMI"
+                 All rights reserved.
+
+   This file is licensed by the copyright holders under the 2-Clause BSD License
+   (https://opensource.org/licenses/BSD-2-Clause):
 
    ----------------------------------------------------------------------------
    Redistribution and use in source and binary forms, with or without
@@ -50,12 +52,10 @@
 
    - Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer.
+
    - Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
-   - Neither the name of the copyright holders nor the names of its
-     contributors may be used to endorse or promote products derived
-     from this software without specific prior written permission.
 
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -69,13 +69,6 @@
    OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
    ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    ----------------------------------------------------------------------------
-
-   with the extension:
-
-   You may distribute or publicly perform any modification only under the
-   terms of this license.
-   (Note, this means that if you distribute a modified file,
-    the modified file must also be provided under this license).
 */
 
 /* Platform (unique identification of this header file) */

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.h
@@ -31,7 +31,6 @@
 #ifndef __FMU2_MODEL_INTERFACE_H__
 #define __FMU2_MODEL_INTERFACE_H__
 
-#include "fmi2Functions.h"
 #include "../simulation_data.h"
 
 #ifdef __cplusplus

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.h
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu_read_flags.h
@@ -32,7 +32,6 @@
 #define __FMU_READ_FLAGS_H__
 
 #include "fmu2_model_interface.h"
-#include "fmi2Functions.h"
 #include "../simulation_data.h"
 
 #ifdef __cplusplus

--- a/testsuite/omsimulator/recompileFMU.mos
+++ b/testsuite/omsimulator/recompileFMU.mos
@@ -29,7 +29,7 @@ buildModelFMU(simpleLoop, version="2.0", fmuType="me"); getErrorString();
 // Re-build FMU
 system("unzip -o -qq simpleLoop.fmu -d simpleLoop_FMU/");
 remove("simpleLoop.fmu");
-system("cd simpleLoop_FMU/sources && ./configure CPPFLAGS=\"-I" + getInstallationDirectoryPath() + "/include/omc/c/fmi\" && make -s", "build_simpleLoop.log"); getErrorString();
+system("cd simpleLoop_FMU/sources && ./configure CPPFLAGS=\"-I" + getInstallationDirectoryPath() + "/include/omc/c/fmi -DFMI2_OVERRIDE_FUNCTION_PREFIX\" && make -s", "build_simpleLoop.log"); getErrorString();
 
 system(getInstallationDirectoryPath() + "/bin/OMSimulator simpleLoop.fmu", "simpleLoop_me_systemCall.log");
 readFile("simpleLoop_me_systemCall.log");


### PR DESCRIPTION
### Related Issues

Fixes  #10485, fixes #10545.

### Purpose

Define `FMI2_FUNCTION_PREFIX` in C sources for Source-Code FMUs.

### Approach

Using FMI 2.0.4 header files, adding `FMI2_FUNCTION_PREFIX` to C sources and defining `FMI2_OVERRIDE_FUNCTION_PREFIX` if the FMU is not Source-Code only.
