### PR TITLE
include header for lseek to fix the builds on mantic

### DIFF
--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/zlib/gzlib.c
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/zlib/gzlib.c
@@ -9,8 +9,12 @@
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
+#include <sys/types.h>
+#include <unistd.h>
 #  define LSEEK lseek64
 #else
+#include <sys/types.h>
+#include <unistd.h>
 #  define LSEEK lseek
 #endif
 #endif


### PR DESCRIPTION
### Related Issues

Fix 
```
openmodelica-1.23.0~dev-62-g06b5c1c/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/zlib/gzlib.c:496:14: error: call to undeclared function 'lseek'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    offset = LSEEK(state->fd, 0, SEEK_CUR);
```