### PR TITLE
Fix time-related 3D animation issues

### DIFF
--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -630,9 +630,9 @@ void AbstractAnimationWindow::repeatSlotFunciton(bool checked)
  */
 void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
 {
-  float time = (mpVisualization->getTimeManager()->getEndTime()
-                - mpVisualization->getTimeManager()->getStartTime())
-      * (float) (value / (float)mSliderRange);
+  double start = mpVisualization->getTimeManager()->getStartTime();
+  double end = mpVisualization->getTimeManager()->getEndTime();
+  float time = (end - start) * (value / (float)mSliderRange);
   mpVisualization->getTimeManager()->setVisTime(time);
   mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
   mpVisualization->updateScene(time);
@@ -645,22 +645,21 @@ void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
  */
 void AbstractAnimationWindow::jumpToTimeSlotFunction()
 {
-  QString str = mpTimeTextBox->text();
-  bool isDouble = true;
-  double start = mpVisualization->getTimeManager()->getStartTime();
-  double end = mpVisualization->getTimeManager()->getEndTime();
-  double value = str.toDouble(&isDouble);
-  if (isDouble && value >= 0.0) {
-    if (value < start) {
-      value = start;
-    } else if (value > end) {
-      value = end;
+  bool isDouble = false;
+  double time = mpTimeTextBox->text().toDouble(&isDouble);
+  if (isDouble && time >= 0.0) {
+    double start = mpVisualization->getTimeManager()->getStartTime();
+    double end = mpVisualization->getTimeManager()->getEndTime();
+    if (time < start) {
+      time = start;
+    } else if (time > end) {
+      time = end;
     }
-    mpVisualization->getTimeManager()->setVisTime(value);
+    mpVisualization->getTimeManager()->setVisTime(time);
     bool state = mpAnimationSlider->blockSignals(true);
     mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
     mpAnimationSlider->blockSignals(state);
-    mpVisualization->updateScene(value);
+    mpVisualization->updateScene(time);
     mpViewerWidget->update();
   }
 }
@@ -671,11 +670,10 @@ void AbstractAnimationWindow::jumpToTimeSlotFunction()
  */
 void AbstractAnimationWindow::setSpeedSlotFunction()
 {
-  QString str = mpSpeedComboBox->lineEdit()->text();
-  bool isDouble = true;
-  double value = str.toDouble(&isDouble);
-  if (isDouble && value > 0.0) {
-    mpVisualization->getTimeManager()->setSpeedUp(value);
+  bool isDouble = false;
+  double speed = mpSpeedComboBox->lineEdit()->text().toDouble(&isDouble);
+  if (isDouble && speed > 0.0) {
+    mpVisualization->getTimeManager()->setSpeedUp(speed);
     mpViewerWidget->update();
   }
 }

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -123,11 +123,11 @@ void AbstractAnimationWindow::openAnimationFile(QString fileName, bool stashCame
       mpAnimationRepeatAction->setEnabled(true);
       mpAnimationSlider->setEnabled(true);
       bool state = mpAnimationSlider->blockSignals(true);
-      mpAnimationSlider->setValue(0);
+      mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
       mpAnimationSlider->blockSignals(state);
       mpSpeedComboBox->setEnabled(true);
       mpTimeTextBox->setEnabled(true);
-      mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getStartTime()));
+      mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
       /* Only use isometric view as default for csv file type.
        * Otherwise use side view as default which suits better for Modelica models.
        */
@@ -589,7 +589,7 @@ void AbstractAnimationWindow::initSlotFunction()
 {
   mpVisualization->initVisualization();
   bool state = mpAnimationSlider->blockSignals(true);
-  mpAnimationSlider->setValue(0);
+  mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
   mpAnimationSlider->blockSignals(state);
   mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
   mpViewerWidget->update();

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -547,23 +547,21 @@ void AbstractAnimationWindow::openFMUSettingsDialog(VisualizationFMU* pVisualiza
 void AbstractAnimationWindow::updateScene()
 {
   if (mpVisualization) {
-    //set time label
-    if (!mpVisualization->getTimeManager()->isPaused()) {
-      mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
-      // set time slider
-      if (mpVisualization->getVisType() != VisType::FMU) {
-        int time = mpVisualization->getTimeManager()->getTimeFraction();
-        bool state = mpAnimationSlider->blockSignals(true);
-        mpAnimationSlider->setValue(time);
-        mpAnimationSlider->blockSignals(state);
-      }
-    }
-
-    //update the scene
+    // update scene
     mpVisualization->sceneUpdate();
     mpViewerWidget->update();
-
-    updateControlPanelValues();
+    if (!mpVisualization->getTimeManager()->isPaused()) {
+      // set time label
+      mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
+      // set time slider
+      bool state = mpAnimationSlider->blockSignals(true);
+      mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
+      mpAnimationSlider->blockSignals(state);
+    }
+    if (mpVisualization->getVisType() == VisType::FMU) {
+      // set state labels
+      updateControlPanelValues();
+    }
   }
 }
 
@@ -588,12 +586,14 @@ void AbstractAnimationWindow::chooseAnimationFileSlotFunction()
 void AbstractAnimationWindow::initSlotFunction()
 {
   mpVisualization->initVisualization();
+  mpViewerWidget->update();
   bool state = mpAnimationSlider->blockSignals(true);
   mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
   mpAnimationSlider->blockSignals(state);
   mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
-  mpViewerWidget->update();
-  updateControlPanelValues();
+  if (mpVisualization->getVisType() == VisType::FMU) {
+    updateControlPanelValues();
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -670,11 +670,14 @@ void AbstractAnimationWindow::jumpToTimeSlotFunction()
       time = end;
     }
     mpVisualization->getTimeManager()->setVisTime(time);
+    mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
     bool state = mpAnimationSlider->blockSignals(true);
     mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
     mpAnimationSlider->blockSignals(state);
     mpVisualization->updateScene(time);
     mpViewerWidget->update();
+  } else {
+    mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
   }
 }
 

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -692,6 +692,8 @@ void AbstractAnimationWindow::setSpeedSlotFunction()
   if (isDouble && speed > 0.0) {
     mpVisualization->getTimeManager()->setSpeedUp(speed);
     mpViewerWidget->update();
+  } else {
+    mpSpeedComboBox->lineEdit()->setText(QString::number(mpVisualization->getTimeManager()->getSpeedUp()));
   }
 }
 

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -632,7 +632,7 @@ void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
 {
   double start = mpVisualization->getTimeManager()->getStartTime();
   double end = mpVisualization->getTimeManager()->getEndTime();
-  float time = (end - start) * (value / (float)mSliderRange);
+  double time = (end - start) * (value / (double)mSliderRange);
   mpVisualization->getTimeManager()->setVisTime(time);
   mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
   mpVisualization->updateScene(time);

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -632,7 +632,7 @@ void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
 {
   double start = mpVisualization->getTimeManager()->getStartTime();
   double end = mpVisualization->getTimeManager()->getEndTime();
-  double time = (end - start) * (value / (double)mSliderRange);
+  double time = (end - start) * (value / (double)mSliderRange) + start;
   mpVisualization->getTimeManager()->setVisTime(time);
   mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
   mpVisualization->updateScene(time);

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -625,6 +625,29 @@ void AbstractAnimationWindow::repeatSlotFunciton(bool checked)
 }
 
 /*!
+ * \brief AbstractAnimationWindow::updateSceneTime
+ * Updates the scene to the provided point of time
+ * \param time The new point of time
+ */
+void AbstractAnimationWindow::updateSceneTime(double time)
+{
+  double start = mpVisualization->getTimeManager()->getStartTime();
+  double end = mpVisualization->getTimeManager()->getEndTime();
+  if (time < start) {
+    time = start;
+  } else if (time > end) {
+    time = end;
+  }
+  mpVisualization->getTimeManager()->setVisTime(time);
+  mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
+  bool state = mpAnimationSlider->blockSignals(true);
+  mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
+  mpAnimationSlider->blockSignals(state);
+  mpVisualization->updateScene(mpVisualization->getTimeManager()->getVisTime());
+  mpViewerWidget->update();
+}
+
+/*!
  * \brief AbstractAnimationWindow::sliderSetTimeSlotFunction
  * slot function for the time slider to jump to the adjusted point of time
  */
@@ -634,18 +657,7 @@ void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
     double start = mpVisualization->getTimeManager()->getStartTime();
     double end = mpVisualization->getTimeManager()->getEndTime();
     double time = (end - start) * (value / (double)mSliderRange) + start;
-    if (time < start) {
-      time = start;
-    } else if (time > end) {
-      time = end;
-    }
-    mpVisualization->getTimeManager()->setVisTime(time);
-    mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
-    bool state = mpAnimationSlider->blockSignals(true);
-    mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
-    mpAnimationSlider->blockSignals(state);
-    mpVisualization->updateScene(time);
-    mpViewerWidget->update();
+    updateSceneTime(time);
   } else {
     bool state = mpAnimationSlider->blockSignals(true);
     mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
@@ -662,20 +674,7 @@ void AbstractAnimationWindow::jumpToTimeSlotFunction()
   bool isDouble = false;
   double time = mpTimeTextBox->text().toDouble(&isDouble);
   if (isDouble && time >= 0.0) {
-    double start = mpVisualization->getTimeManager()->getStartTime();
-    double end = mpVisualization->getTimeManager()->getEndTime();
-    if (time < start) {
-      time = start;
-    } else if (time > end) {
-      time = end;
-    }
-    mpVisualization->getTimeManager()->setVisTime(time);
-    mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
-    bool state = mpAnimationSlider->blockSignals(true);
-    mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
-    mpAnimationSlider->blockSignals(state);
-    mpVisualization->updateScene(time);
-    mpViewerWidget->update();
+    updateSceneTime(time);
   } else {
     mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
   }

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -641,8 +641,15 @@ void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
     }
     mpVisualization->getTimeManager()->setVisTime(time);
     mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
+    bool state = mpAnimationSlider->blockSignals(true);
+    mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
+    mpAnimationSlider->blockSignals(state);
     mpVisualization->updateScene(time);
     mpViewerWidget->update();
+  } else {
+    bool state = mpAnimationSlider->blockSignals(true);
+    mpAnimationSlider->setValue(mpVisualization->getTimeManager()->getTimeFraction());
+    mpAnimationSlider->blockSignals(state);
   }
 }
 

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -218,17 +218,17 @@ void AbstractAnimationWindow::createActions()
   connect(mpPerspectiveDropDownBox, SIGNAL(activated(int)), this, SLOT(setPerspective(int)));
   // rotate camera left action
   mpRotateCameraLeftAction = new QAction(QIcon(":/Resources/icons/rotateCameraLeft.svg"), tr("Rotate Left"), this);
-  mpRotateCameraLeftAction->setStatusTip(tr("Rotates the camera left"));
+  mpRotateCameraLeftAction->setStatusTip(tr("Rotate the camera left"));
   connect(mpRotateCameraLeftAction, SIGNAL(triggered()), this, SLOT(rotateCameraLeft()));
   // rotate camera right action
   mpRotateCameraRightAction = new QAction(QIcon(":/Resources/icons/rotateCameraRight.svg"), tr("Rotate Right"), this);
-  mpRotateCameraRightAction->setStatusTip(tr("Rotates the camera right"));
+  mpRotateCameraRightAction->setStatusTip(tr("Rotate the camera right"));
   connect(mpRotateCameraRightAction, SIGNAL(triggered()), this, SLOT(rotateCameraRight()));
-  //interactive control action
+  // interactive control action
   mpInteractiveControlAction = mpAnimationParameterDockerWidget->toggleViewAction();
   mpInteractiveControlAction->setIcon(QIcon(":/Resources/icons/control-panel.svg"));
-  mpInteractiveControlAction->setText(tr("interactive control"));
-  mpInteractiveControlAction->setStatusTip(tr("Opens the interactive control panel"));
+  mpInteractiveControlAction->setText(tr("Interactive Control"));
+  mpInteractiveControlAction->setStatusTip(tr("Open the interactive control panel"));
   mpInteractiveControlAction->setEnabled(false);
   mpAnimationParameterDockerWidget->hide();
 }

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.cpp
@@ -630,13 +630,20 @@ void AbstractAnimationWindow::repeatSlotFunciton(bool checked)
  */
 void AbstractAnimationWindow::sliderSetTimeSlotFunction(int value)
 {
-  double start = mpVisualization->getTimeManager()->getStartTime();
-  double end = mpVisualization->getTimeManager()->getEndTime();
-  double time = (end - start) * (value / (double)mSliderRange) + start;
-  mpVisualization->getTimeManager()->setVisTime(time);
-  mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
-  mpVisualization->updateScene(time);
-  mpViewerWidget->update();
+  if (value >= 0) {
+    double start = mpVisualization->getTimeManager()->getStartTime();
+    double end = mpVisualization->getTimeManager()->getEndTime();
+    double time = (end - start) * (value / (double)mSliderRange) + start;
+    if (time < start) {
+      time = start;
+    } else if (time > end) {
+      time = end;
+    }
+    mpVisualization->getTimeManager()->setVisTime(time);
+    mpTimeTextBox->setText(QString::number(mpVisualization->getTimeManager()->getVisTime()));
+    mpVisualization->updateScene(time);
+    mpViewerWidget->update();
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.h
+++ b/OMEdit/OMEditLIB/Animation/AbstractAnimationWindow.h
@@ -116,6 +116,7 @@ protected:
   double computeDistanceToOrigin();
   void openFMUSettingsDialog(VisualizationFMU *pVisualizationFMU);
   void updateControlPanelValues();
+  void updateSceneTime(double time);
 
 public slots:
   void updateScene();

--- a/OMEdit/OMEditLIB/Animation/TimeManager.cpp
+++ b/OMEdit/OMEditLIB/Animation/TimeManager.cpp
@@ -48,19 +48,19 @@ TimeManager::TimeManager(const double simTime, const double realTime, const doub
     mSpeedUp(1.0),
     mTimeDiscretization(1000)
 {
-  mpUpdateSceneTimer = new QTimer;
+  mpUpdateSceneTimer = new QTimer();
   mpUpdateSceneTimer->setInterval(100);
   rt_ext_tp_tick_realtime(&_visualTimer);
 }
 
 void TimeManager::updateTick()
 {
-  _realTime = rt_ext_tp_tock(&_visualTimer)*1e9;
+  _realTime = rt_ext_tp_tock(&_visualTimer) * 1e9;
 }
 
 int TimeManager::getTimeFraction()
 {
-  return int(_visTime / (_endTime - _startTime)*mTimeDiscretization);
+  return int(_visTime / (_endTime - _startTime) * mTimeDiscretization);
 }
 
 double TimeManager::getEndTime() const

--- a/OMEdit/OMEditLIB/Animation/TimeManager.cpp
+++ b/OMEdit/OMEditLIB/Animation/TimeManager.cpp
@@ -60,7 +60,7 @@ void TimeManager::updateTick()
 
 int TimeManager::getTimeFraction()
 {
-  return int(_visTime / (_endTime - _startTime) * mTimeDiscretization);
+  return int((_visTime - _startTime) / (_endTime - _startTime) * mTimeDiscretization);
 }
 
 double TimeManager::getEndTime() const

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1190,12 +1190,11 @@ void VisualizationAbstract::setUpScene()
 
 void VisualizationAbstract::sceneUpdate()
 {
-  //measure realtime
+  // measure real time
   mpTimeManager->updateTick();
-  //update scene and set next time step
+  // set next time step
   if (!mpTimeManager->isPaused()) {
-    updateScene(mpTimeManager->getVisTime());
-    //finish animation with pause when endtime is reached
+    // finish animation with pause when end time is reached
     if (mpTimeManager->getVisTime() >= mpTimeManager->getEndTime()) {
       if (mpTimeManager->canRepeat()) {
         initVisualization();
@@ -1203,23 +1202,26 @@ void VisualizationAbstract::sceneUpdate()
       } else {
         mpTimeManager->setPause(true);
       }
-    } else { // get the new visualization time
-      double newTime = mpTimeManager->getVisTime() + (mpTimeManager->getHVisual()*mpTimeManager->getSpeedUp());
+    } else {
+      // set new visualization time
+      double newTime = mpTimeManager->getVisTime() + (mpTimeManager->getHVisual() * mpTimeManager->getSpeedUp());
       if (newTime <= mpTimeManager->getEndTime()) {
         mpTimeManager->setVisTime(newTime);
       } else {
         mpTimeManager->setVisTime(mpTimeManager->getEndTime());
       }
+      // update scene
+      updateScene(mpTimeManager->getVisTime());
     }
   }
 }
 
 void VisualizationAbstract::initVisualization()
 {
-  initializeVisAttributes(mpTimeManager->getStartTime());
-  mpTimeManager->setVisTime(mpTimeManager->getStartTime());
-  mpTimeManager->setRealTimeFactor(0.0);
   mpTimeManager->setPause(true);
+  mpTimeManager->setRealTimeFactor(0.0);
+  mpTimeManager->setVisTime(mpTimeManager->getStartTime());
+  initializeVisAttributes(mpTimeManager->getVisTime());
 }
 
 void VisualizationAbstract::startVisualization()


### PR DESCRIPTION
### Related Issues

1. Fixes #10635
2. Fixes #10636
3. Fixes #10637

### Purpose

Improve user's experience with 3D animation.

### Approach

1. Use `double` type instead of `float` in time computation.
2. Add start time in the computation of visualization time.
3. Reorder scene update and computation of next time.

Test model:
```modelica
model Test
  extends Modelica.Mechanics.MultiBody.Examples.Systems.RobotR3.FullRobot;
equation
  annotation(experiment(StartTime = 1, StopTime = 2));
end Test;
```
