### PR TITLE
Change libomqwt to shared library.

### DIFF
--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -214,15 +214,14 @@ if (QWT_WITH_WIDGETS)
     qwt_wheel.cpp)
 endif ()
 
-add_library(omqwt STATIC ${QWT_HEADERS} ${QWT_SOURCES})
+add_library(omqwt SHARED ${QWT_HEADERS} ${QWT_SOURCES})
 
-## We build it as a static library now. Disable dllimport/export attributes.
-# target_compile_definitions(omqwt
-# 	PUBLIC
-# 		$<$<BOOL:MSVC>:QWT_DLL>
-# 	PRIVATE
-# 		$<$<BOOL:MSVC>:QWT_MAKEDLL>
-# )
+target_compile_definitions(omqwt
+	PUBLIC
+		$<$<BOOL:MSVC>:QWT_DLL>
+	PRIVATE
+		$<$<BOOL:MSVC>:QWT_MAKEDLL>
+)
 
 target_include_directories(omqwt
   PUBLIC


### PR DESCRIPTION
  - This reverts changes made in #9939 and #9956.

  - It should be a shared library (a DLL on Windows at least) because it is used by both `libOMPlotLib.dll` and `OMNoteBook.exe`. However, `OMNoteBook.exe` links to `libOMPlotLib.dll` as well. CMake will add both `libOMPlotLib.dll` and `libomqwt.a` to the linking commandline of `OMNoteBook.exe` and that causes duplicates on some configurations (e.g. using `clang` on `OMDev`. Curiously the issue does not occur with `gcc` on `OMDev`).

    Another way to fix this problem would be to make the linking by `libOMPlotLib.dll` to static `libomqwt.a` a PRIVATE link (in CMake terms.) However, that will require us to manually add the definitions and include directives needed to use `libomqwt.a` by `OMNoteBook.exe` (think of it like `OMNoteBook.exe` uses both `libOMPlotLib.dll` and `libomqwt.a`, not just `libOMPlotLib.dll`). So the most logical and straightforward fix is to make `libomqwt` a shared lib.

