### PR TITLE
Remove non-top-level direction earlier

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -1023,5 +1023,19 @@ public
     end for;
   end hasArrayConnections;
 
+  function removeNonTopLevelDirections
+    input output FlatModel flatModel;
+  protected
+    Integer expose_local_ios;
+  algorithm
+    // Keep the declared directions if --useLocalDirection=true has been set.
+    if Flags.getConfigBool(Flags.USE_LOCAL_DIRECTION) then
+      return;
+    end if;
+
+    expose_local_ios := Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS);
+    flatModel.variables := list(Variable.removeNonTopLevelDirection(v, expose_local_ios) for v in flatModel.variables);
+  end removeNonTopLevelDirections;
+
   annotation(__OpenModelica_Interface="frontend");
 end NFFlatModel;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -144,7 +144,7 @@ protected
   InstNode top, cls, inst_cls;
   String name;
   InstContext.Type context;
-  Integer var_count, eq_count;
+  Integer var_count, eq_count, expose_local_ios;
 algorithm
   //Inst_test(program);
   resetGlobalFlags();
@@ -244,6 +244,8 @@ algorithm
   // propagate hide result attribute
   // ticket #4346
   flatModel.variables := list(Variable.propagateAnnotation("HideResult", false, var) for var in flatModel.variables);
+
+  flatModel := FlatModel.removeNonTopLevelDirections(flatModel);
 
   if Flags.getConfigString(Flags.OBFUSCATE) == "protected" or
      Flags.getConfigString(Flags.OBFUSCATE) == "encrypted" then

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -365,9 +365,48 @@ public
     end if;
   end propagateAnnotation;
 
-    partial function MapFn
-      input output Expression exp;
-    end MapFn;
+  function removeNonTopLevelDirection
+    "Removes input/output prefixes from a variable that's not a top-level
+     component, a component in a top-level connector, or a component in a
+     top-level input component. exposeLocalIOs can be used to keep the direction
+     for variables at lower levels as well, where 0 means top-level, 1 the level
+     below that, and so on."
+    input output Variable var;
+    input Integer exposeLocalIOs;
+  protected
+    ComponentRef rest_name;
+    InstNode node;
+    Attributes attr;
+  algorithm
+    if var.attributes.direction == Direction.NONE then
+      return;
+    end if;
+
+    if exposeLocalIOs > 0 and
+       var.attributes.connectorType <> ConnectorType.NON_CONNECTOR and
+       var.visibility == Visibility.PUBLIC and
+       ComponentRef.depth(var.name) < exposeLocalIOs then
+      return;
+    end if;
+
+    rest_name := ComponentRef.rest(var.name);
+    while not ComponentRef.isEmpty(rest_name) loop
+      node := ComponentRef.node(rest_name);
+
+      if not (InstNode.isConnector(node) or InstNode.isInput(node)) then
+        attr := var.attributes;
+        attr.direction := Direction.NONE;
+        var.attributes := attr;
+        return;
+      end if;
+
+      rest_name := ComponentRef.rest(rest_name);
+    end while;
+  end removeNonTopLevelDirection;
+
+  partial function MapFn
+    input output Expression exp;
+  end MapFn;
 
   function mapExp
     input output Variable var;


### PR DESCRIPTION
- Remove non-top-level variable directions during the instantiation instead of during the conversion to DAE, so it applies to the NB too.