### PR TITLE
Initial support for CMake based NSIS and RPM packaging.

### DIFF
--- a/cmake/packaging/common.cmake
+++ b/cmake/packaging/common.cmake
@@ -19,6 +19,8 @@ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/OSMC-License.txt")
 
 # Generator specific variables go in their own files.
 include(cmake/packaging/debian.cmake)
+include(cmake/packaging/rpm.cmake)
+include(cmake/packaging/nsis.cmake)
 include(cmake/packaging/productbuild.cmake)
 
 # Now that the options/settings variables have been set include CPack and add the components.

--- a/cmake/packaging/debian.cmake
+++ b/cmake/packaging/debian.cmake
@@ -1,10 +1,13 @@
-# Options and settings that are specific to debian packages.
+# Options and settings that are specific to Debian packages.
+# https://cmake.org/cmake/help/latest/cpack_gen/deb.html
+# usage: cpack -G DEB
 
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
 
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "OpenModelica Build System <${CPACK_PACKAGE_CONTACT}>")
 
-# Enable component based packaging (openmodelica-compiler, openmodelica-gui, ...)
+# Enable component based packaging (omc, omedit, omsimulator, fmu, simrtcpp ...)
+# See the file common.cmake for a list of the components.
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 
 # use dpkg-shlibdeps to generate better package dependency list.

--- a/cmake/packaging/nsis.cmake
+++ b/cmake/packaging/nsis.cmake
@@ -1,0 +1,30 @@
+# Options and settings that are specific to Windows NSIS packages.
+# https://cmake.org/cmake/help/latest/cpack_gen/nsis.html
+# usage: cpack -G NSIS64
+
+set(CPACK_PACKAGING_INSTALL_PREFIX ".")
+
+# This assumes the images are in the root OpenModelica directory for now.
+set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}\\OpenModelica.ico")
+set(CPACK_NSIS_MUI_WELCOMEFINISHPAGE_BITMAP "${CMAKE_SOURCE_DIR}\\openmodelica.bmp")
+set(CPACK_NSIS_MUI_UNWELCOMEFINISHPAGE_BITMAP "${CMAKE_SOURCE_DIR}\\openmodelica.bmp")
+
+SET (CPACK_NSIS_HELP_LINK      "https://openmodelica.org/doc/OpenModelicaUsersGuide/latest/")
+SET (CPACK_NSIS_URL_INFO_ABOUT "http://openmodelica.org")
+SET (CPACK_NSIS_CONTACT        "openmodelica@ida.liu.se")
+
+# These need a bit more testing and work. The shortcuts do not work yet.
+set(CPACK_CREATE_DESKTOP_LINKS OMEdit)
+set(CPACK_CREATE_DESKTOP_LINKS OMNotebook)
+set(CPACK_CREATE_DESKTOP_LINKS OMShell)
+
+# Ask to modify path during installation
+set(CPACK_NSIS_MODIFY_PATH ON)
+
+# Ask to uninstall previous installation if the same version is installed.
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+
+# Ask to start OMEdit after installation. right now this says 'Start OpenModelica'.
+# The text at the second command below seems to be ignored for some reason.
+set(CPACK_NSIS_MUI_FINISHPAGE_RUN "OMEdit.exe")
+set(CPACK_NSIS_MUI_FINISHPAGE_RUN_TEXT "Start OpenModelica Connection Editor (OMEdit)")

--- a/cmake/packaging/productbuild.cmake
+++ b/cmake/packaging/productbuild.cmake
@@ -1,2 +1,5 @@
 # Options and settings that are specific to macOS productbuild packages.
+# https://cmake.org/cmake/help/latest/cpack_gen/productbuild.html
+# usage: cpack -G productbuild
+
 set(CPACK_PRODUCTBUILD_IDENTIFIER "org.openmodelica")

--- a/cmake/packaging/rpm.cmake
+++ b/cmake/packaging/rpm.cmake
@@ -1,0 +1,9 @@
+# Options and settings that are specific to RPM packages.
+# https://cmake.org/cmake/help/latest/cpack_gen/rpm.html
+# usage: cpack -G RPM
+
+# Enable component based packaging (omc, omedit, omsimulator, fmu, simrtcpp ...)
+# See the file common.cmake for a list of the components.
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+
+set(CPACK_RPM_PACKAGE_LICENSE "${PROJECT_SOURCE_DIR}/OSMC-License.txt")


### PR DESCRIPTION
  - These is a very basic support. Most of the information is similar between these packages and is already available. For example, these use the same components, contact info, license ... as the existing `debian` and `macOS` `productbuild` package support.

  - NSIS packaging should be improved a bit more to create the shortcuts and other Windows related information.

  - The packages install and seem to work but need a lot of testing to make sure they are usable.

  - The only big platform that does not have a packaging support is Arch Linux. Unfortunately, `cmake` does not have support for `pacman` packages yet.


