### PR TITLE
Fix regressions due to #12315

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -834,5 +834,18 @@ public
     end match;
   end isEvaluated;
 
+  function hasTypeOrigin
+    input Binding binding;
+    output Boolean res;
+  algorithm
+    res := match binding
+      case RAW_BINDING()
+        guard not listEmpty(binding.subs)
+        then Subscript.isSplitClassProxy(listHead(binding.subs));
+
+      else false;
+    end match;
+  end hasTypeOrigin;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFBinding;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2268,7 +2268,7 @@ algorithm
 
   binding := Component.getTypeAttributeBinding(comp, "start");
 
-  if Binding.isBound(binding) then
+  if Binding.isBound(binding) and not Binding.hasTypeOrigin(binding) then
     if not InstContext.inRelaxed(context) then
       Error.addSourceMessage(Error.UNBOUND_PARAMETER_WITH_START_VALUE_WARNING,
         {AbsynUtil.pathString(InstNode.scopePath((node))), Binding.toString(binding)}, InstNode.info(node));

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -1264,6 +1264,16 @@ public
     end match;
   end isSplitIndex;
 
+  function isSplitClassProxy
+    input Subscript sub;
+    output Boolean res;
+  algorithm
+    res := match sub
+      case SPLIT_PROXY() then InstNode.isClass(sub.origin);
+      else false;
+    end match;
+  end isSplitClassProxy;
+
   function expandSplitIndices
     input list<Subscript> subs;
     input list<InstNode> indicesToKeep = {};

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1153,6 +1153,7 @@ TypenameInvalid2.mo \
 TypenameInvalid3.mo \
 UnboundParameter1.mo \
 UnboundParameter2.mo \
+UnboundParameter3.mo \
 usertype1.mo \
 usertype2.mo \
 usertype3.mo \

--- a/testsuite/flattening/modelica/scodeinst/UnboundParameter3.mo
+++ b/testsuite/flattening/modelica/scodeinst/UnboundParameter3.mo
@@ -1,0 +1,20 @@
+// name: UnboundParameter3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model UnboundParameter3
+  type T = Real(start = 1.0);
+  parameter T x[3];
+end UnboundParameter3;
+
+// Result:
+// class UnboundParameter3
+//   parameter Real x[1](start = 1.0);
+//   parameter Real x[2](start = 1.0);
+//   parameter Real x[3](start = 1.0);
+// end UnboundParameter3;
+// [flattening/modelica/scodeinst/UnboundParameter3.mo:9:3-9:19:writable] Warning: Parameter x has no value, and is fixed during initialization (fixed=true), using available start value (start=fill(1.0, 3)) as default value.
+//
+// endResult


### PR DESCRIPTION
- Don't add start values from types as bindings to parameters without bindings, they aren't handled correctly.