### PR TITLE
Fix extent in models without annotation with extend

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -509,6 +509,8 @@ namespace ModelInstance
     // Element annotation
     mChoicesAllMatching = false;
     mHasDialogAnnotation = false;
+    mpIconAnnotation = std::make_unique<IconDiagramAnnotation>(mpParentModel);
+    mpDiagramAnnotation = std::make_unique<IconDiagramAnnotation>(mpParentModel);
   }
 
   void Annotation::deserialize(const QJsonObject &jsonObject)
@@ -605,15 +607,13 @@ namespace ModelInstance
 
   IconDiagramAnnotation *Annotation::getIconAnnotation() const
   {
-    return mpIconAnnotation ? mpIconAnnotation.get() : &IconDiagramAnnotation::defaultIconDiagramAnnotation;
+    return mpIconAnnotation.get();
   }
 
   IconDiagramAnnotation *Annotation::getDiagramAnnotation() const
   {
-    return mpDiagramAnnotation ? mpDiagramAnnotation.get() : &IconDiagramAnnotation::defaultIconDiagramAnnotation;
+    return mpDiagramAnnotation.get();
   }
-
-  IconDiagramAnnotation IconDiagramAnnotation::defaultIconDiagramAnnotation{nullptr};
 
   IconDiagramAnnotation::IconDiagramAnnotation(Model *pParentModel)
   {
@@ -1152,7 +1152,7 @@ namespace ModelInstance
 
   Annotation *Model::getAnnotation() const
   {
-    return mpAnnotation ? mpAnnotation.get() : &Annotation::defaultAnnotation;
+    return mpAnnotation.get();
   }
 
   void Model::readCoordinateSystemFromExtendsClass(CoordinateSystem *pCoordinateSystem, bool isIcon)
@@ -1449,6 +1449,7 @@ namespace ModelInstance
     mConnections.clear();
     mTransitions.clear();
     mInitialStates.clear();
+    mpAnnotation = std::make_unique<Annotation>(this);
   }
 
   Transformation::Transformation()

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -277,8 +277,6 @@ private:
 
     CoordinateSystem mCoordinateSystem;
     CoordinateSystem mMergedCoOrdinateSystem;
-
-    static IconDiagramAnnotation defaultIconDiagramAnnotation;
   private:
     Model *mpParentModel;
     QList<Shape*> mGraphics;


### PR DESCRIPTION
### Related Issues

Wrong extent for models with extend and without annotation #11363

### Purpose

Function `Model::deserialize()` use function `Model::readCoordinateSystemFromExtendsClass(CoordinateSystem *pCoordinateSystem, bool isIcon)` which modify extent through pointer `CoordinateSystem *pCoordinateSystem`. But if model hasn`t annotation `Model::deserialize()` pass into `Model::readCoordinateSystemFromExtendsClass` pointer to static fields `static Annotation defaultAnnotation` and `static IconDiagramAnnotation defaultIconDiagramAnnotation`

### Approach

Create empty (default) Annotation and IconDiagramAnnotation instead of use `&Annotation::defaultAnnotation` and `&IconDiagramAnnotation::defaultIconDiagramAnnotation`.

