### PR TITLE
Use the defaultComponentName annotation as it is

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -1297,7 +1297,7 @@ QString GraphicsView::getUniqueElementName(const QString &nameStructure, const Q
   *defaultName = MainWindow::instance()->getOMCProxy()->getDefaultComponentName(nameStructure);
   QString newName;
   if (!defaultName->isEmpty()) {
-    newName = getUniqueElementName(nameStructure, StringHandler::toCamelCase(*defaultName));
+    newName = getUniqueElementName(nameStructure, *defaultName);
   } else {
     newName = getUniqueElementName(nameStructure, StringHandler::toCamelCase(name));
   }


### PR DESCRIPTION
### Related Issues

Fixes #10862

### Purpose

Respect the defaultComponentName case.

### Approach

Do not convert the defaultComponentName to camel case
