### PR TITLE
Improve vectorization of bindings for the newbackend

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1427,7 +1427,7 @@ protected
 algorithm
   sub_map := UnorderedMap.new<SubscriptList>(InstNode.hash, InstNode.refEqual);
 
-  for cr in ComponentRef.toListReverse(Prefix.prefix(prefix)) loop
+  for cr in ComponentRef.toListReverse(Prefix.indexedPrefix(prefix)) loop
     if ComponentRef.hasSubscripts(cr) then
       UnorderedMap.addUnique(ComponentRef.node(cr), ComponentRef.getSubscripts(cr), sub_map);
     end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -297,6 +297,7 @@ function resetGlobalFlags
 algorithm
   if Flags.getConfigBool(Flags.NEW_BACKEND) then
     FlagsUtil.set(Flags.NF_SCALARIZE, false);
+    FlagsUtil.set(Flags.VECTORIZE_BINDINGS, true);
   end if;
 
   // gather here all the flags to disable expansion


### PR DESCRIPTION
- Turn on vectorization of bindings when `--newBackend` is used.
- Fix vectorization of some cases by using the indexed prefix in flattenCrefSplitSubscripts instead of the non-indexed one.