### PR TITLE
Use docker.openmodelica.org/fmpy:v0.3.18 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -659,7 +659,7 @@ pipeline {
           agent {
             docker {
               label 'linux'
-              image 'anheuermann/fmpy:v0.3.18'
+              image 'docker.openmodelica.org/fmpy:v0.3.18'
             }
           }
           when {


### PR DESCRIPTION
### Related Issues

Some Jenkins pipelines are failing on the master branch, because I updated `anheuermann/fmpy:v0.3.18` and some runners are still using the older version and not pulling the image again.

I uploaded anheuermann/fmpy:v0.3.18 to docker.openmodelica.org to fix this and get rid of my DockerHub name in the Jenkinsfile.

### Purpose

  - Same image as [anheuermann/fmpy:v0.3.18](https://hub.docker.com/layers/anheuermann/fmpy/v0.3.18/images/sha256-bd80eff61c9f1fd6a6613e5b4b8acebfb913e8be295caaa942aee6f6d7cb6a15?context=repo), but not on DockerHub.
  - Build files: https://github.com/AnHeuermann/fmpy-dockerimage
