### PR TITLE
use startTime defined in <DefaultExperiment> tag in modeldescription.xml

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -190,7 +190,8 @@ end translateModel;
     extern void <%symbolName(modelNamePrefixStr,"function_initSynchronous")%>(DATA * data, threadData_t *threadData);
     extern void <%symbolName(modelNamePrefixStr,"function_updateSynchronous")%>(DATA * data, threadData_t *threadData, long base_idx);
     extern int <%symbolName(modelNamePrefixStr,"function_equationsSynchronous")%>(DATA * data, threadData_t *threadData, long base_idx, long sub_idx);
-    extern void <%symbolName(modelNamePrefixStr,"read_input_fmu")%>(MODEL_DATA* modelData, SIMULATION_INFO* simulationData);
+    extern void <%symbolName(modelNamePrefixStr,"read_simulation_info")%>(SIMULATION_INFO* simulationData);
+    extern void <%symbolName(modelNamePrefixStr,"read_input_fmu")%>(MODEL_DATA* modelData);
     extern void <%symbolName(modelNamePrefixStr,"function_savePreSynchronous")%>(DATA *data, threadData_t *threadData);
     extern int <%symbolName(modelNamePrefixStr,"inputNames")%>(DATA* data, char ** names);
     extern int <%symbolName(modelNamePrefixStr,"dataReconciliationInputNames")%>(DATA* data, char ** names);
@@ -1333,6 +1334,7 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
        <%symbolName(modelNamePrefixStr,"inputNames")%>,
        <%symbolName(modelNamePrefixStr,"dataReconciliationInputNames")%>,
        <%symbolName(modelNamePrefixStr,"dataReconciliationUnmeasuredVariables")%>,
+       <% if isModelExchangeFMU then symbolName(modelNamePrefixStr,"read_simulation_info") else "NULL" %>,
        <% if isModelExchangeFMU then symbolName(modelNamePrefixStr,"read_input_fmu") else "NULL" %>,
        <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"initialAnalyticJacobianFMIDER") else "NULL" else "NULL" %>,
        <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"functionJacFMIDER_column") else "NULL" else "NULL" %>,

--- a/OMCompiler/Compiler/Template/CodegenFMU.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMU.tpl
@@ -3203,7 +3203,8 @@ case SIMCODE(modelInfo = MODELINFO(functions = functions, varInfo = vi as VARINF
   #include "simulation_data.h"
 
   OMC_DISABLE_OPT<%/* This function is very simple and doesn't need to be optimized. GCC/clang spend way too much time looking at it. */%>
-  void <%symbolName(modelNamePrefix(simCode),"read_input_fmu")%>(MODEL_DATA* modelData, SIMULATION_INFO* simulationInfo)
+
+  void <%symbolName(modelNamePrefix(simCode),"read_simulation_info")%>(SIMULATION_INFO* simulationInfo)
   {
     simulationInfo->startTime = <%s.startTime%>;
     simulationInfo->stopTime = <%s.stopTime%>;
@@ -3213,6 +3214,10 @@ case SIMCODE(modelInfo = MODELINFO(functions = functions, varInfo = vi as VARINF
     simulationInfo->outputFormat = "<%s.outputFormat%>";
     simulationInfo->variableFilter = "<%s.variableFilter%>";
     simulationInfo->OPENMODELICAHOME = "<%makefileParams.omhome%>";
+  }
+
+  void <%symbolName(modelNamePrefix(simCode),"read_input_fmu")%>(MODEL_DATA* modelData)
+  {
     <%System.tmpTickReset(1000)%>
     <%System.tmpTickResetIndex(0,2)%>
     <%vars.stateVars       |> var => ScalarVariableFMU(var,"realVarsData") ;separator="\n";empty%>

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -357,9 +357,14 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   int (*dataReconciliationUnmeasuredVariables)(DATA* modelData, char ** names);
 
   /*
+  * FMU's have simulation settings in <DefaultExperiment> and we need to read those settings during instantiation
+  */
+  void (*read_simulation_info)(SIMULATION_INFO* simulationSettings);
+
+  /*
   * FMU's do not need the XML-file; they use this callback instead.
   */
-  void (*read_input_fmu)(MODEL_DATA* modelData, SIMULATION_INFO* simulationData);
+  void (*read_input_fmu)(MODEL_DATA* modelData);
 
   /*
   * FMU continuous partial derivative functions

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/model_help.c
@@ -1008,7 +1008,11 @@ void initializeDataStruc(DATA *data, threadData_t *threadData)
   for(i=0; i<SIZERINGBUFFER; i++)
   {
     /* set time value */
-    tmpSimData.timeValue = 0;
+    /*
+    * fix issue #11855, always take the startTime provided in modeldescription.xml
+    * to handle models that have startTime > 0 (e.g) startTime = 0.2
+    */
+    tmpSimData.timeValue = data->simulationInfo->startTime;
     /* buffer for all variable values */
     tmpSimData.realVars = (modelica_real*) calloc(data->modelData->nVariablesReal, sizeof(modelica_real));
     assertStreamPrint(threadData, 0 == data->modelData->nVariablesReal || 0 != tmpSimData.realVars, "out of memory");

--- a/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
+++ b/OMCompiler/SimulationRuntime/fmi/export/openmodelica/fmu2_model_interface.c.inc
@@ -626,13 +626,19 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
   useStream[LOG_STDOUT] = 1;
   useStream[LOG_ASSERT] = 1;
   fmu2_model_interface_setupDataStruc(comp->fmuData, comp->threadData);
+  /*
+   * load the simulation settings before initializing the DataStruct for fmus
+   * fix issue #11855, always take the startTime provided in modeldescription.xml
+   * to handle model that have startTime > 0 (e.g) startTime = 0.2
+   */
+  comp->fmuData->callback->read_simulation_info(comp->fmuData->simulationInfo);
   initializeDataStruc(comp->fmuData, comp->threadData);
 
   /* setup model data with default start data */
   setDefaultStartValues(comp);
   setAllParamsToStart(comp->fmuData);
   setAllVarsToStart(comp->fmuData);
-  comp->fmuData->callback->read_input_fmu(comp->fmuData->modelData, comp->fmuData->simulationInfo);
+  comp->fmuData->callback->read_input_fmu(comp->fmuData->modelData);
 
 #if !defined(OMC_MINIMAL_METADATA)
   modelInfoInit(&(comp->fmuData->modelData->modelDataXml));
@@ -986,13 +992,14 @@ fmi2Status fmi2Reset(fmi2Component c)
   useStream[LOG_STDOUT] = 1;
   useStream[LOG_ASSERT] = 1;
   fmu2_model_interface_setupDataStruc(comp->fmuData, comp->threadData);
+  comp->fmuData->callback->read_simulation_info(comp->fmuData->simulationInfo);
   initializeDataStruc(comp->fmuData, comp->threadData);
 
   /* reset model data with default start data */
   setDefaultStartValues(comp);
   setAllParamsToStart(comp->fmuData);
   setAllVarsToStart(comp->fmuData);
-  comp->fmuData->callback->read_input_fmu(comp->fmuData->modelData, comp->fmuData->simulationInfo);
+  comp->fmuData->callback->read_input_fmu(comp->fmuData->modelData);
 #if !defined(OMC_MINIMAL_METADATA)
   modelInfoInit(&(comp->fmuData->modelData->modelDataXml));
 #endif

--- a/testsuite/omsimulator/Makefile
+++ b/testsuite/omsimulator/Makefile
@@ -8,6 +8,7 @@ DualMassOscillator.mos \
 enumeration.mos \
 enumeration2.mos \
 enumeration3.mos \
+experimentAnnotation.mos \
 fmi_interpolate_cs.mos \
 fmiBlackBox.mos \
 fmiProtected.mos \

--- a/testsuite/omsimulator/experimentAnnotation.mos
+++ b/testsuite/omsimulator/experimentAnnotation.mos
@@ -1,0 +1,33 @@
+// keywords: fmu export import
+// status: correct
+// teardown_command: rm -rf M.lua M.fmu M.log M_systemCall.log/
+
+loadString("model M
+  Real x = time;
+  parameter Real x0(fixed = false);
+initial equation
+  x0 = x;
+equation
+  annotation(experiment(StartTime = 0.2, StopTime = 1.0, Interval = 1e-2));
+end M;"); getErrorString();
+
+buildModelFMU(M, version="2.0", fmuType="me_cs", platforms={"static"}); getErrorString();
+
+system(getInstallationDirectoryPath() + "/bin/OMSimulator M.fmu -r=experiment_annotation.mat", "M_systemCall.log");
+readFile("M_systemCall.log");
+
+val(x, 1.0, "experiment_annotation.mat");
+val(x0, 1.0, "experiment_annotation.mat");
+
+// Result:
+// true
+// ""
+// "M.fmu"
+// ""
+// 0
+// "info:    model doesn't contain any continuous state
+// info:    Result file: experiment_annotation.mat (bufferSize=1)
+// "
+// 1.0
+// 0.2
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11855
https://github.com/OpenModelica/OpenModelica/issues/11802

### Purpose

This PR uses the `startTime` defined in `modeldescription.xml to Instantiate the fmu`,  It is possible that model has different startTime > 0 and we should always instantiate the fmus with the startTime provided in the `DefaultExperiment`  tag.
