### PR TITLE
Enable basic DAE mode in C++ runtime

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1436,6 +1436,10 @@ protected
   numberofMixedSys, numberOfJacobians, numberofFixedParameters;
   Boolean tmpB;
 
+  HashTableCrIListArray.HashTable varToArrayIndexMapping "maps each array-variable to a array of positions";
+  HashTableCrILst.HashTable varToIndexMapping "maps each variable to an array position";
+  HashTable.HashTable crefToClockIndexHT;
+
   list<DAE.ComponentRef> discreteModelVars;
   list<BackendDAE.TimeEvent> timeEvents;
   BackendDAE.ZeroCrossingSet zeroCrossingsSet, sampleZCSet;
@@ -1671,6 +1675,15 @@ algorithm
     // The updated variable 'numEquations' (by SimCodeUtil.addNumEqns) is not even used in createCrefToSimVarHT :/
     // crefToSimVarHT := SimCodeUtil.createCrefToSimVarHT(modelInfo);
 
+    if stringEqual(Config.simCodeTarget(), "Cpp") then
+      (varToArrayIndexMapping, varToIndexMapping) := SimCodeUtil.createVarToArrayIndexMapping(modelInfo);
+      (crefToClockIndexHT, _) := List.fold(listReverse(inBackendDAE.eqs), SimCodeUtil.collectClockedVars, (HashTable.emptyHashTable(), 1));
+    else
+      varToArrayIndexMapping := HashTableCrIListArray.emptyHashTable();
+      varToIndexMapping := HashTableCrILst.emptyHashTable();
+      crefToClockIndexHT := HashTable.emptyHashTable();
+    end if;
+
     simCode := SimCode.SIMCODE(
       modelInfo                   = modelInfo,
       literals                    = {},               // Set by the traversal below...
@@ -1712,10 +1725,10 @@ algorithm
       fmuTargetName               = "",
       hpcomData                   = HpcOmSimCode.emptyHpcomData,
       valueReferences             = AvlTreeCRToInt.EMPTY(),
-      varToArrayIndexMapping      = HashTableCrIListArray.emptyHashTable(),
-      varToIndexMapping           = HashTableCrILst.emptyHashTable(),
+      varToArrayIndexMapping      = varToArrayIndexMapping,
+      varToIndexMapping           = varToIndexMapping,
       crefToSimVarHT              = crefToSimVarHT,
-      crefToClockIndexHT          = HashTable.emptyHashTable(),
+      crefToClockIndexHT          = crefToClockIndexHT,
       backendMapping              = NONE(),
       modelStructure              = NONE(),
       fmiSimulationFlags          = NONE(),

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -978,7 +978,7 @@ algorithm
     clockedPartitions := listReverse(clockedPartitions); // in order to keep the correct indexes for the correct clkfire-calls
 end createClockedSimPartitions;
 
-protected function collectClockedVars "author: rfranke
+public function collectClockedVars "author: rfranke
   This function collects clocked variables along with their clockIndex"
   input BackendDAE.EqSystem inEqSystem;
   input tuple<HashTable.HashTable, Integer> inTpl;

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -72,9 +72,9 @@ template translateModel(SimCode simCode)
         let()= textFile(simulationJacobianCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", &jacobianVarsInit, stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>Jacobian.cpp')
         let()= textFile(simulationStateSelectionCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>StateSelection.cpp')
         let()= textFile(simulationStateSelectionHeaderFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>StateSelection.h')
-        let()= textFile(simulationMixedSystemCppFile(simCode, updateResiduals(simCode, extraFuncs, extraResidualsFuncsDecl, className, stateDerVectorName /*=__zDot*/, false),
+        let()= textFile(simulationMixedSystemCppFile(simCode, updateResiduals(simCode, extraResidualsFuncsDecl, className, stateDerVectorName /*=__zDot*/, false),
                                                      &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>Mixed.cpp')
-        let()= textFile(simulationMixedSystemHeaderFile(simCode, &extraFuncs, &extraResidualsFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>Mixed.h')
+        let()= textFile(simulationMixedSystemHeaderFile(simCode, &extraResidualsFuncsDecl), 'OMCpp<%fileNamePrefix%>Mixed.h')
         let _ =  match  Config.simCodeTarget()
         case "Cpp" then
         let()= textFile(simulationWriteOutputCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>WriteOutput.cpp')
@@ -398,7 +398,7 @@ template getPreVarsCount(ModelInfo modelInfo)
 end getPreVarsCount;
 
 
-template simulationMixedSystemHeaderFile(SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace)
+template simulationMixedSystemHeaderFile(SimCode simCode, Text& extraResidualsFuncsDecl)
  "Generates code for header file for simulation target."
 ::=
 match simCode
@@ -449,7 +449,8 @@ case SIMCODE(modelInfo=MODELINFO(vars = vars as SIMVARS(__))) then
     virtual  shared_ptr<ISimObjects> getSimObjects();
    private:
     //update residual methods
-  <%simulationDAEMethodsDeclaration(simCode)%>
+    <%extraResidualsFuncsDecl%>
+    <%simulationDAEMethodsDeclaration(simCode)%>
   };
   >>
 end simulationMixedSystemHeaderFile;
@@ -13713,7 +13714,7 @@ match simCode
  >>
 end simulationDAEMethodsDeclaration;
 
-template updateResiduals(SimCode simCode,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace,  Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
+template updateResiduals(SimCode simCode,Text& extraFuncsDecl,Text extraFuncsNamespace,  Text stateDerVectorName /*=__zDot*/, Boolean useFlatArrayNotation)
 ::=
  let &extraFuncsResidual = buffer "" /*BUFD*/
 <<

--- a/OMCompiler/Compiler/Template/CodegenCppHpcom.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppHpcom.tpl
@@ -23,7 +23,7 @@ template translateModel(SimCode simCode)
       let target  = simulationCodeTarget()
       let &extraFuncs = buffer "" /*BUFD*/
       let &extraFuncsDecl = buffer "" /*BUFD*/
-    let &extraResidualsFuncsDecl = buffer "" /*BUFD*/
+      let &extraResidualsFuncsDecl = buffer "" /*BUFD*/
       let &dummyTypeElemCreation = buffer "" //remove this workaround if GCC > 4.4 is the default compiler
       let stateDerVectorName = "__zDot"
       let useMemoryOptimization = Flags.isSet(Flags.HPCOM_MEMORY_OPT)
@@ -84,9 +84,9 @@ template translateModel(SimCode simCode)
       let() = textFile(simulationStateSelectionCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>StateSelection.cpp')
       let() = textFile(simulationStateSelectionHeaderFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>StateSelection.h')
 
-      let()= textFile(simulationMixedSystemCppFile(simCode ,updateResiduals(simCode,extraFuncs,extraResidualsFuncsDecl,className,stateDerVectorName /*=__zDot*/, false)
-                                                   , &extraFuncs , &extraFuncsDecl, "", stateDerVectorName, false),'OMCpp<%fileNamePrefix%>Mixed.cpp')
-    let() = textFile(simulationMixedSystemHeaderFile(simCode, &extraFuncs, &extraResidualsFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>Mixed.h')
+      let()= textFile(simulationMixedSystemCppFile(simCode, updateResiduals(simCode, extraResidualsFuncsDecl, className, stateDerVectorName /*=__zDot*/, false),
+                                                   &extraFuncs , &extraFuncsDecl, "", stateDerVectorName, false),'OMCpp<%fileNamePrefix%>Mixed.cpp')
+      let() = textFile(simulationMixedSystemHeaderFile(simCode, &extraResidualsFuncsDecl), 'OMCpp<%fileNamePrefix%>Mixed.h')
       let() = textFile(simulationWriteOutputHeaderFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>WriteOutput.h')
       let() = textFile(simulationWriteOutputCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>WriteOutput.cpp')
       let() = textFile(simulationFactoryFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>FactoryExport.cpp')

--- a/OMCompiler/Compiler/Template/CodegenCppHpcomOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppHpcomOld.tpl
@@ -23,7 +23,7 @@ template translateModel(SimCode simCode)
       let target  = simulationCodeTarget()
       let &extraFuncs = buffer "" /*BUFD*/
       let &extraFuncsDecl = buffer "" /*BUFD*/
-    let &extraResidualsFuncsDecl = buffer "" /*BUFD*/
+      let &extraResidualsFuncsDecl = buffer "" /*BUFD*/
       let &dummyTypeElemCreation = buffer "" //remove this workaround if GCC > 4.4 is the default compiler
       let stateDerVectorName = "__zDot"
       let useMemoryOptimization = Flags.isSet(Flags.HPCOM_MEMORY_OPT)
@@ -84,9 +84,9 @@ template translateModel(SimCode simCode)
       let() = textFile(simulationStateSelectionCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>StateSelection.cpp')
       let() = textFile(simulationStateSelectionHeaderFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>StateSelection.h')
 
-      let()= textFile(simulationMixedSystemCppFile(simCode ,updateResiduals(simCode,extraFuncs,extraResidualsFuncsDecl,className,stateDerVectorName /*=__zDot*/, false)
-                                                   , &extraFuncs , &extraFuncsDecl, "", stateDerVectorName, false),'OMCpp<%fileNamePrefix%>Mixed.cpp')
-    let() = textFile(simulationMixedSystemHeaderFile(simCode, &extraFuncs, &extraResidualsFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>Mixed.h')
+      let()= textFile(simulationMixedSystemCppFile(simCode, updateResiduals(simCode, extraResidualsFuncsDecl, className, stateDerVectorName /*=__zDot*/, false),
+                                                   &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false),'OMCpp<%fileNamePrefix%>Mixed.cpp')
+      let() = textFile(simulationMixedSystemHeaderFile(simCode, &extraResidualsFuncsDecl), 'OMCpp<%fileNamePrefix%>Mixed.h')
       let() = textFile(simulationWriteOutputHeaderFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>WriteOutput.h')
       let() = textFile(simulationWriteOutputCppFile(simCode, &extraFuncs, &extraFuncsDecl, "", stateDerVectorName, false), 'OMCpp<%fileNamePrefix%>WriteOutput.cpp')
       let() = textFile(simulationFactoryFile(simCode, &extraFuncs, &extraFuncsDecl, ""), 'OMCpp<%fileNamePrefix%>FactoryExport.cpp')

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -1528,9 +1528,7 @@ case SIMCODE(modelInfo=MODELINFO(__)) then
 end functionStateSets;
 
 
-
-
-template simulationMainRunScript(SimCode simCode ,Text& extraFuncs,Text& extraFuncsDecl,Text extraFuncsNamespace, String preRunCommandLinux, String preRunCommandWindows, String execCommandLinux)
+template simulationMainRunScript(SimCode simCode, Text& extraFuncs, Text& extraFuncsDecl, Text extraFuncsNamespace, String preRunCommandLinux, String preRunCommandWindows, String execCommandLinux)
  "Generates code for header file for simulation target."
 ::=
   match simCode
@@ -1540,15 +1538,15 @@ template simulationMainRunScript(SimCode simCode ,Text& extraFuncs,Text& extraFu
     let stepsize  = settings.stepSize
     let intervals = settings.numberOfIntervals
     let tol       = settings.tolerance
-    let solver    = match simCode case SIMCODE(daeModeData=NONE()) then settings.method else 'ida' //for dae mode only ida is supported
-    let moLib     =  makefileParams.compileDir
+    let solver    = settings.method
+    let moLib     = makefileParams.compileDir
     let home      = makefileParams.omhome
     let outputformat = settings.outputFormat
     let execParameters = '-S <%start%> -E <%end%> -H <%stepsize%> -G <%intervals%> -P <%outputformat%> -T <%tol%> -I <%solver%> -R "<%simulationLibDir(simulationCodeTarget(),simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)%>" -M "<%moLib%>" -r "<%simulationResults(Testsuite.isRunning(),simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)%>"'
     let outputParameter = if (stringEq(settings.outputFormat, "empty")) then "-O none" else ""
     let fileNamePrefixx = fileNamePrefix
 
-    let libFolder = simulationLibDir(simulationCodeTarget(),simCode , &extraFuncs , &extraFuncsDecl,  extraFuncsNamespace)
+    let libFolder = simulationLibDir(simulationCodeTarget(), simCode, &extraFuncs, &extraFuncsDecl, extraFuncsNamespace)
     let libPaths = makefileParams.libPaths |> path => path; separator=";"
 
     match makefileParams.platform

--- a/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.h
+++ b/OMCompiler/SimulationRuntime/cpp/Solver/DASSL/DASSL.h
@@ -92,7 +92,7 @@ private:
   void DASSLCore();
 
   /// evaluate right hand side of ODE
-  int calcFunction(const double& time, const double* y, double* yp);
+  int calcFunction(const double& time, const double* y, const double* yp, double *f);
 
   // callback for right hand side
   static int _res(double *t, double *y, double *yp, double *cj,
@@ -141,6 +141,10 @@ private:
 
   // Variables for Coloured Jacobians
   int  _maxColors;
+
+  // DAE support
+  int	_dimStates;
+  int _dimAE;
 
   ISystemProperties* _properties;
   IContinuous* _continuous_system;

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -29,6 +29,7 @@ RefArrayDim2.mos \
 solveTest.mos \
 solveOneNonlinearEquationTest.mos \
 testArrayEquations.mos \
+testDAE.mos \
 testMatrixIO.mos \
 testMatrixState.mos \
 testReduction.mos \

--- a/testsuite/openmodelica/cppruntime/testDAE.mos
+++ b/testsuite/openmodelica/cppruntime/testDAE.mos
@@ -1,0 +1,40 @@
+// name: testDAE
+// keywords: DAE mode
+// status: correct
+// teardown_command: rm -f *DAETest*
+
+setCommandLineOptions("--simCodeTarget=Cpp");
+
+loadString("
+model DAETest
+  Real x1(start = -1);
+  Real x2;
+  Real x3;
+equation
+  der(x1) = x3;
+  x2 * (1 - x2) = 0;
+  x1*x2 + x3*(1 - x2) = time;
+  annotation(experiment(StopTime = 1), __OpenModelica_commandLineOptions = \"--daeMode\");
+end DAETest;
+");
+getErrorString();
+
+simulate(DAETest);
+
+val(x1, 1);
+val(x2, 1);
+val(x3, 1);
+
+// Result:
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "DAETest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'DAETest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// -0.5000000000000006
+// 0.0
+// 1.0
+// endResult


### PR DESCRIPTION
This involves:
- Add variable index mappings for C++ to DAE code generation (SimCodeMain.generateModelCodeDAE)
- Fix declaration of C++ methods for DAE residuals
- Enhance DASSL in C++ runtime to support basic DAE mode and add test

DASSL is the default solver, whereas IDA fails for the simple test.
So far not supplying DAE Jacobian.