### PR TITLE
Add Absyn.Exp.SUBSCRIPTED_EXP() to utility functions

### DIFF
--- a/OMCompiler/Compiler/Script/Conversion.mo
+++ b/OMCompiler/Compiler/Script/Conversion.mo
@@ -2038,6 +2038,13 @@ protected
         then
           ();
 
+      case Absyn.Exp.SUBSCRIPTED_EXP()
+        algorithm
+          exp.exp := convertExp(exp.exp, localRules, rules, env, info);
+          exp.subscripts := convertSubscripts(exp.subscripts, localRules, rules, env, info);
+        then
+          ();
+
       else ();
     end match;
   end convertExp;

--- a/OMCompiler/Compiler/Template/AbsynDumpTV.mo
+++ b/OMCompiler/Compiler/Template/AbsynDumpTV.mo
@@ -649,6 +649,10 @@ package Absyn
       list<String> commentsAfter;
     end EXPRESSIONCOMMENT;
 
+    record SUBSCRIPTED_EXP
+      Exp exp;
+      list<Subscript> subscripts;
+    end SUBSCRIPTED_EXP;
   end Exp;
 
   uniontype Case

--- a/OMCompiler/Compiler/Template/AbsynDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/AbsynDumpTpl.tpl
@@ -845,6 +845,8 @@ match exp
     '<%dumpExp(exp)%>.<%dumpExp(index)%>'
   case EXPRESSIONCOMMENT(__) then
     ((commentsBefore |> cmt => cmt ; absIndent=0) + dumpExp(exp) + (commentsAfter |> cmt => cmt ; absIndent=0))
+  case SUBSCRIPTED_EXP(__) then
+    '(<%dumpExp(exp)%>)[<%dumpSubscripts(subscripts)%>]'
   case _ then '/* AbsynDumpTpl.dumpExp: UNHANDLED Abyn.Exp */'
 end dumpExp;
 


### PR DESCRIPTION
- `Absyn.Exp.SUBSCRIPTED_EXP()` was added in #10732 but not fully implemented since it was only meant to be used internally by the NF. This adds support for it in e.g. the Absyn utility and dumping functions in case we want to use it for other things.