### PR TITLE
Clear the model from the clipboard when its unloaded

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -2791,6 +2791,13 @@ void unloadHelper(LibraryTreeItem *pLibraryTreeItem)
   MainWindow *pMainWindow = MainWindow::instance();
   /* close the ModelWidget of LibraryTreeItem. */
   if (pLibraryTreeItem->getModelWidget()) {
+    // clear model from clipboard
+    if (QApplication::clipboard()->mimeData() && QApplication::clipboard()->mimeData()->hasFormat(Helper::cutCopyPasteFormat)) {
+      const MimeData *pMimeData = qobject_cast<const MimeData*>(QApplication::clipboard()->mimeData());
+      if (pMimeData && pMimeData->getName().compare(pLibraryTreeItem->getNameStructure()) == 0) {
+        QApplication::clipboard()->clear();
+      }
+    }
     // if ModelWidget is used by DiagramWindow
     if (MainWindow::instance()->getPlotWindowContainer()->getDiagramSubWindowFromMdi()
         && MainWindow::instance()->getPlotWindowContainer()->getDiagramWindow()->getModelWidget() == pLibraryTreeItem->getModelWidget()) {

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -3594,7 +3594,7 @@ void GraphicsView::copyItems(bool cut)
   if (!selectedItems.isEmpty()) {
     QStringList components, connections, shapes, allItems;
     connections << "equation";
-    MimeData *pMimeData = new MimeData;
+    MimeData *pMimeData = new MimeData(mpModelWidget->getLibraryTreeItem()->getNameStructure());
     for (int i = itemsList.size() - 1 ; i >= 0 ; i--) {
       if (itemsList.at(i)->isSelected()) {
         if (Element *pElement = dynamic_cast<Element*>(itemsList.at(i))) {
@@ -3645,7 +3645,10 @@ void GraphicsView::modelicaGraphicsViewContextMenu(QMenu *pMenu)
     pExportMenu->addAction(MainWindow::instance()->getExportToOMNotebookAction());
     pMenu->addSeparator();
     bool isSystemLibrary = mpModelWidget->getLibraryTreeItem()->isSystemLibrary() || isVisualizationView();
-    mpPasteAction->setEnabled(!isSystemLibrary && QApplication::clipboard()->mimeData()->hasFormat(Helper::cutCopyPasteFormat) && qobject_cast<const MimeData*>(QApplication::clipboard()->mimeData()));
+    mpPasteAction->setEnabled(!isSystemLibrary
+                              && QApplication::clipboard()->mimeData()
+                              && QApplication::clipboard()->mimeData()->hasFormat(Helper::cutCopyPasteFormat)
+                              && qobject_cast<const MimeData*>(QApplication::clipboard()->mimeData()));
     pMenu->addAction(mpPasteAction);
     pMenu->addSeparator();
     pMenu->addAction(MainWindow::instance()->getPrintModelAction());
@@ -3933,9 +3936,8 @@ QString replaceComponentNameInConnection(const QString &oldConnectionComponentNa
  */
 void GraphicsView::pasteItems()
 {
-  QClipboard *pClipboard = QApplication::clipboard();
-  if (pClipboard->mimeData()->hasFormat(Helper::cutCopyPasteFormat)) {
-    if (const MimeData *pMimeData = qobject_cast<const MimeData*>(pClipboard->mimeData())) {
+  if (QApplication::clipboard()->mimeData() && QApplication::clipboard()->mimeData()->hasFormat(Helper::cutCopyPasteFormat)) {
+    if (const MimeData *pMimeData = qobject_cast<const MimeData*>(QApplication::clipboard()->mimeData())) {
       const QString action = "Paste items from clipboard";
       mpModelWidget->beginMacro(action);
       ModelInfo oldModelInfo;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -539,12 +539,14 @@ class MimeData : public QMimeData
 {
   Q_OBJECT
 public:
-  MimeData() : QMimeData()
+  MimeData(const QString &name) : QMimeData()
   {
+    mName = name;
     mComponents.clear();
     mConnections.clear();
     mShapes.clear();
   }
+  QString getName() const {return mName;}
   void addComponent(Element *pComponent) {mComponents.append(pComponent);}
   QList<Element*> getComponents() const {return mComponents;}
   void addModifier(ModelInstance::Modifier modifier) {mModifiers.append(modifier);}
@@ -554,6 +556,7 @@ public:
   void addShape(ShapeAnnotation *pShapeAnnotation) {mShapes.append(pShapeAnnotation);}
   QList<ShapeAnnotation*> getShapes() const {return mShapes;}
 private:
+  QString mName;
   QList<Element*> mComponents;
   QList<ModelInstance::Modifier> mModifiers;
   QList<LineAnnotation*> mConnections;


### PR DESCRIPTION
### Related Issues

Fixes #11516

### Purpose

Do not crash when pasting items from unloaded models.

### Approach

Clear the model the clipboard when its unloaded.
