### PR TITLE
 Improve handling of uriToFilename

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -1583,6 +1583,7 @@ public constant CallAttributes callAttrBuiltinOther = CALL_ATTR(T_UNKNOWN_DEFAUL
 public constant CallAttributes callAttrBuiltinImpureBool = CALL_ATTR(T_BOOL_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
 public constant CallAttributes callAttrBuiltinImpureInteger = CALL_ATTR(T_INTEGER_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
 public constant CallAttributes callAttrBuiltinImpureReal = CALL_ATTR(T_REAL_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
+public constant CallAttributes callAttrBuiltinImpureString = CALL_ATTR(T_STRING_DEFAULT,false,true,true,false,NO_INLINE(),NO_TAIL());
 public constant CallAttributes callAttrOther = CALL_ATTR(T_UNKNOWN_DEFAULT,false,false,false,false,NO_INLINE(),NO_TAIL());
 
 public

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -1394,8 +1394,10 @@ protected
   Expression marg;
   FFI.ArgSpec arg_spec;
   Integer args_len, i = 1;
+  list<Expression> input_args;
 algorithm
-  arg_map := createArgumentMap(fn.inputs, fn.outputs, fn.locals, inputArgs,
+  input_args := list(makeExternalArg(arg) for arg in inputArgs);
+  arg_map := createArgumentMap(fn.inputs, fn.outputs, fn.locals, input_args,
     mutableParams = false, buildArrayBinding = false);
 
   args_len := listLength(extArgs);
@@ -1409,6 +1411,16 @@ algorithm
     i := i + 1;
   end for;
 end mapExternalArgs;
+
+function makeExternalArg
+  input Expression arg;
+  output Expression extArg;
+algorithm
+  extArg := match arg
+    case Expression.FILENAME() then Expression.STRING(arg.filename);
+    else arg;
+  end match;
+end makeExternalArg;
 
 function mapExternalArg
   input Expression extArg;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -90,6 +90,7 @@ public
       case Expression.LUNARY()   then expandLogicalUnary(exp);
       case Expression.RELATION() then (exp, true);
       case Expression.CAST()     then expandCast(exp);
+      case Expression.FILENAME() then (exp, true);
       else expandGeneric(exp);
     end match;
   end expand;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1389,6 +1389,8 @@ algorithm
     case Expression.PARTIAL_FUNCTION_APPLICATION()
       then Function.typePartialApplication(exp, context, info);
 
+    case Expression.FILENAME() then (exp, Type.STRING(),  Variability.CONSTANT, Purity.PURE);
+
     else
       algorithm
         Error.assertion(false, getInstanceName() + " got unknown expression: " + Expression.toString(exp), sourceInfo());


### PR DESCRIPTION
- Change `uriToFilename` to return a filename expression that behaves mostly like a string, to make it possible to identify filenames later.
- Wrap filename expressions in `OpenModelica_fmuLoadResource` calls when generating the DAE and building an FMU.