### PR TITLE
Improve EvalConstants.evaluateBinding

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4461,15 +4461,15 @@ public
     end match;
   end isLiteral;
 
-  function isLiteralFill
+  function isKnownSizeFill
     input Expression exp;
     output Boolean literal;
   algorithm
     literal := match exp
-      case CALL() then Call.isNamed(exp.call, "fill") and List.all(Call.arguments(exp.call), isLiteral);
+      case CALL() then Call.isKnownSizeFill(exp.call);
       else false;
     end match;
-  end isLiteralFill;
+  end isKnownSizeFill;
 
   function isInteger
     input Expression exp;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1160,6 +1160,7 @@ usertype6.mo \
 VectorizeBindings1.mo \
 VectorizeBindings2.mo \
 VectorizeBindings3.mo \
+VectorizeBindings4.mo \
 VectorTest.mo \
 Visibility1.mo \
 Visibility2.mo \

--- a/testsuite/flattening/modelica/scodeinst/VectorizeBindings4.mo
+++ b/testsuite/flattening/modelica/scodeinst/VectorizeBindings4.mo
@@ -1,0 +1,25 @@
+// name: VectorizeBindings4
+// keywords:
+// status: correct
+// cflags: -d=newInst,evaluateAllParameters,-nfScalarize,vectorizeBindings
+//
+
+model A
+  parameter Real p1 = 10 + 5;
+  parameter Real p2;
+  Real X(start = p1, fixed = true);
+end A;
+
+model VectorizeBindings4
+  final parameter Real p = 3;
+  A a[4,5,6](each X(start = 20, fixed = true), each p2 = 2*p);
+end VectorizeBindings4;
+
+// Result:
+// class VectorizeBindings4
+//   final parameter Real p = 3.0;
+//   Real[4, 5, 6] a.X(start = fill(20.0, 4, 5, 6), fixed = fill(true, 4, 5, 6));
+//   final parameter Real[4, 5, 6] a.p2 = fill(6.0, 4, 5, 6);
+//   final parameter Real[4, 5, 6] a.p1 = fill(15.0, 4, 5, 6);
+// end VectorizeBindings4;
+// endResult


### PR DESCRIPTION
- Use `evaluateExp` and simplify the result when evaluating bindings before checking if the binding needs to be constant evaluated, to avoid expanding fill/array constructors unnecessarily.

Fixes #12267