### PR TITLE
Avoid extra end message tag when logging LOG_INIT

### DIFF
--- a/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/nonlinearSystem.c
@@ -1484,7 +1484,10 @@ int check_nonlinear_solution(DATA *data, int printFailingSystems, int sysNumber)
         warningStreamPrint(LOG_INIT, 0, "[%ld] Real %s(start=?, nominal=?)", j+1, modelInfoGetEquation(&data->modelData->modelDataXml, (nonlinsys[i]).equationIndex).vars[j]);
       }
     }
-    messageCloseWarning(LOG_INIT);
+    if(data->simulationInfo->initial)
+    {
+      messageCloseWarning(LOG_INIT);
+    }
     return 1;
   }
   if(nonlinsys[i].solved == NLS_SOLVED_LESS_ACCURACY)


### PR DESCRIPTION
### Related Issues

#12386