### PR TITLE
Fix `toString` for multary

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1907,16 +1907,16 @@ public
                         ) + ")";
       case END() then "end";
 
-      case MULTARY() guard(listEmpty(exp.inv_arguments)) then multaryString(exp.arguments, exp, exp.operator, false);
+      case MULTARY() guard(listEmpty(exp.inv_arguments)) then multaryFlatString(exp.arguments, exp, exp.operator, false);
 
       case MULTARY() guard(listEmpty(exp.arguments) and Operator.isDashClassification(Operator.getMathClassification(exp.operator)))
-                     then "-" + multaryString(exp.inv_arguments, exp, exp.operator);
+                     then "-" + multaryFlatString(exp.inv_arguments, exp, exp.operator);
 
-      case MULTARY() guard(listEmpty(exp.arguments)) then "1/" + multaryString(exp.inv_arguments, exp, exp.operator);
+      case MULTARY() guard(listEmpty(exp.arguments)) then "1/" + multaryFlatString(exp.inv_arguments, exp, exp.operator);
 
-      case MULTARY() then multaryString(exp.arguments, exp, exp.operator) +
+      case MULTARY() then multaryFlatString(exp.arguments, exp, exp.operator) +
                           Operator.symbol(Operator.invert(exp.operator)) +
-                          multaryString(exp.inv_arguments, exp, exp.operator);
+                          multaryFlatString(exp.inv_arguments, exp, exp.operator);
 
       case BINARY() then operandFlatString(exp.exp1, exp, true) +
                          Operator.symbol(exp.operator) +
@@ -2049,8 +2049,8 @@ public
       if operand_prio > operator_prio then
         parenthesize := true;
       elseif operand_prio == operator_prio then
-        parenthesize := if lhs then isNonAssociativeExp(operand) else not
-                                    isAssociativeExp(operand);
+        parenthesize := if lhs then isNonAssociativeExp(operand)
+                               else not isAssociativeExp(operand);
       end if;
     end if;
 
@@ -2063,14 +2063,27 @@ public
     input list<Expression> arguments;
     input Expression exp;
     input Operator operator;
-    input Boolean useParanthesis = true;
+    input Boolean parenthesize = true;
     output String str;
   algorithm
     str := stringDelimitList(list(operandString(e, exp, false) for e in arguments), Operator.symbol(operator));
-    if useParanthesis and listLength(arguments) > 1 then
+    if parenthesize and listLength(arguments) > 1 then
       str := "(" + str + ")";
     end if;
   end multaryString;
+
+  function multaryFlatString
+    input list<Expression> arguments;
+    input Expression exp;
+    input Operator operator;
+    input Boolean parenthesize = true;
+    output String str;
+  algorithm
+    str := stringDelimitList(list(operandFlatString(e, exp, false) for e in arguments), Operator.symbol(operator));
+    if parenthesize and listLength(arguments) > 1 then
+      str := "(" + str + ")";
+    end if;
+  end multaryFlatString;
 
   function priority
     input Expression exp;
@@ -2088,6 +2101,9 @@ public
       case RELATION() then 6;
       case RANGE() then 10;
       case IF() then 11;
+      case CAST() then priority(exp.exp, lhs);
+      case BOX() then priority(exp.exp, lhs);
+      case UNBOX() then priority(exp.exp, lhs);
       else 0;
     end match;
   end priority;
@@ -6069,6 +6085,18 @@ public
           json := JSON.addPair("lhs", toJSON(exp.exp1), json);
           json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
           json := JSON.addPair("rhs", toJSON(exp.exp2), json);
+        then
+          json;
+
+      case MULTARY()
+        algorithm
+          json := JSON.emptyObject();
+          json := JSON.addPair("$kind", JSON.makeString("multary_op"), json);
+          json := JSON.addPair("args",
+            JSON.makeArray(list(toJSON(a) for a in exp.arguments)), json);
+          json := JSON.addPair("inv_args",
+            JSON.makeArray(list(toJSON(a) for a in exp.inv_arguments)), json);
+          json := JSON.addPair("op", JSON.makeString(Operator.symbol(exp.operator, spacing = "")), json);
         then
           json;
 

--- a/testsuite/simulation/modelica/NBackend/functions/function_annotation_der.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_annotation_der.mos
@@ -85,7 +85,7 @@ simulate(function_annotation_der); getErrorString();
 //   output Real '$fDER_y';
 //   Real 'y';
 // algorithm
-//   '$fDER_y' := (k * (2.0 * x * $fDER_x) + $fDER_k * x ^ 2.0) + $fDER_m;
+//   '$fDER_y' := ('k' * (2.0 * 'x' * '$fDER_x') + '$fDER_k' * 'x' ^ 2.0) + '$fDER_m';
 //   'y' := 'k' * 'x' ^ 2.0 + 'm';
 //   annotation(Inline = false);
 // end '$fDER1.f'

--- a/testsuite/simulation/modelica/NBackend/functions/function_diff.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_diff.mos
@@ -60,7 +60,7 @@ simulate(function_diff); getErrorString();
 //   Real 'b';
 // algorithm
 //   if 'a' >= 0.0 then
-//     '$fDER_b' := 2.0 * a * $fDER_a;
+//     '$fDER_b' := 2.0 * 'a' * '$fDER_a';
 //     'b' := 'a' ^ 2.0;
 //   elseif true then
 //     '$fDER_b' := '$fDER0.f'(-'a', -'$fDER_a');


### PR DESCRIPTION
When CAST was involved, parentheses were not printed correctly.

### Related Issues

PR #12133