### PR TITLE
11538 tearing select vendor annotation

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1131,24 +1131,22 @@ end simplifySubscript;
 
 
 public function setTearingSelectAttribute
-  "Returns the expression of the tearingSelect annotation"
+  "Returns the expression of the __OpenModelica_tearingSelect annotation"
   input Option<SCode.Comment> comment;
   output Option<BackendDAE.TearingSelect> ts;
 protected
   SCode.Annotation ann;
   Absyn.Exp val;
-  String ts_str;
 algorithm
   try
     SOME(SCode.COMMENT(annotation_=SOME(ann))) := comment;
-    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "tearingSelect");
-    ts_str := AbsynUtil.crefIdent(AbsynUtil.expCref(val));
-    ts := match(ts_str)
-      case "always" then SOME(BackendDAE.ALWAYS());
-      case "prefer" then SOME(BackendDAE.PREFER());
-      case "avoid"  then SOME(BackendDAE.AVOID());
-      case "never"  then SOME(BackendDAE.NEVER());
-      case "default" then SOME(BackendDAE.DEFAULT());
+    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "__OpenModelica_tearingSelect");
+    ts := match AbsynUtil.crefIdent(AbsynUtil.expCref(val))
+      case "always"   then SOME(BackendDAE.ALWAYS());
+      case "prefer"   then SOME(BackendDAE.PREFER());
+      case "avoid"    then SOME(BackendDAE.AVOID());
+      case "never"    then SOME(BackendDAE.NEVER());
+      case "default"  then SOME(BackendDAE.DEFAULT());
       else NONE();
     end match;
   else

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1140,7 +1140,12 @@ protected
 algorithm
   try
     SOME(SCode.COMMENT(annotation_=SOME(ann))) := comment;
-    SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "__OpenModelica_tearingSelect");
+    try
+      SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "__OpenModelica_tearingSelect");
+    else
+      SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "tearingSelect");
+      Error.addCompilerWarning("Deprecated vendor annotation 'tearingSelect' found. Use '__OpenModelica_tearingSelect' instead.");
+    end try;
     ts := match AbsynUtil.crefIdent(AbsynUtil.expCref(val))
       case "always"   then SOME(BackendDAE.ALWAYS());
       case "prefer"   then SOME(BackendDAE.PREFER());

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -543,7 +543,7 @@ algorithm
   end if;
   columark := arrayCreate(size,-1);
 
-  // Collect variables with annotation attribute 'tearingSelect=always', 'tearingSelect=prefer', 'tearingSelect=avoid' and 'tearingSelect=never'
+  // Collect variables with annotation attribute '__OpenModelica_tearingSelect in [always, prefer, avoid, never]'
   (tSel_always,tSel_prefer,tSel_avoid,tSel_never,_) := tearingSelect(var_lst, {}, DAEtypeStr);
 
   // determine tvars and do cheap matching until a maximum matching is there
@@ -917,7 +917,7 @@ algorithm
     case (tvar::rest,{})
       equation
         if listMember(tvar,tSel_never) then
-          Error.addCompilerWarning("There are tearing variables with annotation attribute 'tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+          Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
         end if;
         if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("\nForced selection of Tearing Variable:\n" + UNDERLINE + "\n");
@@ -1017,7 +1017,7 @@ algorithm
         false = listEmpty(unsolvables);
         tvar = listHead(unsolvables);
         if listMember(tvar,tSel_never) then
-          Error.addCompilerWarning("There are tearing variables with annotation attribute 'tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+          Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
         end if;
         if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("\nForced selection of Tearing Variable:\n" + UNDERLINE + "\n");
@@ -1063,12 +1063,12 @@ algorithm
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Points after 'discriminateDiscrete':\n" + stringDelimitList(List.map(arrayList(points),intString),",") + "\n\n");
         end if;
-        // 4th: Prefer variables with annotation attribute 'tearingSelect=prefer'
+        // 4th: Prefer variables with annotation attribute '__OpenModelica_tearingSelect = prefer'
         pointsLst = preferAvoidVariables(freeVars, arrayList(points), tSel_prefer, 3.0);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Points after preferring variables with attribute 'prefer':\n" + stringDelimitList(List.map(pointsLst,intString),",") + "\n\n");
         end if;
-        // 5th: Avoid variables with annotation attribute 'tearingSelect=avoid'
+        // 5th: Avoid variables with annotation attribute '__OpenModelica_tearingSelect = avoid'
         pointsLst = preferAvoidVariables(freeVars, pointsLst, tSel_avoid, 0.334);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Points after discrimination against variables with attribute 'avoid':\n" + stringDelimitList(List.map(pointsLst,intString),",") + "\n\n");
@@ -1079,7 +1079,7 @@ algorithm
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("tVar: " + intString(tvar) + " (" + intString(listGet(pointsLst,tvar)) + " points)\n\n");
         elseif listMember(tvar,tSel_avoid) then
-          Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+          Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
         end if;
       then
         tvar;
@@ -1728,7 +1728,7 @@ try
   unsolvedDiscreteVars := findDiscreteWarnTearingSelect(var_lst);
   // print("All discrete Vars: " + stringDelimitList(List.map(unsolvedDiscreteVars,intString),",") + "\n");
 
-  // also find $cse vars and try to make them inner vars since they have implicit tearingSelect never
+  // also find $cse vars and try to make them inner vars since they have implicit '__OpenModelica_tearingSelect = never'
   unsolvedCSEVars := findCSE(var_lst);
   // print("All CSE Vars: " + stringDelimitList(List.map(unsolvedCSEVars,intString),",") + "\n");
 
@@ -2086,7 +2086,7 @@ algorithm
     print("\nDiscrete Vars:\n" + stringDelimitList(List.map(discreteVars,intString),",") + "\n\n");
   end if;
 
-  // Collect variables with annotation attribute 'tearingSelect=always', 'tearingSelect=prefer', 'tearingSelect=avoid' and 'tearingSelect=never'
+  // Collect variables with annotation attribute '__OpenModelica_tearingSelect in [always, prefer, avoid, never]'
   (tSel_always, tSel_prefer, tSel_avoid, tSel_never, tSel_alwaysByUser) := tearingSelect(var_lst, tearingSelect_always, DAEtypeStr);
   if not listEmpty(tSel_alwaysByUser) then
     Error.addMessage(Error.USER_TEARING_VARS, {intString(strongComponentIndex), BackendDump.printBackendDAEType2String(DAEtype), BackendDump.dumpMarkedVarList(var_lst, tSel_alwaysByUser)});
@@ -2271,7 +2271,7 @@ end CellierTearing;
 
 
 protected function tearingSelect
- "collects variables with annotation attribute 'tearingSelect=always', 'tearingSelect=prefer', 'tearingSelect=avoid' and 'tearingSelect=never'
+ "collects variables with annotation attribute '__OpenModelica_tearingSelect in [always, prefer, avoid, never]'
   author: ptaeuber FHB 2014-05"
   input list<BackendDAE.Var> var_lstIn;
   input output list<Integer> always;
@@ -2279,7 +2279,7 @@ protected function tearingSelect
   output list<Integer> prefer = {};
   output list<Integer> avoid = {};
   output list<Integer> never = {};
-  output list<Integer> alwaysByUser = always "distinguish betwween user choice and compiler choice";
+  output list<Integer> alwaysByUser = always "distinguish between user choice and compiler choice";
 protected
   BackendDAE.Var var;
   Integer index = 1;
@@ -2290,7 +2290,7 @@ protected
 algorithm
   preferTVarsWithStartValue := Flags.getConfigBool(Flags.PREFER_TVARS_WITH_START_VALUE) and (DAEtypeStr == "initialization");
   for var in var_lstIn loop
-    // Get the value of the variable's tearingSelect attribute.
+    // Get the value of the variable's __OpenModelica_tearingSelect attribute.
     BackendDAE.VAR(tearingSelectOption = ts) := var;
 
     // Add the variable's index to the appropriate list.
@@ -2324,7 +2324,7 @@ algorithm
   end for;
 
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
-    print("\nExternal influence on selection of iteration variables by variable annotations (tearingSelect)" + (if preferTVarsWithStartValue then " and preference of variables with start attribute" else "") + ":\n");
+    print("\nExternal influence on selection of iteration variables by variable annotations (__OpenModelica_tearingSelect)" + (if preferTVarsWithStartValue then " and preference of variables with start attribute" else "") + ":\n");
     print("Always: " + stringDelimitList(List.map(always, intString), ",") + "\n");
     print("Prefer: " + stringDelimitList(List.map(prefer, intString), ",")+ "\n");
     print("Avoid: " + stringDelimitList(List.map(avoid, intString), ",")+ "\n");
@@ -2375,11 +2375,11 @@ algorithm
 
       _ := match(var.tearingSelectOption)
         case SOME(BackendDAE.ALWAYS()) algorithm
-          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring tearingSelect=always annotation for discrete variable: "
+          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: "
             + BackendDump.varString(var)},ElementSource.getInfo(var.source));
         then ();
         case SOME(BackendDAE.PREFER()) algorithm
-          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring tearingSelect=prefer annotation for discrete variable: "
+          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: "
             + BackendDump.varString(var)},ElementSource.getInfo(var.source));
         then ();
         else ();
@@ -2476,7 +2476,7 @@ algorithm
     list<Integer> tvars,unsolvables,tVar_never,tVar_discrete,order;
     Boolean causal;
 
-  // case: There are no unsolvables and no variables with annotation 'tearingSelect = always'
+  // case: There are no unsolvables and no variables with annotation '__OpenModelica_tearingSelect = always'
   case ({},{})
     equation
       // select tearing Var
@@ -2538,7 +2538,7 @@ algorithm
    then
      (tvars,order);
 
-  // case: There are unsolvables and/or variables with annotation 'tearingSelect = always'
+  // case: There are unsolvables and/or variables with annotation '__OpenModelica_tearingSelect = always'
   else
     equation
       // First choose unsolvables and 'always'-vars as tVars
@@ -2546,7 +2546,7 @@ algorithm
       tVar_never = List.intersectionOnTrue(tSel_never,tvars,intEq);
       tVar_discrete = List.intersectionOnTrue(discreteVars,tvars,intEq);
       if not listEmpty(tVar_never) then
-        Error.addCompilerWarning("There are tearing variables with annotation attribute 'tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+        Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
       end if;
       if not listEmpty(tVar_discrete) then
         Error.addCompilerWarning("There are discrete tearing variables because otherwise the system could not have been torn (unsolvables). This may lead to problems during simulation.");
@@ -2653,7 +2653,7 @@ algorithm
   end try;
 
   if listMember(OutTVar,tSel_avoid) then
-    Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+    Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
   end if;
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("\nEND of TearingHeuristic\n" + BORDER + "\n\n");
@@ -3154,10 +3154,10 @@ algorithm
 
   // 3. Remove variables we don't want as tearing variables
   // ******************************************************
-  // Remove variables with attribute tearingSelect=never
+  // Remove variables with attribute '__OpenModelica_tearingSelect = never'
   (_,potentialTVars,_) := List.intersection1OnTrue(potentialTVars,tSel_never,intEq);
   if listEmpty(potentialTVars) then
-    Error.addCompilerError("It is not possible to select a new tearing variable, because all remaining variables have the attribute tearingSelect=never");
+    Error.addCompilerError("It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = never'.");
     return;
   end if;
 
@@ -3201,7 +3201,7 @@ algorithm
   end if;
   if debug then execStat("TEARINGHEURISTIC4_3"); end if;
 
-  // 4.4 Prefer variables with annotation attribute 'tearingSelect=prefer'
+  // 4.4 Prefer variables with annotation attribute '__OpenModelica_tearingSelect = prefer'
   if not listEmpty(tSel_prefer) then
     points := preferAvoidVariables(potentialTVars, points, tSel_prefer, 3.0);
     if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -3210,7 +3210,7 @@ algorithm
   end if;
   if debug then execStat("TEARINGHEURISTIC4_4"); end if;
 
-  // 4.5 Avoid variables with annotation attribute 'tearingSelect=avoid'
+  // 4.5 Avoid variables with annotation attribute '__OpenModelica_tearingSelect = avoid'
   if not listEmpty(tSel_avoid) then
     points := preferAvoidVariables(potentialTVars, points, tSel_avoid, 0.334);
     if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -3322,7 +3322,7 @@ end ModifiedCellierHeuristic_4;
 
 
 protected function preferAvoidVariables
- "multiplies points of variables with annotation attribute 'tearingSelect=prefer' or 'tearingSelect=avoid' with factor
+ "multiplies points of variables with annotation attribute '__OpenModelica_tearingSelect in [prefer, avoid]' with factor
   author: ptaeuber FHB 2014-05"
   input list<Integer> varsIn;
   input output list<Integer> points;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -939,37 +939,29 @@ public
     function stateSelectString
       input Option<StateSelect> optStateSelect;
       input output list<String> buffer;
-    protected
-      StateSelect stateSelect;
     algorithm
-      if isSome(optStateSelect) then
-        SOME(stateSelect) := optStateSelect;
-        buffer := match stateSelect
-          case StateSelect.NEVER    then "StateSelect = never" :: buffer;
-          case StateSelect.AVOID    then "StateSelect = avoid" :: buffer;
-          case StateSelect.DEFAULT  then "StateSelect = default" :: buffer;
-          case StateSelect.PREFER   then "StateSelect = prefer" :: buffer;
-          case StateSelect.ALWAYS   then "StateSelect = always" :: buffer;
-        end match;
-      end if;
+      buffer := match optStateSelect
+        case SOME(StateSelect.NEVER)    then "StateSelect = never" :: buffer;
+        case SOME(StateSelect.AVOID)    then "StateSelect = avoid" :: buffer;
+        case SOME(StateSelect.DEFAULT)  then "StateSelect = default" :: buffer;
+        case SOME(StateSelect.PREFER)   then "StateSelect = prefer" :: buffer;
+        case SOME(StateSelect.ALWAYS)   then "StateSelect = always" :: buffer;
+        else buffer;
+      end match;
     end stateSelectString;
 
     function tearingSelectString
       input Option<TearingSelect> optTearingSelect;
       input output list<String> buffer;
-    protected
-      TearingSelect tearingSelect;
     algorithm
-      if isSome(optTearingSelect) then
-        SOME(tearingSelect) := optTearingSelect;
-        buffer := match tearingSelect
-          case TearingSelect.NEVER    then "TearingSelect = never" :: buffer;
-          case TearingSelect.AVOID    then "TearingSelect = avoid" :: buffer;
-          case TearingSelect.DEFAULT  then "TearingSelect = default" :: buffer;
-          case TearingSelect.PREFER   then "TearingSelect = prefer" :: buffer;
-          case TearingSelect.ALWAYS   then "TearingSelect = always" :: buffer;
-        end match;
-      end if;
+      buffer := match optTearingSelect
+        case SOME(TearingSelect.NEVER)    then "TearingSelect = never" :: buffer;
+        case SOME(TearingSelect.AVOID)    then "TearingSelect = avoid" :: buffer;
+        case SOME(TearingSelect.DEFAULT)  then "TearingSelect = default" :: buffer;
+        case SOME(TearingSelect.PREFER)   then "TearingSelect = prefer" :: buffer;
+        case SOME(TearingSelect.ALWAYS)   then "TearingSelect = always" :: buffer;
+        else buffer;
+      end match;
     end tearingSelectString;
 
     function createReal
@@ -1236,7 +1228,7 @@ public
     end getStateSelectName;
 
     function createTearingSelect
-      "tearingSelect is an annotation and has to be extracted from the comment."
+      "__OpenModelica_tearingSelect is an annotation and has to be extracted from the comment."
       input Option<SCode.Comment> optComment;
       output Option<TearingSelect> tearingSelect;
     protected
@@ -1246,7 +1238,7 @@ public
     algorithm
       try
         SOME(SCode.COMMENT(annotation_=SOME(anno))) := optComment;
-        SOME(val) := SCodeUtil.lookupAnnotationBinding(anno, "tearingSelect");
+        SOME(val) := SCodeUtil.lookupAnnotationBinding(anno, "__OpenModelica_tearingSelect");
         name := AbsynUtil.crefIdent(AbsynUtil.expCref(val));
         tearingSelect := SOME(lookupTearingSelectMember(name));
       else
@@ -1277,11 +1269,11 @@ public
       output StateSelect stateSelect;
     algorithm
       stateSelect := match name
-        case "never" then TearingSelect.NEVER;
-        case "avoid" then TearingSelect.AVOID;
-        case "default" then TearingSelect.DEFAULT;
-        case "prefer" then TearingSelect.PREFER;
-        case "always" then TearingSelect.ALWAYS;
+        case "never"    then TearingSelect.NEVER;
+        case "avoid"    then TearingSelect.AVOID;
+        case "default"  then TearingSelect.DEFAULT;
+        case "prefer"   then TearingSelect.PREFER;
+        case "always"   then TearingSelect.ALWAYS;
         else
           algorithm
             Error.assertion(false, getInstanceName() + " got unknown TearingSelect literal " + name, sourceInfo());
@@ -1313,7 +1305,7 @@ public
   uniontype Annotations
     record ANNOTATIONS
       "all annotations that are vendor specific
-      note: doesn't inculde tearingSelect, this is considered a first class attribute"
+      note: doesn't inculde __OpenModelica_tearingSelect, this is considered a first class attribute"
       Boolean hideResult;
     end ANNOTATIONS;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -1238,7 +1238,12 @@ public
     algorithm
       try
         SOME(SCode.COMMENT(annotation_=SOME(anno))) := optComment;
-        SOME(val) := SCodeUtil.lookupAnnotationBinding(anno, "__OpenModelica_tearingSelect");
+        try
+          SOME(val) := SCodeUtil.lookupAnnotationBinding(anno, "__OpenModelica_tearingSelect");
+        else
+          SOME(val) := SCodeUtil.lookupAnnotationBinding(anno, "tearingSelect");
+          Error.addCompilerWarning("Deprecated vendor annotation 'tearingSelect' found. Use '__OpenModelica_tearingSelect' instead.");
+        end try;
         name := AbsynUtil.crefIdent(AbsynUtil.expCref(val));
         tearingSelect := SOME(lookupTearingSelectMember(name));
       else

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop5.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop5.mos
@@ -9,8 +9,8 @@ getErrorString();
 loadString("
 model testAlgLoop5
   parameter Real one = 1;
-  Real t1(start=1, min = -0.4) annotation(tearingSelect = always);
-  Real t2(start=1,min=-2,max=1/2) annotation(tearingSelect = always);
+  Real t1(start=1, min = -0.4) annotation(__OpenModelica_tearingSelect = always);
+  Real t2(start=1,min=-2,max=1/2) annotation(__OpenModelica_tearingSelect = always);
   Real t3(start=5);
   Real t4(start=5, min=1, max=5);
   Real x(start=1,fixed=true,min=-3,max=3.0);
@@ -22,7 +22,7 @@ model testAlgLoop5
   input Real u3(min=-1,max=1, start=1);
   Real cost annotation(isLagrange = true);
   Real costM = sin(u*u1) annotation(isMayer = true);
-  Real dummyCon = one*con annotation(tearingSelect = always);
+  Real dummyCon = one*con annotation(__OpenModelica_tearingSelect = always);
   Real con(min=1, start=1, max = 2.5) = 2*t3 + 3*t1 + t2 annotation(isConstraint=true);
   Real conDer(min=-2, start=1, max = 2) = der(x) annotation(isConstraint=true);
   Real fcon(min=0,max=0) = 10*der(x) annotation(isFinalConstraint = true);

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
@@ -12,14 +12,14 @@ model testAlgLoop6
   Real y2(start = 0,min=-1,max=1);
   Real y3(start = 0,min=-0.3,max=0.3);
   Real x1(start=1,min=0);
-  Real x2(start=1,min=-1,max=1) annotation(tearingSelect = always);
+  Real x2(start=1,min=-1,max=1) annotation(__OpenModelica_tearingSelect = always);
   input Real u(min=-1,max=1,start=0);
   input Real u1(min=-1,max=1,start=0);
   input Real u2(min=-5,max=5,start=0);
   input Real u3(min=-1,max=1,start=1);
   Real cost annotation(isLagrange = true);
   Real con(min=-0.9,max=0.9,start=1) = y1 + u;
-  Real conDer(min=-1,max=1) = der(y1) annotation(tearingSelect = always);
+  Real conDer(min=-1,max=1) = der(y1) annotation(__OpenModelica_tearingSelect = always);
 equation
   sin(der(y1)) = con;
   der(y2) = asin(con);

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
@@ -2282,7 +2282,7 @@ getErrorString();
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph.mo:76:3-76:60:writable] Warning: dh2satp was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph_der.mo:179:3-182:49:writable] Warning: du1satp_der was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph_der.mo:179:3-182:49:writable] Warning: du2satp_der was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// Error: It is not possible to select a new tearing variable, because all remaining variables have the attribute tearingSelect=never
+// Error: It is not possible to select a new tearing variable, because all remaining variables have the attribute __OpenModelica_tearingSelect=never
 // Warning: Function Tearing.selectTearingVar failed at least once. Use -d=tearingdump or -d=tearingdumpV for more information.
 // "
 // endResult

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
@@ -2282,7 +2282,7 @@ getErrorString();
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph.mo:76:3-76:60:writable] Warning: dh2satp was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph_der.mo:179:3-182:49:writable] Warning: du1satp_der was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph_der.mo:179:3-182:49:writable] Warning: du2satp_der was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// Error: It is not possible to select a new tearing variable, because all remaining variables have the attribute __OpenModelica_tearingSelect=never
+// Error: It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = never'.
 // Warning: Function Tearing.selectTearingVar failed at least once. Use -d=tearingdump or -d=tearingdumpV for more information.
 // "
 // endResult

--- a/testsuite/simulation/modelica/commonSubExp/cse1.mos
+++ b/testsuite/simulation/modelica/commonSubExp/cse1.mos
@@ -257,6 +257,6 @@ simulate(Tearing15); getErrorString();
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Warning: There are tearing variables with annotation attribute 'tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// "Warning: There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // "
 // endResult

--- a/testsuite/simulation/modelica/initialization/homotopy4.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy4.mos
@@ -13,7 +13,7 @@ within ;
 package initializationTests
   model homotopy4
     Real x,y,z,x1,y1,z1,x2,y2,z2,x3,y3,z3,a,b,c,d,e,f;
-    // Real x,y,z,x1,y1,z1,x2,y2,z2 annotation(tearingSelect=always),x3,y3,z3,a,b,c,d,e,f;
+    // Real x,y,z,x1,y1,z1,x2,y2,z2 annotation(__OpenModelica_tearingSelect=always),x3,y3,z3,a,b,c,d,e,f;
     parameter Real p1 = 10;
 
   equation

--- a/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
+++ b/testsuite/simulation/modelica/initialization/homotopy4_solver.mos
@@ -12,7 +12,7 @@ within ;
 package initializationTests
   model homotopy4_solver
     Real x,y,z,x1,y1,z1,x2,y2,z2,x3,y3,z3,a,b,c,d,e,f;
-    // Real x,y,z,x1,y1,z1,x2,y2,z2 annotation(tearingSelect=always),x3,y3,z3,a,b,c,d,e,f;
+    // Real x,y,z,x1,y1,z1,x2,y2,z2 annotation(__OpenModelica_tearingSelect=always),x3,y3,z3,a,b,c,d,e,f;
     parameter Real p1 = 10;
 
   equation

--- a/testsuite/simulation/modelica/tearing/MixedTearing2-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/MixedTearing2-minimal.mos
@@ -6,8 +6,8 @@
 loadString("
 model mixedTest2
   Real a(start=0);
-  Integer b annotation(tearingSelect = always);
-  Boolean c annotation(tearingSelect = prefer);
+  Integer b annotation(__OpenModelica_tearingSelect = always);
+  Boolean c annotation(__OpenModelica_tearingSelect = prefer);
 equation
   a = b * time;
   c = a > 0;
@@ -36,8 +36,8 @@ simulate(mixedTest2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 3
 //  * Number of variables: 3
-// [<interactive>:5:3-5:47:writable] Warning: Minimal Tearing is ignoring tearingSelect=prefer annotation for discrete variable: c:DISCRETE(fixed = false )  type: Boolean
-// [<interactive>:4:3-4:47:writable] Warning: Minimal Tearing is ignoring tearingSelect=always annotation for discrete variable: b:DISCRETE(fixed = false )  type: Integer
+// [<interactive>:5:3-5:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE(fixed = false )  type: Boolean
+// [<interactive>:4:3-4:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE(fixed = false )  type: Integer
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
@@ -59,8 +59,8 @@ simulate(mixedTest2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,2)}
-// [<interactive>:4:3-4:47:writable] Warning: Minimal Tearing is ignoring tearingSelect=always annotation for discrete variable: b:DISCRETE()  type: Integer
-// [<interactive>:5:3-5:47:writable] Warning: Minimal Tearing is ignoring tearingSelect=prefer annotation for discrete variable: c:DISCRETE()  type: Boolean
+// [<interactive>:4:3-4:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE()  type: Integer
+// [<interactive>:5:3-5:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE()  type: Boolean
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/MixedTearing2-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/MixedTearing2-minimal.mos
@@ -36,8 +36,8 @@ simulate(mixedTest2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 3
 //  * Number of variables: 3
-// [<interactive>:5:3-5:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE(fixed = false )  type: Boolean
-// [<interactive>:4:3-4:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE(fixed = false )  type: Integer
+// [<interactive>:5:3-5:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE(fixed = false )  type: Boolean
+// [<interactive>:4:3-4:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE(fixed = false )  type: Integer
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
@@ -59,8 +59,8 @@ simulate(mixedTest2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,2)}
-// [<interactive>:4:3-4:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE()  type: Integer
-// [<interactive>:5:3-5:47:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE()  type: Boolean
+// [<interactive>:4:3-4:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE()  type: Integer
+// [<interactive>:5:3-5:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE()  type: Boolean
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/tearingSelect.mo
+++ b/testsuite/simulation/modelica/tearing/tearingSelect.mo
@@ -1,10 +1,10 @@
 model tearingSelect
    Real u0;
-   Real i1 annotation(tearingSelect=prefer);
+   Real i1 annotation(__OpenModelica_tearingSelect=prefer);
    Real i2 (start=1);
    Real i3;
    Real u1;
-   Real u2 (start=1) annotation(tearingSelect=avoid);
+   Real u2 (start=1) annotation(__OpenModelica_tearingSelect=avoid);
    Real u3;
    parameter Real r1=10;
    parameter Real r2=10;

--- a/testsuite/simulation/modelica/tearing/tearingSelect2-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect2-celMC3.mos
@@ -29,7 +29,7 @@ simulate(tearingSelect2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 6
 //  * Number of variables: 6
-// Warning: The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
@@ -52,7 +52,7 @@ simulate(tearingSelect2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,5)}
-// Warning: The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/tearingSelect2-omc.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect2-omc.mos
@@ -29,7 +29,7 @@ simulate(tearingSelect2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 6
 //  * Number of variables: 6
-// Warning: The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
@@ -52,7 +52,7 @@ simulate(tearingSelect2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,5)}
-// Warning: The Tearing heuristic has chosen variables with annotation attribute 'tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/tearingSelect2.mo
+++ b/testsuite/simulation/modelica/tearing/tearingSelect2.mo
@@ -1,5 +1,5 @@
 model tearingSelect2
-   Real x1 annotation(tearingSelect = avoid);
+   Real x1 annotation(__OpenModelica_tearingSelect = avoid);
    Real x2;
    Real x3;
    Real x4;


### PR DESCRIPTION
### Related Issues

#11538

### Purpose

Tearing Select is (still) a vendor annotation so it needs the prefix `__OpenModelica_`.

### Approach

The old `tearingSelect` is still accepted but a deprecation warning is printed.
