### PR TITLE
Handle invalid components better in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -93,9 +93,10 @@ public
     Modifier modifier;
   end TYPE_ATTRIBUTE;
 
-  record DELETED_COMPONENT
+  record INVALID_COMPONENT
     Component component;
-  end DELETED_COMPONENT;
+    String errors;
+  end INVALID_COMPONENT;
 
   record WILD "needed for new crefs in the backend" end WILD;
 
@@ -236,6 +237,7 @@ public
       case COMPONENT() then component.ty;
       case ITERATOR() then component.ty;
       case TYPE_ATTRIBUTE() then component.ty;
+      case INVALID_COMPONENT() then getType(component.component);
       else Type.UNKNOWN();
     end match;
   end getType;
@@ -905,6 +907,16 @@ public
       else false;
     end match;
   end isDeleted;
+
+  function isInvalid
+    input Component component;
+    output Boolean invalid;
+  algorithm
+    invalid := match component
+      case INVALID_COMPONENT() then true;
+      else false;
+    end match;
+  end isInvalid;
 
   function isTypeAttribute
     input Component component;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1356,6 +1356,18 @@ algorithm
       then
         ();
 
+    case (Component.INVALID_COMPONENT(), SCode.Element.COMPONENT())
+      algorithm
+        json := JSON.addPair("$kind", JSON.makeString("component"), json);
+        json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
+        json := JSON.addPair("type", dumpJSONComponentType(cls, node, Component.getType(comp)), json);
+        json := dumpJSONSCodeMod(elem.modifications, scope, json);
+        json := JSON.addPairNotNull("prefixes", dumpJSONAttributes(elem.attributes, elem.prefixes, scope), json);
+        json := dumpJSONCommentOpt(SOME(elem.comment), scope, json);
+        json := JSON.addPair("$error", JSON.makeString(comp.errors), json);
+      then
+        ();
+
     case (Component.COMPONENT(), SCode.Element.COMPONENT())
 algorithm
         json := JSON.addPair("$kind", JSON.makeString("component"), json);

--- a/testsuite/openmodelica/instance-API/GetModelInstanceBinding10.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceBinding10.mos
@@ -1,0 +1,63 @@
+// name: GetModelInstanceBinding10
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model A
+    Real x[:, :];
+  end A;
+
+  model M
+    A a(x = [0, -1; 1, 1, 1.1, -1]);
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"a\",
+//       \"type\": {
+//         \"name\": \"A\",
+//         \"restriction\": \"model\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"x\",
+//             \"type\": \"Real\",
+//             \"$error\": \"[<interactive>:3:5-3:17:writable] Error: Type mismatch for positional argument 2 in cat(arg=cat(2, {{0}}, {{-1}})). The argument has type:\\n  Real[1, 2]\\nexpected type:\\n  Real[:, 4]\\n\"
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 4,
+//           \"columnEnd\": 8
+//         }
+//       },
+//       \"modifiers\": {
+//         \"x\": \"[0, -1; 1, 1, 1.1, -1]\"
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 6,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 8,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/GetModelInstanceBinding9.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceBinding9.mos
@@ -1,4 +1,4 @@
-// name: GetModelInstanceBinding8
+// name: GetModelInstanceBinding9
 // keywords:
 // status: correct
 // cflags: -d=newInst

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -24,6 +24,7 @@ GetModelInstanceBinding6.mos \
 GetModelInstanceBinding7.mos \
 GetModelInstanceBinding8.mos \
 GetModelInstanceBinding9.mos \
+GetModelInstanceBinding10.mos \
 GetModelInstanceBreak1.mos \
 GetModelInstanceChoices1.mos \
 GetModelInstanceChoices2.mos \


### PR DESCRIPTION
- Mark components as invalid if the typing of them fails in any way with the instance API, and dump them similar to deleted components along with any error messages.