### PR TITLE
Change type of nextTimerDefined from int to modelica_boolean in handlerTimersFMI

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
@@ -332,8 +332,8 @@ fire_timer_t handleTimers(DATA* data, threadData_t *threadData, SOLVER_INFO* sol
  * @param data                            data
  * @param threadData                      thread data, for errro handling
  * @param currentTime                     Current solver timer.
- * @param nextTimerDefined                0 (false) if no next timer is defined.
- *                                        1 (true) if a next timer is defined. Then the time is outputted in nextTimerActivationTime.
+ * @param nextTimerDefined                FALSE if no next timer is defined.
+ *                                        TRUE if a next timer is defined. Then the time is outputted in nextTimerActivationTime.
  * @param nextTimerActivationTime         If nextTimerDefined is true it will contain the next time a timer will fire.
  * @return int                            Return 0, if there is no fired timers;
  *                                               1, if there is a fired timer;
@@ -349,7 +349,7 @@ int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, mo
   fire_timer_t ret = NO_TIMER_FIRED;
   SUBCLOCK_DATA* subClock;
 
-  *nextTimerDefined = 0;
+  *nextTimerDefined = FALSE;
 
   if (data->simulationInfo->intvlTimers == NULL || listLen(data->simulationInfo->intvlTimers) <= 0) {
     TRACE_POP
@@ -398,7 +398,7 @@ int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, mo
     nextTimer = (SYNC_TIMER*)listNodeData(listFirstNode(data->simulationInfo->intvlTimers));
     /* Next time a timer will activate: */
     *nextTimerActivationTime = nextTimer->activationTime;
-    *nextTimerDefined = 1;
+    *nextTimerDefined = TRUE;
   }
 
   TRACE_POP

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.c
@@ -339,7 +339,7 @@ fire_timer_t handleTimers(DATA* data, threadData_t *threadData, SOLVER_INFO* sol
  *                                               1, if there is a fired timer;
  *                                               2, if there is a fired timer which trigger event;
  */
-int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, int *nextTimerDefined, double *nextTimerActivationTime)
+int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, modelica_boolean *nextTimerDefined, double *nextTimerActivationTime)
 {
   int base_idx, sub_idx;
   double activationTime;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.h
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/synchronous.h
@@ -56,7 +56,7 @@ void initSynchronous(DATA* data, threadData_t *threadData, modelica_real startTi
 void checkForSynchronous(DATA *data, SOLVER_INFO* solverInfo);
 modelica_boolean handleBaseClock(DATA* data, threadData_t *threadData, long idx, double curTime);
 fire_timer_t handleTimers(DATA* data, threadData_t *threadData, SOLVER_INFO* solverInfo);
-int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, int *nextTimerDefined, double *nextTimerActivationTime);
+int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, modelica_boolean *nextTimerDefined, double *nextTimerActivationTime);
 
 #ifdef __cplusplus
 }

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -264,7 +264,7 @@ fmi2Status internalEventUpdate(fmi2Component c, fmi2EventInfo* eventInfo)
   threadData_t *threadData = comp->threadData;
   fmi2Real nextSampleEvent;
   fmi2Boolean nextSampleEventDefined;
-  fmi2Boolean nextTimerDefined;
+  modelica_boolean nextTimerDefined;
   fmi2Real nextTimerActivationTime;
   int syncRet;
 


### PR DESCRIPTION
Type mismatched of argument 4 in  `handlersTimersFMI` when integrating FMU from OM in rt-env
[Discussion 11436](https://github.com/OpenModelica/OpenModelica/discussions/11436)

### Purpose
So FMU from OM could be integrated in rt-env

### Approach
```diff
-int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, int *nextTimerDefined, double *nextTimerActivationTime)
+int handleTimersFMI(DATA* data, threadData_t *threadData, double currentTime, modelica_boolean *nextTimerDefined, double *nextTimerActivationTime)
```
