### PR TITLE
Add omc-diff to the omc install component.

### DIFF
--- a/testsuite/difftool/CMakeLists.txt
+++ b/testsuite/difftool/CMakeLists.txt
@@ -8,5 +8,6 @@ else()
   FLEX_TARGET(omc_diff_lexer omc-diff.l ${CMAKE_CURRENT_BINARY_DIR}/lex.yy.c)
   add_executable(omc-diff ${FLEX_omc_diff_lexer_OUTPUTS})
 
-  install(TARGETS omc-diff)
+  install(TARGETS omc-diff
+          COMPONENT omc)
 endif()


### PR DESCRIPTION
  - This seems to be the reasonable place for it. It will be installed when omc is installed. Maybe it is not needed to be installed at all. In that case we can remove it completely. If it is installed though it needs to be part of some component.

