### PR TITLE
Fix compiler warning printing size_t

### DIFF
--- a/OMCompiler/Compiler/SimCode/SerializeSparsityPattern.mo
+++ b/OMCompiler/Compiler/SimCode/SerializeSparsityPattern.mo
@@ -86,7 +86,7 @@ protected
       j += (unsigned int) MMC_UNTAGFIXNUM(MMC_STRUCTDATA(colPtrs)[i]);
       count = omc_fwrite(&j, sizeof(unsigned int), 1, pFile);
       if (count != 1) {
-        throwStreamPrint(NULL, \"Error while writing sparsePattern->leadindex. Expected %d, got %ld\", 1, count);
+        throwStreamPrint(NULL, \"Error while writing sparsePattern->leadindex. Expected %d, got %zu\", 1, count);
       }
     }
 
@@ -95,7 +95,7 @@ protected
       j = (unsigned int) MMC_UNTAGFIXNUM(MMC_STRUCTDATA(rowInds)[i]);
       count = omc_fwrite(&j, sizeof(unsigned int), 1, pFile);
       if (count != 1) {
-        throwStreamPrint(NULL, \"Error while writing sparsePattern->index. Expected %d, got %ld\", 1, count);
+        throwStreamPrint(NULL, \"Error while writing sparsePattern->index. Expected %d, got %zu\", 1, count);
       }
     }
 
@@ -126,7 +126,7 @@ protected
       j = (unsigned int) MMC_UNTAGFIXNUM(MMC_STRUCTDATA(columns)[i]);
       count = omc_fwrite(&j, sizeof(unsigned int), 1, pFile);
       if (count != 1) {
-        throwStreamPrint(NULL, \"Error while writing sparsePattern->colorCols. Expected %d, got %ld\", 1, count);
+        throwStreamPrint(NULL, \"Error while writing sparsePattern->colorCols. Expected %d, got %zu\", 1, count);
       }
     }
 

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -5586,13 +5586,13 @@ match sparsepattern
         /* read lead index of compressed sparse column */
         count = omc_fread(jacobian->sparsePattern->leadindex, sizeof(unsigned int), <%sizeleadindex%>+1, pFile, FALSE);
         if (count != <%sizeleadindex%>+1) {
-          throwStreamPrint(threadData, "Error while reading lead index list of sparsity pattern. Expected %d, got %ld", <%sizeleadindex%>+1, count);
+          throwStreamPrint(threadData, "Error while reading lead index list of sparsity pattern. Expected %d, got %zu", <%sizeleadindex%>+1, count);
         }
 
         /* read sparse index */
         count = omc_fread(jacobian->sparsePattern->index, sizeof(unsigned int), <%sp_size_index%>, pFile, FALSE);
         if (count != <%sp_size_index%>) {
-          throwStreamPrint(threadData, "Error while reading row index list of sparsity pattern. Expected %d, got %ld", <%sizeleadindex%>+1, count);
+          throwStreamPrint(threadData, "Error while reading row index list of sparsity pattern. Expected %d, got %zu", <%sizeleadindex%>+1, count);
         }
 
         /* write color array */

--- a/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/jacobian_util.c
@@ -175,7 +175,7 @@ void readSparsePatternColor(threadData_t* threadData, FILE * pFile, unsigned int
   for (i = 0; i < length; i++) {
     count = omc_fread(&index, sizeof(unsigned int), 1, pFile, FALSE);
     if (count != 1) {
-      throwStreamPrint(threadData, "Error while reading color %d of sparsity pattern.", color);
+      throwStreamPrint(threadData, "Error while reading color %u of sparsity pattern.", color);
     }
     colorCols[index] = color;
   }

--- a/OMCompiler/SimulationRuntime/c/util/omc_file.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_file.c
@@ -145,7 +145,7 @@ size_t omc_fread(void *buffer, size_t size, size_t count, FILE *stream, int allo
   if(read_len != count)  {
     if (feof(stream) && !allow_early_eof) {
       fprintf(stderr, "Error reading stream: unexpected end of file.\n");
-      fprintf(stderr, "Expected to read %ld. Read only %ld\n", count, read_len);
+      fprintf(stderr, "Expected to read %zu. Read only %zu\n", count, read_len);
     }
     else if (ferror(stream)) {
       fprintf(stderr, "Error: omc_fread() failed to read file.\n");
@@ -171,7 +171,7 @@ size_t omc_fwrite(void *buffer, size_t size, size_t count, FILE *stream) {
   }
   if (write_len != count) {
     fprintf(stderr, "Error writing stream: unexpected end of file.\n");
-    fprintf(stderr, "Expected to write %ld. Wrote only %ld\n", count, write_len);
+    fprintf(stderr, "Expected to write %zu. Wrote only %zu\n", count, write_len);
   }
 
   return write_len;


### PR DESCRIPTION
  - Print size_t with %zu

### Related Issues
Fixes #10701