### PR TITLE
Nb expand in start val

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -84,6 +84,7 @@ public
       case Expression.CALL()     then expandCall(exp.call, exp);
       case Expression.SIZE()     then expandSize(exp);
       case Expression.BINARY()   then expandBinary(exp, exp.operator);
+      case Expression.MULTARY()  then expand(SimplifyExp.splitMultary(exp), backend);
       case Expression.UNARY()    then expandUnary(exp);
       case Expression.LBINARY()  then expandLogicalBinary(exp);
       case Expression.LUNARY()   then expandLogicalUnary(exp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1481,6 +1481,8 @@ uniontype InstNode
         then referenceEq(Pointer.access(node1.cls), Pointer.access(node2.cls));
       case (COMPONENT_NODE(), COMPONENT_NODE())
         then referenceEq(Pointer.access(node1.component), Pointer.access(node2.component));
+      case (VAR_NODE(), VAR_NODE())
+        then referenceEq(Pointer.access(node1.varPointer), Pointer.access(node2.varPointer));
       // Other nodes like ref nodes might be equal, but we neither know nor care.
       else false;
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
@@ -808,7 +808,6 @@ public
       case Op.MUL_ARRAY_SCALAR  then true;
       else false;
     end match;
-
   end isCommutative;
 
   function isSoftCommutative

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -622,10 +622,10 @@ function combineBinaries
    --> MULTARY({2, 3, x}, {y^2}, *)"
   input output FlatModel flatModel;
 algorithm
-  flatModel.variables := list(Variable.mapExp(var, SimplifyExp.combineBinaries) for var in flatModel.variables);
-  flatModel.equations := list(Equation.mapExp(eqn, SimplifyExp.combineBinaries) for eqn in flatModel.equations);
-  flatModel.initialEquations := list(Equation.mapExp(eqn, SimplifyExp.combineBinaries) for eqn in flatModel.initialEquations);
-  flatModel.algorithms := list(Algorithm.mapExp(alg, SimplifyExp.combineBinaries) for alg in flatModel.algorithms);
+  flatModel.variables         := list(Variable.mapExp(var, SimplifyExp.combineBinaries) for var in flatModel.variables);
+  flatModel.equations         := list(Equation.mapExp(eqn, SimplifyExp.combineBinaries) for eqn in flatModel.equations);
+  flatModel.initialEquations  := list(Equation.mapExp(eqn, SimplifyExp.combineBinaries) for eqn in flatModel.initialEquations);
+  flatModel.algorithms        := list(Algorithm.mapExp(alg, SimplifyExp.combineBinaries) for alg in flatModel.algorithms);
   flatModel.initialAlgorithms := list(Algorithm.mapExp(alg, SimplifyExp.combineBinaries) for alg in flatModel.initialAlgorithms);
 end combineBinaries;
 


### PR DESCRIPTION
### Related Issues
solves #9986

### Purpose
allows proper scalarization of constant start values/bindings to be used for initialization

### Approach

 [NF] add a way to split up multaries
 - use the split up multaries in expand expression module to parse multaries

 [NF] add referenceEq for var_nodes 
