### PR TITLE
Fix handling of pure/impure

### DIFF
--- a/OMCompiler/Compiler/FFrontEnd/FGraph.mo
+++ b/OMCompiler/Compiler/FFrontEnd/FGraph.mo
@@ -851,7 +851,7 @@ public function scopeTypeToRestriction
 algorithm
   outRestriction := match inScopeType
     case FCore.PARALLEL_SCOPE() then SCode.R_FUNCTION(SCode.FR_PARALLEL_FUNCTION());
-    case FCore.FUNCTION_SCOPE() then SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(false));
+    case FCore.FUNCTION_SCOPE() then SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(Absyn.FunctionPurity.NO_PURITY()));
     else SCode.R_CLASS();
   end match;
 end scopeTypeToRestriction;

--- a/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynToSCode.mo
@@ -260,17 +260,6 @@ algorithm
   end match;
 end getListofQualOperatorFuncsfromOperator;
 
-public function translatePurity
-  input Absyn.FunctionPurity inPurity;
-  output Boolean outPurity;
-algorithm
-  outPurity := match(inPurity)
-    case Absyn.IMPURE() then true;
-    else false;
-  end match;
-end translatePurity;
-
-// Changed to public! krsta
 public function translateRestriction
 "Convert a class restriction."
   input Absyn.Class inClass;
@@ -288,11 +277,9 @@ algorithm
 
     // ?? Only normal functions can have 'external'
     case (d,Absyn.R_FUNCTION(Absyn.FR_NORMAL_FUNCTION(purity)))
-      equation
-        isImpure = translatePurity(purity);
       then if containsExternalFuncDecl(d)
-             then SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(isImpure))
-             else SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(isImpure));
+             then SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(purity))
+             else SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(purity));
 
     case (_,Absyn.R_FUNCTION(Absyn.FR_OPERATOR_FUNCTION())) then SCode.R_FUNCTION(SCode.FR_OPERATOR_FUNCTION());
     case (_,Absyn.R_FUNCTION(Absyn.FR_PARALLEL_FUNCTION())) then SCode.R_FUNCTION(SCode.FR_PARALLEL_FUNCTION());

--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6329,5 +6329,40 @@ algorithm
   item.comment := setCommentAnnotation(item.comment, inAnnotation);
 end setComponentItemAnnotation;
 
+function isImpure
+  input Absyn.FunctionPurity purity;
+  input Boolean defaultImpure = false; // No prefix = impure if true, otherwise = pure.
+  output Boolean isImpure;
+algorithm
+  isImpure := match purity
+    case Absyn.FunctionPurity.IMPURE() then true;
+    case Absyn.FunctionPurity.NO_PURITY() then defaultImpure;
+    else false;
+  end match;
+end isImpure;
+
+function purityEqual
+  input Absyn.FunctionPurity purity1;
+  input Absyn.FunctionPurity purity2;
+  input Boolean defaultImpure = false; // No prefix = impure if true, otherwise = pure.
+  output Boolean isEqual;
+algorithm
+  if valueConstructor(purity1) == valueConstructor(purity2) then
+    isEqual := true;
+  elseif defaultImpure then
+    isEqual := match (purity1, purity2)
+      case (Absyn.FunctionPurity.NO_PURITY(), Absyn.FunctionPurity.IMPURE()) then true;
+      case (Absyn.FunctionPurity.IMPURE(), Absyn.FunctionPurity.NO_PURITY()) then true;
+      else false;
+    end match;
+  else
+    isEqual := match (purity1, purity2)
+      case (Absyn.FunctionPurity.PURE(), Absyn.FunctionPurity.IMPURE()) then true;
+      case (Absyn.FunctionPurity.IMPURE(), Absyn.FunctionPurity.PURE()) then true;
+      else false;
+    end match;
+  end if;
+end purityEqual;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/OMCompiler/Compiler/FrontEnd/ClassInf.mo
+++ b/OMCompiler/Compiler/FrontEnd/ClassInf.mo
@@ -55,6 +55,7 @@ protected import Error;
 protected import Flags;
 protected import Print;
 protected import SCodeDump;
+protected import SCodeUtil;
 
 public
 uniontype State "- Machine states, the string contains the classname."
@@ -421,10 +422,7 @@ algorithm
     case (SCode.R_CONNECTOR(isExpandable),p) then CONNECTOR(p,isExpandable);
     case (SCode.R_TYPE(),p) then TYPE(p);
     case (SCode.R_PACKAGE(),p) then PACKAGE(p);
-    case (SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(isImpure)),p) then FUNCTION(p, isImpure);
-    case (SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(isImpure)),p) then FUNCTION(p, isImpure);
-    case (SCode.R_FUNCTION(SCode.FR_RECORD_CONSTRUCTOR()),p) then FUNCTION(p, false);
-    case (SCode.R_FUNCTION(_),p) then FUNCTION(p, false);
+    case (SCode.R_FUNCTION(),p) then FUNCTION(p, SCodeUtil.isRestrictionImpure(inRestriction, true));
     case (SCode.R_OPERATOR(),p) then FUNCTION(p, false);
     case (SCode.R_ENUMERATION(),p) then ENUMERATION(p);
     case (SCode.R_PREDEFINED_INTEGER(),p) then TYPE_INTEGER(p);

--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -7209,9 +7209,11 @@ algorithm
       DAE.InlineType inlineType;
       String name;
       list<DAE.Var> inVars,outVars;
+      Absyn.FunctionPurity purity;
 
-    case SCode.CLASS(restriction=SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(isImpure)))
+    case SCode.CLASS(restriction=SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(purity)))
       equation
+        isImpure = AbsynUtil.isImpure(purity);
         inVars = List.select(vl,Types.isInputVar);
         outVars = List.select(vl,Types.isOutputVar);
         name = SCodeUtil.isBuiltinFunction(cl,List.map(inVars,Types.getVarName),List.map(outVars,Types.getVarName));

--- a/OMCompiler/Compiler/FrontEnd/SCode.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCode.mo
@@ -101,10 +101,10 @@ end Restriction;
 public
 uniontype FunctionRestriction
   record FR_NORMAL_FUNCTION "a normal function"
-    Boolean isImpure "true for impure functions, false otherwise";
+    Absyn.FunctionPurity purity;
   end FR_NORMAL_FUNCTION;
   record FR_EXTERNAL_FUNCTION "an external function"
-    Boolean isImpure "true for impure functions, false otherwise";
+    Absyn.FunctionPurity purity;
   end FR_EXTERNAL_FUNCTION;
 
   record FR_OPERATOR_FUNCTION "an operator function" end FR_OPERATOR_FUNCTION;

--- a/OMCompiler/Compiler/FrontEnd/SCodeDump.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeDump.mo
@@ -171,14 +171,18 @@ algorithm
     case SCode.R_CONNECTOR(false) then "connector";
     case SCode.R_CONNECTOR(true) then "expandable connector";
     case SCode.R_OPERATOR() then "operator";
-    case SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(false)) then "pure function";
-    case SCode.R_FUNCTION(SCode.FR_NORMAL_FUNCTION(true)) then "impure function";
-    case SCode.R_FUNCTION(SCode.FR_OPERATOR_FUNCTION()) then "operator function";
-    case SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(false)) then "pure external function";
-    case SCode.R_FUNCTION(SCode.FR_EXTERNAL_FUNCTION(true)) then "impure external function";
-    case SCode.R_FUNCTION(SCode.FR_RECORD_CONSTRUCTOR()) then "record constructor";
-    case SCode.R_FUNCTION(SCode.FR_PARALLEL_FUNCTION()) then "parallel function";
-    case SCode.R_FUNCTION(SCode.FR_KERNEL_FUNCTION()) then "kernel function";
+    case SCode.R_FUNCTION()
+      then match inRestriction.functionRestriction
+        case SCode.FR_NORMAL_FUNCTION(purity = Absyn.FunctionPurity.PURE()) then "pure function";
+        case SCode.FR_NORMAL_FUNCTION(purity = Absyn.FunctionPurity.IMPURE()) then "impure function";
+        case SCode.FR_OPERATOR_FUNCTION() then "operator function";
+        case SCode.FR_EXTERNAL_FUNCTION(purity = Absyn.FunctionPurity.PURE()) then "pure external function";
+        case SCode.FR_EXTERNAL_FUNCTION(purity = Absyn.FunctionPurity.IMPURE()) then "impure external function";
+        case SCode.FR_RECORD_CONSTRUCTOR() then "record constructor";
+        case SCode.FR_PARALLEL_FUNCTION() then "parallel function";
+        case SCode.FR_KERNEL_FUNCTION() then "kernel function";
+        else "function";
+      end match;
     case SCode.R_TYPE() then "type";
     case SCode.R_PACKAGE() then "package";
     case SCode.R_ENUMERATION() then "enumeration";

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -72,7 +72,7 @@ constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
   SCode.defaultPrefixes,
   SCode.Encapsulated.ENCAPSULATED(),
   SCode.Partial.NOT_PARTIAL(),
-  SCode.Restriction.R_FUNCTION(SCode.FunctionRestriction.FR_NORMAL_FUNCTION(false)),
+  SCode.Restriction.R_FUNCTION(SCode.FunctionRestriction.FR_NORMAL_FUNCTION(Absyn.FunctionPurity.NO_PURITY())),
   SCode.ClassDef.PARTS({}, {}, {}, {}, {}, {}, {}, NONE()),
   SCode.Comment.COMMENT(NONE(), NONE()),
   AbsynUtil.dummyInfo

--- a/OMCompiler/Compiler/Template/AbsynDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/AbsynDumpTpl.tpl
@@ -127,6 +127,14 @@ match cls
     '<%redecl_str%><%fin_str%><%io_str%><%repl_str%><%enc_str%><%partial_str%>'
 end dumpClassPrefixes;
 
+template dumpPurity(Absyn.FunctionPurity purity)
+::=
+match purity
+  case PURE(__) then "pure "
+  case IMPURE(__) then "impure "
+  case NO_PURITY(__) then ""
+end dumpPurity;
+
 template dumpRestriction(Absyn.Restriction restriction)
 ::=
 match restriction
@@ -141,9 +149,7 @@ match restriction
   case R_PACKAGE(__) then "package"
   case R_FUNCTION(__) then
     let prefix_str = match functionRestriction
-      case FR_NORMAL_FUNCTION(purity = IMPURE()) then "impure "
-      case FR_NORMAL_FUNCTION(purity = PURE()) then "pure "
-      case FR_NORMAL_FUNCTION(purity = NO_PURITY()) then ""
+      case FR_NORMAL_FUNCTION() then dumpPurity(purity)
       case FR_OPERATOR_FUNCTION() then "operator "
       case FR_PARALLEL_FUNCTION() then "parallel "
       case FR_KERNEL_FUNCTION() then "kernel "

--- a/OMCompiler/Compiler/Template/SCodeDumpTpl.tpl
+++ b/OMCompiler/Compiler/Template/SCodeDumpTpl.tpl
@@ -694,9 +694,8 @@ end dumpRestrictionTypeVars;
 template dumpFunctionRestriction(SCode.FunctionRestriction funcRest)
 ::=
 match funcRest
-  case FR_NORMAL_FUNCTION(__) then if isImpure then 'impure function' else 'function'
-  case FR_EXTERNAL_FUNCTION(__) then if isImpure then 'impure function' else 'function'
-
+  case FR_NORMAL_FUNCTION(__) then '<%AbsynDumpTpl.dumpPurity(purity)%>function'
+  case FR_EXTERNAL_FUNCTION(__) then '<%AbsynDumpTpl.dumpPurity(purity)%>function'
   case FR_OPERATOR_FUNCTION(__) then 'operator function'
   case FR_RECORD_CONSTRUCTOR(__) then 'function'
   else errorMsg("SCodeDump.dumpFunctionRestriction: Unknown Function restriction.")

--- a/OMCompiler/Compiler/Template/SCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SCodeTV.mo
@@ -392,10 +392,10 @@ package SCode
 
   uniontype FunctionRestriction
     record FR_NORMAL_FUNCTION "a normal function"
-      Boolean isImpure;
+      Absyn.FunctionPurity purity;
     end FR_NORMAL_FUNCTION;
     record FR_EXTERNAL_FUNCTION "an external function"
-      Boolean isImpure;
+      Absyn.FunctionPurity purity;
     end FR_EXTERNAL_FUNCTION;
 
     record FR_OPERATOR_FUNCTION "an operator function" end FR_OPERATOR_FUNCTION;

--- a/testsuite/flattening/modelica/scodeinst/ConnectExternalObject1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ConnectExternalObject1.mo
@@ -30,13 +30,13 @@ equation
 end ConnectExternalObject1;
 
 // Result:
-// function ExtObj.constructor
+// impure function ExtObj.constructor
 //   output ExtObj obj;
 //
 //   external "C" obj = initObject();
 // end ExtObj.constructor;
 //
-// function ExtObj.destructor
+// impure function ExtObj.destructor
 //   input ExtObj obj;
 //
 //   external "C" destroyObject(obj);

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionExplicit1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionExplicit1.mo
@@ -18,7 +18,7 @@ algorithm
 end ExternalFunctionExplicit1;
 
 // Result:
-// function f
+// impure function f
 //   input Real x;
 //   output Real y;
 //

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionExplicit2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionExplicit2.mo
@@ -18,7 +18,7 @@ algorithm
 end ExternalFunctionExplicit2;
 
 // Result:
-// function f
+// impure function f
 //   input Real[3] x;
 //   output Real y;
 //

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionExplicit3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionExplicit3.mo
@@ -18,7 +18,7 @@ algorithm
 end ExternalFunctionExplicit3;
 
 // Result:
-// function f
+// impure function f
 //   input Real[:] x;
 //   output Real y;
 //

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit1.mo
@@ -18,7 +18,7 @@ algorithm
 end ExternalFunctionImplict1;
 
 // Result:
-// function f
+// impure function f
 //   input Real x;
 //   output Real y;
 //

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit2.mo
@@ -19,7 +19,7 @@ algorithm
 end ExternalFunctionImplicit2;
 
 // Result:
-// function f
+// impure function f
 //   input Real x;
 //   output Real y;
 //   output Real z;

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit3.mo
@@ -19,7 +19,7 @@ algorithm
 end ExternalFunctionImplicit3;
 
 // Result:
-// function f
+// impure function f
 //   input Real[3] x;
 //   input Real[2, 4] y;
 //   output Real z;

--- a/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit4.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalFunctionImplicit4.mo
@@ -18,7 +18,7 @@ algorithm
 end ExternalFunctionImplicit4;
 
 // Result:
-// function f
+// impure function f
 //   input Real x;
 //   output Real[3] y;
 //

--- a/testsuite/flattening/modelica/scodeinst/ExternalObject2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObject2.mo
@@ -25,13 +25,13 @@ model ExternalObject2
 end ExternalObject2;
 
 // Result:
-// function ExtObj.constructor
+// impure function ExtObj.constructor
 //   output ExtObj obj;
 //
 //   external "C" obj = initObject();
 // end ExtObj.constructor;
 //
-// function ExtObj.destructor
+// impure function ExtObj.destructor
 //   input ExtObj obj;
 //
 //   external "C" destroyObject(obj);

--- a/testsuite/flattening/modelica/scodeinst/ExternalObject3.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObject3.mo
@@ -25,14 +25,14 @@ model ExternalObject3
 end ExternalObject3;
 
 // Result:
-// function ExtObj.constructor
+// impure function ExtObj.constructor
 //   input Integer i;
 //   output ExtObj obj;
 //
 //   external "C" obj = initObject();
 // end ExtObj.constructor;
 //
-// function ExtObj.destructor
+// impure function ExtObj.destructor
 //   input ExtObj obj;
 //
 //   external "C" destroyObject(obj);

--- a/testsuite/flattening/modelica/scodeinst/ExternalObject4.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObject4.mo
@@ -25,14 +25,14 @@ model ExternalObject3
 end ExternalObject3;
 
 // Result:
-// function ExternalObject3.ExtObj.constructor
+// impure function ExternalObject3.ExtObj.constructor
 //   input Integer i;
 //   output ExternalObject3.ExtObj obj;
 //
 //   external "C" obj = initObject();
 // end ExternalObject3.ExtObj.constructor;
 //
-// function ExternalObject3.ExtObj.destructor
+// impure function ExternalObject3.ExtObj.destructor
 //   input ExternalObject3.ExtObj obj;
 //
 //   external "C" destroyObject(obj);

--- a/testsuite/flattening/modelica/scodeinst/ExternalObjectVariability1.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExternalObjectVariability1.mo
@@ -24,13 +24,13 @@ model ExternalObjectVariability1
 end ExternalObjectVariability1;
 
 // Result:
-// function ExtObj.constructor
+// impure function ExtObj.constructor
 //   output ExtObj obj;
 //
 //   external "C" obj = initObject();
 // end ExtObj.constructor;
 //
-// function ExtObj.destructor
+// impure function ExtObj.destructor
 //   input ExtObj obj;
 //
 //   external "C" destroyObject(obj);

--- a/testsuite/flattening/modelica/scodeinst/InstanceRestriction2.mo
+++ b/testsuite/flattening/modelica/scodeinst/InstanceRestriction2.mo
@@ -11,7 +11,7 @@ end InstanceRestriction2;
 
 // Result:
 // Error processing file: InstanceRestriction2.mo
-// [flattening/modelica/scodeinst/InstanceRestriction2.mo:7:1-10:25:writable] Error: Cannot instantiate InstanceRestriction2 due to class specialization pure function.
+// [flattening/modelica/scodeinst/InstanceRestriction2.mo:7:1-10:25:writable] Error: Cannot instantiate InstanceRestriction2 due to class specialization function.
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.

--- a/testsuite/flattening/modelica/scodeinst/Ticket5821.mo
+++ b/testsuite/flattening/modelica/scodeinst/Ticket5821.mo
@@ -2,7 +2,7 @@
 // keywords: tests Connections.branch/Connections.uniqueRoot/Connections.uniqueRootIndices
 // status:   correct
 //
-// cflags:   -d=newInst
+// cflags:   -d=newInst --std=3.2
 //
 
 

--- a/testsuite/openmodelica/interactive-API/instantiateFunction.mos
+++ b/testsuite/openmodelica/interactive-API/instantiateFunction.mos
@@ -13,7 +13,7 @@ instantiateModel(Derived.Foo); getErrorString();
 // true
 // ""
 // ""
-// "[openmodelica/interactive-API/instantiateFunction.mo:2:3-4:10:writable] Error: Cannot instantiate Derived.Foo due to class specialization pure function.
+// "[openmodelica/interactive-API/instantiateFunction.mo:2:3-4:10:writable] Error: Cannot instantiate Derived.Foo due to class specialization function.
 // Error: Error occurred while flattening model Derived.Foo
 // "
 // endResult

--- a/testsuite/simulation/modelica/arrays/gc.mos
+++ b/testsuite/simulation/modelica/arrays/gc.mos
@@ -23,39 +23,7 @@ simulate(gctest, numberOfIntervals=2); getErrorString();
 // ""
 // true
 // ""
-// "impure function Modelica.Utilities.Streams.close \"Close file\"
-//   input String fileName \"Name of the file that shall be closed\";
-//
-//   external \"C\" ModelicaStreams_closeFile(fileName);
-// end Modelica.Utilities.Streams.close;
-//
-// function Modelica.Utilities.Streams.countLines \"Returns the number of lines in a file\"
-//   input String fileName \"Name of the file that shall be read\";
-//   output Integer numberOfLines \"Number of lines in file\";
-//
-//   external \"C\" numberOfLines = ModelicaInternal_countLines(fileName);
-// end Modelica.Utilities.Streams.countLines;
-//
-// impure function Modelica.Utilities.Streams.readFile \"Read content of a file and return it in a vector of strings\"
-//   input String fileName \"Name of the file that shall be read\";
-//   output String[Modelica.Utilities.Streams.countLines(fileName)] stringVector \"Content of file\";
-// algorithm
-//   for i in 1:size(stringVector, 1) loop
-//     stringVector[i] := Modelica.Utilities.Streams.readLine(fileName, i)[1];
-//   end for;
-//   Modelica.Utilities.Streams.close(fileName);
-// end Modelica.Utilities.Streams.readFile;
-//
-// function Modelica.Utilities.Streams.readLine \"Reads a line of text from a file and returns it in a string\"
-//   input String fileName \"Name of the file that shall be read\";
-//   input Integer lineNumber(min = 1) \"Number of line to read\";
-//   output String string \"Line of text\";
-//   output Boolean endOfFile \"If true, end-of-file was reached when trying to read line\";
-//
-//   external \"C\" string = ModelicaInternal_readLine(fileName, lineNumber, endOfFile);
-// end Modelica.Utilities.Streams.readLine;
-//
-// class gctest
+// "class gctest
 //   String str[1];
 //   String str[2];
 //   String str[3];
@@ -73,7 +41,7 @@ simulate(gctest, numberOfIntervals=2); getErrorString();
 //   String str[15];
 //   String s;
 // equation
-//   str = Modelica.Utilities.Streams.readFile(\"gc.mo\");
+//   str = {\"model gctest\", \"  String str[:] = Modelica.Utilities.Streams.readFile(\\\"gc.mo\\\"); // Reads itself\", \"  String s;\", \"algorithm\", \"  for i in 1:1000 loop\", \"    // print(String(i) + \\\"\\\\n\\\");\", \"    s := String(i) + \\\"\\\\n\\\";\", \"    if noEvent(i == 1000) then print(s); end if;\", \"    for j in 1:size(str, 1) loop\", \"      // print(str[j] + \\\"\\\\n\\\");\", \"     s := str[j] + \\\"\\\\n\\\";\", \"     if  noEvent(i == 1000) then print(s); end if;\", \"    end for;\", \"  end for;\", \"end gctest;\"};
 // algorithm
 //   for i in 1:1000 loop
 //     s := String(i, 0, true) + \"


### PR DESCRIPTION
- Use `Absyn.FunctionPurity` in `SCode.Restriction` instead of a boolean to allow differentiating between pure, impure, and no prefix.
- Fix incorrect condition for considering external functions with no prefix to be impure or not.