### PR TITLE
Remove unnecessary version checks for QScreen

### DIFF
--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -46,7 +46,6 @@
 #include <QButtonGroup>
 #include <QMessageBox>
 #include <QDesktopServices>
-#include <QDesktopWidget>
 #include <QList>
 #include <QScreen>
 #include <QStringList>
@@ -1229,13 +1228,8 @@ QSize ParametersScrollArea::minimumSizeHint() const
 {
   QSize size = QWidget::sizeHint();
   // find optimal width and height
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   int screenWidth = QApplication::primaryScreen()->availableGeometry().width() - 100;
   int screenHeight = QApplication::primaryScreen()->availableGeometry().height() - 300;
-#else // QT_VERSION_CHECK
-  int screenWidth = QApplication::desktop()->availableGeometry().width() - 100;
-  int screenHeight = QApplication::desktop()->availableGeometry().height() - 300;
-#endif // QT_VERSION_CHECK
   int widgetWidth = mpWidget->minimumSizeHint().width() + (verticalScrollBar()->isVisible() ? verticalScrollBar()->width() : 0);
   size.rwidth() = qMin(screenWidth, widgetWidth);
   int widgetHeight = mpWidget->minimumSizeHint().height() + (horizontalScrollBar()->isVisible() ? horizontalScrollBar()->height() : 0);

--- a/OMEdit/OMEditLIB/Element/ElementProperties.cpp
+++ b/OMEdit/OMEditLIB/Element/ElementProperties.cpp
@@ -458,6 +458,8 @@ void Parameter::setValueWidget(QString value, bool defaultValue, QString fromUni
     mDefaultValue = value;
   }
   QFontMetrics fm = QFontMetrics(QFont());
+  // Allow to take 70% of screen width
+  int screenWidth = QApplication::primaryScreen()->availableGeometry().width() * 0.7;
   bool signalsState;
   switch (mValueType) {
     case Parameter::Boolean:
@@ -487,11 +489,8 @@ void Parameter::setValueWidget(QString value, bool defaultValue, QString fromUni
          */
         fm = QFontMetrics(mpValueComboBox->lineEdit()->font());
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-        // Allow to take 70% of screen width
-        int screenWidth = QApplication::primaryScreen()->availableGeometry().width() * 0.7;
         mpValueComboBox->setMinimumWidth(qMin(qMax(fm.horizontalAdvance(value), mpValueComboBox->minimumSizeHint().width()), screenWidth) + 50);
 #else // QT_VERSION_CHECK
-        int screenWidth = QApplication::desktop()->availableGeometry().width() * 0.7;
         mpValueComboBox->setMinimumWidth(qMin(qMax(fm.width(value), mpValueComboBox->minimumSizeHint().width()), screenWidth) + 50);
 #endif // QT_VERSION_CHECK
       }
@@ -515,11 +514,8 @@ void Parameter::setValueWidget(QString value, bool defaultValue, QString fromUni
         /* Set the minimum width so that the value text will be readable */
         fm = QFontMetrics(mpValueTextBox->font());
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-        // Allow to take 70% of screen width
-        int screenWidth = QApplication::primaryScreen()->availableGeometry().width() * 0.7;
         mpValueTextBox->setMinimumWidth(qMin(fm.horizontalAdvance(value), screenWidth) + 50);
 #else // QT_VERSION_CHECK
-        int screenWidth = QApplication::desktop()->availableGeometry().width() * 0.7;
         mpValueTextBox->setMinimumWidth(qMin(fm.width(value), screenWidth) + 50);
 #endif // QT_VERSION_CHECK
       }

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.cpp
@@ -55,12 +55,7 @@
 #include <QDrag>
 #include <QMessageBox>
 #include <QMenu>
-
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
 #include <QScreen>
-#else // QT_VERSION_CHECK
-#include <QDesktopWidget>
-#endif // QT_VERSION_CHECK
 
 /*!
  * \class LibraryTreeItem
@@ -3534,11 +3529,7 @@ void LibraryTreeView::openInformationDialog()
     pInformationDialog->setWindowTitle(QString("%1 - %2 - %3").arg(Helper::applicationName, pLibraryTreeItem->getNameStructure(), Helper::information));
     pInformationDialog->setMinimumWidth(300);
     // Allow to take 90% of screen width
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
     int screenWidth = QApplication::primaryScreen()->availableGeometry().width() * 0.9;
-#else // QT_VERSION_CHECK
-    int screenWidth = QApplication::desktop()->availableGeometry().width() * 0.9;
-#endif // QT_VERSION_CHECK
     pInformationDialog->setMaximumWidth(screenWidth);
     Label *pHeadingLabel = Utilities::getHeadingLabel(pLibraryTreeItem->getNameStructure());
     pHeadingLabel->setElideMode(Qt::ElideMiddle);

--- a/OMEdit/OMEditLIB/TLM/TLMCoSimulationDialog.cpp
+++ b/OMEdit/OMEditLIB/TLM/TLMCoSimulationDialog.cpp
@@ -54,7 +54,6 @@
 #endif
 
 #include <QDockWidget>
-#include <QDesktopWidget>
 #include <QMessageBox>
 #include <QScreen>
 
@@ -171,13 +170,8 @@ TLMCoSimulationDialog::TLMCoSimulationDialog(QWidget *pParent)
   setLayout(pMainLayout);
   // create TLMCoSimulationOutputWidget
   mpTLMCoSimulationOutputWidget = new TLMCoSimulationOutputWidget;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   int xPos = QApplication::primaryScreen()->availableGeometry().width() - mpTLMCoSimulationOutputWidget->frameSize().width() - 20;
   int yPos = QApplication::primaryScreen()->availableGeometry().height() - mpTLMCoSimulationOutputWidget->frameSize().height() - 20;
-#else // QT_VERSION_CHECK
-  int xPos = QApplication::desktop()->availableGeometry().width() - mpTLMCoSimulationOutputWidget->frameSize().width() - 20;
-  int yPos = QApplication::desktop()->availableGeometry().height() - mpTLMCoSimulationOutputWidget->frameSize().height() - 20;
-#endif // QT_VERSION_CHECK
   mpTLMCoSimulationOutputWidget->setGeometry(xPos, yPos, mpTLMCoSimulationOutputWidget->width(), mpTLMCoSimulationOutputWidget->height());
 }
 

--- a/OMEdit/OMEditLIB/Util/Utilities.cpp
+++ b/OMEdit/OMEditLIB/Util/Utilities.cpp
@@ -42,11 +42,6 @@
 #include <QApplication>
 #include <QCryptographicHash>
 #include <QByteArray>
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-#include <QScreen>
-#else // QT_VERSION_CHECK
-#include <QDesktopWidget>
-#endif // QT_VERSION_CHECK
 #include <QGridLayout>
 #include <QStylePainter>
 #include <QPainter>


### PR DESCRIPTION
OMEdit requires Qt 5 for compilation and QScreen is available since Qt 5.0.