### PR TITLE
Fix prefixing of connector crefs

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -389,6 +389,23 @@ public
     end match;
   end append;
 
+  function appendScope
+    "Appends the instance scope of the given node to a component reference, as
+     defined by InstNode.scopeList."
+    input InstNode scope;
+    input output ComponentRef cref;
+    input Boolean includeRoot = false "Whether to include the root class name or not.";
+  protected
+    ComponentRef prefix;
+  algorithm
+    prefix := fromNodeList(InstNode.scopeList(scope, includeRoot));
+
+    if not ComponentRef.isEmpty(prefix) then
+      cref := append(cref, prefix);
+      cref := removeOuterCrefPrefix(cref);
+    end if;
+  end appendScope;
+
   function prepend
     input ComponentRef restCref;
     input output ComponentRef cref;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2725,15 +2725,7 @@ algorithm
       then
         fail();
 
-    else
-      algorithm
-        prefixed_cref := ComponentRef.fromNodeList(InstNode.scopeList(scope));
-        prefixed_cref := if ComponentRef.isEmpty(prefixed_cref) then
-          cref else ComponentRef.append(cref, prefixed_cref);
-        prefixed_cref := ComponentRef.removeOuterCrefPrefix(prefixed_cref);
-      then
-        Expression.CREF(Type.UNKNOWN(), prefixed_cref);
-
+    else Expression.CREF(Type.UNKNOWN(), ComponentRef.appendScope(scope, cref));
   end match;
 end instCrefComponent;
 
@@ -2746,8 +2738,7 @@ function instCrefFunction
 protected
   ComponentRef fn_ref;
 algorithm
-  fn_ref := ComponentRef.fromNodeList(InstNode.scopeList(scope, includeRoot = true));
-  fn_ref := ComponentRef.append(cref, fn_ref);
+  fn_ref := ComponentRef.appendScope(scope, cref, includeRoot = true);
   fn_ref := Function.instFunctionRef(fn_ref, context, info);
   crefExp := Expression.CREF(Type.UNKNOWN(), fn_ref);
 end instCrefFunction;
@@ -3171,12 +3162,7 @@ protected
 algorithm
   (cref, found_scope) := Lookup.lookupConnector(absynCref, scope, context, info);
   cref := instCrefSubscripts(cref, scope, context, info);
-
-  prefix := ComponentRef.fromNodeList(InstNode.scopeList(found_scope));
-  if not ComponentRef.isEmpty(prefix) then
-    cref := ComponentRef.append(cref, prefix);
-  end if;
-
+  cref := ComponentRef.appendScope(found_scope, cref);
   outExp := Expression.CREF(Type.UNKNOWN(), cref);
 end instConnectorCref;
 

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterConnect1.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterConnect1.mo
@@ -1,0 +1,38 @@
+// name: InnerOuterConnect1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+connector RealOutput = output Real;
+connector RealInput = input Real;
+
+model A
+  RealOutput x;
+  RealOutput y;
+equation
+  connect(x, y);
+end A;
+
+model B
+  A a;
+end B;
+
+model C
+  outer B b;
+end C;
+
+model InnerOuterConnect1
+  C c;
+end InnerOuterConnect1;
+
+// Result:
+// class InnerOuterConnect1
+//   Real b.a.x;
+//   Real b.a.y;
+// equation
+//   b.a.x = b.a.y;
+// end InnerOuterConnect1;
+// [flattening/modelica/scodeinst/InnerOuterConnect1.mo:22:3-22:12:writable] Warning: An inner declaration for outer component b could not be found and was automatically generated.
+//
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -769,6 +769,7 @@ InnerOuter10.mo \
 InnerOuter11.mo \
 InnerOuter12.mo \
 InnerOuterClass1.mo \
+InnerOuterConnect1.mo \
 InnerOuterDuplicate1.mo \
 InnerOuterInvalidMod1.mo \
 InnerOuterInvalidMod2.mo \


### PR DESCRIPTION
- Refactor the code for appending a scope to a cref into a function instead of repeating it in several places of the instantiation, to make sure outer prefixes are always removed.

Fixes #11068