### PR TITLE
do not add OMSens to cmake list as it does not have cmake support yet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,8 @@ if(OM_ENABLE_GUI_CLIENTS)
   omc_add_subdirectory(OMSens_Qt)
 endif()
 
-omc_add_subdirectory(OMSens)
+## do not add OMSens to cmake list as it does not have cmake support yet
+## omc_add_subdirectory(OMSens)
 omc_add_subdirectory(libraries)
 omc_add_subdirectory(testsuite)
 


### PR DESCRIPTION
### Purpose

Do not add OMSens to cmake list as it does not have cmake support yet
