### PR TITLE
Do not automatically enlarge Message Browser setting

### DIFF
--- a/OMEdit/OMEditLIB/MainWindow.h
+++ b/OMEdit/OMEditLIB/MainWindow.h
@@ -41,6 +41,8 @@ extern "C" {
 #include "meta/meta_modelica.h"
 }
 
+#include "Util/StringHandler.h"
+
 #include <QtGlobal>
 #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
 #error "OMEdit requires Qt 5.0.0 or newer"
@@ -58,6 +60,7 @@ extern "C" {
 #include <QMdiArea>
 #include <QShortcut>
 #include <QRadioButton>
+#include <QTimer>
 
 class OMCProxy;
 class TransformationsWidget;
@@ -132,7 +135,6 @@ public:
   VariablesWidget* getVariablesWidget() {return mpVariablesWidget;}
   QDockWidget* getVariablesDockWidget() {return mpVariablesDockWidget;}
   SearchWidget* getSearchWidget() {return mpSearchWidget;}
-
 #if !defined(WITHOUT_OSG)
   bool isThreeDViewerInitialized();
   ThreeDViewer* getThreeDViewer();
@@ -146,6 +148,7 @@ public:
   GitCommands* getGitCommands() {return mpGitCommands;}
   CommitChangesDialog* getCommitChangesDialog() {return mpCommitChangesDialog;}
   TraceabilityInformationURI* getTraceabilityInformationURI() {return mpTraceabilityInformationURI;}
+  QTabWidget* getMessagesTabWidget() {return mpMessagesTabWidget;}
   StatusBar* getStatusBar() {return mpStatusBar;}
   QProgressBar* getProgressBar() {return mpProgressBar;}
   void showProgressBar() {mpProgressBar->setVisible(true);}
@@ -267,6 +270,7 @@ public:
   void addSystemLibraries();
   QString getLibraryIndexFilePath() const;
   void writeNewApiProfiling(const QString &str);
+  void animateMessagesTabWidgetForNewMessage(StringHandler::OpenModelicaErrors errorType);
 
   QList<QString> mFMUDirectoriesList;
   QList<QString> mMOLDirectoriesList;
@@ -487,6 +491,8 @@ private:
   QToolBar *mpTLMSimulationToolbar;
   QToolBar *mpOMSimulatorToolbar;
   QHash<QString, TransformationsWidget*> mTransformationsWidgetHash;
+signals:
+  void stopMessagesTabWidgetAnimation();
 public slots:
   void showMessageBrowser();
   void switchToWelcomePerspectiveSlot();
@@ -648,13 +654,20 @@ class MessageTab : public QWidget
 public:
   MessageTab(bool fixedTab);
   void setIndex(int index) {mIndex = index;}
+  void setColor(const QColor &color) {mColor = color;}
+  void startAnimation();
 private:
   int mIndex = -1;
+  QColor mColor;
   Label *mpProgressLabel;
   QProgressBar *mpProgressBar;
+  QTimer mTimer;
+  int mAnimationCounter = 0;
 public slots:
   void updateText(const QString &text);
   void updateProgress(QProgressBar *pProgressBar);
+  void stopAnimation();
+  void updateTabTextColor();
 signals:
   void clicked(int index);
   // QObject interface

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -621,7 +621,11 @@ void MessagesWidget::addGUIMessage(MessageItem messageItem)
       break;
   }
   mpMessagesTabWidget->setCurrentWidget(mpAllMessageWidget);
-  emit messageAdded();
+  if (!OptionsDialog::instance()->getMessagesPage()->getEnlargeMessageBrowserCheckBox()->isChecked()) {
+    emit messageAdded();
+  } else {
+    MainWindow::instance()->animateMessagesTabWidgetForNewMessage(messageItem.getErrorType());
+  }
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.h
@@ -128,7 +128,6 @@ private:
   MessageWidget *mpNotificationMessageWidget;
   MessageWidget *mpWarningMessageWidget;
   MessageWidget *mpErrorMessageWidget;
-  QVector<QWidget*> mSimulationWidgetsVector;
 
   QStringList mSuppressMessagesList;
   QQueue<MessageItem> mPendingMessagesQueue;

--- a/OMEdit/OMEditLIB/Options/OptionsDefaults.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDefaults.h
@@ -175,6 +175,7 @@ namespace OptionsDefaults
     int outputSize = 0;
     bool resetMessagesNumberBeforeSimulation = true;
     bool clearMessagesBrowserBeforeSimulation = false;
+    bool enlargeMessageBrowserCheckBox = false;
     QColor notificationColor = Qt::black;
     QColor warningColor = QColor(255, 170, 0);
     QColor errorColor = Qt::red;

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -1019,6 +1019,12 @@ void OptionsDialog::readMessagesSettings()
   } else {
     mpMessagesPage->getClearMessagesBrowserBeforeSimulationCheckBox()->setChecked(OptionsDefaults::Messages::clearMessagesBrowserBeforeSimulation);
   }
+  // read enlarge message browser
+  if (mpSettings->contains("messages/enlargeMessagesBrowser")) {
+    mpMessagesPage->getEnlargeMessageBrowserCheckBox()->setChecked(mpSettings->value("messages/enlargeMessagesBrowser").toBool());
+  } else {
+    mpMessagesPage->getEnlargeMessageBrowserCheckBox()->setChecked(OptionsDefaults::Messages::enlargeMessageBrowserCheckBox);
+  }
   // read font family
   QTextBrowser textBrowser;
   if (mpSettings->contains("messages/fontFamily")) {
@@ -2564,6 +2570,13 @@ void OptionsDialog::saveMessagesSettings()
     mpSettings->remove("messages/clearMessagesBrowser");
   } else {
     mpSettings->setValue("messages/clearMessagesBrowser", clearMessagesBrowserBeforeSimulation);
+  }
+  // save enlarge message browser
+  bool enlargeMessagesBrowserBeforeSimulation = mpMessagesPage->getEnlargeMessageBrowserCheckBox()->isChecked();
+  if (enlargeMessagesBrowserBeforeSimulation == OptionsDefaults::Messages::enlargeMessageBrowserCheckBox) {
+    mpSettings->remove("messages/enlargeMessagesBrowser");
+  } else {
+    mpSettings->setValue("messages/enlargeMessagesBrowser", enlargeMessagesBrowserBeforeSimulation);
   }
   // save font
   QTextBrowser textBrowser;
@@ -5738,6 +5751,8 @@ MessagesPage::MessagesPage(OptionsDialog *pOptionsDialog)
   mpResetMessagesNumberBeforeSimulationCheckBox->setChecked(OptionsDefaults::Messages::resetMessagesNumberBeforeSimulation);
   // clear message browser before simulation
   mpClearMessagesBrowserBeforeSimulationCheckBox = new QCheckBox(tr("Clear message browser before checking, instantiation, and simulation"));
+  // enlarge message browser on a new message
+  mpEnlargeMessageBrowserCheckBox = new QCheckBox(tr("Do not automatically enlarge message browser when a new message is available"));
   // set general groupbox layout
   QGridLayout *pGeneralGroupBoxLayout = new QGridLayout;
   pGeneralGroupBoxLayout->setColumnStretch(1, 1);
@@ -5745,6 +5760,7 @@ MessagesPage::MessagesPage(OptionsDialog *pOptionsDialog)
   pGeneralGroupBoxLayout->addWidget(mpOutputSizeSpinBox, 0, 1);
   pGeneralGroupBoxLayout->addWidget(mpResetMessagesNumberBeforeSimulationCheckBox, 1, 0, 1, 2);
   pGeneralGroupBoxLayout->addWidget(mpClearMessagesBrowserBeforeSimulationCheckBox, 2, 0, 1, 2);
+  pGeneralGroupBoxLayout->addWidget(mpEnlargeMessageBrowserCheckBox, 3, 0, 1, 2);
   mpGeneralGroupBox->setLayout(pGeneralGroupBoxLayout);
   // Font and Colors
   mpFontColorsGroupBox = new QGroupBox(Helper::Colors);

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.h
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.h
@@ -717,6 +717,7 @@ public:
   QSpinBox* getOutputSizeSpinBox() {return mpOutputSizeSpinBox;}
   QCheckBox* getResetMessagesNumberBeforeSimulationCheckBox() {return mpResetMessagesNumberBeforeSimulationCheckBox;}
   QCheckBox* getClearMessagesBrowserBeforeSimulationCheckBox() {return mpClearMessagesBrowserBeforeSimulationCheckBox;}
+  QCheckBox* getEnlargeMessageBrowserCheckBox() {return mpEnlargeMessageBrowserCheckBox;}
   QFontComboBox* getFontFamilyComboBox() {return mpFontFamilyComboBox;}
   DoubleSpinBox* getFontSizeSpinBox() {return mpFontSizeSpinBox;}
   void setNotificationColor(QColor color) {mNotificaitonColor = color;}
@@ -736,6 +737,7 @@ private:
   QSpinBox *mpOutputSizeSpinBox;
   QCheckBox *mpResetMessagesNumberBeforeSimulationCheckBox;
   QCheckBox *mpClearMessagesBrowserBeforeSimulationCheckBox;
+  QCheckBox *mpEnlargeMessageBrowserCheckBox;
   QGroupBox *mpFontColorsGroupBox;
   Label *mpFontFamilyLabel;
   QFontComboBox *mpFontFamilyComboBox;

--- a/doc/UsersGuide/source/omedit.rst
+++ b/doc/UsersGuide/source/omedit.rst
@@ -1737,7 +1737,7 @@ Messages Options
 
 -  General
 
-  -  *Output Size* - Specifies the maximum number of rows the Messages
+  -  *Output Size* - Specifies the maximum number of rows the Message
      Browser may have. If there are more rows then the rows are removed
      from the beginning.
 
@@ -1745,7 +1745,10 @@ Messages Options
      counter before starting the simulation.
 
   -  *Clear messages browser before checking, instantiation & simulation* - If enabled then the
-     messages browser is cleared before checking, instantiation & simulation of model.
+     message browser is cleared before checking, instantiation & simulation of model.
+
+  -  *Do not automatically enlarge message browser when a new message is available* - If enabled then the
+     message browser will not be enlarged instead the tabbar shown will start blinking indicating that a new message is available.
 
 -  Font and Colors
 


### PR DESCRIPTION
### Related Issues

#9889

### Purpose

Have a setting to disable opening of the message browser.

### Approach

The setting is disabled by default. If enabled, the message browser will not open on new messages. Instead the small messages tab bar shown will start blinking indicating that a new message is available.
