### PR TITLE
Improve handling of array bindings for Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -561,6 +561,28 @@ public
     end match;
   end isExternalObjectConstructor;
 
+  function isLiteral
+    input Call call;
+    output Boolean literal;
+  protected
+    function is_literal_iter
+      input tuple<InstNode, Expression> iter;
+      output Boolean literal = Expression.isLiteral(Util.tuple22(iter));
+    end is_literal_iter;
+  algorithm
+    literal := match call
+      case TYPED_CALL() then List.all(call.arguments, Expression.isLiteral);
+
+      case TYPED_REDUCTION()
+        then Expression.isLiteral(call.exp) and List.all(call.iters, is_literal_iter);
+
+      case TYPED_ARRAY_CONSTRUCTOR()
+        then Expression.isLiteral(call.exp) and List.all(call.iters, is_literal_iter);
+
+      else false;
+    end match;
+  end isLiteral;
+
   function inlineType
     input NFCall call;
     output DAE.InlineType inlineTy;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4443,8 +4443,6 @@ public
     output Boolean literal;
   algorithm
     literal := match exp
-      local
-        Expression e;
       case INTEGER() then true;
       case REAL() then true;
       case STRING() then true;
@@ -4454,7 +4452,7 @@ public
       case RECORD() then List.all(exp.elements, isLiteral);
       case RANGE() then isLiteral(exp.start) and isLiteral(exp.stop) and
                         Util.applyOptionOrDefault(exp.step, isLiteral, true);
-      case CALL(call = Call.TYPED_ARRAY_CONSTRUCTOR(exp = e)) then isLiteral(e);
+      case CALL(call = Call.TYPED_ARRAY_CONSTRUCTOR()) then Call.isLiteral(exp.call);
       case CAST() then isLiteral(exp.exp);
       case BOX() then isLiteral(exp.exp);
       case UNBOX() then isLiteral(exp.exp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -1170,7 +1170,7 @@ algorithm
   binding_ty := Type.liftArrayLeftList(binding_ty, dims);
 
   if not listEmpty(dims) then
-    if Expression.isLiteral(exp) then
+    if Expression.isLiteral(exp) or not Expression.contains(exp, Expression.isIterator) then
       array_call := Call.makeTypedCall(NFBuiltinFuncs.FILL_FUNC,
         exp :: list(Dimension.sizeExp(d) for d in dims),
         Binding.variability(binding), Purity.PURE, binding_ty);

--- a/testsuite/flattening/modelica/scodeinst/VectorizeBindings1.mo
+++ b/testsuite/flattening/modelica/scodeinst/VectorizeBindings1.mo
@@ -18,6 +18,6 @@ end VectorizeBindings1;
 // class VectorizeBindings1
 //   parameter Real p = 2.0;
 //   parameter Real[2, 3] m.q = fill(2.0, 2, 3);
-//   parameter Real[2, 3] m.p = array(array(2.0 * p for $m2 in 1:3) for $m1 in 1:2);
+//   parameter Real[2, 3] m.p = fill(2.0 * p, 2, 3);
 // end VectorizeBindings1;
 // endResult

--- a/testsuite/openmodelica/basemodelica/ArrayBinding1.mo
+++ b/testsuite/openmodelica/basemodelica/ArrayBinding1.mo
@@ -1,0 +1,21 @@
+// name: ArrayBinding1
+// status: correct
+// cflags: -d=newInst -f -d=-nfScalarize,vectorizeBindings,evaluateAllParameters
+
+model A
+  parameter Real p;
+end A;
+
+model ArrayBinding1
+  final parameter Real P = 1;
+  A a[4,4,4](each p = P);
+end ArrayBinding1;
+
+// Result:
+// package 'ArrayBinding1'
+//   model 'ArrayBinding1'
+//     final parameter Real 'P' = 1.0;
+//     parameter Real[4, 4, 4] 'a.p' = fill(1.0, 4, 4, 4);
+//   end 'ArrayBinding1';
+// end 'ArrayBinding1';
+// endResult

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -9,6 +9,7 @@ else
 endif
 
 TESTFILES = \
+  ArrayBinding1.mo \
 	Comments.mo \
   DoublePendulum.mos \
 	Expression1.mo \


### PR DESCRIPTION
- Generate fill expression instead of array constructors when vectorizing expressions that aren't subscripted.
- Don't expand binding expressions that could be considered literals after evaluating structural parameters, such as fill expressions and array constructors with literal arguments.

Fixes #12257