### PR TITLE
Remove Type.ENUMERATION_ANY

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -339,7 +339,7 @@ constant LookupTree.Tree ENUM_LOOKUP_TREE = LookupTree.Tree.NODE(
 
 constant InstNode ENUM_NODE = InstNode.CLASS_NODE("enumeration",
   Elements.ENUMERATION, Visibility.PUBLIC,
-  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ENUMERATION_ANY(), NFClassTree.EMPTY_TREE(),
+  Pointer.createImmutable(Class.PARTIAL_BUILTIN(Type.ENUMERATION(Absyn.Path.IDENT(":"), {}), NFClassTree.EMPTY_TREE(),
     Modifier.NOMOD(), NFClass.DEFAULT_PREFIXES, Restriction.ENUMERATION())),
   EMPTY_NODE_CACHE, InstNode.EMPTY_NODE(), InstNodeType.BUILTIN_CLASS());
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -120,7 +120,7 @@ constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
 
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
-  Type.ENUMERATION_ANY(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
+  Type.ENUMERATION(Absyn.Path.IDENT(":"), {}), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
   NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -2574,7 +2574,6 @@ protected
       case Type.BOOLEAN() then true;
       case Type.CLOCK() then true;
       case Type.ENUMERATION() then true;
-      case Type.ENUMERATION_ANY() then true;
       case Type.POLYMORPHIC() then true;
       case Type.ARRAY() then isValidParamType(ty.elementType);
       case Type.COMPLEX() then isValidParamState(ty.cls);

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -80,8 +80,10 @@ public
     list<String> literals;
   end ENUMERATION;
 
-  record ENUMERATION_ANY "enumeration(:)"
-  end ENUMERATION_ANY;
+  // TODO: Remove this, which requires updating the bootstrapping sources to
+  //       avoid breaking the ffi interface.
+  record __ENUMERATION_ANY_NOT_USED__
+  end __ENUMERATION_ANY_NOT_USED__;
 
   record ARRAY
     Type elementType;
@@ -447,10 +449,19 @@ public
   algorithm
     isEnum := match ty
       case ENUMERATION() then true;
-      case ENUMERATION_ANY() then true;
       else false;
     end match;
   end isEnumeration;
+
+  function isUnspecifiedEnumeration
+    input Type ty;
+    output Boolean res;
+  algorithm
+    res := match ty
+      case ENUMERATION(literals = {}) then true;
+      else false;
+    end match;
+  end isUnspecifiedEnumeration;
 
   function isComplex
     input Type ty;
@@ -576,7 +587,6 @@ public
       case BOOLEAN() then true;
       case CLOCK() then true;
       case ENUMERATION() then true;
-      case ENUMERATION_ANY() then true;
       case FUNCTION() then isScalarBuiltin(Function.returnType(ty.fn));
       else false;
     end match;
@@ -884,9 +894,8 @@ public
       case Type.STRING() then "String";
       case Type.BOOLEAN() then "Boolean";
       case Type.CLOCK() then "Clock";
-      case Type.ENUMERATION() then "enumeration " + AbsynUtil.pathString(ty.typePath) +
+      case Type.ENUMERATION() then if listEmpty(ty.literals) then "enumeration(:)" else "enumeration " + AbsynUtil.pathString(ty.typePath) +
         "(" + stringDelimitList(ty.literals, ", ") + ")";
-      case Type.ENUMERATION_ANY() then "enumeration(:)";
       case Type.ARRAY() then List.toString(ty.dimensions, Dimension.toString, toString(ty.elementType), "[", ", ", "]", false);
       case Type.TUPLE() then "(" + stringDelimitList(List.map(ty.types, toString), ", ") + ")";
       case Type.NORETCALL() then "()";
@@ -919,8 +928,7 @@ public
       case Type.STRING() then "String";
       case Type.BOOLEAN() then "Boolean";
       case Type.CLOCK() then "Clock";
-      case Type.ENUMERATION() then Util.makeQuotedIdentifier(AbsynUtil.pathString(ty.typePath));
-      case Type.ENUMERATION_ANY() then "enumeration(:)";
+      case Type.ENUMERATION() then if listEmpty(ty.literals) then "enumeration(:)" else Util.makeQuotedIdentifier(AbsynUtil.pathString(ty.typePath));
       case Type.ARRAY() then List.toString(ty.dimensions, Dimension.toFlatString, toFlatString(ty.elementType), "[", ", ", "]", false);
       case Type.TUPLE() then "(" + stringDelimitList(List.map(ty.types, toFlatString), ", ") + ")";
       case Type.NORETCALL() then "()";

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1538,8 +1538,6 @@ algorithm
       then
         type1;
 
-    case Type.ENUMERATION_ANY() then type1;
-
     case Type.ARRAY()
       algorithm
         (exp1, exp2, compatibleType, matchKind) :=
@@ -1621,11 +1619,13 @@ algorithm
 
     case Type.ENUMERATION()
       algorithm
-        matchKind := matchEnumerationTypes(actualType, expectedType);
+        if Type.isUnspecifiedEnumeration(expectedType) then
+          matchKind := MatchKind.EXACT;
+        else
+          matchKind := matchEnumerationTypes(actualType, expectedType);
+        end if;
       then
         actualType;
-
-    case Type.ENUMERATION_ANY() then actualType;
 
     case Type.ARRAY()
       algorithm
@@ -2442,13 +2442,6 @@ algorithm
         expression := Expression.typeCast(expression, expectedType);
       then
         (expectedType, MatchKind.CAST);
-
-    // Any enumeration is compatible with enumeration(:).
-    case (Type.ENUMERATION(), Type.ENUMERATION_ANY())
-      algorithm
-        // TODO: FIXME: Maybe this should be generic match
-      then
-        (actualType, MatchKind.CAST);
 
     // Allow using enumeration as Integer without the explicit cast
     case (Type.ENUMERATION(), Type.INTEGER()) guard Flags.isConfigFlagSet(Flags.ALLOW_NON_STANDARD_MODELICA, "nonStdEnumerationAsIntegers")


### PR DESCRIPTION
- Remove `Type.ENUMERATION_ANY` and represent `enumeration(:)` as an empty enumeration type instead, since it's unnecessary to have a completely separate type just for `enumeration(:)`.