### PR TITLE
Don't move non-scalarized array bindings

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -662,9 +662,10 @@ algorithm
     unfix := false;
   end if;
 
-  // If the component is an array component with a binding and at least discrete variability,
-  // move the binding into an equation. This avoids having to scalarize the binding.
-  if not settings.nfAPI then
+  // If the component is an array component with a binding and at least discrete
+  // variability, and scalarization is enabled, move the binding into an equation.
+  // This avoids having to scalarize the binding.
+  if not settings.nfAPI and settings.scalarize then
     if Type.isArray(ty) and Binding.isBound(binding) and var >= Variability.DISCRETE then
       name := ComponentRef.prefixCref(comp_node, ty, {}, Prefix.prefix(prefix));
       eq := Equation.ARRAY_EQUALITY(Expression.CREF(ty, name), Binding.getTypedExp(binding), ty,

--- a/testsuite/flattening/modelica/scodeinst/BindingArray10.mo
+++ b/testsuite/flattening/modelica/scodeinst/BindingArray10.mo
@@ -1,0 +1,15 @@
+// name: BindingArray10
+// keywords:
+// status: correct
+// cflags: -d=newInst --newBackend
+//
+
+model BindingArray10
+  Real x[:] = ones(3);
+end BindingArray10;
+
+// Result:
+// class BindingArray10
+//   Real[3] x = array(1.0 for $i1 in 1:3);
+// end BindingArray10;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -51,6 +51,7 @@ BindingArray6.mo \
 BindingArray7.mo \
 BindingArray8.mo \
 BindingArray9.mo \
+BindingArray10.mo \
 BindingInvalidType1.mo \
 BindingInvalidType2.mo \
 BindingInvalidType3.mo \


### PR DESCRIPTION
- Don't move bindings of non-scalarized variables to equations, since such variables can have array bindings without having to scalarize the binding.