### PR TITLE
Fix handling of multi segment directory creation (#11257)

### DIFF
--- a/OMCompiler/Compiler/Util/Util.mo
+++ b/OMCompiler/Compiler/Util/Util.mo
@@ -1395,6 +1395,8 @@ algorithm
 
     case _
       equation
+        // this is because System.dirname(".openmodelica") != ".openmodelica"
+        // System.dirname(".openmodelica") = "." on Windows!
         true = stringEqual(parentDir, System.dirname(parentDir));
         b = System.createDirectory(inString);
       then b;
@@ -1421,9 +1423,14 @@ protected
   String parentDir;
   Boolean parentDirExists;
 algorithm
-  parentDir := System.dirname(inString);
-  parentDirExists := System.directoryExists(parentDir);
-  outBool := createDirectoryTreeH(inString,parentDir,parentDirExists);
+  // if is already there, just retrun true!
+  if System.directoryExists(inString) then
+    outBool := true;
+  else
+    parentDir := System.dirname(inString);
+    parentDirExists := System.directoryExists(parentDir);
+    outBool := createDirectoryTreeH(inString,parentDir,parentDirExists);
+  end if;
 end createDirectoryTree;
 
 public function nextPowerOf2

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -945,7 +945,10 @@ extern int SystemImpl__createDirectory(const char *str)
 #endif
   if (rv == -1)
   {
-    return 0;
+    if (errno == EEXIST) // directory exists, return success!
+      return 1;
+    else
+      return 0;
   }
   else
   {

--- a/libraries/install-index.mos
+++ b/libraries/install-index.mos
@@ -7,10 +7,12 @@ setModelicaPath(OpenModelica.Scripting.cd() + "/.openmodelica/libraries/");
 getModelicaPath();
 echo(false);
 OpenModelica.Scripting.mkdir(".openmodelica");
-if not OpenModelica.Scripting.mkdir(".openmodelica/libraries/") then
-  print("\nmkdir failed\n");
-  print(getErrorString());
-  exit(1);
+if not OpenModelica.Scripting.directoryExists(".openmodelica/libraries/") then
+  if not OpenModelica.Scripting.mkdir(".openmodelica/libraries/") then
+    print("\nmkdir failed\n");
+    print(getErrorString());
+    exit(1);
+  end if;
 end if;
 vers:=OpenModelica.Scripting.getAvailablePackageVersions(Modelica, "3.2.3");
 if size(vers,1) <> 1 then


### PR DESCRIPTION
- mkdir now returns true when the directory exists
- Util.createDirectories checks if the directory exists and returns true if so
- libraries/install-index.mos checks if directory exists before creating it

