### PR TITLE
Handle non-expandable expressions in ExpressionIterator

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -99,7 +99,7 @@ public
 
       else
         algorithm
-          e := ExpandExp.expand(exp, backend);
+          (e, true) := ExpandExp.expand(exp, backend);
         then
           if referenceEq(e, exp) then SCALAR_ITERATOR(exp) else fromExp(e, backend);
 


### PR DESCRIPTION
- Fail on non-expandable array expressions in ExpressionIterator instead of creating a scalar iterator, to avoid treating array expressions as scalar.