### PR TITLE
Hide the parameters marked final

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -192,7 +192,7 @@ public:
   GraphicsView *getGraphicsView() const {return mpGraphicsView;}
   bool isInherited() const {return mInherited;}
   QString getModification() const {return mModification;}
-  static void applyStartFixedAndDisplayUnitModifiers(Parameter *pParameter, const ModelInstance::Modifier &modifier, bool defaultValue);
+  void applyFinalStartFixedAndDisplayUnitModifiers(Parameter *pParameter, const ModelInstance::Modifier &modifier, bool defaultValue);
   void updateParameters();
 private:
   ModelInstance::Element *mpElement;


### PR DESCRIPTION
### Related Issues

Fixes #10394

### Purpose

Hide the parameters marked final at the element modifier level.

### Approach

Check if the parameter is marked final and hide it.
