### PR TITLE
Improve redeclare of inner/outer components

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2011,10 +2011,10 @@ algorithm
     fail();
   end if;
 
-  orig_comp := InstNode.component(originalNode);
+  orig_comp := InstNode.component(InstNode.resolveInner(originalNode));
   rdcl_type := InstNodeType.REDECLARED_COMP(InstNode.parent(originalNode));
   rdcl_node := InstNode.setNodeType(rdcl_type, redeclareNode);
-  rdcl_node := InstNode.copyInstancePtr(originalNode, rdcl_node);
+  rdcl_node := InstNode.copyInstancePtr(InstNode.resolveInner(originalNode), rdcl_node);
   rdcl_node := InstNode.updateComponent(InstNode.component(redeclareNode), rdcl_node);
   instComponent(rdcl_node, outerAttr, constrainingMod, true, instLevel, context,
     SOME(Component.getAttributes(orig_comp)), propagatedSubs);
@@ -2059,7 +2059,7 @@ algorithm
 
   end match;
 
-  InstNode.updateComponent(new_comp, redeclaredNode);
+  InstNode.updateComponent(new_comp, InstNode.resolveInner(redeclaredNode));
 end redeclareComponent;
 
 function checkOuterComponentMod

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -414,7 +414,7 @@ algorithm
   end while;
 
   // No inner found, try to generate one.
-  innerNode := generateInner(outerNode, prev_scope);
+  innerNode := generateInner(outerNode, InstNode.topScope(prev_scope));
 end lookupInner;
 
 function lookupLocalSimpleName

--- a/testsuite/flattening/modelica/scodeinst/InnerOuterReplaceable2.mo
+++ b/testsuite/flattening/modelica/scodeinst/InnerOuterReplaceable2.mo
@@ -1,0 +1,25 @@
+// name: InnerOuterReplaceable2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model A
+  outer Real x;
+end A;
+
+model B
+  inner parameter A a;
+  inner replaceable Real x;
+end B;
+
+model InnerOuterReplaceable2
+  extends B(redeclare Real x = 2);
+end InnerOuterReplaceable2;
+
+
+// Result:
+// class InnerOuterReplaceable2
+//   parameter Real x = 2.0;
+// end InnerOuterReplaceable2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -792,6 +792,7 @@ InnerOuterNotInner1.mo \
 InnerOuterPartialOuter1.mo \
 InnerOuterPartialOuter2.mo \
 InnerOuterReplaceable1.mo \
+InnerOuterReplaceable2.mo \
 InstanceRestriction1.mo \
 InstanceRestriction2.mo \
 InStreamArray.mo \


### PR DESCRIPTION
- Resolve the inner component when redeclaring.
- Make sure we get the top scope when generating inners.