### PR TITLE
Improve isExperiment() API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6111,5 +6111,25 @@ algorithm
   end match;
 end isElementRedeclare;
 
+function isModel
+  input Absyn.Class cls;
+  output Boolean res;
+algorithm
+  res := match cls
+    case Absyn.Class.CLASS(restriction = Absyn.Restriction.R_MODEL()) then true;
+    else false;
+  end match;
+end isModel;
+
+function isBlock
+  input Absyn.Class cls;
+  output Boolean res;
+algorithm
+  res := match cls
+    case Absyn.Class.CLASS(restriction = Absyn.Restriction.R_BLOCK()) then true;
+    else false;
+  end match;
+end isBlock;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3890,7 +3890,7 @@ function isExperiment
   output Boolean res;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>An experiment is defined as having annotation experiment(StopTime=...)</p>
+<p>An experiment is defined as a non-partial model or block having annotation experiment(StopTime=...)</p>
 </html>"));
 end isExperiment;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4143,7 +4143,7 @@ function isExperiment
   output Boolean res;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>An experiment is defined as having annotation experiment(StopTime=...)</p>
+<p>An experiment is defined as a non-partial model or block having annotation experiment(StopTime=...)</p>
 </html>"));
 end isExperiment;
 

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -2149,13 +2149,7 @@ algorithm
       then Values.BOOL(false);
 
     case ("isExperiment",{Values.CODE(Absyn.C_TYPENAME(classpath))})
-      equation
-        b = Interactive.getNamedAnnotation(classpath, SymbolTable.getAbsyn(), Absyn.IDENT("experiment"), SOME(false), hasStopTime);
-      then
-        Values.BOOL(b);
-
-    case ("isExperiment",_)
-      then Values.BOOL(false);
+      then Values.BOOL(isExperiment(classpath, SymbolTable.getAbsyn()));
 
     case ("getInheritedClasses",{Values.CODE(Absyn.C_TYPENAME(classpath))})
       equation
@@ -7354,6 +7348,23 @@ algorithm
     else false;
   end matchcontinue;
 end isShortDefinition;
+
+protected function isExperiment
+  input Absyn.Path path;
+  input Absyn.Program program;
+  output Boolean res;
+protected
+  Absyn.Class cdef;
+algorithm
+  try
+    cdef := InteractiveUtil.getPathedClassInProgram(path, program);
+    false := AbsynUtil.isPartial(cdef);
+    true := AbsynUtil.isModel(cdef) or AbsynUtil.isBlock(cdef);
+    SOME(res) := AbsynUtil.getNamedAnnotationInClass(cdef, Absyn.Path.IDENT("experiment"), hasStopTime);
+  else
+    res := false;
+  end try;
+end isExperiment;
 
 protected function hasStopTime "For use with getNamedAnnotation"
   input Option<Absyn.Modification> mod;

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -56,6 +56,7 @@ interactive_api_loadsave.mos \
 interactive_api_param.mos \
 interactive_api_simulations.mos \
 interactive_test.mos \
+isExperiment.mos \
 isRedeclare.mos \
 isReplaceable.mos \
 Issue7544.mos \

--- a/testsuite/openmodelica/interactive-API/isExperiment.mos
+++ b/testsuite/openmodelica/interactive-API/isExperiment.mos
@@ -1,0 +1,57 @@
+// name: isExperiment
+// keywords:
+// status: correct
+// cflags: -d=-newInst
+//
+
+loadString("
+  package P
+    model NotExperiment
+    end NotExperiment;
+
+    model Experiment1
+      annotation(experiment(StopTime = 1.0));
+    end Experiment1;
+
+    model Experiment2
+      annotation(experiment(StartTime = 1.0, StopTime = 4.0));
+    end Experiment2;
+
+    block Experiment3
+      annotation(experiment(StopTime = 3.0));
+    end Experiment3;
+
+    model MissingStopTime
+      annotation(experiment(StartTime = 1.0));
+    end MissingStopTime;
+
+    partial model PartialModel
+      annotation(experiment(StopTime = 2.0));
+    end PartialModel;
+
+    package NotModelOrBlock
+      annotation(experiment(StopTime = 1.0));
+    end NotModelOrBlock;
+  end P;
+");
+
+isExperiment(P);
+isExperiment(P.NotExperiment);
+isExperiment(P.Experiment1);
+isExperiment(P.Experiment2);
+isExperiment(P.Experiment3);
+isExperiment(P.MissingStopTime);
+isExperiment(P.PartialModel);
+isExperiment(P.NotModelOrBlock);
+
+// Result:
+// true
+// false
+// false
+// true
+// true
+// true
+// false
+// false
+// false
+// endResult


### PR DESCRIPTION
- Restrict the definition of what an experiment is to non-partial models/blocks.