### PR TITLE
Only show the hidden classes if they are not encrypted

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -285,9 +285,7 @@ LibraryTreeItem::Access LibraryTreeItem::getAccess()
   /* Activate the access annotations if the class is encrypted
    * OR if the LibraryTreeItem's mAccessAnnotations is marked true based on the activate access annotation setting.
    */
-  bool isEncryptedClass = mFileName.endsWith(".moc");
-
-  if (isEncryptedClass || isAccessAnnotationsEnabled()) {
+  if (isEncryptedClass() || isAccessAnnotationsEnabled()) {
     if (mClassInformation.access.compare("Access.hide") == 0) {
       return LibraryTreeItem::hide;
     } else if (mClassInformation.access.compare("Access.icon") == 0) {
@@ -307,7 +305,7 @@ LibraryTreeItem::Access LibraryTreeItem::getAccess()
     } else if (mpParentLibraryTreeItem && !mpParentLibraryTreeItem->isRootItem()) {   // if there is no override for Access annotation then look in the parent class.
       return mpParentLibraryTreeItem->getAccess();
     } else {
-      if (isEncryptedClass) { // if a class is encrypted and no Protection annotation is defined, the access annotation has the default value Access.documentation
+      if (isEncryptedClass()) { // if a class is encrypted and no Protection annotation is defined, the access annotation has the default value Access.documentation
         return LibraryTreeItem::documentation;
       } else {
         return LibraryTreeItem::all;
@@ -1116,7 +1114,7 @@ bool LibraryTreeProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &s
     }
 
     bool hide = ((pLibraryTreeItem->getAccess() == LibraryTreeItem::hide
-                  && !OptionsDialog::instance()->getGeneralSettingsPage()->getShowHiddenClasses())
+                  && !(OptionsDialog::instance()->getGeneralSettingsPage()->getShowHiddenClasses() && !pLibraryTreeItem->isEncryptedClass()))
                  || (pLibraryTreeItem->isProtected() && !OptionsDialog::instance()->getGeneralSettingsPage()->getShowProtectedClasses()));
 
     // if any of children matches the filter, then current index matches the filter as well

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -129,6 +129,7 @@ public:
   bool isExpanded() const {return mExpanded;}
   void setNonExisting(bool nonExisting) {mNonExisting = nonExisting;}
   bool isNonExisting() const {return mNonExisting;}
+  bool isEncryptedClass() const {return mFileName.endsWith(".moc");}
   bool isAccessAnnotationsEnabled() const {return mAccessAnnotations;}
   void setAccessAnnotations(bool accessAnnotations) {mAccessAnnotations = accessAnnotations;}
   void setOMSElement(oms_element_t *pOMSComponent) {mpOMSElement = pOMSComponent;}

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -3645,7 +3645,7 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   // show protected classes
   mpShowProtectedClasses = new QCheckBox(tr("Show Protected Classes"));
   // show hidden classes
-  mpShowHiddenClasses = new QCheckBox(tr("Show Hidden Classes (Ignores the annotation(Protection(access = Access.hide)))"));
+  mpShowHiddenClasses = new QCheckBox(tr("Show Hidden Classes if not encrypted"));
   // synchronize Libraries Browser with ModelWidget
   mpSynchronizeWithModelWidgetCheckBox = new QCheckBox(tr("Synchronize with Model Widget"));
   mpSynchronizeWithModelWidgetCheckBox->setChecked(OptionsDefaults::GeneralSettings::synchronizeWithModelWidget);


### PR DESCRIPTION
### Related Issues

Fixes #11121

### Purpose

Only show the hidden classes if they are not encrypted.

### Approach

Renamed the option `Show Hidden Classes` to `Show Hidden Classes if not encrypted`. The option does not have an influence on encrypted libraries.