### PR TITLE
Improve annotation API performance

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -2713,7 +2713,7 @@ algorithm
         absynClass := InteractiveUtil.getPathedClassInProgram(classpath, p);
         absynClass := InteractiveUtil.updateConnectionAnnotationInClass(absynClass, str1, str2, Absyn.ANNOTATION(annlst));
         p := InteractiveUtil.updateProgram(Absyn.PROGRAM({absynClass}, if AbsynUtil.pathIsIdent(classpath) then Absyn.TOP() else Absyn.WITHIN(AbsynUtil.stripLast(classpath))), p);
-        SymbolTable.setAbsyn(p);
+        SymbolTable.setAbsynClass(p, absynClass, classpath);
       then
         Values.BOOL(true);
 
@@ -3084,7 +3084,6 @@ algorithm
            Values.CODE(Absyn.C_MODIFICATION(modification = mod))})
       algorithm
         (p, b) := InteractiveUtil.setElementAnnotation(path, mod, SymbolTable.getAbsyn());
-        SymbolTable.setAbsyn(p);
       then
         Values.BOOL(b);
 


### PR DESCRIPTION
- Add `SymbolTable.setAbsynElement/Class` to make it possible to update a single element/class without invalidating the cached SCode.
- Change `InteractiveUtil.transformPathedElementInProgram` to return the transformed element to allow it to be used with the new SymbolTable functions.
- Update `setElementAnnotation` and `updateConnectionAnnotation` to use the new SymbolTable functions.