### PR TITLE
Silence MetaModelica string warnings from GCC

### DIFF
--- a/OMCompiler/Compiler/CMakeLists.txt
+++ b/OMCompiler/Compiler/CMakeLists.txt
@@ -224,6 +224,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Ap
   target_compile_options(OpenModelicaCompiler PRIVATE -Wno-parentheses-equality)
 endif()
 
+# Silence GCC warnings about invalid reads of MetaModelica strings.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(OpenModelicaCompiler PRIVATE -Wno-stringop-overread)
+endif()
+
 # There is a lonely omc_file.h in Util/. It belongs in runtime/. Remove this when it is moved.
 target_include_directories(OpenModelicaCompiler PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Util)
 

--- a/OMCompiler/Compiler/boot/CMakeLists.txt
+++ b/OMCompiler/Compiler/boot/CMakeLists.txt
@@ -45,6 +45,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Ap
   target_compile_options(bomc PRIVATE -Wno-parentheses-equality)
 endif()
 
+# Silence GCC warnings about invalid reads of MetaModelica strings.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(bomc PRIVATE -Wno-stringop-overread)
+endif()
+
 # OMC will overflow the stack (at least on Windows old OMDev) on very deep recursive calls.
 # E.g., try translating the CodegenCpp* tpl files to mo files with
 # an omc compiled without large stack size. The tpl parser is quite recursive and will


### PR DESCRIPTION
- Disable the `stringop-overread` warnings from GCC in the CMake build caused by the way MetaModelica implements strings.