### PR TITLE
Fix copy of the libOMSimulator dll on Windows.

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -106,7 +106,7 @@ omsimulator:
 		-DCMAKE_INSTALL_PREFIX=../install
 	$(MAKE) -C OMSimulator/build/ install
 	cp -vpPR OMSimulator/install/include/OMSimulator/ $(OMBUILDDIR)/include/omc
-	cp -vpPR OMSimulator/install/bin/OMSimulator* $(OMBUILDDIR)/bin
+	cp -vpPR OMSimulator/install/bin/* $(OMBUILDDIR)/bin
 	cp -vpPR OMSimulator/install/share/OMSimulator/ $(OMBUILDDIR)/share
 	cp -vpPR OMSimulator/install/lib/* $(OMBUILDDIR)/lib/omc/
 


### PR DESCRIPTION
  - This used to be installed to the lib folder by OMSimulator. Now it is installed to the bin folder as it should be. Copy it from there. Copy everything from the bin folder anyway. Not just the files `OMSimulator*`


