### PR TITLE
Allow disabling connector balance checks with flag

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -375,7 +375,7 @@ algorithm
   // For each non-partial connector class the number of flow variables shall
   // be equal to the number of variables that are neither parameter, constant,
   // input, output, stream nor flow.
-  if pots <> flows then
+  if pots <> flows and not Flags.isConfigFlagSet(Flags.ALLOW_NON_STANDARD_MODELICA, "unbalancedModel") then
     Error.addStrictMessage(Error.UNBALANCED_CONNECTOR,
       {InstNode.name(component), String(pots), String(flows)}, InstNode.info(component));
   end if;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1393,7 +1393,8 @@ constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG(146, "allowNonStan
     ("nonStdDifferentCaseFileVsClassName", Gettext.gettext("Allow directory or file with different case in the name than the contained class name.\nSee: https://specification.modelica.org/maint/3.5/packages.html#mapping-package-class-structures-to-a-hierarchical-file-system")),
     ("nonStdTopLevelOuter", Gettext.gettext("Allow top level outer.\nSee: https://specification.modelica.org/maint/3.6/scoping-name-lookup-and-flattening.html#S4.p1")),
     ("protectedAccess", Gettext.gettext("Allow access of protected elements")),
-    ("reinitInAlgorithms", Gettext.gettext("Allow reinit in algorithm sections"))
+    ("reinitInAlgorithms", Gettext.gettext("Allow reinit in algorithm sections")),
+    ("unbalancedModel", Gettext.gettext("Allow models to be locally unbalanced and to have unbalanced connectors"))
     })),
   Gettext.gettext("Flags to allow non-standard Modelica."));
 

--- a/testsuite/flattening/modelica/connectors/ConnectorBalance9.mo
+++ b/testsuite/flattening/modelica/connectors/ConnectorBalance9.mo
@@ -1,0 +1,35 @@
+// name: ConnectorBalance9
+// keywords: connector
+// status: correct
+// cflags: -d=newInst, --allowNonStandardModelica=unbalancedModel
+//
+//
+
+connector C
+  Real e1;
+  Real e2;
+  flow Real f1;
+end C;
+
+model ConnectorBalance9
+  C c1, c2;
+equation
+  connect(c1, c2);
+end ConnectorBalance9;
+
+// Result:
+// class ConnectorBalance9
+//   Real c1.e1;
+//   Real c1.e2;
+//   Real c1.f1;
+//   Real c2.e1;
+//   Real c2.e2;
+//   Real c2.f1;
+// equation
+//   c1.e1 = c2.e1;
+//   c1.e2 = c2.e2;
+//   (-c1.f1) - c2.f1 = 0.0;
+//   c1.f1 = 0.0;
+//   c2.f1 = 0.0;
+// end ConnectorBalance9;
+// endResult

--- a/testsuite/flattening/modelica/connectors/Makefile
+++ b/testsuite/flattening/modelica/connectors/Makefile
@@ -43,6 +43,7 @@ ConnectorBalance5.mo \
 ConnectorBalance6.mo \
 ConnectorBalance7.mo \
 ConnectorBalance8.mos \
+ConnectorBalance9.mo \
 ConnectorComponents.mo \
 ConnectorCompOrder.mo \
 ConnectorIllegal.mo \


### PR DESCRIPTION
- Add flag `--allowNonStandardModelica=unbalancedModel` to disable connector balance checking.

Fixes #11824