### PR TITLE
Forbid type dimensions when redeclaring components

### DIFF
--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -775,6 +775,21 @@ type_specifier returns [void* ast]
   ;
   finally{ OM_POP(3); }
 
+type_specifier_no_dims returns [void* ast]
+@init { OM_PUSHZ2(np, ts); } :
+  np=name_path (lt=LESS ts=type_specifier_list gt=GREATER)?
+    {
+      if (ts != NULL) {
+        modelicaParserAssert(metamodelica_enabled(),"Algebraic data types are only available in MetaModelica", type_specifier_no_dims, $start->line, $start->charPosition+1, $gt->line, $gt->charPosition+2);
+
+        $ast = Absyn__TCOMPLEX(np,ts,mmc_mk_nil());
+      } else {
+        $ast = Absyn__TPATH(np,mmc_mk_nil());
+      }
+    }
+  ;
+  finally{ OM_POP(2); }
+
 type_specifier_list returns [void* ast]
 @init { OM_PUSHZ3($np1.ast, np2, ast); } :
   np1=type_specifier ( COMMA np2=type_specifier_list )? { ast = mmc_mk_cons_typed(Absyn_TypeSpec, $np1.ast, or_nil(np2)); }
@@ -950,7 +965,7 @@ element_replaceable [int each, int final, int redeclare] returns [void* ast]
 
 component_clause1 returns [void* ast]
 @init { OM_PUSHZ3(attr, ts.ast, comp_decl); } :
-  attr=base_prefix ts=type_specifier comp_decl=component_declaration1
+  attr=base_prefix ts=type_specifier_no_dims comp_decl=component_declaration1
     {
       ast = Absyn__COMPONENTS(attr, $ts.ast, mmc_mk_cons_typed(Absyn_ComponentItem, comp_decl, mmc_mk_nil()));
     }

--- a/testsuite/flattening/modelica/redeclare/Makefile
+++ b/testsuite/flattening/modelica/redeclare/Makefile
@@ -38,6 +38,7 @@ RedeclareArrayComponent1.mo \
 RedeclareBaseClass1.mo \
 RedeclareClass1.mo \
 RedeclareClass4.mo \
+RedeclareComponentInvalidDims1.mo \
 RedeclareElementCondition.mo \
 RedeclareFlowEffort.mo \
 RedeclareFunction.mo \

--- a/testsuite/flattening/modelica/redeclare/RedeclareComponentInvalidDims1.mo
+++ b/testsuite/flattening/modelica/redeclare/RedeclareComponentInvalidDims1.mo
@@ -1,0 +1,29 @@
+// name:     RedeclareComponentInvalidDims1
+// keywords: redeclare component
+// status:   incorrect
+// cflags: -d=newInst
+//
+// Checks that a redeclare of a component is not allowed to have dimensions on
+// the type.
+//
+
+model A
+  Real x[:];
+end A;
+
+model RedeclareComponentInvalidDims1
+  extends A(redeclare A[2] x);
+end RedeclareComponentInvalidDims1;
+
+// Result:
+// Error processing file: RedeclareComponentInvalidDims1.mo
+// Failed to parse file: RedeclareComponentInvalidDims1.mo!
+//
+// [flattening/modelica/redeclare/RedeclareComponentInvalidDims1.mo:15:24-15:24:writable] Error: No viable alternative near token: [
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+// Failed to parse file: RedeclareComponentInvalidDims1.mo!
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/RedeclareClass2.mo
+++ b/testsuite/flattening/modelica/scodeinst/RedeclareClass2.mo
@@ -29,7 +29,7 @@ partial model PartialDistribution2Pipe
 end PartialDistribution2Pipe;
 
 model RedeclareClass2
-  extends PartialDistribution2Pipe(redeclare Connection2PipeLossless[nCon] con);
+  extends PartialDistribution2Pipe(redeclare Connection2PipeLossless con[nCon]);
 end RedeclareClass2;
 
 


### PR DESCRIPTION
- Change the parser to reject dimensions on the type of a component redeclare, since it's not valid syntax according to the Modelica grammar.

Fixes #2312