### PR TITLE
do not export <DiscreteStates> in <ModelStructure> for FMU's

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -316,7 +316,7 @@ case SOME(fmistruct as FMIMODELSTRUCTURE(__)) then
   <ModelStructure>
     <%ModelStructureOutputs(fmistruct.fmiOutputs)%>
     <%ModelStructureDerivatives(fmistruct.fmiDerivatives)%>
-    <%ModelStructureDiscreteStates(fmistruct.fmiDiscreteStates)%>
+    <% if Flags.getConfigBool(Flags.EXPORT_CLOCKS_IN_MODELDESCRIPTION) then ModelStructureDiscreteStates(fmistruct.fmiDiscreteStates) else "" %>
     <%ModelStructureInitialUnknowns(fmistruct.fmiInitialUnknowns)%>
   </ModelStructure>
   >>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/testArrayEquations.mos
@@ -945,12 +945,16 @@ readFile("modelDescription.tmp.xml");
 //   </ModelVariables>
 //   <ModelStructure>
 //     <Outputs>
-//       <Unknown index=\"105\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"106\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"107\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"108\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"101\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"102\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"103\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"104\" dependencies=\"\" dependenciesKind=\"\" />
 //     </Outputs>
 //     <DiscreteStates>
+//       <Unknown index=\"61\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"62\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"63\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"64\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"65\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"66\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"67\" dependencies=\"\" dependenciesKind=\"\" />
@@ -987,10 +991,6 @@ readFile("modelDescription.tmp.xml");
 //       <Unknown index=\"98\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"99\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"100\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"101\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"102\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"103\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"104\" dependencies=\"\" dependenciesKind=\"\" />
 //     </DiscreteStates>
 //   </ModelStructure>
 // </fmiModelDescription>

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -20,6 +20,7 @@ fmi_attributes_16.mos \
 fmi_attributes_17.mos \
 fmi_attributes_18.mos \
 fmi_attributes_19.mos \
+fmi_attributes_20.mos \
 FMUResourceTest.mos \
 testBug2764.mos \
 testBug2765.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_20.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_20.mos
@@ -122,8 +122,11 @@ readFile("fmi_attributes_20.xml"); getErrorString();
 // ""
 // "  <ModelStructure>
 //     <Outputs>
-//       <Unknown index=\"7\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"7\" dependencies=\"1 2\" dependenciesKind=\"dependent dependent\" />
 //     </Outputs>
+//     <InitialUnknowns>
+//       <Unknown index=\"7\" dependencies=\"1\" dependenciesKind=\"dependent\" />
+//     </InitialUnknowns>
 //   </ModelStructure>
 // "
 // ""

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_20.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_20.mos
@@ -1,0 +1,130 @@
+// name: fmi_attributes_20.mos
+// keywords: FMI 2.0 export
+// status: correct
+// teardown_command: rm -rf fmi_attributes_20.fmu fmi_attributes_20.log fmi_attributes_20.xml fmi_attributes_20_tmp.xml
+
+loadString("
+model fmi_attributes_20
+  parameter Real T = 0.1;
+  parameter Real k = 1;
+  Real u;
+  Real a;
+  Real x(start = 0);
+  output Real y;
+  Real Ts = interval(u);
+  equation
+  a = sin(time);
+  when Clock(0.1) then
+      u = sample(a);
+      x = previous(x) + previous(Ts) / T * u;
+  end when;
+  y = k * hold(x);
+end fmi_attributes_20;
+"); getErrorString();
+
+buildModelFMU(fmi_attributes_20); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq fmi_attributes_20.fmu modelDescription.xml > fmi_attributes_20_tmp.xml"); getErrorString();
+system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" fmi_attributes_20_tmp.xml > fmi_attributes_20.xml"); getErrorString();
+readFile("fmi_attributes_20.xml"); getErrorString();
+
+system("sed -n \"/<ModelStructure>/,/<\\/ModelStructure>/p\" fmi_attributes_20_tmp.xml > fmi_attributes_20.xml"); getErrorString();
+readFile("fmi_attributes_20.xml"); getErrorString();
+
+// Result:
+// true
+// ""
+// "fmi_attributes_20.fmu"
+// ""
+// 0
+// ""
+// 0
+// ""
+// "  <ModelVariables>
+//   <!-- Index of variable = \"1\" -->
+//   <ScalarVariable
+//     name=\"previous(Ts)\"
+//     valueReference=\"0\"
+//     variability=\"discrete\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"2\" -->
+//   <ScalarVariable
+//     name=\"previous(x)\"
+//     valueReference=\"1\"
+//     variability=\"discrete\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"3\" -->
+//   <ScalarVariable
+//     name=\"Ts\"
+//     valueReference=\"2\"
+//     variability=\"discrete\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"4\" -->
+//   <ScalarVariable
+//     name=\"a\"
+//     valueReference=\"3\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"5\" -->
+//   <ScalarVariable
+//     name=\"u\"
+//     valueReference=\"4\"
+//     variability=\"discrete\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"6\" -->
+//   <ScalarVariable
+//     name=\"x\"
+//     valueReference=\"5\"
+//     variability=\"discrete\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"7\" -->
+//   <ScalarVariable
+//     name=\"y\"
+//     valueReference=\"6\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"8\" -->
+//   <ScalarVariable
+//     name=\"T\"
+//     valueReference=\"7\"
+//     variability=\"fixed\"
+//     causality=\"parameter\"
+//     >
+//     <Real start=\"0.1\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"9\" -->
+//   <ScalarVariable
+//     name=\"k\"
+//     valueReference=\"8\"
+//     variability=\"fixed\"
+//     causality=\"parameter\"
+//     >
+//     <Real start=\"1.0\"/>
+//   </ScalarVariable>
+//   </ModelVariables>
+// "
+// ""
+// 0
+// ""
+// "  <ModelStructure>
+//     <Outputs>
+//       <Unknown index=\"7\" dependencies=\"\" dependenciesKind=\"\" />
+//     </Outputs>
+//   </ModelStructure>
+// "
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

#11265 

### Purpose

This PR filters exporting `<DiscreteStates>` in `<ModelStructure>` to` modeldescription.xml` in fmus according to the FMI-2.0 specification as `discreteStates` variables belongs to `CLOCK`  and it will be exported to modeldescription.xml using the config flag  `exportClocksInModeldescription=true`

### TODO

- [ ] Filter `CLOCK` related variables with prefix `previous`