### PR TITLE
Use Dockerfile with CMake

### DIFF
--- a/.CI/cache-bionic-cmake-3.17.2/Dockerfile
+++ b/.CI/cache-bionic-cmake-3.17.2/Dockerfile
@@ -1,11 +1,6 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.16.3
+FROM docker.openmodelica.org/build-deps-cmake:v1.16.3
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 RUN mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/ \
     && apt-get remove -qy cmake cmake-data
-
-# Install cmake 3.17.2.
-RUN wget cmake.org/files/v3.17/cmake-3.17.2-Linux-x86_64.sh
-RUN mkdir -p /opt/cmake-3.17.2
-RUN sh cmake-3.17.2-Linux-x86_64.sh --prefix=/opt/cmake-3.17.2 --skip-license


### PR DESCRIPTION
### Related Issues

Jenkins fails to download `cmake.org/files/v3.17/cmake-3.17.2-Linux-x86_64.sh`, so we should switch to a Dockerfile where CMake is already installed.

This needs
  - [x] https://github.com/OpenModelica/OpenModelicaBuildScripts/pull/28
  - [x] Dockerfile uploaded to https://docker.openmodelica.org.

### Purpose

  - Stop breaking the test pipelines

### Approach

  - Use docker.openmodelica.org/build-deps-cmake:v1.16.3 with already installed CMake v3.17.2
