### PR TITLE
Make it possible to silence LOG_ASSERT debug print for NLS/LS

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3225,7 +3225,8 @@ match system
           for (j=0; j<<%listLength(nls.crefs)%>; j++) {
             res[j] = NAN;
           }
-          throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+          debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+          omc_throw(threadData);
           <%if intEq(whichSet, 0) then "return;" else "return 1;"%>
         }
       }
@@ -6376,7 +6377,8 @@ case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = at) th
   /* check if solution process was successful */
   if (retValue > 0){
     const int indexes[2] = {1,<%ls.index%>};
-    throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
+    debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
+    omc_throw(threadData);
     <%returnval2%>
   }
   /* write solution */
@@ -6490,7 +6492,8 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       /* check if solution process was successful */
       if (retValue > 0){
         const int indexes[2] = {1,<%nls.index%>};
-        throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+        debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+        omc_throw(threadData);
         <%returnval2%>
       }
       /* write solution */

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3225,7 +3225,7 @@ match system
           for (j=0; j<<%listLength(nls.crefs)%>; j++) {
             res[j] = NAN;
           }
-          debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+          debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, 0, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
           omc_throw(threadData);
           <%if intEq(whichSet, 0) then "return;" else "return 1;"%>
         }
@@ -6377,7 +6377,7 @@ case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = at) th
   /* check if solution process was successful */
   if (retValue > 0){
     const int indexes[2] = {1,<%ls.index%>};
-    debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
+    debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, 0, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
     omc_throw(threadData);
     <%returnval2%>
   }
@@ -6492,7 +6492,7 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       /* check if solution process was successful */
       if (retValue > 0){
         const int indexes[2] = {1,<%nls.index%>};
-        debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
+        debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, 0, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
         omc_throw(threadData);
         <%returnval2%>
       }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3225,8 +3225,7 @@ match system
           for (j=0; j<<%listLength(nls.crefs)%>; j++) {
             res[j] = NAN;
           }
-          debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, 0, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
-          omc_throw(threadData);
+          throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, equationIndexes, "residualFunc<%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
           <%if intEq(whichSet, 0) then "return;" else "return 1;"%>
         }
       }
@@ -6377,8 +6376,7 @@ case e as SES_LINEAR(lSystem=ls as LINEARSYSTEM(__), alternativeTearing = at) th
   /* check if solution process was successful */
   if (retValue > 0){
     const int indexes[2] = {1,<%ls.index%>};
-    debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, 0, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
-    omc_throw(threadData);
+    throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving linear system <%ls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_LS.", data->localData[0]->timeValue);
     <%returnval2%>
   }
   /* write solution */
@@ -6492,8 +6490,7 @@ template equationNonlinear(SimEqSystem eq, Context context, String modelNamePref
       /* check if solution process was successful */
       if (retValue > 0){
         const int indexes[2] = {1,<%nls.index%>};
-        debugStreamPrintWithEquationIndexes(LOG_ASSERT, omc_dummyFileInfo, 0, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
-        omc_throw(threadData);
+        throwStreamPrintWithEquationIndexes(threadData, omc_dummyFileInfo, indexes, "Solving non-linear system <%nls.index%> failed at time=%.15g.\nFor more information please use -lv LOG_NLS.", data->localData[0]->timeValue);
         <%returnval2%>
       }
       /* write solution */

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -633,10 +633,12 @@ void throwStreamPrintWithEquationIndexes(threadData_t *threadData, FILE_INFO inf
 #if !defined(OMC_MINIMAL_LOGGING)
   char logBuffer[SIZE_LOG_BUFFER];
   va_list args;
-  va_start(args, format);
-  vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-  va_end(args);
-  messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, info, 0, logBuffer, 0, indexes);
+  if (useStream[LOG_ASSERT]) {
+    va_start(args, format);
+    vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
+    va_end(args);
+    messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, info, 0, logBuffer, 0, indexes);
+  }
 #endif
   threadData = threadData ? threadData : (threadData_t*)pthread_getspecific(mmc_thread_data_key);
   longjmp(*getBestJumpBuffer(threadData), 1);

--- a/OMCompiler/SimulationRuntime/c/util/omc_error.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.c
@@ -604,17 +604,35 @@ static inline jmp_buf* getBestJumpBuffer(threadData_t *threadData)
   }
 }
 
+/**
+ * @brief Variadic stream print and throw.
+ *
+ * Print message to LOG_ASSERT.
+ *
+ * @param threadData  Thread data for throwing.
+ * @param format      Format string.
+ * @param args        Variadic argument list for format string
+ */
 void va_throwStreamPrint(threadData_t *threadData, const char *format, va_list args)
 {
 #if !defined(OMC_MINIMAL_LOGGING)
-  char logBuffer[SIZE_LOG_BUFFER];
-  vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
-  messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, omc_dummyFileInfo, 0, logBuffer, 0, NULL);
+  if (useStream[LOG_ASSERT]) {
+    char logBuffer[SIZE_LOG_BUFFER];
+    vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
+    messageFunction(LOG_TYPE_DEBUG, LOG_ASSERT, omc_dummyFileInfo, 0, logBuffer, 0, NULL);
+  }
 #endif
   threadData = threadData ? threadData : (threadData_t*)pthread_getspecific(mmc_thread_data_key);
   longjmp(*getBestJumpBuffer(threadData), 1);
 }
 
+/**
+ * @brief Print message to LOG_ASSERT and throw.
+ *
+ * @param threadData  Thread data for throwing.
+ * @param format      Format string.
+ * @param ...         Additional arguments for format string.
+ */
 void throwStreamPrint(threadData_t *threadData, const char *format, ...)
 {
 #if !defined(OMC_MINIMAL_LOGGING)
@@ -628,12 +646,21 @@ void throwStreamPrint(threadData_t *threadData, const char *format, ...)
 #endif
 }
 
+/**
+ * @brief Print message with equation indices to LOG_ASSERT stream and throw.
+ *
+ * @param threadData    Thread data for throwing.
+ * @param info          File info, can be omc_dummyFileInfo.
+ * @param indexes       Equation indices.
+ * @param format        Format string.
+ * @param ...           Additional arguments for format string.
+ */
 void throwStreamPrintWithEquationIndexes(threadData_t *threadData, FILE_INFO info, const int *indexes, const char *format, ...)
 {
 #if !defined(OMC_MINIMAL_LOGGING)
-  char logBuffer[SIZE_LOG_BUFFER];
-  va_list args;
   if (useStream[LOG_ASSERT]) {
+    char logBuffer[SIZE_LOG_BUFFER];
+    va_list args;
     va_start(args, format);
     vsnprintf(logBuffer, SIZE_LOG_BUFFER, format, args);
     va_end(args);


### PR DESCRIPTION
### Related Issues

It's super annoying to get a giant load of 
```
LOG_ASSERT        | debug   | Solving non-linear system 14 failed at time=0.
```
errors and there is currently no way to deactivate them by deactivating `LOG_ASSERT`.

### Purpose

  - Deactivating `LOG_ASSERT` silences the message, but it still throws.

### Approach

Use `debugStreamPrintWithEquationIndexes` and `omc_throw` instead of `throwStreamPrintWithEquationIndexes`.
