### PR TITLE
Improve omqwt compilation. Fix possbile errors.

### DIFF
--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.c
@@ -258,7 +258,7 @@ static const char* GetLastErrorAsString()
   return str;
 }
 
-char* omc_dlerror()
+const char* omc_dlerror()
 {
   return GetLastErrorAsString();
 }
@@ -277,7 +277,7 @@ void* dlopen(const char *filename, int flag) {
   return omc_dlopen(filename, flag);
 }
 
-char* dlerror() {
+const char* dlerror() {
   return omc_dlerror();
 }
 

--- a/OMCompiler/SimulationRuntime/c/util/omc_msvc.h
+++ b/OMCompiler/SimulationRuntime/c/util/omc_msvc.h
@@ -159,13 +159,13 @@ typedef struct {
 
 char* mkdtemp(char *tpl);
 void* omc_dlopen(const char *filename, int flag);
-char* omc_dlerror();
+const char* omc_dlerror();
 void* omc_dlsym(void *handle, const char *symbol);
 int omc_dlclose(void *handle);
 int omc_dladdr(void *addr, Dl_info *info);
 
 void* dlopen(const char *filename, int flag);
-char* dlerror();
+const char* dlerror();
 void* dlsym(void *handle, const char *symbol);
 int dlclose(void *handle);
 int dladdr(void *addr, Dl_info *info);

--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -216,12 +216,14 @@ endif ()
 
 add_library(omqwt SHARED ${QWT_HEADERS} ${QWT_SOURCES})
 
-target_compile_definitions(omqwt
-	PUBLIC
-		$<$<BOOL:MSVC>:QWT_DLL>
-	PRIVATE
-		$<$<BOOL:MSVC>:QWT_MAKEDLL>
-)
+if(WIN32)
+  # define QWT_DLL so the headers add the dll export/import specifiers .
+  target_compile_definitions(omqwt PUBLIC QWT_DLL)
+  # When compiling omqwt itself, define QWT_MAKEDLL so the headers export the functions.
+  # Target that link to omqwt will not fet this define (private) which means they will
+  # dllimport the functions. See src/qwt_global.h:27-35
+  target_compile_definitions(omqwt PRIVATE QWT_MAKEDLL)
+endif()
 
 target_include_directories(omqwt
   PUBLIC


### PR DESCRIPTION
  - Define `QWT_DL` and `QWT_MAKEDLL` accordingly for all Windows compilations not just for `MSVC`.

  - Fix const qualifiers in `omc_msvc.c`. Removing const qualifiers on return values seems to be considered an error by `MinGW clang-11`. Possibly a warning on others.
