### PR TITLE
Improve loadClassContentString

### DIFF
--- a/testsuite/openmodelica/interactive-API/loadClassContentString1.mos
+++ b/testsuite/openmodelica/interactive-API/loadClassContentString1.mos
@@ -12,7 +12,7 @@ loadString("
       Real u;
       Real w;
 
-      class C
+      connector C
         Real x;
       end C;
 
@@ -34,8 +34,10 @@ loadClassContentString("
     end C;
 
     C c;
+    C c1;
   equation
     x = z;
+    connect(c, c1);
   algorithm
     y := z;
   protected
@@ -54,7 +56,7 @@ list(P.A);
 //   Real u;
 //   Real w;
 //
-//   class C
+//   connector C
 //     Real x;
 //   end C;
 //
@@ -67,12 +69,14 @@ list(P.A);
 //     Real y;
 //   end C1;
 //
+//   C1 c2;
 //   C1 c1;
 // protected
 //   Real p;
 // equation
 //   x = y;
 //   x1 = z;
+//   connect(c2, c1);
 // algorithm
 //   x := y;
 // algorithm


### PR DESCRIPTION
- Traverse equations/algorithms manually when renaming instead of using the AbsynUtil traversal functions, since the traversal functions only traverses expressions and not crefs in e.g. connect equations.
- Rewrite the conflict handling to avoid generating new names that conflicts with the elements being added.