### PR TITLE
Fix Flatten.splitRecordCref

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1003,7 +1003,11 @@ algorithm
       guard Expression.variability(outExp.condition) <= Variability.PARAMETER
       algorithm
         cond := Ceval.tryEvalExp(outExp.condition);
-        Structural.markExp(outExp.condition);
+
+        // Only mark the condition as structural if it could be evaluated.
+        if not referenceEq(cond, outExp.condition) then
+          Structural.markExp(outExp.condition);
+        end if;
       then
         match cond
           case Expression.BOOLEAN() then splitRecordCref(if cond.value then outExp.trueBranch else outExp.falseBranch);

--- a/testsuite/flattening/modelica/scodeinst/CevalBinding9.mo
+++ b/testsuite/flattening/modelica/scodeinst/CevalBinding9.mo
@@ -1,0 +1,53 @@
+// name: CevalBinding9
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+pure function ext_fun
+  input Real u1;
+  output Real y;
+  external "C";
+end ext_fun;
+
+model Pump
+  parameter Real m_flow_nominal;
+  parameter Integer nOri = 2;
+  parameter Real V_flow = 2.0*m_flow_nominal;
+  final parameter power pow = if V_flow < 0 then power(V_flow=1) else power(V_flow=2);
+end Pump;
+
+record power
+  parameter Real V_flow = 0;
+end power;
+
+model CevalBinding9
+  Pump pumHeaPum(m_flow_nominal = Q);
+  parameter Real T = 0;
+  parameter Real Q = ext_fun(T);
+end CevalBinding9;
+
+// Result:
+// function ext_fun
+//   input Real u1;
+//   output Real y;
+//
+//   external "C" y = ext_fun(u1);
+// end ext_fun;
+//
+// function power "Automatically generated record constructor for power"
+//   input Real V_flow = 0.0;
+//   output power res;
+// end power;
+//
+// class CevalBinding9
+//   parameter Real pumHeaPum.m_flow_nominal = Q;
+//   parameter Integer pumHeaPum.nOri = 2;
+//   parameter Real pumHeaPum.V_flow = 2.0 * pumHeaPum.m_flow_nominal;
+//   final parameter Real pumHeaPum.pow.V_flow(fixed = false);
+//   parameter Real T = 0.0;
+//   parameter Real Q = ext_fun(T);
+// initial equation
+//   pumHeaPum.pow = if pumHeaPum.V_flow < 0.0 then power(1.0) else power(2.0);
+// end CevalBinding9;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -126,6 +126,7 @@ CevalBinding5.mo \
 CevalBinding6.mo \
 CevalBinding7.mo \
 CevalBinding8.mo \
+CevalBinding9.mo \
 CevalConstant1.mo \
 CevalCeil1.mo \
 CevalCos1.mo \


### PR DESCRIPTION
- Only mark the condition of an if-expression as structural if it could actually be evaluated.