### PR TITLE
Fix parsing of within followed by comment and EOF

### DIFF
--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -234,7 +234,7 @@ stored_definition returns [void* ast]
 #endif
         }
       }
-      if (!listEmpty(commentAfter) && !listEmpty(cl)) {
+      if (!listEmpty(commentAfter) && cl && !listEmpty(cl)) {
         void *last = cl;
         while (!listEmpty(MMC_CDR(last))) {
           last = MMC_CDR(last);

--- a/testsuite/openmodelica/parser/Makefile
+++ b/testsuite/openmodelica/parser/Makefile
@@ -50,7 +50,8 @@ ReloadClass.mos \
 SimpleIntegrator4.mo \
 WildLexerModelica.mo \
 WildLexerMetaModelica.mo \
-ParseModel.mos
+ParseModel.mos \
+WithinComment1.mo
 
 FAILINGTESTFILES= \
 

--- a/testsuite/openmodelica/parser/WithinComment1.mo
+++ b/testsuite/openmodelica/parser/WithinComment1.mo
@@ -1,0 +1,18 @@
+// name: WithinComment
+// keywords:
+// status: incorrect
+// cflags: -d=-newInst
+//
+// Checks that the parser doesn't crash on a within-statement followed by a
+// commment and nothing else.
+//
+
+within P;//
+
+// Result:
+// Error processing file: WithinComment1.mo
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult


### PR DESCRIPTION
- Fix use of null pointer when parsing a within-statement followed by a comment and nothing else.

Fixes #11240