### PR TITLE
Fix list of iteration variables for more than one strong component

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEOptimize.mo
@@ -5659,7 +5659,7 @@ protected
 algorithm
   if not listEmpty(varIndices) then
     vars := list(BackendVariable.getVarAt(allVars, v) for v in varIndices);
-    crefs := list(BackendVariable.varCref(v) for v in vars);
+    crefs := List.append_reverse(list(BackendVariable.varCref(v) for v in vars), crefs);
     warnings := (message + warnAboutVars(vars)) :: warnings;
   end if;
 end listAllIterationVariables3;

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_06.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_06.mos
@@ -105,8 +105,8 @@ readFile("fmi_attributes_06.xml"); getErrorString();
 //   <ScalarVariable
 //     name=\"Fo\"
 //     valueReference=\"8\"
-//     >
-//     <Real/>
+//     initial=\"approx\">
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable


### PR DESCRIPTION
This prevents the removal of start attributes from iteration variables during FMI export.

See issue #10680, e.g.:
`translateModelFMU(ThermofluidStream.Examples.Utilities.Tests.Piston, version = "2.0");`

