### PR TITLE
Updating CI to Ubuntu Noble Numbat

### DIFF
--- a/.CI/Jenkinsfile.more-compilers
+++ b/.CI/Jenkinsfile.more-compilers
@@ -25,9 +25,50 @@ pipeline {
     }
     stage('builds') {
       parallel {
-        stage('clang-6.0') {
+        stage('gcc-11 (Ubuntu Jammy)') {
+          agent {
+             dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-jammy'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-7-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
           steps {
-            print "Ubuntu Bionic clang 6.0 tested on every pull request"
+            script {
+              common.buildOMC('gcc', 'g++', '')
+              common.makeLibsAndCache()
+              common.buildGUI('')
+              common.partest()
+            }
+          }
+        }
+        stage('clang-14 (Ubuntu Jammy)') {
+          agent {
+             dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-jammy'
+              label 'linux'
+              args "--mount type=volume,source=runtest-gcc-7-cache,target=/cache/runtest " +
+                   "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            LIBRARIES = "/cache/omlibrary"
+          }
+          steps {
+            script {
+              common.buildOMC('clang', 'clang++', '')
+              common.makeLibsAndCache()
+              common.buildGUI('')
+              common.partest()
+            }
           }
         }
       }

--- a/.CI/cache-jammy/Dockerfile
+++ b/.CI/cache-jammy/Dockerfile
@@ -1,0 +1,6 @@
+# Cannot be parametrized in Jenkins...
+FROM openmodelica/build-deps:v1.22.3
+
+# We don't know the uid of the user who will build, so make the /cache directories world writable
+
+RUN mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/

--- a/.CI/cache-noble/Dockerfile
+++ b/.CI/cache-noble/Dockerfile
@@ -1,5 +1,4 @@
-# Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.22.2
+FROM openmodelica/build-deps:v1.23.0-wip
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 

--- a/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
+++ b/.CI/cmake/Jenkinsfile.cmake.ubuntu.gcc.test
@@ -22,10 +22,10 @@ pipeline {
     }
     stage('build') {
       parallel {
-        stage('autoconf-jammy-gcc') {
+        stage('autoconf-noble-gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -37,11 +37,11 @@ pipeline {
             stash name: 'omc-gcc', includes: 'build/bin/OMCppOSUSimulation, build/include/omc/omsi/**, build/include/omc/omsic/**, build/lib/x86_64-linux-gnu/omc/omsi/**, build/lib/x86_64-linux-gnu/omc/omsicpp/**, **/config.status'
           }
         }
-        stage('cmake-jammy-gcc') {
+        stage('cmake-noble-gcc') {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
                     "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
@@ -67,7 +67,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -92,7 +92,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -117,7 +117,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -11,7 +11,7 @@ continuous integration.
 We added three images that are used by the continuous integration used to compile or test
 the pull requests on github.com/OpenModelica/OpenMOdelica.
 
-  - [build-deps-v1.22](./build-deps-v1.22/devcontainer.json): Default build image to
+  - [build-deps-v1.23](./build-deps-v1.23/devcontainer.json): Default build image to
     compile OpenModelica.
   - [fmuchecker](./fmuchecker/devcontainer.json): Image with FMU checker to test generated
     FMUs.

--- a/.devcontainer/build-deps-v1.23/Dockerfile
+++ b/.devcontainer/build-deps-v1.23/Dockerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ENV SHELL /bin/bash
+
+ARG USERNAME=openmodelica-user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Additional software (gdb, valgrind)
+RUN apt-get update \
+    && apt-get install -qy build-essential gdb valgrind
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
+
+# [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+RUN apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+ENV USER=$USERNAME

--- a/.devcontainer/build-deps-v1.23/devcontainer.json
+++ b/.devcontainer/build-deps-v1.23/devcontainer.json
@@ -1,13 +1,13 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
-  "name": "build-deps:v1.22",
+  "name": "build-deps:v1.23",
 
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-        "BASE_IMAGE": "openmodelica/build-deps:v1.22.3",
+        "BASE_IMAGE": "openmodelica/build-deps:v1.23.0-wip",
         // On Windows USERNAME is set, on Linux USER is set
         // We hope only one is set
         "USERNAME": "${localEnv:USER}${localEnv:USERNAME}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
         stage('gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -73,7 +73,7 @@ pipeline {
         stage('clang') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -118,10 +118,10 @@ pipeline {
             }
           }
         }
-        stage('cmake-jammy-gcc') {
+        stage('cmake-noble-gcc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -201,7 +201,7 @@ pipeline {
         stage('checks') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -240,7 +240,7 @@ pipeline {
           }
           steps {
             script {
-              def deps = docker.build('testsuite-fmu-crosscompile', '--pull .CI/cache')
+              def deps = docker.build('testsuite-fmu-crosscompile', '--pull .CI/cache-noble')
               // deps.pull() // Already built...
               def dockergid = sh (script: 'stat -c %g /var/run/docker.sock', returnStdout: true).trim()
               deps.inside("-v /var/run/docker.sock:/var/run/docker.sock --group-add '${dockergid}' " +
@@ -262,7 +262,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               /* The cache Dockerfile makes /cache/runtest, etc world writable
                * This is necessary because we run the docker image as a user and need to
                * be able to have a global caching of the omlibrary parts and the runtest database.
@@ -296,7 +296,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               /* The cache Dockerfile makes /cache/runtest, etc world writable
                * This is necessary because we run the docker image as a user and need to
                * be able to have a global caching of the omlibrary parts and the runtest database.
@@ -330,7 +330,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               /* The cache Dockerfile makes /cache/runtest, etc world writable
                * This is necessary because we run the docker image as a user and need to
                * be able to have a global caching of the omlibrary parts and the runtest database.
@@ -365,7 +365,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -393,7 +393,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -421,7 +421,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=runtest-gcc-cache,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -450,7 +450,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               /* The cache Dockerfile makes /cache/runtest, etc world writable
                * This is necessary because we run the docker image as a user and need to
                * be able to have a global caching of the omlibrary parts and the runtest database.
@@ -479,7 +479,7 @@ pipeline {
         stage('10 build-gui-clang-qt5') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -497,7 +497,7 @@ pipeline {
           agent {
             dockerfile {
               additionalBuildArgs '--pull'
-              dir '.CI/cache'
+              dir '.CI/cache-noble'
               label 'linux'
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
                    "-v /var/lib/jenkins/gitcache:/var/lib/jenkins/gitcache"
@@ -536,8 +536,8 @@ pipeline {
         stage('11 testsuite-clang-parmod') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
-              label 'linux-intel-x64'   // TODO: We didn't get OpenCL to work on AMD CPU on Ubuntu Jammy, so Intel it is
+              image 'openmodelica/build-deps:v1.23.0-wip'
+              //label 'linux-intel-x64'   // TODO: We didn't get OpenCL to work on AMD CPU on Ubuntu Jammy, so Intel it is
               alwaysPull true
               // No runtest.db cache necessary; the tests run in serial and do not load libraries!
             }
@@ -558,7 +558,7 @@ pipeline {
         stage('12 testsuite-clang-metamodelica') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
             }
           }
@@ -576,7 +576,7 @@ pipeline {
         stage('13 testsuite-matlab-translator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
             }
@@ -598,7 +598,7 @@ pipeline {
         stage('14 test-clang-icon-generator') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               args "--mount type=volume,source=runtest-clang-icon-generator,target=/cache/runtest " +
                    "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary " +
@@ -734,7 +734,7 @@ pipeline {
         stage('clang-qt5-omedit-testsuite') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
               args "--mount type=volume,source=omlibrary-cache,target=/cache/omlibrary"
@@ -757,7 +757,7 @@ pipeline {
         stage('fmuchecker-results') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
             }
@@ -785,7 +785,7 @@ pipeline {
         stage('upload-compliance') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
             }
@@ -803,7 +803,7 @@ pipeline {
         stage('upload-doc') {
           agent {
             docker {
-              image 'docker.openmodelica.org/build-deps:v1.22.2'
+              image 'openmodelica/build-deps:v1.23.0-wip'
               label 'linux'
               alwaysPull true
             }

--- a/doc/UsersGuide/README.md
+++ b/doc/UsersGuide/README.md
@@ -5,7 +5,7 @@ OpenModelica User's Guide using Sphinx (Python Documentation Generator).
 ## Dependencies
 
 Getting all dependencies right is a nightmare. Just use the dev container
-`build-deps:v1.22.0` from [.devcontainer/README.md](./../../.devcontainer/README.md) and
+`build-deps:v1.23` from [.devcontainer/README.md](./../../.devcontainer/README.md) and
 set `GITHUB_AUTH`.
 
  - omc, omc-diff and omsimulator


### PR DESCRIPTION
### Related Issues

Ubuntu Noble Numbat (24.04 LTS) was released.

### Purpose

Update CI from Ubuntu Jammy to Noble.
