### PR TITLE
Draw the connections on top of components

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.cpp
@@ -197,18 +197,22 @@ void BitmapAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *
   Q_UNUSED(option);
   Q_UNUSED(widget);
   if (mVisible) {
-    drawBitmapAnnotation(painter);
+    drawAnnotation(painter, false);
   }
 }
 
 /*!
- * \brief BitmapAnnotation::drawBitmapAnnotation
+ * \brief BitmapAnnotation::drawAnnotation
  * Draws the bitmap.
  * \param painter
+ * \param scene
  */
-void BitmapAnnotation::drawBitmapAnnotation(QPainter *painter)
+void BitmapAnnotation::drawAnnotation(QPainter *painter, bool scene)
 {
   QRectF rect = getBoundingRect().normalized();
+  if (scene) {
+    rect = mapToScene(getBoundingRect()).boundingRect().normalized();
+  }
   QImage image = mImage.scaled(rect.width(), rect.height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
   QPointF centerPoint = rect.center() - image.rect().center();
   QRectF target(centerPoint.x(), centerPoint.y(), image.width(), image.height());

--- a/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/BitmapAnnotation.h
@@ -58,7 +58,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawBitmapAnnotation(QPainter *painter);
+  virtual void drawAnnotation(QPainter *painter, bool scene) override;
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.cpp
@@ -155,27 +155,41 @@ void EllipseAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem 
   Q_UNUSED(option);
   Q_UNUSED(widget);
   if (mVisible) {
-    drawEllipseAnnotation(painter);
+    drawAnnotation(painter, false);
   }
 }
 
-void EllipseAnnotation::drawEllipseAnnotation(QPainter *painter)
+/*!
+ * \brief EllipseAnnotation::drawAnnotation
+ * Draws the ellipse.
+ * \param painter
+ * \param scene
+ */
+void EllipseAnnotation::drawAnnotation(QPainter *painter, bool scene)
 {
   // first we invert the painter since we have our coordinate system inverted.
   // inversion is required to draw the elliptic curves at correct angles.
   painter->scale(1.0, -1.0);
-  painter->translate(0, ((-boundingRect().top()) - boundingRect().bottom()));
+  QRectF boundingRectangle = boundingRect();
+  if (scene) {
+    boundingRectangle = mapToScene(boundingRect()).boundingRect();
+  }
+  painter->translate(0, ((-boundingRectangle.top()) - boundingRectangle.bottom()));
   applyLinePattern(painter);
   if (mClosure != StringHandler::ClosureNone) {
     applyFillPattern(painter);
   }
 
+  boundingRectangle = getBoundingRect();
+  if (scene) {
+    boundingRectangle = mapToScene(getBoundingRect()).boundingRect();
+  }
   if (mClosure == StringHandler::ClosureNone) {
-    painter->drawArc(getBoundingRect(), mStartAngle*16, mEndAngle*16 - mStartAngle*16);
+    painter->drawArc(boundingRectangle, mStartAngle*16, mEndAngle*16 - mStartAngle*16);
   } else if (mClosure == StringHandler::ClosureChord) {
-    painter->drawChord(getBoundingRect(), mStartAngle*16, mEndAngle*16 - mStartAngle*16);
+    painter->drawChord(boundingRectangle, mStartAngle*16, mEndAngle*16 - mStartAngle*16);
   } else { // StringHandler::ClosureRadial
-    painter->drawPie(getBoundingRect(), mStartAngle*16, mEndAngle*16 - mStartAngle*16);
+    painter->drawPie(boundingRectangle, mStartAngle*16, mEndAngle*16 - mStartAngle*16);
   }
 }
 

--- a/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/EllipseAnnotation.h
@@ -56,7 +56,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawEllipseAnnotation(QPainter *painter);
+  virtual void drawAnnotation(QPainter *painter, bool scene) override;
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -89,7 +89,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawLineAnnotation(QPainter *painter);
+  virtual void drawAnnotation(QPainter *painter, bool scene) override;
   void drawArrow(QPainter *painter, QPointF startPos, QPointF endPos, qreal size, int arrowType) const;
   QPolygonF perpendicularLine(QPointF startPos, QPointF endPos, qreal size) const;
   QString getOMCShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.cpp
@@ -224,15 +224,21 @@ void PolygonAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem 
   Q_UNUSED(option);
   Q_UNUSED(widget);
   if (mVisible) {
-    drawPolygonAnnotation(painter);
+    drawAnnotation(painter, false);
   }
 }
 
-void PolygonAnnotation::drawPolygonAnnotation(QPainter *painter)
+/*!
+ * \brief PolygonAnnotation::drawAnnotation
+ * Draws the polygon.
+ * \param painter
+ * \param scene
+ */
+void PolygonAnnotation::drawAnnotation(QPainter *painter, bool scene)
 {
   applyLinePattern(painter);
   applyFillPattern(painter);
-  painter->drawPath(getShape());
+  painter->drawPath(scene ? mapToScene(getShape()) : getShape());
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/PolygonAnnotation.h
@@ -58,7 +58,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawPolygonAnnotation(QPainter *painter);
+  virtual void drawAnnotation(QPainter *painter, bool scene) override;
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
@@ -202,15 +202,25 @@ void RectangleAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsIte
         painter->setOpacity(0.2);
       }
     }
-    drawRectangleAnnotation(painter);
+    drawAnnotation(painter, false);
   }
 }
 
-void RectangleAnnotation::drawRectangleAnnotation(QPainter *painter)
+/*!
+ * \brief RectangleAnnotation::drawAnnotation
+ * Draws the rectangle.
+ * \param painter
+ * \param scene
+ */
+void RectangleAnnotation::drawAnnotation(QPainter *painter, bool scene)
 {
   applyLinePattern(painter);
   applyFillPattern(painter);
-  painter->drawRoundedRect(getBoundingRect().normalized(), mRadius, mRadius);
+  if (scene) {
+    painter->drawRoundedRect(mapToScene(getBoundingRect()).boundingRect().normalized(), mRadius, mRadius);
+  } else {
+    painter->drawRoundedRect(getBoundingRect().normalized(), mRadius, mRadius);
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.h
@@ -59,7 +59,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawRectangleAnnotation(QPainter *painter);
+  virtual void drawAnnotation(QPainter *painter, bool scene) override;
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.h
@@ -144,6 +144,7 @@ public:
   virtual QString getOMCShapeAnnotation() = 0;
   virtual QString getOMCShapeAnnotationWithShapeName() = 0;
   virtual QString getShapeAnnotation() = 0;
+  virtual void drawAnnotation(QPainter *painter, bool scene) = 0;
   QList<QPointF> getExtentsForInheritedShapeFromIconDiagramMap(GraphicsView *pGraphicsView, ShapeAnnotation *pReferenceShapeAnnotation);
   void applyTransformation();
   void drawCornerItems();

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -351,16 +351,17 @@ void TextAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
         painter->setOpacity(0.2);
       }
     }
-    drawTextAnnotation(painter);
+    drawAnnotation(painter, false);
   }
 }
 
 /*!
- * \brief TextAnnotation::drawTextAnnotation
- * Draws the Text annotation
+ * \brief TextAnnotation::drawAnnotation
+ * Draws the text.
  * \param painter
+ * \param scene
  */
-void TextAnnotation::drawTextAnnotation(QPainter *painter)
+void TextAnnotation::drawAnnotation(QPainter *painter, bool scene)
 {
   applyLinePattern(painter);
   /* Don't apply the fill patterns on Text shapes. */
@@ -396,9 +397,10 @@ void TextAnnotation::drawTextAnnotation(QPainter *painter)
     sy = scaleY;
   }
   // map the existing bounding rect to new transformation
-  QRectF mappedBoundingRect = QRectF(boundingRect().x() * sx, boundingRect().y() * sy, boundingRect().width() * sx, boundingRect().height() * sy);
+  QRectF boundingRectangle = scene ? mapToScene(boundingRect()).boundingRect() : boundingRect();
+  QRectF mappedBoundingRect = QRectF(boundingRectangle.x() * sx, boundingRectangle.y() * sy, boundingRectangle.width() * sx, boundingRectangle.height() * sy);
   // map the existing bounding rect to new transformation but with positive width and height so that font metrics can work
-  QRectF absMappedBoundingRect = QRectF(boundingRect().x() * sx, boundingRect().y() * sy, qAbs(boundingRect().width() * sx), qAbs(boundingRect().height() * sy));
+  QRectF absMappedBoundingRect = QRectF(boundingRectangle.x() * sx, boundingRectangle.y() * sy, qAbs(boundingRectangle.width() * sx), qAbs(boundingRectangle.height() * sy));
   // normalize the text for drawing
   QString textString = StringHandler::removeFirstLastQuotes(mTextString);
   textString = StringHandler::unparse(QString("\"").append(mTextString).append("\""));

--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.h
@@ -63,7 +63,7 @@ public:
   QRectF boundingRect() const override;
   QPainterPath shape() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = 0) override;
-  void drawTextAnnotation(QPainter *painter);
+  virtual void drawAnnotation(QPainter *painter, bool scene) override;
   QString getOMCShapeAnnotation() override;
   QString getOMCShapeAnnotationWithShapeName() override;
   QString getShapeAnnotation() override;

--- a/OMEdit/OMEditLIB/Element/CornerItem.cpp
+++ b/OMEdit/OMEditLIB/Element/CornerItem.cpp
@@ -200,16 +200,19 @@ void CornerItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
   \param pComponent - pointer to Component.
   */
 ResizerItem::ResizerItem(Element *pComponent)
-  : QGraphicsItem(pComponent), mIsPressed(false)
+  : mIsPressed(false)
 {
-  setZValue(2999);
+  setZValue(4000);
   setFlags(QGraphicsItem::ItemIgnoresTransformations | QGraphicsItem::ItemIsSelectable);
   setCursor(Qt::ArrowCursor);
   setToolTip(Helper::clickAndDragToResize);
   mpComponent = pComponent;
   mActivePen = QPen(Qt::red);
+  mActivePen.setCosmetic(true);
   mInheritedActivePen = QPen(Qt::darkRed);
+  mInheritedActivePen.setCosmetic(true);
   mPassivePen = QPen(Qt::transparent);
+  mPassivePen.setCosmetic(true);
   mRectangle = QRectF (-3, -3, 6, 6);
   mPen = mPassivePen;
 }
@@ -238,6 +241,7 @@ ResizerItem::ResizePositions ResizerItem::getResizePosition()
   */
 void ResizerItem::setActive()
 {
+  setZValue(4000);
   if (mpComponent->isInheritedElement()
       || (mpComponent->getLibraryTreeItem() && mpComponent->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::OMS
           && (mpComponent->getLibraryTreeItem()->getOMSConnector()
@@ -257,6 +261,7 @@ void ResizerItem::setActive()
   */
 void ResizerItem::setPassive()
 {
+  setZValue(-4000);
   mPen = mPassivePen;
   setToolTip("");
   setVisible(false);
@@ -376,13 +381,14 @@ OriginItem::OriginItem(ShapeAnnotation *pShapeAnnotation)
  */
 void OriginItem::initialize()
 {
-  setZValue(3000);
+  setZValue(4000);
   mActivePen = QPen(Qt::red, 2);
   mActivePen.setCosmetic(true);
   mInheritedActivePen = QPen(Qt::darkRed, 2);
   mInheritedActivePen.setCosmetic(true);
-  mPassivePen = QPen(Qt::transparent);
-  mRectangle = QRectF (-1.5, -1.5, 3, 3);
+  mPassivePen = QPen(Qt::transparent, 2);
+  mPassivePen.setCosmetic(true);
+  mRectangle = QRectF (-1, -1, 2, 2);
   mPen = mPassivePen;
 }
 
@@ -393,7 +399,7 @@ void OriginItem::initialize()
  */
 void OriginItem::setActive()
 {
-  setZValue(3000);
+  setZValue(4000);
   if ((mpShapeAnnotation && mpShapeAnnotation->isInheritedShape())
       || (mpComponent && (mpComponent->isInheritedElement()
                           || (mpComponent->getLibraryTreeItem() && mpComponent->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::OMS
@@ -413,7 +419,7 @@ void OriginItem::setActive()
  */
 void OriginItem::setPassive()
 {
-  setZValue(-3000);
+  setZValue(-4000);
   mPen = mPassivePen;
 }
 

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -2240,6 +2240,34 @@ ModelInstance::Component* Element::getModelComponentByName(ModelInstance::Model 
 }
 
 /*!
+ * \brief Element::reDrawConnector
+ * Redraws the connector that collides with the connection.
+ * \param painter
+ */
+void Element::reDrawConnector(QPainter *painter)
+{
+  if (mpDefaultElementRectangle && mpDefaultElementRectangle->isVisible()) {
+    mpDefaultElementRectangle->drawAnnotation(painter, true);
+  }
+
+  if (mpDefaultElementText && mpDefaultElementText->isVisible()) {
+    mpDefaultElementText->drawAnnotation(painter, true);
+  }
+
+  foreach (Element *pInheritedElement, mInheritedElementsList) {
+    pInheritedElement->reDrawConnector(painter);
+  }
+
+  foreach (ShapeAnnotation *pShapeAnnotation, mShapesList) {
+    pShapeAnnotation->drawAnnotation(painter, true);
+  }
+
+  foreach (Element *pElement, mElementsList) {
+    pElement->reDrawConnector(painter);
+  }
+}
+
+/*!
  * \brief Element::createNonExistingElement
  * Creates a non-existing element.
  */
@@ -2743,7 +2771,7 @@ void Element::createResizerItems()
   getResizerItemsPositions(&x1, &y1, &x2, &y2);
   //Bottom left resizer
   mpBottomLeftResizerItem = new ResizerItem(this);
-  mpBottomLeftResizerItem->setPos(mapFromScene(x1, y1));
+  mpBottomLeftResizerItem->setPos(x1, y1);
   mpBottomLeftResizerItem->setResizePosition(ResizerItem::BottomLeft);
   connect(mpBottomLeftResizerItem, SIGNAL(resizerItemPressed(ResizerItem*)), SLOT(prepareResizeElement(ResizerItem*)));
   connect(mpBottomLeftResizerItem, SIGNAL(resizerItemMoved(QPointF)), SLOT(resizeElement(QPointF)));
@@ -2752,7 +2780,7 @@ void Element::createResizerItems()
   mpBottomLeftResizerItem->blockSignals(isSystemLibrary || isInheritedElement() || isOMSConnector || isOMSBusConnecor || isOMSTLMBusConnecor);
   //Top left resizer
   mpTopLeftResizerItem = new ResizerItem(this);
-  mpTopLeftResizerItem->setPos(mapFromScene(x1, y2));
+  mpTopLeftResizerItem->setPos(x1, y2);
   mpTopLeftResizerItem->setResizePosition(ResizerItem::TopLeft);
   connect(mpTopLeftResizerItem, SIGNAL(resizerItemPressed(ResizerItem*)), SLOT(prepareResizeElement(ResizerItem*)));
   connect(mpTopLeftResizerItem, SIGNAL(resizerItemMoved(QPointF)), SLOT(resizeElement(QPointF)));
@@ -2761,7 +2789,7 @@ void Element::createResizerItems()
   mpTopLeftResizerItem->blockSignals(isSystemLibrary || isInheritedElement() || isOMSConnector || isOMSBusConnecor || isOMSTLMBusConnecor);
   //Top Right resizer
   mpTopRightResizerItem = new ResizerItem(this);
-  mpTopRightResizerItem->setPos(mapFromScene(x2, y2));
+  mpTopRightResizerItem->setPos(x2, y2);
   mpTopRightResizerItem->setResizePosition(ResizerItem::TopRight);
   connect(mpTopRightResizerItem, SIGNAL(resizerItemPressed(ResizerItem*)), SLOT(prepareResizeElement(ResizerItem*)));
   connect(mpTopRightResizerItem, SIGNAL(resizerItemMoved(QPointF)), SLOT(resizeElement(QPointF)));
@@ -2770,7 +2798,7 @@ void Element::createResizerItems()
   mpTopRightResizerItem->blockSignals(isSystemLibrary || isInheritedElement() || isOMSConnector || isOMSBusConnecor || isOMSTLMBusConnecor);
   //Bottom Right resizer
   mpBottomRightResizerItem = new ResizerItem(this);
-  mpBottomRightResizerItem->setPos(mapFromScene(x2, y1));
+  mpBottomRightResizerItem->setPos(x2, y1);
   mpBottomRightResizerItem->setResizePosition(ResizerItem::BottomRight);
   connect(mpBottomRightResizerItem, SIGNAL(resizerItemPressed(ResizerItem*)), SLOT(prepareResizeElement(ResizerItem*)));
   connect(mpBottomRightResizerItem, SIGNAL(resizerItemMoved(QPointF)), SLOT(resizeElement(QPointF)));
@@ -2813,16 +2841,16 @@ void Element::showResizerItems()
   qreal x1, y1, x2, y2;
   getResizerItemsPositions(&x1, &y1, &x2, &y2);
   //Bottom left resizer
-  mpBottomLeftResizerItem->setPos(mapFromScene(x1, y1));
+  mpBottomLeftResizerItem->setPos(x1, y1);
   mpBottomLeftResizerItem->setActive();
   //Top left resizer
-  mpTopLeftResizerItem->setPos(mapFromScene(x1, y2));
+  mpTopLeftResizerItem->setPos(x1, y2);
   mpTopLeftResizerItem->setActive();
   //Top Right resizer
-  mpTopRightResizerItem->setPos(mapFromScene(x2, y2));
+  mpTopRightResizerItem->setPos(x2, y2);
   mpTopRightResizerItem->setActive();
   //Bottom Right resizer
-  mpBottomRightResizerItem->setPos(mapFromScene(x2, y1));
+  mpBottomRightResizerItem->setPos(x2, y1);
   mpBottomRightResizerItem->setActive();
 }
 
@@ -3153,6 +3181,16 @@ void Element::updatePlacementAnnotation()
 void Element::updateOriginItem()
 {
   mpOriginItem->setPos(mTransformation.getOrigin());
+  qreal x1, y1, x2, y2;
+  getResizerItemsPositions(&x1, &y1, &x2, &y2);
+  //Bottom left resizer
+  mpBottomLeftResizerItem->setPos(x1, y1);
+  //Top left resizer
+  mpTopLeftResizerItem->setPos(x1, y2);
+  //Top Right resizer
+  mpTopRightResizerItem->setPos(x2, y2);
+  //Bottom Right resizer
+  mpBottomRightResizerItem->setPos(x2, y1);
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -236,6 +236,10 @@ public:
   bool hasChoices() {return (mChoices.size() > 0);}
   CoOrdinateSystem getCoOrdinateSystem() const;
   ModelInstance::CoordinateSystem getCoOrdinateSystemNew() const;
+  ResizerItem* getBottomLeftResizerItem() {return mpBottomLeftResizerItem;}
+  ResizerItem* getTopLeftResizerItem() {return mpTopLeftResizerItem;}
+  ResizerItem* getTopRightResizerItem() {return mpTopRightResizerItem;}
+  ResizerItem* getBottomRightResizerItem() {return mpBottomRightResizerItem;}
   OriginItem* getOriginItem() {return mpOriginItem;}
   QAction* getParametersAction() {return mpParametersAction;}
   QAction* getFetchInterfaceDataAction() {return mpFetchInterfaceDataAction;}
@@ -305,6 +309,7 @@ public:
   Element* getBusComponent() {return mpBusComponent;}
   Element* getElementByName(const QString &elementName);
   static ModelInstance::Component *getModelComponentByName(ModelInstance::Model *pModel, const QString &name);
+  void reDrawConnector(QPainter *painter);
 
   Transformation mTransformation;
   Transformation mOldTransformation;

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -262,8 +262,7 @@ void AddComponentCommand::redoInternal()
   if (mpLibraryTreeItem && mpLibraryTreeItem->isConnector() && pModelWidget->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::Modelica) {
     // Connector type components exists on icon view as well
     if (mpIconComponent->mTransformation.isValid() && mpIconComponent->mTransformation.getVisible()) {
-      mpIconGraphicsView->addItem(mpIconComponent);
-      mpIconGraphicsView->addItem(mpIconComponent->getOriginItem());
+      mpIconGraphicsView->addElementItem(mpIconComponent);
     }
     mpIconGraphicsView->addElementToList(mpIconComponent);
     mpIconGraphicsView->deleteElementFromOutOfSceneList(mpIconComponent);
@@ -272,8 +271,7 @@ void AddComponentCommand::redoInternal()
     mpIconComponent->setVisible(!mpComponentInfo->getProtected());
   }
   if (mpDiagramComponent->mTransformation.isValid() && mpDiagramComponent->mTransformation.getVisible()) {
-    mpDiagramGraphicsView->addItem(mpDiagramComponent);
-    mpDiagramGraphicsView->addItem(mpDiagramComponent->getOriginItem());
+    mpDiagramGraphicsView->addElementItem(mpDiagramComponent);
   }
   mpDiagramGraphicsView->addElementToList(mpDiagramComponent);
   mpDiagramGraphicsView->deleteElementFromOutOfSceneList(mpDiagramComponent);
@@ -304,14 +302,12 @@ void AddComponentCommand::undo()
   // if component is of connector type && containing class is Modelica type.
   if (mpLibraryTreeItem && mpLibraryTreeItem->isConnector() && pModelWidget->getLibraryTreeItem()->getLibraryType() == LibraryTreeItem::Modelica) {
     // Connector type components exists on icon view as well
-    mpIconGraphicsView->removeItem(mpIconComponent);
-    mpIconGraphicsView->removeItem(mpIconComponent->getOriginItem());
+    mpIconGraphicsView->removeElementItem(mpIconComponent);
     mpIconGraphicsView->deleteElementFromList(mpIconComponent);
     mpIconGraphicsView->addElementToOutOfSceneList(mpIconComponent);
     mpIconComponent->emitDeleted();
   }
-  mpDiagramGraphicsView->removeItem(mpDiagramComponent);
-  mpDiagramGraphicsView->removeItem(mpDiagramComponent->getOriginItem());
+  mpDiagramGraphicsView->removeElementItem(mpDiagramComponent);
   mpDiagramGraphicsView->deleteElementFromList(mpDiagramComponent);
   mpDiagramGraphicsView->addElementToOutOfSceneList(mpDiagramComponent);
   mpDiagramComponent->emitDeleted();
@@ -697,15 +693,13 @@ void DeleteComponentCommand::redoInternal()
     }
     Element *pComponent = pGraphicsView->getElementObject(mpComponent->getName());
     if (pComponent) {
-      pGraphicsView->removeItem(pComponent);
-      pGraphicsView->removeItem(pComponent->getOriginItem());
+      pGraphicsView->removeElementItem(pComponent);
       pGraphicsView->deleteElementFromList(pComponent);
       pGraphicsView->addElementToOutOfSceneList(pComponent);
       pComponent->emitDeleted();
     }
   }
-  mpGraphicsView->removeItem(mpComponent);
-  mpGraphicsView->removeItem(mpComponent->getOriginItem());
+  mpGraphicsView->removeElementItem(mpComponent);
   mpGraphicsView->deleteElementFromList(mpComponent);
   mpGraphicsView->addElementToOutOfSceneList(mpComponent);
   mpComponent->emitDeleted();
@@ -730,15 +724,13 @@ void DeleteComponentCommand::undo()
     }
     Element *pComponent = pGraphicsView->getElementObject(mpComponent->getName());
     if (pComponent) {
-      pGraphicsView->addItem(pComponent);
-      pGraphicsView->addItem(pComponent->getOriginItem());
+      pGraphicsView->addElementItem(pComponent);
       pGraphicsView->addElementToList(pComponent);
       pGraphicsView->deleteElementFromOutOfSceneList(pComponent);
       pComponent->emitAdded();
     }
   }
-  mpGraphicsView->addItem(mpComponent);
-  mpGraphicsView->addItem(mpComponent->getOriginItem());
+  mpGraphicsView->addElementItem(mpComponent);
   mpGraphicsView->addElementToList(mpComponent);
   mpGraphicsView->deleteElementFromOutOfSceneList(mpComponent);
   mpComponent->emitAdded();

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -254,6 +254,8 @@ public:
   void addElementToOutOfSceneList(Element *pElement) {mOutOfSceneElementsList.append(pElement);}
   void addInheritedElementToList(Element *pElement) {mInheritedElementsList.append(pElement);}
   void addElementToClass(Element *pElement);
+  void addElementItem(Element *pElement);
+  void removeElementItem(Element *pElement);
   void deleteElement(Element *pElement);
   void deleteElementFromClass(Element *pElement);
   void deleteElementFromList(Element *pElement) {mElementsList.removeOne(pElement);}


### PR DESCRIPTION
### Related Issues

Fixes #4645 and fixes #4839

### Purpose

Improve the connections visibility in the diagrams.

### Approach

The connections are drawn on top of components but below connectors.
Improves the visibility and selection of connections.
