### PR TITLE
Handle too many subscripts in Type.subscript

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1138,6 +1138,10 @@ public
 
     ty := match ty
       case ARRAY(dimensions = dims)
+        guard not failOnError and listLength(subs) > listLength(dims)
+        then Type.UNKNOWN();
+
+      case ARRAY(dimensions = dims)
         algorithm
           for sub in subs loop
             dim :: dims := dims;

--- a/testsuite/flattening/modelica/scodeinst/BuiltinAttribute24.mo
+++ b/testsuite/flattening/modelica/scodeinst/BuiltinAttribute24.mo
@@ -1,0 +1,20 @@
+// name: BuiltinAttribute23
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model BuiltinAttribute24
+  Real x[2,2](start = {3,1});
+end BuiltinAttribute24;
+
+// Result:
+// Error processing file: BuiltinAttribute24.mo
+// [flattening/modelica/scodeinst/BuiltinAttribute24.mo:8:15-8:28:writable] Notification: From here:
+// [flattening/modelica/scodeinst/BuiltinAttribute24.mo:8:3-8:29:writable] Error: Type mismatch in binding 'start = {3.0, 1.0}', expected array dimensions [2, 2], got [2].
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -89,6 +89,7 @@ BuiltinAttribute20.mo \
 BuiltinAttribute21.mo \
 BuiltinAttribute22.mo \
 BuiltinAttribute23.mo \
+BuiltinAttribute24.mo \
 BuiltinLookup1.mo \
 BuiltinTime.mo \
 BuiltinTimeSubscripted.mo \


### PR DESCRIPTION
- Don't fail in `Type.subscript` if too many subscripts are given and `failOnError=false`.

Fixes #12296