### PR TITLE
Cpp: add code for zero crossing of Integer equality (#12557)

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCpp.tpl
@@ -12238,6 +12238,10 @@ template giveZeroFunc3(Integer index1, Exp relation, Text &varDecls /*BUFP*/,Tex
         else
             f[<%index1%>] = (<%e1%> - _zeroTol - <%e2%>);
         >>
+      case EQUAL(ty = T_INTEGER(__)) then
+        <<
+        f[<%index1%>] = std::abs(<%e2%> - <%e1%>);
+        >>
       else
         <<
         error(sourceInfo(), 'Unsupported relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')

--- a/OMCompiler/Compiler/Template/CodegenCppOMSI.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCppOMSI.tpl
@@ -12118,9 +12118,13 @@ template giveZeroFunc3(Integer index1, Exp relation, Text &varDecls /*BUFP*/,Tex
         else
             f[<%index1%>] = (<%e1%> - 1e-6 - <%e2%>);
         >>
+      case EQUAL(ty = T_INTEGER(__)) then
+        <<
+        f[<%index1%>] = std::abs(<%e2%> - <%e1%>);
+        >>
       else
         <<
-        error(sourceInfo(), 'Unknown relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')
+        error(sourceInfo(), 'Unsupported relation: <%ExpressionDumpTpl.dumpExp(rel,"\"")%> for <%index1%>')
         >>
       end match
   case CALL(path=IDENT(name="sample"), expLst={_, start, interval}) then


### PR DESCRIPTION
Zero crossings seem to be generated for models like:

```Modelica
model ZeroCrossings
  input Integer flag;
  output Real y;
equation
  y = if flag == 1 then u else 0;
end ZeroCrossings;
```