### PR TITLE
Cache shared libraries in EvalFunction

### DIFF
--- a/OMCompiler/Compiler/Global/Global.mo
+++ b/OMCompiler/Compiler/Global/Global.mo
@@ -70,6 +70,7 @@ constant Integer interactiveCache = 26;
 constant Integer isInStream = 27;
 constant Integer MMToJLListIndex = 28;
 constant Integer packageIndexCacheIndex = 29;
+constant Integer sharedLibraryCacheIndex = 30;
 
 // indexes in System.tick
 // ----------------------
@@ -101,6 +102,7 @@ algorithm
   setGlobalRoot(instNFInstCacheIndex, {});
   setGlobalRoot(instNFNodeCacheIndex, {});
   setGlobalRoot(instNFLookupCacheIndex, {});
+  setGlobalRoot(sharedLibraryCacheIndex, {});
 end initialize;
 
 annotation(__OpenModelica_Interface="util");

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -108,6 +108,7 @@ import VerifyModel = NFVerifyModel;
 import Structural = NFStructural;
 import UnorderedMap;
 import CheckModel = NFCheckModel;
+import EvalFunction = NFEvalFunction;
 
 public
 
@@ -235,6 +236,8 @@ algorithm
 
   //(var_count, eq_count) := CheckModel.checkModel(flatModel);
   //print(name + " has " + String(var_count) + " variable(s) and " + String(eq_count) + " equation(s).\n");
+
+  clearCaches();
 end instClassInProgram;
 
 function instClassForConnection
@@ -275,6 +278,8 @@ algorithm
   // Flatten the model and get connections
   conns := Flatten.flattenConnection(inst_cls, name);
   connList := Connections.toStringList(conns);
+
+  clearCaches();
 end instClassForConnection;
 
 function resetGlobalFlags
@@ -296,6 +301,12 @@ algorithm
   System.setHasOverconstrainedConnectors(false);
   System.setHasStreamConnectors(false);
 end resetGlobalFlags;
+
+function clearCaches
+  "Clears global caches used by the instantiation."
+algorithm
+  EvalFunction.clearLibraryCache();
+end clearCaches;
 
 function lookupRootClass
   "Looks up the class to instantiate and marks it as a root node."

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -676,6 +676,8 @@ algorithm
   if Flags.isSet(Flags.EXEC_STAT) then
     execStat("NFApi.frontEndFront_dispatch(" + name + ")");
   end if;
+
+  Inst.clearCaches();
 end frontEndFront_dispatch;
 
 protected
@@ -800,6 +802,7 @@ algorithm
     execStat("NFApi.frontEndLookup_dispatch("+ name +")");
   end if;
 
+  Inst.clearCaches();
 end frontEndLookup_dispatch;
 
 public
@@ -882,6 +885,7 @@ algorithm
   execStat("NFApi.dumpJSONInstanceTree");
   res := Values.STRING(JSON.toString(json, prettyPrint));
   execStat("JSON.toString");
+  Inst.clearCaches();
 end getModelInstance;
 
 function getModelInstanceIcon
@@ -902,6 +906,7 @@ algorithm
 
   json := dumpJSONInstanceIcon(cls_node);
   res := Values.STRING(JSON.toString(json, prettyPrint));
+  Inst.clearCaches();
 end getModelInstanceIcon;
 
 function parseModifier


### PR DESCRIPTION
- Cache shared libraries in EvalFunction, and unload them at the end of the instantiation instead to avoid excessive loading/unloading of shared libraries.