### PR TITLE
Skip record field names with `--obfuscate=protected`

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -753,21 +753,32 @@ public
   function obfuscateCref
     input output ComponentRef cref;
     input ObfuscationMap obfuscationMap;
+    output Boolean insideRecord = false;
   protected
     Option<String> name;
+    ComponentRef rest_cref;
   algorithm
     () := match cref
       case ComponentRef.CREF()
         algorithm
-          name := UnorderedMap.get(cref.node, obfuscationMap);
+          (rest_cref, insideRecord) := obfuscateCref(cref.restCref, obfuscationMap);
+          cref.restCref := rest_cref;
 
-          if isSome(name) then
-            cref.node := InstNode.rename(Util.getOption(name), cref.node);
+          // Only obfuscate variables that do not belong to a record instance,
+          // record field names need to be kept to keep them consistent with the
+          // record constructors.
+          if not insideRecord then
+            name := UnorderedMap.get(cref.node, obfuscationMap);
+
+            if isSome(name) then
+              cref.node := InstNode.rename(Util.getOption(name), cref.node);
+            end if;
           end if;
+
+          insideRecord := InstNode.isRecord(cref.node);
 
           cref.subscripts := list(Subscript.mapShallowExp(s,
             function obfuscateExp(obfuscationMap = obfuscationMap)) for s in cref.subscripts);
-          cref.restCref := obfuscateCref(cref.restCref, obfuscationMap);
         then
           ();
 

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -78,6 +78,7 @@ Obfuscation1.mos \
 Obfuscation2.mos \
 Obfuscation3.mos \
 Obfuscation4.mos \
+Obfuscation5.mos \
 ProtectedHandlingBug2917.mos \
 ReadOnlyPkg.mos \
 refactorGraphAnn1.mos \

--- a/testsuite/openmodelica/interactive-API/Obfuscation5.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation5.mos
@@ -1,0 +1,46 @@
+// name: Obfuscation5
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+setCommandLineOptions("--obfuscate=protected");
+loadString("
+   record R
+    Real x;
+    Real y;
+  end R;
+
+  model M
+    R r1;
+  protected
+    R r2;
+  equation
+    r1 = R(1, 2);
+    r2 = R(3, 4);
+  end M;
+");
+
+instantiateModel(M); getErrorString();
+
+// Result:
+// true
+// true
+// "function R \"Automatically generated record constructor for R\"
+//   input Real x;
+//   input Real y;
+//   output R res;
+// end R;
+//
+// class M
+//   Real r1.x;
+//   Real r1.y;
+//   protected Real n1.x;
+//   protected Real n1.y;
+// equation
+//   r1 = R(1.0, 2.0);
+//   n1 = R(3.0, 4.0);
+// end M;
+// "
+// ""
+// endResult


### PR DESCRIPTION
- Don't obfuscate record field names when `--obfuscate=protected` is used, since doing so causes the names to be inconsistent with the names in the record constructors/types.

Fixes #11994