### PR TITLE
Fix for memory leak in fmi2GetFMUstate

### DIFF
--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -1362,6 +1362,10 @@ fmi2Status fmi2GetFMUstate(fmi2Component c, fmi2FMUstate* FMUstate)
   //printRingBufferSimulationData(fmudata->simulationData, fmudata); // original ringBuffer data
   //printRingBufferSimulationData(internal_state->simulationData, fmudata); // copied ringBuffer data
 
+  /* release previous fmu state if existent */
+  /* TODO: ideally, previous state's memory should be re-used instead of re-allocation */
+  if (*FMUstate != NULL) fmi2FreeFMUstate(c, FMUstate);
+
   // return the fmu state
   *FMUstate = (fmi2FMUstate) internal_state;
   return fmi2OK;


### PR DESCRIPTION
### Related Issues
#11231

### Purpose
Resolve memory leak in fmi2GetFMUstate

### Approach
De-allocate old FMUstate object before updating reference with newly allocated object.
