### PR TITLE
Fix OMEdit crashes on close with animation window and messages browser

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -3624,9 +3624,12 @@ void MainWindow::messagesTabBarClicked(int index)
  */
 void MainWindow::messagesDockWidgetVisibilityChanged(bool visible)
 {
-  mpMessagesTabWidget->setVisible(!visible);
-  if (!visible && MessagesWidget::instance()) {
-    mpMessagesTabWidget->setCurrentIndex(MessagesWidget::instance()->getMessagesTabWidget()->currentIndex());
+  // Avoid firing a paint event on the animation window when the main window is closing
+  if (MessagesWidget::instance()) {
+    mpMessagesTabWidget->setVisible(!visible);
+    if (!visible) {
+      mpMessagesTabWidget->setCurrentIndex(MessagesWidget::instance()->getMessagesTabWidget()->currentIndex());
+    }
   }
 }
 


### PR DESCRIPTION
### Related Issues

Fixes #11692.

### Purpose

On the [close event](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L780), OMEdit [calls `beforeClosingMainWindow`](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L785) which among other things [destroys the messages widget](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L902-L903), which in turn [deletes the singleton instance](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp#L430-L431) of the messages widget.
Then, the [`messagesDockWidgetVisibilityChanged` slot is triggered](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L396), which [changes the visibility of the messages tab widget](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L3627).
This has the effect of firing a [paint event on the animation window](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp#L128), which draws a new frame and tries to [show pending messages in the messages browser](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp#L149), but at this point, the object previously pointed to by `MessagesWidget::instance()` (including the [mutex](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/Modeling/MessagesWidget.h#L135) causing the crash [here](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp#L642)) is already deleted and `MessagesWidget::instance()` is actually a null pointer.
This is surely why there was already a [null pointer check](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L3628) before updating the index of the messages tab widget.
The proposed fix also wraps the change of visibility inside the null pointer check, to not fire a paint event when the main window closes.

### Approach

Change the visibility of the messages tab widget only if the messages widget instance still exists, i.e., bypass the change when the main window is closing.

Although another obvious fix could be to add a null pointer check [directly in the paint event](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/Animation/ViewerWidget.cpp#L149), we should not do that because it is fair to assume that `MessagesWidget::instance()` always exists when we draw a frame.
That will save a pointless check, especially welcome in high frame rates.
Anyway, we should just not draw any new frames when the main window is closing.

@adeas31 I think a proper solution would be to disconnect or block [this signal](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L396) just [before destroying the messages widget](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L902-L903), so that we can safely assume that `MessagesWidget::instance()` always exists when we try to access it (which is already the case everywhere else) and thus remove [this null pointer check](https://github.com/OpenModelica/OpenModelica/blob/ddbb85bbe309aa2e77a56a7ddd4f6a77f4561efc/OMEdit/OMEditLIB/MainWindow.cpp#L3628).
However, disconnecting/blocking signals should be done properly for all widgets on close, not only the messages dock widget, thus I decided to keep the signal active but check for null pointer before changing visibility to avoid firing a paint event on the animation window.
