### PR TITLE
Implement inheritance of experiment annotations

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/InstUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/InstUtil.mo
@@ -8462,7 +8462,7 @@ algorithm
       then getNDcr(cr1);
     case DAE.CREF_IDENT(identType = DAE.T_COMPLEX(varLst = varLst))
       equation
-        N = List.findSome(varLst,findN);
+        SOME(N) = List.findSome(varLst,findN);
       then (N,dcr);
   end match;
 end getNDcr;
@@ -8672,7 +8672,7 @@ protected function getDomNFields
   output List<Absyn.ComponentRef> outFieldLst = {};
 algorithm
   try
-    (outN,outFieldLst) := List.findSome1(inDomFieldLst,domNFieldsFindFun,inDomainCr);
+    SOME((outN,outFieldLst)) := List.findSome(inDomFieldLst, function domNFieldsFindFun(inDomainCr = inDomainCr));
   else
     Error.addSourceMessageAndFail(Error.COMPILER_ERROR,{"There are no fields defined within the domain of this equation."}, info);
   end try;
@@ -8693,7 +8693,7 @@ algorithm
       equation
       true = absynDAECrefEqualName(inDomainCr,domainCr);
       DAE.CREF_IDENT(identType = DAE.T_COMPLEX(varLst = varLst)) = domainCr;
-      N = List.findSome(varLst,findN);
+      SOME(N) = List.findSome(varLst,findN);
     then
       SOME((N,fieldCrLst));
     else

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -402,21 +402,19 @@ algorithm
       GlobalScript.SimulationOptions defaults, simOpt;
       String experimentAnnotationStr;
       list<Absyn.NamedArg> named;
+      Option<Absyn.Modification> experiment_ann;
 
     // search inside annotation(experiment(...))
     case (_, _, _)
       equation
         defaults = Util.getOptionOrDefault(defaultOption, setFileNamePrefixInSimulationOptions(defaultSimulationOptions, inFileNamePrefix));
 
-        experimentAnnotationStr =
-          Interactive.getNamedAnnotation(
-            inModelPath,
-            SymbolTable.getAbsyn(),
-            Absyn.IDENT("experiment"),
-            SOME("{}"),
-            Interactive.getExperimentAnnotationString);
-                // parse the string we get back, either {} or {StopTime=5, Tolerance = 0.10};
+        experiment_ann = InteractiveUtil.getInheritedAnnotation(inModelPath, "experiment", SymbolTable.getAbsyn());
 
+        // TODO: Get the values from the modifier directly instead of this mess.
+        experimentAnnotationStr = Interactive.getExperimentAnnotationString(experiment_ann);
+
+        // parse the string we get back, either {} or {StopTime=5, Tolerance = 0.10};
         // jump to next case if the annotation is empty
         false = stringEq(experimentAnnotationStr, "{}");
 

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -815,6 +815,11 @@ protected
   InstNode cls_node;
   Class cls;
 algorithm
+  if not Flags.isSet(Flags.SCODE_INST) then
+    extendsPaths := {};
+    return;
+  end if;
+
   (_, _, cls_node) := frontEndLookup(program, classPath);
 
   if not InstNode.isClass(cls_node) then

--- a/OMCompiler/Compiler/Util/Error.mo
+++ b/OMCompiler/Compiler/Util/Error.mo
@@ -899,6 +899,8 @@ public constant ErrorTypes.Message UNKNOWN_ANNOTATION_VALUE = ErrorTypes.MESSAGE
   Gettext.gettext("Unknown value '%s' for annotation '%s'"));
 public constant ErrorTypes.Message NON_FIXED_CONSTANT = ErrorTypes.MESSAGE(413, ErrorTypes.TRANSLATION(), ErrorTypes.ERROR(),
   Gettext.gettext("Constant '%s' must be fixed but has 'fixed = false'"));
+public constant ErrorTypes.Message CONFLICTING_INHERITED_ANNOTATIONS = ErrorTypes.MESSAGE(414, ErrorTypes.SCRIPTING(), ErrorTypes.WARNING(),
+  Gettext.gettext("Conflicting '%s' annotations inherited by class '%s':\n  %s from 'extends %s'\n  %s from 'extends %s'"));
 
 public constant ErrorTypes.Message INITIALIZATION_NOT_FULLY_SPECIFIED = ErrorTypes.MESSAGE(496, ErrorTypes.TRANSLATION(), ErrorTypes.WARNING(),
   Gettext.gettext("The initial conditions are not fully specified. %s."));

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -7013,56 +7013,25 @@ algorithm
 end findAndMap;
 
 public function findSome<T1,T2>
-  "Applies the given function over the list and returns first returned value that is not NONE()."
+  "Applies the given function over the list and returns either the first SOME()
+   value the function returns or NONE() if no SOME() is returned."
   input list<T1> inList;
   input FuncType inFunc;
-  output T2 outVal;
+  output Option<T2> outVal = NONE();
 
   partial function FuncType
     input T1 inElement;
     output Option<T2> outValOpt;
   end FuncType;
-protected
-  Option<T2> retOpt = NONE();
-  T1 e;
-  list<T1> rest = inList;
 algorithm
-  while isNone(retOpt)/*not listEmpty(rest) and not outFound*/ loop
-    e :: rest := rest;
-    retOpt := inFunc(e);
-  end while;
-  outVal := match retOpt
-    case SOME(outVal)
-      then outVal;
-    end match;
+  for e in inList loop
+    outVal := inFunc(e);
+
+    if isSome(outVal) then
+      return;
+    end if;
+  end for;
 end findSome;
-
-public function findSome1<T1,T2,Arg>
-  "Applies the given function with one extra argument over the list and returns first returned value that is not NONE()."
-  input list<T1> inList;
-  input FuncType inFunc;
-  input Arg inArg;
-  output T2 outVal;
-
-  partial function FuncType
-    input T1 inElement;
-    input Arg inArg;
-    output Option<T2> outValOpt;
-  end FuncType;
-protected
-  Option<T2> retOpt = NONE();
-  T1 e;
-  list<T1> rest = inList;
-algorithm
-  while isNone(retOpt)/*not listEmpty(rest) and not outFound*/ loop
-    e :: rest := rest;
-    retOpt := inFunc(e,inArg);
-  end while;
-  outVal := match retOpt
-    case SOME(outVal)
-      then outVal;
-    end match;
-end findSome1;
 
 public function splitEqualPrefix<T1, T2>
   input list<T1> inFullList;

--- a/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationDialog.cpp
@@ -634,17 +634,15 @@ void SimulationDialog::initializeFields(bool isReSimulate, SimulationOptions sim
      * by the user.
      */
     if (!mpLibraryTreeItem->mSimulationOptions.isValid()) {
-      // if the class has experiment annotation then read it.
-      if (MainWindow::instance()->getOMCProxy()->isExperiment(mClassName)) {
-        // get the simulation options....
-        OMCInterface::getSimulationOptions_res simulationOptions_res = MainWindow::instance()->getOMCProxy()->getSimulationOptions(mClassName);
-        // since we always get simulationOptions so just get the values from array
-        mpStartTimeTextBox->setText(QString::number(simulationOptions_res.startTime));
-        mpStopTimeTextBox->setText(QString::number(simulationOptions_res.stopTime));
-        mpToleranceTextBox->setText(QString::number(simulationOptions_res.tolerance));
-        mpNumberofIntervalsSpinBox->setValue(simulationOptions_res.numberOfIntervals);
-        mpIntervalTextBox->setText(QString::number(simulationOptions_res.interval));
-      }
+      // get the simulation options....
+      OMCInterface::getSimulationOptions_res simulationOptions_res = MainWindow::instance()->getOMCProxy()->getSimulationOptions(mClassName);
+      // since we always get simulationOptions so just get the values from array
+      mpStartTimeTextBox->setText(QString::number(simulationOptions_res.startTime));
+      mpStopTimeTextBox->setText(QString::number(simulationOptions_res.stopTime));
+      mpToleranceTextBox->setText(QString::number(simulationOptions_res.tolerance));
+      mpNumberofIntervalsSpinBox->setValue(simulationOptions_res.numberOfIntervals);
+      mpIntervalTextBox->setText(QString::number(simulationOptions_res.interval));
+
       // apply the global translation flags
       TranslationFlagsWidget *pGlobalTranslationFlagsWidget = OptionsDialog::instance()->getSimulationPage()->getTranslationFlagsWidget();
       mpTranslationFlagsWidget->getMatchingAlgorithmComboBox()->setCurrentIndex(pGlobalTranslationFlagsWidget->getMatchingAlgorithmComboBox()->currentIndex());

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -54,6 +54,8 @@ getDefinitions.mos \
 getDialogAnnotation.mos \
 getElementAnnotation.mos \
 getIconAnnotation.mos \
+getSimulationOptions1.mos \
+getSimulationOptions2.mos \
 IfStatementIllegal.mos \
 IfStatement.mos\
 IllegalGraphics.mos\

--- a/testsuite/openmodelica/interactive-API/Ticket5565.mos
+++ b/testsuite/openmodelica/interactive-API/Ticket5565.mos
@@ -1,7 +1,7 @@
 // name: Ticket5565.mos
 // keywords: test fix for but 5565
 // status: correct
-// cflags: -d=-newInst
+// cflags: -d=newInst
 //
 
 setCommandLineOptions("-d=nfAPI,showStatement");

--- a/testsuite/openmodelica/interactive-API/getSimulationOptions1.mos
+++ b/testsuite/openmodelica/interactive-API/getSimulationOptions1.mos
@@ -1,0 +1,31 @@
+// name: getSimulationOptions1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  model A
+    annotation(experiment(StopTime = 2.0, Tolerance = 0.004));
+  end A;
+
+  model B
+    extends A;
+    annotation(experiment(StartTime = 1.0));
+  end B;
+
+  model M
+    extends B;
+    annotation(experiment(Tolerance = 0.01));
+  end M;
+");
+getErrorString();
+
+getSimulationOptions(M);
+getErrorString();
+
+// Result:
+// true
+// ""
+// (1.0,2.0,0.01,500,0.002)
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/getSimulationOptions2.mos
+++ b/testsuite/openmodelica/interactive-API/getSimulationOptions2.mos
@@ -1,0 +1,33 @@
+// name: getSimulationOptions2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  model A
+    annotation(experiment(StopTime = 1.0));
+  end A;
+
+  model B
+    annotation(experiment(StopTime = 2.0));
+  end B;
+
+  model M
+    extends A;
+    extends B;
+  end M;
+");
+getErrorString();
+
+getSimulationOptions(M);
+getErrorString();
+
+// Result:
+// true
+// ""
+// (0.0,1.0,1e-6,500,0.002)
+// "Warning: Conflicting 'experiment' annotations inherited by class 'M':
+//   (StopTime = 1.0) from 'extends A'
+//   (StopTime = 2.0) from 'extends B'
+// "
+// endResult


### PR DESCRIPTION
- Change the simulation options API to also take annotations from inherited classes into account.
- Change `List.findSome` to return an option instead of failing, and remove `List.findSome1` which isn't really needed.