### PR TITLE
Fix LOG_NLS_V

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -1212,13 +1212,13 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
   }
 #endif
 
+  /* set log activation from equationIndex and lv_system */
+  setLVSystems(data, threadData);
+
   /* initialize static data of mixed/linear/non-linear system solvers */
   initializeMixedSystems(data, threadData);
   initializeLinearSystems(data, threadData);
   initializeNonlinearSystems(data, threadData);
-
-  /* set log activation from equationIndex and lv_system */
-  setLVSystems(data, threadData);
 
   sim_noemit = omc_flag[FLAG_NOEMIT];
 

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/kinsolSolver.c
@@ -976,7 +976,6 @@ static void nlsKinsolConfigPrint(NLS_KINSOL_DATA *kinsolData,
   _omc_initVector(&vecFScaling, kinsolData->size,
                   NV_DATA_S(kinsolData->fScale));
 
-  infoStreamPrint(LOG_NLS_V, 1, "Kinsol Configuration");
   _omc_printVectorWithEquationInfo(
       &vecStart, "Initial guess values", LOG_NLS_V,
       modelInfoGetEquation(&data->modelData->modelDataXml, eqSystemNumber));
@@ -998,8 +997,6 @@ static void nlsKinsolConfigPrint(NLS_KINSOL_DATA *kinsolData,
   infoStreamPrint(LOG_NLS_V, 0, "KINSOL max step %g", kinsolData->mxnstepin);
   infoStreamPrint(LOG_NLS_V, 0, "KINSOL linear solver %d",
                   kinsolData->linearSolverMethod);
-
-  messageClose(LOG_NLS_V);
 }
 
 /**
@@ -1169,7 +1166,8 @@ static modelica_boolean nlsKinsolErrorHandler(int errorCode, DATA *data,
 NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DATA* nlsData) {
 
   NLS_KINSOL_DATA *kinsolData = (NLS_KINSOL_DATA *)nlsData->solverData;
-  int indexes[2] = {1, nlsData->equationIndex};
+  int eqSystemNumber = nlsData->equationIndex;
+  int indexes[2] = {1, eqSystemNumber};
 
   int flag;
   long nFEval;
@@ -1180,8 +1178,8 @@ NLS_SOLVER_STATUS nlsKinsolSolve(DATA* data, threadData_t* threadData, NONLINEAR
   double fNormValue;
 
   infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes,
-                                     "Start Kinsol solver at time %g",
-                                     data->localData[0]->timeValue);
+    "Start solving Non-Linear System %d (size %d) at time %g with Kinsol Solver",
+    eqSystemNumber, (int) nlsData->size, data->localData[0]->timeValue);
 
   /* Solve nonlinear system with KINSol() */
   kinsolData->retries = 0;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverKlu.c
@@ -194,9 +194,9 @@ int solveKlu(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
   double tmpJacEvalTime;
   int reuseMatrixJac = (data->simulationInfo->currentContext == CONTEXT_SYM_JACOBIAN && data->simulationInfo->currentJacobianEval > 0);
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Klu Solver",
-   eqSystemNumber, (int) systemData->size,
-   data->localData[0]->timeValue);
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes,
+    "Start solving Linear System %d (size %d) at time %g with Klu Solver",
+    eqSystemNumber, (int) systemData->size, data->localData[0]->timeValue);
 
   rt_ext_tp_tick(&(solverData->timeClock));
   if (0 == systemData->method)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLapack.c
@@ -185,9 +185,9 @@ int solveLapack(DATA *data, threadData_t *threadData, int sysNumber, double* aux
   double tmpJacEvalTime;
   int reuseMatrixJac = (data->simulationInfo->currentContext == CONTEXT_SYM_JACOBIAN && data->simulationInfo->currentJacobianEval > 0);
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Lapack Solver",
-         eqSystemNumber, (int) systemData->size,
-         data->localData[0]->timeValue);
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes,
+    "Start solving Linear System %d (size %d) at time %g with Lapack Solver",
+    eqSystemNumber, (int) systemData->size, data->localData[0]->timeValue);
 
   /* set data */
   _omc_setVectorData(solverData->x, aux_x);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverLis.c
@@ -211,9 +211,9 @@ int solveLis(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
 
   int indexes[2] = {1,eqSystemNumber};
   double tmpJacEvalTime;
-  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Lis Solver",
-         eqSystemNumber, (int) systemData->size,
-         data->localData[0]->timeValue);
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes,
+    "Start solving Linear System %d (size %d) at time %g with Lis Solver",
+    eqSystemNumber, (int) systemData->size, data->localData[0]->timeValue);
 
   /* set old values as start value for the iteration */
   for(i=0; i<n; i++){

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverTotalPivot.c
@@ -424,9 +424,9 @@ int solveTotalPivot(DATA *data, threadData_t *threadData, int sysNumber, double*
   int success = 1;
   double tmpJacEvalTime;
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with Total Pivot Solver",
-                                     eqSystemNumber, (int) systemData->size,
-                                     data->localData[0]->timeValue);
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes,
+    "Start solving Linear System %d (size %d) at time %g with Total Pivot Solver",
+    eqSystemNumber, (int) systemData->size, data->localData[0]->timeValue);
 
   debugVectorDoubleLS(LOG_LS_V,"SCALING",systemData->nominal,n);
   debugVectorDoubleLS(LOG_LS_V,"Old VALUES",aux_x,n);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/linearSolverUmfpack.c
@@ -205,9 +205,9 @@ solveUmfPack(DATA *data, threadData_t *threadData, int sysNumber, double* aux_x)
   double tmpJacEvalTime;
   int reuseMatrixJac = (data->simulationInfo->currentContext == CONTEXT_SYM_JACOBIAN && data->simulationInfo->currentJacobianEval > 0);
 
-  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes, "Start solving Linear System %d (size %d) at time %g with UMFPACK Solver",
-   eqSystemNumber, (int) systemData->size,
-   data->localData[0]->timeValue);
+  infoStreamPrintWithEquationIndexes(LOG_LS, omc_dummyFileInfo, 0, indexes,
+    "Start solving Linear System %d (size %d) at time %g with UMFPACK Solver",
+    eqSystemNumber, (int) systemData->size, data->localData[0]->timeValue);
 
   rt_ext_tp_tick(&(solverData->timeClock));
   if (0 == systemData->method)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/newtonIteration.c
@@ -517,6 +517,7 @@ void damping_heuristic(double* x, genericResidualFunc f,
 {
   int i,j=0;
   double enorm_new, treshold = 1e-2;
+  modelica_boolean startDamping = FALSE; /* remember to close log message */
 
   /* calculate new function values */
   (*f)(n, solverData->x_new, fvec, userData, 1);
@@ -524,8 +525,10 @@ void damping_heuristic(double* x, genericResidualFunc f,
 
   enorm_new=enorm_(&n,fvec);
 
-  if (enorm_new >= current_fvec_enorm)
+  if (enorm_new >= current_fvec_enorm) {
+    startDamping = TRUE;
     infoStreamPrint(LOG_NLS_V, 1, "Start Damping: enorm_new : %e; current_fvec_enorm: %e ", enorm_new, current_fvec_enorm);
+  }
 
   while (enorm_new >= current_fvec_enorm)
   {
@@ -569,7 +572,8 @@ void damping_heuristic(double* x, genericResidualFunc f,
 
   *lambda = 1;
 
-  messageClose(LOG_NLS_V);
+  if (startDamping)
+    messageClose(LOG_NLS_V);
 }
 
 /*! \fn damping_heuristic2
@@ -587,6 +591,7 @@ void damping_heuristic2(double damping_parameter, double* x, genericResidualFunc
 {
   int i,j=0;
   double enorm_new, treshold = 1e-4, lambda=1;
+  modelica_boolean startDamping = FALSE; /* remember to close log message */
 
   /* calculate new function values */
   (*f)(n, solverData->x_new, fvec, userdata, 1);
@@ -594,8 +599,10 @@ void damping_heuristic2(double damping_parameter, double* x, genericResidualFunc
 
   enorm_new=enorm_(&n,fvec);
 
-  if (enorm_new >= current_fvec_enorm)
-    infoStreamPrint(LOG_NLS_V, 1, "StartDamping: ");
+  if (enorm_new >= current_fvec_enorm) {
+    startDamping = TRUE;
+    infoStreamPrint(LOG_NLS_V, 1, "StartDamping:");
+  }
 
   while (enorm_new >= current_fvec_enorm)
   {
@@ -638,7 +645,8 @@ void damping_heuristic2(double damping_parameter, double* x, genericResidualFunc
     }
   }
 
-  messageClose(LOG_NLS_V);
+  if (startDamping)
+    messageClose(LOG_NLS_V);
 }
 
 /*! \fn LineSearch

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -1602,11 +1602,6 @@ static int newtonAlgorithm(DATA_HOMOTOPY* solverData, double* x)
         vecCopy(solverData->n, solverData->x1, x);
       }
 
-      /* debug information */
-      debugString(LOG_NLS_V, "NEWTON SOLVER DID CONVERGE TO A SOLUTION!!!");
-      printUnknowns(LOG_NLS_V, solverData);
-      debugString(LOG_NLS_V, "******************************************************");
-
       /* update statistics */
       solverData->numberOfIterations += numberOfIterations;
       solverData->error_f_sqrd = error_f_sqrd;
@@ -2176,7 +2171,6 @@ NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_
   int tries = 0;
   int runHomotopy = 0;
   int skipNewton = 0;
-  int numberOfFunctionEvaluationsOld = homotopyData->numberOfFunctionEvaluations;
   homotopyData->casualTearingSet = nlsData->strictTearingFunctionCall != NULL;
   int constraintViolated;
   homotopyData->initHomotopy = nlsData->initHomotopy;
@@ -2197,14 +2191,17 @@ NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_
 
   vecConst(homotopyData->m,1.0,homotopyData->ones);
 
-  debugString(LOG_NLS_V, "------------------------------------------------------");
-  if (!homotopyData->initHomotopy)
-    debugString(LOG_NLS_V, "SOLVING NON-LINEAR SYSTEM USING MIXED SOLVER (Newton/Homotopy solver)");
-  else
+  if (!homotopyData->initHomotopy) {
+    int indexes[2] = {1,eqSystemNumber};
+    infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes,
+      "Start solving Non-Linear System %d (size %d) at time %g with Mixed (Newton/Homotopy) Solver",
+      eqSystemNumber, (int) nlsData->size, data->localData[0]->timeValue);
+  } else {
+    debugString(LOG_NLS_V, "------------------------------------------------------");
     debugString(LOG_NLS_V, "SOLVING HOMOTOPY INITIALIZATION PROBLEM WITH THE HOMOTOPY SOLVER");
-  debugInt(LOG_NLS_V, "EQUATION NUMBER:", eqSystemNumber);
-  debugDouble(LOG_NLS_V, "TIME:", homotopyData->timeValue);
-  debugInt(LOG_NLS_V,   "number of function calls (so far!): ",numberOfFunctionEvaluationsOld);
+    debugInt(LOG_NLS_V, "EQUATION NUMBER:", eqSystemNumber);
+    debugDouble(LOG_NLS_V, "TIME:", homotopyData->timeValue);
+  }
 
   /* set x vector */
   if(data->simulationInfo->discreteCall)
@@ -2397,14 +2394,8 @@ NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_
       }
       if (success == NLS_SOLVED)
       {
-        debugString(LOG_NLS_V,"SYSTEM SOLVED");
-        debugInt(LOG_NLS_V,   "homotopy method:          ",runHomotopy);
-        debugInt(LOG_NLS_V,   "number of function calls: ",homotopyData->numberOfFunctionEvaluations-numberOfFunctionEvaluationsOld);
-        printUnknowns(LOG_NLS_V, homotopyData);
-        debugString(LOG_NLS_V, "------------------------------------------------------");
         /* take the solution */
         vecCopy(homotopyData->n, homotopyData->x, nlsData->nlsx);
-        debugVectorDouble(LOG_NLS_V,"Solution", homotopyData->x, homotopyData->n);
         /* reset continous flag */
         ((DATA*)data)->simulationInfo->solveContinuous = 0;
         break;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHomotopy.c
@@ -2517,6 +2517,8 @@ NLS_SOLVER_STATUS solveHomotopy(DATA *data, threadData_t *threadData, NONLINEAR_
   }
   free(relationsPreBackup);
 
+  messageClose(LOG_NLS_V);
+
   /* write statistics */
   nlsData->numberOfFEval = homotopyData->numberOfFunctionEvaluations;
   nlsData->numberOfIterations = homotopyData->numberOfIterations;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSolverHybrd.c
@@ -472,9 +472,11 @@ NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYS
   if(ACTIVE_STREAM(LOG_NLS_V))
   {
     int indexes[2] = {1,eqSystemNumber};
-    infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes, "Start solving non-linear system >>%d<< using Hybrd solver at time %g", eqSystemNumber, data->localData[0]->timeValue);
-    for(i=0; i<hybrdData->n; i++)
-    {
+    infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes,
+      "Start solving Non-Linear System %d (size %d) at time %g with Hybrd Solver",
+      eqSystemNumber, (int) nlsData->size, data->localData[0]->timeValue);
+
+    for(i = 0; i < hybrdData->n; i++) {
       infoStreamPrint(LOG_NLS_V, 1, "%d. %s = %f", i+1, modelInfoGetEquation(&data->modelData->modelDataXml,eqSystemNumber).vars[i], nlsData->nlsx[i]);
       infoStreamPrint(LOG_NLS_V, 0, "    nominal = %f\nold = %f\nextrapolated = %f",
           nlsData->nominal[i], nlsData->nlsxOld[i], nlsData->nlsxExtrapolation[i]);
@@ -711,21 +713,10 @@ NLS_SOLVER_STATUS solveHybrd(DATA *data, threadData_t *threadData, NONLINEAR_SYS
 
       success = NLS_SOLVED;
       nfunc_evals += hybrdData->nfev;
-      if(ACTIVE_STREAM(LOG_NLS_V))
-      {
-        int indexes[2] = {1,eqSystemNumber};
-        /* output solution */
-        infoStreamPrintWithEquationIndexes(LOG_NLS_V, omc_dummyFileInfo, 1, indexes, "solution for NLS %d at t=%g", eqSystemNumber, data->localData[0]->timeValue);
-        for(i=0; i<hybrdData->n; ++i)
-        {
-          infoStreamPrint(LOG_NLS_V, 0, "[%d] %s = %g", i+1, modelInfoGetEquation(&data->modelData->modelDataXml,eqSystemNumber).vars[i],  hybrdData->x[i]);
-        }
-        messageClose(LOG_NLS_V);
-      }else if (ACTIVE_STREAM(LOG_NLS_V)){
-        infoStreamPrint(LOG_NLS_V, 1, "system solved");
+      if (ACTIVE_STREAM(LOG_NLS_V)){
+        infoStreamPrint(LOG_NLS_V, 1, "System solved");
         infoStreamPrint(LOG_NLS_V, 0, "%d retries\n%d restarts", retries, retries2+retries3);
         messageClose(LOG_NLS_V);
-        printStatus(data, hybrdData, eqSystemNumber, &nfunc_evals, &xerror, &xerror_scaled, LOG_NLS_V);
       }
       scaling = hybrdData->useXScaling;
       if(scaling)

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/omc_math.c
@@ -724,7 +724,7 @@ void _omc_printVectorWithEquationInfo(_omc_vector* vec, const char* name, const 
   infoStreamPrint(stream, 1, "%s", name);
   for (i = 0; i < vec->size; ++i)
   {
- //   infoStreamPrint(stream, 0, "[%3d] %-40s = %20.12g",   (int)i+1, eqnInfo.vars[i], vec->data[i]);
+    infoStreamPrint(stream, 0, "[%3d] %-40s = %20.12g", (int)i+1, eqnInfo.vars[i], vec->data[i]);
   }
   messageClose(stream);
 }

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -303,7 +303,7 @@ typedef struct NLS_USERDATA NLS_USERDATA;
 typedef enum {
   NLS_FAILED = 0,                   /* NLS Solver failed to solve system */
   NLS_SOLVED = 1,                   /* NLS Solver solved system successfully */
-  NLS_SOLVED_LESS_ACCURACY = 2     /* NLS Solver found a solution with low accuracy */
+  NLS_SOLVED_LESS_ACCURACY = 2      /* NLS Solver found a solution with low accuracy */
 } NLS_SOLVER_STATUS;
 
 #if !defined(OMC_NUM_NONLINEAR_SYSTEMS) || OMC_NUM_NONLINEAR_SYSTEMS>0

--- a/OMCompiler/SimulationRuntime/c/util/simulation_options.c
+++ b/OMCompiler/SimulationRuntime/c/util/simulation_options.c
@@ -238,7 +238,7 @@ const char *FLAG_DESC[FLAG_MAX+1] = {
   /* FLAG_LV */                           "[string list] value specifies the logging level",
   /* FLAG_LV_MAX_WARN */                  "[int (default " EXPANDSTRING(DEFAULT_FLAG_LV_MAX_WARN) ")] maximum times repeating warnings will be displayed",
   /* FLAG_LV_TIME */                      "[double list] specifying time interval to allow loging in",
-  /* FLAG_LV_SYSTEM */                    "[int list] list of systems for which solver logs are shown",
+  /* FLAG_LV_SYSTEM */                    "[int list] list of system indices for which solver logs are shown (by default logs for all systems are shown)",
   /* FLAG_MAX_BISECTION_ITERATIONS */     "[int (default 0)] value specifies the maximum number of bisection iterations for state event detection or zero for default behavior",
   /* FLAG_MAX_EVENT_ITERATIONS */         "[int (default 20)] value specifies the maximum number of event iterations",
   /* FLAG_MAX_ORDER */                    "value specifies maximum integration order for supported solver",
@@ -480,7 +480,7 @@ const char *FLAG_DETAILED_DESC[FLAG_MAX+1] = {
   "  time interval logging is active. Doesn't affect LOG_STDOUT, LOG_ASSERT, and\n"
   "  LOG_SUCCESS, LOG_STATS, LOG_STATS_V.",
   /* FLAG_LV_SYSTEM */
-  "  Value is a comma-separated list of equation indices for which solver logs are shown",
+  "  Value is a comma-separated list of equation indices (available in the transformational debugger) for which solver logs are shown (by default logs for all systems are shown)",
   /* FLAG_MAX_BISECTION_ITERATIONS */
   "  Value specifies the maximum number of bisection iterations for state event\n"
   "  detection or zero for default behavior",

--- a/testsuite/simulation/modelica/nonlinear_system/bug_2841.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/bug_2841.mos
@@ -263,51 +263,51 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              x  =       -77390.689		 nom =           100000
 // |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05
-// LOG_NLS_V         | info    | | Start solving Non-Linear System 18 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
-// |                 | |       | | | System values [2-dim]
-// |                 | |       | | | |       -77390.689    3.3118158e-06
-// |                 | |       | | | Nominal values [2-dim]
-// |                 | |       | | | |           100000            1e-05
-// |                 | |       | | | Scaling values [3-dim]
-// |                 | |       | | | |           100000            1e-05                1
-// |                 | |       | | | x0 [2-dim]
-// |                 | |       | | | |       -77390.689    3.3118158e-06
-// |                 | |       | | | indRow: [2-dim]
-// |                 | |       | | | | 0 1
-// |                 | |       | | | indCol: [3-dim]
-// |                 | |       | | | | 1 0 2
-// |                 | |       | | | vector x (solution): [3-dim]
-// |                 | |       | | | |   -2.9880129e-17   -6.2675771e-17                1
-// |                 | |       | | | regular initial point!!!
-// |                 | |       | | | ******************************************************
-// |                 | |       | | | NEWTON SOLVER STARTED! equation number:  18
-// |                 | |       | | | maximum number of function evaluation:  200
-// |                 | |       | | | nls status
-// |                 | |       | | | | variables
-// |                 | |       | | | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | | Iteration: 1
-// |                 | |       | | | newton step
-// |                 | |       | | | | variables
-// |                 | |       | | | | [ 1]                              x  =       -77390.689		 step =   -2.9880129e-12		 old =       -77390.689
-// |                 | |       | | | | [ 2]                              y  =    3.3118158e-06		 step =   -6.2675771e-22		 old =    3.3118158e-06
-// |                 | |       | | | Need to damp, grad_f =   -9.8607613153e-32
-// |                 | |       | | | Need to damp, error_f =    2.2204460493e-16
-// |                 | |       | | | Need to damp this!! lambda1 =    1.0000000000e+00
-// |                 | |       | | | Need to damp, error_f1 =    2.2204460493e-16
-// |                 | |       | | | Need to damp, forced error =    3.9443045261e-32
-// |                 | |       | | | function values: [2-dim]
-// |                 | |       | | | |    -2.220446e-16                0
-// |                 | |       | | | scaled function values: [2-dim]
-// |                 | |       | | | |   -4.4236473e-17                0
-// |                 | |       | | | error measurements:
-// |                 | |       | | | delta_x        =   2.9880129153e-12
-// |                 | |       | | | delta_x_scaled =   6.9433956834e-17
-// |                 | |       | | | newtonXTol          =   1.0000000000e-12
-// |                 | |       | | | error_f        =   2.2204460493e-16
-// |                 | |       | | | error_f_scaled =   4.4236473073e-17
-// |                 | |       | | | newtonFTol          =   1.0000000000e-12
-// |                 | |       | | | Note: newton solver rejected last x because previous was as good
+// LOG_NLS_V         | info    | Start solving Non-Linear System 18 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [2-dim]
+// |                 | |       | | |       -77390.689    3.3118158e-06
+// |                 | |       | | Nominal values [2-dim]
+// |                 | |       | | |           100000            1e-05
+// |                 | |       | | Scaling values [3-dim]
+// |                 | |       | | |           100000            1e-05                1
+// |                 | |       | | x0 [2-dim]
+// |                 | |       | | |       -77390.689    3.3118158e-06
+// |                 | |       | | indRow: [2-dim]
+// |                 | |       | | | 0 1
+// |                 | |       | | indCol: [3-dim]
+// |                 | |       | | | 1 0 2
+// |                 | |       | | vector x (solution): [3-dim]
+// |                 | |       | | |   -2.9880129e-17   -6.2675771e-17                1
+// |                 | |       | | regular initial point!!!
+// |                 | |       | | ******************************************************
+// |                 | |       | | NEWTON SOLVER STARTED! equation number:  18
+// |                 | |       | | maximum number of function evaluation:  200
+// |                 | |       | | nls status
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | Iteration: 1
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              x  =       -77390.689		 step =   -2.9880129e-12		 old =       -77390.689
+// |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 step =   -6.2675771e-22		 old =    3.3118158e-06
+// |                 | |       | | Need to damp, grad_f =   -9.8607613153e-32
+// |                 | |       | | Need to damp, error_f =    2.2204460493e-16
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    2.2204460493e-16
+// |                 | |       | | Need to damp, forced error =    3.9443045261e-32
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |    -2.220446e-16                0
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |   -4.4236473e-17                0
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   2.9880129153e-12
+// |                 | |       | | delta_x_scaled =   6.9433956834e-17
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   2.2204460493e-16
+// |                 | |       | | error_f_scaled =   4.4236473073e-17
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Note: newton solver rejected last x because previous was as good
 // LOG_NLS           | info    | | Solution status: SOLVED
 // |                 | |       | | |  number of iterations           : 1
 // |                 | |       | | |  number of function evaluations : 2
@@ -320,51 +320,51 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              x  =       -77390.689		 nom =           100000
 // |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05
-// LOG_NLS_V         | info    | | | Start solving Non-Linear System 18 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
-// |                 | |       | | | | System values [2-dim]
-// |                 | |       | | | | |       -77390.689    3.3118158e-06
-// |                 | |       | | | | Nominal values [2-dim]
-// |                 | |       | | | | |           100000            1e-05
-// |                 | |       | | | | Scaling values [3-dim]
-// |                 | |       | | | | |           100000            1e-05                1
-// |                 | |       | | | | x0 [2-dim]
-// |                 | |       | | | | |       -77390.689    3.3118158e-06
-// |                 | |       | | | | indRow: [2-dim]
-// |                 | |       | | | | | 0 1
-// |                 | |       | | | | indCol: [3-dim]
-// |                 | |       | | | | | 1 0 2
-// |                 | |       | | | | vector x (solution): [3-dim]
-// |                 | |       | | | | |    2.9880129e-17    6.2675771e-17                1
-// |                 | |       | | | | regular initial point!!!
-// |                 | |       | | | | ******************************************************
-// |                 | |       | | | | NEWTON SOLVER STARTED! equation number:  18
-// |                 | |       | | | | maximum number of function evaluation:  200
-// |                 | |       | | | | nls status
-// |                 | |       | | | | | variables
-// |                 | |       | | | | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | | | Iteration: 1
-// |                 | |       | | | | newton step
-// |                 | |       | | | | | variables
-// |                 | |       | | | | | [ 1]                              x  =       -77390.689		 step =    2.9880129e-12		 old =       -77390.689
-// |                 | |       | | | | | [ 2]                              y  =    3.3118158e-06		 step =    6.2675771e-22		 old =    3.3118158e-06
-// |                 | |       | | | | Need to damp, grad_f =   -9.8607613153e-32
-// |                 | |       | | | | Need to damp, error_f =    2.2204460493e-16
-// |                 | |       | | | | Need to damp this!! lambda1 =    1.0000000000e+00
-// |                 | |       | | | | Need to damp, error_f1 =    2.2204460493e-16
-// |                 | |       | | | | Need to damp, forced error =    3.9443045261e-32
-// |                 | |       | | | | function values: [2-dim]
-// |                 | |       | | | | |     2.220446e-16                0
-// |                 | |       | | | | scaled function values: [2-dim]
-// |                 | |       | | | | |    4.4236473e-17                0
-// |                 | |       | | | | error measurements:
-// |                 | |       | | | | delta_x        =   2.9880129153e-12
-// |                 | |       | | | | delta_x_scaled =   6.9433956834e-17
-// |                 | |       | | | | newtonXTol          =   1.0000000000e-12
-// |                 | |       | | | | error_f        =   2.2204460493e-16
-// |                 | |       | | | | error_f_scaled =   4.4236473073e-17
-// |                 | |       | | | | newtonFTol          =   1.0000000000e-12
-// |                 | |       | | | | Note: newton solver rejected last x because previous was as good
+// LOG_NLS_V         | info    | Start solving Non-Linear System 18 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [2-dim]
+// |                 | |       | | |       -77390.689    3.3118158e-06
+// |                 | |       | | Nominal values [2-dim]
+// |                 | |       | | |           100000            1e-05
+// |                 | |       | | Scaling values [3-dim]
+// |                 | |       | | |           100000            1e-05                1
+// |                 | |       | | x0 [2-dim]
+// |                 | |       | | |       -77390.689    3.3118158e-06
+// |                 | |       | | indRow: [2-dim]
+// |                 | |       | | | 0 1
+// |                 | |       | | indCol: [3-dim]
+// |                 | |       | | | 1 0 2
+// |                 | |       | | vector x (solution): [3-dim]
+// |                 | |       | | |    2.9880129e-17    6.2675771e-17                1
+// |                 | |       | | regular initial point!!!
+// |                 | |       | | ******************************************************
+// |                 | |       | | NEWTON SOLVER STARTED! equation number:  18
+// |                 | |       | | maximum number of function evaluation:  200
+// |                 | |       | | nls status
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | Iteration: 1
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              x  =       -77390.689		 step =    2.9880129e-12		 old =       -77390.689
+// |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 step =    6.2675771e-22		 old =    3.3118158e-06
+// |                 | |       | | Need to damp, grad_f =   -9.8607613153e-32
+// |                 | |       | | Need to damp, error_f =    2.2204460493e-16
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    2.2204460493e-16
+// |                 | |       | | Need to damp, forced error =    3.9443045261e-32
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |     2.220446e-16                0
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |    4.4236473e-17                0
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   2.9880129153e-12
+// |                 | |       | | delta_x_scaled =   6.9433956834e-17
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   2.2204460493e-16
+// |                 | |       | | error_f_scaled =   4.4236473073e-17
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Note: newton solver rejected last x because previous was as good
 // LOG_NLS           | info    | | Solution status: SOLVED
 // |                 | |       | | |  number of iterations           : 2
 // |                 | |       | | |  number of function evaluations : 4

--- a/testsuite/simulation/modelica/nonlinear_system/bug_2841.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/bug_2841.mos
@@ -28,7 +28,7 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // ""
 // record SimulationResult
 //     resultFile = "nonlinearSolverTests.bug_2841_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'nonlinearSolverTests.bug_2841', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V,LOG_NLS_V'",
+//     simulationOptions = "startTime = 0.0, stopTime = 0.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'nonlinearSolverTests.bug_2841', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_INIT_V,LOG_NLS_V'",
 //     messages = "LOG_NLS           | info    | initialize non-linear system solvers
 // |                 | |       | | 2 non-linear systems
 // LOG_INIT          | info    | ### START INITIALIZATION ###
@@ -47,220 +47,200 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              y  =            5e-06		 nom =            1e-05
 // |                 | |       | | | [ 2]                              x  =            50000		 nom =           100000
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | SOLVING NON-LINEAR SYSTEM USING MIXED SOLVER (Newton/Homotopy solver)
-// LOG_NLS_V         | info    | EQUATION NUMBER: 7
-// LOG_NLS_V         | info    | TIME:   0.0000000000e+00
-// LOG_NLS_V         | info    | number of function calls (so far!):  0
-// LOG_NLS_V         | info    | System values [2-dim]
-// |                 | |       | |            5e-06            50000
-// LOG_NLS_V         | info    | Nominal values [2-dim]
-// |                 | |       | |            1e-05           100000
-// LOG_NLS_V         | info    | Scaling values [3-dim]
-// |                 | |       | |            1e-05           100000                1
-// LOG_NLS_V         | info    | x0 [2-dim]
-// |                 | |       | |            5e-06            50000
-// LOG_NLS_V         | info    | indRow: [2-dim]
-// |                 | |       | | 0 1
-// LOG_NLS_V         | info    | indCol: [3-dim]
-// |                 | |       | | 0 1 2
-// LOG_NLS_V         | info    | vector x (solution): [3-dim]
-// |                 | |       | |      -0.51701271       -2.5510381                1
-// LOG_NLS_V         | info    | regular initial point!!!
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | NEWTON SOLVER STARTED! equation number:  7
-// LOG_NLS_V         | info    | maximum number of function evaluation:  200
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =            5e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              x  =            50000		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | Iteration: 1
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =   -1.7012708e-07		 step =   -5.1701271e-06		 old =            5e-06
-// |                 | |       | | [ 2]                              x  =       -205103.81		 step =       -255103.81		 old =            50000
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -4.3608668960e+00
-// LOG_NLS_V         | info    | Need to damp, error_f =    1.4766290827e+00
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    1.4962663898e+00
-// LOG_NLS_V         | info    | Need to damp, forced error =    1.7443467584e+00
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |       -1.1300587       0.98070403
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |      -0.56502936        1.2592489
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   2.5510381250e+05
-// LOG_NLS_V         | info    | delta_x_scaled =   2.6029017761e+00
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   1.4962663898e+00
-// LOG_NLS_V         | info    | error_f_scaled =   1.3802050509e+00
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 2
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    1.0588367e-06		 step =    1.2289638e-06		 old =   -1.7012708e-07
-// |                 | |       | | [ 2]                              x  =       -46310.553		 step =        158793.26		 old =       -205103.81
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -4.4776262184e+00
-// LOG_NLS_V         | info    | Need to damp, error_f =    1.4962663898e+00
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    9.6161691115e-01
-// LOG_NLS_V         | info    | Need to damp, forced error =    1.7910504874e+00
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |      -0.81295855      -0.51361997
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |       -0.1063414       -0.1028369
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   1.5879325945e+05
-// LOG_NLS_V         | info    | delta_x_scaled =   1.5926812124e+00
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   9.6161691115e-01
-// LOG_NLS_V         | info    | error_f_scaled =   1.4793215481e-01
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 3
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    4.8481624e-06		 step =    3.7893257e-06		 old =    1.0588367e-06
-// |                 | |       | | [ 2]                              x  =       -85181.842		 step =       -38871.289		 old =       -46310.553
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -1.8494141676e+00
-// LOG_NLS_V         | info    | Need to damp, error_f =    9.6161691115e-01
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    8.9282194723e-01
-// LOG_NLS_V         | info    | Need to damp, forced error =    7.3976566705e-01
-// LOG_NLS_V         | info    | Need to damp this!! lambda2 =    5.3704647184e-01
-// LOG_NLS_V         | info    | Need to damp, error_f2 =    2.4573839117e-01
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |      -0.17461754      -0.17290481
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |     -0.081575501      -0.13029728
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   3.8871288659e+04
-// LOG_NLS_V         | info    | delta_x_scaled =   5.4285136346e-01
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   2.4573839117e-01
-// LOG_NLS_V         | info    | error_f_scaled =   1.5372684717e-01
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 4
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    3.3408112e-06		 step =    2.4693046e-07		 old =    3.0938807e-06
-// |                 | |       | | [ 2]                              x  =       -77891.638		 step =       -10705.397		 old =       -67186.241
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -1.2077471379e-01
-// LOG_NLS_V         | info    | Need to damp, error_f =    2.4573839117e-01
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    1.9741282299e-02
-// LOG_NLS_V         | info    | Need to damp, forced error =    4.8309885515e-02
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |       0.01676503      0.010423627
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |     0.0038820924     0.0051030272
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   1.0705396718e+04
-// LOG_NLS_V         | info    | delta_x_scaled =   1.0986490978e-01
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   1.9741282299e-02
-// LOG_NLS_V         | info    | error_f_scaled =   6.4118271551e-03
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 5
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =     3.312016e-06		 step =   -2.8795153e-08		 old =    3.3408112e-06
-// |                 | |       | | [ 2]                              x  =       -77392.651		 step =        498.98725		 old =       -77891.638
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -7.7943645363e-04
-// LOG_NLS_V         | info    | Need to damp, error_f =    1.9741282299e-02
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    1.1072572859e-04
-// LOG_NLS_V         | info    | Need to damp, forced error =    3.1177458145e-04
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |    0.00010009472    4.7341682e-05
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |    1.9715336e-05    1.9548009e-05
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   4.9898724582e+02
-// LOG_NLS_V         | info    | delta_x_scaled =   5.7611141106e-03
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   1.1072572859e-04
-// LOG_NLS_V         | info    | error_f_scaled =   2.7763630140e-05
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 6
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    3.3118158e-06		 step =   -2.0020165e-10		 old =     3.312016e-06
-// |                 | |       | | [ 2]                              x  =       -77390.689		 step =        1.9617465		 old =       -77392.651
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -2.4520373942e-08
-// LOG_NLS_V         | info    | Need to damp, error_f =    1.1072572859e-04
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    3.3977700044e-09
-// LOG_NLS_V         | info    | Need to damp, forced error =    9.8081495766e-09
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |    3.1818099e-09    1.1920263e-09
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |    6.3385048e-10    4.9722581e-10
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   1.9617464993e+00
-// LOG_NLS_V         | info    | delta_x_scaled =   2.8029483704e-05
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   3.3977700044e-09
-// LOG_NLS_V         | info    | error_f_scaled =   8.0560532423e-10
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 7
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    3.3118158e-06		 step =   -6.9084721e-15		 old =    3.3118158e-06
-// |                 | |       | | [ 2]                              x  =       -77390.689		 step =    4.0495536e-05		 old =       -77390.689
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -2.3089682006e-17
-// LOG_NLS_V         | info    | Need to damp, error_f =    3.3977700044e-09
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp, forced error =    9.2358728024e-18
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |    -2.220446e-16                0
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |   -4.4236473e-17                0
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   4.0495535620e-05
-// LOG_NLS_V         | info    | delta_x_scaled =   8.0078630793e-10
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   2.2204460493e-16
-// LOG_NLS_V         | info    | error_f_scaled =   4.4236472988e-17
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Iteration: 8
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    3.3118158e-06		 step =    6.2675771e-22		 old =    3.3118158e-06
-// |                 | |       | | [ 2]                              x  =       -77390.689		 step =    2.9880129e-12		 old =       -77390.689
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -9.8607613153e-32
-// LOG_NLS_V         | info    | Need to damp, error_f =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp, forced error =    3.9443045261e-32
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |     2.220446e-16                0
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |    4.4236473e-17                0
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   2.9880129153e-12
-// LOG_NLS_V         | info    | delta_x_scaled =   6.9433956834e-17
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   2.2204460493e-16
-// LOG_NLS_V         | info    | error_f_scaled =   4.4236473073e-17
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Note: newton solver rejected last x because previous was as good
-// LOG_NLS_V         | info    | NEWTON SOLVER DID CONVERGE TO A SOLUTION!!!
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | SYSTEM SOLVED
-// LOG_NLS_V         | info    | homotopy method:           0
-// LOG_NLS_V         | info    | number of function calls:  10
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | Solution [2-dim]
-// |                 | |       | |    3.3118158e-06       -77390.689
+// LOG_NLS_V         | info    | Start solving Non-Linear System 7 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [2-dim]
+// |                 | |       | | |            5e-06            50000
+// |                 | |       | | Nominal values [2-dim]
+// |                 | |       | | |            1e-05           100000
+// |                 | |       | | Scaling values [3-dim]
+// |                 | |       | | |            1e-05           100000                1
+// |                 | |       | | x0 [2-dim]
+// |                 | |       | | |            5e-06            50000
+// |                 | |       | | indRow: [2-dim]
+// |                 | |       | | | 0 1
+// |                 | |       | | indCol: [3-dim]
+// |                 | |       | | | 0 1 2
+// |                 | |       | | vector x (solution): [3-dim]
+// |                 | |       | | |      -0.51701271       -2.5510381                1
+// |                 | |       | | regular initial point!!!
+// |                 | |       | | ******************************************************
+// |                 | |       | | NEWTON SOLVER STARTED! equation number:  7
+// |                 | |       | | maximum number of function evaluation:  200
+// |                 | |       | | nls status
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =            5e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | [ 2]                              x  =            50000		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | Iteration: 1
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =   -1.7012708e-07		 step =   -5.1701271e-06		 old =            5e-06
+// |                 | |       | | | [ 2]                              x  =       -205103.81		 step =       -255103.81		 old =            50000
+// |                 | |       | | Need to damp, grad_f =   -4.3608668960e+00
+// |                 | |       | | Need to damp, error_f =    1.4766290827e+00
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    1.4962663898e+00
+// |                 | |       | | Need to damp, forced error =    1.7443467584e+00
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |       -1.1300587       0.98070403
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |      -0.56502936        1.2592489
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   2.5510381250e+05
+// |                 | |       | | delta_x_scaled =   2.6029017761e+00
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   1.4962663898e+00
+// |                 | |       | | error_f_scaled =   1.3802050509e+00
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 2
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =    1.0588367e-06		 step =    1.2289638e-06		 old =   -1.7012708e-07
+// |                 | |       | | | [ 2]                              x  =       -46310.553		 step =        158793.26		 old =       -205103.81
+// |                 | |       | | Need to damp, grad_f =   -4.4776262184e+00
+// |                 | |       | | Need to damp, error_f =    1.4962663898e+00
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    9.6161691115e-01
+// |                 | |       | | Need to damp, forced error =    1.7910504874e+00
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |      -0.81295855      -0.51361997
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |       -0.1063414       -0.1028369
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   1.5879325945e+05
+// |                 | |       | | delta_x_scaled =   1.5926812124e+00
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   9.6161691115e-01
+// |                 | |       | | error_f_scaled =   1.4793215481e-01
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 3
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =    4.8481624e-06		 step =    3.7893257e-06		 old =    1.0588367e-06
+// |                 | |       | | | [ 2]                              x  =       -85181.842		 step =       -38871.289		 old =       -46310.553
+// |                 | |       | | Need to damp, grad_f =   -1.8494141676e+00
+// |                 | |       | | Need to damp, error_f =    9.6161691115e-01
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    8.9282194723e-01
+// |                 | |       | | Need to damp, forced error =    7.3976566705e-01
+// |                 | |       | | Need to damp this!! lambda2 =    5.3704647184e-01
+// |                 | |       | | Need to damp, error_f2 =    2.4573839117e-01
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |      -0.17461754      -0.17290481
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |     -0.081575501      -0.13029728
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   3.8871288659e+04
+// |                 | |       | | delta_x_scaled =   5.4285136346e-01
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   2.4573839117e-01
+// |                 | |       | | error_f_scaled =   1.5372684717e-01
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 4
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =    3.3408112e-06		 step =    2.4693046e-07		 old =    3.0938807e-06
+// |                 | |       | | | [ 2]                              x  =       -77891.638		 step =       -10705.397		 old =       -67186.241
+// |                 | |       | | Need to damp, grad_f =   -1.2077471379e-01
+// |                 | |       | | Need to damp, error_f =    2.4573839117e-01
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    1.9741282299e-02
+// |                 | |       | | Need to damp, forced error =    4.8309885515e-02
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |       0.01676503      0.010423627
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |     0.0038820924     0.0051030272
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   1.0705396718e+04
+// |                 | |       | | delta_x_scaled =   1.0986490978e-01
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   1.9741282299e-02
+// |                 | |       | | error_f_scaled =   6.4118271551e-03
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 5
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =     3.312016e-06		 step =   -2.8795153e-08		 old =    3.3408112e-06
+// |                 | |       | | | [ 2]                              x  =       -77392.651		 step =        498.98725		 old =       -77891.638
+// |                 | |       | | Need to damp, grad_f =   -7.7943645363e-04
+// |                 | |       | | Need to damp, error_f =    1.9741282299e-02
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    1.1072572859e-04
+// |                 | |       | | Need to damp, forced error =    3.1177458145e-04
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |    0.00010009472    4.7341682e-05
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |    1.9715336e-05    1.9548009e-05
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   4.9898724582e+02
+// |                 | |       | | delta_x_scaled =   5.7611141106e-03
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   1.1072572859e-04
+// |                 | |       | | error_f_scaled =   2.7763630140e-05
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 6
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =    3.3118158e-06		 step =   -2.0020165e-10		 old =     3.312016e-06
+// |                 | |       | | | [ 2]                              x  =       -77390.689		 step =        1.9617465		 old =       -77392.651
+// |                 | |       | | Need to damp, grad_f =   -2.4520373942e-08
+// |                 | |       | | Need to damp, error_f =    1.1072572859e-04
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    3.3977700044e-09
+// |                 | |       | | Need to damp, forced error =    9.8081495766e-09
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |    3.1818099e-09    1.1920263e-09
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |    6.3385048e-10    4.9722581e-10
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   1.9617464993e+00
+// |                 | |       | | delta_x_scaled =   2.8029483704e-05
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   3.3977700044e-09
+// |                 | |       | | error_f_scaled =   8.0560532423e-10
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 7
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =    3.3118158e-06		 step =   -6.9084721e-15		 old =    3.3118158e-06
+// |                 | |       | | | [ 2]                              x  =       -77390.689		 step =    4.0495536e-05		 old =       -77390.689
+// |                 | |       | | Need to damp, grad_f =   -2.3089682006e-17
+// |                 | |       | | Need to damp, error_f =    3.3977700044e-09
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    2.2204460493e-16
+// |                 | |       | | Need to damp, forced error =    9.2358728024e-18
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |    -2.220446e-16                0
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |   -4.4236473e-17                0
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   4.0495535620e-05
+// |                 | |       | | delta_x_scaled =   8.0078630793e-10
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   2.2204460493e-16
+// |                 | |       | | error_f_scaled =   4.4236472988e-17
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Iteration: 8
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              y  =    3.3118158e-06		 step =    6.2675771e-22		 old =    3.3118158e-06
+// |                 | |       | | | [ 2]                              x  =       -77390.689		 step =    2.9880129e-12		 old =       -77390.689
+// |                 | |       | | Need to damp, grad_f =   -9.8607613153e-32
+// |                 | |       | | Need to damp, error_f =    2.2204460493e-16
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    2.2204460493e-16
+// |                 | |       | | Need to damp, forced error =    3.9443045261e-32
+// |                 | |       | | function values: [2-dim]
+// |                 | |       | | |     2.220446e-16                0
+// |                 | |       | | scaled function values: [2-dim]
+// |                 | |       | | |    4.4236473e-17                0
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   2.9880129153e-12
+// |                 | |       | | delta_x_scaled =   6.9433956834e-17
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   2.2204460493e-16
+// |                 | |       | | error_f_scaled =   4.4236473073e-17
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Note: newton solver rejected last x because previous was as good
 // LOG_NLS           | info    | | Solution status: SOLVED
 // |                 | |       | | |  number of iterations           : 8
 // |                 | |       | | |  number of function evaluations : 10
@@ -283,71 +263,51 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              x  =       -77390.689		 nom =           100000
 // |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | SOLVING NON-LINEAR SYSTEM USING MIXED SOLVER (Newton/Homotopy solver)
-// LOG_NLS_V         | info    | EQUATION NUMBER: 18
-// LOG_NLS_V         | info    | TIME:   0.0000000000e+00
-// LOG_NLS_V         | info    | number of function calls (so far!):  0
-// LOG_NLS_V         | info    | System values [2-dim]
-// |                 | |       | |       -77390.689    3.3118158e-06
-// LOG_NLS_V         | info    | Nominal values [2-dim]
-// |                 | |       | |           100000            1e-05
-// LOG_NLS_V         | info    | Scaling values [3-dim]
-// |                 | |       | |           100000            1e-05                1
-// LOG_NLS_V         | info    | x0 [2-dim]
-// |                 | |       | |       -77390.689    3.3118158e-06
-// LOG_NLS_V         | info    | indRow: [2-dim]
-// |                 | |       | | 0 1
-// LOG_NLS_V         | info    | indCol: [3-dim]
-// |                 | |       | | 1 0 2
-// LOG_NLS_V         | info    | vector x (solution): [3-dim]
-// |                 | |       | |   -2.9880129e-17   -6.2675771e-17                1
-// LOG_NLS_V         | info    | regular initial point!!!
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | NEWTON SOLVER STARTED! equation number:  18
-// LOG_NLS_V         | info    | maximum number of function evaluation:  200
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | Iteration: 1
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 step =   -2.9880129e-12		 old =       -77390.689
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 step =   -6.2675771e-22		 old =    3.3118158e-06
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -9.8607613153e-32
-// LOG_NLS_V         | info    | Need to damp, error_f =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp, forced error =    3.9443045261e-32
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |    -2.220446e-16                0
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |   -4.4236473e-17                0
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   2.9880129153e-12
-// LOG_NLS_V         | info    | delta_x_scaled =   6.9433956834e-17
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   2.2204460493e-16
-// LOG_NLS_V         | info    | error_f_scaled =   4.4236473073e-17
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Note: newton solver rejected last x because previous was as good
-// LOG_NLS_V         | info    | NEWTON SOLVER DID CONVERGE TO A SOLUTION!!!
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | SYSTEM SOLVED
-// LOG_NLS_V         | info    | homotopy method:           0
-// LOG_NLS_V         | info    | number of function calls:  2
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | Solution [2-dim]
-// |                 | |       | |       -77390.689    3.3118158e-06
+// LOG_NLS_V         | info    | | Start solving Non-Linear System 18 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | | System values [2-dim]
+// |                 | |       | | | |       -77390.689    3.3118158e-06
+// |                 | |       | | | Nominal values [2-dim]
+// |                 | |       | | | |           100000            1e-05
+// |                 | |       | | | Scaling values [3-dim]
+// |                 | |       | | | |           100000            1e-05                1
+// |                 | |       | | | x0 [2-dim]
+// |                 | |       | | | |       -77390.689    3.3118158e-06
+// |                 | |       | | | indRow: [2-dim]
+// |                 | |       | | | | 0 1
+// |                 | |       | | | indCol: [3-dim]
+// |                 | |       | | | | 1 0 2
+// |                 | |       | | | vector x (solution): [3-dim]
+// |                 | |       | | | |   -2.9880129e-17   -6.2675771e-17                1
+// |                 | |       | | | regular initial point!!!
+// |                 | |       | | | ******************************************************
+// |                 | |       | | | NEWTON SOLVER STARTED! equation number:  18
+// |                 | |       | | | maximum number of function evaluation:  200
+// |                 | |       | | | nls status
+// |                 | |       | | | | variables
+// |                 | |       | | | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | Iteration: 1
+// |                 | |       | | | newton step
+// |                 | |       | | | | variables
+// |                 | |       | | | | [ 1]                              x  =       -77390.689		 step =   -2.9880129e-12		 old =       -77390.689
+// |                 | |       | | | | [ 2]                              y  =    3.3118158e-06		 step =   -6.2675771e-22		 old =    3.3118158e-06
+// |                 | |       | | | Need to damp, grad_f =   -9.8607613153e-32
+// |                 | |       | | | Need to damp, error_f =    2.2204460493e-16
+// |                 | |       | | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | | Need to damp, error_f1 =    2.2204460493e-16
+// |                 | |       | | | Need to damp, forced error =    3.9443045261e-32
+// |                 | |       | | | function values: [2-dim]
+// |                 | |       | | | |    -2.220446e-16                0
+// |                 | |       | | | scaled function values: [2-dim]
+// |                 | |       | | | |   -4.4236473e-17                0
+// |                 | |       | | | error measurements:
+// |                 | |       | | | delta_x        =   2.9880129153e-12
+// |                 | |       | | | delta_x_scaled =   6.9433956834e-17
+// |                 | |       | | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | | error_f        =   2.2204460493e-16
+// |                 | |       | | | error_f_scaled =   4.4236473073e-17
+// |                 | |       | | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | | Note: newton solver rejected last x because previous was as good
 // LOG_NLS           | info    | | Solution status: SOLVED
 // |                 | |       | | |  number of iterations           : 1
 // |                 | |       | | |  number of function evaluations : 2
@@ -360,71 +320,51 @@ simulate(nonlinearSolverTests.bug_2841, stopTime=0.0, simflags="-lv=LOG_INIT_V,L
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              x  =       -77390.689		 nom =           100000
 // |                 | |       | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | SOLVING NON-LINEAR SYSTEM USING MIXED SOLVER (Newton/Homotopy solver)
-// LOG_NLS_V         | info    | EQUATION NUMBER: 18
-// LOG_NLS_V         | info    | TIME:   0.0000000000e+00
-// LOG_NLS_V         | info    | number of function calls (so far!):  2
-// LOG_NLS_V         | info    | System values [2-dim]
-// |                 | |       | |       -77390.689    3.3118158e-06
-// LOG_NLS_V         | info    | Nominal values [2-dim]
-// |                 | |       | |           100000            1e-05
-// LOG_NLS_V         | info    | Scaling values [3-dim]
-// |                 | |       | |           100000            1e-05                1
-// LOG_NLS_V         | info    | x0 [2-dim]
-// |                 | |       | |       -77390.689    3.3118158e-06
-// LOG_NLS_V         | info    | indRow: [2-dim]
-// |                 | |       | | 0 1
-// LOG_NLS_V         | info    | indCol: [3-dim]
-// |                 | |       | | 1 0 2
-// LOG_NLS_V         | info    | vector x (solution): [3-dim]
-// |                 | |       | |    2.9880129e-17    6.2675771e-17                1
-// LOG_NLS_V         | info    | regular initial point!!!
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | NEWTON SOLVER STARTED! equation number:  18
-// LOG_NLS_V         | info    | maximum number of function evaluation:  200
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | Iteration: 1
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 step =    2.9880129e-12		 old =       -77390.689
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 step =    6.2675771e-22		 old =    3.3118158e-06
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -9.8607613153e-32
-// LOG_NLS_V         | info    | Need to damp, error_f =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    2.2204460493e-16
-// LOG_NLS_V         | info    | Need to damp, forced error =    3.9443045261e-32
-// LOG_NLS_V         | info    | function values: [2-dim]
-// |                 | |       | |     2.220446e-16                0
-// LOG_NLS_V         | info    | scaled function values: [2-dim]
-// |                 | |       | |    4.4236473e-17                0
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   2.9880129153e-12
-// LOG_NLS_V         | info    | delta_x_scaled =   6.9433956834e-17
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   2.2204460493e-16
-// LOG_NLS_V         | info    | error_f_scaled =   4.4236473073e-17
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Note: newton solver rejected last x because previous was as good
-// LOG_NLS_V         | info    | NEWTON SOLVER DID CONVERGE TO A SOLUTION!!!
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | SYSTEM SOLVED
-// LOG_NLS_V         | info    | homotopy method:           0
-// LOG_NLS_V         | info    | number of function calls:  2
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// |                 | |       | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | Solution [2-dim]
-// |                 | |       | |       -77390.689    3.3118158e-06
+// LOG_NLS_V         | info    | | | Start solving Non-Linear System 18 (size 2) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | | | System values [2-dim]
+// |                 | |       | | | | |       -77390.689    3.3118158e-06
+// |                 | |       | | | | Nominal values [2-dim]
+// |                 | |       | | | | |           100000            1e-05
+// |                 | |       | | | | Scaling values [3-dim]
+// |                 | |       | | | | |           100000            1e-05                1
+// |                 | |       | | | | x0 [2-dim]
+// |                 | |       | | | | |       -77390.689    3.3118158e-06
+// |                 | |       | | | | indRow: [2-dim]
+// |                 | |       | | | | | 0 1
+// |                 | |       | | | | indCol: [3-dim]
+// |                 | |       | | | | | 1 0 2
+// |                 | |       | | | | vector x (solution): [3-dim]
+// |                 | |       | | | | |    2.9880129e-17    6.2675771e-17                1
+// |                 | |       | | | | regular initial point!!!
+// |                 | |       | | | | ******************************************************
+// |                 | |       | | | | NEWTON SOLVER STARTED! equation number:  18
+// |                 | |       | | | | maximum number of function evaluation:  200
+// |                 | |       | | | | nls status
+// |                 | |       | | | | | variables
+// |                 | |       | | | | | [ 1]                              x  =       -77390.689		 nom =           100000		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | | | [ 2]                              y  =    3.3118158e-06		 nom =            1e-05		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | | | Iteration: 1
+// |                 | |       | | | | newton step
+// |                 | |       | | | | | variables
+// |                 | |       | | | | | [ 1]                              x  =       -77390.689		 step =    2.9880129e-12		 old =       -77390.689
+// |                 | |       | | | | | [ 2]                              y  =    3.3118158e-06		 step =    6.2675771e-22		 old =    3.3118158e-06
+// |                 | |       | | | | Need to damp, grad_f =   -9.8607613153e-32
+// |                 | |       | | | | Need to damp, error_f =    2.2204460493e-16
+// |                 | |       | | | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | | | Need to damp, error_f1 =    2.2204460493e-16
+// |                 | |       | | | | Need to damp, forced error =    3.9443045261e-32
+// |                 | |       | | | | function values: [2-dim]
+// |                 | |       | | | | |     2.220446e-16                0
+// |                 | |       | | | | scaled function values: [2-dim]
+// |                 | |       | | | | |    4.4236473e-17                0
+// |                 | |       | | | | error measurements:
+// |                 | |       | | | | delta_x        =   2.9880129153e-12
+// |                 | |       | | | | delta_x_scaled =   6.9433956834e-17
+// |                 | |       | | | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | | | error_f        =   2.2204460493e-16
+// |                 | |       | | | | error_f_scaled =   4.4236473073e-17
+// |                 | |       | | | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | | | Note: newton solver rejected last x because previous was as good
 // LOG_NLS           | info    | | Solution status: SOLVED
 // |                 | |       | | |  number of iterations           : 2
 // |                 | |       | | |  number of function evaluations : 4

--- a/testsuite/simulation/modelica/start_value_selection/ticket5807.mos
+++ b/testsuite/simulation/modelica/start_value_selection/ticket5807.mos
@@ -20,74 +20,56 @@ simulate(TestInitStart); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "TestInitStart_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'TestInitStart', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_NLS_V'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'TestInitStart', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-lv=LOG_NLS_V'",
 //     messages = "LOG_NLS           | info    | initialize non-linear system solvers
 // |                 | |       | | 1 non-linear systems
 // LOG_NLS           | info    | update static data of non-linear system solvers
 // LOG_NLS           | info    | ############ Solve nonlinear system 2 at time 0 ############
 // |                 | |       | | initial variable values:
 // |                 | |       | | | [ 1]                              p  =               -2		 nom =                1
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | SOLVING NON-LINEAR SYSTEM USING MIXED SOLVER (Newton/Homotopy solver)
-// LOG_NLS_V         | info    | EQUATION NUMBER: 2
-// LOG_NLS_V         | info    | TIME:   0.0000000000e+00
-// LOG_NLS_V         | info    | number of function calls (so far!):  0
-// LOG_NLS_V         | info    | System values [1-dim]
-// |                 | |       | |               -2
-// LOG_NLS_V         | info    | Nominal values [1-dim]
-// |                 | |       | |                1
-// LOG_NLS_V         | info    | Scaling values [2-dim]
-// |                 | |       | |                2                1
-// LOG_NLS_V         | info    | x0 [1-dim]
-// |                 | |       | |               -2
-// LOG_NLS_V         | info    | indRow: [1-dim]
-// |                 | |       | | 0
-// LOG_NLS_V         | info    | indCol: [2-dim]
-// |                 | |       | | 0 1
-// LOG_NLS_V         | info    | vector x (solution): [2-dim]
-// |                 | |       | |               -0                1
-// LOG_NLS_V         | info    | regular initial point!!!
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | NEWTON SOLVER STARTED! equation number:  2
-// LOG_NLS_V         | info    | maximum number of function evaluation:  100
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              p  =               -2		 nom =                2		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | Iteration: 1
-// LOG_NLS_V         | info    | newton step
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              p  =               -2		 step =               -0		 old =               -2
-// LOG_NLS_V         | info    | Need to damp, grad_f =   -0.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f =    0.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp this!! lambda1 =    1.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, error_f1 =    0.0000000000e+00
-// LOG_NLS_V         | info    | Need to damp, forced error =    0.0000000000e+00
-// LOG_NLS_V         | info    | function values: [1-dim]
-// |                 | |       | |                0
-// LOG_NLS_V         | info    | scaled function values: [1-dim]
-// |                 | |       | |                0
-// LOG_NLS_V         | info    | error measurements:
-// LOG_NLS_V         | info    | delta_x        =   0.0000000000e+00
-// LOG_NLS_V         | info    | delta_x_scaled =   0.0000000000e+00
-// LOG_NLS_V         | info    | newtonXTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | error_f        =   0.0000000000e+00
-// LOG_NLS_V         | info    | error_f_scaled =   0.0000000000e+00
-// LOG_NLS_V         | info    | newtonFTol          =   1.0000000000e-12
-// LOG_NLS_V         | info    | Note: newton solver rejected last x because previous was as good
-// LOG_NLS_V         | info    | NEWTON SOLVER DID CONVERGE TO A SOLUTION!!!
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              p  =               -2		 nom =                2		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ******************************************************
-// LOG_NLS_V         | info    | SYSTEM SOLVED
-// LOG_NLS_V         | info    | homotopy method:           0
-// LOG_NLS_V         | info    | number of function calls:  3
-// LOG_NLS_V         | info    | nls status
-// |                 | |       | | variables
-// |                 | |       | | [ 1]                              p  =               -2		 nom =                2		 min =  -1.7976931e+308		 max =   1.7976931e+308
-// LOG_NLS_V         | info    | ------------------------------------------------------
-// LOG_NLS_V         | info    | Solution [1-dim]
-// |                 | |       | |               -2
+// LOG_NLS_V         | info    | Start solving Non-Linear System 2 (size 1) at time 0 with Mixed (Newton/Homotopy) Solver
+// |                 | |       | | System values [1-dim]
+// |                 | |       | | |               -2
+// |                 | |       | | Nominal values [1-dim]
+// |                 | |       | | |                1
+// |                 | |       | | Scaling values [2-dim]
+// |                 | |       | | |                2                1
+// |                 | |       | | x0 [1-dim]
+// |                 | |       | | |               -2
+// |                 | |       | | indRow: [1-dim]
+// |                 | |       | | | 0
+// |                 | |       | | indCol: [2-dim]
+// |                 | |       | | | 0 1
+// |                 | |       | | vector x (solution): [2-dim]
+// |                 | |       | | |               -0                1
+// |                 | |       | | regular initial point!!!
+// |                 | |       | | ******************************************************
+// |                 | |       | | NEWTON SOLVER STARTED! equation number:  2
+// |                 | |       | | maximum number of function evaluation:  100
+// |                 | |       | | nls status
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              p  =               -2		 nom =                2		 min =  -1.7976931e+308		 max =   1.7976931e+308
+// |                 | |       | | Iteration: 1
+// |                 | |       | | newton step
+// |                 | |       | | | variables
+// |                 | |       | | | [ 1]                              p  =               -2		 step =               -0		 old =               -2
+// |                 | |       | | Need to damp, grad_f =   -0.0000000000e+00
+// |                 | |       | | Need to damp, error_f =    0.0000000000e+00
+// |                 | |       | | Need to damp this!! lambda1 =    1.0000000000e+00
+// |                 | |       | | Need to damp, error_f1 =    0.0000000000e+00
+// |                 | |       | | Need to damp, forced error =    0.0000000000e+00
+// |                 | |       | | function values: [1-dim]
+// |                 | |       | | |                0
+// |                 | |       | | scaled function values: [1-dim]
+// |                 | |       | | |                0
+// |                 | |       | | error measurements:
+// |                 | |       | | delta_x        =   0.0000000000e+00
+// |                 | |       | | delta_x_scaled =   0.0000000000e+00
+// |                 | |       | | newtonXTol          =   1.0000000000e-12
+// |                 | |       | | error_f        =   0.0000000000e+00
+// |                 | |       | | error_f_scaled =   0.0000000000e+00
+// |                 | |       | | newtonFTol          =   1.0000000000e-12
+// |                 | |       | | Note: newton solver rejected last x because previous was as good
 // LOG_NLS           | info    | | Solution status: SOLVED
 // |                 | |       | | |  number of iterations           : 1
 // |                 | |       | | |  number of function evaluations : 3


### PR DESCRIPTION
### Related Issues

#11623

### Purpose

Some logs were redundant, some indentations were wrong.

### Approach

I couldn't unify the logs across solvers as much as I wanted. At some point we should decide what the logs should look like for all of the solvers.