### PR TITLE
Fix enumeration connectors in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -655,6 +655,7 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
   algorithm
     isEnum := match cls
       case PARTIAL_BUILTIN(ty = Type.ENUMERATION()) then true;
+      case INSTANCED_BUILTIN(ty = Type.ENUMERATION()) then true;
       case EXPANDED_DERIVED() then isEnumeration(InstNode.getClass(cls.baseClass));
       case TYPED_DERIVED() then isEnumeration(InstNode.getClass(cls.baseClass));
       else false;

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1184,7 +1184,7 @@ namespace ModelInstance
 
   bool Model::isEnumeration() const
   {
-    return (mRestriction.compare(QStringLiteral("enumeration")) == 0);
+    return getRootType() == QLatin1String("enumeration");
   }
 
   bool Model::isType() const

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -369,7 +369,8 @@ private:
   Element* connectorElementAtPosition(QPoint position);
   Element* stateElementAtPosition(QPoint position);
   static bool updateElementConnectorSizingParameter(GraphicsView *pGraphicsView, QString className, Element *pElement);
-  QString getConnectorName(Element *connector);
+  Element* getConnectorElement(ModelInstance::Connector *pConnector);
+  QString getConnectorName(Element *pConnector);
   bool handleDoubleClickOnComponent(QMouseEvent *event);
   void uncheckAllShapeDrawingActions();
   void setOriginAdjustAndInitialize(ShapeAnnotation* shapeAnnotation);

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum1.mos
@@ -29,12 +29,16 @@ getModelInstance(M, prettyPrint=true);
 //       \"name\": \"analogFil\",
 //       \"type\": {
 //         \"name\": \"AnalogFilter\",
-//         \"restriction\": \"enumeration\",
+//         \"restriction\": \"type\",
 //         \"comment\": \"Enumeration defining the method of filtering\",
 //         \"annotation\": {
 //           \"Evaluate\": true
 //         },
 //         \"elements\": [
+//           {
+//             \"$kind\": \"extends\",
+//             \"baseClass\": \"enumeration\"
+//           },
 //           {
 //             \"$kind\": \"component\",
 //             \"name\": \"CriticalDamping\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
@@ -26,8 +26,28 @@ getModelInstance(M, prettyPrint=true);
 //       \"name\": \"e\",
 //       \"type\": {
 //         \"name\": \"E2\",
-//         \"restriction\": \"enumeration\",
+//         \"restriction\": \"type\",
 //         \"elements\": [
+//           {
+//             \"$kind\": \"extends\",
+//             \"baseClass\": {
+//               \"name\": \"E1\",
+//               \"restriction\": \"type\",
+//               \"elements\": [
+//                 {
+//                   \"$kind\": \"extends\",
+//                   \"baseClass\": \"enumeration\"
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 3,
+//                 \"columnStart\": 5,
+//                 \"lineEnd\": 3,
+//                 \"columnEnd\": 47
+//               }
+//             }
+//           },
 //           {
 //             \"$kind\": \"component\",
 //             \"name\": \"a\",


### PR DESCRIPTION
- Dump the actual restriction of enumeration types rather than using `enumeration`, since `enumeration` is not a restriction but a type.
- Dump the full extends chain for an enumeration type, terminating in an extends of `enumeration` to indicate an enumeration type.
- Refactor the fetching of connector elements in OMEdit into a `getConnectorElement` method to avoid repetition.

Fixes #11726