### PR TITLE
Do not use variables before they are set.

### DIFF
--- a/OMCompiler/Makefile.in
+++ b/OMCompiler/Makefile.in
@@ -15,6 +15,17 @@ docdir = @docdir@
 AR = @AR@
 host = @host@
 host_short = @host_short@
+
+CC=@CC@
+CXX=@CXX@
+CFLAGS=@CFLAGS@
+MSGPACK_CFLAGS =
+CPPFLAGS=@CPPFLAGS@
+CXXFLAGS=@CXXFLAGS@
+LDFLAGS=@LDFLAGS@
+LDFLAGS_LIBSTDCXX=@LDFLAGS_LIBSTDCXX@
+LINK=@LINK@
+
 FC = @FC@
 FCFLAGS = @FCFLAGS@
 CMAKE=@OMC_CMAKE_EXE@
@@ -34,15 +45,6 @@ MAKEFILE_BOOT = LinkMain.makefile
 QMAKE=@QMAKE@
 APP=@APP@
 
-CC=@CC@
-CXX=@CXX@
-CFLAGS=@CFLAGS@
-MSGPACK_CFLAGS =
-CPPFLAGS=@CPPFLAGS@
-CXXFLAGS=@CXXFLAGS@
-LDFLAGS=@LDFLAGS@
-LDFLAGS_LIBSTDCXX=@LDFLAGS_LIBSTDCXX@
-LINK=@LINK@
 MSL_EXTRA_ARGS=@MSL_EXTRA_ARGS@
 # LIBGC configuration is different for Linux (this file) and Windows (Makefile.omdev.mingw)
 # Do not use munmap; it crashes processes...

--- a/testsuite/openmodelica/dataReconciliation/Makefile
+++ b/testsuite/openmodelica/dataReconciliation/Makefile
@@ -45,7 +45,6 @@ TSP_FourFlows.mos\
 TSP_FourFlows1.mos\
 TSP_FourFlows3.mos\
 TSP_FourFlows8.mos\
-TSP_FourFlows9.mos\
 
 # test that currently fail. Move up when fixed.
 # Run make testfailing
@@ -55,6 +54,7 @@ TSP_FourFlows4.mos\
 TSP_FourFlows5.mos\
 TSP_FourFlows6.mos\
 TSP_FourFlows7.mos\
+TSP_FourFlows9.mos\
 TSP_FourFlows11.mos\
 TSP_Pipe6.mos\
 TSP_Pipe5.mos\


### PR DESCRIPTION
  - Usages of these variables were setting things to the default value, e.g. using CXX will use g++ somehow until we see these variables being set in the current Makefile.
