### PR TITLE
Fix contact extents #11361

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1193,10 +1193,10 @@ ModelInstance::CoordinateSystem Element::getCoOrdinateSystemNew() const
 {
   ModelInstance::CoordinateSystem coordinateSystem;
   if (mpModel->isConnector()) {
-    if (mpGraphicsView->getViewType() == StringHandler::Icon) {
-      coordinateSystem = mpModel->getAnnotation()->getIconAnnotation()->mMergedCoOrdinateSystem;
-    } else {
+    if ((mpGraphicsView->getViewType() == StringHandler::Diagram) && canUseDiagramAnnotation()) {
       coordinateSystem = mpModel->getAnnotation()->getDiagramAnnotation()->mMergedCoOrdinateSystem;
+    } else {
+      coordinateSystem = mpModel->getAnnotation()->getIconAnnotation()->mMergedCoOrdinateSystem;
     }
   } else {
     coordinateSystem = mpModel->getAnnotation()->getIconAnnotation()->mMergedCoOrdinateSystem;
@@ -3097,15 +3097,19 @@ void Element::updateToolTip()
  * then we should not use the diagram annotation.
  * \return
  */
-bool Element::canUseDiagramAnnotation()
+bool Element::canUseDiagramAnnotation() const
 {
-  Element *pElement = this;
-  while (pElement->getParentElement()) {
+  if (getElementType() == Element::Port)
+    return false;
+
+  Element *pElement = getParentElement();
+  while (pElement) {
     if (pElement->getElementType() == Element::Port) {
       return false;
     }
     pElement = pElement->getParentElement();
   }
+
   return true;
 }
 

--- a/OMEdit/OMEditLIB/Element/Element.h
+++ b/OMEdit/OMEditLIB/Element/Element.h
@@ -221,9 +221,9 @@ public:
   bool isCondition() const;
   GraphicsView* getGraphicsView() {return mpGraphicsView;}
   Element *getReferenceElement() {return mpReferenceElement;}
-  Element* getParentElement() {return mpParentElement;}
+  Element* getParentElement() const {return mpParentElement;}
   Element* getRootParentElement();
-  ElementType getElementType() {return mElementType;}
+  ElementType getElementType() const {return mElementType;}
   QString getTransformationString() {return mTransformationString;}
   void setDialogAnnotation(QStringList dialogAnnotation) {mDialogAnnotation = dialogAnnotation;}
   QStringList getDialogAnnotation() {return mDialogAnnotation;}
@@ -384,7 +384,7 @@ private:
   static QString getParameterDisplayStringFromExtendsParameters(ModelInstance::Model *pModel, QString parameterName, QString modifierString);
   static bool checkEnumerationDisplayString(QString &displayString, const QString &typeName);
   void updateToolTip();
-  bool canUseDiagramAnnotation();
+  bool canUseDiagramAnnotation() const;
 signals:
   void added();
   void transformChange(bool positionChanged);


### PR DESCRIPTION
### Related Issues

Wrong contact sizing #11361

### Purpose

Use canUseDiagramAnnotation function for correctly choose extent of contact of element when on diagram layer

### Approach

Use canUseDiagramAnnotation function. Add some const for use canUseDiagramAnnotation inside getCoOrdinateSystemNew
