### PR TITLE
Fix unassigned variable in Inst.lookupRootClass

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -354,6 +354,7 @@ algorithm
       ErrorExt.rollBack(getInstanceName());
     else
       ErrorExt.delCheckpoint(getInstanceName());
+      fail();
     end try;
   end try;
 


### PR DESCRIPTION
Fixes #11237