### PR TITLE
fail-fast fix for FMUs that crash

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -377,7 +377,7 @@ fmi2Status internalEventIteration(fmi2Component c, fmi2EventInfo *eventInfo)
   fmi2Status status = fmi2OK;
   eventInfo->newDiscreteStatesNeeded = fmi2True;
   eventInfo->terminateSimulation     = fmi2False;
-  while (eventInfo->newDiscreteStatesNeeded && !eventInfo->terminateSimulation) {
+  while (eventInfo->newDiscreteStatesNeeded && !eventInfo->terminateSimulation && status != fmi2Error) {
     status = internalEventUpdate((ModelInstance *)c, eventInfo);
   }
   return status;


### PR DESCRIPTION
### Related Issues
#11229

### Purpose
If an FMU crashes in its internalEventUpdate routine, it tends to run into an infinite while loop.
This patch tries to fix this problem, such that the FMU actually is able to return "fmi2error" to its caller.

### Approach
added a fail-fast exit condition to the offending while loop.