### PR TITLE
Added a context menu to allow setting final and each modifiers

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -3568,7 +3568,8 @@ void Element::duplicate()
     ModelInstance::Component *pModelInstanceComponent = GraphicsView::createModelInstanceComponent(mpGraphicsView->getModelWidget()->getModelInstance(), name, getClassName());
     mpGraphicsView->addElementToView(pModelInstanceComponent, false, true, false, QPointF(0, 0), getOMCPlacementAnnotation(gridStep), false);
     // set modifiers
-    GraphicsView::setModifiers(mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure(), name, "", mpModelComponent->getModifier());
+    MainWindow::instance()->getOMCProxy()->setElementModifierValue(mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure(), name,
+                                                                   mpModelComponent->getModifier().toString());
   } else {
     mpElementInfo->getModifiersMap(MainWindow::instance()->getOMCProxy(), mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure(), this);
     ElementInfo *pElementInfo = new ElementInfo(mpElementInfo);

--- a/OMEdit/OMEditLIB/Element/ElementProperties.h
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.h
@@ -39,6 +39,27 @@
 
 #include <QRadioButton>
 
+class FinalEachToolButton : public QToolButton
+{
+  Q_OBJECT
+public:
+  FinalEachToolButton(bool canHaveEach, QWidget *parent = nullptr);
+
+  void setFinal(bool final);
+  bool isFinal() const {return mpFinalAction->isChecked();}
+  void setEach(bool each);
+  bool isEach() const {return mpEachAction->isChecked();}
+  bool isModified() const;
+private:
+  QMenu *mpFinalEachMenu;
+  QAction *mpFinalAction;
+  bool mFinalDefault = false;
+  QAction *mpEachAction;
+  bool mEachDefault = false;
+public slots:
+  void showParameterMenu();
+};
+
 class ElementParametersOld;
 class ElementParameters;
 class Parameter : public QObject
@@ -74,7 +95,8 @@ public:
   void updateNameLabel();
   Label* getNameLabel() {return mpNameLabel;}
   FixedCheckBox* getFixedCheckBox() {return mpFixedCheckBox;}
-  QString getOriginalFixedValue() {return mOriginalFixedValue;}
+  QString getOriginalFixedValue() const {return mOriginalFixedValue;}
+  FinalEachToolButton *getFixedFinalEachMenu() const {return mpFixedFinalEachMenuButton;}
   void setValueType(ValueType valueType) {mValueType = valueType;}
   void setValueWidget(QString value, bool defaultValue, QString fromUnit, bool valueModified = false, bool adjustSize = true, bool unitComboBoxChanged = false);
   ValueType getValueType() {return mValueType;}
@@ -82,6 +104,7 @@ public:
   bool isValueModified();
   QString getValue();
   QToolButton *getEditRedeclareClassButton() const {return mpEditRedeclareClassButton;}
+  FinalEachToolButton *getFinalEachMenu() const {return mpFinalEachMenuButton;}
   QToolButton* getFileSelectorButton() {return mpFileSelectorButton;}
   void setLoadSelectorFilter(QString loadSelectorFilter) {mLoadSelectorFilter = loadSelectorFilter;}
   QString getLoadSelectorFilter() {return mLoadSelectorFilter;}
@@ -91,10 +114,13 @@ public:
   QString getSaveSelectorFilter() {return mSaveSelectorFilter;}
   void setSaveSelectorCaption(QString saveSelectorCaption) {mSaveSelectorCaption = saveSelectorCaption;}
   QString getSaveSelectorCaption() {return mSaveSelectorCaption;}
+  void setHasDisplayUnit(bool hasDisplayUnit) {mHasDisplayUnit = hasDisplayUnit;}
+  bool hasDisplayUnit() const {return mHasDisplayUnit;}
   QString getUnit() {return mUnit;}
   void setDisplayUnit(QString displayUnit) {mDisplayUnit = displayUnit;}
   QString getDisplayUnit() {return mDisplayUnit;}
   QComboBox* getUnitComboBox() {return mpUnitComboBox;}
+  FinalEachToolButton *getDisplayUnitFinalEachMenu() const {return mpDisplayUnitFinalEachMenuButton;}
   Label* getCommentLabel() {return mpCommentLabel;}
   void setFixedState(QString fixed, bool defaultValue);
   QString getFixedState() const;
@@ -122,6 +148,7 @@ private:
   Label *mpNameLabel;
   FixedCheckBox *mpFixedCheckBox;
   QString mOriginalFixedValue;
+  FinalEachToolButton *mpFixedFinalEachMenuButton = 0;
   ValueType mValueType;
   bool mValueCheckBoxModified;
   QString mDefaultValue;
@@ -129,16 +156,20 @@ private:
   QLineEdit *mpValueTextBox;
   QCheckBox *mpValueCheckBox;
   QToolButton *mpEditRedeclareClassButton = 0;
+  FinalEachToolButton *mpFinalEachMenuButton = 0;
   QToolButton *mpFileSelectorButton;
+  bool mHasDisplayUnit = false;
   QString mUnit;
   QString mDisplayUnit;
   QString mPreviousUnit;
   QComboBox *mpUnitComboBox;
+  FinalEachToolButton *mpDisplayUnitFinalEachMenuButton = 0;
   Label *mpCommentLabel;
 
   void createValueWidget();
   void enableDisableUnitComboBox(const QString &value);
   void updateValueBinding(const FlatModelica::Expression expression);
+  bool isValueModifiedHelper() const;
 public slots:
   void editRedeclareClassButtonClicked();
   void fileSelectorButtonClicked();
@@ -193,7 +224,7 @@ public:
   GraphicsView *getGraphicsView() const {return mpGraphicsView;}
   bool isInherited() const {return mInherited;}
   QString getModification() const {return mModification;}
-  void applyFinalStartFixedAndDisplayUnitModifiers(Parameter *pParameter, const ModelInstance::Modifier &modifier, bool defaultValue, bool isElementModification);
+  void applyFinalStartFixedAndDisplayUnitModifiers(Parameter *pParameter, const ModelInstance::Modifier &modifier, bool defaultValue, bool isElementModification, bool checkFinal);
   void updateParameters();
 private:
   ModelInstance::Element *mpElement;

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -566,7 +566,7 @@ void UpdateElementAttributesCommand::updateComponentModifiers(Element *pComponen
   for (modifiersIterator = modifiers.begin(); modifiersIterator != modifiers.end(); ++modifiersIterator) {
     QString modifierName = QString(pComponent->getName()).append(".").append(modifiersIterator.key());
     QString modifierValue = modifiersIterator.value();
-    if (MainWindow::instance()->getOMCProxy()->setElementModifierValue(modelName, modifierName, modifierValue)) {
+    if (MainWindow::instance()->getOMCProxy()->setElementModifierValueOld(modelName, modifierName, modifierValue)) {
       modifierValueChanged = true;
     }
   }
@@ -606,7 +606,7 @@ void UpdateElementParametersCommand::redoInternal()
     for (componentModifier = mNewComponentModifiersMap.begin(); componentModifier != mNewComponentModifiersMap.end(); ++componentModifier) {
       QString modifierValue = componentModifier.value();
       QString modifierKey = QString(mpComponent->getName()).append(".").append(componentModifier.key());
-      pOMCProxy->setElementModifierValue(className, modifierKey, modifierValue);
+      pOMCProxy->setElementModifierValueOld(className, modifierKey, modifierValue);
     }
     // we want to load modifiers even if they are loaded already
     mpComponent->getElementInfo()->setModifiersLoaded(false);
@@ -618,7 +618,7 @@ void UpdateElementParametersCommand::redoInternal()
     QMap<QString, QString>::iterator componentExtendsModifier;
     for (componentExtendsModifier = mNewComponentExtendsModifiersMap.begin(); componentExtendsModifier != mNewComponentExtendsModifiersMap.end(); ++componentExtendsModifier) {
       QString modifierValue = componentExtendsModifier.value();
-      pOMCProxy->setExtendsModifierValue(className, inheritedClassName, componentExtendsModifier.key(), modifierValue);
+      pOMCProxy->setExtendsModifierValueOld(className, inheritedClassName, componentExtendsModifier.key(), modifierValue);
     }
     mpComponent->getGraphicsView()->getModelWidget()->fetchExtendsModifiers(inheritedClassName);
   }
@@ -641,7 +641,7 @@ void UpdateElementParametersCommand::undo()
     for (componentModifier = mOldComponentModifiersMap.begin(); componentModifier != mOldComponentModifiersMap.end(); ++componentModifier) {
       QString modifierValue = componentModifier.value();
       QString modifierKey = QString(mpComponent->getName()).append(".").append(componentModifier.key());
-      pOMCProxy->setElementModifierValue(className, modifierKey, modifierValue);
+      pOMCProxy->setElementModifierValueOld(className, modifierKey, modifierValue);
     }
     // we want to load modifiers even if they are loaded already
     mpComponent->getElementInfo()->setModifiersLoaded(false);
@@ -655,7 +655,7 @@ void UpdateElementParametersCommand::undo()
     QMap<QString, QString>::iterator componentExtendsModifier;
     for (componentExtendsModifier = mOldComponentExtendsModifiersMap.begin(); componentExtendsModifier != mOldComponentExtendsModifiersMap.end(); ++componentExtendsModifier) {
       QString modifierValue = componentExtendsModifier.value();
-      pOMCProxy->setExtendsModifierValue(className, inheritedClassName, componentExtendsModifier.key(), modifierValue);
+      pOMCProxy->setExtendsModifierValueOld(className, inheritedClassName, componentExtendsModifier.key(), modifierValue);
     }
     mpComponent->getGraphicsView()->getModelWidget()->fetchExtendsModifiers(inheritedClassName);
   }

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -720,41 +720,50 @@ namespace ModelInstance
     }
   }
 
-  QString Modifier::getValueWithSubModifiers() const
+  QString Modifier::toString() const
   {
-    if (mModifiers.isEmpty()) {
+    if (isRedeclare()) {
       return mValue;
     } else {
-      QStringList modifiers;
+      QString value;
+      value.append(printRedeclare());
+      value.append(printEach());
+      value.append(printFinal());
+      value.append(printReplaceable());
+      value.append(mName);
+      QStringList subModifiers;
       foreach (auto subModifier, mModifiers) {
-        if (subModifier.getModifiers().isEmpty()) {
-          modifiers.append(subModifier.getName() % "=" % subModifier.getValue());
-        } else {
-          modifiers.append(subModifier.getName() % subModifier.getValueWithSubModifiers());
-        }
+        subModifiers.append(subModifier.toString());
       }
-      return "(" % modifiers.join(",") % ")";
+      if (!subModifiers.isEmpty()) {
+        value.append("(" % subModifiers.join(", ") % ")");
+      }
+      if (mValue.isEmpty()) {
+        return value;
+      } else {
+        return value.append(mName.isEmpty() ? mValue : " = " % mValue);
+      }
     }
   }
 
-  QString Modifier::getModifier(const QString &m) const
+  Modifier Modifier::getModifier(const QString &m) const
   {
-    foreach (auto modifier, mModifiers) {
+    foreach (Modifier modifier, mModifiers) {
       if (modifier.getName().compare(m) == 0) {
-        return modifier.getValue();
+        return modifier;
       }
     }
-    return "";
+    return Modifier();
+  }
+
+  QString Modifier::getModifierValue(const QString &m) const
+  {
+    return getModifier(m).getValue();
   }
 
   bool Modifier::hasModifier(const QString &m) const
   {
-    foreach (auto modifier, mModifiers) {
-      if (modifier.getName().compare(m) == 0) {
-        return true;
-      }
-    }
-    return false;
+    return getModifier(m).getName().compare(m) == 0;
   }
 
   QString Modifier::getModifierValue(QStringList qualifiedModifierName) const
@@ -785,6 +794,26 @@ namespace ModelInstance
     }
 
     return "";
+  }
+
+  QString Modifier::printEach() const
+  {
+    return isEach() ? "each " : "";
+  }
+
+  QString Modifier::printFinal() const
+  {
+    return isFinal() ? "final " : "";
+  }
+
+  QString Modifier::printRedeclare() const
+  {
+    return isRedeclare() ? "redeclare " : "";
+  }
+
+  QString Modifier::printReplaceable() const
+  {
+    return isReplaceable() ? "replaceable " : "";
   }
 
   Replaceable::Replaceable(Model *pParentModel)

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -460,15 +460,22 @@ private:
     void setName(const QString &name) {mName = name;}
     const QString &getValue() const {return mValue;}
     QString getValueWithoutQuotes() const {return StringHandler::removeFirstLastQuotes(getValue());}
-    QString getValueWithSubModifiers() const;
-    QString getModifier(const QString &m) const;
-    bool hasModifier(const QString &m) const;
+    QString toString() const;
+    Modifier getModifier(const QString &m) const;
+    QString getModifierValue(const QString &m) const;
+    bool hasModifier(const QString &modifier) const;
     const QList<Modifier> &getModifiers() const {return mModifiers;}
     bool isFinal() const {return mFinal;}
     bool isEach() const {return mEach;}
     bool isRedeclare() const {return mRedeclare;}
     bool isReplaceable() const {return mReplaceable;}
     QString getModifierValue(QStringList qualifiedModifierName) const;
+
+    QString printEach() const;
+    QString printFinal() const;
+    QString printRedeclare() const;
+    QString printReplaceable() const;
+
   private:
     QString mName;
     QString mValue;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -931,25 +931,6 @@ ModelInstance::Component *GraphicsView::createModelInstanceComponent(ModelInstan
   return pComponent;
 }
 
-/*!
- * \brief GraphicsView::setModifiers
- * Sets the modifiers on Element.
- * \param modelName
- * \param name
- * \param modifierNames
- * \param modifier
- */
-void GraphicsView::setModifiers(const QString &modelName, const QString &name, QString modifierNames, const ModelInstance::Modifier modifier)
-{
-  foreach (auto subModifier, modifier.getModifiers()) {
-    if (!subModifier.getValue().isEmpty()) {
-      const QString modifierName = name % "." % modifierNames % subModifier.getName();
-      MainWindow::instance()->getOMCProxy()->setElementModifierValue(modelName, modifierName, subModifier.getValue());
-    }
-    GraphicsView::setModifiers(modelName, name, modifierNames % subModifier.getName() % ".", subModifier);
-  }
-}
-
 bool GraphicsView::addComponent(QString className, QPointF position)
 {
   MainWindow *pMainWindow = MainWindow::instance();
@@ -3132,7 +3113,7 @@ bool GraphicsView::updateElementConnectorSizingParameter(GraphicsView *pGraphics
         return true;
       } else {
         QString modifierKey = QString("%1.%2").arg(pElement->getRootParentElement()->getName()).arg(parameter);
-        MainWindow::instance()->getOMCProxy()->setElementModifierValue(className, modifierKey, QString::number(numberOfElementConnections));
+        MainWindow::instance()->getOMCProxy()->setElementModifierValueOld(className, modifierKey, QString::number(numberOfElementConnections));
         return true;
       }
     }
@@ -3977,7 +3958,8 @@ void GraphicsView::pasteItems()
           ModelInstance::Component *pModelInstanceComponent = GraphicsView::createModelInstanceComponent(mpModelWidget->getModelInstance(), name, className);
           addElementToView(pModelInstanceComponent, false, true, false, QPointF(0, 0), pComponent->getOMCPlacementAnnotation(QPointF(0, 0)), false);
           // set modifiers
-          GraphicsView::setModifiers(mpModelWidget->getLibraryTreeItem()->getNameStructure(), name, "", pMimeData->getModifiers().at(index));
+          MainWindow::instance()->getOMCProxy()->setElementModifierValue(mpModelWidget->getLibraryTreeItem()->getNameStructure(), name,
+                                                                         pMimeData->getModifiers().at(index).toString());
         } else {
           ElementInfo *pComponentInfo = new ElementInfo(pComponent->getElementInfo());
           pComponentInfo->setName(name);

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -246,7 +246,6 @@ public:
   QAction* getFlipVerticalAction() {return mpFlipVerticalAction;}
   bool performElementCreationChecks(LibraryTreeItem *pLibraryTreeItem, QString *name, QString *defaultPrefix);
   static ModelInstance::Component* createModelInstanceComponent(ModelInstance::Model *pModelInstance, const QString &name, const QString &className);
-  static void setModifiers(const QString &modelName, const QString &name, QString modifierNames, const ModelInstance::Modifier modifier);
   bool addComponent(QString className, QPointF position);
   void addComponentToView(QString name, LibraryTreeItem *pLibraryTreeItem, QString annotation, QPointF position,
                           ElementInfo *pComponentInfo, bool addObject, bool openingClass, bool emitComponentAdded);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -1081,14 +1081,16 @@ QString OMCProxy::getElementModifierValue(QString className, QString name)
 }
 
 /*!
- * \brief OMCProxy::setElementModifierValue
+ * \brief OMCProxy::setElementModifierValueOld
  * Sets the element modifier value.
  * \param className - is the name of the class whose modifier value is set.
  * \param modifierName - is the name of the modifier whose value is set.
  * \param modifierValue - is the value to set.
  * \return true on success.
+ * \deprecated
+ * \see OMCProxy::setElementModifierValue(QString className, QString modifierName, QString modifierValue)
  */
-bool OMCProxy::setElementModifierValue(QString className, QString modifierName, QString modifierValue)
+bool OMCProxy::setElementModifierValueOld(QString className, QString modifierName, QString modifierValue)
 {
   const QString sapi = QString("setElementModifierValue");
   QString expression;
@@ -1101,6 +1103,28 @@ bool OMCProxy::setElementModifierValue(QString className, QString modifierName, 
   } else {
     expression = QString("%1(%2, %3, $Code(=%4))").arg(sapi).arg(className).arg(modifierName).arg(modifierValue);
   }
+  sendCommand(expression);
+  if (StringHandler::unparseBool(getResult())) {
+    return true;
+  } else {
+    QString msg = tr("Unable to set the element modifier value using command <b>%1</b>").arg(expression);
+    MessageItem messageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel);
+    MessagesWidget::instance()->addGUIMessage(messageItem);
+    return false;
+  }
+}
+
+/*!
+ * \brief OMCProxy::setElementModifierValue
+ * Sets the element modifier value.
+ * \param className - is the name of the class whose modifier value is set.
+ * \param modifierName - is the name of the modifier whose value is set.
+ * \param modifierValue - is the value to set.
+ * \return true on success.
+ */
+bool OMCProxy::setElementModifierValue(QString className, QString modifierName, QString modifierValue)
+{
+  const QString expression = "setElementModifierValue(" % className % ", " % modifierName % ", $Code((" % modifierValue % ")))";
   sendCommand(expression);
   if (StringHandler::unparseBool(getResult())) {
     return true;
@@ -1161,15 +1185,17 @@ QString OMCProxy::getExtendsModifierValue(QString className, QString extendsClas
 }
 
 /*!
- * \brief OMCProxy::setExtendsModifierValue
+ * \brief OMCProxy::setExtendsModifierValueOld
  * Sets the extends modifier value.
  * \param className - is the name of the class whose modifier value is set.
  * \param extendsClassName - is the name of the extends class.
  * \param modifierName - is the name of the modifier whose value is set.
  * \param modifierValue - is the value to set.
  * \return true on success.
+ * \deprecated
+ * \see OMCProxy::setExtendsModifierValue(QString className, QString extendsClassName, QString modifierName, QString modifierValue)
  */
-bool OMCProxy::setExtendsModifierValue(QString className, QString extendsClassName, QString modifierName, QString modifierValue)
+bool OMCProxy::setExtendsModifierValueOld(QString className, QString extendsClassName, QString modifierName, QString modifierValue)
 {
   const QString sapi = QString("setExtendsModifierValue");
   QString expression;
@@ -1182,6 +1208,29 @@ bool OMCProxy::setExtendsModifierValue(QString className, QString extendsClassNa
   } else {
     expression = QString("%1(%2, %3, %4, $Code(=%5))").arg(sapi, className, extendsClassName, modifierName, modifierValue);
   }
+  sendCommand(expression);
+  if (StringHandler::unparseBool(getResult())) {
+    return true;
+  } else {
+    QString msg = tr("Unable to set the extends modifier value using command <b>%1</b>").arg(expression);
+    MessageItem messageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel);
+    MessagesWidget::instance()->addGUIMessage(messageItem);
+    return false;
+  }
+}
+
+/*!
+ * \brief OMCProxy::setExtendsModifierValue
+ * Sets the extends modifier value.
+ * \param className - is the name of the class whose modifier value is set.
+ * \param extendsClassName - is the name of the extends class.
+ * \param modifierName - is the name of the modifier whose value is set.
+ * \param modifierValue - is the value to set.
+ * \return true on success.
+ */
+bool OMCProxy::setExtendsModifierValue(QString className, QString extendsClassName, QString modifierName, QString modifierValue)
+{
+  const QString expression = "setExtendsModifierValue(" % className % ", " % extendsClassName % ", " % modifierName % ", $Code((" % modifierValue % ")))";
   sendCommand(expression);
   if (StringHandler::unparseBool(getResult())) {
     return true;
@@ -3525,7 +3574,7 @@ QJsonObject OMCProxy::modifierToJSON(const QString &modifier, bool prettyPrint)
 {
   QString modifierJson = mpOMCInterface->modifierToJSON(modifier, prettyPrint);
   printMessagesStringInternal();
-  if (!modifierJson.isEmpty()) {
+  if (!modifierJson.isEmpty() && modifierJson.compare(QStringLiteral("null")) != 0) {
     QJsonParseError jsonParserError;
     QJsonDocument doc = QJsonDocument::fromJson(modifierJson.toUtf8(), &jsonParserError);
     if (doc.isNull()) {

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -134,11 +134,13 @@ public:
   QString getParameterValue(const QString &className, const QString &parameter);
   QStringList getElementModifierNames(QString className, QString name);
   QString getElementModifierValue(QString className, QString name);
+  bool setElementModifierValueOld(QString className, QString modifierName, QString modifierValue);
   bool setElementModifierValue(QString className, QString modifierName, QString modifierValue);
   bool removeElementModifiers(QString className, QString name);
   QString getElementModifierValues(QString className, QString name);
   QStringList getExtendsModifierNames(QString className, QString extendsClassName);
   QString getExtendsModifierValue(QString className, QString extendsClassName, QString modifierName);
+  bool setExtendsModifierValueOld(QString className, QString extendsClassName, QString modifierName, QString modifierValue);
   bool setExtendsModifierValue(QString className, QString extendsClassName, QString modifierName, QString modifierValue);
   bool isExtendsModifierFinal(QString className, QString extendsClassName, QString modifierName);
   bool removeExtendsModifiers(QString className, QString extendsClassName);

--- a/OMEdit/OMEditLIB/Resources/icons/drop-menu.svg
+++ b/OMEdit/OMEditLIB/Resources/icons/drop-menu.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="32px"
+   height="32px"
+   id="svg3026"
+   version="1.1"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="drop-menu.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3028" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.217768"
+     inkscape:cx="16.855297"
+     inkscape:cy="16.001032"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1003"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid823" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3031">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       y="0"
+       x="0"
+       height="32"
+       width="32"
+       id="rect3025"
+       style="fill:#969696;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.40613;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:1.84885;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1528"
+       width="24"
+       height="4.5"
+       x="4"
+       y="4.4456778" />
+    <rect
+       style="fill:#90c8f6;fill-opacity:1;stroke-width:1.84884;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1528-7"
+       width="24"
+       height="4.5"
+       x="4"
+       y="13.471552" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke-width:1.84884;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect1528-5"
+       width="24"
+       height="4.5"
+       x="4"
+       y="22.485865" />
+    <g
+       id="g7676"
+       transform="translate(1.3571395,0.01596423)">
+      <path
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.11765;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 4.2424697,19.2433 11.6912553,-4.381196 -3.513895,12 z"
+         id="path5408"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke-width:0.517219"
+         id="rect1131"
+         width="8.0924816"
+         height="4.7602839"
+         x="-18.379494"
+         y="19.378519"
+         transform="rotate(-47.010947)" />
+    </g>
+  </g>
+</svg>

--- a/OMEdit/OMEditLIB/Resources/icons/fill-horizontal.svg
+++ b/OMEdit/OMEditLIB/Resources/icons/fill-horizontal.svg
@@ -2,19 +2,19 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16px"
    height="16px"
    id="svg3017"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="fill-horizontal.svg">
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="fill-horizontal.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -22,18 +22,23 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="22.197802"
-     inkscape:cx="0.83712865"
-     inkscape:cy="8"
+     inkscape:zoom="47.545201"
+     inkscape:cx="8.6549219"
+     inkscape:cy="8.486661"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
-     inkscape:window-width="1600"
-     inkscape:window-height="838"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1" />
+     inkscape:window-width="1920"
+     inkscape:window-height="1003"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1384" />
+  </sodipodi:namedview>
   <defs
      id="defs3019" />
   <metadata
@@ -52,30 +57,36 @@
      inkscape:groupmode="layer"
      inkscape:label="Layer 1"
      id="layer1">
-    <rect
-       y="1.5"
-       x="0.5"
-       height="13"
-       width="15"
-       id="rect3025"
-       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0056c1;stroke-opacity:1" />
-    <path
-       transform="matrix(1.000000,0.000000,0.000000,1.000000,0.000000,0.000000)"
-       inkscape:connector-curvature="0"
-       id="path5352"
-       d="M0.5 4.5L15.5001812172 4.5"
-       style="stroke-linejoin:miter;stroke-opacity:1;stroke:#0056c1;stroke-linecap:butt;stroke-width:1.0;fill:none" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path5352-1"
-       d="M0.5 8.5L15.5001812172 8.5"
-       style="stroke-linejoin:miter;stroke-opacity:1;stroke:#0056c1;stroke-linecap:butt;stroke-width:1.0;fill:none"
-       transform="matrix(1.000000,0.000000,0.000000,1.000000,0.000000,0.000000)" />
-    <path
-       transform="matrix(1.000000,0.000000,0.000000,1.000000,0.000000,0.000000)"
-       inkscape:connector-curvature="0"
-       id="path5352-4"
-       d="M0.5 11.5L15.5029000024 11.5"
-       style="stroke-linejoin:miter;stroke-opacity:1;stroke:#0056c1;stroke-linecap:butt;stroke-width:1.0;fill:none" />
+    <g
+       id="g164"
+       transform="matrix(1.0000151,0,0,0.87499478,2.1457996e-6,1)">
+      <rect
+         y="0.53460997"
+         x="0.53460783"
+         height="14.930784"
+         width="14.930784"
+         id="rect3025"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0056c1;stroke-width:1.06922;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352"
+         d="M 0.5,3.5075353 H 15.500181"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352-1"
+         d="M 0.5,6.5004364 H 15.500181"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352-4"
+         d="M 0.5,9.4921043 H 15.5029"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352-4-3"
+         d="M 0.5,12.497054 H 15.502893"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
   </g>
 </svg>

--- a/OMEdit/OMEditLIB/Resources/icons/fill-vertical.svg
+++ b/OMEdit/OMEditLIB/Resources/icons/fill-vertical.svg
@@ -2,19 +2,19 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16px"
    height="16px"
    id="svg3017"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="fill-vertical.svg">
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="fill-vertical.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      id="base"
      pagecolor="#ffffff"
@@ -22,18 +22,19 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="22.197802"
-     inkscape:cx="0.83712865"
-     inkscape:cy="8"
+     inkscape:zoom="33.96021"
+     inkscape:cx="6.4928927"
+     inkscape:cy="8.613021"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
-     inkscape:window-width="1600"
-     inkscape:window-height="838"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1" />
+     inkscape:window-width="1920"
+     inkscape:window-height="1003"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0" />
   <defs
      id="defs3019" />
   <metadata
@@ -52,30 +53,36 @@
      id="layer1"
      inkscape:label="Layer 1"
      inkscape:groupmode="layer">
-    <rect
-       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0056c1;stroke-opacity:1"
-       id="rect3025"
-       width="15"
-       height="13"
-       x="0.5"
-       y="1.5" />
-    <path
-       transform="matrix(1.000000,0.000000,0.000000,1.000000,0.000000,0.000000)"
-       inkscape:connector-curvature="0"
-       id="path5434"
-       d="M4.5 1.5L4.5 14.4999574268"
-       style="stroke-linejoin:miter;stroke-opacity:1;stroke:#0056c1;stroke-linecap:butt;stroke-width:1.0;fill:none" />
-    <path
-       transform="matrix(1.000000,0.000000,0.000000,1.000000,0.000000,0.000000)"
-       inkscape:connector-curvature="0"
-       id="path5434-0"
-       d="M12.5 1.5L12.5 14.4916565268"
-       style="stroke-linejoin:miter;stroke-opacity:1;stroke:#0056c1;stroke-linecap:butt;stroke-width:1.0;fill:none" />
-    <path
-       transform="matrix(1.000000,0.000000,0.000000,1.000000,0.000000,0.000000)"
-       inkscape:connector-curvature="0"
-       id="path5434-9"
-       d="M8.5 1.5L8.5 14.491656563"
-       style="stroke-linejoin:miter;stroke-opacity:1;stroke:#0056c1;stroke-linecap:butt;stroke-width:1.0;fill:none" />
+    <g
+       id="g164"
+       transform="matrix(0,0.87497799,-1.0000106,0,16.000174,1.0000019)">
+      <rect
+         y="0.53460997"
+         x="0.53460783"
+         height="14.930784"
+         width="14.930784"
+         id="rect3025"
+         style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0056c1;stroke-width:1.06922;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352"
+         d="M 0.5,3.5075353 H 15.500181"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352-1"
+         d="M 0.5,6.5004364 H 15.500181"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352-4"
+         d="M 0.5,9.4921043 H 15.5029"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5352-4-3"
+         d="M 0.5,12.497054 H 15.502893"
+         style="fill:none;stroke:#0056c1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
   </g>
 </svg>

--- a/OMEdit/OMEditLIB/resource_omedit.qrc
+++ b/OMEdit/OMEditLIB/resource_omedit.qrc
@@ -215,5 +215,6 @@
         <file>Resources/icons/completerAnnotation.svg</file>
         <file>Resources/icons/import-tlmmodel.svg</file>
         <file>Resources/icons/auto_scale.svg</file>
+        <file>Resources/icons/drop-menu.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
### Related Issues

#5395, #5405, #5489, #5737, #7750 and #10226

### Purpose

Allow setting final and each modifiers.

### Approach

Added a context menu next to parameter fields with final and each options.

Things todo,

- [x] Update the code to set the modifiers of the element with single call to `setElementModifierValue`. Right now we call `setElementModifierValue` for each modifier.
- [x] Show each option only if the parameter is an array.
- [x] Add the same functionality for sub modifiers as well.