### PR TITLE
Remove subscripting functions from Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -783,7 +783,7 @@ public
 
       s := IOStream.append(s, name);
       s := IOStream.append(s, " = ");
-      s := IOStream.append(s, Binding.toFlatString(binding));
+      s := IOStream.append(s, Expression.toFlatString(bind_exp));
 
       ty_attrs := listRest(ty_attrs);
       if listEmpty(ty_attrs) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1948,7 +1948,7 @@ public
       case UNBOX() then "UNBOX(" + toFlatString(exp.exp) + ")";
       case BOX() then "BOX(" + toFlatString(exp.exp) + ")";
 
-      case SUBSCRIPTED_EXP() then toFlatSubscriptedString(exp.exp, exp.subscripts);
+      case SUBSCRIPTED_EXP() then "(" + toFlatString(exp.exp) + ")" + Subscript.toFlatStringList(exp.subscripts);
       case TUPLE_ELEMENT() then toFlatString(exp.tupleExp) + "[" + intString(exp.index) + "]";
       case RECORD_ELEMENT() then toFlatString(exp.recordExp) + "[field: " + exp.fieldName + "]";
       case MUTABLE() then toFlatString(Mutable.access(exp.exp));
@@ -1961,47 +1961,6 @@ public
       else anyString(exp);
     end match;
   end toFlatString;
-
-  function toFlatSubscriptedString
-    input Expression exp;
-    input list<Subscript> subscripts;
-    output String str;
-  protected
-    Type exp_ty;
-    list<Type> sub_tyl;
-    list<Dimension> dims;
-    list<String> strl;
-    String name;
-    list<Subscript> subs;
-  algorithm
-    if Flags.getConfigBool(Flags.MODELICA_OUTPUT) then
-      subs := list(s for s guard not Subscript.isSplitIndex(s) in subscripts);
-
-      if listEmpty(subs) then
-        str := toFlatString(exp);
-      else
-        exp_ty := typeOf(exp);
-        dims := List.firstN(Type.arrayDims(exp_ty), listLength(subs));
-        sub_tyl := list(Dimension.subscriptType(d) for d in dims);
-        name := Type.subscriptedTypeName(exp_ty, sub_tyl);
-
-        strl := {")"};
-
-        for s in subs loop
-          strl := Subscript.toFlatString(s) :: strl;
-          strl := "," :: strl;
-        end for;
-
-        strl := toFlatString(exp) :: strl;
-        strl := "'(" :: strl;
-        strl := name :: strl;
-        strl := "'" :: strl;
-        str := stringAppendList(strl);
-      end if;
-    else
-      str := "(" + toFlatString(exp) + ")" + Subscript.toFlatStringList(subscripts);
-    end if;
-  end toFlatSubscriptedString;
 
   function operandString
     "Helper function to toString, prints an operator and adds parentheses as needed."

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -553,21 +553,7 @@ public
     input Expression exp;
     input output TypeMap types;
   algorithm
-    () := match exp
-      case Expression.SUBSCRIPTED_EXP()
-        guard Flags.getConfigBool(Flags.MODELICA_OUTPUT)
-        algorithm
-          collectSubscriptedFlatType(exp.exp, exp.subscripts, exp.ty, types);
-        then
-          ();
-
-      else
-        algorithm
-          collectFlatType(Expression.typeOf(exp), types);
-        then
-          ();
-
-    end match;
+    collectFlatType(Expression.typeOf(exp), types);
   end collectExpFlatTypes_traverse;
 
   function collectFunctionFlatTypes
@@ -592,25 +578,6 @@ public
     collectFlatType(Component.getType(comp), types);
     collectBindingFlatTypes(Component.getBinding(comp), types);
   end collectComponentFlatTypes;
-
-  function collectSubscriptedFlatType
-    input Expression exp;
-    input list<Subscript> subs;
-    input Type subscriptedTy;
-    input TypeMap types;
-  protected
-    Type exp_ty;
-    list<Type> sub_tyl;
-    list<Dimension> dims;
-    list<String> strl;
-    String name;
-  algorithm
-    exp_ty := Expression.typeOf(exp);
-    dims := List.firstN(Type.arrayDims(exp_ty), listLength(subs));
-    sub_tyl := list(Dimension.subscriptType(d) for d in dims);
-    name := Type.subscriptedTypeName(exp_ty, sub_tyl);
-    UnorderedMap.tryAdd(Absyn.IDENT(name), Type.SUBSCRIPTED(name, exp_ty, sub_tyl, subscriptedTy), types);
-  end collectSubscriptedFlatType;
 
   function reconstructRecordInstances
     input list<Variable> variables;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -123,13 +123,6 @@ public
   record ANY
   end ANY;
 
-  record SUBSCRIPTED
-    String name;
-    Type ty;
-    list<Type> subs;
-    Type subscriptedTy;
-  end SUBSCRIPTED;
-
   record CONDITIONAL_ARRAY
     "A type that might be one of two types depending on a condition.
      The two types are assumed to be array types with equal number of dimensions."
@@ -1030,43 +1023,6 @@ public
           s := IOStream.append(s, name);
         then s;
 
-      case SUBSCRIPTED()
-        algorithm
-          s := IOStream.append(s, indent);
-          s := IOStream.append(s, "function ");
-          s := IOStream.append(s, Util.makeQuotedIdentifier(ty.name));
-          s := IOStream.append(s, "\n");
-
-          s := IOStream.append(s, indent);
-          s := IOStream.append(s, "  input ");
-          s := IOStream.append(s, toString(ty.ty));
-          s := IOStream.append(s, " exp;\n");
-
-          index := 1;
-          for sub in ty.subs loop
-            s := IOStream.append(s, indent);
-            s := IOStream.append(s, "  input ");
-            s := IOStream.append(s, toString(sub));
-            s := IOStream.append(s, " s");
-            s := IOStream.append(s, String(index));
-            s := IOStream.append(s, ";\n");
-            index := index + 1;
-          end for;
-
-          s := IOStream.append(s, indent);
-          s := IOStream.append(s, "  output ");
-          s := IOStream.append(s, toString(ty.subscriptedTy));
-          s := IOStream.append(s, " result = exp[");
-          s := IOStream.append(s,
-            stringDelimitList(list("s" + String(i) for i in 1:listLength(ty.subs)), ","));
-          s := IOStream.append(s, "];\n");
-
-          s := IOStream.append(s, indent);
-          s := IOStream.append(s, "end ");
-          s := IOStream.append(s, Util.makeQuotedIdentifier(ty.name));
-        then
-          s;
-
       else s;
     end match;
   end toFlatDeclarationStream;
@@ -1368,20 +1324,6 @@ public
       sizeTy := Type.ARRAY(Type.INTEGER(), {Dimension.fromInteger(dimensionCount(arrayTy))});
     end if;
   end sizeType;
-
-  function subscriptedTypeName
-    input Type expType;
-    input list<Type> subscriptTypes;
-    output String str;
-  protected
-    list<String> strl;
-  algorithm
-    strl := list(toString(t) for t in subscriptTypes);
-    strl := "_" :: strl;
-    strl := toString(expType) :: strl;
-    strl := "subscript" :: strl;
-    str := stringAppendList(strl);
-  end subscriptedTypeName;
 
   function simplify
     input output Type ty;


### PR DESCRIPTION
- Use normal subscripting of expressions in Base Modelica instead of generating subscripting helper functions, since subscripting expressions is allowed in both Modelica and Base Modelica now.