### PR TITLE
Improve default arguments in record constructors

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -421,7 +421,7 @@ protected
     //  TypeCheck.checkValidOperatorOverload("'String'", fn, recopnode);
     //end for;
 
-    matchedFunctions := Function.matchFunctionsSilent(candidates, args, namedArgs, info);
+    matchedFunctions := Function.matchFunctionsSilent(candidates, args, namedArgs, context, info);
     exactMatches := MatchedFunction.getExactMatches(matchedFunctions);
     if listEmpty(exactMatches) then
       Error.addSourceMessage(Error.NO_MATCHING_FUNCTION_FOUND_NFINST,

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -355,7 +355,7 @@ public
     Expression arg_exp;
   algorithm
     ARG_TYPED_CALL(call_scope = scope) := call;
-    matchedFunc := checkMatchingFunctions(call, info, vectorize);
+    matchedFunc := checkMatchingFunctions(call, context, info, vectorize);
 
     func := matchedFunc.func;
     typed_args := matchedFunc.args;
@@ -2567,6 +2567,7 @@ protected
 
   function checkMatchingFunctions
     input NFCall call;
+    input InstContext.Type context;
     input SourceInfo info;
     input Boolean vectorize = true;
     output MatchedFunction matchedFunc;
@@ -2589,7 +2590,7 @@ protected
             allfuncs := list(fn for fn guard not Function.isDefaultRecordConstructor(fn) in allfuncs);
           end if;
         then
-          Function.matchFunctions(allfuncs, call.positional_args, call.named_args, info, vectorize);
+          Function.matchFunctions(allfuncs, call.positional_args, call.named_args, context, info, vectorize);
     end match;
 
     if listEmpty(matchedFunctions) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -2094,7 +2094,7 @@ public
                   case Subscript.WHOLE()
                     then Expression.makeRange(Dimension.lowerBoundExp(dim),
                                               NONE(),
-                                              Dimension.endExp(dim, cref, dim_index));
+                                              Dimension.endExp(dim, Expression.CREF(cref.ty, cref), dim_index));
                 end match;
 
                 iterator := InstNode.newIndexedIterator(iter_index);

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -360,7 +360,7 @@ public
   function endExp
     "Returns an expression for the last index in a dimension."
     input Dimension dim;
-    input ComponentRef cref;
+    input Expression subscriptedExp;
     input Integer index;
     output Expression sizeExp;
   algorithm
@@ -374,8 +374,13 @@ public
         then Expression.makeEnumLiteral(ty, listLength(ty.literals));
       case EXP() then dim.exp;
       case UNKNOWN()
-        then Expression.SIZE(Expression.fromCref(ComponentRef.stripSubscripts(cref)),
-                             SOME(Expression.INTEGER(index)));
+        then match subscriptedExp
+          case Expression.CREF()
+            then Expression.SIZE(Expression.fromCref(ComponentRef.stripSubscripts(subscriptedExp.cref)),
+                                 SOME(Expression.INTEGER(index)));
+          case Expression.SUBSCRIPTED_EXP()
+            then Expression.SIZE(subscriptedExp.exp, SOME(Expression.INTEGER(index)));
+        end match;
     end match;
   end endExp;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -82,6 +82,7 @@ import InstContext = NFInstContext;
 import UnorderedSet;
 import Graph;
 import FlatModelicaUtil = NFFlatModelicaUtil;
+import Subscript = NFSubscript;
 
 public
 
@@ -978,6 +979,7 @@ uniontype Function
     input list<TypedArg> posArgs;
     input list<TypedArg> namedArgs;
     input Function fn;
+    input InstContext.Type context;
     input SourceInfo info;
     output list<TypedArg> args = posArgs;
     output Boolean matching;
@@ -1027,7 +1029,7 @@ uniontype Function
       end if;
     end for;
 
-    (args, matching) := collectArgs(slots_arr, info);
+    (args, matching) := collectArgs(slots_arr, context, info);
   end fillArgs;
 
   function fillNamedArg
@@ -1092,6 +1094,7 @@ uniontype Function
   function collectArgs
     "Collects the arguments from the given slots."
     input array<Slot> slots;
+    input InstContext.Type context;
     input SourceInfo info;
     output list<TypedArg> args = {};
     output Boolean matching = true;
@@ -1109,7 +1112,7 @@ uniontype Function
         case SOME(a) then a :: args;
 
         // Otherwise, try to fill the slot with its default argument.
-        case _ then fillDefaultSlot(s, slots, info) :: args;
+        case _ then fillDefaultSlot(s, slots, context, info) :: args;
 
         else
           algorithm
@@ -1125,6 +1128,7 @@ uniontype Function
   function fillDefaultSlot
     input Slot slot;
     input array<Slot> slots;
+    input InstContext.Type context;
     input SourceInfo info;
     output TypedArg outArg;
   algorithm
@@ -1134,7 +1138,7 @@ uniontype Function
 
       // Slot not filled by function argument, but has default value.
       case SLOT(default = SOME(_))
-        then fillDefaultSlot2(slot, slots, info);
+        then fillDefaultSlot2(slot, slots, context, info);
 
       // Give an error if no argument was given and there's no default argument.
       else
@@ -1149,6 +1153,7 @@ uniontype Function
   function fillDefaultSlot2
     input Slot slot;
     input array<Slot> slots;
+    input InstContext.Type context;
     input SourceInfo info;
     output TypedArg outArg;
   algorithm
@@ -1176,8 +1181,8 @@ uniontype Function
           slot.evalStatus := SlotEvalStatus.EVALUATING;
           arrayUpdate(slots, slot.index, slot);
 
-          exp := evaluateSlotExp(Util.getOption(slot.default), slots, info);
-          (exp, ty, var, pur) := Typing.typeExp(exp, NFInstContext.FUNCTION, info);
+          exp := evaluateSlotExp(Util.getOption(slot.default), slots, context, info);
+          (exp, ty, var, pur) := Typing.typeExp(exp, context, info);
           outArg := TypedArg.TYPED_ARG(NONE(), exp, ty, var, pur);
 
           slot.arg := SOME(outArg);
@@ -1192,21 +1197,23 @@ uniontype Function
   function evaluateSlotExp
     input Expression exp;
     input array<Slot> slots;
+    input InstContext.Type context;
     input SourceInfo info;
     output Expression outExp;
   algorithm
     outExp := Expression.map(exp,
-      function evaluateSlotExp_traverser(slots = slots, info = info));
+      function evaluateSlotExp_traverser(slots = slots, context = context, info = info));
   end evaluateSlotExp;
 
   function evaluateSlotExp_traverser
     input Expression exp;
     input array<Slot> slots;
+    input InstContext.Type context;
     input SourceInfo info;
     output Expression outExp;
   algorithm
     outExp := match exp
-      case Expression.CREF() then evaluateSlotCref(exp, slots, info);
+      case Expression.CREF() then evaluateSlotCref(exp, slots, context, info);
       else exp;
     end match;
   end evaluateSlotExp_traverser;
@@ -1214,6 +1221,7 @@ uniontype Function
   function evaluateSlotCref
     input output Expression crefExp;
     input array<Slot> slots;
+    input InstContext.Type context;
     input SourceInfo info;
   protected
     ComponentRef cref;
@@ -1234,13 +1242,13 @@ uniontype Function
     slot := lookupSlotInArray(cref_node, slots);
 
     if isSome(slot) then
-      arg := fillDefaultSlot(Util.getOption(slot), slots, info);
+      arg := fillDefaultSlot(Util.getOption(slot), slots, context, info);
       crefExp := arg.value;
-      crefExp := Expression.applySubscripts(ComponentRef.getSubscripts(cref), crefExp);
+      crefExp := applyCrefSubs(cref, crefExp);
 
       for cr in cref_parts loop
         crefExp := Expression.recordElement(ComponentRef.firstName(cr), crefExp);
-        crefExp := Expression.applySubscripts(ComponentRef.getSubscripts(cr), crefExp);
+        crefExp := applyCrefSubs(cref, crefExp);
       end for;
 
       if Type.isKnown(cref_ty) then
@@ -1248,6 +1256,27 @@ uniontype Function
       end if;
     end if;
   end evaluateSlotCref;
+
+  function applyCrefSubs
+    input ComponentRef cref;
+    input output Expression exp;
+  protected
+    list<Subscript> subs;
+  algorithm
+    subs := ComponentRef.getSubscripts(cref);
+
+    if listEmpty(subs) then
+      return;
+    end if;
+
+    try
+      exp := Expression.applySubscripts(subs, exp);
+    else
+      // Applying the subscripts might not work if the expression is not typed,
+      // in that case just create a subscripted expression.
+      exp := Expression.SUBSCRIPTED_EXP(exp, subs, ComponentRef.getSubscriptedType(cref), false);
+    end try;
+  end applyCrefSubs;
 
   function lookupSlotInArray
     input InstNode node;
@@ -1410,6 +1439,7 @@ uniontype Function
     input Function func;
     input list<TypedArg> args;
     input list<TypedArg> named_args;
+    input InstContext.Type context;
     input SourceInfo info;
     input Boolean vectorize = true;
     output list<TypedArg> out_args;
@@ -1417,7 +1447,7 @@ uniontype Function
   protected
     Boolean slot_matched;
   algorithm
-    (out_args, slot_matched) := fillArgs(args, named_args, func, info);
+    (out_args, slot_matched) := fillArgs(args, named_args, func, context, info);
 
     if slot_matched then
       (out_args, matchKind) := matchArgs(func, out_args, info, vectorize);
@@ -1428,6 +1458,7 @@ uniontype Function
     input list<Function> funcs;
     input list<TypedArg> args;
     input list<TypedArg> named_args;
+    input InstContext.Type context;
     input SourceInfo info;
     input Boolean vectorize = true;
     output list<MatchedFunction> matchedFunctions;
@@ -1438,7 +1469,7 @@ uniontype Function
   algorithm
     matchedFunctions := {};
     for func in funcs loop
-      (m_args, matchKind) := matchFunction(func, args, named_args, info, vectorize);
+      (m_args, matchKind) := matchFunction(func, args, named_args, context, info, vectorize);
 
       if FunctionMatchKind.isValid(matchKind) then
         matchedFunctions := MatchedFunction.MATCHED_FUNC(func,m_args,matchKind)::matchedFunctions;
@@ -1450,13 +1481,14 @@ uniontype Function
     input list<Function> funcs;
     input list<TypedArg> args;
     input list<TypedArg> named_args;
+    input InstContext.Type context;
     input SourceInfo info;
     input Boolean vectorize = true;
     output list<MatchedFunction> matchedFunctions;
   protected
   algorithm
     ErrorExt.setCheckpoint("NFFunction:matchFunctions");
-    matchedFunctions := matchFunctions(funcs, args, named_args, info, vectorize);
+    matchedFunctions := matchFunctions(funcs, args, named_args, context, info, vectorize);
     ErrorExt.rollBack("NFFunction:matchFunctions");
   end matchFunctionsSilent;
 
@@ -1539,6 +1571,7 @@ uniontype Function
   algorithm
     if not isTyped(fn) then
       fn_context := InstContext.set(context, NFInstContext.FUNCTION);
+      fn.slots := makeSlots(fn.inputs);
 
       // Type all the components in the function.
       Typing.typeClassType(node, NFBinding.EMPTY_BINDING, fn_context, node);
@@ -1549,7 +1582,6 @@ uniontype Function
       end if;
 
       // Make the slots and return type for the function.
-      fn.slots := makeSlots(fn.inputs);
       checkParamTypes(fn);
       checkPartialDerivativeTypes(fn);
       fn.returnType := makeReturnType(fn);

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -260,6 +260,7 @@ algorithm
     locals := comp_node :: locals;
   else
     setFieldDirection(comp_node, Direction.INPUT);
+    InstNode.componentApply(comp_node, Component.setVariability, Variability.CONTINUOUS);
     inputs := comp_node :: inputs;
   end if;
 end collectRecordParam;

--- a/testsuite/flattening/modelica/scodeinst/FunctionRecordArg3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionRecordArg3.mo
@@ -32,7 +32,7 @@ end FunctionRecordArg3;
 //
 // function R "Automatically generated record constructor for R"
 //   input Integer n = 2;
-//   input Real[2] x;
+//   input Real[n] x;
 //   output R res;
 // end R;
 //

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -713,7 +713,6 @@ IfExpression8.mo \
 IfExpression10.mo \
 IfExpression11.mo \
 IfExpression12.mo \
-IfExpression13.mo \
 IfExpression14.mo \
 IfEquationInvalidCond1.mo \
 ih1.mo \
@@ -961,6 +960,7 @@ RecordBinding12.mo \
 RecordBinding13.mo \
 RecordConstructor1.mo \
 RecordConstructor2.mo \
+RecordConstructor3.mo \
 RecordExtends1.mo \
 RecordExtends2.mo \
 RecordUnknownDim1.mo \
@@ -1165,6 +1165,7 @@ sts.mos \
 # test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES=\
+IfExpression13.mo \
 ProtectedMod4.mo \
 CevalFuncRecord3.mo \
 CevalFuncRecord4.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordConstructor3.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordConstructor3.mo
@@ -1,0 +1,24 @@
+// name: RecordConstructor3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+record R
+  parameter Real[:, 3] A;
+  parameter Real x = max(A[:, 1]);
+end R;
+
+model RecordConstructor3
+  parameter R r = R(A = [0, 1, 2]);
+end RecordConstructor3;
+
+// Result:
+// class RecordConstructor3
+//   parameter Real r.A[1,1] = 0.0;
+//   parameter Real r.A[1,2] = 1.0;
+//   parameter Real r.A[1,3] = 2.0;
+//   parameter Real r.x = 0.0;
+// end RecordConstructor3;
+// endResult


### PR DESCRIPTION
Improve default arguments in record constructors

- Create slots before typing a function in order to make sure the
  default arguments are typed correctly when inserting them into calls.
- Use the proper context when typing default arguments.
- Remove variability prefixes from inputs when creating record
  constructors, similar to what's done for normal functions.
- Evaluate `end` in generic subscripted expressions.
- Disable test case `IfExpression13` which no longer works correctly due
  to some issue with conditional array types, but the related model
  still works.

Fixes https://github.com/OpenModelica/OpenModelica/issues/11045