### PR TITLE
Add CMake support for ParModExp.

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ParModelica/CMakeLists.txt
@@ -1,10 +1,16 @@
 
-set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/ParModelica)
-
 find_package(Boost COMPONENTS graph chrono)
 
 if(Boost_graph_FOUND AND Boost_chrono_FOUND)
   omc_add_subdirectory(auto)
 else()
   message(STATUS "Required boost libraries (graph, chrono) not found for ParModAuto. Disabling ParModAuto.")
+endif()
+
+find_package(OpenCL)
+
+if(OpenCL_FOUND)
+  omc_add_subdirectory(explicit/openclrt)
+else()
+  message(STATUS "Required OpenCL libraries not found for ParModExp. Disabling ParModExp.")
 endif()

--- a/OMCompiler/SimulationRuntime/ParModelica/auto/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ParModelica/auto/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
-
-project(ParModelicaAuto)
-set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/auto)
+set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/ParModelica/auto)
 
 find_package(Boost COMPONENTS graph chrono REQUIRED)
 

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/CMakeLists.txt
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/CMakeLists.txt
@@ -1,19 +1,27 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/ParModelica/auto)
 
-PROJECT(ParModelicaExpl)
+find_package(OpenCL REQUIRED)
 
-SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}")
-
-FIND_PACKAGE(OpenCL REQUIRED)
-
-SET(PARMODELICA_SRC omc_ocl_memory_ops.cpp
+set(PARMODEXP_SOURCES omc_ocl_memory_ops.cpp
                     omc_ocl_interface.cpp
                     omc_ocl_builtin_kernels.cpp
                     omc_ocl_util.cpp)
 
 
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-INCLUDE_DIRECTORIES(../../../c)
+add_library(ParModelicaExpl STATIC)
+TARGET_SOURCES(ParModelicaExpl PRIVATE ${PARMODEXP_SOURCES})
+
+target_link_libraries(ParModelicaExpl PUBLIC omc::simrt::runtime)
+target_link_libraries(ParModelicaExpl PUBLIC OpenCL::OpenCL)
 
 
-ADD_LIBRARY(ParModelicaExpl ${PARMODELICA_SRC})
+install(TARGETS ParModelicaExpl)
+install(FILES ParModelicaBuiltin.mo
+            DESTINATION lib/omc)
+
+install(FILES
+            omc_ocl_interface.h
+            omc_ocl_common_header.h
+            omc_ocl_memory_ops.h
+            OCLRuntimeUtil.cl
+        TYPE INCLUDE)

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_builtin_kernels.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_builtin_kernels.cpp
@@ -50,7 +50,7 @@
 */
 
 
-#include <omc_ocl_builtin_kernels.h>
+#include "omc_ocl_builtin_kernels.h"
 
 void ocl_real_arr_arr_arr(const char* kernel_name, modelica_real* src_1, modelica_real* src_2, modelica_real* dest, int size_){
 

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_builtin_kernels.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_builtin_kernels.h
@@ -53,12 +53,12 @@
 #ifndef _OMC_OCL_BUILTIN_KERNELS_H
 #define _OMC_OCL_BUILTIN_KERNELS_H
 
+#include <time.h>
 // Don't need this. Avoid unneccesary header inclusions,
 // obey the dependencies.
 // #include <omc_ocl_common_header.h>
 // This include will bring the omc_ocl_common_header.h
-#include <omc_ocl_memory_ops.h>
-#include <time.h>
+#include "omc_ocl_memory_ops.h"
 
 
 

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_memory_ops.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_memory_ops.cpp
@@ -44,7 +44,7 @@
 
 
 
-#include <omc_ocl_memory_ops.h>
+#include "omc_ocl_memory_ops.h"
 
 
 

--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.h
@@ -52,13 +52,13 @@
 #ifndef _OMC_OCL_UTIL_H
 #define _OMC_OCL_UTIL_H
 
-#include <omc_ocl_common_header.h>
 
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
 #include <sys/stat.h>
 
+#include "omc_ocl_common_header.h"
 
 // The compiled OpenCL program containing kerenls generated for a simulation
 cl_program omc_ocl_program = NULL;


### PR DESCRIPTION
  - This was overlooked until now. On Jenkins, it was being tested with the Makefiles build. Because of that and due to the fact that it does not have many users it was not noticed that it was missing from the CMake build so far.

  - The component will be enabled only if OpenCL is found in the host system. Otherwise it is disabled/skipped.
