### PR TITLE
[BE] fix? resolve loops

### DIFF
--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -1816,6 +1816,11 @@ algorithm
       // constant
     then
       (false,false);
+  case(DAE.ICONST(),_)
+    equation
+      // constant
+    then
+      (false,false);
   else
     equation
       print("add a case to expIsCref:"+ExpressionDump.printExpStr(expIn)+"\n");

--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -1330,18 +1330,20 @@ algorithm
       equation
       then
         listReverse(sortLoopIn);
-    case(_,_,_,start::rest)
-      equation
-        vars = arrayGet(m,start);
-        varEqs = List.map1(vars,Array.getIndexFirst,mT);
-        eqs = List.flatten(varEqs);
-        eqs = List.unique(eqs);
-        eqs = List.intersectionOnTrue(eqs,loopIn,intEq);
-        next = listHead(eqs);
-        rest = List.deleteMember(loopIn,next);
-        rest = sortLoop(rest,m,mT,next::sortLoopIn);
-      then
-        rest;
+    case(_,_,_,start::_)
+      algorithm
+        vars := arrayGet(m,start);
+        varEqs := List.map1(vars,Array.getIndexFirst,mT);
+        eqs := List.flatten(varEqs);
+        eqs := List.unique(eqs);
+        eqs := List.intersectionOnTrue(eqs,loopIn,intEq);
+        if listEmpty(eqs) then
+          next := List.first(loopIn);
+        else
+          next := List.first(eqs);
+        end if;
+        rest := List.deleteMember(loopIn,next);
+      then sortLoop(rest,m,mT,next::sortLoopIn);
   end matchcontinue;
 end sortLoop;
 


### PR DESCRIPTION
 - take any equation if no order is enforced when sorting loop equations
 - (can occur because previous steps removed actual loop dependencies)
 related to #11236

   Co-authored-by: phannebohm <phannebohm@hsbi.de>