### PR TITLE
[Util] clean up flags

### DIFF
--- a/OMCompiler/Compiler/BackEnd/SymbolicImplicitSolver.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicImplicitSolver.mo
@@ -130,7 +130,7 @@ algorithm
 
   inlineBDAE := BackendDAE.DAE(osystlst, shared);
 
-  execbool := FlagsUtil.disableDebug(Flags.EXEC_STAT);
+  execbool := FlagsUtil.set(Flags.EXEC_STAT, false);
   if Flags.isSet(Flags.DUMP_INLINE_SOLVER) then
     BackendDump.bltdump("Generated inline system:",inlineBDAE);
   end if;

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -2305,7 +2305,7 @@ algorithm
           if Flags.isSet(Flags.JAC_DUMP) then
             BackendDump.bltdump("Symbolic Jacobian",backendDAE);
           else
-            b = FlagsUtil.disableDebug(Flags.EXEC_STAT);
+            b = FlagsUtil.set(Flags.EXEC_STAT, false);
           end if;
 
           strPostOptModules = {"wrapFunctionCalls",

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -964,7 +964,7 @@ algorithm
       algorithm
         if not Flags.isSet(Flags.SCODE_INST) then
           Builtin.clearInitialGraph();
-          FlagsUtil.enableDebug(Flags.SCODE_INST);
+          FlagsUtil.set(Flags.SCODE_INST, true);
           outCache := FCore.emptyCache();
         end if;
       then
@@ -976,7 +976,7 @@ algorithm
     case ("disableNewInstantiation",_)
       algorithm
         if Flags.isSet(Flags.SCODE_INST) then
-          FlagsUtil.disableDebug(Flags.SCODE_INST);
+          FlagsUtil.set(Flags.SCODE_INST, false);
           outCache := FCore.emptyCache();
           Builtin.clearInitialGraph();
         end if;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1417,7 +1417,7 @@ algorithm
         FlagsUtil.setConfigBool(Flags.REDUCE_TERMS, true);
         // FlagsUtil.setConfigBool(Flags.DISABLE_EXTRA_LABELING, true);
         FlagsUtil.setConfigBool(Flags.GENERATE_LABELED_SIMCODE, false);
-        FlagsUtil.disableDebug(Flags.WRITE_TO_BUFFER);
+        FlagsUtil.set(Flags.WRITE_TO_BUFFER, false);
         List.map_0(ClockIndexes.buildModelClocks,System.realtimeClear);
         System.realtimeTick(ClockIndexes.RT_CLOCK_SIMULATE_TOTAL);
 

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -522,7 +522,7 @@ algorithm
       if Flags.getConfigBool(Flags.REDUCE_TERMS) then
         (allEquations,modelInfo) := ReduceDAE.reduceTerms(allEquations,modelInfo,args);
         FlagsUtil.setConfigBool(Flags.REDUCE_TERMS, false);
-        FlagsUtil.disableDebug(Flags.REDUCE_DAE);
+        FlagsUtil.set(Flags.REDUCE_DAE, false);
         if debug then execStat("ReduceDAE: reduceTerms"); end if;
       end if;
     end if;
@@ -4963,7 +4963,7 @@ algorithm
       Option<BackendDAE.Jacobian> jacH;
     case (_, _, _)
       algorithm
-        // b := FlagsUtil.disableDebug(Flags.EXEC_STAT);
+        // b := FlagsUtil.set(Flags.EXEC_STAT, false);
         crefSimVarHT := createCrefToSimVarHT(inModelInfo);
         // The jacobian code requires single systems;
         // I did not rewrite it to take advantage of any parallelism in the code

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -56,12 +56,13 @@ encapsulated package Flags
 
 public
 import Gettext;
+import UnorderedMap;
 protected
+import Error;
 import Global;
 
 public uniontype DebugFlag
   record DEBUG_FLAG
-    Integer index "Unique index.";
     String name "The name of the flag used by -d";
     Boolean default "Default enabled or not";
     Gettext.TranslatableContent description "A description of the flag.";
@@ -70,7 +71,6 @@ end DebugFlag;
 
 public uniontype ConfigFlag
   record CONFIG_FLAG
-    Integer index "Unique index.";
     String name "The whole name of the flag.";
     Option<String> shortname "A short name one-character name for the flag.";
     FlagVisibility visibility "Whether the flag is visible to the user or not.";
@@ -133,11 +133,15 @@ end FlagVisibility;
 public uniontype Flag
   "The structure which stores the flags."
   record FLAGS
-    array<Boolean> debugFlags;
-    array<FlagData> configFlags;
+    UnorderedMap<String, Boolean> debugFlags;
+    UnorderedMap<String, FlagData> configFlags;
   end FLAGS;
 
-  record NO_FLAGS end NO_FLAGS;
+  function empty
+    output Flag flags = FLAGS(
+      debugFlags  = UnorderedMap.new<Boolean>(stringHashDjb2, stringEqual),
+      configFlags = UnorderedMap.new<Flags.FlagData>(stringHashDjb2, stringEqual));
+  end empty;
 end Flag;
 
 public uniontype ValidOptions
@@ -171,448 +175,448 @@ constant Gettext.TranslatableContent collapseArrayExpressionsText = Gettext.gett
 
 // DEBUG FLAGS
 public
-constant DebugFlag FAILTRACE = DEBUG_FLAG(1, "failtrace", false,
+constant DebugFlag FAILTRACE = DEBUG_FLAG("failtrace", false,
   Gettext.gettext("Sets whether to print a failtrace or not."));
-constant DebugFlag CEVAL = DEBUG_FLAG(2, "ceval", false,
+constant DebugFlag CEVAL = DEBUG_FLAG("ceval", false,
   Gettext.gettext("Prints extra information from Ceval."));
-constant DebugFlag CHECK_BACKEND_DAE = DEBUG_FLAG(3, "checkBackendDae", false,
+constant DebugFlag CHECK_BACKEND_DAE = DEBUG_FLAG("checkBackendDae", false,
   Gettext.gettext("Do some simple analyses on the datastructure from the frontend to check if it is consistent."));
-constant DebugFlag PTHREADS = DEBUG_FLAG(4, "pthreads", false,
+constant DebugFlag PTHREADS = DEBUG_FLAG("pthreads", false,
   Gettext.gettext("Experimental: Unused parallelization."));
-constant DebugFlag EVENTS = DEBUG_FLAG(5, "events", true,
+constant DebugFlag EVENTS = DEBUG_FLAG("events", true,
   Gettext.gettext("Turns on/off events handling."));
-constant DebugFlag DUMP_INLINE_SOLVER = DEBUG_FLAG(6, "dumpInlineSolver", false,
+constant DebugFlag DUMP_INLINE_SOLVER = DEBUG_FLAG("dumpInlineSolver", false,
   Gettext.gettext("Dumps the inline solver equation system."));
-constant DebugFlag EVAL_FUNC = DEBUG_FLAG(7, "evalfunc", true,
+constant DebugFlag EVAL_FUNC = DEBUG_FLAG("evalfunc", true,
   Gettext.gettext("Turns on/off symbolic function evaluation."));
-constant DebugFlag GEN = DEBUG_FLAG(8, "gen", false,
+constant DebugFlag GEN = DEBUG_FLAG("gen", false,
   Gettext.gettext("Turns on/off dynamic loading of functions that are compiled during translation. Only enable this if external functions are needed to calculate structural parameters or constants."));
-constant DebugFlag DYN_LOAD = DEBUG_FLAG(9, "dynload", false,
+constant DebugFlag DYN_LOAD = DEBUG_FLAG("dynload", false,
   Gettext.gettext("Display debug information about dynamic loading of compiled functions."));
-constant DebugFlag GENERATE_CODE_CHEAT = DEBUG_FLAG(10, "generateCodeCheat", false,
+constant DebugFlag GENERATE_CODE_CHEAT = DEBUG_FLAG("generateCodeCheat", false,
   Gettext.gettext("Used to generate code for the bootstrapped compiler."));
-constant DebugFlag CGRAPH_GRAPHVIZ_FILE = DEBUG_FLAG(11, "cgraphGraphVizFile", false,
+constant DebugFlag CGRAPH_GRAPHVIZ_FILE = DEBUG_FLAG("cgraphGraphVizFile", false,
   Gettext.gettext("Generates a graphviz file of the connection graph."));
-constant DebugFlag CGRAPH_GRAPHVIZ_SHOW = DEBUG_FLAG(12, "cgraphGraphVizShow", false,
+constant DebugFlag CGRAPH_GRAPHVIZ_SHOW = DEBUG_FLAG("cgraphGraphVizShow", false,
   Gettext.gettext("Displays the connection graph with the GraphViz lefty tool."));
-constant DebugFlag GC_PROF = DEBUG_FLAG(13, "gcProfiling", false,
+constant DebugFlag GC_PROF = DEBUG_FLAG("gcProfiling", false,
   Gettext.gettext("Prints garbage collection stats to standard output."));
-constant DebugFlag CHECK_DAE_CREF_TYPE = DEBUG_FLAG(14, "checkDAECrefType", false,
+constant DebugFlag CHECK_DAE_CREF_TYPE = DEBUG_FLAG("checkDAECrefType", false,
   Gettext.gettext("Enables extra type checking for cref expressions."));
-constant DebugFlag CHECK_ASUB = DEBUG_FLAG(15, "checkASUB", false,
+constant DebugFlag CHECK_ASUB = DEBUG_FLAG("checkASUB", false,
   Gettext.gettext("Prints out a warning if an ASUB is created from a CREF expression."));
-constant DebugFlag INSTANCE = DEBUG_FLAG(16, "instance", false,
+constant DebugFlag INSTANCE = DEBUG_FLAG("instance", false,
   Gettext.gettext("Prints extra failtrace from InstanceHierarchy."));
-constant DebugFlag CACHE = DEBUG_FLAG(17, "Cache", true,
+constant DebugFlag CACHE = DEBUG_FLAG("Cache", true,
   Gettext.gettext("Turns off the instantiation cache."));
-constant DebugFlag RML = DEBUG_FLAG(18, "rml", false,
+constant DebugFlag RML = DEBUG_FLAG("rml", false,
   Gettext.gettext("Converts Modelica-style arrays to lists."));
-constant DebugFlag TAIL = DEBUG_FLAG(19, "tail", false,
+constant DebugFlag TAIL = DEBUG_FLAG("tail", false,
   Gettext.gettext("Prints out a notification if tail recursion optimization has been applied."));
-constant DebugFlag LOOKUP = DEBUG_FLAG(20, "lookup", false,
+constant DebugFlag LOOKUP = DEBUG_FLAG("lookup", false,
   Gettext.gettext("Print extra failtrace from lookup."));
-constant DebugFlag PATTERNM_SKIP_FILTER_UNUSED_AS_BINDINGS = DEBUG_FLAG(21, "patternmSkipFilterUnusedBindings", false,
+constant DebugFlag PATTERNM_SKIP_FILTER_UNUSED_AS_BINDINGS = DEBUG_FLAG("patternmSkipFilterUnusedBindings", false,
   Gettext.notrans(""));
-constant DebugFlag PATTERNM_ALL_INFO = DEBUG_FLAG(22, "patternmAllInfo", false,
+constant DebugFlag PATTERNM_ALL_INFO = DEBUG_FLAG("patternmAllInfo", false,
   Gettext.gettext("Adds notifications of all pattern-matching optimizations that are performed."));
-constant DebugFlag PATTERNM_DCE = DEBUG_FLAG(23, "patternmDeadCodeElimination", true,
+constant DebugFlag PATTERNM_DCE = DEBUG_FLAG("patternmDeadCodeElimination", true,
   Gettext.gettext("Performs dead code elimination in match-expressions."));
-constant DebugFlag PATTERNM_MOVE_LAST_EXP = DEBUG_FLAG(24, "patternmMoveLastExp", true,
+constant DebugFlag PATTERNM_MOVE_LAST_EXP = DEBUG_FLAG("patternmMoveLastExp", true,
   Gettext.gettext("Optimization that moves the last assignment(s) into the result of a match-expression. For example: equation c = fn(b); then c; => then fn(b);"));
-constant DebugFlag EXPERIMENTAL_REDUCTIONS = DEBUG_FLAG(25, "experimentalReductions", false,
+constant DebugFlag EXPERIMENTAL_REDUCTIONS = DEBUG_FLAG("experimentalReductions", false,
   Gettext.gettext("Turns on custom reduction functions (OpenModelica extension)."));
-constant DebugFlag EVAL_PARAM = DEBUG_FLAG(26, "evaluateAllParameters", false,
+constant DebugFlag EVAL_PARAM = DEBUG_FLAG("evaluateAllParameters", false,
   Gettext.gettext("Evaluates all parameters if set."));
-constant DebugFlag TYPES = DEBUG_FLAG(27, "types", false,
+constant DebugFlag TYPES = DEBUG_FLAG("types", false,
   Gettext.gettext("Prints extra failtrace from Types."));
-constant DebugFlag SHOW_STATEMENT = DEBUG_FLAG(28, "showStatement", false,
+constant DebugFlag SHOW_STATEMENT = DEBUG_FLAG("showStatement", false,
   Gettext.gettext("Shows the statement that is currently being evaluated when evaluating a script."));
-constant DebugFlag DUMP = DEBUG_FLAG(29, "dump", false,
+constant DebugFlag DUMP = DEBUG_FLAG("dump", false,
   Gettext.gettext("Dumps the absyn representation of a program."));
-constant DebugFlag DUMP_GRAPHVIZ = DEBUG_FLAG(30, "graphviz", false,
+constant DebugFlag DUMP_GRAPHVIZ = DEBUG_FLAG("graphviz", false,
   Gettext.gettext("Dumps the absyn representation of a program in graphviz format."));
-constant DebugFlag EXEC_STAT = DEBUG_FLAG(31, "execstat", false,
+constant DebugFlag EXEC_STAT = DEBUG_FLAG("execstat", false,
   Gettext.gettext("Prints out execution statistics for the compiler."));
-constant DebugFlag TRANSFORMS_BEFORE_DUMP = DEBUG_FLAG(32, "transformsbeforedump", false,
+constant DebugFlag TRANSFORMS_BEFORE_DUMP = DEBUG_FLAG("transformsbeforedump", false,
   Gettext.gettext("Applies transformations required for code generation before dumping flat code."));
-constant DebugFlag DAE_DUMP_GRAPHV = DEBUG_FLAG(33, "daedumpgraphv", false,
+constant DebugFlag DAE_DUMP_GRAPHV = DEBUG_FLAG("daedumpgraphv", false,
   Gettext.gettext("Dumps the DAE in graphviz format."));
-constant DebugFlag INTERACTIVE_TCP = DEBUG_FLAG(34, "interactive", false,
+constant DebugFlag INTERACTIVE_TCP = DEBUG_FLAG("interactive", false,
   Gettext.gettext("Starts omc as a server listening on the socket interface."));
-constant DebugFlag INTERACTIVE_CORBA = DEBUG_FLAG(35, "interactiveCorba", false,
+constant DebugFlag INTERACTIVE_CORBA = DEBUG_FLAG("interactiveCorba", false,
   Gettext.gettext("Starts omc as a server listening on the Corba interface."));
-constant DebugFlag INTERACTIVE_DUMP = DEBUG_FLAG(36, "interactivedump", false,
+constant DebugFlag INTERACTIVE_DUMP = DEBUG_FLAG("interactivedump", false,
   Gettext.gettext("Prints out debug information for the interactive server."));
-constant DebugFlag RELIDX = DEBUG_FLAG(37, "relidx", false,
+constant DebugFlag RELIDX = DEBUG_FLAG("relidx", false,
   Gettext.notrans("Prints out debug information about relations, that are used as zero crossings."));
-constant DebugFlag DUMP_REPL = DEBUG_FLAG(38, "dumprepl", false,
+constant DebugFlag DUMP_REPL = DEBUG_FLAG("dumprepl", false,
   Gettext.gettext("Dump the found replacements for simple equation removal."));
-constant DebugFlag DUMP_FP_REPL = DEBUG_FLAG(39, "dumpFPrepl", false,
+constant DebugFlag DUMP_FP_REPL = DEBUG_FLAG("dumpFPrepl", false,
   Gettext.gettext("Dump the found replacements for final parameters."));
-constant DebugFlag DUMP_PARAM_REPL = DEBUG_FLAG(40, "dumpParamrepl", false,
+constant DebugFlag DUMP_PARAM_REPL = DEBUG_FLAG("dumpParamrepl", false,
   Gettext.gettext("Dump the found replacements for remove parameters."));
-constant DebugFlag DUMP_PP_REPL = DEBUG_FLAG(41, "dumpPPrepl", false,
+constant DebugFlag DUMP_PP_REPL = DEBUG_FLAG("dumpPPrepl", false,
   Gettext.gettext("Dump the found replacements for protected parameters."));
-constant DebugFlag DUMP_EA_REPL = DEBUG_FLAG(42, "dumpEArepl", false,
+constant DebugFlag DUMP_EA_REPL = DEBUG_FLAG("dumpEArepl", false,
   Gettext.gettext("Dump the found replacements for evaluate annotations (evaluate=true) parameters."));
-constant DebugFlag DEBUG_ALIAS = DEBUG_FLAG(43, "debugAlias", false,
+constant DebugFlag DEBUG_ALIAS = DEBUG_FLAG("debugAlias", false,
   Gettext.gettext("Dumps some information about the process of removeSimpleEquations."));
-constant DebugFlag TEARING_DUMP = DEBUG_FLAG(44, "tearingdump", false,
+constant DebugFlag TEARING_DUMP = DEBUG_FLAG("tearingdump", false,
   Gettext.gettext("Dumps tearing information."));
-constant DebugFlag JAC_DUMP = DEBUG_FLAG(45, "symjacdump", false,
+constant DebugFlag JAC_DUMP = DEBUG_FLAG("symjacdump", false,
   Gettext.gettext("Dumps information about symbolic Jacobians. Can be used only with postOptModules: generateSymbolicJacobian, generateSymbolicLinearization."));
-constant DebugFlag JAC_DUMP2 = DEBUG_FLAG(46, "symjacdumpverbose", false,
+constant DebugFlag JAC_DUMP2 = DEBUG_FLAG("symjacdumpverbose", false,
   Gettext.gettext("Dumps information in verbose mode about symbolic Jacobians. Can be used only with postOptModules: generateSymbolicJacobian, generateSymbolicLinearization."));
-constant DebugFlag JAC_DUMP_EQN = DEBUG_FLAG(47, "symjacdumpeqn", false,
+constant DebugFlag JAC_DUMP_EQN = DEBUG_FLAG("symjacdumpeqn", false,
   Gettext.gettext("Dump for debug purpose of symbolic Jacobians. (deactivated now)."));
-constant DebugFlag JAC_WARNINGS = DEBUG_FLAG(48, "symjacwarnings", false,
+constant DebugFlag JAC_WARNINGS = DEBUG_FLAG("symjacwarnings", false,
   Gettext.gettext("Prints warnings regarding symoblic jacbians."));
-constant DebugFlag DUMP_SPARSE = DEBUG_FLAG(49, "dumpSparsePattern", false,
+constant DebugFlag DUMP_SPARSE = DEBUG_FLAG("dumpSparsePattern", false,
   Gettext.gettext("Dumps sparse pattern with coloring used for simulation."));
-constant DebugFlag DUMP_SPARSE_VERBOSE = DEBUG_FLAG(50, "dumpSparsePatternVerbose", false,
+constant DebugFlag DUMP_SPARSE_VERBOSE = DEBUG_FLAG("dumpSparsePatternVerbose", false,
   Gettext.gettext("Dumps in verbose mode sparse pattern with coloring used for simulation."));
-constant DebugFlag BLT_DUMP = DEBUG_FLAG(51, "bltdump", false,
+constant DebugFlag BLT_DUMP = DEBUG_FLAG("bltdump", false,
   Gettext.gettext("Dumps information from index reduction."));
-constant DebugFlag DUMMY_SELECT = DEBUG_FLAG(52, "dummyselect", false,
+constant DebugFlag DUMMY_SELECT = DEBUG_FLAG("dummyselect", false,
   Gettext.gettext("Dumps information from dummy state selection heuristic."));
-constant DebugFlag DUMP_DAE_LOW = DEBUG_FLAG(53, "dumpdaelow", false,
+constant DebugFlag DUMP_DAE_LOW = DEBUG_FLAG("dumpdaelow", false,
   Gettext.gettext("Dumps the equation system at the beginning of the back end."));
-constant DebugFlag DUMP_INDX_DAE = DEBUG_FLAG(54, "dumpindxdae", false,
+constant DebugFlag DUMP_INDX_DAE = DEBUG_FLAG("dumpindxdae", false,
   Gettext.gettext("Dumps the equation system after index reduction and optimization."));
-constant DebugFlag OPT_DAE_DUMP = DEBUG_FLAG(55, "optdaedump", false,
+constant DebugFlag OPT_DAE_DUMP = DEBUG_FLAG("optdaedump", false,
   Gettext.gettext("Dumps information from the optimization modules."));
-constant DebugFlag EXEC_HASH = DEBUG_FLAG(56, "execHash", false,
+constant DebugFlag EXEC_HASH = DEBUG_FLAG("execHash", false,
   Gettext.gettext("Measures the time it takes to hash all simcode variables before code generation."));
-constant DebugFlag PARAM_DLOW_DUMP = DEBUG_FLAG(57, "paramdlowdump", false,
+constant DebugFlag PARAM_DLOW_DUMP = DEBUG_FLAG("paramdlowdump", false,
   Gettext.gettext("Enables dumping of the parameters in the order they are calculated."));
-constant DebugFlag DUMP_ENCAPSULATECONDITIONS = DEBUG_FLAG(58, "dumpEncapsulateConditions", false,
+constant DebugFlag DUMP_ENCAPSULATECONDITIONS = DEBUG_FLAG("dumpEncapsulateConditions", false,
   Gettext.gettext("Dumps the results of the preOptModule encapsulateWhenConditions."));
-constant DebugFlag SHORT_OUTPUT = DEBUG_FLAG(59, "shortOutput", false,
+constant DebugFlag SHORT_OUTPUT = DEBUG_FLAG("shortOutput", false,
   Gettext.gettext("Enables short output of the simulate() command. Useful for tools like OMNotebook."));
-constant DebugFlag COUNT_OPERATIONS = DEBUG_FLAG(60, "countOperations", false,
+constant DebugFlag COUNT_OPERATIONS = DEBUG_FLAG("countOperations", false,
   Gettext.gettext("Count operations."));
-constant DebugFlag CGRAPH = DEBUG_FLAG(61, "cgraph", false,
+constant DebugFlag CGRAPH = DEBUG_FLAG("cgraph", false,
   Gettext.gettext("Prints out connection graph information."));
-constant DebugFlag UPDMOD = DEBUG_FLAG(62, "updmod", false,
+constant DebugFlag UPDMOD = DEBUG_FLAG("updmod", false,
   Gettext.gettext("Prints information about modification updates."));
-constant DebugFlag STATIC = DEBUG_FLAG(63, "static", false,
+constant DebugFlag STATIC = DEBUG_FLAG("static", false,
   Gettext.gettext("Enables extra debug output from the static elaboration."));
-constant DebugFlag TPL_PERF_TIMES = DEBUG_FLAG(64, "tplPerfTimes", false,
+constant DebugFlag TPL_PERF_TIMES = DEBUG_FLAG("tplPerfTimes", false,
   Gettext.gettext("Enables output of template performance data for rendering text to file."));
-constant DebugFlag CHECK_SIMPLIFY = DEBUG_FLAG(65, "checkSimplify", false,
+constant DebugFlag CHECK_SIMPLIFY = DEBUG_FLAG("checkSimplify", false,
   Gettext.gettext("Enables checks for expression simplification and prints a notification whenever an undesirable transformation has been performed."));
-constant DebugFlag SCODE_INST = DEBUG_FLAG(66, "newInst", true,
+constant DebugFlag SCODE_INST = DEBUG_FLAG("newInst", true,
   Gettext.gettext("Enables new instantiation phase."));
-constant DebugFlag WRITE_TO_BUFFER = DEBUG_FLAG(67, "writeToBuffer", false,
+constant DebugFlag WRITE_TO_BUFFER = DEBUG_FLAG("writeToBuffer", false,
   Gettext.gettext("Enables writing simulation results to buffer."));
-constant DebugFlag DUMP_BACKENDDAE_INFO = DEBUG_FLAG(68, "backenddaeinfo", false,
+constant DebugFlag DUMP_BACKENDDAE_INFO = DEBUG_FLAG("backenddaeinfo", false,
   Gettext.gettext("Enables dumping of back-end information about system (Number of equations before back-end,...)."));
-constant DebugFlag GEN_DEBUG_SYMBOLS = DEBUG_FLAG(69, "gendebugsymbols", false,
+constant DebugFlag GEN_DEBUG_SYMBOLS = DEBUG_FLAG("gendebugsymbols", false,
   Gettext.gettext("Generate code with debugging symbols."));
-constant DebugFlag DUMP_STATESELECTION_INFO = DEBUG_FLAG(70, "stateselection", false,
+constant DebugFlag DUMP_STATESELECTION_INFO = DEBUG_FLAG("stateselection", false,
   Gettext.gettext("Enables dumping of selected states. Extends -d=backenddaeinfo."));
-constant DebugFlag DUMP_EQNINORDER = DEBUG_FLAG(71, "dumpeqninorder", false,
+constant DebugFlag DUMP_EQNINORDER = DEBUG_FLAG("dumpeqninorder", false,
   Gettext.gettext("Enables dumping of the equations in the order they are calculated."));
-constant DebugFlag SEMILINEAR = DEBUG_FLAG(72, "semiLinear", false,
+constant DebugFlag SEMILINEAR = DEBUG_FLAG("semiLinear", false,
   Gettext.gettext("Enables dumping of the optimization information when optimizing calls to semiLinear."));
-constant DebugFlag UNCERTAINTIES = DEBUG_FLAG(73, "uncertainties", false,
+constant DebugFlag UNCERTAINTIES = DEBUG_FLAG("uncertainties", false,
   Gettext.gettext("Enables dumping of status when calling modelEquationsUC."));
-constant DebugFlag SHOW_START_ORIGIN = DEBUG_FLAG(74, "showStartOrigin", false,
+constant DebugFlag SHOW_START_ORIGIN = DEBUG_FLAG("showStartOrigin", false,
   Gettext.gettext("Enables dumping of the DAE startOrigin attribute of the variables."));
-constant DebugFlag DUMP_SIMCODE = DEBUG_FLAG(75, "dumpSimCode", false,
+constant DebugFlag DUMP_SIMCODE = DEBUG_FLAG("dumpSimCode", false,
   Gettext.gettext("Dumps the simCode model used for code generation."));
-constant DebugFlag DUMP_INITIAL_SYSTEM = DEBUG_FLAG(76, "dumpinitialsystem", false,
+constant DebugFlag DUMP_INITIAL_SYSTEM = DEBUG_FLAG("dumpinitialsystem", false,
   Gettext.gettext("Dumps the initial equation system."));
-constant DebugFlag GRAPH_INST = DEBUG_FLAG(77, "graphInst", false,
+constant DebugFlag GRAPH_INST = DEBUG_FLAG("graphInst", false,
   Gettext.gettext("Do graph based instantiation."));
-constant DebugFlag GRAPH_INST_RUN_DEP = DEBUG_FLAG(78, "graphInstRunDep", false,
+constant DebugFlag GRAPH_INST_RUN_DEP = DEBUG_FLAG("graphInstRunDep", false,
   Gettext.gettext("Run scode dependency analysis. Use with -d=graphInst"));
-constant DebugFlag GRAPH_INST_GEN_GRAPH = DEBUG_FLAG(79, "graphInstGenGraph", false,
+constant DebugFlag GRAPH_INST_GEN_GRAPH = DEBUG_FLAG("graphInstGenGraph", false,
   Gettext.gettext("Dumps a graph of the program. Use with -d=graphInst"));
-constant DebugFlag DUMP_CONST_REPL = DEBUG_FLAG(80, "dumpConstrepl", false,
+constant DebugFlag DUMP_CONST_REPL = DEBUG_FLAG("dumpConstrepl", false,
   Gettext.gettext("Dump the found replacements for constants."));
-constant DebugFlag SHOW_EQUATION_SOURCE = DEBUG_FLAG(81, "showEquationSource", false,
+constant DebugFlag SHOW_EQUATION_SOURCE = DEBUG_FLAG("showEquationSource", false,
   Gettext.gettext("Display the element source information in the dumped DAE for easier debugging."));
-constant DebugFlag LS_ANALYTIC_JACOBIAN = DEBUG_FLAG(82, "LSanalyticJacobian", false,
+constant DebugFlag LS_ANALYTIC_JACOBIAN = DEBUG_FLAG("LSanalyticJacobian", false,
   Gettext.gettext("Enables analytical jacobian for linear strong components. Defaults to false"));
-constant DebugFlag NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG(83, "NLSanalyticJacobian", true,
+constant DebugFlag NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG("NLSanalyticJacobian", true,
   Gettext.gettext("Enables analytical jacobian for non-linear strong components without user-defined function calls, for that see forceNLSanalyticJacobian"));
-constant DebugFlag INLINE_SOLVER = DEBUG_FLAG(84, "inlineSolver", false,
+constant DebugFlag INLINE_SOLVER = DEBUG_FLAG("inlineSolver", false,
   Gettext.gettext("Generates code for inline solver."));
-constant DebugFlag HPCOM = DEBUG_FLAG(85, "hpcom", false,
+constant DebugFlag HPCOM = DEBUG_FLAG("hpcom", false,
   Gettext.gettext("Enables parallel calculation based on task-graphs."));
-constant DebugFlag INITIALIZATION = DEBUG_FLAG(86, "initialization", false,
+constant DebugFlag INITIALIZATION = DEBUG_FLAG("initialization", false,
   Gettext.gettext("Shows additional information from the initialization process."));
-constant DebugFlag INLINE_FUNCTIONS = DEBUG_FLAG(87, "inlineFunctions", true,
+constant DebugFlag INLINE_FUNCTIONS = DEBUG_FLAG("inlineFunctions", true,
   Gettext.gettext("Controls if function inlining should be performed."));
-constant DebugFlag DUMP_SCC_GRAPHML = DEBUG_FLAG(88, "dumpSCCGraphML", false,
+constant DebugFlag DUMP_SCC_GRAPHML = DEBUG_FLAG("dumpSCCGraphML", false,
   Gettext.gettext("Dumps graphml files with the strongly connected components."));
-constant DebugFlag TEARING_DUMPVERBOSE = DEBUG_FLAG(89, "tearingdumpV", false,
+constant DebugFlag TEARING_DUMPVERBOSE = DEBUG_FLAG("tearingdumpV", false,
   Gettext.gettext("Dumps verbose tearing information."));
-constant DebugFlag DISABLE_SINGLE_FLOW_EQ = DEBUG_FLAG(90, "disableSingleFlowEq", false,
+constant DebugFlag DISABLE_SINGLE_FLOW_EQ = DEBUG_FLAG("disableSingleFlowEq", false,
   Gettext.gettext("Disables the generation of single flow equations."));
-constant DebugFlag DUMP_DISCRETEVARS_INFO = DEBUG_FLAG(91, "discreteinfo", false,
+constant DebugFlag DUMP_DISCRETEVARS_INFO = DEBUG_FLAG("discreteinfo", false,
   Gettext.gettext("Enables dumping of discrete variables. Extends -d=backenddaeinfo."));
-constant DebugFlag ADDITIONAL_GRAPHVIZ_DUMP = DEBUG_FLAG(92, "graphvizDump", false,
+constant DebugFlag ADDITIONAL_GRAPHVIZ_DUMP = DEBUG_FLAG("graphvizDump", false,
   Gettext.gettext("Activates additional graphviz dumps (as .dot files). It can be used in addition to one of the following flags: {dumpdaelow|dumpinitialsystems|dumpindxdae}."));
-constant DebugFlag INFO_XML_OPERATIONS = DEBUG_FLAG(93, "infoXmlOperations", false,
+constant DebugFlag INFO_XML_OPERATIONS = DEBUG_FLAG("infoXmlOperations", false,
   Gettext.gettext("Enables output of the operations in the _info.xml file when translating models."));
-constant DebugFlag HPCOM_DUMP = DEBUG_FLAG(94, "hpcomDump", false,
+constant DebugFlag HPCOM_DUMP = DEBUG_FLAG("hpcomDump", false,
   Gettext.gettext("Dumps additional information on the parallel execution with hpcom."));
-constant DebugFlag RESOLVE_LOOPS_DUMP = DEBUG_FLAG(95, "resolveLoopsDump", false,
+constant DebugFlag RESOLVE_LOOPS_DUMP = DEBUG_FLAG("resolveLoopsDump", false,
   Gettext.gettext("Debug Output for ResolveLoops Module."));
-constant DebugFlag DISABLE_WINDOWS_PATH_CHECK_WARNING = DEBUG_FLAG(96, "disableWindowsPathCheckWarning", false,
+constant DebugFlag DISABLE_WINDOWS_PATH_CHECK_WARNING = DEBUG_FLAG("disableWindowsPathCheckWarning", false,
   Gettext.gettext("Disables warnings on Windows if OPENMODELICAHOME/MinGW is missing."));
-constant DebugFlag DISABLE_RECORD_CONSTRUCTOR_OUTPUT = DEBUG_FLAG(97, "disableRecordConstructorOutput", false,
+constant DebugFlag DISABLE_RECORD_CONSTRUCTOR_OUTPUT = DEBUG_FLAG("disableRecordConstructorOutput", false,
   Gettext.gettext("Disables output of record constructors in the flat code."));
-constant DebugFlag IMPL_ODE = DEBUG_FLAG(98, "implOde", false,
+constant DebugFlag IMPL_ODE = DEBUG_FLAG("implOde", false,
   Gettext.gettext("activates implicit codegen"));
-constant DebugFlag EVAL_FUNC_DUMP = DEBUG_FLAG(99, "evalFuncDump", false,
+constant DebugFlag EVAL_FUNC_DUMP = DEBUG_FLAG("evalFuncDump", false,
   Gettext.gettext("dumps debug information about the function evaluation"));
-constant DebugFlag PRINT_STRUCTURAL = DEBUG_FLAG(100, "printStructuralParameters", false,
+constant DebugFlag PRINT_STRUCTURAL = DEBUG_FLAG("printStructuralParameters", false,
   Gettext.gettext("Prints the structural parameters identified by the front-end"));
-constant DebugFlag ITERATION_VARS = DEBUG_FLAG(101, "iterationVars", false,
+constant DebugFlag ITERATION_VARS = DEBUG_FLAG("iterationVars", false,
   Gettext.gettext("Shows a list of all iteration variables."));
-constant DebugFlag ALLOW_RECORD_TOO_MANY_FIELDS = DEBUG_FLAG(102, "acceptTooManyFields", false,
+constant DebugFlag ALLOW_RECORD_TOO_MANY_FIELDS = DEBUG_FLAG("acceptTooManyFields", false,
   Gettext.gettext("Accepts passing records with more fields than expected to a function. This is not allowed, but is used in Fluid.Dissipation. See https://trac.modelica.org/Modelica/ticket/1245 for details."));
-constant DebugFlag HPCOM_MEMORY_OPT = DEBUG_FLAG(103, "hpcomMemoryOpt", false,
+constant DebugFlag HPCOM_MEMORY_OPT = DEBUG_FLAG("hpcomMemoryOpt", false,
   Gettext.gettext("Optimize the memory structure regarding the selected scheduler"));
-constant DebugFlag DUMP_SYNCHRONOUS = DEBUG_FLAG(104, "dumpSynchronous", false,
+constant DebugFlag DUMP_SYNCHRONOUS = DEBUG_FLAG("dumpSynchronous", false,
   Gettext.gettext("Dumps information of the clock partitioning."));
-constant DebugFlag STRIP_PREFIX = DEBUG_FLAG(105, "stripPrefix", true,
+constant DebugFlag STRIP_PREFIX = DEBUG_FLAG("stripPrefix", true,
   Gettext.gettext("Strips the environment prefix from path/crefs. Defaults to true."));
-constant DebugFlag DO_SCODE_DEP = DEBUG_FLAG(106, "scodeDep", true,
+constant DebugFlag DO_SCODE_DEP = DEBUG_FLAG("scodeDep", true,
   Gettext.gettext("Does scode dependency analysis prior to instantiation. Defaults to true."));
-constant DebugFlag SHOW_INST_CACHE_INFO = DEBUG_FLAG(107, "showInstCacheInfo", false,
+constant DebugFlag SHOW_INST_CACHE_INFO = DEBUG_FLAG("showInstCacheInfo", false,
   Gettext.gettext("Prints information about instantiation cache hits and additions. Defaults to false."));
-constant DebugFlag DUMP_UNIT = DEBUG_FLAG(108, "dumpUnits", false,
+constant DebugFlag DUMP_UNIT = DEBUG_FLAG("dumpUnits", false,
   Gettext.gettext("Dumps all the calculated units."));
-constant DebugFlag DUMP_EQ_UNIT = DEBUG_FLAG(109, "dumpEqInUC", false,
+constant DebugFlag DUMP_EQ_UNIT = DEBUG_FLAG("dumpEqInUC", false,
   Gettext.gettext("Dumps all equations handled by the unit checker."));
-constant DebugFlag DUMP_EQ_UNIT_STRUCT = DEBUG_FLAG(110, "dumpEqUCStruct", false,
+constant DebugFlag DUMP_EQ_UNIT_STRUCT = DEBUG_FLAG("dumpEqUCStruct", false,
   Gettext.gettext("Dumps all the equations handled by the unit checker as tree-structure."));
-constant DebugFlag SHOW_DAE_GENERATION = DEBUG_FLAG(111, "showDaeGeneration", false,
+constant DebugFlag SHOW_DAE_GENERATION = DEBUG_FLAG("showDaeGeneration", false,
   Gettext.gettext("Show the dae variable declarations as they happen."));
-constant DebugFlag RESHUFFLE_POST = DEBUG_FLAG(112, "reshufflePost", false,
+constant DebugFlag RESHUFFLE_POST = DEBUG_FLAG("reshufflePost", false,
   Gettext.gettext("Reshuffles the systems of equations."));
-constant DebugFlag SHOW_EXPANDABLE_INFO = DEBUG_FLAG(113, "showExpandableInfo", false,
+constant DebugFlag SHOW_EXPANDABLE_INFO = DEBUG_FLAG("showExpandableInfo", false,
   Gettext.gettext("Show information about expandable connector handling."));
-constant DebugFlag DUMP_HOMOTOPY = DEBUG_FLAG(114, "dumpHomotopy", false,
+constant DebugFlag DUMP_HOMOTOPY = DEBUG_FLAG("dumpHomotopy", false,
   Gettext.gettext("Dumps the results of the postOptModule optimizeHomotopyCalls."));
-constant DebugFlag OMC_RELOCATABLE_FUNCTIONS = DEBUG_FLAG(115, "relocatableFunctions", false,
+constant DebugFlag OMC_RELOCATABLE_FUNCTIONS = DEBUG_FLAG("relocatableFunctions", false,
   Gettext.gettext("Generates relocatable code: all functions become function pointers and can be replaced at run-time."));
-constant DebugFlag GRAPHML = DEBUG_FLAG(116, "graphml", false,
+constant DebugFlag GRAPHML = DEBUG_FLAG("graphml", false,
   Gettext.gettext("Dumps .graphml files for the bipartite graph after Index Reduction and a task graph for the SCCs. Can be displayed with yEd. "));
-constant DebugFlag USEMPI = DEBUG_FLAG(117, "useMPI", false,
+constant DebugFlag USEMPI = DEBUG_FLAG("useMPI", false,
   Gettext.gettext("Add MPI init and finalize to main method (CPPruntime). "));
-constant DebugFlag DUMP_CSE = DEBUG_FLAG(118, "dumpCSE", false,
+constant DebugFlag DUMP_CSE = DEBUG_FLAG("dumpCSE", false,
   Gettext.gettext("Additional output for CSE module."));
-constant DebugFlag DUMP_CSE_VERBOSE = DEBUG_FLAG(119, "dumpCSE_verbose", false,
+constant DebugFlag DUMP_CSE_VERBOSE = DEBUG_FLAG("dumpCSE_verbose", false,
   Gettext.gettext("Additional output for CSE module."));
-constant DebugFlag NO_START_CALC = DEBUG_FLAG(120, "disableStartCalc", false,
+constant DebugFlag NO_START_CALC = DEBUG_FLAG("disableStartCalc", false,
   Gettext.gettext("Deactivates the pre-calculation of start values during compile-time."));
-constant DebugFlag CONSTJAC = DEBUG_FLAG(121, "constjac", false,
+constant DebugFlag CONSTJAC = DEBUG_FLAG("constjac", false,
   Gettext.gettext("solves linear systems with constant Jacobian and variable b-Vector symbolically"));
-constant DebugFlag VISUAL_XML = DEBUG_FLAG(122, "visxml", false,
+constant DebugFlag VISUAL_XML = DEBUG_FLAG("visxml", false,
   Gettext.gettext("Outputs a xml-file that contains information for visualization."));
-constant DebugFlag VECTORIZE = DEBUG_FLAG(123, "vectorize", false,
+constant DebugFlag VECTORIZE = DEBUG_FLAG("vectorize", false,
   Gettext.gettext("Activates vectorization in the backend."));
-constant DebugFlag CHECK_EXT_LIBS = DEBUG_FLAG(124, "buildExternalLibs", true,
+constant DebugFlag CHECK_EXT_LIBS = DEBUG_FLAG("buildExternalLibs", true,
   Gettext.gettext("Use the autotools project in the Resources folder of the library to build missing external libraries."));
-constant DebugFlag RUNTIME_STATIC_LINKING = DEBUG_FLAG(125, "runtimeStaticLinking", false,
+constant DebugFlag RUNTIME_STATIC_LINKING = DEBUG_FLAG("runtimeStaticLinking", false,
   Gettext.gettext("Use the static simulation runtime libraries (C++ simulation runtime)."));
-constant DebugFlag SORT_EQNS_AND_VARS = DEBUG_FLAG(126, "dumpSortEqnsAndVars", false,
+constant DebugFlag SORT_EQNS_AND_VARS = DEBUG_FLAG("dumpSortEqnsAndVars", false,
   Gettext.gettext("Dumps debug output for the modules sortEqnsVars."));
-constant DebugFlag DUMP_SIMPLIFY_LOOPS = DEBUG_FLAG(127, "dumpSimplifyLoops", false,
+constant DebugFlag DUMP_SIMPLIFY_LOOPS = DEBUG_FLAG("dumpSimplifyLoops", false,
   Gettext.gettext("Dump between steps of simplifyLoops"));
-constant DebugFlag DUMP_RTEARING = DEBUG_FLAG(128, "dumpRecursiveTearing", false,
+constant DebugFlag DUMP_RTEARING = DEBUG_FLAG("dumpRecursiveTearing", false,
   Gettext.gettext("Dump between steps of recursiveTearing"));
-constant DebugFlag DIS_SYMJAC_FMI20 = DEBUG_FLAG(129, "disableDirectionalDerivatives", true,
+constant DebugFlag DIS_SYMJAC_FMI20 = DEBUG_FLAG("disableDirectionalDerivatives", true,
   Gettext.gettext("For FMI 2.0 only dependecy analysis will be perform."));
-constant DebugFlag EVAL_OUTPUT_ONLY = DEBUG_FLAG(130, "evalOutputOnly", false,
+constant DebugFlag EVAL_OUTPUT_ONLY = DEBUG_FLAG("evalOutputOnly", false,
   Gettext.gettext("Generates equations to calculate top level outputs only."));
-constant DebugFlag HARDCODED_START_VALUES = DEBUG_FLAG(131, "hardcodedStartValues", false,
+constant DebugFlag HARDCODED_START_VALUES = DEBUG_FLAG("hardcodedStartValues", false,
   Gettext.gettext("Embed the start values of variables and parameters into the c++ code and do not read it from xml file."));
-constant DebugFlag DUMP_FUNCTIONS = DEBUG_FLAG(132, "dumpFunctions", false,
+constant DebugFlag DUMP_FUNCTIONS = DEBUG_FLAG("dumpFunctions", false,
   Gettext.gettext("Add functions to backend dumps."));
-constant DebugFlag DEBUG_DIFFERENTIATION = DEBUG_FLAG(133, "debugDifferentiation", false,
+constant DebugFlag DEBUG_DIFFERENTIATION = DEBUG_FLAG("debugDifferentiation", false,
   Gettext.gettext("Dumps debug output for the differentiation process."));
-constant DebugFlag DEBUG_DIFFERENTIATION_VERBOSE = DEBUG_FLAG(134, "debugDifferentiationVerbose", false,
+constant DebugFlag DEBUG_DIFFERENTIATION_VERBOSE = DEBUG_FLAG("debugDifferentiationVerbose", false,
   Gettext.gettext("Dumps verbose debug output for the differentiation process."));
-constant DebugFlag FMU_EXPERIMENTAL = DEBUG_FLAG(135, "fmuExperimental", false,
+constant DebugFlag FMU_EXPERIMENTAL = DEBUG_FLAG("fmuExperimental", false,
   Gettext.gettext("Adds features to the FMI export that are considered experimental as of now: fmi2GetSpecificDerivatives, canGetSetFMUState, canSerializeFMUstate"));
-constant DebugFlag DUMP_DGESV = DEBUG_FLAG(136, "dumpdgesv", false,
+constant DebugFlag DUMP_DGESV = DEBUG_FLAG("dumpdgesv", false,
   Gettext.gettext("Enables dumping of the information whether DGESV is used to solve linear systems."));
-constant DebugFlag MULTIRATE_PARTITION = DEBUG_FLAG(137, "multirate", false,
+constant DebugFlag MULTIRATE_PARTITION = DEBUG_FLAG("multirate", false,
   Gettext.gettext("The solver can switch partitions in the system."));
-constant DebugFlag DUMP_EXCLUDED_EXP = DEBUG_FLAG(138, "dumpExcludedSymJacExps", false,
+constant DebugFlag DUMP_EXCLUDED_EXP = DEBUG_FLAG("dumpExcludedSymJacExps", false,
   Gettext.gettext("This flags dumps all expression that are excluded from differentiation of a symbolic Jacobian."));
-constant DebugFlag DEBUG_ALGLOOP_JACOBIAN = DEBUG_FLAG(139, "debugAlgebraicLoopsJacobian", false,
+constant DebugFlag DEBUG_ALGLOOP_JACOBIAN = DEBUG_FLAG("debugAlgebraicLoopsJacobian", false,
   Gettext.gettext("Dumps debug output while creating symbolic jacobians for non-linear systems."));
-constant DebugFlag DISABLE_JACSCC = DEBUG_FLAG(140, "disableJacsforSCC", false,
+constant DebugFlag DISABLE_JACSCC = DEBUG_FLAG("disableJacsforSCC", false,
   Gettext.gettext("Disables calculation of jacobians to detect if a SCC is linear or non-linear. By disabling all SCC will handled like non-linear."));
-constant DebugFlag FORCE_NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG(141, "forceNLSanalyticJacobian", false,
+constant DebugFlag FORCE_NLS_ANALYTIC_JACOBIAN = DEBUG_FLAG("forceNLSanalyticJacobian", false,
   Gettext.gettext("Forces calculation analytical jacobian also for non-linear strong components with user-defined functions."));
-constant DebugFlag DUMP_LOOPS = DEBUG_FLAG(142, "dumpLoops", false,
+constant DebugFlag DUMP_LOOPS = DEBUG_FLAG("dumpLoops", false,
   Gettext.gettext("Dumps loop equation."));
-constant DebugFlag DUMP_LOOPS_VERBOSE = DEBUG_FLAG(143, "dumpLoopsVerbose", false,
+constant DebugFlag DUMP_LOOPS_VERBOSE = DEBUG_FLAG("dumpLoopsVerbose", false,
   Gettext.gettext("Dumps loop equation and enhanced adjacency matrix."));
-constant DebugFlag SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR = DEBUG_FLAG(144, "skipInputOutputSyntacticSugar", false,
+constant DebugFlag SKIP_INPUT_OUTPUT_SYNTACTIC_SUGAR = DEBUG_FLAG("skipInputOutputSyntacticSugar", false,
   Gettext.gettext("Used when bootstrapping to preserve the input output parsing of the code output by the list command."));
-constant DebugFlag OMC_RECORD_ALLOC_WORDS = DEBUG_FLAG(145, "metaModelicaRecordAllocWords", false,
+constant DebugFlag OMC_RECORD_ALLOC_WORDS = DEBUG_FLAG("metaModelicaRecordAllocWords", false,
   Gettext.gettext("Instrument the source code to record memory allocations (requires run-time and generated files compiled with -DOMC_RECORD_ALLOC_WORDS)."));
-constant DebugFlag TOTAL_TEARING_DUMP = DEBUG_FLAG(146, "totaltearingdump", false,
+constant DebugFlag TOTAL_TEARING_DUMP = DEBUG_FLAG("totaltearingdump", false,
   Gettext.gettext("Dumps total tearing information."));
-constant DebugFlag TOTAL_TEARING_DUMPVERBOSE = DEBUG_FLAG(147, "totaltearingdumpV", false,
+constant DebugFlag TOTAL_TEARING_DUMPVERBOSE = DEBUG_FLAG("totaltearingdumpV", false,
   Gettext.gettext("Dumps verbose total tearing information."));
-constant DebugFlag PARALLEL_CODEGEN = DEBUG_FLAG(148, "parallelCodegen", true,
+constant DebugFlag PARALLEL_CODEGEN = DEBUG_FLAG("parallelCodegen", true,
   Gettext.gettext("Enables code generation in parallel (disable this if compiling a model causes you to run out of RAM)."));
-constant DebugFlag SERIALIZED_SIZE = DEBUG_FLAG(149, "reportSerializedSize", false,
+constant DebugFlag SERIALIZED_SIZE = DEBUG_FLAG("reportSerializedSize", false,
   Gettext.gettext("Reports serialized sizes of various data structures used in the compiler."));
-constant DebugFlag BACKEND_KEEP_ENV_GRAPH = DEBUG_FLAG(150, "backendKeepEnv", true,
+constant DebugFlag BACKEND_KEEP_ENV_GRAPH = DEBUG_FLAG("backendKeepEnv", true,
   Gettext.gettext("When enabled, the environment is kept when entering the backend, which enables CevalFunction (function interpretation) to work. This module not essential for the backend to function in most cases, but can improve simulation performance by evaluating functions. The drawback to keeping the environment graph in memory is that it is huge (~80% of the total memory in use when returning the frontend DAE)."));
-constant DebugFlag DUMPBACKENDINLINE = DEBUG_FLAG(151, "dumpBackendInline", false,
+constant DebugFlag DUMPBACKENDINLINE = DEBUG_FLAG("dumpBackendInline", false,
   Gettext.gettext("Dumps debug output while inline function."));
-constant DebugFlag DUMPBACKENDINLINE_VERBOSE = DEBUG_FLAG(152, "dumpBackendInlineVerbose", false,
+constant DebugFlag DUMPBACKENDINLINE_VERBOSE = DEBUG_FLAG("dumpBackendInlineVerbose", false,
   Gettext.gettext("Dumps debug output while inline function."));
-constant DebugFlag BLT_MATRIX_DUMP = DEBUG_FLAG(153, "bltmatrixdump", false,
+constant DebugFlag BLT_MATRIX_DUMP = DEBUG_FLAG("bltmatrixdump", false,
   Gettext.gettext("Dumps the blt matrix in html file. IE seems to be very good in displaying large matrices."));
-constant DebugFlag LIST_REVERSE_WRONG_ORDER = DEBUG_FLAG(154, "listAppendWrongOrder", true,
+constant DebugFlag LIST_REVERSE_WRONG_ORDER = DEBUG_FLAG("listAppendWrongOrder", true,
   Gettext.gettext("Print notifications about bad usage of listAppend."));
-constant DebugFlag PARTITION_INITIALIZATION = DEBUG_FLAG(155, "partitionInitialization", true,
+constant DebugFlag PARTITION_INITIALIZATION = DEBUG_FLAG("partitionInitialization", true,
   Gettext.gettext("This flag controls if partitioning is applied to the initialization system."));
-constant DebugFlag EVAL_PARAM_DUMP = DEBUG_FLAG(156, "evalParameterDump", false,
+constant DebugFlag EVAL_PARAM_DUMP = DEBUG_FLAG("evalParameterDump", false,
   Gettext.gettext("Dumps information for evaluating parameters."));
-constant DebugFlag NF_UNITCHECK = DEBUG_FLAG(157, "frontEndUnitCheck", false,
+constant DebugFlag NF_UNITCHECK = DEBUG_FLAG("frontEndUnitCheck", false,
   Gettext.gettext("Checks the consistency of units in equation."));
-constant DebugFlag DISABLE_COLORING = DEBUG_FLAG(158, "disableColoring", false,
+constant DebugFlag DISABLE_COLORING = DEBUG_FLAG("disableColoring", false,
   Gettext.gettext("Disables coloring algorithm while spasity detection."));
-constant DebugFlag MERGE_ALGORITHM_SECTIONS = DEBUG_FLAG(159, "mergeAlgSections", false,
+constant DebugFlag MERGE_ALGORITHM_SECTIONS = DEBUG_FLAG("mergeAlgSections", false,
   Gettext.gettext("Disables coloring algorithm while sparsity detection."));
-constant DebugFlag WARN_NO_NOMINAL = DEBUG_FLAG(160, "warnNoNominal", false,
+constant DebugFlag WARN_NO_NOMINAL = DEBUG_FLAG("warnNoNominal", false,
   Gettext.gettext("Prints the iteration variables in the initialization and simulation DAE, which do not have a nominal value."));
-constant DebugFlag REDUCE_DAE = DEBUG_FLAG(161, "backendReduceDAE", false,
+constant DebugFlag REDUCE_DAE = DEBUG_FLAG("backendReduceDAE", false,
   Gettext.gettext("Prints all Reduce DAE debug information."));
-constant DebugFlag IGNORE_CYCLES = DEBUG_FLAG(162, "ignoreCycles", false,
+constant DebugFlag IGNORE_CYCLES = DEBUG_FLAG("ignoreCycles", false,
   Gettext.gettext("Ignores cycles between constant/parameter components."));
-constant DebugFlag ALIAS_CONFLICTS = DEBUG_FLAG(163, "aliasConflicts", false,
+constant DebugFlag ALIAS_CONFLICTS = DEBUG_FLAG("aliasConflicts", false,
   Gettext.gettext("Dumps alias sets with different start or nominal values."));
-constant DebugFlag SUSAN_MATCHCONTINUE_DEBUG = DEBUG_FLAG(164, "susanDebug", false,
+constant DebugFlag SUSAN_MATCHCONTINUE_DEBUG = DEBUG_FLAG("susanDebug", false,
   Gettext.gettext("Makes Susan generate code using try/else to better debug which function broke the expected match semantics."));
-constant DebugFlag OLD_FE_UNITCHECK = DEBUG_FLAG(165, "oldFrontEndUnitCheck", false,
+constant DebugFlag OLD_FE_UNITCHECK = DEBUG_FLAG("oldFrontEndUnitCheck", false,
   Gettext.gettext("Checks the consistency of units in equation (for the old front-end)."));
-constant DebugFlag EXEC_STAT_EXTRA_GC = DEBUG_FLAG(166, "execstatGCcollect", false,
+constant DebugFlag EXEC_STAT_EXTRA_GC = DEBUG_FLAG("execstatGCcollect", false,
   Gettext.gettext("When running execstat, also perform an extra full garbage collection."));
-constant DebugFlag DEBUG_DAEMODE = DEBUG_FLAG(167, "debugDAEmode", false,
+constant DebugFlag DEBUG_DAEMODE = DEBUG_FLAG("debugDAEmode", false,
   Gettext.gettext("Dump debug output for the DAEmode."));
-constant DebugFlag NF_SCALARIZE = DEBUG_FLAG(168, "nfScalarize", true,
+constant DebugFlag NF_SCALARIZE = DEBUG_FLAG("nfScalarize", true,
   Gettext.gettext("Run scalarization in NF, default true."));
-constant DebugFlag NF_EVAL_CONST_ARG_FUNCS = DEBUG_FLAG(169, "nfEvalConstArgFuncs", true,
+constant DebugFlag NF_EVAL_CONST_ARG_FUNCS = DEBUG_FLAG("nfEvalConstArgFuncs", true,
   Gettext.gettext("Evaluate all functions with constant arguments in the new frontend."));
-constant DebugFlag NF_EXPAND_OPERATIONS = DEBUG_FLAG(170, "nfExpandOperations", true,
+constant DebugFlag NF_EXPAND_OPERATIONS = DEBUG_FLAG("nfExpandOperations", true,
   Gettext.gettext("Expand all unary/binary operations to scalar expressions in the new frontend."));
-constant DebugFlag NF_API = DEBUG_FLAG(171, "nfAPI", true,
+constant DebugFlag NF_API = DEBUG_FLAG("nfAPI", true,
   Gettext.gettext("Enables experimental new instantiation use in the OMC API."));
-constant DebugFlag NF_API_DYNAMIC_SELECT = DEBUG_FLAG(172, "nfAPIDynamicSelect", false,
+constant DebugFlag NF_API_DYNAMIC_SELECT = DEBUG_FLAG("nfAPIDynamicSelect", false,
   Gettext.gettext("Show DynamicSelect(static, dynamic) in annotations. Default to false and will select the first (static) expression"));
-constant DebugFlag NF_API_NOISE = DEBUG_FLAG(173, "nfAPINoise", false,
+constant DebugFlag NF_API_NOISE = DEBUG_FLAG("nfAPINoise", false,
   Gettext.gettext("Enables error display for the experimental new instantiation use in the OMC API."));
-constant DebugFlag FMI20_DEPENDENCIES = DEBUG_FLAG(174, "disableFMIDependency", false,
+constant DebugFlag FMI20_DEPENDENCIES = DEBUG_FLAG("disableFMIDependency", false,
   Gettext.gettext("Disables the dependency analysis and generation for FMI 2.0."));
-constant DebugFlag WARNING_MINMAX_ATTRIBUTES = DEBUG_FLAG(175, "warnMinMax", true,
+constant DebugFlag WARNING_MINMAX_ATTRIBUTES = DEBUG_FLAG("warnMinMax", true,
   Gettext.gettext("Makes a warning assert from min/max variable attributes instead of error."));
-constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG(176, "nfExpandFuncArgs", false,
+constant DebugFlag NF_EXPAND_FUNC_ARGS = DEBUG_FLAG("nfExpandFuncArgs", false,
   Gettext.gettext("Expand all function arguments in the new frontend."));
-constant DebugFlag DUMP_JL = DEBUG_FLAG(177, "dumpJL", false,
+constant DebugFlag DUMP_JL = DEBUG_FLAG("dumpJL", false,
   Gettext.gettext("Dumps the absyn representation of a program as a Julia representation"));
-constant DebugFlag DUMP_ASSC = DEBUG_FLAG(178, "dumpASSC", false,
+constant DebugFlag DUMP_ASSC = DEBUG_FLAG("dumpASSC", false,
   Gettext.gettext("Dumps the conversion process of analytical to structural singularities."));
-constant DebugFlag SPLIT_CONSTANT_PARTS_SYMJAC = DEBUG_FLAG(179, "symJacConstantSplit", false,
+constant DebugFlag SPLIT_CONSTANT_PARTS_SYMJAC = DEBUG_FLAG("symJacConstantSplit", false,
   Gettext.gettext("Generates all symbolic Jacobians with splitted constant parts."));
-constant DebugFlag DUMP_FORCE_FMI_ATTRIBUTES = DEBUG_FLAG(180, "force-fmi-attributes", false,
+constant DebugFlag DUMP_FORCE_FMI_ATTRIBUTES = DEBUG_FLAG("force-fmi-attributes", false,
   Gettext.gettext("Force to export all fmi attributes to the modelDescription.xml, including those which have default values"));
-constant DebugFlag DUMP_DATARECONCILIATION = DEBUG_FLAG(181, "dataReconciliation", false,
+constant DebugFlag DUMP_DATARECONCILIATION = DEBUG_FLAG("dataReconciliation", false,
   Gettext.gettext("Dumps all the dataReconciliation extraction algorithm procedure"));
-constant DebugFlag ARRAY_CONNECT = DEBUG_FLAG(182, "arrayConnect", false,
+constant DebugFlag ARRAY_CONNECT = DEBUG_FLAG("arrayConnect", false,
   Gettext.gettext("Use experimental array connection handler."));
-constant DebugFlag COMBINE_SUBSCRIPTS = DEBUG_FLAG(183, "combineSubscripts", false,
+constant DebugFlag COMBINE_SUBSCRIPTS = DEBUG_FLAG("combineSubscripts", false,
   Gettext.gettext("Move all subscripts to the end of component references."));
-constant DebugFlag ZMQ_LISTEN_TO_ALL = DEBUG_FLAG(184, "zmqDangerousAcceptConnectionsFromAnywhere", false,
+constant DebugFlag ZMQ_LISTEN_TO_ALL = DEBUG_FLAG("zmqDangerousAcceptConnectionsFromAnywhere", false,
   Gettext.gettext("When opening a zmq connection, listen on all interfaces instead of only connections from 127.0.0.1."));
-constant DebugFlag DUMP_CONVERSION_RULES = DEBUG_FLAG(185, "dumpConversionRules", false,
+constant DebugFlag DUMP_CONVERSION_RULES = DEBUG_FLAG("dumpConversionRules", false,
   Gettext.gettext("Dumps the rules when converting a package using a conversion script."));
-constant DebugFlag PRINT_RECORD_TYPES = DEBUG_FLAG(186, "printRecordTypes", false,
+constant DebugFlag PRINT_RECORD_TYPES = DEBUG_FLAG("printRecordTypes", false,
   Gettext.gettext("Prints out record types as part of the flat code."));
-constant DebugFlag DUMP_SIMPLIFY = DEBUG_FLAG(187, "dumpSimplify", false,
+constant DebugFlag DUMP_SIMPLIFY = DEBUG_FLAG("dumpSimplify", false,
   Gettext.gettext("Dumps expressions before and after simplification."));
-constant DebugFlag DUMP_BACKEND_CLOCKS = DEBUG_FLAG(188, "dumpBackendClocks", false,
+constant DebugFlag DUMP_BACKEND_CLOCKS = DEBUG_FLAG("dumpBackendClocks", false,
   Gettext.gettext("Dumps times for each backend module (only new backend)."));
-constant DebugFlag DUMP_SET_BASED_GRAPHS = DEBUG_FLAG(189, "dumpSetBasedGraphs", false,
+constant DebugFlag DUMP_SET_BASED_GRAPHS = DEBUG_FLAG("dumpSetBasedGraphs", false,
   Gettext.gettext("Dumps information about set based graphs for efficient array handling (only new frontend and new backend)."));
-constant DebugFlag MERGE_COMPONENTS = DEBUG_FLAG(190, "mergeComponents", false,
+constant DebugFlag MERGE_COMPONENTS = DEBUG_FLAG("mergeComponents", false,
   Gettext.gettext("Enables automatic merging of components into arrays."));
-constant DebugFlag DUMP_SLICE = DEBUG_FLAG(191, "dumpSlice", false,
+constant DebugFlag DUMP_SLICE = DEBUG_FLAG("dumpSlice", false,
   Gettext.gettext("Dumps information about the slicing process (pseudo-array causalization)."));
-constant DebugFlag VECTORIZE_BINDINGS = DEBUG_FLAG(192, "vectorizeBindings", false,
+constant DebugFlag VECTORIZE_BINDINGS = DEBUG_FLAG("vectorizeBindings", false,
   Gettext.gettext("Turns on vectorization of bindings when scalarization is turned off."));
-constant DebugFlag DUMP_EVENTS = DEBUG_FLAG(193, "dumpEvents", false,
+constant DebugFlag DUMP_EVENTS = DEBUG_FLAG("dumpEvents", false,
   Gettext.gettext("Dumps information about the detected event functions."));
-constant DebugFlag DUMP_BINDINGS = DEBUG_FLAG(194, "dumpBindings", false,
+constant DebugFlag DUMP_BINDINGS = DEBUG_FLAG("dumpBindings", false,
   Gettext.gettext("Dumps information about the equations created from bindings."));
 
 public
 // CONFIGURATION FLAGS
-constant ConfigFlag DEBUG = CONFIG_FLAG(1, "debug",
+constant ConfigFlag DEBUG = CONFIG_FLAG("debug",
   SOME("d"), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Sets debug flags. Use --help=debug to see available flags."));
 
-constant ConfigFlag HELP = CONFIG_FLAG(2, "help",
+constant ConfigFlag HELP = CONFIG_FLAG("help",
   SOME("h"), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Displays the help text. Use --help=topics for more information."));
 
-constant ConfigFlag RUNNING_TESTSUITE = CONFIG_FLAG(3, "running-testsuite",
+constant ConfigFlag RUNNING_TESTSUITE = CONFIG_FLAG("running-testsuite",
   NONE(), INTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Used when running the testsuite."));
 
-constant ConfigFlag SHOW_VERSION = CONFIG_FLAG(4, "version",
+constant ConfigFlag SHOW_VERSION = CONFIG_FLAG("version",
   SOME("-v"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Print the version and exit."));
 
-constant ConfigFlag TARGET = CONFIG_FLAG(5, "target", NONE(), EXTERNAL(),
+constant ConfigFlag TARGET = CONFIG_FLAG("target", NONE(), EXTERNAL(),
   STRING_FLAG("gcc"), SOME(STRING_OPTION({"gcc", "msvc","msvc10","msvc12","msvc13","msvc15","msvc19", "vxworks69", "debugrt"})),
   Gettext.gettext("Sets the target compiler to use."));
 
-constant ConfigFlag GRAMMAR = CONFIG_FLAG(6, "grammar", SOME("g"), EXTERNAL(),
+constant ConfigFlag GRAMMAR = CONFIG_FLAG("grammar", SOME("g"), EXTERNAL(),
   ENUM_FLAG(MODELICA, {("Modelica", MODELICA), ("MetaModelica", METAMODELICA), ("ParModelica", PARMODELICA), ("Optimica", OPTIMICA), ("PDEModelica", PDEMODELICA)}),
   SOME(STRING_OPTION({"Modelica", "MetaModelica", "ParModelica", "Optimica", "PDEModelica"})),
   Gettext.gettext("Sets the grammar and semantics to accept."));
 
-constant ConfigFlag ANNOTATION_VERSION = CONFIG_FLAG(7, "annotationVersion",
+constant ConfigFlag ANNOTATION_VERSION = CONFIG_FLAG("annotationVersion",
   NONE(), EXTERNAL(), STRING_FLAG("3.x"), SOME(STRING_OPTION({"1.x", "2.x", "3.x"})),
   Gettext.gettext("Sets the annotation version that should be used."));
 
-constant ConfigFlag LANGUAGE_STANDARD = CONFIG_FLAG(8, "std", NONE(), EXTERNAL(),
+constant ConfigFlag LANGUAGE_STANDARD = CONFIG_FLAG("std", NONE(), EXTERNAL(),
   ENUM_FLAG(1000,
     {("1.x", 10), ("2.x", 20), ("3.0", 30), ("3.1", 31), ("3.2", 32), ("3.3", 33),
      ("3.4", 34), ("3.5", 35), ("latest",1000), ("experimental", 9999)}),
   SOME(STRING_OPTION({"1.x", "2.x", "3.1", "3.2", "3.3", "3.4", "3.5", "latest", "experimental"})),
   Gettext.gettext("Sets the language standard that should be used."));
 
-constant ConfigFlag SHOW_ERROR_MESSAGES = CONFIG_FLAG(9, "showErrorMessages",
+constant ConfigFlag SHOW_ERROR_MESSAGES = CONFIG_FLAG("showErrorMessages",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Show error messages immediately when they happen."));
 
-constant ConfigFlag SHOW_ANNOTATIONS = CONFIG_FLAG(10, "showAnnotations",
+constant ConfigFlag SHOW_ANNOTATIONS = CONFIG_FLAG("showAnnotations",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Show annotations in the flattened code."));
 
-constant ConfigFlag NO_SIMPLIFY = CONFIG_FLAG(11, "noSimplify",
+constant ConfigFlag NO_SIMPLIFY = CONFIG_FLAG("noSimplify",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Do not simplify expressions if set."));
 constant Gettext.TranslatableContent removeSimpleEquationDesc = Gettext.gettext("Performs alias elimination and removes constant variables from the DAE, replacing all occurrences of the old variable reference with the new value (constants) or variable reference (alias elimination).");
 
 public
-constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
+constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG("preOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "normalInlineFunction",
     "evaluateParameters",
@@ -662,7 +666,7 @@ constant ConfigFlag PRE_OPT_MODULES = CONFIG_FLAG(12, "preOptModules",
     })),
   Gettext.gettext("Sets the pre optimization modules to use in the back end. See --help=optmodules for more info."));
 
-constant ConfigFlag CHEAPMATCHING_ALGORITHM = CONFIG_FLAG(13, "cheapmatchingAlgorithm",
+constant ConfigFlag CHEAPMATCHING_ALGORITHM = CONFIG_FLAG("cheapmatchingAlgorithm",
   NONE(), EXTERNAL(), INT_FLAG(3),
   SOME(STRING_DESC_OPTION({
     ("0", Gettext.gettext("No cheap matching.")),
@@ -670,7 +674,7 @@ constant ConfigFlag CHEAPMATCHING_ALGORITHM = CONFIG_FLAG(13, "cheapmatchingAlgo
     ("3", Gettext.gettext("Random Karp-Sipser: R. M. Karp and M. Sipser. Maximum matching in sparse random graphs."))})),
     Gettext.gettext("Sets the cheap matching algorithm to use. A cheap matching algorithm gives a jump start matching by heuristics."));
 
-constant ConfigFlag MATCHING_ALGORITHM = CONFIG_FLAG(14, "matchingAlgorithm",
+constant ConfigFlag MATCHING_ALGORITHM = CONFIG_FLAG("matchingAlgorithm",
   NONE(), EXTERNAL(), STRING_FLAG("PFPlusExt"),
   SOME(STRING_DESC_OPTION({
     ("BFSB", Gettext.gettext("Breadth First Search based algorithm.")),
@@ -696,7 +700,7 @@ constant ConfigFlag MATCHING_ALGORITHM = CONFIG_FLAG(14, "matchingAlgorithm",
     ("pseudo", Gettext.gettext("Pseudo array matching that uses scalar matching and reconstructs arrays afterwards as much as possible."))})),
     Gettext.gettext("Sets the matching algorithm to use. See --help=optmodules for more info."));
 
-constant ConfigFlag INDEX_REDUCTION_METHOD = CONFIG_FLAG(15, "indexReductionMethod",
+constant ConfigFlag INDEX_REDUCTION_METHOD = CONFIG_FLAG("indexReductionMethod",
   NONE(), EXTERNAL(), STRING_FLAG("dynamicStateSelection"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("Skip index reduction")),
@@ -706,7 +710,7 @@ constant ConfigFlag INDEX_REDUCTION_METHOD = CONFIG_FLAG(15, "indexReductionMeth
     })),
     Gettext.gettext("Sets the index reduction method to use. See --help=optmodules for more info."));
 
-constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
+constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG("postOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "lateInlineFunction",
     "wrapFunctionCalls",
@@ -772,118 +776,118 @@ constant ConfigFlag POST_OPT_MODULES = CONFIG_FLAG(16, "postOptModules",
     })),
   Gettext.gettext("Sets the post optimization modules to use in the back end. See --help=optmodules for more info."));
 
-constant ConfigFlag SIMCODE_TARGET = CONFIG_FLAG(17, "simCodeTarget",
+constant ConfigFlag SIMCODE_TARGET = CONFIG_FLAG("simCodeTarget",
   NONE(), EXTERNAL(), STRING_FLAG("C"),
   SOME(STRING_OPTION({"None", "C", "Cpp","omsicpp", "ExperimentalEmbeddedC", "JavaScript", "omsic", "XML", "MidC"})),
   Gettext.gettext("Sets the target language for the code generation."));
 
 
-constant ConfigFlag ORDER_CONNECTIONS = CONFIG_FLAG(18, "orderConnections",
+constant ConfigFlag ORDER_CONNECTIONS = CONFIG_FLAG("orderConnections",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Orders connect equations alphabetically if set."));
 
-constant ConfigFlag TYPE_INFO = CONFIG_FLAG(19, "typeinfo",
+constant ConfigFlag TYPE_INFO = CONFIG_FLAG("typeinfo",
   SOME("t"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Prints out extra type information if set."));
 
-constant ConfigFlag KEEP_ARRAYS = CONFIG_FLAG(20, "keepArrays",
+constant ConfigFlag KEEP_ARRAYS = CONFIG_FLAG("keepArrays",
   SOME("a"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Sets whether to split arrays or not."));
 
-constant ConfigFlag MODELICA_OUTPUT = CONFIG_FLAG(21, "modelicaOutput",
+constant ConfigFlag MODELICA_OUTPUT = CONFIG_FLAG("modelicaOutput",
   SOME("m"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables valid modelica output for flat modelica."));
 
-constant ConfigFlag SILENT = CONFIG_FLAG(22, "silent",
+constant ConfigFlag SILENT = CONFIG_FLAG("silent",
   SOME("q"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Turns on silent mode."));
 
-constant ConfigFlag CORBA_SESSION = CONFIG_FLAG(23, "corbaSessionName",
+constant ConfigFlag CORBA_SESSION = CONFIG_FLAG("corbaSessionName",
   SOME("c"), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Sets the name of the corba session if -d=interactiveCorba or --interactive=corba is used."));
 
-constant ConfigFlag NUM_PROC = CONFIG_FLAG(24, "numProcs",
+constant ConfigFlag NUM_PROC = CONFIG_FLAG("numProcs",
   SOME("n"), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the number of processors to use (0=default=auto)."));
 
-constant ConfigFlag LATENCY = CONFIG_FLAG(25, "latency",
+constant ConfigFlag LATENCY = CONFIG_FLAG("latency",
   SOME("l"), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the latency for parallel execution."));
 
-constant ConfigFlag BANDWIDTH = CONFIG_FLAG(26, "bandwidth",
+constant ConfigFlag BANDWIDTH = CONFIG_FLAG("bandwidth",
   SOME("b"), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the bandwidth for parallel execution."));
 
-constant ConfigFlag INST_CLASS = CONFIG_FLAG(27, "instClass",
+constant ConfigFlag INST_CLASS = CONFIG_FLAG("instClass",
   SOME("i"), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Instantiate the class given by the fully qualified path."));
 
-constant ConfigFlag VECTORIZATION_LIMIT = CONFIG_FLAG(28, "vectorizationLimit",
+constant ConfigFlag VECTORIZATION_LIMIT = CONFIG_FLAG("vectorizationLimit",
   SOME("v"), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the vectorization limit, arrays and matrices larger than this will not be vectorized."));
 
-constant ConfigFlag SIMULATION_CG = CONFIG_FLAG(29, "simulationCg",
+constant ConfigFlag SIMULATION_CG = CONFIG_FLAG("simulationCg",
   SOME("s"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Turns on simulation code generation."));
 
-constant ConfigFlag EVAL_PARAMS_IN_ANNOTATIONS = CONFIG_FLAG(30,
+constant ConfigFlag EVAL_PARAMS_IN_ANNOTATIONS = CONFIG_FLAG(
   "evalAnnotationParams", NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Sets whether to evaluate parameters in annotations or not."));
 
-constant ConfigFlag CHECK_MODEL = CONFIG_FLAG(31,
+constant ConfigFlag CHECK_MODEL = CONFIG_FLAG(
   "checkModel", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Set when checkModel is used to turn on specific features for checking."));
 
-constant ConfigFlag CEVAL_EQUATION = CONFIG_FLAG(32,
+constant ConfigFlag CEVAL_EQUATION = CONFIG_FLAG(
   "cevalEquation", NONE(), INTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.notrans(""));
 
-constant ConfigFlag UNIT_CHECKING = CONFIG_FLAG(33,
+constant ConfigFlag UNIT_CHECKING = CONFIG_FLAG(
   "unitChecking", NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.notrans("Enable unit checking."));
 
-constant ConfigFlag TRANSLATE_DAE_STRING = CONFIG_FLAG(34,
+constant ConfigFlag TRANSLATE_DAE_STRING = CONFIG_FLAG(
   "translateDAEString", NONE(), INTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.notrans(""));
 
-constant ConfigFlag GENERATE_LABELED_SIMCODE = CONFIG_FLAG(35,
+constant ConfigFlag GENERATE_LABELED_SIMCODE = CONFIG_FLAG(
   "generateLabeledSimCode", NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Turns on labeled SimCode generation for reduction algorithms."));
 
-constant ConfigFlag REDUCE_TERMS = CONFIG_FLAG(36,
+constant ConfigFlag REDUCE_TERMS = CONFIG_FLAG(
   "reduceTerms", NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Turns on reducing terms for reduction algorithms."));
 
-constant ConfigFlag REDUCTION_METHOD = CONFIG_FLAG(37, "reductionMethod",
+constant ConfigFlag REDUCTION_METHOD = CONFIG_FLAG("reductionMethod",
   NONE(), EXTERNAL(), STRING_FLAG("deletion"),
   SOME(STRING_OPTION({"deletion","substitution","linearization"})),
     Gettext.gettext("Sets the reduction method to be used."));
 
-constant ConfigFlag DEMO_MODE = CONFIG_FLAG(38, "demoMode",
+constant ConfigFlag DEMO_MODE = CONFIG_FLAG("demoMode",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Disable Warning/Error Massages."));
 
-constant ConfigFlag LOCALE_FLAG = CONFIG_FLAG(39, "locale",
+constant ConfigFlag LOCALE_FLAG = CONFIG_FLAG("locale",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Override the locale from the environment."));
 
-constant ConfigFlag DEFAULT_OPENCL_DEVICE = CONFIG_FLAG(40, "defaultOCLDevice",
+constant ConfigFlag DEFAULT_OPENCL_DEVICE = CONFIG_FLAG("defaultOCLDevice",
   SOME("o"), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the default OpenCL device to be used for parallel execution."));
 
-constant ConfigFlag MAXTRAVERSALS = CONFIG_FLAG(41, "maxTraversals",
+constant ConfigFlag MAXTRAVERSALS = CONFIG_FLAG("maxTraversals",
   NONE(), EXTERNAL(), INT_FLAG(2),NONE(),
   Gettext.gettext("Maximal traversals to find simple equations in the acausal system."));
 
-constant ConfigFlag DUMP_TARGET = CONFIG_FLAG(42, "dumpTarget",
+constant ConfigFlag DUMP_TARGET = CONFIG_FLAG("dumpTarget",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Redirect the dump to file. If the file ends with .html HTML code is generated."));
 
-constant ConfigFlag DELAY_BREAK_LOOP = CONFIG_FLAG(43, "delayBreakLoop",
+constant ConfigFlag DELAY_BREAK_LOOP = CONFIG_FLAG("delayBreakLoop",
   NONE(), EXTERNAL(), BOOL_FLAG(true),NONE(),
   Gettext.gettext("Enables (very) experimental code to break algebraic loops using the delay() operator. Probably messes with initialization."));
 
-constant ConfigFlag TEARING_METHOD = CONFIG_FLAG(44, "tearingMethod",
+constant ConfigFlag TEARING_METHOD = CONFIG_FLAG("tearingMethod",
   NONE(), EXTERNAL(), STRING_FLAG("cellier"),
   SOME(STRING_DESC_OPTION({
     ("noTearing", Gettext.gettext("Deprecated, use minimalTearing.")),
@@ -893,7 +897,7 @@ constant ConfigFlag TEARING_METHOD = CONFIG_FLAG(44, "tearingMethod",
 
     Gettext.gettext("Sets the tearing method to use. Select no tearing or choose tearing method."));
 
-constant ConfigFlag TEARING_HEURISTIC = CONFIG_FLAG(45, "tearingHeuristic",
+constant ConfigFlag TEARING_HEURISTIC = CONFIG_FLAG("tearingHeuristic",
   NONE(), EXTERNAL(), STRING_FLAG("MC3"),
   SOME(STRING_DESC_OPTION({
     ("MC1", Gettext.gettext("Original cellier with consideration of impossible assignments and discrete Vars.")),
@@ -909,36 +913,36 @@ constant ConfigFlag TEARING_HEURISTIC = CONFIG_FLAG(45, "tearingHeuristic",
     ("MC4", Gettext.gettext("Modified cellier, use all heuristics, choose var that occurs most in potential sets"))})),
     Gettext.gettext("Sets the tearing heuristic to use for Cellier-tearing."));
 
-constant ConfigFlag SCALARIZE_MINMAX = CONFIG_FLAG(46, "scalarizeMinMax",
+constant ConfigFlag SCALARIZE_MINMAX = CONFIG_FLAG("scalarizeMinMax",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Scalarizes the builtin min/max reduction operators if true."));
 
-constant ConfigFlag STRICT = CONFIG_FLAG(47, "strict",
+constant ConfigFlag STRICT = CONFIG_FLAG("strict",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables stricter enforcement of Modelica language rules."));
 
-constant ConfigFlag SCALARIZE_BINDINGS = CONFIG_FLAG(48, "scalarizeBindings",
+constant ConfigFlag SCALARIZE_BINDINGS = CONFIG_FLAG("scalarizeBindings",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Always scalarizes bindings if set."));
 
-constant ConfigFlag CORBA_OBJECT_REFERENCE_FILE_PATH = CONFIG_FLAG(49, "corbaObjectReferenceFilePath",
+constant ConfigFlag CORBA_OBJECT_REFERENCE_FILE_PATH = CONFIG_FLAG("corbaObjectReferenceFilePath",
   NONE(), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Sets the path for corba object reference file if -d=interactiveCorba is used."));
 
-constant ConfigFlag HPCOM_SCHEDULER = CONFIG_FLAG(50, "hpcomScheduler",
+constant ConfigFlag HPCOM_SCHEDULER = CONFIG_FLAG("hpcomScheduler",
   NONE(), EXTERNAL(), STRING_FLAG("level"), NONE(),
   Gettext.gettext("Sets the scheduler for task graph scheduling (list | listr | level | levelfix | ext | metis | mcp | taskdep | tds | bls | rand | none). Default: level."));
 
-constant ConfigFlag HPCOM_CODE = CONFIG_FLAG(51, "hpcomCode",
+constant ConfigFlag HPCOM_CODE = CONFIG_FLAG("hpcomCode",
   NONE(), EXTERNAL(), STRING_FLAG("openmp"), NONE(),
   Gettext.gettext("Sets the code-type produced by hpcom (openmp | pthreads | pthreads_spin | tbb | mpi). Default: openmp."));
 
 
-constant ConfigFlag REWRITE_RULES_FILE = CONFIG_FLAG(52, "rewriteRulesFile", NONE(), EXTERNAL(),
+constant ConfigFlag REWRITE_RULES_FILE = CONFIG_FLAG("rewriteRulesFile", NONE(), EXTERNAL(),
   STRING_FLAG(""), NONE(),
   Gettext.gettext("Activates user given rewrite rules for Absyn expressions. The rules are read from the given file and are of the form rewrite(fromExp, toExp);"));
 
-constant ConfigFlag REPLACE_HOMOTOPY = CONFIG_FLAG(53, "replaceHomotopy",
+constant ConfigFlag REPLACE_HOMOTOPY = CONFIG_FLAG("replaceHomotopy",
   NONE(), EXTERNAL(), STRING_FLAG("none"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("Default, do not replace homotopy.")),
@@ -947,19 +951,19 @@ constant ConfigFlag REPLACE_HOMOTOPY = CONFIG_FLAG(53, "replaceHomotopy",
     })),
     Gettext.gettext("Replaces homotopy(actual, simplified) with the actual expression or the simplified expression. Good for debugging models which use homotopy. The default is to not replace homotopy."));
 
-constant ConfigFlag GENERATE_SYMBOLIC_JACOBIAN = CONFIG_FLAG(54, "generateSymbolicJacobian",
+constant ConfigFlag GENERATE_SYMBOLIC_JACOBIAN = CONFIG_FLAG("generateSymbolicJacobian",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Generates symbolic Jacobian matrix, where der(x) is differentiated w.r.t. x. This matrix can be used by dassl or ida solver with simulation flag '-jacobian'."));
 
-constant ConfigFlag GENERATE_SYMBOLIC_LINEARIZATION = CONFIG_FLAG(55, "generateSymbolicLinearization",
+constant ConfigFlag GENERATE_SYMBOLIC_LINEARIZATION = CONFIG_FLAG("generateSymbolicLinearization",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Generates symbolic linearization matrices A,B,C,D for linear model:\n\t\t:math:`\\dot x = Ax + Bu`\n\t\t:math:`y = Cx +Du`"));
 
-constant ConfigFlag INT_ENUM_CONVERSION = CONFIG_FLAG(56, "intEnumConversion",
+constant ConfigFlag INT_ENUM_CONVERSION = CONFIG_FLAG("intEnumConversion",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Allow Integer to enumeration conversion."));
 
-constant ConfigFlag PROFILING_LEVEL = CONFIG_FLAG(57, "profiling",
+constant ConfigFlag PROFILING_LEVEL = CONFIG_FLAG("profiling",
   NONE(), EXTERNAL(), STRING_FLAG("none"), SOME(STRING_DESC_OPTION({
     ("none",Gettext.gettext("Generate code without profiling")),
     ("blocks",Gettext.gettext("Generate code for profiling function calls as well as linear and non-linear systems of equations")),
@@ -970,23 +974,23 @@ constant ConfigFlag PROFILING_LEVEL = CONFIG_FLAG(57, "profiling",
     })),
   Gettext.gettext("Sets the profiling level to use. Profiled equations and functions record execution time and count for each time step taken by the integrator."));
 
-constant ConfigFlag RESHUFFLE = CONFIG_FLAG(58, "reshuffle",
+constant ConfigFlag RESHUFFLE = CONFIG_FLAG("reshuffle",
   NONE(), EXTERNAL(), INT_FLAG(1), NONE(),
   Gettext.gettext("sets tolerance of reshuffling algorithm: 1: conservative, 2: more tolerant, 3 resolve all"));
 
-constant ConfigFlag GENERATE_DYN_OPTIMIZATION_PROBLEM = CONFIG_FLAG(59, "gDynOpt",
+constant ConfigFlag GENERATE_DYN_OPTIMIZATION_PROBLEM = CONFIG_FLAG("gDynOpt",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Generate dynamic optimization problem based on annotation approach."));
 
-constant ConfigFlag MAX_SIZE_FOR_SOLVE_LINIEAR_SYSTEM = CONFIG_FLAG(60, "maxSizeSolveLinearSystem",
+constant ConfigFlag MAX_SIZE_FOR_SOLVE_LINIEAR_SYSTEM = CONFIG_FLAG("maxSizeSolveLinearSystem",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Max size for solveLinearSystem."));
 
-constant ConfigFlag CPP_FLAGS = CONFIG_FLAG(61, "cppFlags",
+constant ConfigFlag CPP_FLAGS = CONFIG_FLAG("cppFlags",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({""}), NONE(),
   Gettext.gettext("Sets extra flags for compilation with the C++ compiler (e.g. +cppFlags=-O3,-Wall)"));
 
-constant ConfigFlag REMOVE_SIMPLE_EQUATIONS = CONFIG_FLAG(62, "removeSimpleEquations",
+constant ConfigFlag REMOVE_SIMPLE_EQUATIONS = CONFIG_FLAG("removeSimpleEquations",
   NONE(), EXTERNAL(), STRING_FLAG("default"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("Disables module")),
@@ -998,7 +1002,7 @@ constant ConfigFlag REMOVE_SIMPLE_EQUATIONS = CONFIG_FLAG(62, "removeSimpleEquat
     })),
     Gettext.gettext("Specifies method that removes simple equations."));
 
-constant ConfigFlag DYNAMIC_TEARING = CONFIG_FLAG(63, "dynamicTearing",
+constant ConfigFlag DYNAMIC_TEARING = CONFIG_FLAG("dynamicTearing",
   NONE(), EXTERNAL(), STRING_FLAG("false"),
   SOME(STRING_DESC_OPTION({
     ("false", Gettext.gettext("No dynamic tearing.")),
@@ -1008,11 +1012,11 @@ constant ConfigFlag DYNAMIC_TEARING = CONFIG_FLAG(63, "dynamicTearing",
   })),
   Gettext.gettext("Activates dynamic tearing (TearingSet can be changed automatically during runtime, strict set vs. casual set.)"));
 
-constant ConfigFlag SYM_SOLVER = CONFIG_FLAG(64, "symSolver",
+constant ConfigFlag SYM_SOLVER = CONFIG_FLAG("symSolver",
   NONE(), EXTERNAL(), ENUM_FLAG(0, {("none",0), ("impEuler", 1), ("expEuler",2)}), SOME(STRING_OPTION({"none", "impEuler", "expEuler"})),
   Gettext.gettext("Activates symbolic implicit solver (original system is not changed)."));
 
-constant ConfigFlag LOOP2CON = CONFIG_FLAG(65, "loop2con",
+constant ConfigFlag LOOP2CON = CONFIG_FLAG("loop2con",
   NONE(), EXTERNAL(), STRING_FLAG("none"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("Disables module")),
@@ -1021,11 +1025,11 @@ constant ConfigFlag LOOP2CON = CONFIG_FLAG(65, "loop2con",
     ("all", Gettext.gettext("loops --> constraints"))})),
     Gettext.gettext("Specifies method that transform loops in constraints. hint: using initial guess from file!"));
 
-constant ConfigFlag FORCE_TEARING = CONFIG_FLAG(66, "forceTearing",
+constant ConfigFlag FORCE_TEARING = CONFIG_FLAG("forceTearing",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Use tearing set even if it is not smaller than the original component."));
 
-constant ConfigFlag SIMPLIFY_LOOPS = CONFIG_FLAG(67, "simplifyLoops",
+constant ConfigFlag SIMPLIFY_LOOPS = CONFIG_FLAG("simplifyLoops",
   NONE(), EXTERNAL(), INT_FLAG(0),
   SOME(STRING_DESC_OPTION({
     ("0", Gettext.gettext("do nothing")),
@@ -1034,7 +1038,7 @@ constant ConfigFlag SIMPLIFY_LOOPS = CONFIG_FLAG(67, "simplifyLoops",
     })),
     Gettext.gettext("Simplify algebraic loops."));
 
-constant ConfigFlag RTEARING = CONFIG_FLAG(68, "recursiveTearing",
+constant ConfigFlag RTEARING = CONFIG_FLAG("recursiveTearing",
   NONE(), EXTERNAL(), INT_FLAG(0),
   SOME(STRING_DESC_OPTION({
     ("0", Gettext.gettext("do nothing")),
@@ -1043,19 +1047,19 @@ constant ConfigFlag RTEARING = CONFIG_FLAG(68, "recursiveTearing",
     })),
     Gettext.gettext("Inline and repeat tearing."));
 
-constant ConfigFlag FLOW_THRESHOLD = CONFIG_FLAG(69, "flowThreshold",
+constant ConfigFlag FLOW_THRESHOLD = CONFIG_FLAG("flowThreshold",
   NONE(), EXTERNAL(), REAL_FLAG(1e-7), NONE(),
   Gettext.gettext("Sets the minium threshold for stream flow rates"));
 
-constant ConfigFlag MATRIX_FORMAT = CONFIG_FLAG(70, "matrixFormat",
+constant ConfigFlag MATRIX_FORMAT = CONFIG_FLAG("matrixFormat",
   NONE(), EXTERNAL(), STRING_FLAG("dense"), NONE(),
   Gettext.gettext("Sets the matrix format type in cpp runtime which should be used (dense | sparse ). Default: dense."));
 
-constant ConfigFlag PARTLINTORN = CONFIG_FLAG(71, "partlintorn",
+constant ConfigFlag PARTLINTORN = CONFIG_FLAG("partlintorn",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the limit for partitionin of linear torn systems."));
 
-constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG(72, "initOptModules",
+constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG("initOptModules",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "simplifyComplexFunction",
     "tearingSystem",
@@ -1085,119 +1089,119 @@ constant ConfigFlag INIT_OPT_MODULES = CONFIG_FLAG(72, "initOptModules",
     })),
   Gettext.gettext("Sets the initialization optimization modules to use in the back end. See --help=optmodules for more info."));
 
-constant ConfigFlag MAX_MIXED_DETERMINED_INDEX = CONFIG_FLAG(73, "maxMixedDeterminedIndex",
+constant ConfigFlag MAX_MIXED_DETERMINED_INDEX = CONFIG_FLAG("maxMixedDeterminedIndex",
   NONE(), EXTERNAL(), INT_FLAG(10), NONE(),
   Gettext.gettext("Sets the maximum mixed-determined index that is handled by the initialization."));
-constant ConfigFlag USE_LOCAL_DIRECTION = CONFIG_FLAG(74, "useLocalDirection",
+constant ConfigFlag USE_LOCAL_DIRECTION = CONFIG_FLAG("useLocalDirection",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Keeps the input/output prefix for all variables in the flat model, not only top-level ones."));
-constant ConfigFlag DEFAULT_OPT_MODULES_ORDERING = CONFIG_FLAG(75, "defaultOptModulesOrdering",
+constant ConfigFlag DEFAULT_OPT_MODULES_ORDERING = CONFIG_FLAG("defaultOptModulesOrdering",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("If this is activated, then the specified pre-/post-/init-optimization modules will be rearranged to the recommended ordering."));
-constant ConfigFlag PRE_OPT_MODULES_ADD = CONFIG_FLAG(76, "preOptModules+",
+constant ConfigFlag PRE_OPT_MODULES_ADD = CONFIG_FLAG("preOptModules+",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Enables additional pre-optimization modules, e.g. --preOptModules+=module1,module2 would additionally enable module1 and module2. See --help=optmodules for more info."));
-constant ConfigFlag PRE_OPT_MODULES_SUB = CONFIG_FLAG(77, "preOptModules-",
+constant ConfigFlag PRE_OPT_MODULES_SUB = CONFIG_FLAG("preOptModules-",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Disables a list of pre-optimization modules, e.g. --preOptModules-=module1,module2 would disable module1 and module2. See --help=optmodules for more info."));
-constant ConfigFlag POST_OPT_MODULES_ADD = CONFIG_FLAG(78, "postOptModules+",
+constant ConfigFlag POST_OPT_MODULES_ADD = CONFIG_FLAG("postOptModules+",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Enables additional post-optimization modules, e.g. --postOptModules+=module1,module2 would additionally enable module1 and module2. See --help=optmodules for more info."));
-constant ConfigFlag POST_OPT_MODULES_SUB = CONFIG_FLAG(79, "postOptModules-",
+constant ConfigFlag POST_OPT_MODULES_SUB = CONFIG_FLAG("postOptModules-",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Disables a list of post-optimization modules, e.g. --postOptModules-=module1,module2 would disable module1 and module2. See --help=optmodules for more info."));
-constant ConfigFlag INIT_OPT_MODULES_ADD = CONFIG_FLAG(80, "initOptModules+",
+constant ConfigFlag INIT_OPT_MODULES_ADD = CONFIG_FLAG("initOptModules+",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Enables additional init-optimization modules, e.g. --initOptModules+=module1,module2 would additionally enable module1 and module2. See --help=optmodules for more info."));
-constant ConfigFlag INIT_OPT_MODULES_SUB = CONFIG_FLAG(81, "initOptModules-",
+constant ConfigFlag INIT_OPT_MODULES_SUB = CONFIG_FLAG("initOptModules-",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Disables a list of init-optimization modules, e.g. --initOptModules-=module1,module2 would disable module1 and module2. See --help=optmodules for more info."));
-constant ConfigFlag PERMISSIVE = CONFIG_FLAG(82, "permissive",
+constant ConfigFlag PERMISSIVE = CONFIG_FLAG("permissive",
   NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Disables some error checks to allow erroneous models to compile."));
-constant ConfigFlag HETS = CONFIG_FLAG(83, "hets",
+constant ConfigFlag HETS = CONFIG_FLAG("hets",
   NONE(), INTERNAL(), STRING_FLAG("none"),SOME(
     STRING_DESC_OPTION({
     ("none", Gettext.gettext("do nothing")),
     ("derCalls", Gettext.gettext("sort terms based on der-calls"))
     })),
   Gettext.gettext("Heuristic equation terms sort"));
-constant ConfigFlag DEFAULT_CLOCK_PERIOD = CONFIG_FLAG(84, "defaultClockPeriod",
+constant ConfigFlag DEFAULT_CLOCK_PERIOD = CONFIG_FLAG("defaultClockPeriod",
   NONE(), INTERNAL(), REAL_FLAG(1.0), NONE(),
   Gettext.gettext("Sets the default clock period (in seconds) for state machines (default: 1.0)."));
-constant ConfigFlag INST_CACHE_SIZE = CONFIG_FLAG(85, "instCacheSize",
+constant ConfigFlag INST_CACHE_SIZE = CONFIG_FLAG("instCacheSize",
   NONE(), EXTERNAL(), INT_FLAG(25343), NONE(),
   Gettext.gettext("Sets the size of the internal hash table used for instantiation caching."));
-constant ConfigFlag MAX_SIZE_LINEAR_TEARING = CONFIG_FLAG(86, "maxSizeLinearTearing",
+constant ConfigFlag MAX_SIZE_LINEAR_TEARING = CONFIG_FLAG("maxSizeLinearTearing",
   NONE(), EXTERNAL(), INT_FLAG(200), NONE(),
   Gettext.gettext("Sets the maximum system size for tearing of linear systems (default 200)."));
-constant ConfigFlag MAX_SIZE_NONLINEAR_TEARING = CONFIG_FLAG(87, "maxSizeNonlinearTearing",
+constant ConfigFlag MAX_SIZE_NONLINEAR_TEARING = CONFIG_FLAG("maxSizeNonlinearTearing",
   NONE(), EXTERNAL(), INT_FLAG(10000), NONE(),
   Gettext.gettext("Sets the maximum system size for tearing of nonlinear systems (default 10000)."));
-constant ConfigFlag NO_TEARING_FOR_COMPONENT = CONFIG_FLAG(88, "noTearingForComponent",
+constant ConfigFlag NO_TEARING_FOR_COMPONENT = CONFIG_FLAG("noTearingForComponent",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
   Gettext.gettext("Deactivates tearing for the specified components.\nUse '-d=tearingdump' to find out the relevant indexes."));
-constant ConfigFlag CT_STATE_MACHINES = CONFIG_FLAG(89, "ctStateMachines",
+constant ConfigFlag CT_STATE_MACHINES = CONFIG_FLAG("ctStateMachines",
   NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Experimental: Enable continuous-time state machine prototype"));
-constant ConfigFlag DAE_MODE = CONFIG_FLAG(90, "daeMode",
+constant ConfigFlag DAE_MODE = CONFIG_FLAG("daeMode",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Generates code to simulate models in DAE mode. The whole system is passed directly to the DAE solver SUNDIALS/IDA and no algebraic solver is involved in the simulation process."));
-constant ConfigFlag INLINE_METHOD = CONFIG_FLAG(91, "inlineMethod",
+constant ConfigFlag INLINE_METHOD = CONFIG_FLAG("inlineMethod",
   NONE(), EXTERNAL(), ENUM_FLAG(1, {("replace",1), ("append",2)}),
   SOME(STRING_OPTION({"replace", "append"})),
   Gettext.gettext("Sets the inline method to use.\n"+
                "replace : This method inlines by replacing in place all expressions. Might lead to very long expression.\n"+
                "append  : This method inlines by adding additional variables to the whole system. Might lead to much bigger system."));
-constant ConfigFlag SET_TEARING_VARS = CONFIG_FLAG(92, "setTearingVars",
+constant ConfigFlag SET_TEARING_VARS = CONFIG_FLAG("setTearingVars",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
   Gettext.gettext("Sets the tearing variables by its strong component indexes. Use '-d=tearingdump' to find out the relevant indexes.\nUse following format: '--setTearingVars=(sci,n,t1,...,tn)*', with sci = strong component index, n = number of tearing variables, t1,...tn = tearing variables.\nE.g.: '--setTearingVars=4,2,3,5' would select variables 3 and 5 in strong component 4."));
-constant ConfigFlag SET_RESIDUAL_EQNS = CONFIG_FLAG(93, "setResidualEqns",
+constant ConfigFlag SET_RESIDUAL_EQNS = CONFIG_FLAG("setResidualEqns",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
   Gettext.gettext("Sets the residual equations by its strong component indexes. Use '-d=tearingdump' to find out the relevant indexes for the collective equations.\nUse following format: '--setResidualEqns=(sci,n,r1,...,rn)*', with sci = strong component index, n = number of residual equations, r1,...rn = residual equations.\nE.g.: '--setResidualEqns=4,2,3,5' would select equations 3 and 5 in strong component 4.\nOnly works in combination with 'setTearingVars'."));
-constant ConfigFlag IGNORE_COMMAND_LINE_OPTIONS_ANNOTATION = CONFIG_FLAG(94, "ignoreCommandLineOptionsAnnotation",
+constant ConfigFlag IGNORE_COMMAND_LINE_OPTIONS_ANNOTATION = CONFIG_FLAG("ignoreCommandLineOptionsAnnotation",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Ignores the command line options specified as annotation in the class."));
-constant ConfigFlag CALCULATE_SENSITIVITIES = CONFIG_FLAG(95, "calculateSensitivities",
+constant ConfigFlag CALCULATE_SENSITIVITIES = CONFIG_FLAG("calculateSensitivities",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Generates sensitivities variables and matrices."));
-constant ConfigFlag ALARM = CONFIG_FLAG(96, "alarm",
+constant ConfigFlag ALARM = CONFIG_FLAG("alarm",
   SOME("r"), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the number seconds until omc timeouts and exits. Used by the testing framework to terminate infinite running processes."));
-constant ConfigFlag TOTAL_TEARING = CONFIG_FLAG(97, "totalTearing",
+constant ConfigFlag TOTAL_TEARING = CONFIG_FLAG("totalTearing",
   NONE(), EXTERNAL(), INT_LIST_FLAG({}), NONE(),
   Gettext.gettext("Activates total tearing (determination of all possible tearing sets) for the specified components.\nUse '-d=tearingdump' to find out the relevant indexes."));
-constant ConfigFlag IGNORE_SIMULATION_FLAGS_ANNOTATION = CONFIG_FLAG(98, "ignoreSimulationFlagsAnnotation",
+constant ConfigFlag IGNORE_SIMULATION_FLAGS_ANNOTATION = CONFIG_FLAG("ignoreSimulationFlagsAnnotation",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Ignores the simulation flags specified as annotation in the class."));
-constant ConfigFlag DYNAMIC_TEARING_FOR_INITIALIZATION = CONFIG_FLAG(99, "dynamicTearingForInitialization",
+constant ConfigFlag DYNAMIC_TEARING_FOR_INITIALIZATION = CONFIG_FLAG("dynamicTearingForInitialization",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enable Dynamic Tearing also for the initialization system."));
-constant ConfigFlag PREFER_TVARS_WITH_START_VALUE = CONFIG_FLAG(100, "preferTVarsWithStartValue",
+constant ConfigFlag PREFER_TVARS_WITH_START_VALUE = CONFIG_FLAG("preferTVarsWithStartValue",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Prefer tearing variables with start value for initialization."));
-constant ConfigFlag EQUATIONS_PER_FILE = CONFIG_FLAG(101, "equationsPerFile",
+constant ConfigFlag EQUATIONS_PER_FILE = CONFIG_FLAG("equationsPerFile",
   NONE(), EXTERNAL(), INT_FLAG(2000), NONE(),
   Gettext.gettext("Generate code for at most this many equations per C-file (partially implemented in the compiler)."));
-constant ConfigFlag EVALUATE_FINAL_PARAMS = CONFIG_FLAG(102, "evaluateFinalParameters",
+constant ConfigFlag EVALUATE_FINAL_PARAMS = CONFIG_FLAG("evaluateFinalParameters",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Evaluates all the final parameters in addition to parameters with annotation(Evaluate=true)."));
-constant ConfigFlag EVALUATE_PROTECTED_PARAMS = CONFIG_FLAG(103, "evaluateProtectedParameters",
+constant ConfigFlag EVALUATE_PROTECTED_PARAMS = CONFIG_FLAG("evaluateProtectedParameters",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Evaluates all the protected parameters in addition to parameters with annotation(Evaluate=true)."));
-constant ConfigFlag REPLACE_EVALUATED_PARAMS = CONFIG_FLAG(104, "replaceEvaluatedParameters",
+constant ConfigFlag REPLACE_EVALUATED_PARAMS = CONFIG_FLAG("replaceEvaluatedParameters",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Replaces all the evaluated parameters in the DAE."));
-constant ConfigFlag CONDENSE_ARRAYS = CONFIG_FLAG(105, "condenseArrays",
+constant ConfigFlag CONDENSE_ARRAYS = CONFIG_FLAG("condenseArrays",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Sets whether array expressions containing function calls are condensed or not."));
-constant ConfigFlag WFC_ADVANCED = CONFIG_FLAG(106, "wfcAdvanced",
+constant ConfigFlag WFC_ADVANCED = CONFIG_FLAG("wfcAdvanced",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("wrapFunctionCalls ignores more then default cases, e.g. exp, sin, cos, log, (experimental flag)"));
-constant ConfigFlag GRAPHICS_EXP_MODE = CONFIG_FLAG(107,
+constant ConfigFlag GRAPHICS_EXP_MODE = CONFIG_FLAG(
   "graphicsExpMode", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Sets whether we are in graphics exp mode (evaluating icons)."));
-constant ConfigFlag TEARING_STRICTNESS = CONFIG_FLAG(108, "tearingStrictness",
+constant ConfigFlag TEARING_STRICTNESS = CONFIG_FLAG("tearingStrictness",
   NONE(), EXTERNAL(), STRING_FLAG("strict"),SOME(
     STRING_DESC_OPTION({
     ("casual", Gettext.gettext("Loose tearing rules using ExpressionSolve to determine the solvability instead of considering the partial derivative. Allows to solve for everything that is analytically possible. This could lead to singularities during simulation.")),
@@ -1205,7 +1209,7 @@ constant ConfigFlag TEARING_STRICTNESS = CONFIG_FLAG(108, "tearingStrictness",
     ("veryStrict", Gettext.gettext("Very strict tearing rules that do not allow to divide by any parameter. Use this if you aim at overriding parameters after compilation with values equal to or close to zero."))
     })),
   Gettext.gettext("Sets the strictness of the tearing method regarding the solvability restrictions."));
-constant ConfigFlag INTERACTIVE = CONFIG_FLAG(109, "interactive",
+constant ConfigFlag INTERACTIVE = CONFIG_FLAG("interactive",
   NONE(), EXTERNAL(), STRING_FLAG("none"),SOME(
     STRING_DESC_OPTION({
     ("none", Gettext.gettext("do nothing")),
@@ -1214,10 +1218,10 @@ constant ConfigFlag INTERACTIVE = CONFIG_FLAG(109, "interactive",
     ("zmq", Gettext.gettext("Starts omc as a ZeroMQ server listening on the socket interface."))
     })),
   Gettext.gettext("Sets the interactive mode for omc."));
-constant ConfigFlag ZEROMQ_FILE_SUFFIX = CONFIG_FLAG(110, "zeroMQFileSuffix",
+constant ConfigFlag ZEROMQ_FILE_SUFFIX = CONFIG_FLAG("zeroMQFileSuffix",
   SOME("z"), EXTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("Sets the file suffix for zeroMQ port file if --interactive=zmq is used."));
-constant ConfigFlag HOMOTOPY_APPROACH = CONFIG_FLAG(111, "homotopyApproach",
+constant ConfigFlag HOMOTOPY_APPROACH = CONFIG_FLAG("homotopyApproach",
   NONE(), EXTERNAL(), STRING_FLAG("equidistantGlobal"),
   SOME(STRING_DESC_OPTION({
     ("equidistantLocal", Gettext.gettext("Local homotopy approach with equidistant lambda steps. The homotopy parameter only effects the local strongly connected component.")),
@@ -1226,35 +1230,35 @@ constant ConfigFlag HOMOTOPY_APPROACH = CONFIG_FLAG(111, "homotopyApproach",
     ("adaptiveGlobal", Gettext.gettext("Global homotopy approach with adaptive lambda steps. The homotopy parameter effects the entire initialization system."))
     })),
     Gettext.gettext("Sets the homotopy approach."));
-constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG(112, "ignoreReplaceable",
+constant ConfigFlag IGNORE_REPLACEABLE = CONFIG_FLAG("ignoreReplaceable",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Sets whether to ignore replaceability or not when redeclaring."));
 
-constant ConfigFlag LABELED_REDUCTION = CONFIG_FLAG(113,
+constant ConfigFlag LABELED_REDUCTION = CONFIG_FLAG(
   "labeledReduction", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Turns on labeling and reduce terms to do whole process of reduction."));
 
-constant ConfigFlag DISABLE_EXTRA_LABELING = CONFIG_FLAG(114,
+constant ConfigFlag DISABLE_EXTRA_LABELING = CONFIG_FLAG(
   "disableExtraLabeling", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Disable adding extra label into the whole experssion with more than one term and +,- operations."));
 
-constant ConfigFlag LOAD_MSL_MODEL = CONFIG_FLAG(115,
+constant ConfigFlag LOAD_MSL_MODEL = CONFIG_FLAG(
   "loadMSLModel", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Used to know loadFile doesn't need to be called in cpp-runtime (for labeled model reduction)."));
 
-constant ConfigFlag LOAD_PACKAGE_FILE = CONFIG_FLAG(116,
+constant ConfigFlag LOAD_PACKAGE_FILE = CONFIG_FLAG(
   "loadPackageFile", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("used when the outside name is different with the inside name of the packge, in cpp-runtime (for labeled model reduction)."));
 
-constant ConfigFlag BUILDING_FMU = CONFIG_FLAG(117,
+constant ConfigFlag BUILDING_FMU = CONFIG_FLAG(
   "", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Is true when building an FMU (so the compiler can look for URIs to package as FMI resources)."));
 
-constant ConfigFlag BUILDING_MODEL = CONFIG_FLAG(118,
+constant ConfigFlag BUILDING_MODEL = CONFIG_FLAG(
   "", NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Is true when building a model (as opposed to running a Modelica script)."));
 
-constant ConfigFlag POST_OPT_MODULES_DAE = CONFIG_FLAG(119, "postOptModulesDAE",
+constant ConfigFlag POST_OPT_MODULES_DAE = CONFIG_FLAG("postOptModulesDAE",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     "lateInlineFunction",
     "wrapFunctionCalls",
@@ -1271,82 +1275,82 @@ constant ConfigFlag POST_OPT_MODULES_DAE = CONFIG_FLAG(119, "postOptModulesDAE",
     }),NONE(),
     Gettext.gettext("Sets the optimization modules for the DAEmode in the back end. See --help=optmodules for more info."));
 
-constant ConfigFlag EVAL_LOOP_LIMIT = CONFIG_FLAG(120,
+constant ConfigFlag EVAL_LOOP_LIMIT = CONFIG_FLAG(
   "evalLoopLimit", NONE(), EXTERNAL(), INT_FLAG(100000), NONE(),
   Gettext.gettext("The loop iteration limit used when evaluating constant function calls."));
 
-constant ConfigFlag EVAL_RECURSION_LIMIT = CONFIG_FLAG(121,
+constant ConfigFlag EVAL_RECURSION_LIMIT = CONFIG_FLAG(
   "evalRecursionLimit", NONE(), EXTERNAL(), INT_FLAG(256), NONE(),
   Gettext.gettext("The recursion limit used when evaluating constant function calls."));
 
-constant ConfigFlag SINGLE_INSTANCE_AGLSOLVER = CONFIG_FLAG(122, "singleInstanceAglSolver",
+constant ConfigFlag SINGLE_INSTANCE_AGLSOLVER = CONFIG_FLAG("singleInstanceAglSolver",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Sets to instantiate only  one algebraic loop solver all algebraic loops"));
 
-constant ConfigFlag SHOW_STRUCTURAL_ANNOTATIONS = CONFIG_FLAG(123, "showStructuralAnnotations",
+constant ConfigFlag SHOW_STRUCTURAL_ANNOTATIONS = CONFIG_FLAG("showStructuralAnnotations",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Show annotations affecting the solution process in the flattened code."));
 
-constant ConfigFlag INITIAL_STATE_SELECTION = CONFIG_FLAG(124, "initialStateSelection",
+constant ConfigFlag INITIAL_STATE_SELECTION = CONFIG_FLAG("initialStateSelection",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Activates the state selection inside initialization to avoid singularities."));
 
-constant ConfigFlag LINEARIZATION_DUMP_LANGUAGE = CONFIG_FLAG(125, "linearizationDumpLanguage",
+constant ConfigFlag LINEARIZATION_DUMP_LANGUAGE = CONFIG_FLAG("linearizationDumpLanguage",
   NONE(), EXTERNAL(), STRING_FLAG("modelica"),
   SOME(STRING_OPTION({"modelica","matlab","julia","python"})),
     Gettext.gettext("Sets the target language for the produced code of linearization. Only works with '--generateSymbolicLinearization' and 'linearize(modelName)'."));
 
-constant ConfigFlag NO_ASSC = CONFIG_FLAG(126, "noASSC",
+constant ConfigFlag NO_ASSC = CONFIG_FLAG("noASSC",
   NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
   Gettext.gettext("Disables analytical to structural singularity conversion."));
 
-constant ConfigFlag FULL_ASSC = CONFIG_FLAG(127, "fullASSC",
+constant ConfigFlag FULL_ASSC = CONFIG_FLAG("fullASSC",
   NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables full equation replacement for BLT transformation from the ASSC algorithm."));
 
-constant ConfigFlag REAL_ASSC = CONFIG_FLAG(128, "realASSC",
+constant ConfigFlag REAL_ASSC = CONFIG_FLAG("realASSC",
   NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables the ASSC algorithm to evaluate real valued coefficients (usually only integers)."));
 
-constant ConfigFlag INIT_ASSC = CONFIG_FLAG(129, "initASSC",
+constant ConfigFlag INIT_ASSC = CONFIG_FLAG("initASSC",
   NONE(), EXTERNAL(),  BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables the ASSC algorithm for initialization."));
 
-constant ConfigFlag MAX_SIZE_ASSC = CONFIG_FLAG(130, "maxSizeASSC",
+constant ConfigFlag MAX_SIZE_ASSC = CONFIG_FLAG("maxSizeASSC",
   NONE(), EXTERNAL(), INT_FLAG(200), NONE(),
   Gettext.gettext("Sets the maximum system size for the analytical to structural conversion algorithm (default 200)."));
 
-constant ConfigFlag USE_ZEROMQ_IN_SIM = CONFIG_FLAG(131, "useZeroMQInSim",
+constant ConfigFlag USE_ZEROMQ_IN_SIM = CONFIG_FLAG("useZeroMQInSim",
   NONE(), INTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Configures to use zeroMQ in simulation runtime to exchange information via ZeroMQ with other applications"));
 
-constant ConfigFlag ZEROMQ_PUB_PORT = CONFIG_FLAG(132, "zeroMQPubPort",
+constant ConfigFlag ZEROMQ_PUB_PORT = CONFIG_FLAG("zeroMQPubPort",
   NONE(), INTERNAL(), INT_FLAG(3203), NONE(),
   Gettext.gettext("Configures port number for simulation runtime to send information via ZeroMQ"));
 
-constant ConfigFlag ZEROMQ_SUB_PORT = CONFIG_FLAG(133, "zeroMQSubPort",
+constant ConfigFlag ZEROMQ_SUB_PORT = CONFIG_FLAG("zeroMQSubPort",
   NONE(), INTERNAL(), INT_FLAG(3204), NONE(),
   Gettext.gettext("Configures port number for simulation runtime to receive information via ZeroMQ"));
 
-constant ConfigFlag ZEROMQ_JOB_ID = CONFIG_FLAG(134, "zeroMQJOBID",
+constant ConfigFlag ZEROMQ_JOB_ID = CONFIG_FLAG("zeroMQJOBID",
   NONE(), INTERNAL(), STRING_FLAG("empty"), NONE(),
   Gettext.gettext("Configures the ID with which the omc api call is labelled for zeroMQ communication."));
-constant ConfigFlag ZEROMQ_SERVER_ID = CONFIG_FLAG(135, "zeroMQServerID",
+constant ConfigFlag ZEROMQ_SERVER_ID = CONFIG_FLAG("zeroMQServerID",
   NONE(), INTERNAL(), STRING_FLAG("empty"), NONE(),
   Gettext.gettext("Configures the ID with which server application is labelled for zeroMQ communication."));
-constant ConfigFlag ZEROMQ_CLIENT_ID = CONFIG_FLAG(136, "zeroMQClientID",
+constant ConfigFlag ZEROMQ_CLIENT_ID = CONFIG_FLAG("zeroMQClientID",
   NONE(), INTERNAL(), STRING_FLAG("empty"), NONE(),
   Gettext.gettext("Configures the ID with which the client application is labelled for zeroMQ communication."));
 
-constant ConfigFlag FMI_VERSION = CONFIG_FLAG(137,
+constant ConfigFlag FMI_VERSION = CONFIG_FLAG(
   "", NONE(), INTERNAL(), STRING_FLAG(""), NONE(),
   Gettext.gettext("returns the FMI Version either 1.0 or 2.0."));
 
-constant ConfigFlag FLAT_MODELICA = CONFIG_FLAG(138, "flatModelica",
+constant ConfigFlag FLAT_MODELICA = CONFIG_FLAG("flatModelica",
   SOME("f"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Outputs experimental flat Modelica."));
 
-constant ConfigFlag FMI_FILTER = CONFIG_FLAG(139, "fmiFilter", NONE(), EXTERNAL(),
+constant ConfigFlag FMI_FILTER = CONFIG_FLAG("fmiFilter", NONE(), EXTERNAL(),
   ENUM_FLAG(FMI_PROTECTED, {("none", FMI_NONE), ("internal", FMI_INTERNAL), ("protected", FMI_PROTECTED), ("blackBox", FMI_BLACKBOX)}),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("All variables are exposed, even variables introduced by the symbolic transformations. This is mainly for debugging purposes.")),
@@ -1356,31 +1360,31 @@ constant ConfigFlag FMI_FILTER = CONFIG_FLAG(139, "fmiFilter", NONE(), EXTERNAL(
     })),
   Gettext.gettext("Specifies which model variables are exposed by the modelDescription.xml"));
 
-constant ConfigFlag FMI_SOURCES = CONFIG_FLAG(140, "fmiSources", NONE(), EXTERNAL(),
+constant ConfigFlag FMI_SOURCES = CONFIG_FLAG("fmiSources", NONE(), EXTERNAL(),
   BOOL_FLAG(true), NONE(),
   Gettext.gettext("Defines if FMUs will be exported with sources or not. --fmiFilter=blackBox might override this, because black box FMUs do never contain their source code."));
 
-constant ConfigFlag FMI_FLAGS = CONFIG_FLAG(141, "fmiFlags", NONE(), EXTERNAL(),
+constant ConfigFlag FMI_FLAGS = CONFIG_FLAG("fmiFlags", NONE(), EXTERNAL(),
   STRING_LIST_FLAG({}), NONE(),
   Gettext.gettext("Add simulation flags to FMU. Will create <fmiPrefix>_flags.json in resources folder with given flags. Use --fmiFlags or --fmiFlags=none to disable [default]. Use --fmiFlags=default for the default simulation flags. To pass flags use e.g. --fmiFlags=s:cvode,nls:homotopy or --fmiFlags=path/to/yourFlags.json."));
 
-constant ConfigFlag FMU_CMAKE_BUILD = CONFIG_FLAG(142, "fmuCMakeBuild",
+constant ConfigFlag FMU_CMAKE_BUILD = CONFIG_FLAG("fmuCMakeBuild",
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Configured and build FMU with CMake if true."));
 
-constant ConfigFlag NEW_BACKEND = CONFIG_FLAG(143, "newBackend",
+constant ConfigFlag NEW_BACKEND = CONFIG_FLAG("newBackend",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Activates experimental new backend for better array handling. This also activates the new frontend. [WIP]"));
 
-constant ConfigFlag PARMODAUTO = CONFIG_FLAG(144, "parmodauto",
+constant ConfigFlag PARMODAUTO = CONFIG_FLAG("parmodauto",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Experimental: Enable parallelization of independent systems of equations in the translated model. Only works on Linux systems."));
 
-constant ConfigFlag INTERACTIVE_PORT = CONFIG_FLAG(145, "interactivePort",
+constant ConfigFlag INTERACTIVE_PORT = CONFIG_FLAG("interactivePort",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Sets the port used by the interactive server."));
 
-constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG(146, "allowNonStandardModelica",
+constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG("allowNonStandardModelica",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({
     }),
   SOME(STRING_DESC_OPTION({
@@ -1393,22 +1397,22 @@ constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG(146, "allowNonStan
     })),
   Gettext.gettext("Flags to allow non-standard Modelica."));
 
-constant ConfigFlag EXPORT_CLOCKS_IN_MODELDESCRIPTION = CONFIG_FLAG(147, "exportClocksInModelDescription",
+constant ConfigFlag EXPORT_CLOCKS_IN_MODELDESCRIPTION = CONFIG_FLAG("exportClocksInModelDescription",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("exports clocks in modeldescription.xml for fmus, The default is false."));
 
-constant ConfigFlag LINK_TYPE = CONFIG_FLAG(148, "linkType",
+constant ConfigFlag LINK_TYPE = CONFIG_FLAG("linkType",
   NONE(), EXTERNAL(), ENUM_FLAG(1, {("dynamic",1), ("static",2)}),
   SOME(STRING_OPTION({"dynamic", "static"})),
   Gettext.gettext("Sets the link type for the simulation executable.\n"+
                "dynamic: libraries are dynamically linked; the executable is built very fast but is not portable because of DLL dependencies.\n"+
                "static: libraries are statically linked; the executable is built more slowly but it is portable and dependency-free.\n"));
 
-constant ConfigFlag TEARING_ALWAYS_DERIVATIVES = CONFIG_FLAG(149, "tearingAlwaysDer",
+constant ConfigFlag TEARING_ALWAYS_DERIVATIVES = CONFIG_FLAG("tearingAlwaysDer",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Always choose state derivatives as iteration variables in strong components."));
 
-constant ConfigFlag DUMP_FLAT_MODEL = CONFIG_FLAG(150, "dumpFlatModel",
+constant ConfigFlag DUMP_FLAT_MODEL = CONFIG_FLAG("dumpFlatModel",
   NONE(), EXTERNAL(), STRING_LIST_FLAG({"all"}),
   SOME(STRING_DESC_OPTION({
     ("flatten", Gettext.gettext("After flattening but before connection handling.")),
@@ -1419,11 +1423,11 @@ constant ConfigFlag DUMP_FLAT_MODEL = CONFIG_FLAG(150, "dumpFlatModel",
   })),
   Gettext.gettext("Dumps the flat model at the given stages of the frontend."));
 
-constant ConfigFlag SIMULATION = CONFIG_FLAG(151, "simulation",
+constant ConfigFlag SIMULATION = CONFIG_FLAG("simulation",
   SOME("u"), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Simulates the last model in the given Modelica file."));
 
-constant ConfigFlag OBFUSCATE = CONFIG_FLAG(152, "obfuscate",
+constant ConfigFlag OBFUSCATE = CONFIG_FLAG("obfuscate",
   NONE(), EXTERNAL(), STRING_FLAG("none"),
   SOME(STRING_DESC_OPTION({
     ("none", Gettext.gettext("No obfuscation.")),
@@ -1433,7 +1437,7 @@ constant ConfigFlag OBFUSCATE = CONFIG_FLAG(152, "obfuscate",
   })),
   Gettext.gettext("Obfuscates identifiers in the simulation model"));
 
-constant ConfigFlag FMU_RUNTIME_DEPENDS = CONFIG_FLAG(153, "fmuRuntimeDepends",
+constant ConfigFlag FMU_RUNTIME_DEPENDS = CONFIG_FLAG("fmuRuntimeDepends",
   NONE(), EXTERNAL(), STRING_FLAG("default"),
   SOME(STRING_DESC_OPTION({
     ("default",  Gettext.notrans("Depending on CMake version. If CMake version >= 3.21 use  \"modelica\", otherwise use \"none\"")),
@@ -1447,11 +1451,11 @@ constant ConfigFlag FMU_RUNTIME_DEPENDS = CONFIG_FLAG(153, "fmuRuntimeDepends",
     })),
   Gettext.gettext("Defines if runtime library dependencies are included in the FMU. Only used when compiler flag fmuCMakeBuild=true."));
 
-constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(154, "frontendInline",
+constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG("frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
-constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(155, "nonStdExposeLocalIOs",
+constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG("nonStdExposeLocalIOs",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
   Gettext.gettext("Keeps input/output prefixes for unconnected input/output connectors at requested levels, provided they are public, " +
                   "0 meaning top-level (standard Modelica), 1 inputs/outputs of top-level components, >1 going deeper. " +
@@ -1471,14 +1475,15 @@ function isSet
   input DebugFlag inFlag;
   output Boolean outValue;
 protected
-  array<Boolean> debug_flags;
-  Flag flags;
-  Integer index;
+  UnorderedMap<String, Boolean> debug_flags;
 algorithm
-  DEBUG_FLAG(index = index) := inFlag;
-  flags := getFlags();
-  FLAGS(debugFlags = debug_flags) := flags;
-  outValue := arrayGet(debug_flags, index);
+  FLAGS(debugFlags = debug_flags) := getFlags();
+  if UnorderedMap.contains(inFlag.name, debug_flags) then
+    outValue := UnorderedMap.getSafe(inFlag.name, debug_flags, sourceInfo());
+  else
+    // this should not happen, but in case its not set, just use default
+    outValue := inFlag.default;
+  end if;
 end isSet;
 
 function isConfigFlagSet
@@ -1503,15 +1508,15 @@ public function getConfigValue
   input ConfigFlag inFlag;
   output FlagData outValue;
 protected
-  array<FlagData> config_flags;
-  Integer index;
-  Flag flags;
-  String name;
+  UnorderedMap<String, FlagData> config_flags;
 algorithm
-  CONFIG_FLAG(name = name, index = index) := inFlag;
-  flags := getFlags();
-  FLAGS(configFlags = config_flags) := flags;
-  outValue := arrayGet(config_flags, index);
+  FLAGS(configFlags = config_flags) := getFlags();
+  if UnorderedMap.contains(inFlag.name, config_flags) then
+    outValue := UnorderedMap.getSafe(inFlag.name, config_flags, sourceInfo());
+  else
+    Error.addMessage(Error.UNKNOWN_DEBUG_FLAG, {inFlag.name});
+    fail();
+  end if;
 end getConfigValue;
 
 function getConfigBool


### PR DESCRIPTION
 - remove bad to maintain index structure in flags. everything works with unordered maps now
 - flags can be ordered in any way, no consecutive indices to maintain
 - remove some unnecessary code and clean up
 - no functional changes