### PR TITLE
Undo some changes made in #11027.

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -3198,10 +3198,10 @@ case "gcc" then
             $(eval LDSYSTEMFLAGS_COMMON=$(LDSYSTEMFLAGS_COMMON) <%papiLibs%>)
             endif
 
-            LDSYSTEMFLAGS_DYNAMIC=-lOMCppSystem -lboost_program_options -lboost_filesystem -ldl -lOMCppModelicaUtilities -lOMCppDataExchange -lOMCppMath -lOMCppExtensionUtilities -lOMCppOMCFactory $(LDSYSTEMFLAGS_COMMON)
+            LDSYSTEMFLAGS_DYNAMIC=-lOMCppSystem -lOMCppModelicaUtilities -lOMCppDataExchange -lOMCppMath -lOMCppExtensionUtilities -lOMCppOMCFactory $(LDSYSTEMFLAGS_COMMON)
             LDSYSTEMFLAGS_STATIC=$(LDSYSTEMFLAGS_COMMON) <%staticLibs%>
 
-            LDMAINFLAGS_DYNAMIC= -lOMCppOMCFactory -lboost_program_options -lboost_filesystem -ldl -lOMCppModelicaUtilities -lOMCppExtensionUtilities $(LDMAINFLAGS_COMMON)
+            LDMAINFLAGS_DYNAMIC= -lOMCppOMCFactory -lOMCppModelicaUtilities -lOMCppExtensionUtilities $(LDMAINFLAGS_COMMON)
             LDMAINFLAGS_STATIC=$(LDMAINFLAGS_COMMON) <%staticLibs%> $(SUNDIALS_LIBRARIES) $(LAPACK_LIBRARIES)
 
             ifeq ($(RUNTIME_STATIC_LINKING),ON)


### PR DESCRIPTION
  - This was added to fix compilation of CPP simulation code generated by a CMake built `omc`. The generated CPP code was failing to link because it was missing these boost libraries on the command-line.

    Unfortunately boost libs might not be named exactly like this on all systems. On Windows with MSVC, for example, they might have debug and thread related suffixes (`*d` or `*-mt`, ...). So this needs to be handled specially based on the platform.

    The proper place to do this is to put the library names in the files `SimulationRuntime/cpp/Core/Modelica/ModelicaConfig_*.inc` at CMake configure time.
