### PR TITLE
Fetch the diagram annotation when adding component to the diagram

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -923,7 +923,7 @@ ModelInstance::Component *GraphicsView::createModelInstanceComponent(ModelInstan
   ModelInstance::Component *pComponent = new ModelInstance::Component(pModelInstance);
   pComponent->setName(name);
   pComponent->setType(className);
-  /* We use getModelInstanceIcon here for bettter performance
+  /* We use getModelInstanceAnnotation here for bettter performance
    * This model will be updated right after this so it doesn't matter if the Component has complete model or not.
    */
   pComponent->setModel(new ModelInstance::Model(MainWindow::instance()->getOMCProxy()->getModelInstance(className, "", false, true)));

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3471,10 +3471,11 @@ QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &
 
   QString modelInstanceJson = "";
   if (icon) {
-    modelInstanceJson = mpOMCInterface->getModelInstanceAnnotation(className, {"Icon", "IconMap"}, prettyPrint);
+    modelInstanceJson = mpOMCInterface->getModelInstanceAnnotation(className, {"Icon", "IconMap", "Diagram", "DiagramMap"}, prettyPrint);
     if (modelInstanceJson.isEmpty()) {
       if (MainWindow::instance()->isDebug()) {
-        QString msg = QString("<b>getModelInstanceAnnotation(%1, {\"Icon\", \"IconMap\"}, %2)</b> failed. Using <b>getModelInstance(%1, %2)</b>.").arg(className).arg(prettyPrint ? "true" : "false");
+        QString msg = QString("<b>getModelInstanceAnnotation(%1, {\"Icon\", \"IconMap\", \"Diagram\", \"DiagramMap\"}, %2)</b> failed. Using <b>getModelInstance(%1, %2)</b>.")
+                      .arg(className).arg(prettyPrint ? "true" : "false");
         MessageItem messageItem(MessageItem::Modelica, msg, Helper::scriptingKind, Helper::errorLevel);
         MessagesWidget::instance()->addGUIMessage(messageItem);
         printMessagesStringInternal();
@@ -3488,7 +3489,7 @@ QJsonObject OMCProxy::getModelInstance(const QString &className, const QString &
   }
 
   if (MainWindow::instance()->isNewApiProfiling()) {
-    const QString api = icon ? "getModelInstanceIcon" : "getModelInstance";
+    const QString api = icon ? "getModelInstanceAnnotation" : "getModelInstance";
     double elapsed = (double)timer.elapsed() / 1000.0;
     MainWindow::instance()->writeNewApiProfiling(QString("Time for %1 %2 secs").arg(api, QString::number(elapsed, 'f', 6)));
   }


### PR DESCRIPTION
This is needed for connectors since they have different representation on icon and diagram layer.