### PR TITLE
Only break the loop when we found the value

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -1502,8 +1502,8 @@ void ElementParameters::fetchClassExtendsModifiers()
               Parameter *pParameter = findParameter(subModifier.getName());
               applyFinalStartFixedAndDisplayUnitModifiers(pParameter, subModifier, false);
             }
+            break;
           }
-          break;
         }
       }
     }


### PR DESCRIPTION
### Related Issues

Fixes #10864

### Purpose

Show the correct value.

### Approach

Check the complete list instead of just looking the first value. Stop when value is found.