### PR TITLE
Calling fmi2SetXXX in continuous time mode

### DIFF
--- a/OMCompiler/SimulationRuntime/c/fmi/FMI2Common.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI2Common.c
@@ -156,7 +156,7 @@ void fmi2SetInteger_OMC(void* in_fmi2, int numberOfValueReferences, double* inte
 {
   if (fmiType == 1) {
     FMI2ModelExchange* FMI2ME = (FMI2ModelExchange*)in_fmi2;
-    if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode) {
+    if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode || FMI2ME->FMISolvingMode == fmi2_continuousTime_mode) {
       fmi2_value_reference_t* valuesReferences_int = real_to_fmi2_value_reference(numberOfValueReferences, integerValuesReferences);
       fmi2_status_t status = fmi2_import_set_integer(FMI2ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences, (fmi2_integer_t*)integerValues);
       free(valuesReferences_int);
@@ -202,7 +202,7 @@ void fmi2SetBoolean_OMC(void* in_fmi2, int numberOfValueReferences, double* bool
 {
   if (fmiType == 1) {
     FMI2ModelExchange* FMI2ME = (FMI2ModelExchange*)in_fmi2;
-    if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode) {
+    if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode || FMI2ME->FMISolvingMode == fmi2_continuousTime_mode) {
       fmi2_value_reference_t* valuesReferences_int = real_to_fmi2_value_reference(numberOfValueReferences, booleanValuesReferences);
       int* fmiBoolean = malloc(sizeof(int)*numberOfValueReferences);
       fmi2_status_t status;
@@ -247,7 +247,7 @@ void fmi2SetString_OMC(void* in_fmi2, int numberOfValueReferences, double* strin
 {
   if (fmiType == 1) {
     FMI2ModelExchange* FMI2ME = (FMI2ModelExchange*)in_fmi2;
-    if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode) {
+    if (FMI2ME->FMISolvingMode == fmi2_instantiated_mode || FMI2ME->FMISolvingMode == fmi2_initialization_mode || FMI2ME->FMISolvingMode == fmi2_event_mode || FMI2ME->FMISolvingMode == fmi2_continuousTime_mode) {
       fmi2_value_reference_t* valuesReferences_int = real_to_fmi2_value_reference(numberOfValueReferences, stringValuesReferences);
       fmi2_status_t status = fmi2_import_set_string(FMI2ME->FMIImportInstance, valuesReferences_int, numberOfValueReferences, (fmi2_string_t*)stringValues);
       free(valuesReferences_int);


### PR DESCRIPTION
as requested by @AnHeuermann 
Here is the reopened fix for #10915

This fix makes integer, boolean and string inputs work for generated FMUs from other simulation tools. This fix is not standard compliant, but all other tools call fmi2SetXXX in continuous time mode too. Therefor this fix is in line with all other simulation tools.