### PR TITLE
Skip discrete conditions at event collection

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -1048,6 +1048,11 @@ protected
   protected
     Boolean failed = true;
   algorithm
+    // skip if there is no continuous change in `exp`
+    if not BackendUtil.isContinuous(exp) then
+      return;
+    end if;
+
     // try to create time event or composite time event
     if BackendUtil.isOnlyTimeDependent(exp) then
       (exp, bucket, failed) := TimeEvent.create(exp, bucket, iter, eqn, funcTree, createAux);


### PR DESCRIPTION
### Purpose

In equations like this, the condition `i == j` should not be collected as event:
```modelica
for i in 1:N loop
  for j in 1:M loop
    if i == j then
      x[i,j] = 0;
    else
      x[i,j] = (i-j)*time;
    end if;
  end for;
end for;
```

### Approach

If the condition expression is not continuous it will not be collected.
