### PR TITLE
Updating README.Linux

### DIFF
--- a/OMCompiler/README.Linux.md
+++ b/OMCompiler/README.Linux.md
@@ -49,7 +49,7 @@ echo \
  $(lsb_release -cs) nightly" | sudo tee /etc/apt/sources.list.d/openmodelica.list > /dev/null
 echo \
  "deb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt \
- nightly contrib" | sudo tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null
+ $(lsb_release -cs) nightly" | sudo tee -a /etc/apt/sources.list.d/openmodelica.list > /dev/null
 ```
 
 To verify that the correct key is installed (optional):


### PR DESCRIPTION
### Related Issues

  - The deb-src with contrib is no longer working. Using lsb_release nightly instead.

### Purpose

Something changed and now instead of

```
deb [arch=amd64 signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt jammy nightly
deb-src [arch=amd64 signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt nightly contrib
```

one has to to use

```
deb [arch=amd64 signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt jammy nightly
deb-src [arch=amd64 signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/apt jammy nightly
```
