### PR TITLE
Deprecate translateModelFMU

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2478,7 +2478,8 @@ annotation(preferredView="text");
 end importFMUModelDescription;
 
 function translateModelFMU
-"translates a modelica model into a Functional Mockup Unit.
+"Deprecated: Use buildModelFMU instead.
+Translates a modelica model into a Functional Mockup Unit.
 The only required argument is the className, while all others have some default values.
   Example command:
   translateModelFMU(className, version=\"2.0\");"
@@ -2489,7 +2490,7 @@ The only required argument is the className, while all others have some default 
   input Boolean includeResources = false "include Modelica based resources via loadResource or not";
   output String generatedFileName "Returns the full path of the generated FMU.";
 external "builtin";
-annotation(preferredView="text");
+annotation(preferredView="text", version="Deprecated");
 end translateModelFMU;
 
 function buildModelFMU
@@ -2956,7 +2957,7 @@ public function compareSimulationResults "compares simulation results."
   input String[:] vars = fill("",0);
   output String[:] result;
 external "builtin";
-annotation(preferredView="text");
+annotation(preferredView="text", version="Deprecated");
 end compareSimulationResults;
 
 public function deltaSimulationResults "calculates the sum of absolute errors."

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2731,7 +2731,8 @@ annotation(preferredView="text");
 end importFMUModelDescription;
 
 function translateModelFMU
-"translates a modelica model into a Functional Mockup Unit.
+"Deprecated: Use buildModelFMU instead.
+Translates a modelica model into a Functional Mockup Unit.
 The only required argument is the className, while all others have some default values.
   Example command:
   translateModelFMU(className, version=\"2.0\");"
@@ -2742,7 +2743,7 @@ The only required argument is the className, while all others have some default 
   input Boolean includeResources = false "include Modelica based resources via loadResource or not";
   output String generatedFileName "Returns the full path of the generated FMU.";
 external "builtin";
-annotation(preferredView="text");
+annotation(preferredView="text", version="Deprecated");
 end translateModelFMU;
 
 function buildModelFMU
@@ -3209,7 +3210,7 @@ public function compareSimulationResults "compares simulation results."
   input String[:] vars = fill("",0);
   output String[:] result;
 external "builtin";
-annotation(preferredView="text");
+annotation(preferredView="text", version="Deprecated");
 end compareSimulationResults;
 
 public function deltaSimulationResults "calculates the sum of absolute errors."

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1251,6 +1251,7 @@ algorithm
 
     case ("translateModelFMU", Values.CODE(Absyn.C_TYPENAME(className))::Values.STRING(str1)::Values.STRING(str2)::Values.STRING(filenameprefix)::_)
       algorithm
+        Error.addMessage(Error.DEPRECATED_API_CALL, {"translateModelFMU", "buildModelFMU"});
         (outCache, ret_val) := buildModelFMU(outCache, inEnv, className, str1, str2, filenameprefix, true);
       then
         ret_val;

--- a/OMCompiler/SimulationRuntime/fmi/export/fmi1/model_fmu.in
+++ b/OMCompiler/SimulationRuntime/fmi/export/fmi1/model_fmu.in
@@ -1,4 +1,4 @@
 loadModel(Modelica); getErrorString();
 loadModel(ModelicaServices); getErrorString();
 loadFile("@OMC_MODELDIR@/@OMC_MODELNAME@.mo");
-translateModelFMU(@OMC_MODELNAME@);
+buildModelFMU(@OMC_MODELNAME@);

--- a/doc/UsersGuide/interface.mos
+++ b/doc/UsersGuide/interface.mos
@@ -34,7 +34,20 @@ algorithm
     out := out + sum(\"  \" + l + \"\\n\" for l in OpenModelica.Scripting.strtok(s, \"\\n\")) + \"  \\n\";
   end if;
 end reSTInterface;
+
+function isDeprecatedVersion
+  input OpenModelica.Scripting.TypeName cl;
+  output Boolean deprecated;
+protected
+  String version = OpenModelica.Scripting.getVersion(cl);
+algorithm
+  if stringEq(version, \"Deprecated\") then
+    deprecated := true;
+  else
+    deprecated := false;
+  end if;
+end isDeprecatedVersion;
 ");
 getErrorString();
 
-writeFile("interface.inc", sum(reSTInterface(cl) for cl guard isFunction(cl) and not isPartial(cl) and not regexBool(typeNameString(cl), "Internal") in getClassNames(OpenModelica.Scripting, sort=true, recursive=true)));getErrorString();
+writeFile("interface.inc", sum(reSTInterface(cl) for cl guard isFunction(cl) and not isPartial(cl) and not isDeprecatedVersion(cl) and not regexBool(typeNameString(cl), "Internal") in getClassNames(OpenModelica.Scripting, sort=true, recursive=true)));getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/CoupledClutches_FMU1_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/CoupledClutches_FMU1_CPP.mos
@@ -8,7 +8,7 @@
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
 loadFile("CoupledClutches.mo"); getErrorString();
-translateModelFMU(CoupledClutches, version="1.0"); getErrorString();
+buildModelFMU(CoupledClutches, version="1.0"); getErrorString();
 
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();
 importFMU("CoupledClutches.fmu"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/Crane_FMU1_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/Crane_FMU1_CPP.mos
@@ -8,7 +8,7 @@
 loadModel(Modelica, {"3.2.2"}); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
 loadFile("cranes.mo"); getErrorString();
-translateModelFMU(cranes.crane, version="1.0"); getErrorString();
+buildModelFMU(cranes.crane, version="1.0"); getErrorString();
 
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();
 //importFMU("cranes_crane.fmu", "<default>", 6, false, true); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/DIC_FMU1_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/DIC_FMU1_CPP.mos
@@ -21,7 +21,7 @@ equation
   der(y2) = y1;
 end DIC;
 ");
-translateModelFMU(DIC, version="1.0"); getErrorString();
+buildModelFMU(DIC, version="1.0"); getErrorString();
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/Modelica.Fluid.Examples.BranchingDynamicPipes_FMU1_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/1.0/Modelica.Fluid.Examples.BranchingDynamicPipes_FMU1_CPP.mos
@@ -9,7 +9,7 @@
 
 loadModel(Modelica, {"3.2.1"}); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
-translateModelFMU(Modelica.Fluid.Examples.BranchingDynamicPipes, version="1.0"); getErrorString();
+buildModelFMU(Modelica.Fluid.Examples.BranchingDynamicPipes, version="1.0"); getErrorString();
 
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();
 importFMU("Modelica_Fluid_Examples_BranchingDynamicPipes.fmu"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/CoupledClutches_FMU2_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/CoupledClutches_FMU2_CPP.mos
@@ -8,7 +8,7 @@
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
 loadFile("CoupledClutches.mo"); getErrorString();
-translateModelFMU(CoupledClutches, version = "2.0"); getErrorString();
+buildModelFMU(CoupledClutches, version = "2.0"); getErrorString();
 
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();
 importFMU("CoupledClutches.fmu"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Crane_FMU2_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/Crane_FMU2_CPP.mos
@@ -13,7 +13,7 @@ setCommandLineOptions("+simCodeTarget=Cpp"); getErrorString();
 setCommandLineOptions("+d=disableDirectionalDerivatives"); getErrorString();
 
 loadFile("../1.0/cranes.mo"); getErrorString();
-translateModelFMU(cranes.crane, version="2.0"); getErrorString();
+buildModelFMU(cranes.crane, version="2.0"); getErrorString();
 
 //importFMU("cranes.crane.fmu", "<default>", 6, false, true); getErrorString();
 importFMU("cranes.crane.fmu", "<default>"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/DIC_FMU2_CPP.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/DIC_FMU2_CPP.mos
@@ -21,7 +21,7 @@ equation
   der(y2) = y1;
 end DIC;
 ");
-translateModelFMU(DIC, version = "2.0"); getErrorString();
+buildModelFMU(DIC, version = "2.0"); getErrorString();
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 importFMU("DIC.fmu"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -82,7 +82,7 @@ end LocalIOs;
 ");
 getErrorString();
 
-translateModelFMU(LocalIOs.System, version="2.0"); getErrorString();
+buildModelFMU(LocalIOs.System, version="2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq LocalIOs.System.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > modelDescription.tmp.xml");

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/solveOneNonlinearEquationTest.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/solveOneNonlinearEquationTest.mos
@@ -36,7 +36,7 @@ end SolveOneNonlinearEquationTest;
 ");
 getErrorString();
 
-translateModelFMU(SolveOneNonlinearEquationTest, version = "2.0"); getErrorString();
+buildModelFMU(SolveOneNonlinearEquationTest, version = "2.0"); getErrorString();
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 importFMU("SolveOneNonlinearEquationTest.fmu"); getErrorString();
 loadFile("SolveOneNonlinearEquationTest_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
@@ -51,7 +51,7 @@ equation
 end ArrayEquationsTest;
 "); getErrorString();
 
-translateModelFMU(ArrayEquationsTest, version = "2.0"); getErrorString();
+buildModelFMU(ArrayEquationsTest, version = "2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq ArrayEquationsTest.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > modelDescription.tmp.xml");

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCSTR.mos
@@ -19,7 +19,7 @@ getErrorString();
 // enable directional derivatives
 setCommandLineOptions("-d=-disableDirectionalDerivatives"); getErrorString();
 
-translateModelFMU(CSTRModel, version="2.0"); getErrorString();
+buildModelFMU(CSTRModel, version="2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq CSTRModel.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > modelDescription.tmp.xml");

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testClockDescription.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testClockDescription.mos
@@ -40,7 +40,7 @@ end SubClocks;
 ");
 getErrorString();
 
-translateModelFMU(SubClocks, version="2.0");
+buildModelFMU(SubClocks, version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCombiTable2D.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testCombiTable2D.mos
@@ -21,7 +21,7 @@ getErrorString();
 // enable directional derivatives
 setCommandLineOptions("-d=-disableDirectionalDerivatives"); getErrorString();
 
-translateModelFMU(TableTest, version="2.0"); getErrorString();
+buildModelFMU(TableTest, version="2.0"); getErrorString();
 
 importFMU("TableTest.fmu"); getErrorString();
 loadFile("TableTest_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testDrumBoiler.mos
@@ -20,7 +20,7 @@ getErrorString();
 // enable directional derivatives
 setCommandLineOptions("-d=-disableDirectionalDerivatives"); getErrorString();
 
-translateModelFMU(DrumBoilerModel, version="2.0"); getErrorString();
+buildModelFMU(DrumBoilerModel, version="2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq DrumBoilerModel.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > modelDescription.tmp.xml");

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testFMU2MatrixIO.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testFMU2MatrixIO.mos
@@ -20,7 +20,7 @@ model MatrixIOTest
 end MatrixIOTest;
 "); getErrorString();
 
-translateModelFMU(MatrixIOTest, version = "2.0"); getErrorString();
+buildModelFMU(MatrixIOTest, version = "2.0"); getErrorString();
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 importFMU("MatrixIOTest.fmu"); getErrorString();
 loadFile("MatrixIOTest_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testModelDescription.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testModelDescription.mos
@@ -25,7 +25,7 @@ end SIDTest;
 ");
 getErrorString();
 
-translateModelFMU(SIDTest, version="2.0");
+buildModelFMU(SIDTest, version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/ticket6296.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/ticket6296.mos
@@ -26,7 +26,7 @@ equation
   y1 = sum(x1);
 end ArrayEquationsTest;");
 
-translateModelFMU(ArrayEquationsTest, version = "2.0"); getErrorString();
+buildModelFMU(ArrayEquationsTest, version = "2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq ArrayEquationsTest.fmu modelDescription.xml > ArrayEquationsTest_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/CoupledClutches.mos
+++ b/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/CoupledClutches.mos
@@ -9,7 +9,7 @@ loadModel(Modelica, {"3.2.3"}); getErrorString();
 setDebugFlags("hpcom,hardcodedStartValues"); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp +n=1 +hpcomCode=openmp +hpcomScheduler=level"); getErrorString();
 loadFile("CoupledClutches.mo"); getErrorString();
-translateModelFMU(CoupledClutches); getErrorString();
+buildModelFMU(CoupledClutches); getErrorString();
 
 clearDebugFlags(); getErrorString();
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/CoupledClutches_FMU1_CPP_HPCOM.mos
+++ b/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/CoupledClutches_FMU1_CPP_HPCOM.mos
@@ -9,7 +9,7 @@ loadModel(Modelica, {"3.2.3"}); getErrorString();
 setDebugFlags("hpcom,hardcodedStartValues"); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp +n=2 +hpcomCode=openmp +hpcomScheduler=list"); getErrorString();
 loadFile("CoupledClutches.mo"); getErrorString();
-translateModelFMU(CoupledClutches); getErrorString();
+buildModelFMU(CoupledClutches); getErrorString();
 
 
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();

--- a/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/Crane_FMU1_CPP_HPCOM.mos
+++ b/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/Crane_FMU1_CPP_HPCOM.mos
@@ -8,7 +8,7 @@ loadModel(Modelica, {"3.2.3"}); getErrorString();
 setDebugFlags("hpcom,hardcodedStartValues"); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp +n=2 +hpcomCode=openmp +hpcomScheduler=level"); getErrorString();
 loadFile("cranes.mo"); getErrorString();
-translateModelFMU(cranes.crane); getErrorString();
+buildModelFMU(cranes.crane); getErrorString();
 
 setCommandLineOptions("+simCodeTarget=C"); getErrorString();
 clearDebugFlags(); getErrorString();

--- a/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/crane.mos
+++ b/testsuite/openmodelica/cppruntime/hpcom/fmu/modelExchange/1.0/crane.mos
@@ -8,7 +8,7 @@ loadModel(Modelica, {"3.2.3"}); getErrorString();
 setDebugFlags("hpcom"); getErrorString();
 setCommandLineOptions("+simCodeTarget=Cpp +n=2 +hpcomCode=openmp +hpcomScheduler=level"); getErrorString();
 loadFile("cranes.mo"); getErrorString();
-translateModelFMU(cranes.crane); getErrorString();
+buildModelFMU(cranes.crane); getErrorString();
 
 //importFMU("cranes_crane.fmu", "<default>", 6); getErrorString();
 //importFMU("cranes_crane.fmu"); getErrorString();

--- a/testsuite/openmodelica/cruntime/msvc/BouncingBall.mos
+++ b/testsuite/openmodelica/cruntime/msvc/BouncingBall.mos
@@ -24,7 +24,7 @@ equation
 
 end BouncingBallFMI20;
 "); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0"); getErrorString();
 importFMU("BouncingBallFMI20.fmu"); getErrorString();
 loadFile("BouncingBallFMI20_me_FMU.mo"); getErrorString();
 simulate(BouncingBallFMI20_me_FMU, stopTime=3.0); getErrorString();

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/ExportCvodeFmu_static.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/ExportCvodeFmu_static.mos
@@ -12,7 +12,7 @@ loadString("model Pendulum
 extends Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum;
 end Pendulum;"); getErrorString();
 setCommandLineOptions("--fmiFlags=s:cvode"); getErrorString();
-translateModelFMU(Pendulum, version = "2.0", fmuType="me_cs"); getErrorString();
+buildModelFMU(Pendulum, version = "2.0", fmuType="me_cs"); getErrorString();
 
 // Check _flags.json for simulation flags
 system("unzip -cqq Pendulum.fmu resources/Pendulum_flags.json > Pendulum_flags_static.json"); getErrorString();

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/FmuExportFlags.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/FmuExportFlags.mos
@@ -28,20 +28,20 @@ end BouncingBallFMI20;
 
 // Don't generate simulation settings file
 setCommandLineOptions("--fmiFlags=none"); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
 
 system("unzip -cqq BouncingBallFMI20.fmu resources/BouncingBallFMI20_flags.json > BouncingBallFMI20_flags.json"); getErrorString();
 
 // Generate default simulation settings file
 setCommandLineOptions("--fmiFlags=default"); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
 
 system("unzip -cqq BouncingBallFMI20.fmu resources/BouncingBallFMI20_flags.json > BouncingBallFMI20_flags.json"); getErrorString();
 readFile("BouncingBallFMI20_flags.json"); getErrorString();
 
 // Comandline options for simflags
 setCommandLineOptions("--fmiFlags=s:cvode,nls:homotopy,yourFlagName:here"); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
 
 system("unzip -cqq BouncingBallFMI20.fmu resources/BouncingBallFMI20_flags.json > BouncingBallFMI20_flags.json"); getErrorString();
 readFile("BouncingBallFMI20_flags.json"); getErrorString();
@@ -54,14 +54,14 @@ writeFile("exampleFlags.json",
 }"); getErrorString();
 
 setCommandLineOptions("--fmiFlags=exampleFlags.json"); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
 
 system("unzip -cqq BouncingBallFMI20.fmu resources/BouncingBallFMI20_flags.json > BouncingBallFMI20_flags.json"); getErrorString();
 readFile("BouncingBallFMI20_flags.json"); getErrorString();
 
 // Give file with simflags as absolute path
 setCommandLineOptions("--fmiFlags=" + realpath(".") + "/exampleFlags.json"); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0", fmuType="cs"); getErrorString();
 
 system("unzip -cqq BouncingBallFMI20.fmu resources/BouncingBallFMI20_flags.json > BouncingBallFMI20_flags.json"); getErrorString();
 readFile("BouncingBallFMI20_flags.json"); getErrorString();

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/fmi_interpolation_01.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/fmi_interpolation_01.mos
@@ -14,7 +14,7 @@ equation
 end fmi_interpolation_01;
 "); getErrorString();
 
-translateModelFMU(fmi_interpolation_01, fmuType="cs"); getErrorString();
+buildModelFMU(fmi_interpolation_01, fmuType="cs"); getErrorString();
 
 //unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_interpolation_01.fmu modelDescription.xml > fmi_interpolation_01_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/CoSimulation/2.0/simpleStiffFMU.mos
+++ b/testsuite/openmodelica/fmi/CoSimulation/2.0/simpleStiffFMU.mos
@@ -19,7 +19,7 @@ equation
 end stiffProblem;
 "); getErrorString();
 setCommandLineOptions("-d=newInst --fmiFlags=s:cvode"); getErrorString();
-translateModelFMU(stiffProblem, version = "2.0", fmuType="me_cs"); getErrorString();
+buildModelFMU(stiffProblem, version = "2.0", fmuType="me_cs"); getErrorString();
 
 // Check _flags.json for simulation flags
 system("unzip -cqq stiffProblem.fmu resources/stiffProblem_flags.json > stiffProblem_flags_dynamic.json"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/BooleanNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/BooleanNetwork1.mos
@@ -16,7 +16,7 @@ val(y4, 10);
 val(Q, 10);
 val(QI, 10);
 
-translateModelFMU(BooleanNetwork1, version="1.0"); getErrorString();
+buildModelFMU(BooleanNetwork1, version="1.0"); getErrorString();
 
 importFMU("BooleanNetwork1.fmu"); getErrorString();
 loadFile("BooleanNetwork1_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBall.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/BouncingBall.mos
@@ -8,7 +8,7 @@
 setCFlags(getCFlags() + " -g"); getErrorString();
 loadFile("BouncingBall.mo"); getErrorString();
 
-if ""==translateModelFMU(BouncingBall, version="1.0") then
+if ""==buildModelFMU(BouncingBall, version="1.0") then
   print(getErrorString());
   exit(1);
 end if;

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/CoupledClutches.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/CoupledClutches.mos
@@ -7,7 +7,7 @@
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 loadFile("CoupledClutches.mo"); getErrorString();
-translateModelFMU(CoupledClutches, version="1.0"); getErrorString();
+buildModelFMU(CoupledClutches, version="1.0"); getErrorString();
 
 importFMU("CoupledClutches.fmu"); getErrorString();
 loadFile("CoupledClutches_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/EnumerationTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/EnumerationTest.mos
@@ -10,7 +10,7 @@
 
 loadFile("EnumerationTest.mo");
 //instantiateModel(EnumerationTest);
-translateModelFMU(EnumerationTest, version="1.0");
+buildModelFMU(EnumerationTest, version="1.0");
 getErrorString();
 
 importFMU("EnumerationTest.fmu"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/HelloFMIWorld.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/HelloFMIWorld.mos
@@ -7,7 +7,7 @@
 //
 
 loadFile("HelloFMIWorld.mo");
-translateModelFMU(HelloFMIWorld, version="1.0");
+buildModelFMU(HelloFMIWorld, version="1.0");
 getErrorString();
 importFMU("HelloFMIWorld.fmu");
 loadFile("HelloFMIWorld_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/InOutTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/InOutTest.mos
@@ -8,7 +8,7 @@
 
 loadModel(Modelica, {"3.2.1"});getErrorString();
 loadFile("InOutTest.mo");getErrorString();
-translateModelFMU(InOutTest, version="1.0");getErrorString();
+buildModelFMU(InOutTest, version="1.0");getErrorString();
 importFMU("InOutTest.fmu");getErrorString();
 loadFile("InOutTest_me_FMU.mo");getErrorString();
 loadFile("testInOut.mo");getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/IntegerNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/IntegerNetwork1.mos
@@ -7,7 +7,7 @@
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 loadFile("IntegerNetwork1.mo"); getErrorString();
-translateModelFMU(IntegerNetwork1, version="1.0"); getErrorString();
+buildModelFMU(IntegerNetwork1, version="1.0"); getErrorString();
 
 importFMU("IntegerNetwork1.fmu"); getErrorString();
 loadFile("IntegerNetwork1_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/JuliansBib.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/JuliansBib.mos
@@ -18,7 +18,7 @@ val(theta,1);
 val(s, 0);
 val(s, 1);
 
-translateModelFMU(JuliansBib.Connector_Hebelarm_einfach, version="1.0"); getErrorString();
+buildModelFMU(JuliansBib.Connector_Hebelarm_einfach, version="1.0"); getErrorString();
 importFMU("JuliansBib_Connector_Hebelarm_einfach.fmu"); getErrorString();
 loadFile("JuliansBib_Connector_Hebelarm_einfach_me_FMU.mo"); getErrorString();
 simulate(JuliansBib_Connector_Hebelarm_einfach_me_FMU, stopTime=1,numberOfIntervals=1000); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Blocks.Sources.BooleanPulse.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Blocks.Sources.BooleanPulse.mos
@@ -8,7 +8,7 @@
 //
 
 loadModel(Modelica, {"3.2.1"});
-translateModelFMU(Modelica.Blocks.Sources.BooleanPulse, version="1.0");
+buildModelFMU(Modelica.Blocks.Sources.BooleanPulse, version="1.0");
 getErrorString();
 
 importFMU("Modelica_Blocks_Sources_BooleanPulse.fmu"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
@@ -8,7 +8,7 @@
 //
 
 loadModel(Modelica,{"3.1"});
-translateModelFMU(Modelica.Electrical.Analog.Examples.ChuaCircuit, version="1.0");
+buildModelFMU(Modelica.Electrical.Analog.Examples.ChuaCircuit, version="1.0");
 getErrorString();
 
 importFMU("Modelica_Electrical_Analog_Examples_ChuaCircuit.fmu"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
@@ -11,7 +11,7 @@ loadModel(Modelica, {"3.2.3"});
 // Although it is not correct to do it by default, evaluate protected parameters,
 // otherwise building the _me_FMU.mo fails. It seems that it is necessary to evaluate string parameters.
 setCommandLineOptions("--evaluateProtectedParameters"); getErrorString();
-translateModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum, version="1.0");
+buildModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum, version="1.0");
 getErrorString();
 importFMU("Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.fmu", loglevel=0);
 getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
@@ -8,7 +8,7 @@
 //
 
 loadModel(Modelica, {"3.2.2"}); getErrorString();
-translateModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum, version="1.0"); getErrorString();
+buildModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum, version="1.0"); getErrorString();
 importFMU("Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.fmu", loglevel=0); getErrorString();
 loadFile("Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum_me_FMU.mo"); getErrorString();
 simulate(Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum_me_FMU,stopTime=3.0); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/Pendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/Pendulum.mos
@@ -9,7 +9,7 @@
 //
 
 loadFile("Pendulum.mo");
-translateModelFMU(Pendulum, version="1.0");
+buildModelFMU(Pendulum, version="1.0");
 getErrorString();
 importFMU("Pendulum.fmu");
 getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/SampleExample.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/SampleExample.mos
@@ -17,7 +17,7 @@ equation
   end when;
 end SampleEvent;
 ");
-translateModelFMU(SampleEvent, version="1.0");
+buildModelFMU(SampleEvent, version="1.0");
 getErrorString();
 importFMU("SampleEvent.fmu");
 loadFile("SampleEvent_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/StringParameters.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/StringParameters.mos
@@ -7,7 +7,7 @@
 //
 setCFlags(getCFlags() + " -g"); getErrorString();
 loadFile("StringParameters.mo"); getErrorString();
-translateModelFMU(StringParameters, version="1.0"); getErrorString();
+buildModelFMU(StringParameters, version="1.0"); getErrorString();
 importFMU("StringParameters.fmu"); getErrorString();
 loadFile("StringParameters_me_FMU.mo"); getErrorString();
 simulate(StringParameters_me_FMU, stopTime=3.0, simflags="-output=sball,eball"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/TanksConnectedPI.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/TanksConnectedPI.mos
@@ -6,7 +6,7 @@
 //
 
 loadFile("TanksConnectedPI.mo");
-translateModelFMU(TanksConnectedPI, version="1.0");
+buildModelFMU(TanksConnectedPI, version="1.0");
 importFMU("TanksConnectedPI.fmu");
 loadFile("TanksConnectedPI_me_FMU.mo");
 simulate(TanksConnectedPI_me_FMU,stopTime=210,numberOfIntervals=250, tolerance=1e-5);

--- a/testsuite/openmodelica/fmi/ModelExchange/1.0/testAssert.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/1.0/testAssert.mos
@@ -13,7 +13,7 @@ equation
   assert(x < 1.5, \"x is too big at time = \" + String(time));
 end testAssertFMI;
 ");
-translateModelFMU(testAssertFMI, version="1.0");
+buildModelFMU(testAssertFMI, version="1.0");
 getErrorString();
 importFMU("testAssertFMI.fmu");
 loadFile("testAssertFMI_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/BooleanNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/BooleanNetwork1.mos
@@ -13,7 +13,7 @@ val(onDelay.y, 10);
 val(rSFlipFlop.Q, 10);
 val(rSFlipFlop.QI, 10);
 
-translateModelFMU(Modelica.Blocks.Examples.BooleanNetwork1, version="2.0"); getErrorString();
+buildModelFMU(Modelica.Blocks.Examples.BooleanNetwork1, version="2.0"); getErrorString();
 importFMU("Modelica.Blocks.Examples.BooleanNetwork1.fmu"); getErrorString();
 loadFile("Modelica_Blocks_Examples_BooleanNetwork1_me_FMU.mo"); getErrorString();
 simulate(Modelica_Blocks_Examples_BooleanNetwork1_me_FMU, stopTime=10, numberOfIntervals=150); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/BouncingBall.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/BouncingBall.mos
@@ -24,7 +24,7 @@ equation
 
 end BouncingBallFMI20;
 "); getErrorString();
-translateModelFMU(BouncingBallFMI20, version = "2.0", fmuType="me_cs"); getErrorString();
+buildModelFMU(BouncingBallFMI20, version = "2.0", fmuType="me_cs"); getErrorString();
 importFMU("BouncingBallFMI20.fmu"); getErrorString();
 loadFile("BouncingBallFMI20_me_FMU.mo"); getErrorString();
 simulate(BouncingBallFMI20_me_FMU, stopTime=3.0); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/EnumerationTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/EnumerationTest.mos
@@ -10,7 +10,7 @@
 
 loadFile("EnumerationTest.mo");
 //instantiateModel(EnumerationTest);
-translateModelFMU(EnumerationTest, version="2.0");
+buildModelFMU(EnumerationTest, version="2.0");
 getErrorString();
 
 importFMU("EnumerationTest.fmu"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/FMIExercise.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/FMIExercise.mos
@@ -8,7 +8,7 @@
 echo(false);
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 loadFile("FMIExercise.mo"); getErrorString();
-translateModelFMU(FMIExercise.Components.PI, version="2.0"); getErrorString();
+buildModelFMU(FMIExercise.Components.PI, version="2.0"); getErrorString();
 importFMU("FMIExercise.Components.PI.fmu"); getErrorString();
 loadFile("FMIExercise_Components_PI_me_FMU.mo"); getErrorString();
 simulate(FMIExercise.TestPIFMU); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/FMUResourceTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/FMUResourceTest.mos
@@ -12,7 +12,7 @@ mkdir("@");
 echo(false);
 cd("@");
 echo(true);
-translateModelFMU(FMUResourceTest.TestResource, version="2.0"); getErrorString();
+buildModelFMU(FMUResourceTest.TestResource, version="2.0"); getErrorString();
 importFMU("FMUResourceTest.TestResource.fmu"); getErrorString();
 loadFile("FMUResourceTest_TestResource_me_FMU.mo"); getErrorString();
 echo(false);

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/HelloFMIWorld.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/HelloFMIWorld.mos
@@ -13,7 +13,7 @@ equation
 end HelloFMI20World;
 "); getErrorString();
 
-translateModelFMU(HelloFMI20World, version="2.0"); getErrorString();
+buildModelFMU(HelloFMI20World, version="2.0"); getErrorString();
 importFMU("HelloFMI20World.fmu"); getErrorString();
 loadFile("HelloFMI20World_me_FMU.mo"); getErrorString();
 simulate(HelloFMI20World_me_FMU); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/HelloFMIWorldEvent.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/HelloFMIWorldEvent.mos
@@ -14,7 +14,7 @@ equation
 end HelloFMI20WorldEvent;
 ");
 
-translateModelFMU(HelloFMI20WorldEvent, version="2.0");
+buildModelFMU(HelloFMI20WorldEvent, version="2.0");
 getErrorString();
 importFMU("HelloFMI20WorldEvent.fmu");
 loadFile("HelloFMI20WorldEvent_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/IntegerNetwork1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/IntegerNetwork1.mos
@@ -7,7 +7,7 @@
 
 loadModel(Modelica, {"3.2.3"}); getErrorString();
 loadFile("IntegerNetwork1.mo"); getErrorString();
-translateModelFMU(IntegerNetwork1, version="2.0"); getErrorString();
+buildModelFMU(IntegerNetwork1, version="2.0"); getErrorString();
 
 importFMU("IntegerNetwork1.fmu"); getErrorString();
 loadFile("IntegerNetwork1_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica.Blocks.Sources.BooleanPulse.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica.Blocks.Sources.BooleanPulse.mos
@@ -8,7 +8,7 @@
 //
 
 loadModel(Modelica, {"3.2.1"});
-translateModelFMU(Modelica.Blocks.Sources.BooleanPulse, version="2.0"); getErrorString();
+buildModelFMU(Modelica.Blocks.Sources.BooleanPulse, version="2.0"); getErrorString();
 
 importFMU("Modelica.Blocks.Sources.BooleanPulse.fmu"); getErrorString();
 loadFile("Modelica_Blocks_Sources_BooleanPulse_me_FMU.mo"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica.Electrical.Analog.Examples.ChuaCircuit.mos
@@ -8,7 +8,7 @@
 //
 
 loadModel(Modelica,{"3.1"});
-translateModelFMU(Modelica.Electrical.Analog.Examples.ChuaCircuit, version="2.0"); getErrorString();
+buildModelFMU(Modelica.Electrical.Analog.Examples.ChuaCircuit, version="2.0"); getErrorString();
 
 importFMU("Modelica.Electrical.Analog.Examples.ChuaCircuit.fmu"); getErrorString();
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.mos
@@ -21,7 +21,7 @@ val(revolute2.phi, 1);
 val(revolute2.phi, 2);
 val(revolute2.phi, 3);
 
-translateModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum, version="2.0");
+buildModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum, version="2.0");
 getErrorString();
 importFMU("Modelica_Mechanics_MultiBody_Examples_Elementary_DoublePendulum.fmu");
 getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum.mos
@@ -11,7 +11,7 @@ val(rev.phi, 0);
 val(rev.phi, 1);
 val(rev.phi, 2);
 val(rev.phi, 3);
-translateModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum, version="2.0"); getErrorString();
+buildModelFMU(Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum, version="2.0"); getErrorString();
 importFMU("Modelica.Mechanics.MultiBody.Examples.Elementary.Pendulum.fmu"); getErrorString();
 loadFile("Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum_me_FMU.mo"); getErrorString();
 simulate(Modelica_Mechanics_MultiBody_Examples_Elementary_Pendulum_me_FMU, stopTime=3.0); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ZeroStates.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ZeroStates.mos
@@ -15,7 +15,7 @@ equation
 end ZeroStates20;
 ");
 getErrorString();
-translateModelFMU(ZeroStates20, version="2.0");
+buildModelFMU(ZeroStates20, version="2.0");
 getErrorString();
 importFMU("ZeroStates20.fmu");
 loadFile("ZeroStates20_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_01.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_01.mos
@@ -16,7 +16,7 @@ equation
 end fmi_attributes_01;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_01); getErrorString();
+buildModelFMU(fmi_attributes_01); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_01.fmu modelDescription.xml > fmi_attributes_01_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_02.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_02.mos
@@ -18,7 +18,7 @@ equation
 end fmi_attributes_02;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_02); getErrorString();
+buildModelFMU(fmi_attributes_02); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_02.fmu modelDescription.xml > fmi_attributes_02_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_03.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_03.mos
@@ -14,7 +14,7 @@ equation
 end fmi_attributes_03;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_03); getErrorString();
+buildModelFMU(fmi_attributes_03); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_03.fmu modelDescription.xml > fmi_attributes_03_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_04.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_04.mos
@@ -19,7 +19,7 @@ equation
 end fmi_attributes_04;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_04); getErrorString();
+buildModelFMU(fmi_attributes_04); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_04.fmu modelDescription.xml > fmi_attributes_04_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_05.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_05.mos
@@ -22,7 +22,7 @@ equation
 end fmi_attributes_05;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_05); getErrorString();
+buildModelFMU(fmi_attributes_05); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_05.fmu modelDescription.xml > fmi_attributes_05_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_06.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_06.mos
@@ -22,7 +22,7 @@ equation
 end fmi_attributes_06;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_06); getErrorString();
+buildModelFMU(fmi_attributes_06); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_06.fmu modelDescription.xml > fmi_attributes_06_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_07.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_07.mos
@@ -23,7 +23,7 @@ equation
 end fmi_attributes_07;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_07); getErrorString();
+buildModelFMU(fmi_attributes_07); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_07.fmu modelDescription.xml > fmi_attributes_07_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_08.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_08.mos
@@ -17,7 +17,7 @@ equation
 end fmi_attributes_08;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_08); getErrorString();
+buildModelFMU(fmi_attributes_08); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_08.fmu modelDescription.xml > fmi_attributes_08_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_09.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_09.mos
@@ -37,7 +37,7 @@ equation
 end fmi_attributes_09;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_09); getErrorString();
+buildModelFMU(fmi_attributes_09); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_09.fmu modelDescription.xml > fmi_attributes_09_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_10.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_10.mos
@@ -15,7 +15,7 @@ equation
   der(x) = 0;
 end fmi_attributes_10;
 "); getErrorString();
-translateModelFMU(fmi_attributes_10); getErrorString();
+buildModelFMU(fmi_attributes_10); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_10.fmu modelDescription.xml > fmi_attributes_10_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_11.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_11.mos
@@ -24,7 +24,7 @@ end fmi_attributes_11;
 "); getErrorString();
 
 setCommandLineOptions("--fmiFilter=blackBox"); getErrorString();
-translateModelFMU(fmi_attributes_11); getErrorString();
+buildModelFMU(fmi_attributes_11); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_11.fmu modelDescription.xml > fmi_attributes_11_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_12.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_12.mos
@@ -28,7 +28,7 @@ end fmi_attributes_12;
 "); getErrorString();
 
 setCommandLineOptions("--fmiFilter=protected"); getErrorString();
-translateModelFMU(fmi_attributes_12); getErrorString();
+buildModelFMU(fmi_attributes_12); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_12.fmu modelDescription.xml > fmi_attributes_12_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_13.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_13.mos
@@ -28,7 +28,7 @@ end fmi_attributes_13;
 "); getErrorString();
 
 setCommandLineOptions("--fmiFilter=none"); getErrorString();
-translateModelFMU(fmi_attributes_13); getErrorString();
+buildModelFMU(fmi_attributes_13); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_13.fmu modelDescription.xml > fmi_attributes_13_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_14.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_14.mos
@@ -28,7 +28,7 @@ end fmi_attributes_14;
 "); getErrorString();
 
 setCommandLineOptions("--fmiFilter=internal"); getErrorString();
-translateModelFMU(fmi_attributes_14); getErrorString();
+buildModelFMU(fmi_attributes_14); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_14.fmu modelDescription.xml > fmi_attributes_14_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_15.mos
@@ -18,7 +18,7 @@ equation
 end fmi_attributes_15;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_15); getErrorString();
+buildModelFMU(fmi_attributes_15); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_15.fmu modelDescription.xml | grep -v guid | grep -v generationDateAndTime | grep -v generationTool > fmi_attributes_15_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_16.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_16.mos
@@ -16,7 +16,7 @@ equation
 end fmi_attributes_16;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_16); getErrorString();
+buildModelFMU(fmi_attributes_16); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_16.fmu modelDescription.xml > fmi_attributes_16_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
@@ -38,7 +38,7 @@ equation
 end fmi_attributes_17;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_17); getErrorString();
+buildModelFMU(fmi_attributes_17); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_17.fmu modelDescription.xml > fmi_attributes_17_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_18.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_18.mos
@@ -19,7 +19,7 @@ equation
 end fmi_attributes_18;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_18, version="2.0", fmuType="me_cs"); getErrorString();
+buildModelFMU(fmi_attributes_18, version="2.0", fmuType="me_cs"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_18.fmu modelDescription.xml > fmi_attributes_18_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_19.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_19.mos
@@ -21,7 +21,7 @@ equation
 end fmi_attributes_19;
 "); getErrorString();
 
-translateModelFMU(fmi_attributes_19, fmuType="cs"); getErrorString();
+buildModelFMU(fmi_attributes_19, fmuType="cs"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq fmi_attributes_19.fmu modelDescription.xml > fmi_attributes_19_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testAssert.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testAssert.mos
@@ -13,7 +13,7 @@ equation
   assert(x < 1.5, \"x is too big at time = \" + String(time));
 end testAssertFMI;
 ");
-translateModelFMU(testAssertFMI, version="2.0");
+buildModelFMU(testAssertFMI, version="2.0");
 getErrorString();
 importFMU("testAssertFMI.fmu");
 loadFile("testAssertFMI_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2764.mos
@@ -24,7 +24,7 @@ end test_Bug2764;
 ");
 getErrorString();
 
-translateModelFMU(test_Bug2764, version="2.0");
+buildModelFMU(test_Bug2764, version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2765.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug2765.mos
@@ -24,7 +24,7 @@ equation
 end test_Bug2765;
 "); getErrorString();
 
-translateModelFMU(test_Bug2765, version="2.0"); getErrorString();
+buildModelFMU(test_Bug2765, version="2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq test_Bug2765.fmu modelDescription.xml > testBug2765_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3034.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3034.mos
@@ -16,7 +16,7 @@ end test_Bug3034;
 getErrorString();
 
 loadModel(Modelica, {"3.2.3"});
-translateModelFMU(test_Bug3034, version="2.0");
+buildModelFMU(test_Bug3034, version="2.0");
 getErrorString();
 importFMU("test_Bug3034.fmu");
 loadFile("test_Bug3034_me_FMU.mo");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3049.mos
@@ -15,7 +15,7 @@ end test_Bug3049;
 ");
 getErrorString();
 
-translateModelFMU(test_Bug3049, version="2.0");
+buildModelFMU(test_Bug3049, version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3763.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug3763.mos
@@ -7,7 +7,7 @@ model DrumBoiler
   extends Modelica.Fluid.Examples.DrumBoiler.DrumBoiler(use_inputs=false);
 end DrumBoiler;
 ");
-translateModelFMU(DrumBoiler);getErrorString();
+buildModelFMU(DrumBoiler);getErrorString();
 
 // Result:
 // true

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testBug5673.mos
@@ -36,7 +36,7 @@ system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" aliasCheck.test2_in
 readFile("Bug5673.xml"); getErrorString();
 
 
-translateModelFMU(aliasCheck.test2,version="2.0");
+buildModelFMU(aliasCheck.test2,version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testChangeParam.mos
@@ -27,7 +27,7 @@ getErrorString();
 loadModel(Modelica, {"3.2.3"});
 
 
-translateModelFMU(test_ChangeParam, version="2.0");
+buildModelFMU(test_ChangeParam, version="2.0");
 getErrorString();
 importFMU("test_ChangeParam.fmu");
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDisableDep.mos
@@ -29,7 +29,7 @@ end testDID;
 ");
 getErrorString();
 
-translateModelFMU(testDID, version="2.0");
+buildModelFMU(testDID, version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testDiscreteStructe.mos
@@ -26,7 +26,7 @@ end testDID;
 ");
 getErrorString();
 
-translateModelFMU(testDID, version="2.0");
+buildModelFMU(testDID, version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testExperimentalFMU.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testExperimentalFMU.mos
@@ -20,7 +20,7 @@ equation
   end for;
 end advection; ");
 setDebugFlags("fmuExperimental");
-translateModelFMU(advection ,"2","me","<default>");
+buildModelFMU(advection ,"2","me","<default>");
 getErrorString();
 system("rm -f log.txt");
 system("unzip -cqq advection.fmu sources/advection.c | grep \"void advection_functionODE_Partial(\"", "log.txt");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/testInitialEquationsFMI.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/testInitialEquationsFMI.mos
@@ -42,21 +42,21 @@ package initializationTestsFMI
 end initializationTestsFMI;
 "); getErrorString();
 
-translateModelFMU(initializationTestsFMI.initial_equation1, version="2.0"); getErrorString();
+buildModelFMU(initializationTestsFMI.initial_equation1, version="2.0"); getErrorString();
 importFMU("initializationTestsFMI.initial_equation1.fmu"); getErrorString();
 loadFile("initializationTestsFMI_initial_equation1_me_FMU.mo"); getErrorString();
 simulate(initializationTestsFMI_initial_equation1_me_FMU, stopTime=0.0); getErrorString();
 val(x, 0.0);
 val(y, 0.0);
 
-translateModelFMU(initializationTestsFMI.initial_equation2, version="2.0"); getErrorString();
+buildModelFMU(initializationTestsFMI.initial_equation2, version="2.0"); getErrorString();
 importFMU("initializationTestsFMI.initial_equation2.fmu"); getErrorString();
 loadFile("initializationTestsFMI_initial_equation2_me_FMU.mo"); getErrorString();
 simulate(initializationTestsFMI_initial_equation2_me_FMU, stopTime=0.0); getErrorString();
 val(x, 0.0);
 val(y, 0.0);
 
-translateModelFMU(initializationTestsFMI.initial_equation3, version="2.0"); getErrorString();
+buildModelFMU(initializationTestsFMI.initial_equation3, version="2.0"); getErrorString();
 importFMU("initializationTestsFMI.initial_equation3.fmu"); getErrorString();
 loadFile("initializationTestsFMI_initial_equation3_me_FMU.mo"); getErrorString();
 simulate(initializationTestsFMI_initial_equation3_me_FMU, stopTime=0.0); getErrorString();

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket5670.mos
@@ -25,7 +25,7 @@ getErrorString();
 system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" ticket5670_init.xml >Bug5670.xml"); getErrorString();
 readFile("Bug5670.xml"); getErrorString();
 
-translateModelFMU(ticket5670,version="2.0");
+buildModelFMU(ticket5670,version="2.0");
 getErrorString();
 
 // unzip to console, quiet, extra quiet

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket6262.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/ticket6262.mos
@@ -12,7 +12,7 @@ equation
 end ticket6262;
 "); getErrorString();
 
-translateModelFMU(ticket6262, version = "2.0"); getErrorString();
+buildModelFMU(ticket6262, version = "2.0"); getErrorString();
 
 // unzip to console, quiet, extra quiet
 system("unzip -cqq ticket6262.fmu modelDescription.xml > ticket6262_tmp.xml"); getErrorString();

--- a/testsuite/openmodelica/visualization/device.mos
+++ b/testsuite/openmodelica/visualization/device.mos
@@ -11,4 +11,4 @@ loadModel(Modelica_DeviceDrivers);getErrorString();
 loadFile("device.mo");getErrorString();
 setDebugFlags("visxml"); getErrorString();
 setCommandLineOptions("+n=1"); getErrorString();
-translateModelFMU(device, version = "1.0", fmuType = "me");getErrorString();
+buildModelFMU(device, version = "1.0", fmuType = "me");getErrorString();

--- a/testsuite/simulation/modelica/arrays/ParametricInitialArrayEquationBug.mos
+++ b/testsuite/simulation/modelica/arrays/ParametricInitialArrayEquationBug.mos
@@ -5,7 +5,7 @@
 
 loadFile("ParametricInitialArrayEquationBug.mo"); getErrorString();
 buildModel(TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2); getErrorString();
-translateModelFMU(TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2, fileNamePrefix="PEM"); getErrorString();
+buildModelFMU(TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2, fileNamePrefix="PEM"); getErrorString();
 
 // Result:
 // true


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/10550

### Purpose

  - Deprecate translateModelFMU

### Approach

  - Use buildModelFMU instead of translateModelFMU
  - Skip documentation generation for depreacted API functions
