### PR TITLE
Fix memory leak in FMU memory_pools for multi-instantiated case

### DIFF
--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -73,7 +73,6 @@ static void pool_init(void)
   // pool_init is called unconditionally in fmi2Instantiate, so let's put the condition here
   if (!memory_pools) {
     memory_pools = (OMCMemPoolBlock*) omc_alloc_interface.malloc_uncollectable(sizeof(OMCMemPoolBlock));
-    printf("pool_init %p\n", memory_pools);
     memory_pools->used = 0;
     memory_pools->size = OMC_INITIAL_BLOCK_SIZE;
     memory_pools->memory = omc_alloc_interface.malloc_uncollectable(memory_pools->size);

--- a/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
+++ b/OMCompiler/SimulationRuntime/c/gc/memory_pool.c
@@ -70,11 +70,15 @@ static int GC_collect_a_little_or_not(void)
 
 static void pool_init(void)
 {
-  memory_pools = (OMCMemPoolBlock*) omc_alloc_interface.malloc_uncollectable(sizeof(OMCMemPoolBlock));
-  memory_pools->used = 0;
-  memory_pools->size = OMC_INITIAL_BLOCK_SIZE;
-  memory_pools->memory = omc_alloc_interface.malloc_uncollectable(memory_pools->size);
-  memory_pools->previous = NULL;
+  // pool_init is called unconditionally in fmi2Instantiate, so let's put the condition here
+  if (!memory_pools) {
+    memory_pools = (OMCMemPoolBlock*) omc_alloc_interface.malloc_uncollectable(sizeof(OMCMemPoolBlock));
+    printf("pool_init %p\n", memory_pools);
+    memory_pools->used = 0;
+    memory_pools->size = OMC_INITIAL_BLOCK_SIZE;
+    memory_pools->memory = omc_alloc_interface.malloc_uncollectable(memory_pools->size);
+    memory_pools->previous = NULL;
+  }
 }
 
 static inline size_t round_up(size_t num, size_t factor)
@@ -115,9 +119,7 @@ static void* pool_malloc(size_t requested_size)
 #endif
 
   /// If we forgot to explicitly initialize the pool, initialize it now.
-  if (!memory_pools) {
-    pool_init();
-  }
+  pool_init();
 
   /// If the current block does not have enough remaining space, expand the pool
   /// by creating another block. The new block should, at least, be as big as
@@ -151,9 +153,7 @@ static void print_mem_pool(OMCMemPoolBlock* chunk) {
 MemPoolState omc_util_get_pool_state() {
   MemPoolState state;
   /// If we forgot to explicitly initialize the pool, initialize it now.
-  if (!memory_pools) {
-    pool_init();
-  }
+  pool_init();
 
   state.block = memory_pools;
   state.used = memory_pools->used;


### PR DESCRIPTION
Related to #10901 and #10790.

Subsequent calls to `fmi2Instantiate` without associated `fmi2FreeInstance` where making `memory_pools` become unreachable.

However, I'm not sure if the unreachability was in fact hiding possible memory corruption, which would now surface with this patch. @mahge Wouldn't it make more sense for each instantiation (assuming `canBeInstantiatedOnlyOncePerProcess` false here) to have its own unique memory_pools? Sorry if I'm misunderstanding this.

