### PR TITLE
Require C++17 for OMCompiler/OMEdit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ omc_option(OM_USE_CCACHE "Use ccache to speedup compilations." ON)
 # set(CMAKE_C_STANDARD 90)
 
 ## Set the C++ standard to use.
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 ## Make sure we do not start relying on extensions down the road.
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
@@ -574,7 +574,7 @@ size_t Record::size() const noexcept
   return get_slots(_value) - 1;
 }
 
-Value Record::operator[](const std::string &name) const noexcept
+Value Record::operator[](std::string_view name) const noexcept
 {
   return *find(name);
 }
@@ -593,7 +593,7 @@ Value Record::at(size_t index) const
   return (*this)[index];
 }
 
-IndexedConstIterator Record::find(const std::string &name) const noexcept
+IndexedConstIterator Record::find(std::string_view name) const noexcept
 {
   auto desc = static_cast<record_description*>(get_index(_value, 0));
 
@@ -606,7 +606,7 @@ IndexedConstIterator Record::find(const std::string &name) const noexcept
   return end();
 }
 
-bool Record::contains(const std::string &name) const noexcept
+bool Record::contains(std::string_view name) const noexcept
 {
   return find(name) != end();
 }

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <ostream>
 
 namespace OpenModelica
@@ -221,12 +222,11 @@ namespace OpenModelica
         IndexedConstIterator cend() const noexcept;
         size_t size() const noexcept;
 
-        // TODO: Change to C++17 and use string_view instead.
-        Value operator[](const std::string &name) const noexcept;
+        Value operator[](std::string_view name) const noexcept;
         Value operator[](size_t index) const noexcept;
         Value at(size_t index) const;
-        IndexedConstIterator find(const std::string &name) const noexcept;
-        bool contains(const std::string &name) const noexcept;
+        IndexedConstIterator find(std::string_view name) const noexcept;
+        bool contains(std::string_view name) const noexcept;
 
       private:
         void *_value;

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -310,7 +310,7 @@ AC_LANG_POP([C++])
 fi
 
 m4_include([common/m4/ax_cxx_compile_stdcxx.m4])
-AX_CXX_COMPILE_STDCXX(14,[noext],[optional])
+AX_CXX_COMPILE_STDCXX(17,[noext],[mandatory])
 
 if test "`getconf LONG_BIT`" = "32"; then
 dnl Simulations spin forever unless -msse2 -mfpmath=sse is set

--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omedit)
 omc_option(OM_OMEDIT_INSTALL_RUNTIME_DLLS "Install the required runtime dll dependency DLLs to the binary directory. Valid only for Windows builds." ON)
 omc_option(OM_OMEDIT_ENABLE_TESTS "Enable building of OMEdit Testsuite tests." OFF)
 
-## Set the C++ standard to use. OMEdit uses C++14
-set(CMAKE_CXX_STANDARD 14)
+## Set the C++ standard to use. OMEdit uses C++17
+set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 ## Make sure we do not start relying on extensions down the road.
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -34,7 +34,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++14
+CONFIG += c++17
 
 TARGET = OMEdit
 TEMPLATE = app

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -34,7 +34,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++14
+CONFIG += c++17
 
 TARGET = OMEdit
 TEMPLATE = lib

--- a/OMEdit/configure.ac
+++ b/OMEdit/configure.ac
@@ -29,10 +29,7 @@ test -z "$CXXFLAGS" && CXXFLAGS="$CFLAGS"
 AC_LANG([C++])
 AC_PROG_CC
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX(17, [noext],[optional])
-if test "$ax_cv_cxx_compile_cxx17__std_cpp17" != "yes"; then
-  AX_CXX_COMPILE_STDCXX(14, [noext],[mandatory])
-fi
+AX_CXX_COMPILE_STDCXX(17, [noext],[mandatory])
 host_short=$host_cpu-$host_os
 
 m4_include([common/m4/qmake.m4])


### PR DESCRIPTION
- Update the required C++ version for OMCompiler/OMEdit to C++17.
- Change some uses of std::string to std::string_view to check that the builds actually support C++17.