### PR TITLE
Allow evaluation of structural params to fail

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -352,6 +352,24 @@ algorithm
   outEvaluated := evaluated and outEvaluated;
 end evalExpPartial;
 
+function tryEvalCref
+  input ComponentRef cref;
+  input Expression defaultExp;
+  input Boolean evalSubscripts = true;
+  input Boolean liftExp = true;
+  output Expression exp;
+algorithm
+  ErrorExt.setCheckpoint(getInstanceName());
+
+  try
+    exp := evalCref(cref, defaultExp, EvalTarget.IGNORE_ERRORS(), evalSubscripts, liftExp);
+  else
+    exp := defaultExp;
+  end try;
+
+  ErrorExt.rollBack(getInstanceName());
+end tryEvalCref;
+
 function evalCref
   input ComponentRef cref;
   input Expression defaultExp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -203,7 +203,10 @@ algorithm
         if ComponentRef.nodeVariability(cref) <= Variability.STRUCTURAL_PARAMETER and
            not Type.isExternalObject(ty) then
           // Evaluate all constants and structural parameters.
-          outExp := Ceval.evalCref(cref, outExp, Ceval.EvalTarget.IGNORE_ERRORS(), evalSubscripts = false);
+          // TODO: A structural parameter that can't be evaluated should either
+          //       give an error or not be marked as structural in the first
+          //       place, so tryEvalCref shouldn't be necessary here.
+          outExp := Ceval.tryEvalCref(cref, outExp, evalSubscripts = false);
           outExp := Flatten.flattenExp(outExp, Flatten.Prefix.PREFIX(InstNode.EMPTY_NODE(), cref));
           outChanged := true;
         elseif outChanged then
@@ -636,11 +639,7 @@ algorithm
       algorithm
         if evaluateAll or not isLocalFunctionVariable(e.cref, fnNode) then
           ErrorExt.setCheckpoint(getInstanceName());
-          try
-            outExp := Ceval.evalCref(e.cref, e, Ceval.EvalTarget.IGNORE_ERRORS(), evalSubscripts = false);
-          else
-            outExp := e;
-          end try;
+          outExp := Ceval.tryEvalCref(e.cref, e, evalSubscripts = false);
           ErrorExt.rollBack(getInstanceName());
           outChanged := true;
         elseif outChanged then

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -901,6 +901,8 @@ algorithm
       binding_exp := Ceval.evalExp(binding_exp);
       binding_exp := flattenExp(binding_exp, prefix);
     elseif binding_var == Variability.PARAMETER and Component.isFinal(comp) then
+      binding_exp := SimplifyExp.simplify(binding_exp);
+
       // Try to use inlining first.
       try
         binding_exp := Inline.inlineCallExp(binding_exp, forceInline = true);

--- a/testsuite/flattening/modelica/scodeinst/CevalBinding9.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalBinding9.mo
@@ -1,0 +1,53 @@
+// name: CevalBinding9
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+pure function ext_fun
+  input Real u1;
+  output Real y;
+  external "C";
+end ext_fun;
+
+model Pump
+  parameter Real m_flow_nominal;
+  parameter Integer nOri = 2;
+  parameter Real V_flow = 2.0*m_flow_nominal;
+  final parameter power pow = if V_flow < 0 then power(V_flow=1) else power(V_flow=2);
+end Pump;
+
+record power
+  parameter Real V_flow = 0;
+end power;
+
+model CevalBinding9
+  Pump pumHeaPum(m_flow_nominal = Q);
+  parameter Real T = 0;
+  parameter Real Q = ext_fun(T);
+end CevalBinding9;
+
+// Result:
+// function ext_fun
+//   input Real u1;
+//   output Real y;
+//
+//   external "C" y = ext_fun(u1);
+// end ext_fun;
+//
+// function power "Automatically generated record constructor for power"
+//   input Real V_flow = 0.0;
+//   output power res;
+// end power;
+//
+// class CevalBinding9
+//   parameter Real pumHeaPum.m_flow_nominal = Q;
+//   parameter Integer pumHeaPum.nOri = 2;
+//   parameter Real pumHeaPum.V_flow = 2.0 * pumHeaPum.m_flow_nominal;
+//   final parameter Real pumHeaPum.pow.V_flow(fixed = false);
+//   parameter Real T = 0.0;
+//   parameter Real Q = ext_fun(T);
+// initial equation
+//   pumHeaPum.pow = if pumHeaPum.V_flow < 0.0 then power(1.0) else power(2.0);
+// end CevalBinding9;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -126,6 +126,7 @@ CevalBinding5.mo \
 CevalBinding6.mo \
 CevalBinding7.mo \
 CevalBinding8.mo \
+CevalBinding9.mo \
 CevalConstant1.mo \
 CevalCeil1.mo \
 CevalCos1.mo \


### PR DESCRIPTION
- Allow evaluation of structural parameters in EvalConstants.evaluateExpTraverser to fail, since we currently mark some parameters as structural even though they can't be evaluated at compile time.