### PR TITLE
OMCompiler: Relocatable compilation tools

### DIFF
--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3509,8 +3509,8 @@ algorithm
   fmuSourceDir := fmutmp+"/sources/";
   quote := "'";
   dquote := if isWindows then "\"" else "'";
-  CC := "-DCMAKE_C_COMPILER=" + dquote + makefileParams.ccompiler + dquote;
-  CXX := "-DCMAKE_CXX_COMPILER=" + dquote + makefileParams.cxxcompiler + dquote;
+  CC := "-DCMAKE_C_COMPILER=" + dquote + System.basename(makefileParams.ccompiler) + dquote;
+  CXX := "-DCMAKE_CXX_COMPILER=" + dquote + System.basename(makefileParams.cxxcompiler) + dquote;
   defaultFmiIncludeDirectoy := dquote + Settings.getInstallationDirectoryPath() + "/include/omc/c/fmi" + dquote;
 
   // Set build type

--- a/OMCompiler/Compiler/Util/Autoconf.mo.in
+++ b/OMCompiler/Compiler/Util/Autoconf.mo.in
@@ -9,7 +9,7 @@ encapsulated package Autoconf
   constant String platform = if isWindows and is64Bit then "WIN64" elseif isWindows then "WIN32" else "Unix";
 
   constant String make = "@OMC_MAKE_EXE@";
-  constant String cmake = "\"@OMC_CMAKE_EXE@\"";
+  constant String cmake = "cmake";
 
   constant String exeExt = if isWindows then ".exe" else "";
   constant String dllExt = "@SHREXT@";


### PR DESCRIPTION
### Related Issues

The location of compilation tools (cmake & gcc) for fmu export might not be the same when OM is compiled on a different machine than the one on which it will be used (eg conda packages built from conda-forge automatic builders),
and in that case the export can fail (the _build_env directory only existed on the build machine):
```
Error: Error building simulator. Build log: cmd: cd 'deviation.fmutmp/sources/' && mkdir build_cmake_dynamic && cd build_cmake_dynamic && \"/home/conda/feedstock_root/build_artifacts/omcompiler_1709022273479/_build_env/bin/cmake\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER='/home/runner/miniconda3/envs/test/bin/x86_64-conda-linux-gnu-cc' -DCMAKE_CXX_COMPILER='/home/conda/feedstock_root/build_artifacts/omcompiler_1709022273479/_build_env/bin/x86_64-conda-linux-gnu-c++' .. && \"/home/conda/feedstock_root/build_artifacts/omcompiler_1709022273479/_build_env/bin/cmake\" --build . --parallel  --target install && cd .. && rm -rf build_cmake_dynamic
/bin/sh: 1: /home/conda/feedstock_root/build_artifacts/omcompiler_1709022273479/_build_env/bin/cmake: not found
```

### Purpose

Allow for usable fmu export on conda-forge

### Approach

I patched OM to drop absolute paths (and rely on PATH)
xref https://github.com/conda-forge/omcompiler-feedstock/blob/main/recipe/meta.yaml