### PR TITLE
[NB] fix pre() variable detection

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -241,8 +241,8 @@ public
       (simplify,           "simplify1"),
       (Alias.main,         "Alias"),
       (simplify,           "simplify2"), // TODO simplify in Alias only
-      (Events.main,        "Events"),
-      (DetectStates.main,  "Detect States")
+      (DetectStates.main,  "Detect States"),
+      (Events.main,        "Events")
     };
 
     mainModules := {


### PR DESCRIPTION
 - collect pre(not b) calls
 - report and fail on all pre calls that are not `pre(b)` or `pre(not b)`. Future work needed here?
 - swap DetectStates and Events module so that pre() variables are correctly parsed before collecting the events