### PR TITLE
Do not hide the top level conditional components

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -713,7 +713,12 @@ void LineAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
       if (isActiveState()) {
         painter->setOpacity(1.0);
       } else {
-        painter->setOpacity(0.2);
+        painter->setOpacity(0.3);
+      }
+    } else if (mLineType == LineAnnotation::ConnectionType) {
+      if ((mpStartElement && mpStartElement->getModelComponent() && !mpStartElement->getModelComponent()->getCondition())
+          || (mpEndElement && mpEndElement->getModelComponent() && !mpEndElement->getModelComponent()->getCondition())) {
+        painter->setOpacity(0.3);
       }
     }
     drawLineAnnotation(painter);

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1056,7 +1056,20 @@ void Element::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
   Q_UNUSED(option);
   Q_UNUSED(widget);
   if (mTransformation.isValid()) {
-    setVisible(mTransformation.getVisible() && isCondition());
+    const bool condition = isCondition();
+    if (mElementType == Element::Root) {
+      setVisible(mTransformation.getVisible());
+      if (!condition) {
+        setOpacity(0.3);
+      }
+    } else if (mElementType == Element::Port) {
+      setVisible(mTransformation.getVisible() && condition);
+    } else {
+      /* Element::Extend type ends up in this block
+       * we don't set the opacity for it since it will take the opacity of parent.
+       */
+      setVisible(mTransformation.getVisible());
+    }
     if (mpStateElementRectangle) {
       if (isVisible()) {
         if (mHasTransition && mIsInitialState) {


### PR DESCRIPTION
### Related Issues

#10543 

### Purpose

Show the top level conditional components.

### Approach

Set the opacity for conditional components.
If the component is a connector and used inside the component then just hide or show it.
