### PR TITLE
Check if component name is not same as class name when inside package

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -1343,7 +1343,11 @@ bool GraphicsView::checkElementName(const QString &nameStructure, QString elemen
     }
   }
   // if element name is same as class name
-  if (nameStructure.compare(elementName) == 0) {
+  QString className = nameStructure;
+  if (mpModelWidget->getLibraryTreeItem()->isInPackageOneFile()) {
+    className = StringHandler::getLastWordAfterDot(className);
+  }
+  if (className.compare(elementName) == 0) {
     return false;
   }
   // if element with same name exists


### PR DESCRIPTION
We make the class name relative when inside package so check if dragged component name is different than the relative name