### PR TITLE
Fix some compiler warnings

### DIFF
--- a/OMCompiler/SimulationRuntime/c/fmi/FMI1CoSimulation.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI1CoSimulation.c
@@ -71,7 +71,7 @@ void* FMI1CoSimulationConstructor_OMC(int fmi_log_level, char* working_directory
   /* Load the binary (dll/so) */
   status = fmi1_import_create_dllfmu(FMI1CS->FMIImportInstance, FMI1CS->FMICallbackFunctions, 0);
   if (status == jm_status_error) {
-    ModelicaFormatError("Loading of FMU dynamic link library failed with status : %s\n", jm_log_level_to_string(status));
+    ModelicaFormatError("Loading of FMU dynamic link library failed");
     return 0;
   }
   FMI1CS->FMIInstanceName = (char*) malloc(strlen(instanceName)+1);
@@ -85,7 +85,7 @@ void* FMI1CoSimulationConstructor_OMC(int fmi_log_level, char* working_directory
   FMI1CS->FMIInteractive = interactive;
   instantiateSlaveStatus = fmi1_import_instantiate_slave(FMI1CS->FMIImportInstance, FMI1CS->FMIInstanceName, FMI1CS->FMIFmuLocation, FMI1CS->FMIMimeType, FMI1CS->FMITimeOut, FMI1CS->FMIVisible, FMI1CS->FMIInteractive);
   if (instantiateSlaveStatus == jm_status_error) {
-    ModelicaFormatError("fmiInstantiateSlave failed with status : %s\n", jm_log_level_to_string(instantiateSlaveStatus));
+    ModelicaFormatError("fmiInstantiateSlave failed with status");
     return 0;
   }
   FMI1CS->FMIDebugLogging = debugLogging;

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI1ModelExchange.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI1ModelExchange.c
@@ -69,7 +69,7 @@ void* FMI1ModelExchangeConstructor_OMC(int fmi_log_level, char* working_director
   /* Load the binary (dll/so) */
   status = fmi1_import_create_dllfmu(FMI1ME->FMIImportInstance, FMI1ME->FMICallbackFunctions, 0);
   if (status == jm_status_error) {
-    ModelicaFormatError("Loading of FMU dynamic link library failed with status : %s\n", jm_log_level_to_string(status));
+    ModelicaFormatError("Loading of FMU dynamic link library failed");
     return 0;
   }
   FMI1ME->FMIInstanceName = (char*) malloc(strlen(instanceName)+1);
@@ -77,7 +77,7 @@ void* FMI1ModelExchangeConstructor_OMC(int fmi_log_level, char* working_director
   FMI1ME->FMIDebugLogging = debugLogging;
   instantiateModelStatus = fmi1_import_instantiate_model(FMI1ME->FMIImportInstance, FMI1ME->FMIInstanceName);
   if (instantiateModelStatus == jm_status_error) {
-    ModelicaFormatError("fmiInstantiateModel failed with status : %s\n", jm_log_level_to_string(instantiateModelStatus));
+    ModelicaFormatError("fmiInstantiateModel failed");
     return 0;
   }
   debugLoggingStatus = fmi1_import_set_debug_logging(FMI1ME->FMIImportInstance, FMI1ME->FMIDebugLogging);

--- a/OMCompiler/SimulationRuntime/c/fmi/FMI2ModelExchange.c
+++ b/OMCompiler/SimulationRuntime/c/fmi/FMI2ModelExchange.c
@@ -71,7 +71,7 @@ void* FMI2ModelExchangeConstructor_OMC(int fmi_log_level, char* working_director
   status = fmi2_import_create_dllfmu(FMI2ME->FMIImportInstance, fmi2_fmu_kind_me, &FMI2ME->FMICallbackFunctions);
   if (status == jm_status_error) {
     FMI2ME->FMISolvingMode = fmi2_none_mode;
-    ModelicaFormatError("Loading of FMU dynamic link library failed with status : %s\n", jm_log_level_to_string(status));
+    ModelicaFormatError("Loading of FMU dynamic link library failed");
     return 0;
   }
   FMI2ME->FMIInstanceName = (char*) malloc(strlen(instanceName)+1);
@@ -80,7 +80,7 @@ void* FMI2ModelExchangeConstructor_OMC(int fmi_log_level, char* working_director
   instantiateModelStatus = fmi2_import_instantiate(FMI2ME->FMIImportInstance, FMI2ME->FMIInstanceName, fmi2_model_exchange, NULL, fmi2_false);
   if (instantiateModelStatus == jm_status_error) {
     FMI2ME->FMISolvingMode = fmi2_none_mode;
-    ModelicaFormatError("fmi2InstantiateModel failed with status : %s\n", jm_log_level_to_string(instantiateModelStatus));
+    ModelicaFormatError("fmi2InstantiateModel failed");
     return 0;
   }
   /* Only call fmi2SetDebugLogging if debugLogging is true */

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -1235,7 +1235,7 @@ void PlotWindow::plotArrayParametric(double time, PlotCurve *pPlotCurve)
       for (int j = 0; j<2; j++){
         res.clear();
         double *arrElement;
-        for (int i = 1; i++; true){
+        for (int i = 1; i++;){
           QString varNameQS = varPair[j];
           if (QRegExp("der\\(\\D(\\w)*\\)").exactMatch(varNameQS)){
             varNameQS.chop(1);


### PR DESCRIPTION
- Don't use `jm_log_level_to_status` on `status` of different type `jm_status_enu_t` in the FMI cosimulation/model exchange code, it doesn't work and printing the status is unnecessary anyway since it's always just `jm_status_error`.
- Don't use a dummy unused expression as the condition in a for-loop, just omit it instead.