### PR TITLE
Do the collision detection when the model is modified

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.h
@@ -156,6 +156,8 @@ public:
   void updateLine();
 
   static QColor findLineColorForConnection(Element *pComponent);
+  void clearCollidingConnections();
+  void handleCollidingConnections();
 private:
   ModelInstance::Line *mpLine;
 
@@ -185,6 +187,8 @@ protected:
   QString mAlpha;
   oms_connection_type_enu_t mOMSConnectionType;
   bool mActiveState;
+  QVector<Element*> mCollidingConnectorElements;
+  QVector<LineAnnotation*> mCollidingConnections;
 public slots:
   void handleComponentMoved(bool positionChanged);
   void updateConnectionAnnotation();

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -359,6 +359,9 @@ void UpdateComponentTransformationsCommand::redoInternal()
   mpComponent->setPos(0, 0);
   mpComponent->setFlag(QGraphicsItem::ItemSendsGeometryChanges, state);
   mpComponent->setTransform(mNewTransformation.getTransformationMatrix());
+  if (mpComponent->getGraphicsView()->getViewType() == StringHandler::Diagram && mpComponent->getGraphicsView()->getModelWidget()->isNewApi()) {
+    mpComponent->getGraphicsView()->handleCollidingConnections();
+  }
   mpComponent->mTransformation = mNewTransformation;
   mpComponent->emitTransformChange(mPositionChanged);
   mpComponent->emitTransformHasChanged();
@@ -397,6 +400,9 @@ void UpdateComponentTransformationsCommand::undo()
   mpComponent->setPos(0, 0);
   mpComponent->setFlag(QGraphicsItem::ItemSendsGeometryChanges, state);
   mpComponent->setTransform(mOldTransformation.getTransformationMatrix());
+  if (mpComponent->getGraphicsView()->getViewType() == StringHandler::Diagram && mpComponent->getGraphicsView()->getModelWidget()->isNewApi()) {
+    mpComponent->getGraphicsView()->handleCollidingConnections();
+  }
   mpComponent->mTransformation = mOldTransformation;
   mpComponent->emitTransformChange(mPositionChanged);
   mpComponent->emitTransformHasChanged();

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -2597,7 +2597,9 @@ LibraryTreeItem* LibraryTreeModel::createLibraryTreeItemImpl(QString name, Libra
       // load the LibraryTreeItem pixmap
       loadLibraryTreeItemPixmap(pLibraryTreeItem);
     }
-    emit modelStateChanged(nameStructure);
+    if (!isCreatingAutoLoadedLibrary()) {
+      emit modelStateChanged(nameStructure);
+    }
   }
   return pLibraryTreeItem;
 }
@@ -5317,8 +5319,10 @@ void LibraryWidget::handleAutoLoadedLibrary()
   if (isLoadingLibraries()) {
     mAutoLoadedLibrariesTimer.start();
   } else {
+    mpLibraryTreeModel->setCreatingAutoLoadedLibrary(true);
     mpLibraryTreeModel->loadDependentLibraries(mAutoLoadedLibrariesList);
     mAutoLoadedLibrariesList.clear();
+    mpLibraryTreeModel->setCreatingAutoLoadedLibrary(false);
   }
 }
 

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -333,10 +333,14 @@ public:
   void createLibraryTreeItems(LibraryTreeItem *pLibraryTreeItem);
   void unloadFileChildren(LibraryTreeItem *pLibraryTreeItem);
   void emitModelStateChanged(const QString &name) {emit modelStateChanged(name);}
+  bool isCreatingAutoLoadedLibrary() const {return mCreatingAutoLoadedLibrary;}
+  void setCreatingAutoLoadedLibrary(bool creatingAutoLoadedLibrary) {mCreatingAutoLoadedLibrary = creatingAutoLoadedLibrary;}
 private:
   LibraryWidget *mpLibraryWidget;
   LibraryTreeItem *mpRootLibraryTreeItem;
   QList<LibraryTreeItem*> mNonExistingLibraryTreeItemsList;
+  bool mCreatingAutoLoadedLibrary = false;
+
   QModelIndex libraryTreeItemIndexHelper(const LibraryTreeItem *pLibraryTreeItem, const LibraryTreeItem *pParentLibraryTreeItem, const QModelIndex &parentIndex) const;
   LibraryTreeItem* getLibraryTreeItemFromFileHelper(LibraryTreeItem *pLibraryTreeItem, QString fileName, int lineNumber);
   void readLibraryTreeItemClassTextFromText(LibraryTreeItem *pLibraryTreeItem, QString contents);

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -697,6 +697,22 @@ void GraphicsView::drawInitialStates(ModelInstance::Model *pModelInstance, bool 
   }
 }
 
+/*!
+ * \brief GraphicsView::handleCollidingConnections
+ * Detect the colliding connections for the diagram view.
+ */
+void GraphicsView::handleCollidingConnections()
+{
+  // First clear the colliding connector elements and connections.
+  foreach (LineAnnotation *pConnectionLineAnnotation, mConnectionsList) {
+    pConnectionLineAnnotation->clearCollidingConnections();
+  }
+
+  foreach (LineAnnotation *pConnectionLineAnnotation, mConnectionsList) {
+    pConnectionLineAnnotation->handleCollidingConnections();
+  }
+}
+
 bool GraphicsView::isCreatingShape()
 {
   return isCreatingLineShape() ||
@@ -2280,6 +2296,7 @@ void GraphicsView::removeOutOfSceneShapes()
 void GraphicsView::removeConnectionsFromScene()
 {
   foreach (LineAnnotation *pConnectionLineAnnotation, mConnectionsList) {
+    pConnectionLineAnnotation->clearCollidingConnections();
     removeConnectionDetails(pConnectionLineAnnotation);
     removeItem(pConnectionLineAnnotation);
     addConnectionToOutOfSceneList(pConnectionLineAnnotation);
@@ -5913,6 +5930,7 @@ void ModelWidget::drawModel(const ModelInfo &modelInfo)
   clearDependsOnModels();
   disconnect(MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel(), SIGNAL(modelStateChanged(QString)), this, SLOT(updateModelIfDependsOn(QString)));
   drawModelIconDiagram(mpModelInstance, false, modelInfo);
+  mpDiagramGraphicsView->handleCollidingConnections();
 }
 
 void ModelWidget::drawModelIconDiagram(ModelInstance::Model *pModelInstance, bool inherited, const ModelInfo &modelInfo)
@@ -7906,7 +7924,7 @@ void ModelWidget::processPendingModelUpdate()
  */
 void ModelWidget::updateModelIfDependsOn(const QString &modelName)
 {
-  if (dependsOnModel(modelName)) {
+  if (mDiagramViewLoaded && dependsOnModel(modelName)) {
     reDrawModelWidget(createModelInfo());
   }
 }

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -192,6 +192,7 @@ public:
   void drawConnections(ModelInstance::Model *pModelInstance, bool inherited, const ModelInfo &modelInfo);
   void drawTransitions(ModelInstance::Model *pModelInstance, bool inherited, const ModelInfo &modelInfo);
   void drawInitialStates(ModelInstance::Model *pModelInstance, bool inherited, const ModelInfo &modelInfo);
+  void handleCollidingConnections();
 
 
   void setExtentRectangle(const QRectF rectangle);


### PR DESCRIPTION
### Related Issues

Fixes #11271

### Purpose

The zooming and moving of items should be very quick.

### Approach

The detection of collision is expensive operation. Do not perform this in the paint event. Check for collisions when the model is modified.
