### PR TITLE
Select printf format specifier based on OS.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -5151,7 +5151,7 @@ template crefToPrintfArg(ComponentRef cr)
 ::=
   match crefType(cr)
   case "modelica_real" then "%g"
-  case "modelica_integer" then "%ld"
+  case "modelica_integer" then "\"OMC_INT_FORMAT\""
   case "modelica_boolean" then "%d"
   case "modelica_string" then "%s"
   else error(sourceInfo(), 'Do not know what printf argument to give <%crefStr(cr)%>')

--- a/OMCompiler/SimulationRuntime/c/openmodelica_types.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_types.h
@@ -86,12 +86,14 @@ typedef int mmc_sint_t;
 /* helpers for mmc_sint_t: printing / div */
 #if defined(_WIN64) || defined(__MINGW64__)
 #define modelica_div_integer lldiv
-#define OMC_INT_FORMAT_LEFT_JUSTIFIED "%-*lld"
-#define OMC_INT_FORMAT "%*lld"
+#define OMC_INT_FORMAT "%lld"
+#define OMC_INT_WIDTH_FORMAT "%*lld"
+#define OMC_INT_WIDTH_LEFT_FORMAT "%-*lld"
 #else
 #define modelica_div_integer ldiv
-#define OMC_INT_FORMAT_LEFT_JUSTIFIED "%-*ld"
-#define OMC_INT_FORMAT "%*ld"
+#define OMC_INT_FORMAT "%ld"
+#define OMC_INT_WIDTH_FORMAT "%*ld"
+#define OMC_INT_WIDTH_LEFT_FORMAT "%-*ld"
 #endif
 
 typedef void* modelica_complex; /* currently only External objects are represented using modelica_complex.*/

--- a/OMCompiler/SimulationRuntime/c/util/modelica_string.c
+++ b/OMCompiler/SimulationRuntime/c/util/modelica_string.c
@@ -206,9 +206,9 @@ modelica_string modelica_string_to_modelica_string(modelica_string s)
 /* Convert a modelica_integer to a modelica_string, used in String(i) */
 modelica_string modelica_integer_to_modelica_string(modelica_integer i, modelica_integer minLen, modelica_boolean leftJustified)
 {
-  size_t sz = snprintf(NULL, 0, leftJustified ? OMC_INT_FORMAT_LEFT_JUSTIFIED : OMC_INT_FORMAT, (int) minLen, i);
+  size_t sz = snprintf(NULL, 0, leftJustified ? OMC_INT_WIDTH_LEFT_FORMAT : OMC_INT_WIDTH_FORMAT, (int) minLen, i);
   void *res = alloc_modelica_string(sz);
-  sprintf(MMC_STRINGDATA(res), leftJustified ? OMC_INT_FORMAT_LEFT_JUSTIFIED : OMC_INT_FORMAT, (int) minLen, i);
+  sprintf(MMC_STRINGDATA(res), leftJustified ? OMC_INT_WIDTH_LEFT_FORMAT : OMC_INT_WIDTH_FORMAT, (int) minLen, i);
   return res;
 }
 


### PR DESCRIPTION
  - Select the format `printf` specifier for `modelica_integer` based on the OS. For Windows this should be defined to `"%lld" ` because `modelica_integer` is long long int on Windows. For other OSs, it should be `"%ld"`.

  - The generated code can be a little confusing. See discussions in https://github.com/OpenModelica/OpenModelica/issues/10702#issuecomment-1559544783 for how it works and why it is done like this.


Fixes #10702.
