### PR TITLE
[NF] use makeRange() to have correct type

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -514,7 +514,6 @@ protected
     BackendExtension.VariableAttributes attributes;
     BackendExtension.Annotations annotations;
   algorithm
-    // ToDo! extract tearing select option
     try
       attributes := BackendExtension.VariableAttributes.create(var.typeAttributes, var.ty, var.attributes, var.children, var.comment);
       annotations := BackendExtension.Annotations.create(var.comment);

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2054,7 +2054,7 @@ public
           step          := NONE();
           for stop in rest loop
             iter_name   := InstNode.newIndexedIterator(index);
-            iter_range  := Expression.RANGE(Type.INTEGER(), start, step, stop);
+            iter_range  := Expression.makeRange(start, step, stop);
             iterators   := (iter_name, iter_range) :: iterators;
             index       := index + 1;
           end for;


### PR DESCRIPTION
Fixes `ScalableTestSuite.Electrical.TransmissionLine.ScaledExperiments.TransmissionLineModelica_N_X` models.

Ranges created from `fill()` now have the correct type, so the function trying to get its dimensions doesnt fail anymore.

### Related Issues
#10001 