### PR TITLE
Send abort message to OMEdit

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1489,7 +1489,15 @@ void setStreamPrintXML(int isXML)
   }
 }
 
-void communicateStatus(const char *phase, double completionPercent /*0.0 to 1.0*/, double currentTime, double currentStepSize)
+/**
+ * @brief Send status via XMLTCP or TCP.
+ *
+ * @param phase               Simulation phase.
+ * @param completionPercent   Percentage of simulation progress: 0.0 to 1.0
+ * @param currentTime         Current simulation time.
+ * @param currentStepSize     Current solver step size.
+ */
+void communicateStatus(const char *phase, double completionPercent, double currentTime, double currentStepSize)
 {
 #ifndef NO_INTERACTIVE_DEPENDENCY
   if (sim_communication_port_open && isXMLTCP) {

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/solver_main.c
@@ -555,7 +555,7 @@ int finishSimulation(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
   SIMULATION_INFO *simInfo = data->simulationInfo;
 
   /* Last step with terminal()=true */
-  if(solverInfo->currentTime >= simInfo->stopTime && solverInfo->solverMethod != S_OPTIMIZATION) {
+  if (solverInfo->currentTime >= simInfo->stopTime && solverInfo->solverMethod != S_OPTIMIZATION) {
     infoStreamPrint(LOG_EVENTS_V, 0, "terminal event at stop time %g", solverInfo->currentTime);
     data->simulationInfo->terminal = 1;
     updateDiscreteSystem(data, threadData);
@@ -569,7 +569,11 @@ int finishSimulation(DATA* data, threadData_t *threadData, SOLVER_INFO* solverIn
   }
 
   if (0 != strcmp("ia", data->simulationInfo->outputFormat)) {
-    communicateStatus("Finished", 1, solverInfo->currentTime, solverInfo->currentStepSize);
+    if (simInfo->simulationSuccess) {
+      communicateStatus("Finished", 1, solverInfo->currentTime, solverInfo->currentStepSize);
+    } else {
+      communicateStatus("Simulation aborted", (solverInfo->currentTime-simInfo->startTime)/(simInfo->stopTime-simInfo->startTime), solverInfo->currentTime, 0.0);
+    }
   }
 
   /* we have output variables in the command line -output a,b,c */


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/11128.

### Purpose
Send failure `Simulation aborted` to OMEdit if simulation didn't finish with `simInfo->simulationSuccess`.

### Approach

![grafik](https://github.com/OpenModelica/OpenModelica/assets/38031952/92ea0b74-870c-405d-9c3f-52097175ec09)
