### PR TITLE
Improve handling of records in Base Modelica

### DIFF
--- a/OMCompiler/Compiler/Util/IOStream.mo
+++ b/OMCompiler/Compiler/Util/IOStream.mo
@@ -151,6 +151,48 @@ algorithm
   outStream := List.foldr(inStringList, append, inStream);
 end appendList;
 
+function appendListReverse
+  input output IOStream s;
+  input list<String> data;
+protected
+  IOStreamData s_data = s.data;
+algorithm
+  () := match s_data
+    case IOStreamData.FILE_DATA()
+      algorithm
+        for str in data loop
+          IOStreamExt.appendFile(s_data.data, str);
+        end for;
+      then
+        ();
+
+    case IOStreamData.LIST_DATA()
+      algorithm
+        s_data.data := listAppend(data, s_data.data);
+        s.data := s_data;
+      then
+        ();
+
+    case IOStreamData.BUFFER_DATA()
+      algorithm
+        for str in data loop
+          IOStreamExt.appendBuffer(s_data.data, str);
+        end for;
+      then
+        ();
+  end match;
+end appendListReverse;
+
+function appendListStream
+  input IOStream srcStream;
+  input output IOStream dstStream;
+protected
+  list<String> data;
+algorithm
+  IOStream.IOSTREAM(data = IOStreamData.LIST_DATA(data = data)) := srcStream;
+  dstStream := appendListReverse(dstStream, data);
+end appendListStream;
+
 function close
   input IOStream inStream;
   output IOStream outStream;
@@ -229,6 +271,17 @@ algorithm
         bStream;
   end matchcontinue;
 end clear;
+
+function empty
+  input IOStream inStream;
+  output Boolean res;
+protected
+  IOStreamData data = inStream.data;
+algorithm
+  res := match data
+    case LIST_DATA() then listEmpty(data.data);
+  end match;
+end empty;
 
 function string
   input IOStream inStream;

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -11,10 +11,10 @@ endif
 TESTFILES = \
   ArrayBinding1.mo \
 	Comments.mo \
-  DoublePendulum.mos \
 	Expression1.mo \
 	InStreamNominalThreshold.mo \
 	Record1.mo \
+	Record2.mo \
 	SD.mo \
 	SimpleCoolingCycle.mo \
   Tables.mos \
@@ -23,6 +23,7 @@ TESTFILES = \
 # test that currently fail. Move up when fixed.
 # Run make testfailing
 FAILINGTESTFILES= \
+  DoublePendulum.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/openmodelica/basemodelica/Record1.mo
+++ b/testsuite/openmodelica/basemodelica/Record1.mo
@@ -25,8 +25,8 @@ end Record1;
 //   end 'R';
 //
 //   model 'Record1'
-//     'R' 'r1';
-//     'R' 'r2';
+//     'R' 'r1'('x'(start = 1.0) = 1.0, 'y'(start = 2.0));
+//     'R' 'r2'('x'(start = 3.0), 'y'(start = 4.0));
 //   equation
 //     'r1' = 'Record1.R'(0.0, 0.0, 3);
 //     'r2' = 'Record1.R'(0.0, 0.0, 3);

--- a/testsuite/openmodelica/basemodelica/Record2.mo
+++ b/testsuite/openmodelica/basemodelica/Record2.mo
@@ -1,0 +1,41 @@
+// name: Record2
+// status: correct
+// cflags: -d=newInst -f
+
+model Record2
+  record R
+    Real x;
+    Real y;
+  end R;
+
+  R r1(x(start = 1), y(start = 2));
+  R r2(x(start = 3), y(start = 4));
+  R r3(x(start = 5));
+  R r4(y(start = 6));
+  R r5;
+  R r6(x(start = 1.0)) = R(1.0, 2.0);
+equation
+  r1 = R(0,0);
+  r2 = R(0,0);
+end Record2;
+
+// Result:
+// package 'Record2'
+//   record 'R'
+//     Real 'x';
+//     Real 'y';
+//   end 'R';
+//
+//   model 'Record2'
+//     'R' 'r1'('x'(start = 1.0), 'y'(start = 2.0));
+//     'R' 'r2'('x'(start = 3.0), 'y'(start = 4.0));
+//     'R' 'r3'('x'(start = 5.0));
+//     'R' 'r4'('y'(start = 6.0));
+//     'R' 'r5';
+//     'R' 'r6'('x'(start = 1.0)) = 'Record2.R'(1.0, 2.0);
+//   equation
+//     'r1' = 'Record2.R'(0.0, 0.0);
+//     'r2' = 'Record2.R'(0.0, 0.0);
+//   end 'Record2';
+// end 'Record2';
+// endResult


### PR DESCRIPTION
- Remove the reconstruction of record instances when dumping Base Modelica and instead use the non-splitting flattening used by the new backend.
- Dump record field bindings/type attributes as modifiers on the record instances.
- Disable the DoublePendulum test for now until we implement proper compilation of Base Modelica, since using `-f` for both dumping and compilation of Base Modelica doesn't work.