### PR TITLE
Fix tooltip location in plots

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/PlotPicker.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotPicker.cpp
@@ -61,7 +61,7 @@ bool containsPoint(QPointF point, QPointF point1, QPointF point2, double xSelect
   // If point is out of bounds, no need to do further checks.
   if (point.x() + xSelectionMargin < leftPoint.x() || rightPoint.x() < point.x() - xSelectionMargin) {
     return false;
-  } else if (point.y() + ySelectionMargin < qMin(leftPoint.y(), rightPoint.y()) || qMin(leftPoint.y(), rightPoint.y()) < point.y() - ySelectionMargin) {
+  } else if (point.y() + ySelectionMargin < qMin(leftPoint.y(), rightPoint.y()) || qMax(leftPoint.y(), rightPoint.y()) < point.y() - ySelectionMargin) {
     return false;
   }
   double deltaX = rightPoint.x() - leftPoint.x();


### PR DESCRIPTION
### Related Issues

```modelica
model Test
  final input Real params[:] = {time * i for i in 1:3};
equation
  annotation(experiment(StartTime = 1, StopTime = 2));
end Test;
```
Simulate this model, then plot `params` as an array plot and try to display the tooltip around the last point `(3, 3)`.

### Purpose

The above test will fail!
It also shows how the fix makes "picking the points" much smoother and funnier.

### Approach

Fixed a buggy condition (typo) in a function that checks whether a point belongs the a line segment with margins.
