### PR TITLE
Use hdf5 for ModelicaMatIO libraries.

### DIFF
--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/CMakeLists.txt
@@ -55,12 +55,19 @@ endif()
 
 
 ## ModelicaMatIO #########################################################################
+find_package(HDF5 REQUIRED)
+
 set(libModelicaMatIO_SOURCES C-Sources/ModelicaMatIO.c C-Sources/snprintf.c)
 # Static version
 add_library(ModelicaMatIO STATIC ${libModelicaMatIO_SOURCES})
 add_library(omc::simrt::Modelica::MatIO ALIAS ModelicaMatIO)
 
 target_compile_definitions(ModelicaMatIO PRIVATE HAVE_ZLIB)
+target_compile_definitions(ModelicaMatIO PRIVATE HAVE_HDF5)
+
+target_include_directories(ModelicaMatIO PRIVATE ${HDF5_INCLUDE_DIRS})
+
+target_link_libraries(ModelicaMatIO PUBLIC ${HDF5_LIBRARIES})
 target_link_libraries(ModelicaMatIO PUBLIC omc::3rd::zlib)
 target_link_libraries(ModelicaMatIO PUBLIC omc::simrt::runtime)
 
@@ -70,7 +77,12 @@ add_library(omc::simrt::Modelica::MatIO::shared ALIAS ModelicaMatIO_shared)
 set_target_properties(ModelicaMatIO_shared
                       PROPERTIES OUTPUT_NAME ModelicaMatIO CLEAN_DIRECT_OUTPUT 1)
 
-target_compile_definitions(ModelicaMatIO_shared PUBLIC HAVE_ZLIB)
+target_compile_definitions(ModelicaMatIO_shared PRIVATE HAVE_ZLIB)
+target_compile_definitions(ModelicaMatIO_shared PRIVATE HAVE_HDF5)
+
+target_include_directories(ModelicaMatIO_shared PRIVATE ${HDF5_INCLUDE_DIRS})
+
+target_link_libraries(ModelicaMatIO_shared PUBLIC ${HDF5_LIBRARIES})
 target_link_libraries(ModelicaMatIO_shared PUBLIC omc::3rd::zlib)
 target_link_libraries(ModelicaMatIO_shared PUBLIC omc::simrt::runtime)
 

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/MEC_standalone_2.8.cmake
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/MEC_standalone_2.8.cmake
@@ -62,12 +62,19 @@ endif()
 
 
 ## ModelicaMatIO #########################################################################
+find_package(HDF5 REQUIRED)
+
 set(libModelicaMatIO_SOURCES C-Sources/ModelicaMatIO.c C-Sources/snprintf.c)
 # Static version
 add_library(ModelicaMatIO STATIC ${libModelicaMatIO_SOURCES})
 add_library(omc::simrt::Modelica::MatIO ALIAS ModelicaMatIO)
 
 target_compile_definitions(ModelicaMatIO PRIVATE HAVE_ZLIB)
+target_compile_definitions(ModelicaMatIO PRIVATE HAVE_HDF5)
+
+target_include_directories(ModelicaMatIO PRIVATE ${HDF5_INCLUDE_DIRS})
+
+target_link_libraries(ModelicaMatIO PUBLIC ${HDF5_LIBRARIES})
 target_link_libraries(ModelicaMatIO PUBLIC zlib)
 target_link_libraries(ModelicaMatIO PUBLIC OpenModelicaRuntimeC)
 target_link_libraries(ModelicaMatIO PUBLIC omcgc)
@@ -79,6 +86,11 @@ set_target_properties(ModelicaMatIO_shared
                       PROPERTIES OUTPUT_NAME ModelicaMatIO CLEAN_DIRECT_OUTPUT 1)
 
 target_compile_definitions(ModelicaMatIO_shared PUBLIC HAVE_ZLIB)
+target_compile_definitions(ModelicaMatIO_shared PUBLIC HAVE_HDF5)
+
+target_include_directories(ModelicaMatIO_shared PRIVATE ${HDF5_INCLUDE_DIRS})
+
+target_link_libraries(ModelicaMatIO_shared PUBLIC ${HDF5_LIBRARIES})
 target_link_libraries(ModelicaMatIO_shared PUBLIC zlib)
 target_link_libraries(ModelicaMatIO_shared PUBLIC OpenModelicaRuntimeC)
 target_link_libraries(ModelicaMatIO_shared PUBLIC omcgc)


### PR DESCRIPTION
  - hdf5 is now a required library. We can make it optional if needed but it is something that is readily available on most systems so make it required to enforce consistency for everyone. This is of course subjective and can be changed if needed.

  - CMake 3.14 (our minimum required version now) does not provide an imported target for hdf5. So do it the manual way.

### Related Issues

  - Improves #10880.
