### PR TITLE
[NB] replace pre variables in when conditions

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -1029,6 +1029,13 @@ protected
         Pointer.update(bucket_ptr, bucket);
       then exp;
 
+      // replace $PRE variables with auxiliaries
+      // necessary if the $PRE variable is a when condition (cannot check the pre of a pre variable)
+      case Expression.CALL(call = Call.TYPED_CALL(arguments = {Expression.CREF()})) guard(Call.isNamed(exp.call, "pre")) algorithm
+        (exp, bucket) := CompositeEvent.add(Condition.CONDITION(exp, iter), Pointer.access(bucket_ptr), true);
+        Pointer.update(bucket_ptr, bucket);
+      then exp;
+
       // ToDo: math events (check the call name in a function and merge with sample case?)
 
       else exp;


### PR DESCRIPTION
 - necessary to parse when pre(b) because the condition is checked if it differs from its pre value. there is no pre value for a variable that already is a pre value