### PR TITLE
[NB] use minimal tearing as default

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -208,8 +208,8 @@ public
     String flag = Flags.getConfigString(Flags.TEARING_METHOD);
   algorithm
     funcs := match flag
-      case "cellier"        then {initialize, none, finalize};
-      case "noTearing"      then {initialize, none, finalize};
+      case "cellier"        then {initialize, minimal, finalize};
+      case "noTearing"      then {initialize, minimal, finalize};
       case "omcTearing"     then {initialize, minimal, finalize};
       case "minimalTearing" then {initialize, minimal, finalize};
       /* ... New tearing modules have to be added here */
@@ -333,7 +333,7 @@ protected
         (jacobian, funcTree) := BJacobian.nonlinear(
           variables = VariablePointers.fromList(list(Slice.getT(var) for var in strict.iteration_vars)),
           equations = EquationPointers.fromList(list(Slice.getT(eqn) for eqn in strict.residual_eqns)),
-          comps     = listArray(residual_comps),
+          comps     = arrayAppend(strict.innerEquations,listArray(residual_comps)),
           funcTree  = funcTree,
           name      = System.System.systemTypeString(systemType) + tag + intString(index));
         strict.jac := jacobian;

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -348,6 +348,9 @@ simulationnewbackend-records.log: omc-diff
 simulationnewbackend-ScalableTestsuite.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/ScalableTestsuite/ -f Makefile test > $@
 	@echo $@ done
+simulationnewbackend-tearing.log: omc-diff
+	$(MAKE) -C simulation/modelica/NBackend/tearing/ -f Makefile test > $@
+	@echo $@ done
 simulationdeclarations.log: omc-diff
 	$(MAKE) -C simulation/modelica/declarations -f Makefile test > $@
 	@echo $@ done

--- a/testsuite/simulation/modelica/NBackend/tearing/Makefile
+++ b/testsuite/simulation/modelica/NBackend/tearing/Makefile
@@ -1,0 +1,49 @@
+TEST = ../../../../rtest -v
+
+TESTFILES = \
+minimalTearing_simple.mos \
+
+# test that currently fail. Move up when fixed.
+# Run make failingtest
+FAILINGTESTFILES = \
+
+# Dependency files that are not .mo .mos or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.mo \
+*.mos \
+Makefile \
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps failingtest
+
+test:
+	@echo
+	@echo Running tests...
+	@echo
+	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
+	@$(TEST) $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@rm -f $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+# do it after cleaning and updating the folder
+# then you can get a list of file names (which must be dependencies
+# since you got them from repository + your own new files)
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
+
+failingtest:
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/testsuite/simulation/modelica/NBackend/tearing/minimalTearing_simple.mos
+++ b/testsuite/simulation/modelica/NBackend/tearing/minimalTearing_simple.mos
@@ -1,0 +1,37 @@
+// name: minimalTearing_simple1
+// keywords: minimal tearing, mixed system
+// status: correct
+// cflags:
+// teardown_command: rm -rf minimalTearing_simple1* _minimalTearing_simple1* output.log
+// cflags: --newBackend
+//
+// Tearing with discrete variables inside loop.
+
+loadString("
+model minimalTearing_simple1
+  Real a(start=0);
+  Integer b;
+  Boolean c;
+equation
+  a = b * time;
+  c = a > 0;
+  b = if c then integer(time*10) else -integer(time*10);
+end minimalTearing_simple1;
+"); getErrorString();
+
+setTearingMethod("minimalTearing"); getErrorString();
+simulate(minimalTearing_simple1); getErrorString();
+// Result:
+// true
+// ""
+// true
+// ""
+// record SimulationResult
+//     resultFile = "minimalTearing_simple1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'minimalTearing_simple1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
 - all tearing methods will point to minimal tearing (no tearing does not exist anymore)
 - update jacobian to also differentiate inner equations