### PR TITLE
Fix type checking of cref binding equations

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2950,6 +2950,30 @@ algorithm
       then
         ();
 
+    case Expression.CREF()
+      algorithm
+        bindingType := ComponentRef.getSubscriptedType(ComponentRef.expandSplitSubscripts(bindingExp.cref));
+
+        dims := {};
+        for s in ComponentRef.subscriptsAllFlat(bindingExp.cref) loop
+          dims := match s
+            case Subscript.SPLIT_INDEX()
+              algorithm
+                if isParent(s.node, component) then
+                  dims := Type.nthDimension(InstNode.getType(s.node), s.dimIndex) :: dims;
+                end if;
+              then
+                dims;
+
+            else dims;
+          end match;
+        end for;
+
+        dims := listReverseInPlace(dims);
+        componentType := Type.liftArrayLeftList(componentType, dims);
+      then
+        ();
+
     else ();
   end match;
 end elaborateBindingType;

--- a/testsuite/flattening/modelica/scodeinst/BuiltinAttribute24.mo
+++ b/testsuite/flattening/modelica/scodeinst/BuiltinAttribute24.mo
@@ -1,4 +1,4 @@
-// name: BuiltinAttribute23
+// name: BuiltinAttribute24
 // keywords:
 // status: incorrect
 // cflags: -d=newInst

--- a/testsuite/flattening/modelica/scodeinst/BuiltinAttribute25.mo
+++ b/testsuite/flattening/modelica/scodeinst/BuiltinAttribute25.mo
@@ -1,0 +1,21 @@
+// name: BuiltinAttribute25
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model BuiltinAttribute25
+  parameter Real x_start[:] = {1, 2};
+  Real x[3](start = x_start);
+end BuiltinAttribute25;
+
+// Result:
+// Error processing file: BuiltinAttribute25.mo
+// [flattening/modelica/scodeinst/BuiltinAttribute25.mo:9:13-9:28:writable] Notification: From here:
+// [flattening/modelica/scodeinst/BuiltinAttribute25.mo:9:3-9:29:writable] Error: Type mismatch in binding 'start = x_start', expected array dimensions [3], got [2].
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/BuiltinAttribute26.mo
+++ b/testsuite/flattening/modelica/scodeinst/BuiltinAttribute26.mo
@@ -1,0 +1,21 @@
+// name: BuiltinAttribute26
+// keywords:
+// status: incorrect
+// cflags: -d=newInst
+//
+
+model BuiltinAttribute26
+  parameter Real x_start[:, :] = {{1, 2, 3, 4}, {5, 6, 7, 8}};
+  Real x[3](start = x_start[1]);
+end BuiltinAttribute26;
+
+// Result:
+// Error processing file: BuiltinAttribute26.mo
+// [flattening/modelica/scodeinst/BuiltinAttribute26.mo:9:13-9:31:writable] Notification: From here:
+// [flattening/modelica/scodeinst/BuiltinAttribute26.mo:9:3-9:32:writable] Error: Type mismatch in binding 'start = x_start[1]', expected array dimensions [3], got [4].
+//
+// # Error encountered! Exiting...
+// # Please check the error message and the flags.
+//
+// Execution failed!
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -90,6 +90,8 @@ BuiltinAttribute21.mo \
 BuiltinAttribute22.mo \
 BuiltinAttribute23.mo \
 BuiltinAttribute24.mo \
+BuiltinAttribute25.mo \
+BuiltinAttribute26.mo \
 BuiltinLookup1.mo \
 BuiltinTime.mo \
 BuiltinTimeSubscripted.mo \


### PR DESCRIPTION
- Handle component references with split indices in `TypeCheck.elaborateBindingType`.

Fixes #12367