### PR TITLE
Improve setElementModifierValue

### DIFF
--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -661,7 +661,7 @@ algorithm
         function AbsynUtil.elementArgEqualName(inArg2 = narg));
 
       if not found then
-        outArgs := narg :: outArgs;
+        outArgs := List.appendElt(narg, outArgs);
       end if;
     end for;
   end if;

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -2091,8 +2091,8 @@ code_expression returns [void* ast]
       ( (EQUATION eq=code_equation_clause)
        |(CONSTRAINT constr=code_constraint_clause)
        |(T_ALGORITHM alg=code_algorithm_clause))
-    | (LPAR expression[metamodelica_enabled()] RPAR) => e=expression[metamodelica_enabled()]   /* Allow Code((<expr>)) */
     | m=modification
+    | (LPAR expression[metamodelica_enabled()] RPAR) => e=expression[metamodelica_enabled()]   /* Allow Code((<expr>)) */
     | (expression[metamodelica_enabled()] RPAR) => e=expression[metamodelica_enabled()]
     | el=element (SEMICOLON)?
     )  RPAR

--- a/testsuite/openmodelica/interactive-API/setComponentModifierValue.mos
+++ b/testsuite/openmodelica/interactive-API/setComponentModifierValue.mos
@@ -79,7 +79,7 @@ setComponentModifierValue(M, q, $Code(=1));
 //
 //   A a(b.x = 11, b.c(u = 13), y = 9, z = 10);
 //   A a2(b(x = 12));
-//   Real w(min = 5, start = 4) = 3;
+//   Real w(start = 4, min = 5) = 3;
 // end M;"
 // true
 // true

--- a/testsuite/openmodelica/interactive-API/setElementModifierValue.mos
+++ b/testsuite/openmodelica/interactive-API/setElementModifierValue.mos
@@ -28,6 +28,10 @@ setElementModifierValue(M, classwithReplaceable.otherClass, $Code((redeclare Cla
 getErrorString();
 list(M);
 
+setElementModifierValue(M, classwithReplaceable, $Code((A = 1, B = 2)));
+getErrorString();
+list(M);
+
 // Result:
 // true
 // true
@@ -49,5 +53,10 @@ list(M);
 // ""
 // "model M
 //   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"C\"));
+// end M;"
+// true
+// ""
+// "model M
+//   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"C\"), A = 1, B = 2);
 // end M;"
 // endResult


### PR DESCRIPTION
- Change the parsing of code quotations so that modifiers have higher priority than expressions to avoid modifiers being parsed as tuple expression, since tuples don't appear as function arguments anyway.
- Change InteractiveUtil.mergeElementArgs to append new submodifiers at the end of the list in the given order, instead of in reverse order at the front.