### PR TITLE
Remove bindings of scalar parameters to records or tuples in SimCode

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -10372,6 +10372,11 @@ algorithm
       DAE.Exp e;
       DAE.Type tp;
 
+    // Don't extract bindings of scalar parameters to tuples or records (#10505).
+    // They are treated by createParameterEquations calling createSimEqsForGlobalKnownVars.
+    case (BackendDAE.VAR(varKind = BackendDAE.PARAM(), tplExp = SOME(_)))
+    then NONE();
+
     case (BackendDAE.VAR(varKind = BackendDAE.VARIABLE(), values = dae_var_attr)) equation
       e = DAEUtil.getStartAttrFail(dae_var_attr);
     then SOME(e);

--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -5750,11 +5750,11 @@ case SIMCODE(modelInfo = MODELINFO(__),makefileParams = MAKEFILE_PARAMS(__))  th
       stepStarted(0.0);
    #endif
 
-      /*Start complex expressions */
+      /* Start complex expressions */
       <%complexStartExpressions%>
       /* End complex expression */
       <%if(boolAnd(boolNot(Flags.isSet(Flags.HARDCODED_START_VALUES)), Flags.isSet(Flags.GEN_DEBUG_SYMBOLS))) then 'checkParameters();' else '//checkParameters();'%>
-                                                                                      //delete reader;
+      //delete reader;
    }
 
    void <%lastIdentOfPath(modelInfo.name)%>Initialize::initializeBoundVariables()

--- a/OMCompiler/SimulationRuntime/cpp/Core/ModelicaDefine.h
+++ b/OMCompiler/SimulationRuntime/cpp/Core/ModelicaDefine.h
@@ -3,6 +3,9 @@
  *  @{
  */
 
+// this might be used by external C code to identify OpenModelica
+#define OPENMODELICA_H_
+
 typedef double modelica_real;
 typedef int modelica_integer;
 typedef bool modelica_boolean;

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -33,6 +33,7 @@ testArrayEquations.mos \
 testDAE.mos \
 testMatrixIO.mos \
 testMatrixState.mos \
+testRecordStartValue.mos \
 testReduction.mos \
 testVectorizedBlocks.mos \
 testVectorizedSolarSystem.mos \

--- a/testsuite/openmodelica/cppruntime/testRecordStartValue.mos
+++ b/testsuite/openmodelica/cppruntime/testRecordStartValue.mos
@@ -1,0 +1,49 @@
+// name: testReduction
+// keywords: cse record parameter binding #10505
+// status: correct
+// teardown_command: rm -f *RecordStartValueTest*
+// cflags:
+
+setCommandLineOptions("+simCodeTarget=Cpp");
+
+loadModel(Modelica, {"4.0.0"});
+loadString("
+model RecordStartValueTest
+  record R
+    Real a;
+    Real b;
+  end R;
+  function f
+    input R r1;
+    output R r2;
+  algorithm
+    r2.a := r1.b;
+    r2.b := r1.a;
+  end f;
+  R r1(a = 1, b = 2);
+  R r2;
+  parameter Real p = 4;
+equation
+  r2 = f(r1);
+end RecordStartValueTest;
+");
+getErrorString();
+
+simulate(RecordStartValueTest); getErrorString();
+val(r2.a, 0);
+val(r2.b, 0);
+
+// Result:
+// true
+// true
+// true
+// ""
+// record SimulationResult
+//     resultFile = "RecordStartValueTest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'RecordStartValueTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// ""
+// 2.0
+// 1.0
+// endResult


### PR DESCRIPTION
They are treated with parameter equations.
This shall fix issue #10505 "Wrong and unnecessary initial values in SimCode with records"
effecting the generation of modelDescription.xml during FMI export and the C++ runtime.
