### PR TITLE
Enable using WSL OMC to skip bootstrapping on Windows/OMDEV

### DIFF
--- a/OMCompiler/Compiler/boot/MakeSources.mos
+++ b/OMCompiler/Compiler/boot/MakeSources.mos
@@ -5,14 +5,14 @@ end if;
 runScript("LoadCompilerSources.mos");
 mkdir("build");
 workingDir := cd();
-relDir := cd("..");
+relDir := cd("../..");
 cd(workingDir);
 writeFile("Makefile.sources.tmp", "ALL_OBJECTS="+sum(typeNameString(cl) + ".o " for cl in getClassNames())+ "\n" +
 "ALL_SOURCES=" + sum(file + " " for file in files) + "\n" +
 "ALL_INTERFACES=" + sum("$(GEN_DIR)" + typeNameString(cl) + ".stamp.mo " for cl in getClassNames()) + "\n" +
-sum("\n$(GEN_DIR)" + typeNameString(cl) + ".stamp.mo: " + stringReplace(getSourceFile(cl),relDir,"..") for cl in getClassNames()) + "\n" +
+sum("\n$(GEN_DIR)" + typeNameString(cl) + ".stamp.mo: " + stringReplace(getSourceFile(cl),relDir,"../..") for cl in getClassNames()) + "\n" +
 sum("$(GEN_DIR)" + typeNameString(cl) + ".o: $(GEN_DIR)" + typeNameString(cl) + ".h $(GEN_DIR)" + typeNameString(cl) + "_includes.h\n" for cl in getClassNames()) + "\n" +
-sum("RELPATH_" + typeNameString(cl) + "=" + stringReplace(getSourceFile(cl),relDir,"..") + "\n" for cl in getClassNames())
+sum("RELPATH_" + typeNameString(cl) + "=" + stringReplace(getSourceFile(cl),relDir,"../..") + "\n" for cl in getClassNames())
 /* Add this if we need the additional dependencies on the included header files. If the interface changed we did already recompile this file, so... Probably not needed. Probably.
 + sum("\n" +
 "ifeq ($(wildcard $(GEN_DIR)"+typeNameString(cl)+".deps),$(GEN_DIR)"+typeNameString(cl)+".deps)" + "\n" +

--- a/OMCompiler/Compiler/boot/Makefile.common
+++ b/OMCompiler/Compiler/boot/Makefile.common
@@ -1,4 +1,4 @@
-ifeq ($(wildcard $(OMC)),)
+ifeq ($(wildcard $(OMC))$(WSL_OMC),)
 all:
 	$(MAKE) -f $(defaultMakefileTarget) bootstrap-from-tarball
 else
@@ -143,7 +143,7 @@ interfaces: $(ALL_INTERFACES) $(ALL_SOURCES)
 	@touch $@
 %.interface.mo: %.stamp.mo
 
-ifeq ($(wildcard $(OMC)),)
+ifeq ($(wildcard $(OMC))$(WSL_OMC),)
 else
 Makefile.sources: LoadCompilerSources.mos MakeSources.mos ../Util/Autoconf.mo
 	$(OMC) -g=MetaModelica -n=1 MakeSources.mos

--- a/OMCompiler/Compiler/boot/Makefile.omdev.mingw
+++ b/OMCompiler/Compiler/boot/Makefile.omdev.mingw
@@ -53,7 +53,11 @@ CPPFLAGS= -DOM_HAVE_PTHREADS -I"$(OMHOME)/include/omc/c" -I../Util/ -DADD_METARE
 CORBALIBS=
 ULIMIT_CMD=true
 SHREXT=.dll
+ifeq ($(WSL_OMC),)
 OMC=$(OMHOME)/bin/omc.exe
+else
+OMC=$(WSL_OMC)
+endif
 RPATH=
 #STATIC=static
 BOOTSTRAP_OMC=$(OMBUILDDIR)/bin/omc.exe


### PR DESCRIPTION
Simply put in your OMDEV ~/.profile or ~/.bashrc:
```bash
export WSL_OMC="wsl.exe omc"
```