### PR TITLE
Sanity check for external objects

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3534,6 +3534,14 @@ template functionUpdateBoundParameters(list<SimEqSystem> simpleParameterEquation
         else error(sourceInfo(), 'Cannot get attributes of alias variable <%crefStr(cref)%>. Alias variables should have been replaced by the compiler before SimCode')%>
       >> ; separator="\n" %>
     <%fncalls%>
+
+    /* External object sanity check */
+    for(int i=0; i<data->modelData->nExtObjs; i++) {
+      if (data->simulationInfo->extObjs[i] == NULL) {
+        warningStreamPrint(LOG_ASSERT, 0, "<%symbolName(modelNamePrefix,"updateBoundParameters")%>: External object %i is NULL, did a external constructor fail?", i);
+      }
+    }
+
     TRACE_POP
     return 0;
   }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3534,7 +3534,6 @@ template functionUpdateBoundParameters(list<SimEqSystem> simpleParameterEquation
         else error(sourceInfo(), 'Cannot get attributes of alias variable <%crefStr(cref)%>. Alias variables should have been replaced by the compiler before SimCode')%>
       >> ; separator="\n" %>
     <%fncalls%>
-
     TRACE_POP
     return 0;
   }

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -3535,13 +3535,6 @@ template functionUpdateBoundParameters(list<SimEqSystem> simpleParameterEquation
       >> ; separator="\n" %>
     <%fncalls%>
 
-    /* External object sanity check */
-    for(int i=0; i<data->modelData->nExtObjs; i++) {
-      if (data->simulationInfo->extObjs[i] == NULL) {
-        warningStreamPrint(LOG_ASSERT, 0, "<%symbolName(modelNamePrefix,"updateBoundParameters")%>: External object %i is NULL, did a external constructor fail?", i);
-      }
-    }
-
     TRACE_POP
     return 0;
   }

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/initialization/initialization.c
@@ -793,6 +793,14 @@ int initialization(DATA *data, threadData_t *threadData, const char* pInitMethod
     throwStreamPrint(threadData, "unsupported option -iim");
   }
 
+  /* External object sanity check
+   * At this point all external objects should be initialized (bound parameters or initial system) */
+  for(int i=0; i<data->modelData->nExtObjs; i++) {
+    if (data->simulationInfo->extObjs[i] == NULL) {
+      warningStreamPrint(LOG_STDOUT, 0, "External object %i is NULL, did a external constructor fail?", i);
+    }
+  }
+
   /* check for unsolved (nonlinear|linear|mixed) systems
    * This is a workaround and should be removed as soon as possible.
    */


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11114.

### Purpose

  - Print warning if external object is NULL
  - Hopefully this will catch some future errors!

### Approach

  - Function `updateBoundParameters` should call external constructors for external objects. If the pointer is NULL after that something is fishy.
