### PR TITLE
Fix names of records in Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFRecord.mo
@@ -364,9 +364,13 @@ function toFlatDeclarationStream
   input output IOStream.IOStream s;
 protected
   InstNode node;
+  InstNodeType node_ty;
 algorithm
+  node_ty := InstNode.nodeType(recordNode);
   node := instRecord(recordNode);
   Typing.typeClass(node, NFInstContext.RELAXED);
+  // Keep the node type from the original node to get the correct name.
+  node := InstNode.setNodeType(node_ty, node);
   s := IOStream.append(s, InstNode.toFlatString(node, indent));
 end toFlatDeclarationStream;
 

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -16,6 +16,7 @@ TESTFILES = \
 	InStreamNominalThreshold.mo \
 	Record1.mo \
 	Record2.mo \
+	Record3.mo \
 	SD.mo \
 	SimpleCoolingCycle.mo \
   Tables.mos \

--- a/testsuite/openmodelica/basemodelica/Record3.mo
+++ b/testsuite/openmodelica/basemodelica/Record3.mo
@@ -1,0 +1,44 @@
+// name: Record3
+// status: correct
+// cflags: -d=newInst -f
+
+package P
+  record R
+    Real x;
+    Real y;
+  end R;
+
+  record R2 = R;
+end P;
+
+model Record3
+  record R3 = P.R2;
+  P.R2 r1;
+  R3 r2;
+equation
+  r1 = P.R2(0,0);
+  r2 = R3(0,0);
+end Record3;
+
+// Result:
+// //! base 0.1.0
+// package 'Record3'
+//   record 'P.R2'
+//     Real 'x';
+//     Real 'y';
+//   end 'P.R2';
+//
+//   record 'R3'
+//     Real 'x';
+//     Real 'y';
+//   end 'R3';
+//
+//   model 'Record3'
+//     'P.R2' 'r1';
+//     'R3' 'r2';
+//   equation
+//     'r1' = 'P.R2'(0.0, 0.0);
+//     'r2' = 'R3'(0.0, 0.0);
+//   end 'Record3';
+// end 'Record3';
+// endResult


### PR DESCRIPTION
- Keep the node type from the original node when instantiating a record for dumping to Base Modelica, since it contains information needed to get the correct name of the record.

Fixes #12422