### PR TITLE
QLineF::intersects is introduced in Qt 5.14

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -748,7 +748,11 @@ void LineAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
                   QLineF line1(mPoints.at(i), mPoints.at(i + 1));
                   QLineF line2(points.at(j), points.at(j + 1));
                   QPointF intersectionPoint;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
                   QLineF::IntersectionType type = line1.intersects(line2, &intersectionPoint);
+#else // < Qt 5.14
+                  QLineF::IntersectType type = line1.intersect(line2, &intersectionPoint);
+#endif // QT_VERSION_CHECK
                   if (type == QLineF::BoundedIntersection) {
                     painter->save();
                     painter->setPen(Qt::NoPen);


### PR DESCRIPTION
Use QLineF::intersect for Qt < 5.14
Fixes Linux builds