### PR TITLE
Don't run the environment job on Windows anymore

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
   stages {
     stage('Environment') {
       agent {
-        label '!windows'
+        label 'linux || osx'
       }
       steps {
         script {


### PR DESCRIPTION
The Windows machines no longer have the Windows label, so look for Linux or OSX instead.