### PR TITLE
OMEdit: Added the capability to rename plot tabs

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -57,10 +57,6 @@ PlotWindowContainer::PlotWindowContainer(QWidget *pParent)
   setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   setActivationOrder(QMdiArea::ActivationHistoryOrder);
   setDocumentMode(true);
-  //Create the plot renaming action
-  mpRenamePlotWindowAction = new QAction(tr("Rename"), MainWindow::instance());
-  mpRenamePlotWindowAction->setStatusTip(tr("Renames the plot tab"));
-  connect(mpRenamePlotWindowAction, SIGNAL(triggered()), SLOT(renamePlotWindow()));
 #if QT_VERSION >= 0x040800
   setTabsClosable(true);
   setTabsMovable(true);
@@ -690,6 +686,4 @@ void PlotWindowContainer::addRenameTabToSubWindowSystemMenu(QMdiSubWindow *pMdiS
   connect(pRenamePlotWindowAction, SIGNAL(triggered()), SLOT(renamePlotWindow()));
   QMenu *pMenu = pMdiSubWindow->systemMenu();
   pMenu->addAction(pRenamePlotWindowAction);
-  //  QMenu *pMenu = pMdiSubWindow->systemMenu();
-  //  pMenu->addAction(mpRenamePlotWindowAction);
 }

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -57,6 +57,11 @@ PlotWindowContainer::PlotWindowContainer(QWidget *pParent)
   setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
   setActivationOrder(QMdiArea::ActivationHistoryOrder);
   setDocumentMode(true);
+  //Create the plot renaming action
+  mpRenamePlotWindowAction = new QAction(tr("Rename Plot Tab"), MainWindow::instance());
+  mpRenamePlotWindowAction->setStatusTip(tr("Renames the plot tab"));
+  mpRenamePlotWindowAction->setEnabled(true);
+  connect(mpRenamePlotWindowAction, SIGNAL(triggered()), SLOT(renamePlotWindow()));
 #if QT_VERSION >= 0x040800
   setTabsClosable(true);
   setTabsMovable(true);
@@ -283,6 +288,7 @@ void PlotWindowContainer::addPlotWindow(bool maximized)
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
+    addRenameTabToSubWindowSystemMenu(pSubWindow);
     pSubWindow->setWindowIcon(QIcon(":/Resources/icons/plot-window.svg"));
     pPlotWindow->show();
     if (maximized) {
@@ -316,6 +322,7 @@ void PlotWindowContainer::addParametricPlotWindow()
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
+    addRenameTabToSubWindowSystemMenu(pSubWindow);
     pSubWindow->setWindowIcon(QIcon(":/Resources/icons/parametric-plot-window.svg"));
     pPlotWindow->show();
   }
@@ -355,6 +362,7 @@ void PlotWindowContainer::addArrayPlotWindow(bool maximized)
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
+    addRenameTabToSubWindowSystemMenu(pSubWindow);
     pSubWindow->setWindowIcon(QIcon(":/Resources/icons/array-plot-window.svg"));
     pPlotWindow->show();
     if (maximized) {
@@ -392,6 +400,7 @@ PlotWindow* PlotWindowContainer::addInteractivePlotWindow(bool maximized, QStrin
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     pPlotWindow->setSubWindow(pSubWindow);
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
+    addRenameTabToSubWindowSystemMenu(pSubWindow);
     pSubWindow->setWindowIcon(QIcon(":/Resources/icons/interaction.svg"));
     pPlotWindow->show();
     if (maximized) {
@@ -434,6 +443,7 @@ void PlotWindowContainer::addArrayParametricPlotWindow()
                                          pPlottingPage->getHorizontalAxisTitleFontSizeSpinBox()->value(), pPlottingPage->getHorizontalAxisNumbersFontSizeSpinBox()->value(), pPlottingPage->getFooterFontSizeSpinBox()->value(),
                                          pPlottingPage->getLegendFontSizeSpinBox()->value());
     addCloseActionsToSubWindowSystemMenu(pSubWindow);
+    addRenameTabToSubWindowSystemMenu(pSubWindow);
     pSubWindow->setWindowIcon(QIcon(":/Resources/icons/array-parametric-plot-window.svg"));
     pPlotWindow->show();
   }
@@ -499,6 +509,24 @@ void PlotWindowContainer::removeInteractivePlotWindow()
   PlotWindow *pPlotWindow = qobject_cast<PlotWindow*>(sender());
   QString owner = pPlotWindow->getInteractiveOwner();
   MainWindow::instance()->getVariablesWidget()->getVariablesTreeModel()->removeVariableTreeItem(owner);
+}
+
+/*!
+ * \brief PlotWindowContainer::renamePlotWindow
+ * Enables the renaming of an existing plot window using right click.
+ */
+void PlotWindowContainer::renamePlotWindow()
+{
+  PlotWindow *pPlotWindow = getCurrentWindow();
+  bool okPressed = false;
+  QString text = QInputDialog::getText(this,
+                                       tr("Name Plot Tab"),
+                                       tr("Name:"),
+                                       QLineEdit::Normal,
+                                       "Plot :", &okPressed);
+  if (okPressed && !text.isEmpty()) {
+    pPlotWindow->setWindowTitle(text);
+  }
 }
 
 /*!
@@ -627,4 +655,14 @@ void PlotWindowContainer::updatePlotWindows(QString variable)
       }
     } // is plotWidget
   }
+}
+
+/*!
+ * \brief addCloseActionsToSubWindowSystemMenu
+ * Adds the rename tab action to the sub system menu
+ */
+void PlotWindowContainer::addRenameTabToSubWindowSystemMenu(QMdiSubWindow *pMdiSubWindow)
+{
+  QMenu *pMenu = pMdiSubWindow->systemMenu();
+  pMenu->addAction(mpRenamePlotWindowAction);
 }

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
@@ -67,7 +67,9 @@ public:
   bool isDiagramWindow(QObject *pObject);
   bool eventFilter(QObject *pObject, QEvent *pEvent);
 private:
+  void addRenameTabToSubWindowSystemMenu(QMdiSubWindow *pMdiSubWindow);
   DiagramWindow *mpDiagramWindow;
+  QAction *mpRenamePlotWindowAction;
 public slots:
   void addPlotWindow(bool maximized = false);
   void addParametricPlotWindow();
@@ -78,6 +80,7 @@ public slots:
   void addDiagramWindow(ModelWidget *pModelWidget = 0, bool maximized = false);
   void clearPlotWindow();
   void removeInteractivePlotWindow();
+  void renamePlotWindow();
   void exportVariables();
   void updatePlotWindows(QString variable);
 };

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
@@ -70,7 +70,6 @@ public:
 private:
   void addRenameTabToSubWindowSystemMenu(QMdiSubWindow *pMdiSubWindow);
   DiagramWindow *mpDiagramWindow;
-  QAction *mpRenamePlotWindowAction;
 public slots:
   void addPlotWindow(bool maximized = false);
   void addParametricPlotWindow();

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
@@ -65,6 +65,7 @@ public:
   bool isPlotWindow(QObject *pObject);
   bool isAnimationWindow(QObject *pObject);
   bool isDiagramWindow(QObject *pObject);
+  bool isUniqueName(QString name);
   bool eventFilter(QObject *pObject, QEvent *pEvent);
 private:
   void addRenameTabToSubWindowSystemMenu(QMdiSubWindow *pMdiSubWindow);


### PR DESCRIPTION
### Related Issues
N/A
### Purpose
The purpose of this PR is to add the capability of renaming plot tabs in OMEdit

### Approach
Added a new option when right-clicking plot tabs to name them. Useful if one works with several plots of several variables at the same time

Example:

![image](https://github.com/OpenModelica/OpenModelica/assets/8775827/85b09fe7-d013-4604-9aaa-9cd9b022d58d)

![image](https://github.com/OpenModelica/OpenModelica/assets/8775827/f2e19f38-79b6-4c79-99e4-b456b1896fa9)

![image](https://github.com/OpenModelica/OpenModelica/assets/8775827/2d8b3cef-b896-4ded-9a56-2a2962eeb447)
