### PR TITLE
Change getModelInstanceIcon to getModelInstanceAnnotation

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4507,14 +4507,15 @@ function getModelInstance
 external "builtin";
 end getModelInstance;
 
-function getModelInstanceIcon
-  "Dumps only the Icon and IconMap annotations of a model, using the same JSON
-   format as getModelInstance."
+function getModelInstanceAnnotation
+  "Dumps the annotation of a model using the same JSON format as
+   getModelInstance, optionally filtering out only certain parts."
   input TypeName className;
+  input String[:] filter = fill("", 0);
   input Boolean prettyPrint = false;
   output String result;
 external "builtin";
-end getModelInstanceIcon;
+end getModelInstanceAnnotation;
 
 function modifierToJSON
   "Parses a modifier given as a string and dumps it as JSON."

--- a/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
@@ -1101,6 +1101,13 @@ algorithm
   end matchcontinue;
 end valueReals;
 
+public function valueString
+  input Values.Value value;
+  output String str;
+algorithm
+  Values.Value.STRING(string = str) := value;
+end valueString;
+
 public function arrayValueInts
   "Returns the integer values of a Values array."
   input Values.Value inValue;
@@ -1148,6 +1155,13 @@ algorithm
 
   end matchcontinue;
 end matrixValueReals;
+
+public function arrayValueStrings
+  input Values.Value value;
+  output list<String> strings;
+algorithm
+  strings := list(valueString(v) for v in arrayValues(value));
+end arrayValueStrings;
 
 public function valueNeg "author: PA
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4760,14 +4760,15 @@ function getModelInstance
 external "builtin";
 end getModelInstance;
 
-function getModelInstanceIcon
-  "Dumps only the Icon and IconMap annotations of a model, using the same JSON
-   format as getModelInstance."
+function getModelInstanceAnnotation
+  "Dumps the annotation of a model using the same JSON format as
+   getModelInstance, optionally filtering out only certain parts."
   input TypeName className;
+  input String[:] filter = fill("", 0);
   input Boolean prettyPrint = false;
   output String result;
 external "builtin";
-end getModelInstanceIcon;
+end getModelInstanceAnnotation;
 
 function modifierToJSON
   "Parses a modifier given as a string and dumps it as JSON."

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3118,8 +3118,8 @@ algorithm
     case ("getModelInstance", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(str), Values.BOOL(b)})
       then NFApi.getModelInstance(classpath, str, b);
 
-    case ("getModelInstanceIcon", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.BOOL(b)})
-      then NFApi.getModelInstanceIcon(classpath, b);
+    case ("getModelInstanceAnnotation", {Values.CODE(Absyn.C_TYPENAME(classpath)), v as Values.ARRAY(), Values.BOOL(b)})
+      then NFApi.getModelInstanceAnnotation(classpath, ValuesUtil.arrayValueStrings(v), b);
 
     case ("modifierToJSON", {Values.STRING(str), Values.BOOL(b)})
       then NFApi.modifierToJSON(str, b);

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -894,8 +894,9 @@ algorithm
   Inst.clearCaches();
 end getModelInstance;
 
-function getModelInstanceIcon
+function getModelInstanceAnnotation
   input Absyn.Path classPath;
+  input list<String> filter;
   input Boolean prettyPrint;
   output Values.Value res;
 protected
@@ -910,10 +911,10 @@ algorithm
   cls_node := Inst.lookupRootClass(classPath, top, context);
   cls_node := InstNode.resolveInner(cls_node);
 
-  json := dumpJSONInstanceIcon(cls_node);
+  json := dumpJSONInstanceAnnotation(cls_node, filter);
   res := Values.STRING(JSON.toString(json, prettyPrint));
   Inst.clearCaches();
-end getModelInstanceIcon;
+end getModelInstanceAnnotation;
 
 function parseModifier
   input String modifierValue;
@@ -1114,8 +1115,9 @@ algorithm
   json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(node)), json);
 end dumpJSONInstanceTree;
 
-function dumpJSONInstanceIcon
+function dumpJSONInstanceAnnotation
   input InstNode node;
+  input list<String> filter;
   output JSON json = JSON.makeNull();
 protected
   Option<SCode.Comment> cmt;
@@ -1142,7 +1144,7 @@ algorithm
     j := JSON.emptyArray();
 
     for ext in exts loop
-      j := JSON.addElement(dumpJSONInstanceIconExtends(ext), j);
+      j := JSON.addElement(dumpJSONInstanceAnnotationExtends(ext, filter), j);
     end for;
 
     json := JSON.addPair("elements", j, json);
@@ -1153,8 +1155,11 @@ algorithm
   cmt := match cmt
     case SOME(SCode.Comment.COMMENT(annotation_ = SOME(ann as SCode.Annotation.ANNOTATION())))
       algorithm
-        ann.modification := SCodeUtil.filterSubMods(ann.modification,
-          function SCodeUtil.filterGivenSubModNames(namesToKeep = {"Icon", "IconMap"}));
+        if not listEmpty(filter) then
+          ann.modification := SCodeUtil.filterSubMods(ann.modification,
+            function SCodeUtil.filterGivenSubModNames(namesToKeep = filter));
+        end if;
+
         annotation_is_literal := SCodeUtil.onlyLiteralsInMod(ann.modification);
       then
         if SCodeUtil.isEmptyMod(ann.modification) then NONE() else SOME(SCode.Comment.COMMENT(SOME(ann), NONE()));
@@ -1178,15 +1183,16 @@ algorithm
   end if;
 
   json := dumpJSONCommentOpt(cmt, scope, json, failOnError = true);
-end dumpJSONInstanceIcon;
+end dumpJSONInstanceAnnotation;
 
-function dumpJSONInstanceIconExtends
+function dumpJSONInstanceAnnotationExtends
   input InstNode ext;
+  input list<String> filter;
   output JSON json = JSON.makeNull();
 algorithm
   json := JSON.addPair("$kind", JSON.makeString("extends"), json);
-  json := JSON.addPair("baseClass", dumpJSONInstanceIcon(ext), json);
-end dumpJSONInstanceIconExtends;
+  json := JSON.addPair("baseClass", dumpJSONInstanceAnnotation(ext, filter), json);
+end dumpJSONInstanceAnnotationExtends;
 
 function dumpJSONNodePath
   input InstNode node;

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3471,10 +3471,10 @@ QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &
 
   QString modelInstanceJson = "";
   if (icon) {
-    modelInstanceJson = mpOMCInterface->getModelInstanceIcon(className, prettyPrint);
+    modelInstanceJson = mpOMCInterface->getModelInstanceAnnotation(className, {"Icon", "IconMap"}, prettyPrint);
     if (modelInstanceJson.isEmpty()) {
       if (MainWindow::instance()->isDebug()) {
-        QString msg = QString("<b>getModelInstanceIcon(%1, %2)</b> failed. Using <b>getModelInstance(%1, %2)</b>.").arg(className).arg(prettyPrint ? "true" : "false");
+        QString msg = QString("<b>getModelInstanceAnnotation(%1, {\"Icon\", \"IconMap\"}, %2)</b> failed. Using <b>getModelInstance(%1, %2)</b>.").arg(className).arg(prettyPrint ? "true" : "false");
         MessageItem messageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel);
         MessagesWidget::instance()->addGUIMessage(messageItem);
         printMessagesStringInternal();

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon1.mos
@@ -13,7 +13,7 @@ loadString("
   end M;
 ");
 
-getModelInstanceIcon(M, prettyPrint=true);
+getModelInstanceAnnotation(M, {"Icon"}, prettyPrint=true);
 
 // Result:
 // true

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon2.mos
@@ -23,7 +23,7 @@ loadString("
   end M;
 ");
 
-getModelInstanceIcon(M, prettyPrint=true);
+getModelInstanceAnnotation(M, {"Icon", "IconMap"}, prettyPrint=true);
 
 // Result:
 // true

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon3.mos
@@ -25,7 +25,7 @@ loadString("
   end M;
 ");
 
-getModelInstanceIcon(M, prettyPrint=true);
+getModelInstanceAnnotation(M, {"Icon", "IconMap"}, prettyPrint=true);
 
 // Result:
 // true

--- a/testsuite/openmodelica/instance-API/GetModelInstanceIcon4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceIcon4.mos
@@ -31,7 +31,7 @@ loadString("
   end M;
 ");
 
-getModelInstanceIcon(M, prettyPrint=true);
+getModelInstanceAnnotation(M, prettyPrint=true);
 getErrorString();
 
 // Result:


### PR DESCRIPTION
- Rename getModelInstanceIcon API to getModelInstanceAnnotation and add a filter argument, to allow fetching any annotations instead of only Icon annotations.