### PR TITLE
Fixing getCMakeVersion on Windows

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15826,7 +15826,7 @@ algorithm
   // regex \d doesn't work on Linux, using [0-9] instead
   (numMatches, regexOut) := System.regex(
     System.trimWhitespace(System.readFile(cmakeVersionLogFile)),
-    "[0-9]+\\.[0-9]+\\.[0-9]+]",
+    "[0-9]+\\.[0-9]+\\.[0-9]+",
     maxMatches=1,
     extended=true
   );


### PR DESCRIPTION
### Related Issues

Fixes #12013.

### Purpose

Fix piping issue in function `SimCodeUtil.getCMakeVersion`.

### Approach

  - Use System.regex instead of piping a string and then using system regex.
  - Fixes issue with wrong Flags.FMU_RUNTIME_DEPENDS value
