### PR TITLE
Fix compiler warnings

### DIFF
--- a/OMCompiler/SimulationRuntime/c/gc/omc_gc.h
+++ b/OMCompiler/SimulationRuntime/c/gc/omc_gc.h
@@ -175,8 +175,8 @@ static inline void* mmc_check_out_of_memory(void *ptr)
 #define GC_free                           omc_alloc_interface_pooled.free_uncollectable
 #define nofree                            omc_alloc_interface_pooled.free_string_persist
 #define GC_malloc_atomic_ignore_off_page  omc_alloc_interface_pooled.malloc_atomic
-#define GC_register_displacement          /* nothing */
-#define GC_set_force_unmap_on_gcollect    /* nothing */
+#define GC_register_displacement(X)       /* nothing */
+#define GC_set_force_unmap_on_gcollect(X) /* nothing */
 #define omc_GC_set_max_heap_size(X)       /* nothing */
 #define omc_GC_get_max_heap_size()        0
 #endif

--- a/OMNotebook/OMNotebook/OMNotebookGUI/ModelicaTextHighlighter.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/ModelicaTextHighlighter.h
@@ -46,6 +46,7 @@ namespace IAEX
     Q_OBJECT
   public:
     ModelicaTextHighlighter(QTextDocument *pTextDocument);
+    virtual ~ModelicaTextHighlighter() = default;
     void initializeSettings();
     void highlightMultiLine(const QString &text);
   protected:

--- a/OMNotebook/OMNotebook/OMNotebookGUI/application.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/application.h
@@ -57,6 +57,7 @@ namespace IAEX
    class Application
    {
    public:
+      virtual ~Application() = default;
       virtual CommandCenter *commandCenter() = 0;
       virtual void setCommandCenter(CommandCenter *) = 0;
       virtual void addToPasteboard(Cell *cell) = 0;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.cpp
@@ -643,20 +643,19 @@ namespace IAEX
         // clear selection before changing cell strucure
         document()->clearSelection();
 
-        vector<Cell *>::iterator c_iter = cells.begin();
-        for(; c_iter != cells.end() ; ++c_iter )
+        for (auto cell: cells)
         {
           //check if groupcell
-          if( typeid( *(*c_iter) ) == typeid( CellGroup ))
+          if( dynamic_cast<CellGroup*>(cell) )
           {
-            if( !(*c_iter)->hasChilds() )
+            if( !cell->hasChilds() )
               throw runtime_error( "No children" );
 
             // get child
-            Cell* child = (*c_iter)->child();
-            Cell* deletedCellsParent = (*c_iter)->parentCell();
-            Cell* deletedCellsPrevious = (*c_iter)->previous();
-            Cell* deletedCellsNext = (*c_iter)->next();
+            Cell* child = cell->child();
+            Cell* deletedCellsParent = cell->parentCell();
+            Cell* deletedCellsPrevious = cell->previous();
+            Cell* deletedCellsNext = cell->next();
 
             // if previous is 0 = first in cell
             child->setPrevious( deletedCellsPrevious );
@@ -693,8 +692,8 @@ namespace IAEX
               }
             }
 
-            (*c_iter)->setChild( 0 );
-            (*c_iter)->hide();
+            cell->setChild( 0 );
+            cell->hide();
 
             // must update groupcells parents layout
             deletedCellsParent->removeCellWidgets();
@@ -703,7 +702,7 @@ namespace IAEX
             // delete groupcell
             //(document()->getCursor())->moveAfter( (*c_iter) );
             //(document()->getCursor())->deleteCurrentCell();
-            delete (*c_iter);
+            delete cell;
 
             // update document
             document()->setChanged( true );
@@ -731,11 +730,11 @@ namespace IAEX
     {
       if( document()->getCursor()->currentCell() )
       {
-        if( typeid( *document()->getCursor()->currentCell() ) == typeid( TextCell ) ||
-          typeid( *document()->getCursor()->currentCell() ) == typeid( InputCell ) )
+        auto cell = document()->getCursor()->currentCell();
+        if( dynamic_cast<TextCell*>(cell) || dynamic_cast<InputCell*>(cell) )
         {
           // extraxt text
-          QTextEdit* editor = document()->getCursor()->currentCell()->textEdit();
+          QTextEdit* editor = cell->textEdit();
           if( editor )
           {
             QTextCursor cursor = editor->textCursor();
@@ -744,7 +743,7 @@ namespace IAEX
             cursor.removeSelectedText();
 
             // add new cell
-            if( typeid( *document()->getCursor()->currentCell() ) == typeid( TextCell ) )
+            if( dynamic_cast<TextCell*>(cell) )
             {
               AddCellCommand addcellCommand;
               addcellCommand.setApplication( application() );

--- a/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
@@ -799,7 +799,7 @@ namespace IAEX
       if( cursor )
       {
         // ignore, if selected cell is a groupcell
-        if( typeid( *cursor->currentCell() ) != typeid( CellGroup ) )
+        if (!dynamic_cast<CellGroup*>(cursor->currentCell()))
         {
           // calculate the position of the cursor, by adding the height
           // of all the cells before the cellcursor, using a visitor

--- a/OMNotebook/OMNotebook/OMNotebookGUI/command.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/command.h
@@ -64,6 +64,7 @@ namespace IAEX
    class Command
    {
    public:
+      virtual ~Command() = default;
       virtual void execute() = 0;
 
       virtual QString commandName(){ return QString("NoCommandNameSet");}

--- a/OMNotebook/OMNotebook/OMNotebookGUI/commandcenter.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/commandcenter.h
@@ -49,6 +49,7 @@ namespace IAEX
    class CommandCenter
    {
    public:
+      virtual ~CommandCenter() = default;
       virtual void executeCommand(Command *) = 0;
       virtual CellApplication *application() = 0;
       virtual void setApplication(CellApplication *) = 0;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/document.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/document.h
@@ -82,6 +82,8 @@ namespace IAEX
     Q_OBJECT
 
   public:
+    virtual ~Document() = default;
+
     //Application
     virtual CellApplication *application() = 0;
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/factory.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/factory.h
@@ -47,6 +47,7 @@ namespace IAEX
    class Factory
    {
    public:
+      virtual ~Factory() = default;
       virtual Cell *createCell(const QString &style, Cell *parent=0) = 0;
 
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
@@ -1544,7 +1544,11 @@ namespace IAEX {
   * highlightning is used in the output cell.
   *
   */
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QRecursiveMutex* guard = new QRecursiveMutex();
+#else // QT_VERSION_CHECK
   QMutex* guard = new QMutex(QMutex::Recursive);
+#endif // QT_VERSION_CHECK
 
   void GraphCell::eval()
   {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcelldelegate.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcelldelegate.h
@@ -53,12 +53,13 @@ namespace IAEX
    class GraphCellDelegate
    {
    public:
-      virtual QString getResult() = 0;
-      virtual QString getError() = 0;          // Added 2006-02-02 AF
-      virtual void evalExpression(QString &expr) = 0;
-    virtual void closeConnection() = 0;        // Added 2006-02-02 AF
-    virtual void reconnect() = 0;            // Added 2006-02-02 AF
-    virtual bool startDelegate() = 0;          // Added 2006-02-09 AF
+     virtual ~GraphCellDelegate() = default;
+     virtual QString getResult() = 0;
+     virtual QString getError() = 0;          // Added 2006-02-02 AF
+     virtual void evalExpression(QString &expr) = 0;
+     virtual void closeConnection() = 0;        // Added 2006-02-02 AF
+     virtual void reconnect() = 0;            // Added 2006-02-02 AF
+     virtual bool startDelegate() = 0;          // Added 2006-02-09 AF
    };
 
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/inputcelldelegate.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/inputcelldelegate.h
@@ -53,6 +53,7 @@ namespace IAEX
    class InputCellDelegate
    {
    public:
+     virtual ~InputCellDelegate() = default;
      virtual QString getResult() = 0;
      virtual QString getError() = 0;          // Added 2006-02-02 AF
      virtual int getErrorLevel() = 0;          // Added 2006-02-02 AF

--- a/OMNotebook/OMNotebook/OMNotebookGUI/nbparser.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/nbparser.h
@@ -44,6 +44,7 @@ namespace IAEX
    class NBParser
    {
    public:
+      virtual ~NBParser() = default;
       virtual Cell *parse() = 0;
    };
 };

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
@@ -3994,7 +3994,7 @@ void NotebookWindow::shiftcellsUp()
     Cell *current=subject_->getCursor()->currentCell();
     if (current->hasPrevious())
     {
-      if( typeid(CellGroup) == typeid( *current->previous()))
+      if( dynamic_cast<CellGroup*>(current->previous()) )
       {
         QMessageBox::warning( 0, tr("Warning"), err_hierarchy, "OK" );
       }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/parserfactory.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/parserfactory.h
@@ -51,6 +51,7 @@ namespace IAEX
    class ParserFactory
    {
    public:
+      virtual ~ParserFactory() = default;
       virtual NBParser *createParser(QString filename, Factory *f, Document *document, int readmode) = 0;
    };
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/searchform.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/searchform.cpp
@@ -567,18 +567,10 @@ namespace IAEX
    */
   void SearchForm::closeForm()
   {
-    QList<Cell*>::iterator iter = openedCells_.begin();
-    while( iter != openedCells_.end() )
-    {
-      (*iter)->setClosed( true, false );
-      if( typeid( (*(*iter)) ) == typeid( CellGroup ) )
-      {
-        CellGroup* groupcell = dynamic_cast<CellGroup*>( (*iter) );
-        if( groupcell )
-          groupcell->closeChildCells();
-      }
-
-      ++iter;
+    for (auto cell: openedCells_) {
+      cell->setClosed( true, false );
+      CellGroup* groupcell = dynamic_cast<CellGroup*>( cell );
+      if( groupcell ) groupcell->closeChildCells();
     }
 
     close();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/visitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/visitor.h
@@ -61,6 +61,8 @@ namespace IAEX{
    class Visitor
    {
    public:
+      virtual ~Visitor() = default;
+
       virtual void visitCellNodeBefore(Cell *node) = 0;
       virtual void visitCellNodeAfter(Cell *node) = 0;
 

--- a/OMShell/mosh/src/mosh.cpp
+++ b/OMShell/mosh/src/mosh.cpp
@@ -111,8 +111,8 @@ void doOMCCommunication(const string *scriptname)
 
   if (scriptname) { // Execute script and output return value
     cout << "executing <" << scriptname << ">" << endl;
-    const char * str=("runScript(\""+*scriptname+"\")").c_str();
-    env->evalExpression(str);
+    std::string cmd = "runScript(\"" + *scriptname + "\")";
+    env->evalExpression(cmd);
     string res = env->getResult();
     cout << res << endl;
     return;


### PR DESCRIPTION
- Include the argument in noop GC macros to avoid warnings about unused expressions.
- Add virtual destructors to abstract base classes in OMNotebook.
- Avoid using `typeid` on expressions with possible side effects in OMNotebook.
- Use `QRecursiveMutex` instead of deprecated `QMutex(QMutex::Recursive)` if Qt >= 5.14.
- Don't save the result of `c_str()` on a temporary `std::string` in OMShell (which is then just converted back to a `std::string` anyway).