### PR TITLE
Improve setElementModifierValue

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -4649,16 +4649,7 @@ end elementArgName;
 public function elementArgEqualName
   input Absyn.ElementArg inArg1;
   input Absyn.ElementArg inArg2;
-  output Boolean outEqual;
-protected
-  Absyn.Path name1, name2;
-algorithm
-  outEqual := match(inArg1, inArg2)
-    case (Absyn.MODIFICATION(path = name1), Absyn.MODIFICATION(path = name2))
-      then pathEqual(name1, name2);
-
-    else false;
-  end match;
+  output Boolean outEqual = pathEqual(elementArgName(inArg1), elementArgName(inArg2));
 end elementArgEqualName;
 
 public function optMsg

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -748,14 +748,8 @@ protected
   Absyn.ElementArg e;
 algorithm
   if AbsynUtil.pathIsIdent(inComponentName) then
-    outSubMod := match inMod
-      case Absyn.CLASSMOD(elementArgLst = {e as Absyn.REDECLARATION()})
-        then
-          e;
-      else
-        Absyn.MODIFICATION(false, Absyn.NON_EACH(), inComponentName,
-          SOME(inMod), NONE(), AbsynUtil.dummyInfo);
-    end match;
+    outSubMod := Absyn.MODIFICATION(false, Absyn.NON_EACH(), inComponentName,
+      SOME(inMod), NONE(), AbsynUtil.dummyInfo);
   else
     outSubMod := createNestedSubMod(AbsynUtil.pathRest(inComponentName), inMod);
     outSubMod := Absyn.MODIFICATION(false, Absyn.NON_EACH(),

--- a/testsuite/openmodelica/interactive-API/Ticket6287and6288.mos
+++ b/testsuite/openmodelica/interactive-API/Ticket6287and6288.mos
@@ -17,7 +17,7 @@ getAllSubtypeOf(DC_Drive.DriveParameters.MachineDataSets.MachineData,DC_Drive.Dr
 removeElementModifiers(DC_Drive.Examples.DCPMCurrentControlled,"driveData",false); getErrorString();
 setElementModifierValue(DC_Drive.Examples.DCPMCurrentControlled, driveData.machineData, $Code(())); getErrorString();
 getElementModifierNames(DC_Drive.Examples.DCPMCurrentControlled,"driveData"); getErrorString();
-setElementModifierValue(DC_Drive.Examples.DCPMCurrentControlled, driveData.machineData, $Code((redeclare DC_Drive.DriveParameters.MachineDataSets.M48V machineData))); getErrorString();
+setElementModifierValue(DC_Drive.Examples.DCPMCurrentControlled, driveData, $Code((redeclare DC_Drive.DriveParameters.MachineDataSets.M48V machineData))); getErrorString();
 getElementModifierNames(DC_Drive.Examples.DCPMCurrentControlled,"driveData"); getErrorString();
 getElementModifierValues(DC_Drive.Examples.DCPMCurrentControlled,driveData.machineData); getErrorString();
 
@@ -66,7 +66,7 @@ getAllSubtypeOf(DC_Drive2.DCPM_Utilities.MachineData,DC_Drive2.DCPM_Utilities.Dr
 // {}
 // Evaluating: getErrorString()
 // ""
-// Evaluating: setElementModifierValue(DC_Drive.Examples.DCPMCurrentControlled, driveData.machineData, $Code((redeclare DC_Drive.DriveParameters.MachineDataSets.M48V machineData)))
+// Evaluating: setElementModifierValue(DC_Drive.Examples.DCPMCurrentControlled, driveData, $Code((redeclare DC_Drive.DriveParameters.MachineDataSets.M48V machineData)))
 // true
 // Evaluating: getErrorString()
 // ""

--- a/testsuite/openmodelica/interactive-API/setElementModifierValue.mos
+++ b/testsuite/openmodelica/interactive-API/setElementModifierValue.mos
@@ -12,11 +12,19 @@ loadString("
   end M;
 ");
 
-setElementModifierValue(M, classwithReplaceable.testClass, $Code((redeclare ClassB testClass "A")));
+setElementModifierValue(M, classwithReplaceable.otherClass, $Code((redeclare ClassB testClass "A")));
 getErrorString();
 list(M);
 
-setElementModifierValue(M, classwithReplaceable.testClass, $Code((redeclare ClassB testClass "B")));
+setElementModifierValue(M, classwithReplaceable.otherClass, $Code((redeclare ClassB testClass "B")));
+getErrorString();
+list(M);
+
+setElementModifierValue(M, classwithReplaceable.otherClass, $Code((testClass=12)));
+getErrorString();
+list(M);
+
+setElementModifierValue(M, classwithReplaceable.otherClass, $Code((redeclare ClassB testClass "C")));
 getErrorString();
 list(M);
 
@@ -25,11 +33,21 @@ list(M);
 // true
 // ""
 // "model M
-//   ClasswithReplaceable classwithReplaceable(redeclare ClassB testClass \"A\");
+//   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"A\"));
 // end M;"
 // true
 // ""
 // "model M
-//   ClasswithReplaceable classwithReplaceable(redeclare ClassB testClass \"B\");
+//   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"B\"));
+// end M;"
+// true
+// ""
+// "model M
+//   ClasswithReplaceable classwithReplaceable(otherClass(testClass = 12));
+// end M;"
+// true
+// ""
+// "model M
+//   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"C\"));
 // end M;"
 // endResult


### PR DESCRIPTION
- Don't strip one level of the modifier when it's a redeclare.
- Improve `AbsynUtil.elementArgEqualName` to also handle redeclares.