### PR TITLE
export html documentation to FMU

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeMain.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeMain.mo
@@ -106,6 +106,7 @@ import System;
 import Testsuite;
 import Util;
 import SerializeTaskSystemInfo;
+import File;
 
 public
 uniontype TranslateModelKind
@@ -1045,7 +1046,7 @@ protected function exportHTMLDocumentation
   input String FMUVersion;
   output String fileName;
 protected
-  File.File file := File.File();
+  File.File file;
   String info, revisions, infoHeader;
 algorithm
   (info, revisions, infoHeader) := Interactive.getNamedAnnotation(className, program, Absyn.IDENT("Documentation"), SOME(("","","")),Interactive.getDocumentationAnnotationString);
@@ -1054,6 +1055,7 @@ algorithm
   else
     fileName := "index.html";
   end if;
+  file := File.File();
   File.open(file, fileName, File.Mode.Write);
   File.write(file, infoHeader + "\n");
   File.write(file, "<h4> Information </h4>" + info + "\n");

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -23,6 +23,7 @@ fmi_attributes_19.mos \
 fmi_attributes_20.mos \
 fmi_attributes_21.mos \
 fmi_attributes_22.mos \
+fmi_attributes_23.mos \
 FMUResourceTest.mos \
 QuotedIdentifierExport.mos \
 testBug2764.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_23.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmi_attributes_23.mos
@@ -1,0 +1,67 @@
+// name: fmi_attributes_23.mos
+// keywords: FMI 2.0 export html documentation
+// status: correct
+// teardown_command: rm -rf fmi_attributes_23.fmu fmi_attributes_23.log fmi_attributes_23_index.html fmi_attributes_23_info.json
+
+loadString("
+  model fmi_attributes_23
+    parameter Real A = 2;
+    output Real B;
+  equation
+    B = A*time;
+  annotation(
+      Documentation(info=\"<html>
+  <p>The linear resistor connects the branch voltage <em>v</em> with the branch current <em>i</em> by <em>i*R = v</em>. The Resistance <em>R</em> is allowed to be positive, zero, or negative.</p>
+  </html>\",
+          revisions=\"<html>
+  <ul>
+  <li><em> August 07, 2009   </em>
+         by Anton Haumer<br> temperature dependency of resistance added<br>
+         </li>
+  <li><em> March 11, 2009   </em>
+         by Christoph Clauss<br> conditional heat port added<br>
+         </li>
+  <li><em> 1998   </em>
+         by Christoph Clauss<br> initially implemented<br>
+         </li>
+  </ul>
+  </html>\", __OpenModelica_infoHeader = \"<html><h2>TestModel</h2></html>\"));
+
+  end fmi_attributes_23;
+"); getErrorString();
+
+buildModelFMU(fmi_attributes_23); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq fmi_attributes_23.fmu documentation/index.html > fmi_attributes_23_index.html"); getErrorString();
+
+readFile("fmi_attributes_23_index.html"); getErrorString();
+
+
+// Result:
+// true
+// ""
+// "fmi_attributes_23.fmu"
+// ""
+// 0
+// ""
+// "<html><h2>TestModel</h2></html>
+// <h4> Information </h4><html>
+//   <p>The linear resistor connects the branch voltage <em>v</em> with the branch current <em>i</em> by <em>i*R = v</em>. The Resistance <em>R</em> is allowed to be positive, zero, or negative.</p>
+//   </html>
+// <h4> Revisions </h4><html>
+//   <ul>
+//   <li><em> August 07, 2009   </em>
+//          by Anton Haumer<br> temperature dependency of resistance added<br>
+//          </li>
+//   <li><em> March 11, 2009   </em>
+//          by Christoph Clauss<br> conditional heat port added<br>
+//          </li>
+//   <li><em> 1998   </em>
+//          by Christoph Clauss<br> initially implemented<br>
+//          </li>
+//   </ul>
+//   </html>
+// "
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12465

### Purpose

This PR exports the optional html documentation to fmu's parsed from `Documentation`  `annotation` of model.


