### PR TITLE
[NB] consider name nodes dummy variables

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -219,6 +219,7 @@ public
       local
         Pointer<Variable> varPointer;
       case ComponentRef.CREF(node = InstNode.VAR_NODE(varPointer = varPointer)) then varPointer;
+      case ComponentRef.CREF(node = InstNode.NAME_NODE())                       then Pointer.create(DUMMY_VARIABLE);
       else algorithm
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed for " + ComponentRef.toString(cref) +
         ", because of wrong InstNode (not VAR_NODE). Show lowering errors with -d=failtrace."});

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -898,6 +898,7 @@ uniontype InstNode
     component := match node
       case COMPONENT_NODE() then Pointer.access(node.component);
       case VAR_NODE()       then Component.WILD();
+      case NAME_NODE()      then Component.WILD();
     end match;
   end component;
 


### PR DESCRIPTION
 - some name nodes remain after lowering (e.g. reduction fold expressions) skip them by considering them as dummy variables