### PR TITLE
Fix compilation of OMEdit

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -58,6 +58,8 @@
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
 #include <QScreen>
+#else // QT_VERSION_CHECK
+#include <QDesktopWidget>
 #endif // QT_VERSION_CHECK
 
 /*!


### PR DESCRIPTION
Follow-up of https://github.com/OpenModelica/OpenModelica/pull/12515 after https://github.com/OpenModelica/OpenModelica/pull/12506.

In my case I had this error:
```
Modeling/LibraryTreeWidget.cpp: In member function 'void LibraryTreeView::openInformationDialog()':
Modeling/LibraryTreeWidget.cpp:3538:46: error: invalid use of incomplete type 'class QDesktopWidget'
 3538 |     int screenWidth = QApplication::desktop()->availableGeometry().width() * 0.9;
      |                                              ^~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QApplication:1,
                 from ./Util/Utilities.h:35,
                 from ./OMC/OMCProxy.h:41,
                 from Modeling/LibraryTreeWidget.h:38,
                 from Modeling/LibraryTreeWidget.cpp:35:
/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qapplication.h:57:7: note: forward declaration of 'class QDesktopWidget'
   57 | class QDesktopWidget;
```
I applied the fix suggested in https://www.qtcentre.org/threads/15466-QApplication-desktop()-incomplete-type but didn't investigate more than that.