### PR TITLE
Load dependencies in loadString

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1194,6 +1194,9 @@ was read in binary format from a file with the same name.
   input String filename = "<interactive>";
   input String encoding = "UTF-8";
   input Boolean merge = false "if merge is true the parsed AST is merged with the existing AST, default to false which means that is replaced, not merged";
+  input Boolean uses = true;
+  input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
+  input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
   output Boolean success;
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1448,6 +1448,9 @@ was read in binary format from a file with the same name.
   input String filename = "<interactive>";
   input String encoding = "UTF-8" "Deprecated as *ALL* strings are now UTF-8 encoded";
   input Boolean merge = false "if merge is true the parsed AST is merged with the existing AST, default to false which means that is replaced, not merged";
+  input Boolean uses = true;
+  input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
+  input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
   output Boolean success;
 external "builtin";
 annotation(preferredView="text");

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -1710,7 +1710,7 @@ bool OMCProxy::loadFile(QString fileName, QString encoding, bool uses, bool noti
  */
 bool OMCProxy::loadString(QString value, QString fileName, QString encoding, bool merge, bool checkError)
 {
-  bool result = mpOMCInterface->loadString(value, fileName, encoding, merge);
+  bool result = mpOMCInterface->loadString(value, fileName, encoding, merge, true, true, false);
   if (checkError) {
     printMessagesStringInternal();
   }

--- a/testsuite/openmodelica/conversion/ConvertPackage1.mos
+++ b/testsuite/openmodelica/conversion/ConvertPackage1.mos
@@ -12,7 +12,7 @@ loadString("
     testlib.Integer2 i;
     annotation(uses(testlib(version = \"1.0.2\")));
   end ConvertPackage1;
-");
+", uses=false);
 
 setModelicaPath("libs/");
 convertPackageToLibrary(ConvertPackage1, testlib, "2.0.0");

--- a/testsuite/openmodelica/conversion/ConvertPackage2.mos
+++ b/testsuite/openmodelica/conversion/ConvertPackage2.mos
@@ -12,7 +12,7 @@ loadString("
     testlib.Integer0 i;
     annotation(uses(testlib(version = \"1.0.0\")));
   end ConvertPackage2;
-");
+", uses=false);
 
 setModelicaPath("libs/");
 convertPackageToLibrary(ConvertPackage2, testlib, "2.0.0");

--- a/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBlocks.mos
@@ -45,7 +45,13 @@ val(y[10], 1.0);
 // true
 // ""
 // true
-// ""
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from VectorizedBlocksTest.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica_Synchronous 0.93.0-dev due to uses annotation from VectorizedBlocksTest.
+// Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// "
 //
 // ########################################
 // dumpDAE
@@ -190,13 +196,10 @@ val(y[10], 1.0);
 //
 // record SimulationResult
 //     resultFile = "VectorizedBlocksTest_res.mat",
-//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-06, method = 'dassl', fileNamePrefix = 'VectorizedBlocksTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'VectorizedBlocksTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
 //     messages = ""
 // end SimulationResult;
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from VectorizedBlocksTest.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
-// Notification: Automatically loaded package Modelica_Synchronous 0.93.0-dev due to uses annotation from VectorizedBlocksTest.
+// "Warning: Requested package Modelica_Synchronous of version 0.92.1, but this package was already loaded with version 0.93.0-dev. There are no conversion annotations and 0.92.1 is older than 0.93.0-dev, so the libraries are probably incompatible.
 // Warning: Requested package Modelica of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: Requested package ModelicaServices of version 3.2.3, but this package was already loaded with version 3.2.2. There are no conversion annotations for this version but 3.2.3 is newer than 3.2.2. There is a possibility that 3.2.2 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
 // Warning: The initial conditions are over specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").

--- a/testsuite/openmodelica/diff/ticket3619.mos
+++ b/testsuite/openmodelica/diff/ticket3619.mos
@@ -6,7 +6,7 @@
 echo(false);
 s1 := readFile("ticket3619.mo");
 
-loadString(s1);
+loadString(s1, uses=false);
 
 deleteClass(withFolder.OLD);
 

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_17.mos
@@ -52,12 +52,12 @@ readFile("fmi_attributes_17.xml"); getErrorString();
 // true
 // ""
 // true
-// ""
-// "fmi_attributes_17.fmu"
 // "Notification: Automatically loaded package Modelica 3.2.3 due to uses annotation from fmi_attributes_17.
 // Notification: Automatically loaded package Complex 3.2.3 due to uses annotation from Modelica.
 // Notification: Automatically loaded package ModelicaServices 3.2.3 due to uses annotation from Modelica.
-// Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// "fmi_attributes_17.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
 // "
 // 0
 // ""

--- a/testsuite/openmodelica/interactive-API/UsesAnnotation1.mos
+++ b/testsuite/openmodelica/interactive-API/UsesAnnotation1.mos
@@ -30,7 +30,10 @@ instantiateModel(A.B); getErrorString();
 
 // Result:
 // true
-// ""
+// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from A.
+// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
+// "
 // "function A.B.f
 //   input Real x;
 //   output Real y;
@@ -44,8 +47,5 @@ instantiateModel(A.B); getErrorString();
 //   x = A.B.f(time);
 // end A.B;
 // "
-// "Notification: Automatically loaded package Modelica 3.2.2 due to uses annotation from A.
-// Notification: Automatically loaded package Complex 3.2.2 due to uses annotation from Modelica.
-// Notification: Automatically loaded package ModelicaServices 3.2.2 due to uses annotation from Modelica.
-// "
+// ""
 // endResult

--- a/testsuite/openmodelica/interactive-API/UsesAnnotation2.mos
+++ b/testsuite/openmodelica/interactive-API/UsesAnnotation2.mos
@@ -47,7 +47,8 @@ instantiateModel('0.8.1');getErrorString();
 // true
 // ""
 // true
-// ""
+// "Warning: '2.2.2' requested package Modelica of version 2.2.2. Modelica 3.2.3 is used instead which states that it is only compatible with a conversion script. Use convertPackageToLibrary('2.2.2', Modelica, \"3.2.3\") to run the conversion script or proceed with potential issues as a result.
+// "
 // "class '2.2.2'
 // end '2.2.2';
 // "
@@ -57,7 +58,8 @@ instantiateModel('0.8.1');getErrorString();
 // true
 // ""
 // true
-// ""
+// "Warning: Requested package Modelica of version 5.0.0, but this package was already loaded with version 3.2.3. There are no conversion annotations for this version but 5.0.0 is newer than 3.2.3. There is a possibility that 3.2.3 remains backwards compatible, but it is not loaded so OpenModelica cannot verify this.
+// "
 // "class '5.0.0'
 // end '5.0.0';
 // "
@@ -67,7 +69,8 @@ instantiateModel('0.8.1');getErrorString();
 // true
 // ""
 // true
-// ""
+// "Warning: Requested package Modelica of version 0.8.1, but this package was already loaded with version 4.0.0. There are no conversion annotations and 0.8.1 is older than 4.0.0, so the libraries are probably incompatible.
+// "
 // "class '0.8.1'
 // end '0.8.1';
 // "


### PR DESCRIPTION
- Load dependencies based on uses-annotations when loading classes with loadString, for parity with e.g. loadFile or loadModel.