### PR TITLE
Do not replace variable subscripts with wholdims.

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -3208,19 +3208,19 @@ algorithm
       then
         (vLst,indxs);
     // try again check if variable indexes used
-    case (_,_)
-      equation
-        // replace variables with WHOLEDIM()
-        (cr1,true) = replaceVarWithWholeDim(cr, false);
-        crlst = ComponentReference.expandCref(cr1,true);
-        if isPresent(outIntegerLst) then
-          (vLst as _::_,indxs) = getVarLst(crlst,inVariables);
-        else
-          (vLst as _::_,_) = getVarLst(crlst,inVariables);
-          indxs = {};
-        end if;
-      then
-        (vLst,indxs);
+    // case (_,_)
+    //   equation
+    //     // replace variables with WHOLEDIM()
+    //     (cr1,true) = replaceVarWithWholeDim(cr, false);
+    //     crlst = ComponentReference.expandCref(cr1,true);
+    //     if isPresent(outIntegerLst) then
+    //       (vLst as _::_,indxs) = getVarLst(crlst,inVariables);
+    //     else
+    //       (vLst as _::_,_) = getVarLst(crlst,inVariables);
+    //       indxs = {};
+    //     end if;
+    //   then
+    //     (vLst,indxs);
     /* failure
     case (_,_)
       equation


### PR DESCRIPTION
  - I am not sure why this is done the way it is now. However, it does not seem like it is correct. It takes a cref, replaces all variable subscripts (non-constant subscripts) with whole dims, expands the now array type cref (because of the new wholdims) to scalars, and returns them for potential replacement.

    I am not sure why this has worked so far. Maybe it is complemented by some other mechanism somewhere else but it does not look right.

    This fixes the issue in #10580.

