### PR TITLE
Fix creation of binding equations from start values

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -788,6 +788,21 @@ public
     end match;
   end propagate;
 
+  function unpropagate
+    input output Binding binding;
+    input InstNode node;
+  algorithm
+    () := match binding
+      case RAW_BINDING()
+        algorithm
+          binding.subs := list(s for s guard not Subscript.isSplitFromOrigin(s, node) in binding.subs);
+        then
+          ();
+
+      else ();
+    end match;
+  end unpropagate;
+
   function source
     input Binding binding;
     output Source source;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2274,6 +2274,7 @@ algorithm
         {AbsynUtil.pathString(InstNode.scopePath((node))), Binding.toString(binding)}, InstNode.info(node));
     end if;
 
+    binding := Binding.unpropagate(binding, node);
     comp := Component.setBinding(binding, comp);
     InstNode.updateComponent(comp, node);
   end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -1274,6 +1274,17 @@ public
     end match;
   end isSplitClassProxy;
 
+  function isSplitFromOrigin
+    input Subscript sub;
+    input InstNode origin;
+    output Boolean res;
+  algorithm
+    res := match sub
+      case SPLIT_PROXY() then InstNode.refEqual(origin, sub.origin);
+      else false;
+    end match;
+  end isSplitFromOrigin;
+
   function expandSplitIndices
     input list<Subscript> subs;
     input list<InstNode> indicesToKeep = {};

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1154,6 +1154,7 @@ TypenameInvalid3.mo \
 UnboundParameter1.mo \
 UnboundParameter2.mo \
 UnboundParameter3.mo \
+UnboundParameter4.mo \
 usertype1.mo \
 usertype2.mo \
 usertype3.mo \

--- a/testsuite/flattening/modelica/scodeinst/UnboundParameter4.mo
+++ b/testsuite/flattening/modelica/scodeinst/UnboundParameter4.mo
@@ -1,0 +1,23 @@
+// name: UnboundParameter4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model A
+  parameter Real x[3](start = {0, 0, 0});
+end A;
+
+model UnboundParameter4
+  A a;
+end UnboundParameter4;
+
+// Result:
+// class UnboundParameter4
+//   parameter Real a.x[1](start = 0.0) = 0.0;
+//   parameter Real a.x[2](start = 0.0) = 0.0;
+//   parameter Real a.x[3](start = 0.0) = 0.0;
+// end UnboundParameter4;
+// [flattening/modelica/scodeinst/UnboundParameter4.mo:8:3-8:41:writable] Warning: Parameter a.x has no value, and is fixed during initialization (fixed=true), using available start value (start={0, 0, 0}) as default value.
+//
+// endResult


### PR DESCRIPTION
- Unpropagate the binding when copying it from the start attribute to the component.