### PR TITLE
Clarify and rename to --nonStdExposeLocalIOs

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1518,7 +1518,7 @@ algorithm
     else
       algorithm
         /* Consider toplevel inputs as known unless they are protected. Ticket #5591 */
-        /* Consider all inputs known with flag exposeLocalIOs > 0 unless they are protected */
+        /* Consider all inputs known with flag --nonStdExposeLocalIOs > 0 unless they are protected */
         if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
           false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
         else

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -212,7 +212,7 @@ algorithm
   if Connector.variability(c1) > Variability.PARAMETER then
     equations := list(makeEqualityEquation(c1.name, c1.source, c2.name, c2.source)
       for c2 in listRest(elements));
-    // collect inputs and outputs that are inside in connections if exposeLocalIOs > 0
+    // collect inputs and outputs that are inside in connections if --nonStdExposeLocalIOs > 0
     // strip array indices so that the variables will be found later
     if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) > 0 then
       for c in elements loop

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -175,11 +175,11 @@ algorithm
       algorithm
         // Strip input/output from non top-level components unless
         // --useLocalDirection=true has been set.
-        // Alternatively strip input/output only from non connectors and from protected connectors if
-        // --exposeLocalIOs has been set.
-        if (attr.direction == Direction.NONE or settings.useLocalDirection) or
-           (settings.exposeLocalIOs > 0 and attr.connectorType <> ConnectorType.NON_CONNECTOR and
-            ComponentRef.depth(cref) <= settings.exposeLocalIOs + 1 and vis == Visibility.PUBLIC) then
+        // Alternatively strip input/output from bound inputs and from protected variables if
+        // --nonStdExposeLocalIOs has been set.
+        if attr.direction == Direction.NONE or settings.useLocalDirection or
+           (settings.exposeLocalIOs > 0 and (match binding case NONE() then true; else attr.direction == Direction.OUTPUT; end match) and
+            vis == Visibility.PUBLIC and ComponentRef.depth(cref) <= settings.exposeLocalIOs + 1) then
           dir := attr.direction;
         else
           dir := getComponentDirection(attr.direction, cref);

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1453,9 +1453,11 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
-constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(155, "exposeLocalIOs",
+constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(155, "nonStdExposeLocalIOs",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
-  Gettext.gettext("Keeps the input/output prefix for unconnected inputs and outputs at requested levels, 0 meaning top-level."));
+  Gettext.gettext("Keeps input/output prefixes for unconnected input/output connectors, other outputs and unbound inputs at requested levels, provided they are public, " +
+                  "0 meaning top-level (standard Modelica), 1 inputs/outputs of top-level components, >1 going deeper. " +
+                  "This flag is particularly useful for FMI export. It breaks the Modelica standard for exposed local inputs."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -4,7 +4,7 @@
 // teardown_command: rm -f *LocalIOs.System* modelDescription.tmp.xml
 
 setCommandLineOptions("--simCodeTarget=Cpp");
-setCommandLineOptions("--exposeLocalIOs=10"); getErrorString();
+setCommandLineOptions("--nonStdExposeLocalIOs=10"); getErrorString();
 
 loadString("
 package LocalIOs
@@ -38,16 +38,25 @@ equation
   y = {c.p, c.f};
 end Source;
 
+function f
+  input Real u;
+  output Real y;
+algorithm
+  y := 0.5*u;
+end f;
+
 model Component
   PhysicalConnector c;
   input Real modifiedInput annotation(Dialog(enable=true));
+  input Real simpleInput(start = 3);
+  output Real simpleOutput = signaling.y;
   RealOutput measurement;
 protected
   Signaling signaling(u1 = 1);
 equation
   signaling.u2 = 2;
   signaling.u = 3:4;
-  c.f = 0.5*c.p + modifiedInput + signaling.y;
+  c.f = f(c.p) + modifiedInput + signaling.y;
   connect(signaling.y, measurement);
 end Component;
 
@@ -117,131 +126,147 @@ readFile("modelDescription.tmp.xml");
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
-//     name=\"component.measurement\"
+//     name=\"component.modifiedInput\"
 //     valueReference=\"0\"
-//     causality=\"output\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
-//     name=\"component.modifiedInput\"
-//     valueReference=\"1\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\"/>
+//     name=\"component.simpleInput\"
+//     valueReference=\"5\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"3.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
-//     name=\"signaling.u2\"
+//     name=\"component.simpleOutput\"
 //     valueReference=\"6\"
-//     causality=\"input\"
-//     >
+//     causality=\"output\"
+//     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"4\" -->
 //   <ScalarVariable
-//     name=\"signaling.y\"
+//     name=\"signaling.u2\"
 //     valueReference=\"7\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"5\" -->
+//   <ScalarVariable
+//     name=\"signaling.y\"
+//     valueReference=\"8\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"5\" -->
+//   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
 //     name=\"source.u_in\"
-//     valueReference=\"8\"
+//     valueReference=\"9\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"6\" -->
+//   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
 //     name=\"source.y[2]\"
-//     valueReference=\"9\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"7\" -->
+//   <!-- Index of variable = \"8\" -->
 //   <ScalarVariable
 //     name=\"source.u_par\"
-//     valueReference=\"10\"
+//     valueReference=\"11\"
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"8\" -->
-//   <ScalarVariable
-//     name=\"component.c.f\"
-//     valueReference=\"11\"
-//     >
-//     <Real/>
-//   </ScalarVariable>
 //   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
-//     name=\"component.c.p\"
-//     valueReference=\"8\"
+//     name=\"component.c.f\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"8\"
+//     name=\"component.c.p\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[2]\"
-//     valueReference=\"9\"
+//     name=\"component.measurement\"
+//     valueReference=\"6\"
+//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"12\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
+//     name=\"signaling.u[1]\"
 //     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"13\" -->
 //   <ScalarVariable
-//     name=\"source.c.f\"
-//     valueReference=\"9\"
+//     name=\"signaling.u[2]\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"14\" -->
 //   <ScalarVariable
-//     name=\"source.c.p\"
-//     valueReference=\"8\"
+//     name=\"signaling.u1\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
-//     name=\"source.y[1]\"
-//     valueReference=\"8\"
+//     name=\"source.c.f\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
-//     name=\"source.yf\"
+//     name=\"source.c.p\"
 //     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"17\" -->
 //   <ScalarVariable
-//     name=\"source.yp\"
-//     valueReference=\"8\"
-//     causality=\"output\"
+//     name=\"source.y[1]\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"18\" -->
+//   <ScalarVariable
+//     name=\"source.yf\"
+//     valueReference=\"10\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"19\" -->
+//   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"9\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"20\" -->
 //   <ScalarVariable
 //     name=\"source.use_u_in\"
 //     valueReference=\"0\"
@@ -253,8 +278,8 @@ readFile("modelDescription.tmp.xml");
 //   </ModelVariables>
 //   <ModelStructure>
 //     <InitialUnknowns>
-//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"18\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"5\" dependencies=\"4 6\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"20\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>
 // </fmiModelDescription>


### PR DESCRIPTION
This is to clearly indicate that models using this flag break the current Modelica standard for exposed local inputs.

See discussion in #10599.