### PR TITLE
Set CXX standard to c++17/c++1z

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,10 @@ omc_option(OM_USE_CCACHE "Use ccache to speedup compilations." ON)
 ## Our sources contain a lot of c99 and gnu extension code.
 # set(CMAKE_C_STANDARD 90)
 
-## Set the C++ standard to use.
+## Set the C++ standard to use. We use C++17 for everything in OpenModelica now.
+## Note that 3rdParty libraries might set their own standards.
+## If you need to use a different C++ standard for parts of OpenModelica, you can
+## of course override this in the corresponding directory's CMake file.
 set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 ## Make sure we do not start relying on extensions down the road.

--- a/OMEdit/CMakeLists.txt
+++ b/OMEdit/CMakeLists.txt
@@ -8,13 +8,6 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omedit)
 omc_option(OM_OMEDIT_INSTALL_RUNTIME_DLLS "Install the required runtime dll dependency DLLs to the binary directory. Valid only for Windows builds." ON)
 omc_option(OM_OMEDIT_ENABLE_TESTS "Enable building of OMEdit Testsuite tests." OFF)
 
-## Set the C++ standard to use. OMEdit uses C++17
-set(CMAKE_CXX_STANDARD 17)
-set(CXX_STANDARD_REQUIRED ON)
-## Make sure we do not start relying on extensions down the road.
-set(CMAKE_CXX_EXTENSIONS OFF)
-
-
 find_package(Qt5 COMPONENTS Widgets PrintSupport WebKitWidgets Xml XmlPatterns OpenGL Network Svg REQUIRED)
 find_package(OpenSceneGraph COMPONENTS osg osgViewer osgUtil osgDB osgGA REQUIRED)
 find_package(OpenGL REQUIRED)

--- a/OMEdit/OMEditGUI/OMEditGUI.pro
+++ b/OMEdit/OMEditGUI/OMEditGUI.pro
@@ -34,7 +34,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++17
+CONFIG += c++1z
 
 TARGET = OMEdit
 TEMPLATE = app

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -34,7 +34,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++17
+CONFIG += c++1z
 
 TARGET = OMEdit
 TEMPLATE = lib

--- a/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/OMNotebookGUI.pro
@@ -10,7 +10,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++14
+CONFIG += c++1z
 
 TRANSLATIONS = Resources/nls/OMNotebook_de_DE.ts
 

--- a/OMPlot/CMakeLists.txt
+++ b/OMPlot/CMakeLists.txt
@@ -5,12 +5,6 @@ project(OMPlot)
 ## to the install component 'omplot' if it is not explicitly changed.
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omplot)
 
-## Set the C++ standard to use. OMPlot uses C++14.
-set(CMAKE_CXX_STANDARD 14)
-set(CXX_STANDARD_REQUIRED ON)
-## Make sure we do not start relying on extensions down the road.
-set(CMAKE_CXX_EXTENSIONS OFF)
-
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.pro
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlotGUI.pro
@@ -10,7 +10,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++14
+CONFIG += c++1z
 
 TARGET = OMPlot
 TEMPLATE = app

--- a/OMPlot/OMPlot/OMPlotGUI/OMPlotLib.pro
+++ b/OMPlot/OMPlot/OMPlotGUI/OMPlotLib.pro
@@ -10,7 +10,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++14
+CONFIG += c++1z
 
 TARGET = OMPlot
 TEMPLATE = lib

--- a/OMShell/OMShell/OMShellGUI/OMShellGUI.pro
+++ b/OMShell/OMShell/OMShellGUI/OMShellGUI.pro
@@ -4,7 +4,7 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 }
 
 # Set the C++ standard.
-CONFIG += c++14
+CONFIG += c++1z
 
 TRANSLATIONS = \
   OMShell_de.ts \


### PR DESCRIPTION
  - CMake 
    - OpenModelica now uses C++17 for all its own code. Remove parts where the standard was specifically set to the required version only for some parts. C++17 covers all we need now.

  - Autoconf+qmake
  
    - Set the standard specifier to `c++1z` instead of `c++17` in the Qt `.pro` files. It seems `c++17` causes addition of faulty `-std=gnu++1y` option on some systems (e.g. `EL7` Using Qt version 5.9.7) Hopefully this will fix it.

    - Upgrade the c++ standard to `c++1z` for OMPlot, OMNotebook, and OMShell as well.




