### PR TITLE
Dump redeclares as structures in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1290,44 +1290,7 @@ protected
 algorithm
   node := InstNode.getRedeclaredNode(cls);
   elem := InstNode.definition(node);
-
-  json := JSON.addPair("$kind", JSON.makeString("class"), json);
-  json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
-  json := JSON.addPair("restriction",
-    JSON.makeString(SCodeDump.restrictionStringPP(SCodeUtil.getClassRestriction(elem))), json);
-  json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(elem, scope), json);
-
-  SCode.Element.CLASS(classDef = cdef, cmt = cmt) := elem;
-
-  () := match cdef
-    case SCode.ClassDef.DERIVED(typeSpec = Absyn.TypeSpec.TPATH(path = path, arrayDim = odims))
-      algorithm
-        try
-          derivedNode := Lookup.lookupName(path, scope, NFInstContext.RELAXED, false);
-          json := JSON.addPair("baseClass", dumpJSONNodeEnclosingPath(derivedNode), json);
-        else
-        end try;
-
-        if isSome(odims) then
-          json := JSON.addPairNotNull("dims", dumpJSONDims(Util.getOption(odims), {}), json);
-        end if;
-
-        json := dumpJSONSCodeMod(cdef.modifications, scope, json);
-      then
-        ();
-
-    case SCode.ClassDef.CLASS_EXTENDS()
-      algorithm
-        json := dumpJSONSCodeMod(cdef.modifications, scope, json);
-      then
-        ();
-
-    else ();
-  end match;
-
-  json := dumpJSONCommentOpt(SOME(cmt), scope, json);
-  json := dumpJSONCommentAnnotation(SOME(cmt), scope, json,
-    {"Dialog", "choices", "choicesAllMatching"});
+  json := dumpJSONSCodeClass(elem, scope, true, json);
   json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(node)), json);
 end dumpJSONReplaceableClass;
 
@@ -1371,7 +1334,7 @@ algorithm
         ();
 
     case (Component.COMPONENT(), SCode.Element.COMPONENT())
-      algorithm
+algorithm
         json := JSON.addPair("$kind", JSON.makeString("component"), json);
         json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
         json := JSON.addPair("type", dumpJSONComponentType(cls, node, comp.ty), json);
@@ -1554,20 +1517,24 @@ function dumpJSONDims
 protected
   JSON ty_json, absyn_json;
 algorithm
-  absyn_json := JSON.emptyArray();
-  for d in absynDims loop
-    absyn_json := JSON.addElement(JSON.makeString(Dump.printSubscriptStr(d)), absyn_json);
-  end for;
+  json := JSON.addPairNotNull("absyn", dumpJSONAbsynDims(absynDims), json);
 
-  json := JSON.addPairNotNull("absyn", absyn_json, json);
-
-  ty_json := JSON.emptyArray();
+  ty_json := JSON.makeNull();
   for d in typedDims loop
     ty_json := JSON.addElement(JSON.makeString(Dimension.toString(d)), ty_json);
   end for;
 
   json := JSON.addPairNotNull("typed", ty_json, json);
 end dumpJSONDims;
+
+function dumpJSONAbsynDims
+  input list<Absyn.Subscript> dims;
+  output JSON json = JSON.makeNull();
+algorithm
+  for d in dims loop
+    json := JSON.addElement(JSON.makeString(Dump.printSubscriptStr(d)), json);
+  end for;
+end dumpJSONAbsynDims;
 
 function dumpJSONAttributes
   input SCode.Attributes attrs;
@@ -2131,17 +2098,21 @@ algorithm
           json := JSON.addPair("each", JSON.makeBoolean(true), json);
         end if;
 
-        json := JSON.addPair("redeclare", JSON.makeBoolean(true), json);
+        if Flags.isSet(Flags.STRUCTURED_REDECLARE) then
+          json := JSON.addPair("$value", dumpJSONSCodeElement(mod.element, scope), json);
+        else
+          json := JSON.addPair("redeclare", JSON.makeBoolean(true), json);
 
-        if SCodeUtil.isElementReplaceable(mod.element) then
-          json := JSON.addPair("replaceable", JSON.makeBoolean(true), json);
-        end if;
+          if SCodeUtil.isElementReplaceable(mod.element) then
+            json := JSON.addPair("replaceable", JSON.makeBoolean(true), json);
+          end if;
 
-        binding_json := JSON.makeString(SCodeDump.unparseElementStr(mod.element));
-        json := JSON.addPair("$value", binding_json, json);
+          binding_json := JSON.makeString(SCodeDump.unparseElementStr(mod.element));
+          json := JSON.addPair("$value", binding_json, json);
 
-        if isChoices then
-          json := dumpJSONRedeclareType(mod.element, scope, json);
+          if isChoices then
+            json := dumpJSONRedeclareType(mod.element, scope, json);
+          end if;
         end if;
       then
         ();
@@ -2172,6 +2143,105 @@ algorithm
     else ();
   end matchcontinue;
 end dumpJSONRedeclareType;
+
+function dumpJSONSCodeElement
+  input SCode.Element element;
+  input InstNode scope;
+  input output JSON json = JSON.makeNull();
+algorithm
+  json := match element
+    case SCode.Element.COMPONENT()
+      algorithm
+        json := JSON.addPair("$kind", JSON.makeString("component"), json);
+        json := JSON.addPair("name", JSON.makeString(element.name), json);
+        json := JSON.addPair("type", dumpJSONPath(AbsynUtil.typeSpecPath(element.typeSpec)), json);
+        json := JSON.addPairNotNull("dims", dumpJSONDims(element.attributes.arrayDims, {}), json);
+        json := dumpJSONSCodeMod(element.modifications, scope, json);
+        json := JSON.addPairNotNull("prefixes", dumpJSONAttributes(element.attributes, element.prefixes, scope), json);
+
+        if isSome(element.condition) then
+          json := JSON.addPair("condition", dumpJSONAbsynExpression(Util.getOption(element.condition)), json);
+        end if;
+
+        json := dumpJSONCommentOpt(SOME(element.comment), scope, json);
+      then
+        json;
+
+    case SCode.Element.CLASS()
+      then dumpJSONSCodeClass(element, scope, false, json);
+
+    else json;
+  end match;
+end dumpJSONSCodeElement;
+
+function dumpJSONSCodeClass
+  input SCode.Element element;
+  input InstNode scope;
+  input Boolean isRedeclare;
+  input output JSON json = JSON.makeNull();
+protected
+  Option<list<Absyn.Subscript>> odims;
+algorithm
+  () := match element
+    case SCode.CLASS()
+      algorithm
+        json := JSON.addPair("$kind", JSON.makeString("class"), json);
+        json := JSON.addPair("name", JSON.makeString(element.name), json);
+        json := JSON.addPair("restriction",
+          JSON.makeString(SCodeDump.restrictionStringPP(element.restriction)), json);
+        json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(element, scope), json);
+        json := dumpJSONSCodeClassDef(element.classDef, scope, isRedeclare, json);
+        json := dumpJSONCommentOpt(SOME(element.cmt), scope, json, dumpAnnotation = not isRedeclare);
+
+        if isRedeclare then
+          json := dumpJSONCommentAnnotation(SOME(element.cmt), scope, json,
+            {"Dialog", "choices", "choicesAllMatching"});
+        end if;
+      then
+        ();
+  end match;
+end dumpJSONSCodeClass;
+
+function dumpJSONSCodeClassDef
+  input SCode.ClassDef classDef;
+  input InstNode scope;
+  input Boolean qualifyPath;
+  input output JSON json;
+protected
+  Absyn.Path path;
+  Option<list<Absyn.Subscript>> odims;
+  InstNode derivedNode;
+algorithm
+  () := match classDef
+    case SCode.ClassDef.DERIVED(typeSpec = Absyn.TypeSpec.TPATH(path = path, arrayDim = odims))
+      algorithm
+        if qualifyPath then
+          try
+            derivedNode := Lookup.lookupName(path, scope, NFInstContext.RELAXED, false);
+            json := JSON.addPair("baseClass", dumpJSONNodeEnclosingPath(derivedNode), json);
+          else
+          end try;
+        else
+          json := JSON.addPair("baseClass", dumpJSONPath(path), json);
+        end if;
+
+        if isSome(odims) then
+          json := JSON.addPairNotNull("dims", dumpJSONDims(Util.getOption(odims), {}), json);
+        end if;
+
+        json := dumpJSONSCodeMod(classDef.modifications, scope, json);
+      then
+        ();
+
+    case SCode.ClassDef.CLASS_EXTENDS()
+      algorithm
+        json := dumpJSONSCodeMod(classDef.modifications, scope, json);
+      then
+        ();
+
+    else ();
+  end match;
+end dumpJSONSCodeClassDef;
 
 function dumpJSONChoicesAnnotation
   input list<SCode.SubMod> mods;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -559,6 +559,8 @@ constant DebugFlag DUMP_EVENTS = DEBUG_FLAG(193, "dumpEvents", false,
   Gettext.gettext("Dumps information about the detected event functions."));
 constant DebugFlag DUMP_BINDINGS = DEBUG_FLAG(194, "dumpBindings", false,
   Gettext.gettext("Dumps information about the equations created from bindings."));
+constant DebugFlag STRUCTURED_REDECLARE = DEBUG_FLAG(195, "structuredRedeclare", false,
+  Gettext.gettext("Dumps redeclares as structures in getModelInstance."));
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -250,7 +250,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DUMP_SLICE,
   Flags.VECTORIZE_BINDINGS,
   Flags.DUMP_EVENTS,
-  Flags.DUMP_BINDINGS
+  Flags.DUMP_BINDINGS,
+  Flags.STRUCTURED_REDECLARE
 };
 
 protected

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -208,7 +208,7 @@
                   "$ref": "#"
                 },
                 {
-                  "description": "Builtin type",
+                  "description": "A builtin or Absyn type",
                   "type": "string"
                 },
                 {
@@ -424,6 +424,19 @@
       },
       "required": ["binding"]
     },
+    "scodeElement": {
+      "description": "An SCode element",
+      "oneOf": [
+        {
+          "description": "A component declaration",
+          "$ref": "#/definitions/component"
+        },
+        {
+          "description": "A class declaration",
+          "$ref": "#/definitions/replaceableClass"
+        }
+      ]
+    },
     "scodeModifier": {
       "description": "An SCode modifier",
       "oneOf": [
@@ -435,13 +448,9 @@
           "type": "object",
           "description": "A modifier with submodifiers",
           "properties": {
-            "$value": {
-              "type": "string",
-              "description": "The string representation of the binding equation"
-            },
             "$type": {
               "type": "string",
-              "description": "The fully qualified type name of a redeclare element"
+              "description": "The fully qualified type name of a redeclare element in a choices annotation"
             }
             "final": {
               "type": "boolean",
@@ -451,13 +460,17 @@
               "type": "boolean",
               "description": "Whether the modifier is each or not"
             },
-            "redeclare": {
-              "type": "boolean",
-              "description": "Whether the modifier is a redeclare or not"
-            },
-            "replaceable": {
-              "type": "boolean",
-              "description": "Whether the modifier is a replaceable or not"
+            "$value": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The binding equation of a modifier"
+                },
+                {
+                  "description": "The element declaration of a redeclare",
+                  "$ref": "#/definitions/scodeElement"
+                }
+              ]
             }
           },
           "additionalProperties": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceChoices2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceChoices2.mos
@@ -1,7 +1,7 @@
 // name: GetModelInstanceChoices2
 // keywords:
 // status: correct
-// cflags: -d=newInst
+// cflags: -d=newInst,structuredRedeclare
 //
 //
 
@@ -42,23 +42,52 @@ getErrorString();
 //         \"choices\": {
 //           \"choice\": [
 //             {
-//               \"redeclare\": true,
-//               \"$value\": \"redeclare Real x = 1.0 \\\"A\\\"\",
-//               \"$type\": \"Real\"
+//               \"$value\": {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"x\",
+//                 \"type\": \"Real\",
+//                 \"modifiers\": \"1.0\",
+//                 \"prefixes\": {
+//                   \"redeclare\": true
+//                 },
+//                 \"comment\": \"A\"
+//               }
 //             },
 //             {
-//               \"redeclare\": true,
-//               \"$value\": \"redeclare Real x = 2.0 \\\"B\\\"\",
-//               \"$type\": \"Real\"
+//               \"$value\": {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"x\",
+//                 \"type\": \"Real\",
+//                 \"modifiers\": \"2.0\",
+//                 \"prefixes\": {
+//                   \"redeclare\": true
+//                 },
+//                 \"comment\": \"B\"
+//               }
 //             },
 //             {
-//               \"redeclare\": true,
-//               \"$value\": \"redeclare P2.OtherReal x = 3.0 \\\"C\\\"\",
-//               \"$type\": \"P.P2.OtherReal\"
+//               \"$value\": {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"x\",
+//                 \"type\": \"P2.OtherReal\",
+//                 \"modifiers\": \"3.0\",
+//                 \"prefixes\": {
+//                   \"redeclare\": true
+//                 },
+//                 \"comment\": \"C\"
+//               }
 //             },
 //             {
-//               \"redeclare\": true,
-//               \"$value\": \"redeclare MissingReal x = 4.0 \\\"D\\\"\"
+//               \"$value\": {
+//                 \"$kind\": \"component\",
+//                 \"name\": \"x\",
+//                 \"type\": \"MissingReal\",
+//                 \"modifiers\": \"4.0\",
+//                 \"prefixes\": {
+//                   \"redeclare\": true
+//                 },
+//                 \"comment\": \"D\"
+//               }
 //             }
 //           ]
 //         }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
@@ -1,7 +1,7 @@
 // name: GetModelInstanceReplaceable3
 // keywords:
 // status: correct
-// cflags: -d=newInst
+// cflags: -d=newInst,structuredRedeclare
 //
 //
 
@@ -41,12 +41,29 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"extends\",
 //       \"modifiers\": {
 //         \"B\": {
-//           \"redeclare\": true,
-//           \"$value\": \"redeclare model B = MB\"
+//           \"$value\": {
+//             \"$kind\": \"class\",
+//             \"name\": \"B\",
+//             \"restriction\": \"model\",
+//             \"prefixes\": {
+//               \"redeclare\": true
+//             },
+//             \"baseClass\": \"MB\"
+//           }
 //         },
 //         \"C\": {
-//           \"redeclare\": true,
-//           \"$value\": \"redeclare model C = C(y = 2.0)\"
+//           \"$value\": {
+//             \"$kind\": \"class\",
+//             \"name\": \"C\",
+//             \"restriction\": \"model\",
+//             \"prefixes\": {
+//               \"redeclare\": true
+//             },
+//             \"baseClass\": \"C\",
+//             \"modifiers\": {
+//               \"y\": \"2.0\"
+//             }
+//           }
 //         }
 //       },
 //       \"baseClass\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable6.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable6.mos
@@ -1,4 +1,4 @@
-// name: GetModelInstanceReplaceable5
+// name: GetModelInstanceReplaceable6
 // keywords:
 // status: correct
 // cflags: -d=newInst,structuredRedeclare
@@ -8,11 +8,11 @@
 loadString("
   package P
     model A
-      replaceable Real x;
+      replaceable Real x[:];
     end A;
 
     model M
-      A a(redeclare replaceable Real x = 1.0);
+      A a(redeclare replaceable Real x[2] = {1, 2});
     end M;
   end P;
 ");
@@ -36,8 +36,19 @@ getModelInstance(P.M, prettyPrint = true);
 //             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
+//             \"dims\": {
+//               \"absyn\": [
+//                 \":\"
+//               ],
+//               \"typed\": [
+//                 \"2\"
+//               ]
+//             },
 //             \"value\": {
-//               \"binding\": 1
+//               \"binding\": [
+//                 1,
+//                 2
+//               ]
 //             },
 //             \"prefixes\": {
 //               \"replaceable\": true
@@ -58,7 +69,12 @@ getModelInstance(P.M, prettyPrint = true);
 //             \"$kind\": \"component\",
 //             \"name\": \"x\",
 //             \"type\": \"Real\",
-//             \"modifiers\": \"1.0\",
+//             \"dims\": {
+//               \"absyn\": [
+//                 \"2\"
+//               ]
+//             },
+//             \"modifiers\": \"{1, 2}\",
 //             \"prefixes\": {
 //               \"replaceable\": true,
 //               \"redeclare\": true

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -67,6 +67,7 @@ GetModelInstanceReplaceable2.mos \
 GetModelInstanceReplaceable3.mos \
 GetModelInstanceReplaceable4.mos \
 GetModelInstanceReplaceable5.mos \
+GetModelInstanceReplaceable6.mos \
 GetModelInstanceReplaceableComment.mos \
 GetModelInstanceStateMachine1.mos \
 ModifierToJSON1.mos \

--- a/testsuite/openmodelica/instance-API/ModifierToJSON1.mos
+++ b/testsuite/openmodelica/instance-API/ModifierToJSON1.mos
@@ -1,7 +1,7 @@
 // name: ModifierToJSON1
 // keywords:
 // status: correct
-// cflags: -d=newInst
+// cflags: -d=newInst,structuredRedeclare
 //
 //
 
@@ -12,8 +12,15 @@ getErrorString();
 // "{
 //   \"a\": {
 //     \"y\": {
-//       \"redeclare\": true,
-//       \"$value\": \"redeclare MyReal y = 4\"
+//       \"$value\": {
+//         \"$kind\": \"component\",
+//         \"name\": \"y\",
+//         \"type\": \"MyReal\",
+//         \"modifiers\": \"4\",
+//         \"prefixes\": {
+//           \"redeclare\": true
+//         }
+//       }
 //     },
 //     \"x\": \"3\"
 //   },


### PR DESCRIPTION
- Dump redeclare modifiers as JSON structures in getModelInstance instead of just strings when `-d=structuredRedeclare` is set.