### PR TITLE
Do not call childrenBoundingRect from the boundingRect

### DIFF
--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1035,33 +1035,33 @@ bool Element::hasNonExistingClass()
  */
 QRectF Element::boundingRect() const
 {
-  if (isRoot()) {
-    if (mpGraphicsView->getModelWidget()->isNewApi()) {
+  if (mpGraphicsView->getModelWidget()->isNewApi()) {
+    if (isRoot()) {
       ModelInstance::CoordinateSystem coordinateSystem = getCoOrdinateSystemNew();
       return coordinateSystem.getExtentRectangle();
-    } else {
-      CoOrdinateSystem coOrdinateSystem = getCoOrdinateSystem();
-      ExtentAnnotation extent = coOrdinateSystem.getExtent();
+    } else if (isPort()) {
+      ExtentAnnotation extent;
+      if (mpModelComponent->getModel()->isConnector() && (mpGraphicsView->getViewType() == StringHandler::Diagram) && canUseDiagramAnnotation()) {
+        mpModelComponent->getAnnotation()->getPlacementAnnotation().getTransformation().getExtent();
+      } else {
+        mpModelComponent->getAnnotation()->getPlacementAnnotation().getIconTransformation().getExtent();
+      }
       qreal left = extent.at(0).x();
       qreal bottom = extent.at(0).y();
       qreal right = extent.at(1).x();
       qreal top = extent.at(1).y();
       return QRectF(left, bottom, qFabs(left - right), qFabs(bottom - top));
-    }
-  } else if (isPort()) {
-    ExtentAnnotation extent;
-    if (mpModelComponent->getModel()->isConnector() && (mpGraphicsView->getViewType() == StringHandler::Diagram) && canUseDiagramAnnotation()) {
-      mpModelComponent->getAnnotation()->getPlacementAnnotation().getTransformation().getExtent();
     } else {
-      mpModelComponent->getAnnotation()->getPlacementAnnotation().getIconTransformation().getExtent();
+      return QRectF();
     }
+  } else {
+    CoOrdinateSystem coOrdinateSystem = getCoOrdinateSystem();
+    ExtentAnnotation extent = coOrdinateSystem.getExtent();
     qreal left = extent.at(0).x();
     qreal bottom = extent.at(0).y();
     qreal right = extent.at(1).x();
     qreal top = extent.at(1).y();
     return QRectF(left, bottom, qFabs(left - right), qFabs(bottom - top));
-  } else {
-    return QRectF();
   }
 }
 

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -1049,7 +1049,17 @@ QRectF Element::boundingRect() const
       return QRectF(left, bottom, qFabs(left - right), qFabs(bottom - top));
     }
   } else if (isPort()) {
-    return childrenBoundingRect();
+    ExtentAnnotation extent;
+    if (mpModelComponent->getModel()->isConnector() && (mpGraphicsView->getViewType() == StringHandler::Diagram) && canUseDiagramAnnotation()) {
+      mpModelComponent->getAnnotation()->getPlacementAnnotation().getTransformation().getExtent();
+    } else {
+      mpModelComponent->getAnnotation()->getPlacementAnnotation().getIconTransformation().getExtent();
+    }
+    qreal left = extent.at(0).x();
+    qreal bottom = extent.at(0).y();
+    qreal right = extent.at(1).x();
+    qreal top = extent.at(1).y();
+    return QRectF(left, bottom, qFabs(left - right), qFabs(bottom - top));
   } else {
     return QRectF();
   }
@@ -1858,7 +1868,7 @@ QPair<QString, bool> Element::getParameterDisplayString(QString parameterName)
   /* case 0 */
   if (isInheritedElement()) {
     if (mpGraphicsView->getModelWidget()->isNewApi()) {
-      displayString = mpModel->getParameterValueFromExtendsModifiers(parameterName);
+      displayString = mpGraphicsView->getModelWidget()->getModelInstance()->getParameterValueFromExtendsModifiers(QStringList() << getName() << parameterName);
       if (displayString.second) {
         return displayString;
       }
@@ -3007,7 +3017,7 @@ QPair<QString, bool> Element::getParameterDisplayStringFromExtendsModifiers(QStr
    * Get the extends modifiers of the class not the inherited class.
    */
   if (mpGraphicsView->getModelWidget()->isNewApi()) {
-    displayString = mpModel->getParameterValueFromExtendsModifiers(parameterName);
+    displayString = mpModel->getParameterValueFromExtendsModifiers(QStringList() << parameterName);
   } else if (mpLibraryTreeItem) {
     foreach (Element *pElement, mInheritedElementsList) {
       if (pElement->getLibraryTreeItem()) {

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1470,14 +1470,14 @@ namespace ModelInstance
     return value;
   }
 
-  QPair<QString, bool> Model::getParameterValueFromExtendsModifiers(const QString &parameter)
+  QPair<QString, bool> Model::getParameterValueFromExtendsModifiers(const QStringList &parameter)
   {
     QPair<QString, bool> value("", false);
     foreach (auto pElement, mElements) {
       if (pElement->isExtend()) {
         auto pExtend = dynamic_cast<Extend*>(pElement);
         if (pExtend->getModifier()) {
-          value = pExtend->getModifier()->getModifierValue(QStringList() << parameter);
+          value = pExtend->getModifier()->getModifierValue(parameter);
         }
         if (value.second) {
           return value;

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -609,7 +609,7 @@ private:
     bool isValidConnection(const Name &lhsConnector, const Name &rhsConnector) const;
     bool isTypeCompatibleWith(const Model &other, bool lhsOutside, bool rhsOutside) const;
     QPair<QString, bool> getParameterValue(const QString &parameter, QString &typeName);
-    QPair<QString, bool> getParameterValueFromExtendsModifiers(const QString &parameter);
+    QPair<QString, bool> getParameterValueFromExtendsModifiers(const QStringList &parameter);
 
     FlatModelica::Expression* getVariableBinding(const QString &variableName);
     const Element *lookupElement(const QString &name) const;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -9211,14 +9211,13 @@ void ModelWidget::removeInheritedClasses(LibraryTreeItem *pLibraryTreeItem)
 /*!
  * \brief ModelWidget::dependsOnModel
  * Checks if modelName exists in dependsOnModel list
- * We check for complete name OR if the name ends with same name.
  * \param modelName
  * \return
  */
 bool ModelWidget::dependsOnModel(const QString &modelName)
 {
   foreach (QString model, mDependsOnModelsList) {
-    if ((model.compare(modelName) == 0) || (StringHandler::getLastWordAfterDot(modelName).compare(StringHandler::getLastWordAfterDot(model)) == 0)) {
+    if ((model.compare(modelName) == 0)) {
       return true;
     }
   }


### PR DESCRIPTION
#12219

Calling childrenBoundingRect ends up in infinite loop.

Fix parameter display of inherited components when value is defined in extends clause.

Do not check if the name ends with same name in ModelWidget::dependsOnModel. Causes redundant calls to ModelWidget::reDrawModelWidget.