### PR TITLE
delete the file if not renamed

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -1061,8 +1061,12 @@ algorithm
     case ("compareFilesAndMove",{Values.STRING(str1),Values.STRING(str2)})
       algorithm
         true := System.regularFileExists(str1);
-        b := System.regularFileExists(str2) and System.fileContentsEqual(str1,str2);
+        b1 := System.fileContentsEqual(str1,str2)
+        b := System.regularFileExists(str2) and b1;
         b := if not b then System.rename(str1,str2) else b;
+        if b1 then // if contents are equal we did not do the rename so remove the file
+          System.removeFile(str1);
+        end if
       then
         Values.BOOL(b);
 

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1428,6 +1428,11 @@ package SimCodeUtil
     input list<BackendDAE.SimIterator> iters;
     output Integer size ;
   end getSimIteratorSize;
+
+  function simVarString
+    input SimCodeVar.SimVar inVar;
+    output String s;
+  end simVarString;
 end SimCodeUtil;
 
 package SimCodeFunctionUtil


### PR DESCRIPTION
### Related Issues

compareFilesAndMove was leaving the temporary file if its contents were equal to the compared file.
change so the equal contents file is removed.