### PR TITLE
Improve AbsynUtil.pathStripSamePrefix

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -1539,25 +1539,19 @@ public function pathStripSamePrefix
   "strips the same prefix paths and returns the stripped path. e.g pathStripSamePrefix(P.M.A, P.M.B) => A"
   input Absyn.Path inPath1;
   input Absyn.Path inPath2;
-  output Absyn.Path outPath;
+  output Absyn.Path outPath = inPath1;
+protected
+  Absyn.Path path2 = inPath2;
 algorithm
-  outPath := matchcontinue(inPath1, inPath2)
-    local
-      Absyn.Ident ident1, ident2;
-      Absyn.Path path1, path2;
+  while pathFirstIdent(outPath) == pathFirstIdent(path2) loop
+    outPath := pathRest(outPath);
 
-    case (_, _)
-      equation
-        ident1 = pathFirstIdent(inPath1);
-        ident2 = pathFirstIdent(inPath2);
-        true = stringEq(ident1, ident2);
-        path1 = pathRest(inPath1);
-        path2 = pathRest(inPath2);
-      then
-        pathStripSamePrefix(path1, path2);
+    if pathIsIdent(path2) then
+      return;
+    end if;
 
-    else inPath1;
-  end matchcontinue;
+    path2 := pathRest(path2);
+  end while;
 end pathStripSamePrefix;
 
 public function pathPrefix

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -2,6 +2,7 @@ TEST = ../../rtest -v
 
 TESTFILES = \
 AddClassAnnotation.mos \
+addComponent1.mos \
 ArraySlicing.mos \
 Bug2871.mos \
 Bug2882.mos \

--- a/testsuite/openmodelica/interactive-API/addComponent1.mos
+++ b/testsuite/openmodelica/interactive-API/addComponent1.mos
@@ -1,0 +1,40 @@
+// name: addComponent1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the addComponent API.
+//
+
+loadString("model InstantiationExample
+  block MyBlock
+    extends Modelica.Blocks.Icons.Block;
+  end MyBlock;
+end InstantiationExample;");
+getErrorString();
+list(InstantiationExample);
+addComponent(myBlock, InstantiationExample.MyBlock,InstantiationExample,annotate=Placement(transformation=transformation(origin={-32,-62},extent={{-10,-10},{10,10}})));
+getErrorString();
+list(InstantiationExample);
+getErrorString();
+
+// Result:
+// true
+// ""
+// "model InstantiationExample
+//   block MyBlock
+//     extends Modelica.Blocks.Icons.Block;
+//   end MyBlock;
+// end InstantiationExample;"
+// true
+// ""
+// "model InstantiationExample
+//   block MyBlock
+//     extends Modelica.Blocks.Icons.Block;
+//   end MyBlock;
+//
+//   MyBlock myBlock annotation(
+//     Placement(transformation(origin = {-32, -62}, extent = {{-10, -10}, {10, 10}})));
+// end InstantiationExample;"
+// ""
+// endResult


### PR DESCRIPTION
- Rewrite `pathStripSamePrefix` to not fail on e.g. (A.B, A)`, i.e. when the prefix matches completely but the second path is shorter.

Fixes #12187