### PR TITLE
Fix InteractiveUtil.getPathedElementInProgram for builtins

### DIFF
--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -4633,7 +4633,11 @@ public function getPathedElementInProgram
 protected
   Absyn.Class cls;
 algorithm
-  cls := getClassInProgram(AbsynUtil.pathFirstIdent(path), program);
+  try
+    cls := getClassInProgram(AbsynUtil.pathFirstIdent(path), program);
+  else
+    cls := getClassInProgram(AbsynUtil.pathFirstIdent(path), FBuiltin.getInitialFunctions());
+  end try;
 
   if AbsynUtil.pathIsIdent(path) then
     // Since the program only stores classes instead of elements we have to

--- a/testsuite/openmodelica/interactive-API/getClassComment.mos
+++ b/testsuite/openmodelica/interactive-API/getClassComment.mos
@@ -23,6 +23,7 @@ getClassComment(P.M2);
 getClassComment(P.M3);
 getClassComment(P.M);
 getClassComment(P.ME);
+getClassComment(OpenModelica.Scripting.loadFile);
 
 // Result:
 // true
@@ -32,4 +33,5 @@ getClassComment(P.ME);
 // "After constraint"
 // "M comment"
 // "ME comment"
+// "load file (*.mo) and merge it with the loaded AST."
 // endResult


### PR DESCRIPTION
- Retry the lookup in the builtin environment if the element isn't found among the userdefined elements.