### PR TITLE
Simplify --exposeLocalIOs and conform to Modelica standard (#10599)

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAECreate.mo
@@ -1589,12 +1589,7 @@ algorithm
     else
       algorithm
         /* Consider toplevel inputs as known unless they are protected. Ticket #5591 */
-        /* Consider all inputs known with flag --nonStdExposeLocalIOs > 0 unless they are protected */
-        if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
-          false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
-        else
-          false := DAEUtil.varDirectionEqual(inVarDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(protection);
-        end if;
+        false := DAEUtil.topLevelInput(inComponentRef, inVarDirection, inConnectorType, protection);
       then
         match (inVarKind, inType)
           case (DAE.VARIABLE(), DAE.T_BOOL()) then BackendDAE.DISCRETE();
@@ -1622,11 +1617,7 @@ algorithm
     case DAE.CONST() then BackendDAE.CONST();
     case DAE.VARIABLE()
       equation
-        if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) == 0 then
-          true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
-        else
-          true = DAEUtil.varDirectionEqual(varDirection, DAE.INPUT()) and not DAEUtil.boolVarVisibility(visibility);
-        end if;
+        true = DAEUtil.topLevelInput(componentRef, varDirection, connectorType, visibility);
       then
         BackendDAE.VARIABLE();
     // adrpo: topLevelInput might fail!

--- a/OMCompiler/Compiler/BackEnd/BackendVariable.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendVariable.mo
@@ -2027,7 +2027,7 @@ end getVarKindForVar;
 
 public function isVarOnTopLevelAndOutput "has the DAE.VarDirection = OUTPUT
   Don't check for top level here as this is done by NFConvertDAE.makeDAEVar.
-  Otherwise the list of model variables may contradict with model structure, e.g. with --nonStdExposeLocalIOs."
+  Otherwise the list of model variables may contradict with model structure."
   input BackendDAE.Var inVar;
   //output Boolean outBoolean = DAEUtil.topLevelOutput(inVar.varName, inVar.varDirection, inVar.connectorType);
   output Boolean outBoolean = isOutputVar(inVar);
@@ -2035,7 +2035,7 @@ end isVarOnTopLevelAndOutput;
 
 public function isVarOnTopLevelAndInput "has the DAE.VarDirection = INPUT
   Don't check for top level here as this is done by NFConvertDAE.makeDAEVar.
-  Otherwise the list of model variables may contradict with model structure, e.g. with --nonStdExposeLocalIOs."
+  Otherwise the list of model variables may contradict with model structure."
   input BackendDAE.Var inVar;
   //output Boolean outBoolean = DAEUtil.topLevelInput(inVar.varName, inVar.varDirection, inVar.connectorType);
   output Boolean outBoolean = isInput(inVar);

--- a/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnectEquations.mo
@@ -212,7 +212,7 @@ algorithm
   if Connector.variability(c1) > Variability.PARAMETER then
     equations := list(makeEqualityEquation(c1.name, c1.source, c2.name, c2.source)
       for c2 in listRest(elements));
-    // collect inputs and outputs that are inside in connections if --nonStdExposeLocalIOs > 0
+    // collect inputs and outputs that are inside in connections if --exposeLocalIOs > 0
     // strip array indices so that the variables will be found later
     if Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS) > 0 then
       for c in elements loop

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -1045,16 +1045,13 @@ public
 
   function removeNonTopLevelDirections
     input output FlatModel flatModel;
-  protected
-    Integer expose_local_ios;
   algorithm
     // Keep the declared directions if --useLocalDirection=true has been set.
     if Flags.getConfigBool(Flags.USE_LOCAL_DIRECTION) then
       return;
     end if;
 
-    expose_local_ios := Flags.getConfigInt(Flags.EXPOSE_LOCAL_IOS);
-    flatModel.variables := list(Variable.removeNonTopLevelDirection(v, expose_local_ios) for v in flatModel.variables);
+    flatModel.variables := list(Variable.removeNonTopLevelDirection(v) for v in flatModel.variables);
   end removeNonTopLevelDirections;
 
   annotation(__OpenModelica_Interface="frontend");

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2284,22 +2284,27 @@ algorithm
       (attributes.direction == Direction.INPUT or attributes.direction == Direction.OUTPUT) and
       not UnorderedSet.contains(variable.name, connectedLocalIOs)
     then
-      tlio_var := variable; // same attributes like start, unit
-      tlio_var.name := ComponentRef.combineSubscripts(tlio_var.name);
-      tlio_var.binding := UNBOUND(); // value is defined with tlio_eql
-      // find new name in global scope, using underscore instead of dot
-      cref := tlio_var.name;
-      name := stringDelimitList(ComponentRef.toString_impl(cref, {}), ".");
-      while UnorderedMap.contains(tlio_var.name, variables) loop
-        tlio_node := InstNode.NAME_NODE(Util.makeQuotedIdentifier(name));
-        tlio_var.name := match cref case ComponentRef.CREF() then
-          ComponentRef.CREF(tlio_node, cref.subscripts, cref.ty, cref.origin, ComponentRef.EMPTY());
-        end match;
-        name := name + "_" "append underscore until name is unique";
-      end while;
-      tlio_vars := tlio_var :: tlio_vars;
-      tlio_eql := Equation.makeCrefEquality(variable.name, tlio_var.name,
-        InstNode.EMPTY_NODE(), ElementSource.createElementSource(variable.info)) :: tlio_eql;
+      // add a new variable and equation if removeNonTopLevelDirection removes the direction
+      tlio_var := Variable.removeNonTopLevelDirection(variable);
+      attributes := tlio_var.attributes;
+      if attributes.direction == Direction.NONE then
+        tlio_var := variable; // same attributes like start, unit
+        tlio_var.name := ComponentRef.combineSubscripts(tlio_var.name);
+        tlio_var.binding := UNBOUND(); // value is defined with tlio_eql
+        // find new name in global scope, starting with quoted identifier
+        cref := tlio_var.name;
+        name := stringDelimitList(ComponentRef.toString_impl(cref, {}), ".");
+        while UnorderedMap.contains(tlio_var.name, variables) loop
+          tlio_node := InstNode.NAME_NODE(Util.makeQuotedIdentifier(name));
+          tlio_var.name := match cref case ComponentRef.CREF() then
+            ComponentRef.CREF(tlio_node, cref.subscripts, cref.ty, cref.origin, ComponentRef.EMPTY());
+          end match;
+          name := name + "_" "append underscore until name is unique";
+        end while;
+        tlio_vars := tlio_var :: tlio_vars;
+        tlio_eql := Equation.makeCrefEquality(variable.name, tlio_var.name,
+          InstNode.EMPTY_NODE(), ElementSource.createElementSource(variable.info)) :: tlio_eql;
+      end if;
     end if;
   end for;
 end generateTopLevelIOs;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2289,9 +2289,9 @@ algorithm
       tlio_var.binding := UNBOUND(); // value is defined with tlio_eql
       // find new name in global scope, using underscore instead of dot
       cref := tlio_var.name;
-      name := stringDelimitList(ComponentRef.toString_impl(cref, {}), "_");
+      name := stringDelimitList(ComponentRef.toString_impl(cref, {}), ".");
       while UnorderedMap.contains(tlio_var.name, variables) loop
-        tlio_node := InstNode.NAME_NODE(name);
+        tlio_node := InstNode.NAME_NODE(Util.makeQuotedIdentifier(name));
         tlio_var.name := match cref case ComponentRef.CREF() then
           ComponentRef.CREF(tlio_node, cref.subscripts, cref.ty, cref.origin, ComponentRef.EMPTY());
         end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -417,24 +417,14 @@ public
   function removeNonTopLevelDirection
     "Removes input/output prefixes from a variable that's not a top-level
      component, a component in a top-level connector, or a component in a
-     top-level input component. exposeLocalIOs can be used to keep the direction
-     for variables at lower levels as well, where 0 means top-level, 1 the level
-     below that, and so on."
+     top-level input component."
     input output Variable var;
-    input Integer exposeLocalIOs;
   protected
     ComponentRef rest_name;
     InstNode node;
     Attributes attr;
   algorithm
     if var.attributes.direction == Direction.NONE then
-      return;
-    end if;
-
-    if exposeLocalIOs > 0 and
-       var.attributes.connectorType <> ConnectorType.NON_CONNECTOR and
-       var.visibility == Visibility.PUBLIC and
-       ComponentRef.depth(var.name) < exposeLocalIOs then
       return;
     end if;
 

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1444,11 +1444,11 @@ constant ConfigFlag FRONTEND_INLINE = CONFIG_FLAG(151, "frontendInline",
   NONE(), EXTERNAL(), BOOL_FLAG(false), NONE(),
   Gettext.gettext("Enables inlining of functions in the frontend."));
 
-constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(152, "nonStdExposeLocalIOs",
+constant ConfigFlag EXPOSE_LOCAL_IOS = CONFIG_FLAG(152, "exposeLocalIOs",
   NONE(), EXTERNAL(), INT_FLAG(0), NONE(),
-  Gettext.gettext("Keeps input/output prefixes for unconnected input/output connectors at requested levels, provided they are public, " +
+  Gettext.gettext("Introduces top-level inputs/outputs for unconnected input/output connectors at requested levels, provided they are public, " +
                   "0 meaning top-level (standard Modelica), 1 inputs/outputs of top-level components, >1 going deeper. " +
-                  "This flag is particularly useful for FMI export. It extends the Modelica standard when exposing local inputs."));
+                  "This flag is particularly useful for FMI export."));
 
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -59,7 +59,7 @@ protected
   Signaling signaling(u1 = 1);
 equation
   m.p = 1;
-  signaling.u2 = 2;
+  signaling.'u2' = 2;
   signaling.u = 3:4;
   c.f = f(c.p) + modifiedInput + signaling.y;
   connect(signaling.y, measurement);
@@ -67,19 +67,19 @@ end Component;
 
 block Signaling
   RealInput u1;
-  RealInput u2;
+  RealInput 'u2';
   RealInput[2] u;
-  RealOutput y \"unconnected IO at level 0\";
+  RealOutput y;
 equation
-  y = u1 + u2 + sum(u);
+  y = u1 + 'u2' + sum(u);
 end Signaling;
 
 model System
   Source source(use_u_in = true);
   Component component(modifiedInput = 1);
   Signaling signaling;
-  Real component_measurement = 0 \"name already in use\";
-  RealOutput y;
+  Real 'component.measurement' = 0 \"name already in use\";
+  RealOutput y \"unconnected IO at level 0\";
 equation
   y = time;
   connect(source.c, component.c);
@@ -133,72 +133,71 @@ readFile("modelDescription.tmp.xml");
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
-//     name=\"component.m.p\"
+//     name=\"'component.measurement'\"
 //     valueReference=\"1\"
-//     description=\"unconnected IO at level 2\"
+//     description=\"name already in use\"
 //     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
-//     name=\"component.modifiedInput\"
+//     name=\"'component.measurement_'\"
 //     valueReference=\"2\"
-//     initial=\"exact\">
-//     <Real start=\"0.0\"/>
+//     causality=\"output\"
+//     >
+//     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
-//     name=\"component_measurement\"
-//     valueReference=\"7\"
-//     description=\"name already in use\"
-//     initial=\"exact\">
+//     name=\"'signaling.\\'u2\\''\"
+//     valueReference=\"3\"
+//     causality=\"input\"
+//     >
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"4\" -->
 //   <ScalarVariable
-//     name=\"component_measurement_\"
-//     valueReference=\"8\"
+//     name=\"'signaling.y'\"
+//     valueReference=\"4\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
-//     name=\"signaling_u2\"
-//     valueReference=\"9\"
+//     name=\"'source.u_in'\"
+//     valueReference=\"5\"
 //     causality=\"input\"
 //     >
-//     <Real start=\"0.0\"/>
+//     <Real start=\"2.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
-//     name=\"signaling_y\"
-//     valueReference=\"10\"
-//     description=\"unconnected IO at level 0\"
+//     name=\"'source.yp'\"
+//     valueReference=\"6\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
-//     name=\"source.y[2]\"
-//     valueReference=\"11\"
-//     >
-//     <Real/>
+//     name=\"component.m.p\"
+//     valueReference=\"7\"
+//     description=\"unconnected IO at level 2\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"8\" -->
 //   <ScalarVariable
-//     name=\"source_u_in\"
-//     valueReference=\"12\"
-//     causality=\"input\"
-//     >
-//     <Real start=\"2.0\"/>
+//     name=\"component.modifiedInput\"
+//     valueReference=\"8\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
-//     name=\"source_yp\"
+//     name=\"source.y[2]\"
 //     valueReference=\"13\"
-//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -206,6 +205,7 @@ readFile("modelDescription.tmp.xml");
 //   <ScalarVariable
 //     name=\"y\"
 //     valueReference=\"14\"
+//     description=\"unconnected IO at level 0\"
 //     causality=\"output\"
 //     >
 //     <Real/>
@@ -229,99 +229,98 @@ readFile("modelDescription.tmp.xml");
 //   <!-- Index of variable = \"13\" -->
 //   <ScalarVariable
 //     name=\"component.c.p\"
-//     valueReference=\"12\"
+//     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"14\" -->
 //   <ScalarVariable
 //     name=\"component.measurement\"
-//     valueReference=\"8\"
+//     valueReference=\"2\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
 //     name=\"component.simpleOutput\"
-//     valueReference=\"8\"
+//     valueReference=\"2\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"12\"
+//     name=\"signaling.'u2'\"
+//     valueReference=\"3\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"17\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[2]\"
-//     valueReference=\"11\"
+//     name=\"signaling.u[1]\"
+//     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"18\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
-//     valueReference=\"11\"
+//     name=\"signaling.u[2]\"
+//     valueReference=\"13\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"19\" -->
 //   <ScalarVariable
-//     name=\"signaling.u2\"
-//     valueReference=\"9\"
+//     name=\"signaling.u1\"
+//     valueReference=\"13\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"20\" -->
 //   <ScalarVariable
 //     name=\"signaling.y\"
-//     valueReference=\"10\"
-//     description=\"unconnected IO at level 0\"
+//     valueReference=\"4\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"21\" -->
 //   <ScalarVariable
 //     name=\"source.c.f\"
-//     valueReference=\"11\"
+//     valueReference=\"13\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"22\" -->
 //   <ScalarVariable
 //     name=\"source.c.p\"
-//     valueReference=\"12\"
+//     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"23\" -->
 //   <ScalarVariable
 //     name=\"source.u_in\"
-//     valueReference=\"12\"
+//     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"24\" -->
 //   <ScalarVariable
 //     name=\"source.y[1]\"
-//     valueReference=\"12\"
+//     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"25\" -->
 //   <ScalarVariable
 //     name=\"source.yf\"
-//     valueReference=\"11\"
+//     valueReference=\"13\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"26\" -->
 //   <ScalarVariable
 //     name=\"source.yp\"
-//     valueReference=\"12\"
+//     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
@@ -337,15 +336,15 @@ readFile("modelDescription.tmp.xml");
 //   </ModelVariables>
 //   <ModelStructure>
 //     <Outputs>
-//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"6\" dependencies=\"5 8\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"9\" dependencies=\"8\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"2\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"6\" dependencies=\"5\" dependenciesKind=\"dependent\" />
 //       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
 //     </Outputs>
 //     <InitialUnknowns>
-//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"6\" dependencies=\"5 8\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"9\" dependencies=\"8\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"2\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"6\" dependencies=\"5\" dependenciesKind=\"dependent\" />
 //       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"27\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -12,6 +12,11 @@ package LocalIOs
 connector RealInput = input Real;
 connector RealOutput = output Real;
 
+connector StructuredConnector
+  input Real u;
+  output Real y;
+end StructuredConnector;
+
 connector PhysicalConnector
   Real p;
   flow Real f;
@@ -51,6 +56,7 @@ end Medium;
 
 model Component
   PhysicalConnector c;
+  StructuredConnector s;
   input Real modifiedInput annotation(Dialog(enable=true));
   output Real simpleOutput = signaling.y;
   RealOutput measurement;
@@ -62,6 +68,7 @@ equation
   signaling.'u2' = 2;
   signaling.u = 3:4;
   c.f = f(c.p) + modifiedInput + signaling.y;
+  s.y = s.u;
   connect(signaling.y, measurement);
 end Component;
 
@@ -80,11 +87,13 @@ model System
   Signaling signaling;
   Real 'component.measurement' = 0 \"name already in use\";
   RealOutput y \"unconnected IO at level 0\";
+  StructuredConnector s;
 equation
   y = time;
   connect(source.c, component.c);
   connect(source.yf, signaling.u1);
   connect(source.y, signaling.u);
+  connect(s, component.s);
 end System;
 
 end LocalIOs;
@@ -196,135 +205,165 @@ readFile("modelDescription.tmp.xml");
 //   </ScalarVariable>
 //   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
-//     name=\"source.y[2]\"
+//     name=\"s.u\"
 //     valueReference=\"13\"
+//     causality=\"input\"
 //     >
-//     <Real/>
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"y\"
+//     name=\"s.y\"
 //     valueReference=\"14\"
-//     description=\"unconnected IO at level 0\"
 //     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"source.u_par\"
+//     name=\"source.y[2]\"
 //     valueReference=\"15\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"12\" -->
+//   <ScalarVariable
+//     name=\"y\"
+//     valueReference=\"16\"
+//     description=\"unconnected IO at level 0\"
+//     causality=\"output\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"13\" -->
+//   <ScalarVariable
+//     name=\"source.u_par\"
+//     valueReference=\"17\"
 //     variability=\"fixed\"
 //     causality=\"parameter\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"12\" -->
+//   <!-- Index of variable = \"14\" -->
 //   <ScalarVariable
 //     name=\"component.c.f\"
-//     valueReference=\"20\"
+//     valueReference=\"23\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"13\" -->
+//   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
 //     name=\"component.c.p\"
 //     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"14\" -->
+//   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
 //     name=\"component.measurement\"
 //     valueReference=\"2\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"15\" -->
-//   <ScalarVariable
-//     name=\"component.simpleOutput\"
-//     valueReference=\"2\"
-//     >
-//     <Real/>
-//   </ScalarVariable>
-//   <!-- Index of variable = \"16\" -->
-//   <ScalarVariable
-//     name=\"signaling.'u2'\"
-//     valueReference=\"3\"
-//     >
-//     <Real/>
-//   </ScalarVariable>
 //   <!-- Index of variable = \"17\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"5\"
+//     name=\"component.s.u\"
+//     valueReference=\"13\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"18\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[2]\"
+//     name=\"component.s.y\"
 //     valueReference=\"13\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"19\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
-//     valueReference=\"13\"
+//     name=\"component.simpleOutput\"
+//     valueReference=\"2\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"20\" -->
+//   <ScalarVariable
+//     name=\"signaling.'u2'\"
+//     valueReference=\"3\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"21\" -->
+//   <ScalarVariable
+//     name=\"signaling.u[1]\"
+//     valueReference=\"5\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"22\" -->
+//   <ScalarVariable
+//     name=\"signaling.u[2]\"
+//     valueReference=\"15\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"23\" -->
+//   <ScalarVariable
+//     name=\"signaling.u1\"
+//     valueReference=\"15\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"24\" -->
 //   <ScalarVariable
 //     name=\"signaling.y\"
 //     valueReference=\"4\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"21\" -->
+//   <!-- Index of variable = \"25\" -->
 //   <ScalarVariable
 //     name=\"source.c.f\"
-//     valueReference=\"13\"
+//     valueReference=\"15\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"22\" -->
+//   <!-- Index of variable = \"26\" -->
 //   <ScalarVariable
 //     name=\"source.c.p\"
 //     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"23\" -->
+//   <!-- Index of variable = \"27\" -->
 //   <ScalarVariable
 //     name=\"source.u_in\"
 //     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"24\" -->
+//   <!-- Index of variable = \"28\" -->
 //   <ScalarVariable
 //     name=\"source.y[1]\"
 //     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"25\" -->
+//   <!-- Index of variable = \"29\" -->
 //   <ScalarVariable
 //     name=\"source.yf\"
-//     valueReference=\"13\"
+//     valueReference=\"15\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"26\" -->
+//   <!-- Index of variable = \"30\" -->
 //   <ScalarVariable
 //     name=\"source.yp\"
 //     valueReference=\"5\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
-//   <!-- Index of variable = \"27\" -->
+//   <!-- Index of variable = \"31\" -->
 //   <ScalarVariable
 //     name=\"source.use_u_in\"
 //     valueReference=\"0\"
@@ -339,14 +378,16 @@ readFile("modelDescription.tmp.xml");
 //       <Unknown index=\"2\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
 //       <Unknown index=\"6\" dependencies=\"5\" dependenciesKind=\"dependent\" />
-//       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"10\" dependencies=\"9\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"12\" dependencies=\"\" dependenciesKind=\"\" />
 //     </Outputs>
 //     <InitialUnknowns>
 //       <Unknown index=\"2\" dependencies=\"\" dependenciesKind=\"\" />
 //       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
 //       <Unknown index=\"6\" dependencies=\"5\" dependenciesKind=\"dependent\" />
-//       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"27\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"10\" dependencies=\"9\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"12\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"31\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>
 // </fmiModelDescription>

--- a/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
+++ b/testsuite/openmodelica/cppruntime/fmu/modelExchange/2.0/exposeLocalIOs.mos
@@ -4,7 +4,7 @@
 // teardown_command: rm -f *LocalIOs.System* modelDescription.tmp.xml
 
 setCommandLineOptions("--simCodeTarget=Cpp");
-setCommandLineOptions("--nonStdExposeLocalIOs=10"); getErrorString();
+setCommandLineOptions("--exposeLocalIOs=1"); getErrorString();
 
 loadString("
 package LocalIOs
@@ -45,14 +45,20 @@ algorithm
   y := 0.5*u;
 end f;
 
+model Medium
+  RealInput p \"unconnected IO at level 2\";
+end Medium;
+
 model Component
   PhysicalConnector c;
   input Real modifiedInput annotation(Dialog(enable=true));
   output Real simpleOutput = signaling.y;
   RealOutput measurement;
+  Medium m;
 protected
   Signaling signaling(u1 = 1);
 equation
+  m.p = 1;
   signaling.u2 = 2;
   signaling.u = 3:4;
   c.f = f(c.p) + modifiedInput + signaling.y;
@@ -63,7 +69,7 @@ block Signaling
   RealInput u1;
   RealInput u2;
   RealInput[2] u;
-  RealOutput y;
+  RealOutput y \"unconnected IO at level 0\";
 equation
   y = u1 + u2 + sum(u);
 end Signaling;
@@ -72,7 +78,10 @@ model System
   Source source(use_u_in = true);
   Component component(modifiedInput = 1);
   Signaling signaling;
+  Real component_measurement = 0 \"name already in use\";
+  RealOutput y;
 equation
+  y = time;
   connect(source.c, component.c);
   connect(source.yf, signaling.u1);
   connect(source.y, signaling.u);
@@ -120,15 +129,15 @@ readFile("modelDescription.tmp.xml");
 //     <Category name=\"logAll\" />
 //     <Category name=\"logFmi2Call\" />
 //   </LogCategories>
-//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-06\" stepSize=\"0.002\"/>
+//   <DefaultExperiment startTime=\"0.0\" stopTime=\"1.0\" tolerance=\"1e-6\" stepSize=\"0.002\"/>
 //   <ModelVariables>
 //   <!-- Index of variable = \"1\" -->
 //   <ScalarVariable
-//     name=\"component.measurement\"
+//     name=\"component.m.p\"
 //     valueReference=\"1\"
-//     causality=\"output\"
-//     >
-//     <Real/>
+//     description=\"unconnected IO at level 2\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"2\" -->
 //   <ScalarVariable
@@ -139,15 +148,15 @@ readFile("modelDescription.tmp.xml");
 //   </ScalarVariable>
 //   <!-- Index of variable = \"3\" -->
 //   <ScalarVariable
-//     name=\"signaling.u2\"
+//     name=\"component_measurement\"
 //     valueReference=\"7\"
-//     causality=\"input\"
-//     >
+//     description=\"name already in use\"
+//     initial=\"exact\">
 //     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"4\" -->
 //   <ScalarVariable
-//     name=\"signaling.y\"
+//     name=\"component_measurement_\"
 //     valueReference=\"8\"
 //     causality=\"output\"
 //     >
@@ -155,107 +164,168 @@ readFile("modelDescription.tmp.xml");
 //   </ScalarVariable>
 //   <!-- Index of variable = \"5\" -->
 //   <ScalarVariable
-//     name=\"source.u_in\"
+//     name=\"signaling_u2\"
 //     valueReference=\"9\"
 //     causality=\"input\"
 //     >
-//     <Real start=\"2.0\"/>
+//     <Real start=\"0.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"6\" -->
 //   <ScalarVariable
-//     name=\"source.y[2]\"
+//     name=\"signaling_y\"
 //     valueReference=\"10\"
+//     description=\"unconnected IO at level 0\"
+//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"7\" -->
 //   <ScalarVariable
-//     name=\"source.yp\"
+//     name=\"source.y[2]\"
 //     valueReference=\"11\"
-//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"8\" -->
 //   <ScalarVariable
-//     name=\"source.u_par\"
+//     name=\"source_u_in\"
 //     valueReference=\"12\"
-//     variability=\"fixed\"
-//     causality=\"parameter\"
+//     causality=\"input\"
 //     >
 //     <Real start=\"2.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"9\" -->
 //   <ScalarVariable
-//     name=\"component.c.f\"
-//     valueReference=\"16\"
+//     name=\"source_yp\"
+//     valueReference=\"13\"
+//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"10\" -->
 //   <ScalarVariable
-//     name=\"component.c.p\"
-//     valueReference=\"9\"
+//     name=\"y\"
+//     valueReference=\"14\"
+//     causality=\"output\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"11\" -->
 //   <ScalarVariable
-//     name=\"component.simpleOutput\"
-//     valueReference=\"1\"
+//     name=\"source.u_par\"
+//     valueReference=\"15\"
+//     variability=\"fixed\"
+//     causality=\"parameter\"
 //     >
-//     <Real/>
+//     <Real start=\"2.0\"/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"12\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[1]\"
-//     valueReference=\"9\"
+//     name=\"component.c.f\"
+//     valueReference=\"20\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"13\" -->
 //   <ScalarVariable
-//     name=\"signaling.u[2]\"
-//     valueReference=\"10\"
+//     name=\"component.c.p\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"14\" -->
 //   <ScalarVariable
-//     name=\"signaling.u1\"
-//     valueReference=\"10\"
+//     name=\"component.measurement\"
+//     valueReference=\"8\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"15\" -->
 //   <ScalarVariable
-//     name=\"source.c.f\"
-//     valueReference=\"10\"
+//     name=\"component.simpleOutput\"
+//     valueReference=\"8\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"16\" -->
 //   <ScalarVariable
-//     name=\"source.c.p\"
-//     valueReference=\"9\"
+//     name=\"signaling.u[1]\"
+//     valueReference=\"12\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"17\" -->
 //   <ScalarVariable
-//     name=\"source.y[1]\"
-//     valueReference=\"9\"
+//     name=\"signaling.u[2]\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"18\" -->
 //   <ScalarVariable
-//     name=\"source.yf\"
-//     valueReference=\"10\"
+//     name=\"signaling.u1\"
+//     valueReference=\"11\"
 //     >
 //     <Real/>
 //   </ScalarVariable>
 //   <!-- Index of variable = \"19\" -->
+//   <ScalarVariable
+//     name=\"signaling.u2\"
+//     valueReference=\"9\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"20\" -->
+//   <ScalarVariable
+//     name=\"signaling.y\"
+//     valueReference=\"10\"
+//     description=\"unconnected IO at level 0\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"21\" -->
+//   <ScalarVariable
+//     name=\"source.c.f\"
+//     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"22\" -->
+//   <ScalarVariable
+//     name=\"source.c.p\"
+//     valueReference=\"12\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"23\" -->
+//   <ScalarVariable
+//     name=\"source.u_in\"
+//     valueReference=\"12\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"24\" -->
+//   <ScalarVariable
+//     name=\"source.y[1]\"
+//     valueReference=\"12\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"25\" -->
+//   <ScalarVariable
+//     name=\"source.yf\"
+//     valueReference=\"11\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"26\" -->
+//   <ScalarVariable
+//     name=\"source.yp\"
+//     valueReference=\"12\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"27\" -->
 //   <ScalarVariable
 //     name=\"source.use_u_in\"
 //     valueReference=\"0\"
@@ -267,15 +337,17 @@ readFile("modelDescription.tmp.xml");
 //   </ModelVariables>
 //   <ModelStructure>
 //     <Outputs>
-//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"7\" dependencies=\"5\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"6\" dependencies=\"5 8\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"9\" dependencies=\"8\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
 //     </Outputs>
 //     <InitialUnknowns>
-//       <Unknown index=\"1\" dependencies=\"\" dependenciesKind=\"\" />
-//       <Unknown index=\"4\" dependencies=\"3 5\" dependenciesKind=\"dependent dependent\" />
-//       <Unknown index=\"7\" dependencies=\"5\" dependenciesKind=\"dependent\" />
-//       <Unknown index=\"19\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"4\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"6\" dependencies=\"5 8\" dependenciesKind=\"dependent dependent\" />
+//       <Unknown index=\"9\" dependencies=\"8\" dependenciesKind=\"dependent\" />
+//       <Unknown index=\"10\" dependencies=\"\" dependenciesKind=\"\" />
+//       <Unknown index=\"27\" dependencies=\"\" dependenciesKind=\"\" />
 //     </InitialUnknowns>
 //   </ModelStructure>
 // </fmiModelDescription>


### PR DESCRIPTION
Add top-level variables for unconnected local IOs. This way only NFFlatten.mo and NFConnectEquations.mo are extended. Previous changes to the backend, NFFlatModel.mo and NFVariable.mo are reverted.
Quoted identifiers allow compatibility with the previous implementation.