### PR TITLE
Treat package.mo/moc the same in script vs commandline.

### DIFF
--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -351,9 +351,8 @@ algorithm
     // A .mo-file.
     case true
       equation
-        pnew = Parser.parse(inLib, "UTF-8");
         p = SymbolTable.getAbsyn();
-        pnew = Interactive.mergeProgram(pnew, p);
+        pnew = CevalScript.loadFile(inLib, "UTF-8", p, true, true, false);
         SymbolTable.setAbsyn(pnew);
       then ();
 

--- a/OMCompiler/Compiler/Main/Main.mo
+++ b/OMCompiler/Compiler/Main/Main.mo
@@ -414,8 +414,6 @@ algorithm
         for lib in libs loop
           loadLib(lib);
         end for;
-        // Show any errors that occured during parsing.
-        showErrors(Print.getErrorString(), ErrorExt.printMessagesStr(false));
 
         if Flags.isSet(Flags.DUMP) then
           Debug.trace("\n--------------- Parsed program ---------------\n");

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -114,6 +114,7 @@ import SymbolTable;
 import System;
 import Tpl;
 import Types;
+import UnorderedMap;
 import Unparsing;
 import Util;
 import ValuesUtil;
@@ -337,8 +338,60 @@ algorithm
   end if;
   outProgram := Parser.parse(name,encoding);
   ClassLoader.checkOnLoadMessage(outProgram);
+
+  // Check if we have duplicate top level classes before calling checkUsesAndUpdateProgram()
+  // which will update the program by repeatedly replacing duplicates with last one seen.
+  if checkDuplicateTopLevelClasses(outProgram) then
+    fail();
+  end if;
+
   outProgram := checkUsesAndUpdateProgram(outProgram, p, checkUses, Settings.getModelicaPath(Testsuite.isRunning()), notifyLoad, requireExactVersion);
 end loadFile;
+
+protected function checkDuplicateTopLevelClasses
+  input Absyn.Program program;
+  output Boolean hasDuplicates = false;
+protected
+  Boolean skip;
+  list<SourceInfo> infos;
+  UnorderedMap<String, Absyn.Info> classInfoMap;
+  Option<Absyn.Info> optClassInfo;
+algorithm
+
+  if listLength(program.classes) < 2 then
+    return;
+  end if;
+
+  classInfoMap := UnorderedMap.new<Absyn.Info>(stringHashDjb2, stringEq);
+  for cl in program.classes loop
+    _ := match cl
+      case Absyn.CLASS(info=SOURCEINFO())
+        algorithm
+          // If the class comes from the interactive env or builtin files, ignore it.
+          skip := stringEq(cl.info.fileName,"<interactive>")
+                  or stringEq(System.basename(cl.info.fileName), "ModelicaBuiltin.mo")
+                  or stringEq(System.basename(cl.info.fileName), "MetaModelicaBuiltin.mo");
+
+          if not skip then
+            optClassInfo := UnorderedMap.get(cl.name, classInfoMap);
+
+            if Util.isSome(optClassInfo) then
+              // It is a duplicate named top level class. Print error and return.
+              infos := {Util.getOption(optClassInfo), cl.info};
+              Error.addMultiSourceMessage(Error.DOUBLE_DECLARATION_OF_ELEMENTS, {cl.name}, infos);
+              hasDuplicates := true;
+              return;
+            else
+              // It is not a duplicate yet. Add it to the map and continue.
+              UnorderedMap.add(cl.name, cl.info, classInfoMap);
+            end if;
+
+          end if;
+        then ();
+      else ();
+    end match;
+  end for;
+end checkDuplicateTopLevelClasses;
 
 protected function checkUsesAndUpdateProgram
   input Absyn.Program newp;
@@ -351,7 +404,7 @@ protected
   list<tuple<Absyn.Path,String,list<String>,Boolean>> modelsToLoad;
 algorithm
   modelsToLoad := if checkUses then Interactive.getUsesAnnotationOrDefault(newp, requireExactVersion) else {};
-  p := Interactive.mergeProgram(newp, p);
+  p := InteractiveUtil.updateProgram(newp, p);
   (p, _) := loadModel(modelsToLoad, modelicaPath, p, false, notifyLoad, checkUses, requireExactVersion, false);
 end checkUsesAndUpdateProgram;
 

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -311,7 +311,7 @@ algorithm
   end if;
 end compileModel;
 
-protected function loadFile "load the file or the directory structure if the file is named package.mo"
+public function loadFile "load the file or the directory structure if the file is named package.mo"
   input String name;
   input String encoding;
   input Absyn.Program p;

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -351,7 +351,7 @@ protected
   list<tuple<Absyn.Path,String,list<String>,Boolean>> modelsToLoad;
 algorithm
   modelsToLoad := if checkUses then Interactive.getUsesAnnotationOrDefault(newp, requireExactVersion) else {};
-  p := InteractiveUtil.updateProgram(newp, p);
+  p := Interactive.mergeProgram(newp, p);
   (p, _) := loadModel(modelsToLoad, modelicaPath, p, false, notifyLoad, checkUses, requireExactVersion, false);
 end checkUsesAndUpdateProgram;
 

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -340,7 +340,7 @@ algorithm
   ClassLoader.checkOnLoadMessage(outProgram);
 
   // Check if we have duplicate top level classes before calling checkUsesAndUpdateProgram()
-  // which will update the program by repeatedly replacing duplicates with last one seen.
+  // which will update the program by repeatedly replacing duplicate classes with last one seen.
   if checkDuplicateTopLevelClasses(outProgram) then
     fail();
   end if;

--- a/testsuite/flattening/modelica/scoping/InnerOuterSamePrefix.mo
+++ b/testsuite/flattening/modelica/scoping/InnerOuterSamePrefix.mo
@@ -3582,7 +3582,7 @@ model InnerOuterSamePrefix
     annotation(Diagram(coordinateSystem(extent = {{-148.5, -105}, {148.5, 105}}, preserveAspectRatio = true, initialScale = 0.1, grid = {5, 5})));
   end B;
   annotation(Diagram(coordinateSystem(extent = {{-148.5, -105}, {148.5, 105}}, preserveAspectRatio = true, initialScale = 0.1, grid = {5, 5})));
-end InnerOuterSamePrefix;// Result:
+end InnerOuterSamePrefix;
 
 
 // Result:

--- a/testsuite/openmodelica/parser/DocumentationBackslash.mo
+++ b/testsuite/openmodelica/parser/DocumentationBackslash.mo
@@ -12,9 +12,9 @@ model DocumentationBackslash
 end DocumentationBackslash;
 
 // Result:
+// class DocumentationBackslash
+// end DocumentationBackslash;
 // [openmodelica/parser/DocumentationBackslash.mo:10:158-10:172:writable] Warning: Lexer treating \ as \\, since \L is not a valid Modelica escape sequence.
 // [openmodelica/parser/DocumentationBackslash.mo:10:158-10:182:writable] Warning: Lexer treating \ as \\, since \C is not a valid Modelica escape sequence.
 //
-// class DocumentationBackslash
-// end DocumentationBackslash;
 // endResult

--- a/testsuite/openmodelica/parser/RealLiterals1.mo
+++ b/testsuite/openmodelica/parser/RealLiterals1.mo
@@ -13,13 +13,13 @@ model RealLiterals1
 end RealLiterals1;
 
 // Result:
-// [openmodelica/parser/RealLiterals1.mo:11:24-11:32:writable] Warning: Underflow: 4.9e-325 cannot be represented by a double on this machine. It will be converted to 0.0.
-// [openmodelica/parser/RealLiterals1.mo:12:23-12:31:writable] Warning: Underflow: 4.9e-325 cannot be represented by a double on this machine. It will be converted to 0.0.
-//
 // class RealLiterals1
 //   Real x_min1 = -4.940656458412465e-324;
 //   Real x_min2 = 4.940656458412465e-324;
 //   Real x_underflow1 = -0.0;
 //   Real x_underflow2 = 0.0;
 // end RealLiterals1;
+// [openmodelica/parser/RealLiterals1.mo:11:24-11:32:writable] Warning: Underflow: 4.9e-325 cannot be represented by a double on this machine. It will be converted to 0.0.
+// [openmodelica/parser/RealLiterals1.mo:12:23-12:31:writable] Warning: Underflow: 4.9e-325 cannot be represented by a double on this machine. It will be converted to 0.0.
+//
 // endResult


### PR DESCRIPTION
  -
    ```sh

    >$ omc FooBar/package.mo

    ```

    on the commandline should now behave the same as

    ```mo

    loadFile("FooBar/package.mo");

    ```

    in a mos script.

    That is, omc will load `FooBar` as a library. These are now more or
    less equivalent to

    ```mo

    loadLibrary(Foobar);

    ```

    if we assume `FooBar` was on `MODELICAPATH`.

### Related Issues
Fixes #10564.
