### PR TITLE
Improve overconstrained connection handling

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectionSets.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectionSets.mo
@@ -124,17 +124,15 @@ package ConnectionSets
     input BrokenEdges broken;
     output Boolean b = false;
   protected
-    ComponentRef lhs, rhs, cr1, cr2;
+    ComponentRef cr1, cr2;
   algorithm
     cr1 := Connector.name(c1);
     cr2 := Connector.name(c2);
     // print("Check: connect(" + ComponentRef.toString(cr1) + ", " + ComponentRef.toString(cr2) + ")\n");
 
     for c in broken loop
-      ((lhs, rhs, _)) := c;
-
-      if ComponentRef.isPrefix(lhs, cr1) and ComponentRef.isPrefix(rhs, cr2) or
-         ComponentRef.isPrefix(lhs, cr2) and ComponentRef.isPrefix(rhs, cr1)
+      if ComponentRef.isPrefix(c.lhs, cr1) and ComponentRef.isPrefix(c.rhs, cr2) or
+         ComponentRef.isPrefix(c.lhs, cr2) and ComponentRef.isPrefix(c.rhs, cr1)
       then
         // print("Ignore broken: connect(" + Connector.toString(c1) + ", " + Connector.toString(c2) + ")\n");
         b := true;

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -49,7 +49,15 @@ protected
   import Type = NFType;
 
 public
-  type BrokenEdge = tuple<ComponentRef, ComponentRef, list<Equation>>;
+  uniontype BrokenEdge
+    record BROKEN_EDGE
+      ComponentRef lhs;
+      ComponentRef rhs;
+      DAE.ElementSource source;
+      list<Equation> brokenEquations;
+    end BROKEN_EDGE;
+  end BrokenEdge;
+
   type BrokenEdges = list<BrokenEdge>;
 
   record CONNECTIONS

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2068,7 +2068,7 @@ algorithm
 
   // append the equalityConstraint call equations for the broken connects
   if System.getHasOverconstrainedConnectors() then
-    ec_eql := List.flatten(list(Util.tuple33(e) for e in broken));
+    ec_eql := List.flatten(list(e.brokenEquations for e in broken));
     flatModel.equations := listAppend(ec_eql, flatModel.equations);
   end if;
 

--- a/testsuite/flattening/modelica/scodeinst/EqualityConstraint2.mo
+++ b/testsuite/flattening/modelica/scodeinst/EqualityConstraint2.mo
@@ -1,0 +1,83 @@
+// name: EqualityConstraint2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+type Real2 = Real[2];
+type Overconstrained
+  extends Real2;
+  function equalityConstraint
+    input Real u1[2];
+    input Real u2[2];
+    output Real residue[1];
+  algorithm
+    residue[1] := u1[1] - u2[1];
+  end equalityConstraint;
+end Overconstrained;
+
+connector C
+  Real e;
+  flow Real f;
+  Overconstrained o;
+  flow Real g;
+end C;
+
+model EqualityConstraint2
+  C c1, c2, c3, c4;
+equation
+  Connections.potentialRoot(c1.o);
+  Connections.branch(c1.o, c2.o);
+  Connections.branch(c1.o, c3.o);
+  connect(c2, c4);
+  connect(c3, c4);
+end EqualityConstraint2;
+
+// Result:
+// function Overconstrained.equalityConstraint
+//   input Real[2] u1;
+//   input Real[2] u2;
+//   output Real[1] residue;
+// algorithm
+//   residue[1] := u1[1] - u2[1];
+// end Overconstrained.equalityConstraint;
+//
+// class EqualityConstraint2
+//   Real c1.e;
+//   Real c1.f;
+//   Real c1.o[1];
+//   Real c1.o[2];
+//   Real c1.g;
+//   Real c2.e;
+//   Real c2.f;
+//   Real c2.o[1];
+//   Real c2.o[2];
+//   Real c2.g;
+//   Real c3.e;
+//   Real c3.f;
+//   Real c3.o[1];
+//   Real c3.o[2];
+//   Real c3.g;
+//   Real c4.e;
+//   Real c4.f;
+//   Real c4.o[1];
+//   Real c4.o[2];
+//   Real c4.g;
+// equation
+//   c3.e = c4.e;
+//   c3.e = c2.e;
+//   (-c3.f) - c4.f - c2.f = 0.0;
+//   (-c3.g) - c4.g - c2.g = 0.0;
+//   c3.o[1] = c4.o[1];
+//   c3.o[2] = c4.o[2];
+//   c1.f = 0.0;
+//   c1.g = 0.0;
+//   c2.f = 0.0;
+//   c2.g = 0.0;
+//   c3.f = 0.0;
+//   c3.g = 0.0;
+//   c4.f = 0.0;
+//   c4.g = 0.0;
+//   Overconstrained.equalityConstraint(c2.o, c4.o) = {0.0};
+// end EqualityConstraint2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/EqualityConstraint3.mo
+++ b/testsuite/flattening/modelica/scodeinst/EqualityConstraint3.mo
@@ -1,0 +1,87 @@
+// name: EqualityConstraint3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+type Real2 = Real[2];
+type Overconstrained
+  extends Real2;
+  function equalityConstraint
+    input Real u1[2];
+    input Real u2[2];
+    output Real residue[1];
+  algorithm
+    residue[1] := u1[1] - u2[1];
+  end equalityConstraint;
+end Overconstrained;
+
+connector C
+  Real e;
+  flow Real f;
+  Overconstrained o;
+  flow Real g;
+end C;
+
+model Source
+  C c;
+equation
+  c.e = 1;
+  Connections.potentialRoot(c.o);
+  if Connections.isRoot(c.o) then
+    c.o = {1, 0};
+  end if;
+end Source;
+
+model Sink
+  C c;
+equation
+  c.f = 1;
+  c.g = 1;
+end Sink;
+
+model EqualityConstraint3
+  Source source;
+  Sink sink1;
+  Sink sink2;
+equation
+  connect(source.c, sink1.c);
+  connect(source.c, sink2.c);
+  connect(sink1.c, sink2.c);
+end EqualityConstraint3;
+
+// Result:
+// class EqualityConstraint3
+//   Real source.c.e;
+//   Real source.c.f;
+//   Real source.c.o[1];
+//   Real source.c.o[2];
+//   Real source.c.g;
+//   Real sink1.c.e;
+//   Real sink1.c.f;
+//   Real sink1.c.o[1];
+//   Real sink1.c.o[2];
+//   Real sink1.c.g;
+//   Real sink2.c.e;
+//   Real sink2.c.f;
+//   Real sink2.c.o[1];
+//   Real sink2.c.o[2];
+//   Real sink2.c.g;
+// equation
+//   sink1.c.e = sink2.c.e;
+//   sink1.c.e = source.c.e;
+//   sink1.c.o[1] = sink2.c.o[1];
+//   sink1.c.o[1] = source.c.o[1];
+//   sink1.c.o[2] = sink2.c.o[2];
+//   sink1.c.o[2] = source.c.o[2];
+//   sink2.c.f + sink1.c.f + source.c.f = 0.0;
+//   sink2.c.g + sink1.c.g + source.c.g = 0.0;
+//   source.c.e = 1.0;
+//   source.c.o[1] = 1.0;
+//   source.c.o[2] = 0.0;
+//   sink1.c.f = 1.0;
+//   sink1.c.g = 1.0;
+//   sink2.c.f = 1.0;
+//   sink2.c.g = 1.0;
+// end EqualityConstraint3;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -417,6 +417,8 @@ eq7.mo \
 eq8.mo \
 eq10.mo \
 EqualityConstraint1.mo \
+EqualityConstraint2.mo \
+EqualityConstraint3.mo \
 EquationInvalidType1.mo \
 EvaluateAllParams.mo \
 EvaluateAllParams2.mo \


### PR DESCRIPTION
- Remove redundant breakable branches before building the connection graph.
- Generate equalityConstraint equations when they are needed, instead of generating all possible equalityConstraint equations at the start and then discarding the unused ones.

Fixes #10717