### PR TITLE
[Runtime] Fixing memory leak in KINSOL F scaling

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.h
@@ -88,8 +88,8 @@ typedef struct NLS_KINSOL_DATA {
 
   /* ### work arrays ### */
   N_Vector initialGuess;
-  N_Vector xScale;
-  N_Vector fScale;
+  N_Vector xScale;                      /* x scaling vector */
+  N_Vector fScale;                      /* f(x) scaling vector */
   N_Vector fRes;
   N_Vector fTmp;
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.c
@@ -81,32 +81,31 @@ void setJacElementSundialsSparse(int row, int column, int nth, double value, voi
 /**
  * @brief             Scaling of a sparse matrix column-wise by a vector
  *
- * @param A           Sparse matrix in CSC.
- * @param vScale      Vector for scaling
- * @return SUNMatrix  Returns the scaled sparse matrix
+ * @param A           Sparse matrix in CSC. Will be scaled on return.
+ * @param vScale      Vector for scaling.
+ * @return            Return `SUNMAT_SUCCESS` on success.
  */
-SUNMatrix _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale)
+int _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale)
 {
 
   /* should not be called unless A is a sparse matrix in CSC format;
     otherwise return immediately */
-  if (SUNMatGetID(A) != SUNMATRIX_SPARSE || SM_SPARSETYPE_S(A) == CSR_MAT)
-    return(A);
+  if (SUNMatGetID(A) != SUNMATRIX_SPARSE || SM_SPARSETYPE_S(A) == CSR_MAT) {
+    return SUNMAT_ILL_INPUT;
+  }
 
   sunindextype i, j;
   char *matrixtype;
   char *indexname;
   realtype *vScaling = N_VGetArrayPointer(vScale);
-  SUNMatrix B = SUNMatClone_Sparse(A);
-  SUNMatCopy_Sparse(A, B);
 
   for (j=0; j<SM_NP_S(A); j++) {
     for (i=(SM_INDEXPTRS_S(A))[j]; i<(SM_INDEXPTRS_S(A))[j+1]; i++) {
-      (SM_DATA_S(B))[i] = (SM_DATA_S(A))[i]/vScaling[j];
+      (SM_DATA_S(A))[i] = (SM_DATA_S(A))[i]/vScaling[j];
     }
   }
 
-  return(B);
+  return SUNMAT_SUCCESS;
 }
 
 /**

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/sundials_util.h
@@ -52,7 +52,7 @@ extern "C" {
 
 void setJacElementSundialsSparse(int row, int column, int nth, double value, void* Jac, int nRows);
 int _omc_SUNMatScaleIAdd_Sparse(realtype c, SUNMatrix A);
-SUNMatrix _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale);
+int _omc_SUNSparseMatrixVecScaling(SUNMatrix A, N_Vector vScale);
 
 #endif /* WITH_SUNDIALS */
 


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/11431.

### Purpose

Don't loose pointer to memory.

### Approach

  - Don't alloc yet another matrix
  - Don't overwrite pointer to memory
  - Make sure data for spJac is set
