### PR TITLE
Fix connecting potentially present variables

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1369,6 +1369,11 @@ namespace ModelInstance
       return true;
     }
 
+    Model *lhs_model = lhs->getModel();
+    Model *rhs_model = rhs->getModel();
+
+    if (!lhs_model || !rhs_model) return true;
+
     auto lhs_outside = isOutsideConnector(lhsConnector, *this);
     auto rhs_outside = isOutsideConnector(rhsConnector, *this);
 
@@ -1377,11 +1382,6 @@ namespace ModelInstance
     }
 
     // Check that the connectors are type compatible.
-    Model *lhs_model = lhs->getModel();
-    Model *rhs_model = rhs->getModel();
-
-    if (!lhs_model || !rhs_model) return false;
-
     return lhs_model->isTypeCompatibleWith(*rhs_model, lhs_outside, rhs_outside);
   }
 


### PR DESCRIPTION
- Assume that connectors are compatible if either of the connector elements are missing an associated model, in which case they're probably a potentially present variable in an expandable connector.

Fixes #12471