### PR TITLE
Improve copyClass API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2714,7 +2714,7 @@ function copyClass
 "Copies a class within the same level"
  input TypeName className "the class that should be copied";
  input String newClassName "the name for new class";
- input TypeName withIn = $TypeName(TopLevel) "the with in path for new class";
+ input TypeName withIn = $TypeName(__OpenModelica_TopLevel) "the with in path for new class";
  output Boolean result;
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2967,7 +2967,7 @@ function copyClass
 "Copies a class within the same level"
  input TypeName className "the class that should be copied";
  input String newClassName "the name for new class";
- input TypeName withIn = $TypeName(TopLevel) "the with in path for new class";
+ input TypeName withIn = $TypeName(__OpenModelica_TopLevel) "the with in path for new class";
  output Boolean result;
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1502,7 +1502,7 @@ algorithm
 
     case ("moveClassToBottom", _) then Values.BOOL(false);
 
-    case ("copyClass",{Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(name), Values.CODE(Absyn.C_TYPENAME(Absyn.IDENT("TopLevel")))})
+    case ("copyClass",{Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(name), Values.CODE(Absyn.C_TYPENAME(Absyn.IDENT("__OpenModelica_TopLevel")))})
       equation
         p = SymbolTable.getAbsyn();
         absynClass = InteractiveUtil.getPathedClassInProgram(classpath, p);
@@ -5083,8 +5083,12 @@ algorithm
 
   end match;
 
+  // Update the paths in the class to reflect the new location.
+  cls := NFApi.updateMovedClassPaths(inClass, inClassPath, inWithin);
+
   // Replace the filename of each element with the new path.
-  cls := moveClassInfo(inClass, dst_path);
+  cls := moveClassInfo(cls, dst_path);
+
   // Change the name of the class and put it in as a copy in the program.
   cls := AbsynUtil.setClassName(cls, inName);
   outProg := InteractiveUtil.updateProgram(Absyn.PROGRAM({cls}, inWithin), inProg);

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -3214,7 +3214,7 @@ bool OMCProxy::exportToFigaro(QString className, QString directory, QString data
  */
 bool OMCProxy::copyClass(QString className, QString newClassName, QString withIn)
 {
-  bool result = mpOMCInterface->copyClass(className, newClassName, withIn.isEmpty() ? "TopLevel" : withIn);
+  bool result = mpOMCInterface->copyClass(className, newClassName, withIn.isEmpty() ? "__OpenModelica_TopLevel" : withIn);
   if (!result) printMessagesStringInternal();
   return result;
 }

--- a/testsuite/openmodelica/interactive-API/CopyClass.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClass.mos
@@ -1,7 +1,7 @@
 // name:      CopyClass
 // keywords:  copyClass
 // status:    correct
-// cflags: -d=-newInst
+// cflags: -d=newInst
 //
 // Tests the copyClass API.
 //

--- a/testsuite/openmodelica/interactive-API/CopyClass1.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClass1.mos
@@ -1,0 +1,40 @@
+// name:     CopyClass1
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+
+loadString("
+  package P
+    model A
+      Real x;
+    end A;
+
+    model B
+      A a;
+    end B;
+  end P;
+");
+
+copyClass(P.B, "C", P);
+getErrorString();
+list(P);
+
+// Result:
+// true
+// true
+// ""
+// "package P
+//   model A
+//     Real x;
+//   end A;
+//
+//   model B
+//     A a;
+//   end B;
+//
+//   model C
+//     A a;
+//   end C;
+// end P;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/CopyClass2.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClass2.mos
@@ -1,0 +1,73 @@
+// name:     CopyClass2
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+
+loadString("
+  package P
+    model A
+      Real x;
+    end A;
+
+    function f
+      input Real x;
+      output Real y = x;
+    end f;
+
+    model B
+      A a;
+      Real x = f(time);
+      A2 a2;
+    equation
+      a2.y = P2.P3.f(time);
+    algorithm
+      a.x := f(time);
+    end B;
+  end P;
+
+  package P2
+    model A2
+      Real y;
+    end A2;
+
+    package P3
+      function f
+        input Real x;
+        output Real y = x;
+      end f;
+    end P3;
+  end P2;
+");
+
+copyClass(P.B, "B", P2);
+getErrorString();
+list(P2);
+
+// Result:
+// true
+// true
+// ""
+// "package P2
+//   model A2
+//     Real y;
+//   end A2;
+//
+//   package P3
+//     function f
+//       input Real x;
+//       output Real y = x;
+//     end f;
+//   end P3;
+//
+//   model B
+//     P.A a;
+//     Real x = P.f(time);
+//     A2 a2;
+//   equation
+//     a2.y = P3.f(time);
+//   algorithm
+//     a.x := P.f(time);
+//   end B;
+// end P2;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/CopyClass3.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClass3.mos
@@ -1,0 +1,37 @@
+// name:     CopyClass3
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+
+loadString("
+  package P
+    model A
+      Real x;
+    end A;
+
+    model B
+      import P.A;
+      A a;
+    end B;
+  end P;
+
+  package P2
+  end P2;
+");
+
+copyClass(P.B, "B", P2);
+getErrorString();
+list(P2);
+
+// Result:
+// true
+// true
+// ""
+// "package P2
+//   model B
+//     import P.A;
+//     A a;
+//   end B;
+// end P2;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/CopyClass4.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClass4.mos
@@ -1,0 +1,35 @@
+// name:     CopyClass4
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+// Checks that copyClass can handle builtin names.
+//
+
+loadString("
+  package P
+    model A
+      StateSelect s = StateSelect.always;
+      Real x[:] = ones(3);
+    end A;
+  end P;
+
+  package P2
+  end P2;
+");
+
+copyClass(P.A, "A", P2);
+getErrorString();
+list(P2);
+
+// Result:
+// true
+// true
+// ""
+// "package P2
+//   model A
+//     StateSelect s = StateSelect.always;
+//     Real x[:] = ones(3);
+//   end A;
+// end P2;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/CopyClass5.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClass5.mos
@@ -1,0 +1,34 @@
+// name:     CopyClass5
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+// Checks that copyClass doesn't load libraries if they're referenced,
+// since such references are already fully qualified anyway.
+//
+
+loadString("
+  package P
+    model A
+      Modelica.Units.SI.Voltage v;
+    end A;
+  end P;
+
+  package P2
+  end P2;
+");
+
+copyClass(P.A, "A", P2);
+getErrorString();
+list(P2);
+
+// Result:
+// true
+// true
+// ""
+// "package P2
+//   model A
+//     Modelica.Units.SI.Voltage v;
+//   end A;
+// end P2;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/CopyClassInvalid1.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClassInvalid1.mos
@@ -1,0 +1,34 @@
+// name:     CopyClassInvalid1
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+// Checks that copyClass can handle references to non-existent elements.
+//
+
+loadString("
+  package P
+    model B
+      A a;
+    end B;
+  end P;
+");
+
+copyClass(P.B, "C", P);
+getErrorString();
+list(P);
+
+// Result:
+// true
+// true
+// ""
+// "package P
+//   model B
+//     A a;
+//   end B;
+//
+//   model C
+//     A a;
+//   end C;
+// end P;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/CopyClassRedeclare1.mos
+++ b/testsuite/openmodelica/interactive-API/CopyClassRedeclare1.mos
@@ -1,0 +1,40 @@
+// name:     CopyClassRedeclare1
+// keywords:
+// status:   correct
+// cflags:   -d=newInst
+//
+
+loadString("
+  package P
+    model A
+      replaceable package Medium_1 end Medium_1;
+    end A;
+
+    model M
+      package Medium end Medium;
+      A a(redeclare package Medium_1 = Medium_1);
+    end M;
+  end P;
+
+  package P2
+
+  end P2;
+");
+
+copyClass(P.M, "M", P2);
+getErrorString();
+list(P2);
+
+// Result:
+// true
+// true
+// ""
+// "package P2
+//   model M
+//     package Medium
+//     end Medium;
+//
+//     P.A a(redeclare package Medium_1 = Medium_1);
+//   end M;
+// end P2;"
+// endResult

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -23,6 +23,13 @@ ConnectionList.mos \
 ConversionVersions.mos \
 ConvertUnits.mos \
 CopyClass.mos \
+CopyClass1.mos \
+CopyClass2.mos \
+CopyClass3.mos \
+CopyClass4.mos \
+CopyClass5.mos \
+CopyClassInvalid1.mos \
+CopyClassRedeclare1.mos \
 DefaultComponentName.mos \
 DeleteConnection.mos \
 DialogAnnotation.mos \


### PR DESCRIPTION
- Improved `copyClass` so that it updates the paths in the copied class to be valid in the new location of the class where possible.
- Changed default `within` argument of `copyClass` from `TopLevel` to `__OpenModelica_TopLevel` to make it a bit less likely to conflict with user models.