### PR TITLE
Change the flag --exposeLocalIOs to integer specifying the level

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1518,8 +1518,8 @@ algorithm
     else
       algorithm
         /* Consider toplevel inputs as known unless they are protected. Ticket #5591 */
-        /* Consider all inputs known with flag exposeLocalIOs unless they are protected */
-        if not Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS) then
+        /* Consider all inputs known with flag exposeLocalIOs > 0 unless they are protected */
+        if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
           false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
         else
           false := DAEUtil.varDirectionEqual(inVarDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(protection);
@@ -1551,7 +1551,7 @@ algorithm
     case DAE.CONST() then BackendDAE.CONST();
     case DAE.VARIABLE()
       equation
-        if not Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS) then
+        if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
           true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
         else
           true = DAEUtil.varDirectionEqual(varDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(visibility);

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -212,11 +212,12 @@ algorithm
   if Connector.variability(c1) > Variability.PARAMETER then
     equations := list(makeEqualityEquation(c1.name, c1.source, c2.name, c2.source)
       for c2 in listRest(elements));
-    // collect inputs and outputs that are inside in connections if --exposeLocalIOs
-    if Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS) then
+    // collect inputs and outputs that are inside in connections if exposeLocalIOs > 0
+    // strip array indices so that the variables will be found later
+    if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) > 0 then
       for c in elements loop
         if (Connector.isInside(c) and (ComponentRef.isInput(c.name) or ComponentRef.isOutput(c.name))) then
-          UnorderedSet.add(c.name, connectedLocalIOs);
+          UnorderedSet.add(ComponentRef.stripSubscripts(c.name), connectedLocalIOs);
         end if;
       end for;
     end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -104,14 +104,14 @@ protected
 uniontype VariableConversionSettings
   record VARIABLE_CONVERSION_SETTINGS
     Boolean useLocalDirection;
-    Boolean exposeLocalIOs;
+    Integer exposeLocalIOs;
     Boolean isFunctionParameter;
     Boolean addTypeToSource;
   end VARIABLE_CONVERSION_SETTINGS;
 end VariableConversionSettings;
 
 constant VariableConversionSettings FUNCTION_VARIABLE_CONVERSION_SETTINGS =
-  VARIABLE_CONVERSION_SETTINGS(false, false, true, false);
+  VARIABLE_CONVERSION_SETTINGS(false, 0, true, false);
 
 function convertVariables
   input list<Variable> variables;
@@ -121,7 +121,7 @@ protected
 algorithm
   settings := VariableConversionSettings.VARIABLE_CONVERSION_SETTINGS(
     useLocalDirection = Flags.getConfigBool(Flags.USE_LOCAL_DIRECTION),
-    exposeLocalIOs = Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS),
+    exposeLocalIOs = Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS),
     isFunctionParameter = false,
     addTypeToSource = Flags.isSet(Flags.INFO_XML_OPERATIONS) or Flags.isSet(Flags.VISUAL_XML)
   );
@@ -178,7 +178,8 @@ algorithm
         // Alternatively strip input/output only from non connectors and from protected connectors if
         // --exposeLocalIOs has been set.
         if (attr.direction == Direction.NONE or settings.useLocalDirection) or
-           (settings.exposeLocalIOs and attr.connectorType <> ConnectorType.NON_CONNECTOR and vis == Visibility.PUBLIC) then
+           (settings.exposeLocalIOs > 0 and attr.connectorType <> ConnectorType.NON_CONNECTOR and
+            ComponentRef.depth(cref) <= settings.exposeLocalIOs + 1 and vis == Visibility.PUBLIC) then
           dir := attr.direction;
         else
           dir := getComponentDirection(attr.direction, cref);

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2066,7 +2066,7 @@ algorithm
   flatModel.variables := list(v for v guard Variable.isPresent(v) in flatModel.variables);
 
   // remove input and output prefixes from local IOs that are determined through connect equations
-  if Flags.getConfigBool(Flags.EXPOSE_LOCAL_IOS) then
+  if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) > 0 then
     flatModel.variables := list(stripInputOutputForConnected(v, connectedLocalIOs) for v in flatModel.variables);
   end if;
 

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1454,8 +1454,8 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
 constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(155, "exposeLocalIOs",
-  NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
-  Gettext.gettext("Keeps the input/output prefix for unconnected inputs and outputs at all levels, besides top-level ones."));
+  NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
+  Gettext.gettext("Keeps the input/output prefix for unconnected inputs and outputs at requested levels, 0 meaning top-level."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -4,7 +4,7 @@
 // teardown_command: rm -f *LocalIOs.System* modelDescription.tmp.xml
 
 setCommandLineOptions("--simCodeTarget=Cpp");
-setCommandLineOptions("--exposeLocalIOs=true"); getErrorString();
+setCommandLineOptions("--exposeLocalIOs=10"); getErrorString();
 
 loadString("
 package LocalIOs
@@ -23,6 +23,7 @@ model Source
   RealInput u_in(start = u_par) if use_u_in;
   RealOutput yp;
   RealOutput yf;
+  RealOutput[2] y;
   PhysicalConnector c;
 protected
   RealInput u_in_internal;
@@ -34,6 +35,7 @@ equation
   c.p = u_in_internal;
   connect(u_in_internal, yp);
   yf = c.f;
+  y = {c.p, c.f};
 end Source;
 
 model Component
@@ -44,6 +46,7 @@ protected
   Signaling signaling(u1 = 1);
 equation
   signaling.u2 = 2;
+  signaling.u = 3:4;
   c.f = 0.5*c.p + modifiedInput + signaling.y;
   connect(signaling.y, measurement);
 end Component;
@@ -51,9 +54,10 @@ end Component;
 block Signaling
   RealInput u1;
   RealInput u2;
+  RealInput[2] u;
   RealOutput y;
 equation
-  y = u1 + u2;
+  y = u1 + u2 + sum(u);
 end Signaling;
 
 model System
@@ -63,6 +67,7 @@ model System
 equation
   connect(source.c, component.c);
   connect(source.yf, signaling.u1);
+  connect(source.y, signaling.u);
 end System;
 
 end LocalIOs;
@@ -128,7 +133,7 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
 //     name=\"signaling.u2\"
-//     valueReference=\"4\"
+//     valueReference=\"6\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"0.0\"/>
@@ -136,7 +141,7 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"4\" -->
 //   <ScalarVariable
 //     name=\"signaling.y\"
-//     valueReference=\"5\"
+//     valueReference=\"7\"
 //     causality=\"output\"
 //     >
 //     <Real/>
@@ -144,22 +149,22 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
 //     name=\"source.u_in\"
-//     valueReference=\"6\"
+//     valueReference=\"8\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
-//     name=\"source.yf\"
-//     valueReference=\"7\"
+//     name=\"source.y[2]\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
 //     name=\"source.u_par\"
-//     valueReference=\"8\"
+//     valueReference=\"10\"
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
@@ -168,47 +173,75 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"8\" -->
 //   <ScalarVariable
 //     name=\"component.c.f\"
-//     valueReference=\"9\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
 //     name=\"component.c.p\"
-//     valueReference=\"6\"
+//     valueReference=\"8\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
-//     valueReference=\"7\"
+//     name=\"signaling.u[1]\"
+//     valueReference=\"8\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"source.c.f\"
-//     valueReference=\"7\"
+//     name=\"signaling.u[2]\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"12\" -->
 //   <ScalarVariable
-//     name=\"source.c.p\"
-//     valueReference=\"6\"
+//     name=\"signaling.u1\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"13\" -->
 //   <ScalarVariable
-//     name=\"source.yp\"
-//     valueReference=\"6\"
-//     causality=\"output\"
+//     name=\"source.c.f\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"14\" -->
+//   <ScalarVariable
+//     name=\"source.c.p\"
+//     valueReference=\"8\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"15\" -->
+//   <ScalarVariable
+//     name=\"source.y[1]\"
+//     valueReference=\"8\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"16\" -->
+//   <ScalarVariable
+//     name=\"source.yf\"
+//     valueReference=\"9\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"17\" -->
+//   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"8\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"18\" -->
 //   <ScalarVariable
 //     name=\"source.use_u_in\"
 //     valueReference=\"0\"
@@ -221,7 +254,7 @@ readFile("modelDescription.tmp.xml");
 //   <ModelStructure>
 //     <InitialUnknowns>
 //       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"14\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"18\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>
 // </fmiModelDescription>


### PR DESCRIPTION
--exposeLocalIOs=0 is the top-level (default).
--exposeLocalIOs=1 are input/output connectors of top-level components ...
This enables the use of Modelica.Media that internally defines local input connectors and leaves them unconnected at deeper levels, see also #10599.

Also strip subscripts so that arrays in connection sets are identified. See e.g. Modelica.Electrical.Machines.Examples.InductionMachines.IMC_DOL. Besides using arrays, it is also a good example for local outputs at different levels.
