### PR TITLE
Handle uninstantiated dimension in Dimension.toString

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -32,6 +32,7 @@
 encapsulated uniontype NFDimension
 protected
   import Dimension = NFDimension;
+  import Dump;
   import Operator = NFOperator;
   import Prefixes = NFPrefixes;
   import List;
@@ -368,6 +369,7 @@ public
       local
         Type ty;
 
+      case RAW_DIM() then Dump.printSubscriptStr(dim.dim);
       case INTEGER() then String(dim.size);
       case BOOLEAN() then "Boolean";
       case ENUM(enumType = ty as Type.ENUMERATION()) then AbsynUtil.pathString(ty.typePath);

--- a/testsuite/flattening/modelica/scodeinst/DuplicateElements11.mo
+++ b/testsuite/flattening/modelica/scodeinst/DuplicateElements11.mo
@@ -1,0 +1,32 @@
+// name: DuplicateElements11
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+//
+
+model A
+  Real x[3];
+end A;
+
+model B
+  Real x[3];
+end B;
+
+model DuplicateElements11
+  extends A(x = {1, 2, 3});
+  extends B;
+end DuplicateElements11;
+
+// Result:
+// Error processing file: DuplicateElements11.mo
+// [flattening/modelica/scodeinst/DuplicateElements11.mo:9:3-9:12:writable] Notification: From here:
+// [flattening/modelica/scodeinst/DuplicateElements11.mo:13:3-13:12:writable] Error: Duplicate elements (due to inherited elements) not identical:
+//   first element is:  Real[3] x = {1, 2, 3}
+//   second element is: Real[3] x
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -383,6 +383,7 @@ DuplicateElements4.mo \
 DuplicateElements5.mo \
 DuplicateElements9.mo \
 DuplicateElements10.mo \
+DuplicateElements11.mo \
 DuplicateElementsValid1.mo \
 DuplicateElementsValid2.mo \
 DuplicateMod1.mo \


### PR DESCRIPTION
- Add case for `Dimension.RAW_DIM` in `Dimension.toString`.

Fixes #12297