### PR TITLE
Improve handling of partial derivative of function

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -643,6 +643,13 @@ algorithm
                                 SCode.NOMOD(), SCode.defaultVarAttr),
          node, info);
 
+    case SCode.PDER()
+      algorithm
+        Error.addSourceMessage(Error.UNSUPPORTED_LANGUAGE_FEATURE,
+          {"partial derivative of function", "use --newBackend flag."}, InstNode.info(node));
+      then
+        fail();
+
     else
       algorithm
         Error.assertion(false, getInstanceName() + " got unknown class:\n" + SCodeDump.unparseElementStr(def), sourceInfo());


### PR DESCRIPTION
- Give a proper error message for partial derivatives of functions when not using the `--newBackend` flag, instead of just failing with an unrelated internal error.