### PR TITLE
Reduced max number of equations per C file to 500

### DIFF
--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1168,7 +1168,7 @@ constant ConfigFlag PREFER_TVARS_WITH_START_VALUE = CONFIG_FLAG(97, "preferTVars
   NONE(), EXTERNAL(), BOOL_FLAG(true), NONE(),
   Gettext.gettext("Prefer tearing variables with start value for initialization."));
 constant ConfigFlag EQUATIONS_PER_FILE = CONFIG_FLAG(98, "equationsPerFile",
-  NONE(), EXTERNAL(), INT_FLAG(2000), NONE(),
+  NONE(), EXTERNAL(), INT_FLAG(500), NONE(),
   Gettext.gettext("Generate code for at most this many equations per C-file (partially implemented in the compiler)."));
 constant ConfigFlag EVALUATE_FINAL_PARAMS = CONFIG_FLAG(99, "evaluateFinalParameters",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),


### PR DESCRIPTION
### Purpose

the split 06_inz and 08_bnd files are often too large with the default of 2000 equations, so the parallel C compilation phase has a long queue with only 2-3 files being compiled in parallel, even on CPUs that have many more cores.

This PR reduces the default max number of equations by a factor four, allowing a more fine-grained parallel compilation of the C source code files.
