### PR TITLE
Revert update of configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.63])
 AC_INIT([OpenModelica],[dev],[https://trac.openmodelica.org/OpenModelica],[openmodelica],[https://openmodelica.org])
 
 AC_LANG([C])
@@ -62,5 +62,4 @@ if test ! -z "$USE_CORBA"; then
   AC_CONFIG_SUBDIRS([OMOptim])
 fi
 
-AC_CONFIG_FILES([Makefile])
-AC_OUTPUT
+AC_OUTPUT(Makefile)


### PR DESCRIPTION
### Related Issues

PR https://github.com/OpenModelica/OpenModelica/pull/11027 changed the minimum required autotools version from 2.63 to 2.71 by accident and that broke many Linux nightly builds: https://test.openmodelica.org/jenkins/blue/organizations/jenkins/LINUX_BUILDS/detail/LINUX_BUILDS/2328/pipeline

### Purpose

Revert minimum required version.
