### PR TITLE
Do not run the environment job on 'osx' labled machines.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
   stages {
     stage('Environment') {
       agent {
-        label 'linux || osx'
+        label 'linux'
       }
       steps {
         script {


### PR DESCRIPTION
  - Do not run the environment job on 'osx' labeled machines. They might not be functional and that will block the PR completely from running even though we have not asked for mac builds.

  - There are two mac machines: x64 and arm/M1. The 'osx' label includes both. Unfortunately, the x64 has been broken for quite some time so we should at least not use the 'osx' label for the Environment job. We can probably use the 'M1' label to get the M1 mac machine. That one works fine at the moment.

