### PR TITLE
Fix warnings due to ambiguous endl usage

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
@@ -179,7 +179,7 @@ namespace IAEX
       setStyle( style );
     else
     {
-      std::cout << "Can't set style, style name: " << stylename.toStdString() << " is not valid" << endl;
+      std::cout << "Can't set style, style name: " << stylename.toStdString() << " is not valid" << std::endl;
     }
   }
 
@@ -274,7 +274,7 @@ namespace IAEX
     QRegExp expression( "InitializationCell|CellTags|FontSlant|TextAlignment|TextJustification|FontSize|FontWeight|FontFamily|PageWidth|CellMargins|CellDingbat|ImageSize|ImageMargins|ImageRegion|OMNotebook_Margin|OMNotebook_Padding|OMNotebook_Border" );
     if( 0 > r->attribute().indexOf( expression ))
     {
-      std::cout << "[NEW] Rule <" << r->attribute().toStdString() << "> <" << r->value().toStdString() << ">" << endl;
+      std::cout << "[NEW] Rule <" << r->attribute().toStdString() << "> <" << r->value().toStdString() << ">" << std::endl;
     }
     else
     {
@@ -282,25 +282,25 @@ namespace IAEX
       {
         QRegExp fontslant( "Italic" );
         if( 0 > r->value().indexOf( fontslant ))
-          std::cout << "[NEW] Rule Value <FontSlant>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <FontSlant>, VALUE: " << r->value().toStdString() << std::endl;
       }
       else if( r->attribute() == "TextAlignment" )
       {
         QRegExp textalignment( "Right|Left|Center|Justify" );
         if( 0 > r->value().indexOf( textalignment ))
-          std::cout << "[NEW] Rule Value <TextAlignment>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <TextAlignment>, VALUE: " << r->value().toStdString() << std::endl;
       }
       else if( r->attribute() == "TextJustification" )
       {
         QRegExp textjustification( "1|0" );
         if( 0 > r->value().indexOf( textjustification ))
-          std::cout << "[NEW] Rule Value <TextJustification>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <TextJustification>, VALUE: " << r->value().toStdString() << std::endl;
       }
       else if( r->attribute() == "FontWeight" )
       {
         QRegExp fontweight( "Bold|Plain" );
         if( 0 > r->value().indexOf( fontweight ))
-          std::cout << "[NEW] Rule Value <FontWeight>, VALUE: " << r->value().toStdString() << endl;
+          std::cout << "[NEW] Rule Value <FontWeight>, VALUE: " << r->value().toStdString() << std::endl;
       }
     }
 
@@ -869,12 +869,12 @@ namespace IAEX
 
   void Cell::printCell(Cell *current)
   {
-    std::cout << "This: " << current << endl
-      << "Parent: " << current->parentCell() << endl
-      << "Child: " << current->child() << endl
-      << "Last: " << current->last() << endl
-      << "Next: " << current->next() << endl
-      << "Prev: " << current->previous() << endl;
+    std::cout << "This: " << current << std::endl
+      << "Parent: " << current->parentCell() << std::endl
+      << "Child: " << current->child() << std::endl
+      << "Last: " << current->last() << std::endl
+      << "Next: " << current->next() << std::endl
+      << "Prev: " << current->previous() << std::endl;
   }
 
   void Cell::printSurrounding(Cell *current)

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellapplication.cpp
@@ -227,7 +227,7 @@ namespace IAEX
         }
         else
         {
-          std::cout << "File not found: " << fileToOpen.toStdString() << endl;
+          std::cout << "File not found: " << fileToOpen.toStdString() << std::endl;
           open(QString());
         }
       }
@@ -255,8 +255,8 @@ namespace IAEX
             open( "DrModelica/DrModelica.onb", READMODE_NORMAL, 1);
           else
           {
-            std::cout << "Unable to find (1): " << drmodelica.toStdString() << endl;
-            std::cout << "Unable to find (2): DrModelica/DrModelica.onb" << endl;
+            std::cout << "Unable to find (1): " << drmodelica.toStdString() << std::endl;
+            std::cout << "Unable to find (2): DrModelica/DrModelica.onb" << std::endl;
             open(QString());
           }
         }
@@ -525,8 +525,8 @@ namespace IAEX
   */
   void CellApplication::convertDrModelica()
   {
-    std::cout << "CONVERTING DRMODELICA" << endl;
-    std::cout << "---------------------" << endl << endl;
+    std::cout << "CONVERTING DRMODELICA" << std::endl;
+    std::cout << "---------------------" << std::endl << std::endl;
 
     // load from
     QString path = "C:/OpenModelica132/DrModelicaConv";
@@ -553,7 +553,7 @@ namespace IAEX
         for( int j = 0; j < fileList.size(); ++j )
         {
           std::cout << "Loading: " << fileDir.absolutePath().toStdString() +
-            std::string( "/" ) + fileList.at(j).toStdString() << endl;
+            std::string( "/" ) + fileList.at(j).toStdString() << std::endl;
 
           Document *d = new CellDocument( this, fileDir.absolutePath() +
             QString( "/" ) + fileList.at(j), READMODE_CONVERTING_ONB );
@@ -564,13 +564,13 @@ namespace IAEX
 
           std::cout << "Saving: " << dir.absolutePath().toStdString() +
             std::string( "/" ) + dirList.at(i).toStdString() + std::string( "/" ) +
-            filename.toStdString() << endl;
+            filename.toStdString() << std::endl;
 
           SaveDocumentCommand command( d, dir.absolutePath() +
             QString( "/" ) + dirList.at(i) + QString( "/" ) + filename );
           this->commandCenter()->executeCommand( &command );
 
-          std::cout << "DONE!" << endl << endl;
+          std::cout << "DONE!" << std::endl << std::endl;
 
           // delete file
           delete d;
@@ -579,7 +579,7 @@ namespace IAEX
       }
      }
 
-    std::cout << "CONVERTION DONE !!!" << endl;
+    std::cout << "CONVERTION DONE !!!" << std::endl;
   }
 
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellcommandcenter.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellcommandcenter.cpp
@@ -112,7 +112,7 @@ namespace IAEX
 
       for(;i!= storage_.end();++i)
       {
-      diskstorage << (*i)->commandName().toStdString() << endl;
+      diskstorage << (*i)->commandName().toStdString() << std::endl;
       }
    }
 }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/celldocument.cpp
@@ -701,7 +701,7 @@ namespace IAEX
       image = images_[name];
     else
     {
-      //cout << "Could not find image: " << name.toStdString() << endl;
+      //std::cout << "Could not find image: " << name.toStdString() << std::endl;
       image = new QImage();
     }
 
@@ -816,11 +816,11 @@ namespace IAEX
 
 #ifndef QT_NO_DEBUG_OUTPUT
 
-          std::cout << "*********************************************" << endl;
-          std::cout << "SCROLL TOP: " << scrollTop << endl;
-          std::cout << "SCROLL BOTTOM: " << scrollBottom << endl;
-          std::cout << "CELL CURSOR: " << pos << endl;
-          std::cout << "CELL HEIGHT: " << height << endl;
+          std::cout << "*********************************************" << std::endl;
+          std::cout << "SCROLL TOP: " << scrollTop << std::endl;
+          std::cout << "SCROLL BOTTOM: " << scrollBottom << std::endl;
+          std::cout << "CELL CURSOR: " << pos << std::endl;
+          std::cout << "CELL HEIGHT: " << height << std::endl;
 #endif
 
 
@@ -837,7 +837,7 @@ namespace IAEX
             scrollBottom > (scroll_->widget()->height() - 2 ) )
           {
 #ifndef QT_NO_DEBUG_OUTPUT
-            std::cout << "END OF DOCUMENT, widget height(" << scroll_->widget()->height() << ")" << endl;
+            std::cout << "END OF DOCUMENT, widget height(" << scroll_->widget()->height() << ")" << std::endl;
 #endif
             // 2006-03-03 AF, ignore if cursor at end of document
             return;
@@ -854,7 +854,7 @@ namespace IAEX
               pos = 0;
 
             // set new scrollvalue
-            //cout << "UP: old(" << scroll_->verticalScrollBar()->value() << "), new(" << pos << ")" << endl;
+            //std::cout << "UP: old(" << scroll_->verticalScrollBar()->value() << "), new(" << pos << ")" << std::endl;
             scroll_->verticalScrollBar()->setValue( pos );
           }
           // DOWN
@@ -873,7 +873,7 @@ namespace IAEX
             if( pos >= scroll_->verticalScrollBar()->maximum() )
             {
 #ifndef QT_NO_DEBUG_OUTPUT
-              std::cout << "more then max!" << endl;
+              std::cout << "more then max!" << std::endl;
 #endif
               scroll_->verticalScrollBar()->triggerAction( QAbstractSlider::SliderToMaximum );
               //pos = scroll_->verticalScrollBar()->maximum();
@@ -886,7 +886,7 @@ namespace IAEX
             {
               // set new scrollvalue
 #ifndef QT_NO_DEBUG_OUTPUT
-              std::cout << "DOWN: old(" << scroll_->verticalScrollBar()->value() << "), new(" << pos << ")" << endl;
+              std::cout << "DOWN: old(" << scroll_->verticalScrollBar()->value() << "), new(" << pos << ")" << std::endl;
 #endif
               scroll_->verticalScrollBar()->setValue( pos );
             }

--- a/OMNotebook/OMNotebook/OMNotebookGUI/commandcompletion.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/commandcompletion.cpp
@@ -181,9 +181,9 @@ namespace IAEX
             currentList_->append( commandList.at(i) );
         }
 
-        //cout << "Found commands (" << command.toStdString() << "):" << endl;
+        //std::cout << "Found commands (" << command.toStdString() << "):" << std::endl;
         //for( int i = 0; i < currentList_->size(); ++i )
-        //  std::cout << " >" << currentList_->at(i).toStdString() << endl;
+        //  std::cout << " >" << currentList_->at(i).toStdString() << std::endl;
 
         // found one or more commands that match the word
         if( currentList_->size() > 0 )

--- a/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/graphcell.cpp
@@ -1292,7 +1292,7 @@ namespace IAEX {
     }
     catch(...)
     {
-      // qDebug() << "setReadOnly: crash" << endl;
+      // qDebug() << "setReadOnly: crash" << Qt::endl;
     }
   }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/indent.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/indent.cpp
@@ -269,7 +269,7 @@ QString Indent::indentedText(QMap<int, IndentationState*>* states) {
     //}
 
     ism.newToken(current, next);
-    //qDebug() << ism.state << ", " << ism.level << ", " << ism.lMod << endl;
+    //qDebug() << ism.state << ", " << ism.level << ", " << ism.lMod << Qt::endl;
 
     if(current == "<newLine>") {
       current = "\n";

--- a/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/inputcell.cpp
@@ -1114,7 +1114,7 @@ namespace IAEX
       emit textChanged(true);
     }
     else
-      std::cout << "Not delegate on inputcell" << endl;
+      std::cout << "Not delegate on inputcell" << std::endl;
 
     input_->blockSignals(false);
     output_->blockSignals(false);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
@@ -702,7 +702,7 @@ namespace IAEX {
     }
     catch(...)
     {
-      // qDebug() << "setReadOnly: crash" << endl;
+      // qDebug() << "setReadOnly: crash" << Qt::endl;
     }
   }
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/stripstring.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/stripstring.h
@@ -194,7 +194,7 @@ public:
           str.insert( index, "font-weight:600; " );
         // OTHER
         else
-          std::cout << "[UNKNOWN] Rule::FontWeight::Value: " << (*r_iter).second.c_str() << endl;
+          std::cout << "[UNKNOWN] Rule::FontWeight::Value: " << (*r_iter).second.c_str() << std::endl;
       }
       // FONT SLANT
       else if( (*r_iter).first == "FontSlant" )
@@ -206,7 +206,7 @@ public:
           str.insert( index, "font-style:italic; " );
         // OTHER
         else
-          std::cout << "[UNKNOWN] Rule::FontSlant::Value: " << (*r_iter).second.c_str() << endl;
+          std::cout << "[UNKNOWN] Rule::FontSlant::Value: " << (*r_iter).second.c_str() << std::endl;
       }
       // FONT COLOR
       else if( (*r_iter).first == "FontColor" )
@@ -260,10 +260,10 @@ public:
             str.insert( index, color.toStdString() );
           }
           else
-            std::cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << endl;
+            std::cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << std::endl;
         }
         else
-          std::cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << endl;
+          std::cout << "[UNKNOWN] StyleBox::Rule::RBGColor::Value: " << (*r_iter).second.c_str() << std::endl;
       }
       // FONT VARIATIONS
       else if( (*r_iter).first == "FontVariations" )
@@ -272,7 +272,7 @@ public:
       }
       // OTHER / MISC
       else
-        std::cout << "[UNKNOWN] StyleBox::Rule: " << (*r_iter).first.c_str() << " - " << (*r_iter).second.c_str() << endl;
+        std::cout << "[UNKNOWN] StyleBox::Rule: " << (*r_iter).first.c_str() << " - " << (*r_iter).second.c_str() << std::endl;
     }
 
     return str;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcell.cpp
@@ -741,7 +741,7 @@ namespace IAEX
   {
     int height = text_->document()->documentLayout()->documentSize().toSize().height();
 
-    //cout << "Height: " << height << endl;
+    //std::cout << "Height: " << height << std::endl;
 
     if( height < 0 )
       height = 30;

--- a/OMNotebook/OMNotebook/OMNotebookGUI/updatelinkvisitor.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/updatelinkvisitor.cpp
@@ -121,8 +121,8 @@ namespace IAEX
           QString newLink = newDir_.relativeFilePath( oldDir_.absoluteFilePath( oldLink ));
           html.replace( startPos, endPos - startPos, newLink );
 
-          //cout << "OLD LINK: " << oldLink.toStdString() << endl;
-          //cout << "NEW LINK: " << newLink.toStdString() << endl;
+          //std::cout << "OLD LINK: " << oldLink.toStdString() << std::endl;
+          //std::cout << "NEW LINK: " << newLink.toStdString() << std::endl;
 
           // set pos to the end of the link
           pos = startPos + newLink.length();

--- a/OMNotebook/OMNotebook/OMNotebookGUI/xmlparser.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/xmlparser.cpp
@@ -438,7 +438,7 @@ namespace IAEX
             while (done > -1)
             {
               // int numX = rx.numCaptures(); QString s1 = rx.cap(1),s2 = rx.cap(2);
-              // std::cout << numX << " " << s1.toStdString() << "-" << s2.toStdString() << endl;
+              // std::cout << numX << " " << s1.toStdString() << "-" << s2.toStdString() << std::endl;
               text = text.replace(rx, rx.cap(1) + QString::fromAscii("/") + rx.cap(2));
               done = rx.indexIn(text);
             }

--- a/OMShell/OMShell/OMShellGUI/commandcompletion.cpp
+++ b/OMShell/OMShell/OMShellGUI/commandcompletion.cpp
@@ -166,9 +166,9 @@ namespace IAEX
             currentList_->append( commandList_.at(i) );
         }
 
-        //cout << "Found commands (" << command.toStdString() << "):" << endl;
+        //std::cout << "Found commands (" << command.toStdString() << "):" << std::endl;
         //for( int i = 0; i < currentList_->size(); ++i )
-        //  cout << " >" << currentList_->at(i).toStdString() << endl;
+        //  std::cout << " >" << currentList_->at(i).toStdString() << std::endl;
 
         // found one or more commands that match the word
         if( currentList_->size() > 0 )

--- a/OMShell/OMShell/OMShellGUI/oms.cpp
+++ b/OMShell/OMShell/OMShellGUI/oms.cpp
@@ -152,9 +152,9 @@ bool MyTextEdit::insideCommandSign()
     int cursorPos = textCursor().position();
     if( blockStartPos <= cursorPos && cursorPos < (blockStartPos+3) && signPos == 0)
     {
-      std::cerr << "Inside Command Sign" << endl;
+      std::cerr << "Inside Command Sign" << std::endl;
       std::cerr << "BlockStart: " << blockStartPos <<
-        ", Cursor: " << cursorPos << endl << endl;
+        ", Cursor: " << cursorPos << std::endl << std::endl;
 
       return true;
     }
@@ -162,7 +162,7 @@ bool MyTextEdit::insideCommandSign()
       return false;
   }
   else
-    std::cerr << "Not a valid QTextBlock (insideCommandSign)" << endl;
+    std::cerr << "Not a valid QTextBlock (insideCommandSign)" << std::endl;
 
   return true;
 }
@@ -181,7 +181,7 @@ bool MyTextEdit::startOfCommandSign()
       return false;
   }
   else
-    std::cerr << "Not a valid QTextBlock (startOfCommandSign)" << endl;
+    std::cerr << "Not a valid QTextBlock (startOfCommandSign)" << std::endl;
 
   return true;
 }
@@ -477,7 +477,7 @@ void OMS::returnPressed()
     }
     else
     {
-      std::cerr << "Not a valid QTextBlock (returnPressed)" << endl;
+      std::cerr << "Not a valid QTextBlock (returnPressed)" << std::endl;
       break;
     }
   }
@@ -627,7 +627,7 @@ void OMS::goHome( bool shift )
     moshEdit_->setTextCursor( cursor_ );
   }
   else
-    std::cout << "Not a valid QTextBlock (selectCommandLine)" << endl;
+    std::cout << "Not a valid QTextBlock (selectCommandLine)" << std::endl;
 }
 
 void OMS::codeCompletion( bool same )
@@ -686,7 +686,7 @@ void OMS::selectCommandLine()
     }
     else
     {
-      std::cout << "Not a valid QTextBlock (selectCommandLine)" << endl;
+      std::cout << "Not a valid QTextBlock (selectCommandLine)" << std::endl;
       break;
     }
   }


### PR DESCRIPTION
- Prefix `endl` with `std::` to avoid having it resolve to (the deprecated) `QTextStreamFunctions::endl`.