### PR TITLE
Run install before zipping FMU

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -926,7 +926,7 @@ algorithm
         System.copyFile(source = install_share_buildproject_dir + "CMakeLists.txt.in",
                         destination = fmu_tmp_sources_dir + "CMakeLists.txt");
         cmakelistsStr := System.readFile(fmu_tmp_sources_dir + "CMakeLists.txt");
-        cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_NAME_IN@", simCode.fileNamePrefix);
+        cmakelistsStr := System.stringReplace(cmakelistsStr, "@FMU_NAME_IN@", simCode.fmuTargetName);
 
         // Set CMake runtime dependencies level
         _ := match (Flags.getConfigString(Flags.FMU_RUNTIME_DEPENDS))

--- a/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/buildproject/CMakeLists.txt.in
@@ -181,10 +181,11 @@ else()
 endif()
 
 # Zip target creating modelname.fmu
-add_custom_target(create_zip COMMAND
-    ${CMAKE_COMMAND} -E tar "cfv" "../${CMAKE_PROJECT_NAME}.fmu" --format=zip
-    "binaries/"
-    "resources/"
-    "sources/"
-    "modelDescription.xml"
+add_custom_target(create_fmu
+    COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target install
+    COMMAND "${CMAKE_COMMAND}" -E tar "cfv" "../${CMAKE_PROJECT_NAME}.fmu" --format=zip
+      "binaries/"
+      "resources/"
+      "sources/"
+      "modelDescription.xml"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../")

--- a/doc/UsersGuide/source/fmitlm.rst
+++ b/doc/UsersGuide/source/fmitlm.rst
@@ -165,7 +165,7 @@ The CMake compilation accepts the following settings:
 
 
 Then use CMake to configure, build and install the FMU.
-To repack the FMU after installation use custom target ``create_zip``.
+To repack the FMU after installation use custom target ``create_fmu``.
 
 For example to re-compile the FMU with cmake and runtime dependencies use:
 
@@ -176,7 +176,7 @@ For example to re-compile the FMU with cmake and runtime dependencies use:
     $ cmake -S . -B build_cmake \
       -D RUNTIME_DEPENDENCIES_LEVEL=modelica \
       -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++
-    $ cmake --build build_cmake --target install create_zip --parallel
+    $ cmake --build build_cmake --target create_fmu --parallel
 
 .. _fmitlm-export-options :
 

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/RecompileSourceCodeFMU.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/RecompileSourceCodeFMU.mos
@@ -1,7 +1,7 @@
 // name:     RecompileSourceCodeFMU
 // keywords: fmu export simulation flags
 // status: correct
-// teardown_command: rm -rf Test_SinSource* reCompile.log Test.SinSource.fmu
+// teardown_command: rm -rf Test_SinSource* Test.SinSource* reCompile.log Test.SinSource.fmu
 //
 // Export SinSource as 2.0 CS FMU with CVODE solver and re-compile FMU with static library
 
@@ -32,7 +32,12 @@ system("cd Test_SinSource_FMU/sources/build_cmake && cmake .. -DBUILD_SHARED_LIB
 
 // Check if static library was compiled and that it used FMI2_FUNCTION_PREFIX=Test_SinSource_FMU for function names
 // Has to return "Test_SinSource_fmi2GetReal"
-system("nm Test_SinSource_FMU/binaries/linux64/Test_SinSource.a | grep -wo Test_SinSource_fmi2GetReal"); getErrorString();
+system("nm Test_SinSource_FMU/binaries/linux64/Test.SinSource.a | grep -wo Test_SinSource_fmi2GetReal"); getErrorString();
+
+// Repack Test.SinSource.fmu
+system("rm -rf Test.SinSource.fmu && cd Test_SinSource_FMU/sources/build_cmake && cmake --build . && make create_fmu", outputFile="reCompile.log"); getErrorString();
+//readFile("reCompile.log");
+regularFileExists("Test.SinSource.fmu"); getErrorString();
 
 // Result:
 // true
@@ -49,5 +54,9 @@ system("nm Test_SinSource_FMU/binaries/linux64/Test_SinSource.a | grep -wo Test_
 // ""
 // Test_SinSource_fmi2GetReal
 // 0
+// ""
+// 0
+// ""
+// true
 // ""
 // endResult


### PR DESCRIPTION
### Related Issues

For #10719.

### Purpose

  - Ensure that target install is executed before generating zip.

### Approach

  - Renamed FMU custom taget `create_zip` to `create_fmu`.
  - Always run install when calling `create_fmu`.
