### PR TITLE
Use the default CMake for the extra CI job.

### DIFF
--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -52,8 +52,7 @@ pipeline {
               common.buildOMC_CMake("-DCMAKE_BUILD_TYPE=Release"
                                         + " -DOM_USE_CCACHE=OFF"
                                         + " -DCMAKE_INSTALL_PREFIX=build"
-                                        + " -DSUNDIALS_BUILD_SHARED_LIBS=ON"
-                                    , '/opt/cmake-3.17.2/bin/cmake')
+                                        + " -DSUNDIALS_BUILD_SHARED_LIBS=ON")
               sh "build/bin/omc --version"
             }
             stash name: 'omc-cmake-gcc', includes: 'build/**'


### PR DESCRIPTION
  - The images are now updated and default CMake is more than sufficient.
