### PR TITLE
Deprecate includeResources in buildModelFMU

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2507,7 +2507,7 @@ The only required argument is the className, while all others have some default 
                                           \"static\"=current platform, statically link everything.
                                           \"<cpu>-<vendor>-<os>\", host tripple, e.g. \"x86_64-linux-gnu\" or \"x86_64-w64-mingw32\".
                                           \"<cpu>-<vendor>-<os> docker run <image>\" host tripple with Docker image, e.g. \"x86_64-linux-gnu docker run --pull=never multiarch/crossbuild\"";
-  input Boolean includeResources = false "include Modelica based resources via loadResource or not";
+  input Boolean includeResources = false "Depreacted and no effect";
   output String generatedFileName "Returns the full path of the generated FMU.";
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1444,7 +1444,7 @@ was read in binary format from a file with the same name.
   "
   input String data;
   input String filename = "<interactive>";
-  input String encoding = "UTF-8";
+  input String encoding = "UTF-8" "Deprecated as *ALL* strings are now UTF-8 encoded";
   input Boolean merge = false "if merge is true the parsed AST is merged with the existing AST, default to false which means that is replaced, not merged";
   output Boolean success;
 external "builtin";
@@ -2760,7 +2760,7 @@ The only required argument is the className, while all others have some default 
                                           \"static\"=current platform, statically link everything.
                                           \"<cpu>-<vendor>-<os>\", host tripple, e.g. \"x86_64-linux-gnu\" or \"x86_64-w64-mingw32\".
                                           \"<cpu>-<vendor>-<os> docker run <image>\" host tripple with Docker image, e.g. \"x86_64-linux-gnu docker run --pull=never multiarch/crossbuild\"";
-  input Boolean includeResources = false "include Modelica based resources via loadResource or not";
+  input Boolean includeResources = false "Depreacted and no effect";
   output String generatedFileName "Returns the full path of the generated FMU.";
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -295,7 +295,7 @@ public constant ErrorTypes.Message NON_PARAMETER_ITERATOR_RANGE = ErrorTypes.MES
 public constant ErrorTypes.Message IMPLICIT_ITERATOR_NOT_FOUND_IN_LOOP_BODY = ErrorTypes.MESSAGE(110, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Identifier %s of implicit for iterator must be present as array subscript in the loop body."));
 public constant ErrorTypes.Message CONNECTOR_NON_PARAMETER_SUBSCRIPT = ErrorTypes.MESSAGE(111, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Connector ‘%s‘ has non-parameter subscript ‘%s‘."));
+  Gettext.gettext("Connector '%s' has non-parameter subscript '%s'."));
 public constant ErrorTypes.Message LOOKUP_CLASS_VIA_COMP_COMP = ErrorTypes.MESSAGE(112, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Illegal access of class '%s' via a component when looking for '%s'."));
 public constant ErrorTypes.Message SUBSCRIPTED_FUNCTION_CALL = ErrorTypes.MESSAGE(113, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -371,7 +371,7 @@ public constant ErrorTypes.Message TUPLE_ASSIGN_CREFS_ONLY = ErrorTypes.MESSAGE(
 public constant ErrorTypes.Message LOOKUP_FUNCTION_GOT_CLASS = ErrorTypes.MESSAGE(148, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Looking for a function %s but found a %s."));
 public constant ErrorTypes.Message NON_STREAM_OPERAND_IN_STREAM_OPERATOR = ErrorTypes.MESSAGE(149, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Operand ‘%s‘ to operator ‘%s‘ is not a stream variable."));
+  Gettext.gettext("Operand '%s' to operator '%s' is not a stream variable."));
 public constant ErrorTypes.Message UNBALANCED_CONNECTOR = ErrorTypes.MESSAGE(150, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("Connector %s is not balanced: The number of potential variables (%s) is not equal to the number of flow variables (%s)."));
 public constant ErrorTypes.Message RESTRICTION_VIOLATION = ErrorTypes.MESSAGE(151, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -661,7 +661,7 @@ public constant ErrorTypes.Message EACH_ON_NON_ARRAY = ErrorTypes.MESSAGE(292, E
 public constant ErrorTypes.Message BUILTIN_EXTENDS_INVALID_ELEMENTS = ErrorTypes.MESSAGE(293, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("A class extending from builtin type %s may not have other elements."));
 public constant ErrorTypes.Message INITIAL_CALL_WARNING = ErrorTypes.MESSAGE(294, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("initial() may only be used as a when condition (when initial() or when {..., initial(), ...}), but got condition ‘%s‘."));
+  Gettext.gettext("initial() may only be used as a when condition (when initial() or when {..., initial(), ...}), but got condition '%s'."));
 public constant ErrorTypes.Message RANGE_TYPE_MISMATCH = ErrorTypes.MESSAGE(295, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Type mismatch in range: '%s' of type\n  %s\nis not type compatible with '%s' of type\n  %s"));
 public constant ErrorTypes.Message RANGE_TOO_SMALL_STEP = ErrorTypes.MESSAGE(296, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -677,7 +677,7 @@ public constant ErrorTypes.Message CYCLIC_DIMENSIONS = ErrorTypes.MESSAGE(300, E
 public constant ErrorTypes.Message INVALID_DIMENSION_TYPE = ErrorTypes.MESSAGE(301, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Dimension '%s' of type %s is not an integer expression or an enumeration or Boolean type name."));
 public constant ErrorTypes.Message NON_PARAMETER_EXPRESSION_DIMENSION = ErrorTypes.MESSAGE(302, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Expression ‘%s‘ that determines the size of dimension ‘%s‘ of ‘%s‘ is not an evaluable parameter expression."));
+  Gettext.gettext("Expression '%s' that determines the size of dimension '%s' of '%s' is not an evaluable parameter expression."));
 public constant ErrorTypes.Message INVALID_TYPENAME_USE = ErrorTypes.MESSAGE(303, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Type name '%s' is not allowed in this context."));
 public constant ErrorTypes.Message FOUND_WRONG_INNER_ELEMENT = ErrorTypes.MESSAGE(305, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -729,9 +729,9 @@ public constant ErrorTypes.Message REDECLARE_MISMATCHED_PREFIX = ErrorTypes.MESS
 public constant ErrorTypes.Message EXTERNAL_ARG_NONCONSTANT_SIZE_INDEX = ErrorTypes.MESSAGE(328, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Invalid external argument '%s', the dimension index must be a constant expression."));
 public constant ErrorTypes.Message FAILURE_TO_DEDUCE_DIMS_EACH = ErrorTypes.MESSAGE(329, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Failed to deduce dimension %s of ‘%s‘ due to ‘each‘ prefix on binding equation."));
+  Gettext.gettext("Failed to deduce dimension %s of '%s' due to 'each' prefix on binding equation."));
 public constant ErrorTypes.Message MISSING_TYPE_BASETYPE = ErrorTypes.MESSAGE(330, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Type ‘%s‘ does not extend a basic type."));
+  Gettext.gettext("Type '%s' does not extend a basic type."));
 public constant ErrorTypes.Message ASSERT_TRIGGERED_WARNING = ErrorTypes.MESSAGE(331, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("assert triggered: %s"));
 public constant ErrorTypes.Message ASSERT_TRIGGERED_ERROR = ErrorTypes.MESSAGE(332, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
@@ -745,53 +745,53 @@ public constant ErrorTypes.Message UNASSIGNED_FUNCTION_OUTPUT = ErrorTypes.MESSA
 public constant ErrorTypes.Message INVALID_WHEN_STATEMENT_CONTEXT = ErrorTypes.MESSAGE(336, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("A when-statement may not be used inside a function or a while, if, or for-clause."));
 public constant ErrorTypes.Message MISSING_FUNCTION_DERIVATIVE_NAME = ErrorTypes.MESSAGE(337, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("Derivative annotation for function ‘%s‘ does not specify a derivative function."));
+  Gettext.gettext("Derivative annotation for function '%s' does not specify a derivative function."));
 public constant ErrorTypes.Message INVALID_FUNCTION_ANNOTATION_ATTR = ErrorTypes.MESSAGE(338, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("‘%s‘ is not a valid function %s attribute."));
+  Gettext.gettext("'%s' is not a valid function %s attribute."));
 public constant ErrorTypes.Message INVALID_FUNCTION_ANNOTATION_INPUT = ErrorTypes.MESSAGE(339, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("‘%s‘ is not an input of function ‘%s‘."));
+  Gettext.gettext("'%s' is not an input of function '%s'."));
 public constant ErrorTypes.Message OPERATOR_OVERLOADING_ONE_OUTPUT_ERROR = ErrorTypes.MESSAGE(340, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Operator %s must have exactly one output."));
 public constant ErrorTypes.Message OPERATOR_OVERLOADING_INVALID_OUTPUT_TYPE = ErrorTypes.MESSAGE(341, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Output ‘%s‘ in operator %s must be of type %s, got type %s."));
+  Gettext.gettext("Output '%s' in operator %s must be of type %s, got type %s."));
 public constant ErrorTypes.Message OPERATOR_NOT_ENCAPSULATED = ErrorTypes.MESSAGE(342, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Operator %s is not encapsulated."));
 public constant ErrorTypes.Message NO_SUCH_INPUT_PARAMETER = ErrorTypes.MESSAGE(343, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Function %s has no input parameter named %s."));
 public constant ErrorTypes.Message INVALID_REDUCTION_TYPE = ErrorTypes.MESSAGE(344, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Invalid expression ‘%s‘ of type %s in %s reduction, expected %s."));
+  Gettext.gettext("Invalid expression '%s' of type %s in %s reduction, expected %s."));
 public constant ErrorTypes.Message INVALID_COMPONENT_PREFIX = ErrorTypes.MESSAGE(345, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Prefix ‘%s‘ on component ‘%s‘ not allowed in class specialization ‘%s‘."));
+  Gettext.gettext("Prefix '%s' on component '%s' not allowed in class specialization '%s'."));
 public constant ErrorTypes.Message INVALID_CARDINALITY_CONTEXT = ErrorTypes.MESSAGE(346, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("cardinality may only be used in the condition of an if-statement/equation or an assert."));
 public constant ErrorTypes.Message VARIABLE_BINDING_DIMS_MISMATCH = ErrorTypes.MESSAGE(347, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Type mismatch in binding ‘%s = %s‘, expected array dimensions %s, got %s."));
+  Gettext.gettext("Type mismatch in binding '%s = %s', expected array dimensions %s, got %s."));
 public constant ErrorTypes.Message MODIFIER_NON_ARRAY_TYPE_ERROR = ErrorTypes.MESSAGE(348, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Non-array modification ‘%s‘ for array component ‘%s‘, possibly due to missing ‘each‘."));
+  Gettext.gettext("Non-array modification '%s' for array component '%s', possibly due to missing 'each'."));
 public constant ErrorTypes.Message INST_RECURSION_LIMIT_REACHED = ErrorTypes.MESSAGE(349, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Recursion limit reached while instantiating ‘%s‘."));
+  Gettext.gettext("Recursion limit reached while instantiating '%s'."));
 public constant ErrorTypes.Message WHEN_IF_VARIABLE_MISMATCH = ErrorTypes.MESSAGE(350, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The branches of an if-equation inside a when-equation must have the same set of component references on the left-hand side."));
 public constant ErrorTypes.Message DIMENSION_DEDUCTION_FROM_BINDING_FAILURE = ErrorTypes.MESSAGE(351, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Dimension %s of ‘%s‘ could not be deduced from the component's binding equation ‘%s‘."));
+  Gettext.gettext("Dimension %s of '%s' could not be deduced from the component's binding equation '%s'."));
 public constant ErrorTypes.Message NON_REAL_FLOW_OR_STREAM = ErrorTypes.MESSAGE(352, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Invalid prefix ‘%s‘ on non-Real component ‘%s‘."));
+  Gettext.gettext("Invalid prefix '%s' on non-Real component '%s'."));
 public constant ErrorTypes.Message LIBRARY_UNEXPECTED_NAME_CASE_SENSITIVE = ErrorTypes.MESSAGE(353, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("Expected the package to have name %s, but got %s. Proceeding since only the case of the names are different."));
 public constant ErrorTypes.Message PACKAGE_ORDER_CASE_SENSITIVE = ErrorTypes.MESSAGE(354, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("The package.order file contains a class %s, which is expected to be stored in file %s, but seems to be named %s. Proceeding since only the case of the names are different."));
 public constant ErrorTypes.Message REDECLARE_CLASS_NON_SUBTYPE = ErrorTypes.MESSAGE(355, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Redeclaration of %s ‘%s‘ is not a subtype of the redeclared element."));
+  Gettext.gettext("Redeclaration of %s '%s' is not a subtype of the redeclared element."));
 public constant ErrorTypes.Message REDECLARE_ENUM_NON_SUBTYPE = ErrorTypes.MESSAGE(356, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Redeclaration of enumeration ‘%s‘ is not a subtype of the redeclared element (use enumeration(:) for a generic replaceable enumeration)."));
+  Gettext.gettext("Redeclaration of enumeration '%s' is not a subtype of the redeclared element (use enumeration(:) for a generic replaceable enumeration)."));
 public constant ErrorTypes.Message CONDITIONAL_COMPONENT_INVALID_CONTEXT = ErrorTypes.MESSAGE(357, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("Conditional component ‘%s‘ is used in a non-connect context."));
+  Gettext.gettext("Conditional component '%s' is used in a non-connect context."));
 public constant ErrorTypes.Message OPERATOR_RECORD_MISSING_OPERATOR = ErrorTypes.MESSAGE(358, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Type ‘%s‘ of expression ‘%s‘ in ‘%s‘ does not implement the required operator ‘%s‘"));
+  Gettext.gettext("Type '%s' of expression '%s' in '%s' does not implement the required operator '%s'"));
 public constant ErrorTypes.Message IMPORT_IN_COMPOSITE_NAME = ErrorTypes.MESSAGE(359, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Found imported name ‘%s‘ while looking up composite name ‘%s‘."));
+  Gettext.gettext("Found imported name '%s' while looking up composite name '%s'."));
 public constant ErrorTypes.Message SHADOWED_ITERATOR = ErrorTypes.MESSAGE(360, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("An iterator named ‘%s‘ is already declared in this scope."));
+  Gettext.gettext("An iterator named '%s' is already declared in this scope."));
 public constant ErrorTypes.Message W_INVALID_ARGUMENT_TYPE_BRANCH_FIRST = ErrorTypes.MESSAGE(361, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The first argument '%s' of %s must have the form A.R, where A is a connector and R an over-determined type/record."));
 public constant ErrorTypes.Message W_INVALID_ARGUMENT_TYPE_BRANCH_SECOND = ErrorTypes.MESSAGE(362, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
@@ -803,13 +803,13 @@ public constant ErrorTypes.Message INVALID_FLAG_CONDITION = ErrorTypes.MESSAGE(3
 public constant ErrorTypes.Message EXPERIMENTAL_REQUIRED = ErrorTypes.MESSAGE(365, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("%s is an experimental feature and requires the --std=experimental flag."));
 public constant ErrorTypes.Message INVALID_NUMBER_OF_DIMENSIONS_FOR_PROMOTE = ErrorTypes.MESSAGE(366, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("The second argument ‘%s‘ of promote may not be smaller than the number of dimensions (%s) of the first argument."));
+  Gettext.gettext("The second argument '%s' of promote may not be smaller than the number of dimensions (%s) of the first argument."));
 public constant ErrorTypes.Message PURE_FUNCTION_WITH_IMPURE_CALLS = ErrorTypes.MESSAGE(367, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("Pure function ‘%s‘ contains a call to impure function ‘%s‘."));
+  Gettext.gettext("Pure function '%s' contains a call to impure function '%s'."));
 public constant ErrorTypes.Message DISCRETE_REAL_UNDEFINED = ErrorTypes.MESSAGE(368, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Following variable is discrete, but does not appear on the LHS of a when-statement: ‘%s‘."));
+  Gettext.gettext("Following variable is discrete, but does not appear on the LHS of a when-statement: '%s'."));
 public constant ErrorTypes.Message DER_OF_NONDIFFERENTIABLE_EXP = ErrorTypes.MESSAGE(369, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Argument ‘%s‘ of der is not differentiable."));
+  Gettext.gettext("Argument '%s' of der is not differentiable."));
 public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_WITHOUT_CONVERSION = ErrorTypes.MESSAGE(370, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("%1 requested package %2 of version %3. %2 %4 is used instead which states that it is fully compatible without conversion script needed."));
 // The following errors (371, 372, 373) are used by OMEdit. Do not change them.
@@ -822,51 +822,51 @@ public constant ErrorTypes.Message LOAD_MODEL_DIFFERENT_VERSIONS_NEWER = ErrorTy
 public constant ErrorTypes.Message EQUATION_NOT_SOLVABLE_DIFFERENT_COUNT = ErrorTypes.MESSAGE(374, ErrorTypes.SYMBOLIC(), ErrorTypes.ERROR(),
   Gettext.gettext("%s has size %s but %s variables (%s)"));
 public constant ErrorTypes.Message PARTIAL_COMPONENT_TYPE = ErrorTypes.MESSAGE(375, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Component ‘%s‘ has partial type ‘%s‘."));
+  Gettext.gettext("Component '%s' has partial type '%s'."));
 public constant ErrorTypes.Message PARTIAL_FUNCTION_CALL = ErrorTypes.MESSAGE(376, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Called function ‘%s‘ is partial."));
+  Gettext.gettext("Called function '%s' is partial."));
 public constant ErrorTypes.Message TOO_MANY_TYPE_VARS_IN_CALL = ErrorTypes.MESSAGE(377, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Too many type variables given in call to ‘%s‘."));
+  Gettext.gettext("Too many type variables given in call to '%s'."));
 public constant ErrorTypes.Message BREAK_OUTSIDE_LOOP = ErrorTypes.MESSAGE(378, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("‘break' may only be used in a while- or for-loop."));
+  Gettext.gettext("'break' may only be used in a while- or for-loop."));
 public constant ErrorTypes.Message TOP_LEVEL_OUTER = ErrorTypes.MESSAGE(379, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("The model can't be instantiated due to top-level outer element ‘%s‘, it may only be used as part of a simulation model."));
+  Gettext.gettext("The model can't be instantiated due to top-level outer element '%s', it may only be used as part of a simulation model."));
 public constant ErrorTypes.Message MISSING_INNER_NAME_CONFLICT = ErrorTypes.MESSAGE(380, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("An inner declaration for outer element ‘%s‘ could not be found, and could not be automatically generated due to an existing declaration of that name."));
+  Gettext.gettext("An inner declaration for outer element '%s' could not be found, and could not be automatically generated due to an existing declaration of that name."));
 public constant ErrorTypes.Message TOP_LEVEL_INPUT_WITH_BINDING = ErrorTypes.MESSAGE(381, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
-  Gettext.gettext("Top-level input ‘%s‘ has a binding equation and will not be accessible as an input of the model."));
+  Gettext.gettext("Top-level input '%s' has a binding equation and will not be accessible as an input of the model."));
 public constant ErrorTypes.Message NON_DISCRETE_WHEN_CONDITION = ErrorTypes.MESSAGE(382, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("When-condition ‘%s‘ is not a discrete-time expression."));
+  Gettext.gettext("When-condition '%s' is not a discrete-time expression."));
 public constant ErrorTypes.Message CYCLIC_FUNCTION_COMPONENTS = ErrorTypes.MESSAGE(383, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Cyclically dependent function components found: %s"));
 public constant ErrorTypes.Message EXTERNAL_FUNCTION_NOT_FOUND = ErrorTypes.MESSAGE(384, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("External function ‘%s‘ could not be found in any of the given shared libraries:\n%s"));
+  Gettext.gettext("External function '%s' could not be found in any of the given shared libraries:\n%s"));
 public constant ErrorTypes.Message INVALID_CONVERSION_RULE = ErrorTypes.MESSAGE(385, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  Gettext.gettext("Invalid conversion rule ‘%s‘."));
+  Gettext.gettext("Invalid conversion rule '%s'."));
 public constant ErrorTypes.Message CONVERSION_MESSAGE = ErrorTypes.MESSAGE(386, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
   Gettext.gettext("%s"));
 public constant ErrorTypes.Message CONVERSION_MISMATCHED_PLACEHOLDER = ErrorTypes.MESSAGE(387, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
-  Gettext.gettext("Mismatched % in conversion modifier ‘%s‘."));
+  Gettext.gettext("Mismatched % in conversion modifier '%s'."));
 public constant ErrorTypes.Message CONVERSION_MISSING_PLACEHOLDER_VALUE = ErrorTypes.MESSAGE(388, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
-  Gettext.gettext("No replacement value for placeholder ‘%s‘ could be found."));
+  Gettext.gettext("No replacement value for placeholder '%s' could be found."));
 public constant ErrorTypes.Message UNSUPPORTED_RECORD_REORDERING = ErrorTypes.MESSAGE(389, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("The record constructor for ‘%s‘ requires reordering of local fields to initialize them in the correct order, which is not yet supported."));
+  Gettext.gettext("The record constructor for '%s' requires reordering of local fields to initialize them in the correct order, which is not yet supported."));
 public constant ErrorTypes.Message FUNCTION_INVALID_OUTPUTS_FOR_INVERSE = ErrorTypes.MESSAGE(390, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Invalid inverse annotation for ‘%s‘, only functions with exactly one output may have an inverse."));
+  Gettext.gettext("Invalid inverse annotation for '%s', only functions with exactly one output may have an inverse."));
 public constant ErrorTypes.Message NOTIFY_IMPLICIT_LOAD = ErrorTypes.MESSAGE(391, ErrorTypes.SCRIPTING(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("Automatically loaded package %s %s due to usage."));
 public constant ErrorTypes.Message CONVERSION_MISSING_USES = ErrorTypes.MESSAGE(392, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  Gettext.gettext("Cannot convert ‘%s‘ since it has no uses-annotation for ‘%s‘."));
+  Gettext.gettext("Cannot convert '%s' since it has no uses-annotation for '%s'."));
 public constant ErrorTypes.Message CONVERSION_NO_COMPATIBLE_SCRIPT_FOUND = ErrorTypes.MESSAGE(393, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
   Gettext.gettext("No compatible conversion script for converting from %s %s to %s could be found."));
 
 public constant Gettext.TranslatableContent FUNCTION_CALL_EXPRESSION = Gettext.gettext("a function call expression");
 public constant ErrorTypes.Message FUNCTION_ARGUMENT_MUST_BE = ErrorTypes.MESSAGE(394, ErrorTypes.SCRIPTING(), ErrorTypes.ERROR(),
-  Gettext.gettext("The argument to ‘%s‘ must be %s."));
+  Gettext.gettext("The argument to '%s' must be %s."));
 public constant ErrorTypes.Message UNEXPECTED_COMPONENT_IN_COMPOSITE_NAME = ErrorTypes.MESSAGE(395, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Found component ‘%s‘ in composite name ‘%s‘, expected class."));
+  Gettext.gettext("Found component '%s' in composite name '%s', expected class."));
 public constant ErrorTypes.Message NF_MODIFY_PROTECTED = ErrorTypes.MESSAGE(396, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Protected element ‘%s‘ may not be modified, got ‘%s‘."));
+  Gettext.gettext("Protected element '%s' may not be modified, got '%s'."));
 public constant ErrorTypes.Message PROTECTED_TRANSITION_FAILURE = ErrorTypes.MESSAGE(397, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Protected sections are not allowed in %s."));
 public constant ErrorTypes.Message DEPRECATED_TRANSITION_FAILURE = ErrorTypes.MESSAGE(398, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
@@ -874,17 +874,17 @@ public constant ErrorTypes.Message DEPRECATED_TRANSITION_FAILURE = ErrorTypes.ME
 public constant ErrorTypes.Message INITIAL_ALGORITHM_TRANSITION_FAILURE = ErrorTypes.MESSAGE(399, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Initial algorithm sections are not allowed in %s."));
 public constant ErrorTypes.Message INVALID_SPECIALIZATION_FOR_BINDING_EQUATION = ErrorTypes.MESSAGE(400, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Component ‘%s‘ may not have a binding equation due to class specialization ‘%s‘."));
+  Gettext.gettext("Component '%s' may not have a binding equation due to class specialization '%s'."));
 public constant ErrorTypes.Message INVALID_SPECIALIZATION_IN_ASSIGNMENT = ErrorTypes.MESSAGE(401, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Component ‘%s‘ may not be assigned to due to class specialization ‘%s‘."));
+  Gettext.gettext("Component '%s' may not be assigned to due to class specialization '%s'."));
 public constant ErrorTypes.Message NF_PDE_NOT_IMPLEMENTED = ErrorTypes.MESSAGE(402, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("PDEModelica is not yet supported by the new front-end, using the old front-end instead."));
 public constant ErrorTypes.Message NON_CONSTANT_IN_ENCLOSING_SCOPE = ErrorTypes.MESSAGE(403, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("Component ‘%s‘ was found in an enclosing scope but is not a constant."));
+  Gettext.gettext("Component '%s' was found in an enclosing scope but is not a constant."));
 public constant ErrorTypes.Message PARTIAL_DERIVATIVE_INPUT_NOT_FOUND = ErrorTypes.MESSAGE(404, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("‘%s‘ in partial derivative of ‘%s‘ does not name an input parameter of the function."));
+  Gettext.gettext("'%s' in partial derivative of '%s' does not name an input parameter of the function."));
 public constant ErrorTypes.Message PARTIAL_DERIVATIVE_INPUT_INVALID_TYPE = ErrorTypes.MESSAGE(405, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
-  Gettext.gettext("‘%s‘ in partial derivative of ‘%s‘ is not a scalar Real input parameter of the function."));
+  Gettext.gettext("'%s' in partial derivative of '%s' is not a scalar Real input parameter of the function."));
 public constant ErrorTypes.Message CONNECT_TYPE_MISMATCH = ErrorTypes.MESSAGE(406, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("The connectors in connect(%s, %s) are not type compatible."));
 
@@ -921,7 +921,7 @@ public constant ErrorTypes.Message CONSISTENT_UNITS = ErrorTypes.MESSAGE(518, Er
 public constant ErrorTypes.Message INCOMPLETE_UNITS = ErrorTypes.MESSAGE(519, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
   Gettext.gettext("The system of units is incomplete. Please provide unit information to the model by e.g. using types from the SIunits package."));
 public constant ErrorTypes.Message INVALID_UNIT = ErrorTypes.MESSAGE(520, ErrorTypes.TRANSLATION(), ErrorTypes.NOTIFICATION(),
-  Gettext.gettext("Invalid unit expression ‘%s‘."));
+  Gettext.gettext("Invalid unit expression '%s'."));
 
 public constant ErrorTypes.Message ASSIGN_RHS_ELABORATION = ErrorTypes.MESSAGE(521, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Failed to elaborate rhs of %s."));
@@ -1072,7 +1072,7 @@ public constant ErrorTypes.Message NON_STATE_STATESELECT_ALWAYS = ErrorTypes.MES
 public constant ErrorTypes.Message STATE_STATESELECT_NEVER = ErrorTypes.MESSAGE(593, ErrorTypes.SYMBOLIC(), ErrorTypes.WARNING(),
   Gettext.gettext("Variable %s has attribute stateSelect=StateSelect.never, but was selected as a state"));
 public constant ErrorTypes.Message FUNCTION_HIGHER_VARIABILITY_BINDING = ErrorTypes.MESSAGE(594, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
-  Gettext.gettext("Component ‘%s’ of variability %s has binding %s of higher variability %s."));
+  Gettext.gettext("Component '%s’ of variability %s has binding %s of higher variability %s."));
 public constant ErrorTypes.Message OCG_MISSING_BRANCH = ErrorTypes.MESSAGE(595, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("Connections.rooted(%s) needs exactly one statement Connections.branch(%s, B.R) involving %s but we found none in the graph. Run with -d=cgraphGraphVizFile to debug"));
 public constant ErrorTypes.Message UNBOUND_PARAMETER_EVALUATE_TRUE = ErrorTypes.MESSAGE(596, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),

--- a/testsuite/flattening/modelica/equations/WhenNotInitial.mo
+++ b/testsuite/flattening/modelica/equations/WhenNotInitial.mo
@@ -17,6 +17,6 @@ end WhenNotInitial;
 //     r = 1.0;
 //   end when;
 // end WhenNotInitial;
-// [flattening/modelica/equations/WhenNotInitial.mo:7:3-9:11:writable] Warning: initial() may only be used as a when condition (when initial() or when {..., initial(), ...}), but got condition ‘not initial()‘.
+// [flattening/modelica/equations/WhenNotInitial.mo:7:3-9:11:writable] Warning: initial() may only be used as a when condition (when initial() or when {..., initial(), ...}), but got condition 'not initial()'.
 //
 // endResult

--- a/testsuite/flattening/modelica/ffi/MissingFunction1.mos
+++ b/testsuite/flattening/modelica/ffi/MissingFunction1.mos
@@ -12,7 +12,7 @@ instantiateModel(FFITest.ErrorChecking.MissingFunction1); getErrorString();
 // true
 // ""
 // ""
-// "[flattening/modelica/ffi/FFITest/package.mo:252:5-256:25:writable] Error: External function ‘missingFunction1_ext‘ could not be found in any of the given shared libraries:
+// "[flattening/modelica/ffi/FFITest/package.mo:252:5-256:25:writable] Error: External function 'missingFunction1_ext' could not be found in any of the given shared libraries:
 //   bin/../lib/x86_64-linux-gnu/omc/FFITestLib.so
 //   flattening/modelica/ffi/FFITest/Resources/Library/linux64/FFITestLib.so
 //   flattening/modelica/ffi/FFITest/Resources/Library/FFITestLib.so

--- a/testsuite/flattening/modelica/scodeinst/ActualStreamNoStream1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ActualStreamNoStream1.mo
@@ -17,7 +17,7 @@ end ActualStreamNoStream1;
 
 // Result:
 // Error processing file: ActualStreamNoStream1.mo
-// [flattening/modelica/scodeinst/ActualStreamNoStream1.mo:15:3-15:30:writable] Error: Operand ‘c.f‘ to operator ‘actualStream‘ is not a stream variable.
+// [flattening/modelica/scodeinst/ActualStreamNoStream1.mo:15:3-15:30:writable] Error: Operand 'c.f' to operator 'actualStream' is not a stream variable.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ActualStreamNonCref1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ActualStreamNonCref1.mo
@@ -10,7 +10,7 @@ end ActualStreamNonCref1;
 
 // Result:
 // Error processing file: ActualStreamNonCref1.mo
-// [flattening/modelica/scodeinst/ActualStreamNonCref1.mo:8:3-8:28:writable] Error: Operand ‘1‘ to operator ‘actualStream‘ is not a stream variable.
+// [flattening/modelica/scodeinst/ActualStreamNonCref1.mo:8:3-8:28:writable] Error: Operand '1' to operator 'actualStream' is not a stream variable.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ActualStreamVariability1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ActualStreamVariability1.mo
@@ -18,7 +18,7 @@ end ActualStreamVariability1;
 
 // Result:
 // Error processing file: ActualStreamVariability1.mo
-// [flattening/modelica/scodeinst/ActualStreamVariability1.mo:16:3-16:29:writable] Error: Connector ‘c[n].s‘ has non-parameter subscript ‘n‘.
+// [flattening/modelica/scodeinst/ActualStreamVariability1.mo:16:3-16:29:writable] Error: Connector 'c[n].s' has non-parameter subscript 'n'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/AssignModel1.mo
+++ b/testsuite/flattening/modelica/scodeinst/AssignModel1.mo
@@ -16,7 +16,7 @@ end AssignModel1;
 
 // Result:
 // Error processing file: AssignModel1.mo
-// [flattening/modelica/scodeinst/AssignModel1.mo:14:3-14:11:writable] Error: Component ‘a1‘ may not be assigned to due to class specialization ‘model‘.
+// [flattening/modelica/scodeinst/AssignModel1.mo:14:3-14:11:writable] Error: Component 'a1' may not be assigned to due to class specialization 'model'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/AssignPackage1.mo
+++ b/testsuite/flattening/modelica/scodeinst/AssignPackage1.mo
@@ -16,7 +16,7 @@ end AssignPackage1;
 
 // Result:
 // Error processing file: AssignPackage1.mo
-// [flattening/modelica/scodeinst/AssignPackage1.mo:14:3-14:11:writable] Error: Component ‘p1‘ may not be assigned to due to class specialization ‘package‘.
+// [flattening/modelica/scodeinst/AssignPackage1.mo:14:3-14:11:writable] Error: Component 'p1' may not be assigned to due to class specialization 'package'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/BindingInvalidType2.mo
+++ b/testsuite/flattening/modelica/scodeinst/BindingInvalidType2.mo
@@ -10,7 +10,7 @@ end BindingInvalidType2;
 
 // Result:
 // Error processing file: BindingInvalidType2.mo
-// [flattening/modelica/scodeinst/BindingInvalidType2.mo:8:3-8:21:writable] Error: Type mismatch in binding ‘x = {1, 2, 3}‘, expected array dimensions [], got [3].
+// [flattening/modelica/scodeinst/BindingInvalidType2.mo:8:3-8:21:writable] Error: Type mismatch in binding 'x = {1, 2, 3}', expected array dimensions [], got [3].
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/BindingInvalidType3.mo
+++ b/testsuite/flattening/modelica/scodeinst/BindingInvalidType3.mo
@@ -10,7 +10,7 @@ end BindingInvalidType3;
 
 // Result:
 // Error processing file: BindingInvalidType3.mo
-// [flattening/modelica/scodeinst/BindingInvalidType3.mo:8:3-8:21:writable] Error: Type mismatch in binding ‘x = {1, 2}‘, expected array dimensions [3], got [2].
+// [flattening/modelica/scodeinst/BindingInvalidType3.mo:8:3-8:21:writable] Error: Type mismatch in binding 'x = {1, 2}', expected array dimensions [3], got [2].
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/BindingInvalidType4.mo
+++ b/testsuite/flattening/modelica/scodeinst/BindingInvalidType4.mo
@@ -10,7 +10,7 @@ end BindingInvalidType4;
 
 // Result:
 // Error processing file: BindingInvalidType4.mo
-// [flattening/modelica/scodeinst/BindingInvalidType4.mo:8:3-8:16:writable] Error: Non-array modification ‘1‘ for array component ‘x‘, possibly due to missing ‘each‘.
+// [flattening/modelica/scodeinst/BindingInvalidType4.mo:8:3-8:16:writable] Error: Non-array modification '1' for array component 'x', possibly due to missing 'each'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/Break2.mo
+++ b/testsuite/flattening/modelica/scodeinst/Break2.mo
@@ -18,7 +18,7 @@ end Break2;
 
 // Result:
 // Error processing file: Break2.mo
-// [flattening/modelica/scodeinst/Break2.mo:12:3-12:8:writable] Error: ‘break' may only be used in a while- or for-loop.
+// [flattening/modelica/scodeinst/Break2.mo:12:3-12:8:writable] Error: 'break' may only be used in a while- or for-loop.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/Clock3.mo
+++ b/testsuite/flattening/modelica/scodeinst/Clock3.mo
@@ -14,7 +14,7 @@ end Clock3;
 
 // Result:
 // Error processing file: Clock3.mo
-// [flattening/modelica/scodeinst/Clock3.mo:12:3-12:20:writable] Error: Component ‘c‘ may not have a binding equation due to class specialization ‘model‘.
+// [flattening/modelica/scodeinst/Clock3.mo:12:3-12:20:writable] Error: Component 'c' may not have a binding equation due to class specialization 'model'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ConditionInvalidContext1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ConditionInvalidContext1.mo
@@ -13,7 +13,7 @@ end ConditionInvalidContext1;
 
 // Result:
 // Error processing file: ConditionInvalidContext1.mo
-// [flattening/modelica/scodeinst/ConditionInvalidContext1.mo:10:3-10:8:writable] Error: Conditional component ‘x‘ is used in a non-connect context.
+// [flattening/modelica/scodeinst/ConditionInvalidContext1.mo:10:3-10:8:writable] Error: Conditional component 'x' is used in a non-connect context.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ConditionInvalidContext2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ConditionInvalidContext2.mo
@@ -12,7 +12,7 @@ end ConditionInvalidContext2;
 
 // Result:
 // Error processing file: ConditionInvalidContext2.mo
-// [flattening/modelica/scodeinst/ConditionInvalidContext2.mo:9:3-9:13:writable] Error: Conditional component ‘x‘ is used in a non-connect context.
+// [flattening/modelica/scodeinst/ConditionInvalidContext2.mo:9:3-9:13:writable] Error: Conditional component 'x' is used in a non-connect context.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ConnectArraysInvalidSubscript1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ConnectArraysInvalidSubscript1.mo
@@ -19,7 +19,7 @@ end ConnectArraysInvalidSubscript1;
 
 // Result:
 // Error processing file: ConnectArraysInvalidSubscript1.mo
-// [flattening/modelica/scodeinst/ConnectArraysInvalidSubscript1.mo:17:3-17:24:writable] Error: Connector ‘c1[n]‘ has non-parameter subscript ‘n‘.
+// [flattening/modelica/scodeinst/ConnectArraysInvalidSubscript1.mo:17:3-17:24:writable] Error: Connector 'c1[n]' has non-parameter subscript 'n'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown4.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown4.mo
@@ -19,7 +19,7 @@ end DimUnknown4;
 
 // Result:
 // Error processing file: DimUnknown4.mo
-// [flattening/modelica/scodeinst/DimUnknown4.mo:9:3-9:15:writable] Error: Dimension 1 of ‘x‘ could not be deduced from the component's binding equation ‘3.0‘.
+// [flattening/modelica/scodeinst/DimUnknown4.mo:9:3-9:15:writable] Error: Dimension 1 of 'x' could not be deduced from the component's binding equation '3.0'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/Each3.mo
+++ b/testsuite/flattening/modelica/scodeinst/Each3.mo
@@ -15,7 +15,7 @@ end Each3;
 // Result:
 // Error processing file: Each3.mo
 // [flattening/modelica/scodeinst/Each3.mo:12:14-12:24:writable] Notification: From here:
-// [flattening/modelica/scodeinst/Each3.mo:8:3-8:12:writable] Error: Non-array modification ‘true‘ for array component ‘fixed‘, possibly due to missing ‘each‘.
+// [flattening/modelica/scodeinst/Each3.mo:8:3-8:12:writable] Error: Non-array modification 'true' for array component 'fixed', possibly due to missing 'each'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ExpandableConnectorFlow1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExpandableConnectorFlow1.mo
@@ -16,7 +16,7 @@ end ExpandableConnectorFlow1;
 
 // Result:
 // Error processing file: ExpandableConnectorFlow1.mo
-// [flattening/modelica/scodeinst/ExpandableConnectorFlow1.mo:10:3-10:14:writable] Error: Prefix ‘flow‘ on component ‘f‘ not allowed in class specialization ‘expandable connector‘.
+// [flattening/modelica/scodeinst/ExpandableConnectorFlow1.mo:10:3-10:14:writable] Error: Prefix 'flow' on component 'f' not allowed in class specialization 'expandable connector'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ForEquationShadow1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ForEquationShadow1.mo
@@ -24,6 +24,6 @@ end ForEquationShadow1;
 //   x = 4.0;
 // end ForEquationShadow1;
 // [flattening/modelica/scodeinst/ForEquationShadow1.mo:10:3-14:10:writable] Notification: From here:
-// [flattening/modelica/scodeinst/ForEquationShadow1.mo:11:5-13:12:writable] Warning: An iterator named ‘i‘ is already declared in this scope.
+// [flattening/modelica/scodeinst/ForEquationShadow1.mo:11:5-13:12:writable] Warning: An iterator named 'i' is already declared in this scope.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinDerInvalid1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinDerInvalid1.mo
@@ -17,7 +17,7 @@ end FuncBuiltinDerInvalid1;
 
 // Result:
 // Error processing file: FuncBuiltinDerInvalid1.mo
-// [flattening/modelica/scodeinst/FuncBuiltinDerInvalid1.mo:11:3-11:18:writable] Error: Argument ‘x‘ of der is not differentiable.
+// [flattening/modelica/scodeinst/FuncBuiltinDerInvalid1.mo:11:3-11:18:writable] Error: Argument 'x' of der is not differentiable.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo
@@ -17,7 +17,7 @@ end FuncBuiltinDerInvalid2;
 
 // Result:
 // Error processing file: FuncBuiltinDerInvalid2.mo
-// [flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo:11:3-11:18:writable] Error: Argument ‘x‘ of der is not differentiable.
+// [flattening/modelica/scodeinst/FuncBuiltinDerInvalid2.mo:11:3-11:18:writable] Error: Argument 'x' of der is not differentiable.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinFill2.mo
@@ -13,7 +13,7 @@ end FuncBuiltinFill2;
 
 // Result:
 // Error processing file: FuncBuiltinFill2.mo
-// [flattening/modelica/scodeinst/FuncBuiltinFill2.mo:11:3-11:31:writable] Error: Expression ‘n‘ that determines the size of dimension ‘2‘ of ‘fill(0, 1, n)‘ is not an evaluable parameter expression.
+// [flattening/modelica/scodeinst/FuncBuiltinFill2.mo:11:3-11:31:writable] Error: Expression 'n' that determines the size of dimension '2' of 'fill(0, 1, n)' is not an evaluable parameter expression.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPromoteInvalid1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPromoteInvalid1.mo
@@ -13,7 +13,7 @@ end FuncBuiltinPromoteInvalid1;
 
 // Result:
 // Error processing file: FuncBuiltinPromoteInvalid1.mo
-// [flattening/modelica/scodeinst/FuncBuiltinPromoteInvalid1.mo:11:3-11:28:writable] Error: The second argument ‘1‘ of promote may not be smaller than the number of dimensions (2) of the first argument.
+// [flattening/modelica/scodeinst/FuncBuiltinPromoteInvalid1.mo:11:3-11:28:writable] Error: The second argument '1' of promote may not be smaller than the number of dimensions (2) of the first argument.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FuncBuiltinPure2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncBuiltinPure2.mo
@@ -11,7 +11,7 @@ end FuncBuiltinPure2;
 
 // Result:
 // Error processing file: FuncBuiltinPure2.mo
-// [flattening/modelica/scodeinst/FuncBuiltinPure2.mo:9:3-9:21:writable] Error: The argument to ‘pure‘ must be a function call expression.
+// [flattening/modelica/scodeinst/FuncBuiltinPure2.mo:9:3-9:21:writable] Error: The argument to 'pure' must be a function call expression.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FunctionDerivativeInvalidInput1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionDerivativeInvalidInput1.mo
@@ -25,7 +25,7 @@ end FunctionDerivativeInvalidInput1;
 
 // Result:
 // Error processing file: FunctionDerivativeInvalidInput1.mo
-// [flattening/modelica/scodeinst/FunctionDerivativeInvalidInput1.mo:12:14-12:49:writable] Error: ‘z‘ is not an input of function ‘f1‘.
+// [flattening/modelica/scodeinst/FunctionDerivativeInvalidInput1.mo:12:14-12:49:writable] Error: 'z' is not an input of function 'f1'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FunctionDerivativeMissingName1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionDerivativeMissingName1.mo
@@ -27,6 +27,6 @@ end FunctionDerivativeMissingName1;
 // class FunctionDerivativeMissingName1
 //   Real x = f1(time, time);
 // end FunctionDerivativeMissingName1;
-// [flattening/modelica/scodeinst/FunctionDerivativeMissingName1.mo:12:14-12:35:writable] Warning: Derivative annotation for function ‘f1‘ does not specify a derivative function.
+// [flattening/modelica/scodeinst/FunctionDerivativeMissingName1.mo:12:14-12:35:writable] Warning: Derivative annotation for function 'f1' does not specify a derivative function.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionInverseInvalid1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionInverseInvalid1.mo
@@ -21,6 +21,6 @@ end FunctionInverseInvalid1;
 // class FunctionInverseInvalid1
 //   Real x = 3.0;
 // end FunctionInverseInvalid1;
-// [flattening/modelica/scodeinst/FunctionInverseInvalid1.mo:13:14-13:28:writable] Warning: ‘y = z‘ is not a valid function inverse attribute.
+// [flattening/modelica/scodeinst/FunctionInverseInvalid1.mo:13:14-13:28:writable] Warning: 'y = z' is not a valid function inverse attribute.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/FunctionInverseInvalid2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionInverseInvalid2.mo
@@ -27,7 +27,7 @@ end FunctionInverseInvalid2;
 
 // Result:
 // Error processing file: FunctionInverseInvalid2.mo
-// [flattening/modelica/scodeinst/FunctionInverseInvalid2.mo:13:14-13:38:writable] Error: ‘z‘ is not an input of function ‘f‘.
+// [flattening/modelica/scodeinst/FunctionInverseInvalid2.mo:13:14-13:38:writable] Error: 'z' is not an input of function 'f'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FunctionInverseInvalid3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionInverseInvalid3.mo
@@ -29,7 +29,7 @@ end FunctionInverseInvalid3;
 
 // Result:
 // Error processing file: FunctionInverseInvalid3.mo
-// [flattening/modelica/scodeinst/FunctionInverseInvalid3.mo:15:14-15:43:writable] Error: Invalid inverse annotation for ‘f‘, only functions with exactly one output may have an inverse.
+// [flattening/modelica/scodeinst/FunctionInverseInvalid3.mo:15:14-15:43:writable] Error: Invalid inverse annotation for 'f', only functions with exactly one output may have an inverse.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative2.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative2.mo
@@ -17,7 +17,7 @@ end FunctionPartialDerivative2;
 
 // Result:
 // Error processing file: FunctionPartialDerivative2.mo
-// [flattening/modelica/scodeinst/FunctionPartialDerivative2.mo:15:3-15:17:writable] Error: ‘y‘ in partial derivative of ‘FunctionPartialDerivative2.f‘ does not name an input parameter of the function.
+// [flattening/modelica/scodeinst/FunctionPartialDerivative2.mo:15:3-15:17:writable] Error: 'y' in partial derivative of 'FunctionPartialDerivative2.f' does not name an input parameter of the function.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionPartialDerivative3.mo
@@ -17,7 +17,7 @@ end FunctionPartialDerivative3;
 
 // Result:
 // Error processing file: FunctionPartialDerivative3.mo
-// [flattening/modelica/scodeinst/FunctionPartialDerivative3.mo:13:3-13:26:writable] Error: ‘x‘ in partial derivative of ‘FunctionPartialDerivative3.f‘ is not a scalar Real input parameter of the function.
+// [flattening/modelica/scodeinst/FunctionPartialDerivative3.mo:13:3-13:26:writable] Error: 'x' in partial derivative of 'FunctionPartialDerivative3.f' is not a scalar Real input parameter of the function.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ImportInCompositeName1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImportInCompositeName1.mo
@@ -19,7 +19,7 @@ end ImportInCompositeName1;
 
 // Result:
 // Error processing file: ImportInCompositeName1.mo
-// [flattening/modelica/scodeinst/ImportInCompositeName1.mo:17:3-17:13:writable] Error: Found imported name ‘MyType‘ while looking up composite name ‘B.MyType‘.
+// [flattening/modelica/scodeinst/ImportInCompositeName1.mo:17:3-17:13:writable] Error: Found imported name 'MyType' while looking up composite name 'B.MyType'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ImportInCompositeName2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImportInCompositeName2.mo
@@ -19,7 +19,7 @@ end ImportInCompositeName2;
 
 // Result:
 // Error processing file: ImportInCompositeName2.mo
-// [flattening/modelica/scodeinst/ImportInCompositeName2.mo:17:3-17:17:writable] Error: Found imported name ‘PI‘ while looking up composite name ‘P2.PI‘.
+// [flattening/modelica/scodeinst/ImportInCompositeName2.mo:17:3-17:17:writable] Error: Found imported name 'PI' while looking up composite name 'P2.PI'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ImportSubPackage1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImportSubPackage1.mo
@@ -21,7 +21,7 @@ end M;
 
 // Result:
 // Error processing file: ImportSubPackage1.mo
-// [flattening/modelica/scodeinst/ImportSubPackage1.mo:19:3-19:9:writable] Error: Found imported name ‘A‘ while looking up composite name ‘P1.A‘.
+// [flattening/modelica/scodeinst/ImportSubPackage1.mo:19:3-19:9:writable] Error: Found imported name 'A' while looking up composite name 'P1.A'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ImpureCall1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImpureCall1.mo
@@ -37,6 +37,6 @@ end ImpureCall1;
 // class ImpureCall1
 //   Real x = f2(1.0);
 // end ImpureCall1;
-// [flattening/modelica/scodeinst/ImpureCall1.mo:13:1-18:7:writable] Warning: Pure function ‘f2‘ contains a call to impure function ‘f‘.
+// [flattening/modelica/scodeinst/ImpureCall1.mo:13:1-18:7:writable] Warning: Pure function 'f2' contains a call to impure function 'f'.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/InStreamNoStream1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InStreamNoStream1.mo
@@ -17,7 +17,7 @@ end InStreamNoStream1;
 
 // Result:
 // Error processing file: InStreamNoStream1.mo
-// [flattening/modelica/scodeinst/InStreamNoStream1.mo:15:3-15:26:writable] Error: Operand ‘c.f‘ to operator ‘inStream‘ is not a stream variable.
+// [flattening/modelica/scodeinst/InStreamNoStream1.mo:15:3-15:26:writable] Error: Operand 'c.f' to operator 'inStream' is not a stream variable.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/InStreamNonCref1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InStreamNonCref1.mo
@@ -10,7 +10,7 @@ end InStreamNonCref1;
 
 // Result:
 // Error processing file: InStreamNonCref1.mo
-// [flattening/modelica/scodeinst/InStreamNonCref1.mo:8:3-8:24:writable] Error: Operand ‘1‘ to operator ‘inStream‘ is not a stream variable.
+// [flattening/modelica/scodeinst/InStreamNonCref1.mo:8:3-8:24:writable] Error: Operand '1' to operator 'inStream' is not a stream variable.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/InStreamVariability1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InStreamVariability1.mo
@@ -18,7 +18,7 @@ end InStreamVariability1;
 
 // Result:
 // Error processing file: InStreamVariability1.mo
-// [flattening/modelica/scodeinst/InStreamVariability1.mo:16:3-16:29:writable] Error: Connector ‘c[n].s‘ has non-parameter subscript ‘n‘.
+// [flattening/modelica/scodeinst/InStreamVariability1.mo:16:3-16:29:writable] Error: Connector 'c[n].s' has non-parameter subscript 'n'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterMissing1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterMissing1.mo
@@ -10,7 +10,7 @@ end InnerOuterMissing1;
 
 // Result:
 // Error processing file: InnerOuterMissing1.mo
-// [flattening/modelica/scodeinst/InnerOuterMissing1.mo:8:3-8:15:writable] Error: The model can't be instantiated due to top-level outer element ‘x‘, it may only be used as part of a simulation model.
+// [flattening/modelica/scodeinst/InnerOuterMissing1.mo:8:3-8:15:writable] Error: The model can't be instantiated due to top-level outer element 'x', it may only be used as part of a simulation model.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterMissing7.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterMissing7.mo
@@ -16,7 +16,7 @@ end InnerOuterMissing7;
 // Result:
 // Error processing file: InnerOuterMissing7.mo
 // [flattening/modelica/scodeinst/InnerOuterMissing7.mo:13:3-13:9:writable] Notification: From here:
-// [flattening/modelica/scodeinst/InnerOuterMissing7.mo:8:3-8:15:writable] Error: An inner declaration for outer element ‘x‘ could not be found, and could not be automatically generated due to an existing declaration of that name.
+// [flattening/modelica/scodeinst/InnerOuterMissing7.mo:8:3-8:15:writable] Error: An inner declaration for outer element 'x' could not be found, and could not be automatically generated due to an existing declaration of that name.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterMissing9.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterMissing9.mo
@@ -17,7 +17,7 @@ end P;
 
 // Result:
 // Error processing file: InnerOuterMissing9.mo
-// [flattening/modelica/scodeinst/InnerOuterMissing9.mo:14:5-14:17:writable] Error: The model can't be instantiated due to top-level outer element ‘x‘, it may only be used as part of a simulation model.
+// [flattening/modelica/scodeinst/InnerOuterMissing9.mo:14:5-14:17:writable] Error: The model can't be instantiated due to top-level outer element 'x', it may only be used as part of a simulation model.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ModelBinding1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ModelBinding1.mo
@@ -15,7 +15,7 @@ end ModelBinding1;
 
 // Result:
 // Error processing file: ModelBinding1.mo
-// [flattening/modelica/scodeinst/ModelBinding1.mo:13:3-13:12:writable] Error: Component ‘a2‘ may not have a binding equation due to class specialization ‘model‘.
+// [flattening/modelica/scodeinst/ModelBinding1.mo:13:3-13:12:writable] Error: Component 'a2' may not have a binding equation due to class specialization 'model'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/OperatorOverloadConstructorInvalidOutput1.mo
+++ b/testsuite/flattening/modelica/scodeinst/OperatorOverloadConstructorInvalidOutput1.mo
@@ -24,7 +24,7 @@ end OperatorOverloadConstructorInvalidOutput1;
 
 // Result:
 // Error processing file: OperatorOverloadConstructorInvalidOutput1.mo
-// [flattening/modelica/scodeinst/OperatorOverloadConstructorInvalidOutput1.mo:8:1-16:6:writable] Error: Output ‘x‘ in operator C.'constructor' must be of type C, got type Real.
+// [flattening/modelica/scodeinst/OperatorOverloadConstructorInvalidOutput1.mo:8:1-16:6:writable] Error: Output 'x' in operator C.'constructor' must be of type C, got type Real.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/PackageBinding1.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageBinding1.mo
@@ -15,7 +15,7 @@ end PackageBinding1;
 
 // Result:
 // Error processing file: PackageBinding1.mo
-// [flattening/modelica/scodeinst/PackageBinding1.mo:13:3-13:12:writable] Error: Component ‘a2‘ may not have a binding equation due to class specialization ‘package‘.
+// [flattening/modelica/scodeinst/PackageBinding1.mo:13:3-13:12:writable] Error: Component 'a2' may not have a binding equation due to class specialization 'package'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/PackageConstant5.mo
+++ b/testsuite/flattening/modelica/scodeinst/PackageConstant5.mo
@@ -17,7 +17,7 @@ end PackageConstant5;
 // Result:
 // Error processing file: PackageConstant5.mo
 // [flattening/modelica/scodeinst/PackageConstant5.mo:8:3-8:9:writable] Notification: From here:
-// [flattening/modelica/scodeinst/PackageConstant5.mo:11:5-11:15:writable] Error: Component ‘x‘ was found in an enclosing scope but is not a constant.
+// [flattening/modelica/scodeinst/PackageConstant5.mo:11:5-11:15:writable] Error: Component 'x' was found in an enclosing scope but is not a constant.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/PartialFunction1.mo
+++ b/testsuite/flattening/modelica/scodeinst/PartialFunction1.mo
@@ -15,7 +15,7 @@ end PartialFunction1;
 
 // Result:
 // Error processing file: PartialFunction1.mo
-// [flattening/modelica/scodeinst/PartialFunction1.mo:13:3-13:19:writable] Error: Called function ‘f‘ is partial.
+// [flattening/modelica/scodeinst/PartialFunction1.mo:13:3-13:19:writable] Error: Called function 'f' is partial.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/PartialType1.mo
+++ b/testsuite/flattening/modelica/scodeinst/PartialType1.mo
@@ -15,7 +15,7 @@ end PartialType1;
 // Result:
 // Error processing file: PartialType1.mo
 // [flattening/modelica/scodeinst/PartialType1.mo:7:1-9:6:writable] Notification: From here:
-// [flattening/modelica/scodeinst/PartialType1.mo:12:3-12:6:writable] Error: Component ‘a‘ has partial type ‘A‘.
+// [flattening/modelica/scodeinst/PartialType1.mo:12:3-12:6:writable] Error: Component 'a' has partial type 'A'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/PartialType2.mo
+++ b/testsuite/flattening/modelica/scodeinst/PartialType2.mo
@@ -17,7 +17,7 @@ end PartialType2;
 // Result:
 // Error processing file: PartialType2.mo
 // [flattening/modelica/scodeinst/PartialType2.mo:11:1-11:12:writable] Notification: From here:
-// [flattening/modelica/scodeinst/PartialType2.mo:14:3-14:6:writable] Error: Component ‘b‘ has partial type ‘B‘.
+// [flattening/modelica/scodeinst/PartialType2.mo:14:3-14:6:writable] Error: Component 'b' has partial type 'B'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod1.mo
@@ -16,7 +16,7 @@ end ProtectedMod1;
 // Result:
 // Error processing file: ProtectedMod1.mo
 // [flattening/modelica/scodeinst/ProtectedMod1.mo:13:7-13:14:writable] Notification: From here:
-// [flattening/modelica/scodeinst/ProtectedMod1.mo:9:13-9:25:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 2.0‘.
+// [flattening/modelica/scodeinst/ProtectedMod1.mo:9:13-9:25:writable] Error: Protected element 'x' may not be modified, got 'x = 2.0'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod3.mo
@@ -20,7 +20,7 @@ end ProtectedMod3;
 // Result:
 // Error processing file: ProtectedMod3.mo
 // [flattening/modelica/scodeinst/ProtectedMod3.mo:17:15-17:22:writable] Notification: From here:
-// [flattening/modelica/scodeinst/ProtectedMod3.mo:9:13-9:25:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 2.0‘.
+// [flattening/modelica/scodeinst/ProtectedMod3.mo:9:13-9:25:writable] Error: Protected element 'x' may not be modified, got 'x = 2.0'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod4.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod4.mo
@@ -17,7 +17,7 @@ end ProtectedMod4;
 
 // Result:
 // Error processing file: ProtectedMod4.mo
-// [flattening/modelica/scodeinst/ProtectedMod4.mo:9:13-9:25:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 1.0‘.
+// [flattening/modelica/scodeinst/ProtectedMod4.mo:9:13-9:25:writable] Error: Protected element 'x' may not be modified, got 'x = 1.0'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ProtectedMod6.mo
+++ b/testsuite/flattening/modelica/scodeinst/ProtectedMod6.mo
@@ -21,7 +21,7 @@ end ProtectedMod6;
 // Result:
 // Error processing file: ProtectedMod6.mo
 // [flattening/modelica/scodeinst/ProtectedMod6.mo:18:7-18:14:writable] Notification: From here:
-// [flattening/modelica/scodeinst/ProtectedMod6.mo:9:3-9:15:writable] Error: Protected element ‘x‘ may not be modified, got ‘x = 2.0‘.
+// [flattening/modelica/scodeinst/ProtectedMod6.mo:9:3-9:15:writable] Error: Protected element 'x' may not be modified, got 'x = 2.0'.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/RedeclareEnum2.mo
+++ b/testsuite/flattening/modelica/scodeinst/RedeclareEnum2.mo
@@ -17,7 +17,7 @@ end RedeclareEnum2;
 // Result:
 // Error processing file: RedeclareEnum2.mo
 // [flattening/modelica/scodeinst/RedeclareEnum2.mo:13:23-13:52:writable] Notification: From here:
-// [flattening/modelica/scodeinst/RedeclareEnum2.mo:8:15-8:38:writable] Error: Redeclaration of enumeration ‘E‘ is not a subtype of the redeclared element (use enumeration(:) for a generic replaceable enumeration).
+// [flattening/modelica/scodeinst/RedeclareEnum2.mo:8:15-8:38:writable] Error: Redeclaration of enumeration 'E' is not a subtype of the redeclared element (use enumeration(:) for a generic replaceable enumeration).
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/RedeclareEnum4.mo
+++ b/testsuite/flattening/modelica/scodeinst/RedeclareEnum4.mo
@@ -17,7 +17,7 @@ end RedeclareEnum1;
 // Result:
 // Error processing file: RedeclareEnum4.mo
 // [flattening/modelica/scodeinst/RedeclareEnum4.mo:13:23-13:36:writable] Notification: From here:
-// [flattening/modelica/scodeinst/RedeclareEnum4.mo:8:15-8:38:writable] Error: Redeclaration of enumeration ‘E‘ is not a subtype of the redeclared element.
+// [flattening/modelica/scodeinst/RedeclareEnum4.mo:8:15-8:38:writable] Error: Redeclaration of enumeration 'E' is not a subtype of the redeclared element.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeMax;
 
 // Result:
 // Error processing file: ReductionInvalidTypeMax.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo:10:3-10:36:writable] Error: Invalid expression ‘"test"‘ of type String in max reduction, expected scalar enumeration, Boolean, Integer, or Real.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeMax.mo:10:3-10:36:writable] Error: Invalid expression '"test"' of type String in max reduction, expected scalar enumeration, Boolean, Integer, or Real.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeMin;
 
 // Result:
 // Error processing file: ReductionInvalidTypeMin.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo:10:3-10:39:writable] Error: Invalid expression ‘{1, 2, 3}‘ of type Integer[3] in min reduction, expected scalar enumeration, Boolean, Integer, or Real.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeMin.mo:10:3-10:39:writable] Error: Invalid expression '{1, 2, 3}' of type Integer[3] in min reduction, expected scalar enumeration, Boolean, Integer, or Real.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeProduct.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeProduct.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeProduct;
 
 // Result:
 // Error processing file: ReductionInvalidTypeProduct.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeProduct.mo:10:3-10:43:writable] Error: Invalid expression ‘{1, 2, 3}‘ of type Integer[3] in product reduction, expected scalar Integer or Real.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeProduct.mo:10:3-10:43:writable] Error: Invalid expression '{1, 2, 3}' of type Integer[3] in product reduction, expected scalar Integer or Real.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo
+++ b/testsuite/flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo
@@ -12,7 +12,7 @@ end ReductionInvalidTypeSum;
 
 // Result:
 // Error processing file: ReductionInvalidTypeSum.mo
-// [flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo:10:3-10:36:writable] Error: Invalid expression ‘"test"‘ of type String in sum reduction, expected Integer or Real, or operator record.
+// [flattening/modelica/scodeinst/ReductionInvalidTypeSum.mo:10:3-10:36:writable] Error: Invalid expression '"test"' of type String in sum reduction, expected Integer or Real, or operator record.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/TopLevelInputs2.mo
+++ b/testsuite/flattening/modelica/scodeinst/TopLevelInputs2.mo
@@ -19,6 +19,6 @@ end TopLevelInputs2;
 // equation
 //   x = {1.0, 2.0, 3.0};
 // end TopLevelInputs2;
-// [flattening/modelica/scodeinst/TopLevelInputs2.mo:11:3-11:30:writable] Notification: Top-level input ‘x‘ has a binding equation and will not be accessible as an input of the model.
+// [flattening/modelica/scodeinst/TopLevelInputs2.mo:11:3-11:30:writable] Notification: Top-level input 'x' has a binding equation and will not be accessible as an input of the model.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/TypeMissingBaseType1.mo
+++ b/testsuite/flattening/modelica/scodeinst/TypeMissingBaseType1.mo
@@ -13,7 +13,7 @@ end TypeMissingBaseType1;
 
 // Result:
 // Error processing file: TypeMissingBaseType1.mo
-// [flattening/modelica/scodeinst/TypeMissingBaseType1.mo:7:1-8:6:writable] Error: Type ‘T‘ does not extend a basic type.
+// [flattening/modelica/scodeinst/TypeMissingBaseType1.mo:7:1-8:6:writable] Error: Type 'T' does not extend a basic type.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/WhenCondition4.mo
+++ b/testsuite/flattening/modelica/scodeinst/WhenCondition4.mo
@@ -15,7 +15,7 @@ end WhenCondition4;
 
 // Result:
 // Error processing file: WhenCondition4.mo
-// [flattening/modelica/scodeinst/WhenCondition4.mo:11:3-13:11:writable] Error: When-condition ‘noEvent(time > 0)‘ is not a discrete-time expression.
+// [flattening/modelica/scodeinst/WhenCondition4.mo:11:3-13:11:writable] Error: When-condition 'noEvent(time > 0)' is not a discrete-time expression.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/WhenCondition5.mo
+++ b/testsuite/flattening/modelica/scodeinst/WhenCondition5.mo
@@ -15,7 +15,7 @@ end WhenCondition5;
 
 // Result:
 // Error processing file: WhenCondition5.mo
-// [flattening/modelica/scodeinst/WhenCondition5.mo:11:3-13:11:writable] Error: When-condition ‘noEvent(time > 0)‘ is not a discrete-time expression.
+// [flattening/modelica/scodeinst/WhenCondition5.mo:11:3-13:11:writable] Error: When-condition 'noEvent(time > 0)' is not a discrete-time expression.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/WhenInitial3.mo
+++ b/testsuite/flattening/modelica/scodeinst/WhenInitial3.mo
@@ -20,6 +20,6 @@ end WhenInitial3;
 //     i = 1;
 //   end when;
 // end WhenInitial3;
-// [flattening/modelica/scodeinst/WhenInitial3.mo:10:3-12:11:writable] Warning: initial() may only be used as a when condition (when initial() or when {..., initial(), ...}), but got condition ‘not initial()‘.
+// [flattening/modelica/scodeinst/WhenInitial3.mo:10:3-12:11:writable] Warning: initial() may only be used as a when condition (when initial() or when {..., initial(), ...}), but got condition 'not initial()'.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/const13.mo
+++ b/testsuite/flattening/modelica/scodeinst/const13.mo
@@ -22,7 +22,7 @@ end C;
 
 // Result:
 // Error processing file: const13.mo
-// [flattening/modelica/scodeinst/const13.mo:20:3-20:17:writable] Error: Found component ‘y‘ in composite name ‘a.B.y‘, expected class.
+// [flattening/modelica/scodeinst/const13.mo:20:3-20:17:writable] Error: Found component 'y' in composite name 'a.B.y', expected class.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/lookup4.mo
+++ b/testsuite/flattening/modelica/scodeinst/lookup4.mo
@@ -25,7 +25,7 @@ end M;
 
 // Result:
 // Error processing file: lookup4.mo
-// [flattening/modelica/scodeinst/lookup4.mo:23:3-23:21:writable] Error: Found component ‘d‘ in composite name ‘a.b.C.d.x‘, expected class.
+// [flattening/modelica/scodeinst/lookup4.mo:23:3-23:21:writable] Error: Found component 'd' in composite name 'a.b.C.d.x', expected class.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/streams/InStreamInvalidArgument.mo
+++ b/testsuite/flattening/modelica/streams/InStreamInvalidArgument.mo
@@ -16,7 +16,7 @@ end InStreamInvalidArgument;
 
 // Result:
 // Error processing file: InStreamInvalidArgument.mo
-// [flattening/modelica/streams/InStreamInvalidArgument.mo:14:3-14:25:writable] Error: Operand ‘r‘ to operator ‘inStream‘ is not a stream variable.
+// [flattening/modelica/streams/InStreamInvalidArgument.mo:14:3-14:25:writable] Error: Operand 'r' to operator 'inStream' is not a stream variable.
 // Error: Error occurred while flattening model InStreamInvalidArgument
 //
 // # Error encountered! Exiting...

--- a/testsuite/metamodelica/meta/PolymorphicCallTypeSpec2.mos
+++ b/testsuite/metamodelica/meta/PolymorphicCallTypeSpec2.mos
@@ -27,7 +27,7 @@ getErrorString();
 // true
 // ""
 //
-// "[<interactive>:13:5-13:59:writable] Error: Too many type variables given in call to ‘.U.new‘.
+// "[<interactive>:13:5-13:59:writable] Error: Too many type variables given in call to '.U.new'.
 // [metamodelica/meta/PolymorphicCallTypeSpec2.mos:22:1-22:7:writable] Error: Class test not found in scope <global scope> (looking for a function or record).
 // "
 // endResult

--- a/testsuite/openmodelica/conversion/ConvertClassVectorize3.mos
+++ b/testsuite/openmodelica/conversion/ConvertClassVectorize3.mos
@@ -18,6 +18,6 @@ getErrorString();
 // Result:
 // true
 // false
-// "[scripts/ConvertClassVectorize3.mos:1:1-1:31:writable] Error: Invalid conversion rule ‘convertClass({\"A\", \"B\"}, {\"X\"})‘.
+// "[scripts/ConvertClassVectorize3.mos:1:1-1:31:writable] Error: Invalid conversion rule 'convertClass({\"A\", \"B\"}, {\"X\"})'.
 // "
 // endResult

--- a/testsuite/openmodelica/conversion/ConvertModifiersMissingValue1.mos
+++ b/testsuite/openmodelica/conversion/ConvertModifiersMissingValue1.mos
@@ -19,7 +19,7 @@ list(ConvertModifiersMissingValue1);
 // true
 // false
 // "[<internal>:1:1-1:0:writable] Notification: From here:
-// [scripts/ConvertModifiers3.mos:1:1-2:72:writable] Warning: No replacement value for placeholder ‘%forceDiameter%‘ could be found.
+// [scripts/ConvertModifiers3.mos:1:1-2:72:writable] Warning: No replacement value for placeholder '%forceDiameter%' could be found.
 // "
 // "package ConvertModifiersMissingValue1
 //   model M

--- a/testsuite/openmodelica/conversion/ConvertPackageMissingUses.mos
+++ b/testsuite/openmodelica/conversion/ConvertPackageMissingUses.mos
@@ -15,6 +15,6 @@ getErrorString();
 // Result:
 // true
 // false
-// "Error: Cannot convert ‘ConvertPackageMissingUses‘ since it has no uses-annotation for ‘testlib‘.
+// "Error: Cannot convert 'ConvertPackageMissingUses' since it has no uses-annotation for 'testlib'.
 // "
 // endResult

--- a/testsuite/simulation/modelica/arrays/ParametricInitialArrayEquationBug.mos
+++ b/testsuite/simulation/modelica/arrays/ParametricInitialArrayEquationBug.mos
@@ -13,7 +13,7 @@ buildModelFMU(TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2, f
 // "
 // {"TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2","TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2_init.xml"}
 // "[simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:28578:17-28582:23:writable] Warning: In relation EM.i_dens_a == 0.0, == on Real numbers is only allowed inside functions.
-// [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:19607:9-19689:22:writable] Warning: Pure function ‘TransiEnt.Basics.Functions.GasProperties.verboseXi‘ contains a call to impure function ‘Modelica.Utilities.Streams.print‘.
+// [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:19607:9-19689:22:writable] Warning: Pure function 'TransiEnt.Basics.Functions.GasProperties.verboseXi' contains a call to impure function 'Modelica.Utilities.Streams.print'.
 // [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:23942:9-23947:15:writable] Warning: In relation sink_0thOrder.realGasNCV_xi.NCVIn <> 0.0, <> on Real numbers is only allowed inside functions.
 // [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:23861:9-23866:15:writable] Warning: In relation sink_0thOrder.realGasGCV_xi.GCVIn <> 0.0, <> on Real numbers is only allowed inside functions.
 // Warning: It was not possible to determine if the initialization problem is consistent, because of not evaluable parameters/start values during compile time: modelStatistics.heatingPower.E[6] = 0.0 ($START.modelStatistics.heatingPower.E[6] = 0.0)
@@ -96,7 +96,7 @@ buildModelFMU(TransiEnt.Producer.Gas.Electrolyzer.Check.Test_400A_Espinosa_L2, f
 // "
 // "PEM.fmu"
 // "[simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:28578:17-28582:23:writable] Warning: In relation EM.i_dens_a == 0.0, == on Real numbers is only allowed inside functions.
-// [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:19607:9-19689:22:writable] Warning: Pure function ‘TransiEnt.Basics.Functions.GasProperties.verboseXi‘ contains a call to impure function ‘Modelica.Utilities.Streams.print‘.
+// [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:19607:9-19689:22:writable] Warning: Pure function 'TransiEnt.Basics.Functions.GasProperties.verboseXi' contains a call to impure function 'Modelica.Utilities.Streams.print'.
 // [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:23942:9-23947:15:writable] Warning: In relation sink_0thOrder.realGasNCV_xi.NCVIn <> 0.0, <> on Real numbers is only allowed inside functions.
 // [simulation/modelica/arrays/ParametricInitialArrayEquationBug.mo:23861:9-23866:15:writable] Warning: In relation sink_0thOrder.realGasGCV_xi.GCVIn <> 0.0, <> on Real numbers is only allowed inside functions.
 // Warning: It was not possible to determine if the initialization problem is consistent, because of not evaluable parameters/start values during compile time: modelStatistics.heatingPower.E[6] = 0.0 ($START.modelStatistics.heatingPower.E[6] = 0.0)

--- a/testsuite/simulation/modelica/built_in_functions/DerInvalid.mos
+++ b/testsuite/simulation/modelica/built_in_functions/DerInvalid.mos
@@ -31,6 +31,6 @@ buildModel(DerInvalid); getErrorString();
 // true
 // ""
 // {"",""}
-// "[<interactive>:3:3-3:30:writable] Error: Argument ‘x‘ of der is not differentiable.
+// "[<interactive>:3:3-3:30:writable] Error: Argument 'x' of der is not differentiable.
 // Error: pre-optimization module expandDerOperator (simulation) failed.
 // "

--- a/testsuite/simulation/modelica/unitcheck/UnitCheck20.mos
+++ b/testsuite/simulation/modelica/unitcheck/UnitCheck20.mos
@@ -23,6 +23,6 @@ instantiateModel(unitCheckTests.UnitCheck20); getErrorString();
 //   Real A(unit = \"m^2\");
 // end unitCheckTests.UnitCheck20;
 // "
-// "[<interactive>:4:5-4:25:writable] Notification: Invalid unit expression ‘m^2‘.
+// "[<interactive>:4:5-4:25:writable] Notification: Invalid unit expression 'm^2'.
 // "
 // endResult


### PR DESCRIPTION
### Related Issues

Fixes #10550 

### Purpose

  - Document that input  `includeResources` of `buildModelFMU` has no influence.

### Changes

  - Update doc string for input `includeResources` of `buildModelFMU`.
  - Changed `‘` to `'` in Error.mo
