### PR TITLE
Use default wrap mode i.e., QTextOption::WrapAtWordBoundaryOrAnywhere

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
@@ -68,7 +68,6 @@ QString ItemDelegate::formatDisplayText(QVariant variant) const
 void ItemDelegate::initTextDocument(QTextDocument *pTextDocument, QFont font, int width) const
 {
   QTextOption textOption = pTextDocument->defaultTextOption();
-  textOption.setWrapMode(QTextOption::WordWrap);
   pTextDocument->setDefaultTextOption(textOption);
   pTextDocument->setDefaultFont(font);
   pTextDocument->setTextWidth(width);


### PR DESCRIPTION
### Related Issues

Fixes #9808 and fixes #11118

### Purpose

Make sure the simulation output is wrapped correctly.

### Approach

Use `QTextOption::WrapAtWordBoundaryOrAnywhere` instead of `QTextOption::WordWrap`.
With `QTextOption::WrapAtWordBoundaryOrAnywhere`, if possible, wrapping occurs at a word boundary; otherwise it will occur at the appropriate point on the line, even in the middle of a word.
