### PR TITLE
Check if `delayTime` is larger than `delayMax`

### DIFF
--- a/.CI/compliance.failures
+++ b/.CI/compliance.failures
@@ -98,7 +98,6 @@ ModelicaCompliance.Operators.Events.SampleIncorrect
 ModelicaCompliance.Operators.Overloading.VectorizeConstructAndApply
 ModelicaCompliance.Operators.Special.Cardinality
 ModelicaCompliance.Operators.Special.Delay
-ModelicaCompliance.Operators.Special.DelayIncorrect3
 ModelicaCompliance.Operators.Special.DerConstantIncorrect1
 ModelicaCompliance.Redeclare.ClassExtends.ClassExtendsNonReplaceable
 ModelicaCompliance.Redeclare.ClassExtends.NonRedeclareClassExtends

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/delay.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/delay.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of OpenModelica.
  *
- * Copyright (c) 1998-2014, Open Source Modelica Consortium (OSMC),
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
  * c/o Linköpings universitet, Department of Computer and Information Science,
  * SE-58183 Linköping, Sweden.
  *
@@ -120,8 +120,6 @@ void storeDelayedExpression(DATA* data, threadData_t *threadData, int exprNumber
 
   assertStreamPrint(threadData, exprNumber < data->modelData->nDelayExpressions, "storeDelayedExpression: invalid expression number %d", exprNumber);
   assertStreamPrint(threadData, 0 <= exprNumber, "storeDelayedExpression: invalid expression number %d", exprNumber);
-  assertStreamPrint(threadData, data->simulationInfo->startTime <= time, "storeDelayedExpression: time is smaller than starting time.");
-  assertStreamPrint(threadData, delayTime >= 0, "Negative delay requested: delayTime = %g", delayTime);
 
   /* Check if time is greater equal then last stored time in delay structure */
   if (length > 0) {
@@ -198,6 +196,7 @@ double delayImpl(DATA* data, threadData_t *threadData, int exprNumber, double ex
   assertStreamPrint(threadData, delayTime >= 0, "Negative delay requested: delayTime = %g", delayTime);
   assertStreamPrint(threadData, delayTime >= DASSL_STEP_EPS, "delayImpl: delayTime is zero or too small.\n" \
     "OpenModelica doesn't support delay operator with zero delay time.");
+  assertStreamPrint(threadData, delayTime <= delayMax, "Too large delay requested: delayTime = %g, delayMax = %g", delayTime, delayMax);
 
   /* Return expression value before simulation start */
   if(time <= data->simulationInfo->startTime)


### PR DESCRIPTION
### Purpose

For varying delay times we had some bogus results if `delayTime > delayMax`.

### Approach

Check and abort simulation if delayTime is too large.
