### PR TITLE
Improve typing of array constructor in relaxed context

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2302,7 +2302,11 @@ protected
             (range, iter_ty, iter_var, iter_pur) := Typing.typeIterator(iter, range, next_context, is_structural);
 
             if is_structural then
-              range := Ceval.evalExp(range, Ceval.EvalTarget.RANGE(info));
+              if InstContext.inRelaxed(context) then
+                range := Ceval.tryEvalExp(range);
+              else
+                range := Ceval.evalExp(range, Ceval.EvalTarget.RANGE(info));
+              end if;
               iter_ty := Expression.typeOf(range);
             end if;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -656,7 +656,7 @@ algorithm
         if Binding.isUnbound(binding) then
           // If the component has no binding, try to use its parent's binding
           // (i.e. for record fields where the record instance has a binding).
-          (b, parent_dims) := getRecordElementBinding(component);
+          (b, parent_dims) := getRecordElementBinding(component, context);
 
           if Binding.isUnbound(b) then
             // If the component still doesn't have a binding, try to use the start attribute instead.
@@ -831,6 +831,7 @@ function getRecordElementBinding
   "Tries to fetch the binding for a given record field by using the binding of
    the record instance."
   input InstNode component;
+  input InstContext.Type context;
   output Binding binding;
   output Integer parentDims = 0;
 protected
@@ -848,10 +849,10 @@ algorithm
 
     if Binding.isUnbound(parent_binding) then
       // If the parent has no binding, try the parent's parent.
-      (binding, parentDims) := getRecordElementBinding(parent);
+      (binding, parentDims) := getRecordElementBinding(parent, context);
     else
       // Otherwise type the binding, so we can safely look up the field name.
-      binding := typeBinding(parent_binding, InstContext.set(NFInstContext.CLASS, NFInstContext.DIMENSION));
+      binding := typeBinding(parent_binding, InstContext.set(context, NFInstContext.DIMENSION));
 
       // If the binding wasn't typed before, update the parent component with it
       // so we don't have to type it again.

--- a/testsuite/openmodelica/instance-API/GetModelInstanceExp2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceExp2.mos
@@ -1,0 +1,85 @@
+// name: GetModelInstanceExp2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    parameter Integer n;
+    Real x[3] = {i for i in 1:n};
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"n\",
+//       \"type\": \"Integer\",
+//       \"prefixes\": {
+//         \"variability\": \"parameter\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"x\",
+//       \"type\": \"Real\",
+//       \"dims\": {
+//         \"absyn\": [
+//           \"3\"
+//         ],
+//         \"typed\": [
+//           \"3\"
+//         ]
+//       },
+//       \"modifiers\": \"{i for i in 1:n}\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"iterator_call\",
+//           \"name\": \"$array\",
+//           \"exp\": {
+//             \"$kind\": \"cref\",
+//             \"parts\": [
+//               {
+//                 \"name\": \"i\"
+//               }
+//             ]
+//           },
+//           \"iterators\": [
+//             {
+//               \"name\": \"i\",
+//               \"range\": {
+//                 \"$kind\": \"range\",
+//                 \"start\": 1,
+//                 \"stop\": {
+//                   \"$kind\": \"cref\",
+//                   \"parts\": [
+//                     {
+//                       \"name\": \"n\"
+//                     }
+//                   ]
+//                 }
+//               }
+//             }
+//           ]
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 5,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -30,6 +30,7 @@ GetModelInstanceEnum1.mos \
 GetModelInstanceEnum2.mos \
 GetModelInstanceEvaluate1.mos \
 GetModelInstanceExp1.mos \
+GetModelInstanceExp2.mos \
 GetModelInstanceExtends1.mos \
 GetModelInstanceExtends2.mos \
 GetModelInstanceExtends3.mos \


### PR DESCRIPTION
- Don't require the range of an array constructor to have a known size when in a relaxed context.
- Propagate the context to Typing.getRecordElementBinding.