### PR TITLE
Removing warning in QuotedIdentifier test

### DIFF
--- a/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mo
+++ b/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mo
@@ -1,12 +1,13 @@
 model QuotedIdentifier
-  Real 'a"b';
-  Real 'c d';
-  Real 'e"f g';
-  Real 'h\'i //j';
-  Real '\\\\\'';
-  Real '';
-  Real '*/ no code injection';
-  Real '\'';
+  Real 'a"b'(start = 1, fixed = true);
+  Real 'c d'(start = 1, fixed = true);
+  Real 'e"f g'(start = 1, fixed = true);
+  Real 'h\'i //j'(start = 1, fixed = true);
+  Real '\\\\\''(start = 1, fixed = true);
+  Real ''(start = 1, fixed = true);
+  Real '*/ no code injection'(start = 1, fixed = true);
+  Real '\''(start = 1, fixed = true);
+  Real /*(y)*/ 'stupid,name'(start = 1, fixed = true);
 equation
   der('a"b') = 1;
   der('c d') = -1;
@@ -16,4 +17,5 @@ equation
   der('') = -3;
   der('*/ no code injection') = 4;
   der('\'') = -4;
+  der('stupid,name') = 5;
 end QuotedIdentifier;

--- a/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mos
+++ b/testsuite/flattening/modelica/mosfiles/QuotedIdentifier.mos
@@ -11,7 +11,7 @@ echo(false);
 mkdir("QuotedIdentifier_tmp"); cd("QuotedIdentifier_tmp");
 echo(true);
 
-buildModel(QuotedIdentifier); getErrorString();
+simulate(QuotedIdentifier); getErrorString();
 linearize(QuotedIdentifier); getErrorString();
 
 loadFile("linearized_model.mo"); getErrorString();
@@ -22,9 +22,14 @@ simulate(linearized_model); getErrorString();
 // true
 // ""
 // true
-// {"QuotedIdentifier","QuotedIdentifier_init.xml"}
-// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// record SimulationResult
+//     resultFile = "QuotedIdentifier_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'QuotedIdentifier', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
+// end SimulationResult;
+// ""
 // record SimulationResult
 //     resultFile = "QuotedIdentifier_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'QuotedIdentifier', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
@@ -34,8 +39,7 @@ simulate(linearized_model); getErrorString();
 // LOG_STDOUT        | info    | Linear model is created.
 // "
 // end SimulationResult;
-// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
-// "
+// ""
 // true
 // ""
 // record SimulationResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12235

### Purpose

Removing warning in QuotedIdentifier test

### Approach

Providing start values.
