### PR TITLE
Simplify --exposeLocalIOs and conform to Modelica standard (#10599)

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1589,12 +1589,7 @@ algorithm
     else
       algorithm
         /* Consider toplevel inputs as known unless they are protected. Ticket #5591 */
-        /* Consider all inputs known with flag --nonStdExposeLocalIOs > 0 unless they are protected */
-        if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
-          false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
-        else
-          false := DAEUtil.varDirectionEqual(inVarDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(protection);
-        end if;
+        false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
       then
         match (inVarKind, inType)
           case (DAE.VARIABLE(), DAE.T_BOOL()) then BackendDAE.DISCRETE();
@@ -1622,11 +1617,7 @@ algorithm
     case DAE.CONST() then BackendDAE.CONST();
     case DAE.VARIABLE()
       equation
-        if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
-          true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
-        else
-          true = DAEUtil.varDirectionEqual(varDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(visibility);
-        end if;
+        true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
       then
         BackendDAE.VARIABLE();
     // adrpo: topLevelInput might fail!

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -2027,7 +2027,7 @@ end getVarKindForVar;
 
 public function isVarOnTopLevelAndOutput "has the DAE.VarDirection = OUTPUT
   Don't check for top level here as this is done by NFConvertDAE.makeDAEVar.
-  Otherwise the list of model variables may contradict with model structure, e.g. with --nonStdExposeLocalIOs."
+  Otherwise the list of model variables may contradict with model structure."
   input BackendDAE.Var inVar;
   //output Boolean outBoolean = DAEUtil.topLevelOutput(inVar.varName, inVar.varDirection, inVar.connectorType);
   output Boolean outBoolean = isOutputVar(inVar);
@@ -2035,7 +2035,7 @@ end isVarOnTopLevelAndOutput;
 
 public function isVarOnTopLevelAndInput "has the DAE.VarDirection = INPUT
   Don't check for top level here as this is done by NFConvertDAE.makeDAEVar.
-  Otherwise the list of model variables may contradict with model structure, e.g. with --nonStdExposeLocalIOs."
+  Otherwise the list of model variables may contradict with model structure."
   input BackendDAE.Var inVar;
   //output Boolean outBoolean = DAEUtil.topLevelInput(inVar.varName, inVar.varDirection, inVar.connectorType);
   output Boolean outBoolean = isInput(inVar);

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -212,7 +212,7 @@ algorithm
   if Connector.variability(c1) > Variability.PARAMETER then
     equations := list(makeEqualityEquation(c1.name, c1.source, c2.name, c2.source)
       for c2 in listRest(elements));
-    // collect inputs and outputs that are inside in connections if --nonStdExposeLocalIOs > 0
+    // collect inputs and outputs that are inside in connections if --exposeLocalIOs > 0
     // strip array indices so that the variables will be found later
     if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) > 0 then
       for c in elements loop

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -1045,16 +1045,13 @@ public
 
   function removeNonTopLevelDirections
     input output FlatModel flatModel;
-  protected
-    Integer expose_local_ios;
   algorithm
     // Keep the declared directions if --useLocalDirection=true has been set.
     if Flags.getConfigBool(Flags.USE_LOCAL_DIRECTION) then
       return;
     end if;
 
-    expose_local_ios := Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS);
-    flatModel.variables := list(Variable.removeNonTopLevelDirection(v, expose_local_ios) for v in flatModel.variables);
+    flatModel.variables := list(Variable.removeNonTopLevelDirection(v) for v in flatModel.variables);
   end removeNonTopLevelDirections;
 
   annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -417,24 +417,14 @@ public
   function removeNonTopLevelDirection
     "Removes input/output prefixes from a variable that's not a top-level
      component, a component in a top-level connector, or a component in a
-     top-level input component. exposeLocalIOs can be used to keep the direction
-     for variables at lower levels as well, where 0 means top-level, 1 the level
-     below that, and so on."
+     top-level input component."
     input output Variable var;
-    input Integer exposeLocalIOs;
   protected
     ComponentRef rest_name;
     InstNode node;
     Attributes attr;
   algorithm
     if var.attributes.direction == Direction.NONE then
-      return;
-    end if;
-
-    if exposeLocalIOs > 0 and
-       var.attributes.connectorType <> ConnectorType.NON_CONNECTOR and
-       var.visibility == Visibility.PUBLIC and
-       ComponentRef.depth(var.name) < exposeLocalIOs then
       return;
     end if;
 

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1444,11 +1444,11 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(151, "frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
-constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(152, "nonStdExposeLocalIOs",
+constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(152, "exposeLocalIOs",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
-  Gettext.gettext("Keeps input/output prefixes for unconnected input/output connectors at requested levels, provided they are public, " +
+  Gettext.gettext("Introduces top-level inputs/outputs for unconnected input/output connectors at requested levels, provided they are public, " +
                   "0 meaning top-level (standard Modelica), 1 inputs/outputs of top-level components, >1 going deeper. " +
-                  "This flag is particularly useful for FMI export. It extends the Modelica standard when exposing local inputs."));
+                  "This flag is particularly useful for FMI export."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -4,8 +4,7 @@
 // teardown_command: rm -f *LocalIOs.System* modelDescription.tmp.xml
 
 setCommandLineOptions("--simCodeTarget=Cpp");
-//setCommandLineOptions("--exposeLocalIOs=10 --allowNonStandardModelica=nonStdExposeLocalIOs"); getErrorString();
-setCommandLineOptions("--exposeLocalIOs=10"); getErrorString();
+setCommandLineOptions("--exposeLocalIOs=1"); getErrorString();
 
 loadString("
 package LocalIOs
@@ -46,14 +45,20 @@ algorithm
   y := 0.5*u;
 end f;
 
+model Medium
+  RealInput p \"unconnected IO at level 2\";
+end Medium;
+
 model Component
   PhysicalConnector c;
   input Real modifiedInput annotation(Dialog(enable=true));
   output Real simpleOutput = signaling.y;
   RealOutput measurement;
+  Medium m;
 protected
   Signaling signaling(u1 = 1);
 equation
+  m.p = 1;
   signaling.u2 = 2;
   signaling.u = 3:4;
   c.f = f(c.p) + modifiedInput + signaling.y;
@@ -64,7 +69,7 @@ block Signaling
   RealInput u1;
   RealInput u2;
   RealInput[2] u;
-  RealOutput y;
+  RealOutput y \"unconnected IO at level 0\";
 equation
   y = u1 + u2 + sum(u);
 end Signaling;
@@ -74,7 +79,9 @@ model System
   Component component(modifiedInput = 1);
   Signaling signaling;
   Real component_measurement = 0 \"name already in use\";
+  RealOutput y;
 equation
+  y = time;
   connect(source.c, component.c);
   connect(source.yf, signaling.u1);
   connect(source.y, signaling.u);
@@ -126,181 +133,199 @@ readFile("modelDescription.tmp.xml");
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
-//     name=\"component.modifiedInput\"
+//     name=\"component.m.p\"
 //     valueReference=\"1\"
+//     description=\"unconnected IO at level 2\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
-//     name=\"component_measurement\"
-//     valueReference=\"6\"
-//     description=\"name already in use\"
+//     name=\"component.modifiedInput\"
+//     valueReference=\"2\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
-//     name=\"component_measurement_\"
+//     name=\"component_measurement\"
 //     valueReference=\"7\"
+//     description=\"name already in use\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"4\" -->
+//   <ScalarVariable
+//     name=\"component_measurement_\"
+//     valueReference=\"8\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"4\" -->
+//   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
 //     name=\"signaling_u2\"
-//     valueReference=\"8\"
+//     valueReference=\"9\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"5\" -->
-//   <ScalarVariable
-//     name=\"signaling_y\"
-//     valueReference=\"9\"
-//     causality=\"output\"
-//     >
-//     <Real/>
-//   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
-//     name=\"source.y[2]\"
+//     name=\"signaling_y\"
 //     valueReference=\"10\"
+//     description=\"unconnected IO at level 0\"
+//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
-//     name=\"source_u_in\"
+//     name=\"source.y[2]\"
 //     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"8\" -->
+//   <ScalarVariable
+//     name=\"source_u_in\"
+//     valueReference=\"12\"
 //     causality=\"input\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"8\" -->
+//   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
 //     name=\"source_yp\"
-//     valueReference=\"12\"
+//     valueReference=\"13\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"9\" -->
-//   <ScalarVariable
-//     name=\"source.u_par\"
-//     valueReference=\"13\"
-//     variability=\"fixed\"
-//     causality=\"parameter\"
-//     >
-//     <Real start=\"2.0\"/>
-//   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"component.c.f\"
-//     valueReference=\"17\"
+//     name=\"y\"
+//     valueReference=\"14\"
+//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"component.c.p\"
-//     valueReference=\"11\"
+//     name=\"source.u_par\"
+//     valueReference=\"15\"
+//     variability=\"fixed\"
+//     causality=\"parameter\"
 //     >
-//     <Real/>
+//     <Real start=\"2.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"12\" -->
 //   <ScalarVariable
-//     name=\"component.measurement\"
-//     valueReference=\"7\"
+//     name=\"component.c.f\"
+//     valueReference=\"20\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"13\" -->
 //   <ScalarVariable
-//     name=\"component.simpleOutput\"
-//     valueReference=\"7\"
+//     name=\"component.c.p\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"14\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"11\"
+//     name=\"component.measurement\"
+//     valueReference=\"8\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[2]\"
-//     valueReference=\"10\"
+//     name=\"component.simpleOutput\"
+//     valueReference=\"8\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
-//     valueReference=\"10\"
+//     name=\"signaling.u[1]\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"17\" -->
 //   <ScalarVariable
-//     name=\"signaling.u2\"
-//     valueReference=\"8\"
+//     name=\"signaling.u[2]\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"18\" -->
 //   <ScalarVariable
-//     name=\"signaling.y\"
-//     valueReference=\"9\"
+//     name=\"signaling.u1\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"19\" -->
 //   <ScalarVariable
-//     name=\"source.c.f\"
-//     valueReference=\"10\"
+//     name=\"signaling.u2\"
+//     valueReference=\"9\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"20\" -->
 //   <ScalarVariable
-//     name=\"source.c.p\"
-//     valueReference=\"11\"
+//     name=\"signaling.y\"
+//     valueReference=\"10\"
+//     description=\"unconnected IO at level 0\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"21\" -->
 //   <ScalarVariable
-//     name=\"source.u_in\"
+//     name=\"source.c.f\"
 //     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"22\" -->
 //   <ScalarVariable
-//     name=\"source.y[1]\"
-//     valueReference=\"11\"
+//     name=\"source.c.p\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"23\" -->
 //   <ScalarVariable
-//     name=\"source.yf\"
-//     valueReference=\"10\"
+//     name=\"source.u_in\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"24\" -->
 //   <ScalarVariable
-//     name=\"source.yp\"
-//     valueReference=\"11\"
+//     name=\"source.y[1]\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"25\" -->
+//   <ScalarVariable
+//     name=\"source.yf\"
+//     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"26\" -->
+//   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"12\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"27\" -->
 //   <ScalarVariable
 //     name=\"source.use_u_in\"
 //     valueReference=\"0\"
@@ -312,15 +337,17 @@ readFile("modelDescription.tmp.xml");
 //   </ModelVariables>
 //   <ModelStructure>
 //     <Outputs>
-//       <Unknown index=\"3\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"5\" dependencies=\"4 7\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"8\" dependencies=\"7\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"6\" dependencies=\"5 8\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"9\" dependencies=\"8\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
 //     </Outputs>
 //     <InitialUnknowns>
-//       <Unknown index=\"3\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"5\" dependencies=\"4 7\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"8\" dependencies=\"7\" dependenciesKind=\"dependent\" />
-//       <Unknown index=\"25\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"6\" dependencies=\"5 8\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"9\" dependencies=\"8\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"27\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>
 // </fmiModelDescription>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -4,7 +4,8 @@
 // teardown_command: rm -f *LocalIOs.System* modelDescription.tmp.xml
 
 setCommandLineOptions("--simCodeTarget=Cpp");
-setCommandLineOptions("--nonStdExposeLocalIOs=10"); getErrorString();
+//setCommandLineOptions("--exposeLocalIOs=10 --allowNonStandardModelica=nonStdExposeLocalIOs"); getErrorString();
+setCommandLineOptions("--exposeLocalIOs=10"); getErrorString();
 
 loadString("
 package LocalIOs
@@ -72,6 +73,7 @@ model System
   Source source(use_u_in = true);
   Component component(modifiedInput = 1);
   Signaling signaling;
+  Real component_measurement = 0 \"name already in use\";
 equation
   connect(source.c, component.c);
   connect(source.yf, signaling.u1);
@@ -120,46 +122,46 @@ readFile("modelDescription.tmp.xml");
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\" stepSize=\"0.002\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-6\" stepSize=\"0.002\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
-//     name=\"component.measurement\"
+//     name=\"component.modifiedInput\"
 //     valueReference=\"1\"
-//     causality=\"output\"
-//     >
-//     <Real/>
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
-//     name=\"component.modifiedInput\"
-//     valueReference=\"2\"
+//     name=\"component_measurement\"
+//     valueReference=\"6\"
+//     description=\"name already in use\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
-//     name=\"signaling.u2\"
+//     name=\"component_measurement_\"
 //     valueReference=\"7\"
-//     causality=\"input\"
-//     >
-//     <Real start=\"0.0\"/>
-//   </ScalarVariable>
-//   <!-- Index of variable = \"4\" -->
-//   <ScalarVariable
-//     name=\"signaling.y\"
-//     valueReference=\"8\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"5\" -->
+//   <!-- Index of variable = \"4\" -->
 //   <ScalarVariable
-//     name=\"source.u_in\"
-//     valueReference=\"9\"
+//     name=\"signaling_u2\"
+//     valueReference=\"8\"
 //     causality=\"input\"
 //     >
-//     <Real start=\"2.0\"/>
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"5\" -->
+//   <ScalarVariable
+//     name=\"signaling_y\"
+//     valueReference=\"9\"
+//     causality=\"output\"
+//     >
+//     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
@@ -170,92 +172,135 @@ readFile("modelDescription.tmp.xml");
 //   </ScalarVariable>
 //   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
-//     name=\"source.yp\"
+//     name=\"source_u_in\"
 //     valueReference=\"11\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"2.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"8\" -->
+//   <ScalarVariable
+//     name=\"source_yp\"
+//     valueReference=\"12\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"8\" -->
+//   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
 //     name=\"source.u_par\"
-//     valueReference=\"12\"
+//     valueReference=\"13\"
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"9\" -->
-//   <ScalarVariable
-//     name=\"component.c.f\"
-//     valueReference=\"16\"
-//     >
-//     <Real/>
-//   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"component.c.p\"
-//     valueReference=\"9\"
+//     name=\"component.c.f\"
+//     valueReference=\"17\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"component.simpleOutput\"
-//     valueReference=\"1\"
+//     name=\"component.c.p\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"12\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"9\"
+//     name=\"component.measurement\"
+//     valueReference=\"7\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"13\" -->
+//   <ScalarVariable
+//     name=\"component.simpleOutput\"
+//     valueReference=\"7\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"14\" -->
+//   <ScalarVariable
+//     name=\"signaling.u[1]\"
+//     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
 //     name=\"signaling.u[2]\"
 //     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"14\" -->
+//   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
 //     name=\"signaling.u1\"
 //     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"15\" -->
+//   <!-- Index of variable = \"17\" -->
+//   <ScalarVariable
+//     name=\"signaling.u2\"
+//     valueReference=\"8\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"18\" -->
+//   <ScalarVariable
+//     name=\"signaling.y\"
+//     valueReference=\"9\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"19\" -->
 //   <ScalarVariable
 //     name=\"source.c.f\"
 //     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"16\" -->
+//   <!-- Index of variable = \"20\" -->
 //   <ScalarVariable
 //     name=\"source.c.p\"
-//     valueReference=\"9\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"17\" -->
+//   <!-- Index of variable = \"21\" -->
+//   <ScalarVariable
+//     name=\"source.u_in\"
+//     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"22\" -->
 //   <ScalarVariable
 //     name=\"source.y[1]\"
-//     valueReference=\"9\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"18\" -->
+//   <!-- Index of variable = \"23\" -->
 //   <ScalarVariable
 //     name=\"source.yf\"
 //     valueReference=\"10\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"19\" -->
+//   <!-- Index of variable = \"24\" -->
+//   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"25\" -->
 //   <ScalarVariable
 //     name=\"source.use_u_in\"
 //     valueReference=\"0\"
@@ -267,15 +312,15 @@ readFile("modelDescription.tmp.xml");
 //   </ModelVariables>
 //   <ModelStructure>
 //     <Outputs>
-//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"7\" dependencies=\"5\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"3\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"5\" dependencies=\"4 7\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"8\" dependencies=\"7\" dependenciesKind=\"dependent\" />
 //     </Outputs>
 //     <InitialUnknowns>
-//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"7\" dependencies=\"5\" dependenciesKind=\"dependent\" />
-//       <Unknown index=\"19\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"3\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"5\" dependencies=\"4 7\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"8\" dependencies=\"7\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"25\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>
 // </fmiModelDescription>


### PR DESCRIPTION
Idea: add top-level variables for unconnected local IOs. Only NFFlatten.mo and NFConnectEquations.mo are extended. Untouch backend.

@perost please have a particular look at NFFlatten.generateTopLevelIOs. There might be a smarter way to create a ComponentRef for a newly added variable.