### PR TITLE
Do not exit before printing the assertion message.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/omc_error.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_error.h
@@ -239,8 +239,8 @@ static void OMC_INLINE assertStreamPrint(threadData_t *threadData, int cond, con
 
 #define omc_assert_macro(expr) \
   if (!(expr)) {                \
-    abort(); \
     throwStreamPrint(NULL, "%s:%d: %s: Assertion `%s` failed.\n",  __FILE__, __LINE__, OMC_FUNCTION, #expr); \
+    exit(1); \
   }
 
 #ifdef USE_DEBUG_OUTPUT


### PR DESCRIPTION
  - Do not `abort()`. Just `exit()`. If we run into an assertion, we know what went wrong and it is better to exit properly. `abort()` seems unnecessary.

  - Print the assert message first and then exit.
