### PR TITLE
fix OMSimulator PYTHONPATH in OMEdit

### DIFF
--- a/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.cpp
@@ -304,7 +304,7 @@ OMSSimulationOutputWidget::OMSSimulationOutputWidget(const QString &cref, const 
     process = QString("python");
     QProcessEnvironment processEnvironment = QProcessEnvironment::systemEnvironment();
     QString OMHOME = QString(Helper::OpenModelicaHome);
-    processEnvironment.insert("PYTHONPATH",  OMHOME + "/bin;" + OMHOME + "/lib;" + processEnvironment.value("PYTHONPATH"));
+    processEnvironment.insert("PYTHONPATH",  OMHOME + "/bin;" + OMHOME + "/lib/omc;" + processEnvironment.value("PYTHONPATH"));
     processEnvironment.insert("PATH",  OMHOME + "/bin;" + OMHOME + "/lib;" + processEnvironment.value("PATH"));
     mpSimulationProcess->setProcessEnvironment(processEnvironment);
 #else


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11514

### Purpose

This PR fixes the ssp simulation from OMEdit.  It basically fixes the `PYTHONPATH` of OMSimulator in `windows`  as now OMSimulator package is copied into `lib/omc/OMSimulator` compared to `lib/OMSimulator` in older versions
