### PR TITLE
Improve handling of exponentiation

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -4087,7 +4087,7 @@ algorithm
     then expPow(makeDiv(e4,e3), negate(e2));
 
     // x^0.5 => sqrt(x)
-    case (_, _) guard(isHalf(e2))
+    case (_, _) guard(isHalf(e2) and isPositiveOrZero(e1))
     then Expression.makePureBuiltinCall("sqrt",{e1},DAE.T_REAL_DEFAULT);
 
     else equation

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5736,7 +5736,11 @@ case BINARY(__) then
       let &preExp +=
         <<
         <%tmp%> = <%e1%>;
-        <%assertCommonVar('<%tmp%> >= 0.0', '"Model error: Argument of sqrt(<%Util.escapeModelicaStringToCString(cstr)%>) was %g should be >= 0", <%tmp%>', context, &varDecls, dummyInfo)%>
+        if(<%tmp%> < 0.0) {
+          <%if acceptMetaModelicaGrammar()
+            then '<%generateThrow()%>;<%\n%>'
+            else 'throwStreamPrint(threadData, "%s:%d: Invalid root: (%g)^(%g)", __FILE__, __LINE__, <%tmp%>, 0.5);<%\n%>'%>
+        }
         >>
       'sqrt(<%tmp%>)'
     else match realExpIntLit(exp2)


### PR DESCRIPTION
- Disable simplification `x^0.5 => sqrt(x)` when `x` is negative in the old simplification module.
- Change the check added during code generation for a 0.5 exponent to use the same `Invalid root` error message as for other exponents instead of mentioning `sqrt`, since that's an implementation detail that only obscures the actual issue.
