### PR TITLE
New compile flag --exposeLocalIOs, particularly for improved FMI export

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1518,7 +1518,12 @@ algorithm
     else
       algorithm
         /* Consider toplevel inputs as known unless they are protected. Ticket #5591 */
-        false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
+        /* Consider all inputs known with flag exposeLocalIOs unless they are protected */
+        if not Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS) then
+          false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
+        else
+          false := DAEUtil.varDirectionEqual(inVarDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(protection);
+        end if;
       then
         match (inVarKind, inType)
           case (DAE.VARIABLE(), DAE.T_BOOL()) then BackendDAE.DISCRETE();
@@ -1546,7 +1551,11 @@ algorithm
     case DAE.CONST() then BackendDAE.CONST();
     case DAE.VARIABLE()
       equation
-        true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
+        if not Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS) then
+          true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
+        else
+          true = DAEUtil.varDirectionEqual(varDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(visibility);
+        end if;
       then
         BackendDAE.VARIABLE();
     // adrpo: topLevelInput might fail!

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -191,6 +191,16 @@ public
     end match;
   end isInput;
 
+  function isOutput
+    input ComponentRef cref;
+    output Boolean res;
+  algorithm
+    res := match cref
+      case CREF() then InstNode.isOutput(cref.node);
+      else false;
+    end match;
+  end isOutput;
+
   function node
     input ComponentRef cref;
     output InstNode node;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1453,6 +1453,10 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
+constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(155, "exposeLocalIOs",
+  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
+  Gettext.gettext("Keeps the input/output prefix for unconnected inputs and outputs at all levels, besides top-level ones."));
+
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."
   input Boolean initialize = true;

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -410,7 +410,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.SIMULATION,
   Flags.OBFUSCATE,
   Flags.FMU_RUNTIME_DEPENDS,
-  Flags.FRONTEND_INLINE
+  Flags.FRONTEND_INLINE,
+  Flags.EXPOSE_LOCAL_IOS
 };
 
 public function new

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Makefile
@@ -3,6 +3,7 @@ TEST = ../../../../../rtest -v
 
 TESTFILES = \
 DIC_FMU2_CPP.mos \
+exposeLocalIOs.mos \
 solveOneNonlinearEquationTest.mos \
 testArrayEquations.mos \
 testFMU2MatrixIO.mos \

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -1,0 +1,229 @@
+// name: exposeLocalIOs
+// keywords: FMI input output
+// status: correct
+// teardown_command: rm -f *LocalIOs.System* modelDescription.tmp.xml
+
+setCommandLineOptions("--simCodeTarget=Cpp");
+setCommandLineOptions("--exposeLocalIOs=true"); getErrorString();
+
+loadString("
+package LocalIOs
+
+connector RealInput = input Real;
+connector RealOutput = output Real;
+
+connector PhysicalConnector
+  Real p;
+  flow Real f;
+end PhysicalConnector;
+
+model Source
+  parameter Real u_par = 2;
+  parameter Boolean use_u_in = false;
+  RealInput u_in(start = u_par) if use_u_in;
+  RealOutput yp;
+  RealOutput yf;
+  PhysicalConnector c;
+protected
+  RealInput u_in_internal;
+equation
+  connect(u_in, u_in_internal);
+  if not use_u_in then
+    u_in_internal = u_par;
+  end if;
+  c.p = u_in_internal;
+  connect(u_in_internal, yp);
+  yf = c.f;
+end Source;
+
+model Component
+  PhysicalConnector c;
+  input Real modifiedInput annotation(Dialog(enable=true));
+  RealOutput measurement;
+protected
+  Signaling signaling(u1 = 1);
+equation
+  signaling.u2 = 2;
+  c.f = 0.5*c.p + modifiedInput + signaling.y;
+  connect(signaling.y, measurement);
+end Component;
+
+block Signaling
+  RealInput u1;
+  RealInput u2;
+  RealOutput y;
+equation
+  y = u1 + u2;
+end Signaling;
+
+model System
+  Source source(use_u_in = true);
+  Component component(modifiedInput = 1);
+  Signaling signaling;
+equation
+  connect(source.c, component.c);
+  connect(source.yf, signaling.u1);
+end System;
+
+end LocalIOs;
+");
+getErrorString();
+
+translateModelFMU(LocalIOs.System, version="2.0"); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq LocalIOs.System.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > modelDescription.tmp.xml");
+readFile("modelDescription.tmp.xml");
+
+// Result:
+// true
+// true
+// ""
+// true
+// ""
+// "LocalIOs.System.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 0
+// "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+// <fmiModelDescription
+//   fmiVersion=\"2.0\"
+//   modelName=\"LocalIOs.System\"
+//   description=\"\"
+//   variableNamingConvention=\"structured\"
+//   numberOfEventIndicators=\"0\">
+//   <ModelExchange
+//     modelIdentifier=\"LocalIOs_System\">
+//   </ModelExchange>
+//   <LogCategories>
+//     <Category name=\"logEvents\" />
+//     <Category name=\"logSingularLinearSystems\" />
+//     <Category name=\"logNonlinearSystems\" />
+//     <Category name=\"logDynamicStateSelection\" />
+//     <Category name=\"logStatusWarning\" />
+//     <Category name=\"logStatusDiscard\" />
+//     <Category name=\"logStatusError\" />
+//     <Category name=\"logStatusFatal\" />
+//     <Category name=\"logStatusPending\" />
+//     <Category name=\"logAll\" />
+//     <Category name=\"logFmi2Call\" />
+//   </LogCategories>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\"/>
+//   <ModelVariables>
+//   <!-- Index of variable = \"1\" -->
+//   <ScalarVariable
+//     name=\"component.measurement\"
+//     valueReference=\"0\"
+//     causality=\"output\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"2\" -->
+//   <ScalarVariable
+//     name=\"component.modifiedInput\"
+//     valueReference=\"1\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"3\" -->
+//   <ScalarVariable
+//     name=\"signaling.u2\"
+//     valueReference=\"4\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"4\" -->
+//   <ScalarVariable
+//     name=\"signaling.y\"
+//     valueReference=\"5\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"5\" -->
+//   <ScalarVariable
+//     name=\"source.u_in\"
+//     valueReference=\"6\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"2.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"6\" -->
+//   <ScalarVariable
+//     name=\"source.yf\"
+//     valueReference=\"7\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"7\" -->
+//   <ScalarVariable
+//     name=\"source.u_par\"
+//     valueReference=\"8\"
+//     variability=\"fixed\"
+//     causality=\"parameter\"
+//     >
+//     <Real start=\"2.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"8\" -->
+//   <ScalarVariable
+//     name=\"component.c.f\"
+//     valueReference=\"9\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"9\" -->
+//   <ScalarVariable
+//     name=\"component.c.p\"
+//     valueReference=\"6\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"10\" -->
+//   <ScalarVariable
+//     name=\"signaling.u1\"
+//     valueReference=\"7\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"11\" -->
+//   <ScalarVariable
+//     name=\"source.c.f\"
+//     valueReference=\"7\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"12\" -->
+//   <ScalarVariable
+//     name=\"source.c.p\"
+//     valueReference=\"6\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"13\" -->
+//   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"6\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"14\" -->
+//   <ScalarVariable
+//     name=\"source.use_u_in\"
+//     valueReference=\"0\"
+//     variability=\"fixed\"
+//     causality=\"calculatedParameter\"
+//     >
+//     <Boolean/>
+//   </ScalarVariable>
+//   </ModelVariables>
+//   <ModelStructure>
+//     <InitialUnknowns>
+//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"14\" dependencies=\"\" dependenciesKind=\"\" />
+//     </InitialUnknowns>
+//   </ModelStructure>
+// </fmiModelDescription>
+// "
+// endResult


### PR DESCRIPTION
### Related Issues

This addresses #10599.

### Purpose

Avoid the messy propagation of exposed inputs and outputs to the top-level.

### Approach

Keep input/output prefix for unconnected inputs and outputs at all levels, besides top-level ones.

It shows that "unconnected" means that the connectors never appear as inside in a connection set. This can be treated when generating connect equations in the frontend.

Following additions:
- Flags, FlagsUtil: introduce --exposeLocalIOs for this feature
- NFConvertDAE: only strip input/output from non connectors and from protected connectors
- NFFlatten, NFConnectEquations, NFComponentRef: strip input/output from inside connector variables
- BackendDAECreate: allow non top-level inputs when counting variables
- exposeLocalIOs.mos: test
