### PR TITLE
Install omqwt.

### DIFF
--- a/OMPlot/qwt/src/CMakeLists.txt
+++ b/OMPlot/qwt/src/CMakeLists.txt
@@ -255,4 +255,7 @@ set_target_properties(omqwt PROPERTIES
   VERSION ${QWT_VERSION}
   SOVERSION ${QWT_VER_MAJ}
   AUTOMOC ON)
+
 target_compile_definitions(omqwt PRIVATE QWT_MOC_INCLUDE)
+
+install(TARGETS omqwt)


### PR DESCRIPTION
  - It is now built as a shared library. Needs to be installed to be used by the targets that depend on it.

