### PR TITLE
Clean up SCodeUtil Annotation functions

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1141,7 +1141,7 @@ protected
 algorithm
   try
     SOME(SCode.COMMENT(annotation_=SOME(ann))) := comment;
-    val := SCodeUtil.getNamedAnnotation(ann, "tearingSelect");
+    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "tearingSelect");
     ts_str := AbsynUtil.crefIdent(AbsynUtil.expCref(val));
     ts := match(ts_str)
       case "always" then SOME(BackendDAE.ALWAYS());
@@ -1171,7 +1171,7 @@ protected
 algorithm
   try
     SOME(SCode.COMMENT(annotation_=SOME(ann))) := comment;
-    val := SCodeUtil.getNamedAnnotation(ann, "HideResult");
+    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "HideResult");
     hr := Expression.fromAbsynExp(val);
 
     hideResult := match(inCref)

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -1683,7 +1683,7 @@ protected
 algorithm
   try
     BackendDAE.VAR(comment=SOME(SCode.COMMENT(annotation_ = SOME(ann)))) := inVar;
-    (val,_) := SCodeUtil.getNamedAnnotation(ann, "Evaluate");
+    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "Evaluate");
     isTrue := stringEqual(Dump.printExpStr(val), "true");
   else
     isTrue := false;
@@ -1701,7 +1701,7 @@ protected
 algorithm
   try
     BackendDAE.VAR(comment=SOME(SCode.COMMENT(annotation_ = SOME(ann)))) := inVar;
-    (val,_) := SCodeUtil.getNamedAnnotation(ann, "Evaluate");
+    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "Evaluate");
     isFalse := stringEqual(Dump.printExpStr(val), "false");
   else
     isFalse := false;
@@ -1728,7 +1728,7 @@ protected
   SCode.Annotation ann;
 algorithm
   BackendDAE.VAR(comment = SOME(SCode.COMMENT(annotation_ = SOME(ann)))) := inVar;
-  outValue := SCodeUtil.getNamedAnnotation(ann, inName);
+  SOME(outValue) := SCodeUtil.lookupAnnotationBinding(ann, inName);
 end getNamedAnnotation;
 
 public function getAnnotationComment"gets the annotation comment, if there is one"

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -1234,7 +1234,7 @@ public
     algorithm
       try
         SOME(SCode.COMMENT(annotation_=SOME(anno))) := optComment;
-        val := SCodeUtil.getNamedAnnotation(anno, "tearingSelect");
+        SOME(val) := SCodeUtil.lookupAnnotationBinding(anno, "tearingSelect");
         name := AbsynUtil.crefIdent(AbsynUtil.expCref(val));
         tearingSelect := SOME(lookupTearingSelectMember(name));
       else

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1349,7 +1349,7 @@ protected
   list<SCode.Mod> mods;
   Absyn.Exp exp;
 algorithm
-  mods := SCodeUtil.lookupNamedAnnotations(ann, name);
+  mods := SCodeUtil.lookupAnnotations(ann, name);
 
   for m in mods loop
     strl := match m

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
@@ -227,10 +227,10 @@ protected
 
       case SCode.Element.CLASS(classDef = SCode.ClassDef.PARTS(
           externalDecl = SOME(SCode.ExternalDecl.EXTERNALDECL(annotation_ = SOME(ann)))))
-        then SCodeUtil.lookupNamedAnnotations(ann, "derivative");
+        then SCodeUtil.lookupAnnotations(ann, "derivative");
 
       case SCode.Element.CLASS(cmt = SCode.Comment.COMMENT(annotation_ = SOME(ann)))
-        then SCodeUtil.lookupNamedAnnotations(ann, "derivative");
+        then SCodeUtil.lookupAnnotations(ann, "derivative");
 
       else {};
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionInverse.mo
@@ -116,10 +116,10 @@ protected
 
       case SCode.Element.CLASS(classDef = SCode.ClassDef.PARTS(
           externalDecl = SOME(SCode.ExternalDecl.EXTERNALDECL(annotation_ = SOME(ann)))))
-        then SCodeUtil.lookupNamedAnnotations(ann, "inverse");
+        then SCodeUtil.lookupAnnotations(ann, "inverse");
 
       case SCode.Element.CLASS(cmt = SCode.Comment.COMMENT(annotation_ = SOME(ann)))
-        then SCodeUtil.lookupNamedAnnotations(ann, "inverse");
+        then SCodeUtil.lookupAnnotations(ann, "inverse");
 
       else {};
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -3578,7 +3578,7 @@ algorithm
       // to give a diagnostic message.
       if not InstContext.inInstanceAPI(context) then
         try
-          Absyn.STRING(str) := SCodeUtil.getElementNamedAnnotation(
+          SOME(Absyn.STRING(str)) := SCodeUtil.lookupElementAnnotationBinding(
             InstNode.definition(InstNode.classScope(n)), "missingInnerMessage");
           Error.addSourceMessage(Error.MISSING_INNER_MESSAGE, {System.unescapedString(str)}, InstNode.info(n));
         else

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -1157,8 +1157,8 @@ algorithm
       // version it is so we can tell the user.
       if name == SCodeUtil.getElementName(scls) then
         try
-          Absyn.Exp.STRING(value = version) :=
-            SCodeUtil.getElementNamedAnnotation(scls, "version");
+          SOME(Absyn.Exp.STRING(value = version)) :=
+            SCodeUtil.lookupElementAnnotationBinding(scls, "version");
         else
         end try;
       end if;

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -2474,8 +2474,9 @@ algorithm
       SourceInfo info;
     case (SCode.CLASS(restriction=SCode.R_METARECORD(moved=true)),_) then ();
     case (SCode.CLASS(cmt=SCode.COMMENT(annotation_=SOME(ann))),name::_)
-      equation
-        (Absyn.STRING(str),info) = SCodeUtil.getNamedAnnotation(ann,"__OpenModelica_Interface");
+      algorithm
+        SCode.MOD(binding = SOME(Absyn.STRING(str)), info = info) :=
+          SCodeUtil.lookupAnnotation(ann, "__OpenModelica_Interface");
         Error.assertionOrAddSourceMessage(listMember(str, expected), Error.MISMATCHING_INTERFACE_TYPE, {str,name}, info);
       then ();
     else
@@ -2499,7 +2500,7 @@ algorithm
       SourceInfo info;
     case (SCode.CLASS(cmt=SCode.COMMENT(annotation_=SOME(ann))),_)
       equation
-        (Absyn.STRING(str),_) = SCodeUtil.getNamedAnnotation(ann,"__OpenModelica_Interface");
+        SOME(Absyn.STRING(str)) = SCodeUtil.lookupAnnotationBinding(ann,"__OpenModelica_Interface");
         it = Util.assoc(str,assoc);
       then it;
     else


### PR DESCRIPTION
- Rename functions to be more consistent and always return a value rather than failing in some cases: `lookupNamedAnnotation` -> `lookupAnnotation` `lookupNamedBooleanAnnotation` -> `lookupBooleanAnnotation` `lookupNamedAnnotations` -> `lookupAnnotations` `lookupNamedAnnotationBinding` -> `lookupAnnotationBinding` `getElementNamedAnnotation` -> `lookupElementAnnotationBinding`
- Add `lookupElementAnnotation`.
- Remove `getNamedAnnotation`, use `lookupAnnotationBinding` instead or `lookupAnnotation` if also needing the SourceInfo of the modifier.
- Remove some unused functions.