### PR TITLE
Add System.waitForInput

### DIFF
--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -1327,5 +1327,11 @@ Outputs a string using the C function fputs.
 </html>"));
 end fputs;
 
+function waitForInput
+  external "C" SystemImpl__waitForInput() annotation(Library = "omcruntime", Documentation(info="<html>
+Waits for input, useful for e.g. pausing the compiler in order to turn valgrind instrumentation on/off.
+</html>"));
+end waitForInput;
+
 annotation(__OpenModelica_Interface="util");
 end System;

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -3308,6 +3308,12 @@ int SystemImpl__fputs(const char *str, int stream)
   return -1;
 }
 
+void SystemImpl__waitForInput()
+{
+  printf("Press enter to continue\n");
+  getchar();
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Add System.waitForInput to make e.g. profiling specific parts of the compiler with valgrind a bit easier.