### PR TITLE
Declare auxiliary DAE variables in C++ simulation code

### DIFF
--- a/testsuite/openmodelica/cppruntime/testDAE.mos
+++ b/testsuite/openmodelica/cppruntime/testDAE.mos
@@ -1,5 +1,5 @@
 // name: testDAE
-// keywords: DAE mode
+// keywords: DAE mode, auxiliary variables (cse)
 // status: correct
 // teardown_command: rm -f *DAETest*
 
@@ -11,9 +11,9 @@ model DAETest
   Real x2;
   Real x3;
 equation
-  der(x1) = x3;
+  der(x1) = x3 + sin(time);
   x2 * (1 - x2) = 0;
-  x1*x2 + x3*(1 - x2) = time;
+  x1*x2 + x3*(1 - x2) = sin(time);
   annotation(experiment(StopTime = 1), __OpenModelica_commandLineOptions = \"--daeMode\");
 end DAETest;
 ");
@@ -34,7 +34,7 @@ val(x3, 1);
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'DAETest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
-// -0.5000000000000006
+// -0.08060461191868702
 // 0.0
-// 1.0
+// 0.8414709848078965
 // endResult


### PR DESCRIPTION
They are used for common subexpressions for instance.
