### PR TITLE
[NB] update bindings start equations

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpressionIterator.mo
@@ -64,6 +64,26 @@ public
     list<Expression> all;
   end REPEAT_ITERATOR;
 
+  function toString
+    input ExpressionIterator iter;
+    output String str;
+  algorithm
+    str := match iter
+      case ARRAY_ITERATOR() algorithm
+        str := "[ARRY] array iterator:\n";
+        for arr in iter.arrays loop
+          str := str + List.toString(arrayList(arr), Expression.toString) + "\n";
+        end for;
+      then str;
+
+      case REPEAT_ITERATOR() then "[REAP] repeat iterator:\n" + List.toString(iter.all, Expression.toString);
+      case SCALAR_ITERATOR() then "[SCAL] scalar iterator: " + Expression.toString(iter.exp) + "\n";
+      case EACH_ITERATOR() then "[EACH] each iterator: " + Expression.toString(iter.exp) + "\n";
+      case NONE_ITERATOR() then "[NONE] no iterator.\n";
+    end match;
+  end toString;
+
+
   function fromExp
     input Expression exp;
     input Boolean backend = false;

--- a/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOperator.mo
@@ -682,6 +682,51 @@ public
     end match;
   end mathSymbol;
 
+  function classificationString
+    input Classification cla;
+    output String str;
+  protected
+    MathClassification mcl;
+    SizeClassification scl;
+  algorithm
+    (mcl, scl) := cla;
+    str := mathClassificationString(mcl) + sizeClassificationString(scl);
+  end classificationString;
+
+  function mathClassificationString
+    input MathClassification mcl;
+    output String str;
+  algorithm
+    str := match mcl
+      case MathClassification.ADDITION        then "[ADD]";
+      case MathClassification.SUBTRACTION     then "[SUB]";
+      case MathClassification.MULTIPLICATION  then "[MUL]";
+      case MathClassification.DIVISION        then "[DIV]";
+      case MathClassification.POWER           then "[POW]";
+      case MathClassification.LOGICAL         then "[LOG]";
+      case MathClassification.RELATION        then "[REL]";
+                                              else fail();
+    end match;
+  end mathClassificationString;
+
+  function sizeClassificationString
+    input SizeClassification scl;
+    output String str;
+  algorithm
+    str := match scl
+      case SizeClassification.SCALAR          then "[SCALAR]";
+      case SizeClassification.ELEMENT_WISE    then "[ELMWIS]";
+      case SizeClassification.ARRAY_SCALAR    then "[ARR-SC]";
+      case SizeClassification.SCALAR_ARRAY    then "[SC-ARR]";
+      case SizeClassification.MATRIX          then "[MATRIX]";
+      case SizeClassification.VECTOR_MATRIX   then "[VEC-MA]";
+      case SizeClassification.MATRIX_VECTOR   then "[MA-VEC]";
+      case SizeClassification.LOGICAL         then "[LOGICL]";
+      case SizeClassification.RELATION        then "[RELATN]";
+                                              else fail();
+    end match;
+  end sizeClassificationString;
+
   function classify
     input Operator op;
     output Classification cl;
@@ -739,27 +784,36 @@ public
       case (MathClassification.ADDITION,        SizeClassification.SCALAR)                  then Op.ADD;
       case (MathClassification.SUBTRACTION,     SizeClassification.SCALAR)                  then Op.SUB;
       case (MathClassification.MULTIPLICATION,  SizeClassification.SCALAR)                  then Op.MUL;
+      // this has to be done correctly. use type of the expressions?
+      //case (MathClassification.MULTIPLICATION,  SizeClassification.SCALAR)                  then Op.SCALAR_PRODUCT;
       case (MathClassification.DIVISION,        SizeClassification.SCALAR)                  then Op.DIV;
       case (MathClassification.POWER,           SizeClassification.SCALAR)                  then Op.POW;
+
       case (MathClassification.ADDITION,        SizeClassification.ELEMENT_WISE)            then Op.ADD_EW;
       case (MathClassification.SUBTRACTION,     SizeClassification.ELEMENT_WISE)            then Op.SUB_EW;
       case (MathClassification.MULTIPLICATION,  SizeClassification.ELEMENT_WISE)            then Op.MUL_EW;
       case (MathClassification.DIVISION,        SizeClassification.ELEMENT_WISE)            then Op.DIV_EW;
       case (MathClassification.POWER,           SizeClassification.ELEMENT_WISE)            then Op.POW_EW;
       case (MathClassification.MULTIPLICATION,  SizeClassification.ARRAY_SCALAR)            then Op.MUL_ARRAY_SCALAR;
+
       case (MathClassification.ADDITION,        SizeClassification.ARRAY_SCALAR)            then Op.ADD_ARRAY_SCALAR;
+      case (MathClassification.SUBTRACTION,     SizeClassification.ARRAY_SCALAR)            then Op.SUB_ARRAY_SCALAR;
+      case (MathClassification.MULTIPLICATION,  SizeClassification.ARRAY_SCALAR)            then Op.MUL_ARRAY_SCALAR;
+      case (MathClassification.DIVISION,        SizeClassification.ARRAY_SCALAR)            then Op.DIV_ARRAY_SCALAR;
+      case (MathClassification.POWER,           SizeClassification.ARRAY_SCALAR)            then Op.POW_ARRAY_SCALAR;
+
+      case (MathClassification.ADDITION,        SizeClassification.SCALAR_ARRAY)            then Op.ADD_SCALAR_ARRAY;
       case (MathClassification.SUBTRACTION,     SizeClassification.SCALAR_ARRAY)            then Op.SUB_SCALAR_ARRAY;
-      case (MathClassification.MULTIPLICATION,  SizeClassification.SCALAR)                  then Op.SCALAR_PRODUCT;
+      case (MathClassification.MULTIPLICATION,  SizeClassification.SCALAR_ARRAY)            then Op.MUL_SCALAR_ARRAY;
+      case (MathClassification.DIVISION,        SizeClassification.SCALAR_ARRAY)            then Op.DIV_SCALAR_ARRAY;
+      case (MathClassification.POWER,           SizeClassification.SCALAR_ARRAY)            then Op.POW_SCALAR_ARRAY;
+
+      case (MathClassification.POWER,           SizeClassification.MATRIX)                  then Op.POW_MATRIX;
       case (MathClassification.MULTIPLICATION,  SizeClassification.MATRIX)                  then Op.MATRIX_PRODUCT;
       case (MathClassification.MULTIPLICATION,  SizeClassification.VECTOR_MATRIX)           then Op.MUL_VECTOR_MATRIX;
       case (MathClassification.MULTIPLICATION,  SizeClassification.MATRIX_VECTOR)           then Op.MUL_MATRIX_VECTOR;
-      case (MathClassification.DIVISION,        SizeClassification.ARRAY_SCALAR)            then Op.DIV_ARRAY_SCALAR;
-      case (MathClassification.DIVISION,        SizeClassification.SCALAR_ARRAY)            then Op.DIV_SCALAR_ARRAY;
-      case (MathClassification.POWER,           SizeClassification.ARRAY_SCALAR)            then Op.POW_ARRAY_SCALAR;
-      case (MathClassification.POWER,           SizeClassification.SCALAR_ARRAY)            then Op.POW_SCALAR_ARRAY;
-      case (MathClassification.POWER,           SizeClassification.MATRIX)                  then Op.POW_MATRIX;
       else algorithm
-        Error.addInternalError(getInstanceName() + ": Don't know how to handle math class and size class combination.", sourceInfo());
+        Error.addInternalError(getInstanceName() + ": Don't know how to handle math class and size class combination: " + classificationString(cl), sourceInfo());
       then fail();
     end match;
     result := OPERATOR(ty, op);

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -1362,7 +1362,7 @@ algorithm
     local
       Expression new_exp;
       list<Expression> args, inv_args;
-      Operator inv_op;
+      Operator inv_op, fixed_op;
 
     case Expression.MULTARY() algorithm
       if listLength(exp.arguments) > 0 then
@@ -1396,11 +1396,13 @@ algorithm
       inv_op := Operator.invert(exp.operator);
       // chain all arguments
       for arg in args loop
-        new_exp := Expression.BINARY(new_exp, exp.operator, arg);
+        fixed_op := Operator.repairBinary(exp.operator, Expression.typeOf(new_exp), Expression.typeOf(arg));
+        new_exp   := Expression.BINARY(new_exp, fixed_op, arg);
       end for;
       // chain all inverse arguments
       for arg in inv_args loop
-        new_exp := Expression.BINARY(new_exp, inv_op, arg);
+        fixed_op := Operator.repairBinary(inv_op, Expression.typeOf(new_exp), Expression.typeOf(arg));
+        new_exp   := Expression.BINARY(new_exp, fixed_op, arg);
       end for;
     then new_exp;
 

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
@@ -22,6 +22,7 @@ OneDHeatTransferTT_Modelica.mos \
 CocurrentHeatExchangerEquations.mos \
 CounterCurrentHeatExchangerEquations.mos \
 PowerSystemStepLoad.mos \
+SimpleAdvection.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/SimpleAdvection.mos
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/SimpleAdvection.mos
@@ -1,0 +1,27 @@
+// name: ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend
+
+loadModel(ScalableTestSuite); getErrorString();
+
+simulate(ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection); getErrorString();
+
+res := OpenModelica.Scripting.compareSimulationResults("ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection_res.mat",
+  "ReferenceFiles/ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection_res.mat",
+  "ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection_diff.csv",0.01,0.0001,
+  {"T[1]", "T[100]"});
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 15.0, numberOfIntervals = 3750, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ScalableTestSuite.Thermal.Advection.Verification.SimpleAdvection', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// {"Files Equal!"}
+// endResult


### PR DESCRIPTION
 - fix SimplifyExp.splitMultary so that it does not break the non symmetrical operators
 - create array binding equations instead of for loops if possible
 - add SimpleAdvection test to testsuite

### Related Issues

- fixes #11845
