### PR TITLE
Fix spelling/grammar of OMEdit GUI

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/ShapeAnnotation.cpp
@@ -533,7 +533,7 @@ void ShapeAnnotation::applyLinePattern(QPainter *painter)
   pen.setCosmetic(true);
   /* Ticket #2272, Ticket #2268.
    * If thickness is greater than 4 then don't make the pen cosmetic since cosmetic pens don't change the width with respect to zoom.
-   * Use non cosmetic pens for Libraries Browser and shapes inside component when thickness is greater than 4.
+   * Use non cosmetic pens for Library Browser and shapes inside component when thickness is greater than 4.
    */
   if (thickness > 4
       && ((mpGraphicsView && mpGraphicsView->isRenderingLibraryPixmap()) || mpParentComponent)) {

--- a/OMEdit/OMEditLIB/Editors/CompositeModelEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/CompositeModelEditor.cpp
@@ -92,7 +92,7 @@ bool CompositeModelEditor::validateText()
                                                                             NotificationsDialog::CriticalIcon,
                                                                             MainWindow::instance());
         pNotificationsDialog->setNotificationLabelString(GUIMessages::getMessage(GUIMessages::ERROR_IN_TEXT).arg("Composite Model")
-                                                         .append(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGES_BROWSER))
+                                                         .append(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGE_BROWSER))
                                                          .append(GUIMessages::getMessage(GUIMessages::REVERT_PREVIOUS_OR_FIX_ERRORS_MANUALLY)));
         pNotificationsDialog->getOkButton()->setText(Helper::revertToLastCorrectVersion);
         pNotificationsDialog->getOkButton()->setAutoDefault(false);

--- a/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
@@ -408,7 +408,7 @@ bool ModelicaEditor::validateText(LibraryTreeItem **pLibraryTreeItem)
                                                                             NotificationsDialog::CriticalIcon,
                                                                             MainWindow::instance());
         pNotificationsDialog->setNotificationLabelString(GUIMessages::getMessage(GUIMessages::ERROR_IN_TEXT).arg("Modelica")
-                                                         .append(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGES_BROWSER))
+                                                         .append(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGE_BROWSER))
                                                          .append(GUIMessages::getMessage(GUIMessages::REVERT_PREVIOUS_OR_FIX_ERRORS_MANUALLY)));
         pNotificationsDialog->getOkButton()->setText(Helper::revertToLastCorrectVersion);
         pNotificationsDialog->getOkButton()->setAutoDefault(false);
@@ -438,7 +438,7 @@ bool ModelicaEditor::validateText(LibraryTreeItem **pLibraryTreeItem)
       mLastValidText = mpPlainTextEdit->toPlainText();
     }
   }
-  /* Update the Libraries Browser when Modelica text change is done
+  /* Update the Library Browser when Modelica text change is done
    * See discussion #10728
    */
   MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->showHideProtectedClasses();

--- a/OMEdit/OMEditLIB/Editors/OMSimulatorEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/OMSimulatorEditor.cpp
@@ -65,7 +65,7 @@ bool OMSimulatorEditor::validateText()
                                                                             NotificationsDialog::CriticalIcon,
                                                                             MainWindow::instance());
         pNotificationsDialog->setNotificationLabelString(GUIMessages::getMessage(GUIMessages::ERROR_IN_TEXT).arg("SSP Model")
-                                                         .append(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGES_BROWSER))
+                                                         .append(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGE_BROWSER))
                                                          .append(GUIMessages::getMessage(GUIMessages::REVERT_PREVIOUS_OR_FIX_ERRORS_MANUALLY)));
         pNotificationsDialog->getOkButton()->setText(Helper::revertToLastCorrectVersion);
         pNotificationsDialog->getOkButton()->setAutoDefault(false);

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -184,13 +184,13 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // Create an object of MessagesWidget.
   MessagesWidget::create();
   // Create MessagesDockWidget dock
-  mpMessagesDockWidget = new QDockWidget(tr("Messages Browser"), this);
+  mpMessagesDockWidget = new QDockWidget(tr("Messages"), this);
   mpMessagesDockWidget->setObjectName("Messages");
   mpMessagesDockWidget->setAllowedAreas(Qt::BottomDockWidgetArea);
   mpMessagesDockWidget->setWidget(MessagesWidget::instance());
   addDockWidget(Qt::BottomDockWidgetArea, mpMessagesDockWidget);
   mpMessagesDockWidget->hide();
-  connect(MessagesWidget::instance(), SIGNAL(messageAdded()), SLOT(showMessagesBrowser()));
+  connect(MessagesWidget::instance(), SIGNAL(messageAdded()), SLOT(showMessageBrowser()));
   // Create the OMCProxy object.
   mpOMCProxy = new OMCProxy(threadData, this);
   if (getExitApplicationStatus()) {
@@ -254,7 +254,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // Create an object of LibraryWidget
   mpLibraryWidget = new LibraryWidget(this);
   // Create LibraryDockWidget
-  mpLibraryDockWidget = new QDockWidget(tr("Libraries Browser"), this);
+  mpLibraryDockWidget = new QDockWidget(tr("Libraries"), this);
   mpLibraryDockWidget->setObjectName("Libraries");
   mpLibraryDockWidget->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
   mpLibraryDockWidget->setWidget(mpLibraryWidget);
@@ -262,7 +262,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   mpLibraryWidget->getLibraryTreeView()->setFocus(Qt::ActiveWindowFocusReason);
   // Create an object of SearchWidget
   mpSearchWidget = new SearchWidget(this);
-  mpSearchDockWidget = new QDockWidget(tr("Search Browser"),this);
+  mpSearchDockWidget = new QDockWidget(tr("Search"),this);
   mpSearchDockWidget->setObjectName("Search");
   mpSearchDockWidget->setAllowedAreas(Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
   mpSearchDockWidget->setWidget(mpSearchWidget);
@@ -273,14 +273,14 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // create stack frames widget
   mpStackFramesWidget = new StackFramesWidget(this);
   // Create stack frames dock widget
-  mpStackFramesDockWidget = new QDockWidget(tr("Stack Frames Browser"), this);
+  mpStackFramesDockWidget = new QDockWidget(tr("Stack Frames"), this);
   mpStackFramesDockWidget->setObjectName("StackFrames");
   mpStackFramesDockWidget->setWidget(mpStackFramesWidget);
   addDockWidget(Qt::TopDockWidgetArea, mpStackFramesDockWidget);
   // create breakpoints widget
   mpBreakpointsWidget = new BreakpointsWidget(this);
   // Create breakpoints dock widget
-  mpBreakpointsDockWidget = new QDockWidget(tr("BreakPoints Browser"), this);
+  mpBreakpointsDockWidget = new QDockWidget(tr("Breakpoints"), this);
   mpBreakpointsDockWidget->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
   mpBreakpointsDockWidget->setObjectName("BreakPoints");
   mpBreakpointsDockWidget->setWidget(mpBreakpointsWidget);
@@ -288,14 +288,14 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // create locals widget
   mpLocalsWidget = new LocalsWidget(this);
   // Create locals dock widget
-  mpLocalsDockWidget = new QDockWidget(tr("Locals Browser"), this);
+  mpLocalsDockWidget = new QDockWidget(tr("Locals"), this);
   mpLocalsDockWidget->setObjectName("Locals");
   mpLocalsDockWidget->setWidget(mpLocalsWidget);
   addDockWidget(Qt::RightDockWidgetArea, mpLocalsDockWidget);
   // Create target output widget
   mpTargetOutputWidget = new TargetOutputWidget(this);
   // Create GDB console dock widget
-  mpTargetOutputDockWidget = new QDockWidget(tr("Output Browser"), this);
+  mpTargetOutputDockWidget = new QDockWidget(tr("Console Output"), this);
   mpTargetOutputDockWidget->setObjectName("OutputBrowser");
   mpTargetOutputDockWidget->setWidget(mpTargetOutputWidget);
   addDockWidget(Qt::BottomDockWidgetArea, mpTargetOutputDockWidget);
@@ -311,7 +311,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // create an object of DocumentationWidget
   mpDocumentationWidget = new DocumentationWidget(this);
   // Create DocumentationWidget dock
-  mpDocumentationDockWidget = new QDockWidget(tr("Documentation Browser"), this);
+  mpDocumentationDockWidget = new QDockWidget(tr("Documentation"), this);
   mpDocumentationDockWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
   mpDocumentationDockWidget->setObjectName("Documentation");
   mpDocumentationDockWidget->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
@@ -324,7 +324,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   // create an object of VariablesWidget
   mpVariablesWidget = new VariablesWidget(this);
   // Create VariablesWidget dock
-  mpVariablesDockWidget = new QDockWidget(Helper::variablesBrowser, this);
+  mpVariablesDockWidget = new QDockWidget(Helper::variableBrowser, this);
   mpVariablesDockWidget->setObjectName("Variables");
   mpVariablesDockWidget->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
   addDockWidget(Qt::RightDockWidgetArea, mpVariablesDockWidget);
@@ -339,7 +339,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
    */
   mpThreeDViewer = 0;
   // Create ThreeDViewer dock
-  mpThreeDViewerDockWidget = new QDockWidget(tr("3D Viewer Browser"), this);
+  mpThreeDViewerDockWidget = new QDockWidget(tr("3D Viewer"), this);
   mpThreeDViewerDockWidget->setObjectName("3DViewer");
   mpThreeDViewerDockWidget->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
   addDockWidget(Qt::RightDockWidgetArea, mpThreeDViewerDockWidget);
@@ -357,7 +357,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   createActions();
   createToolbars();
   createMenus();
-  // enable/disable re-simulation toolbar based on variables browser visibiltiy.
+  // enable/disable re-simulation toolbar based on variable browser visibiltiy.
   connect(mpVariablesDockWidget, SIGNAL(visibilityChanged(bool)), this, SLOT(enableReSimulationToolbar(bool)));
   // Create the archived simulation widget
   ArchivedSimulationsWidget::create();
@@ -388,7 +388,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
   pCentralWidgetLayout->setContentsMargins(0, 0, 0, 0);
   QWidget *pCentralWidget = new QWidget;
   pCentralWidgetLayout->addWidget(mpCentralStackedWidget, 1);
-  // Create a QTabWidget that mimicks the Messages Browser
+  // Create a QTabWidget that mimicks the Message Browser
   mpMessagesTabWidget = new QTabWidget(this);
   mpMessagesTabWidget->setTabsClosable(true);
   mpMessagesTabWidget->setDocumentMode(true);
@@ -426,7 +426,7 @@ void MainWindow::setUpMainWindow(threadData_t *threadData)
     mpLocalsWidget->getLocalsTreeView()->header()->restoreState(pSettings->value("localsTreeState").toByteArray());
     pSettings->endGroup();
     if (restoreMessagesWidget) {
-      showMessagesBrowser();
+      showMessageBrowser();
     }
   }
   switchToWelcomePerspective();
@@ -1073,7 +1073,7 @@ void MainWindow::instantiateModel(LibraryTreeItem *pLibraryTreeItem)
   if (OptionsDialog::instance()->getMessagesPage()->getResetMessagesNumberBeforeSimulationCheckBox()->isChecked()) {
     MessagesWidget::instance()->resetMessagesNumber();
   }
-  // check clear messages browser before instantiating
+  // check clear message browser before instantiating
   if (OptionsDialog::instance()->getMessagesPage()->getClearMessagesBrowserBeforeSimulationCheckBox()->isChecked()) {
     MessagesWidget::instance()->clearMessages();
   }
@@ -1106,7 +1106,7 @@ void MainWindow::checkModel(LibraryTreeItem *pLibraryTreeItem)
   if (OptionsDialog::instance()->getMessagesPage()->getResetMessagesNumberBeforeSimulationCheckBox()->isChecked()) {
     MessagesWidget::instance()->resetMessagesNumber();
   }
-  // check clear messages browser before checking
+  // check clear message browser before checking
   if (OptionsDialog::instance()->getMessagesPage()->getClearMessagesBrowserBeforeSimulationCheckBox()->isChecked()) {
     MessagesWidget::instance()->clearMessages();
   }
@@ -1596,7 +1596,7 @@ void MainWindow::findFileAndGoToLine(QString fileName, QString lineNumber)
 
 /*!
  * \brief MainWindow::printStandardOutAndErrorFilesMessages
- * Reads the omeditoutput.txt and omediterror.txt files and add the data to Messages Browser if there is any.
+ * Reads the omeditoutput.txt and omediterror.txt files and add the data to Message Browser if there is any.
  */
 void MainWindow::printStandardOutAndErrorFilesMessages()
 {
@@ -1816,14 +1816,14 @@ void MainWindow::writeNewApiProfiling(const QString &str)
 }
 
 /*!
- * \brief MainWindow::showMessagesBrowser
+ * \brief MainWindow::showMessageBrowser
  * Slot activated when MessagesWidget::messageAdded signal is raised.\n
- * Shows the Messages Browser.
+ * Shows the Message Browser.
  */
-void MainWindow::showMessagesBrowser()
+void MainWindow::showMessageBrowser()
 {
   mpMessagesDockWidget->show();
-  // In case user has tabbed the dock widgets then make Messages Browser active.
+  // In case user has tabbed the dock widgets then make Message Browser active.
   QList<QDockWidget*> tabifiedDockWidgetsList = tabifiedDockWidgets(mpMessagesDockWidget);
   if (tabifiedDockWidgetsList.size() > 0) {
     tabifyDockWidget(tabifiedDockWidgetsList.at(0), mpMessagesDockWidget);
@@ -2288,7 +2288,7 @@ void MainWindow::redo()
 
 /*!
  * \brief MainWindow::focusFilterClasses
- * Sets the focus on filter classes text box in Libraries Browser.
+ * Sets the focus on filter classes text box in Library Browser.
  */
 void MainWindow::focusFilterClasses()
 {
@@ -3613,7 +3613,7 @@ void MainWindow::threeDViewerDockWidgetVisibilityChanged(bool visible)
  */
 void MainWindow::messagesTabBarClicked(int index)
 {
-  showMessagesBrowser();
+  showMessageBrowser();
   MessagesWidget::instance()->getMessagesTabWidget()->setCurrentIndex(index);
 }
 
@@ -5295,7 +5295,7 @@ void AboutOMEditDialog::showReportIssue()
 
 /*!
  * \class MessageTab
- * \brief Creates a tab that mimicks the tab of Messages Browser.
+ * \brief Creates a tab that mimicks the tab of Message Browser.
  */
 /*!
  * \brief MessageTab::MessageTab
@@ -5308,7 +5308,7 @@ MessageTab::MessageTab(bool fixedTab)
   mpProgressLabel->setElideMode(Qt::ElideMiddle);
   mpProgressLabel->installEventFilter(this);
   if (fixedTab) {
-    mpProgressLabel->setText(tr("Click to open Messages Browser."));
+    mpProgressLabel->setText(tr("Click to open message browser."));
   }
   mpProgressBar = new QProgressBar;
   mpProgressBar->setAlignment(Qt::AlignHCenter);

--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -488,7 +488,7 @@ private:
   QToolBar *mpOMSimulatorToolbar;
   QHash<QString, TransformationsWidget*> mTransformationsWidgetHash;
 public slots:
-  void showMessagesBrowser();
+  void showMessageBrowser();
   void switchToWelcomePerspectiveSlot();
   void switchToModelingPerspectiveSlot();
   void switchToPlottingPerspectiveSlot();

--- a/OMEdit/OMEditLIB/Modeling/InstallLibraryDialog.cpp
+++ b/OMEdit/OMEditLIB/Modeling/InstallLibraryDialog.cpp
@@ -243,7 +243,7 @@ void InstallLibraryDialog::installLibrary()
     accept();
   } else {
     QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                          tr("The library <b>%1</b> is not installed. See Messages Browser for any possible messages.").arg(library), Helper::ok);
+                          tr("The library <b>%1</b> is not installed. See message browser for any possible messages.").arg(library), Helper::ok);
     mpProgressLabel->hide();
     mpOkButton->setEnabled(true);
   }
@@ -307,7 +307,7 @@ void UpgradeInstalledLibrariesDialog::upgradeInstalledLibraries()
     accept();
   } else {
     QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                          tr("Fail to upgrade libraries. See Messages Browser for any possible messages."), Helper::ok);
+                          tr("Failed to upgrade libraries. See message browser for any possible messages."), Helper::ok);
     mpProgressLabel->hide();
     mpUpgradeButton->setEnabled(true);
   }

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -964,7 +964,7 @@ void LibraryTreeItem::handleLoaded(LibraryTreeItem *pLibraryTreeItem)
     }
     // load new icon for the class.
     pMainWindow->getLibraryWidget()->getLibraryTreeModel()->loadLibraryTreeItemPixmap(this);
-    // update the icon in the libraries browser view.
+    // update the icon in the library browser view.
     pMainWindow->getLibraryWidget()->getLibraryTreeModel()->updateLibraryTreeItem(this);
   }
   emit loaded(this);
@@ -986,7 +986,7 @@ void LibraryTreeItem::handleUnloaded()
     MainWindow *pMainWindow = MainWindow::instance();
     // load new icon for the class.
     pMainWindow->getLibraryWidget()->getLibraryTreeModel()->loadLibraryTreeItemPixmap(this);
-    // update the icon in the libraries browser view.
+    // update the icon in the library browser view.
     pMainWindow->getLibraryWidget()->getLibraryTreeModel()->updateLibraryTreeItem(this);
   }
   emit unLoaded();
@@ -1061,7 +1061,7 @@ void LibraryTreeItem::handleIconUpdated()
   MainWindow *pMainWindow = MainWindow::instance();
   // load new icon for the class.
   pMainWindow->getLibraryWidget()->getLibraryTreeModel()->loadLibraryTreeItemPixmap(this);
-  // update the icon in the libraries browser view.
+  // update the icon in the library browser view.
   pMainWindow->getLibraryWidget()->getLibraryTreeModel()->updateLibraryTreeItem(this);
   emit iconUpdated();
 }
@@ -1080,7 +1080,7 @@ void LibraryTreeItem::handleCoOrdinateSystemUpdated(GraphicsView *pGraphicsView)
 
 /*!
  * \class LibraryTreeProxyModel
- * \brief A sort filter proxy model for Libraries Browser.
+ * \brief A sort filter proxy model for Library Browser.
  */
 /*!
  * \brief LibraryTreeProxyModel::LibraryTreeProxyModel
@@ -1139,7 +1139,7 @@ bool LibraryTreeProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &s
 
 /*!
  * \class LibraryTreeModel
- * \brief A model for Libraries Browser.
+ * \brief A model for Library Browser.
  */
 /*!
  * \brief LibraryTreeModel::LibraryTreeModel
@@ -1476,7 +1476,7 @@ LibraryTreeItem* LibraryTreeModel::createNonExistingLibraryTreeItem(QString name
 
 /*!
  * \brief LibraryTreeModel::createLibraryTreeItem
- * Creates a LibraryTreeItem and add it to the Libraries Browser.
+ * Creates a LibraryTreeItem and add it to the Library Browser.
  * \param type
  * \param name
  * \param nameStructure
@@ -1501,7 +1501,7 @@ LibraryTreeItem* LibraryTreeModel::createLibraryTreeItem(LibraryTreeItem::Librar
 
 /*!
  * \brief LibraryTreeModel::createLibraryTreeItem
- * Creates a OMS LibraryTreeItem and add it to the Libraries Browser.
+ * Creates a OMS LibraryTreeItem and add it to the Library Browser.
  * \param name
  * \param nameStructure
  * \param path
@@ -1567,7 +1567,7 @@ void LibraryTreeModel::checkIfAnyNonExistingClassLoaded()
 
 /*!
  * \brief LibraryTreeModel::updateLibraryTreeItem
- * Triggers a view update for the LibraryTreeItem in the Libraries Browser.
+ * Triggers a view update for the LibraryTreeItem in the Library Browser.
  * \param pLibraryTreeItem
  */
 void LibraryTreeModel::updateLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem)
@@ -2050,7 +2050,7 @@ void LibraryTreeModel::reLoadOMSimulatorModel(const QString &modelName, const QS
   if (!sameModelAndEditedCref && pEditedLibraryTreeItem) {
     pEditedLibraryTreeItem->setModelWidget(0);
   }
-  // Get the position of LibraryTreeItem in the Libraries Browser.
+  // Get the position of LibraryTreeItem in the Library Browser.
   const int row = pModelLibraryTreeItem->row();
   // unload the LibraryTreeItems and close the ModelWidgets
   unloadOMSModel(pModelLibraryTreeItem, false, false);
@@ -2091,7 +2091,7 @@ bool LibraryTreeModel::unloadLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, 
    */
   if (!doDeleteClass || MainWindow::instance()->getOMCProxy()->deleteClass(pLibraryTreeItem->getNameStructure())) {
     int row = pLibraryTreeItem->row();
-    // remove the LibraryTreeItem from Libraries Browser
+    // remove the LibraryTreeItem from Library Browser
     row = pLibraryTreeItem->row();
     beginRemoveRows(libraryTreeItemIndex(pLibraryTreeItem->parent()), row, row);
     int i = 0;
@@ -2131,7 +2131,7 @@ bool LibraryTreeModel::unloadLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem, 
  */
 bool LibraryTreeModel::removeLibraryTreeItem(LibraryTreeItem *pLibraryTreeItem)
 {
-  // remove the LibraryTreeItem from Libraries Browser
+  // remove the LibraryTreeItem from Library Browser
   int row = pLibraryTreeItem->row();
   beginRemoveRows(libraryTreeItemIndex(pLibraryTreeItem->parent()), row, row);
   if (pLibraryTreeItem->getLibraryType() == LibraryTreeItem::Modelica) {
@@ -2176,7 +2176,7 @@ bool LibraryTreeModel::deleteTextFile(LibraryTreeItem *pLibraryTreeItem, bool as
     }
   }
   int row = pLibraryTreeItem->row();
-  // remove the LibraryTreeItem from Libraries Browser
+  // remove the LibraryTreeItem from Library Browser
   beginRemoveRows(libraryTreeItemIndex(pLibraryTreeItem->parent()), row, row);
   // Deletes the LibraryTreeItem children if any and then deletes the LibraryTreeItem.
   deleteFileChildren(pLibraryTreeItem);
@@ -2942,6 +2942,7 @@ LibraryTreeView::LibraryTreeView(LibraryWidget *pLibraryWidget)
   setContextMenuPolicy(Qt::CustomContextMenu);
   setExpandsOnDoubleClick(false);
   setUniformRowHeights(true);
+  setHeaderHidden(true);
   createActions();
   connect(this, SIGNAL(expanded(QModelIndex)), SLOT(libraryTreeItemExpanded(QModelIndex)));
   connect(this, SIGNAL(doubleClicked(QModelIndex)), SLOT(libraryTreeItemDoubleClicked(QModelIndex)));
@@ -4059,7 +4060,7 @@ void LibraryTreeView::keyPressEvent(QKeyEvent *event)
 
 /*!
  * \class LibraryWidget
- * \brief A widget for Libraries Browser.
+ * \brief A widget for Library Browser.
  */
 /*!
  * \brief LibraryWidget::LibraryWidget
@@ -4091,7 +4092,7 @@ LibraryWidget::LibraryWidget(QWidget *pParent)
   connect(mpLibraryTreeModel, SIGNAL(rowsInserted(QModelIndex,int,int)), mpLibraryTreeProxyModel, SLOT(invalidate()));
   connect(mpLibraryTreeModel, SIGNAL(rowsRemoved(QModelIndex,int,int)), mpLibraryTreeProxyModel, SLOT(invalidate()));
   mpTreeSearchFilters->getExpandAllButton()->setEnabled(false);
-  mpTreeSearchFilters->getExpandAllButton()->setToolTip(tr("Expanding the Libraries Browser is a time consuming and non-responsive operation so this button is disabled intentionally."));
+  mpTreeSearchFilters->getExpandAllButton()->setToolTip(tr("Expanding the Library Browser is a time consuming and non-responsive operation so this button is disabled intentionally."));
   connect(mpTreeSearchFilters->getCollapseAllButton(), SIGNAL(clicked()), mpLibraryTreeView, SLOT(collapseAll()));
   // create a dummy librarytreeItem
   mpLibraryTreeModel->createLibraryTreeItem(LibraryTreeItem::Text, "All", "OMEdit.Search.Feature", "", true, mpLibraryTreeModel->getRootLibraryTreeItem());
@@ -5436,7 +5437,7 @@ void LibraryWidget::scrollToActiveLibraryTreeItem()
 
 /*!
  * \brief LibraryWidget::searchClasses
- * Searches the classes in the Libraries Browser.
+ * Searches the classes in the Library Browser.
  */
 void LibraryWidget::searchClasses()
 {

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -5632,7 +5632,7 @@ ModelWidget::ModelWidget(LibraryTreeItem* pLibraryTreeItem, ModelWidgetContainer
       getModelIconDiagramShapes(StringHandler::Icon);
       /* Ticket:2960
      * Just a workaround to make browsing faster.
-     * We don't get the components here i.e items are shown without connectors in the Libraries Browser.
+     * We don't get the components here i.e items are shown without connectors in the Library Browser.
      * Fetch the components when we really need to draw them.
      */
       /*! @todo Uncomment the following code once we have new faster frontend and remove the flag mComponentsLoaded. */

--- a/OMEdit/OMEditLIB/OMS/ModelDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/ModelDialog.cpp
@@ -436,7 +436,7 @@ void AddSubModelDialog::addSubModel()
 
   if (failed) {
     QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                          tr("Failed to add submodel. %1").arg(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGES_BROWSER)), Helper::ok);
+                          tr("Failed to add submodel. %1").arg(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGE_BROWSER)), Helper::ok);
   }
 }
 
@@ -563,7 +563,7 @@ void ReplaceSubModelDialog::replaceSubModel()
 
   if (failed) {
     QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error),
-                          tr("Failed to replace submodel. %1").arg(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGES_BROWSER)), Helper::ok);
+                          tr("Failed to replace submodel. %1").arg(GUIMessages::getMessage(GUIMessages::CHECK_MESSAGE_BROWSER)), Helper::ok);
   }
 }
 

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -219,7 +219,7 @@ void OptionsDialog::readGeneralSettings()
   } else {
     mpGeneralSettingsPage->setTerminalCommandArguments(OptionsDefaults::GeneralSettings::terminalCommandArguments);
   }
-  // read hide variables browser
+  // read hide variable browser
   if (mpSettings->contains("hideVariablesBrowser")) {
     mpGeneralSettingsPage->getHideVariablesBrowserCheckBox()->setChecked(mpSettings->value("hideVariablesBrowser").toBool());
   } else {
@@ -1013,7 +1013,7 @@ void OptionsDialog::readMessagesSettings()
   } else {
     mpMessagesPage->getResetMessagesNumberBeforeSimulationCheckBox()->setChecked(OptionsDefaults::Messages::resetMessagesNumberBeforeSimulation);
   }
-  // read clear messages browser
+  // read clear message browser
   if (mpSettings->contains("messages/clearMessagesBrowser")) {
     mpMessagesPage->getClearMessagesBrowserBeforeSimulationCheckBox()->setChecked(mpSettings->value("messages/clearMessagesBrowser").toBool());
   } else {
@@ -1587,7 +1587,7 @@ void OptionsDialog::saveGeneralSettings()
   } else {
     mpSettings->setValue("terminalCommandArgs", terminalCommandArguments);
   }
-  // save hide variables browser
+  // save hide variable browser
   bool hideVariablesBrowser = mpGeneralSettingsPage->getHideVariablesBrowserCheckBox()->isChecked();
   if (hideVariablesBrowser == OptionsDefaults::GeneralSettings::hideVariablesBrowser) {
     mpSettings->remove("hideVariablesBrowser");
@@ -2558,7 +2558,7 @@ void OptionsDialog::saveMessagesSettings()
   } else {
     mpSettings->setValue("messages/resetMessagesNumber", resetMessagesNumberBeforeSimulation);
   }
-  // save clear messages browser
+  // save clear message browser
   bool clearMessagesBrowserBeforeSimulation = mpMessagesPage->getClearMessagesBrowserBeforeSimulationCheckBox()->isChecked();
   if (clearMessagesBrowserBeforeSimulation == OptionsDefaults::Messages::clearMessagesBrowserBeforeSimulation) {
     mpSettings->remove("messages/clearMessagesBrowser");
@@ -3584,9 +3584,9 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   // terminal command args
   mpTerminalCommandArgumentsLabel = new Label(tr("Terminal Command Arguments:"));
   mpTerminalCommandArgumentsTextBox = new QLineEdit;
-  // hide variables browser checkbox
-  mpHideVariablesBrowserCheckBox = new QCheckBox(tr("Hide Variables Browser"));
-  mpHideVariablesBrowserCheckBox->setToolTip(tr("Hides the variable browser when switching away from plotting perspective."));
+  // autohide variable browser checkbox
+  mpHideVariablesBrowserCheckBox = new QCheckBox(tr("Autohide Variable Browser"));
+  mpHideVariablesBrowserCheckBox->setToolTip(tr("Automatically hide the variable browser when switching away from plotting perspective."));
   mpHideVariablesBrowserCheckBox->setChecked(OptionsDefaults::GeneralSettings::hideVariablesBrowser);
   // activate access annotation
   mpActivateAccessAnnotationsLabel = new Label(tr("Activate Access Annotations *"));
@@ -3628,8 +3628,8 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   pGeneralSettingsLayout->addWidget(mpCreateBackupFileCheckbox, 8, 0, 1, 3);
   pGeneralSettingsLayout->addWidget(mpDisplayNFAPIErrorsWarningsCheckBox, 9, 0, 1, 3);
   mpGeneralSettingsGroupBox->setLayout(pGeneralSettingsLayout);
-  // Libraries Browser group box
-  mpLibrariesBrowserGroupBox = new QGroupBox(tr("Libraries Browser"));
+  // Library Browser group box
+  mpLibraryBrowserGroupBox = new QGroupBox(tr("Library Browser"));
   // library icon size
   mpLibraryIconSizeLabel = new Label(tr("Library Icon Size: *"));
   mpLibraryIconSizeSpinBox = new QSpinBox;
@@ -3646,21 +3646,21 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   mpShowProtectedClasses = new QCheckBox(tr("Show Protected Classes"));
   // show hidden classes
   mpShowHiddenClasses = new QCheckBox(tr("Show Hidden Classes if not encrypted"));
-  // synchronize Libraries Browser with ModelWidget
+  // synchronize library browser with ModelWidget
   mpSynchronizeWithModelWidgetCheckBox = new QCheckBox(tr("Synchronize with Model Widget"));
   mpSynchronizeWithModelWidgetCheckBox->setChecked(OptionsDefaults::GeneralSettings::synchronizeWithModelWidget);
-  // Libraries Browser group box layout
-  QGridLayout *pLibrariesBrowserLayout = new QGridLayout;
-  pLibrariesBrowserLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-  pLibrariesBrowserLayout->setColumnStretch(1, 1);
-  pLibrariesBrowserLayout->addWidget(mpLibraryIconSizeLabel, 0, 0);
-  pLibrariesBrowserLayout->addWidget(mpLibraryIconSizeSpinBox, 0, 1);
-  pLibrariesBrowserLayout->addWidget(mpLibraryIconTextLengthLabel, 1, 0);
-  pLibrariesBrowserLayout->addWidget(mpLibraryIconTextLengthSpinBox, 1, 1);
-  pLibrariesBrowserLayout->addWidget(mpShowProtectedClasses, 2, 0, 1, 2);
-  pLibrariesBrowserLayout->addWidget(mpShowHiddenClasses, 3, 0, 1, 2);
-  pLibrariesBrowserLayout->addWidget(mpSynchronizeWithModelWidgetCheckBox, 4, 0, 1, 2);
-  mpLibrariesBrowserGroupBox->setLayout(pLibrariesBrowserLayout);
+  // Library browser group box layout
+  QGridLayout *pLibraryBrowserLayout = new QGridLayout;
+  pLibraryBrowserLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+  pLibraryBrowserLayout->setColumnStretch(1, 1);
+  pLibraryBrowserLayout->addWidget(mpLibraryIconSizeLabel, 0, 0);
+  pLibraryBrowserLayout->addWidget(mpLibraryIconSizeSpinBox, 0, 1);
+  pLibraryBrowserLayout->addWidget(mpLibraryIconTextLengthLabel, 1, 0);
+  pLibraryBrowserLayout->addWidget(mpLibraryIconTextLengthSpinBox, 1, 1);
+  pLibraryBrowserLayout->addWidget(mpShowProtectedClasses, 2, 0, 1, 2);
+  pLibraryBrowserLayout->addWidget(mpShowHiddenClasses, 3, 0, 1, 2);
+  pLibraryBrowserLayout->addWidget(mpSynchronizeWithModelWidgetCheckBox, 4, 0, 1, 2);
+  mpLibraryBrowserGroupBox->setLayout(pLibraryBrowserLayout);
   // Auto Save
   mpEnableAutoSaveGroupBox = new QGroupBox(tr("Enable Auto Save"));
   mpEnableAutoSaveGroupBox->setToolTip("Auto save feature is experimental. If you encounter unexpected crashes then disable it.");
@@ -3731,7 +3731,7 @@ GeneralSettingsPage::GeneralSettingsPage(OptionsDialog *pOptionsDialog)
   QVBoxLayout *pMainLayout = new QVBoxLayout;
   pMainLayout->setAlignment(Qt::AlignTop | Qt::AlignLeft);
   pMainLayout->addWidget(mpGeneralSettingsGroupBox);
-  pMainLayout->addWidget(mpLibrariesBrowserGroupBox);
+  pMainLayout->addWidget(mpLibraryBrowserGroupBox);
   pMainLayout->addWidget(mpEnableAutoSaveGroupBox);
   pMainLayout->addWidget(mpWelcomePageGroupBox);
   pMainLayout->addWidget(mpOptionalFeaturesGroupBox);
@@ -5725,7 +5725,7 @@ MessagesPage::MessagesPage(OptionsDialog *pOptionsDialog)
   mpGeneralGroupBox = new QGroupBox(Helper::general);
   // output size
   mpOutputSizeLabel = new Label(tr("Output size:"));
-  mpOutputSizeLabel->setToolTip(tr("Specifies the maximum number of rows the Messages Browser may have. "
+  mpOutputSizeLabel->setToolTip(tr("Specifies the maximum number of rows the message browser may have. "
                                    "If there are more rows then the rows are removed from the beginning."));
   mpOutputSizeSpinBox = new QSpinBox;
   mpOutputSizeSpinBox->setRange(0, std::numeric_limits<int>::max());
@@ -5734,10 +5734,10 @@ MessagesPage::MessagesPage(OptionsDialog *pOptionsDialog)
   mpOutputSizeSpinBox->setSpecialValueText(Helper::unlimited);
   mpOutputSizeSpinBox->installEventFilter(mpOptionsDialog);
   // reset messages number before simulation
-  mpResetMessagesNumberBeforeSimulationCheckBox = new QCheckBox(tr("Reset messages number before checking, instantiation && simulation"));
+  mpResetMessagesNumberBeforeSimulationCheckBox = new QCheckBox(tr("Reset messages number before checking, instantiation, and simulation"));
   mpResetMessagesNumberBeforeSimulationCheckBox->setChecked(OptionsDefaults::Messages::resetMessagesNumberBeforeSimulation);
-  // clear messages browser before simulation
-  mpClearMessagesBrowserBeforeSimulationCheckBox = new QCheckBox(tr("Clear messages browser before checking, instantiation && simulation"));
+  // clear message browser before simulation
+  mpClearMessagesBrowserBeforeSimulationCheckBox = new QCheckBox(tr("Clear message browser before checking, instantiation, and simulation"));
   // set general groupbox layout
   QGridLayout *pGeneralGroupBoxLayout = new QGridLayout;
   pGeneralGroupBoxLayout->setColumnStretch(1, 1);

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -313,7 +313,7 @@ private:
   QComboBox *mpActivateAccessAnnotationsComboBox;
   QCheckBox *mpCreateBackupFileCheckbox;
   QCheckBox *mpDisplayNFAPIErrorsWarningsCheckBox;
-  QGroupBox *mpLibrariesBrowserGroupBox;
+  QGroupBox *mpLibraryBrowserGroupBox;
   Label *mpLibraryIconSizeLabel;
   QSpinBox *mpLibraryIconSizeSpinBox;
   Label *mpLibraryIconTextLengthLabel;

--- a/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditLIB/Plotting/VariablesWidget.cpp
@@ -564,7 +564,7 @@ VariablesTreeItem* VariablesTreeModel::findVariablesTreeItemOneLevel(const QStri
 
 /*!
  * \brief VariablesTreeModel::updateVariablesTreeItem
- * Triggers a view update for the VariablesTreeItem in the Variables Browser.
+ * Triggers a view update for the VariablesTreeItem in the Variable Browser.
  * \param pVariablesTreeItem
  */
 void VariablesTreeModel::updateVariablesTreeItem(VariablesTreeItem *pVariablesTreeItem)
@@ -662,7 +662,7 @@ bool VariablesTreeModel::removeVariableTreeItem(QString variable, bool closeInte
 
 /*!
  * \brief VariablesTreeModel::insertVariablesItems
- * Inserts the variables in the Variables Browser.
+ * Inserts the variables in the Variable Browser.
  * \param fileName
  * \param filePath
  * \param variablesList
@@ -785,7 +785,7 @@ bool VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
   if (simulationOptions.isValid() && simulationOptions.getCPUTime()) {
     variablesList.append("$cpuTime");
   }
-  /* Issue #7632 Variables Browser show non-existing variable
+  /* Issue #7632 Variable Browser show non-existing variable
    * Show the non-existing variables as we want to use them for resimulation e.g., string variables.
    * But don't make them checkable so user can't plot them.
    */
@@ -1286,7 +1286,7 @@ void VariablesTreeModel::setVariableTreeItemActive()
 
 /*!
  * \class VariableTreeProxyModel
- * \brief A sort filter proxy model for Variables Browser.
+ * \brief A sort filter proxy model for Variable Browser.
  */
 /*!
  * \brief VariableTreeProxyModel::VariableTreeProxyModel
@@ -1545,7 +1545,7 @@ void VariablesWidget::enableVisualizationControls(bool enable)
 
 /*!
  * \brief VariablesWidget::insertVariablesItemsToTree
- * Inserts the result variables in the Variables Browser.
+ * Inserts the result variables in the Variable Browser.
  * \param fileName
  * \param filePath
  * \param variablesList
@@ -1990,11 +1990,11 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
           pPlotWindow->plotArray(timePercent, pPlotCurve);
         }
         /* Ticket:4231
-         * Only update the variables browser value and unit when updating some curve not when checking/unchecking variable.
+         * Only update the variable browser value and unit when updating some curve not when checking/unchecking variable.
          */
         if (pPlotCurve) {
           /* Ticket:2250
-           * Update the value of Variables Browser display unit according to the display unit of already plotted curve.
+           * Update the value of Variable Browser display unit according to the display unit of already plotted curve.
            */
           pVariablesTreeItem->setData(3, pPlotCurve->getYDisplayUnit(), Qt::EditRole);
           QString value = pVariablesTreeItem->getValue(pVariablesTreeItem->getPreviousUnit(), pVariablesTreeItem->getDisplayUnit()).toString();
@@ -2784,7 +2784,7 @@ void VariablesWidget::showContextMenu(QPoint point)
 
 /*!
  * \brief VariablesWidget::findVariables
- * Finds the variables in the Variables Browser.
+ * Finds the variables in the Variable Browser.
  */
 void VariablesWidget::findVariables()
 {

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -1068,7 +1068,7 @@ bool SimulationDialog::translateModel(QString simulationParameters)
   if (OptionsDialog::instance()->getMessagesPage()->getResetMessagesNumberBeforeSimulationCheckBox()->isChecked()) {
     MessagesWidget::instance()->resetMessagesNumber();
   }
-  // check clear messages browser before simulation option
+  // check clear message browser before simulation option
   if (OptionsDialog::instance()->getMessagesPage()->getClearMessagesBrowserBeforeSimulationCheckBox()->isChecked()) {
     MessagesWidget::instance()->clearMessages();
   }
@@ -1410,7 +1410,7 @@ void SimulationDialog::createAndShowSimulationOutputWidget(const SimulationOptio
     if (OptionsDialog::instance()->getSimulationPage()->getSwitchToPlottingPerspectiveCheckBox()->isChecked()) {
       MainWindow::instance()->switchToPlottingPerspectiveSlot();
     } else {
-      // stay in current perspective and show variables browser
+      // stay in current perspective and show variable browser
       MainWindow::instance()->getVariablesDockWidget()->show();
     }
   }
@@ -1907,7 +1907,7 @@ OpcUaClient* SimulationDialog::getOpcUaClient(int port)
  * \param simulationOptions
  * \param resultFileLastModifiedDateTime
  * Handles what should be done after the simulation process has finished.\n
- * Reads the result variables and inserts them into the variables browser.\n
+ * Reads the result variables and inserts them into the variable browser.\n
  */
 void SimulationDialog::simulationProcessFinished(SimulationOptions simulationOptions, QDateTime resultFileLastModifiedDateTime)
 {
@@ -1931,7 +1931,7 @@ void SimulationDialog::simulationProcessFinished(SimulationOptions simulationOpt
     if (OptionsDialog::instance()->getSimulationPage()->getSwitchToPlottingPerspectiveCheckBox()->isChecked()) {
       MainWindow::instance()->switchToPlottingPerspectiveSlot();
     } else {
-      // stay in current perspective and show variables browser
+      // stay in current perspective and show variable browser
       MainWindow::instance()->getVariablesDockWidget()->show();
     }
     bool showPlotWindow = true;

--- a/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/TransformationsWidget.cpp
@@ -564,8 +564,8 @@ TransformationsWidget::TransformationsWidget(QString infoJSONFullFileName, bool 
   pStatusBar->addPermanentWidget(pReloadToolButton, 0);
   pStatusBar->addPermanentWidget(pInfoXMLFilePathLabel, 1);
   /* Variables Heading */
-  Label *pVariablesBrowserLabel = new Label(Helper::variablesBrowser);
-  pVariablesBrowserLabel->setObjectName("LabelWithBorder");
+  Label *pVariableBrowserLabel = new Label(Helper::variableBrowser);
+  pVariableBrowserLabel->setObjectName("LabelWithBorder");
   // tree search filters
   mpTreeSearchFilters = new TreeSearchFilters(this);
   mpTreeSearchFilters->getFilterTextBox()->setPlaceholderText(Helper::filterVariables);
@@ -587,7 +587,7 @@ TransformationsWidget::TransformationsWidget(QString infoJSONFullFileName, bool 
   QGridLayout *pVariablesGridLayout = new QGridLayout;
   pVariablesGridLayout->setSpacing(1);
   pVariablesGridLayout->setContentsMargins(0, 0, 0, 0);
-  pVariablesGridLayout->addWidget(pVariablesBrowserLabel, 0, 0);
+  pVariablesGridLayout->addWidget(pVariableBrowserLabel, 0, 0);
   pVariablesGridLayout->addWidget(mpTreeSearchFilters, 1, 0);
   pVariablesGridLayout->addWidget(mpTVariablesTreeView, 2, 0);
   QFrame *pVariablesFrame = new QFrame;
@@ -631,15 +631,15 @@ TransformationsWidget::TransformationsWidget(QString infoJSONFullFileName, bool 
   QFrame *pVariableOperationsFrame = new QFrame;
   pVariableOperationsFrame->setLayout(pVariableOperationsGridLayout);
   /* Equations Heading */
-  Label *pEquationsBrowserLabel = new Label(tr("Equations Browser"));
-  pEquationsBrowserLabel->setObjectName("LabelWithBorder");
+  Label *pEquationBrowserLabel = new Label(tr("Equations"));
+  pEquationBrowserLabel->setObjectName("LabelWithBorder");
   /* Equations tree widget */
   mpEquationsTreeWidget = new EquationTreeWidget(this);
   mpEquationsTreeWidget->setIndentation(Helper::treeIndentation);
   QGridLayout *pEquationsGridLayout = new QGridLayout;
   pEquationsGridLayout->setSpacing(1);
   pEquationsGridLayout->setContentsMargins(0, 0, 0, 0);
-  pEquationsGridLayout->addWidget(pEquationsBrowserLabel, 0, 0);
+  pEquationsGridLayout->addWidget(pEquationBrowserLabel, 0, 0);
   pEquationsGridLayout->addWidget(mpEquationsTreeWidget, 1, 0);
   QFrame *pEquationsFrame = new QFrame;
   pEquationsFrame->setLayout(pEquationsGridLayout);
@@ -1306,7 +1306,7 @@ void TransformationsWidget::reloadTransformations()
 
 /*!
  * \brief TransformationsWidget::findVariables
- * Finds the variables in the TransformationsWidget Variables Browser.
+ * Finds the variables in the TransformationsWidget Variable Browser.
  */
 void TransformationsWidget::findVariables()
 {

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -319,7 +319,7 @@ QString Helper::viewDocumentationTip;
 QString Helper::dontShowThisMessageAgain;
 QString Helper::clickAndDragToResize;
 QString Helper::variables;
-QString Helper::variablesBrowser;
+QString Helper::variableBrowser;
 QString Helper::description;
 QString Helper::previous;
 QString Helper::next;
@@ -627,7 +627,7 @@ void Helper::initHelperVariables()
   Helper::dontShowThisMessageAgain = tr("Don't show this message again");
   Helper::clickAndDragToResize = tr("Click and drag to resize");
   Helper::variables = tr("Variables");
-  Helper::variablesBrowser = tr("Variables Browser");
+  Helper::variableBrowser = tr("Variables");
   Helper::description = tr("Description");
   Helper::previous = tr("Previous");
   Helper::next = tr("Next");
@@ -750,8 +750,8 @@ QString GUIMessages::getMessage(int type)
 {
   switch (type)
   {
-    case CHECK_MESSAGES_BROWSER:
-      return tr("Please check the Messages Browser for more error specific details.");
+    case CHECK_MESSAGE_BROWSER:
+      return tr("Please check the message browser for more error specific details.");
     case SAME_COMPONENT_NAME:
       return tr("A component with the name <b>%1</b> already exists or is a Modelica keyword. Please choose another name.");
     case MISMATCHED_CONNECTORS_IN_CONNECT:

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -321,7 +321,7 @@ public:
   static QString dontShowThisMessageAgain;
   static QString clickAndDragToResize;
   static QString variables;
-  static QString variablesBrowser;
+  static QString variableBrowser;
   static QString description;
   static QString previous;
   static QString next;
@@ -446,7 +446,7 @@ class GUIMessages : public QObject
   Q_OBJECT
 public:
   enum MessagesTypes {
-    CHECK_MESSAGES_BROWSER,
+    CHECK_MESSAGE_BROWSER,
     SAME_COMPONENT_NAME,
     SAME_COMPONENT_CONNECT,
     MISMATCHED_CONNECTORS_IN_CONNECT,


### PR DESCRIPTION
- Change incorrect pluralization, e.g. Libraries Browser => Library Browser.
- Fix inconsistent capitalization, use lower case everywhere when referring to e.g. the message browser.
- Simplify most GUI headers, e.g. Library Browser => Libraries.
- Hide the header of the library tree view since the library browser window itself already has a header.
- Change Hide => Autohide Variable Browser in options to better describe what the option does.
- Change && => and in options.