### PR TITLE
Fix some issues with edit redeclerable parameter button

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -901,7 +901,7 @@ void Parameter::editRedeclareClassButtonClicked()
       const QJsonObject defaultModifierJSON = MainWindow::instance()->getOMCProxy()->modifierToJSON(defaultModifier);
       ModelInstance::Modifier *pDefaultElementModifier = new ModelInstance::Modifier("", QJsonValue(), mpModelInstanceElement->getParentModel());
       pDefaultElementModifier->deserialize(QJsonValue(defaultModifierJSON));
-      ModelInstance::Model *pNewModel = new ModelInstance::Model(newModelJSON);
+      ModelInstance::Model *pNewModel = new ModelInstance::Model(newModelJSON, mpModelInstanceElement);
       mpModelInstanceElement->setModel(pNewModel);
       MainWindow::instance()->getProgressBar()->setRange(0, 0);
       MainWindow::instance()->showProgressBar();


### PR DESCRIPTION
### Related Issues

Incorrect component name in dialogue of nested replaceables #11119
Parameter dialog crash #11899

### Approach

Add ParentElement when create a model for replaceable parameter.
Remove condition when add parameter to window. With this condition after set redeclare component this parameter disappear from parameter`s window.