### PR TITLE
Remove duplicate check for top level IOs in BackendVariable

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -2042,18 +2042,20 @@ algorithm
   kind := getVarKind(var);
 end getVarKindForVar;
 
-public function isVarOnTopLevelAndOutput "and has the DAE.VarDirection = OUTPUT
-  The check for top-model is done by spliting the name at \'.\' and
-  check if the list-length is 1"
+public function isVarOnTopLevelAndOutput "has the DAE.VarDirection = OUTPUT
+  Don't check for top level here as this is done by NFConvertDAE.makeDAEVar.
+  Otherwise the list of model variables may contradict with model structure, e.g. with --nonStdExposeLocalIOs."
   input BackendDAE.Var inVar;
-  output Boolean outBoolean = DAEUtil.topLevelOutput(inVar.varName, inVar.varDirection, inVar.connectorType);
+  //output Boolean outBoolean = DAEUtil.topLevelOutput(inVar.varName, inVar.varDirection, inVar.connectorType);
+  output Boolean outBoolean = isOutputVar(inVar);
 end isVarOnTopLevelAndOutput;
 
-public function isVarOnTopLevelAndInput "and has the DAE.VarDirection = INPUT
-  The check for top-model is done by splitting the name at '.' and checking if
-  the list-length is 1."
+public function isVarOnTopLevelAndInput "has the DAE.VarDirection = INPUT
+  Don't check for top level here as this is done by NFConvertDAE.makeDAEVar.
+  Otherwise the list of model variables may contradict with model structure, e.g. with --nonStdExposeLocalIOs."
   input BackendDAE.Var inVar;
-  output Boolean outBoolean = DAEUtil.topLevelInput(inVar.varName, inVar.varDirection, inVar.connectorType);
+  //output Boolean outBoolean = DAEUtil.topLevelInput(inVar.varName, inVar.varDirection, inVar.connectorType);
+  output Boolean outBoolean = isInput(inVar);
 end isVarOnTopLevelAndInput;
 
 public function isVarOnTopLevelAndInputNoDerInput

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -95,8 +95,7 @@ readFile("modelDescription.tmp.xml");
 // true
 // ""
 // "LocalIOs.System.fmu"
-// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
-// "
+// ""
 // 0
 // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 // <fmiModelDescription
@@ -125,22 +124,23 @@ readFile("modelDescription.tmp.xml");
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
-//     name=\"component.modifiedInput\"
-//     valueReference=\"0\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\"/>
+//     name=\"component.measurement\"
+//     valueReference=\"1\"
+//     causality=\"output\"
+//     >
+//     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
-//     name=\"component.simpleOutput\"
-//     valueReference=\"5\"
+//     name=\"component.modifiedInput\"
+//     valueReference=\"2\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
 //     name=\"signaling.u2\"
-//     valueReference=\"6\"
+//     valueReference=\"7\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"0.0\"/>
@@ -148,7 +148,7 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"4\" -->
 //   <ScalarVariable
 //     name=\"signaling.y\"
-//     valueReference=\"7\"
+//     valueReference=\"8\"
 //     causality=\"output\"
 //     >
 //     <Real/>
@@ -156,7 +156,7 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
 //     name=\"source.u_in\"
-//     valueReference=\"8\"
+//     valueReference=\"9\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"2.0\"/>
@@ -164,95 +164,94 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
 //     name=\"source.y[2]\"
-//     valueReference=\"9\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"11\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"8\" -->
+//   <ScalarVariable
 //     name=\"source.u_par\"
-//     valueReference=\"10\"
+//     valueReference=\"12\"
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"8\" -->
-//   <ScalarVariable
-//     name=\"component.c.f\"
-//     valueReference=\"11\"
-//     >
-//     <Real/>
-//   </ScalarVariable>
 //   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
-//     name=\"component.c.p\"
-//     valueReference=\"8\"
+//     name=\"component.c.f\"
+//     valueReference=\"16\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"component.measurement\"
-//     valueReference=\"5\"
-//     causality=\"output\"
+//     name=\"component.c.p\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"8\"
+//     name=\"component.simpleOutput\"
+//     valueReference=\"1\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"12\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[2]\"
+//     name=\"signaling.u[1]\"
 //     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"13\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
-//     valueReference=\"9\"
+//     name=\"signaling.u[2]\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"14\" -->
 //   <ScalarVariable
-//     name=\"source.c.f\"
-//     valueReference=\"9\"
+//     name=\"signaling.u1\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
-//     name=\"source.c.p\"
-//     valueReference=\"8\"
+//     name=\"source.c.f\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
-//     name=\"source.y[1]\"
-//     valueReference=\"8\"
+//     name=\"source.c.p\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"17\" -->
 //   <ScalarVariable
-//     name=\"source.yf\"
+//     name=\"source.y[1]\"
 //     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"18\" -->
 //   <ScalarVariable
-//     name=\"source.yp\"
-//     valueReference=\"8\"
-//     causality=\"output\"
+//     name=\"source.yf\"
+//     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -267,8 +266,15 @@ readFile("modelDescription.tmp.xml");
 //   </ScalarVariable>
 //   </ModelVariables>
 //   <ModelStructure>
-//     <InitialUnknowns>
+//     <Outputs>
+//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"7\" dependencies=\"5\" dependenciesKind=\"dependent\" />
+//     </Outputs>
+//     <InitialUnknowns>
+//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"7\" dependencies=\"5\" dependenciesKind=\"dependent\" />
 //       <Unknown index=\"19\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>


### PR DESCRIPTION
NFConvertDAE.makeDAEVar takes care of this. An additional check in BackendVariable only effects the model structure and not the list of model variables and thus may cause contradictions, e.g. when using --nonStdExposeLocalIOs, see #10599.
