### PR TITLE
Improve the moving of components in a diagram (#11901)

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/RectangleAnnotation.cpp
@@ -181,10 +181,11 @@ QPainterPath RectangleAnnotation::shape() const
 {
   QPainterPath path;
   path.addRoundedRect(getBoundingRect(), mRadius, mRadius);
-  if (mFillPattern == StringHandler::FillNone)
+  if (mFillPattern == StringHandler::FillNone) {
     return addPathStroker(path);
-  else
+  } else {
     return path;
+  }
 }
 
 void RectangleAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -363,8 +363,8 @@ void UpdateComponentTransformationsCommand::redoInternal()
   mpComponent->mTransformation = mNewTransformation;
   mpComponent->emitTransformChange(mPositionChanged);
   mpComponent->emitTransformHasChanged();
-  if (mpComponent->getGraphicsView()->getViewType() == StringHandler::Diagram && mpComponent->getGraphicsView()->getModelWidget()->isNewApi()) {
-    mpComponent->getGraphicsView()->handleCollidingConnections();
+  if (mpComponent->getGraphicsView()->getViewType() == StringHandler::Diagram && pModelWidget->isNewApi()) {
+    pModelWidget->setHandleCollidingConnectionsNeeded(true);
   }
 }
 
@@ -405,8 +405,8 @@ void UpdateComponentTransformationsCommand::undo()
   mpComponent->mTransformation = mOldTransformation;
   mpComponent->emitTransformChange(mPositionChanged);
   mpComponent->emitTransformHasChanged();
-  if (mpComponent->getGraphicsView()->getViewType() == StringHandler::Diagram && mpComponent->getGraphicsView()->getModelWidget()->isNewApi()) {
-    mpComponent->getGraphicsView()->handleCollidingConnections();
+  if (mpComponent->getGraphicsView()->getViewType() == StringHandler::Diagram && pModelWidget->isNewApi()) {
+    pModelWidget->setHandleCollidingConnectionsNeeded(true);
   }
 }
 

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -7040,6 +7040,7 @@ void ModelWidget::updateModelText()
     setWindowTitle(QString("%1*").arg(mpLibraryTreeItem->getName()));
     mUpdateModelTimer.start();
     if (isNewApi()) {
+      callHandleCollidingConnectionsIfNeeded();
       // announce the change.
       MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->emitModelStateChanged(mpLibraryTreeItem->getNameStructure());
     }
@@ -7050,6 +7051,18 @@ void ModelWidget::updateModelText()
     MainWindow::instance()->getModelWidgetContainer()->updateThreeDViewer(this);
   }
 #endif
+}
+
+/*!
+ * \brief ModelWidget::callHandleCollidingConnectionsIfNeeded
+ * Calls GraphicsView::handleCollidingConnections if needed.
+ */
+void ModelWidget::callHandleCollidingConnectionsIfNeeded()
+{
+  if (mpLibraryTreeItem->getLibraryType() == LibraryTreeItem::Modelica && mpDiagramGraphicsView && isHandleCollidingConnectionsNeeded()) {
+    mpDiagramGraphicsView->handleCollidingConnections();
+    setHandleCollidingConnectionsNeeded(false);
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -579,6 +579,8 @@ public:
   bool isNewApi();
   void addDependsOnModel(const QString &dependsOnModel);
   void clearDependsOnModels() {mDependsOnModelsList.clear();}
+  void setHandleCollidingConnectionsNeeded(bool needed) {mHandleCollidingConnectionsNeeded = needed;}
+  bool isHandleCollidingConnectionsNeeded() {return mHandleCollidingConnectionsNeeded;}
 
   void fetchExtendsModifiers(QString extendsClass);
   void reDrawModelWidgetInheritedClasses();
@@ -614,6 +616,7 @@ public:
   void clearSelection();
   void updateClassAnnotationIfNeeded();
   void updateModelText();
+  void callHandleCollidingConnectionsIfNeeded();
   void updateUndoRedoActions();
   bool writeCoSimulationResultFile(QString fileName);
   bool writeVisualXMLFile(QString fileName, bool canWriteVisualXMLFile = false);
@@ -671,6 +674,7 @@ private:
   QTimer mUpdateModelTimer;
   QStringList mDependsOnModelsList;
   bool mHasMissingType = false;
+  bool mHandleCollidingConnectionsNeeded = false;
 
   void createUndoStack();
   void handleCanUndoRedoChanged();


### PR DESCRIPTION
### Related Issues

#11887

### Purpose

Move the components in the diagram without a major delay.

### Approach

Do not try to detect the collision of connections and components whenever a component is updated. In case of batch operation only do it once.