### PR TITLE
Don't warn about vendor experiment options

### DIFF
--- a/testsuite/flattening/modelica/connectors/Ticket4062.mo
+++ b/testsuite/flattening/modelica/connectors/Ticket4062.mo
@@ -486,7 +486,4 @@ end Ticket4062;
 //   serialReceive.pkgOut.userPkgBitSize = unpackInt.pkgIn.userPkgBitSize;
 //   integerToReal.u = unpackInt.y;
 // end Ticket4062;
-// Warning: Ignoring unknown experiment annotation option: __Dymola_fixedstepsize = 0.001
-// Warning: Ignoring unknown experiment annotation option: __Dymola_Algorithm = "Euler"
-//
 // endResult


### PR DESCRIPTION
- Clean up CevalScriptBackend.populateSimulationOptions.
- Don't print warnings about unknown experiment options in they're vendor-specific options that begin with `__`.
- Spelling defaulSimOpt => defaultSimOpt.