### PR TITLE
Reduce evaluation of external functions in instance API

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -35,7 +35,7 @@ public
   import Expression = NFExpression;
   import NFInstNode.InstNode;
   import Type = NFType;
-  import NFPrefixes.Variability;
+  import NFPrefixes.{Variability, Purity};
   import ErrorTypes;
   import Mutable;
   import Subscript = NFSubscript;
@@ -91,6 +91,7 @@ public
     Expression bindingExp;
     Type bindingType;
     Variability variability;
+    Purity purity;
     EachType eachType;
     Mutable<EvalState> evalState;
     Boolean isFlattened;
@@ -335,6 +336,7 @@ public
     Expression exp;
     Type ty;
     Variability var;
+    Purity purity;
     String field_name = InstNode.name(fieldNode);
   algorithm
     fieldBinding := match fieldBinding
@@ -348,9 +350,10 @@ public
         algorithm
           exp := Expression.recordElement(field_name, fieldBinding.bindingExp);
           ty := Expression.typeOf(exp);
+          purity := Expression.purity(exp);
           var := Expression.variability(exp);
         then
-          TYPED_BINDING(exp, ty, var, fieldBinding.eachType, fieldBinding.evalState,
+          TYPED_BINDING(exp, ty, var, purity, fieldBinding.eachType, fieldBinding.evalState,
                         fieldBinding.isFlattened, fieldBinding.source, fieldBinding.info);
 
       case FLAT_BINDING()
@@ -383,6 +386,16 @@ public
           fail();
     end match;
   end variability;
+
+  function purity
+    input Binding binding;
+    output Purity purity;
+  algorithm
+    purity := match binding
+      case TYPED_BINDING() then binding.purity;
+      else Purity.PURE;
+    end match;
+  end purity;
 
   function getInfo
     input Binding binding;
@@ -714,6 +727,7 @@ public
           bindingExp  = exp,
           bindingType = Expression.typeOf(exp),
           variability = Expression.variability(exp),
+          purity      = Expression.purity(exp),
           eachType    = EachType.NOT_EACH,
           evalState   = if Expression.isConstNumber(exp)
                         then Mutable.create(EvalState.EVALUATED)
@@ -825,7 +839,8 @@ public
     output Binding binding;
   algorithm
     binding := TYPED_BINDING(exp, Expression.typeOf(exp),
-      Expression.variability(exp), eachType, Mutable.create(state), false, source, info);
+      Expression.variability(exp), Expression.purity(exp),
+      eachType, Mutable.create(state), false, source, info);
   end makeTyped;
 
   function makeFlat

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalFunction.mo
@@ -174,6 +174,7 @@ algorithm
       then evaluateExternal2(name, fn, args, ext_args);
 
     case _
+      guard not EvalTarget.isInstanceAPI(target)
       // For anything else, try to call the function via FFI.
       then callExternalFunction(name, fn, args, ext_args, output_ref, ann);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -5118,6 +5118,7 @@ public
       case LBINARY() then Prefixes.purityMin(purity(exp.exp1), purity(exp.exp2));
       case LUNARY() then purity(exp.exp);
       case RELATION() then Prefixes.purityMin(purity(exp.exp1), purity(exp.exp2));
+      case MULTARY() then Prefixes.purityMin(purityList(exp.arguments), purityList(exp.inv_arguments));
       case IF() then Prefixes.purityMin(purity(exp.condition),
                        Prefixes.purityMin(purity(exp.trueBranch), purity(exp.falseBranch)));
       case CAST() then purity(exp.exp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -2868,7 +2868,7 @@ algorithm
             fail();
           end if;
         elseif isCastMatch(ty_match) then
-          binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.eachType,
+          binding := Binding.TYPED_BINDING(exp, ty, binding.variability, binding.purity, binding.eachType,
             binding.evalState, binding.isFlattened, binding.source, binding.info);
         end if;
       then

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1159,15 +1159,16 @@ algorithm
       Expression exp;
       Type ty;
       Variability var;
+      Purity purity;
       SourceInfo info;
       NFBinding.EachType each_ty;
 
     case Binding.UNTYPED_BINDING(bindingExp = exp)
       algorithm
         info := Binding.getInfo(binding);
-        (exp, ty, var) := typeExp(exp, context, info);
+        (exp, ty, var, purity) := typeExp(exp, context, info);
       then
-        Binding.TYPED_BINDING(exp, ty, var, binding.eachType,
+        Binding.TYPED_BINDING(exp, ty, var, purity, binding.eachType,
           Mutable.create(NFBinding.EvalState.NOT_EVALUATED), false,
           binding.source, binding.info);
 
@@ -1193,6 +1194,7 @@ algorithm
       Expression exp;
       Type ty;
       Variability var;
+      Purity purity;
       SourceInfo info;
       MatchKind mk;
       NFBinding.EvalState eval_state;
@@ -1200,7 +1202,7 @@ algorithm
     case Binding.UNTYPED_BINDING(bindingExp = exp)
       algorithm
         info := Binding.getInfo(condition);
-        (exp, ty, var) := typeExp(exp, InstContext.set(context, NFInstContext.CONDITION), info);
+        (exp, ty, var, purity) := typeExp(exp, InstContext.set(context, NFInstContext.CONDITION), info);
         (exp, _, mk) := TypeCheck.matchTypes(ty, Type.BOOLEAN(), exp);
 
         if TypeCheck.isIncompatibleMatch(mk) then
@@ -1228,7 +1230,7 @@ algorithm
           ErrorExt.rollBack(getInstanceName());
         end if;
       then
-        Binding.TYPED_BINDING(exp, ty, var, NFBinding.EachType.NOT_EACH,
+        Binding.TYPED_BINDING(exp, ty, var, purity, NFBinding.EachType.NOT_EACH,
           Mutable.create(eval_state), false, condition.source, info);
 
   end match;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -79,7 +79,7 @@ import NFCall.Call;
 import Ceval = NFCeval;
 import NFClassTree.ClassTree;
 import NFFlatten.FunctionTree;
-import NFPrefixes.{Variability};
+import NFPrefixes.{Variability, Purity};
 import NFSections.Sections;
 import Package = NFPackage;
 import Parser;
@@ -1381,7 +1381,8 @@ algorithm
 
         json := dumpJSONSCodeMod(elem.modifications, scope, json);
 
-        is_constant := comp.attributes.variability <= Variability.PARAMETER;
+        is_constant := comp.attributes.variability <= Variability.PARAMETER and
+                       Binding.purity(comp.binding) == Purity.PURE;
         if Binding.isExplicitlyBound(comp.binding) then
           json := JSON.addPair("value", dumpJSONBinding(comp.binding, originalBinding, evaluate = is_constant), json);
         end if;
@@ -1520,7 +1521,7 @@ algorithm
   if evaluate and not Expression.isLiteral(exp) then
     ErrorExt.setCheckpoint(getInstanceName());
     try
-      exp := Ceval.evalExp(exp);
+      exp := Ceval.evalExp(exp, NFCeval.EvalTarget.INSTANCE_API());
       json := JSON.addPair("value", Expression.toJSON(exp), json);
     else
     end try;


### PR DESCRIPTION
- Don't evaluate impure bindings in `NFApi.dumpJSONBinding`.
- Don't evaluate external function calls that require using FFI in `NFApi.dumpJSONBinding`.