### PR TITLE
Improve error checking of external objects

### DIFF
--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -889,6 +889,8 @@ public constant ErrorTypes.Message CONNECT_TYPE_MISMATCH = ErrorTypes.MESSAGE(40
   Gettext.gettext("The connectors in connect(%s, %s) are not type compatible."));
 public constant ErrorTypes.Message UNSPECIFIED_ENUM_COMPONENT = ErrorTypes.MESSAGE(407, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Component '%s' has an unspecified enumeration type (enumeration(:))."));
+public constant ErrorTypes.Message ELEMENT_REPLACEABLE_NOT_ALLOWED = ErrorTypes.MESSAGE(408, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
+  Gettext.gettext("'%s' may not be replaceable."));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/flattening/modelica/scodeinst/ExternalObjectMod1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObjectMod1.mo
@@ -1,0 +1,34 @@
+// name: ExternalObjectMod1
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+class ExtObj
+  extends ExternalObject;
+
+  function constructor
+    output ExtObj obj;
+    external "C" obj = initObject();
+  end constructor;
+
+  function destructor
+    input ExtObj obj;
+    external "C" destroyObject(obj);
+  end destructor;
+end ExtObj;
+
+model ExternalObjectMod1
+  ExtObj eo1(x = 1);
+end ExternalObjectMod1;
+
+// Result:
+// Error processing file: ExternalObjectMod1.mo
+// [flattening/modelica/scodeinst/ExternalObjectMod1.mo:23:14-23:19:writable] Error: Modified element x not found in class ExtObj.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/ExternalObjectReplaceable1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObjectReplaceable1.mo
@@ -1,0 +1,34 @@
+// name: ExternalObjectReplaceable1
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+class ExtObj
+  extends ExternalObject;
+
+  replaceable function constructor
+    output ExtObj obj;
+    external "C" obj = initObject();
+  end constructor;
+
+  replaceable function destructor
+    input ExtObj obj;
+    external "C" destroyObject(obj);
+  end destructor;
+end ExtObj;
+
+model ExternalObjectReplaceable1
+  ExtObj eo1;
+end ExternalObjectReplaceable1;
+
+// Result:
+// Error processing file: ExternalObjectReplaceable1.mo
+// [flattening/modelica/scodeinst/ExternalObjectReplaceable1.mo:11:15-14:18:writable] Error: 'constructor' may not be replaceable.
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -492,6 +492,8 @@ ExternalObject5.mo \
 ExternalObjectInvalidElement1.mo \
 ExternalObjectInvalidStructor1.mo \
 ExternalObjectMissingStructor1.mo \
+ExternalObjectMod1.mo \
+ExternalObjectReplaceable1.mo \
 ExternalObjectStructorCall1.mo \
 ExternalObjectStructorCall2.mo \
 Final1.mo \


### PR DESCRIPTION
- Try to apply modifiers on external objects even though they have nothing to modify, to make sure we get an error message in that case.
- Check that external object structors are not replaceable.