### PR TITLE
Improve OMSimulator integration and installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,10 +165,6 @@ if(OM_ENABLE_GUI_CLIENTS)
   omc_add_subdirectory(OMPlot)
   omc_add_subdirectory(OMShell)
   omc_add_subdirectory(OMNotebook)
-  # Tell OMSimulator that it is being built as part of OpenModelica.
-  # It will affect things like which 3rdParty libraries are added to the
-  # build process (to avoid duplicates)
-  set(OPENMODELICA_SUPERPROJECT ON)
   omc_add_subdirectory(OMSimulator)
   omc_add_subdirectory(OMEdit)
   omc_add_subdirectory(OMSens_Qt)

--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,9 @@ omsimulator.skip:
 		-DCMAKE_CXX_FLAGS="@CXXFLAGS@" \
 		-DCMAKE_INSTALL_PREFIX=../install
 	$(MAKE) -C OMSimulator/build/ install
+	cp -vpPR OMSimulator/install/include/OMSimulator/ @OMBUILDDIR@/include/omc
 	cp -vpPR OMSimulator/install/bin/OMSimulator* @OMBUILDDIR@/bin
+	cp -vpPR OMSimulator/install/share/OMSimulator/ @OMBUILDDIR@/share
 #	copy the libraries from lib/@host_short@/ OR lib64/. Fails if it can not find at least one of them.
 #	This is needed because the autoconf configuration adds the '@host_short@' (e.g. 'x86_64-linux-gnu') even
 #	on systems that do not use it to signify library architecture differences. For example, on fedora

--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -105,7 +105,9 @@ omsimulator:
 		-DCMAKE_VERBOSE_MAKEFILE=ON \
 		-DCMAKE_INSTALL_PREFIX=../install
 	$(MAKE) -C OMSimulator/build/ install
+	cp -vpPR OMSimulator/install/include/OMSimulator/ @OMBUILDDIR@/include/omc
 	cp -vpPR OMSimulator/install/bin/OMSimulator* $(OMBUILDDIR)/bin
+	cp -vpPR OMSimulator/install/share/OMSimulator/ @OMBUILDDIR@/share
 	cp -vpPR OMSimulator/install/lib/* $(OMBUILDDIR)/lib/omc/
 
 omnotebook: omc omplot qtclientsDLLs


### PR DESCRIPTION
  - There is no longer a need for the variable OPENMODELICA_SUPERPROJECT. It signifies the same thing as the variable OPENMODELICA_NEW_CMAKE_BUILD which is already set and used in other places.

  - Copy the OMsimulator headers and share/data files to the final build dir. These are expected by the packaging scripts.

