### PR TITLE
Use nominal values for zero-crossing tolerance

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -2013,22 +2013,13 @@ end getVarDirection;
 public function getVarNominalValue "
   Returns the DAE.NominalValue or default value of a variable."
   input BackendDAE.Var InVar;
-  output DAE.Exp nom;
-algorithm
-  nom := match(InVar)
-         local Option<DAE.VariableAttributes> attr;
-           case(BackendDAE.VAR(values = attr)) then DAEUtil.getNominalAttr(attr);
-         end match;
+  output DAE.Exp nom = DAEUtil.getNominalAttr(InVar.values);
 end getVarNominalValue;
 
 public function getVarKind "
   Get the DAE.VarKind of a variable"
   input BackendDAE.Var inVar;
-  output BackendDAE.VarKind varKind;
-algorithm
-  varKind := match (inVar)
-    case (BackendDAE.VAR(varKind = varKind)) then  varKind;
-  end match;
+  output BackendDAE.VarKind varKind = inVar.varKind;
 end getVarKind;
 
 public function getVarKindForVar"fetch the varkind for an indexed var inside the variable-array."

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -1122,11 +1122,10 @@ public function getNominalAttr "
   input Option<DAE.VariableAttributes> attr;
   output DAE.Exp nominal;
 algorithm
-  nominal:=
-  match (attr)
+  nominal:= match attr
     local
       DAE.Exp n;
-    case (SOME(DAE.VAR_ATTR_REAL(nominal=SOME(n)))) then n;
+    case SOME(DAE.VAR_ATTR_REAL(nominal=SOME(n))) then n;
     else DAE.RCONST(1.0);
   end match;
 end getNominalAttr;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15829,5 +15829,28 @@ algorithm
   end for;
 end getSimIteratorSize;
 
+function getExpNominal
+  "Returns the nominal value of an expression.
+  Used to scale zero-crossings like `a > b`."
+  input DAE.Exp exp;
+  output DAE.Exp nom;
+algorithm
+  nom := match exp
+    local
+      DAE.ComponentRef cr;
+      SimCodeVar.SimVar v;
+    case DAE.CREF(componentRef = cr) algorithm
+      v := cref2simvar(cr, getSimCode());
+    then Util.getOptionOrDefault(v.nominalValue, DAE.RCONST(1.0));
+
+    // for DAE.RCONST(0.0) use zero nominal to not saturate the other side of the zero-crossing
+    case DAE.RCONST() then exp;
+
+    // TODO find good rules for nominal propagation
+
+    else DAE.RCONST(1.0);
+  end match;
+end getExpNominal;
+
 annotation(__OpenModelica_Interface="backend");
 end SimCodeUtil;

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15829,7 +15829,7 @@ algorithm
   end for;
 end getSimIteratorSize;
 
-function getExpNominal
+public function getExpNominal
   "Returns the nominal value of an expression.
   Used to scale zero-crossings like `a > b`."
   input DAE.Exp exp;

--- a/OMCompiler/Compiler/Stubs/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/Stubs/SimCodeUtil.mo
@@ -63,6 +63,12 @@ algorithm
   /* Do nothing */
 end codegenExpSanityCheck;
 
+function getExpNominal
+  input output DAE.Exp e;
+algorithm
+  /* Do nothing */
+end getExpNominal;
+
 function getValueReference
   input SimCodeVar.SimVar inSimVar;
   input SimCode.SimCode inSimCode;

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -6131,7 +6131,7 @@ case rel as RELATION(__) then
       let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
       let res = tempDecl("modelica_boolean", &varDecls)
       if intEq(rel.index,-1) then
-        let &preExp += '<%res%> = <%rel_f%>>(<%e1%>,<%e2%>);<%\n%>'
+        let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
         res
       else
         let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5995,6 +5995,7 @@ case rel as RELATION(__) then
     let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
     let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
     match rel.operator
+
     case LESS(ty = T_BOOL(__))             then '(!<%e1%> && <%e2%>)'
     case LESS(ty = T_STRING(__))           then '(stringCompare(<%e1%>, <%e2%>) < 0)'
     case LESS(ty = T_INTEGER(__))          then '(<%e1%> < <%e2%>)'
@@ -6019,7 +6020,7 @@ case rel as RELATION(__) then
     case GREATEREQ(ty = T_REAL(__))        then '(<%e1%> >= <%e2%>)'
     case GREATEREQ(ty = T_ENUMERATION(__)) then '(<%e1%> >= <%e2%>)'
 
-    case EQUAL(ty = T_BOOL(__))            then '((!<%e1%> && !<%e2%>) || (<%e1%> && <%e2%>))'
+    case EQUAL(ty = T_BOOL(__))            then '(!<%e1%> == !<%e2%>)' /* the ! converts to bool if not already */
     case EQUAL(ty = T_STRING(__))          then '(stringEqual(<%e1%>, <%e2%>))'
     case EQUAL(ty = T_INTEGER(__))         then '(<%e1%> == <%e2%>)'
     case EQUAL(ty = T_REAL(__))            then '(<%e1%> == <%e2%>)'
@@ -6027,7 +6028,7 @@ case rel as RELATION(__) then
     //case EQUAL(ty = T_ARRAY(__))           then '<%e2%>' /* Used for Boolean array. Called from daeExpLunary. */
     case EQUAL(ty = T_ARRAY(__))           then '(<%e1%> == <%e2%>)'
 
-    case NEQUAL(ty = T_BOOL(__))           then '((!<%e1%> && <%e2%>) || (<%e1%> && !<%e2%>))'
+    case NEQUAL(ty = T_BOOL(__))           then '(!<%e1%> != !<%e2%>)' /* the ! converts to bool if not already */
     case NEQUAL(ty = T_STRING(__))         then '(!stringEqual(<%e1%>, <%e2%>))'
     case NEQUAL(ty = T_INTEGER(__))        then '(<%e1%> != <%e2%>)'
     case NEQUAL(ty = T_REAL(__))           then '(<%e1%> != <%e2%>)'
@@ -6048,32 +6049,32 @@ match exp
 case rel as RELATION(__) then
   match context
   case OMSI_CONTEXT(__) then
-      let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
-      let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
-      let res = tempDecl("omsi_bool", &varDecls)
-      let _ = match rel.operator
-        case LESS(__) then
-          let &preExp += '<%res%> = <%e1%> < <%e2%>;<%\n%>'
-          <<>>
-        case LESSEQ(__) then
-          let &preExp += '<%res%> = <%e1%> <= <%e2%>;<%\n%>'
-          <<>>
-        case GREATER(__) then
-          let &preExp += '<%res%> = <%e1%> > <%e2%>;<%\n%>'
-          <<>>
-        case GREATEREQ(__) then
-          let &preExp += '<%res%> = <%e1%> >= <%e2%>;<%\n%>'
-          <<>>
-        end match
-      if intEq(rel.index,-1) then
-        res
-      else
-        match  Config.simCodeTarget()
-          case "omsic" then
-            'omsi_function_zero_crossings(this_function, <%res%>, <%rel.index%>, omsic_get_model_state())'
-           /*deactivated case "omsicpp" then
-            'omsi_function_zero_crossings(this_function, <%res%>, <%rel.index%>, omsic_get_model_state())'*/
-        end match
+    let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
+    let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
+    let res = tempDecl("omsi_bool", &varDecls)
+    let _ = match rel.operator
+      case LESS(__) then
+        let &preExp += '<%res%> = <%e1%> < <%e2%>;<%\n%>'
+        <<>>
+      case LESSEQ(__) then
+        let &preExp += '<%res%> = <%e1%> <= <%e2%>;<%\n%>'
+        <<>>
+      case GREATER(__) then
+        let &preExp += '<%res%> = <%e1%> > <%e2%>;<%\n%>'
+        <<>>
+      case GREATEREQ(__) then
+        let &preExp += '<%res%> = <%e1%> >= <%e2%>;<%\n%>'
+        <<>>
+    end match
+    if intEq(rel.index,-1) then
+      res
+    else
+      match  Config.simCodeTarget()
+        case "omsic" then
+          'omsi_function_zero_crossings(this_function, <%res%>, <%rel.index%>, omsic_get_model_state())'
+          /*deactivated case "omsicpp" then
+          'omsi_function_zero_crossings(this_function, <%res%>, <%rel.index%>, omsic_get_model_state())'*/
+      end match
   case JACOBIAN_CONTEXT(__)
   case DAE_MODE_CONTEXT(__)
   case SIMULATION_CONTEXT(__) then
@@ -6083,41 +6084,39 @@ case rel as RELATION(__) then
     case GREATER(__) then 'Greater'
     case GREATEREQ(__) then 'GreaterEq'
     end match
-    match rel.optionExpisASUB
-    case NONE() then
+    if rel_f then
       let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
       let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
       let res = tempDecl("modelica_boolean", &varDecls)
-      if intEq(rel.index,-1) then
-        let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
-        res
-      else
-        let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
-        let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
-        let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
-        let &preExp += if isReal then
-          'relationhysteresis(data, &<%res%>, <%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, <%rel.index%>, <%rel_f%>, <%rel_f%>ZC);<%\n%>'
+      match rel.optionExpisASUB
+      case NONE() then
+        if intEq(rel.index,-1) then
+          let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
+          res
         else
-          'relation(data, &<%res%>, <%e1%>, <%e2%>, <%rel.index%>, <%rel_f%>);<%\n%>'
-        res
-    case SOME((exp,i,j)) then
-      let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
-      let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
-      let iterator = daeExp(exp, context, &preExp, &varDecls, &auxFunction)
-      let res = tempDecl("modelica_boolean", &varDecls)
-      if intEq(rel.index,-1) then
-        let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
-        res
-      else
-        let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
-        let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
-        let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
-        let &preExp += if isReal then
-          'relationhysteresis(data, &<%res%>, <%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, <%rel.index%> + (<%iterator%> - <%i%>)/<%j%>, <%rel_f%>, <%rel_f%>ZC);<%\n%>'
+          let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
+          let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
+          let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
+          let &preExp += if isReal then
+            'relationhysteresis(data, &<%res%>, <%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, <%rel.index%>, <%rel_f%>, <%rel_f%>ZC);<%\n%>'
+          else
+            'relation(data, &<%res%>, <%e1%>, <%e2%>, <%rel.index%>, <%rel_f%>);<%\n%>'
+          res
+      case SOME((exp,i,j)) then
+        let iterator = daeExp(exp, context, &preExp, &varDecls, &auxFunction)
+        if intEq(rel.index,-1) then
+          let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
+          res
         else
-          'relation(data, &<%res%>, <%e1%>, <%e2%>, <%rel.index%> + (<%iterator%> - <%i%>)/<%j%>, <%rel_f%>);<%\n%>'
-        res
-    end match
+          let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
+          let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
+          let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
+          let &preExp += if isReal then
+            'relationhysteresis(data, &<%res%>, <%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, <%rel.index%> + (<%iterator%> - <%i%>)/<%j%>, <%rel_f%>, <%rel_f%>ZC);<%\n%>'
+          else
+            'relation(data, &<%res%>, <%e1%>, <%e2%>, <%rel.index%> + (<%iterator%> - <%i%>)/<%j%>, <%rel_f%>);<%\n%>'
+          res
+      end match
   case ZEROCROSSINGS_CONTEXT(__) then
     let rel_f = match rel.operator
     case LESS(__) then 'Less'
@@ -6125,36 +6124,34 @@ case rel as RELATION(__) then
     case GREATER(__) then 'Greater'
     case GREATEREQ(__) then 'GreaterEq'
     end match
-    match rel.optionExpisASUB
-    case NONE() then
+    if rel_f then
       let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
       let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
       let res = tempDecl("modelica_boolean", &varDecls)
-      if intEq(rel.index,-1) then
-        let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
-        res
-      else
-        let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
-        let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
-        let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
-        let hysteresisfunction = if isReal then '<%rel_f%>ZC(<%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, data->simulationInfo->storedRelations[<%rel.index%>])' else '<%rel_f%>(<%e1%>,<%e2%>)'
-        let &preExp += '<%res%> = <%hysteresisfunction%>;<%\n%>'
-        res
-    case SOME((exp,i,j)) then
-      let e1 = daeExp(rel.exp1, context, &preExp, &varDecls, &auxFunction)
-      let e2 = daeExp(rel.exp2, context, &preExp, &varDecls, &auxFunction)
-      let res = tempDecl("modelica_boolean", &varDecls)
-      if intEq(rel.index,-1) then
-        let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
-        res
-      else
-        let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
-        let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
-        let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
-        let hysteresisfunction = if isReal then '<%rel_f%>ZC(<%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, data->simulationInfo->storedRelations[<%rel.index%>])' else '<%rel_f%>(<%e1%>,<%e2%>)'
-        let &preExp += '<%res%> = <%hysteresisfunction%>;<%\n%>'
-        res
-    end match
+      match rel.optionExpisASUB
+      case NONE() then
+        if intEq(rel.index,-1) then
+          let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
+          res
+        else
+          let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
+          let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
+          let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
+          let hysteresisfunction = if isReal then '<%rel_f%>ZC(<%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, data->simulationInfo->storedRelations[<%rel.index%>])' else '<%rel_f%>(<%e1%>,<%e2%>)'
+          let &preExp += '<%res%> = <%hysteresisfunction%>;<%\n%>'
+          res
+      case SOME((exp,i,j)) then
+        if intEq(rel.index,-1) then
+          let &preExp += '<%res%> = <%rel_f%>(<%e1%>,<%e2%>);<%\n%>'
+          res
+        else
+          let isReal = if isRealType(typeof(rel.exp1)) then (if isRealType(typeof(rel.exp2)) then 'true' else '') else ''
+          let e1_nom = daeExp(getExpNominal(rel.exp1), context, &preExp, &varDecls, &auxFunction)
+          let e2_nom = daeExp(getExpNominal(rel.exp2), context, &preExp, &varDecls, &auxFunction)
+          let hysteresisfunction = if isReal then '<%rel_f%>ZC(<%e1%>, <%e2%>, <%e1_nom%>, <%e2_nom%>, data->simulationInfo->storedRelations[<%rel.index%>])' else '<%rel_f%>(<%e1%>,<%e2%>)'
+          let &preExp += '<%res%> = <%hysteresisfunction%>;<%\n%>'
+          res
+      end match
   end match
 end match
 end daeExpRelationSim;

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -1433,6 +1433,11 @@ package SimCodeUtil
     input SimCodeVar.SimVar simVar;
     output String out_string;
   end getFmiInitialAttributeStr;
+
+  function getExpNominal
+    input DAE.Exp exp;
+    output DAE.Exp nom;
+  end getExpNominal;
 end SimCodeUtil;
 
 package SimCodeFunctionUtil

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1416,27 +1416,27 @@ void setZCtol(double relativeTol)
 }
 
 /* TODO: fix this */
-modelica_boolean LessZC(double a, double b, modelica_boolean direction)
+modelica_boolean LessZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean direction)
 {
-  double eps = tolZC * fmax(fabs(a), fabs(b)) + tolZC;
+  double eps = tolZC * (fmax(fabs(a), fabs(b)) + fmax(fabs(a_nominal), fabs(b_nominal)));
   return direction ? (a - b <= eps) : (a - b <= -eps);
 }
 
-modelica_boolean LessEqZC(double a, double b, modelica_boolean direction)
+modelica_boolean LessEqZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean direction)
 {
-  return !GreaterZC(a, b, !direction);
+  return !GreaterZC(a, b, a_nominal, b_nominal, !direction);
 }
 
 /* TODO: fix this */
-modelica_boolean GreaterZC(double a, double b, modelica_boolean direction)
+modelica_boolean GreaterZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean direction)
 {
-  double eps = tolZC * fmax(fabs(a), fabs(b)) + tolZC;
+  double eps = tolZC * (fmax(fabs(a), fabs(b)) + fmax(fabs(a_nominal), fabs(b_nominal)));
   return direction ? (a - b >= -eps ) : (a - b >= eps);
 }
 
-modelica_boolean GreaterEqZC(double a, double b, modelica_boolean direction)
+modelica_boolean GreaterEqZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean direction)
 {
-  return !LessZC(a, b, !direction);
+  return !LessZC(a, b, a_nominal, b_nominal, !direction);
 }
 
 modelica_boolean Less(double a, double b)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.h
@@ -136,10 +136,10 @@ modelica_boolean GreaterEq(double a, double b);
 /* functions used to evaluate relation in
  * zero-crossing with hysteresis effect
  */
-modelica_boolean LessZC(double a, double b, modelica_boolean);
-modelica_boolean LessEqZC(double a, double b, modelica_boolean);
-modelica_boolean GreaterZC(double a, double b, modelica_boolean);
-modelica_boolean GreaterEqZC(double a, double b, modelica_boolean);
+modelica_boolean LessZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean);
+modelica_boolean LessEqZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean);
+modelica_boolean GreaterZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean);
+modelica_boolean GreaterEqZC(double a, double b, double a_nominal, double b_nominal, modelica_boolean);
 
 
 /**
@@ -189,7 +189,7 @@ static inline void relation(DATA* data, modelica_boolean* res, double exp1, doub
  * @param[in]   op_w      Comparison function, e.g. Less.
  * @param[in]   op_w_zc   Matching comparison function of op_w for zero-crossing, e.g. LessZC.
  */
-static inline void relationhysteresis(DATA* data, modelica_boolean* res, double exp1, double exp2, int index, modelica_boolean(*op_w)(double, double), modelica_boolean(*op_w_zc)(double, double, modelica_boolean))
+static inline void relationhysteresis(DATA* data, modelica_boolean* res, double exp1, double exp2, double exp1_nominal, double exp2_nominal, int index, modelica_boolean(*op_w)(double, double), modelica_boolean(*op_w_zc)(double, double, double, double, modelica_boolean))
 {
   if(data->simulationInfo->initial)
   {
@@ -202,7 +202,7 @@ static inline void relationhysteresis(DATA* data, modelica_boolean* res, double 
   }
   else
   {
-    *res = op_w_zc(exp1, exp2, data->simulationInfo->storedRelations[index]);
+    *res = op_w_zc(exp1, exp2, exp1_nominal, exp2_nominal, data->simulationInfo->storedRelations[index]);
     data->simulationInfo->relations[index] = *res;
   }
 }


### PR DESCRIPTION
### Related Issues

Fixes basic case of #6970

TODO propagate nominal value through general expressions.