### PR TITLE
Add isReplaceable/isRedeclare API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -930,6 +930,18 @@ algorithm
   end match;
 end isClassNamed;
 
+public function isComponentItemNamed
+  input String name;
+  input Absyn.ComponentItem component;
+  output Boolean res = isComponentNamed(name, component.component);
+end isComponentItemNamed;
+
+public function isComponentNamed
+  input String name;
+  input Absyn.Component component;
+  output Boolean res = name == component.name;
+end isComponentNamed;
+
 public function elementSpecName
   "The Absyn.ElementSpec type contains the name of the element, and this function
    extracts this name."
@@ -4918,6 +4930,41 @@ algorithm
   end match;
 end isElementItemClassNamed;
 
+public function isElementItemNamed
+  input String name;
+  input Absyn.ElementItem element;
+  output Boolean res;
+algorithm
+  res := match element
+    case Absyn.ELEMENTITEM() then isElementNamed(name, element.element);
+    else false;
+  end match;
+end isElementItemNamed;
+
+public function isElementNamed
+  input String name;
+  input Absyn.Element element;
+  output Boolean res;
+algorithm
+  res := match element
+    case Absyn.Element.ELEMENT() then isElementSpecNamed(name, element.specification);
+    else false;
+  end match;
+end isElementNamed;
+
+public function isElementSpecNamed
+  input String name;
+  input Absyn.ElementSpec elementSpec;
+  output Boolean res;
+algorithm
+  res := match elementSpec
+    case Absyn.ElementSpec.CLASSDEF() then isClassNamed(name, elementSpec.class_);
+    case Absyn.ElementSpec.COMPONENTS()
+      then List.exist(elementSpec.components, function isComponentItemNamed(name = name));
+    else false;
+  end match;
+end isElementSpecNamed;
+
 public function isEmptyClassPart
   input Absyn.ClassPart inClassPart;
   output Boolean outIsEmpty;
@@ -6028,6 +6075,41 @@ algorithm
     else NONE();
   end match;
 end getElementConstrainingClass;
+
+function isElementReplaceable
+  input Absyn.Element element;
+  output Boolean res;
+protected
+  Absyn.RedeclareKeywords redecl;
+algorithm
+  res := match element
+    case Absyn.Element.ELEMENT(redeclareKeywords = SOME(redecl))
+      then match redecl
+             case Absyn.RedeclareKeywords.REPLACEABLE() then true;
+             case Absyn.RedeclareKeywords.REDECLARE_REPLACEABLE() then true;
+             else false;
+           end match;
+
+    else false;
+  end match;
+end isElementReplaceable;
+
+function isElementRedeclare
+  input Absyn.Element element;
+  output Boolean res;
+protected
+  Absyn.RedeclareKeywords redecl;
+algorithm
+  res := match element
+    case Absyn.Element.ELEMENT(redeclareKeywords = SOME(redecl))
+      then match redecl
+             case Absyn.RedeclareKeywords.REDECLARE() then true;
+             else false;
+           end match;
+
+    else false;
+  end match;
+end isElementRedeclare;
 
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3698,6 +3698,28 @@ annotation(
   preferredView="text");
 end isPartial;
 
+function isReplaceable
+  input TypeName element;
+  output Boolean b;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Returns true if the given element is replaceable.
+</html>"),
+  preferredView="text");
+end isReplaceable;
+
+function isRedeclare
+  input TypeName element;
+  output Boolean b;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Returns true if the given element is a redeclare.
+</html>"),
+  preferredView="text");
+end isRedeclare;
+
 function isModel
   input TypeName cl;
   output Boolean b;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3951,6 +3951,28 @@ annotation(
   preferredView="text");
 end isPartial;
 
+function isReplaceable
+  input TypeName element;
+  output Boolean b;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Returns true if the given element is replaceable.
+</html>"),
+  preferredView="text");
+end isReplaceable;
+
+function isRedeclare
+  input TypeName element;
+  output Boolean b;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Returns true if the given element is a redeclare.
+</html>"),
+  preferredView="text");
+end isRedeclare;
+
 function isModel
   input TypeName cl;
   output Boolean b;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -2065,6 +2065,18 @@ algorithm
       then
         Values.BOOL(b);
 
+    case ("isReplaceable",{Values.CODE(Absyn.C_TYPENAME(path))})
+      equation
+        b = Interactive.isReplaceable(path, SymbolTable.getAbsyn());
+      then
+        Values.BOOL(b);
+
+    case ("isRedeclare",{Values.CODE(Absyn.C_TYPENAME(path))})
+      equation
+        b = Interactive.isRedeclare(path, SymbolTable.getAbsyn());
+      then
+        Values.BOOL(b);
+
     case ("isModel",{Values.CODE(Absyn.C_TYPENAME(classpath))})
       equation
         b = Interactive.isModel(classpath, SymbolTable.getAbsyn());

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -4634,7 +4634,7 @@ algorithm
 end removeClassInElementitemlist;
 
 public function getPathedElementInProgram
-  "Looks up a class element in the program using the given path."
+  "Looks up an element in the program using the given path."
   input Absyn.Path path;
   input Absyn.Program program;
   output Absyn.Element element;
@@ -4675,7 +4675,7 @@ protected
   Absyn.Element e;
 algorithm
   for item in AbsynUtil.getElementItemsInClassPart(part) loop
-    if AbsynUtil.isElementItemClassNamed(AbsynUtil.pathFirstIdent(path), item) then
+    if AbsynUtil.isElementItemNamed(AbsynUtil.pathFirstIdent(path), item) then
       Absyn.ElementItem.ELEMENTITEM(element = e) := item;
 
       if AbsynUtil.pathIsIdent(path) then

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -967,15 +967,24 @@ bool OMCProxy::isPartial(QString className)
 
 /*!
  * \brief OMCProxy::isReplaceable
- * Returns true if the className is replaceable in parentClassName.
- * \param parentClassName
- * \param className
+ * Returns true if the elementName is replaceable.
+ * \param elementName
  * \return
  */
-bool OMCProxy::isReplaceable(QString parentClassName, QString className)
+bool OMCProxy::isReplaceable(QString elementName)
 {
-  sendCommand("isReplaceable(" + parentClassName + ", \"" + className + "\")");
-  return StringHandler::unparseBool(getResult());
+  return mpOMCInterface->isReplaceable(elementName);
+}
+
+/*!
+ * \brief OMCProxy::isRedeclare
+ * Returns true if the elementName is a redeclare.
+ * \param elementName
+ * \return
+ */
+bool OMCProxy::isRedeclare(QString elementName)
+{
+  return mpOMCInterface->isRedeclare(elementName);
 }
 
 /*!

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -127,7 +127,8 @@ public:
   bool isWhat(StringHandler::ModelicaClasses type, QString className);
   bool isProtectedClass(QString className, QString nestedClassName);
   bool isPartial(QString className);
-  bool isReplaceable(QString parentClassName, QString className);
+  bool isReplaceable(QString elementName);
+  bool isRedeclare(QString elementName);
   StringHandler::ModelicaClasses getClassRestriction(QString className);
   bool setParameterValue(const QString &className, const QString &parameter, const QString &value);
   QString getParameterValue(const QString &className, const QString &parameter);

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -56,6 +56,8 @@ interactive_api_loadsave.mos \
 interactive_api_param.mos \
 interactive_api_simulations.mos \
 interactive_test.mos \
+isRedeclare.mos \
+isReplaceable.mos \
 Issue7544.mos \
 Issue7706.mos \
 ListAnnotation.mos \

--- a/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
@@ -35,8 +35,8 @@ isEnumeration(C); getErrorString();
 getEnumerationLiterals(C); getErrorString();
 isEnumeration(sizeE); getErrorString();
 getEnumerationLiterals(sizeE); getErrorString();
-isReplaceable(ReplaceableClass, "M1"); getErrorString();
-isReplaceable(RealSignal, "SignalType"); getErrorString();
+isReplaceable(ReplaceableClass.M1); getErrorString();
+isReplaceable(RealSignal.SignalType); getErrorString();
 isProtectedClass(RealSignal, "SignalType"); getErrorString();
 isProtectedClass(ProtectedClass, "M1"); getErrorString();
 getBuiltinType(Resistance); getErrorString();
@@ -238,11 +238,11 @@ getMessagesStringInternal(unique = false); // not unique
 // {"Small","Medium","Large"}
 // Evaluating: getErrorString()
 // ""
-// Evaluating: isReplaceable(ReplaceableClass, "M1")
+// Evaluating: isReplaceable(ReplaceableClass.M1)
 // true
 // Evaluating: getErrorString()
 // ""
-// Evaluating: isReplaceable(RealSignal, "SignalType")
+// Evaluating: isReplaceable(RealSignal.SignalType)
 // true
 // Evaluating: getErrorString()
 // ""

--- a/testsuite/openmodelica/interactive-API/isRedeclare.mos
+++ b/testsuite/openmodelica/interactive-API/isRedeclare.mos
@@ -1,0 +1,33 @@
+// name: isRedeclare
+// keywords:
+// status: correct
+// cflags: -d=-newInst
+//
+
+loadString("
+  package P
+    redeclare Real x;
+    Real y;
+
+    redeclare model A
+    end A;
+
+    model B
+    end B;
+  end P;
+");
+
+isRedeclare(P);
+isRedeclare(P.A);
+isRedeclare(P.B);
+isRedeclare(P.x);
+isRedeclare(P.y);
+
+// Result:
+// true
+// false
+// true
+// false
+// true
+// false
+// endResult

--- a/testsuite/openmodelica/interactive-API/isReplaceable.mos
+++ b/testsuite/openmodelica/interactive-API/isReplaceable.mos
@@ -1,0 +1,36 @@
+// name: isReplaceable
+// keywords:
+// status: correct
+// cflags: -d=-newInst
+//
+
+loadString("
+  package P
+    replaceable type B = Real;
+
+    replaceable model C
+      replaceable Real x;
+      Real y;
+    end C;
+
+    model D
+    end D;
+  end P;
+");
+
+isReplaceable(P);
+isReplaceable(P.B);
+isReplaceable(P.C);
+isReplaceable(P.D);
+isReplaceable(P.C.x);
+isReplaceable(P.C.y);
+
+// Result:
+// true
+// false
+// true
+// true
+// false
+// true
+// false
+// endResult


### PR DESCRIPTION
- Remove the old `isReplaceable` API which was undocumented and confusing, and replace it with a new implementation that just takes an element name as argument.
- Also add isRedeclare for good measure.

Fixes #10143