### PR TITLE
Evaluate HideResult annotations

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFAttributes.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFAttributes.mo
@@ -533,7 +533,7 @@ public
       attr.variability := Variability.IMPLICITLY_DISCRETE;
     elseif var < Variability.CONTINUOUS and InstContext.inFunction(context) and
            attr.direction <> Direction.NONE and
-           isNone(InstNode.getAnnotation("__OpenModelica_functionVariability", compNode)) then
+           SCodeUtil.isEmptyMod(InstNode.getAnnotation("__OpenModelica_functionVariability", compNode)) then
       // Variability prefixes on function parameters has no semantic meaning,
       // remove them so we don't have to worry about accidentally evaluating
       // e.g. an input declared as constant/parameter.

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -416,7 +416,6 @@ constant InstNode TIME =
       NFBinding.EMPTY_BINDING,
       NFAttributes.INPUT_ATTR,
       NONE(),
-      NONE(),
       ComponentState.TypeChecked,
       AbsynUtil.dummyInfo)),
     InstNode.EMPTY_NODE(),

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -81,7 +81,7 @@ constant SCode.Element DUMMY_ELEMENT = SCode.CLASS(
 // Default Integer parameter.
 constant Component INT_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
   Type.INTEGER(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
+  NFAttributes.DEFAULT_ATTR, NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
   NONE(), Visibility.PUBLIC,
@@ -91,7 +91,7 @@ constant InstNode INT_PARAM = InstNode.COMPONENT_NODE("i",
 // Default Real parameter.
 constant Component REAL_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
   Type.REAL(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
+  NFAttributes.DEFAULT_ATTR, NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
   NONE(), Visibility.PUBLIC,
@@ -101,7 +101,7 @@ constant InstNode REAL_PARAM = InstNode.COMPONENT_NODE("r",
 // Default Boolean parameter.
 constant Component BOOL_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
   Type.BOOLEAN(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
+  NFAttributes.DEFAULT_ATTR, NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
   NONE(), Visibility.PUBLIC,
@@ -111,7 +111,7 @@ constant InstNode BOOL_PARAM = InstNode.COMPONENT_NODE("b",
 // Default String parameter.
 constant Component STRING_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
   Type.STRING(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
+  NFAttributes.DEFAULT_ATTR, NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
   NONE(), Visibility.PUBLIC,
@@ -121,7 +121,7 @@ constant InstNode STRING_PARAM = InstNode.COMPONENT_NODE("s",
 // Default enumeration(:) parameter.
 constant Component ENUM_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
   Type.ENUMERATION(Absyn.Path.IDENT(":"), {}), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
+  NFAttributes.DEFAULT_ATTR, NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode ENUM_PARAM = InstNode.COMPONENT_NODE("e",
   NONE(), Visibility.PUBLIC,
@@ -391,7 +391,7 @@ constant Function SAMPLE = Function.FUNCTION(Path.QUALIFIED("OMC_NO_CLOCK", Path
 
 constant Component CLOCK_COMPONENT = Component.COMPONENT(NFInstNode.EMPTY_NODE(),
   Type.CLOCK(), NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-  NFAttributes.DEFAULT_ATTR, NONE(), NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
+  NFAttributes.DEFAULT_ATTR, NONE(), ComponentState.TypeChecked, AbsynUtil.dummyInfo);
 
 constant InstNode CLOCK_PARAM = InstNode.COMPONENT_NODE("s",
   NONE(), Visibility.PUBLIC,

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -71,7 +71,6 @@ public
     Binding binding;
     Binding condition;
     Attributes attributes;
-    Option<Modifier> ann "the annotation from SCode.Comment as a modifier";
     Option<SCode.Comment> comment;
     ComponentState state;
     SourceInfo info;
@@ -830,16 +829,6 @@ public
       else NONE();
     end match;
   end comment;
-
-  function ann
-    input Component component;
-    output Option<Modifier> ann;
-  algorithm
-    ann := match component
-      case COMPONENT() then component.ann;
-      else NONE();
-    end match;
-  end ann;
 
   function getEvaluateAnnotation
     input Component component;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -244,7 +244,7 @@ algorithm
 
   // propagate hide result attribute
   // ticket #4346
-  flatModel.variables := list(Variable.propagateAnnotation("HideResult", false, var) for var in flatModel.variables);
+  flatModel.variables := list(Variable.propagateAnnotation("HideResult", false, true, var) for var in flatModel.variables);
 
   flatModel := FlatModel.removeNonTopLevelDirections(flatModel);
 
@@ -1885,7 +1885,7 @@ algorithm
         // is created by instClass. To break the circle we leave the class node
         // empty here, and let instClass set it for us instead.
         inst_comp := Component.COMPONENT(InstNode.EMPTY_NODE(), Type.UNKNOWN(),
-          binding, condition, attr, NONE(), SOME(component.comment),
+          binding, condition, attr, SOME(component.comment),
           ComponentState.PartiallyInstantiated, info);
         InstNode.updateComponent(inst_comp, node);
 
@@ -2121,7 +2121,7 @@ algorithm
         cmt := orig_comp.comment;
       then
         Component.COMPONENT(rdcl_comp.classInst, rdcl_ty, binding, condition,
-          attr, NONE(), cmt, ComponentState.PartiallyInstantiated, rdcl_comp.info);
+          attr, cmt, ComponentState.PartiallyInstantiated, rdcl_comp.info);
 
     else
       algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -160,7 +160,7 @@ algorithm
   // Create the output record element, using the instance created above as both parent and type.
   out_comp := Component.COMPONENT(ctor_node, Type.UNTYPED(node, listArray({})),
                 NFBinding.EMPTY_BINDING, NFBinding.EMPTY_BINDING,
-                NFAttributes.OUTPUT_ATTR, NONE(), NONE(),
+                NFAttributes.OUTPUT_ATTR, NONE(),
                 ComponentState.FullyInstantiated, AbsynUtil.dummyInfo);
   out_rec := InstNode.fromComponent("$out" + InstNode.name(ctor_node), out_comp, ctor_node);
 

--- a/testsuite/flattening/modelica/others/HideResult1.mo
+++ b/testsuite/flattening/modelica/others/HideResult1.mo
@@ -1,0 +1,39 @@
+// name: HideResult1
+// keywords:
+// status: correct
+// cflags: -d=newInst --showAnnotations
+//
+//
+
+model A
+  Real x;
+  Real y annotation(HideResult = false);
+end A;
+
+model B
+  A a1 annotation(HideResult = true);
+  A a2;
+  Real z;
+end B;
+
+model HideResult1
+  B b1 annotation(HideResult = false);
+  parameter Boolean hide = true;
+  B b2 annotation(HideResult = hide);
+end HideResult1;
+
+// Result:
+// class HideResult1
+//   Real b1.a1.x annotation(HideResult = true);
+//   Real b1.a1.y annotation(HideResult = false);
+//   Real b1.a2.x annotation(HideResult = false);
+//   Real b1.a2.y annotation(HideResult = false);
+//   Real b1.z annotation(HideResult = false);
+//   parameter Boolean hide = true;
+//   Real b2.a1.x annotation(HideResult = true);
+//   Real b2.a1.y annotation(HideResult = false);
+//   Real b2.a2.x annotation(HideResult = true);
+//   Real b2.a2.y annotation(HideResult = false);
+//   Real b2.z annotation(HideResult = true);
+// end HideResult1;
+// endResult

--- a/testsuite/flattening/modelica/others/Makefile
+++ b/testsuite/flattening/modelica/others/Makefile
@@ -41,6 +41,7 @@ ForIterator1.mo \
 ForIterator2.mo \
 ForIterator3.mo \
 GetInstanceName.mo \
+HideResult1.mo \
 IconsRecursiveTest.mo \
 if_then_elseif_else.mo \
 IfExpCombiTable1.mo \

--- a/testsuite/simulation/modelica/daemode/testDAEModeFileSplit_Issue4851.mos
+++ b/testsuite/simulation/modelica/daemode/testDAEModeFileSplit_Issue4851.mos
@@ -16,7 +16,6 @@ system("ls *16dae_part*.c"); getErrorString();
 // true
 // {"PowerGrids.Examples.IEEE14bus.IEEE14busGen2Disconnection","PowerGrids.Examples.IEEE14bus.IEEE14busGen2Disconnection_init.xml"}
 // "Warning: The model contains alias variables with redundant start and/or conflicting nominal values. It is recommended to resolve the conflicts, because otherwise the system could be hard to solve. To print the conflicting alias sets and the chosen candidates please use -d=aliasConflicts.
-// Warning: The hideResult annotation could not be evaluated, probably due to missing annotation(Evaluate=true). It is removed.
 // "
 // PowerGrids.Examples.IEEE14bus.IEEE14busGen2Disconnection_16dae_part0.c
 // PowerGrids.Examples.IEEE14bus.IEEE14busGen2Disconnection_16dae_part1.c


### PR DESCRIPTION
- Rewrite `Variable.propagateAnnotation` to optionally evaluate the annotation value and use it when propagating HideResult.
- Remove the annotation field from `Component.COMPONENT` since it's not actually used anywhere.