### PR TITLE
Fix compiler warnings

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_common_header.h
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_common_header.h
@@ -43,6 +43,8 @@
 #ifndef _OMC_OCL_COMMON_HEADER
 #define _OMC_OCL_COMMON_HEADER
 
+#define CL_TARGET_OPENCL_VERSION 120
+
 #include <stdio.h>
 #ifdef __APPLE__
 #include <OpenCL/cl.h>
@@ -52,8 +54,6 @@
 #include <openmodelica.h>
 #include <stdarg.h>
 #include <sys/time.h>
-
-
 
 #define MAX_DEVICE 4
 #define SHOW_DEVICE_SELECTION

--- a/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotWindow.cpp
@@ -64,7 +64,7 @@ PlotWindow::PlotWindow(QStringList arguments, QWidget *parent, bool isInteractiv
 {
   /* set the widget background white. so that the plot is more useable in books and publications. */
   QPalette p(palette());
-  p.setColor(QPalette::Background, Qt::white);
+  p.setColor(QPalette::Window, Qt::white);
   setAutoFillBackground(true);
   setPalette(p);
   // setup the main window widget


### PR DESCRIPTION
- Define OpenCL version in ParModelica to get rid of warnings about deprecated functions.
- Use QPalette::Window instead of deprecated QPalette::Background.