### PR TITLE
Use class name instead of full path in Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConvertDAE.mo
@@ -87,7 +87,7 @@ algorithm
   elems := convertAlgorithms(flatModel.algorithms, elems);
   elems := convertInitialAlgorithms(flatModel.initialAlgorithms, elems);
 
-  class_elem := DAE.COMP(flatModel.name, elems, flatModel.source, ElementSource.getOptComment(flatModel.source));
+  class_elem := DAE.COMP(FlatModel.fullName(flatModel), elems, flatModel.source, ElementSource.getOptComment(flatModel.source));
   dae := DAE.DAE({class_elem});
 
   execStat(getInstanceName());

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -68,7 +68,7 @@ protected
 
 public
   record FLAT_MODEL
-    String name;
+    Absyn.Path name;
     list<Variable> variables;
     list<Equation> equations;
     list<Equation> initialEquations;
@@ -116,6 +116,16 @@ public
     flatModel.initialAlgorithms := list(fn(alg) for alg in flatModel.initialAlgorithms);
   end mapAlgorithms;
 
+  function fullName
+    input FlatModel flatModel;
+    output String name = AbsynUtil.pathString(flatModel.name);
+  end fullName;
+
+  function className
+    input FlatModel flatModel;
+    output String name = AbsynUtil.pathLastIdent(flatModel.name);
+  end className;
+
   function toString
     input FlatModel flatModel;
     input Boolean printBindingTypes = false;
@@ -145,8 +155,10 @@ public
     input FlatModel flatModel;
     input Boolean printBindingTypes = false;
     input output IOStream.IOStream s;
+  protected
+    String name = className(flatModel);
   algorithm
-    s := IOStream.append(s, "class " + flatModel.name + "\n");
+    s := IOStream.append(s, "class " + name + "\n");
 
     for v in flatModel.variables loop
       s := Variable.toStream(v, "  ", printBindingTypes, s);
@@ -177,7 +189,7 @@ public
       end if;
     end for;
 
-    s := IOStream.append(s, "end " + flatModel.name + ";\n");
+    s := IOStream.append(s, "end " + name + ";\n");
   end appendStream;
 
   function toFlatString
@@ -207,7 +219,7 @@ public
     input Boolean printBindingTypes = false;
     output IOStream.IOStream s;
   algorithm
-    s := IOStream.create(flatModel.name, IOStream.IOStreamType.LIST());
+    s := IOStream.create(className(flatModel), IOStream.IOStreamType.LIST());
     s := appendFlatStream(flatModel, functions, printBindingTypes, s);
   end toFlatStream;
 
@@ -220,8 +232,9 @@ public
   protected
     FlatModel flat_model = flatModel;
     Visibility visibility = Visibility.PUBLIC;
+    String name = className(flatModel);
   algorithm
-    s := IOStream.append(s, "package '" + flat_model.name + "'\n");
+    s := IOStream.append(s, "package '" + name + "'\n");
     flat_model.variables := reconstructRecordInstances(flat_model.variables);
 
     for fn in functions loop
@@ -236,7 +249,7 @@ public
       s := IOStream.append(s, ";\n\n");
     end for;
 
-    s := IOStream.append(s, "  model '" + flat_model.name + "'");
+    s := IOStream.append(s, "  model '" + name + "'");
     s := FlatModelicaUtil.appendElementSourceCommentString(flat_model.source, s);
     s := IOStream.append(s, "\n");
 
@@ -277,8 +290,8 @@ public
     end for;
 
     s := FlatModelicaUtil.appendElementSourceCommentAnnotation(flat_model.source, "    ", ";\n", s);
-    s := IOStream.append(s, "  end '" + flat_model.name + "';\n");
-    s := IOStream.append(s, "end '" + flat_model.name + "';\n");
+    s := IOStream.append(s, "  end '" + name + "';\n");
+    s := IOStream.append(s, "end '" + name + "';\n");
   end appendFlatStream;
 
   function collectFlatTypes

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -311,7 +311,7 @@ constant Prefix EMPTY_INDEXED_PREFIX = Prefix.INDEXED_PREFIX(InstNode.EMPTY_NODE
 
 function flatten
   input InstNode classInst;
-  input String name;
+  input Absyn.Path classPath;
   input Boolean getConnectionResolved = true;
   output FlatModel flatModel;
 protected
@@ -354,9 +354,9 @@ algorithm
         alg := listReverseInPlace(sections.algorithms);
         ialg := listReverseInPlace(sections.initialAlgorithms);
       then
-        FlatModel.FLAT_MODEL(name, vars, eql, ieql, alg, ialg, src);
+        FlatModel.FLAT_MODEL(classPath, vars, eql, ieql, alg, ialg, src);
 
-      else FlatModel.FLAT_MODEL(name, vars, {}, {}, {}, {}, src);
+      else FlatModel.FLAT_MODEL(classPath, vars, {}, {}, {}, {}, src);
   end match;
 
   // get inputs and outputs for algorithms now that types are computed
@@ -378,13 +378,13 @@ end flatten;
 
 function flattenConnection
   input InstNode classInst;
-  input String name;
+  input Absyn.Path classPath;
   output Connections conns;
 protected
   FlatModel flatModel;
   UnorderedSet<ComponentRef> deleted_vars;
 algorithm
-  flatModel := flatten(classInst, name, false);
+  flatModel := flatten(classInst, classPath, false);
   deleted_vars := UnorderedSet.new(ComponentRef.hash, ComponentRef.isEqual);
 
   // get the connections from the model

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -143,7 +143,6 @@ function instClassInProgram
   output String flatString "The flat model as a string if dumpFlat = true.";
 protected
   InstNode top, cls, inst_cls;
-  String name;
   InstContext.Type context;
   Integer var_count, eq_count, expose_local_ios;
   SCode.Program prog = program;
@@ -156,7 +155,6 @@ algorithm
 
   // Create a top scope from the given top-level classes.
   top := makeTopNode(prog, annotationProgram);
-  name := AbsynUtil.pathString(classPath);
 
   // Look up the class to instantiate.
   cls := lookupRootClass(classPath, top, context);
@@ -171,7 +169,7 @@ algorithm
 
   // Instantiate the class.
   inst_cls := instantiateRootClass(cls, context);
-  execStat("NFInst.instantiate(" + name + ")");
+  execStat("NFInst.instantiate(" + AbsynUtil.pathString(classPath) + ")");
 
   // Instantiate expressions (i.e. anything that can contains crefs, like
   // bindings, dimensions, etc). This is done as a separate step after
@@ -187,7 +185,7 @@ algorithm
   Typing.typeClass(inst_cls, context);
 
   // Flatten the model and evaluate constants in it.
-  flatModel := Flatten.flatten(inst_cls, name);
+  flatModel := Flatten.flatten(inst_cls, classPath);
   flatModel := EvalConstants.evaluate(flatModel, context);
 
   InstUtil.dumpFlatModelDebug("eval", flatModel);
@@ -271,7 +269,6 @@ function instClassForConnection
 protected
   Connections conns;
   InstNode top, cls, inst_cls;
-  String name;
   InstContext.Type context;
 algorithm
   resetGlobalFlags();
@@ -280,7 +277,6 @@ algorithm
 
   // Create a top scope from the given top-level classes.
   top := makeTopNode(program, annotationProgram);
-  name := AbsynUtil.pathString(classPath);
 
   // Look up the class to instantiate.
   cls := lookupRootClass(classPath, top, context);
@@ -297,7 +293,7 @@ algorithm
   Typing.typeClass(inst_cls, context);
 
   // Flatten the model and get connections
-  conns := Flatten.flattenConnection(inst_cls, name);
+  conns := Flatten.flattenConnection(inst_cls, classPath);
   connList := Connections.toStringList(conns);
 
   clearCaches();
@@ -399,7 +395,7 @@ algorithm
     functions := Flatten.flattenFunction(fn, functions);
   end for;
 
-  flatModel := FlatModel.FLAT_MODEL(InstNode.name(funcNode), {}, {}, {}, {}, {},
+  flatModel := FlatModel.FLAT_MODEL(Absyn.Path.IDENT(InstNode.name(funcNode)), {}, {}, {}, {}, {},
     ElementSource.createElementSource(InstNode.info(funcNode)));
 end instantiateRootFunction;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFOCConnectionGraph.mo
@@ -197,7 +197,7 @@ algorithm
 
   // now we have the graph, remove the broken connects and evaluate the equation operators
   ieql := flatModel.initialEquations;
-  (eql, ieql, connected, broken) := handleOverconstrainedConnections_dispatch(graph, flatModel.name, eql, ieql);
+  (eql, ieql, connected, broken) := handleOverconstrainedConnections_dispatch(graph, FlatModel.fullName(flatModel), eql, ieql);
 
   eql := removeBrokenConnects(eql, connected, broken, isDeleted);
 

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -711,7 +711,7 @@ algorithm
   Typing.typeClass(inst_cls, NFInstContext.RELAXED);
 
   // Flatten and simplify the model.
-  flat_model := Flatten.flatten(inst_cls, name);
+  flat_model := Flatten.flatten(inst_cls, Absyn.Path.IDENT(name));
   flat_model := EvalConstants.evaluate(flat_model, NFInstContext.RELAXED);
   flat_model := UnitCheck.checkUnits(flat_model);
   flat_model := SimplifyModel.simplify(flat_model);

--- a/testsuite/openmodelica/flatmodelica/DoublePendulum.mos
+++ b/testsuite/openmodelica/flatmodelica/DoublePendulum.mos
@@ -7,7 +7,7 @@ writeFile("DoublePendulum.mo", OpenModelica.Scripting.instantiateModel(Modelica.
 clear();
 loadFile("DoublePendulum.mo");getErrorString();
 setCommandLineOptions("--std=experimental");
-translateModel('Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum'.'Modelica.Mechanics.MultiBody.Examples.Elementary.DoublePendulum', fileNamePrefix="DP");getErrorString();
+translateModel('DoublePendulum'.'DoublePendulum', fileNamePrefix="DP");getErrorString();
 // Result:
 // true
 // ""

--- a/testsuite/openmodelica/flatmodelica/Tables.mos
+++ b/testsuite/openmodelica/flatmodelica/Tables.mos
@@ -10,7 +10,7 @@ loadFile("Tables.mo");getErrorString();
 setCommandLineOptions("--std=experimental");
 setCommandLineOptions("-d=nonewInst");
 echo(false);
-res := simulate('ModelicaTest.Tables.CombiTable1D.Test33', fileNamePrefix="Tables");
+res := simulate('Test33'.'Test33', fileNamePrefix="Tables");
 echo(true);
 getErrorString();
 res.resultFile;


### PR DESCRIPTION
- Change the name in `FlatModel` to a path instead of a string.
- Only use the last part of the path, the class name, when dumping Base Modelica models.