### PR TITLE
Remove # when printing boxed types

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -893,7 +893,7 @@ public
       case Type.UNKNOWN() then "unknown()";
       case Type.COMPLEX() then AbsynUtil.pathString(InstNode.scopePath(ty.cls));
       case Type.FUNCTION() then Function.typeString(ty.fn);
-      case Type.METABOXED() then "#" + toString(ty.ty);
+      case Type.METABOXED() then toString(ty.ty);
       case Type.POLYMORPHIC()
         then if Util.stringStartsWith("__", ty.name) then
           substring(ty.name, 3, stringLength(ty.name)) else "<" + ty.name + ">";

--- a/testsuite/flattening/modelica/scodeinst/FunctionalArgInvalidType1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionalArgInvalidType1.mo
@@ -31,7 +31,7 @@ end FunctionalArgInvalidType1;
 // [flattening/modelica/scodeinst/FunctionalArgInvalidType1.mo:26:3-26:21:writable] Error: Type mismatch for positional argument 1 in f1(f=f2). The argument has type:
 //   f2<function>(Integer) => Integer
 // expected type:
-//   f<function>(#Real) => #Real
+//   f<function>(Real) => Real
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.


### PR DESCRIPTION
- Type.toString is mostly just used for error messages, and boxed types are an implementation detail that we shouldn't leak to users.