### PR TITLE
Add the missing copy assignment operator for OMVariable

### DIFF
--- a/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.cpp
@@ -191,6 +191,17 @@ OMVariable::OMVariable()
 
 OMVariable::OMVariable(const OMVariable &var)
 {
+  copyData(var);
+}
+
+OMVariable& OMVariable::operator=(const OMVariable &var)
+{
+  copyData(var);
+  return *this;
+}
+
+void OMVariable::copyData(const OMVariable &var)
+{
   name = var.name;
   comment = var.comment;
   info = var.info;
@@ -198,7 +209,7 @@ OMVariable::OMVariable(const OMVariable &var)
   definedIn = var.definedIn;
   usedIn = var.usedIn;
   foreach (OMOperation *op, var.ops) {
-    qDebug() << "dynamic_cast op: " << op->toString();
+    //qDebug() << "dynamic_cast op: " << op->toString();
     if (dynamic_cast<OMOperationSimplify*>(op))
       ops.append(new OMOperationSimplify(*dynamic_cast<OMOperationSimplify*>(op)));
     else if (dynamic_cast<OMOperationScalarize*>(op))

--- a/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.cpp
@@ -210,32 +210,7 @@ void OMVariable::copyData(const OMVariable &var)
   usedIn = var.usedIn;
   foreach (OMOperation *op, var.ops) {
     //qDebug() << "dynamic_cast op: " << op->toString();
-    if (dynamic_cast<OMOperationSimplify*>(op))
-      ops.append(new OMOperationSimplify(*dynamic_cast<OMOperationSimplify*>(op)));
-    else if (dynamic_cast<OMOperationScalarize*>(op))
-      ops.append(new OMOperationScalarize(*dynamic_cast<OMOperationScalarize*>(op)));
-    else if (dynamic_cast<OMOperationInline*>(op))
-      ops.append(new OMOperationInline(*dynamic_cast<OMOperationInline*>(op)));
-    else if (dynamic_cast<OMOperationSubstitution*>(op))
-      ops.append(new OMOperationSubstitution(*dynamic_cast<OMOperationSubstitution*>(op)));
-    else if (dynamic_cast<OMOperationSolved*>(op))
-      ops.append(new OMOperationSolved(*dynamic_cast<OMOperationSolved*>(op)));
-    else if (dynamic_cast<OMOperationLinearSolved*>(op))
-      ops.append(new OMOperationLinearSolved(*dynamic_cast<OMOperationLinearSolved*>(op)));
-    else if (dynamic_cast<OMOperationSolve*>(op))
-      ops.append(new OMOperationSolve(*dynamic_cast<OMOperationSolve*>(op)));
-    else if (dynamic_cast<OMOperationDifferentiate*>(op))
-      ops.append(new OMOperationDifferentiate(*dynamic_cast<OMOperationDifferentiate*>(op)));
-    else if (dynamic_cast<OMOperationResidual*>(op))
-      ops.append(new OMOperationResidual(*dynamic_cast<OMOperationResidual*>(op)));
-    else if (dynamic_cast<OMOperationDummyDerivative*>(op))
-      ops.append(new OMOperationDummyDerivative(*dynamic_cast<OMOperationDummyDerivative*>(op)));
-    else if (dynamic_cast<OMOperationFlattening*>(op))
-      ops.append(new OMOperationFlattening(*dynamic_cast<OMOperationFlattening*>(op)));
-    else if (dynamic_cast<OMOperationInfo*>(op))
-      ops.append(new OMOperationInfo(*dynamic_cast<OMOperationInfo*>(op)));
-    else
-      ops.append(new OMOperation(*op));
+    ops.append(op->clone());
   }
 }
 

--- a/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.h
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.h
@@ -167,6 +167,8 @@ struct OMVariable {
   QList<OMOperation*> ops;
   OMVariable();
   OMVariable(const OMVariable& var);
+  OMVariable& operator=(const OMVariable& var);
+  void copyData(const OMVariable& var);
   ~OMVariable();
 };
 

--- a/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.h
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.h
@@ -43,6 +43,7 @@
 class OMOperation {
 public:
   virtual ~OMOperation() {}
+  virtual OMOperation* clone() const {return new OMOperation(*this);}
   virtual QString toString();
   virtual QString toHtml(HtmlDiff htmlDiff = HtmlDiff::Both);
   QString diffHtml(QString &before, QString &after, HtmlDiff htmlDiff);
@@ -53,8 +54,11 @@ class OMOperationInfo : public OMOperation
 public:
   QString name,info;
   OMOperationInfo(QString name, QString info);
-  QString toString();
-  QString toHtml(HtmlDiff htmlDiff);
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationInfo(*this);}
+  virtual QString toString() override;
+  virtual QString toHtml(HtmlDiff htmlDiff) override;
 };
 
 class OMOperationBeforeAfter : public OMOperation
@@ -62,14 +66,20 @@ class OMOperationBeforeAfter : public OMOperation
 public:
   QString name,before,after;
   OMOperationBeforeAfter(QString name, QStringList ops);
-  QString toString();
-  QString toHtml(HtmlDiff htmlDiff);
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationBeforeAfter(*this);}
+  virtual QString toString() override;
+  virtual QString toHtml(HtmlDiff htmlDiff) override;
 };
 
 class OMOperationSimplify : public OMOperationBeforeAfter
 {
 public:
   OMOperationSimplify(QStringList ops) : OMOperationBeforeAfter("simplify",ops) {}
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationSimplify(*this);}
 };
 
 class OMOperationScalarize : public OMOperation
@@ -78,19 +88,28 @@ public:
   int index;
   QString before,after;
   OMOperationScalarize(int _index,QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationScalarize(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationInline : public OMOperationBeforeAfter
 {
 public:
   OMOperationInline(QStringList ops) : OMOperationBeforeAfter("inline",ops) {}
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationInline(*this);}
 };
 
 class OMOperationSubstitution : public OMOperationBeforeAfter
 {
 public:
   OMOperationSubstitution(QStringList ops) : OMOperationBeforeAfter("substitution",ops) {}
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationSubstitution(*this);}
 };
 
 class OMOperationSolved : public OMOperation
@@ -98,7 +117,10 @@ class OMOperationSolved : public OMOperation
 public:
   QString lhs,rhs;
   OMOperationSolved(QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationSolved(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationLinearSolved : public OMOperation
@@ -106,7 +128,10 @@ class OMOperationLinearSolved : public OMOperation
 public:
   QString text;
   OMOperationLinearSolved(QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationLinearSolved(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationSolve : public OMOperation
@@ -115,7 +140,10 @@ public:
   QString lhs_old,rhs_old;
   QString lhs_new,rhs_new;
   OMOperationSolve(QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationSolve(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationDifferentiate : public OMOperation
@@ -123,7 +151,10 @@ class OMOperationDifferentiate : public OMOperation
 public:
   QString exp,wrt,result;
   OMOperationDifferentiate(QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationDifferentiate(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationResidual : public OMOperation
@@ -131,7 +162,10 @@ class OMOperationResidual : public OMOperation
 public:
   QString lhs,rhs,result;
   OMOperationResidual(QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationResidual(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationDummyDerivative : public OMOperation
@@ -140,13 +174,19 @@ public:
   QString chosen;
   QStringList candidates;
   OMOperationDummyDerivative(QStringList ops);
-  QString toString();
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationDummyDerivative(*this);}
+  virtual QString toString() override;
 };
 
 class OMOperationFlattening : public OMOperationBeforeAfter
 {
 public:
   OMOperationFlattening(QStringList ops) : OMOperationBeforeAfter("flattening", ops) {}
+  // OMOperation interface
+public:
+  virtual OMOperation* clone() const override {return new OMOperationFlattening(*this);}
 };
 
 struct OMInfo {


### PR DESCRIPTION
### Related Issues

#11038

### Purpose

Avoid crashing OMEdit when loading Transformations Widget with operations.

### Approach

Implemented the copy assignment operator that is needed to make the deep copy of OMVariable.