### PR TITLE
allow top level outer on an non standard flag

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3532,7 +3532,7 @@ algorithm
     node := Lookup.lookupSimpleName(name, scope, context);
 
     if InstNode.isInner(node) then
-      is_error := not InstContext.inRelaxed(context);
+      is_error := not (InstContext.inRelaxed(context) or Flags.isConfigFlagSet(Flags.ALLOW_NON_STANDARD_MODELICA, "nonStdTopLevelOuter"));
 
       if is_error then
         Error.addSourceMessageAsError(Error.TOP_LEVEL_OUTER, {name}, InstNode.info(node));

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1388,6 +1388,7 @@ constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG(146, "allowNonStan
     ("nonStdEnumerationAsIntegers", Gettext.gettext("Allow enumeration as integer without casting via Integer(Enum).\nSee: https://specification.modelica.org/maint/3.5/class-predefined-types-and-declarations.html#type-conversion-of-enumeration-values-to-string-or-integer")),
     ("nonStdIntegersAsEnumeration", Gettext.gettext("Allow integer as enumeration without casting via Enum(Integer).\nSee: https://specification.modelica.org/maint/3.5/class-predefined-types-and-declarations.html#type-conversion-of-integer-to-enumeration-values")),
     ("nonStdDifferentCaseFileVsClassName", Gettext.gettext("Allow directory or file with different case in the name than the contained class name.\nSee: https://specification.modelica.org/maint/3.5/packages.html#mapping-package-class-structures-to-a-hierarchical-file-system")),
+    ("nonStdTopLevelOuter", Gettext.gettext("Allow top level outer.\nSee: https://specification.modelica.org/maint/3.6/scoping-name-lookup-and-flattening.html#S4.p1")),
     ("protectedAccess", Gettext.gettext("Allow access of protected elements")),
     ("reinitInAlgorithms", Gettext.gettext("Allow reinit in algorithm sections"))
     })),

--- a/testsuite/flattening/modelica/others/Makefile
+++ b/testsuite/flattening/modelica/others/Makefile
@@ -98,6 +98,7 @@ VectorizeExtendedType.mo \
 WillowForest.mo \
 Homotopy.mos \
 TestEnumAsInteger.mos \
+TestTopLevelOuter.mos \
 
 
 # test that currently fail. Move up when fixed. 

--- a/testsuite/flattening/modelica/others/TestTopLevelOuter.mo
+++ b/testsuite/flattening/modelica/others/TestTopLevelOuter.mo
@@ -1,0 +1,12 @@
+package TestNonStandardExtensions
+
+model InnerDefinition
+  parameter Real x = 1;
+end InnerDefinition;
+
+model TestTopLevelOuter
+  outer InnerDefinition o;
+  parameter Real y = 2;
+end TestTopLevelOuter;
+
+end TestNonStandardExtensions;

--- a/testsuite/flattening/modelica/others/TestTopLevelOuter.mos
+++ b/testsuite/flattening/modelica/others/TestTopLevelOuter.mos
@@ -1,0 +1,30 @@
+// name:     TestTopLevelOuter.mos
+// keywords: non-standard Modelica extensions
+// status:   correct
+//
+// Test non-standard Modelica flags that allow usage of integer as enums and enums as integers
+//
+//
+
+loadFile("TestTopLevelOuter.mo"); getErrorString();
+instantiateModel(TestNonStandardExtensions.TestTopLevelOuter); getErrorString();
+setCommandLineOptions("--allowNonStandardModelica=nonStdTopLevelOuter"); getErrorString();
+instantiateModel(TestNonStandardExtensions.TestTopLevelOuter); getErrorString();
+
+// Result:
+// true
+// ""
+// ""
+// "[flattening/modelica/others/TestTopLevelOuter.mo:8:3-8:26:writable] Error: The model can't be instantiated due to top-level outer element 'o', it may only be used as part of a simulation model.
+// "
+// true
+// ""
+// "class TestNonStandardExtensions.TestTopLevelOuter
+//   parameter Real y = 2.0;
+//   parameter Real o.x = 1.0;
+// end TestNonStandardExtensions.TestTopLevelOuter;
+// "
+// "[flattening/modelica/others/TestTopLevelOuter.mo:8:3-8:26:writable] Warning: The model can't be instantiated due to top-level outer element 'o', it may only be used as part of a simulation model.
+// [flattening/modelica/others/TestTopLevelOuter.mo:8:3-8:26:writable] Warning: An inner declaration for outer component o could not be found and was automatically generated.
+// "
+// endResult


### PR DESCRIPTION
### Purpose

Allow top level outer when --allowNonStandardModelica=nonStdTopLevelOuter is given.