### PR TITLE
Fix StaticDataNLS memory leak in FMU

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -2737,6 +2737,7 @@ template generateNonLinearSystemData(NonlinearSystem system, Integer indexStrict
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].initialAnalyticalJacobian = <%initialJac%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].jacobianIndex = <%jacIndex%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].initializeStaticNLSData = initializeStaticDataNLS<%nls.index%>;
+      nonLinearSystemData[<%nls.indexNonLinearSystem%>].freeStaticNLSData = freeStaticDataNLS<%nls.index%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].getIterationVars = getIterationVarsNLS<%nls.index%>;
       nonLinearSystemData[<%nls.indexNonLinearSystem%>].checkConstraints = <%constraintsCall%>;
       >>
@@ -2909,6 +2910,7 @@ template getNLSPrototypes(Integer index)
   <<
   void residualFunc<%index%>(RESIDUAL_USERDATA* userData, const double* xloc, double* res, const int* iflag);
   void initializeStaticDataNLS<%index%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData, modelica_boolean initSparsePattern, modelica_boolean initNonlinearPattern);
+  void freeStaticDataNLS<%index%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *inSystemData);
   void getIterationVarsNLS<%index%>(DATA* data, double *array);
   >>
 end getNLSPrototypes;
@@ -3203,6 +3205,11 @@ template generateStaticSparseData(String indexName, String systemType, SparsityP
         /* no sparsity pattern available */
         inSysData->isPatternAvailable = FALSE;
       }
+      OMC_DISABLE_OPT
+      void freeSparsePattern<%indexName%>(<%systemType%>* inSysData)
+      {
+        /* nothing to free */
+      }
       >>
   case _ then
       let sp_size_index = lengthListElements(unzipSecond(sparsepattern))
@@ -3233,6 +3240,17 @@ template generateStaticSparseData(String indexName, String systemType, SparsityP
 
         /* write color array */
         <%colorString%>
+      }
+
+      OMC_DISABLE_OPT
+      void freeSparsePattern<%indexName%>(<%systemType%>* inSysData)
+      {
+        if (inSysData->isPatternAvailable) {
+          freeSparsePattern(inSysData->sparsePattern);
+          free(inSysData->sparsePattern);
+          inSysData->sparsePattern = NULL;
+          inSysData->isPatternAvailable = FALSE;
+        }
       }
       >>
    end match
@@ -3328,6 +3346,12 @@ template generateStaticInitialData(list<ComponentRef> crefs, String indexName)
     if (initNonlinearPattern) {
       initializeNonlinearPattern<%indexName%>(sysData);
     }
+  }
+
+  OMC_DISABLE_OPT
+  void freeStaticData<%indexName%>(DATA* data, threadData_t *threadData, NONLINEAR_SYSTEM_DATA *sysData)
+  {
+    freeSparsePattern<%indexName%>(sysData);
   }
   >>
 end generateStaticInitialData;

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -690,6 +690,8 @@ void freeNonlinearSyst(DATA* data, threadData_t* threadData, NONLINEAR_SYSTEM_DA
   free(nonlinsys->nominal);
   free(nonlinsys->min);
   free(nonlinsys->max);
+  nonlinsys->freeStaticNLSData(data, threadData, nonlinsys);
+
   freeValueList(nonlinsys->oldValueList, 1);
   freeNonlinearPattern(nonlinsys->nonlinearPattern);
 

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -338,6 +338,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
   int (*residualFuncConstraints)(RESIDUAL_USERDATA* userData, const double*, double*, const int*);
   void (*initializeStaticNLSData)(DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys, modelica_boolean initSparsePattern, modelica_boolean initNonlinearPattern);
+  void (*freeStaticNLSData)(DATA* data, threadData_t *threadData, struct NONLINEAR_SYSTEM_DATA* nonlinsys);
   int (*strictTearingFunctionCall)(DATA* data, threadData_t *threadData);
   void (*getIterationVars)(DATA* data, double* array);
   int (*checkConstraints)(DATA* data, threadData_t *threadData);


### PR DESCRIPTION
It looks like there was no freeing counterpart of the `allocSparsePattern()` happening inside initializeStaticNLSData
