### PR TITLE
[OMEdit] oms edit sub model rotation bug (#10673)

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -8648,18 +8648,32 @@ void ModelWidget::drawOMSModelDiagramElements()
         y2 = pChildLibraryTreeItem->getOMSElement()->geometry->y2;
         double width = x2 - x1;
         double height = y2 - y1;
-        if (width <= 0 && height <= 0) {
+        // check zero width
+        if (qFuzzyCompare(width, 0.0)) {
           x1 = -10.0;
-          y1 = -10.0;
           x2 = 10.0;
+        }
+        // check zero height
+        if (qFuzzyCompare(height, 0.0)) {
+          y1 = -10.0;
           y2 = 10.0;
         }
+        // origin
+        double origX = (x1 + x2) / 2;
+        double origY = (y1 + y2) / 2;
+        // horizontal position
+        x1 = x1 - origX;
+        x2 = x2 - origX;
+        // vertical position
+        y1 = y1 - origY;
+        y2 = y2 - origY;
         // Load the ModelWidget if not loaded already
         if (!pChildLibraryTreeItem->getModelWidget()) {
           MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->showModelWidget(pChildLibraryTreeItem, false);
         }
 
-        QString annotation = QString("Placement(true,-,-,%1,%2,%3,%4,%5,-,-,-,-,-,-,)")
+        QString annotation = QString("Placement(true,%1,%2,%3,%4,%5,%6,%7,-,-,-,-,-,-,)")
+                             .arg(origX).arg(origY)
                              .arg(x1).arg(y1)
                              .arg(x2).arg(y2)
                              .arg(pChildLibraryTreeItem->getOMSElement()->geometry->rotation);


### PR DESCRIPTION
* oms edit sub model rotation bug

* Fix rotation and flipping of OMS sub models

Check for the zero width and height
Adjust the extents according to the origin