### PR TITLE
BUILD_ALWAYS for OMSimulator_external

### DIFF
--- a/omsimulator.cmake
+++ b/omsimulator.cmake
@@ -27,6 +27,7 @@ ExternalProject_Add(OMSimulator_external
                                                 host_short=${CMAKE_LIBRARY_ARCHITECTURE}
                                                 CMAKE="${CMAKE_COMMAND}"
     #--Build step-----------------
+    BUILD_ALWAYS 1
     BUILD_COMMAND COMMAND ${CMAKE_MAKE_PROGRAM} -C ${CMAKE_CURRENT_SOURCE_DIR}/OMSimulator
                                                 -j${NUM_PROCESSPRS}
                                                 OMSimulator


### PR DESCRIPTION
### Related Issues

When building OMSimulator from the OpenModelica super-project CMake won't rebuild after changes made in OMSimulator.


### Purpose

  - Rebuild OMSimulator if something changed.

### Approach

  - Adding `BUILD_ALWAYS 1` to `ExternalProject_Add`.
  - Forcing CMake to always run the build command for external project `OMSimulator_external` will run CMake in the OMSimulator sub-directory.  And that CMake will rebuild if (and only if) the sources changed. So not much overhead is added.

