### PR TITLE
Reduce the size of connection nodes

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -757,7 +757,7 @@ void LineAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
                     painter->save();
                     painter->setPen(Qt::NoPen);
                     painter->setBrush(QBrush(mLineColor));
-                    painter->drawEllipse(intersectionPoint, 1, 1);
+                    painter->drawEllipse(intersectionPoint, 0.75, 0.75);
                     painter->restore();
                   }
                 }
@@ -791,10 +791,10 @@ void LineAnnotation::drawAnnotation(QPainter *painter, bool scene)
 
   // draw highlight for connections
   if (mLineType == LineAnnotation::ConnectionType) {
-    qreal strokeWidth = 2.0;
+    qreal strokeWidth = 1.0;
     QColor strokeColor = Qt::white;
     if (isSelected()) {
-      strokeWidth = 3.0;
+      strokeWidth = 2.0;
       strokeColor = QColor(255, 255, 128);
     }
 


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/OpenModelica/OpenModelica/issues/4645#issuecomment-1721903541

@casella I made the nodes 25% smaller. They have to be the big enough to cover the white outline of the connection as mentioned by @ceraolo in https://github.com/OpenModelica/OpenModelica/issues/4645#issuecomment-1722122137

Note that I also reduced the size of connection outline.