### PR TITLE
Fix warning about unbound parameter with Evaluate

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -180,7 +180,7 @@ algorithm
   execStat("NFInst.instExpressions");
 
   // Mark structural parameters.
-  updateImplicitVariability(inst_cls, Flags.isSet(Flags.EVAL_PARAM));
+  updateImplicitVariability(inst_cls, Flags.isSet(Flags.EVAL_PARAM), context);
   execStat("NFInst.updateImplicitVariability");
 
   // Type the class.
@@ -3659,6 +3659,7 @@ end checkTopLevelOuter;
 function updateImplicitVariability
   input InstNode node;
   input Boolean parentEval;
+  input InstContext.Type context;
 protected
   Class cls = InstNode.getClass(node);
   ClassTree cls_tree;
@@ -3667,7 +3668,7 @@ algorithm
     case Class.INSTANCED_CLASS(elements = cls_tree as ClassTree.FLAT_TREE())
       algorithm
         for c in cls_tree.components loop
-          updateImplicitVariabilityComp(c, parentEval);
+          updateImplicitVariabilityComp(c, parentEval, context);
         end for;
 
         Sections.apply(cls.sections,
@@ -3682,14 +3683,14 @@ algorithm
           Structural.markDimension(dim);
         end for;
 
-        updateImplicitVariability(cls.baseClass, parentEval);
+        updateImplicitVariability(cls.baseClass, parentEval, context);
       then
         ();
 
     case Class.INSTANCED_BUILTIN(elements = cls_tree as ClassTree.FLAT_TREE())
       algorithm
         for c in cls_tree.components loop
-          updateImplicitVariabilityComp(c, parentEval);
+          updateImplicitVariabilityComp(c, parentEval, context);
         end for;
       then
         ();
@@ -3701,6 +3702,7 @@ end updateImplicitVariability;
 function updateImplicitVariabilityComp
   input InstNode component;
   input Boolean parentEval;
+  input InstContext.Type context;
 protected
   InstNode node = InstNode.resolveOuter(component);
   Component c = InstNode.component(node);
@@ -3722,7 +3724,7 @@ algorithm
           InstNode.updateComponent(Component.setVariability(Variability.NON_STRUCTURAL_PARAMETER, c), node);
         else
           // Otherwise check if we should mark it as structural.
-          if Structural.isStructuralComponent(c, c.attributes, binding, node, eval, parentEval) then
+          if Structural.isStructuralComponent(c, c.attributes, binding, node, eval, parentEval, context) then
             Structural.markComponent(c, node);
           end if;
         end if;
@@ -3743,7 +3745,7 @@ algorithm
         end if;
 
         if not InstNode.isEmpty(c.classInst) then
-          updateImplicitVariability(c.classInst, eval or parentEval);
+          updateImplicitVariability(c.classInst, eval or parentEval, context);
         end if;
       then
         ();

--- a/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFStructural.mo
@@ -33,18 +33,18 @@ encapsulated package NFStructural
   "Contains utility functions for handling structural parameters."
 
   import Attributes = NFAttributes;
-  import Component = NFComponent;
   import Binding = NFBinding;
+  import Call = NFCall;
+  import Component = NFComponent;
+  import ComponentRef = NFComponentRef;
+  import Dimension = NFDimension;
+  import Expression = NFExpression;
+  import InstContext = NFInstContext;
   import NFInstNode.InstNode;
   import NFPrefixes.Variability;
   import Subscript = NFSubscript;
-  import Expression = NFExpression;
-  import ComponentRef = NFComponentRef;
-  import Call = NFCall;
-  import Dimension = NFDimension;
 
 protected
-  import Flags;
   import Util;
 
 public
@@ -55,6 +55,7 @@ public
     input InstNode compNode;
     input Boolean compEval "If the component has an Evaluate=true annotation";
     input Boolean parentEval "If any parent has an Evaluate=true annotation";
+    input InstContext.Type context;
     output Boolean isStructural;
   protected
     Boolean is_fixed;
@@ -78,7 +79,7 @@ public
         isStructural := false;
       elseif not (Binding.isBound(binding) or InstNode.hasBinding(compNode)) then
         // Except parameters with no bindings.
-        if not parentEval and not Flags.getConfigBool(Flags.CHECK_MODEL) then
+        if not parentEval and not InstContext.inRelaxed(context) then
           // Print a warning if a parameter has an Evaluate=true annotation but no binding.
           Error.addSourceMessage(Error.UNBOUND_PARAMETER_EVALUATE_TRUE,
             {InstNode.name(compNode)}, InstNode.info(compNode));

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -212,7 +212,7 @@ algorithm
           NFInst.instExpressions(inst_anncls, context = ANNOTATION_CONTEXT);
 
           // Mark structural parameters.
-          NFInst.updateImplicitVariability(inst_anncls, Flags.isSet(Flags.EVAL_PARAM));
+          NFInst.updateImplicitVariability(inst_anncls, Flags.isSet(Flags.EVAL_PARAM), ANNOTATION_CONTEXT);
 
           dae := frontEndBack(inst_anncls, annName, false);
           str := DAEUtil.getVariableBindingsStr(DAEUtil.daeElements(dae));
@@ -253,7 +253,7 @@ algorithm
           NFInst.instExpressions(inst_anncls, context = ANNOTATION_CONTEXT);
 
           // Mark structural parameters.
-          NFInst.updateImplicitVariability(inst_anncls, Flags.isSet(Flags.EVAL_PARAM));
+          NFInst.updateImplicitVariability(inst_anncls, Flags.isSet(Flags.EVAL_PARAM), ANNOTATION_CONTEXT);
 
           dae := frontEndBack(inst_anncls, annName, false);
           str := DAEUtil.getVariableBindingsStr(DAEUtil.daeElements(dae));
@@ -671,7 +671,7 @@ algorithm
   NFInst.instExpressions(inst_cls, context = NFInstContext.RELAXED);
 
   // Mark structural parameters.
-  NFInst.updateImplicitVariability(inst_cls, Flags.isSet(Flags.EVAL_PARAM));
+  NFInst.updateImplicitVariability(inst_cls, Flags.isSet(Flags.EVAL_PARAM), NFInstContext.RELAXED);
 
   if Flags.isSet(Flags.EXEC_STAT) then
     execStat("NFApi.frontEndFront_dispatch(" + name + ")");
@@ -884,7 +884,7 @@ algorithm
   inst_tree := buildInstanceTree(cls_node);
   execStat("NFApi.buildInstanceTree");
   Inst.instExpressions(cls_node, context = context, settings = inst_settings);
-  Inst.updateImplicitVariability(cls_node, Flags.isSet(Flags.EVAL_PARAM));
+  Inst.updateImplicitVariability(cls_node, Flags.isSet(Flags.EVAL_PARAM), context);
   execStat("Inst.instExpressions");
 
   Typing.typeClassType(cls_node, NFBinding.EMPTY_BINDING, context, cls_node);

--- a/testsuite/openmodelica/instance-API/GetModelInstanceBinding9.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceBinding9.mos
@@ -1,0 +1,44 @@
+// name: GetModelInstanceBinding8
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    parameter Real p annotation(Evaluate=true);
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"p\",
+//       \"type\": \"Real\",
+//       \"prefixes\": {
+//         \"variability\": \"parameter\"
+//       },
+//       \"annotation\": {
+//         \"Evaluate\": true
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 4,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -21,6 +21,7 @@ GetModelInstanceBinding5.mos \
 GetModelInstanceBinding6.mos \
 GetModelInstanceBinding7.mos \
 GetModelInstanceBinding8.mos \
+GetModelInstanceBinding9.mos \
 GetModelInstanceBreak1.mos \
 GetModelInstanceChoices1.mos \
 GetModelInstanceChoices2.mos \


### PR DESCRIPTION
- Check the context rather than the check model flag to determine whether to print warnings about unbound parameters with Evalute=true, since there are more contexts than check model where we want the warning to be suppressed.

Fixes #11762