### PR TITLE
Use om bootstrapping git

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,7 @@ After Jenkins checks that all is OK a developer will:
 * **reset** (or restart, or **merge**, if there were other commits added to OMCompiler-3rdParty since you started) the OMCompiler-3rdParty master branch so the new HEAD contains the HEAD commit of the branch
 * merge the PR in the OpenModelica glue project
 * delete the branch in the OMCompiler-3rdParty
+
+## Bootstrapping sources
+
+Sometimes one would need to update the bootstrapping sources to add new features to the MetaModelica compiler. The bootstrapping sources are stored at: [OMBootstrapping](https://github.com/OpenModelica/OMBootstrapping.git), just make a PR for it with the contents of OMCompiler/Compiler/boot/build.

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -7,9 +7,23 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz")
 else()
 #download and unpack the sources
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
-file(DOWNLOAD https://build.openmodelica.org/omc/bootstrap/sources.tar.gz
-     ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz SHOW_PROGRESS)
-execute_process(COMMAND tar xzf sources.tar.gz
+file(DOWNLOAD https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz
+     ${CMAKE_CURRENT_SOURCE_DIR}/bomc/sources.tar.gz
+     SHOW_PROGRESS
+     STATUS status
+     LOG log)
+# fetch the elements of the status!
+list(GET status 0 status_code)
+list(GET status 1 status_string)
+# check the download status!
+if(NOT status_code EQUAL 0)
+message(FATAL_ERROR "error: downloading 'https://github.com/OpenModelica/OMBootstrapping/archive/refs/heads/master.tar.gz' failed
+        status_code: ${status_code}
+        status_string: ${status_string}
+        log: ${log}")
+endif()
+message(STATUS "downloading bootstrapping sources ... done")
+execute_process(COMMAND tar xzf sources.tar.gz --strip-components=1
                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bomc/)
 endif()
 

--- a/README.cmake.msvc.md
+++ b/README.cmake.msvc.md
@@ -19,7 +19,7 @@ Modelica model. However, running actual simulations still needs some work.
 
 Unfortunately, it is not possbile to compile `OMEdit`, `OMNotebook` and `OMShell` yet because of missing `QtWebkit` support.
 
-On Windows, a package manager is necessary to get all the ubiquitous linux libraires that we have come to depend on such as `libcurl`, `libiconv`, `gettext` and `pthreads`. In addition, we also need to make availabe the bigger dependencies starting from `Lapack` all the way to `Boost`, `Qt`, `OpenGl`, and `OpenSceneGraph`.
+On Windows, a package manager is necessary to get all the ubiquitous Linux libraries that we have come to depend on such as `libcurl`, `libiconv`, `gettext` and `pthreads`. In addition, we also need to make available the bigger dependencies starting from `Lapack` all the way to `Boost`, `Qt`, `OpenGl`, and `OpenSceneGraph`.
 
 These instructions are intended to be used with:
 - The `Windows Terminal` terminal.


### PR DESCRIPTION
### Related Issues

use https://github.com/OpenModelica/OMBootstrapping to fetch the C sources for the compiler when building with CMake.
