### PR TITLE
Fix InstNode.getAnnotation

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1168,12 +1168,12 @@ uniontype InstNode
         mod := SCodeUtil.lookupAnnotation(Util.getOption(ann), name);
 
         if not SCodeUtil.isEmptyMod(mod) then
-          scope := parent(scope);
+          scope := instanceParent(scope);
           return;
         end if;
       end if;
 
-      scope := parent(scope);
+      scope := instanceParent(scope);
     end while;
 
     mod := SCode.Mod.NOMOD();

--- a/testsuite/flattening/modelica/others/HideResult1.mo
+++ b/testsuite/flattening/modelica/others/HideResult1.mo
@@ -11,6 +11,7 @@ model A
 end A;
 
 model B
+  extends A;
   A a1 annotation(HideResult = true);
   A a2;
   Real z;
@@ -24,12 +25,16 @@ end HideResult1;
 
 // Result:
 // class HideResult1
+//   Real b1.x annotation(HideResult = false);
+//   Real b1.y annotation(HideResult = false);
 //   Real b1.a1.x annotation(HideResult = true);
 //   Real b1.a1.y annotation(HideResult = false);
 //   Real b1.a2.x annotation(HideResult = false);
 //   Real b1.a2.y annotation(HideResult = false);
 //   Real b1.z annotation(HideResult = false);
 //   parameter Boolean hide = true;
+//   Real b2.x annotation(HideResult = true);
+//   Real b2.y annotation(HideResult = false);
 //   Real b2.a1.x annotation(HideResult = true);
 //   Real b2.a1.y annotation(HideResult = false);
 //   Real b2.a2.x annotation(HideResult = true);


### PR DESCRIPTION
- Use `instanceParent()` instead of `parent()` to properly traverse the instance tree when looking for annotations on parents.