### PR TITLE
Simplify SystemImpl to use omc_stat

### DIFF
--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -916,12 +916,19 @@ extern double SystemImpl__time(void)
   return (double)cl / (double)CLOCKS_PER_SEC;
 }
 
-extern int SystemImpl__directoryExists(const char *str)
+/**
+ * @brief Check if regular directory exists.
+ *
+ * Use stat and check mode of directory.
+ *
+ * @param dirname   Multibyte string with directory name.
+ * @return int      Return 1 if it exists, 0 otherwise.
+ */
+extern int SystemImpl__directoryExists(const char *dirname)
 {
-  /* if the string is NULL return 0 */
-  if (!str) return 0;
+  if (!dirname) return 0;
   omc_stat_t buf;
-  if (omc_stat(str, &buf)) {
+  if (omc_stat(dirname, &buf)) {
     return 0;
   }
   return (buf.st_mode & S_IFDIR) != 0;

--- a/OMCompiler/Compiler/runtime/systemimpl.h
+++ b/OMCompiler/Compiler/runtime/systemimpl.h
@@ -90,7 +90,7 @@ extern int SystemImpl__setLinker(const char *str);
 extern int SystemImpl__setCFlags(const char *str);
 extern int SystemImpl__setLDFlags(const char *str);
 extern char* SystemImpl__pwd(void);
-extern int SystemImpl__regularFileExists(const char* str);
+extern int SystemImpl__regularFileExists(const char* filename);
 extern int SystemImpl__removeFile(const char* filename);
 extern int SystemImpl__rename(const char *source, const char *dest);
 extern const char* SystemImpl__basename(const char *str);
@@ -103,7 +103,7 @@ extern void SystemImpl__plotCallBack(threadData_t *threadData, int externalWindo
                                      const char* y2, const char* curveWidth, const char* curveStyle, const char* legendPosition, const char* footer,
                                      const char* autoScale, const char* variables);
 extern double SystemImpl__time(void);
-extern int SystemImpl__directoryExists(const char* str);
+extern int SystemImpl__directoryExists(const char *dirname);
 extern int SystemImpl__copyFile(const char* str_1, const char* str_2);
 extern int SystemImpl__createDirectory(const char *str);
 extern int SystemImpl__removeDirectory(const char *str);


### PR DESCRIPTION
### Related Issues

Related to https://github.com/OpenModelica/OpenModelica/issues/10898.

### Purpose

Use `omc_stat` instead of writing different functions for Windows and Unix.

### Approach 

Simplified:

  - SystemImpl__regularFileExists
  - SystemImpl__directoryExists
