### PR TITLE
Add error check for non-constants in classes

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -894,6 +894,7 @@ PackageConstant3.mo \
 PackageConstant4.mo \
 PackageConstant5.mo \
 PackageConstant6.mo \
+PackageConstant7.mo \
 ParameterBug.mos \
 ParameterDer.mo \
 PartialApplication1.mo \

--- a/testsuite/flattening/modelica/scodeinst/PackageConstant7.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageConstant7.mo
@@ -1,0 +1,24 @@
+// name: PackageConstant7
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model PackageConstant7
+  record R
+    Real x;
+  end R;
+
+  Real x = R.x;
+end PackageConstant7;
+
+// Result:
+// Error processing file: PackageConstant7.mo
+// [flattening/modelica/scodeinst/PackageConstant7.mo:9:5-9:11:writable] Notification: From here:
+// [flattening/modelica/scodeinst/PackageConstant7.mo:12:3-12:15:writable] Error: Class R does not satisfy the requirements for a package. Lookup is therefore restricted to encapsulated elements, but x is not encapsulated.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/lookup4.mo
+++ b/testsuite/flattening/modelica/scodeinst/lookup4.mo
@@ -11,11 +11,11 @@ model A
         Real x;
       end D;
 
-      D d;
+      constant D d;
     end C;
   end B;
 
-  B b;
+  constant B b;
 end A;
 
 model M


### PR DESCRIPTION
- Add error check for non-constant components being looked up in classes, which isn't allowed since lookup is restricted to encapsulated elements (which components can't be) unless the class is a package or operator (which can't contain non-constants).