### PR TITLE
Fix Expression.toFlatString for record expressions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1904,7 +1904,7 @@ public
                         ) + ":" + operandFlatString(exp.stop, exp, false);
 
       case TUPLE() then "(" + stringDelimitList(list(toFlatString(e) for e in exp.elements), ", ") + ")";
-      case RECORD() then List.toString(exp.elements, toFlatString, "'" + AbsynUtil.pathString(exp.path), "'(", ", ", ")", true);
+      case RECORD() then List.toString(exp.elements, toFlatString, Type.toFlatString(exp.ty), "(", ", ", ")", true);
       case CALL() then Call.toFlatString(exp.call);
       case SIZE() then "size(" + toFlatString(exp.exp) +
                         (

--- a/testsuite/openmodelica/basemodelica/Record1.mo
+++ b/testsuite/openmodelica/basemodelica/Record1.mo
@@ -28,8 +28,8 @@ end Record1;
 //     'R' 'r1'('x'(start = 1.0) = 1.0, 'y'(start = 2.0));
 //     'R' 'r2'('x'(start = 3.0), 'y'(start = 4.0));
 //   equation
-//     'r1' = 'Record1.R'(0.0, 0.0, 3);
-//     'r2' = 'Record1.R'(0.0, 0.0, 3);
+//     'r1' = 'R'(0.0, 0.0, 3);
+//     'r2' = 'R'(0.0, 0.0, 3);
 //   end 'Record1';
 // end 'Record1';
 // endResult

--- a/testsuite/openmodelica/basemodelica/Record2.mo
+++ b/testsuite/openmodelica/basemodelica/Record2.mo
@@ -34,8 +34,8 @@ end Record2;
 //     'R' 'r5';
 //     'R' 'r6'('x'(start = 1.0)) = 'R'(1.0, 2.0);
 //   equation
-//     'r1' = 'Record2.R'(0.0, 0.0);
-//     'r2' = 'Record2.R'(0.0, 0.0);
+//     'r1' = 'R'(0.0, 0.0);
+//     'r2' = 'R'(0.0, 0.0);
 //   end 'Record2';
 // end 'Record2';
 // endResult


### PR DESCRIPTION
- Use the type instead of the path when dumping record expressions as Base Modelica, to get a name without the root class included.