### PR TITLE
Instantiate record constructors as functions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -125,6 +125,7 @@ algorithm
   end try;
 
   next_context := InstContext.set(context, NFInstContext.RELAXED);
+  next_context := InstContext.set(next_context, NFInstContext.FUNCTION);
   recordNode := InstNode.setNodeType(NFInstNode.InstNodeType.ROOT_CLASS(InstNode.parent(node)), recordNode);
   recordNode := Inst.instantiate(recordNode, context = next_context);
   Inst.instExpressions(recordNode, context = next_context);

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -994,6 +994,7 @@ RecordBinding13.mo \
 RecordConstructor1.mo \
 RecordConstructor2.mo \
 RecordConstructor3.mo \
+RecordConstructor4.mo \
 RecordExtends1.mo \
 RecordExtends2.mo \
 RecordUnknownDim1.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordConstructor4.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordConstructor4.mo
@@ -1,0 +1,31 @@
+// name: RecordConstructor4
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+record R
+  parameter Real x(start = 1.0);
+end R;
+
+model RecordConstructor4
+  R r;
+equation
+  r = R(time);
+end RecordConstructor4;
+
+// Result:
+// function R "Automatically generated record constructor for R"
+//   input Real x;
+//   output R res;
+// end R;
+//
+// class RecordConstructor4
+//   parameter Real r.x(start = 1.0);
+// equation
+//   r = R(time);
+// end RecordConstructor4;
+// [flattening/modelica/scodeinst/RecordConstructor4.mo:9:3-9:32:writable] Warning: Parameter r.x has no value, and is fixed during initialization (fixed=true), using available start value (start=1.0) as default value.
+//
+// endResult


### PR DESCRIPTION
- Instantiate record constructors as functions, to avoid creating binding equations from start values for parameters without bindings.