### PR TITLE
Fix DAE conversion for some array attributes

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -468,7 +468,7 @@ function convertStateSelectAttribute
 protected
   String name;
 algorithm
-  name := getStateSelectName(Binding.getTypedExp(binding));
+  name := getStateSelectName(Expression.arrayFirstScalar(Binding.getTypedExp(binding)));
   stateSelect := SOME(lookupStateSelectMember(name));
 end convertStateSelectAttribute;
 
@@ -515,7 +515,7 @@ function convertUncertaintyAttribute
 protected
   InstNode node;
   String name;
-  Expression exp = Binding.getTypedExp(binding);
+  Expression exp = Expression.arrayFirstScalar(Binding.getTypedExp(binding));
 algorithm
   name := match exp
     case Expression.ENUM_LITERAL() then exp.name;


### PR DESCRIPTION
- Use the first scalar array element when converting builtin attributes such as stateSelect that can't otherwise be represented in the DAE. This should only happen for the new backend anyway, where the DAE representation is only used for dumping the flat model.