### PR TITLE
[OMNotebook] show asterisk (*) in file name when changing LatexCell

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.cpp
@@ -272,7 +272,12 @@ namespace IAEX {
     }
   }
 
- void LatexCell::createLatexCell()
+  void LatexCell::addToHighlighter()
+  {
+    emit textChanged(true);
+  }
+
+  void LatexCell::createLatexCell()
   {
 
     input_ = new MyTextEdit3( mainWidget() );
@@ -299,7 +304,7 @@ namespace IAEX {
     connect( input_, SIGNAL( wheelMove(QWheelEvent*) ), this, SLOT( wheelEvent(QWheelEvent*) ));
     connect( input_, SIGNAL( eval() ), this, SLOT( eval() ));
 
-    //connect( input_, SIGNAL( textChanged() ), this, SLOT( addToHighlighter() ));
+    connect( input_, SIGNAL( textChanged() ), this, SLOT( addToHighlighter() ));
     connect( input_, SIGNAL( currentCharFormatChanged(const QTextCharFormat &) ),
        this, SLOT( charFormatChanged(const QTextCharFormat &) ));
     connect( input_, SIGNAL( forwardAction(int) ), this, SIGNAL( forwardAction(int) ));
@@ -328,10 +333,12 @@ namespace IAEX {
     output_->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
     output_->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
     connect( output_, SIGNAL( textChanged() ), this, SLOT(contentChanged()));
+    connect( output_, SIGNAL( textChanged() ), this, SLOT( addToHighlighter() ));
     connect( output_, SIGNAL( clickOnCell() ), this, SLOT( clickEventOutput() ));
     connect( output_, SIGNAL( wheelMove(QWheelEvent*) ), this, SLOT( wheelEvent(QWheelEvent*) ));
     connect(output_, SIGNAL(forwardAction(int)), this, SIGNAL(forwardAction(int)));
     connect(output_, SIGNAL(textChanged()), output_, SLOT(setModified()));
+    connect(output_, SIGNAL( eval() ), this, SLOT( eval() ));
 
     setOutputStyle();
 
@@ -992,6 +999,7 @@ void LatexCell::eval(bool silent)
     }
     input_->blockSignals(false);
     output_->blockSignals(false);
+    emit textChanged(true);
 }
 
 

--- a/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/latexcell.h
@@ -107,6 +107,7 @@ namespace IAEX
     void clear();
 
   private slots:
+    void addToHighlighter();
     void charFormatChanged(const QTextCharFormat &);
 
   private:


### PR DESCRIPTION
### Related Issues

Fixes Issue #4174 

### Approach

Correctly detect changes to input and output part of the cell.
Also accepts SHIFT+ENTER for evaluation of cell when LaTeX source is edited in output part (after first evaluation).

