### PR TITLE
Improve component handling

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -49,6 +49,7 @@ import NFBinding;
 import Class = NFClass;
 import NFClassTree.ClassTree;
 import Component = NFComponent;
+import NFComponent.ComponentState;
 import Expression = NFExpression;
 import NFInstNode.InstNode;
 import NFInstNode.InstNodeType;
@@ -408,7 +409,7 @@ constant InstNode TIME =
   InstNode.COMPONENT_NODE("time",
     NONE(),
     Visibility.PUBLIC,
-    Pointer.createImmutable(Component.TYPED_COMPONENT(
+    Pointer.createImmutable(Component.COMPONENT(
       REAL_NODE,
       Type.REAL(),
       NFBinding.EMPTY_BINDING,
@@ -416,6 +417,7 @@ constant InstNode TIME =
       NFAttributes.INPUT_ATTR,
       NONE(),
       NONE(),
+      ComponentState.TypeChecked,
       AbsynUtil.dummyInfo)),
     InstNode.EMPTY_NODE(),
     InstNodeType.NORMAL_COMP());

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -42,6 +42,7 @@ import NFInstNode.CachedData;
 import NFInstNode.InstNode;
 import NFInstNode.InstNodeType;
 import Component = NFComponent;
+import NFComponent.ComponentState;
 import Type = NFType;
 import Expression = NFExpression;
 import Absyn;
@@ -78,8 +79,9 @@ constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
 );
 
 // Default Integer parameter.
-constant Component INT_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.INTEGER(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+constant Component INT_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.INTEGER(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   NONE(), Visibility.PUBLIC,
@@ -87,8 +89,9 @@ constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   InstNodeType.NORMAL_COMP());
 
 // Default Real parameter.
-constant Component REAL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.REAL(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+constant Component REAL_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.REAL(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   NONE(), Visibility.PUBLIC,
@@ -96,8 +99,9 @@ constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   InstNodeType.NORMAL_COMP());
 
 // Default Boolean parameter.
-constant Component BOOL_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.BOOLEAN(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+constant Component BOOL_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.BOOLEAN(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   NONE(), Visibility.PUBLIC,
@@ -105,8 +109,9 @@ constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   InstNodeType.NORMAL_COMP());
 
 // Default String parameter.
-constant Component STRING_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.STRING(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+constant Component STRING_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.STRING(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   NONE(), Visibility.PUBLIC,
@@ -114,8 +119,9 @@ constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   InstNodeType.NORMAL_COMP());
 
 // Default enumeration(:) parameter.
-constant Component ENUM_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.ENUMERATION_ANY(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+constant Component ENUM_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.ENUMERATION_ANY(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   NONE(), Visibility.PUBLIC,
@@ -378,8 +384,9 @@ constant Function SAMPLE = Function.FUNCTION(Path.QUALIFIED("OMC_NO_CLOCK", Path
     Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
-constant Component CLOCK_COMPONENT = Component.TYPED_COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.CLOCK(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING, NFAttributes.DEFAULT_ATTR, NONE(), NONE(), AbsynUtil.dummyInfo);
+constant Component CLOCK_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
+  Type.CLOCK(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode CLOCK_PARAM = InstNode.COMPONENT_NODE("s",
   NONE(), Visibility.PUBLIC,

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -698,7 +698,7 @@ algorithm
         Binding.CEVAL_BINDING(exp);
 
     // A record component without an explicit binding, create one from its children.
-    case Component.TYPED_COMPONENT(ty = Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node)))
+    case Component.COMPONENT(ty = Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node)))
       algorithm
         exp := makeRecordBindingExp(component.classInst, rec_node, component.ty, cref);
         binding := Binding.CEVAL_BINDING(exp);
@@ -710,7 +710,7 @@ algorithm
         binding;
 
     // A record array component without an explicit binding, create one from its children.
-    case Component.TYPED_COMPONENT(ty = Type.ARRAY(elementType = ty as
+    case Component.COMPONENT(ty = Type.ARRAY(elementType = ty as
         Type.COMPLEX(complexTy = ComplexType.RECORD(rec_node))))
       algorithm
         exp := Expression.mapCrefScalars(Expression.fromCref(cref),

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1149,7 +1149,7 @@ algorithm
   comp := InstNode.component(node);
 
   element := match comp
-    case Component.TYPED_COMPONENT(ty = ty, info = info, attributes = attr)
+    case Component.COMPONENT(ty = ty, info = info, attributes = attr)
       algorithm
         cref := ComponentRef.fromNode(node, ty);
         binding := Binding.toDAEExp(comp.binding);
@@ -1162,7 +1162,7 @@ algorithm
 
     else
       algorithm
-        Error.assertion(false, getInstanceName() + " got untyped component.", sourceInfo());
+        Error.assertion(false, getInstanceName() + " got invalid component.", sourceInfo());
       then
         fail();
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -479,7 +479,7 @@ algorithm
   c := InstNode.component(comp_node);
 
   () := match c
-    case Component.TYPED_COMPONENT(condition = condition, ty = ty)
+    case Component.COMPONENT(condition = condition, ty = ty)
       algorithm
         // Delete the component if it has a condition that's false.
         if isDeletedComponent(condition, prefix) then
@@ -616,8 +616,7 @@ protected
   Boolean unfix;
   Prefix pre;
 algorithm
-  Component.TYPED_COMPONENT(ty = ty, binding = binding, attributes = comp_attr,
-    comment = cmt, info = info) := comp;
+  Component.COMPONENT(ty = ty, binding = binding, attributes = comp_attr, comment = cmt, info = info) := comp;
   var := comp_attr.variability;
 
   if isSome(outerBinding) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1923,7 +1923,7 @@ uniontype Function
     end if;
 
     () := match comp
-      case Component.TYPED_COMPONENT()
+      case Component.COMPONENT()
         algorithm
           ty := Type.mapDims(comp.ty, function Dimension.mapExp(func = mapFn));
 
@@ -2006,7 +2006,7 @@ uniontype Function
     arg := Binding.foldExp(Component.getBinding(comp), foldFn, arg);
 
     () := match comp
-      case Component.TYPED_COMPONENT()
+      case Component.COMPONENT()
         algorithm
           arg := Type.foldDims(comp.ty, function Dimension.foldExp(func = foldFn), arg);
           cls := InstNode.getClass(comp.classInst);

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -42,6 +42,7 @@ import Attributes = NFAttributes;
 import Binding = NFBinding;
 import Class = NFClass;
 import Component = NFComponent;
+import NFComponent.ComponentState;
 import Dimension = NFDimension;
 import Expression = NFExpression;
 import NFInstNode.InstNode;
@@ -147,9 +148,10 @@ algorithm
   //all_params := listAppend(inputs, sorted_locals);
 
   // Create the output record element, using the instance created above as both parent and type.
-  out_comp := Component.UNTYPED_COMPONENT(ctor_node, listArray({}),
+  out_comp := Component.COMPONENT(ctor_node, Type.UNTYPED(node, listArray({})),
                 NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-                NFAttributes.OUTPUT_ATTR, NONE(), false, AbsynUtil.dummyInfo);
+                NFAttributes.OUTPUT_ATTR, NONE(), NONE(),
+                ComponentState.FullyInstantiated, AbsynUtil.dummyInfo);
   out_rec := InstNode.fromComponent("$out" + InstNode.name(ctor_node), out_comp, ctor_node);
 
   // Make a record constructor class and create a node for the constructor.

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1337,7 +1337,7 @@ algorithm
   scope := InstNode.parent(node);
 
   () := match (comp, elem)
-    case (Component.TYPED_COMPONENT(), SCode.Element.COMPONENT())
+    case (Component.COMPONENT(), SCode.Element.COMPONENT())
       guard Component.isDeleted(comp)
       algorithm
         json := JSON.addPair("$kind", JSON.makeString("component"), json);
@@ -1350,7 +1350,7 @@ algorithm
       then
         ();
 
-    case (Component.TYPED_COMPONENT(), SCode.Element.COMPONENT())
+    case (Component.COMPONENT(), SCode.Element.COMPONENT())
       algorithm
         json := JSON.addPair("$kind", JSON.makeString("component"), json);
         json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);


### PR DESCRIPTION
- Merge `Component.UNTYPED_COMPONENT` and `Component.TYPED_COMPONENT` into a single `Component.COMPONENT` record, and instead use an enumeration flag to indicate which state a component is in to allow better control over component instantiation/typing and reduce code duplication.
- Add Type.UNTYPED() to store type information for untyped components.