### PR TITLE
Fix dimension typing regression

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -642,6 +642,17 @@ algorithm
                                     not InstNode.isOutput(component))
       then dimension;
 
+    // A dimension of a function output parameter that depends on e.g. an input
+    // can't be determined here, leave it unknown and let the call typing handle it.
+    // TODO: This assumes any binding that contains crefs can't be evaluated to
+    //       avoid e.g. using the default value of an input parameter, but some
+    //       cases such as an output dimension depending on another output
+    //       dimension could be fine.
+    case Dimension.UNKNOWN() guard InstContext.inFunction(context) and
+                                   Binding.hasExp(binding) and
+                                   Expression.contains(Binding.getExp(binding), Expression.isCref)
+      then dimension;
+
     // If the dimension is unknown in a class, try to infer it from the components binding.
     case Dimension.UNKNOWN()
       algorithm

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown15.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown15.mo
@@ -1,0 +1,26 @@
+// name: DimUnknown15
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Real x[:] = {1, 2, 3};
+  output Real y[:] = x;
+end f;
+
+model DimUnknown15
+  Real x[:] = f({1, 2, 3, 4});
+end DimUnknown15;
+
+// Result:
+// class DimUnknown15
+//   Real x[1];
+//   Real x[2];
+//   Real x[3];
+//   Real x[4];
+// equation
+//   x = {1.0, 2.0, 3.0, 4.0};
+// end DimUnknown15;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -365,6 +365,7 @@ DimUnknown11.mo \
 DimUnknown12.mo \
 DimUnknown13.mo \
 DimUnknown14.mo \
+DimUnknown15.mo \
 dim1.mo \
 dim13.mo \
 dim16.mo \


### PR DESCRIPTION
- Be conservative when typing dimensions of function output parameters and assume that any binding that contains component references might be unsafe to evaluate.