### PR TITLE
[C] Fix typo in gbode (#11283)

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/gbode_main.c
@@ -1776,7 +1776,7 @@ int gbode_singlerate(DATA *data, threadData_t *threadData, SOLVER_INFO *solverIn
         gbData->stepSizeValues[i] = gbData->stepSizeValues[i - 1];
       }
       // update new values
-      gbData->errValues[0] = _omc_gen_maximumVectorNorm(gbData->err, nStates);
+      gbData->errValues[0] = err = _omc_gen_maximumVectorNorm(gbData->err, nStates);
       gbData->stepSizeValues[0] = gbData->stepSize;
 
       // Store performed step size for latter interpolation


### PR DESCRIPTION
The single rate solver could not get out of the loop because `err` was not set correctly.

Fixes #11280

Co-authored-by: bernhardbachmann <bernhardbachmann@users.noreply.github.com>
(cherry picked from commit 9613f293d8d38b4b4cff665241f79a82cb2249c1)