### PR TITLE
Frontend support for partial derivatives of functions

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -470,6 +470,11 @@ public uniontype FunctionDefinition
     ComponentRef inputParam "The input parameter the inverse is for";
     Exp inverseCall "The inverse function call";
   end FUNCTION_INVERSE;
+
+  record FUNCTION_PARTIAL_DERIVATIVE
+    Absyn.Path derivedFunction;
+    list<String> derivedVars;
+  end FUNCTION_PARTIAL_DERIVATIVE;
 end FunctionDefinition;
 
 public

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -143,7 +143,7 @@ constant InstNode INTEGER_DUMMY_NODE = NFInstNode.CLASS_NODE("Integer",
 constant Function INTEGER_FUNCTION = Function.FUNCTION(Path.IDENT("Integer"),
   INTEGER_DUMMY_NODE, {ENUM_PARAM}, {}, {}, {
     Slot.SLOT(ENUM_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}), Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+  }, Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}), Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant InstNode INTEGER_NODE = InstNode.CLASS_NODE("IntegerFunc",
   DUMMY_ELEMENT, Visibility.PUBLIC,
@@ -185,7 +185,7 @@ constant Function STRING_REAL = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT(SIGNIFICANT_DIGITS_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(6)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 4, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(r, format="-0.6g")
@@ -193,7 +193,7 @@ constant Function STRING_REAL_FORMAT = Function.FUNCTION(Path.IDENT("String"),
   STRING_DUMMY_NODE, {REAL_PARAM, STRING_PARAM}, {STRING_PARAM}, {}, {
     Slot.SLOT(R_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(FORMAT_PARAM, SlotType.NAMED, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(i, minimumLength=0, leftJustified=true)
@@ -202,7 +202,7 @@ constant Function STRING_INT = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT(I_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(b, minimumLength=0, leftJustified=true)
@@ -211,7 +211,7 @@ constant Function STRING_BOOL = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT(B_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // String(e, minimumLength=0, leftJustified=true)
@@ -220,7 +220,7 @@ constant Function STRING_ENUM = Function.FUNCTION(Path.IDENT("String"),
     Slot.SLOT(E_PARAM, SlotType.POSITIONAL, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(MINIMUM_LENGTH_PARAM, SlotType.NAMED, SOME(Expression.INTEGER(0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(LEFT_JUSTIFIED_PARAM, SlotType.NAMED, SOME(Expression.BOOLEAN(true)), NONE(), 3, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.STRING(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant InstNode STRING_NODE = InstNode.CLASS_NODE("String",
@@ -246,142 +246,142 @@ constant ComponentRef STRING_CREF =
 // TODO: Sort these functions ...
 constant Function COS_REAL = Function.FUNCTION(Path.IDENT("cos"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SIN_REAL = Function.FUNCTION(Path.IDENT("sin"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function TAN_REAL = Function.FUNCTION(Path.IDENT("tan"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function COSH_REAL = Function.FUNCTION(Path.IDENT("cosh"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SINH_REAL = Function.FUNCTION(Path.IDENT("sinh"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function TANH_REAL = Function.FUNCTION(Path.IDENT("tanh"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function EXP_REAL = Function.FUNCTION(Path.IDENT("exp"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function LOG_REAL = Function.FUNCTION(Path.IDENT("log"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function LOG10_REAL = Function.FUNCTION(Path.IDENT("log10"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ABS_REAL = Function.FUNCTION(Path.IDENT("abs"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SIGN_REAL = Function.FUNCTION(Path.IDENT("sign"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MAX_INT = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function MAX_REAL = Function.FUNCTION(Path.IDENT("max"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function DIV_INT = Function.FUNCTION(Path.IDENT("div"),
   InstNode.EMPTY_NODE(), {INT_PARAM, INT_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function DIV_REAL = Function.FUNCTION(Path.IDENT("div"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FLOOR = Function.FUNCTION(Path.IDENT("floor"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INTEGER_REAL = Function.FUNCTION(Path.IDENT("integer"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function INTEGER_ENUM = Function.FUNCTION(Path.IDENT("Integer"),
   InstNode.EMPTY_NODE(), {ENUM_PARAM}, {INT_PARAM}, {}, {},
-    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.INTEGER(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function POSITIVE_MAX_REAL = Function.FUNCTION(Path.IDENT("$OMC$PositiveMax"),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function IN_STREAM = Function.FUNCTION(Path.IDENT("inStream"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function PROMOTE = Function.FUNCTION(Path.IDENT("promote"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function CAT = Function.FUNCTION(Path.IDENT("cat"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function ARRAY_FUNC = Function.FUNCTION(Path.IDENT("array"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function FILL_FUNC = Function.FUNCTION(Path.IDENT("fill"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SMOOTH = Function.FUNCTION(Path.IDENT("smooth"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function NO_EVENT = Function.FUNCTION(Path.IDENT("noEvent"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SUM = Function.FUNCTION(Path.IDENT("sum"),
   InstNode.EMPTY_NODE(), {}, {}, {}, {},
-    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+    Type.UNKNOWN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Function SAMPLE = Function.FUNCTION(Path.QUALIFIED("OMC_NO_CLOCK", Path.IDENT("sample")),
   InstNode.EMPTY_NODE(), {REAL_PARAM, REAL_PARAM}, {REAL_PARAM}, {}, {},
-    Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, listArray({}),
+    Type.BOOLEAN(), DAE.FUNCTION_ATTRIBUTES_BUILTIN_IMPURE, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant Component CLOCK_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
@@ -400,7 +400,7 @@ constant InstNode CLOCK_DUMMY_NODE = NFInstNode.CLASS_NODE("Clock",
 // Clock() - inferred clock
 constant Function CLOCK_INFERRED = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {}, {CLOCK_PARAM}, {}, {}, Type.CLOCK(),
-  DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 constant InstNode INTERVAL_COUNTER_PARAM = InstNode.COMPONENT_NODE("intervalCounter", NONE(),
@@ -423,14 +423,14 @@ constant Function CLOCK_INT = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {INT_PARAM, INT_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT(INTERVAL_COUNTER_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(RESOLUTION_PARAM, SlotType.GENERIC, SOME(Expression.INTEGER(1)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(interval) - clock with Real interval
 constant Function CLOCK_REAL = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {REAL_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT(INTERVAL_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(condition, startInterval = 0.0) - Event clock, triggered by zero-crossing events
@@ -438,7 +438,7 @@ constant Function CLOCK_BOOL = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {BOOL_PARAM, REAL_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT(CONDITION_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(START_INTERVAL_PARAM, SlotType.GENERIC, SOME(Expression.REAL(0.0)), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 // Clock(c, solverMethod) - Solver clock
@@ -446,7 +446,7 @@ constant Function CLOCK_SOLVER = Function.FUNCTION(Path.IDENT("Clock"),
   CLOCK_DUMMY_NODE, {CLOCK_PARAM, STRING_PARAM}, {CLOCK_PARAM}, {}, {
     Slot.SLOT(C_PARAM, SlotType.GENERIC, NONE(), NONE(), 1, SlotEvalStatus.NOT_EVALUATED),
     Slot.SLOT(SOLVER_METHOD_PARAM, SlotType.GENERIC, NONE(), NONE(), 2, SlotEvalStatus.NOT_EVALUATED)
-  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, listArray({}),
+  }, Type.CLOCK(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
   Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -213,6 +213,12 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
     cls := match cls
       case INSTANCED_CLASS()
         then INSTANCED_CLASS(cls.ty, cls.elements, sections, cls.prefixes, cls.restriction);
+
+      case TYPED_DERIVED()
+        algorithm
+          InstNode.classApply(cls.baseClass, setSections, sections);
+        then
+          cls;
     end match;
   end setSections;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -1091,6 +1091,14 @@ algorithm
   cls := InstNode.getClass(Function.instance(func));
 
   dfunc := match cls
+    case Class.TYPED_DERIVED(restriction = Restriction.FUNCTION())
+      guard Function.isPartialDerivative(func)
+      algorithm
+        def := DAE.FunctionDefinition.FUNCTION_PARTIAL_DERIVATIVE(
+          Function.getDerivedFunctionName(func), Function.getDerivedInputNames(func));
+      then
+        Function.toDAE(func, def);
+
     case Class.INSTANCED_CLASS(sections = sections, restriction = Restriction.FUNCTION())
       algorithm
         elems := convertFunctionParams(func.inputs, {});

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -81,6 +81,10 @@ function evaluate
 algorithm
   if Function.isExternal(fn) then
     result := evaluateExternal(fn, args, target);
+  elseif Function.isPartialDerivative(fn) then
+    // Partial derivatives of functions are differentiated by the backend, so
+    // make sure we don't try to evaluate the non-differentiated function body.
+    fail();
   else
     result := evaluateNormal(fn, args);
   end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2533,6 +2533,12 @@ algorithm
       for fn_inv in fn.inverses loop
         funcs := collectExpFuncs(fn_inv.inverseCall, funcs);
       end for;
+
+      if Function.isPartialDerivative(fn) then
+        for f in Function.getCachedFuncs(Class.lastBaseClass(fn.node)) loop
+          flattenFunction(f, funcs);
+        end for;
+      end if;
     end if;
   end if;
 end flattenFunction;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -547,6 +547,15 @@ algorithm
     // get here through e.g. the interactive API. In that case just ignore them.
     case SCode.OVERLOAD() then node;
 
+    // A partial derivative of a function, function df = der(f, x).
+    // Treat it as a short class definition here,
+    case SCode.PDER()
+      guard Flags.getConfigBool(Flags.NEW_BACKEND)
+      then expandClassDerived(def,
+         SCode.ClassDef.DERIVED(Absyn.TypeSpec.TPATH(cdef.functionPath, NONE()),
+                                SCode.NOMOD(), SCode.defaultVarAttr),
+         node, info);
+
     else
       algorithm
         Error.assertion(false, getInstanceName() + " got unknown class:\n" + SCodeDump.unparseElementStr(def), sourceInfo());

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -526,6 +526,21 @@ uniontype InstNode
     end match;
   end name;
 
+  function isNamed
+    input InstNode node;
+    input String name;
+    output Boolean res;
+  algorithm
+    res := match node
+      case CLASS_NODE() then node.name == name;
+      case COMPONENT_NODE() then node.name == name;
+      case INNER_OUTER_NODE() then isNamed(node.innerNode, name);
+      case VAR_NODE() then node.name == name;
+      case NAME_NODE() then node.name == name;
+      else false;
+    end match;
+  end isNamed;
+
   function className
     input InstNode node;
     output String name;

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -163,7 +163,7 @@ algorithm
   attr := DAE.FUNCTION_ATTRIBUTES_DEFAULT;
   status := Pointer.create(FunctionStatus.INITIAL);
   InstNode.cacheAddFunc(node, Function.FUNCTION(path, ctor_node, inputs,
-    {out_rec}, locals, {}, Type.UNKNOWN(), attr, {}, listArray({}), status, Pointer.create(0)), false);
+    {out_rec}, locals, {}, Type.UNKNOWN(), attr, {}, {}, listArray({}), status, Pointer.create(0)), false);
 end instDefaultConstructor;
 
 function checkLocalFieldOrder

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -130,6 +130,7 @@ end typeClass;
 function typeComponents
   input InstNode cls;
   input InstContext.Type context;
+  input Boolean preserveDerived = false;
 protected
   Class c = InstNode.getClass(cls), c2;
   ClassTree cls_tree;
@@ -158,7 +159,8 @@ algorithm
 
     // For derived types with dimensions we keep them as they are, because we
     // need to preserve the dimensions.
-    case Class.TYPED_DERIVED(ty = Type.ARRAY())
+    case Class.TYPED_DERIVED()
+      guard preserveDerived or Type.isArray(c.ty)
       algorithm
         typeComponents(c.baseClass, context);
       then

--- a/OMCompiler/Compiler/Template/DAEDumpTV.mo
+++ b/OMCompiler/Compiler/Template/DAEDumpTV.mo
@@ -998,6 +998,11 @@ package DAE
       ComponentRef inputParam "The input parameter the inverse is for";
       Exp inverseCall "The inverse function call";
     end FUNCTION_INVERSE;
+
+    record FUNCTION_PARTIAL_DERIVATIVE
+      Absyn.Path derivedFunction;
+      list<String> derivedVars;
+    end FUNCTION_PARTIAL_DERIVATIVE;
   end FunctionDefinition;
 
   uniontype derivativeCond "Different conditions on derivatives"

--- a/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/DAEDumpTpl.tpl
@@ -67,6 +67,14 @@ end dumpFunctions;
 template dumpFunction(DAE.Function function)
 ::=
   match function
+    case FUNCTION(functions = {FUNCTION_PARTIAL_DERIVATIVE(__)}) then
+      let fn_name = AbsynDumpTpl.dumpPathNoQual(path)
+      let cmt_str = dumpCommentOpt(comment)
+      let ann_str = dumpClassAnnotation(comment)
+      let impure_str = if isImpure then 'impure '
+      <<
+      <%impure_str%>function <%fn_name%> = <%dumpFunctionDefinitions(functions)%><%cmt_str%><%if ann_str then " "%><%ann_str%>;
+      >>
     case FUNCTION(__) then
       let cmt_str = dumpCommentOpt(comment)
       let ann_str = dumpClassAnnotation(comment)
@@ -111,6 +119,11 @@ match functions
     >>
   case FUNCTION_DER_MAPPER(__) then ''
   case FUNCTION_INVERSE(__) then ''
+  case FUNCTION_PARTIAL_DERIVATIVE(__) then
+    let vars = (derivedVars |> var => var ;separator=", ")
+    <<
+    der(<%AbsynDumpTpl.dumpPathNoQual(derivedFunction)%>, <%vars%>)
+    >>
 end dumpFunctionDefinition;
 
 template dumpExternalDecl(ExternalDecl externalDecl)

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -881,6 +881,10 @@ public constant ErrorTypes.Message NF_PDE_NOT_IMPLEMENTED = ErrorTypes.MESSAGE(4
   Gettext.gettext("PDEModelica is not yet supported by the new front-end, using the old front-end instead."));
 public constant ErrorTypes.Message NON_CONSTANT_IN_ENCLOSING_SCOPE = ErrorTypes.MESSAGE(403, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Component ‘%s‘ was found in an enclosing scope but is not a constant."));
+public constant ErrorTypes.Message PARTIAL_DERIVATIVE_INPUT_NOT_FOUND = ErrorTypes.MESSAGE(404, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  Gettext.gettext("‘%s‘ in partial derivative of ‘%s‘ does not name an input parameter of the function."));
+public constant ErrorTypes.Message PARTIAL_DERIVATIVE_INPUT_INVALID_TYPE = ErrorTypes.MESSAGE(405, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  Gettext.gettext("‘%s‘ in partial derivative of ‘%s‘ is not a scalar Real input parameter of the function."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative1.mo
@@ -1,0 +1,24 @@
+// name: FunctionPartialDerivative1
+// keywords:
+// status: correct
+// cflags: -d=newInst, --newBackend
+//
+
+model FunctionPartialDerivative1
+  function f
+    input Real x;
+    output Real y = x^2;
+  end f;
+
+  function df = der(f, x);
+
+  Real y = df(0);
+end FunctionPartialDerivative1;
+
+// Result:
+// function FunctionPartialDerivative1.df = der(FunctionPartialDerivative1.f, x);
+//
+// class FunctionPartialDerivative1
+//   Real y = FunctionPartialDerivative1.df(0.0);
+// end FunctionPartialDerivative1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative2.mo
@@ -1,0 +1,26 @@
+// name: FunctionPartialDerivative2
+// keywords:
+// status: incorrect
+// cflags: -d=newInst, --newBackend
+//
+
+model FunctionPartialDerivative2
+  function f
+    input Real x;
+    output Real y = x^2;
+  end f;
+
+  function df = der(f, y);
+
+  Real y = df(0);
+end FunctionPartialDerivative2;
+
+// Result:
+// Error processing file: FunctionPartialDerivative2.mo
+// [flattening/modelica/scodeinst/FunctionPartialDerivative2.mo:15:3-15:17:writable] Error: ‘y‘ in partial derivative of ‘FunctionPartialDerivative2.f‘ does not name an input parameter of the function.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative3.mo
@@ -1,0 +1,26 @@
+// name: FunctionPartialDerivative3
+// keywords:
+// status: incorrect
+// cflags: -d=newInst, --newBackend
+//
+
+model FunctionPartialDerivative3
+  function f
+    input Integer x;
+    output Real y = x^2;
+  end f;
+
+  function df = der(f, x);
+
+  Real y = df(0);
+end FunctionPartialDerivative3;
+
+// Result:
+// Error processing file: FunctionPartialDerivative3.mo
+// [flattening/modelica/scodeinst/FunctionPartialDerivative3.mo:13:3-13:26:writable] Error: ‘x‘ in partial derivative of ‘FunctionPartialDerivative3.f‘ is not a scalar Real input parameter of the function.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -662,6 +662,9 @@ FunctionMultiOutput4.mo \
 FunctionMultiOutput5.mo \
 FunctionNoOutput1.mo \
 FunctionNonInputOutputParameter.mo \
+FunctionPartialDerivative1.mo \
+FunctionPartialDerivative2.mo \
+FunctionPartialDerivative3.mo \
 FunctionRecordArg1.mo \
 FunctionRecordArg2.mo \
 FunctionRecordArg3.mo \


### PR DESCRIPTION
- Add frontend support for partial derivatives of functions (`df = der(f, x)`) for use by the new backend. Only enabled when using the `--newBackend` flag since the old backend would handle them incorrectly.