### PR TITLE
Fix Transformation copy constructor

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -538,11 +538,12 @@ Element::Element(ModelInstance::Component *pModelComponent, bool inherited, Grap
   // transformation
   mTransformation = Transformation(mpGraphicsView->getViewType(), this);
   if (createTransformation) {
-    if (boundingRect().width() > 0) {
-      mTransformation.setWidth(boundingRect().width());
+    QRectF boundingRectangle = boundingRect();
+    if (boundingRectangle.width() > 0) {
+      mTransformation.setWidth(boundingRectangle.width());
     }
-    if (boundingRect().height() > 0) {
-      mTransformation.setHeight(boundingRect().height());
+    if (boundingRectangle.height() > 0) {
+      mTransformation.setHeight(boundingRectangle.height());
     }
     // snap to grid while creating component
     position = mpGraphicsView->snapPointToGrid(position);
@@ -550,12 +551,13 @@ Element::Element(ModelInstance::Component *pModelComponent, bool inherited, Grap
     ModelInstance::CoordinateSystem coordinateSystem = getCoOrdinateSystemNew();
     qreal initialScale = coordinateSystem.getInitialScale();
     QVector<QPointF> extent;
-    qreal xExtent = initialScale * boundingRect().width() / 2;
-    qreal yExtent = initialScale * boundingRect().height() / 2;
+    qreal xExtent = initialScale * boundingRectangle.width() / 2;
+    qreal yExtent = initialScale * boundingRectangle.height() / 2;
     extent.append(QPointF(-xExtent, -yExtent));
     extent.append(QPointF(xExtent, yExtent));
     mTransformation.setExtent(extent);
     mTransformation.setRotateAngle(0.0);
+    mTransformation.setExtentCenter(boundingRectangle.center());
   } else if (!placementAnnotation.isEmpty()) {
     mTransformation.parseTransformationString(placementAnnotation, boundingRect().width(), boundingRect().height());
   } else {

--- a/OMEdit/OMEditLIB/Element/Transformation.cpp
+++ b/OMEdit/OMEditLIB/Element/Transformation.cpp
@@ -257,11 +257,13 @@ void Transformation::updateTransformation(const Transformation &transformation)
   mExtentDiagram = transformation.getExtentDiagram();
   mRotateAngleDiagram = transformation.getRotateAngleDiagram();
   mPositionDiagram = transformation.getPositionDiagram();
+  mExtentCenterDiagram = transformation.getExtentCenterDiagram();
   mVisibleIcon = transformation.getVisibleIcon();
   mOriginIcon = transformation.getOriginIcon();
   mExtentIcon = transformation.getExtentIcon();
   mRotateAngleIcon = transformation.getRotateAngleIcon();
   mPositionIcon = transformation.getPositionIcon();
+  mExtentCenterIcon = transformation.getExtentCenterIcon();
 }
 
 QTransform Transformation::getTransformationMatrix()
@@ -325,6 +327,20 @@ QPointF Transformation::getPosition()
     case StringHandler::ModelicaText:
     default:
       return getPositionDiagram();
+  }
+}
+
+void Transformation::setExtentCenter(QPointF extentCenter)
+{
+  switch (mViewType) {
+    case StringHandler::Icon:
+      setExtentCenterIcon(extentCenter);
+      break;
+    case StringHandler::Diagram:
+    case StringHandler::ModelicaText:
+    default:
+      setExtentCenterDiagram(extentCenter);
+      break;
   }
 }
 

--- a/OMEdit/OMEditLIB/Element/Transformation.h
+++ b/OMEdit/OMEditLIB/Element/Transformation.h
@@ -67,6 +67,7 @@ public:
   void setRotateAngle(qreal rotateAngle);
   RealAnnotation getRotateAngle() const;
   QPointF getPosition();
+  void setExtentCenter(QPointF extentCenter);
   // operator overloading
   bool operator==(const Transformation &transformation) const;
 private:
@@ -101,6 +102,8 @@ private:
   void setRotateAngleDiagram(qreal rotateAngle) {mRotateAngleDiagram = rotateAngle;}
   const RealAnnotation &getRotateAngleDiagram() const {return mRotateAngleDiagram;}
   QPointF getPositionDiagram() const;
+  void setExtentCenterDiagram(QPointF extentCenter) {mExtentCenterDiagram = extentCenter;}
+  QPointF getExtentCenterDiagram() const {return mExtentCenterDiagram;}
   QTransform getTransformationMatrixIcon();
   void adjustPositionIcon(qreal x, qreal y);
   void setOriginIcon(QPointF origin);
@@ -110,6 +113,8 @@ private:
   void setRotateAngleIcon(qreal rotateAngle) {mRotateAngleIcon = rotateAngle;}
   const RealAnnotation &getRotateAngleIcon() const {return mRotateAngleIcon;}
   QPointF getPositionIcon() const;
+  void setExtentCenterIcon(QPointF extentCenter) {mExtentCenterIcon = extentCenter;}
+  QPointF getExtentCenterIcon() const {return mExtentCenterIcon;}
 };
 
 #endif // TRANSFORMATION_H


### PR DESCRIPTION
### Related Issues

Fixes #12165

### Purpose

Handle unsymmetrical/uncentered icons.

### Approach

Copy extent center in the copy constructor.
Set extent center when creating the component.
