### PR TITLE
Unroll vectorized connect equations

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1145,7 +1145,7 @@ algorithm
             eq := Equation.FOR(iter, SOME(range), {eq}, scope, src);
           end while;
         then
-          eq :: equations;
+          splitForLoop(eq, EMPTY_PREFIX, equations, settings);
 
     end match;
   end for;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -858,6 +858,7 @@ NonexistentRedeclareModifier1.mo \
 NonexistentRedeclareModifier2.mo \
 NoScalarize1.mo \
 NoScalarize2.mo \
+NoScalarizeConnect1.mo \
 OperationAdd1.mo \
 OperationAddEW1.mo \
 OperationDiv1.mo \

--- a/testsuite/flattening/modelica/scodeinst/NoScalarizeConnect1.mo
+++ b/testsuite/flattening/modelica/scodeinst/NoScalarizeConnect1.mo
@@ -1,0 +1,42 @@
+// name: NoScalarizeConnect1
+// keywords:
+// status: correct
+// cflags: -d=newInst --newBackend
+//
+
+connector C
+  Real e;
+  flow Real f;
+end C;
+
+model M
+  C c1, c2;
+equation
+  connect(c1, c2);
+end M;
+
+model NoScalarizeConnect1
+  M m[3];
+end NoScalarizeConnect1;
+
+// Result:
+// class NoScalarizeConnect1
+//   Real[3] m.c2.f;
+//   Real[3] m.c2.e;
+//   Real[3] m.c1.f;
+//   Real[3] m.c1.e;
+// equation
+//   m[3].c1.e = m[3].c2.e;
+//   (-m[3].c1.f) - m[3].c2.f = 0.0;
+//   m[2].c1.e = m[2].c2.e;
+//   (-m[2].c1.f) - m[2].c2.f = 0.0;
+//   m[1].c1.e = m[1].c2.e;
+//   (-m[1].c1.f) - m[1].c2.f = 0.0;
+//   for $i1 in 1:3 loop
+//     m[$i1].c2.f = 0.0;
+//   end for;
+//   for $i1 in 1:3 loop
+//     m[$i1].c1.f = 0.0;
+//   end for;
+// end NoScalarizeConnect1;
+// endResult


### PR DESCRIPTION
- Unroll vectorized connect equations when using the normal connect handling, to treat them the same as any other for loop containing connect equations.

Fixes #10840