### PR TITLE
Fix enumeration connectors in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -655,6 +655,7 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
   algorithm
     isEnum := match cls
       case PARTIAL_BUILTIN(ty = Type.ENUMERATION()) then true;
+      case INSTANCED_BUILTIN(ty = Type.ENUMERATION()) then true;
       case EXPANDED_DERIVED() then isEnumeration(InstNode.getClass(cls.baseClass));
       case TYPED_DERIVED() then isEnumeration(InstNode.getClass(cls.baseClass));
       else false;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -842,9 +842,15 @@ uniontype InstanceTree
     Boolean isExtends;
   end CLASS;
 
+  record BUILTIN_BASE_CLASS
+    String name;
+  end BUILTIN_BASE_CLASS;
+
   record EMPTY
   end EMPTY;
 end InstanceTree;
+
+constant InstanceTree ENUM_BASE = InstanceTree.BUILTIN_BASE_CLASS("enumeration");
 
 function getModelInstance
   input Absyn.Path classPath;
@@ -949,7 +955,7 @@ algorithm
   cls_node := InstNode.resolveInner(node);
   cls := InstNode.getClass(cls_node);
 
-  if not isDerived and Class.isOnlyBuiltin(cls) then
+  if not isDerived and Class.isOnlyBuiltin(cls) and not Class.isEnumeration(cls) then
     tree := InstanceTree.EMPTY();
     return;
   end if;
@@ -970,7 +976,7 @@ algorithm
         InstanceTree.CLASS(node, elems, isDerived);
 
     case (_, ClassTree.FLAT_TREE())
-      then InstanceTree.CLASS(node, {}, isDerived);
+      then InstanceTree.CLASS(node, if InstNode.isEnumerationType(cls_node) then {ENUM_BASE} else {}, isDerived);
 
     else
       algorithm
@@ -1093,7 +1099,7 @@ algorithm
 
   json := JSON.addPairNotNull("dims", dumpJSONClassDims(node, def), json);
   json := JSON.addPair("restriction",
-    JSON.makeString(Restriction.toString(InstNode.restriction(node))), json);
+    JSON.makeString(SCodeDump.restrictionStringPP(SCodeUtil.getClassRestriction(def))), json);
 
   json := JSON.addPairNotNull("prefixes", dumpJSONClassPrefixes(def, InstNode.parent(node)), json);
 
@@ -1226,6 +1232,7 @@ algorithm
         case InstanceTree.CLASS(isExtends = true) then dumpJSONExtends(e, isDeleted);
         case InstanceTree.CLASS() then dumpJSONReplaceableClass(e.node, scope);
         case InstanceTree.COMPONENT() then dumpJSONComponent(e.node, e.binding, e.cls);
+        case InstanceTree.BUILTIN_BASE_CLASS() then dumpJSONBuiltinBaseClass(e.name);
         else JSON.makeNull();
       end match;
 
@@ -1240,6 +1247,7 @@ function dumpJSONExtends
   output JSON json = JSON.makeNull();
 protected
   InstNode node;
+  Class cls;
   SCode.Element cls_def, ext_def;
   SCode.Mod mod;
 algorithm
@@ -1251,12 +1259,21 @@ algorithm
   json := dumpJSONSCodeMod(getExtendsModifier(ext_def, node), node, json);
   json := dumpJSONCommentOpt(SCodeUtil.getElementComment(ext_def), node, json);
 
-  if Class.isOnlyBuiltin(InstNode.getClass(node)) then
+  cls := InstNode.getClass(node);
+  if Class.isOnlyBuiltin(cls) and not Class.isEnumeration(cls) then
     json := JSON.addPair("baseClass", JSON.makeString(InstNode.name(node)), json);
   else
     json := JSON.addPair("baseClass", dumpJSONInstanceTree(ext, node, root = false, isDeleted = isDeleted), json);
   end if;
 end dumpJSONExtends;
+
+function dumpJSONBuiltinBaseClass
+  input String name;
+  output JSON json = JSON.makeNull();
+algorithm
+  json := JSON.addPair("$kind", JSON.makeString("extends"), json);
+  json := JSON.addPair("baseClass", JSON.makeString(name), json);
+end dumpJSONBuiltinBaseClass;
 
 function getExtendsModifier
   input SCode.Element definition;
@@ -1371,7 +1388,7 @@ function dumpJSONComponentType
   output JSON json;
 algorithm
   json := match (cls, Type.arrayElementType(ty))
-    case (_, Type.ENUMERATION()) then dumpJSONEnumType(node);
+    case (_, Type.ENUMERATION()) then dumpJSONEnumType(cls, node);
     case (_, Type.UNKNOWN()) then dumpJSONSCodeElementType(InstNode.definition(node));
     case (InstanceTree.CLASS(), _) then dumpJSONInstanceTree(cls, node, isDeleted = isDeleted);
     else dumpJSONTypeName(ty);
@@ -1395,23 +1412,31 @@ algorithm
 end dumpJSONSCodeElementType;
 
 function dumpJSONEnumType
+  input InstanceTree tree;
   input InstNode enumNode;
   output JSON json;
 protected
   InstNode node = InstNode.resolveInner(InstNode.classScope(enumNode));
   SCode.Element def;
   array<InstNode> comps;
+  JSON json_elems, json_ext;
+  list<InstanceTree> elems;
 algorithm
   def := InstNode.definition(node);
 
   json := JSON.makeNull();
   json := JSON.addPair("name", dumpJSONNodePath(node), json);
   json := JSON.addPairNotNull("dims", dumpJSONClassDims(node, def), json);
-  json := JSON.addPair("restriction", JSON.makeString("enumeration"), json);
+  json := JSON.addPair("restriction",
+    JSON.makeString(SCodeDump.restrictionStringPP(SCodeUtil.getClassRestriction(def))), json);
   json := dumpJSONCommentOpt(SCodeUtil.getElementComment(def), node, json);
 
+  InstanceTree.CLASS(elements = elems) := tree;
+  json_elems := dumpJSONElements(elems, node, false);
+
   comps := ClassTree.getComponents(Class.classTree(InstNode.getClass(node)));
-  json := JSON.addPair("elements", dumpJSONEnumTypeLiterals(comps, InstNode.parent(node)), json);
+  json_elems := dumpJSONEnumTypeLiterals(comps, InstNode.parent(node), json_elems);
+  json := JSON.addPair("elements", json_elems, json);
 
   json := JSON.addPair("source", dumpJSONSourceInfo(InstNode.info(node)), json);
 end dumpJSONEnumType;
@@ -1419,7 +1444,7 @@ end dumpJSONEnumType;
 function dumpJSONEnumTypeLiterals
   input array<InstNode> literals;
   input InstNode scope;
-  output JSON json = JSON.emptyArray();
+  input output JSON json = JSON.emptyArray();
 algorithm
   for i in 6:arrayLength(literals) loop
     json := JSON.addElement(dumpJSONEnumTypeLiteral(literals[i], scope), json);

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1184,7 +1184,7 @@ namespace ModelInstance
 
   bool Model::isEnumeration() const
   {
-    return (mRestriction.compare(QStringLiteral("enumeration")) == 0);
+    return getRootType() == QLatin1String("enumeration");
   }
 
   bool Model::isType() const

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -369,7 +369,8 @@ private:
   Element* connectorElementAtPosition(QPoint position);
   Element* stateElementAtPosition(QPoint position);
   static bool updateElementConnectorSizingParameter(GraphicsView *pGraphicsView, QString className, Element *pElement);
-  QString getConnectorName(Element *connector);
+  Element* getConnectorElement(ModelInstance::Connector *pConnector);
+  QString getConnectorName(Element *pConnector);
   bool handleDoubleClickOnComponent(QMouseEvent *event);
   void uncheckAllShapeDrawingActions();
   void setOriginAdjustAndInitialize(ShapeAnnotation* shapeAnnotation);

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum1.mos
@@ -29,12 +29,16 @@ getModelInstance(M, prettyPrint=true);
 //       \"name\": \"analogFil\",
 //       \"type\": {
 //         \"name\": \"AnalogFilter\",
-//         \"restriction\": \"enumeration\",
+//         \"restriction\": \"type\",
 //         \"comment\": \"Enumeration defining the method of filtering\",
 //         \"annotation\": {
 //           \"Evaluate\": true
 //         },
 //         \"elements\": [
+//           {
+//             \"$kind\": \"extends\",
+//             \"baseClass\": \"enumeration\"
+//           },
 //           {
 //             \"$kind\": \"component\",
 //             \"name\": \"CriticalDamping\",

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
@@ -26,8 +26,28 @@ getModelInstance(M, prettyPrint=true);
 //       \"name\": \"e\",
 //       \"type\": {
 //         \"name\": \"E2\",
-//         \"restriction\": \"enumeration\",
+//         \"restriction\": \"type\",
 //         \"elements\": [
+//           {
+//             \"$kind\": \"extends\",
+//             \"baseClass\": {
+//               \"name\": \"E1\",
+//               \"restriction\": \"type\",
+//               \"elements\": [
+//                 {
+//                   \"$kind\": \"extends\",
+//                   \"baseClass\": \"enumeration\"
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 3,
+//                 \"columnStart\": 5,
+//                 \"lineEnd\": 3,
+//                 \"columnEnd\": 47
+//               }
+//             }
+//           },
 //           {
 //             \"$kind\": \"component\",
 //             \"name\": \"a\",


### PR DESCRIPTION
- Dump the actual restriction of enumeration types rather than using `enumeration`, since `enumeration` is not a restriction but a type.
- Dump the full extends chain for an enumeration type, terminating in an extends of `enumeration` to indicate an enumeration type.
- Refactor the fetching of connector elements in OMEdit into a `getConnectorElement` method to avoid repetition.

Fixes #11726