### PR TITLE
Fixing push-bibliography Jenkins stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -841,6 +841,8 @@ pipeline {
             sshagent (credentials: ['Hudson-SSH-Key']) {
               sh """
               if ! git diff-index --quiet HEAD; then
+                git config user.name "OpenModelica Jenkins"
+                git config user.email "openmodelicabuilds@ida.liu.se"
                 git commit -m 'Updated bibliography'
                 ssh-keyscan github.com >> ~/.ssh/known_hosts
                 git push --set-upstream origin main


### PR DESCRIPTION
  - Set name and email for git Jenkins user

### Related Issues

The Jenkins pipeline on the master branch is failing in stage `push-bibliography`.
https://test.openmodelica.org/jenkins/blue/organizations/jenkins/OpenModelica/detail/master/4727/pipeline

### Purpose

  - Fix missing user.name in script.

### Approach

  - Set name and email for git user