### PR TITLE
Implement C++ to MetaModelica conversion

### DIFF
--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.cpp
@@ -4,10 +4,17 @@
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
 
+extern record_description SCode_AlgorithmSection_ALGORITHM__desc;
+
 Algorithm::Algorithm(MetaModelica::Record value)
   : _statements{value[0].mapVector<Statement>()}
 {
 
+}
+
+MetaModelica::Value Algorithm::toSCode() const noexcept
+{
+  return MetaModelica::Record(0, SCode_AlgorithmSection_ALGORITHM__desc, { Statement::toSCodeList(_statements) });
 }
 
 std::ostream& OpenModelica::Absyn::operator<< (std::ostream &os, const Algorithm &algorithm)

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Algorithm.h
@@ -11,6 +11,8 @@ namespace OpenModelica::Absyn
     public:
       Algorithm(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       const std::vector<Statement>& statements() const noexcept { return _statements; }
 
     private:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.cpp
@@ -2,12 +2,25 @@
 
 #include "Annotation.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Annotation_ANNOTATION__desc;
 
 Annotation::Annotation(MetaModelica::Record value)
   : _modifier{value[0]}
 {
 
+}
+
+MetaModelica::Value Annotation::toSCode() const noexcept
+{
+  return MetaModelica::Record(0, SCode_Annotation_ANNOTATION__desc, { _modifier.toSCode() });
+}
+
+MetaModelica::Value Annotation::toSCodeOpt() const noexcept
+{
+  return _modifier.isEmpty() ? MetaModelica::Option() : MetaModelica::Option(toSCode());
 }
 
 void Annotation::print(std::ostream &os, std::string_view indent) const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Annotation.h
@@ -15,6 +15,9 @@ namespace OpenModelica::Absyn
       Annotation() = default;
       Annotation(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+      MetaModelica::Value toSCodeOpt() const noexcept;
+
       const Modifier& modifier() const noexcept { return _modifier; }
 
       void print(std::ostream &os, std::string_view indent = {}) const noexcept;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.cpp
@@ -2,7 +2,10 @@
 
 #include "Class.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description Absyn_Class_CLASS__desc;
 
 Class::Class(MetaModelica::Record value)
   : Element::Base(SourceInfo{value[7]}),
@@ -15,6 +18,20 @@ Class::Class(MetaModelica::Record value)
     _comment{value[6]}
 {
 
+}
+
+MetaModelica::Value Class::toSCode() const noexcept
+{
+  return MetaModelica::Record{Element::CLASS, Absyn_Class_CLASS__desc, {
+    MetaModelica::Value{_name},
+    _prefixes.toSCode(),
+    _encapsulated.toSCode(),
+    _partial.toSCode(),
+    _restriction.toSCode(),
+    _classDef.toSCode(),
+    _comment.toSCode(),
+    _info
+  }};
 }
 
 const std::string& Class::name() const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Class.h
@@ -17,6 +17,8 @@ namespace OpenModelica::Absyn
     public:
       Class(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept override;
+
       const std::string& name() const noexcept;
       const Comment& comment() const noexcept;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ClassDef.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ClassDef.h
@@ -28,6 +28,7 @@ namespace OpenModelica::Absyn
           virtual ~Base() = default;
 
           virtual std::unique_ptr<Base> clone() const noexcept = 0;
+          virtual MetaModelica::Value toSCode() const noexcept = 0;
           virtual void print(std::ostream &os, const Class &parent) const noexcept = 0;
           virtual void printBody(std::ostream &os) const noexcept = 0;
       };
@@ -39,6 +40,8 @@ namespace OpenModelica::Absyn
 
       ClassDef& operator= (const ClassDef &other) noexcept;
       ClassDef& operator= (ClassDef &&other) = default;
+
+      MetaModelica::Value toSCode() const noexcept;
 
       void print(std::ostream &os, const Class &parent) const noexcept;
       void printBody(std::ostream &os) const noexcept;
@@ -60,6 +63,7 @@ namespace OpenModelica::Absyn
       void swap(Parts &parts) noexcept;
 
       std::unique_ptr<ClassDef::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os, const Class &parent) const noexcept override;
       void printBody(std::ostream &os) const noexcept override;
 
@@ -80,6 +84,7 @@ namespace OpenModelica::Absyn
       ClassExtends(MetaModelica::Record value);
 
       std::unique_ptr<ClassDef::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os, const Class &parent) const noexcept override;
       void printBody(std::ostream &os) const noexcept override;
 
@@ -94,6 +99,7 @@ namespace OpenModelica::Absyn
       Derived(MetaModelica::Record value);
 
       std::unique_ptr<ClassDef::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os, const Class &parent) const noexcept override;
       void printBody(std::ostream &os) const noexcept override;
 
@@ -112,6 +118,7 @@ namespace OpenModelica::Absyn
       Enumeration(MetaModelica::Record value);
 
       std::unique_ptr<ClassDef::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os, const Class &parent) const noexcept override;
       void printBody(std::ostream &os) const noexcept override;
 
@@ -125,6 +132,7 @@ namespace OpenModelica::Absyn
       Overload(MetaModelica::Record value);
 
       std::unique_ptr<ClassDef::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os, const Class &parent) const noexcept override;
       void printBody(std::ostream &os) const noexcept override;
 
@@ -138,6 +146,7 @@ namespace OpenModelica::Absyn
       PartialDerivative(MetaModelica::Record value);
 
       std::unique_ptr<ClassDef::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os, const Class &parent) const noexcept override;
       void printBody(std::ostream &os) const noexcept override;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.cpp
@@ -2,7 +2,10 @@
 
 #include "Comment.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Comment_COMMENT__desc;
 
 Comment::Comment(MetaModelica::Record value)
   : _annotation{value[0].mapOptionalOrDefault<Annotation>()},
@@ -14,6 +17,14 @@ Comment::Comment(std::string description, Annotation annotation) noexcept
   : _description{std::move(description)}, _annotation{std::move(annotation)}
 {
 
+}
+
+MetaModelica::Value Comment::toSCode() const noexcept
+{
+  return MetaModelica::Record(0, SCode_Comment_COMMENT__desc, {
+    _annotation.toSCodeOpt(),
+    MetaModelica::Option(_description)
+  });
 }
 
 std::optional<std::string> Comment::descriptionString() const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Comment.h
@@ -16,6 +16,8 @@ namespace OpenModelica::Absyn
       Comment(MetaModelica::Record value);
       Comment(std::string description, Annotation annotation = Annotation()) noexcept;
 
+      MetaModelica::Value toSCode() const noexcept;
+
       std::optional<std::string> descriptionString() const noexcept;
       const Annotation& annotation() const noexcept;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.cpp
@@ -3,7 +3,10 @@
 #include "Expression.h"
 #include "Component.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Element_COMPONENT__desc;
 
 Component::Component(MetaModelica::Record value)
   : Element::Base(SourceInfo{value[7]}),
@@ -19,6 +22,20 @@ Component::Component(MetaModelica::Record value)
 }
 
 Component::~Component() = default;
+
+MetaModelica::Value Component::toSCode() const noexcept
+{
+  return MetaModelica::Record(Element::COMPONENT, SCode_Element_COMPONENT__desc, {
+    MetaModelica::Value(_name),
+    _prefixes.toSCode(),
+    _attributes.toSCode(),
+    _typeSpec.toAbsyn(),
+    _modifier.toSCode(),
+    _comment.toSCode(),
+    MetaModelica::Option(_condition, [](const auto &c) { return c.toAbsyn(); }),
+    _info
+  });
+}
 
 const std::string& Component::name() const noexcept
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Component.h
@@ -20,6 +20,8 @@ namespace OpenModelica::Absyn
       Component(MetaModelica::Record value);
       ~Component();
 
+      MetaModelica::Value toSCode() const noexcept override;
+
       const std::string& name() const noexcept;
       const Comment& comment() const noexcept;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ComponentRef.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ComponentRef.h
@@ -22,6 +22,8 @@ namespace OpenModelica::Absyn
       explicit ComponentRef(MetaModelica::Record value);
       ~ComponentRef();
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       void push_back(Part part) noexcept;
 
       bool isIdent() const noexcept;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.cpp
@@ -2,14 +2,26 @@
 
 #include "ConstrainingClass.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
 
+extern record_description SCode_ConstrainClass_CONSTRAINCLASS__desc;
+
 ConstrainingClass::ConstrainingClass(MetaModelica::Record value)
-  : _path{value[0]}
-    //_modifier{value[1].toRecord()},
-    //_comment{value[2].toRecord()}
+  : _path{value[0]},
+    _modifier{value[1]},
+    _comment{value[2]}
 {
 
+}
+
+MetaModelica::Value ConstrainingClass::toSCode() const noexcept
+{
+  return MetaModelica::Record(0, SCode_ConstrainClass_CONSTRAINCLASS__desc, {
+    _path.toAbsyn(),
+    _modifier.toSCode(),
+    _comment.toSCode()
+  });
 }
 
 std::ostream& OpenModelica::Absyn::operator<< (std::ostream &os, const ConstrainingClass &cc) noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ConstrainingClass.h
@@ -5,6 +5,8 @@
 
 #include "MetaModelica.h"
 #include "Path.h"
+#include "Modifier.h"
+#include "Comment.h"
 
 namespace OpenModelica::Absyn
 {
@@ -13,10 +15,14 @@ namespace OpenModelica::Absyn
     public:
       ConstrainingClass(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       const Path& path() const noexcept { return _path; }
 
     private:
       Path _path;
+      Modifier _modifier;
+      Comment _comment;
   };
 
   std::ostream& operator<< (std::ostream &os, const ConstrainingClass &cc) noexcept;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.cpp
@@ -2,6 +2,7 @@
 
 #include "DefineUnit.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
 
 DefineUnit::DefineUnit(MetaModelica::Record value)
@@ -12,6 +13,11 @@ DefineUnit::DefineUnit(MetaModelica::Record value)
     _weight{value[3].toOptional<double>()}
 {
 
+}
+
+MetaModelica::Value DefineUnit::toSCode() const noexcept
+{
+  return MetaModelica::Value(4);
 }
 
 std::unique_ptr<Element::Base> DefineUnit::clone() const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/DefineUnit.h
@@ -12,6 +12,8 @@ namespace OpenModelica::Absyn
     public:
       DefineUnit(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept override;
+
       std::unique_ptr<Element::Base> clone() const noexcept override;
       void print(std::ostream &os, Each) const noexcept override;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.cpp
@@ -7,12 +7,6 @@
 #include "DefineUnit.h"
 #include "Element.h"
 
-constexpr int IMPORT = 0;
-constexpr int EXTENDS = 1;
-constexpr int CLASS = 2;
-constexpr int COMPONENT = 3;
-constexpr int DEFINEUNIT = 4;
-
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
 
@@ -25,11 +19,11 @@ Element::Base::Base(SourceInfo info)
 std::unique_ptr<Element::Base> element_from_mm(MetaModelica::Record value)
 {
   switch (value.index()) {
-    case IMPORT:     return std::make_unique<Absyn::Import>(value);
-    case EXTENDS:    return std::make_unique<Absyn::Extends>(value);
-    case CLASS:      return std::make_unique<Absyn::Class>(value);
-    case COMPONENT:  return std::make_unique<Absyn::Component>(value);
-    case DEFINEUNIT: return std::make_unique<Absyn::DefineUnit>(value);
+    case Element::IMPORT:     return std::make_unique<Absyn::Import>(value);
+    case Element::EXTENDS:    return std::make_unique<Absyn::Extends>(value);
+    case Element::CLASS:      return std::make_unique<Absyn::Class>(value);
+    case Element::COMPONENT:  return std::make_unique<Absyn::Component>(value);
+    case Element::DEFINEUNIT: return std::make_unique<Absyn::DefineUnit>(value);
   }
 
   throw std::runtime_error("Element::Element: invalid record index");
@@ -51,6 +45,16 @@ Element& Element::operator= (const Element &other) noexcept
 {
   _impl = other._impl->clone();
   return *this;
+}
+
+MetaModelica::Value Element::toSCode() const noexcept
+{
+  return _impl->toSCode();
+}
+
+MetaModelica::Value Element::toSCodeList(const std::vector<Element> &elements) noexcept
+{
+  return MetaModelica::List(elements, [](const auto &e) { return e.toSCode(); });
 }
 
 void Element::print(std::ostream &os, Each each) const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Element.h
@@ -13,11 +13,20 @@ namespace OpenModelica::Absyn
   class Element
   {
     public:
+      static constexpr int IMPORT = 0;
+      static constexpr int EXTENDS = 1;
+      static constexpr int CLASS = 2;
+      static constexpr int COMPONENT = 3;
+      static constexpr int DEFINEUNIT = 4;
+
+    public:
       class Base
       {
         public:
           Base(SourceInfo info);
           virtual ~Base() = default;
+
+          virtual MetaModelica::Value toSCode() const noexcept = 0;
 
           const SourceInfo& info() const noexcept { return _info; }
 
@@ -35,6 +44,9 @@ namespace OpenModelica::Absyn
 
       Element& operator= (const Element &other) noexcept;
       Element& operator= (Element &&other) = default;
+
+      MetaModelica::Value toSCode() const noexcept;
+      static MetaModelica::Value toSCodeList(const std::vector<Element> &elements) noexcept;
 
       const SourceInfo& info() const noexcept { return _impl->info(); }
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.cpp
@@ -2,7 +2,10 @@
 
 #include "ElementAttributes.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Attributes_ATTR__desc;
 
 ElementAttributes::ElementAttributes(MetaModelica::Record value)
   : _arrayDims{value[0].mapVector<Subscript>()},
@@ -13,6 +16,18 @@ ElementAttributes::ElementAttributes(MetaModelica::Record value)
     _field{value[5]}
 {
 
+}
+
+MetaModelica::Value ElementAttributes::toSCode() const noexcept
+{
+  return MetaModelica::Record(0, SCode_Attributes_ATTR__desc, {
+    Subscript::toAbsynList(_arrayDims),
+    _connectorType.toSCode(),
+    _parallelism.toSCode(),
+    _variability.toSCode(),
+    _direction.toAbsyn(),
+    _field.toAbsyn()
+  });
 }
 
 std::ostream& OpenModelica::Absyn::operator<< (std::ostream &os, const ElementAttributes &attrs) noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementAttributes.h
@@ -15,6 +15,8 @@ namespace OpenModelica::Absyn
     public:
       explicit ElementAttributes(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       const std::vector<Subscript>& arrayDims() const noexcept { return _arrayDims; }
       ConnectorType connectorType() const noexcept { return _connectorType; }
       Parallelism parallelism() const noexcept { return _parallelism; }

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.cpp
@@ -2,7 +2,10 @@
 
 #include "ElementPrefixes.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Prefixes_PREFIXES__desc;
 
 ElementPrefixes::ElementPrefixes(MetaModelica::Record value)
   : _visibility{value[0]},
@@ -12,6 +15,17 @@ ElementPrefixes::ElementPrefixes(MetaModelica::Record value)
     _replaceable{value[4]}
 {
 
+}
+
+MetaModelica::Value ElementPrefixes::toSCode() const noexcept
+{
+  return MetaModelica::Record{0, SCode_Prefixes_PREFIXES__desc, {
+    _visibility.toSCode(),
+    _redeclare.toSCode(),
+    _final.toSCode(),
+    _innerOuter.toAbsyn(),
+    _replaceable.toSCode()
+  }};
 }
 
 void ElementPrefixes::print(std::ostream &os, Each each) const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ElementPrefixes.h
@@ -15,6 +15,8 @@ namespace OpenModelica::Absyn
       ElementPrefixes() = default;
       ElementPrefixes(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       Visibility visibility() const noexcept { return _visibility; }
       Redeclare redeclare() const noexcept { return _redeclare; }
       Final final() const noexcept { return _final; }

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Equation.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Equation.h
@@ -22,6 +22,7 @@ namespace OpenModelica::Absyn
           virtual ~Base() = default;
 
           virtual std::unique_ptr<Base> clone() const noexcept = 0;
+          virtual MetaModelica::Value toSCode() const noexcept = 0;
           virtual void print(std::ostream &os) const noexcept = 0;
 
         protected:
@@ -37,6 +38,9 @@ namespace OpenModelica::Absyn
       Equation& operator= (const Equation &other) noexcept;
       Equation& operator= (Equation &&other) = default;
 
+      MetaModelica::Value toSCode() const noexcept;
+      static MetaModelica::Value toSCodeList(const std::vector<Equation> &eqs) noexcept;
+
       void print(std::ostream &os, std::string_view indent = {}) const noexcept;
 
     private:
@@ -51,6 +55,7 @@ namespace OpenModelica::Absyn
       EqualityEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -67,6 +72,7 @@ namespace OpenModelica::Absyn
       IfEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -80,6 +86,7 @@ namespace OpenModelica::Absyn
       ConnectEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -93,6 +100,7 @@ namespace OpenModelica::Absyn
       ForEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -110,6 +118,7 @@ namespace OpenModelica::Absyn
       WhenEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -122,6 +131,7 @@ namespace OpenModelica::Absyn
       AssertEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -136,6 +146,7 @@ namespace OpenModelica::Absyn
       TerminateEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -148,6 +159,7 @@ namespace OpenModelica::Absyn
       ReinitEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -161,6 +173,7 @@ namespace OpenModelica::Absyn
       CallEquation(MetaModelica::Record value);
 
       std::unique_ptr<Equation::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.h
@@ -25,6 +25,7 @@ namespace OpenModelica::Absyn
           virtual ~Base() = default;
 
           virtual std::unique_ptr<Base> clone() const noexcept = 0;
+          virtual MetaModelica::Value toAbsyn() const noexcept = 0;
           virtual void print(std::ostream &os) const noexcept = 0;
       };
 
@@ -36,6 +37,16 @@ namespace OpenModelica::Absyn
 
       Expression& operator= (const Expression &other) noexcept;
       Expression& operator= (Expression &&other) = default;
+
+      MetaModelica::Value toAbsyn() const noexcept;
+
+      template<typename T>
+      const T& get() const
+      {
+        return dynamic_cast<const T&>(*_impl.get());
+      }
+
+      std::optional<ComponentRef> toCref() const noexcept;
 
       void print(std::ostream &os) const noexcept;
 
@@ -54,6 +65,7 @@ namespace OpenModelica::Absyn
       int64_t value() const noexcept { return _value; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -69,6 +81,7 @@ namespace OpenModelica::Absyn
       double value() const noexcept;
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -84,6 +97,7 @@ namespace OpenModelica::Absyn
       bool value() const noexcept { return _value; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -99,6 +113,7 @@ namespace OpenModelica::Absyn
       const std::string& value() const noexcept { return _value; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -114,6 +129,7 @@ namespace OpenModelica::Absyn
       const ComponentRef& cref() const { return _cref; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -131,6 +147,7 @@ namespace OpenModelica::Absyn
       const Expression& exp2() const noexcept { return _exp2; };
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -149,6 +166,7 @@ namespace OpenModelica::Absyn
       const Expression& exp() const noexcept { return _exp; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -167,6 +185,7 @@ namespace OpenModelica::Absyn
       const Expression& falseBranch() const noexcept { return _false; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -185,6 +204,7 @@ namespace OpenModelica::Absyn
       const FunctionArgs& args() const noexcept { return _args; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -202,6 +222,7 @@ namespace OpenModelica::Absyn
       const FunctionArgs& args() const noexcept { return _args; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -218,6 +239,7 @@ namespace OpenModelica::Absyn
       const std::vector<Expression>& elements() const noexcept { return _elements; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -233,6 +255,7 @@ namespace OpenModelica::Absyn
       const std::vector<Array>& elements() const noexcept { return _matrix; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -251,6 +274,7 @@ namespace OpenModelica::Absyn
       const std::optional<Expression>& step() const { return _step; }
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -266,6 +290,7 @@ namespace OpenModelica::Absyn
       Tuple(std::vector<Expression> elements) noexcept;
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -278,6 +303,7 @@ namespace OpenModelica::Absyn
       End() = default;
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
   };
 
@@ -287,6 +313,7 @@ namespace OpenModelica::Absyn
       explicit Code(MetaModelica::Record value);
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -299,6 +326,7 @@ namespace OpenModelica::Absyn
       explicit SubscriptedExp(MetaModelica::Record value);
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -312,6 +340,7 @@ namespace OpenModelica::Absyn
       Break() = default;
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
   };
 }

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.cpp
@@ -2,16 +2,30 @@
 
 #include "Extends.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Element_EXTENDS__desc;
 
 Extends::Extends(MetaModelica::Record value)
   : Element::Base(SourceInfo{value[4]}),
     _baseClassPath{value[0]},
     _visibility{value[1]},
     _modifier{value[2]},
-    _annotation{value[3]}
+    _annotation{value[3].mapOptionalOrDefault<Annotation>()}
 {
 
+}
+
+MetaModelica::Value Extends::toSCode() const noexcept
+{
+  return MetaModelica::Record(Element::EXTENDS, SCode_Element_EXTENDS__desc, {
+    _baseClassPath.toAbsyn(),
+    _visibility.toSCode(),
+    _modifier.toSCode(),
+    _annotation.toSCodeOpt(),
+    _info
+  });
 }
 
 std::unique_ptr<Element::Base> Extends::clone() const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Extends.h
@@ -15,6 +15,8 @@ namespace OpenModelica::Absyn
     public:
       Extends(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept override;
+
       std::unique_ptr<Element::Base> clone() const noexcept override;
       void print(std::ostream &os, Each each) const noexcept override;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.cpp
@@ -5,7 +5,10 @@
 #include "ExternalDecl.h"
 #include "Subscript.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_ExternalDecl_EXTERNALDECL__desc;
 
 ExternalDecl::ExternalDecl(MetaModelica::Record value)
   : _functionName{value[0].toOptional<std::string>().value_or("")},
@@ -19,6 +22,17 @@ ExternalDecl::ExternalDecl(MetaModelica::Record value)
 }
 
 ExternalDecl::~ExternalDecl() = default;
+
+MetaModelica::Value ExternalDecl::toSCode() const noexcept
+{
+  return MetaModelica::Record(0, SCode_ExternalDecl_EXTERNALDECL__desc, {
+    _functionName.empty() ? MetaModelica::Option() : MetaModelica::Option(MetaModelica::Value(_functionName)),
+    _language.empty() ? MetaModelica::Option() : MetaModelica::Option(MetaModelica::Value(_language)),
+    MetaModelica::Option(_outputParam, [](const auto &o) { return o.toAbsyn(); }),
+    MetaModelica::List(_args, [](const auto &a) { return a.toAbsyn(); }),
+    _annotation.toSCodeOpt()
+  });
+}
 
 std::ostream& OpenModelica::Absyn::operator<< (std::ostream& os, const ExternalDecl &externalDecl) noexcept
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ExternalDecl.h
@@ -21,6 +21,8 @@ namespace OpenModelica::Absyn
       ExternalDecl(MetaModelica::Record value);
       ~ExternalDecl();
 
+      MetaModelica::Value toSCode() const noexcept;
+
       const std::string& functionName() const noexcept { return _functionName; }
       const std::string& language() const noexcept { return _language; }
       const std::optional<ComponentRef>& outputParam() const noexcept { return _outputParam; }

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.cpp
@@ -34,6 +34,11 @@ FunctionArgs& FunctionArgs::operator= (const FunctionArgs &other) noexcept
   return *this;
 }
 
+MetaModelica::Value FunctionArgs::toAbsyn() const noexcept
+{
+  return _impl->toAbsyn();
+}
+
 void FunctionArgs::print(std::ostream &os) const noexcept
 {
   return _impl->print(os);

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgs.h
@@ -13,12 +13,17 @@ namespace OpenModelica::Absyn
   class FunctionArgs
   {
     public:
+      static constexpr int FUNCTIONARGS = 0;
+      static constexpr int FOR_ITER_FARG = 1;
+
+    public:
       class Base
       {
         public:
           virtual ~Base() = default;
 
           virtual std::unique_ptr<Base> clone() const noexcept = 0;
+          virtual MetaModelica::Value toAbsyn() const noexcept = 0;
           virtual void print(std::ostream &os) const noexcept = 0;
       };
 
@@ -29,6 +34,8 @@ namespace OpenModelica::Absyn
 
       FunctionArgs& operator= (const FunctionArgs &other) noexcept;
       FunctionArgs& operator= (FunctionArgs &&other) = default;
+
+      MetaModelica::Value toAbsyn() const noexcept;
 
       void print(std::ostream &os) const noexcept;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.cpp
@@ -5,6 +5,12 @@
 using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
 
+extern record_description Absyn_FunctionArgs_FOR__ITER__FARG__desc;
+
+extern record_description Absyn_ReductionIterType_COMBINE__desc;
+
+const MetaModelica::Record combineIterType{0, Absyn_ReductionIterType_COMBINE__desc};
+
 FunctionArgsIter::FunctionArgsIter(MetaModelica::Record value)
   : _exp{value[0]},
     _iterators{value[2].mapVector<Iterator>()}
@@ -17,6 +23,15 @@ FunctionArgsIter::~FunctionArgsIter() = default;
 std::unique_ptr<FunctionArgs::Base> FunctionArgsIter::clone() const noexcept
 {
   return std::make_unique<FunctionArgsIter>(*this);
+}
+
+MetaModelica::Value FunctionArgsIter::toAbsyn() const noexcept
+{
+  return MetaModelica::Record(FunctionArgs::FOR_ITER_FARG, Absyn_FunctionArgs_FOR__ITER__FARG__desc, {
+    _exp.toAbsyn(),
+    combineIterType,
+    MetaModelica::List(_iterators, [](const auto &i) { return i.toAbsyn(); })
+  });
 }
 
 void FunctionArgsIter::print(std::ostream &os) const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsIter.h
@@ -17,6 +17,7 @@ namespace OpenModelica::Absyn
       ~FunctionArgsIter();
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.h
@@ -23,6 +23,7 @@ namespace OpenModelica::Absyn
       FunctionArgsList(MetaModelica::Record value);
 
       std::unique_ptr<Base> clone() const noexcept override;
+      MetaModelica::Value toAbsyn() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.cpp
@@ -2,7 +2,10 @@
 
 #include "Import.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description SCode_Element_IMPORT__desc;
 
 Import::Import(MetaModelica::Record value)
   : Element::Base(SourceInfo(value[2])),
@@ -10,6 +13,15 @@ Import::Import(MetaModelica::Record value)
     _visibility(value[1])
 {
 
+}
+
+MetaModelica::Value Import::toSCode() const noexcept
+{
+  return MetaModelica::Record(Element::IMPORT, SCode_Element_IMPORT__desc, {
+    _path.toAbsyn(),
+    _visibility.toSCode(),
+    _info
+  });
 }
 
 std::unique_ptr<Element::Base> Import::clone() const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Import.h
@@ -15,6 +15,8 @@ namespace OpenModelica::Absyn
     public:
       Import(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept override;
+
       std::unique_ptr<Element::Base> clone() const noexcept override;
       void print(std::ostream &os, Each each) const noexcept override;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/ImportPath.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/ImportPath.h
@@ -16,9 +16,12 @@ namespace OpenModelica::Absyn
     public:
       ImportPath(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       const std::optional<Path>& packageName() const noexcept { return _pkgName; }
       const std::vector<std::string>& definitionNames() const noexcept { return _defNames; }
       const std::string& shortName() const noexcept { return _shortName; }
+      Path fullPath() const noexcept;
 
     private:
       std::optional<Path> _pkgName;

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.cpp
@@ -2,13 +2,25 @@
 
 #include "Iterator.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
+
+extern record_description Absyn_ForIterator_ITERATOR__desc;
 
 Iterator::Iterator(MetaModelica::Record value)
   : _name{value[0].toString()},
     _range{value[2].mapOptional<Expression>()}
 {
 
+}
+
+MetaModelica::Value Iterator::toAbsyn() const noexcept
+{
+  return MetaModelica::Record(0, Absyn_ForIterator_ITERATOR__desc, {
+    MetaModelica::Value(_name),
+    MetaModelica::Option(),
+    MetaModelica::Option(_range, [](const auto &e) { return e.toAbsyn(); })
+  });
 }
 
 std::ostream& OpenModelica::Absyn::operator<< (std::ostream& os, const Iterator &iterator)

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Iterator.h
@@ -14,6 +14,8 @@ namespace OpenModelica::Absyn
     public:
       Iterator(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       friend std::ostream& operator<< (std::ostream& os, const Iterator &iterator);
 
     private:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.h
@@ -27,6 +27,8 @@ namespace OpenModelica::Absyn
 public:
           virtual ~Base() = default;
 
+          virtual MetaModelica::Value toSCode() const noexcept = 0;
+
           virtual bool isFinal() const noexcept = 0;
           virtual bool isEach() const noexcept = 0;
 
@@ -48,6 +50,8 @@ public:
 
       Modifier& operator= (const Modifier &other) noexcept;
       Modifier& operator= (Modifier &&other) = default;
+
+      MetaModelica::Value toSCode() const noexcept;
 
       bool isEmpty() const noexcept;
       bool isFinal() const noexcept;
@@ -72,6 +76,8 @@ public:
       BindingModifier(Final finalPrefix, Each eachPrefix, std::vector<Modifier::SubMod> subMods,
           std::optional<Expression> binding, const SourceInfo &info) noexcept;
 
+      MetaModelica::Value toSCode() const noexcept override;
+
       bool isFinal() const noexcept override { return _final.isFinal(); }
       bool isEach() const noexcept override { return _each.isEach(); }
 
@@ -94,6 +100,8 @@ public:
     public:
       RedeclareModifier(MetaModelica::Record value);
       RedeclareModifier(Final isFinal, Each isEach, Element element) noexcept;
+
+      MetaModelica::Value toSCode() const noexcept override;
 
       bool isFinal() const noexcept override { return _final.isFinal(); }
       bool isEach() const noexcept override { return _each.isEach(); }

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.cpp
@@ -16,6 +16,56 @@ constexpr auto spacedSymbols = std::array{
   " + ", " - ", " * ", " / ", " ^ ", "+", "-", " .+ ", " .- ", " .* ", " ./ ", " .^ ",
   "+", "-", " and ", " or ", "not ", " < ", " <= ", " > ", " >= ", " == ", " <> "};
 
+extern record_description Absyn_Operator_ADD__desc;
+extern record_description Absyn_Operator_SUB__desc;
+extern record_description Absyn_Operator_MUL__desc;
+extern record_description Absyn_Operator_DIV__desc;
+extern record_description Absyn_Operator_POW__desc;
+extern record_description Absyn_Operator_UPLUS__desc;
+extern record_description Absyn_Operator_UMINUS__desc;
+extern record_description Absyn_Operator_ADD__EW__desc;
+extern record_description Absyn_Operator_SUB__EW__desc;
+extern record_description Absyn_Operator_MUL__EW__desc;
+extern record_description Absyn_Operator_DIV__EW__desc;
+extern record_description Absyn_Operator_POW__EW__desc;
+extern record_description Absyn_Operator_UPLUS__EW__desc;
+extern record_description Absyn_Operator_UMINUS__EW__desc;
+extern record_description Absyn_Operator_AND__desc;
+extern record_description Absyn_Operator_OR__desc;
+extern record_description Absyn_Operator_NOT__desc;
+extern record_description Absyn_Operator_LESS__desc;
+extern record_description Absyn_Operator_LESSEQ__desc;
+extern record_description Absyn_Operator_GREATER__desc;
+extern record_description Absyn_Operator_GREATEREQ__desc;
+extern record_description Absyn_Operator_EQUAL__desc;
+extern record_description Absyn_Operator_NEQUAL__desc;
+
+constexpr auto descs = std::array{
+  &Absyn_Operator_ADD__desc,
+  &Absyn_Operator_SUB__desc,
+  &Absyn_Operator_MUL__desc,
+  &Absyn_Operator_DIV__desc,
+  &Absyn_Operator_POW__desc,
+  &Absyn_Operator_UPLUS__desc,
+  &Absyn_Operator_UMINUS__desc,
+  &Absyn_Operator_ADD__EW__desc,
+  &Absyn_Operator_SUB__EW__desc,
+  &Absyn_Operator_MUL__EW__desc,
+  &Absyn_Operator_DIV__EW__desc,
+  &Absyn_Operator_POW__EW__desc,
+  &Absyn_Operator_UPLUS__EW__desc,
+  &Absyn_Operator_UMINUS__EW__desc,
+  &Absyn_Operator_AND__desc,
+  &Absyn_Operator_OR__desc,
+  &Absyn_Operator_NOT__desc,
+  &Absyn_Operator_LESS__desc,
+  &Absyn_Operator_LESSEQ__desc,
+  &Absyn_Operator_GREATER__desc,
+  &Absyn_Operator_GREATEREQ__desc,
+  &Absyn_Operator_EQUAL__desc,
+  &Absyn_Operator_NEQUAL__desc
+};
+
 Operator::Value value_from_mm(MetaModelica::Record value)
 {
   if (value.index() < 0 || value.index() > Operator::Value::NotEqual) {
@@ -28,6 +78,26 @@ Operator::Value value_from_mm(MetaModelica::Record value)
 Operator::Operator(MetaModelica::Record value)
   : _value{value_from_mm(value)}
 {
+}
+
+MetaModelica::Value Operator::toAbsyn() const noexcept
+{
+  return MetaModelica::Record(static_cast<int>(_value), *descs[static_cast<int>(_value)]);
+}
+
+bool Operator::isArithmetic() const noexcept
+{
+  return _value <= Value::UnaryMinusEw;
+}
+
+bool Operator::isLogical() const noexcept
+{
+  return _value >= Value::And && _value <= Value::Not;
+}
+
+bool Operator::isRelational() const noexcept
+{
+  return _value >= Value::Less;
 }
 
 std::string_view Operator::symbol() const noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Operator.h
@@ -41,6 +41,12 @@ namespace OpenModelica::Absyn
     public:
       explicit Operator(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
+      bool isArithmetic() const noexcept;
+      bool isLogical() const noexcept;
+      bool isRelational() const noexcept;
+
       std::string_view symbol() const noexcept;
       std::string_view spacedSymbol() const noexcept;
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.h
@@ -27,6 +27,7 @@ namespace OpenModelica::Absyn
           virtual ~Base() = default;
 
           virtual std::unique_ptr<Base> clone() const noexcept = 0;
+          virtual MetaModelica::Value toSCode() const noexcept = 0;
           virtual void print(std::ostream &os) const noexcept = 0;
 
         protected:
@@ -42,6 +43,9 @@ namespace OpenModelica::Absyn
       Statement& operator= (const Statement &other) noexcept;
       Statement& operator= (Statement &&other) = default;
 
+      MetaModelica::Value toSCode() const noexcept;
+      static MetaModelica::Value toSCodeList(const std::vector<Statement> &stmts) noexcept;
+
       void print(std::ostream &os, std::string_view indent = {}) const noexcept;
 
     private:
@@ -56,6 +60,7 @@ namespace OpenModelica::Absyn
       AssignmentStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -72,6 +77,7 @@ namespace OpenModelica::Absyn
       IfStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -85,6 +91,7 @@ namespace OpenModelica::Absyn
       ForStatement(MetaModelica::Record value, bool parallel = false);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -100,6 +107,7 @@ namespace OpenModelica::Absyn
       WhileStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -116,6 +124,7 @@ namespace OpenModelica::Absyn
       WhenStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -128,6 +137,7 @@ namespace OpenModelica::Absyn
       AssertStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -142,6 +152,7 @@ namespace OpenModelica::Absyn
       TerminateStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -154,6 +165,7 @@ namespace OpenModelica::Absyn
       ReinitStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -167,6 +179,7 @@ namespace OpenModelica::Absyn
       CallStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
 
     private:
@@ -179,6 +192,7 @@ namespace OpenModelica::Absyn
       ReturnStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
   };
 
@@ -188,6 +202,7 @@ namespace OpenModelica::Absyn
       BreakStatement(MetaModelica::Record value);
 
       std::unique_ptr<Statement::Base> clone() const noexcept override;
+      MetaModelica::Value toSCode() const noexcept override;
       void print(std::ostream &os) const noexcept override;
   };
 }

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.cpp
@@ -4,15 +4,36 @@
 #include "Expression.h"
 #include "Subscript.h"
 
+using namespace OpenModelica;
 using namespace OpenModelica::Absyn;
 
+constexpr int NOSUB = 0;
+constexpr int SUBSCRIPT = 1;
+
+extern record_description Absyn_Subscript_NOSUB__desc;
+extern record_description Absyn_Subscript_SUBSCRIPT__desc;
+
 Subscript::Subscript(MetaModelica::Record value)
-  : _subscript{value.index() == 1 ? std::make_optional<Expression>(value[0]) : std::nullopt}
+  : _subscript{value.index() == SUBSCRIPT ? std::make_optional<Expression>(value[0]) : std::nullopt}
 {
 
 }
 
 Subscript::~Subscript() noexcept = default;
+
+MetaModelica::Value Subscript::toAbsyn() const noexcept
+{
+  if (_subscript) {
+    return MetaModelica::Record(SUBSCRIPT, Absyn_Subscript_SUBSCRIPT__desc, {_subscript->toAbsyn()});
+  }
+
+  return MetaModelica::Record(NOSUB, Absyn_Subscript_NOSUB__desc);
+}
+
+MetaModelica::Value Subscript::toAbsynList(const std::vector<Subscript> &subs) noexcept
+{
+  return MetaModelica::List(subs, [](const auto &s) { return s.toAbsyn(); });
+}
 
 const std::optional<Expression>& Subscript::expression() const noexcept
 {

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Subscript.h
@@ -16,6 +16,9 @@ namespace OpenModelica::Absyn
       Subscript(MetaModelica::Record value);
       ~Subscript() noexcept;
 
+      MetaModelica::Value toAbsyn() const noexcept;
+      static MetaModelica::Value toAbsynList(const std::vector<Subscript> &subs) noexcept;
+
       const std::optional<Expression>& expression() const noexcept;
 
     private:

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/TypeSpec.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/TypeSpec.h
@@ -14,12 +14,15 @@ namespace OpenModelica::Absyn
     public:
       TypeSpec(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       const Path& path() const noexcept;
       const std::vector<Subscript>& dimensions() const noexcept;
 
     private:
       Path _path;
       std::vector<Subscript> _arrayDims;
+      std::vector<TypeSpec> _typeSpecs;
   };
 
   std::ostream& operator<< (std::ostream &os, const TypeSpec &typeSpec) noexcept;

--- a/OMCompiler/Compiler/FrontEndCpp/Inst.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Inst.h
@@ -5,7 +5,7 @@
   extern "C" {
 #endif
 
-extern void Inst_test(void *scode);
+extern void* Inst_test(void *scode);
 
 #ifdef __cplusplus
   }

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.cpp
@@ -23,6 +23,11 @@ void print_list(Container container, std::ostream &os)
   }
 }
 
+mmc_uint_t get_header(void *data)
+{
+  return MMC_HDR_UNMARK(MMC_GETHDR(data));
+}
+
 void* get_index(void *data, size_t index)
 {
   return MMC_FETCH(MMC_OFFSET(MMC_UNTAGPTR(data), index + 1));
@@ -42,6 +47,42 @@ int get_ctor(void *data)
 Value::Value(void *value) noexcept
   : _value{value}
 {
+}
+
+Value::Value(int64_t value) noexcept
+  : _value{mmc_mk_icon(value)}
+{
+
+}
+
+Value::Value(int value) noexcept
+  : _value{mmc_mk_icon(value)}
+{
+
+}
+
+Value::Value(double value) noexcept
+  : _value{mmc_mk_rcon(value)}
+{
+
+}
+
+Value::Value(bool value) noexcept
+  : _value{mmc_mk_bcon(value)}
+{
+
+}
+
+Value::Value(std::string_view value) noexcept
+  : _value{mmc_mk_scon(value.data())}
+{
+
+}
+
+Value::Value(const char *value) noexcept
+  : Value(std::string_view{value})
+{
+
 }
 
 Value::Type Value::getType() const noexcept
@@ -101,7 +142,7 @@ bool Value::isInteger() const noexcept
 
 bool Value::isReal() const noexcept
 {
-  return getType() == Type::real;
+  return MMC_HDR_UNMARK(MMC_GETHDR(_value)) == MMC_REALHDR;
 }
 
 bool Value::isBoolean() const noexcept
@@ -118,32 +159,36 @@ bool Value::isBoolean() const noexcept
 
 bool Value::isString() const noexcept
 {
-  return getType() == Type::string;
+  return MMC_HDRISSTRING(get_header(_value));
 }
 
 bool Value::isOption() const noexcept
 {
-  return getType() == Type::option;
+  const auto hdr = get_header(_value);
+  return MMC_HDRCTOR(hdr) == 1 && MMC_HDRSLOTS(hdr) < 2;
 }
 
 bool Value::isList() const noexcept
 {
-  return getType() == Type::list;
+  const auto hdr = get_header(_value);
+  return hdr == MMC_NILHDR || (MMC_HDRCTOR(hdr) == 1 && MMC_HDRSLOTS(hdr) >= 2);
 }
 
 bool Value::isArray() const noexcept
 {
-  return getType() == Type::array;
+  return MMC_HDRCTOR(get_header(_value)) == MMC_ARRAY_TAG;
 }
 
 bool Value::isTuple() const noexcept
 {
-  return getType() == Type::tuple;
+  const auto hdr = get_header(_value);
+  return MMC_HDRCTOR(hdr) == 0 && MMC_HDRSLOTS(hdr) > 0;
 }
 
 bool Value::isRecord() const noexcept
 {
-  return getType() == Type::record;
+  const auto hdr = get_header(_value);
+  return MMC_HDRCTOR(hdr) > 1 && MMC_HDRSLOTS(hdr) > 0;
 }
 
 int64_t Value::toInt() const
@@ -151,6 +196,7 @@ int64_t Value::toInt() const
   if (!isInteger()) {
     throw std::runtime_error("Value::toInt(): expected Integer, got " + name());
   }
+
   return static_cast<int64_t>(MMC_UNTAGFIXNUM(_value));
 }
 
@@ -187,7 +233,7 @@ Option Value::toOption() const
     throw std::runtime_error("Value::toOption(): expected Option, got " + name());
   }
 
-  return _value;
+  return Option{_value};
 }
 
 List Value::toList() const
@@ -196,7 +242,7 @@ List Value::toList() const
     throw std::runtime_error("Value::toList(): expected list, got " + name());
   }
 
-  return _value;
+  return List{_value};
 }
 
 Array Value::toArray() const
@@ -205,7 +251,7 @@ Array Value::toArray() const
     throw std::runtime_error("Value::toArray(): expected array, got " + name());
   }
 
-  return _value;
+  return Array{_value};
 }
 
 Tuple Value::toTuple() const
@@ -214,7 +260,7 @@ Tuple Value::toTuple() const
     throw std::runtime_error("Value::toTuple(): expected tuple, got " + name());
   }
 
-  return _value;
+  return Tuple{_value};
 }
 
 Record Value::toRecord() const
@@ -223,7 +269,7 @@ Record Value::toRecord() const
     throw std::runtime_error("Value::toRecord(): expected record, got " + name());
   }
 
-  return _value;
+  return Record{_value};
 }
 
 Value::operator bool() const
@@ -268,6 +314,18 @@ std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, Value va
   return os;
 }
 
+Option::Option() noexcept
+  : _value{mmc_mk_none()}
+{
+
+}
+
+Option::Option(Value value) noexcept
+  : _value{value.data() ? mmc_mk_some(value.data()) : mmc_mk_none()}
+{
+
+}
+
 Option::Option(void *value) noexcept
   : _value{value}
 {
@@ -282,7 +340,7 @@ Value Option::operator*() const noexcept
 Value::ArrowProxy Option::operator->() const noexcept
 {
   assert(hasValue());
-  return get_index(_value, 0);
+  return Value::ArrowProxy{get_index(_value, 0)};
 }
 
 Option::operator bool() const noexcept
@@ -298,7 +356,12 @@ bool Option::hasValue() const noexcept
 Value Option::value() const
 {
   assert(hasValue());
-  return get_index(_value, 0);
+  return Value{get_index(_value, 0)};
+}
+
+void* Option::data() const noexcept
+{
+  return _value;
 }
 
 std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, Option option) noexcept
@@ -320,12 +383,12 @@ List::ConstIterator::ConstIterator(void *value) noexcept
 
 List::ConstIterator::value_type List::ConstIterator::operator*() const noexcept
 {
-  return MMC_CAR(_value);
+  return Value{MMC_CAR(_value)};
 }
 
 Value::ArrowProxy List::ConstIterator::operator->() const noexcept
 {
-  return MMC_CAR(_value);
+  return Value::ArrowProxy{MMC_CAR(_value)};
 }
 
 List::ConstIterator& List::ConstIterator::operator++() noexcept
@@ -352,6 +415,12 @@ bool OpenModelica::MetaModelica::operator != (const List::ConstIterator &i1, con
   return i1._value != i2._value;
 }
 
+List::List() noexcept
+  : _value{mmc_mk_nil()}
+{
+
+}
+
 List::List(void *value) noexcept
   : _value{value}
 {
@@ -359,32 +428,32 @@ List::List(void *value) noexcept
 
 Value List::front() const noexcept
 {
-  return MMC_CAR(_value);
+  return Value{MMC_CAR(_value)};
 }
 
 List List::rest() const noexcept
 {
-  return MMC_CDR(_value);
+  return List{MMC_CDR(_value)};
 }
 
 List::ConstIterator List::begin() const noexcept
 {
-  return _value;
+  return List::ConstIterator{_value};
 }
 
 List::ConstIterator List::cbegin() const noexcept
 {
-  return _value;
+  return List::ConstIterator{_value};
 }
 
 List::ConstIterator List::end() const noexcept
 {
-  return nullptr;
+  return List::ConstIterator{nullptr};
 }
 
 List::ConstIterator List::cend() const noexcept
 {
-  return nullptr;
+  return List::ConstIterator{nullptr};
 }
 
 bool List::empty() const noexcept
@@ -395,6 +464,16 @@ bool List::empty() const noexcept
 size_t List::size() const noexcept
 {
   return listLength(_value);
+}
+
+void List::cons(Value v) noexcept
+{
+  _value = mmc_mk_cons(v.data(), _value);
+}
+
+void* List::data() const noexcept
+{
+  return _value;
 }
 
 std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, List list) noexcept
@@ -413,12 +492,12 @@ IndexedConstIterator::IndexedConstIterator(void *value, size_t index) noexcept
 
 IndexedConstIterator::value_type IndexedConstIterator::operator*() const noexcept
 {
-  return get_index(_value, _index);
+  return Value{get_index(_value, _index)};
 }
 
 Value::ArrowProxy IndexedConstIterator::operator->() const noexcept
 {
-  return get_index(_value, _index);
+  return Value::ArrowProxy{get_index(_value, _index)};
 }
 
 IndexedConstIterator& IndexedConstIterator::operator++() noexcept
@@ -491,7 +570,7 @@ size_t Array::size() const noexcept
 
 Value Array::operator[](size_t index) const noexcept
 {
-  return get_index(_value, index);
+  return Value{get_index(_value, index)};
 }
 
 Value Array::at(size_t index) const
@@ -501,6 +580,11 @@ Value Array::at(size_t index) const
   }
 
   return (*this)[index];
+}
+
+void* Array::data() const noexcept
+{
+  return _value;
 }
 
 std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, Array array) noexcept
@@ -514,6 +598,19 @@ std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, Array ar
 Tuple::Tuple(void *value) noexcept
   : _value{value}
 {
+}
+
+Tuple::Tuple(std::initializer_list<Value> values) noexcept
+{
+  mmc_struct *p = static_cast<mmc_struct*>(mmc_alloc_words(values.size() + 1));
+  p->header = MMC_STRUCTHDR(values.size(), 0);
+
+  void **data = p->data;
+  for (auto v: values) {
+    *data++ = v.data();
+  }
+
+  _value = MMC_TAGPTR(p);
 }
 
 IndexedConstIterator Tuple::begin() const noexcept
@@ -543,7 +640,7 @@ size_t Tuple::size() const noexcept
 
 Value Tuple::operator[](size_t index) const noexcept
 {
-  return get_index(_value, index);
+  return Value{get_index(_value, index)};
 }
 
 Value Tuple::at(size_t index) const
@@ -553,6 +650,11 @@ Value Tuple::at(size_t index) const
   }
 
   return (*this)[index];
+}
+
+void* Tuple::data() const noexcept
+{
+  return _value;
 }
 
 std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, Tuple tuple) noexcept
@@ -572,6 +674,21 @@ Record::Record(Value value)
   : _value{value.toRecord()._value}
 {
 
+}
+
+Record::Record(int index, record_description &desc, std::initializer_list<Value> values)
+{
+  mmc_struct *p = static_cast<mmc_struct*>(mmc_alloc_words(values.size() + 2));
+  p->header = MMC_STRUCTHDR(values.size() + 1, index + 3);
+
+  void **data = p->data;
+  *data++ = &desc;
+
+  for (auto v: values) {
+    *data++ = v.data();
+  }
+
+  _value = MMC_TAGPTR(p);
 }
 
 std::string Record::fullName() const noexcept
@@ -631,7 +748,7 @@ Value Record::operator[](std::string_view name) const noexcept
 
 Value Record::operator[](size_t index) const noexcept
 {
-  return get_index(_value, index + 1);
+  return Value{get_index(_value, index + 1)};
 }
 
 Value Record::at(size_t index) const
@@ -659,6 +776,11 @@ IndexedConstIterator Record::find(std::string_view name) const noexcept
 bool Record::contains(std::string_view name) const noexcept
 {
   return find(name) != end();
+}
+
+void* Record::data() const noexcept
+{
+  return _value;
 }
 
 std::ostream& OpenModelica::MetaModelica::operator<< (std::ostream &os, Record record) noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/Path.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Path.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <string_view>
 #include <iosfwd>
 
 #include "MetaModelica.h"
@@ -13,11 +14,15 @@ namespace OpenModelica
   {
     public:
       Path(std::vector<std::string> path, bool fullyQualified = false);
+      Path(std::string_view path);
       Path(MetaModelica::Record value);
+
+      MetaModelica::Value toAbsyn() const noexcept;
 
       void push_back(std::string name) noexcept;
       void pop_back() noexcept;
 
+      size_t size() const noexcept;
       bool isIdent() const noexcept;
       bool isQualified() const noexcept;
       bool isFullyQualified() const noexcept;
@@ -36,7 +41,7 @@ namespace OpenModelica
 
     private:
       std::vector<std::string> _names;
-      bool _fullyQualified;
+      bool _fullyQualified = false;
   };
 
   std::ostream& operator<< (std::ostream &os, const Path &path) noexcept;

--- a/OMCompiler/Compiler/FrontEndCpp/Prefixes.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Prefixes.h
@@ -8,6 +8,9 @@
 
 #include "MetaModelica.h"
 
+extern record_description SCode_Replaceable_REPLACEABLE__desc;
+extern record_description SCode_Replaceable_NOT__REPLACEABLE__desc;
+
 namespace OpenModelica
 {
   class Visibility
@@ -23,6 +26,8 @@ namespace OpenModelica
       Visibility() = default;
       constexpr Visibility(Value value) noexcept : _value{value} {}
       explicit Visibility(MetaModelica::Record value) noexcept;
+
+      MetaModelica::Value toSCode() const noexcept;
 
       Value value() const noexcept { return _value; }
 
@@ -57,6 +62,8 @@ namespace OpenModelica
       constexpr Variability(Value value) noexcept : _value{value} {}
       explicit Variability(MetaModelica::Record value) noexcept;
 
+      MetaModelica::Value toSCode() const noexcept;
+
       Value value() const noexcept { return _value; }
       Variability effective() const noexcept;
 
@@ -81,6 +88,8 @@ namespace OpenModelica
       constexpr explicit Final(bool value) noexcept : _value{value} {}
       explicit Final(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       bool isFinal() const noexcept { return _value; }
       explicit operator bool() const noexcept { return _value; }
 
@@ -97,6 +106,8 @@ namespace OpenModelica
       Each() = default;
       constexpr explicit Each(bool value) noexcept : _value{value} {}
       explicit Each(MetaModelica::Record value);
+
+      MetaModelica::Value toSCode() const noexcept;
 
       bool isEach() const noexcept { return _value; }
       explicit operator bool() const noexcept { return _value; }
@@ -124,6 +135,8 @@ namespace OpenModelica
       constexpr InnerOuter(Value value) noexcept : _value{value} {}
       explicit InnerOuter(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       bool isInner() const noexcept { return _value & Inner; }
       bool isOuter() const noexcept { return _value & Outer; }
       bool isOnlyInner() const noexcept { return _value == Inner; }
@@ -149,6 +162,8 @@ namespace OpenModelica
       constexpr explicit Redeclare(bool value) noexcept : _value{value} {}
       explicit Redeclare(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       bool isRedeclare() const noexcept { return _value; }
       explicit operator bool() const noexcept { return _value; }
 
@@ -162,12 +177,15 @@ namespace OpenModelica
   template<typename ConstrainingClass>
   class Replaceable
   {
+      static constexpr int REPLACEABLE = 0;
+      static constexpr int NOT_REPLACEABLE = 1;
+
     public:
       Replaceable() = default;
       constexpr explicit Replaceable(bool value) : _value{value} {}
 
       explicit Replaceable(MetaModelica::Record value)
-        : _value{value.index() == 0},
+        : _value{value.index() == REPLACEABLE},
           _cc{_value ? value[0].mapPointer<ConstrainingClass>() : nullptr}
       {
 
@@ -194,6 +212,17 @@ namespace OpenModelica
       {
         std::swap(_value, other._value);
         std::swap(_cc, other._cc);
+      }
+
+      MetaModelica::Value toSCode() const noexcept
+      {
+        if (isReplaceable()) {
+          return MetaModelica::Record(REPLACEABLE, SCode_Replaceable_REPLACEABLE__desc, {
+            _cc ? MetaModelica::Option(_cc->toSCode()) : MetaModelica::Option()
+          });
+        }
+
+        return MetaModelica::Record(NOT_REPLACEABLE, SCode_Replaceable_NOT__REPLACEABLE__desc);
       }
 
       bool isReplaceable() const noexcept { return _value; }
@@ -223,6 +252,8 @@ namespace OpenModelica
       constexpr explicit Encapsulated(bool value) noexcept : _value{value} {}
       explicit Encapsulated(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       bool isEncapsulated() const noexcept { return _value; }
       explicit operator bool() const noexcept { return _value; }
 
@@ -239,6 +270,8 @@ namespace OpenModelica
       Partial() = default;
       constexpr explicit Partial(bool value) : _value{value} {}
       explicit Partial(MetaModelica::Record value);
+
+      MetaModelica::Value toSCode() const noexcept;
 
       bool isPartial() const noexcept { return _value; }
       explicit operator bool() const noexcept { return _value; }
@@ -264,6 +297,8 @@ namespace OpenModelica
       Purity() = default;
       constexpr Purity(Value value) noexcept : _value{value} {}
       explicit Purity(MetaModelica::Record value);
+
+      MetaModelica::Value toAbsyn() const noexcept;
 
       Value value() const noexcept { return _value; }
 
@@ -298,6 +333,8 @@ namespace OpenModelica
       ConnectorType() = default;
       constexpr ConnectorType(Value value) noexcept : _value{value} {}
       explicit ConnectorType(MetaModelica::Record value);
+
+      MetaModelica::Value toSCode() const noexcept;
 
       bool isPotential() const noexcept;
       bool isFlow() const noexcept;
@@ -335,6 +372,8 @@ namespace OpenModelica
       constexpr Parallelism(Value value) noexcept : _value{value} {}
       explicit Parallelism(MetaModelica::Record value);
 
+      MetaModelica::Value toSCode() const noexcept;
+
       Value value() const noexcept { return _value; }
 
       std::string_view str() const noexcept;
@@ -362,6 +401,8 @@ namespace OpenModelica
       constexpr Direction(Value value) noexcept : _value{value} {}
       explicit Direction(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       Value value() const noexcept { return _value; }
 
       static std::optional<Direction> merge(Direction outer, Direction inner, bool allowSame = false);
@@ -383,6 +424,8 @@ namespace OpenModelica
       constexpr explicit Field(bool value) : _value{value} {}
       explicit Field(MetaModelica::Record value);
 
+      MetaModelica::Value toAbsyn() const noexcept;
+
       bool isField() const noexcept { return _value; }
       explicit operator bool() const noexcept { return _value; }
 
@@ -392,7 +435,6 @@ namespace OpenModelica
     private:
       bool _value = false;
   };
-
 }
 
 #endif /* PREFIXES_H */

--- a/OMCompiler/Compiler/FrontEndCpp/Restriction.h
+++ b/OMCompiler/Compiler/FrontEndCpp/Restriction.h
@@ -65,18 +65,22 @@ namespace OpenModelica
       static Restriction OperatorFunction() noexcept  { return {Prefix::Operator, Kind::Function}; }
       static Restriction ExternalObject() noexcept    { return Kind::ExternalObject; }
 
-      bool is(Restriction::Prefix prefix, Restriction::Kind kind) const noexcept;
-      bool is(Restriction::Kind kind) const noexcept;
-      bool is(Restriction::Prefix prefix) const noexcept;
+      MetaModelica::Value toSCode() const noexcept;
+
+      Kind kind() const noexcept;
+      Purity purity() const noexcept;
+      bool is(Prefix prefix, Kind kind) const noexcept;
+      bool is(Kind kind) const noexcept;
+      bool is(Prefix prefix) const noexcept;
 
       std::string str() const noexcept;
 
     private:
       // Private so that users can't create their own combinations.
       Restriction() = default;
-      Restriction(Restriction::Prefix prefix, Restriction::Kind kind) noexcept;
-      Restriction(Restriction::Kind kind) noexcept;
-      Restriction(Restriction::Prefix prefix) noexcept;
+      Restriction(Prefix prefix, Kind kind) noexcept;
+      Restriction(Kind kind) noexcept;
+      Restriction(Prefix prefix) noexcept;
 
     private:
       int _value = 0;

--- a/OMCompiler/Compiler/FrontEndCpp/SourceInfo.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/SourceInfo.cpp
@@ -4,6 +4,8 @@
 
 using namespace OpenModelica;
 
+extern record_description SourceInfo_SOURCEINFO__desc;
+
 SourceInfo::SourceInfo() noexcept
   : _isReadOnly{false}, _lineNumberStart{0}, _columnNumberStart{0},
     _lineNumberEnd{0}, _columnNumberEnd{0}, _lastModification{0.0}
@@ -28,6 +30,19 @@ SourceInfo::SourceInfo(std::string filename, bool readonly, int64_t line_start, 
     _lastModification{modified}
 {
 
+}
+
+SourceInfo::operator MetaModelica::Value() const noexcept
+{
+  return MetaModelica::Record{0, SourceInfo_SOURCEINFO__desc, {
+    MetaModelica::Value{_filename},
+    MetaModelica::Value{_isReadOnly},
+    MetaModelica::Value{_lineNumberStart},
+    MetaModelica::Value{_columnNumberStart},
+    MetaModelica::Value{_lineNumberEnd},
+    MetaModelica::Value{_columnNumberEnd},
+    MetaModelica::Value{_lastModification}
+  }};
 }
 
 const SourceInfo& SourceInfo::dummyInfo() noexcept

--- a/OMCompiler/Compiler/FrontEndCpp/SourceInfo.h
+++ b/OMCompiler/Compiler/FrontEndCpp/SourceInfo.h
@@ -15,6 +15,8 @@ namespace OpenModelica
       SourceInfo(std::string filename, bool readonly, int64_t line_start, int64_t column_start,
           int64_t line_end, int64_t column_end, double modified) noexcept;
 
+      operator MetaModelica::Value() const noexcept;
+
       static const SourceInfo& dummyInfo() noexcept;
 
       const std::string& filename() const noexcept { return _filename; }

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -126,7 +126,8 @@ constant InstSettings DEFAULT_SETTINGS = InstSettings.SETTINGS(
 
 //function Inst_test
 //  input SCode.Program program;
-//  external "C" Inst_test(program);
+//  output SCode.Program res;
+//  external "C" res=Inst_test(program);
 //end Inst_test;
 
 function instClassInProgram
@@ -145,14 +146,16 @@ protected
   String name;
   InstContext.Type context;
   Integer var_count, eq_count, expose_local_ios;
+  SCode.Program prog = program;
 algorithm
-  //Inst_test(program);
+  //prog := Inst_test(program);
+
   resetGlobalFlags();
   context := if relaxedFrontend or Flags.getConfigBool(Flags.CHECK_MODEL) or Flags.isSet(Flags.NF_API) then
     NFInstContext.RELAXED else NFInstContext.NO_CONTEXT;
 
   // Create a top scope from the given top-level classes.
-  top := makeTopNode(program, annotationProgram);
+  top := makeTopNode(prog, annotationProgram);
   name := AbsynUtil.pathString(classPath);
 
   // Look up the class to instantiate.


### PR DESCRIPTION
- Add functionality to the MetaModelica C++ API to allow creating MetaModelica data structures.
- Implement MetaModelica conversion for the C++ frontend classes.