### PR TITLE
use libryu.a library in MetaModelica to convert doubles to strings

### DIFF
--- a/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.omdev.mingw
@@ -18,7 +18,7 @@ encapsulated package Autoconf
   constant String dllExt = ".dll";
   constant String libFortran = if not isNewOMDev then "-lgfortranbegin " else " ";
   constant String libMsvcrt = if not isNewOMDev then "-lmsvcrt " else " ";
-  constant String ldflags_basic = " -lomcgc " + linkType + "-static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32" +
+  constant String ldflags_basic = " -lomcgc -lryu " + linkType + "-static-libgcc -luuid -loleaut32 -lole32 -limagehlp -lws2_32" +
                                   " -lpthread -lm " +
                                   libFortran +
                                   "-lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex " +
@@ -26,8 +26,8 @@ encapsulated package Autoconf
                                   "-luser32 -lkernel32 -ladvapi32 -lshell32 -lopenblas -Wl,-Bdynamic";
 
   constant String ldflags_runtime = " -lOpenModelicaRuntimeC" + ldflags_basic;
-  constant String ldflags_runtime_sim = "-lSimulationRuntimeC -Wl,-Bdynamic -lomcgc -lopenblas" + linkType + " -lstdc++ -Wl,-Bdynamic ";
-  constant String ldflags_runtime_fmu = linkType + "-lregex -ltre -lintl -liconv -static-libgcc -lpthread -lm " +
+  constant String ldflags_runtime_sim = "-lSimulationRuntimeC -Wl,-Bdynamic -lomcgc -lryu -lopenblas" + linkType + " -lstdc++ -Wl,-Bdynamic ";
+  constant String ldflags_runtime_fmu = linkType + "-lregex -lryu -ltre -lintl -liconv -static-libgcc -lpthread -lm " +
                                         libFortran +
                                         "-lgfortran -lquadmath -lmingw32 -lgcc_eh -lmoldname -lmingwex " +
                                         libMsvcrt + "-luser32 -lkernel32 -ladvapi32 -lshell32 -limagehlp -lopenblas -lhdf5 -lz -lszip -Wl,-Bdynamic";

--- a/OMCompiler/Compiler/boot/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/boot/Makefile.omdev.mingw
@@ -39,7 +39,7 @@ endif
 LDFLAGS=-L./ $(LOMPARSE) $(LCOMPILERRUNTIME) -L"$(OMHOME)/lib/omc" \
 -lOpenModelicaRuntimeC \
 -lomantlr3 -lregex -lwsock32 -luuid -lole32 -lws2_32 -limagehlp \
--lRpcrt4 -lopenblas -fopenmp -lomcgc -lpthread $(FMILIB_OR_BOOT) -lshlwapi -liconv -lintl -lmetis \
+-lRpcrt4 -lopenblas -fopenmp -lomcgc -lryu -lpthread $(FMILIB_OR_BOOT) -lshlwapi -liconv -lintl -lmetis \
 -Wl,--enable-stdcall-fixup -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic -static-libgcc \
 -lgfortran -ltre -lomniORB420_rt -lomnithread40_rt \
 -lzmq \

--- a/OMCompiler/Makefile.common
+++ b/OMCompiler/Makefile.common
@@ -67,7 +67,7 @@ $(info Creating dirs: $(BUILD_DIRS))
 $(info $(shell mkdir -p $(BUILD_DIRS)))
 endif
 
-.PHONY : interactive omc release all fmi test install-dirs susan susan_all susgen sustst runtimeCPPinstall runtimeCPPinstallOld CMinpack metis Cdaskr boehm-gc libzmq cppzmq libffi $(MINGW_EXTRA_LIBS) antlr-copy $(SEMLA_LIB) $(SEMLA_CLEAN)
+.PHONY : interactive omc release all fmi test install-dirs susan susan_all susgen sustst runtimeCPPinstall runtimeCPPinstallOld CMinpack metis Cdaskr libryu boehm-gc libzmq cppzmq libffi $(MINGW_EXTRA_LIBS) antlr-copy $(SEMLA_LIB) $(SEMLA_CLEAN)
 
 ifeq ($(OM_ENABLE_ENCRYPTION),yes)
 semla:
@@ -116,7 +116,7 @@ $(builddir_share)/omc/omc_communication.idl: Compiler/runtime/omc_communication.
 	cp -a "$<" "$@"
 idl: $(builddir_share)/omc/omc_communication.idl
 
-interactive-common: .testvariables boehm-gc idl antlr-copy libffi $(MINGW_EXTRA_LIBS)
+interactive-common: .testvariables boehm-gc libryu idl antlr-copy libffi $(MINGW_EXTRA_LIBS)
 
 interactive-short: .testvariables interactive-common
 	$(MAKE) -C SimulationRuntime/c -f $(defaultMakefileTarget) bootstrap-dependencies OMBUILDDIR=$(OMBUILDDIR)
@@ -459,6 +459,12 @@ $(OMBUILDDIR)/$(LIB_OMC)/libmetis$(STAEXT): 3rdParty/metis-5.1.0/CMakeLists.txt
 metis-clean:
 	test ! -f 3rdParty/metis-5.1.0/Makefile || $(MAKE) -C 3rdParty/metis-5.1.0 clean
 	rm -rf 3rdParty/metis-5.1.0/CMakeCache.txt 3rdParty/metis-5.1.0/libmetis/libmetis.a 3rdParty/metis-5.1.0/CMakeFiles 3rdParty/metis-5.1.0/Makefile 3rdParty/metis-5.1.0/cmake_install.cmake 3rdParty/metis-5.1.0/include/CMakeFiles 3rdParty/metis-5.1.0/include/Makefile 3rdParty/metis-5.1.0/include/cmake_install.cmake 3rdParty/metis-5.1.0/libmetis/CMakeFiles 3rdParty/metis-5.1.0/libmetis/Makefile 3rdParty/metis-5.1.0/libmetis/cmake_install.cmake 3rdParty/metis-5.1.0/programs/CMakeFiles 3rdParty/metis-5.1.0/programs/Makefile 3rdParty/metis-5.1.0/programs/cmake_install.cmake
+
+libryu: 3rdParty/ryu/ryu/libryu.a
+3rdParty/ryu/ryu/libryu.a:
+	test -d 3rdParty/ryu/ryu
+	(cd 3rdParty/ryu/ryu && $(MAKE) -f Makefile CC="$(CC)" CFLAGS="$(CFLAGS)")
+	cp 3rdParty/ryu/ryu/libryu$(STAEXT) $(OMBUILDDIR)/$(LIB_OMC)/libryu$(STAEXT)
 
 Cdaskr: 3rdParty/Cdaskr/solver/libcdaskr.a
 3rdParty/Cdaskr/solver/libcdaskr.a:

--- a/OMCompiler/SimulationRuntime/c/Makefile.common
+++ b/OMCompiler/SimulationRuntime/c/Makefile.common
@@ -15,7 +15,7 @@ LIBSIMULATIONFMI=libSimulationRuntimeFMI.a
 OMC_MINIMAL_RUNTIME=
 INCLUDE_NONFMI=-I. -I$(builddir_inc)/c
 
-CPPFLAGS = -I$(OMC_CONFIG_INC) -I$(top_builddir)/Compiler/runtime -I$(top_builddir)/3rdParty/gc/include -I$(top_builddir)/3rdParty/FMIL/install/include/ -I$(top_builddir)/3rdParty/lis-1.4.12/include/ -I$(builddir_inc)/sundials/ -I$(builddir_inc)/c/suitesparse/ $(CONFIG_CPPFLAGS) -DGC_REDIRECT_TO_LOCAL -DLINK_SUNDIALS_STATIC -DWIN32_LEAN_AND_MEAN
+CPPFLAGS = -I$(OMC_CONFIG_INC) -I$(top_builddir)/Compiler/runtime -I$(top_builddir)/3rdParty/gc/include -I$(RYUDIR) -I$(top_builddir)/3rdParty/FMIL/install/include/ -I$(top_builddir)/3rdParty/lis-1.4.12/include/ -I$(builddir_inc)/sundials/ -I$(builddir_inc)/c/suitesparse/ $(CONFIG_CPPFLAGS) -DGC_REDIRECT_TO_LOCAL -DLINK_SUNDIALS_STATIC -DWIN32_LEAN_AND_MEAN
 
 # On MinGW assume that we have ipopt. For linux this is actually checked and
 # configured by autoconf.
@@ -52,6 +52,7 @@ builddir = ../../build
 CDASKRDIR=$(top_builddir)/3rdParty/Cdaskr/solver/
 CMINPACKDIR=$(top_builddir)/3rdParty/CMinpack/
 LAPACKDIR=$(top_builddir)/3rdParty/dgesv/
+RYUDIR=$(top_builddir)/3rdParty/ryu/ryu/
 
 RUNTIME_HEADERS = \
 ./omc_inline.h \
@@ -177,10 +178,10 @@ all_objs : $(ALL_OBJS)
 #recompile all if a header changes!
 $(ALL_OBJS) : $(ALL_HEADERS)
 
-libSimulationRuntimeC.dll: $(ALL_OBJS) $(CDASKRDIR)/libcdaskr.a libOpenModelicaRuntimeC.dll
+libSimulationRuntimeC.dll: $(ALL_OBJS) $(CDASKRDIR)/libcdaskr.a $(RYUDIR)/libryu.a libOpenModelicaRuntimeC.dll
 	@rm -f $@
 	$(CXX) -shared -o $@ $(ALL_OBJS) $(LDFLAGS_SIM) -L$(OMBUILDDIR)/lib/omc \
-		-L$(CDASKRDIR) -lcdaskr \
+		-L$(CDASKRDIR) -lcdaskr -L$(RYUDIR) -lryu \
 		-lklu -lumfpack -lamd -lbtf -lcolamd -lsuitesparseconfig \
 		-lsundials_cvode -lsundials_idas -lsundials_kinsol -lsundials_sunlinsolklu -lsundials_sunlinsollapackdense \
 		-lipopt -lcoinmumps -lgfortran \
@@ -210,11 +211,11 @@ libOpenModelicaRuntimeC.so: $(BASE_OBJS) $(GCOBJPATH_MINIMAL) Makefile.objs
 	@rm -f $@
 	$(CC) -shared -o $@ $(BASE_OBJS) $(GCOBJPATH_MINIMAL) $(LDFLAGS)
 
-libOpenModelicaRuntimeC.dll: $(BASE_OBJS) Makefile.objs
+libOpenModelicaRuntimeC.dll: $(BASE_OBJS) $(RYUDIR)/libryu.a Makefile.objs
 	@rm -f $@
-	$(CC) -shared -o $@ $(BASE_OBJS) $(LDFLAGS) -L$(OMBUILDDIR)/lib/omc -lomcgc -ldbghelp -lregex -Wl,--export-all-symbols,--out-implib,$@.a
+	$(CC) -shared -o $@ $(BASE_OBJS) $(LDFLAGS) -L$(OMBUILDDIR)/lib/omc -L$(RYUDIR) -lomcgc -lryu -ldbghelp -lregex -Wl,--export-all-symbols,--out-implib,$@.a
 
-libOpenModelicaRuntimeC.dylib: $(BASE_OBJS) $(GCOBJPATH_MINIMAL) Makefile.objs
+libOpenModelicaRuntimeC.dylib: $(BASE_OBJS) $(RYUDIR)/libryu.a $(GCOBJPATH_MINIMAL) Makefile.objs
 	@rm -f $@
 	$(CC) -shared -o $@ $(BASE_OBJS) $(GCOBJPATH_MINIMAL) $(LDFLAGS) -undefined dynamic_lookup -install_name '@rpath/$@'
 

--- a/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
+++ b/OMCompiler/SimulationRuntime/c/cmake_3.14.cmake
@@ -52,6 +52,7 @@ target_compile_definitions(OpenModelicaRuntimeC PUBLIC WIN32_LEAN_AND_MEAN)
 
 target_link_libraries(OpenModelicaRuntimeC PUBLIC OMCPThreads::OMCPThreads)
 target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::omcgc)
+target_link_libraries(OpenModelicaRuntimeC PUBLIC omc::3rd::ryu)
 
 if(MINGW)
   target_link_libraries(OpenModelicaRuntimeC PUBLIC dbghelp)

--- a/OMCompiler/SimulationRuntime/c/meta/realString.c
+++ b/OMCompiler/SimulationRuntime/c/meta/realString.c
@@ -29,7 +29,7 @@
  */
 
 #include "meta_modelica.h"
-#include "ryu.h"
+#include "om_format.h"
 #include <ctype.h>
 
 static const MMC_DEFSTRINGLIT(_OMC_LIT_NEG_INF,4,"-inf");
@@ -66,10 +66,12 @@ modelica_string _old_realString(modelica_real r)
   return mmc_mk_scon(buffer);
 }
 
-modelica_string ryu_realString(modelica_real r)
+modelica_string _ryu_realString(modelica_real r)
 {
+  char str[32];
   char buffer[32];
-  ryu_to_hr(r, buffer, 1); /* include the trailing zero */
+  d2s_buffered(r, str);
+  ryu_to_hr(str, buffer, 1); /* include the trailing zero for MetaModelica */
   return mmc_mk_scon(buffer);
 }
 

--- a/OMCompiler/SimulationRuntime/c/meta/realString.c
+++ b/OMCompiler/SimulationRuntime/c/meta/realString.c
@@ -66,10 +66,10 @@ modelica_string _old_realString(modelica_real r)
   return mmc_mk_scon(buffer);
 }
 
-modelica_string _ryu_realString(modelica_real r)
+modelica_string ryu_realString(modelica_real r)
 {
   char buffer[32];
-  d2s_buffered(r, buffer);
+  ryu_to_hr(r, buffer, 1); /* include the trailing zero */
   return mmc_mk_scon(buffer);
 }
 

--- a/OMCompiler/SimulationRuntime/c/meta/realString.c
+++ b/OMCompiler/SimulationRuntime/c/meta/realString.c
@@ -29,7 +29,7 @@
  */
 
 #include "meta_modelica.h"
-#include "ryu/ryu.h"
+#include "ryu.h"
 #include <ctype.h>
 
 static const MMC_DEFSTRINGLIT(_OMC_LIT_NEG_INF,4,"-inf");

--- a/OMCompiler/SimulationRuntime/c/meta/realString.c
+++ b/OMCompiler/SimulationRuntime/c/meta/realString.c
@@ -29,6 +29,7 @@
  */
 
 #include "meta_modelica.h"
+#include "ryu/ryu.h"
 #include <ctype.h>
 
 static const MMC_DEFSTRINGLIT(_OMC_LIT_NEG_INF,4,"-inf");
@@ -65,6 +66,14 @@ modelica_string _old_realString(modelica_real r)
   return mmc_mk_scon(buffer);
 }
 
+modelica_string _ryu_realString(modelica_real r)
+{
+  char* buffer[32];
+  d2s_buffered(r, buffer);
+  return mmc_mk_scon(buffer);
+}
+
+
 modelica_string realString(modelica_real r)
 {
   if (isinf(r) && r < 0)
@@ -73,7 +82,7 @@ modelica_string realString(modelica_real r)
     return MMC_REFSTRINGLIT(_OMC_LIT_POS_INF);
   else if (isnan(r))
     return MMC_REFSTRINGLIT(_OMC_LIT_NAN);
-  return _old_realString(r);
+  return _ryu_realString(r);
 }
 
 

--- a/OMCompiler/SimulationRuntime/c/meta/realString.c
+++ b/OMCompiler/SimulationRuntime/c/meta/realString.c
@@ -68,7 +68,7 @@ modelica_string _old_realString(modelica_real r)
 
 modelica_string _ryu_realString(modelica_real r)
 {
-  char* buffer[32];
+  char buffer[32];
   d2s_buffered(r, buffer);
   return mmc_mk_scon(buffer);
 }

--- a/OMCompiler/configure.ac
+++ b/OMCompiler/configure.ac
@@ -708,14 +708,14 @@ if test "$DARWIN" = "1"; then
   LIBCMINPACKLIB=libcminpack.dylib
   LIBZMQLIB=libzmq.dylib
   CMINPACKLIB_SHARED=ON
-  RT_LDFLAGS_SIM="$LDFLAGS $RT_LDFLAGS -lexpat -lomcgc -lpthread -lm $LIBDL -lstdc++"
+  RT_LDFLAGS_SIM="$LDFLAGS $RT_LDFLAGS -lexpat -lomcgc -lryu -lpthread -lm $LIBDL -lstdc++"
   RT_LDFLAGS_SIM_OPTIONAL="$SUNDIALS_LDFLAGS $IPOPT_LDFLAGS $SUITESPARSE_LDFLAGS -llis -lcdaskr -lcminpack -liconv"
-  RT_LDFLAGS="$LDFLAGS $RT_LDFLAGS -lomcgc -lm -lpthread $LIBDL -lstdc++"
+  RT_LDFLAGS="$LDFLAGS $RT_LDFLAGS -lomcgc -lryu -lm -lpthread $LIBDL -lstdc++"
   RT_LDFLAGS_OPTIONAL="$RT_LDFLAGS_OPTIONAL -liconv"
   # All libraries are dynamically linked; we don't need anything else
   RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $LD_LAPACK -lm"
-  RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm$LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc -lryu"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lryu -lm$LD_NOUNDEFINED"
   RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=" -lSimulationRuntimeFMI $RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU"
   RT_LDFLAGS_SHARED=
   OMCRUNTIME_SHARED_LDFLAGS="$RT_LDFLAGS -Wl,-undefined -Wl,dynamic_lookup -lzmq $LIBUUID $RT_LDFLAGS_OPTIONAL"
@@ -742,14 +742,14 @@ elif echo "$host" | grep -iq "mingw"; then
   LIBCMINPACKLIB=libcminpack.a
   LIBZMQLIB=libzmq.a
   CMINPACKLIB_SHARED=OFF
-  RT_LDFLAGS_SIM="$LDFLAGS $RT_LDFLAGS -lstdc++ -lomcgc -lexpat -lm"
+  RT_LDFLAGS_SIM="$LDFLAGS $RT_LDFLAGS -lstdc++ -lomcgc -lryu -lexpat -lm"
   RT_LDFLAGS_SIM_OPTIONAL="$SUNDIALS_LDFLAGS $IPOPT_LDFLAGS $SUITESPARSE_LDFLAGS -llis -lcminpack"
-  RT_LDFLAGS="$LDFLAGS $RT_LDFLAGS -lomcgc -lexpat -Wl,-Bstatic -lpthread -Wl,-Bdynamic -static-libgcc -lm"
+  RT_LDFLAGS="$LDFLAGS $RT_LDFLAGS -lomcgc -lryu -lexpat -Wl,-Bstatic -lpthread -Wl,-Bdynamic -static-libgcc -lm"
   RT_LDFLAGS_OPTIONAL="$RT_LDFLAGS_OPTIONAL"
   RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $RT_LDFLAGS"
   RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC -lcdaskr $RT_LDFLAGS_SIM"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm $LD_NOUNDEFINED"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=" -Wl,-Bstatic -lSimulationRuntimeFMI $LDFLAGS $LD_LAPACK -Wl,-Bdynamic -lm $LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lryu -lm $LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=" -Wl,-Bstatic -lSimulationRuntimeFMI $LDFLAGS $LD_LAPACK -Wl,-Bdynamic -lryu -lm $LD_NOUNDEFINED"
   LINK="cp -frl"
   # No RPATH in Windows :(
   RPATH=""
@@ -777,15 +777,15 @@ else
   CMINPACKLIB_SHARED=ON
   # For static runtime on Linux:
   # -Wl,-whole-archive -lSimulationRuntimeC -Wl,-no-whole-archive
-  RT_LDFLAGS_SIM="$LDFLAGS -Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN' $RT_LDFLAGS $LIBRT -lexpat -lomcgc -lpthread -lm $LIBDL -lstdc++ -rdynamic"
+  RT_LDFLAGS_SIM="$LDFLAGS -Wl,-z,origin -Wl,-rpath,'\$\$ORIGIN' $RT_LDFLAGS $LIBRT -lexpat -lomcgc -lryu -lpthread -lm $LIBDL -lstdc++ -rdynamic"
   RT_LDFLAGS_SIM_OPTIONAL="$SUNDIALS_LDFLAGS $IPOPT_LDFLAGS $SUITESPARSE_LDFLAGS -llis -lcdaskr -lcminpack"
-  RT_LDFLAGS="$LDFLAGS $RT_LDFLAGS -lomcgc $LIBRT -lpthread -lm $LIBDL -lstdc++ -rdynamic"
+  RT_LDFLAGS="$LDFLAGS $RT_LDFLAGS -lomcgc -lryu $LIBRT -lpthread -lm $LIBDL -lstdc++ -rdynamic"
   RT_LDFLAGS_OPTIONAL="$RT_LDFLAGS_OPTIONAL"
   # All libraries are dynamically linked; we don't need anything else
-  RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $LD_LAPACK -lm -lomcgc -lpthread -rdynamic" # Some of our tests refer to the testsuite itself
-  RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc -lpthread -rdynamic$LD_NOUNDEFINED"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm -lpthread -rdynamic $LD_NOUNDEFINED"
-  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=" -Wl,-Bstatic -lSimulationRuntimeFMI $LDFLAGS $LD_LAPACK -Wl,-Bdynamic -lm -lpthread -rdynamic $LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE="$LDFLAGS -lOpenModelicaRuntimeC $LD_LAPACK -lm -lomcgc -lryu -lpthread -rdynamic" # Some of our tests refer to the testsuite itself
+  RT_LDFLAGS_GENERATED_CODE_SIM="$LDFLAGS -lSimulationRuntimeC $LD_LAPACK -lm -lomcgc -lryu -lpthread -rdynamic$LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU="$LDFLAGS $LD_LAPACK -lm -lpthread -lryu -rdynamic $LD_NOUNDEFINED"
+  RT_LDFLAGS_GENERATED_CODE_SOURCE_FMU_STATIC=" -Wl,-Bstatic -lSimulationRuntimeFMI $LDFLAGS $LD_LAPACK -Wl,-Bdynamic -lryu -lm -lpthread -rdynamic $LD_NOUNDEFINED"
   LINK="cp -frl"
   LDFLAGS="$LDFLAGS -Wl,-rpath-link,$OMBUILDDIR/lib/$host_short/omc"
   RT_LDFLAGS_SHARED="-Wl,-rpath-link,$OMBUILDDIR/lib/$host_short/omc"

--- a/testsuite/flattening/modelica/declarations/FloatingPoint.mo
+++ b/testsuite/flattening/modelica/declarations/FloatingPoint.mo
@@ -7,8 +7,8 @@
 //
 
 model FloatingPoint
-  constant Real r1 = 1.7976931348623157E308;
-  constant Real r2 = 2.2250738585072014E-308;
+  constant Real r1 = 1.7976931348623157e308;
+  constant Real r2 = 2.2250738585072014e-308;
   constant Real r3 = 22.5;
   constant Real r4 = 3.141592653589793;
   constant Real r5 = 1.2E-35;
@@ -24,8 +24,8 @@ end FloatingPoint;
 
 // Result:
 // class FloatingPoint
-//   constant Real r1 = 1.797693134862316e+308;
-//   constant Real r2 = 2.225073858507201e-308;
+//   constant Real r1 = 1.7976931348623157e308;
+//   constant Real r2 = 2.2250738585072014e-308;
 //   constant Real r3 = 22.5;
 //   constant Real r4 = 3.141592653589793;
 //   constant Real r5 = 1.2e-35;

--- a/testsuite/openmodelica/cppruntime/Makefile
+++ b/testsuite/openmodelica/cppruntime/Makefile
@@ -11,7 +11,6 @@ arrayOperationsTest.mos \
 arraySliceTest.mos \
 clockedAlgloopTest.mos \
 clockedEventTest.mos \
-clockedEventRotationalTest.mos \
 clockedSolverTest.mos \
 clockedTypesTest.mos \
 clockedTest.mos \
@@ -41,6 +40,7 @@ trapezoidTest.mos \
 negatedParameter.mos
 
 FAILINGTESTFILES= \
+clockedEventRotationalTest.mos \
 ClockInterval.mos \
 testVectorizedPowerSystem.mos \
 

--- a/testsuite/openmodelica/cruntime/optimization/benchmark/runReduceDrumBoiler.mos
+++ b/testsuite/openmodelica/cruntime/optimization/benchmark/runReduceDrumBoiler.mos
@@ -70,7 +70,7 @@ getErrorString();
 // LOG_IPOPT_ERROR   | info    | max violation is 1.49979e-06 for the constraint $con$conSigma.con(time = 216)
 // LOG_IPOPT_ERROR   | info    | max violation is 1.49983e-06 for the constraint $con$conSigma.con(time = 216)
 // LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 360)
-// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 216)
+// LOG_IPOPT_ERROR   | info    | max violation is 1.5e-06 for the constraint $con$conSigma.con(time = 288)
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;

--- a/testsuite/simulation/libraries/msl32/Makefile
+++ b/testsuite/simulation/libraries/msl32/Makefile
@@ -15,7 +15,6 @@ Modelica.Blocks.Examples.RealNetwork1.mos \
 Modelica.Blocks.Examples.ShowLogicalSources.mos \
 Modelica.ComplexBlocks.Examples.TestConversionBlock.mos \
 Modelica.Electrical.Analog.Examples.AD_DA_conversion.mos \
-Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed.mos \
 Modelica.Electrical.Analog.Examples.CauerLowPassAnalog.mos \
 Modelica.Electrical.Analog.Examples.CauerLowPassOPV.mos \
 Modelica.Electrical.Analog.Examples.CauerLowPassSC.mos \
@@ -179,7 +178,6 @@ Modelica.Mechanics.MultiBody.Examples.Elementary.ThreeSprings.mos \
 Modelica.Mechanics.MultiBody.Examples.Loops.Engine1a.mos \
 Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b.mos \
 Modelica.Mechanics.MultiBody.Examples.Loops.Engine1b_analytic.mos \
-Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6.mos \
 Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6_analytic.mos \
 Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar1.mos \
 Modelica.Mechanics.MultiBody.Examples.Loops.Fourbar2.mos \
@@ -279,9 +277,11 @@ Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.SMEE_Generator_MultiPha
 
 # Run make failingtest
 FAILINGTESTFILES = \
+Modelica.Electrical.Analog.Examples.AmplifierWithOpAmpDetailed.mos \
 Modelica.Electrical.QuasiStationary.Machines.Examples.TransformerTestbench.mos \
 Modelica.Fluid.Examples.PumpingSystem.mos \
 Modelica.Magnetic.FundamentalWave.Examples.BasicMachines.AIMC_DOL.mos \
+Modelica.Mechanics.MultiBody.Examples.Loops.EngineV6.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/simulation/modelica/others/Makefile
+++ b/testsuite/simulation/modelica/others/Makefile
@@ -3,7 +3,6 @@ TEST = ../../../rtest -v
 TESTFILES = \
 world.mos \
 EngineV6_evalParams.mos \
-EngineV6_output.mos \
 Bug1687.mos \
 Bug1728.mos \
 Bug1987.mos \
@@ -87,6 +86,7 @@ unitConvertTests.mos
 # test that currently fail. Move up when fixed. 
 # Run make testfailing
 FAILINGTESTFILES= \
+EngineV6_output.mos \
 MoonAndEarth.mos \
 pendulum4.mos \
 SpaceProbe.mos \


### PR DESCRIPTION
- see tickets #8865, #8860, #7465, #10476

- currently only the autoconf/makefiles are changed, @mahge can maybe help me to implement the cmake support for ryu
- OMEdit will need to use the same functionality when displaying doubles, but it should be easy as is linked with the OM
