### PR TITLE
Fix compiler warnings in C++ runtime / OMSICpp

### DIFF
--- a/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Math/ArrayOperations.cpp
+++ b/OMCompiler/SimulationRuntime/OMSICpp/runtime/src/Core/Math/ArrayOperations.cpp
@@ -258,8 +258,7 @@ void multiply_array(const BaseArray<T>& inputArray, const T& b, BaseArray<T>& ou
         outputArray.setDims(inputArray.getDims());
         const T* data = inputArray.getData();
         T* aim = outputArray.getData();
-        std::transform(data, data + inputArray.getNumElems(),
-                       aim, std::bind2nd(std::multiplies<T>(), b));
+        std::transform(data, data + inputArray.getNumElems(), aim, [&](const T& a) { return a*b; });
     }
 };
 
@@ -343,7 +342,7 @@ void divide_array(const BaseArray<T>& inputArray, const T& b, BaseArray<T>& outp
     }
     const T* data = inputArray.getData();
     T* aim = outputArray.getData();
-    std::transform(data, data + nelems, aim, std::bind2nd(std::divides<T>(), b));
+    std::transform(data, data + nelems, aim, [&](const T& a) { return a/b; });
 }
 
 template <typename T>
@@ -412,8 +411,7 @@ void subtract_array_scalar(const BaseArray<T>& inputArray, T b, BaseArray<T>& ou
         outputArray.setDims(inputArray.getDims());
         const T* data = inputArray.getData();
         T* aim = outputArray.getData();
-        std::transform(data, data + inputArray.getNumElems(),
-                       aim, std::bind2nd(std::minus<T>(), b));
+        std::transform(data, data + inputArray.getNumElems(), aim, [&](const T& a) { return a-b; });
     }
 }
 
@@ -444,8 +442,7 @@ void add_array_scalar(const BaseArray<T>& inputArray, T b, BaseArray<T>& outputA
         outputArray.setDims(inputArray.getDims());
         const T* data = inputArray.getData();
         T* result = outputArray.getData();
-        std::transform(data, data + inputArray.getNumElems(),
-                       result, std::bind2nd(std::plus<T>(), b));
+        std::transform(data, data + inputArray.getNumElems(), result, [&](const T& a) { return a+b; });
     }
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/Math/ArrayOperations.cpp
@@ -142,8 +142,7 @@ void multiply_array(const BaseArray<T>& inputArray, const T &b, BaseArray<T>& ou
 	outputArray.setDims(inputArray.getDims());
 	const T* data = inputArray.getData();
 	T* aim = outputArray.getData();
-	std::transform (data, data + inputArray.getNumElems(),
-                  aim, std::bind2nd(std::multiplies<T>(), b));
+	std::transform (data, data + inputArray.getNumElems(), aim, [&](const T& a) { return a*b; });
   }
 };
 
@@ -229,7 +228,7 @@ void divide_array(const BaseArray<T>& inputArray, const T &b, BaseArray<T>& outp
   }
   const T* data = inputArray.getData();
   T* aim = outputArray.getData();
-  std::transform(data, data + nelems, aim, std::bind2nd(std::divides<T>(), b));
+  std::transform(data, data + nelems, aim, [&](const T& a) { return a/b; });
 }
 
 template <typename T>
@@ -242,7 +241,7 @@ void divide_array(const T &b, const BaseArray<T>& inputArray, BaseArray<T>& outp
   }
   const T* data = inputArray.getData();
   T* aim = outputArray.getData();
-  std::transform(data, data + nelems, aim, std::bind1st(std::divides<T>(), b));
+  std::transform(data, data + nelems, aim, [&](const T& a) { return b/a; });
 }
 
 template <typename T>
@@ -311,8 +310,7 @@ void subtract_array_scalar(const BaseArray<T>& inputArray, T b, BaseArray<T>& ou
     outputArray.setDims(inputArray.getDims());
     const T* data = inputArray.getData();
     T* aim = outputArray.getData();
-    std::transform (data, data + inputArray.getNumElems(),
-                  aim, std::bind2nd(std::minus<T>(), b));
+    std::transform (data, data + inputArray.getNumElems(), aim, [&](const T& a) { return a-b; });
   }
 }
 
@@ -342,8 +340,7 @@ void add_array_scalar(const BaseArray<T>& inputArray, T b, BaseArray<T>& outputA
     outputArray.setDims(inputArray.getDims());
     const T* data = inputArray.getData();
     T* result = outputArray.getData();
-    std::transform (data, data + inputArray.getNumElems(),
-                    result, std::bind2nd(std::plus<T>(), b));
+    std::transform (data, data + inputArray.getNumElems(), result, [&](const T& a) { return a+b; });
   }
 }
 

--- a/OMCompiler/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
+++ b/OMCompiler/SimulationRuntime/cpp/Core/System/SystemDefaultImplementation.cpp
@@ -542,8 +542,7 @@ void SystemDefaultImplementation::storeTime(double time)
   // delete up to last value < time - _delay_max
   buffer_type::iterator first = _time_buffer.begin();
   buffer_type::iterator pos = find_if(first, _time_buffer.end(),
-                                      bind2nd(std::greater_equal<double>(),
-                                              time - _delay_max));
+                                      [=](double t) { return t >= time - _delay_max; });
   if (pos != first && --pos != first) {
     difference_type n = std::distance(first, pos);
     _time_buffer.erase(first, first + n);
@@ -599,7 +598,7 @@ double SystemDefaultImplementation::delay(unsigned int expr_id,double expr_value
       else
       {
         //find posion in value buffer for queried time
-        buffer_type::iterator pos = find_if(_time_buffer.begin(),_time_buffer.end(),bind2nd(std::greater_equal<double>(),ts));
+        buffer_type::iterator pos = find_if(_time_buffer.begin(),_time_buffer.end(), [=](double t) { return t >= ts; });
 
         if(pos!=_time_buffer.end())
         {


### PR DESCRIPTION
- Replace deprecated std::bind1st/bind2nd with lambdas to get rid of compiler warnings.