### PR TITLE
Use setElementAnnotation instead of updateComponent

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1253,7 +1253,7 @@ QString Element::getTransformationAnnotation(bool ModelicaSyntax)
 QString Element::getPlacementAnnotation(bool ModelicaSyntax)
 {
   // create the placement annotation string
-  QString placementAnnotationString = ModelicaSyntax ? "annotation(Placement(" : "annotate=Placement(";
+  QString placementAnnotationString = ModelicaSyntax ? "Placement(" : "annotate=Placement(";
   if (mTransformation.isValid()) {
     if (mTransformation.getVisible().isDynamicSelectExpression() || mTransformation.getVisible().toQString().compare(QStringLiteral("true")) != 0) {
       placementAnnotationString.append(QString("visible=%1,").arg(mTransformation.getVisible().toQString()));
@@ -1280,7 +1280,7 @@ QString Element::getPlacementAnnotation(bool ModelicaSyntax)
   } else {
     placementAnnotationString.append(getTransformationAnnotation(ModelicaSyntax));
   }
-  placementAnnotationString.append(ModelicaSyntax ? "))" : ")");
+  placementAnnotationString.append(ModelicaSyntax ? ")" : ")");
   return placementAnnotationString;
 }
 
@@ -3167,7 +3167,7 @@ void Element::updatePlacementAnnotation()
     }
   } else {
     OMCProxy *pOMCProxy = MainWindow::instance()->getOMCProxy();
-    pOMCProxy->updateComponent(getName(), getClassName(), mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure(), getPlacementAnnotation());
+    pOMCProxy->setElementAnnotation(mpGraphicsView->getModelWidget()->getLibraryTreeItem()->getNameStructure() % "." % getName(), "$Code((" % getPlacementAnnotation(true) % "))");
   }
   /* When something is changed in the icon layer then update the LibraryTreeItem in the Library Browser */
   if (mpGraphicsView->getViewType() == StringHandler::Icon) {

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -3579,7 +3579,7 @@ void GraphicsView::copyItems(bool cut)
           pComponent->getElementInfo()->getModifiersMap(MainWindow::instance()->getOMCProxy(), pComponent->getGraphicsView()->getModelWidget()->getLibraryTreeItem()->getNameStructure(), pComponent);
         }
         pMimeData->addComponent(pComponent);
-        components << QString("%1 %2%3 %4;").arg(pComponent->getClassName(), pComponent->getName(), "", pComponent->getPlacementAnnotation(true));
+        components << pComponent->getClassName() % " " % pComponent->getName() % " " % "annotation(" % pComponent->getPlacementAnnotation(true) % ")";
       } else if (ShapeAnnotation *pShapeAnnotation = dynamic_cast<ShapeAnnotation*>(selectedItems.at(i))) {
         LineAnnotation *pLineAnnotation = dynamic_cast<LineAnnotation*>(selectedItems.at(i));
         if (pLineAnnotation && pLineAnnotation->isConnection()) {

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -2042,16 +2042,36 @@ bool OMCProxy::renameComponent(QString className, QString oldName, QString newNa
 }
 
 /*!
-  Updates the component annotations.
-  \param name - the component name
-  \param className - the component fully qualified name.
-  \param componentName - the name of the component to update.
-  \param annotation - the updated annotation.
-  \return true on success.
-  */
+ * \brief OMCProxy::updateComponent
+ * Updates the component annotations.
+ * \param name - the component name
+ * \param className - the component fully qualified name.
+ * \param componentName - the name of the component to update.
+ * \param placementAnnotation - the updated annotation.
+ * \return true on success.
+ * \deprecated
+ * \see OMCProxy::setElementAnnotation(const QString &elementName, QString annotation)
+ */
 bool OMCProxy::updateComponent(QString name, QString className, QString componentName, QString placementAnnotation)
 {
   sendCommand("updateComponent(" + name + "," + className + "," + componentName + "," + placementAnnotation + ")");
+  if (StringHandler::unparseBool(getResult())) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+/*!
+ * \brief OMCProxy::setElementAnnotation
+ * Sets the element annotation.
+ * \param elementName
+ * \param annotation
+ * \return true on success.
+ */
+bool OMCProxy::setElementAnnotation(const QString &elementName, QString annotation)
+{
+  sendCommand("setElementAnnotation(" % elementName % "," + annotation + ")");
   if (StringHandler::unparseBool(getResult())) {
     return true;
   } else {

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -188,6 +188,7 @@ public:
   bool deleteComponent(QString name, QString componentName);
   bool renameComponent(QString className, QString oldName, QString newName);
   bool updateComponent(QString name, QString className, QString componentName, QString placementAnnotation);
+  bool setElementAnnotation(const QString &elementName, QString annotation);
   bool renameComponentInClass(QString className, QString oldName, QString newName);
   bool updateConnection(QString className, QString from, QString to, QString annotation);
   bool updateConnectionNames(QString className, QString from, QString to, QString fromNew, QString toNew);


### PR DESCRIPTION
### Related Issues

Fixes #11116

### Purpose

Only update the annotation when component is moved around.

### Approach

Use the new API `setElementAnnotation` instead of `updateComponent`.
