### PR TITLE
Change __OpenModelica_tearingSelect to use enum

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1129,36 +1129,91 @@ algorithm
   end matchcontinue;
 end simplifySubscript;
 
-
 public function setTearingSelectAttribute
-  "Returns the expression of the __OpenModelica_tearingSelect annotation"
-  input Option<SCode.Comment> comment;
-  output Option<BackendDAE.TearingSelect> ts;
+  "__OpenModelica_tearingSelect is an annotation and has to be extracted from the comment."
+  input Option<SCode.Comment> optComment;
+  output Option<BackendDAE.TearingSelect> tearingSelect = NONE();
 protected
-  SCode.Annotation ann;
+  Option<SCode.Annotation> opt_anno;
+  SCode.Annotation anno;
+  SCode.Mod mod;
+  Option<Absyn.Exp> opt_val;
   Absyn.Exp val;
+  String name;
+  SourceInfo info;
 algorithm
-  try
-    SOME(SCode.COMMENT(annotation_=SOME(ann))) := comment;
-    try
-      SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "__OpenModelica_tearingSelect");
-    else
-      SOME(val) := SCodeUtil.lookupAnnotationBinding(ann, "tearingSelect");
-      Error.addCompilerWarning("Deprecated vendor annotation 'tearingSelect' found. Use '__OpenModelica_tearingSelect' instead.");
-    end try;
-    ts := match AbsynUtil.crefIdent(AbsynUtil.expCref(val))
-      case "always"   then SOME(BackendDAE.ALWAYS());
-      case "prefer"   then SOME(BackendDAE.PREFER());
-      case "avoid"    then SOME(BackendDAE.AVOID());
-      case "never"    then SOME(BackendDAE.NEVER());
-      case "default"  then SOME(BackendDAE.DEFAULT());
-      else NONE();
-    end match;
-  else
-    ts := NONE();
-  end try;
+  opt_anno := SCodeUtil.optCommentAnnotation(optComment);
+
+  if isNone(opt_anno) then
+    // No annotation.
+    return;
+  end if;
+
+  SOME(anno) := opt_anno;
+  mod := SCodeUtil.lookupAnnotation(anno, "__OpenModelica_tearingSelect");
+
+  if SCodeUtil.isEmptyMod(mod) then
+    mod := SCodeUtil.lookupAnnotation(anno, "tearingSelect");
+
+    if not SCodeUtil.isEmptyMod(mod) then
+      Error.addSourceMessage(Error.DEPRECATED_EXPRESSION,
+        {"tearingSelect", "__OpenModelica_tearingSelect"}, SCodeUtil.getModifierInfo(mod));
+    end if;
+  end if;
+
+  opt_val := SCodeUtil.getModifierBinding(mod);
+
+  if isNone(opt_val) then
+    // Annotation exists but has no value.
+    return;
+  end if;
+
+  SOME(val) := opt_val;
+  info := SCodeUtil.getModifierInfo(mod);
+  name := getTearingSelectName(val, info);
+  tearingSelect := lookupTearingSelectMember(name);
+
+  if isNone(tearingSelect) then
+    Error.addSourceMessage(Error.UNKNOWN_ANNOTATION_VALUE, {Dump.printExpStr(val)}, info);
+  end if;
 end setTearingSelectAttribute;
 
+protected function getTearingSelectName
+  input Absyn.Exp exp;
+  input SourceInfo info;
+  output String name;
+algorithm
+  name := match exp
+    // TearingSelect.name
+    case Absyn.Exp.CREF(componentRef =
+           Absyn.ComponentRef.CREF_QUAL(name = "TearingSelect", subscripts = {}, componentRef =
+             Absyn.ComponentRef.CREF_IDENT(name = name, subscripts = {})))
+      then name;
+
+    // Single name without the TearingSelect prefix is deprecated but still accepted.
+    case Absyn.Exp.CREF(componentRef = Absyn.ComponentRef.CREF_IDENT(name = name, subscripts = {}))
+      algorithm
+        Error.addSourceMessage(Error.DEPRECATED_EXPRESSION, {name, "TearingSelect." + name}, info);
+      then
+        name;
+
+    else "";
+  end match;
+end getTearingSelectName;
+
+protected function lookupTearingSelectMember
+  input String name;
+  output Option<BackendDAE.TearingSelect> tearingSelect;
+algorithm
+  tearingSelect := match name
+    case "never"    then SOME(BackendDAE.TearingSelect.NEVER());
+    case "avoid"    then SOME(BackendDAE.TearingSelect.AVOID());
+    case "default"  then SOME(BackendDAE.TearingSelect.DEFAULT());
+    case "prefer"   then SOME(BackendDAE.TearingSelect.PREFER());
+    case "always"   then SOME(BackendDAE.TearingSelect.ALWAYS());
+    else NONE();
+  end match;
+end lookupTearingSelectMember;
 
 public function setHideResultAttribute
   "Returns the expression of the hideResult annotation.

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -917,7 +917,7 @@ algorithm
     case (tvar::rest,{})
       equation
         if listMember(tvar,tSel_never) then
-          Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+          Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
         end if;
         if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("\nForced selection of Tearing Variable:\n" + UNDERLINE + "\n");
@@ -1017,7 +1017,7 @@ algorithm
         false = listEmpty(unsolvables);
         tvar = listHead(unsolvables);
         if listMember(tvar,tSel_never) then
-          Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+          Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
         end if;
         if Flags.isSet(Flags.TEARING_DUMP) or Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("\nForced selection of Tearing Variable:\n" + UNDERLINE + "\n");
@@ -1063,12 +1063,12 @@ algorithm
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Points after 'discriminateDiscrete':\n" + stringDelimitList(List.map(arrayList(points),intString),",") + "\n\n");
         end if;
-        // 4th: Prefer variables with annotation attribute '__OpenModelica_tearingSelect = prefer'
+        // 4th: Prefer variables with annotation attribute // '__OpenModelica_tearingSelect = TearingSelect.prefer'
         pointsLst = preferAvoidVariables(freeVars, arrayList(points), tSel_prefer, 3.0);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Points after preferring variables with attribute 'prefer':\n" + stringDelimitList(List.map(pointsLst,intString),",") + "\n\n");
         end if;
-        // 5th: Avoid variables with annotation attribute '__OpenModelica_tearingSelect = avoid'
+        // 5th: Avoid variables with annotation attribute // '__OpenModelica_tearingSelect = TearingSelect.avoid'
         pointsLst = preferAvoidVariables(freeVars, pointsLst, tSel_avoid, 0.334);
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("Points after discrimination against variables with attribute 'avoid':\n" + stringDelimitList(List.map(pointsLst,intString),",") + "\n\n");
@@ -1079,7 +1079,7 @@ algorithm
         if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
           print("tVar: " + intString(tvar) + " (" + intString(listGet(pointsLst,tvar)) + " points)\n\n");
         elseif listMember(tvar,tSel_avoid) then
-          Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+          Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
         end if;
       then
         tvar;
@@ -1728,7 +1728,7 @@ try
   unsolvedDiscreteVars := findDiscreteWarnTearingSelect(var_lst);
   // print("All discrete Vars: " + stringDelimitList(List.map(unsolvedDiscreteVars,intString),",") + "\n");
 
-  // also find $cse vars and try to make them inner vars since they have implicit '__OpenModelica_tearingSelect = never'
+  // also find $cse vars and try to make them inner vars since they have implicit '__OpenModelica_tearingSelect = TearingSelect.never'
   unsolvedCSEVars := findCSE(var_lst);
   // print("All CSE Vars: " + stringDelimitList(List.map(unsolvedCSEVars,intString),",") + "\n");
 
@@ -2375,11 +2375,11 @@ algorithm
 
       _ := match(var.tearingSelectOption)
         case SOME(BackendDAE.ALWAYS()) algorithm
-          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: "
+          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring '__OpenModelica_tearingSelect = TearingSelect.always' annotation for discrete variable: "
             + BackendDump.varString(var)},ElementSource.getInfo(var.source));
         then ();
         case SOME(BackendDAE.PREFER()) algorithm
-          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: "
+          Error.addSourceMessage(Error.COMPILER_WARNING,{"Minimal Tearing is ignoring '__OpenModelica_tearingSelect = TearingSelect.prefer' annotation for discrete variable: "
             + BackendDump.varString(var)},ElementSource.getInfo(var.source));
         then ();
         else ();
@@ -2476,7 +2476,7 @@ algorithm
     list<Integer> tvars,unsolvables,tVar_never,tVar_discrete,order;
     Boolean causal;
 
-  // case: There are no unsolvables and no variables with annotation '__OpenModelica_tearingSelect = always'
+  // case: There are no unsolvables and no variables with annotation '__OpenModelica_tearingSelect = TearingSelect.always'
   case ({},{})
     equation
       // select tearing Var
@@ -2538,7 +2538,7 @@ algorithm
    then
      (tvars,order);
 
-  // case: There are unsolvables and/or variables with annotation '__OpenModelica_tearingSelect = always'
+  // case: There are unsolvables and/or variables with annotation '__OpenModelica_tearingSelect = TearingSelect.always'
   else
     equation
       // First choose unsolvables and 'always'-vars as tVars
@@ -2546,7 +2546,7 @@ algorithm
       tVar_never = List.intersectionOnTrue(tSel_never,tvars,intEq);
       tVar_discrete = List.intersectionOnTrue(discreteVars,tvars,intEq);
       if not listEmpty(tVar_never) then
-        Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+        Error.addCompilerWarning("There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.never'. Use -d=tearingdump and -d=tearingdumpV for more information.");
       end if;
       if not listEmpty(tVar_discrete) then
         Error.addCompilerWarning("There are discrete tearing variables because otherwise the system could not have been torn (unsolvables). This may lead to problems during simulation.");
@@ -2653,7 +2653,7 @@ algorithm
   end try;
 
   if listMember(OutTVar,tSel_avoid) then
-    Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
+    Error.addCompilerWarning("The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.");
   end if;
   if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
     print("\nEND of TearingHeuristic\n" + BORDER + "\n\n");
@@ -3154,10 +3154,10 @@ algorithm
 
   // 3. Remove variables we don't want as tearing variables
   // ******************************************************
-  // Remove variables with attribute '__OpenModelica_tearingSelect = never'
+  // Remove variables with attribute '__OpenModelica_tearingSelect = TearingSelect.never'
   (_,potentialTVars,_) := List.intersection1OnTrue(potentialTVars,tSel_never,intEq);
   if listEmpty(potentialTVars) then
-    Error.addCompilerError("It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = never'.");
+    Error.addCompilerError("It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = TearingSelect.never'.");
     return;
   end if;
 
@@ -3201,7 +3201,7 @@ algorithm
   end if;
   if debug then execStat("TEARINGHEURISTIC4_3"); end if;
 
-  // 4.4 Prefer variables with annotation attribute '__OpenModelica_tearingSelect = prefer'
+  // 4.4 Prefer variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.prefer'
   if not listEmpty(tSel_prefer) then
     points := preferAvoidVariables(potentialTVars, points, tSel_prefer, 3.0);
     if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
@@ -3210,7 +3210,7 @@ algorithm
   end if;
   if debug then execStat("TEARINGHEURISTIC4_4"); end if;
 
-  // 4.5 Avoid variables with annotation attribute '__OpenModelica_tearingSelect = avoid'
+  // 4.5 Avoid variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'
   if not listEmpty(tSel_avoid) then
     points := preferAvoidVariables(potentialTVars, points, tSel_avoid, 0.334);
     if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then

--- a/OMCompiler/Compiler/FrontEnd/AnnotationsBuiltin_3_x.mo
+++ b/OMCompiler/Compiler/FrontEnd/AnnotationsBuiltin_3_x.mo
@@ -370,3 +370,5 @@ record Documentation
   String revisions = "" "Revision history";
   // Spec 3.5 Figure[:] figures = {}; "Simulation result figures";
 end Documentation;
+
+type TearingSelect = enumeration(never, avoid, default, prefer, always);

--- a/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/SCodeUtil.mo
@@ -3347,6 +3347,16 @@ algorithm
   end match;
 end hasBooleanNamedAnnotationInComponent;
 
+public function optCommentAnnotation
+  input Option<SCode.Comment> cmt;
+  output Option<SCode.Annotation> ann;
+algorithm
+  ann := match cmt
+    case SOME(SCode.COMMENT(annotation_ = ann)) then ann;
+    else NONE();
+  end match;
+end optCommentAnnotation;
+
 public function optCommentHasBooleanNamedAnnotation
 "check if the named annotation is present and has value true"
   input Option<SCode.Comment> comm;

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -893,6 +893,10 @@ public constant ErrorTypes.Message ELEMENT_REPLACEABLE_NOT_ALLOWED = ErrorTypes.
   Gettext.gettext("'%s' may not be replaceable."));
 public constant ErrorTypes.Message INVALID_NEGATIVE_POW = ErrorTypes.MESSAGE(409, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Invalid operation %s ^ %s, exponent must be an Integer when the base is negative."));
+public constant ErrorTypes.Message DEPRECATED_EXPRESSION = ErrorTypes.MESSAGE(411, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
+  Gettext.gettext("'%s' is deprecated, use '%s' instead."));
+public constant ErrorTypes.Message UNKNOWN_ANNOTATION_VALUE = ErrorTypes.MESSAGE(412, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
+  Gettext.gettext("Unknown value '%s' for annotation '%s'"));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop5.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop5.mos
@@ -9,8 +9,8 @@ getErrorString();
 loadString("
 model testAlgLoop5
   parameter Real one = 1;
-  Real t1(start=1, min = -0.4) annotation(__OpenModelica_tearingSelect = always);
-  Real t2(start=1,min=-2,max=1/2) annotation(__OpenModelica_tearingSelect = always);
+  Real t1(start=1, min = -0.4) annotation(__OpenModelica_tearingSelect = TearingSelect.always);
+  Real t2(start=1,min=-2,max=1/2) annotation(__OpenModelica_tearingSelect = TearingSelect.always);
   Real t3(start=5);
   Real t4(start=5, min=1, max=5);
   Real x(start=1,fixed=true,min=-3,max=3.0);
@@ -22,7 +22,7 @@ model testAlgLoop5
   input Real u3(min=-1,max=1, start=1);
   Real cost annotation(isLagrange = true);
   Real costM = sin(u*u1) annotation(isMayer = true);
-  Real dummyCon = one*con annotation(__OpenModelica_tearingSelect = always);
+  Real dummyCon = one*con annotation(__OpenModelica_tearingSelect = TearingSelect.always);
   Real con(min=1, start=1, max = 2.5) = 2*t3 + 3*t1 + t2 annotation(isConstraint=true);
   Real conDer(min=-2, start=1, max = 2) = der(x) annotation(isConstraint=true);
   Real fcon(min=0,max=0) = 10*der(x) annotation(isFinalConstraint = true);

--- a/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
+++ b/testsuite/openmodelica/cruntime/optimization/basic/testAlgLoop6.mos
@@ -12,14 +12,14 @@ model testAlgLoop6
   Real y2(start = 0,min=-1,max=1);
   Real y3(start = 0,min=-0.3,max=0.3);
   Real x1(start=1,min=0);
-  Real x2(start=1,min=-1,max=1) annotation(__OpenModelica_tearingSelect = always);
+  Real x2(start=1,min=-1,max=1) annotation(__OpenModelica_tearingSelect = TearingSelect.always);
   input Real u(min=-1,max=1,start=0);
   input Real u1(min=-1,max=1,start=0);
   input Real u2(min=-5,max=5,start=0);
   input Real u3(min=-1,max=1,start=1);
   Real cost annotation(isLagrange = true);
   Real con(min=-0.9,max=0.9,start=1) = y1 + u;
-  Real conDer(min=-1,max=1) = der(y1) annotation(__OpenModelica_tearingSelect = always);
+  Real conDer(min=-1,max=1) = der(y1) annotation(__OpenModelica_tearingSelect = TearingSelect.always);
 equation
   sin(der(y1)) = con;
   der(y2) = asin(con);

--- a/testsuite/openmodelica/dataReconciliation/Makefile
+++ b/testsuite/openmodelica/dataReconciliation/Makefile
@@ -27,7 +27,6 @@ FourFlows.mos\
 TSP_Pipe.mos\
 TSP_Pipe1.mos\
 TSP_Pipe2.mos\
-TSP_Pipe3.mos\
 TSP_Pipe4.mos\
 TSP_Pipe7.mos\
 TSP_Pipe8.mos\
@@ -59,6 +58,7 @@ TSP_FourFlows11.mos\
 TSP_Pipe6.mos\
 TSP_Pipe5.mos\
 TSP_FourFlows10.mos\
+TSP_Pipe3.mos\
 
 
 # Dependency files that are not .mo .mos or Makefile

--- a/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
+++ b/testsuite/openmodelica/dataReconciliation/TSP_Pipe3.mos
@@ -36,138 +36,138 @@ getErrorString();
 // 3: singularPressureLoss3.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 4: singularPressureLoss3.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 5: singularPressureLoss3.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 6: singularPressureLoss3.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 7: singularPressureLoss3.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 8: singularPressureLoss3.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 9: singularPressureLoss3.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 10: singularPressureLoss3.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 6: singularPressureLoss3.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 7: singularPressureLoss3.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 8: singularPressureLoss3.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 9: singularPressureLoss3.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 10: singularPressureLoss3.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 11: singularPressureLoss3.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 12: singularPressureLoss3.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 13: singularPressureLoss3.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 14: singularPressureLoss3.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 15: singularPressureLoss3.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 16: singularPressureLoss3.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 17: singularPressureLoss3.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 18: singularPressureLoss3.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 19: singularPressureLoss3.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 16: singularPressureLoss3.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 17: singularPressureLoss3.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 18: singularPressureLoss3.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 19: singularPressureLoss3.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 20: singularPressureLoss3.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 21: singularPressureLoss3.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 22: singularPressureLoss3.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 23: singularPressureLoss3.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 23: singularPressureLoss3.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 24: singularPressureLoss3.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 25: singularPressureLoss3.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 26: singularPressureLoss3.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 25: singularPressureLoss3.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 26: singularPressureLoss3.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 27: singularPressureLoss3.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 28: singularPressureLoss3.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 29: singularPressureLoss3.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 29: singularPressureLoss3.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 30: singularPressureLoss3.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 31: singularPressureLoss3.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 32: singularPressureLoss3.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 33: singularPressureLoss3.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 34: singularPressureLoss3.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 31: singularPressureLoss3.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 32: singularPressureLoss3.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 33: singularPressureLoss3.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 34: singularPressureLoss3.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 35: singularPressureLoss3.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 36: singularPressureLoss3.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 37: singularPressureLoss3.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 38: singularPressureLoss3.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 38: singularPressureLoss3.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 39: singularPressureLoss2.pro_pT.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 40: singularPressureLoss2.pro_pT.duTp:VARIABLE(unit = "J/(kg.K)" )  "Derivative of the inner energy wrt. temperature at constant pressure" type: Real
 // 41: singularPressureLoss2.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 42: singularPressureLoss2.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 43: singularPressureLoss2.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 44: singularPressureLoss2.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 45: singularPressureLoss2.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 46: singularPressureLoss2.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 47: singularPressureLoss2.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 48: singularPressureLoss2.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 44: singularPressureLoss2.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 45: singularPressureLoss2.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 46: singularPressureLoss2.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 47: singularPressureLoss2.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 48: singularPressureLoss2.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 49: singularPressureLoss2.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 50: singularPressureLoss2.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 51: singularPressureLoss2.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 52: singularPressureLoss2.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 53: singularPressureLoss2.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 54: singularPressureLoss2.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 55: singularPressureLoss2.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 56: singularPressureLoss2.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 57: singularPressureLoss2.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 54: singularPressureLoss2.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 55: singularPressureLoss2.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 56: singularPressureLoss2.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 57: singularPressureLoss2.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 58: singularPressureLoss2.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 59: singularPressureLoss2.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 60: singularPressureLoss2.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 61: singularPressureLoss2.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 61: singularPressureLoss2.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 62: singularPressureLoss2.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 63: singularPressureLoss2.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 64: singularPressureLoss2.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 63: singularPressureLoss2.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 64: singularPressureLoss2.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 65: singularPressureLoss2.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 66: singularPressureLoss2.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 67: singularPressureLoss2.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 67: singularPressureLoss2.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 68: singularPressureLoss2.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 69: singularPressureLoss2.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 70: singularPressureLoss2.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 71: singularPressureLoss2.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 72: singularPressureLoss2.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 69: singularPressureLoss2.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 70: singularPressureLoss2.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 71: singularPressureLoss2.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 72: singularPressureLoss2.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 73: singularPressureLoss2.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 74: singularPressureLoss2.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 75: singularPressureLoss2.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 76: singularPressureLoss2.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 76: singularPressureLoss2.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 77: singularPressureLoss1.pro_pT.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 78: singularPressureLoss1.pro_pT.duTp:VARIABLE(unit = "J/(kg.K)" )  "Derivative of the inner energy wrt. temperature at constant pressure" type: Real
 // 79: singularPressureLoss1.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 80: singularPressureLoss1.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 81: singularPressureLoss1.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 82: singularPressureLoss1.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 83: singularPressureLoss1.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 84: singularPressureLoss1.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 85: singularPressureLoss1.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 86: singularPressureLoss1.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 82: singularPressureLoss1.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 83: singularPressureLoss1.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 84: singularPressureLoss1.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 85: singularPressureLoss1.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 86: singularPressureLoss1.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 87: singularPressureLoss1.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 88: singularPressureLoss1.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 89: singularPressureLoss1.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 90: singularPressureLoss1.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 91: singularPressureLoss1.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 92: singularPressureLoss1.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 93: singularPressureLoss1.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 94: singularPressureLoss1.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 95: singularPressureLoss1.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 92: singularPressureLoss1.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 93: singularPressureLoss1.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 94: singularPressureLoss1.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 95: singularPressureLoss1.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 96: singularPressureLoss1.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 97: singularPressureLoss1.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 98: singularPressureLoss1.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 99: singularPressureLoss1.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 99: singularPressureLoss1.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 100: singularPressureLoss1.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 101: singularPressureLoss1.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 102: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 101: singularPressureLoss1.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 102: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 103: singularPressureLoss1.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 104: singularPressureLoss1.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 105: singularPressureLoss1.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 105: singularPressureLoss1.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 106: singularPressureLoss1.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 107: singularPressureLoss1.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 108: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 109: singularPressureLoss1.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 110: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 107: singularPressureLoss1.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 108: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 109: singularPressureLoss1.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 110: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 111: singularPressureLoss1.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 112: singularPressureLoss1.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 113: singularPressureLoss1.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 114: singularPressureLoss1.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 114: singularPressureLoss1.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 115: sink1.C.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 116: sink1.C.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 117: sink1.C.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 117: sink1.C.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 118: sink1.C.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 119: sink1.C.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 120: sink1.C.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 119: sink1.C.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 120: sink1.C.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 121: sink1.ISpecificEnthalpy.signal:VARIABLE(flow=false )  type: Real
 // 122: sink1.h:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy" type: Real
 // 123: sink1.Q:VARIABLE(unit = "kg/s" )  "Mass flow rate" type: Real
-// 124: sink1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure" type: Real
+// 124: sink1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure" type: Real
 // 125: sourcePQ1.C.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 126: sourcePQ1.C.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 127: sourcePQ1.C.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 127: sourcePQ1.C.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 128: sourcePQ1.C.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 129: sourcePQ1.C.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 130: sourcePQ1.C.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 129: sourcePQ1.C.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 130: sourcePQ1.C.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 131: sourcePQ1.ISpecificEnthalpy.signal:VARIABLE(flow=false )  type: Real
 // 132: sourcePQ1.IPressure.signal:VARIABLE(flow=false )  type: Real
 // 133: sourcePQ1.IMassFlow.signal:VARIABLE(flow=false )  type: Real
 // 134: sourcePQ1.h:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy" type: Real
 // 135: sourcePQ1.Q:VARIABLE(unit = "kg/s" )  "Mass flow rate" type: Real
-// 136: sourcePQ1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure" type: Real
-// 137: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
+// 136: sourcePQ1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure" type: Real
+// 137: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
 // 138: sourcePQ1.Q0:VARIABLE(unit = "kg/s" )  "Mass flow (active if IMassFlow connector is not connected)" type: Real
 // 139: sourcePQ1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
 // 140: sink1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
@@ -175,10 +175,10 @@ getErrorString();
 //
 // OrderedEquation (113, 140)
 // ========================================
-// 1/1 (1): sourcePQ1.P0 = 300000.0   [binding |0|0|0|0|]
+// 1/1 (1): sourcePQ1.P0 = 3e5   [binding |0|0|0|0|]
 // 2/2 (1): sourcePQ1.Q0 = 100.0   [binding |0|0|0|0|]
-// 3/3 (1): sourcePQ1.h0 = 100000.0   [binding |0|0|0|0|]
-// 4/4 (1): sink1.h0 = 100000.0   [binding |0|0|0|0|]
+// 3/3 (1): sourcePQ1.h0 = 1e5   [binding |0|0|0|0|]
+// 4/4 (1): sink1.h0 = 1e5   [binding |0|0|0|0|]
 // 5/5 (1): sourcePQ1.C.P = singularPressureLoss1.C1.P   [dynamic |0|0|0|0|]
 // 6/6 (1): sourcePQ1.C.Q = singularPressureLoss1.C1.Q   [dynamic |0|0|0|0|]
 // 7/7 (1): sourcePQ1.C.a = singularPressureLoss1.C1.a   [dynamic |0|0|0|0|]
@@ -436,10 +436,10 @@ getErrorString();
 // Standard BLT of the original model:(140)
 // ============================================================
 //
-// 140: sink1.h0: (4/4): (1): sink1.h0 = 100000.0
-// 139: sourcePQ1.h0: (3/3): (1): sourcePQ1.h0 = 100000.0
+// 140: sink1.h0: (4/4): (1): sink1.h0 = 1e5
+// 139: sourcePQ1.h0: (3/3): (1): sourcePQ1.h0 = 1e5
 // 138: sourcePQ1.Q0: (2/2): (1): sourcePQ1.Q0 = 100.0
-// 137: sourcePQ1.P0: (1/1): (1): sourcePQ1.P0 = 300000.0
+// 137: sourcePQ1.P0: (1/1): (1): sourcePQ1.P0 = 3e5
 // 136: sourcePQ1.P: (35/35): (1): sourcePQ1.P = sourcePQ1.IPressure.signal
 // 135: sourcePQ1.Q: (33/33): (1): sourcePQ1.Q = sourcePQ1.IMassFlow.signal
 // 134: sourcePQ1.h: (37/37): (1): sourcePQ1.h = sourcePQ1.ISpecificEnthalpy.signal
@@ -590,7 +590,7 @@ getErrorString();
 //
 // Boundary conditions (4)
 // ========================================
-// 1: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
+// 1: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
 // 2: sourcePQ1.Q0:VARIABLE(unit = "kg/s" )  "Mass flow (active if IMassFlow connector is not connected)" type: Real
 // 3: sourcePQ1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
 // 4: sink1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
@@ -607,10 +607,10 @@ getErrorString();
 // 104: singularPressureLoss1.C1.a: (108/135): (1): singularPressureLoss1.C1.a = true
 // 116: sink1.C.a: (107/134): (1): sink1.C.a = true
 // 125: sourcePQ1.C.b: (106/133): (1): sourcePQ1.C.b = true
-// 140: sink1.h0: (4/4): (1): sink1.h0 = 100000.0
-// 139: sourcePQ1.h0: (3/3): (1): sourcePQ1.h0 = 100000.0
+// 140: sink1.h0: (4/4): (1): sink1.h0 = 1e5
+// 139: sourcePQ1.h0: (3/3): (1): sourcePQ1.h0 = 1e5
 // 138: sourcePQ1.Q0: (2/2): (1): sourcePQ1.Q0 = 100.0
-// 137: sourcePQ1.P0: (1/1): (1): sourcePQ1.P0 = 300000.0
+// 137: sourcePQ1.P0: (1/1): (1): sourcePQ1.P0 = 3e5
 //
 //
 // E-BLT: equations that compute the variables of interest:(6)
@@ -703,138 +703,138 @@ getErrorString();
 // 3: singularPressureLoss3.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 4: singularPressureLoss3.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 5: singularPressureLoss3.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 6: singularPressureLoss3.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 7: singularPressureLoss3.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 8: singularPressureLoss3.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 9: singularPressureLoss3.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 10: singularPressureLoss3.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 6: singularPressureLoss3.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 7: singularPressureLoss3.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 8: singularPressureLoss3.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 9: singularPressureLoss3.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 10: singularPressureLoss3.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 11: singularPressureLoss3.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 12: singularPressureLoss3.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 13: singularPressureLoss3.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 14: singularPressureLoss3.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 15: singularPressureLoss3.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 16: singularPressureLoss3.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 17: singularPressureLoss3.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 18: singularPressureLoss3.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 19: singularPressureLoss3.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 16: singularPressureLoss3.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 17: singularPressureLoss3.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 18: singularPressureLoss3.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 19: singularPressureLoss3.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 20: singularPressureLoss3.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 21: singularPressureLoss3.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 22: singularPressureLoss3.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 23: singularPressureLoss3.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 23: singularPressureLoss3.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 24: singularPressureLoss3.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 25: singularPressureLoss3.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 26: singularPressureLoss3.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 25: singularPressureLoss3.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 26: singularPressureLoss3.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 27: singularPressureLoss3.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 28: singularPressureLoss3.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 29: singularPressureLoss3.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 29: singularPressureLoss3.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 30: singularPressureLoss3.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 31: singularPressureLoss3.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 32: singularPressureLoss3.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 33: singularPressureLoss3.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 34: singularPressureLoss3.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 31: singularPressureLoss3.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 32: singularPressureLoss3.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 33: singularPressureLoss3.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 34: singularPressureLoss3.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 35: singularPressureLoss3.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 36: singularPressureLoss3.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 37: singularPressureLoss3.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 38: singularPressureLoss3.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 38: singularPressureLoss3.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 39: singularPressureLoss2.pro_pT.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 40: singularPressureLoss2.pro_pT.duTp:VARIABLE(unit = "J/(kg.K)" )  "Derivative of the inner energy wrt. temperature at constant pressure" type: Real
 // 41: singularPressureLoss2.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 42: singularPressureLoss2.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 43: singularPressureLoss2.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 44: singularPressureLoss2.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 45: singularPressureLoss2.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 46: singularPressureLoss2.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 47: singularPressureLoss2.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 48: singularPressureLoss2.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 44: singularPressureLoss2.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 45: singularPressureLoss2.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 46: singularPressureLoss2.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 47: singularPressureLoss2.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 48: singularPressureLoss2.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 49: singularPressureLoss2.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 50: singularPressureLoss2.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 51: singularPressureLoss2.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 52: singularPressureLoss2.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 53: singularPressureLoss2.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 54: singularPressureLoss2.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 55: singularPressureLoss2.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 56: singularPressureLoss2.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 57: singularPressureLoss2.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 54: singularPressureLoss2.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 55: singularPressureLoss2.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 56: singularPressureLoss2.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 57: singularPressureLoss2.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 58: singularPressureLoss2.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 59: singularPressureLoss2.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 60: singularPressureLoss2.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 61: singularPressureLoss2.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 61: singularPressureLoss2.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 62: singularPressureLoss2.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 63: singularPressureLoss2.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 64: singularPressureLoss2.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 63: singularPressureLoss2.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 64: singularPressureLoss2.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 65: singularPressureLoss2.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 66: singularPressureLoss2.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 67: singularPressureLoss2.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 67: singularPressureLoss2.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 68: singularPressureLoss2.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 69: singularPressureLoss2.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 70: singularPressureLoss2.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 71: singularPressureLoss2.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 72: singularPressureLoss2.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 69: singularPressureLoss2.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 70: singularPressureLoss2.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 71: singularPressureLoss2.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 72: singularPressureLoss2.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 73: singularPressureLoss2.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 74: singularPressureLoss2.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 75: singularPressureLoss2.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 76: singularPressureLoss2.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 76: singularPressureLoss2.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 77: singularPressureLoss1.pro_pT.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 78: singularPressureLoss1.pro_pT.duTp:VARIABLE(unit = "J/(kg.K)" )  "Derivative of the inner energy wrt. temperature at constant pressure" type: Real
 // 79: singularPressureLoss1.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 80: singularPressureLoss1.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 81: singularPressureLoss1.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 82: singularPressureLoss1.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 83: singularPressureLoss1.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 84: singularPressureLoss1.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 85: singularPressureLoss1.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 86: singularPressureLoss1.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 82: singularPressureLoss1.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 83: singularPressureLoss1.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 84: singularPressureLoss1.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 85: singularPressureLoss1.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 86: singularPressureLoss1.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 87: singularPressureLoss1.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 88: singularPressureLoss1.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 89: singularPressureLoss1.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 90: singularPressureLoss1.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 91: singularPressureLoss1.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 92: singularPressureLoss1.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 93: singularPressureLoss1.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 94: singularPressureLoss1.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 95: singularPressureLoss1.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 92: singularPressureLoss1.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 93: singularPressureLoss1.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 94: singularPressureLoss1.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 95: singularPressureLoss1.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 96: singularPressureLoss1.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 97: singularPressureLoss1.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 98: singularPressureLoss1.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 99: singularPressureLoss1.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 99: singularPressureLoss1.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 100: singularPressureLoss1.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 101: singularPressureLoss1.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 102: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 101: singularPressureLoss1.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 102: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 103: singularPressureLoss1.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 104: singularPressureLoss1.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 105: singularPressureLoss1.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 105: singularPressureLoss1.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 106: singularPressureLoss1.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 107: singularPressureLoss1.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 108: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 109: singularPressureLoss1.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 110: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 107: singularPressureLoss1.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 108: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 109: singularPressureLoss1.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 110: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 111: singularPressureLoss1.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 112: singularPressureLoss1.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 113: singularPressureLoss1.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 114: singularPressureLoss1.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 114: singularPressureLoss1.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 115: sink1.C.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 116: sink1.C.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 117: sink1.C.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 117: sink1.C.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 118: sink1.C.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 119: sink1.C.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 120: sink1.C.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 119: sink1.C.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 120: sink1.C.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 121: sink1.ISpecificEnthalpy.signal:VARIABLE(flow=false )  type: Real
 // 122: sink1.h:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy" type: Real
 // 123: sink1.Q:VARIABLE(unit = "kg/s" )  "Mass flow rate" type: Real
-// 124: sink1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure" type: Real
+// 124: sink1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure" type: Real
 // 125: sourcePQ1.C.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 126: sourcePQ1.C.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 127: sourcePQ1.C.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 127: sourcePQ1.C.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 128: sourcePQ1.C.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 129: sourcePQ1.C.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 130: sourcePQ1.C.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 129: sourcePQ1.C.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 130: sourcePQ1.C.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 131: sourcePQ1.ISpecificEnthalpy.signal:VARIABLE(flow=false )  type: Real
 // 132: sourcePQ1.IPressure.signal:VARIABLE(flow=false )  type: Real
 // 133: sourcePQ1.IMassFlow.signal:VARIABLE(flow=false )  type: Real
 // 134: sourcePQ1.h:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy" type: Real
 // 135: sourcePQ1.Q:VARIABLE(unit = "kg/s" )  "Mass flow rate" type: Real
-// 136: sourcePQ1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure" type: Real
-// 137: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
+// 136: sourcePQ1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure" type: Real
+// 137: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
 // 138: sourcePQ1.Q0:VARIABLE(unit = "kg/s" )  "Mass flow (active if IMassFlow connector is not connected)" type: Real
 // 139: sourcePQ1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
 // 140: sink1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
@@ -844,10 +844,10 @@ getErrorString();
 // ========================================
 // 1/1 (1): singularPressureLoss3.T = 0.0   [binding |0|0|0|0|]
 // 2/2 (1): singularPressureLoss3.Q = 0.0   [binding |0|0|0|0|]
-// 3/3 (1): sourcePQ1.P0 = 300000.0   [binding |0|0|0|0|]
+// 3/3 (1): sourcePQ1.P0 = 3e5   [binding |0|0|0|0|]
 // 4/4 (1): sourcePQ1.Q0 = 100.0   [binding |0|0|0|0|]
-// 5/5 (1): sourcePQ1.h0 = 100000.0   [binding |0|0|0|0|]
-// 6/6 (1): sink1.h0 = 100000.0   [binding |0|0|0|0|]
+// 5/5 (1): sourcePQ1.h0 = 1e5   [binding |0|0|0|0|]
+// 6/6 (1): sink1.h0 = 1e5   [binding |0|0|0|0|]
 // 7/7 (1): sourcePQ1.C.P = singularPressureLoss1.C1.P   [dynamic |0|0|0|0|]
 // 8/8 (1): sourcePQ1.C.Q = singularPressureLoss1.C1.Q   [dynamic |0|0|0|0|]
 // 9/9 (1): sourcePQ1.C.a = singularPressureLoss1.C1.a   [dynamic |0|0|0|0|]
@@ -1103,10 +1103,10 @@ getErrorString();
 // Standard BLT of the original model:(140)
 // ============================================================
 //
-// 140: sink1.h0: (6/6): (1): sink1.h0 = 100000.0
-// 139: sourcePQ1.h0: (5/5): (1): sourcePQ1.h0 = 100000.0
+// 140: sink1.h0: (6/6): (1): sink1.h0 = 1e5
+// 139: sourcePQ1.h0: (5/5): (1): sourcePQ1.h0 = 1e5
 // 138: sourcePQ1.Q0: (4/4): (1): sourcePQ1.Q0 = 100.0
-// 137: sourcePQ1.P0: (3/3): (1): sourcePQ1.P0 = 300000.0
+// 137: sourcePQ1.P0: (3/3): (1): sourcePQ1.P0 = 3e5
 // 136: sourcePQ1.P: (31/31): (1): sourcePQ1.C.P = sourcePQ1.P
 // 135: sourcePQ1.Q: (32/32): (1): sourcePQ1.C.Q = sourcePQ1.Q
 // 134: sourcePQ1.h: (37/37): (1): sourcePQ1.h = sourcePQ1.ISpecificEnthalpy.signal
@@ -1257,7 +1257,7 @@ getErrorString();
 //
 // Boundary conditions (4)
 // ========================================
-// 1: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
+// 1: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
 // 2: sourcePQ1.Q0:VARIABLE(unit = "kg/s" )  "Mass flow (active if IMassFlow connector is not connected)" type: Real
 // 3: sourcePQ1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
 // 4: sink1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
@@ -1274,10 +1274,10 @@ getErrorString();
 // 104: singularPressureLoss1.C1.a: (108/135): (1): singularPressureLoss1.C1.a = true
 // 116: sink1.C.a: (107/134): (1): sink1.C.a = true
 // 125: sourcePQ1.C.b: (106/133): (1): sourcePQ1.C.b = true
-// 140: sink1.h0: (6/6): (1): sink1.h0 = 100000.0
-// 139: sourcePQ1.h0: (5/5): (1): sourcePQ1.h0 = 100000.0
+// 140: sink1.h0: (6/6): (1): sink1.h0 = 1e5
+// 139: sourcePQ1.h0: (5/5): (1): sourcePQ1.h0 = 1e5
 // 138: sourcePQ1.Q0: (4/4): (1): sourcePQ1.Q0 = 100.0
-// 137: sourcePQ1.P0: (3/3): (1): sourcePQ1.P0 = 300000.0
+// 137: sourcePQ1.P0: (3/3): (1): sourcePQ1.P0 = 3e5
 // 37: singularPressureLoss3.Q: (2/2): (1): singularPressureLoss3.Q = 0.0
 // 35: singularPressureLoss3.T: (1/1): (1): singularPressureLoss3.T = 0.0
 //
@@ -1380,138 +1380,138 @@ getErrorString();
 // 3: singularPressureLoss3.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 4: singularPressureLoss3.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 5: singularPressureLoss3.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 6: singularPressureLoss3.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 7: singularPressureLoss3.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 8: singularPressureLoss3.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 9: singularPressureLoss3.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 10: singularPressureLoss3.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 6: singularPressureLoss3.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 7: singularPressureLoss3.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 8: singularPressureLoss3.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 9: singularPressureLoss3.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 10: singularPressureLoss3.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 11: singularPressureLoss3.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 12: singularPressureLoss3.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 13: singularPressureLoss3.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 14: singularPressureLoss3.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 15: singularPressureLoss3.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 16: singularPressureLoss3.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 17: singularPressureLoss3.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 18: singularPressureLoss3.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 19: singularPressureLoss3.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 16: singularPressureLoss3.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 17: singularPressureLoss3.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 18: singularPressureLoss3.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 19: singularPressureLoss3.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 20: singularPressureLoss3.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 21: singularPressureLoss3.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 22: singularPressureLoss3.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 23: singularPressureLoss3.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 23: singularPressureLoss3.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 24: singularPressureLoss3.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 25: singularPressureLoss3.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 26: singularPressureLoss3.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 25: singularPressureLoss3.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 26: singularPressureLoss3.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 27: singularPressureLoss3.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 28: singularPressureLoss3.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 29: singularPressureLoss3.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 29: singularPressureLoss3.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 30: singularPressureLoss3.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 31: singularPressureLoss3.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 32: singularPressureLoss3.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 33: singularPressureLoss3.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 34: singularPressureLoss3.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 31: singularPressureLoss3.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 32: singularPressureLoss3.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 33: singularPressureLoss3.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 34: singularPressureLoss3.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 35: singularPressureLoss3.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 36: singularPressureLoss3.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 37: singularPressureLoss3.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 38: singularPressureLoss3.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 38: singularPressureLoss3.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 39: singularPressureLoss2.pro_pT.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 40: singularPressureLoss2.pro_pT.duTp:VARIABLE(unit = "J/(kg.K)" )  "Derivative of the inner energy wrt. temperature at constant pressure" type: Real
 // 41: singularPressureLoss2.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 42: singularPressureLoss2.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 43: singularPressureLoss2.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 44: singularPressureLoss2.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 45: singularPressureLoss2.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 46: singularPressureLoss2.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 47: singularPressureLoss2.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 48: singularPressureLoss2.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 44: singularPressureLoss2.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 45: singularPressureLoss2.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 46: singularPressureLoss2.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 47: singularPressureLoss2.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 48: singularPressureLoss2.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 49: singularPressureLoss2.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 50: singularPressureLoss2.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 51: singularPressureLoss2.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 52: singularPressureLoss2.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 53: singularPressureLoss2.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 54: singularPressureLoss2.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 55: singularPressureLoss2.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 56: singularPressureLoss2.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 57: singularPressureLoss2.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 54: singularPressureLoss2.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 55: singularPressureLoss2.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 56: singularPressureLoss2.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 57: singularPressureLoss2.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 58: singularPressureLoss2.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 59: singularPressureLoss2.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 60: singularPressureLoss2.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 61: singularPressureLoss2.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 61: singularPressureLoss2.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 62: singularPressureLoss2.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 63: singularPressureLoss2.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 64: singularPressureLoss2.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 63: singularPressureLoss2.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 64: singularPressureLoss2.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 65: singularPressureLoss2.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 66: singularPressureLoss2.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 67: singularPressureLoss2.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 67: singularPressureLoss2.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 68: singularPressureLoss2.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 69: singularPressureLoss2.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 70: singularPressureLoss2.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 71: singularPressureLoss2.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 72: singularPressureLoss2.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 69: singularPressureLoss2.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 70: singularPressureLoss2.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 71: singularPressureLoss2.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 72: singularPressureLoss2.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 73: singularPressureLoss2.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 74: singularPressureLoss2.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 75: singularPressureLoss2.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 76: singularPressureLoss2.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 76: singularPressureLoss2.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 77: singularPressureLoss1.pro_pT.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 78: singularPressureLoss1.pro_pT.duTp:VARIABLE(unit = "J/(kg.K)" )  "Derivative of the inner energy wrt. temperature at constant pressure" type: Real
 // 79: singularPressureLoss1.pro_pT.dupT:VARIABLE(unit = "J.m.s2/kg" )  "Derivative of the inner energy wrt. pressure at constant temperature" type: Real
 // 80: singularPressureLoss1.pro_pT.ddpT:VARIABLE(unit = "s2/m2" )  "Derivative of the density wrt. presure at constant temperature" type: Real
 // 81: singularPressureLoss1.pro_pT.ddTp:VARIABLE(unit = "kg/(m3.K)" )  "Derivative of the density wrt. temperature at constant pressure" type: Real
-// 82: singularPressureLoss1.pro_pT.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 83: singularPressureLoss1.pro_pT.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 84: singularPressureLoss1.pro_pT.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 85: singularPressureLoss1.pro_pT.h:VARIABLE(min = -1000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific enthalpy" type: Real
-// 86: singularPressureLoss1.pro_pT.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 82: singularPressureLoss1.pro_pT.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 83: singularPressureLoss1.pro_pT.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 84: singularPressureLoss1.pro_pT.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 85: singularPressureLoss1.pro_pT.h:VARIABLE(min = -1e6 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific enthalpy" type: Real
+// 86: singularPressureLoss1.pro_pT.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 87: singularPressureLoss1.pro_ph.x:VARIABLE(unit = "1" )  "Vapor mass fraction" type: Real
 // 88: singularPressureLoss1.pro_ph.duhp:VARIABLE(unit = "1" )  "Derivative of specific inner energy wrt. specific enthalpy at constant pressure" type: Real
 // 89: singularPressureLoss1.pro_ph.duph:VARIABLE(unit = "m3/kg" )  "Derivative of specific inner energy wrt. pressure at constant specific enthalpy" type: Real
 // 90: singularPressureLoss1.pro_ph.ddph:VARIABLE(unit = "s2/m2" )  "Derivative of density wrt. pressure at constant specific enthalpy" type: Real
 // 91: singularPressureLoss1.pro_ph.ddhp:VARIABLE(unit = "kg.s2/m5" )  "Derivative of density wrt. specific enthalpy at constant pressure" type: Real
-// 92: singularPressureLoss1.pro_ph.cp:VARIABLE(min = 1e-09 max = 9.999999999999999e+59 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
-// 93: singularPressureLoss1.pro_ph.s:VARIABLE(min = -1000000.0 max = 1000000.0 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
-// 94: singularPressureLoss1.pro_ph.u:VARIABLE(min = -100000000.0 max = 100000000.0 unit = "J/kg" nominal = 1000000.0 )  "Specific inner energy" type: Real
-// 95: singularPressureLoss1.pro_ph.d:VARIABLE(min = 1e-09 max = 100000.0 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
+// 92: singularPressureLoss1.pro_ph.cp:VARIABLE(min = 1e-9 max = 1e60 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific heat capacity at constant presure" type: Real
+// 93: singularPressureLoss1.pro_ph.s:VARIABLE(min = -1e6 max = 1e6 unit = "J/(kg.K)" nominal = 1000.0 )  "Specific entropy" type: Real
+// 94: singularPressureLoss1.pro_ph.u:VARIABLE(min = -1e8 max = 1e8 unit = "J/kg" nominal = 1e6 )  "Specific inner energy" type: Real
+// 95: singularPressureLoss1.pro_ph.d:VARIABLE(min = 1e-9 max = 1e5 unit = "kg/m3" nominal = 998.0 )  "Density" type: Real
 // 96: singularPressureLoss1.pro_ph.T:VARIABLE(min = 200.0 max = 6000.0 start = 288.15 unit = "K" nominal = 320.0 )  "Temperature" type: Real
 // 97: singularPressureLoss1.C2.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 98: singularPressureLoss1.C2.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 99: singularPressureLoss1.C2.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 99: singularPressureLoss1.C2.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 100: singularPressureLoss1.C2.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 101: singularPressureLoss1.C2.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 102: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 101: singularPressureLoss1.C2.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 102: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 103: singularPressureLoss1.C1.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 104: singularPressureLoss1.C1.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 105: singularPressureLoss1.C1.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 105: singularPressureLoss1.C1.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 106: singularPressureLoss1.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 107: singularPressureLoss1.C1.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 108: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 109: singularPressureLoss1.h:VARIABLE(start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
-// 110: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 107: singularPressureLoss1.C1.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 108: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 109: singularPressureLoss1.h:VARIABLE(start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy" type: Real
+// 110: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 // 111: singularPressureLoss1.T:VARIABLE(min = 0.0 start = 290.0 unit = "K" nominal = 300.0 uncertain=Uncertainty.refine)  "Fluid temperature" type: Real
 // 112: singularPressureLoss1.rho:VARIABLE(min = 0.0 start = 998.0 unit = "kg/m3" )  "Fluid density" type: Real
 // 113: singularPressureLoss1.Q:VARIABLE(start = 100.0 unit = "kg/s" uncertain=Uncertainty.refine)  "Mass flow rate" type: Real
-// 114: singularPressureLoss1.deltaP:VARIABLE(min = -1000000000.0 max = 1000000000.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Singular pressure loss" type: Real
+// 114: singularPressureLoss1.deltaP:VARIABLE(min = -1e9 max = 1e9 start = 1e5 unit = "Pa" nominal = 1e5 )  "Singular pressure loss" type: Real
 // 115: sink1.C.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 116: sink1.C.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 117: sink1.C.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 117: sink1.C.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 118: sink1.C.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 119: sink1.C.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 120: sink1.C.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 119: sink1.C.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 120: sink1.C.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 121: sink1.ISpecificEnthalpy.signal:VARIABLE(flow=false )  type: Real
 // 122: sink1.h:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy" type: Real
 // 123: sink1.Q:VARIABLE(unit = "kg/s" )  "Mass flow rate" type: Real
-// 124: sink1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure" type: Real
+// 124: sink1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure" type: Real
 // 125: sourcePQ1.C.b:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
 // 126: sourcePQ1.C.a:DISCRETE(flow=false )  "Pseudo-variable for the verification of the connection orientation" type: Boolean
-// 127: sourcePQ1.C.h:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
+// 127: sourcePQ1.C.h:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Specific enthalpy of the fluid crossing the boundary of the control volume" type: Real
 // 128: sourcePQ1.C.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 129: sourcePQ1.C.h_vol:VARIABLE(flow=false start = 100000.0 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
-// 130: sourcePQ1.C.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
+// 129: sourcePQ1.C.h_vol:VARIABLE(flow=false start = 1e5 unit = "J/kg" )  "Fluid specific enthalpy in the control volume" type: Real
+// 130: sourcePQ1.C.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
 // 131: sourcePQ1.ISpecificEnthalpy.signal:VARIABLE(flow=false )  type: Real
 // 132: sourcePQ1.IPressure.signal:VARIABLE(flow=false )  type: Real
 // 133: sourcePQ1.IMassFlow.signal:VARIABLE(flow=false )  type: Real
 // 134: sourcePQ1.h:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy" type: Real
 // 135: sourcePQ1.Q:VARIABLE(unit = "kg/s" )  "Mass flow rate" type: Real
-// 136: sourcePQ1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure" type: Real
-// 137: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
+// 136: sourcePQ1.P:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure" type: Real
+// 137: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
 // 138: sourcePQ1.Q0:VARIABLE(unit = "kg/s" )  "Mass flow (active if IMassFlow connector is not connected)" type: Real
 // 139: sourcePQ1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
 // 140: sink1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
@@ -1522,10 +1522,10 @@ getErrorString();
 // 1/1 (1): singularPressureLoss2.T = 0.0   [binding |0|0|0|0|]
 // 2/2 (1): singularPressureLoss3.T = 0.0   [binding |0|0|0|0|]
 // 3/3 (1): singularPressureLoss3.Q = 0.0   [binding |0|0|0|0|]
-// 4/4 (1): sourcePQ1.P0 = 300000.0   [binding |0|0|0|0|]
+// 4/4 (1): sourcePQ1.P0 = 3e5   [binding |0|0|0|0|]
 // 5/5 (1): sourcePQ1.Q0 = 100.0   [binding |0|0|0|0|]
-// 6/6 (1): sourcePQ1.h0 = 100000.0   [binding |0|0|0|0|]
-// 7/7 (1): sink1.h0 = 100000.0   [binding |0|0|0|0|]
+// 6/6 (1): sourcePQ1.h0 = 1e5   [binding |0|0|0|0|]
+// 7/7 (1): sink1.h0 = 1e5   [binding |0|0|0|0|]
 // 8/8 (1): sourcePQ1.C.P = singularPressureLoss1.C1.P   [dynamic |0|0|0|0|]
 // 9/9 (1): sourcePQ1.C.Q = singularPressureLoss1.C1.Q   [dynamic |0|0|0|0|]
 // 10/10 (1): sourcePQ1.C.a = singularPressureLoss1.C1.a   [dynamic |0|0|0|0|]
@@ -1780,10 +1780,10 @@ getErrorString();
 // Standard BLT of the original model:(140)
 // ============================================================
 //
-// 140: sink1.h0: (7/7): (1): sink1.h0 = 100000.0
-// 139: sourcePQ1.h0: (6/6): (1): sourcePQ1.h0 = 100000.0
+// 140: sink1.h0: (7/7): (1): sink1.h0 = 1e5
+// 139: sourcePQ1.h0: (6/6): (1): sourcePQ1.h0 = 1e5
 // 138: sourcePQ1.Q0: (5/5): (1): sourcePQ1.Q0 = 100.0
-// 137: sourcePQ1.P0: (4/4): (1): sourcePQ1.P0 = 300000.0
+// 137: sourcePQ1.P0: (4/4): (1): sourcePQ1.P0 = 3e5
 // 136: sourcePQ1.P: (32/32): (1): sourcePQ1.C.P = sourcePQ1.P
 // 135: sourcePQ1.Q: (33/33): (1): sourcePQ1.C.Q = sourcePQ1.Q
 // 134: sourcePQ1.h: (34/34): (1): sourcePQ1.C.h_vol = sourcePQ1.h
@@ -1934,7 +1934,7 @@ getErrorString();
 //
 // Boundary conditions (4)
 // ========================================
-// 1: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
+// 1: sourcePQ1.P0:VARIABLE(min = 0.0 unit = "Pa" nominal = 1e5 )  "Fluid pressure (active if IPressure connector is not connected)" type: Real
 // 2: sourcePQ1.Q0:VARIABLE(unit = "kg/s" )  "Mass flow (active if IMassFlow connector is not connected)" type: Real
 // 3: sourcePQ1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
 // 4: sink1.h0:VARIABLE(unit = "J/kg" )  "Fluid specific enthalpy (active if IEnthalpy connector is not connected)" type: Real
@@ -1951,10 +1951,10 @@ getErrorString();
 // 104: singularPressureLoss1.C1.a: (108/135): (1): singularPressureLoss1.C1.a = true
 // 116: sink1.C.a: (107/134): (1): sink1.C.a = true
 // 125: sourcePQ1.C.b: (106/133): (1): sourcePQ1.C.b = true
-// 140: sink1.h0: (7/7): (1): sink1.h0 = 100000.0
-// 139: sourcePQ1.h0: (6/6): (1): sourcePQ1.h0 = 100000.0
+// 140: sink1.h0: (7/7): (1): sink1.h0 = 1e5
+// 139: sourcePQ1.h0: (6/6): (1): sourcePQ1.h0 = 1e5
 // 138: sourcePQ1.Q0: (5/5): (1): sourcePQ1.Q0 = 100.0
-// 137: sourcePQ1.P0: (4/4): (1): sourcePQ1.P0 = 300000.0
+// 137: sourcePQ1.P0: (4/4): (1): sourcePQ1.P0 = 3e5
 // 37: singularPressureLoss3.Q: (3/3): (1): singularPressureLoss3.Q = 0.0
 // 35: singularPressureLoss3.T: (2/2): (1): singularPressureLoss3.T = 0.0
 // 73: singularPressureLoss2.T: (1/1): (1): singularPressureLoss2.T = 0.0
@@ -2169,13 +2169,13 @@ getErrorString();
 // ========================================
 // 1: singularPressureLoss3.mode:PARAM()  = 0  "IF97 region. 1:liquid - 2:steam - 4:saturation line - 0:automatic" type: Integer
 // 2: singularPressureLoss3.fluid:PARAM()  = 1  "1: water/steam - 2: C3H3F5" type: Integer
-// 3: singularPressureLoss3.K:PARAM()  = 0.0001  "Pressure loss coefficient" type: Real
+// 3: singularPressureLoss3.K:PARAM()  = 1e-4  "Pressure loss coefficient" type: Real
 // 4: singularPressureLoss2.mode:PARAM()  = 0  "IF97 region. 1:liquid - 2:steam - 4:saturation line - 0:automatic" type: Integer
 // 5: singularPressureLoss2.fluid:PARAM()  = 1  "1: water/steam - 2: C3H3F5" type: Integer
-// 6: singularPressureLoss2.K:PARAM()  = 0.0001  "Pressure loss coefficient" type: Real
+// 6: singularPressureLoss2.K:PARAM()  = 1e-4  "Pressure loss coefficient" type: Real
 // 7: singularPressureLoss1.mode:PARAM()  = 0  "IF97 region. 1:liquid - 2:steam - 4:saturation line - 0:automatic" type: Integer
 // 8: singularPressureLoss1.fluid:PARAM()  = 1  "1: water/steam - 2: C3H3F5" type: Integer
-// 9: singularPressureLoss1.K:PARAM()  = 0.0001  "Pressure loss coefficient" type: Real
+// 9: singularPressureLoss1.K:PARAM()  = 1e-4  "Pressure loss coefficient" type: Real
 //
 //
 //
@@ -2227,18 +2227,18 @@ getErrorString();
 // ========================================
 // 1: singularPressureLoss1.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
 // 2: singularPressureLoss2.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 3: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 4: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 5: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 3: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 4: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 5: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 //
 //
 // -SET_S has intermediate variables involved in SET_C:{106, 68, 102, 108, 110} (5)
 // ========================================
 // 1: singularPressureLoss1.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
 // 2: singularPressureLoss2.C1.Q:VARIABLE(flow=false start = 500.0 unit = "kg/s" )  "Mass flow rate of the fluid crossing the boundary of the control volume" type: Real
-// 3: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 4: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Fluid pressure in the control volume" type: Real
-// 5: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 100000.0 unit = "Pa" nominal = 100000.0 )  "Average fluid pressure" type: Real
+// 3: singularPressureLoss1.C2.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 4: singularPressureLoss1.C1.P:VARIABLE(flow=false min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Fluid pressure in the control volume" type: Real
+// 5: singularPressureLoss1.Pm:VARIABLE(min = 0.0 start = 1e5 unit = "Pa" nominal = 1e5 )  "Average fluid pressure" type: Real
 //
 // -Passed
 //
@@ -2251,7 +2251,7 @@ getErrorString();
 // The selection of a new tearing variable failed.
 // record SimulationResult
 //     resultFile = "",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'NewDataReconciliationSimpleTests.TSP_Pipe3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-reconcile -sx=./NewDataReconciliationSimpleTests/resources/DataReconciliationSimpleTests.TSP_Pipe3_Inputs.csv -eps=0.0023 -lv=LOG_JAC'",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'NewDataReconciliationSimpleTests.TSP_Pipe3', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = '-reconcile -sx=./NewDataReconciliationSimpleTests/resources/DataReconciliationSimpleTests.TSP_Pipe3_Inputs.csv -eps=0.0023 -lv=LOG_JAC'",
 //     messages = "Simulation execution failed for model: NewDataReconciliationSimpleTests.TSP_Pipe3
 // LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
@@ -2264,7 +2264,6 @@ getErrorString();
 // LOG_ASSERT        | debug   | Solving non-linear system 76 failed at time=1.
 // |                 | |       | For more information please use -lv LOG_NLS.
 // getBestJumpBuffer got simulationJumpBuffer=(nil)
-// Aborted (core dumped)
 // "
 // end SimulationResult;
 // "[openmodelica/dataReconciliation/NewDataReconciliationSimpleTests/SourcePQ.mo:29:3-30:52:writable] Warning: Connector C is not balanced: The number of potential variables (4) is not equal to the number of flow variables (0).
@@ -2282,7 +2281,7 @@ getErrorString();
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph.mo:76:3-76:60:writable] Warning: dh2satp was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph_der.mo:179:3-182:49:writable] Warning: du1satp_der was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
 // [ThermoSysPro 3.2.0/Properties/WaterSteamSimple/prop4_Ph_der.mo:179:3-182:49:writable] Warning: du2satp_der was used before it was defined (given a value). Additional such uses may exist for the variable, but some messages were suppressed.
-// Error: It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = never'.
+// Error: It is not possible to select a new tearing variable, because all remaining variables have the attribute '__OpenModelica_tearingSelect = TearingSelect.never'.
 // Warning: Function Tearing.selectTearingVar failed at least once. Use -d=tearingdump or -d=tearingdumpV for more information.
 // "
 // endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation10.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation10.mos
@@ -1,0 +1,43 @@
+// name: GetModelInstanceAnnotation3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    Real x annotation (__OpenModelica_tearingSelect=TearingSelect.default);
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"x\",
+//       \"type\": \"Real\",
+//       \"annotation\": {
+//         \"__OpenModelica_tearingSelect\": {
+//           \"$kind\": \"enum\",
+//           \"name\": \"TearingSelect.default\",
+//           \"index\": 3
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 4,
+//     \"columnEnd\": 8
+//   }
+// }"
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -11,6 +11,7 @@ GetModelInstanceAnnotation6.mos \
 GetModelInstanceAnnotation7.mos \
 GetModelInstanceAnnotation8.mos \
 GetModelInstanceAnnotation9.mos \
+GetModelInstanceAnnotation10.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \

--- a/testsuite/openmodelica/interactive-API/Obfuscation4.mos
+++ b/testsuite/openmodelica/interactive-API/Obfuscation4.mos
@@ -7,7 +7,7 @@
 setCommandLineOptions("--obfuscate=full --showAnnotations");
 loadString("
   model M
-    Real x annotation(__OpenModelica_tearingSelect = always);
+    Real x annotation(__OpenModelica_tearingSelect = TearingSelect.always);
   end M;
 ");
 
@@ -17,7 +17,7 @@ instantiateModel(M); getErrorString();
 // true
 // true
 // "class n0
-//   Real n1 annotation(__OpenModelica_tearingSelect = always);
+//   Real n1 annotation(__OpenModelica_tearingSelect = TearingSelect.always);
 // end n0;
 // "
 // ""

--- a/testsuite/simulation/modelica/commonSubExp/cse1.mos
+++ b/testsuite/simulation/modelica/commonSubExp/cse1.mos
@@ -252,11 +252,11 @@ simulate(Tearing15); getErrorString();
 // 1: $cse8 - cos(v6) - {}
 // record SimulationResult
 //     resultFile = "Tearing15_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'Tearing15', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Tearing15', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Warning: There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = never'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// "Warning: There are tearing variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.never'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // "
 // endResult

--- a/testsuite/simulation/modelica/tearing/MixedTearing2-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/MixedTearing2-minimal.mos
@@ -6,8 +6,8 @@
 loadString("
 model mixedTest2
   Real a(start=0);
-  Integer b annotation(__OpenModelica_tearingSelect = always);
-  Boolean c annotation(__OpenModelica_tearingSelect = prefer);
+  Integer b annotation(__OpenModelica_tearingSelect = TearingSelect.always);
+  Boolean c annotation(__OpenModelica_tearingSelect = TearingSelect.prefer);
 equation
   a = b * time;
   c = a > 0;
@@ -28,7 +28,7 @@ simulate(mixedTest2); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "mixedTest2_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'mixedTest2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'mixedTest2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
@@ -36,8 +36,8 @@ simulate(mixedTest2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 3
 //  * Number of variables: 3
-// [<interactive>:5:3-5:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE(fixed = false )  type: Boolean
-// [<interactive>:4:3-4:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE(fixed = false )  type: Integer
+// [<interactive>:5:3-5:76:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = TearingSelect.prefer' annotation for discrete variable: c:DISCRETE(fixed = false )  type: Boolean
+// [<interactive>:4:3-4:76:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = TearingSelect.always' annotation for discrete variable: b:DISCRETE(fixed = false )  type: Integer
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)
@@ -59,8 +59,8 @@ simulate(mixedTest2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,2)}
-// [<interactive>:4:3-4:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = always' annotation for discrete variable: b:DISCRETE()  type: Integer
-// [<interactive>:5:3-5:62:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = prefer' annotation for discrete variable: c:DISCRETE()  type: Boolean
+// [<interactive>:4:3-4:76:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = TearingSelect.always' annotation for discrete variable: b:DISCRETE()  type: Integer
+// [<interactive>:5:3-5:76:writable] Warning: Minimal Tearing is ignoring '__OpenModelica_tearingSelect = TearingSelect.prefer' annotation for discrete variable: c:DISCRETE()  type: Boolean
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-celMC3.mos
@@ -28,12 +28,14 @@ val(i3,0.0); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "tearingSelect_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'tearingSelect', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'tearingSelect', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
+// "[simulation/modelica/tearing/tearingSelect.mo:7:33-7:67:writable] Warning: 'avoid' is deprecated, use 'TearingSelect.avoid' instead.
+// [simulation/modelica/tearing/tearingSelect.mo:3:23-3:58:writable] Warning: 'prefer' is deprecated, use 'TearingSelect.prefer' instead.
+// Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
 // Notification: Model statistics after passing the back-end for initialization:

--- a/testsuite/simulation/modelica/tearing/tearingSelect-minimal.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-minimal.mos
@@ -28,12 +28,14 @@ val(i3,0.0); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "tearingSelect_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'tearingSelect', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'tearingSelect', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
+// "[simulation/modelica/tearing/tearingSelect.mo:7:33-7:67:writable] Warning: 'avoid' is deprecated, use 'TearingSelect.avoid' instead.
+// [simulation/modelica/tearing/tearingSelect.mo:3:23-3:58:writable] Warning: 'prefer' is deprecated, use 'TearingSelect.prefer' instead.
+// Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
 // Notification: Model statistics after passing the back-end for initialization:

--- a/testsuite/simulation/modelica/tearing/tearingSelect-omc.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect-omc.mos
@@ -28,12 +28,14 @@ val(i3,0.0); getErrorString();
 // ""
 // record SimulationResult
 //     resultFile = "tearingSelect_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'tearingSelect', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'tearingSelect', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
+// "[simulation/modelica/tearing/tearingSelect.mo:7:33-7:67:writable] Warning: 'avoid' is deprecated, use 'TearingSelect.avoid' instead.
+// [simulation/modelica/tearing/tearingSelect.mo:3:23-3:58:writable] Warning: 'prefer' is deprecated, use 'TearingSelect.prefer' instead.
+// Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 7
 //  * Number of variables: 7
 // Notification: Model statistics after passing the back-end for initialization:

--- a/testsuite/simulation/modelica/tearing/tearingSelect2-celMC3.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect2-celMC3.mos
@@ -29,7 +29,7 @@ simulate(tearingSelect2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 6
 //  * Number of variables: 6
-// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
@@ -52,7 +52,7 @@ simulate(tearingSelect2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,5)}
-// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/tearingSelect2-omc.mos
+++ b/testsuite/simulation/modelica/tearing/tearingSelect2-omc.mos
@@ -29,7 +29,7 @@ simulate(tearingSelect2); getErrorString();
 // "Notification: Model statistics after passing the front-end and creating the data structures used by the back-end:
 //  * Number of equations: 6
 //  * Number of variables: 6
-// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Warning: There are nonlinear iteration variables with default zero start attribute found in NLSJac0. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // Notification: Model statistics after passing the back-end for initialization:
 //  * Number of independent subsystems: 1
@@ -52,7 +52,7 @@ simulate(tearingSelect2); getErrorString();
 //  * Linear torn systems (#iteration vars, #inner vars, density): 0 systems
 //  * Non-linear torn systems (#iteration vars, #inner vars): 1 system
 //    {(1,5)}
-// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
+// Warning: The Tearing heuristic has chosen variables with annotation attribute '__OpenModelica_tearingSelect = TearingSelect.avoid'. Use -d=tearingdump and -d=tearingdumpV for more information.
 // Notification: Model statistics after passing the back-end for simulation:
 //  * Number of independent subsystems: 1
 //  * Number of states: 0 ('-d=stateselection' for list of states)

--- a/testsuite/simulation/modelica/tearing/tearingSelect2.mo
+++ b/testsuite/simulation/modelica/tearing/tearingSelect2.mo
@@ -1,5 +1,5 @@
 model tearingSelect2
-   Real x1 annotation(__OpenModelica_tearingSelect = avoid);
+   Real x1 annotation(__OpenModelica_tearingSelect = TearingSelect.avoid);
    Real x2;
    Real x3;
    Real x4;


### PR DESCRIPTION
- Add `TearingSelect` enumeration type to the annotation environment.
- Change `__OpenModelica_tearingSelect` to also accept `TearingSelect` values in addition to the existing identifiers such as `always`.
- Give a deprecation warning when using the old identifiers with `__OpenModelica_tearingSelect`.

Fixes #11949