### PR TITLE
Updating doc of some Modelica builtins

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -273,13 +273,13 @@ annotation(Documentation(info="<html>
 </html>"));
 end log10;
 
-function homotopy
+function homotopy "Homotopy operator actual*lambda + simplified*(1-lambda)"
   input Real actual;
   input Real simplified;
   output Real outValue;
 external "builtin";
-annotation(version="Modelica 3.2",Documentation(info="<html>
-  See <a href=\"modelica://ModelicaReference.Operators.'homotopy()'\">homotopy()</a> (experimental implementation)
+annotation(__OpenModelica_builtin=true, version="Modelica 3.2",Documentation(info="<html>
+  See <a href=\"https://specification.modelica.org/maint/3.6/operators-and-expressions.html#homotopy\">homotopy()</a>
 </html>"));
 end homotopy;
 
@@ -742,7 +742,7 @@ If no class was being simulated, the last simulated class or a default will be u
 "),version="Modelica 3.3");
 end getInstanceName;
 
-function spatialDistribution "Not yet implemented"
+function spatialDistribution "Approximation of variable-speed transport of properties"
   input Real in0;
   input Real in1;
   input Real x;
@@ -752,7 +752,9 @@ function spatialDistribution "Not yet implemented"
   output Real out0;
   output Real out1;
 external "builtin";
-annotation(version="Modelica 3.3");
+annotation(Documentation(info="<html>
+spatialDistribution allows approximation of variable-speed transport of properties. For further details, see the Modelica Language Specification <a href=\"https://specification.modelica.org/maint/3.6/operators-and-expressions.html#spatialdistribution\">spatialdistribution()</a>.
+</html>"), version="Modelica 3.3");
 end spatialDistribution;
 
 function previous<T> "Access previous value of a clocked variable"

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -288,13 +288,13 @@ annotation(__OpenModelica_builtin=true, Documentation(info="<html>
 </html>"));
 end log10;
 
-impure function homotopy
+impure function homotopy "Homotopy operator actual*lambda + simplified*(1-lambda)"
   input Real actual;
   input Real simplified;
   output Real outValue;
 external "builtin";
 annotation(__OpenModelica_builtin=true, version="Modelica 3.2",Documentation(info="<html>
-  See <a href=\"modelica://ModelicaReference.Operators.'homotopy()'\">homotopy()</a> (experimental implementation)
+  See <a href=\"https://specification.modelica.org/maint/3.6/operators-and-expressions.html#homotopy\">homotopy()</a>
 </html>"));
 end homotopy;
 
@@ -854,7 +854,7 @@ If no class was being simulated, the last simulated class or a default will be u
 "),version="Modelica 3.3");
 end getInstanceName;
 
-function spatialDistribution "Not yet implemented"
+function spatialDistribution "Approximation of variable-speed transport of properties"
   input Real in0;
   input Real in1;
   input Real x;
@@ -864,7 +864,9 @@ function spatialDistribution "Not yet implemented"
   output Real out0;
   output Real out1;
 external "builtin";
-annotation(__OpenModelica_builtin=true, version="Modelica 3.3");
+annotation(Documentation(info="<html>
+spatialDistribution allows approximation of variable-speed transport of properties. For further details, see the Modelica Language Specification <a href=\"https://specification.modelica.org/maint/3.6/operators-and-expressions.html#spatialdistribution\">spatialdistribution()</a>.
+</html>"), version="Modelica 3.3");
 end spatialDistribution;
 
 function previous<__ComponentExpression> "Access previous value of a clocked variable"


### PR DESCRIPTION
### Related Issues

The `spatialDistribution` operator is listed as not supported in the docs:
![grafik](https://github.com/OpenModelica/OpenModelica/assets/38031952/c6f27524-5bd6-46cd-b1ec-3ec21e5b8dcd)

OpenModelica supports `spatialDistribution` since https://github.com/OpenModelica/OpenModelica/pull/7299.

### Purpose

Updates documentation on https://build.openmodelica.org/Documentation/spatialDistribution.html and https://build.openmodelica.org/Documentation/homotopy.html.

### Approach

 Update ModelicaBuiltin.mo for
  - spatialDistribution operator
  - homotopy operator
