### PR TITLE
Expandable connector fixes

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2095,6 +2095,7 @@ algorithm
 
   // Elaborate expandable connectors.
   (flatModel, conns) := ExpandableConnectors.elaborate(flatModel, conns);
+  flatModel.variables := list(v for v guard Variable.isPresent(v) in flatModel.variables);
 
   // Collect flow variables from the model, which needs to be done after
   // elaborating expandable connectors to get all of them.
@@ -2128,7 +2129,6 @@ algorithm
 
   // add the equations to the flat model
   flatModel.equations := listAppend(conn_eql, flatModel.equations);
-  flatModel.variables := list(v for v guard Variable.isPresent(v) in flatModel.variables);
 
   // remove input and output prefixes from local IOs that are determined through connect equations
   if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) > 0 then

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -360,7 +360,7 @@ algorithm
     return;
   end if;
 
-  parent := InstNode.parent(component);
+  parent := InstNode.instanceParent(component);
   if InstNode.isComponent(parent) and Component.isConnector(InstNode.component(parent)) then
     return;
   end if;
@@ -503,20 +503,6 @@ algorithm
     end if;
   end if;
 end checkComponentStreamAttribute;
-
-function checkConnectorType
-  input InstNode node;
-  output Boolean isConnector;
-protected
-  InstNode dnode = InstNode.getDerivedNode(node);
-algorithm
-  if InstNode.isEmpty(dnode) or InstNode.isInnerOuterNode(dnode) then
-    isConnector := false;
-  else
-    isConnector := Class.isConnectorClass(InstNode.getClass(dnode)) or
-                   checkConnectorType(InstNode.parent(dnode));
-  end if;
-end checkConnectorType;
 
 function typeIterator
   input InstNode iterator;

--- a/testsuite/flattening/modelica/scodeinst/ExpandableConnector10.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExpandableConnector10.mo
@@ -1,0 +1,29 @@
+// name: ExpandableConnector10
+// keywords: expandable connector
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+connector FluidPort
+  flow Real m_flow;
+  Real p;
+  stream Real h_outflow;
+end FluidPort;
+
+connector FluidPort_a
+  extends FluidPort;
+end FluidPort_a;
+
+expandable connector Bus
+  FluidPort_a port_1;
+end Bus;
+
+model ExpandableConnector10
+  Bus bus;
+end ExpandableConnector10;
+
+// Result:
+// class ExpandableConnector10
+// end ExpandableConnector10;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -441,6 +441,7 @@ ExpandableConnector6.mo \
 ExpandableConnector7.mo \
 ExpandableConnector8.mo \
 ExpandableConnector9.mo \
+ExpandableConnector10.mo \
 ExpandableConnectorComplex1.mo \
 ExpandableConnectorFlow1.mo \
 ExpandableConnectorFlow2.mo \


### PR DESCRIPTION
- Fix Typing.checkConnectorTypeBalance by using the instance parent instead of the direct parent when checking if a component is inside a connector or not.
- Remove non-present variables in expandable connectors before collecting unassigned flow variables, to avoid generating equations for non-existent variables.
- Remove unused function Typing.checkConnectorType.
