### PR TITLE
Dump flat model after running the new backend

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -1081,15 +1081,17 @@ algorithm
     timeFrontend := System.realtimeTock(ClockIndexes.RT_CLOCK_FRONTEND);
     ExecStat.execStat("FrontEnd");
 
+    if runBackend then
+      (outLibs, outFileDir, resultValues) := translateModelCallBackendNB(flatModel, funcTree, className, inFileNamePrefix, inSimSettingsOpt);
+    end if;
+
+    // This must be done after calling the backend since it uses the FlatModel,
+    // and converting it to DAE is destructive.
     if dumpValidFlatModelicaNF then
       flatString := NFFlatString;
     elseif not runSilent then
       (dae, funcs) := NFConvertDAE.convert(flatModel, funcTree);
       flatString := DAEDump.dumpStr(dae, funcs);
-    end if;
-
-    if runBackend then
-      (outLibs, outFileDir, resultValues) := translateModelCallBackendNB(flatModel, funcTree, className, inFileNamePrefix, inSimSettingsOpt);
     end if;
 
   // old backend


### PR DESCRIPTION
- Dumping the flat model should be done after running the new backend, since converting the FlatModel to DAE is a destructive process.