### PR TITLE
Prompt for a name change when duplicating component

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -3630,15 +3630,6 @@ void Element::deleteMe()
 void Element::duplicate()
 {
   QString name = getName();
-  // remove any ending digits from the name
-  for (int i = name.size() - 1; i >= 0; --i) {
-    if (name.at(i).isDigit()) {
-      name.chop(1);
-    } else {
-      break;
-    }
-  }
-
   QString defaultPrefix = "";
   if (mpLibraryTreeItem) {
     if (!mpGraphicsView->performElementCreationChecks(mpLibraryTreeItem->getNameStructure(), mpLibraryTreeItem->isPartial(), &name, &defaultPrefix)) {

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -3630,13 +3630,24 @@ void Element::deleteMe()
 void Element::duplicate()
 {
   QString name = getName();
+  // remove any ending digits from the name
+  for (int i = name.size() - 1; i >= 0; --i) {
+    if (name.at(i).isDigit()) {
+      name.chop(1);
+    } else {
+      break;
+    }
+  }
+
   QString defaultPrefix = "";
   if (mpLibraryTreeItem) {
-    if (!mpGraphicsView->performElementCreationChecks(mpLibraryTreeItem, &name, &defaultPrefix)) {
+    if (!mpGraphicsView->performElementCreationChecks(mpLibraryTreeItem->getNameStructure(), mpLibraryTreeItem->isPartial(), &name, &defaultPrefix)) {
       return;
     }
   } else {
-    name = mpGraphicsView->getUniqueElementName(getClassName(), StringHandler::toCamelCase(getName()));
+    if (!mpGraphicsView->performElementCreationChecks(getClassName(), mpModel->isPartial(), &name, &defaultPrefix)) {
+      return;
+    }
   }
   QPointF gridStep(mpGraphicsView->mMergedCoOrdinateSystem.getHorizontalGridStep() * 5, mpGraphicsView->mMergedCoOrdinateSystem.getVerticalGridStep() * 5);
   // add component

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1227,6 +1227,11 @@ namespace ModelInstance
     return false;
   }
 
+  bool Model::isPartial() const
+  {
+    return mpPrefixes ? mpPrefixes.get()->isPartial() : false;
+  }
+
   /*!
    * \brief Model::getDirection
    * Returns the direction of the model, either from the declaration or in the

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -524,6 +524,7 @@ private:
     bool isOuter() const {return mOuter;}
     Replaceable *getReplaceable() const {return mpReplaceable.get();}
     bool isRedeclare() const {return mRedeclare;}
+    bool isPartial() const {return mPartial;}
     const QString &getConnector() const {return mConnector;}
     const QString &getVariability() const {return mVariability;}
     const QString &getDirection() const {return mDirection;}
@@ -588,6 +589,7 @@ private:
     bool isEnumeration() const;
     bool isType() const;
     bool isDerivedType() const;
+    bool isPartial() const;
     QString getDirection() const;
     QString getComment() const {return mComment;}
     Annotation *getAnnotation() const;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -821,32 +821,33 @@ void GraphicsView::updateUndoRedoActions(bool enable)
 /*!
  * \brief GraphicsView::performElementCreationChecks
  * Performs the checks like partial model, default name, inner component etc.
- * \param pLibraryTreeItem
+ * \param nameStructure
+ * \param partial
+ * \param name
  * \param defaultPrefix
  * \return
  */
-bool GraphicsView::performElementCreationChecks(LibraryTreeItem *pLibraryTreeItem, QString *name, QString *defaultPrefix)
+bool GraphicsView::performElementCreationChecks(const QString &nameStructure, bool partial, QString *name, QString *defaultPrefix)
 {
   MainWindow *pMainWindow = MainWindow::instance();
   OptionsDialog *pOptionsDialog = OptionsDialog::instance();
   // check if the model is partial
-  if (pLibraryTreeItem->isPartial()) {
+  if (partial) {
     if (pOptionsDialog->getNotificationsPage()->getReplaceableIfPartialCheckBox()->isChecked()) {
       NotificationsDialog *pNotificationsDialog = new NotificationsDialog(NotificationsDialog::ReplaceableIfPartial, NotificationsDialog::InformationIcon, MainWindow::instance());
-      pNotificationsDialog->setNotificationLabelString(GUIMessages::getMessage(GUIMessages::MAKE_REPLACEABLE_IF_PARTIAL)
-                                                       .arg(StringHandler::getModelicaClassType(pLibraryTreeItem->getRestriction()).toLower()).arg(pLibraryTreeItem->getName()));
+      pNotificationsDialog->setNotificationLabelString(GUIMessages::getMessage(GUIMessages::MAKE_REPLACEABLE_IF_PARTIAL).arg(nameStructure));
       if (!pNotificationsDialog->exec()) {
         return false;
       }
     }
   }
   // get the model defaultComponentPrefixes
-  *defaultPrefix = pMainWindow->getOMCProxy()->getDefaultComponentPrefixes(pLibraryTreeItem->getNameStructure());
+  *defaultPrefix = pMainWindow->getOMCProxy()->getDefaultComponentPrefixes(nameStructure);
   QString defaultName;
-  *name = getUniqueElementName(pLibraryTreeItem->getNameStructure(), *name, &defaultName);
+  *name = getUniqueElementName(nameStructure, *name, &defaultName);
   // Allow user to change the component name if always ask for component name settings is true.
   if (pOptionsDialog->getNotificationsPage()->getAlwaysAskForDraggedComponentName()->isChecked()) {
-    ComponentNameDialog *pComponentNameDialog = new ComponentNameDialog(pLibraryTreeItem->getNameStructure(), *name, this, pMainWindow);
+    ComponentNameDialog *pComponentNameDialog = new ComponentNameDialog(nameStructure, *name, this, pMainWindow);
     if (pComponentNameDialog->exec()) {
       *name = pComponentNameDialog->getComponentName();
       pComponentNameDialog->deleteLater();
@@ -949,7 +950,7 @@ bool GraphicsView::addComponent(QString className, QPointF position)
     } else {
       QString name = pLibraryTreeItem->getName();
       QString defaultPrefix = "";
-      if (!performElementCreationChecks(pLibraryTreeItem, &name, &defaultPrefix)) {
+      if (!performElementCreationChecks(pLibraryTreeItem->getNameStructure(), pLibraryTreeItem->isPartial(), &name, &defaultPrefix)) {
         return false;
       }
       ElementInfo *pElementInfo;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -1314,6 +1314,14 @@ QString GraphicsView::getUniqueElementName(const QString &nameStructure, QString
 {
   QString name = elementName;
   if (number > 0) {
+    if (!name.isEmpty()) {
+      bool ok;
+      int endNumber = name.right(1).toInt(&ok);
+      if (ok) {
+        number = endNumber + 1;
+        elementName.chop(1);
+      }
+    }
     name = QString("%1%2").arg(elementName).arg(number);
   }
 

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -243,7 +243,7 @@ public:
   QAction* getRotateAntiClockwiseAction() {return mpRotateAntiClockwiseAction;}
   QAction* getFlipHorizontalAction() {return mpFlipHorizontalAction;}
   QAction* getFlipVerticalAction() {return mpFlipVerticalAction;}
-  bool performElementCreationChecks(LibraryTreeItem *pLibraryTreeItem, QString *name, QString *defaultPrefix);
+  bool performElementCreationChecks(const QString &nameStructure, bool partial, QString *name, QString *defaultPrefix);
   static ModelInstance::Component* createModelInstanceComponent(ModelInstance::Model *pModelInstance, const QString &name, const QString &className, bool isConnector);
   bool addComponent(QString className, QPointF position);
   void addComponentToView(QString name, LibraryTreeItem *pLibraryTreeItem, QString annotation, QPointF position,

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -823,7 +823,7 @@ QString GUIMessages::getMessage(int type)
     case ITEM_DROPPED_ON_ITSELF:
       return tr("You cannot drop an item on itself.");
     case MAKE_REPLACEABLE_IF_PARTIAL:
-      return tr("The <b>%1</b> <i>%2</i> is defined as <b>partial</b>.<br />The component will be added as a <b>replaceable</b> component.");
+      return tr("<b>%1</b> is defined as <b>partial</b>.<br />The component will be added as a <b>replaceable</b> component.");
     case INNER_MODEL_NAME_CHANGED:
       return tr("A component with the name <b>%1</b> already exists. The name is changed from <b>%1</b> to <b>%2</b>.<br /><br />This is probably wrong because the component is declared as <b>inner</b>.");
     case FMU_GENERATED:


### PR DESCRIPTION
### Related Issues

Fixes #11881

### Purpose

Duplicate component should work same as dragging a component.

### Approach

Use the same algorithm for unique name when dragging or duplicating the component.