### PR TITLE
fix unintended SIGFPE throw (issue 10975)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -679,7 +679,7 @@ void initSample(DATA* data, threadData_t *threadData, double startTime, double s
     }
   }
 
-  if(stopTime < data->simulationInfo->nextSampleEvent) {
+  if(!isnan(data->simulationInfo->nextSampleEvent) && stopTime < data->simulationInfo->nextSampleEvent) {
     debugStreamPrint(LOG_EVENTS, 0, "there are no sample-events");
   } else {
     debugStreamPrint(LOG_EVENTS, 0, "first sample-event at t = %g", data->simulationInfo->nextSampleEvent);


### PR DESCRIPTION
## Related Issues
#10975 

### Purpose
Prevent an unintended SIGFPE throw during FMU initialization.

### Approach
Catch NaN value before executing a floating-point comparison with it.
