### PR TITLE
[OMEdit] Simplify visual properties of visualizers

### DIFF
--- a/OMEdit/OMEditLIB/Animation/AbstractVisualizer.cpp
+++ b/OMEdit/OMEditLIB/Animation/AbstractVisualizer.cpp
@@ -104,53 +104,29 @@ std::string VisualizerAttribute::getValueString() const
 }
 
 template<typename VisualizerObject>
-AbstractVisualProperties::Color::Type VisualProperties<VisualizerObject>::Color::getDefault() const
+AbstractVisualProperties::Color::Type VisualProperties<VisualizerObject>::Color::getProperty() const
 {
-  return QColor(0.0, 0.0, 0.0, 0.0);
+  const VisualizerObject* visualizer = static_cast<const VisualizerObject*>(mpParent);
+  return QColor(visualizer->_color[0].exp, visualizer->_color[1].exp, visualizer->_color[2].exp);
 }
 
 template<typename VisualizerObject>
-AbstractVisualProperties::Specular::Type VisualProperties<VisualizerObject>::Specular::getDefault() const
+AbstractVisualProperties::Specular::Type VisualProperties<VisualizerObject>::Specular::getProperty() const
 {
-  return 0.7;
+  const VisualizerObject* visualizer = static_cast<const VisualizerObject*>(mpParent);
+  return visualizer->_specCoeff.exp;
 }
 
 template<typename VisualizerObject>
-AbstractVisualProperties::Transparency::Type VisualProperties<VisualizerObject>::Transparency::getDefault() const
+AbstractVisualProperties::Transparency::Type VisualProperties<VisualizerObject>::Transparency::getProperty() const
 {
   return 0.0;
 }
 
 template<typename VisualizerObject>
-AbstractVisualProperties::TextureImagePath::Type VisualProperties<VisualizerObject>::TextureImagePath::getDefault() const
+AbstractVisualProperties::TextureImagePath::Type VisualProperties<VisualizerObject>::TextureImagePath::getProperty() const
 {
   return "";
-}
-
-template<typename VisualizerObject>
-AbstractVisualProperties::Color::Type VisualProperties<VisualizerObject>::Color::get() const
-{
-  const VisualizerObject* visualizer = static_cast<const VisualizerObject*>(mpParent);
-  return mCustom ? mProperty : QColor(visualizer->_color[0].exp, visualizer->_color[1].exp, visualizer->_color[2].exp);
-}
-
-template<typename VisualizerObject>
-AbstractVisualProperties::Specular::Type VisualProperties<VisualizerObject>::Specular::get() const
-{
-  const VisualizerObject* visualizer = static_cast<const VisualizerObject*>(mpParent);
-  return mCustom ? mProperty : visualizer->_specCoeff.exp;
-}
-
-template<typename VisualizerObject>
-AbstractVisualProperties::Transparency::Type VisualProperties<VisualizerObject>::Transparency::get() const
-{
-  return AbstractVisualProperties::Transparency::get();
-}
-
-template<typename VisualizerObject>
-AbstractVisualProperties::TextureImagePath::Type VisualProperties<VisualizerObject>::TextureImagePath::get() const
-{
-  return AbstractVisualProperties::TextureImagePath::get();
 }
 
 AbstractVisualizerObject::AbstractVisualizerObject(const VisualizerType type)

--- a/OMEdit/OMEditLIB/Animation/AbstractVisualizer.h
+++ b/OMEdit/OMEditLIB/Animation/AbstractVisualizer.h
@@ -107,15 +107,16 @@ public:
   VisualProperty() {reset();}
   virtual ~VisualProperty() = default;
 protected:
-  virtual Type getDefault() const {return Type();}
+  virtual Type getProperty() const {return mProperty;}
 public:
   virtual bool custom() const {return mCustom;}
-  virtual Type get() const {return mCustom ? mProperty : getDefault();}
-  virtual void reset() {mCustom = false, mProperty = getDefault();}
+  virtual Type get() const {return mCustom ? mProperty : getProperty();}
   virtual void set(const Type& rProperty) {mCustom = true, mProperty = rProperty;}
+  virtual void reset() {mCustom = false, mProperty = Type();}
   virtual void parent(const AbstractVisualProperties* pParent) final {mpParent = pParent;}
 protected:
   const AbstractVisualProperties* mpParent;
+private:
   Type mProperty;
   bool mCustom;
 };
@@ -141,17 +142,13 @@ class VisualProperties : public AbstractVisualProperties
 {
 private:
   class Color final : public AbstractVisualProperties::Color
-  { protected: virtual Type getDefault() const override final;
-    public: virtual Type get() const override final; };
+  { protected: virtual Type getProperty() const override final; };
   class Specular final : public AbstractVisualProperties::Specular
-  { protected: virtual Type getDefault() const override final;
-    public: virtual Type get() const override final; };
+  { protected: virtual Type getProperty() const override final; };
   class Transparency final : public AbstractVisualProperties::Transparency
-  { protected: virtual Type getDefault() const override final;
-    public: virtual Type get() const override final; };
+  { protected: virtual Type getProperty() const override final; };
   class TextureImagePath final : public AbstractVisualProperties::TextureImagePath
-  { protected: virtual Type getDefault() const override final;
-    public: virtual Type get() const override final; };
+  { protected: virtual Type getProperty() const override final; };
 public:
   VisualProperties() noexcept
   {

--- a/OMEdit/OMEditLIB/Animation/Visualization.cpp
+++ b/OMEdit/OMEditLIB/Animation/Visualization.cpp
@@ -1613,6 +1613,8 @@ void UpdateVisitor::apply(osg::Geode& node)
   }//end switch action
 
   if (changeMaterial || changeTexture) {
+    AbstractVisualProperties* visualProperties = _visualizer->getVisualProperties();
+
     osg::ref_ptr<osg::StateSet> stateSet = nullptr;
     bool geometryColors = false;
     bool is3DSShape = false;
@@ -1625,7 +1627,7 @@ void UpdateVisitor::apply(osg::Geode& node)
           osg::ref_ptr<CADFile> cad = dynamic_cast<CADFile*>(transformNode->getChild(0));
           if (cad.valid()) {
             stateSet = cad->getOrCreateStateSet();
-            geometryColors = !shape->getVisualProperties()->getColor().custom();
+            geometryColors = !visualProperties->getColor().custom();
             is3DSShape = is3DSType(shape->_type);
           }
         }
@@ -1635,7 +1637,6 @@ void UpdateVisitor::apply(osg::Geode& node)
     osg::ref_ptr<osg::StateSet> ss = stateSet.valid() ? stateSet.get() : node.getOrCreateStateSet();
     osg::Material::ColorMode mode = geometryColors ? osg::Material::AMBIENT_AND_DIFFUSE : osg::Material::OFF;
 
-    AbstractVisualProperties* visualProperties = _visualizer->getVisualProperties();
     QColor      color            = visualProperties->getColor().get();
     float       specular         = visualProperties->getSpecular().get();
     float       transparency     = visualProperties->getTransparency().get();


### PR DESCRIPTION
### Related Issues

PR #10355.

### Purpose

Simplify template specialization of visual properties.
- There should be no need of checking for a custom property in specializations of `get()`, this could be done upstream.
- Overriding both `getDefault()` and `get()` is tedious and does not provide any interesting feature.

### Approach

Merge template specializations of `getDefault()` and `get()` into a protected method `getProperty()` that is called by `get()` only when the property is not custom.
