### PR TITLE
Fix forward declaration of C++ Functions in FMU export

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -6543,7 +6543,6 @@ case SIMCODE(modelInfo=MODELINFO(__), extObjInfo=EXTOBJINFO(__)) then
     #define BASECLASS  ExtendedSystem
   #endif
   //Forward declaration to speed-up the compilation process
-  class Functions;
   class EventHandling;
   class DiscreteEvents;
   <%algloopForwardDeclaration(listAppend(listAppend(allEquations, initialEquations), getClockedEquations(getSubPartitions(clockedPartitions))), simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace)%>

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -6770,7 +6770,6 @@ case SIMCODE(modelInfo=MODELINFO(__), extObjInfo=EXTOBJINFO(__)) then
   #include <Core/System/SystemDefaultImplementation.h>
 
   //Forward declaration to speed-up the compilation process
-  class Functions;
   class EventHandling;
   class DiscreteEvents;
   <%algloopForwardDeclaration(listAppend(listAppend(allEquations, initialEquations), getClockedEquations(getSubPartitions(clockedPartitions))), simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace)%>

--- a/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
@@ -111,13 +111,15 @@ template fmuCalcHelperMainfile(SimCode simCode)
     #include <Core/Utils/extension/logger.hpp>
 
     #include "OMCpp<%fileNamePrefix%>Types.h"
-    #include "OMCpp<%fileNamePrefix%>.h"
     #include "OMCpp<%fileNamePrefix%>Functions.h"
+    #include "OMCpp<%fileNamePrefix%>.h"
+
     #include "OMCpp<%fileNamePrefix%>Jacobian.h"
     #include "OMCpp<%fileNamePrefix%>Mixed.h"
     #include "OMCpp<%fileNamePrefix%>StateSelection.h"
     #include "OMCpp<%fileNamePrefix%>WriteOutput.h"
     #include "OMCpp<%fileNamePrefix%>Initialize.h"
+
     #include "OMCpp<%fileNamePrefix%>FMU.h"
 
     #include "OMCpp<%fileNamePrefix%>AlgLoopMain.cpp"

--- a/OMCompiler/Compiler/Template/CodegenFMUCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCppOld.tpl
@@ -110,13 +110,15 @@ template fmuCalcHelperMainfile(SimCode simCode)
     #include <Core/Utils/extension/logger.hpp>
 
     #include "OMCpp<%fileNamePrefix%>Types.h"
-    #include "OMCpp<%fileNamePrefix%>.h"
     #include "OMCpp<%fileNamePrefix%>Functions.h"
+    #include "OMCpp<%fileNamePrefix%>.h"
+
     #include "OMCpp<%fileNamePrefix%>Jacobian.h"
     #include "OMCpp<%fileNamePrefix%>Mixed.h"
     #include "OMCpp<%fileNamePrefix%>StateSelection.h"
     #include "OMCpp<%fileNamePrefix%>WriteOutput.h"
     #include "OMCpp<%fileNamePrefix%>Initialize.h"
+
     #include "OMCpp<%fileNamePrefix%>FMU.h"
 
     #include "OMCpp<%fileNamePrefix%>AlgLoopMain.cpp"

--- a/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/IGlobalSettings.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/SimulationSettings/IGlobalSettings.h
@@ -28,7 +28,6 @@ using std::string;
 enum LogCategory {LC_INIT = 0, LC_NLS = 1, LC_LS = 2, LC_SOLVER = 3, LC_OUTPUT = 4, LC_EVENTS = 5, LC_OTHER = 6, LC_MODEL = 7};
 enum LogLevel {LL_ERROR = 0, LL_WARNING = 1, LL_INFO = 2, LL_DEBUG = 3};
 enum LogFormat {LF_TXT = 0, LF_FMI = 1, LF_FMI2 = 2, LF_XML = 3, LF_XMLTCP = 4};
-enum LogOMEdit {LOG_EVENTS = 0, LOG_INIT, LOG_LS, LOG_NLS, LOG_SOLVER, LOG_STATS};
 enum OutputPointType {OPT_ALL, OPT_STEP, OPT_NONE};
 enum OutputFormat {CSV, MAT, BUFFER, EMPTY};
 enum EmitResults {EMIT_ALL, EMIT_HIDDEN, EMIT_PROTECTED, EMIT_PUBLIC, EMIT_NONE};

--- a/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/SimCoreFactory/OMCFactory/OMCFactory.cpp
@@ -185,7 +185,9 @@ static LogSettings initializeLogger(const po::variables_map& vm)
   map<string, LogFormat> logFormatMap = MAP_LIST_OF
     "txt", LF_TXT MAP_LIST_SEP "xml", LF_XML MAP_LIST_SEP
     "xmltcp", LF_XMLTCP MAP_LIST_END;
+  enum LogOMEdit {LOG_STDOUT, LOG_ASSERT, LOG_EVENTS, LOG_INIT, LOG_LS, LOG_NLS, LOG_SOLVER, LOG_STATS};
   map<string, LogOMEdit> logOMEditMap = MAP_LIST_OF
+    "LOG_STDOUT", LOG_STDOUT MAP_LIST_SEP "LOG_ASSERT", LOG_ASSERT MAP_LIST_SEP
     "LOG_EVENTS", LOG_EVENTS MAP_LIST_SEP "LOG_INIT", LOG_INIT MAP_LIST_SEP
     "LOG_LS", LOG_LS  MAP_LIST_SEP "LOG_NLS", LOG_NLS  MAP_LIST_SEP
     "LOG_SOLVER", LOG_SOLVER  MAP_LIST_SEP "LOG_STATS", LOG_STATS MAP_LIST_END;
@@ -201,16 +203,20 @@ static LogSettings initializeLogger(const po::variables_map& vm)
       // each log setting may be a comma separated list of options
       boost::split(opt_vec, log_vec[i], boost::is_any_of(","));
       for (int j = 0; j < opt_vec.size(); j++) {
-        // check for disabled option
-        int disabled = opt_vec[j].rfind("-", 0) == 0? 1: 0;
         // check for option with level, like "-V ls=warning" (default for "-V ls": LL_DEBUG)
         boost::split(cat_lvl, opt_vec[j], boost::is_any_of("="));
-        if (!logUsingOMEdit && opt_vec[j].rfind("LOG_", disabled) == disabled)
+        if (!logUsingOMEdit && opt_vec[j].rfind("LOG_", 0) == 0)
           logUsingOMEdit = true;
         if (logUsingOMEdit && logOMEditMap.find(opt_vec[j]) != logOMEditMap.end()) {
           // OMEdit option
           LogOMEdit logOMEdit = logOMEditMap[opt_vec[j]];
           switch (logOMEdit) {
+          case LOG_STDOUT:
+            // that's given
+            break;
+          case LOG_ASSERT:
+            // that's given
+            break;
           case LOG_EVENTS:
             logSettings.modes[LC_EVENTS] = LL_DEBUG;
             break;

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -27,6 +27,7 @@ functionPointerTest.mos \
 recordTupleReturnTest.mos \
 RefArrayDim2.mos \
 solveTest.mos \
+solveOneNonlinearEquationTest.mos \
 testArrayEquations.mos \
 testMatrixIO.mos \
 testMatrixState.mos \

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -3,6 +3,7 @@ TEST = ../../../../../rtest -v
 
 TESTFILES = \
 DIC_FMU2_CPP.mos \
+solveOneNonlinearEquationTest.mos \
 testArrayEquations.mos \
 testFMU2MatrixIO.mos \
 testModelDescription.mos \

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/solveOneNonlinearEquationTest.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/solveOneNonlinearEquationTest.mos
@@ -1,0 +1,82 @@
+// name: solveOneNonlinearEquationTest
+// keywords: closure
+// status: correct
+// teardown_command: rm -f *SolveOneNonlinearEquationTest*
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadModel(Modelica, {"3.2.3"});
+loadString("
+model SolveOneNonlinearEquationTest
+\"Modelica.Media.Examples.SolveOneNonlinearEquation with input\"
+  import Modelica.Utilities.Streams.print;
+  extends Modelica.Icons.Example;
+
+  parameter Real y_zero = 0.5 \"Desired value of A*sin(w*x)\";
+  parameter Real x_min = -1.7 \"Minimum value of x_zero\";
+  parameter Real x_max = 1.7 \"Maximum value of x_zero\";
+  input Real A(start = 1) \"Amplitude of sine\";
+  input Real w(start = 1) \"Angular frequency of sine\";
+  Real x_zero \"y_zero = A*sin(w*x_zero)\";
+
+  function f_nonlinear \"Define sine as non-linear equation to be solved\"
+    extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+    input Real A = 1 \"Amplitude of sine\";
+    input Real w = 1 \"Angular frequency of sine\";
+    input Real s = 0 \"Shift of sine\";
+  algorithm
+    y := A*Modelica.Math.sin(w*u) + s;
+  end f_nonlinear;
+
+equation
+  x_zero = Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+    function f_nonlinear(A=A, w=w, s=-y_zero), x_min, x_max);
+  annotation (experiment(StopTime=0));
+end SolveOneNonlinearEquationTest;
+");
+getErrorString();
+
+translateModelFMU(SolveOneNonlinearEquationTest, version = "2.0"); getErrorString();
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+importFMU("SolveOneNonlinearEquationTest.fmu"); getErrorString();
+loadFile("SolveOneNonlinearEquationTest_me_FMU.mo"); getErrorString();
+
+setCommandLineOptions("--simCodeTarget=C"); getErrorString();
+simulate(SolveOneNonlinearEquationTest_me_FMU, simflags="-override=A=1,w=1,stopTime=0.0"); getErrorString();
+
+val(A, 0);
+val(w, 0);
+val(x_zero, 0);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// ""
+// "SolveOneNonlinearEquationTest.fmu"
+// ""
+// true
+// ""
+// "SolveOneNonlinearEquationTest_me_FMU.mo"
+// ""
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "SolveOneNonlinearEquationTest_me_FMU_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'SolveOneNonlinearEquationTest_me_FMU', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-override=A=1,w=1,stopTime=0.0'",
+//     messages = "LOG_STDOUT        | warning | Start or stop time was overwritten, but no new integrator step size was provided.
+// |                 | info    | | Re-calculating step size for 500 intervals.
+// |                 | |       | | Add `stepSize=<value>` to `-override=` or override file to silence this warning.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// 1.0
+// 1.0
+// 0.5235987755982987
+// ""
+// endResult

--- a/testsuite/openmodelica/cppruntime/solveOneNonlinearEquationTest.mos
+++ b/testsuite/openmodelica/cppruntime/solveOneNonlinearEquationTest.mos
@@ -1,0 +1,59 @@
+// name: solveOneNonlinearEquationTest
+// keywords: closure
+// status: correct
+// teardown_command: rm -f *SolveOneNonlinearEquationTest*
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadModel(Modelica, {"3.2.3"});
+loadString("
+model SolveOneNonlinearEquationTest
+\"Modelica.Media.Examples.SolveOneNonlinearEquation with input\"
+  import Modelica.Utilities.Streams.print;
+  extends Modelica.Icons.Example;
+
+  parameter Real y_zero = 0.5 \"Desired value of A*sin(w*x)\";
+  parameter Real x_min = -1.7 \"Minimum value of x_zero\";
+  parameter Real x_max = 1.7 \"Maximum value of x_zero\";
+  input Real A(start = 1) \"Amplitude of sine\";
+  input Real w(start = 1) \"Angular frequency of sine\";
+  Real x_zero \"y_zero = A*sin(w*x_zero)\";
+
+  function f_nonlinear \"Define sine as non-linear equation to be solved\"
+    extends Modelica.Math.Nonlinear.Interfaces.partialScalarFunction;
+    input Real A = 1 \"Amplitude of sine\";
+    input Real w = 1 \"Angular frequency of sine\";
+    input Real s = 0 \"Shift of sine\";
+  algorithm
+    y := A*Modelica.Math.sin(w*u) + s;
+  end f_nonlinear;
+
+equation
+  x_zero = Modelica.Math.Nonlinear.solveOneNonlinearEquation(
+    function f_nonlinear(A=A, w=w, s=-y_zero), x_min, x_max);
+  annotation (experiment(StopTime=0));
+end SolveOneNonlinearEquationTest;
+");
+getErrorString();
+
+simulate(SolveOneNonlinearEquationTest);
+val(A, 0);
+val(w, 0);
+val(x_zero, 0);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "SolveOneNonlinearEquationTest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'SolveOneNonlinearEquationTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// 1.0
+// 1.0
+// 0.5235987755982987
+// ""
+// endResult


### PR DESCRIPTION
The functions may be accessed from closures, see new solveOneNonlinearEquationTest.
So far this only worked for simulations.