### PR TITLE
Improve checking of valid connections

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -764,6 +764,9 @@ private:
     QStringList getNameParts() const;
     const QList<Part> getParts() const { return mParts; }
 
+    size_t size() const { return mParts.size(); }
+    Part first() const { return mParts.empty() ? Part() : mParts[0]; }
+
   private:
     QList<Part> mParts;
   };


### PR DESCRIPTION
- Check for inside output and public outside input rather than just output or input when checking if connectors are compatible.

Fixes #10859