### PR TITLE
[NB] move scalarizing dependencies to a later point

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBAdjacency.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBAdjacency.mo
@@ -337,6 +337,7 @@ public
       input list<ComponentRef> unique_dependencies;
     protected
       // get clean pointers -> type checking fails otherwise
+      list<ComponentRef> scalarized_dependencies = List.flatten(list(ComponentRef.scalarizeAll(dep) for dep in unique_dependencies));
       array<array<Integer>> mode_to_var = modes.mode_to_var;
       array<array<ComponentRef>> mode_to_cref = modes.mode_to_cref;
     algorithm
@@ -351,7 +352,7 @@ public
       end for;
 
       // create array mode to cref mapping
-      arrayUpdate(mode_to_cref, eqn_arr_idx, arrayAppend(listArray(unique_dependencies), mode_to_cref[eqn_arr_idx]));
+      arrayUpdate(mode_to_cref, eqn_arr_idx, arrayAppend(listArray(scalarized_dependencies), mode_to_cref[eqn_arr_idx]));
     end update;
 
     function clean
@@ -793,7 +794,6 @@ public
         case Equation.ALGORITHM() then list(cref for cref guard(UnorderedMap.contains(cref, map)) in listAppend(eqn.alg.inputs, eqn.alg.outputs));
         else Equation.collectCrefs(eqn, function Slice.getDependentCref(map = map, pseudo = true));
       end match;
-      dependencies := List.flatten(list(ComponentRef.scalarizeAll(dep) for dep in dependencies));
 
       if (st < MatrixStrictness.FULL) then
         // SOLVABLE & LINEAR
@@ -845,7 +845,6 @@ public
       list<ComponentRef> unique_dependencies;
     algorithm
       unique_dependencies := list(ComponentRef.simplifySubscripts(dep) for dep in dependencies);
-      unique_dependencies := UnorderedSet.unique_list(unique_dependencies, ComponentRef.hash, ComponentRef.isEqual);
       if Flags.isSet(Flags.BLT_MATRIX_DUMP) then
         print("\nFinding dependencies for:\n" + Equation.toString(eqn) + "\n");
         print("dependencies: " + List.toString(unique_dependencies, ComponentRef.toString) + "\n");

--- a/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
@@ -321,11 +321,12 @@ public
     input Mapping mapping                         "array <-> scalar index mapping";
     output list<Integer> indices = {};
   protected
+    list<ComponentRef> scalarized_dependencies = List.flatten(list(ComponentRef.scalarizeAll(dep) for dep in dependencies));
     ComponentRef stripped;
     Integer var_arr_idx, var_start, var_scal_idx;
     list<Integer> sizes, int_subs;
   algorithm
-    for cref in dependencies loop
+    for cref in scalarized_dependencies loop
       stripped := ComponentRef.stripSubscriptsAll(cref);
       var_arr_idx := UnorderedMap.getSafe(stripped, map, sourceInfo());
       (var_start, _) := mapping.var_AtS[var_arr_idx];
@@ -345,6 +346,7 @@ public
     Turns cref dependencies into index lists, used for adjacency."
     extends getDependentCrefIndices;
   protected
+    list<ComponentRef> scalarized_dependencies = List.flatten(list(ComponentRef.scalarizeAll(dep) for dep in dependencies));
     ComponentRef stripped;
     Integer eqn_start, eqn_size, var_arr_idx, var_scal_idx, mode = 1;
     list<Integer> scal_lst;
@@ -359,9 +361,9 @@ public
     mode_to_var := arrayCreate(eqn_size, arrayCreate(0,0));
     // create unique array for each equation
     for i in 1:eqn_size loop
-      mode_to_var[i] := arrayCreate(listLength(dependencies),-1);
+      mode_to_var[i] := arrayCreate(listLength(scalarized_dependencies),-1);
     end for;
-    for cref in dependencies loop
+    for cref in scalarized_dependencies loop
       stripped := ComponentRef.stripSubscriptsAll(cref);
       var_arr_idx := UnorderedMap.getSafe(stripped, map, sourceInfo());
 


### PR DESCRIPTION
 - ToDo: correctly parse unscalarized variable crefs in the case of for-equations
   Idea: scalarize along the crefs first then replace the iterators and 'duplicate'