### PR TITLE
Dump annotation array elements separately

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6608,5 +6608,37 @@ algorithm
   end match;
 end setClassDefType;
 
+function isLiteralExp
+  input Absyn.Exp exp;
+  output Boolean literal;
+algorithm
+  literal := match exp
+    case Absyn.Exp.INTEGER() then true;
+    case Absyn.Exp.REAL() then true;
+    case Absyn.Exp.STRING() then true;
+    case Absyn.Exp.BOOL() then true;
+    case Absyn.Exp.ARRAY() then List.all(exp.arrayExp, isLiteralExp);
+
+    case Absyn.Exp.MATRIX()
+      algorithm
+        literal := true;
+        for row in exp.matrix loop
+          literal := literal and List.all(row, isLiteralExp);
+          if not literal then
+            break;
+          end if;
+        end for;
+      then
+        literal;
+
+    case Absyn.Exp.RANGE()
+      then isLiteralExp(exp.start) and
+           Util.applyOptionOrDefault(exp.step, isLiteralExp, true) and
+           isLiteralExp(exp.stop);
+
+    else false;
+  end match;
+end isLiteralExp;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/doc/instanceAPI/expression.schema.json
+++ b/doc/instanceAPI/expression.schema.json
@@ -429,6 +429,20 @@
         }
       },
       "required": ["$kind", "name", "arguments"]
+    },
+    {
+      "description": "An invalid expression",
+      "type": "object",
+      "properties": {
+        "$error": {
+          "description": "Error message",
+          "type": "string"
+        },
+        "value": {
+          "description": "The invalid expression",
+          "$ref": "#"
+        }
+      }
     }
   ],
   "definitions": {

--- a/doc/instanceAPI/getModelInstance.schema.json
+++ b/doc/instanceAPI/getModelInstance.schema.json
@@ -132,20 +132,6 @@
           },
           {
             "$ref": "expression.schema.json"
-          },
-          {
-            "description": "An invalid annotation",
-            "type": "object",
-            "properties": {
-              "$error": {
-                "description": "Error message",
-                "type": "string"
-              },
-              "value": {
-                "description": "Annotation dumped as a string",
-                "type": "string"
-              }
-            }
           }
         ]
       }

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation12.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation12.mos
@@ -1,0 +1,115 @@
+// name: GetModelInstanceAnnotation12
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    annotation(Icon(graphics = {Rectangle(extent = {{1, 1}, {2, x}}), Text(textString = \"str\")}));
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"annotation\": {
+//     \"Icon\": {
+//       \"graphics\": [
+//         {
+//           \"$error\": \"[<interactive>:3:21-3:96:writable] Error: Variable x not found in scope M.\\n\",
+//           \"value\": {
+//             \"$kind\": \"call\",
+//             \"name\": \"Rectangle\",
+//             \"namedArgs\": {
+//               \"extent\": [
+//                 [
+//                   1,
+//                   1
+//                 ],
+//                 [
+//                   2,
+//                   \"x\"
+//                 ]
+//               ]
+//             }
+//           }
+//         },
+//         {
+//           \"$kind\": \"record\",
+//           \"name\": \"Text\",
+//           \"elements\": [
+//             true,
+//             [
+//               0,
+//               0
+//             ],
+//             0,
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             [
+//               0,
+//               0,
+//               0
+//             ],
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"LinePattern.Solid\",
+//               \"index\": 2
+//             },
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"FillPattern.None\",
+//               \"index\": 1
+//             },
+//             0.25,
+//             [
+//               [
+//                 -10,
+//                 -10
+//               ],
+//               [
+//                 10,
+//                 10
+//               ]
+//             ],
+//             \"str\",
+//             0,
+//             [
+//               -1,
+//               -1,
+//               -1
+//             ],
+//             \"\",
+//             [
+//
+//             ],
+//             {
+//               \"$kind\": \"enum\",
+//               \"name\": \"TextAlignment.Center\",
+//               \"index\": 2
+//             }
+//           ]
+//         }
+//       ]
+//     }
+//   },
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 4,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -13,6 +13,7 @@ GetModelInstanceAnnotation8.mos \
 GetModelInstanceAnnotation9.mos \
 GetModelInstanceAnnotation10.mos \
 GetModelInstanceAnnotation11.mos \
+GetModelInstanceAnnotation12.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \


### PR DESCRIPTION
- Dump elements of array expressions in annotations separately, to avoid e.g. an invalid graphical element invalidating the whole graphics arrays.