### PR TITLE
Link with the CXX compiler.

### DIFF
--- a/testsuite/flattening/modelica/ffi/FFITest/Resources/BuildProjects/gcc/Makefile
+++ b/testsuite/flattening/modelica/ffi/FFITest/Resources/BuildProjects/gcc/Makefile
@@ -18,7 +18,7 @@ OBJS = FFITestLib.o FFITestLibCpp.o
 all: ${TARGET_LIB}
 
 $(TARGET_LIB): $(OBJS)
-	$(CC) ${LDFLAGS} -o $@ $^
+	$(CXX) ${LDFLAGS} -o $@ $^
 	mkdir -p ../../Library/$(TARGET_DIR)
 	cp $@ ../../Library/$(TARGET_DIR)/$@
 


### PR DESCRIPTION
  - One of the source files for the library is a CXX source file. We need to use the CXX compiler to make sure the standard C++ library is linked in as well.
