### PR TITLE
Do not set the Cpack package prefix in the NSIS file.

### DIFF
--- a/cmake/packaging/nsis.cmake
+++ b/cmake/packaging/nsis.cmake
@@ -2,7 +2,7 @@
 # https://cmake.org/cmake/help/latest/cpack_gen/nsis.html
 # usage: cpack -G NSIS64
 
-set(CPACK_PACKAGING_INSTALL_PREFIX ".")
+# set(CPACK_PACKAGING_INSTALL_PREFIX ".")
 
 # This assumes the images are in the root OpenModelica directory for now.
 set(CPACK_NSIS_MUI_ICON "${CMAKE_SOURCE_DIR}\\OpenModelica.ico")


### PR DESCRIPTION
  - This needs some thought. The different platforms have different expectations. For example, on macOS, we want this to be `/opt/omc` for now. On Windows the should just be the directory with the same name as the package in Program Files or something similar. Setting it in again and again in each 'platform' respective file we have will just override the previous values.

  - Maybe it is better to set this on the command line for each platform. For now, however, we want to leave it at `/opt/omc` since we actually build the macOS packages with CMake while the other platform's packages are handled by other methods.

