### PR TITLE
Remove global std namespace uses.

### DIFF
--- a/OMEdit/OMEditLIB/Util/StringHandler.cpp
+++ b/OMEdit/OMEditLIB/Util/StringHandler.cpp
@@ -1595,7 +1595,6 @@ QStringList StringHandler::makeVariableParts(QString variable)
 }
 
 #include <iostream>
-using namespace std;
 
 QStringList StringHandler::makeVariablePartsWithInd(QString variable)
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/application.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/application.h
@@ -42,7 +42,6 @@
 #include "cell.h"
 #include "xmlnodename.h"
 
-using namespace std;
 
 namespace IAEX
 {
@@ -62,10 +61,10 @@ namespace IAEX
       virtual void setCommandCenter(CommandCenter *) = 0;
       virtual void addToPasteboard(Cell *cell) = 0;
       virtual void clearPasteboard() = 0;
-      virtual vector<Cell *> pasteboard() = 0;
+      virtual std::vector<Cell *> pasteboard() = 0;
       virtual void open(const QString filename, int readmode = READMODE_NORMAL, int isDrModelica = 0) = 0;
     virtual void removeTempFiles(QString filename) = 0;    // Added 2006-01-16 AF
-    virtual vector<DocumentView *> documentViewList() = 0;  // Added 2006-01-27 AF
+    virtual std::vector<DocumentView *> documentViewList() = 0;  // Added 2006-01-27 AF
     virtual void removeDocumentView(DocumentView *view) = 0;  // Added 2006-01-27 AF
    };
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
@@ -54,7 +54,6 @@
 
 
 using namespace IAEX;
-using namespace std;
 
 namespace IAEX
 {
@@ -180,7 +179,7 @@ namespace IAEX
       setStyle( style );
     else
     {
-      cout << "Can't set style, style name: " << stylename.toStdString() << " is not valid" << endl;
+      std::cout << "Can't set style, style name: " << stylename.toStdString() << " is not valid" << endl;
     }
   }
 
@@ -275,7 +274,7 @@ namespace IAEX
     QRegExp expression( "InitializationCell|CellTags|FontSlant|TextAlignment|TextJustification|FontSize|FontWeight|FontFamily|PageWidth|CellMargins|CellDingbat|ImageSize|ImageMargins|ImageRegion|OMNotebook_Margin|OMNotebook_Padding|OMNotebook_Border" );
     if( 0 > r->attribute().indexOf( expression ))
     {
-      cout << "[NEW] Rule <" << r->attribute().toStdString() << "> <" << r->value().toStdString() << ">" << endl;
+      std::cout << "[NEW] Rule <" << r->attribute().toStdString() << "> <" << r->value().toStdString() << ">" << endl;
     }
     else
     {
@@ -283,25 +282,25 @@ namespace IAEX
       {
         QRegExp fontslant( "Italic" );
         if( 0 > r->value().indexOf( fontslant ))
-          cout << "[NEW] Rule Value <FontSlant>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <FontSlant>, VALUE: " << r->value().toStdString() << endl;
       }
       else if( r->attribute() == "TextAlignment" )
       {
         QRegExp textalignment( "Right|Left|Center|Justify" );
         if( 0 > r->value().indexOf( textalignment ))
-          cout << "[NEW] Rule Value <TextAlignment>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <TextAlignment>, VALUE: " << r->value().toStdString() << endl;
       }
       else if( r->attribute() == "TextJustification" )
       {
         QRegExp textjustification( "1|0" );
         if( 0 > r->value().indexOf( textjustification ))
-          cout << "[NEW] Rule Value <TextJustification>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <TextJustification>, VALUE: " << r->value().toStdString() << endl;
       }
       else if( r->attribute() == "FontWeight" )
       {
         QRegExp fontweight( "Bold|Plain" );
         if( 0 > r->value().indexOf( fontweight ))
-          cout << "[NEW] Rule Value <FontWeight>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <FontWeight>, VALUE: " << r->value().toStdString() << endl;
       }
     }
 
@@ -531,7 +530,7 @@ namespace IAEX
   QWidget *Cell::mainWidget()
   {
     if(!mainWidget_)
-      throw logic_error("Cell::mainWidget(): No mainWidget set.");
+      throw std::logic_error("Cell::mainWidget(): No mainWidget set.");
 
     return mainWidget_;
   }
@@ -572,7 +571,7 @@ namespace IAEX
   TreeView *Cell::treeView()
   {
     if(!treeView_)
-      throw logic_error("Cell::treeView(): No treeView set.");
+      throw std::logic_error("Cell::treeView(): No treeView set.");
 
     return treeView_;
   }
@@ -622,7 +621,7 @@ namespace IAEX
     }*/
 
     if(!treeView_)
-      throw logic_error("SetHeight(const int height): TreeView is not set.");
+      throw std::logic_error("SetHeight(const int height): TreeView is not set.");
 
         setFixedHeight(h);
 
@@ -870,7 +869,7 @@ namespace IAEX
 
   void Cell::printCell(Cell *current)
   {
-    cout << "This: " << current << endl
+    std::cout << "This: " << current << endl
       << "Parent: " << current->parentCell() << endl
       << "Child: " << current->child() << endl
       << "Last: " << current->last() << endl

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.h
@@ -80,7 +80,7 @@ namespace IAEX
     Q_OBJECT
 
   public:
-    typedef vector<Rule *> rules_t;
+    typedef std::vector<Rule *> rules_t;
 
     Cell(QWidget *parent=0);            // Changed 2005-10-27 AF
     Cell(Cell &c);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
@@ -182,7 +182,7 @@ namespace IAEX
 
       Stylesheet::instance( stylesheetfile );
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       QMessageBox::warning( 0, tr("Error"), e.what(), "OK" );
       exit(-1);
@@ -200,7 +200,7 @@ namespace IAEX
 
       CommandCompletion::instance( commandfile );
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       QString msg = e.what();
       msg += "\nCould not create command completion class, exiting OMNotebook";
@@ -227,7 +227,7 @@ namespace IAEX
         }
         else
         {
-          cout << "File not found: " << fileToOpen.toStdString() << endl;
+          std::cout << "File not found: " << fileToOpen.toStdString() << endl;
           open(QString());
         }
       }
@@ -255,8 +255,8 @@ namespace IAEX
             open( "DrModelica/DrModelica.onb", READMODE_NORMAL, 1);
           else
           {
-            cout << "Unable to find (1): " << drmodelica.toStdString() << endl;
-            cout << "Unable to find (2): DrModelica/DrModelica.onb" << endl;
+            std::cout << "Unable to find (1): " << drmodelica.toStdString() << endl;
+            std::cout << "Unable to find (2): DrModelica/DrModelica.onb" << endl;
             open(QString());
           }
         }
@@ -342,9 +342,9 @@ namespace IAEX
   /*!
    * \author Ingemar Axelsson
    *
-   * \brief returns a vector with all content of the pasteboard.
+   * \brief returns a std::vector with all content of the pasteboard.
    */
-  vector<Cell*> CellApplication::pasteboard()
+  std::vector<Cell*> CellApplication::pasteboard()
   {
     return pasteboard_;
   }
@@ -423,8 +423,8 @@ namespace IAEX
       v->raise();  // for MacOS
       v->activateWindow(); // for Windows
 
-      vector<DocumentView *> windowViews = documentViewList();
-      vector<DocumentView *>::iterator v_iter = windowViews.begin();
+      std::vector<DocumentView *> windowViews = documentViewList();
+      std::vector<DocumentView *>::iterator v_iter = windowViews.begin();
       while( v_iter != windowViews.end() )
       {
         ((NotebookWindow *)*v_iter)->updateWindowMenu();
@@ -440,7 +440,7 @@ namespace IAEX
       UpdateGroupcellVisitor visitor;
       v->document()->runVisitor( visitor );
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -464,7 +464,7 @@ namespace IAEX
   *
   * \brief returns list of all current document views
   */
-  vector<DocumentView *> CellApplication::documentViewList()
+  std::vector<DocumentView *> CellApplication::documentViewList()
   {
     return views_;
   }
@@ -478,7 +478,7 @@ namespace IAEX
   */
   void CellApplication::removeDocumentView( DocumentView *view )
   {
-    vector<Document *>::iterator d_iter = documents_.begin();
+    std::vector<Document *>::iterator d_iter = documents_.begin();
     while( d_iter != documents_.end() )
     {
       if( (*d_iter) == view->document() )
@@ -490,7 +490,7 @@ namespace IAEX
         ++d_iter;
     }
 
-    vector<DocumentView *>::iterator dv_iter = views_.begin();
+    std::vector<DocumentView *>::iterator dv_iter = views_.begin();
     while( dv_iter != views_.end() )
     {
       if( (*dv_iter) == view )
@@ -525,8 +525,8 @@ namespace IAEX
   */
   void CellApplication::convertDrModelica()
   {
-    cout << "CONVERTING DRMODELICA" << endl;
-    cout << "---------------------" << endl << endl;
+    std::cout << "CONVERTING DRMODELICA" << endl;
+    std::cout << "---------------------" << endl << endl;
 
     // load from
     QString path = "C:/OpenModelica132/DrModelicaConv";
@@ -552,8 +552,8 @@ namespace IAEX
         // loop through all files
         for( int j = 0; j < fileList.size(); ++j )
         {
-          cout << "Loading: " << fileDir.absolutePath().toStdString() +
-            string( "/" ) + fileList.at(j).toStdString() << endl;
+          std::cout << "Loading: " << fileDir.absolutePath().toStdString() +
+            std::string( "/" ) + fileList.at(j).toStdString() << endl;
 
           Document *d = new CellDocument( this, fileDir.absolutePath() +
             QString( "/" ) + fileList.at(j), READMODE_CONVERTING_ONB );
@@ -562,15 +562,15 @@ namespace IAEX
           QString filename = fileList.at(j);
           filename.replace( ".nb", ".onb" );
 
-          cout << "Saving: " << dir.absolutePath().toStdString() +
-            string( "/" ) + dirList.at(i).toStdString() + string( "/" ) +
+          std::cout << "Saving: " << dir.absolutePath().toStdString() +
+            std::string( "/" ) + dirList.at(i).toStdString() + std::string( "/" ) +
             filename.toStdString() << endl;
 
           SaveDocumentCommand command( d, dir.absolutePath() +
             QString( "/" ) + dirList.at(i) + QString( "/" ) + filename );
           this->commandCenter()->executeCommand( &command );
 
-          cout << "DONE!" << endl << endl;
+          std::cout << "DONE!" << endl << endl;
 
           // delete file
           delete d;
@@ -579,7 +579,7 @@ namespace IAEX
       }
      }
 
-    cout << "CONVERTION DONE !!!" << endl;
+    std::cout << "CONVERTION DONE !!!" << endl;
   }
 
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.h
@@ -80,7 +80,7 @@ namespace IAEX
 
     virtual void addToPasteboard(Cell *c);
     virtual void clearPasteboard();
-    vector<Cell *> pasteboard();
+    std::vector<Cell *> pasteboard();
 
     int exec();
     void add(Document *doc);
@@ -88,7 +88,7 @@ namespace IAEX
 
     void open(const QString filename, int readmode = READMODE_NORMAL, int isDrModelica=0);
     void removeTempFiles(QString filename);      // Added 2006-01-16 AF
-    vector<DocumentView *> documentViewList();    // Added 2006-01-27 AF
+    std::vector<DocumentView *> documentViewList();    // Added 2006-01-27 AF
     void removeDocumentView( DocumentView *view );  // Added 2006-01-27 AF
     QApplication* getApplication() { return app_; }
     QWidget* getMainWindow() { return mainWindow; }
@@ -102,10 +102,10 @@ namespace IAEX
   private:
     QApplication *app_;
     QWidget* mainWindow;
-    vector<Document *> documents_;
-    vector<DocumentView *> views_;
+    std::vector<Document *> documents_;
+    std::vector<DocumentView *> views_;
     CommandCenter *cmdCenter_;
-    vector<Cell *> pasteboard_;
+    std::vector<Cell *> pasteboard_;
     QStringList removeList_;    // Added 2006-01-16 AF
   };
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommandcenter.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommandcenter.cpp
@@ -46,7 +46,6 @@
 //IAEX Headers
 #include "cellcommandcenter.h"
 
-using namespace std;
 
 namespace IAEX
 {
@@ -81,7 +80,7 @@ namespace IAEX
     {
       cmd->execute();
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       QString msg = e.what();
 
@@ -107,9 +106,9 @@ namespace IAEX
 
    void CellCommandCenter::storeCommands()
    {
-      ofstream diskstorage("lastcommands.txt");
+      std::ofstream diskstorage("lastcommands.txt");
 
-      vector<Command *>::iterator i = storage_.begin();
+      std::vector<Command *>::iterator i = storage_.begin();
 
       for(;i!= storage_.end();++i)
       {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommandcenter.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommandcenter.h
@@ -54,7 +54,7 @@ namespace IAEX
       void storeCommands();
 
       CellApplication *app_;
-      vector<Command *> storage_;
+      std::vector<Command *> storage_;
    };
 }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.cpp
@@ -56,7 +56,7 @@
 #include "cellgroup.h"
 
 
-typedef vector<Rule *> rules_t;
+typedef std::vector<Rule *> rules_t;
 
 namespace IAEX
 {
@@ -125,11 +125,11 @@ namespace IAEX
       //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
     }
-    catch(exception &e)
+    catch(std::exception &e)
     {
       // 2006-01-30 AF, add exception
-      string str = string("AddCellCommand(), Exception: \n") + e.what();
-      throw runtime_error( str.c_str() );
+      std::string str = std::string("AddCellCommand(), Exception: \n") + e.what();
+      throw std::runtime_error( str.c_str() );
     }
   }
 
@@ -181,11 +181,11 @@ namespace IAEX
     //2006-01-18 AF, set docuement changed
     document()->setChanged( true );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
       // 2006-01-30 AF, add exception
-      string str = string("CreateNewCommand(), Exception: \n") + e.what();
-      throw runtime_error( str.c_str() );
+      std::string str = std::string("CreateNewCommand(), Exception: \n") + e.what();
+      throw std::runtime_error( str.c_str() );
       }
    }
 
@@ -207,7 +207,7 @@ namespace IAEX
    void CopySelectedCellsCommand::execute()
    {
       CellCursor *c = document()->getCursor();
-      vector<Cell *> cells = document()->getSelection();
+      std::vector<Cell *> cells = document()->getSelection();
 
       if(cells.empty())
       {
@@ -221,7 +221,7 @@ namespace IAEX
         document()->clearSelection(); //Notice
         application()->clearPasteboard();
 
-        vector<Cell *>::iterator i = cells.begin();
+        std::vector<Cell *>::iterator i = cells.begin();
         for(;i != cells.end();++i)
         {
           application()->addToPasteboard((*i));
@@ -236,7 +236,7 @@ namespace IAEX
       try
       {
    CellCursor *c = document()->getCursor();
-   vector<Cell *> cells = document()->getSelection();
+   std::vector<Cell *> cells = document()->getSelection();
 
    if(cells.empty())
    {
@@ -247,7 +247,7 @@ namespace IAEX
       document()->clearSelection(); //Notice
       application()->clearPasteboard();
 
-      vector<Cell *>::iterator i = cells.begin();
+      std::vector<Cell *>::iterator i = cells.begin();
       for(;i != cells.end();++i)
       {
          c->moveAfter((*i));
@@ -263,11 +263,11 @@ namespace IAEX
    //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
       // 2006-01-30 AF, add message box
-      string str = string("DeleteCurrentCellsCommand(), Exception: \n") + e.what();
-    throw runtime_error( str.c_str() );
+      std::string str = std::string("DeleteCurrentCellsCommand(), Exception: \n") + e.what();
+    throw std::runtime_error( str.c_str() );
       }
    }
 
@@ -283,7 +283,7 @@ namespace IAEX
   {
     try
       {
-      vector<Cell *> cells = application()->pasteboard();
+      std::vector<Cell *> cells = application()->pasteboard();
 
       // Insert new cells before this position.
       if(!cells.empty())
@@ -292,14 +292,14 @@ namespace IAEX
         //vector<Cell *>::reverse_iterator i = cells.rbegin();
         //for(;i != cells.rend();++i)
         // AF, Not reverse
-        vector<Cell *>::iterator i = cells.begin();
+        std::vector<Cell *>::iterator i = cells.begin();
         for(;i != cells.end();++i)
         {
           try
           {
             pasteCell( (*i) );
           }
-          catch(exception &e)
+          catch(std::exception &e)
           {
             throw e;
           }
@@ -313,11 +313,11 @@ namespace IAEX
       //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
     }
-    catch(exception &e)
+    catch(std::exception &e)
     {
       // 2006-01-30 AF, add exception
-      string str = string("PasteCellsCommand(), Exception: \n") + e.what();
-      throw runtime_error( str.c_str() );
+      std::string str = std::string("PasteCellsCommand(), Exception: \n") + e.what();
+      throw std::runtime_error( str.c_str() );
     }
   }
 
@@ -451,7 +451,7 @@ namespace IAEX
     else
     {
       // Error
-      throw runtime_error("pasteCell(): Unknown celltype.");
+      throw std::runtime_error("pasteCell(): Unknown celltype.");
     }
     // *************************************************************************
 
@@ -498,7 +498,7 @@ namespace IAEX
    {
       try
       {
-   vector<Cell *> cells = document()->getSelection();
+   std::vector<Cell *> cells = document()->getSelection();
    if(cells.empty())
    {
       application()->clearPasteboard(); // HACK: clear pasteboard as this cell might be referenced in it
@@ -509,7 +509,7 @@ namespace IAEX
       document()->clearSelection(); //Notice
       application()->clearPasteboard(); // HACK: clear pasteboard as this cell might be referenced in it
 
-      vector<Cell *>::iterator i = cells.begin();
+      std::vector<Cell *>::iterator i = cells.begin();
       for(;i != cells.end();++i)
       {
          (document()->getCursor())->moveAfter((*i));
@@ -520,11 +520,11 @@ namespace IAEX
    //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
       // 2006-01-30 AF, add exception
-      string str = string("DeleteSelectedCellsCommand(), Exception: \n") + e.what();
-    throw runtime_error( str.c_str() );
+      std::string str = std::string("DeleteSelectedCellsCommand(), Exception: \n") + e.what();
+    throw std::runtime_error( str.c_str() );
       }
    }
 
@@ -549,7 +549,7 @@ namespace IAEX
   {
     try
     {
-      vector<Cell *> cells = document()->getSelection();
+      std::vector<Cell *> cells = document()->getSelection();
 
       if(cells.empty())
       {
@@ -557,7 +557,7 @@ namespace IAEX
       }
       else
       {;
-        vector<Cell *>::iterator i = cells.begin();
+        std::vector<Cell *>::iterator i = cells.begin();
 
         for(;i != cells.end() ;++i)
         {
@@ -570,11 +570,11 @@ namespace IAEX
       //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
     }
-    catch(exception &e)
+    catch(std::exception &e)
     {
       // 2006-01-30 AF, add exception
-      string str = string("ChangeStyleOnSelectedCellsCommand(), Exception: \n") + e.what();
-      throw runtime_error( str.c_str() );
+      std::string str = std::string("ChangeStyleOnSelectedCellsCommand(), Exception: \n") + e.what();
+      throw std::runtime_error( str.c_str() );
     }
   }
 
@@ -588,11 +588,11 @@ namespace IAEX
    //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
       // 2006-01-30 AF, add exception
-      string str = string("ChangeStyleOnCurrentCellCommand(), Exception: \n") + e.what();
-    throw runtime_error( str.c_str() );
+      std::string str = std::string("ChangeStyleOnCurrentCellCommand(), Exception: \n") + e.what();
+    throw std::runtime_error( str.c_str() );
       }
    }
 
@@ -616,11 +616,11 @@ namespace IAEX
    //2006-01-18 AF, set docuement changed
       document()->setChanged( true );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
       // 2006-01-30 AF, add exception
-      string str = string("MakeGroupCellCommand(), Exception: \n") + e.what();
-    throw runtime_error( str.c_str() );
+      std::string str = std::string("MakeGroupCellCommand(), Exception: \n") + e.what();
+    throw std::runtime_error( str.c_str() );
 
       }
    }
@@ -636,7 +636,7 @@ namespace IAEX
   {
     try
     {
-      vector<Cell *> cells = document()->getSelection();
+      std::vector<Cell *> cells = document()->getSelection();
 
       if( !cells.empty() )
       {
@@ -649,7 +649,7 @@ namespace IAEX
           if( dynamic_cast<CellGroup*>(cell) )
           {
             if( !cell->hasChilds() )
-              throw runtime_error( "No children" );
+              throw std::runtime_error( "No children" );
 
             // get child
             Cell* child = cell->child();
@@ -710,10 +710,10 @@ namespace IAEX
         }
       }
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
-      string str = string("UngroupCellCommand(), Exception: ") + e.what();
-      throw runtime_error( str.c_str() );
+      std::string str = std::string("UngroupCellCommand(), Exception: ") + e.what();
+      throw std::runtime_error( str.c_str() );
     }
   }
 
@@ -772,10 +772,10 @@ namespace IAEX
         }
       }
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
-      string str = string("SplitCellCommand(), Exception: ") + e.what();
-      throw runtime_error( str.c_str() );
+      std::string str = std::string("SplitCellCommand(), Exception: ") + e.what();
+      throw std::runtime_error( str.c_str() );
     }
   }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommands.h
@@ -51,7 +51,6 @@
 #include "cellapplication.h"
 
 
-using namespace std;
 
 namespace IAEX
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcursor.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcursor.cpp
@@ -469,7 +469,7 @@ namespace IAEX
     }
     else
     {
-      throw runtime_error("LAST CHILD: Tried to move to a child that did not exist.");
+      throw std::runtime_error("LAST CHILD: Tried to move to a child that did not exist.");
     }
 
     // TMP EMIT
@@ -487,7 +487,7 @@ namespace IAEX
     removeFromCurrentPosition();
 
     //if(!current->hasParentCell())
-    //  throw runtime_error("Could not insert after root");
+    //  throw std::runtime_error("Could not insert after root");
 
     if(current->hasParentCell())
     {
@@ -546,7 +546,7 @@ namespace IAEX
 
     }
     else
-      throw runtime_error("Could not insert before root");
+      throw std::runtime_error("Could not insert before root");
 
     setPrevious(current->previous());
     current->setPrevious(this);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
@@ -163,7 +163,7 @@ namespace IAEX
       if(!filename_.isNull())
         open( filename_, readmode );
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -224,7 +224,7 @@ namespace IAEX
       Cell *cell = parser->parse();
       setWorkspace( cell );
     }
-    catch( exception e )
+    catch( std::exception e )
     {
       delete parserFactory;
       delete parser;
@@ -343,7 +343,7 @@ namespace IAEX
       open_ = true;
       emit cursorChanged();
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -362,7 +362,7 @@ namespace IAEX
       executeCommand( new UngroupCellCommand() );
       emit cursorChanged();
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -381,7 +381,7 @@ namespace IAEX
       executeCommand( new SplitCellCommand() );
       emit cursorChanged();
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -816,11 +816,11 @@ namespace IAEX
 
 #ifndef QT_NO_DEBUG_OUTPUT
 
-          cout << "*********************************************" << endl;
-          cout << "SCROLL TOP: " << scrollTop << endl;
-          cout << "SCROLL BOTTOM: " << scrollBottom << endl;
-          cout << "CELL CURSOR: " << pos << endl;
-          cout << "CELL HEIGHT: " << height << endl;
+          std::cout << "*********************************************" << endl;
+          std::cout << "SCROLL TOP: " << scrollTop << endl;
+          std::cout << "SCROLL BOTTOM: " << scrollBottom << endl;
+          std::cout << "CELL CURSOR: " << pos << endl;
+          std::cout << "CELL HEIGHT: " << height << endl;
 #endif
 
 
@@ -837,7 +837,7 @@ namespace IAEX
             scrollBottom > (scroll_->widget()->height() - 2 ) )
           {
 #ifndef QT_NO_DEBUG_OUTPUT
-            cout << "END OF DOCUMENT, widget height(" << scroll_->widget()->height() << ")" << endl;
+            std::cout << "END OF DOCUMENT, widget height(" << scroll_->widget()->height() << ")" << endl;
 #endif
             // 2006-03-03 AF, ignore if cursor at end of document
             return;
@@ -873,7 +873,7 @@ namespace IAEX
             if( pos >= scroll_->verticalScrollBar()->maximum() )
             {
 #ifndef QT_NO_DEBUG_OUTPUT
-              cout << "more then max!" << endl;
+              std::cout << "more then max!" << endl;
 #endif
               scroll_->verticalScrollBar()->triggerAction( QAbstractSlider::SliderToMaximum );
               //pos = scroll_->verticalScrollBar()->maximum();
@@ -886,7 +886,7 @@ namespace IAEX
             {
               // set new scrollvalue
 #ifndef QT_NO_DEBUG_OUTPUT
-              cout << "DOWN: old(" << scroll_->verticalScrollBar()->value() << "), new(" << pos << ")" << endl;
+              std::cout << "DOWN: old(" << scroll_->verticalScrollBar()->value() << "), new(" << pos << ")" << endl;
 #endif
               scroll_->verticalScrollBar()->setValue( pos );
             }
@@ -1275,7 +1275,7 @@ namespace IAEX
   {
     if( cell )
     {
-      vector<Cell*>::iterator found = std::find( selectedCells_.begin(),
+      std::vector<Cell*>::iterator found = std::find( selectedCells_.begin(),
         selectedCells_.end(), cell );
 
       if( found != selectedCells_.end() )
@@ -1288,7 +1288,7 @@ namespace IAEX
 
   void CellDocument::clearSelection()
   {
-    vector<Cell*>::iterator i = selectedCells_.begin();
+    std::vector<Cell*>::iterator i = selectedCells_.begin();
 
     for(;i!= selectedCells_.end();++i)
       (*i)->setSelected(false);
@@ -1404,7 +1404,7 @@ namespace IAEX
     }
   }
 
-  vector<Cell*> CellDocument::getSelection()
+  std::vector<Cell*> CellDocument::getSelection()
   {
     return selectedCells_;
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.h
@@ -73,7 +73,7 @@ namespace IAEX
     Q_OBJECT
 
   public:
-    typedef vector<DocumentView*> observers_t;
+    typedef std::vector<DocumentView*> observers_t;
 
     CellDocument(CellApplication *a, const QString filename, int readmode = READMODE_NORMAL);
     virtual ~CellDocument();
@@ -138,7 +138,7 @@ namespace IAEX
     CellCursor *getCursor();
     Factory *cellFactory();
     Cell* getMainCell();        // Added 2006-08-24 AF
-    vector<Cell*> getSelection();
+    std::vector<Cell*> getSelection();
 
     //Command
     void executeCommand(Command *cmd);
@@ -205,7 +205,7 @@ namespace IAEX
     CellCursor *current_;
     Factory *factory_;
 
-    vector<Cell*> selectedCells_;
+    std::vector<Cell*> selectedCells_;
 
   public:
     observers_t observers_;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellfactory.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellfactory.cpp
@@ -63,7 +63,6 @@
 #include "latexcell.h"
 #include "graphcell.h"
 #include "omcinteractiveenvironment.h"
-using namespace std;
 
 namespace IAEX
 {
@@ -110,9 +109,9 @@ namespace IAEX
         if( cstyle.name() != "null" )
           text->setStyle( cstyle );
         else
-          throw runtime_error("No Input style defined, the inputcell may not work correctly, please define an Input style in stylesheet.xml");
+          throw std::runtime_error("No Input style defined, the inputcell may not work correctly, please define an Input style in stylesheet.xml");
       }
-      catch( exception e )
+      catch( std::exception e )
       {
         QMessageBox::warning( 0, QObject::tr("Warning"), e.what(), "OK" );
       }
@@ -121,7 +120,7 @@ namespace IAEX
       {
         text->setDelegate(OmcInteractiveEnvironment::getInstance());
       }
-      catch( exception e )
+      catch( std::exception e )
       {}
 
       QObject::connect(text, SIGNAL(cellselected(Cell *,Qt::KeyboardModifiers)),
@@ -196,9 +195,9 @@ namespace IAEX
 
           text->setStyle( cstyle );
         else
-          throw runtime_error("No Input style defined, the inputcell may not work correctly, please define an Input style in stylesheet.xml");
+          throw std::runtime_error("No Input style defined, the inputcell may not work correctly, please define an Input style in stylesheet.xml");
       }
-      catch( exception e )
+      catch( std::exception e )
       {
 
         QMessageBox::warning( 0, QObject::tr("Warning"), e.what(), "OK" );
@@ -252,9 +251,9 @@ namespace IAEX
         if( cstyle.name() != "null" )
           text->setStyle( cstyle );
         else
-          throw runtime_error("No Input style defined, the inputcell may not work correctly, please define an Input style in stylesheet.xml");
+          throw std::runtime_error("No Input style defined, the inputcell may not work correctly, please define an Input style in stylesheet.xml");
       }
-      catch( exception e )
+      catch( std::exception e )
       {
         QMessageBox::warning( 0, QObject::tr("Warning"), e.what(), "OK" );
       }
@@ -263,7 +262,7 @@ namespace IAEX
       {
         text->setDelegate(OmcInteractiveEnvironment::getInstance());
       }
-      catch( exception e )
+      catch( std::exception e )
       {
         e.what();
       }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellgroup.h
@@ -58,7 +58,6 @@
 #include "cell.h"
 #include "visitor.h"
 
-using namespace std;
 using namespace IAEX;
 
 namespace IAEX{

--- a/OMNotebook/OMNotebook/OMNotebookGUI/command.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/command.h
@@ -105,7 +105,7 @@ namespace IAEX
 
       virtual void execute()
       {
-   vector<Command*>::iterator i = commands_.begin();
+   std::vector<Command*>::iterator i = commands_.begin();
    for(;i != commands_.end(); ++i)
    {
       (*i)->execute();
@@ -113,7 +113,7 @@ namespace IAEX
       }
 
    private:
-      vector<Command*> commands_;
+      std::vector<Command*> commands_;
    };
 };
 #endif

--- a/OMNotebook/OMNotebook/OMNotebookGUI/commandcompletion.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/commandcompletion.cpp
@@ -53,7 +53,6 @@
 #include "commandcompletion.h"
 
 
-using namespace std;
 
 namespace IAEX
 {
@@ -90,17 +89,17 @@ namespace IAEX
     QFile file( filename );
     if(!file.open(QIODevice::ReadOnly))
     {
-      string tmp = "Could not open file: " + filename.toStdString();
-      throw runtime_error( tmp.c_str() );
+      std::string tmp = "Could not open file: " + filename.toStdString();
+      throw std::runtime_error( tmp.c_str() );
     }
 
     if( !doc_->setContent(&file) )
     {
       file.close();
-      string tmp = "Could not read content from file: " +
+      std::string tmp = "Could not read content from file: " +
         filename.toStdString() +
         " Probably some syntax error in the xml file";
-      throw runtime_error( tmp.c_str() );
+      throw std::runtime_error( tmp.c_str() );
     }
     file.close();
 
@@ -184,7 +183,7 @@ namespace IAEX
 
         //cout << "Found commands (" << command.toStdString() << "):" << endl;
         //for( int i = 0; i < currentList_->size(); ++i )
-        //  cout << " >" << currentList_->at(i).toStdString() << endl;
+        //  std::cout << " >" << currentList_->at(i).toStdString() << endl;
 
         // found one or more commands that match the word
         if( currentList_->size() > 0 )
@@ -397,7 +396,7 @@ namespace IAEX
   void CommandCompletion::parseCommand( QDomNode node, CommandUnit *item ) const
   {
     if( !item )
-      throw runtime_error( "ParseCommand... No ITEM set" );
+      throw std::runtime_error( "ParseCommand... No ITEM set" );
 
     while( !node.isNull() )
     {
@@ -408,7 +407,7 @@ namespace IAEX
       else if( element.tagName() == "helptext" )
         item->setHelptext( element.text() );
       else
-        cout << "Tag not known" << element.tagName().toStdString();
+        std::cout << "Tag not known" << element.tagName().toStdString();
 
       node = node.nextSibling();
     }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cursorcommands.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cursorcommands.h
@@ -42,7 +42,6 @@
 #include "cellcursor.h"
 #include "serializingvisitor.h"
 
-using namespace std;
 
 namespace IAEX
 {
@@ -91,11 +90,11 @@ namespace IAEX
           cursor->currentCell()->setFocus(true);
         }
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("CursorMoveUpCommand(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("CursorMoveUpCommand(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
   };
@@ -145,11 +144,11 @@ namespace IAEX
           cursor->currentCell()->setFocus(true);
         }
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("CursorMoveDownCommand(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("CursorMoveDownCommand(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
   };
@@ -200,11 +199,11 @@ namespace IAEX
         }
 
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("CursorMoveAfterCommand(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("CursorMoveAfterCommand(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
   private:

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cursorposvisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cursorposvisitor.h
@@ -47,7 +47,6 @@
 #include "cellcursor.h"
 #include "graphcell.h"
 
-using namespace std;
 
 namespace IAEX
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/document.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/document.h
@@ -57,7 +57,6 @@ class QUrl;
 
 class CellStyle;
 
-using namespace std;
 
 namespace IAEX
 {
@@ -143,7 +142,7 @@ namespace IAEX
     //Utility operations
     virtual Factory *cellFactory() = 0;
     virtual Cell* getMainCell() = 0;        // Added 2006-08-24 AF
-    virtual vector<Cell *> getSelection() = 0;
+    virtual std::vector<Cell *> getSelection() = 0;
     virtual void clearSelection() = 0;
 
     //command operations

--- a/OMNotebook/OMNotebook/OMNotebookGUI/evalthread.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/evalthread.cpp
@@ -35,7 +35,6 @@
 #include <fstream>
 #include <QApplication>
 #include <QMessageBox>
-using namespace std;
 
 EvalThread::EvalThread(InputCellDelegate* delegate_, QString expr_, QObject* parent):
   QThread(parent), delegate_(delegate_), expr(expr_)

--- a/OMNotebook/OMNotebook/OMNotebookGUI/evalthread.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/evalthread.h
@@ -36,7 +36,6 @@
 #include <QMutex>
 #include "inputcelldelegate.h"
 #include <QString>
-using namespace std;
 using namespace IAEX;
 
 extern QMutex evalMutex; // adrpo 2009-01-19

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
@@ -1789,7 +1789,7 @@ namespace IAEX {
   InputCellDelegate *GraphCell::getDelegate()
   {
     if(!hasDelegate())
-      throw runtime_error("No delegate.");
+      throw std::runtime_error("No delegate.");
 
     return delegate_;
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
@@ -1114,7 +1114,7 @@ namespace IAEX
       emit textChanged(true);
     }
     else
-      cout << "Not delegate on inputcell" << endl;
+      std::cout << "Not delegate on inputcell" << endl;
 
     input_->blockSignals(false);
     output_->blockSignals(false);
@@ -1219,7 +1219,7 @@ namespace IAEX
   InputCellDelegate *InputCell::delegate()
   {
     if(!hasDelegate())
-      throw runtime_error("No delegate.");
+      throw std::runtime_error("No delegate.");
 
     return delegate_;
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.cpp
@@ -90,7 +90,6 @@
 #include "xmlparser.h"
 #include "removehighlightervisitor.h"
 #include "omcinteractiveenvironment.h"
-using namespace std;
 
 namespace IAEX
 {
@@ -220,7 +219,7 @@ NotebookWindow::NotebookWindow(Document *subject,
 
   Cell *current = subject_->getMainCell()->child();
   cells.clear();
-  /**find  and inserts all the present cells in document in a vector**/
+  /**find  and inserts all the present cells in document in a std::vector**/
   cells=SearchCells(current);
 
 #if USE_OMSKETCH
@@ -255,7 +254,7 @@ NotebookWindow::~NotebookWindow()
   //subject_ = 0;
 
   // 2005-11-03/04/07 AF, remova all created QAction
-  map<QString, QAction*>::iterator s_iter = styles_.begin();
+  std::map<QString, QAction*>::iterator s_iter = styles_.begin();
   while( s_iter != styles_.end() )
   {
     delete (*s_iter).second;
@@ -831,8 +830,8 @@ void NotebookWindow::createFormatMenu()
   formatMenu = menuBar()->addMenu( tr("&Format") );
   styleMenu = formatMenu->addMenu( tr("&Styles") );
 
-  vector<QString> styles = sheet->getAvailableStyleNames();
-  vector<QString>::iterator i = styles.begin();
+  std::vector<QString> styles = sheet->getAvailableStyleNames();
+  std::vector<QString>::iterator i = styles.begin();
   for(;i != styles.end(); ++i)
   {
     if ((*i != "Latex") && (*i != "Graph") && (*i != "Input"))
@@ -1689,7 +1688,7 @@ void NotebookWindow::updateMenus()
 void NotebookWindow::updateStyleMenu()
 {
   CellStyle style = *subject_->getCursor()->currentCell()->style();
-  map<QString, QAction*>::iterator cs = styles_.find(style.name());
+  std::map<QString, QAction*>::iterator cs = styles_.find(style.name());
 
   if(cs != styles_.end())
   {
@@ -2183,8 +2182,8 @@ void NotebookWindow::updateWindowMenu()
   windowMenu->clear();
 
   // add new menu items
-  vector<DocumentView *> windowViews = application()->documentViewList();
-  vector<DocumentView *>::iterator v_iter = windowViews.begin();
+  std::vector<DocumentView *> windowViews = application()->documentViewList();
+  std::vector<DocumentView *>::iterator v_iter = windowViews.begin();
   int k = 1;
   while( v_iter != windowViews.end() )
   {
@@ -2362,7 +2361,7 @@ void NotebookWindow::keyReleaseEvent(QKeyEvent *event)
     // 2005-11-22 AF, Support for deleting cells with 'DEL' key.
     if( event->key() == Qt::Key_Delete )
     {
-      vector<Cell *> cells = subject_->getSelection();
+      std::vector<Cell *> cells = subject_->getSelection();
       if( !cells.empty() )
       {
         deleteCurrentCellAsk();
@@ -2493,7 +2492,7 @@ void NotebookWindow::openFile(const QString filename)
       //Cancel pushed. Do nothing
     }
   }
-  catch(exception &e)
+  catch(std::exception &e)
   {
     QMessageBox::warning( 0, tr("Warning"), tr("In OpenFile(), Exception: \n") + e.what(), "OK" );
     openFile();
@@ -2676,7 +2675,7 @@ void NotebookWindow::helpText()
       QMessageBox::warning( 0, tr("Warning"), tr("Could not find the help document OMNotebookHelp.onb"), "OK" );
     }
   }
-  catch(exception &e)
+  catch(std::exception &e)
   {
     QString msg = tr("In HelpText(), Exception: \n") + e.what();
     QMessageBox::warning( 0, tr("Warning"), msg, "OK" );
@@ -2955,7 +2954,7 @@ void NotebookWindow::changeStyle()
 {
   // 2005-10-28 changed in the funtion here because style changed
   // from QString  to CellStyle /AF
-  map<QString, QAction*>::iterator cs = styles_.begin();
+  std::map<QString, QAction*>::iterator cs = styles_.begin();
   Stylesheet *sheet = Stylesheet::instance( "stylesheet.xml" ); //AF
   for(;cs != styles_.end(); ++cs)
   {
@@ -3679,7 +3678,7 @@ void NotebookWindow::openOldFile()
             new OpenOldFileCommand( filename, READMODE_OLD ));
     }
   }
-  catch( exception &e )
+  catch(std::exception &e )
   {
     QString msg = QString("In NotebookWindow(), Exception:\r\n") + e.what();
     QMessageBox::warning( 0, tr("Warning"), msg, "OK" );
@@ -3954,13 +3953,13 @@ QVector<Cell*> NotebookWindow::SearchCells(Cell* current)
 
 void NotebookWindow::shiftselectedcells()
 {
-    vector<Cell *> cells = subject_->getSelection();
+    std::vector<Cell *> cells = subject_->getSelection();
     qDebug()<<cells.size();
 
     if( !cells.empty() )
     {
       // open closed groupcells otherwise OMNotebook does not copy right and crashes afterwards
-      vector<Cell *>::iterator i = cells.begin();
+      std::vector<Cell *>::iterator i = cells.begin();
       for(;i != cells.end();++i)
       {
         (*i)->setClosed(false);
@@ -3987,7 +3986,7 @@ void NotebookWindow::shiftselectedcells()
 
 void NotebookWindow::shiftcellsUp()
 {
-  vector<Cell *> cells = subject_->getSelection();
+  std::vector<Cell *> cells = subject_->getSelection();
 
   if (cells.size()==0)
   {
@@ -4064,8 +4063,8 @@ void NotebookWindow::shiftcellsUp()
         else
         {
           Stylesheet *sheet = Stylesheet::instance( "stylesheet.xml" );
-          std::vector<QString> vector = sheet->getAvailableStyleNames();
-          if (std::find(vector.begin(), vector.end(), style) != vector.end() )
+          std::vector<QString> styles = sheet->getAvailableStyleNames();
+          if (std::find(styles.begin(), styles.end(), style) != styles.end() )
           {
             QString textoutput=current->textHtml();
             subject_->cursorDeleteCell();
@@ -4090,7 +4089,7 @@ void NotebookWindow::shiftcellsUp()
 
 void NotebookWindow::shiftcellsDown()
 {
-  vector<Cell *> cells = subject_->getSelection();
+  std::vector<Cell *> cells = subject_->getSelection();
   if (cells.size()==0)
   {
     Cell *current=subject_->getCursor()->currentCell();
@@ -4171,8 +4170,8 @@ void NotebookWindow::shiftcellsDown()
         else
         {
           Stylesheet *sheet = Stylesheet::instance( "stylesheet.xml" );
-          std::vector<QString> vector = sheet->getAvailableStyleNames();
-          if (std::find(vector.begin(), vector.end(), style) != vector.end() )
+          std::vector<QString> styles = sheet->getAvailableStyleNames();
+          if (std::find(styles.begin(), styles.end(), style) != styles.end() )
           {
             QString textoutput=current->textHtml();
             subject_->cursorDeleteCell();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebook.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebook.h
@@ -395,7 +395,7 @@ private:
   QString filename_;
 
   // QTimer *savingTimer_;
-  map<QString, QAction*> styles_;
+  std::map<QString, QAction*> styles_;
 
   SearchForm* findForm_;
   bool closing_;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/notebookcommands.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/notebookcommands.h
@@ -68,7 +68,6 @@
 #include <QDataStream>
 #include <QTextOption>
 
-using namespace std;
 
 namespace IAEX
 {
@@ -133,7 +132,7 @@ namespace IAEX
             doc_->runVisitor( visitor );
           }
         }
-        catch( exception &e )
+        catch(std::exception &e )
         {
           throw e;
         }
@@ -159,16 +158,16 @@ namespace IAEX
         QByteArray ba = doc.toByteArray(2);
         if (!ba.size())
         {
-          string msg = "Document is empty and will not be saved to file: " +
+          std::string msg = "Document is empty and will not be saved to file: " +
             file.fileName().toStdString();
-          throw runtime_error( msg.c_str() );
+          throw std::runtime_error( msg.c_str() );
         }
 
         if(file.exists() && (file.permissions().testFlag(QFile::WriteUser) != true))
         {
-          string msg = "The file for saving the document is not writable: " +
+          std::string msg = "The file for saving the document is not writable: " +
             file.fileName().toStdString() + "\nPlease use Save As.";
-          throw runtime_error( msg.c_str() );
+          throw std::runtime_error( msg.c_str() );
         }
 
         if (file.open(QIODevice::WriteOnly | QIODevice::Truncate) == true)
@@ -187,17 +186,17 @@ namespace IAEX
         }
         else
         {
-          string msg = "Could not write document to file:\n" +
+          std::string msg = "Could not write document to file:\n" +
             file.fileName().toStdString() + " because:\n" +
             file.errorString().toStdString() + " error code: ";
-          throw runtime_error( msg.c_str() );
+          throw std::runtime_error( msg.c_str() );
         }
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("SaveDocumentCommand(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("SaveDocumentCommand(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
   private:
@@ -223,10 +222,10 @@ namespace IAEX
       {
         application()->open( filename_, READMODE_NORMAL );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
-        string msg = string("OpenFileCommand(), Exception:\r\n") + e.what();
-        throw runtime_error( msg.c_str() );
+        std::string msg = std::string("OpenFileCommand(), Exception:\r\n") + e.what();
+        throw std::runtime_error( msg.c_str() );
       }
     }
   private:
@@ -256,10 +255,10 @@ namespace IAEX
       {
         application()->open( filename_, readmode_ );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
-        string msg = string("OpenOldFileCommand(), Exception:\r\n") + e.what();
-        throw runtime_error( msg.c_str() );
+        std::string msg = std::string("OpenOldFileCommand(), Exception:\r\n") + e.what();
+        throw std::runtime_error( msg.c_str() );
       }
     }
   private:
@@ -303,10 +302,10 @@ namespace IAEX
         // 2006-03-16 AF
         delete printDocument;
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
-        string msg = string("PrintDocumentCommand(), Exception:\r\n") + e.what();
-        throw runtime_error( msg.c_str() );
+        std::string msg = std::string("PrintDocumentCommand(), Exception:\r\n") + e.what();
+        throw std::runtime_error( msg.c_str() );
       }
     }
   private:
@@ -333,11 +332,11 @@ namespace IAEX
 
         document()->close();
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("CloseFileCommand(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("CloseFileCommand(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
   };
@@ -363,11 +362,11 @@ namespace IAEX
         doc = new CellDocument( application(), QString() );
         */
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("NewFileCommand(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("NewFileCommand(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
   };
@@ -398,17 +397,17 @@ namespace IAEX
         }
         else
         {
-          string msg = "Could not export text to file: " + filename_.toStdString();
-          throw runtime_error( msg.c_str() );
+          std::string msg = "Could not export text to file: " + filename_.toStdString();
+          throw std::runtime_error( msg.c_str() );
         }
 
         file.close();
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
         // 2006-01-30 AF, add exception
-        string str = string("ExportToPureText(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("ExportToPureText(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
 
@@ -435,9 +434,9 @@ namespace IAEX
     {
       try
       {
-        vector<Cell *> cells = doc_->getSelection();
+        std::vector<Cell *> cells = doc_->getSelection();
 
-        vector<Cell *>::iterator c_iter = cells.begin();
+        std::vector<Cell *>::iterator c_iter = cells.begin();
         while( c_iter != cells.end() )
         {
           evalCell( (*c_iter) );
@@ -446,10 +445,10 @@ namespace IAEX
 
         doc_->setChanged( true );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
-        string str = string("EvalSelectedCells(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("EvalSelectedCells(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
 
@@ -510,10 +509,10 @@ namespace IAEX
         ChapterCounterVisitor visitor;
         doc_->runVisitor( visitor );
       }
-      catch(exception &e)
+      catch(std::exception &e)
       {
-        string str = string("UpdateChapterCounters(), Exception: ") + e.what();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("UpdateChapterCounters(), Exception: ") + e.what();
+        throw std::runtime_error( str.c_str() );
       }
     }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/omcinteractiveenvironment.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/omcinteractiveenvironment.cpp
@@ -64,7 +64,6 @@ void omc_Main_setWindowsPaths(threadData_t *threadData, void* _inOMHome);
 #endif
 }
 
-using namespace std;
 
 namespace IAEX
 {
@@ -221,7 +220,7 @@ namespace IAEX
       version.remove( "\"" );
       //delete env;
     }
-    catch( exception &e )
+    catch(std::exception &e )
     {
       e.what();
       QMessageBox::critical( 0, QObject::tr("OMC Error"), QObject::tr("Unable to get OMC version, OMC is not started.") );

--- a/OMNotebook/OMNotebook/OMNotebookGUI/printervisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/printervisitor.h
@@ -48,7 +48,6 @@ class QTextTable;
 class QPrinter;
 
 
-using namespace std;
 namespace IAEX
 {
   class PrinterVisitor : public Visitor

--- a/OMNotebook/OMNotebook/OMNotebookGUI/puretextvisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/puretextvisitor.h
@@ -46,7 +46,6 @@
 class QFile;
 class QTextStream;
 
-using namespace std;
 
 namespace IAEX
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/qtapp.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/qtapp.cpp
@@ -70,7 +70,6 @@ extern "C" {
 
 #include <locale.h>
 
-using namespace std;
 using namespace IAEX;
 
 int main(int argc, char *argv[])
@@ -95,7 +94,7 @@ int main(int argc, char *argv[])
     CellApplication a(argc, argv, threadData);
     return a.exec();
   }
-  catch(exception &e)
+  catch(std::exception &e)
   {
     // 2006-01-30 AF, add message box
     QString msg = QString("In main(), exception: \n") + e.what();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/removehighlightervisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/removehighlightervisitor.h
@@ -47,7 +47,6 @@
 #include "cellcursor.h"
 #include "graphcell.h"
 
-using namespace std;
 namespace IAEX
 {
   class RemoveHighlighterVisitor : public Visitor

--- a/OMNotebook/OMNotebook/OMNotebookGUI/rule.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/rule.h
@@ -42,7 +42,6 @@
 #include <string>
 #include <iostream>
 
-using namespace std;
 
 namespace IAEX
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/serializingvisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/serializingvisitor.h
@@ -57,7 +57,6 @@
 #include "document.h"
 
 
-using namespace std;
 
 namespace IAEX
 {
@@ -92,7 +91,7 @@ namespace IAEX
   private:
     void saveImages( QDomElement &current, QString &text );
 
-    stack<QDomElement> parents_;
+    std::stack<QDomElement> parents_;
     QDomElement currentElement_;
     QDomDocument domdoc_;
     Document* doc_;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/stripstring.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/stripstring.h
@@ -47,11 +47,10 @@
 #include <QtCore/QStringList>
 
 
-typedef pair<string,string> rule_t;
-typedef vector<rule_t> rules_t;
+typedef std::pair<string,string> rule_t;
+typedef std::vector<rule_t> rules_t;
 
 
-using namespace std;
 
 
 /*!
@@ -68,10 +67,10 @@ public:
   StripString(){}
   ~StripString(){}
 
-  static string stripNBString( string str )
+  static std::string stripNBString( std::string str )
   {
-        string::size_type pos = 0;
-        while((pos = str.find("\\", pos)) != string::npos)
+        std::string::size_type pos = 0;
+        while((pos = str.find("\\", pos)) != std::string::npos)
         {
             switch(str[pos+1])
             {
@@ -133,10 +132,10 @@ public:
     return str;
   }
 
-  static string stripSimulationData( string str )
+  static std::string stripSimulationData( std::string str )
   {
-    string::size_type pos = 0;
-    if( string::npos != str.find( "\"<SimulationData", pos ))
+    std::string::size_type pos = 0;
+    if( std::string::npos != str.find( "\"<SimulationData", pos ))
     {
       //return "[Strange Mathematica code of SimulationData removed here]";
       return "";
@@ -154,7 +153,7 @@ public:
    *
    * 2005-12-08 AF, Implemented large part of the function
    */
-  static string applyRulesToText( string str, rules_t rules )
+  static std::string applyRulesToText( std::string str, rules_t rules )
   {
     // loop through all rules and apply them
     for( rules_t::iterator r_iter = rules.begin(); r_iter != rules.end(); r_iter++ )
@@ -163,51 +162,51 @@ public:
       if( (*r_iter).first == "FontFamily" )
       {
         // replace 'Courier' with 'Courier New'
-        string family = (*r_iter).second;
+        std::string family = (*r_iter).second;
         if( family == "Courier" )
           family = "Courier New";
 
         // insert font family
         family = "font-family:" + family + "; ";
-        string::size_type index = getSpanIndex( str );
+        std::string::size_type index = getSpanIndex( str );
         str.insert( index, family );
       }
       // FONT SIZE
       else if( (*r_iter).first == "FontSize" )
       {
-        string sizept = (*r_iter).second;
-        string::size_type pos = 0;
+        std::string sizept = (*r_iter).second;
+        std::string::size_type pos = 0;
         pos = sizept.find("`", pos);
-        if( pos != string::npos)
+        if( pos != std::string::npos)
           sizept.erase( pos, 1 );
 
-        string size = "font-size:" + sizept + "pt; ";
-        string::size_type index = getSpanIndex( str );
+        std::string size = "font-size:" + sizept + "pt; ";
+        std::string::size_type index = getSpanIndex( str );
         str.insert( index, size );
       }
       // FONT WEIGHT
       else if( (*r_iter).first == "FontWeight" )
       {
-        string::size_type index = getSpanIndex( str );
+        std::string::size_type index = getSpanIndex( str );
 
         // BOLD
         if( (*r_iter).second == "Bold" )
           str.insert( index, "font-weight:600; " );
         // OTHER
         else
-          cout << "[UNKNOWN] Rule::FontWeight::Value: " << (*r_iter).second.c_str() << endl;
+          std::cout << "[UNKNOWN] Rule::FontWeight::Value: " << (*r_iter).second.c_str() << endl;
       }
       // FONT SLANT
       else if( (*r_iter).first == "FontSlant" )
       {
-        string::size_type index = getSpanIndex( str );
+        std::string::size_type index = getSpanIndex( str );
 
         // ITALIC
         if( (*r_iter).second == "Italic" )
           str.insert( index, "font-style:italic; " );
         // OTHER
         else
-          cout << "[UNKNOWN] Rule::FontSlant::Value: " << (*r_iter).second.c_str() << endl;
+          std::cout << "[UNKNOWN] Rule::FontSlant::Value: " << (*r_iter).second.c_str() << endl;
       }
       // FONT COLOR
       else if( (*r_iter).first == "FontColor" )
@@ -257,14 +256,14 @@ public:
 
             // set the color
             color = "color:#" + color + "; ";
-            string::size_type index = getSpanIndex( str );
+            std::string::size_type index = getSpanIndex( str );
             str.insert( index, color.toStdString() );
           }
           else
-            cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << endl;
+            std::cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << endl;
         }
         else
-          cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << endl;
+          std::cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << endl;
       }
       // FONT VARIATIONS
       else if( (*r_iter).first == "FontVariations" )
@@ -273,7 +272,7 @@ public:
       }
       // OTHER / MISC
       else
-        cout << "[UNKNOWN] StyleBox::Rule: " << (*r_iter).first.c_str() << " - " << (*r_iter).second.c_str() << endl;
+        std::cout << "[UNKNOWN] StyleBox::Rule: " << (*r_iter).first.c_str() << " - " << (*r_iter).second.c_str() << endl;
     }
 
     return str;
@@ -286,12 +285,12 @@ public:
    * \brief Apply a html <span style=""> tag to the text, and
    * return the index of the correct position inside the style
    */
-  static string::size_type getSpanIndex( string &str )
+  static std::string::size_type getSpanIndex( std::string &str )
   {
-    if( str.find( "<span style=\"", 0) == string::npos )
+    if( str.find( "<span style=\"", 0) == std::string::npos )
     {
       // no span tag, add one
-      string tmp = "<span style=\" \">" + str + "</span>";
+      std::string tmp = "<span style=\" \">" + str + "</span>";
       str = tmp;
     }
 
@@ -309,15 +308,15 @@ public:
      * The notebook parser returns: Dir/filename.htmlChapterSeven
      * have to insert # symbol
    */
-  static string fixFilename( string filename )
+  static std::string fixFilename( std::string filename )
   {
-    string::size_type index = filename.find( ".nb" );
+    std::string::size_type index = filename.find( ".nb" );
 
     // didn't found '.nb', assume that it is an internal doc link
     // and add '#' first in the filename
-    if( index == string::npos )
+    if( index == std::string::npos )
     {
-      filename = string("#") + filename;
+      filename = std::string("#") + filename;
       return filename;
     }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/stylesheet.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/stylesheet.cpp
@@ -58,7 +58,6 @@
 #include "stylesheet.h"
 
 
-using namespace std;
 
 namespace IAEX
 {
@@ -87,8 +86,8 @@ namespace IAEX
     if(!file.open(QIODevice::ReadOnly))
     {
       // 2005-10-03 AF, throw exception instead of exit
-      string tmp = "Could not open file: " + filename.toStdString();
-      throw runtime_error( tmp.c_str() );
+      std::string tmp = "Could not open file: " + filename.toStdString();
+      throw std::runtime_error( tmp.c_str() );
     }
 
     //Här kan det bli feeeeel!
@@ -97,10 +96,10 @@ namespace IAEX
       file.close();
 
       // 2005-10-26 AF, throw exception instead of exit
-      string tmp = "Could not read content from file: " +
+      std::string tmp = "Could not read content from file: " +
         filename.toStdString() +
         " Probably some syntax error in the xml file";
-      throw runtime_error( tmp.c_str() );
+      throw std::runtime_error( tmp.c_str() );
     }
     file.close();
 
@@ -169,9 +168,9 @@ namespace IAEX
    * \date 2005-10-26
    *
    * \brief Returns all the CellStyle names of the visible styles
-   * \return A vector with all CellStyle names
+   * \return A std::vector with all CellStyle names
    */
-  vector<QString> Stylesheet::getAvailableStyleNames() const
+  std::vector<QString> Stylesheet::getAvailableStyleNames() const
   {
     return styleNames_;
   }
@@ -263,7 +262,7 @@ namespace IAEX
   void Stylesheet::traverseStyleSettings( QDomNode node, CellStyle *item ) const
   {
     if( !item )
-      throw runtime_error( "STYLESHEET TRAVERSE... No ITEM SET!!" );
+      throw std::runtime_error( "STYLESHEET TRAVERSE... No ITEM SET!!" );
 
     while( !node.isNull() )
     {
@@ -278,7 +277,7 @@ namespace IAEX
       else if( element.tagName() == "chapterlevel" )
         parseChapterLevelTag( element, item );
       else
-        cout << "Tag not known" << element.tagName().toStdString();
+        std::cout << "Tag not known" << element.tagName().toStdString();
 
       node = node.nextSibling();
     }
@@ -331,7 +330,7 @@ namespace IAEX
     else if( alignment == "justify" )
       item->setAlignment( Qt::AlignJustify );
     else
-      cout << "Alignment value not correct: " << alignment.toStdString();
+      std::cout << "Alignment value not correct: " << alignment.toStdString();
 
 
     // VERTICAL ALIGNMENT
@@ -343,7 +342,7 @@ namespace IAEX
     else if( vertical == "super" )
       item->textCharFormat()->setVerticalAlignment( QTextCharFormat::AlignSuperScript );
     else
-      cout << "Vertical Alignment value not correct: " << vertical.toStdString();
+      std::cout << "Vertical Alignment value not correct: " << vertical.toStdString();
   }
 
   /*
@@ -428,7 +427,7 @@ namespace IAEX
             item->textCharFormat()->font().setStretch( QFont::UltraExpanded );
           else
           {
-            cout << "Stretch value not correct: " << stretch.toStdString();
+            std::cout << "Stretch value not correct: " << stretch.toStdString();
             item->textCharFormat()->font().setStretch( QFont::Unstretched );
           }
         }
@@ -478,7 +477,7 @@ namespace IAEX
         }
         else
         {
-          cout << "font tag not specified: " <<
+          std::cout << "font tag not specified: " <<
             fontElement.tagName().toStdString();
         }
       }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.cpp
@@ -618,8 +618,8 @@ namespace IAEX
       }
       else
       {
-        string str = string("Could not open image: ") + filepath_.toStdString().c_str();
-        throw runtime_error( str.c_str() );
+        std::string str = std::string("Could not open image: ") + filepath_.toStdString().c_str();
+        throw std::runtime_error( str.c_str() );
       }
     }
   }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.h
@@ -46,7 +46,6 @@
 #include "application.h"
 
 
-using namespace std;
 
 namespace IAEX
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/updatelinkvisitor.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/updatelinkvisitor.cpp
@@ -73,8 +73,8 @@ namespace IAEX
 
     if( !oldDir_.exists() || !newDir_.exists() )
     {
-      string msg = "UpdateLink, old or new dir don't exists.";
-      throw runtime_error( msg.c_str() );
+      std::string msg = "UpdateLink, old or new dir don't exists.";
+      throw std::runtime_error( msg.c_str() );
     }
   }
 
@@ -130,8 +130,8 @@ namespace IAEX
         else
         {
           // this should never happen!
-          string msg = "Error, found no end of linkpath";
-                    throw runtime_error( msg.c_str() );
+          std::string msg = "Error, found no end of linkpath";
+                    throw std::runtime_error( msg.c_str() );
           break;
         }
       }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/updatelinkvisitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/updatelinkvisitor.h
@@ -45,7 +45,6 @@
 // forward declaration
 class QDir;
 
-using namespace std;
 
 namespace IAEX
 {

--- a/OMNotebook/OMNotebook/OMNotebookGUI/visitor.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/visitor.h
@@ -36,8 +36,7 @@
 #ifndef VISITOR_H
 #define VISITOR_H
 
-//using namespace std;
-
+//
 namespace IAEX{
    class Cell;
    class CellGroup;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/xmlparser.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/xmlparser.cpp
@@ -76,7 +76,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-using namespace std;
 using namespace OMPlot;
 
 namespace IAEX
@@ -132,8 +131,8 @@ namespace IAEX
     QFile file( filename_ );
     if( !file.open( QIODevice::ReadOnly ))
     {
-      string msg = "Could not open " + filename_.toStdString();
-      throw runtime_error( msg.c_str() );
+      std::string msg = "Could not open " + filename_.toStdString();
+      throw std::runtime_error( msg.c_str() );
     }
 
     QByteArray ba = file.readAll();
@@ -145,8 +144,8 @@ namespace IAEX
       if(!(ba = qUncompress(ba)).size())
       {
         file.close();
-        string msg = "The file " + filename_.toStdString() + " is not a valid onbz file.";
-        throw runtime_error(msg.c_str());
+        std::string msg = "The file " + filename_.toStdString() + " is not a valid onbz file.";
+        throw std::runtime_error(msg.c_str());
       }
     }
 
@@ -185,8 +184,8 @@ namespace IAEX
     if(!domdoc.setContent(ba))
     {
       file.close();
-      string msg = "Could not understand content of " + filename_.toStdString();
-      throw runtime_error( msg.c_str() );
+      std::string msg = "Could not understand content of " + filename_.toStdString();
+      throw std::runtime_error( msg.c_str() );
     }
 
     file.close();
@@ -203,7 +202,7 @@ namespace IAEX
         return parseNormal( domdoc );
       }
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -225,9 +224,9 @@ namespace IAEX
     // Check if correct root, otherwise throw exception
     if( root.toElement().tagName() != XML_NOTEBOOK )
     {
-      string msg = "Wrong root node (" + root.toElement().tagName().toStdString() +
+      std::string msg = "Wrong root node (" + root.toElement().tagName().toStdString() +
         ") in file " + filename_.toStdString();
-      throw runtime_error( msg.c_str() );
+      throw std::runtime_error( msg.c_str() );
     }
 
     // Remove first cellgroup.
@@ -248,7 +247,7 @@ namespace IAEX
       if( !node.isNull() )
         traverseCells( rootcell, node );
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -257,8 +256,8 @@ namespace IAEX
     // check if root cell is empty
     if( !rootcell->hasChilds() )
     {
-      string msg = "File " + filename_.toStdString() + " is empty";
-      throw runtime_error( msg.c_str() );
+      std::string msg = "File " + filename_.toStdString() + " is empty";
+      throw std::runtime_error( msg.c_str() );
     }
 */
 
@@ -281,9 +280,9 @@ namespace IAEX
     // Check if correct root, otherwise throw exception
     if( root.toElement().tagName() != "Notebook" )
     {
-      string msg = "Wrong root node (" + root.toElement().tagName().toStdString() +
+      std::string msg = "Wrong root node (" + root.toElement().tagName().toStdString() +
         ") in file " + filename_.toStdString() + " (Old File)";
-      throw runtime_error( msg.c_str() );
+      throw std::runtime_error( msg.c_str() );
     }
 
     // Remove first cellgroup.
@@ -341,15 +340,15 @@ namespace IAEX
             traverseLatexCell( parent, element );
           else
           {
-            string msg = "Unknow tag name: " + element.tagName().toStdString() + ", in file " + filename_.toStdString();
-            throw runtime_error( msg.c_str() );
+            std::string msg = "Unknow tag name: " + element.tagName().toStdString() + ", in file " + filename_.toStdString();
+            throw std::runtime_error( msg.c_str() );
           }
         }
 
         node = node.nextSibling();
       }
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       throw e;
     }
@@ -385,7 +384,7 @@ namespace IAEX
     else if( closed == XML_FALSE )
       groupcell->setClosed( false );
     else
-      throw runtime_error( "Unknown closed value in group cell" );
+      throw std::runtime_error( "Unknown closed value in group cell" );
 
     parent->addChild( groupcell );
   }
@@ -439,7 +438,7 @@ namespace IAEX
             while (done > -1)
             {
               // int numX = rx.numCaptures(); QString s1 = rx.cap(1),s2 = rx.cap(2);
-              // cout << numX << " " << s1.toStdString() << "-" << s2.toStdString() << endl;
+              // std::cout << numX << " " << s1.toStdString() << "-" << s2.toStdString() << endl;
               text = text.replace(rx, rx.cap(1) + QString::fromAscii("/") + rx.cap(2));
               done = rx.indexIn(text);
             }
@@ -462,8 +461,8 @@ namespace IAEX
         }
         else
         {
-          string msg = "Unknown tagname " + e.tagName().toStdString() + ", in text cell";
-          throw runtime_error( msg.c_str() );
+          std::string msg = "Unknown tagname " + e.tagName().toStdString() + ", in text cell";
+          throw std::runtime_error( msg.c_str() );
         }
       }
 
@@ -528,8 +527,8 @@ namespace IAEX
         }
         else
         {
-          string msg = "Unknown tagname " + e.tagName().toStdString() + ", in input cell";
-          throw runtime_error( msg.c_str() );
+          std::string msg = "Unknown tagname " + e.tagName().toStdString() + ", in input cell";
+          throw std::runtime_error( msg.c_str() );
         }
       }
 
@@ -547,7 +546,7 @@ namespace IAEX
     else if( closed == XML_FALSE )
       inputcell->setClosed( false );
     else
-      throw runtime_error( "Unknown closed value in inputcell" );
+      throw std::runtime_error( "Unknown closed value in inputcell" );
 
     parent->addChild( inputcell );
   }
@@ -678,8 +677,8 @@ namespace IAEX
         }
         else
         {
-          string msg = "Unknown tagname " + e.tagName().toStdString() + ", in input cell";
-          throw runtime_error( msg.c_str() );
+          std::string msg = "Unknown tagname " + e.tagName().toStdString() + ", in input cell";
+          throw std::runtime_error( msg.c_str() );
         }
       }
 
@@ -710,7 +709,7 @@ namespace IAEX
     else if( closed == XML_FALSE )
       gCell->setClosed( false,true );
     else
-      throw runtime_error( "Unknown closed value in inputcell" );
+      throw std::runtime_error( "Unknown closed value in inputcell" );
 
     parent->addChild( graphcell );
   }
@@ -753,8 +752,8 @@ namespace IAEX
           }
           else
           {
-            string msg = "Unknown tagname " + e.tagName().toStdString() + ", in Latex cell";
-            throw runtime_error( msg.c_str() );
+            std::string msg = "Unknown tagname " + e.tagName().toStdString() + ", in Latex cell";
+            throw std::runtime_error( msg.c_str() );
           }
         }
 
@@ -775,7 +774,7 @@ namespace IAEX
       else if( closed == XML_FALSE )
         gCell->setClosed( false,true );
       else
-        throw runtime_error( "Unknown closed value in latexcell" ); */
+        throw std::runtime_error( "Unknown closed value in latexcell" ); */
 
       parent->addChild(latexcell);
 
@@ -804,7 +803,7 @@ namespace IAEX
     // Get saved image name
     QString imagename = element.attribute( XML_NAME, "" );
     if( imagename.isEmpty() || imagename.isNull() )
-      throw runtime_error( "No name in image tag" );
+      throw std::runtime_error( "No name in image tag" );
 
 
     // Get saved image data
@@ -863,14 +862,14 @@ namespace IAEX
 
       else
       {
-        string msg = "Unknown typeid of parent cell";
-        throw runtime_error( msg.c_str() );
+        std::string msg = "Unknown typeid of parent cell";
+        throw std::runtime_error( msg.c_str() );
       }
     }
     else
     {
-      string msg = "Error creating image: <"+ imagename.toStdString() +">";
-      throw runtime_error( msg.c_str() );
+      std::string msg = "Error creating image: <"+ imagename.toStdString() +">";
+      throw std::runtime_error( msg.c_str() );
     }
   }
 
@@ -923,8 +922,8 @@ namespace IAEX
         }
         else
         {
-          string msg = "Unknown tag: <"+ e.tagName().toStdString() +">";
-          throw runtime_error( msg.c_str() );
+          std::string msg = "Unknown tag: <"+ e.tagName().toStdString() +">";
+          throw std::runtime_error( msg.c_str() );
         }
       }
       node = node.nextSibling();

--- a/OMNotebook/OMNotebook/OMSketch/Line.cpp
+++ b/OMNotebook/OMNotebook/OMSketch/Line.cpp
@@ -7,8 +7,6 @@
 #include "Line.h"
 #include <iostream>
 
-using namespace std;
-
 Line::Line(QWidget *parent):QWidget(parent)
 {
         label = new QLabel(this);

--- a/OMShell/OMShell/OMShellGUI/commandcompletion.cpp
+++ b/OMShell/OMShell/OMShellGUI/commandcompletion.cpp
@@ -51,8 +51,6 @@
 //IAEX Headers
 #include "commandcompletion.h"
 
-using namespace std;
-
 namespace IAEX
 {
   /*!
@@ -88,17 +86,17 @@ namespace IAEX
     QFile file( filename );
     if(!file.open(QIODevice::ReadOnly))
     {
-      string tmp = "Could not open file: " + filename.toStdString();
-      throw runtime_error( tmp.c_str() );
+      std::string tmp = "Could not open file: " + filename.toStdString();
+      throw std::runtime_error( tmp.c_str() );
     }
 
     if( !doc_->setContent(&file) )
     {
       file.close();
-      string tmp = "Could not read content from file: " +
+      std::string tmp = "Could not read content from file: " +
         filename.toStdString() +
         " Probably some syntax error in the xml file";
-      throw runtime_error( tmp.c_str() );
+      throw std::runtime_error( tmp.c_str() );
     }
     file.close();
 
@@ -372,7 +370,7 @@ namespace IAEX
   void CommandCompletion::parseCommand( QDomNode node, CommandUnit *item ) const
   {
     if( !item )
-      throw runtime_error( "ParseCommand... No ITEM set" );
+      throw std::runtime_error( "ParseCommand... No ITEM set" );
 
     while( !node.isNull() )
     {
@@ -383,7 +381,7 @@ namespace IAEX
       else if( element.tagName() == "helptext" )
         item->setHelptext( element.text() );
       else
-        cout << "Tag not known" << element.tagName().toStdString();
+        std::cout << "Tag not known" << element.tagName().toStdString();
 
       node = node.nextSibling();
     }

--- a/OMShell/OMShell/OMShellGUI/oms.cpp
+++ b/OMShell/OMShell/OMShellGUI/oms.cpp
@@ -54,9 +54,6 @@
 #include "omcinteractiveenvironment.h"
 #include "otherdlg.h"
 
-
-using namespace std;
-
 static QString omc_version_;
 static QString omhome;
 static IAEX::OmcInteractiveEnvironment* delegate_;
@@ -155,8 +152,8 @@ bool MyTextEdit::insideCommandSign()
     int cursorPos = textCursor().position();
     if( blockStartPos <= cursorPos && cursorPos < (blockStartPos+3) && signPos == 0)
     {
-      cerr << "Inside Command Sign" << endl;
-      cerr << "BlockStart: " << blockStartPos <<
+      std::cerr << "Inside Command Sign" << endl;
+      std::cerr << "BlockStart: " << blockStartPos <<
         ", Cursor: " << cursorPos << endl << endl;
 
       return true;
@@ -165,7 +162,7 @@ bool MyTextEdit::insideCommandSign()
       return false;
   }
   else
-    cerr << "Not a valid QTextBlock (insideCommandSign)" << endl;
+    std::cerr << "Not a valid QTextBlock (insideCommandSign)" << endl;
 
   return true;
 }
@@ -184,7 +181,7 @@ bool MyTextEdit::startOfCommandSign()
       return false;
   }
   else
-    cerr << "Not a valid QTextBlock (startOfCommandSign)" << endl;
+    std::cerr << "Not a valid QTextBlock (startOfCommandSign)" << endl;
 
   return true;
 }
@@ -275,7 +272,7 @@ OMS::OMS( QWidget* parent )
 
     commandcompletion_ = IAEX::CommandCompletion::instance( commandfile );
   }
-  catch( exception &e )
+  catch( std::exception &e )
   {
     QString msg = e.what();
     msg += "\nCould not create command completion class!";
@@ -480,7 +477,7 @@ void OMS::returnPressed()
     }
     else
     {
-      cerr << "Not a valid QTextBlock (returnPressed)" << endl;
+      std::cerr << "Not a valid QTextBlock (returnPressed)" << endl;
       break;
     }
   }
@@ -510,7 +507,7 @@ void OMS::returnPressed()
     {
       delegate_->evalExpression( commandText );
     }
-    catch( exception &e )
+    catch( std::exception &e )
     {
       exceptionInEval(e);
       return;
@@ -540,7 +537,7 @@ void OMS::returnPressed()
   addCommandLine();
 }
 
-void OMS::exceptionInEval(exception &e)
+void OMS::exceptionInEval(std::exception &e)
 {
   // 2006-0-09 AF, try to reconnect to OMC first.
   returnPressed();
@@ -630,7 +627,7 @@ void OMS::goHome( bool shift )
     moshEdit_->setTextCursor( cursor_ );
   }
   else
-    cout << "Not a valid QTextBlock (selectCommandLine)" << endl;
+    std::cout << "Not a valid QTextBlock (selectCommandLine)" << endl;
 }
 
 void OMS::codeCompletion( bool same )
@@ -689,7 +686,7 @@ void OMS::selectCommandLine()
     }
     else
     {
-      cout << "Not a valid QTextBlock (selectCommandLine)" << endl;
+      std::cout << "Not a valid QTextBlock (selectCommandLine)" << endl;
       break;
     }
   }

--- a/OMShell/OMShell/OMShellGUI/oms.h
+++ b/OMShell/OMShell/OMShellGUI/oms.h
@@ -41,9 +41,6 @@
 
 #include <exception>
 
-using namespace std;
-
-
 // QT Headers
 #include <QtGlobal>
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
@@ -122,7 +119,7 @@ private:
   void createAction();
   void createMenu();
   void createToolbar();
-  void exceptionInEval(exception &e);
+  void exceptionInEval(std::exception &e);
   void addCommandLine();
   void selectCommandLine();
   QStringList getFunctionNames(QString);

--- a/OMShell/mosh/src/mosh.cpp
+++ b/OMShell/mosh/src/mosh.cpp
@@ -56,10 +56,8 @@
 #include <wordexp.h>
 #endif
 
-using namespace std;
-
 /* Local functios */
-void doOMCCommunication(const string *);
+void doOMCCommunication(const std::string *);
 
 
 /* Global variables */
@@ -89,12 +87,12 @@ int main(int argc, char* argv[])
 
   const char* dateStr = __DATE__; // "Mmm dd yyyy", so dateStr+7 = "yyyy"
 
-  const string *scriptname = getFlagValue("f",argc,argv);
+  const std::string *scriptname = getFlagValue("f",argc,argv);
   if(!scriptname) {
-    cout << "OMShell "
-         << "Copyright 1997-" << dateStr+7 << ", Open Source Modelica Consortium (OSMC)" << endl
-         << "Distributed under OMSC-PL and GPL, see www.openmodelica.org" << endl << endl
-         << "To get help on using OMShell and OpenModelica, type \"help()\" and press enter" << endl;
+    std::cout << "OMShell "
+         << "Copyright 1997-" << dateStr+7 << ", Open Source Modelica Consortium (OSMC)" << std::endl
+         << "Distributed under OMSC-PL and GPL, see www.openmodelica.org" << std::endl << std::endl
+         << "To get help on using OMShell and OpenModelica, type \"help()\" and press enter" << std::endl;
   }
   doOMCCommunication(scriptname);
 
@@ -102,19 +100,19 @@ int main(int argc, char* argv[])
   return EXIT_SUCCESS;
 }
 
-void doOMCCommunication(const string *scriptname)
+void doOMCCommunication(const std::string *scriptname)
 {
   OmcInteractiveEnvironment *env = OmcInteractiveEnvironment::getInstance();
   env->evalExpression("setCommandLineOptions(\"+d=shortOutput\")");
-  string cmdLine = env->getResult();
-  cout << "Set shortOutput flag: " << cmdLine.c_str() << std::endl;
+  std::string cmdLine = env->getResult();
+  std::cout << "Set shortOutput flag: " << cmdLine.c_str() << std::endl;
 
   if (scriptname) { // Execute script and output return value
-    cout << "executing <" << scriptname << ">" << endl;
+    std::cout << "executing <" << scriptname << ">" << std::endl;
     std::string cmd = "runScript(\"" + *scriptname + "\")";
     env->evalExpression(cmd);
-    string res = env->getResult();
-    cout << res << endl;
+    std::string res = env->getResult();
+    std::cout << res << std::endl;
     return;
   }
 
@@ -134,11 +132,11 @@ void doOMCCommunication(const string *scriptname)
     if (strcmp(line,"\n")!=0 && strcmp(line,"") != 0) {
       if (!done) add_history(line);
       env->evalExpression(line);
-      string res = env->getResult();
-      cout << res;
-      string error = env->getError();
+      std::string res = env->getResult();
+      std::cout << res;
+      std::string error = env->getError();
       if (error.size() > 3) {
-        cout << error;
+        std::cout << error;
       }
     }
     free(line);

--- a/OMShell/mosh/src/options.cpp
+++ b/OMShell/mosh/src/options.cpp
@@ -32,36 +32,34 @@
 
 #include <string>
 
-using namespace std;
-
 bool flagSet(const char *option, int argc, char** argv)
 {
   for (int i=0; i<argc;i++) {
-    if (("-"+string(option))==string(argv[i])) return true;
+    if (("-" + std::string(option)) == std::string(argv[i])) return true;
   }
   return false;
 }
 /* returns the value of a flag on the form -flagname=value
  */
-const string* getOption(const char *option, int argc, char **argv)
+const std::string* getOption(const char *option, int argc, char **argv)
 {
   for (int i=0; i<argc;i++) {
-    string tmpStr=string(argv[i]);
-    if (("-"+string(option))==(tmpStr.substr(0,tmpStr.find("=")))) {
-      string str=string(argv[i]);
-      return new string(str.substr(str.find("=")+1));
+    std::string tmpStr = std::string(argv[i]);
+    if (("-" + std::string(option))==(tmpStr.substr(0,tmpStr.find("=")))) {
+      std::string str = std::string(argv[i]);
+      return new std::string(str.substr(str.find("=")+1));
     }
   }
   return NULL;
 }
 /* returns the value of a flag on the form -flagname value */
-const string* getFlagValue(const char *option, int argc, char **argv)
+const std::string* getFlagValue(const char *option, int argc, char **argv)
 {
   for (int i=0; i<argc;i++) {
-    string tmpStr=string(argv[i]);
-    if (("-"+string(option))==string(argv[i])) {
+    std::string tmpStr = std::string(argv[i]);
+    if (("-" + std::string(option)) == std::string(argv[i])) {
       if (argc >= i+1) {
-        return new string(argv[i+1]);
+        return new std::string(argv[i+1]);
       }
     }
   }


### PR DESCRIPTION
  - The actual issue here was that OMShell/OMShellGUI/oms.h was adding using namespace std before including Qt headers which made them get the usage as well. This seems to cause issues where std::byte causes lookup confusion in some of Qt headers on Windows with OMDev.

  - Remove all uses of global std namespace usage to avoid future issues like this which can be confusing.
