### PR TITLE
Adding Debian, EnterpriseLinux and Fedora to CI

### DIFF
--- a/.CI/common.groovy
+++ b/.CI/common.groovy
@@ -492,6 +492,9 @@ def makeCommand() {
   return env.GMAKE ?: "make"
 }
 
+/**
+ *  Return true if lable 'CI/Build MINGW' is set in pull request.
+ */
 def shouldWeBuildMINGW() {
   if (isPR()) {
     if (pullRequest.labels.contains("CI/Build MINGW")) {
@@ -499,6 +502,42 @@ def shouldWeBuildMINGW() {
     }
   }
   return params.BUILD_MINGW
+}
+
+/**
+ *  Return true if lable 'CI/Build Debian' is set in pull request.
+ */
+def shouldWeBuildDebian() {
+  if (isPR()) {
+    if (pullRequest.labels.contains("CI/Build Debian")) {
+      return true
+    }
+  }
+  return params.BUILD_DEBIAN
+}
+
+/**
+ *  Return true if lable 'CI/Build EnterpriseLinux' is set in pull request.
+ */
+def shouldWeBuildEnterpriseLinux() {
+  if (isPR()) {
+    if (pullRequest.labels.contains("CI/Build EnterpriseLinux")) {
+      return true
+    }
+  }
+  return params.BUILD_EL
+}
+
+/**
+ *  Return true if lable 'CI/Build Fedora' is set in pull request.
+ */
+def shouldWeBuildFedora() {
+  if (isPR()) {
+    if (pullRequest.labels.contains("CI/Build Fedora")) {
+      return true
+    }
+  }
+  return params.BUILD_FEDORA
 }
 
 def shouldWeDisableAllCMakeBuilds() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 def common
 def shouldWeBuildMINGW
+def shouldWeBuildDebian
+def shouldWeBuildEnterpriseLinux
+def shouldWeBuildFedora
 def shouldWeDisableAllCMakeBuilds_value
 def shouldWeEnableMacOSCMakeBuild_value
 def shouldWeEnableMinGWCMakeBuild_value
@@ -16,6 +19,9 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'BUILD_MINGW', defaultValue: false, description: 'Build with Win/MinGW')
+    booleanParam(name: 'BUILD_DEBIAN', defaultValue: false, description: 'Build with Debian Bullseye AMD64')
+    booleanParam(name: 'BUILD_EL', defaultValue: false, description: 'Build with AlmaLinux 9 AMD64')
+    booleanParam(name: 'BUILD_FEDORA', defaultValue: false, description: 'Build with Fedora 38 AMD64')
     booleanParam(name: 'DISABLE_ALL_CMAKE_BUILDS', defaultValue: false, description: 'Skip building omc with CMake (CMake 3.17.2) on all platforms')
     booleanParam(name: 'ENABLE_MINGW_CMAKE_BUILD', defaultValue: false, description: 'Enable building omc with CMake on MinGW')
     booleanParam(name: 'ENABLE_MACOS_CMAKE_BUILD', defaultValue: false, description: 'Enable building omc with CMake on macOS')
@@ -39,6 +45,12 @@ pipeline {
           print "isPR: ${isPR}"
           shouldWeBuildMINGW = common.shouldWeBuildMINGW()
           print "shouldWeBuildMINGW: ${shouldWeBuildMINGW}"
+          shouldWeBuildDebian = common.shouldWeBuildDebian()
+          print "shouldWeBuildDebian: ${shouldWeBuildDebian}"
+          shouldWeBuildEnterpriseLinux = common.shouldWeBuildEnterpriseLinux()
+          print "shouldWeBuildEnterpriseLinux: ${shouldWeBuildEnterpriseLinux}"
+          shouldWeBuildFedora = common.shouldWeBuildFedora()
+          print "shouldWeBuildFedora: ${shouldWeBuildFedora}"
           shouldWeDisableAllCMakeBuilds_value = common.shouldWeDisableAllCMakeBuilds()
           print "shouldWeDisableAllCMakeBuilds: ${shouldWeDisableAllCMakeBuilds_value}"
           shouldWeEnableMacOSCMakeBuild_value = common.shouldWeEnableMacOSCMakeBuild()
@@ -114,6 +126,63 @@ pipeline {
                 common.buildGUI('', true)
                 common.buildAndRunOMEditTestsuite('')
               }
+            }
+          }
+        }
+        stage('Debian-Bookworm-gcc') {
+          agent {
+            docker {
+              image 'docker.openmodelica.org/build-deps:bookworm.nightly.amd64'
+              label 'linux'
+              alwaysPull true
+            }
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeBuildDebian }
+          }
+          steps {
+            script {
+              common.buildOMC('gcc', 'g++', '', true, false)
+              common.getVersion()
+            }
+          }
+        }
+        stage('AlmaLinux-9-gcc') {
+          agent {
+            docker {
+              image 'docker.openmodelica.org/build-deps:el9.amd64'
+              label 'linux'
+              alwaysPull true
+            }
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeBuildEnterpriseLinux }
+          }
+          steps {
+            script {
+              common.buildOMC('gcc', 'g++', '', true, false)
+              common.getVersion()
+            }
+          }
+        }
+        stage('Fedora-38-gcc') {
+          agent {
+            docker {
+              image 'docker.openmodelica.org/build-deps:fc38.amd64'
+              label 'linux'
+              alwaysPull true
+            }
+          }
+          when {
+            beforeAgent true
+            expression { shouldWeBuildFedora }
+          }
+          steps {
+            script {
+              common.buildOMC('gcc', 'g++', '', true, false)
+              common.getVersion()
             }
           }
         }


### PR DESCRIPTION
### Related Issues

Make it possible to test some OS before breaking the nightly test. Can be useful for changes in dependencies or build system.

### Approach

Added new labels that use different Docker images to build OpenModelcia:

  -  `CI/Build Debian`: Debian Bookworm + gcc, docker.openmodelica.org/build-deps:bookworm.nightly.amd64
  - `CI/Build EnterpriseLinux` Alma Linux 9 + gcc, docker.openmodelica.org/build-deps:el9.amd64
  - `CI/Build Fedora`: Fedora 38 + gcc, docker.openmodelica.org/build-deps:fc38.amd64