### PR TITLE
Use full path instead of relative in instance API

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1202,7 +1202,7 @@ end dumpJSONInstanceAnnotationExtends;
 
 function dumpJSONNodePath
   input InstNode node;
-  output JSON json = dumpJSONPath(InstNode.scopePath(node, ignoreBaseClass = true));
+  output JSON json = dumpJSONPath(InstNode.fullPath(node, ignoreBaseClass = true));
 end dumpJSONNodePath;
 
 function dumpJSONNodeEnclosingPath

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation6.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation6.mos
@@ -33,7 +33,7 @@ getModelInstance(M, prettyPrint=true);
 //       \"$kind\": \"component\",
 //       \"name\": \"rotatingRect\",
 //       \"type\": {
-//         \"name\": \"RotatingRect\",
+//         \"name\": \"M.RotatingRect\",
 //         \"restriction\": \"model\",
 //         \"annotation\": {
 //           \"Icon\": {
@@ -115,7 +115,7 @@ getModelInstance(M, prettyPrint=true);
 //             \"$kind\": \"component\",
 //             \"name\": \"to_deg\",
 //             \"type\": {
-//               \"name\": \"To_deg\",
+//               \"name\": \"M.To_deg\",
 //               \"restriction\": \"block\",
 //               \"elements\": [
 //                 {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation8.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation8.mos
@@ -81,7 +81,7 @@ getErrorString();
 //             \"$kind\": \"component\",
 //             \"name\": \"c\",
 //             \"type\": {
-//               \"name\": \"C\",
+//               \"name\": \"M.C\",
 //               \"restriction\": \"model\",
 //               \"prefixes\": {
 //                 \"replaceable\": {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes1.mos
@@ -37,7 +37,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"component\",
 //       \"name\": \"deg\",
 //       \"type\": {
-//         \"name\": \"Angle\",
+//         \"name\": \"M.Angle\",
 //         \"restriction\": \"type\",
 //         \"elements\": [
 //           {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAttributes2.mos
@@ -1,4 +1,4 @@
-// name: GetModelInstanceAttributes1
+// name: GetModelInstanceAttributes2
 // keywords:
 // status: correct
 // cflags: -d=newInst

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection4.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection4.mos
@@ -45,7 +45,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"component\",
 //       \"name\": \"c1\",
 //       \"type\": {
-//         \"name\": \"C\",
+//         \"name\": \"M.C\",
 //         \"restriction\": \"connector\",
 //         \"elements\": [
 //           {
@@ -75,7 +75,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"component\",
 //       \"name\": \"c2\",
 //       \"type\": {
-//         \"name\": \"C\",
+//         \"name\": \"M.C\",
 //         \"restriction\": \"connector\",
 //         \"elements\": [
 //           {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceConnection5.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceConnection5.mos
@@ -45,7 +45,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"component\",
 //       \"name\": \"c1\",
 //       \"type\": {
-//         \"name\": \"C\",
+//         \"name\": \"M.C\",
 //         \"restriction\": \"connector\",
 //         \"elements\": [
 //           {
@@ -83,7 +83,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"component\",
 //       \"name\": \"c2\",
 //       \"type\": {
-//         \"name\": \"C\",
+//         \"name\": \"M.C\",
 //         \"restriction\": \"connector\",
 //         \"elements\": [
 //           {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDerived3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDerived3.mos
@@ -25,7 +25,7 @@ getModelInstance(M, prettyPrint = true); getErrorString();
 //       \"$kind\": \"component\",
 //       \"name\": \"T_ref\",
 //       \"type\": {
-//         \"name\": \"Temperature\",
+//         \"name\": \"M.Temperature\",
 //         \"restriction\": \"type\",
 //         \"elements\": [
 //           {
@@ -34,7 +34,7 @@ getModelInstance(M, prettyPrint = true); getErrorString();
 //               \"start\": \"1\"
 //             },
 //             \"baseClass\": {
-//               \"name\": \"ThermodynamicTemperature\",
+//               \"name\": \"M.ThermodynamicTemperature\",
 //               \"restriction\": \"type\",
 //               \"elements\": [
 //                 {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceEnum2.mos
@@ -25,13 +25,13 @@ getModelInstance(M, prettyPrint=true);
 //       \"$kind\": \"component\",
 //       \"name\": \"e\",
 //       \"type\": {
-//         \"name\": \"E2\",
+//         \"name\": \"M.E2\",
 //         \"restriction\": \"type\",
 //         \"elements\": [
 //           {
 //             \"$kind\": \"extends\",
 //             \"baseClass\": {
-//               \"name\": \"E1\",
+//               \"name\": \"M.E1\",
 //               \"restriction\": \"type\",
 //               \"elements\": [
 //                 {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable1.mos
@@ -56,7 +56,7 @@ getModelInstance(M, prettyPrint = true);
 //       \"$kind\": \"component\",
 //       \"name\": \"m\",
 //       \"type\": {
-//         \"name\": \"M\",
+//         \"name\": \"M.M\",
 //         \"restriction\": \"model\",
 //         \"prefixes\": {
 //           \"replaceable\": true

--- a/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceReplaceable3.mos
@@ -74,7 +74,7 @@ getModelInstance(M, prettyPrint = true);
 //             \"$kind\": \"component\",
 //             \"name\": \"b\",
 //             \"type\": {
-//               \"name\": \"B\",
+//               \"name\": \"M.B\",
 //               \"restriction\": \"model\",
 //               \"prefixes\": {
 //                 \"redeclare\": true
@@ -83,7 +83,7 @@ getModelInstance(M, prettyPrint = true);
 //                 {
 //                   \"$kind\": \"extends\",
 //                   \"baseClass\": {
-//                     \"name\": \"MB\",
+//                     \"name\": \"M.MB\",
 //                     \"restriction\": \"model\",
 //                     \"elements\": [
 //                       {

--- a/testsuite/openmodelica/instance-API/GetModelInstanceStateMachine1.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceStateMachine1.mos
@@ -53,7 +53,7 @@ getModelInstance(M, prettyPrint=true);
 //       \"$kind\": \"component\",
 //       \"name\": \"state1\",
 //       \"type\": {
-//         \"name\": \"State1\",
+//         \"name\": \"M.State1\",
 //         \"restriction\": \"model\",
 //         \"elements\": [
 //           {
@@ -81,7 +81,7 @@ getModelInstance(M, prettyPrint=true);
 //       \"$kind\": \"component\",
 //       \"name\": \"state2\",
 //       \"type\": {
-//         \"name\": \"State2\",
+//         \"name\": \"M.State2\",
 //         \"restriction\": \"model\",
 //         \"source\": {
 //           \"filename\": \"<interactive>\",


### PR DESCRIPTION
- Use the fully qualified path when dumping paths with the instance API instead of the path relative to the root class.