### PR TITLE
Restructure and refactor the memory pool implementation. 

### DIFF
--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -43,115 +43,165 @@
 extern "C" {
 #endif
 
+#define OMC_MEGABYTE 1024*1024
+/// 2MB pool by default
+#define OMC_INITIAL_BLOCK_SIZE 2*OMC_MEGABYTE
+/// Error out at a 1GB block request. Something is clearly not going
+/// as intended. If we continue we will most probably overflow at the
+/// 4GB mark anyway so catch it and report it.
+#define OMC_ERROR_AT_EXPAND_REQUEST 1024*OMC_MEGABYTE
+
+
+/// This is the pointer to the current block of memory. The 'memory pool'.
+/// It changes when the program requests memory space that does not fit
+/// in the current block. In which case a new block will be created and
+/// this will be updated. Restoring a saved state (a cleanup operation)
+/// will also update this.
+OMCMemPoolBlock *memory_pools = NULL;
+
+#if !defined(OMC_NO_THREADS)
+static pthread_mutex_t memory_pool_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
 static int GC_collect_a_little_or_not(void)
 {
   return 0;
 }
 
-typedef struct list_s {
-  void *memory;
-  size_t used;
-  size_t size;
-  struct list_s *next;
-} list;
-
-#if !defined(OMC_NO_THREADS)
-static pthread_mutex_t memory_pool_mutex = PTHREAD_MUTEX_INITIALIZER;
-#endif
-static list *memory_pools = NULL;
-
 static void pool_init(void)
 {
-  memory_pools = (list*) omc_alloc_interface.malloc_uncollectable(sizeof(list));
+  memory_pools = (OMCMemPoolBlock*) omc_alloc_interface.malloc_uncollectable(sizeof(OMCMemPoolBlock));
   memory_pools->used = 0;
-  memory_pools->size = 2*1024*1024; /* 2MB pool by default */
+  memory_pools->size = OMC_INITIAL_BLOCK_SIZE;
   memory_pools->memory = omc_alloc_interface.malloc_uncollectable(memory_pools->size);
-  memory_pools->next = NULL;
-}
-
-static size_t upper_power_of_two(size_t v)
-{
-  v--;
-  v |= v >> 1;
-  v |= v >> 2;
-  v |= v >> 4;
-  v |= v >> 8;
-  v |= v >> 16;
-  v++;
-  return v;
+  memory_pools->previous = NULL;
 }
 
 static inline size_t round_up(size_t num, size_t factor)
 {
-  return num + factor - 1 - (num - 1) % factor;
+  return num + factor - 1 - ((num + factor - 1) % factor);
 }
 
 static inline void pool_expand(size_t len)
 {
-  list *newlist = NULL;
-  if (0==memory_pools) {
-    pool_init();
+  OMCMemPoolBlock *newBlock = NULL;
+
+  // The new block will be 1.5x the current block's size. More if we request a very large array.
+  size_t new_size = 3*memory_pools->size / 2;
+  // Align the new size to the initial block size (2MB right now) for easier debugging.
+  new_size = round_up(new_size, OMC_INITIAL_BLOCK_SIZE);
+
+  // Report an error if the size is too big. This will error out before the size request is
+  // able to overflow the the size_t size (at 4GB)
+  if (new_size >= OMC_ERROR_AT_EXPAND_REQUEST) {
+    omc_assert_macro(0 && "Attempt to allocate an unusually large memory. The memory management does not seem to be working as intended. Please create an issue on https://github.com/OpenModelica/OpenModelica/issues.");
   }
-  /* Check if we have enough memory already */
-  if (memory_pools->size - memory_pools->used >= len) {
-    return;
-  }
-  newlist = (list*) omc_alloc_interface.malloc_uncollectable(sizeof(list));
-  newlist->next = memory_pools;
-  memory_pools = newlist;
-  memory_pools->used = 0;
-  memory_pools->size = upper_power_of_two(3*memory_pools->next->size/2 + len); /* expand by 1.5x the old memory pool. More if we request a very large array. */
-  memory_pools->memory = omc_alloc_interface.malloc_uncollectable(memory_pools->size);
+
+  newBlock = (OMCMemPoolBlock*) omc_alloc_interface.malloc_uncollectable(sizeof(OMCMemPoolBlock));
+  newBlock->used = 0;
+  newBlock->size = new_size;
+  newBlock->memory = omc_alloc_interface.malloc_uncollectable(newBlock->size);
+  newBlock->previous = memory_pools;
+  memory_pools = newBlock;
 }
 
-static void* pool_malloc(size_t sz)
+static void* pool_malloc(size_t requested_size)
 {
   void *res;
-  sz = round_up(sz,8);
+  requested_size = round_up(requested_size, 8);
+
 #if !defined(OMC_NO_THREADS)
   pthread_mutex_lock(&memory_pool_mutex);
 #endif
-  pool_expand(sz);
+
+  /// If we forgot to explicitly initialize the pool, initialize it now.
+  if (!memory_pools) {
+    pool_init();
+  }
+
+  /// If the current block does not have enough remaining space, expand the pool
+  /// by creating another block. The new block should, at least, be as big as
+  /// the requested size. Note that, this will update the global memory_pools pointer.
+  if (memory_pools->size - memory_pools->used < requested_size) {
+    pool_expand(requested_size);
+  }
+
   res = (void*)((char*)memory_pools->memory + memory_pools->used);
-  memory_pools->used += sz;
+  memory_pools->used += requested_size;
+
 #if !defined(OMC_NO_THREADS)
   pthread_mutex_unlock(&memory_pool_mutex);
 #endif
-  memset(res,0,sz);
+
+  memset(res, 0, requested_size);
   return res;
 }
 
-static int pool_free_extra_list(void)
+static int pool_collect_a_little()
 {
-  list* current = memory_pools;
-  if (NULL == current) {
-    return 0;
-  }
-
-  // Delete all chunks except the last one.
-  while (current->next) {
-    list *next = current->next;
-    omc_alloc_interface.free_uncollectable(current->memory);
-    omc_alloc_interface.free_uncollectable(current);
-    current->next = NULL;
-    current->size = 0;
-    current->used = 0;
-    current = next;
-  }
-
-  memory_pools = current;
-
   return 0;
+}
+
+static void print_mem_pool(OMCMemPoolBlock* chunk) {
+  printf("----------------------------\n");
+  printf("%p, %ld, %ld, %p\n", chunk->memory, chunk->used, chunk->size, chunk->previous);
+  printf("----------------------------\n");
+}
+
+MemPoolState omc_util_get_pool_state() {
+  MemPoolState state;
+  state.block = memory_pools;
+  state.used = memory_pools->used;
+
+  return state;
+}
+
+void omc_util_restore_pool_state(MemPoolState in_state) {
+  // printf("original state:\n");
+  // print_mem_pool(memory_pools);
+
+  assert(in_state.block);
+
+  OMCMemPoolBlock* currentBlock = memory_pools;
+  /// Start from the current block and traverse the chain until we find the block
+  /// that was saved in the state.
+  /// Clean up the blocks as we go since they will no longer be reachable after updating
+  /// to the saved state.
+  while (currentBlock != in_state.block) {
+    OMCMemPoolBlock* previous = currentBlock->previous;
+    omc_alloc_interface.free_uncollectable(currentBlock->memory);
+    currentBlock->memory = NULL;
+    currentBlock->previous = NULL;
+    currentBlock->size = 0;
+    currentBlock->used = 0;
+    omc_alloc_interface.free_uncollectable(currentBlock);
+    currentBlock = previous;
+  }
+  assert(currentBlock);
+
+  currentBlock->used = in_state.used;
+  memory_pools = currentBlock;
+
+  // printf("updated state:\n");
+  // print_mem_pool(memory_pools);
 }
 
 void free_memory_pool()
 {
-  pool_free_extra_list();
-  if (memory_pools) {
-    omc_alloc_interface.free_uncollectable(memory_pools->memory);
-    omc_alloc_interface.free_uncollectable(memory_pools);
-    memory_pools = NULL;
+  OMCMemPoolBlock* currentBlock = memory_pools;
+
+  while (currentBlock) {
+    OMCMemPoolBlock* previous = currentBlock->previous;
+    omc_alloc_interface.free_uncollectable(currentBlock->memory);
+    currentBlock->memory = NULL;
+    currentBlock->previous = NULL;
+    currentBlock->size = 0;
+    currentBlock->used = 0;
+    omc_alloc_interface.free_uncollectable(currentBlock);
+    currentBlock = previous;
   }
+
+  memory_pools = NULL;
 }
 
 static void nofree(void* ptr)
@@ -179,7 +229,7 @@ omc_alloc_interface_t omc_alloc_interface_pooled = {
   pool_malloc,
   (char*(*)(size_t)) malloc,
   strdup,
-  pool_free_extra_list,
+  pool_collect_a_little, /* No OP. Does not do anything. The pool requires explicit state save and restore. */
   malloc_zero,
   free,
   malloc,
@@ -246,7 +296,7 @@ omc_alloc_interface_t omc_alloc_interface = {
   pool_malloc,
   (char*(*)(size_t)) malloc,
   strdup,
-  pool_free_extra_list,
+  pool_collect_a_little, /* No OP. Does not do anything. The pool requires explicit state save and restore. */
   malloc_zero /* calloc, but with malloc interface */,
   free,
   malloc,

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.h
@@ -38,6 +38,35 @@
 extern "C" {
 #endif
 
+/// @brief
+/// The memory pool is a linked list of blocks of memory. Each block has its own
+/// chink of memory space to be used for requests by the program. It knows the size
+/// of the chunk and keeps track of how much of it used currently. Each block also has
+/// a pointer to the previous block.
+typedef struct OMCMemPoolBlock_s {
+  void *memory;
+  size_t used;
+  size_t size;
+  struct OMCMemPoolBlock_s *previous;
+} OMCMemPoolBlock;
+
+/// @brief
+/// The current state of the pool can be represented by a pointer to the current block
+/// and the currently used amount of that block. Restoring will reset the pool pointer
+/// the block saved in the state and then restors the used value when the satate was created.
+typedef struct {
+  OMCMemPoolBlock *block;
+  size_t used;
+} MemPoolState;
+
+/// @brief Get the current state of the pool (the current block and used amount in that block)
+MemPoolState omc_util_get_pool_state();
+/// @brief Restors the memory pool to a given state (specifc block and used amount in that block).
+void omc_util_restore_pool_state(MemPoolState in_state_v);
+/// @brief Completely cleans up the memory pool by deleting all blocks.
+void free_memory_pool();
+
+
 /* Allocation functions */
 extern modelica_real* real_alloc(int n);
 extern modelica_integer* integer_alloc(int n);
@@ -47,8 +76,6 @@ extern _index_t* size_alloc(int n);
 extern _index_t** index_alloc(int n);
 
 void* generic_alloc(int n, size_t sze);
-
-void free_memory_pool();
 
 #if defined(__cplusplus)
 } /* end extern "C" */

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -244,8 +244,6 @@ static inline void resetThreadData(ModelInstance* comp)
   if (comp->threadDataParent) {
     pthread_setspecific(mmc_thread_data_key, comp->threadDataParent);
   }
-  /* Clear the extra memory pools */
-  omc_alloc_interface.collect_a_little();
 }
 
 static inline void setThreadData(ModelInstance* comp)
@@ -431,6 +429,7 @@ fmi2Status updateIfNeeded(ModelInstance *comp, const char *func)
   if (comp->_need_update)
   {
     setThreadData(comp);
+    MemPoolState mem_pool_state = omc_util_get_pool_state();
 
     /* TRY */
 #if !defined(OMC_EMCC)
@@ -461,6 +460,7 @@ fmi2Status updateIfNeeded(ModelInstance *comp, const char *func)
     threadData->mmc_jumper = old_jmp;
 #endif
 
+    omc_util_restore_pool_state(mem_pool_state);
     resetThreadData(comp);
     if (!success)
     {
@@ -1822,6 +1822,8 @@ fmi2Status internal_CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFM
   FILTERED_LOG(comp, fmi2OK, LOG_FMI2_CALL, "fmi2CompletedIntegratorStep")
 
   setThreadData(comp);
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
+
   /* try */
   MMC_TRY_INTERNAL(simulationJumpBuffer)
     threadData->mmc_jumper = threadData->simulationJumpBuffer;
@@ -1851,6 +1853,7 @@ fmi2Status internal_CompletedIntegratorStep(fmi2Component c, fmi2Boolean noSetFM
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
   threadData->mmc_jumper = old_jmp;
   resetThreadData(comp);
+  omc_util_restore_pool_state(mem_pool_state);
 
   if (done) {
     return fmi2OK;
@@ -1924,6 +1927,7 @@ fmi2Status internalGetDerivatives(fmi2Component c, fmi2Real derivatives[], size_
     return fmi2Error;
 
   setThreadData(comp);
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
   /* try */
   MMC_TRY_INTERNAL(simulationJumpBuffer)
 
@@ -1945,6 +1949,8 @@ fmi2Status internalGetDerivatives(fmi2Component c, fmi2Real derivatives[], size_
     done=1;
   /* catch */
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
+
+  omc_util_restore_pool_state(mem_pool_state);
   resetThreadData(comp);
 
   if (done) {
@@ -1972,6 +1978,7 @@ fmi2Status internalGetEventIndicators(fmi2Component c, fmi2Real eventIndicators[
     return fmi2Error;
 
   setThreadData(comp);
+  MemPoolState mem_pool_state = omc_util_get_pool_state();
   /* try */
   MMC_TRY_INTERNAL(simulationJumpBuffer)
 
@@ -1992,7 +1999,9 @@ fmi2Status internalGetEventIndicators(fmi2Component c, fmi2Real eventIndicators[
 
   /* catch */
   MMC_CATCH_INTERNAL(simulationJumpBuffer)
+  omc_util_restore_pool_state(mem_pool_state);
   resetThreadData(comp);
+
   if (done) {
     return fmi2OK;
   }


### PR DESCRIPTION
Restructure and refactor the memory pool implementation. 

  - The memory pool is organized as a linked list of blocks of memory.

  - The initial block has 2MB size right now.

  - Each block is, at least, 1.5x the old block size aligned to the initial
    block size (2MB right now). It might be bigger if the request that caused
    the new block allocation is actually bigger than 1.5x the old block
    size.

  - Error is reported when a request is made for a new block of size 1GB
    or more. This is clearly a misfunction and should be caught and reported
    before we get to 4GB requests and risk overflowing the values that keep
    track of status.

  - The current state of the memory pool can be saved in the new struct
    `MemPoolState`. This will save the current block and how much of it
    used at the moment.

  - Restoring a state will cleanup all blocks created after the state was
    saved and then restores the used amount tracker to the value saved in
    the state.

Save an restore the memory pool state in FMU operations. 

  - Save and restore the memory pool state at some relevant locations in
    the lifecycle of an FMU.

  - Note that, this is not exhaustive coverage. It is just added in places
    where it seemed appropriate. More places can be covered if needed to
    avoid more wasting of reusable memory.