### PR TITLE
Fix typo in expression sign check

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4375,8 +4375,8 @@ public
     res := match exp
       case INTEGER() then exp.value >= 0;
       case REAL() then exp.value >= 0;
-      case CAST() then isNonPositive(exp.exp);
-      case UNARY() then isNonNegative(exp.exp);
+      case CAST() then isNonNegative(exp.exp);
+      case UNARY() then isNonPositive(exp.exp);
       else false;
     end match;
   end isNonNegative;


### PR DESCRIPTION
## Related Issues

#9778. Probably a copy-paste typo introduced in #10546.