### PR TITLE
Fixing quoted identifier lexing

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenUtil.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtil.tpl
@@ -104,11 +104,17 @@ template crefStr(ComponentRef cr)
 end crefStr;
 
 template crefStrNoUnderscore(ComponentRef cr)
- "Generates the name of a variable for variable name array. However does not use underscores on qualified names.
- a.b not a._b. Used for generating variable names that are exported e.g. xml files"
+ "Generates the name of a variable for variable name array.
+  However does not use underscores on qualified names.
+  a.b not a._b.
+  Escaping single and double quotes from quoted identifiers.
+
+  Used for generating variable names that are exported e.g. xml files"
 ::=
   match cr
-  case CREF_IDENT(__) then '<%ident%><%subscriptsStr(subscriptLst)%>'
+  case CREF_IDENT(__) then
+    let escapedIdent = Util.escapeModelicaStringToCString(escapeSingleQuoteIdent(ident))
+    '<%escapedIdent%><%subscriptsStr(subscriptLst)%>'
   case CREF_QUAL(ident = "$DER") then 'der(<%crefStrNoUnderscore(componentRef)%>)'
   case CREF_QUAL(ident = "$CLKPRE") then 'previous(<%crefStrNoUnderscore(componentRef)%>)'
   case CREF_QUAL(__) then '<%ident%><%subscriptsStr(subscriptLst)%>.<%crefStrNoUnderscore(componentRef)%>'
@@ -193,6 +199,13 @@ template crefCCommentWithVariability(SimVar v)
 end crefCCommentWithVariability;
 
 /*********************************************************/
+
+template escapeSingleQuoteIdent(String ident)
+  "Escape single quotes from quoted identifiers."
+::=
+  // TODO: How to replace "'" with "\'" but not "\'" with "\\'"?
+  '<%System.stringReplace(System.stringReplace(ident, "\\'", "\\\\'"), "'", "\\'")%>'
+end escapeSingleQuoteIdent;
 
 template initDefaultValXml(DAE.Type type_)
 ::=

--- a/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
+++ b/OMCompiler/Compiler/Template/CodegenUtilSimulation.tpl
@@ -141,13 +141,13 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       <<
       equation index: <%equationIndex(eq)%>
       type: SIMPLE_ASSIGN
-      <%dumpCref(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
+      <%escapeCComments(dumpCref(e.cref))%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
       >>
     case e as SES_SIMPLE_ASSIGN_CONSTRAINTS(__) then
       <<
       equation index: <%equationIndex(eq)%>
       type: SIMPLE_ASSIGN_CONSTRAINTS
-      <%dumpCref(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
+      <%escapeCComments(dumpCref(e.cref))%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
       constraints: <%escapeCComments(dumpConstraints(e.cons))%>
       >>
     case e as SES_ARRAY_CALL_ASSIGN(lhs=lhs as CREF(__)) then
@@ -155,7 +155,7 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: ARRAY_CALL_ASSIGN
 
-      <%dumpCref(lhs.componentRef)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
+      <%escapeCComments(dumpCref(lhs.componentRef))%> = <%escapeCComments(dumpExp(e.exp,"\""))%>
       >>
     case e as SES_GENERIC_ASSIGN(__) then
       <<
@@ -185,7 +185,7 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: LINEAR
 
-      <%ls.vars |> SIMVAR(name=cr) => '<var><%dumpCref(cr)%></var>' ; separator = "\n" %>
+      <%ls.vars |> SIMVAR(name=cr) => '<var><%escapeCComments(dumpCref(cr))%></var>' ; separator = "\n" %>
       <row>
         <%ls.beqs |> exp => '<cell><%escapeCComments(dumpExp(exp,"\""))%></cell>' ; separator = "\n" %><%\n%>
       </row>
@@ -218,7 +218,7 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       indexNonlinear: <%nls.indexNonLinearSystem%>
       type: NONLINEAR
 
-      vars: {<%nls.crefs |> cr => '<%dumpCref(cr)%>' ; separator = ", "%>}
+      vars: {<%nls.crefs |> cr => '<%escapeCComments(dumpCref(cr))%>' ; separator = ", "%>}
       eqns: {<%nls.eqs |> eq => '<%equationIndex(eq)%>' ; separator = ", "%>}
       >>
     case e as SES_MIXED(__) then
@@ -231,7 +231,7 @@ template dumpEqsWork(list<SimEqSystem> eqs)
 
       <mixed>
         <continuous index="<%equationIndex(e.cont)%>" />
-        <%e.discVars |> SIMVAR(name=cr) => '<var><%dumpCref(cr)%></var>' ; separator = ","%>
+        <%e.discVars |> SIMVAR(name=cr) => '<var><%escapeCComments(dumpCref(cr))%></var>' ; separator = ","%>
         <%e.discEqs |> eq => '<discrete index="<%equationIndex(eq)%>" />'%>
       </mixed>
       >>
@@ -251,7 +251,7 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       equation index: <%equationIndex(eq)%>
       type: WHEN
 
-      when {<%conditions |> cond => '<%dumpCref(cond)%>' ; separator=", " %>} then
+      when {<%conditions |> cond => '<%escapeCComments(dumpCref(cond))%>' ; separator=", " %>} then
         <%body%>
       end when;
       >>
@@ -269,7 +269,7 @@ template dumpEqsWork(list<SimEqSystem> eqs)
       let &forstatement = buffer ""
       let &forstatement += 'for ' + escapeCComments(dumpExp(e.iter,"\"")) + ' in ' + escapeCComments(dumpExp(e.startIt,"\""))
       let &forstatement += ' : ' + escapeCComments(dumpExp(e.endIt,"\"")) + ' loop<%\n%>'
-      let &forstatement += '  <%dumpCref(e.cref)%> = <%escapeCComments(dumpExp(e.exp,"\""))%>; '
+      let &forstatement += '  <%escapeCComments(dumpCref(e.cref))%> = <%escapeCComments(dumpExp(e.exp,"\""))%>; '
       let &forstatement += 'end for'
       <<
       equation index: <%equationIndex(e)%>

--- a/OMCompiler/Parser/BaseModelica_Lexer.g
+++ b/OMCompiler/Parser/BaseModelica_Lexer.g
@@ -386,7 +386,7 @@ fragment
 SCHAR : NL | ~('\r' | '\n' | '\\' | '"');
 
 fragment
-SESCAPE : esc='\\' ('\\' | '"' | '\'' | '?' | 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' |
+SESCAPE : esc='\\' ('\'' | '"' | '\\' | '?' | 'a' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' |
   {
     char chars[2] = {LA(1),'\0'};
     const char *str = chars;
@@ -428,11 +428,12 @@ IDENT2 : NONDIGIT (NONDIGIT | DIGIT)* | '$cpuTime';
 
 fragment
 QIDENT :
-         '\'' (QCHAR | SESCAPE) (QCHAR | SESCAPE)* '\'' ;
+         '\'' (QCHAR | SESCAPE)* '\'' ;
 
 fragment
-QCHAR :  (DIGIT | NONDIGIT | '!' | '#' | '$' | '%' | '&' | '(' | ')' | '*' | '+' | ',' | '-' | '.' | '/' | ':' | ';' | '<' | '>' | '=' | '?' | '@' | '[' | ']' | '^' |
-'{' | '}' | '|' | '~' | ' ');
+QCHAR :  (DIGIT | NONDIGIT | '!' | '#' | '$' | '%' | '&' | '(' | ')'
+          | '*' | '+' | ',' | '-' | '.' | '/' | ':' | ';' | '<' | '>' | '='
+          | '?' | '@' | '[' | ']' | '^' | '{' | '}' | '|' | '~' | ' ' | '"' );
 
 fragment
 NONDIGIT :   ('_' | 'a'..'z' | 'A'..'Z');

--- a/testsuite/flattening/modelica/mosfiles/.gitignore
+++ b/testsuite/flattening/modelica/mosfiles/.gitignore
@@ -1,0 +1,1 @@
+/QuotedIdentifier_tmp/

--- a/testsuite/flattening/modelica/mosfiles/Makefile
+++ b/testsuite/flattening/modelica/mosfiles/Makefile
@@ -28,6 +28,7 @@ ModifierVariabilityError.mos \
 NotbasicType.mos NotbasicType2.mos \
 OverloadingFunc.mos \
 QuotedFunction.mos \
+QuotedIdentifiers.mos \
 Return.mos \
 StringArrayReturn.mos \
 TestLoadModel.mos \

--- a/testsuite/flattening/modelica/mosfiles/Makefile
+++ b/testsuite/flattening/modelica/mosfiles/Makefile
@@ -28,7 +28,7 @@ ModifierVariabilityError.mos \
 NotbasicType.mos NotbasicType2.mos \
 OverloadingFunc.mos \
 QuotedFunction.mos \
-QuotedIdentifiers.mos \
+QuotedIdentifier.mos \
 Return.mos \
 StringArrayReturn.mos \
 TestLoadModel.mos \

--- a/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mo
+++ b/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mo
@@ -1,0 +1,15 @@
+model QuotedIdentifier
+  Real 'a"b';
+  Real 'c d';
+  Real 'e"f g';
+  Real 'h\'i //j';
+  Real '\\\\\'';
+  Real '';
+equation
+  der('a"b')=1;
+  der('c d')=-1;
+  der('e"f g')=2;
+  der('h\'i //j')=-2;
+  der('\\\\\'')=3;
+  der('')=-3;
+end QuotedIdentifier;

--- a/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mo
+++ b/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mo
@@ -5,11 +5,15 @@ model QuotedIdentifier
   Real 'h\'i //j';
   Real '\\\\\'';
   Real '';
+  Real '*/ no code injection';
+  Real '\'';
 equation
-  der('a"b')=1;
-  der('c d')=-1;
-  der('e"f g')=2;
-  der('h\'i //j')=-2;
-  der('\\\\\'')=3;
-  der('')=-3;
+  der('a"b') = 1;
+  der('c d') = -1;
+  der('e"f g') = 2;
+  der('h\'i //j') = -2;
+  der('\\\\\'') = 3;
+  der('') = -3;
+  der('*/ no code injection') = 4;
+  der('\'') = -4;
 end QuotedIdentifier;

--- a/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mos
+++ b/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mos
@@ -1,6 +1,9 @@
 // name: QuotedIdentifier
 // status: correct
 // teardown_command: rm -rf QuotedIdentifier_tmp
+//
+// Test compilation of C code containing */ or ".
+// Test lineariazion of modle with quoted identifiers containing additional '.
 
 loadFile("QuotedIdentifier.mo");getErrorString();
 
@@ -8,8 +11,40 @@ echo(false);
 mkdir("QuotedIdentifier_tmp"); cd("QuotedIdentifier_tmp");
 echo(true);
 
-translate(QuotedIdentifier); getErrorString();
-simulate(QuotedIdentifier); getErrorString();
+buildModel(QuotedIdentifier); getErrorString();
+linearize(QuotedIdentifier); getErrorString();
+
+loadFile("linearized_model.mo"); getErrorString();
+
+simulate(linearized_model); getErrorString();
 
 // Result:
-
+// true
+// ""
+// true
+// {"QuotedIdentifier","QuotedIdentifier_init.xml"}
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// record SimulationResult
+//     resultFile = "QuotedIdentifier_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'QuotedIdentifier', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_STDOUT        | info    | Linearization will be performed at point of time: 1.000000
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// LOG_STDOUT        | info    | Linear model is created.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// true
+// ""
+// record SimulationResult
+//     resultFile = "linearized_model_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'linearized_model', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// endResult

--- a/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mos
+++ b/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mos
@@ -1,0 +1,15 @@
+// name: QuotedIdentifier
+// status: correct
+// teardown_command: rm -rf QuotedIdentifier_tmp
+
+loadFile("QuotedIdentifier.mo");getErrorString();
+
+echo(false);
+mkdir("QuotedIdentifier_tmp"); cd("QuotedIdentifier_tmp");
+echo(true);
+
+translate(QuotedIdentifier); getErrorString();
+simulate(QuotedIdentifier); getErrorString();
+
+// Result:
+


### PR DESCRIPTION

### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12235

### Purpose

  - Allow empty quoted identifier.
  - Add `"` to QCHAR


### Approach

  - Fixing Lexer rules
  - Adding test (that fails at C code compilation)
