### PR TITLE
Remove OpenModelicaScriptingAPI.tmp.mo after use

### DIFF
--- a/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
+++ b/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
@@ -6,6 +6,8 @@ if bool then
   bool := loadFile("OpenModelicaScriptingAPI.tmp.mo");
   if bool then
     bool := OpenModelica.Scripting.compareFilesAndMove("OpenModelicaScriptingAPI.tmp.mo", "OpenModelicaScriptingAPI.mo");
+    /* FIXME `compareFilesAndMove` should remove the tmp.mo file but for some reason it doesn't, so we delete it explicitly */
+    OpenModelica.Scripting.deleteFile("OpenModelicaScriptingAPI.tmp.mo");
   else
     exit(1);
   end if;

--- a/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
+++ b/OMCompiler/Compiler/Script/OpenModelicaScriptingAPI.mos
@@ -7,7 +7,7 @@ if bool then
   if bool then
     bool := OpenModelica.Scripting.compareFilesAndMove("OpenModelicaScriptingAPI.tmp.mo", "OpenModelicaScriptingAPI.mo");
     /* FIXME `compareFilesAndMove` should remove the tmp.mo file but for some reason it doesn't, so we delete it explicitly */
-    OpenModelica.Scripting.deleteFile("OpenModelicaScriptingAPI.tmp.mo");
+    OpenModelica.Scripting.remove("OpenModelicaScriptingAPI.tmp.mo");
   else
     exit(1);
   end if;


### PR DESCRIPTION
After building (with cmake at least) the .tmp.mo file pollutes the working tree of git. Removing it seems to be fine.