### PR TITLE
Don't consider final modifiers to be empty

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -4674,6 +4674,7 @@ algorithm
     local
       Absyn.Modification mod;
 
+    case Absyn.MODIFICATION(finalPrefix = true) then false;
     case Absyn.MODIFICATION(modification = NONE()) then true;
     case Absyn.MODIFICATION(modification = SOME(mod)) then isEmptyMod(mod);
     else false;
@@ -6198,6 +6199,16 @@ algorithm
     else false;
   end match;
 end isBlock;
+
+function eachBool
+  input Absyn.Each eachPrefix;
+  output Boolean res;
+algorithm
+  res := match eachPrefix
+    case Absyn.Each.EACH() then true;
+    else false;
+  end match;
+end eachBool;
 
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/testsuite/openmodelica/interactive-API/setElementModifierValue.mos
+++ b/testsuite/openmodelica/interactive-API/setElementModifierValue.mos
@@ -32,6 +32,10 @@ setElementModifierValue(M, classwithReplaceable, $Code((A = 1, B = 2)));
 getErrorString();
 list(M);
 
+setElementModifierValue(M, classwithReplaceable, $Code((final A, B = 2)));
+getErrorString();
+list(M);
+
 // Result:
 // true
 // true
@@ -58,5 +62,10 @@ list(M);
 // ""
 // "model M
 //   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"C\"), A = 1, B = 2);
+// end M;"
+// true
+// ""
+// "model M
+//   ClasswithReplaceable classwithReplaceable(otherClass(redeclare ClassB testClass \"C\"), final A, B = 2);
 // end M;"
 // endResult


### PR DESCRIPTION
- A modifier with the `final` prefix should not be considered empty even if it has no binding or submodifiers, since the `final` has semantic meaning on its own.