### PR TITLE
Use start value for unbound fixed parameters

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClassTree.mo
@@ -1171,6 +1171,66 @@ public
       end match;
     end foldComponents;
 
+    function findComponent
+      "Returns the first component for which the given function returns true."
+      input ClassTree tree;
+      input FuncT func;
+      output Option<InstNode> component = NONE();
+
+      partial function FuncT
+        input InstNode component;
+        output Boolean res;
+      end FuncT;
+    algorithm
+      () := match tree
+        case PARTIAL_TREE()
+          algorithm
+            for c in tree.components loop
+              if func(c) then
+                component := SOME(c);
+                break;
+              end if;
+            end for;
+          then
+            ();
+
+        case EXPANDED_TREE()
+          algorithm
+            for c in tree.components loop
+              if func(c) then
+                component := SOME(c);
+                break;
+              end if;
+            end for;
+          then
+            ();
+
+        case INSTANTIATED_TREE()
+          algorithm
+            for c in tree.components loop
+              if func(Mutable.access(c)) then
+                component := SOME(Mutable.access(c));
+                break;
+              end if;
+            end for;
+          then
+            ();
+
+        case FLAT_TREE()
+          algorithm
+            for c in tree.components loop
+              if func(c) then
+                component := SOME(c);
+                break;
+              end if;
+            end for;
+          then
+            ();
+
+        else ();
+      end match;
+    end findComponent;
+
     function classCount
       input ClassTree tree;
       output Integer count;

--- a/testsuite/flattening/modelica/scodeinst/ForConnect2.mo
+++ b/testsuite/flattening/modelica/scodeinst/ForConnect2.mo
@@ -33,7 +33,7 @@ end ForConnect2;
 //   Real c2[2].f;
 //   Real c2[3].e;
 //   Real c2[3].f;
-//   final parameter Integer n(start = 3);
+//   final parameter Integer n(start = 3) = 3;
 // equation
 //   c1[1].e = c2[1].e;
 //   -(c1[1].f + c2[1].f) = 0.0;

--- a/testsuite/flattening/modelica/scodeinst/IfConnect4.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfConnect4.mo
@@ -21,7 +21,7 @@ end IfConnect4;
 
 // Result:
 // class IfConnect4
-//   final parameter Boolean b(start = true);
+//   final parameter Boolean b(start = true) = true;
 //   Real c1.e;
 //   Real c1.f;
 //   Real c2.e;

--- a/testsuite/flattening/modelica/scodeinst/Inline4.mo
+++ b/testsuite/flattening/modelica/scodeinst/Inline4.mo
@@ -43,11 +43,11 @@ end Inline4;
 // Result:
 // class Inline4
 //   parameter Real UStart(fixed = false);
-//   parameter Real port.UNom(start = 4e5);
+//   parameter Real port.UNom(start = 4e5) = 4e5;
 //   final parameter Real port.UStart = UStart;
 //   final parameter Real port.vStart.re = port.UStart / 1.7320508075688772 * cos(port.UStart);
 //   final parameter Real port.vStart.im = port.UStart / 1.7320508075688772 * sin(port.UStart);
 // end Inline4;
-// [flattening/modelica/scodeinst/Inline4.mo:33:3-33:37:writable] Warning: Parameter port.UNom has no value, and is fixed during initialization (fixed=true), using available start value (start=4e5) as default value.
+// [flattening/modelica/scodeinst/Inline4.mo:33:3-33:37:writable] Warning: Parameter port.UNom has no value, and is fixed during initialization (fixed=true), using available start value (start=400e3) as default value.
 //
 // endResult

--- a/testsuite/flattening/modelica/scodeinst/UnboundParameter2.mo
+++ b/testsuite/flattening/modelica/scodeinst/UnboundParameter2.mo
@@ -10,7 +10,7 @@ end UnboundParameter2;
 
 // Result:
 // class UnboundParameter2
-//   parameter Real x(start = 1.0);
+//   parameter Real x(start = 1.0) = 1.0;
 // end UnboundParameter2;
 // [flattening/modelica/scodeinst/UnboundParameter2.mo:8:3-8:32:writable] Warning: Parameter x has no value, and is fixed during initialization (fixed=true), using available start value (start=1.0) as default value.
 //

--- a/testsuite/openmodelica/xml/BB.mos
+++ b/testsuite/openmodelica/xml/BB.mos
@@ -16,7 +16,7 @@ readFile("BB.BouncingBall.xml"); getErrorString();
 // true
 // ""
 // "class BB.BouncingBall
-//   parameter Real e(start = 0.9);
+//   parameter Real e(start = 0.9) = 0.9;
 //   Real b1.y(start = 5.0);
 //   Real b1.vy(start = 0.0);
 //   Real b1.ay;
@@ -34,8 +34,7 @@ readFile("BB.BouncingBall.xml"); getErrorString();
 // "[openmodelica/xml/BB.mo:13:5-13:34:writable] Warning: Parameter e has no value, and is fixed during initialization (fixed=true), using available start value (start=0.9) as default value.
 // "
 // (true,"BB.BouncingBall.xml")
-// "[openmodelica/xml/BB.mo:13:5-13:34:writable] Warning: Parameter e has no value, and is fixed during initialization (fixed=true), using available start value (start=0.9) as default value.
-// "
+// ""
 // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 // <dae xmlns:p1=\"http://www.w3.org/1998/Math/MathML\"
 //                                                 xmlns:xlink=\"http://www.w3.org/1999/xlink\"
@@ -108,6 +107,14 @@ readFile("BB.BouncingBall.xml"); getErrorString();
 // </bindExpression>
 // </variable>
 // <variable id=\"2\" name=\"e\" variability=\"parameter\" direction=\"none\" type=\"Real\" fixed=\"true\" flow=\"NonConnector\" stream=\"NonStreamConnector\">
+// <bindExpression string=\"0.9\">
+// <MathML>
+// <math xmlns=\"http://www.w3.org/1998/Math/MathML\">
+// <cn type=\"real\">0.9
+// </cn>
+// </math>
+// </MathML>
+// </bindExpression>
 // <attributesValues>
 // <initialValue string=\"0.9\">
 // <MathML>

--- a/testsuite/simulation/modelica/initialization/parameters.mos
+++ b/testsuite/simulation/modelica/initialization/parameters.mos
@@ -77,10 +77,6 @@ simulate(initializationTests.parameters, simflags="-lv=LOG_INIT_V"); getErrorStr
 // [<interactive>:20:5-20:37:writable] Warning: Parameter b3 has no value, and is fixed during initialization (fixed=true), using available start value (start=true) as default value.
 // [<interactive>:21:5-21:39:writable] Warning: Parameter s3 has no value, and is fixed during initialization (fixed=true), using available start value (start=\"three\") as default value.
 // [<interactive>:22:5-22:32:writable] Warning: Parameter e3 has no value, and is fixed during initialization (fixed=true), using available start value (start=initializationTests.E.E3) as default value.
-// [<interactive>:21:5-21:39:writable] Warning: Parameter s3 has no value, and is fixed during initialization (fixed=true), using available start value (start=\"three\") as default value.
-// [<interactive>:20:5-20:37:writable] Warning: Parameter b3 has no value, and is fixed during initialization (fixed=true), using available start value (start=true) as default value.
-// [<interactive>:19:5-19:34:writable] Warning: Parameter i3 has no value, and is fixed during initialization (fixed=true), using available start value (start=3) as default value.
-// [<interactive>:18:5-18:33:writable] Warning: Parameter r3 has no value, and is fixed during initialization (fixed=true), using available start value (start=3.0) as default value.
 // [<interactive>:16:5-16:39:writable] Warning: The parameter e2 has fixed = false and a binding equation e2 = initializationTests.E.E2, which is probably redundant.
 // Setting fixed = false usually means there is an additional initial equation to determine the parameter value. The binding was ignored by old Modelica tools, but this is not according to the Modelica specification. Please remove the parameter binding, or bind the parameter to another parameter with fixed = false and no binding.
 // [<interactive>:15:5-15:45:writable] Warning: The parameter s2 has fixed = false and a binding equation s2 = \"two\", which is probably redundant.


### PR DESCRIPTION
- Use the start value, if any, as the binding equation of fixed parameters that lack a binding equation.

Fixes #12304