### PR TITLE
Improve handling of inherited inner/outer elements

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -445,7 +445,7 @@ public
             // If the instance is an empty node, use the cloned clsNode as the instance.
             if InstNode.isEmpty(instance) then
               instance := clsNode;
-              parent_scope := InstNode.parent(clsNode);
+              parent_scope := InstNode.instanceParent(clsNode);
             else
               parent_scope := instance;
               inst_scope := scope;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -627,11 +627,11 @@ uniontype InstNode
     output InstNode parent;
   algorithm
     parent := match node
-      case CLASS_NODE() then getDerivedNode(node.parentScope);
+      case CLASS_NODE() then parent(getDerivedNode(node));
       case COMPONENT_NODE(nodeType = InstNodeType.REDECLARED_COMP(parent = parent))
         then getDerivedNode(parent);
-      case COMPONENT_NODE() then getDerivedNode(node.parent);
-      case IMPLICIT_SCOPE() then getDerivedNode(node.parentScope);
+      case COMPONENT_NODE() then parent(getDerivedNode(node));
+      case IMPLICIT_SCOPE() then parent(getDerivedNode(node));
       else EMPTY_NODE();
     end match;
   end instanceParent;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -395,6 +395,8 @@ protected
   InstNode prev_scope = scope;
 algorithm
   while not InstNode.isEmpty(cur_scope) loop
+    cur_scope := InstNode.getDerivedNode(cur_scope);
+
     try
       // Check if we have an element with the same name as the outer node in this scope.
       innerNode := InstNode.resolveOuter(Class.lookupElement(name, InstNode.getClass(cur_scope)));

--- a/testsuite/flattening/modelica/scodeinst/InnerOuter11.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuter11.mo
@@ -1,0 +1,51 @@
+// name: InnerOuter11
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+partial function A
+  input Real x;
+  output Real y;
+end A;
+
+partial model M1
+  outer function f = A;
+end M1;
+
+model M2
+  extends M1;
+  Real x = f(time);
+end M2;
+
+partial model M3
+  M2 m2;
+end M3;
+
+partial model M4
+  extends M3;
+end M4;
+
+model M5
+  extends M4;
+end M5;
+
+model InnerOuter11
+  function B
+    input Real x;
+    output Real y = x;
+  end B;
+  inner function f = B;
+  M5 m;
+end InnerOuter11;
+
+// Result:
+// function InnerOuter11.f
+//   input Real x;
+//   output Real y = x;
+// end InnerOuter11.f;
+//
+// class InnerOuter11
+//   Real m.m2.x = InnerOuter11.f(time);
+// end InnerOuter11;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -758,6 +758,7 @@ InnerOuter7.mo \
 InnerOuter8.mo \
 InnerOuter9.mo \
 InnerOuter10.mo \
+InnerOuter11.mo \
 InnerOuterClass1.mo \
 InnerOuterDuplicate1.mo \
 InnerOuterInvalidMod1.mo \

--- a/testsuite/openmodelica/interactive-API/Obfuscation2.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation2.mos
@@ -69,8 +69,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real fb \"= f_nonlinear(b) - y_zero\";
 //   protected Real fc;
 //   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
+//   protected Real x_min2 = x_min - 1e-10;
+//   protected Real x_max2 = x_max + 1e-10;
 //   protected Real a = x_min2 \"Current best minimum interval value\";
 //   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
@@ -100,7 +100,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //       fb := fc;
 //       fc := fa;
 //     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
+//     tol := 2.0 * 1e-15 * abs(b) + x_tol;
 //     m := (c - b) / 2.0;
 //     if abs(m) <= tol or fb == 0.0 then
 //       found := true;
@@ -472,8 +472,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real fb \"= f_nonlinear(b) - y_zero\";
 //   protected Real fc;
 //   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
+//   protected Real x_min2 = x_min - 1e-10;
+//   protected Real x_max2 = x_max + 1e-10;
 //   protected Real a = x_min2 \"Current best minimum interval value\";
 //   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
@@ -503,7 +503,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //       fb := fc;
 //       fc := fa;
 //     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
+//     tol := 2.0 * 1e-15 * abs(b) + x_tol;
 //     m := (c - b) / 2.0;
 //     if abs(m) <= tol or fb == 0.0 then
 //       found := true;
@@ -875,8 +875,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real fb \"= f_nonlinear(b) - y_zero\";
 //   protected Real fc;
 //   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
+//   protected Real x_min2 = x_min - 1e-10;
+//   protected Real x_max2 = x_max + 1e-10;
 //   protected Real a = x_min2 \"Current best minimum interval value\";
 //   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
@@ -906,7 +906,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //       fb := fc;
 //       fc := fa;
 //     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
+//     tol := 2.0 * 1e-15 * abs(b) + x_tol;
 //     m := (c - b) / 2.0;
 //     if abs(m) <= tol or fb == 0.0 then
 //       found := true;
@@ -1518,8 +1518,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real fb \"= f_nonlinear(b) - y_zero\";
 //   protected Real fc;
 //   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
+//   protected Real x_min2 = x_min - 1e-10;
+//   protected Real x_max2 = x_max + 1e-10;
 //   protected Real a = x_min2 \"Current best minimum interval value\";
 //   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
@@ -1549,7 +1549,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //       fb := fc;
 //       fc := fa;
 //     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
+//     tol := 2.0 * 1e-15 * abs(b) + x_tol;
 //     m := (c - b) / 2.0;
 //     if abs(m) <= tol or fb == 0.0 then
 //       found := true;
@@ -2381,8 +2381,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real fb \"= f_nonlinear(b) - y_zero\";
 //   protected Real fc;
 //   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
+//   protected Real x_min2 = x_min - 1e-10;
+//   protected Real x_max2 = x_max + 1e-10;
 //   protected Real a = x_min2 \"Current best minimum interval value\";
 //   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
@@ -2412,7 +2412,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //       fb := fc;
 //       fc := fa;
 //     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
+//     tol := 2.0 * 1e-15 * abs(b) + x_tol;
 //     m := (c - b) / 2.0;
 //     if abs(m) <= tol or fb == 0.0 then
 //       found := true;
@@ -3024,8 +3024,8 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //   protected Real fb \"= f_nonlinear(b) - y_zero\";
 //   protected Real fc;
 //   protected Boolean found = false;
-//   protected Real x_min2 = x_min - x_eps;
-//   protected Real x_max2 = x_max + x_eps;
+//   protected Real x_min2 = x_min - 1e-10;
+//   protected Real x_max2 = x_max + 1e-10;
 //   protected Real a = x_min2 \"Current best minimum interval value\";
 //   protected Real b = x_max2 \"Current best maximum interval value\";
 // algorithm
@@ -3055,7 +3055,7 @@ instantiateModel(Modelica.Fluid.Examples.BranchingDynamicPipes); getErrorString(
 //       fb := fc;
 //       fc := fa;
 //     end if;
-//     tol := 2.0 * eps * abs(b) + x_tol;
+//     tol := 2.0 * 1e-15 * abs(b) + x_tol;
 //     m := (c - b) / 2.0;
 //     if abs(m) <= tol or fb == 0.0 then
 //       found := true;


### PR DESCRIPTION
- Use the instance parent as the start scope when looking for inner elements.
- Change InstNode.instanceParent to resolve derived nodes before looking up the parent, not after.