### PR TITLE
Use the build-deps image directly for the CMake job.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,10 +119,10 @@ pipeline {
         }
         stage('cmake-jammy-gcc') {
           agent {
-            dockerfile {
-              additionalBuildArgs '--pull'
-              dir '.CI/cache'
+            docker {
+              image 'docker.openmodelica.org/build-deps:v1.22.2'
               label 'linux'
+              alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
                    "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
             }


### PR DESCRIPTION
  - The `.CI/cache/Dockerfile` does not really add anything to the `build-deps` as far as the CMake build is concerned. Use the image directly.
