### PR TITLE
Added a tab widget at the bottom of MainWindow

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -55,6 +55,7 @@
 #include "Util/Helper.h"
 #include "Simulation/ArchivedSimulationsWidget.h"
 #include "Simulation/SimulationOutputWidget.h"
+#include "OMS/OMSSimulationOutputWidget.h"
 #include "TLM/FetchInterfaceDataDialog.h"
 #include "TLM/TLMCoSimulationOutputWidget.h"
 #include "OMS/OMSSimulationDialog.h"
@@ -185,11 +186,11 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // Create MessagesDockWidget dock
   mpMessagesDockWidget = new QDockWidget(tr("Messages Browser"), this);
   mpMessagesDockWidget->setObjectName("Messages");
-  mpMessagesDockWidget->setAllowedAreas(Qt::TopDockWidgetArea | Qt::BottomDockWidgetArea);
+  mpMessagesDockWidget->setAllowedAreas(Qt::BottomDockWidgetArea);
   mpMessagesDockWidget->setWidget(MessagesWidget::instance());
   addDockWidget(Qt::BottomDockWidgetArea, mpMessagesDockWidget);
   mpMessagesDockWidget->hide();
-  connect(MessagesWidget::instance(), SIGNAL(MessageAdded()), SLOT(showMessagesBrowser()));
+  connect(MessagesWidget::instance(), SIGNAL(messageAdded()), SLOT(showMessagesBrowser()));
   // Create the OMCProxy object.
   mpOMCProxy = new OMCProxy(threadData, this);
   if (getExitApplicationStatus()) {
@@ -381,8 +382,25 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpCentralStackedWidget->addWidget(mpWelcomePageWidget);
   mpCentralStackedWidget->addWidget(mpModelWidgetContainer);
   mpCentralStackedWidget->addWidget(mpPlotWindowContainer);
+  // central widget layout
+  QVBoxLayout *pCentralWidgetLayout = new QVBoxLayout;
+  pCentralWidgetLayout->setSpacing(0);
+  pCentralWidgetLayout->setContentsMargins(0, 0, 0, 0);
+  QWidget *pCentralWidget = new QWidget;
+  pCentralWidgetLayout->addWidget(mpCentralStackedWidget, 1);
+  // Create a QTabWidget that mimicks the Messages Browser
+  mpMessagesTabWidget = new QTabWidget(this);
+  mpMessagesTabWidget->setTabsClosable(true);
+  mpMessagesTabWidget->setDocumentMode(true);
+  connect(mpMessagesTabWidget, SIGNAL(tabBarClicked(int)), SLOT(messagesTabBarClicked(int)));
+  connect(mpMessagesDockWidget, SIGNAL(visibilityChanged(bool)), SLOT(messagesDockWidgetVisibilityChanged(bool)));
+  connect(MessagesWidget::instance(), SIGNAL(messageTabAdded(QWidget*,QString)), SLOT(messageTabAdded(QWidget*,QString)));
+  connect(MessagesWidget::instance(), SIGNAL(messageTabClosed(int)), SLOT(messageTabClosed(int)));
+  connect(mpMessagesTabWidget, SIGNAL(tabCloseRequested(int)), MessagesWidget::instance(), SLOT(closeTab(int)));
+  pCentralWidgetLayout->addWidget(mpMessagesTabWidget, 0);
+  pCentralWidget->setLayout(pCentralWidgetLayout);
   //Set the centralwidget
-  setCentralWidget(mpCentralStackedWidget);
+  setCentralWidget(pCentralWidget);
   // Load and add user defined Modelica libraries into the Library Widget.
   if (!isTestsuiteRunning()) {
     mpLibraryWidget->getLibraryTreeModel()->addModelicaLibraries();
@@ -429,6 +447,18 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   if (OptionsDialog::instance()->getGeneralSettingsPage()->getEnableAutoSaveGroupBox()->isChecked()) {
     mpAutoSaveTimer->start();
   }
+  // create tabs from MessagesWidget
+  QTabBar::ButtonPosition closeSide = (QTabBar::ButtonPosition)style()->styleHint(QStyle::SH_TabBar_CloseButtonPosition, 0, mpMessagesTabWidget);
+  MessagesTabWidget *pMessagesTabWidget = MessagesWidget::instance()->getMessagesTabWidget();
+  for (int i = 0; i < pMessagesTabWidget->count(); ++i) {
+    createMessageTab(pMessagesTabWidget->tabText(i), true);
+    QWidget *pTabButtonWidget = mpMessagesTabWidget->tabBar()->tabButton(i, closeSide);
+    if (pTabButtonWidget) {
+      pTabButtonWidget->deleteLater();
+    }
+    mpMessagesTabWidget->tabBar()->setTabButton(i, closeSide, 0);
+  }
+  mpMessagesTabWidget->setVisible(!mpMessagesDockWidget->isVisible());
 }
 
 /*!
@@ -1785,7 +1815,7 @@ void MainWindow::writeNewApiProfiling(const QString &str)
 
 /*!
  * \brief MainWindow::showMessagesBrowser
- * Slot activated when MessagesWidget::MessageAdded signal is raised.\n
+ * Slot activated when MessagesWidget::messageAdded signal is raised.\n
  * Shows the Messages Browser.
  */
 void MainWindow::showMessagesBrowser()
@@ -3575,6 +3605,62 @@ void MainWindow::threeDViewerDockWidgetVisibilityChanged(bool visible)
 }
 
 /*!
+ * \brief MainWindow::messagesTabBarClicked
+ * Shows the MessagesWidget when tab is clicked.
+ * \param index
+ */
+void MainWindow::messagesTabBarClicked(int index)
+{
+  showMessagesBrowser();
+  MessagesWidget::instance()->getMessagesTabWidget()->setCurrentIndex(index);
+}
+
+/*!
+ * \brief MainWindow::messagesDockWidgetVisibilityChanged
+ * Handles the VisibilityChanged signal of MessagesBrowser Dock Widget.
+ * \param visible
+ */
+void MainWindow::messagesDockWidgetVisibilityChanged(bool visible)
+{
+  mpMessagesTabWidget->setVisible(!visible);
+  if (!visible && MessagesWidget::instance()) {
+    mpMessagesTabWidget->setCurrentIndex(MessagesWidget::instance()->getMessagesTabWidget()->currentIndex());
+  }
+}
+
+/*!
+ * \brief MainWindow::messageTabAdded
+ * Handles the messageTabAdded signal of MessagesWidget.
+ * \param pSimulationOutputTab
+ * \param name
+ */
+void MainWindow::messageTabAdded(QWidget *pSimulationOutputTab, const QString &name)
+{
+  MessageTab *pMessageTab = createMessageTab(name, false);
+  SimulationOutputWidget *pSimulationOutputWidget = qobject_cast<SimulationOutputWidget*>(pSimulationOutputTab);
+  if (pSimulationOutputWidget) {
+    connect(pSimulationOutputWidget, SIGNAL(updateText(QString)), pMessageTab, SLOT(updateText(QString)));
+    connect(pSimulationOutputWidget, SIGNAL(updateProgressBar(QProgressBar*)), pMessageTab, SLOT(updateProgress(QProgressBar*)));
+  } else {
+    OMSSimulationOutputWidget *pOMSSimulationOutputWidget = qobject_cast<OMSSimulationOutputWidget*>(pSimulationOutputTab);
+    if (pOMSSimulationOutputWidget) {
+      connect(pOMSSimulationOutputWidget, SIGNAL(updateText(QString)), pMessageTab, SLOT(updateText(QString)));
+      connect(pOMSSimulationOutputWidget, SIGNAL(updateProgressBar(QProgressBar*)), pMessageTab, SLOT(updateProgress(QProgressBar*)));
+    }
+  }
+}
+
+/*!
+ * \brief MainWindow::messageTabClosed
+ * Handles the messageTabClosed signal of MessagesWidget.
+ * \param name
+ */
+void MainWindow::messageTabClosed(int index)
+{
+  mpMessagesTabWidget->removeTab(index);
+}
+
+/*!
  * \brief MainWindow::autoSave
  * Slot activated when mpAutoSaveTimer timeout SIGNAL is raised.\n
  * Auto saves the classes which user has alreadys saved to a file. Classes not saved to a file are not saved.
@@ -5016,6 +5102,23 @@ void MainWindow::toolBarVisibilityChanged(const QString &toolbar, bool visible)
   pSettings->endGroup();
 }
 
+/*!
+ * \brief MainWindow::createMessageTab
+ * Creates the MessageTab.
+ * \param name
+ * \param fixedTab
+ * \return
+ */
+MessageTab *MainWindow::createMessageTab(const QString &name, bool fixedTab)
+{
+  MessageTab *pMessageTab = new MessageTab(fixedTab);
+  int index = mpMessagesTabWidget->addTab(pMessageTab, name);
+  pMessageTab->setIndex(index);
+  mpMessagesTabWidget->setCurrentIndex(index);
+  connect(pMessageTab, SIGNAL(clicked(int)), mpMessagesTabWidget, SIGNAL(tabBarClicked(int)));
+  return pMessageTab;
+}
+
 //! when the dragged object enters the main window
 //! @param event contains information of the drag operation.
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)
@@ -5183,4 +5286,75 @@ void AboutOMEditDialog::showReportIssue()
   // show the CrashReportDialog
   CrashReportDialog *pCrashReportDialog = new CrashReportDialog("", true);
   pCrashReportDialog->exec();
+}
+
+/*!
+ * \class MessageTab
+ * \brief Creates a tab that mimicks the tab of Messages Browser.
+ */
+/*!
+ * \brief MessageTab::MessageTab
+ * \param fixedTab
+ */
+MessageTab::MessageTab(bool fixedTab)
+ : QWidget()
+{
+  mpProgressLabel = new Label;
+  mpProgressLabel->setElideMode(Qt::ElideMiddle);
+  mpProgressLabel->installEventFilter(this);
+  if (fixedTab) {
+    mpProgressLabel->setText(tr("Click to open Messages Browser."));
+  }
+  mpProgressBar = new QProgressBar;
+  mpProgressBar->setAlignment(Qt::AlignHCenter);
+  mpProgressBar->installEventFilter(this);
+  // layout
+  QGridLayout *pMainLayout = new QGridLayout;
+  pMainLayout->setContentsMargins(5, 5, 5, 5);
+  pMainLayout->addWidget(mpProgressLabel, 0, 0);
+  if (!fixedTab) {
+    pMainLayout->addWidget(mpProgressBar, 0, 1);
+  }
+  setLayout(pMainLayout);
+}
+
+/*!
+ * \brief MessageTab::updateText
+ * Updates the text label.
+ * \param text
+ */
+void MessageTab::updateText(const QString &text)
+{
+  mpProgressLabel->setText(text);
+}
+
+/*!
+ * \brief MessageTab::updateProgress
+ * Updates the progressBar
+ * \param pProgressBar
+ */
+void MessageTab::updateProgress(QProgressBar *pProgressBar)
+{
+  mpProgressBar->setRange(pProgressBar->minimum(), pProgressBar->maximum());
+  mpProgressBar->setValue(pProgressBar->value());
+  mpProgressBar->setTextVisible(pProgressBar->isTextVisible());
+}
+
+/*!
+ * \brief MessageTab::eventFilter
+ * Emits the clicked signal on left mouse press.
+ * \param pObject
+ * \param pEvent
+ * \return
+ */
+bool MessageTab::eventFilter(QObject *pObject, QEvent *pEvent)
+{
+  if (pEvent->type() == QEvent::MouseButtonPress) {
+    QMouseEvent *pMouseEvent = static_cast<QMouseEvent*>(pEvent);
+    if (pMouseEvent && pMouseEvent->button() == Qt::LeftButton) {
+      emit clicked(mIndex);
+      return true;
+    }
+  }
+  return QObject::eventFilter(pObject, pEvent);
 }

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -458,6 +458,8 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
     }
     mpMessagesTabWidget->tabBar()->setTabButton(i, closeSide, 0);
   }
+  // since createMessageTab() changes the index so switch it back to 0.
+  mpMessagesTabWidget->setCurrentIndex(0);
   mpMessagesTabWidget->setVisible(!mpMessagesDockWidget->isVisible());
 }
 

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -91,6 +91,7 @@ class TraceabilityInformationURI;
 class StatusBar;
 class TraceabilityGraphViewWidget;
 class SearchWidget;
+class MessageTab;
 
 class MainWindow : public QMainWindow
 {
@@ -117,6 +118,7 @@ public:
   void setExitApplicationStatus(bool status) {mExitApplicationStatus = status;}
   bool getExitApplicationStatus() {return mExitApplicationStatus;}
   int getNumberOfProcessors() {return mNumberOfProcessors;}
+  QDockWidget* getMessagesDockWidget() {return mpMessagesDockWidget;}
   LibraryWidget* getLibraryWidget() {return mpLibraryWidget;}
   StackFramesWidget* getStackFramesWidget() {return mpStackFramesWidget;}
   BreakpointsWidget* getBreakpointsWidget() {return mpBreakpointsWidget;}
@@ -314,6 +316,7 @@ private:
   CommitChangesDialog *mpCommitChangesDialog;
   TraceabilityInformationURI *mpTraceabilityInformationURI;
   QStackedWidget *mpCentralStackedWidget;
+  QTabWidget *mpMessagesTabWidget;
   QProgressBar *mpProgressBar;
   Label *mpPositionLabel;
   QTabBar *mpPerspectiveTabbar;
@@ -589,6 +592,10 @@ private slots:
   void perspectiveTabChanged(int tabIndex);
   void documentationDockWidgetVisibilityChanged(bool visible);
   void threeDViewerDockWidgetVisibilityChanged(bool visible);
+  void messagesTabBarClicked(int index);
+  void messagesDockWidgetVisibilityChanged(bool visible);
+  void messageTabAdded(QWidget *pSimulationOutputTab, const QString &name);
+  void messageTabClosed(int index);
   void autoSave();
   void showDataReconciliationDialog();
   void showDebugConfigurationsDialog();
@@ -613,6 +620,7 @@ private:
   void tileSubWindows(QMdiArea *pMdiArea, bool horizontally);
   void fetchInterfaceDataHelper(LibraryTreeItem *pLibraryTreeItem, QString singleModel = QString());
   void toolBarVisibilityChanged(const QString &toolbar, bool visible);
+  MessageTab* createMessageTab(const QString &name, bool fixedTab);
 protected:
   virtual void dragEnterEvent(QDragEnterEvent *event) override;
   virtual void dragMoveEvent(QDragMoveEvent *event) override;
@@ -631,6 +639,26 @@ public slots:
   void showReportIssue();
 private slots:
   void readOMContributors(QNetworkReply *pNetworkReply);
+};
+
+class MessageTab : public QWidget
+{
+  Q_OBJECT
+public:
+  MessageTab(bool fixedTab);
+  void setIndex(int index) {mIndex = index;}
+private:
+  int mIndex = -1;
+  Label *mpProgressLabel;
+  QProgressBar *mpProgressBar;
+public slots:
+  void updateText(const QString &text);
+  void updateProgress(QProgressBar *pProgressBar);
+signals:
+  void clicked(int index);
+  // QObject interface
+public:
+  virtual bool eventFilter(QObject *pObject, QEvent *pEvent) override;
 };
 
 #endif // MAINWINDOW_H

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -381,6 +381,7 @@ void MessageWidget::clearAllTabsMessages()
 MessagesTabWidget::MessagesTabWidget(QWidget *pParent)
   : QTabWidget(pParent)
 {
+  setDocumentMode(true);
   setTabsClosable(true);
 }
 
@@ -523,8 +524,8 @@ void MessagesWidget::addSimulationOutputTab(QWidget *pSimulationOutputTab, const
   // add the tab if it doesn't already exist
   if (!tabFound) {
     mpMessagesTabWidget->setCurrentIndex(mpMessagesTabWidget->addTab(pSimulationOutputTab, name));
+    emit messageTabAdded(pSimulationOutputTab, name);
   }
-  emit MessageAdded();
 }
 
 /*!
@@ -568,11 +569,13 @@ bool MessagesWidget::closeTab(int index)
     if (pSimulationOutputWidget->getSimulationOptions().isInteractiveSimulation()) {
       MainWindow::instance()->getSimulationDialog()->removeSimulationOutputWidget(pSimulationOutputWidget);
     }
+    emit messageTabClosed(index);
     return true;
   }
   OMSSimulationOutputWidget *pOMSSimulationOutputWidget = qobject_cast<OMSSimulationOutputWidget*>(mpMessagesTabWidget->widget(index));
   if (pOMSSimulationOutputWidget && !pOMSSimulationOutputWidget->isSimulationProcessRunning()) {
     mpMessagesTabWidget->removeTab(index);
+    emit messageTabClosed(index);
     return true;
   }
   return false;
@@ -616,7 +619,7 @@ void MessagesWidget::addGUIMessage(MessageItem messageItem)
       break;
   }
   mpMessagesTabWidget->setCurrentWidget(mpAllMessageWidget);
-  emit MessageAdded();
+  emit messageAdded();
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.h
@@ -136,6 +136,7 @@ private:
   bool mShowingPendingMessages;
 public:
   static MessagesWidget* instance() {return mpInstance;}
+  MessagesTabWidget* getMessagesTabWidget() const {return mpMessagesTabWidget;}
   MessageWidget* getAllMessageWidget() {return mpAllMessageWidget;}
   MessageWidget* getNotificationMessageWidget() {return mpNotificationMessageWidget;}
   MessageWidget* getWarningMessageWidget() {return mpWarningMessageWidget;}
@@ -146,7 +147,9 @@ public:
   int getSimulationOutputTabsSize();
   SimulationOutputWidget* getSimulationOutputWidget(const QString &className);
 signals:
-  void MessageAdded();
+  void messageAdded();
+  void messageTabAdded(QWidget *pSimulationOutputTab, const QString &name);
+  void messageTabClosed(int index);
 private slots:
   bool closeTab(int index);
 public slots:

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.cpp
@@ -360,6 +360,7 @@ void OMSSimulationOutputWidget::parseSimulationProgress(const QVariant progress)
   int progressValue = progressMap.value("progress").toInt(&ok);
   if (ok) {
     mpProgressBar->setValue(progressValue);
+    updateMessageTabProgress();
   }
 }
 
@@ -383,15 +384,36 @@ void OMSSimulationOutputWidget::parseSimulationVariables(const QVariant variable
 }
 
 /*!
+ * \brief OMSSimulationOutputWidget::updateMessageTab
+ * Updates the corresponsing MessageTab.
+ */
+void OMSSimulationOutputWidget::updateMessageTab(const QString &text)
+{
+  emit updateText(text);
+  emit updateProgressBar(mpProgressBar);
+}
+
+/*!
+ * \brief OMSSimulationOutputWidget::updateMessageTabProgress
+ * Updates the progress bar of MessageTab
+ */
+void OMSSimulationOutputWidget::updateMessageTabProgress()
+{
+  emit updateProgressBar(mpProgressBar);
+}
+
+/*!
  * \brief OMSSimulationOutputWidget::simulationProcessStarted
  * Updates the simulation output window when the simulation has started.
  */
 void OMSSimulationOutputWidget::simulationProcessStarted()
 {
   mIsSimulationProcessRunning = true;
-  mpProgressLabel->setText(tr("Running simulation of %1. Please wait for a while.").arg(mCref));
+  const QString progressStr = tr("Running simulation of %1. Please wait for a while.").arg(mCref);
+  mpProgressLabel->setText(progressStr);
   mpProgressBar->setRange(0, 100);
   mpProgressBar->setTextVisible(true);
+  updateMessageTab(progressStr);
   mpCancelSimulationButton->setEnabled(true);
   mpArchivedSimulationItem->setStatus(Helper::running);
   mpSimulationSubscriberSocket->setSocketConnected(true);
@@ -516,15 +538,19 @@ void OMSSimulationOutputWidget::simulationProcessFinished(int exitCode, QProcess
 {
   mIsSimulationProcessRunning = false;
   QString exitCodeStr = tr("Simulation process failed. Exited with code %1.").arg(Utilities::formatExitCode(exitCode));
+  QString progressStr;
   if (exitStatus == QProcess::NormalExit && exitCode == 0) {
     writeSimulationOutput(tr("Simulation process finished successfully."), StringHandler::OMEditInfo);
+    progressStr = tr("Simulation of %1 finished.").arg(mCref);
   } else if (mpSimulationProcess->error() == QProcess::UnknownError) {
     writeSimulationOutput(exitCodeStr, StringHandler::Error);
+    progressStr = tr("Simulation of %1 failed.").arg(mCref);
   } else {
     writeSimulationOutput(mpSimulationProcess->errorString() + "\n" + exitCodeStr, StringHandler::Error);
+    progressStr = tr("Simulation of %1 failed.").arg(mCref);
   }
-
-  mpProgressLabel->setText(tr("Simulation of %1 is finished.").arg(mCref));
+  mpProgressLabel->setText(progressStr);
+  updateMessageTab(progressStr);
   mpCancelSimulationButton->setEnabled(false);
   // simulation finished show the results
   if (!mpSimulationRequestSocket) {
@@ -551,7 +577,9 @@ void OMSSimulationOutputWidget::cancelSimulation()
   if (isSimulationProcessRunning()) {
     mIsSimulationProcessKilled = true;
     mpSimulationProcess->kill();
-    mpProgressLabel->setText(tr("Simulation of %1 is cancelled.").arg(mCref));
+    const QString progressStr = tr("Simulation of %1 is cancelled.").arg(mCref);
+    mpProgressLabel->setText(progressStr);
+    updateMessageTab(progressStr);
     mpCancelSimulationButton->setEnabled(false);
     mpArchivedSimulationItem->setStatus(Helper::finished);
   }

--- a/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/OMS/OMSSimulationOutputWidget.h
@@ -119,8 +119,12 @@ private:
 
   void parseSimulationProgress(const QVariant progress);
   void parseSimulationVariables(const QVariant variables);
+  void updateMessageTab(const QString &text);
+  void updateMessageTabProgress();
 signals:
   void sendRequest(const QString &function, const QString &argument);
+  void updateText(const QString &text);
+  void updateProgressBar(QProgressBar *pProgressBar);
 public slots:
   void simulationProcessStarted();
   void readSimulationStandardOutput();

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1423,6 +1423,7 @@ void SimulationDialog::createAndShowSimulationOutputWidget(const SimulationOptio
     }
     SimulationOutputWidget *pSimulationOutputWidget = new SimulationOutputWidget(simulationOptions);
     MessagesWidget::instance()->addSimulationOutputTab(pSimulationOutputWidget, simulationOptions.getOutputFileName());
+    pSimulationOutputWidget->start();
     if (OptionsDialog::instance()->getSimulationPage()->getSwitchToPlottingPerspectiveCheckBox()->isChecked()) {
       MainWindow::instance()->switchToPlottingPerspectiveSlot();
     } else {

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputHandler.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputHandler.cpp
@@ -198,10 +198,17 @@ int SimulationMessageModel::getDepth(const QModelIndex &index) const
 void SimulationMessageModel::insertSimulationMessage(SimulationMessage *pSimulationMessage)
 {
   if (pSimulationMessage) {
+    // check scroll position before adding the message
+    auto pVerticalScrollBar = mpSimulationOutputWidget->getSimulationOutputTree()->verticalScrollBar();
+    const bool atBottom = pVerticalScrollBar->value() == pVerticalScrollBar->maximum();
     int row = mpRootSimulationMessage->children().size();
     beginInsertRows(QModelIndex(), row, row);
     mpRootSimulationMessage->insertChild(row, pSimulationMessage);
     endInsertRows();
+    // scroll to bottom
+    if (atBottom) {
+      mpSimulationOutputWidget->getSimulationOutputTree()->scrollToBottom();
+    }
   }
 }
 
@@ -367,6 +374,7 @@ void SimulationOutputHandler::parseSimulationOutput(const QString &output)
       } else if (mXmlStreamReader.name() == "status") {
         int progress = attributes.value("progress").toInt();
         mpSimulationOutputWidget->getProgressBar()->setValue(progress/100);
+        mpSimulationOutputWidget->updateMessageTabProgress();
       }
     } else if (token == QXmlStreamReader::EndElement) {
       if (mXmlStreamReader.name() == "message") {

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputWidget.h
@@ -86,6 +86,7 @@ public:
   };
   SimulationOutputWidget(SimulationOptions simulationOptions, QWidget *pParent = 0);
   ~SimulationOutputWidget();
+  void start();
   SimulationOptions getSimulationOptions() {return mSimulationOptions;}
   QProgressBar* getProgressBar() {return mpProgressBar;}
   QTabWidget* getGeneratedFilesTabWidget() {return mpGeneratedFilesTabWidget;}
@@ -107,6 +108,8 @@ public:
   void addGeneratedFileTab(QString fileName);
   void writeSimulationMessage(SimulationMessage *pSimulationMessage);
   void embeddedServerInitialized();
+  void updateMessageTab(const QString &text);
+  void updateMessageTabProgress();
 private:
   SimulationOptions mSimulationOptions;
   Label *mpProgressLabel;
@@ -175,6 +178,8 @@ public slots:
   void openTransformationBrowser(QUrl url);
 signals:
   void simulationFinished();
+  void updateText(const QString &text);
+  void updateProgressBar(QProgressBar *pProgressBar);
 };
 
 #endif // SIMULATIONOUTPUTWIDGET_H


### PR DESCRIPTION
### Related Issues

Fixes #9889

### Purpose

Keep the Messages Browser hidden when running the simulation so the user can use the space for plotting etc. But still show the simulation progress and message.

### Approach

Added a small tab widget at the bottom of the MainWindow. The tab widget mimics the Messages Browser. It is a shorter version of it. Only shown when Messages Browser is hidden.
Messages Browser can now only be docked at the bottom.