### PR TITLE
Add Jacobian sim and seed vars to crefToSimVarHT in DAE mode

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1624,8 +1624,10 @@ algorithm
     SymbolicJacs := listAppend(listReverse(SymbolicJacsNLS), listAppend(SymbolicJacs, SymbolicJacsTemp));
     jacobianSimvars := SimCodeUtil.collectAllJacobianVars(SymbolicJacs);
     modelInfo := SimCodeUtil.setJacobianVars(jacobianSimvars, modelInfo);
+    crefToSimVarHT:= List.fold(jacobianSimvars, HashTableCrefSimVar.addSimVarToHashTable, crefToSimVarHT);
     seedVars := SimCodeUtil.collectAllSeedVars(SymbolicJacs);
     modelInfo := SimCodeUtil.setSeedVars(seedVars, modelInfo);
+    crefToSimVarHT := List.fold(seedVars, HashTableCrefSimVar.addSimVarToHashTable, crefToSimVarHT);
 
     // create dae SimVars: residual and algebraic
     varsLst := BackendVariable.equationSystemsVarsLst(inBackendDAE.eqs);

--- a/OMCompiler/Compiler/Template/CodegenCppOld.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOld.tpl
@@ -12242,14 +12242,14 @@ template giveZeroFunc3(Integer index1, Exp relation, Text &varDecls /*BUFP*/,Tex
         >>
       else
         <<
-        error(sourceInfo(), 'Unknown relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')
+        error(sourceInfo(), 'Unsupported relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')
         >>
       end match
   case CALL(path=IDENT(name="sample"), expLst={_, start, interval}) then
     //error(sourceInfo(), ' sample not supported for <%index1%> ')
     '//sample for <%index1%>'
   else
-    error(sourceInfo(), ' UNKNOWN ZERO CROSSING for <%index1%> ')
+    error(sourceInfo(), 'Unsupported zero crossing at <%index1%>: <%ExpressionDumpTpl.dumpExp(relation, "\"")%>')
   end match
 end giveZeroFunc3;
 

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -20,6 +20,7 @@ externalRecordTest.mos \
 mathFunctionsTest.mos \
 mslDistributionsTest.mos \
 mslElectricalMachinesTest.mos \
+mslElectricalMachinesTestDAE.mos \
 mslElectricalSensorsTest.mos \
 mslMathFFT1Test.mos \
 nameClashTest.mos \

--- a/testsuite/openmodelica/cppruntime/mslElectricalMachinesTestDAE.mos
+++ b/testsuite/openmodelica/cppruntime/mslElectricalMachinesTestDAE.mos
@@ -1,0 +1,31 @@
+// name: mslElectricalMachinesTestDAE
+// keywords: DAE Jacobian init const string substring
+// status: correct
+// teardown_command: rm -f *AIMC_Transformer*
+
+setCommandLineOptions("--simCodeTarget=Cpp");
+setCommandLineOptions("--daeMode");
+
+loadModel(Modelica, {"3.2.3"}); getErrorString();
+
+simulate(Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer);
+val(currentQuasiRMSSensor.I, 2.5);
+val(aimc.wMechanical, 2.5);
+val(aimc.tauElectrical, 2.5);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 2.5, numberOfIntervals = 25000, tolerance = 1e-06, method = 'ida', fileNamePrefix = 'Modelica.Electrical.Machines.Examples.Transformers.AIMC_Transformer', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// 173.2124789170594
+// 150.8435549841741
+// 161.396425531771
+// ""
+// endResult


### PR DESCRIPTION
The C++ runtime needs this to identify var kinds during code generation. See e.g. the new testsuite/openmodelica/cppruntime/mslElectricalMachinesTestDAE.mos
