### PR TITLE
Apply the new local modifiers of redeclared class

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -3780,7 +3780,7 @@ void Element::showParameters()
   if (MainWindow::instance()->isNewApi()) {
     pMainWindow->getProgressBar()->setRange(0, 0);
     pMainWindow->showProgressBar();
-    ElementParameters *pElementParameters = new ElementParameters(mpModelComponent, mpGraphicsView, isInheritedElement(), false, true, pMainWindow);
+    ElementParameters *pElementParameters = new ElementParameters(mpModelComponent, mpGraphicsView, isInheritedElement(), false, ModelInstance::Modifier(), pMainWindow);
     pMainWindow->hideProgressBar();
     pMainWindow->getStatusBar()->clearMessage();
     pElementParameters->exec();

--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -186,7 +186,7 @@ class ElementParameters : public QDialog
 {
   Q_OBJECT
 public:
-  ElementParameters(ModelInstance::Element *pElement, GraphicsView *pGraphicsView, bool inherited, bool nested, bool defaultModifier, QWidget *pParent = 0);
+  ElementParameters(ModelInstance::Element *pElement, GraphicsView *pGraphicsView, bool inherited, bool nested, const ModelInstance::Modifier elementModifier, QWidget *pParent = 0);
   ~ElementParameters();
   QString getElementParentClassName() const;
   GraphicsView *getGraphicsView() const {return mpGraphicsView;}
@@ -199,7 +199,7 @@ private:
   GraphicsView *mpGraphicsView;
   bool mInherited;
   bool mNested;
-  bool mDefaultModifier;
+  ModelInstance::Modifier mElementModifier;
   QString mModification;
   Label *mpParametersHeading;
   QFrame *mHorizontalLine;
@@ -227,6 +227,7 @@ private:
   void fetchElementExtendsModifiers(ModelInstance::Model *pModelInstance);
   void fetchElementModifiers();
   void fetchClassExtendsModifiers();
+  void applyRedeclareElementModifiers();
   Parameter* findParameter(LibraryTreeItem *pLibraryTreeItem, const QString &parameter, Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive) const;
   Parameter* findParameter(const QString &parameter, Qt::CaseSensitivity caseSensitivity = Qt::CaseSensitive) const;
 public slots:

--- a/OMEdit/OMEditLIB/FlatModelica/Parser.cpp
+++ b/OMEdit/OMEditLIB/FlatModelica/Parser.cpp
@@ -91,6 +91,8 @@ void FlatModelica::Parser::getTypeFromElementRedeclaration(const QString &elment
     if (pElement_redeclarationContext->component_clause1()->component_declaration1()->declaration()->modification()) {
       modifier = getModificationFromStartAndStopInterval(pElement_redeclarationContext->component_clause1()->component_declaration1()->declaration()->modification()->start,
                                                          pElement_redeclarationContext->component_clause1()->component_declaration1()->declaration()->modification()->stop);
+    } else {
+      modifier = "";
     }
     comment = QString::fromStdString(pElement_redeclarationContext->component_clause1()->component_declaration1()->comment()->getText());
   }
@@ -118,6 +120,8 @@ void FlatModelica::Parser::getShortClassTypeFromElementRedeclaration(const QStri
     if (pElement_redeclarationContext->short_class_definition()->short_class_specifier()->class_modification()) {
       modifier = getModificationFromStartAndStopInterval(pElement_redeclarationContext->short_class_definition()->short_class_specifier()->class_modification()->start,
                                                          pElement_redeclarationContext->short_class_definition()->short_class_specifier()->class_modification()->stop);
+    } else {
+      modifier = "";
     }
     comment = QString::fromStdString(pElement_redeclarationContext->short_class_definition()->short_class_specifier()->comment()->getText());
   }

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1537,7 +1537,6 @@ namespace ModelInstance
 
     if (jsonObject.contains("modifiers")) {
       mModifier.deserialize(jsonObject.value("modifiers"));
-      mModifierForReset = mModifier;
     }
 
     if (jsonObject.contains("value")) {

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -604,8 +604,6 @@ private:
     void setModel(Model *pModel) {mpModel = pModel;}
     Model *getModel() const {return mpModel;}
     Modifier getModifier() const {return mModifier;}
-    void setModifier(const Modifier modifier) {mModifier = modifier;}
-    void resetModifier() {mModifier = mModifierForReset;}
     QString getModifierValueFromType(QStringList modifierNames);
     Dimensions getDimensions() const {return mDims;}
     Prefixes *getPrefixes() const {return mpPrefixes.get();}
@@ -630,7 +628,6 @@ private:
     Model *mpModel = 0;
 
     Modifier mModifier;
-    Modifier mModifierForReset;
     Dimensions mDims;
     std::unique_ptr<Prefixes> mpPrefixes;
     QString mComment;


### PR DESCRIPTION
### Related Issues

Fixes #10652 Pass the correct format of  modifier to getModelInstance
Fixes #10655 and fixes #10669 Do not replace the modifiers of the edited component