### PR TITLE
Assert inPosition in bounds

### DIFF
--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -100,7 +100,6 @@ import Array;
 import MetaModelica.Dangerous.{listReverseInPlace, arrayGetNoBoundsChecking, arrayUpdateNoBoundsChecking, arrayCreateNoInit};
 import MetaModelica.Dangerous;
 import DoubleEnded;
-import Error;
 import GCExt;
 
 public function create<T>
@@ -1242,12 +1241,12 @@ protected
   T e;
 algorithm
   // Check if inPosition is a valid value
-  Error.assertion(
-    inPosition >= 0 and inPosition <= listLength(inList),
-    getInstanceName() + " out of bounds error for input argument inPosition: " + intString(inPosition) + "\n",
-    sourceInfo());
+  if inPosition < 0 or inPosition > listLength(inList) then
+    print("function split ERROR:\n");
+    print("Out of bounds error for input argument inPosition=" + intString(inPosition) + "\n");
+    fail();
+  end if;
 
-  true := inPosition >= 0;
   pos := inPosition;
 
   // Move elements from l2 to l1 until we reach the split position.

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -100,6 +100,7 @@ import Array;
 import MetaModelica.Dangerous.{listReverseInPlace, arrayGetNoBoundsChecking, arrayUpdateNoBoundsChecking, arrayCreateNoInit};
 import MetaModelica.Dangerous;
 import DoubleEnded;
+import Error;
 import GCExt;
 
 public function create<T>
@@ -1240,6 +1241,12 @@ protected
   list<T> l1 = {}, l2 = inList;
   T e;
 algorithm
+  // Check if inPosition is a valid value
+  Error.assertion(
+    inPosition >= 0 and inPosition <= listLength(inList),
+    getInstanceName() + " out of bounds error for input argument inPosition: " + intString(inPosition) + "\n",
+    sourceInfo());
+
   true := inPosition >= 0;
   pos := inPosition;
 


### PR DESCRIPTION
### Related Issues

List.split can fail without giving an error message in case `inPosition` is out of bounds.
This is the error that is thrown in https://github.com/OpenModelica/OpenModelica/issues/11083.

### Purpose

  - Check that List.split is in bounds or throw an error with error message.
