### PR TITLE
Improve instantiation of redeclared packages

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -408,7 +408,8 @@ function instantiate
 algorithm
   node := expand(node);
 
-  if instPartial or not InstNode.isPartial(node) or InstContext.inRelaxed(context) then
+  if instPartial or not InstNode.isPartial(node) or
+     InstContext.inRelaxed(context) or InstContext.inRedeclared(context) then
     node := instClass(node, mod, NFAttributes.DEFAULT_ATTR, true, 0, parent, context);
   end if;
 end instantiate;
@@ -1249,47 +1250,63 @@ end instExternalObjectStructors;
 function instPackage
   "This function instantiates a package given a package node. If the package has
    already been instantiated, then the cached instance from the node is
-   returned. Otherwise the node is fully instantiated, the instance is added to
-   the node's cache, and the instantiated node is returned."
+   returned. Otherwise the node is instantiated, the instance is added to the
+   node's cache, and the instantiated node is returned."
   input output InstNode node;
   input InstContext.Type context;
 protected
   CachedData cache;
   InstNode inst;
+  import NFInstNode.PackageCacheState;
+  PackageCacheState state;
 algorithm
   cache := InstNode.getPackageCache(node);
 
-  node := match cache
-    case CachedData.PACKAGE() then cache.instance;
-
-    case CachedData.NO_CACHE()
-      algorithm
-        // Cache the package node itself first, to avoid instantiation loops if
-        // the package uses itself somehow.
-        InstNode.setPackageCache(node, CachedData.PACKAGE(node));
-
-        if InstContext.inFastLookup(context) then
-          inst := expand(node);
-        else
-          // Instantiate the node.
-          inst := instantiate(node, context = context);
-
-          // Cache the instantiated node and instantiate expressions in it too.
-          if not InstNode.isPartial(inst) or InstContext.inRelaxed(context) then
-            InstNode.setPackageCache(node, CachedData.PACKAGE(inst));
-            instExpressions(inst, context = context);
-          end if;
-        end if;
-      then
-        inst;
-
-    else
-      algorithm
-        Error.assertion(false, getInstanceName() + " got invalid instance cache", sourceInfo());
-      then
-        fail();
-
+  // Check which state the cached package is in, if any.
+  (inst, state) := match cache
+    case CachedData.PACKAGE() then (cache.instance, cache.state);
+    else (node, PackageCacheState.NOT_INITIALIZED);
   end match;
+
+  // If the package is already fully instantiated then we don't need to do anything.
+  if state == PackageCacheState.INSTANTIATED then
+    node := inst;
+    return;
+  end if;
+
+  // If we're currently trying to instantiate this package then return it
+  // unchanged to avoid an instantiation loop.
+  if state == PackageCacheState.PROCESSING then
+    node := inst;
+    return;
+  end if;
+
+  // When doing lookup in some of the API functions we only need an expanded package.
+  if InstContext.inFastLookup(context) then
+    if state < PackageCacheState.EXPANDED then
+      InstNode.setPackageCache(node, node, PackageCacheState.PROCESSING);
+      inst := expand(node);
+      InstNode.setPackageCache(node, inst, PackageCacheState.EXPANDED);
+    end if;
+
+    return;
+  end if;
+
+  // Otherwise we need to at least partially instantiate the package.
+  if state < PackageCacheState.PARTIALLY_INSTANTIATED then
+    InstNode.setPackageCache(node, node, PackageCacheState.PROCESSING);
+    inst := instantiate(node, context = context);
+    InstNode.setPackageCache(node, inst, PackageCacheState.PARTIALLY_INSTANTIATED);
+  end if;
+
+  // If the package isn't partial we also instantiate expressions in it.
+  if state < PackageCacheState.INSTANTIATED and
+     (not InstNode.isPartial(inst) or InstContext.inRelaxed(context)) then
+    InstNode.setPackageCache(node, inst, PackageCacheState.INSTANTIATED);
+    instExpressions(inst, context = context);
+  end if;
+
+  node := inst;
 end instPackage;
 
 function modifyExtends

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -120,12 +120,21 @@ end InstNodeType;
 
 constant Integer NUMBER_OF_CACHES = 2;
 
+type PackageCacheState = enumeration(
+  NOT_INITIALIZED,
+  PROCESSING,
+  EXPANDED,
+  PARTIALLY_INSTANTIATED,
+  INSTANTIATED
+);
+
 uniontype CachedData
 
   record NO_CACHE end NO_CACHE;
 
   record PACKAGE
     InstNode instance;
+    PackageCacheState state;
   end PACKAGE;
 
   record FUNCTION
@@ -1424,10 +1433,11 @@ uniontype InstNode
 
   function setPackageCache
     input output InstNode node;
-    input CachedData in_pack_cache;
+    input InstNode packageNode;
+    input PackageCacheState state;
   algorithm
     () := match node
-      case CLASS_NODE() algorithm CachedData.setPackageCache(node.caches, in_pack_cache); then ();
+      case CLASS_NODE() algorithm CachedData.setPackageCache(node.caches, CachedData.PACKAGE(packageNode, state)); then ();
       else algorithm Error.assertion(false, getInstanceName() + " got node without cache", sourceInfo()); then fail();
     end match;
   end setPackageCache;

--- a/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookup.mo
@@ -698,7 +698,7 @@ algorithm
     node := Inst.instPackage(node, context);
 
     // allow lookup in partial nodes if -d=nfAPI is on
-    if InstNode.isPartial(node) and not InstContext.inRelaxed(context) then
+    if InstNode.isPartial(node) and not (InstContext.inRelaxed(context) or InstContext.inRedeclared(context)) then
       state := LookupState.ERROR(LookupState.PARTIAL_CLASS());
       return;
     end if;
@@ -767,7 +767,7 @@ algorithm
     // PartialModelicaServices is mistakenly partial in MSL versions older than
     // 3.2.3. We can't just check for Modelica 3.2 since that will break e.g. 3.2.2,
     // so just disable the check specifically for PartialModelicaServices instead.
-    if InstNode.isPartial(node) and not InstContext.inRelaxed(context) and
+    if InstNode.isPartial(node) and not (InstContext.inRelaxed(context) or InstContext.inRedeclared(context)) and
        not InstNode.name(node) == "PartialModelicaServices" then
       state := LookupState.ERROR(LookupState.PARTIAL_CLASS());
       return;
@@ -974,7 +974,7 @@ algorithm
   if scope_is_class then
     scope := Inst.instPackage(node, context);
 
-    if InstNode.isPartial(scope) and not InstContext.inRelaxed(context) then
+    if InstNode.isPartial(scope) and not (InstContext.inRelaxed(context) or InstContext.inRedeclared(context)) then
       state := LookupState.ERROR(LookupState.PARTIAL_CLASS());
       return;
     end if;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1050,6 +1050,7 @@ RedeclareMod8.mo \
 RedeclareMod9.mo \
 RedeclareMod10.mo \
 RedeclareMod11.mo \
+RedeclareMod12.mo \
 RedeclareNonReplaceable1.mo \
 redeclare10.mo \
 redeclare11.mo \

--- a/testsuite/flattening/modelica/scodeinst/RedeclareMod12.mo
+++ b/testsuite/flattening/modelica/scodeinst/RedeclareMod12.mo
@@ -1,0 +1,40 @@
+// name: RedeclareMod12
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+package Types
+  type AbsolutePressure = Real;
+  type Temperature = Real;
+end Types;
+
+partial package PartialMedium
+  extends Types;
+end PartialMedium;
+
+package Water
+  extends PartialMedium;
+end Water;
+
+block LumpedVolumeDeclarations
+  replaceable package Medium = PartialMedium;
+  parameter Medium.AbsolutePressure p_start = 0;
+  parameter Medium.Temperature T_start = 0;
+end LumpedVolumeDeclarations;
+
+model ComparePower
+  package Medium = Water;
+  replaceable LumpedVolumeDeclarations mov1;
+end ComparePower;
+
+model RedeclareMod12
+  extends ComparePower(redeclare LumpedVolumeDeclarations mov1(redeclare final package Medium = Medium));
+end RedeclareMod12;
+
+// Result:
+// class RedeclareMod12
+//   parameter Real mov1.p_start = 0.0;
+//   parameter Real mov1.T_start = 0.0;
+// end RedeclareMod12;
+// endResult


### PR DESCRIPTION
- Fix lookup in partial redeclared packages.
- Rewrite `Inst.instPackage` to better keep track of the state of the cached package, to allow partially instantiated packages to be cached correctly.

Fixes #12484