### PR TITLE
Fix connector balance check

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -356,7 +356,7 @@ protected
 algorithm
   comp := InstNode.component(component);
 
-  if not Component.isConnector(comp) or Component.isExpandableConnector(comp) then
+  if not ConnectorType.isConnector(Component.connectorType(comp)) then
     return;
   end if;
 

--- a/testsuite/flattening/modelica/scodeinst/ExpandableConnector12.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExpandableConnector12.mo
@@ -1,0 +1,17 @@
+// name: ExpandableConnector12
+// keywords: expandable connector
+// status: correct
+// cflags: -d=newInst
+//
+// Checks that potentially present non-connector variables in an expandable
+// connector doesn't generate warnings about unbalanced connectors.
+//
+
+expandable connector ExpandableConnector12
+  Real x;
+end ExpandableConnector12;
+
+// Result:
+// class ExpandableConnector12
+// end ExpandableConnector12;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -448,6 +448,7 @@ ExpandableConnector8.mo \
 ExpandableConnector9.mo \
 ExpandableConnector10.mo \
 ExpandableConnector11.mo \
+ExpandableConnector12.mo \
 ExpandableConnectorComplex1.mo \
 ExpandableConnectorFlow1.mo \
 ExpandableConnectorFlow2.mo \


### PR DESCRIPTION
- Don't check connector balance of potentially present variables unless they're actually connectors.