### PR TITLE
Suppress more errors in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1911,7 +1911,7 @@ algorithm
     case ComponentRef.CREF(node = InstNode.COMPONENT_NODE())
       algorithm
         if Component.hasCondition(InstNode.component(cref.node)) and
-           (not InstContext.inConnect(context) or InstContext.inSubscript(context)) then
+           (not InstContext.inConnect(context) or InstContext.inSubscript(context)) and not InstContext.inRelaxed(context) then
           Error.addStrictMessage(Error.CONDITIONAL_COMPONENT_INVALID_CONTEXT,
             {InstNode.name(cref.node)}, info);
         end if;


### PR DESCRIPTION
- Don't print errors about conditional components used incorrectly when in a relaxed context.
- Use a relaxed context when instantiating expressions in annotations.