### PR TITLE
Do not exit simulation main function

### DIFF
--- a/OMCompiler/Compiler/.cmake/omc_entry_point.c
+++ b/OMCompiler/Compiler/.cmake/omc_entry_point.c
@@ -59,7 +59,6 @@ int __omc_main(int argc, char **argv)
   }
 
   fflush(NULL);
-  EXIT(0);
   return 0;
 }
 

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1431,9 +1431,6 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
       <%if Flags.isSet(HPCOM) then "terminateHpcOmThreads();" %>
       <%if Flags.getConfigBool(Flags.PARMODAUTO) then "dump_times(pm_model);" %>
       fflush(NULL);
-    #if !defined(OMC_DLL_MAIN_DEFINE) /* do not exit, return in DLL mode */
-      EXIT(res);
-    #endif
       return res;
     }
 

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -78,7 +78,6 @@ DLLExport int __omc_main(int argc, char **argv)
 
   <%if Flags.isSet(HPCOM) then "terminateHpcOmThreads();" %>
   fflush(NULL);
-  EXIT(0);
   return 0;
 }
 
@@ -1549,7 +1548,6 @@ template generateInFunc(Text fname, list<Variable> functionArguments, list<Varia
 
     <%if Flags.isSet(HPCOM) then "terminateHpcOmThreads();" %>
     fflush(NULL);
-    EXIT(0);
     return 0;
   }
   #endif

--- a/OMCompiler/Compiler/boot/bootstrap-sources/build/_main.c
+++ b/OMCompiler/Compiler/boot/bootstrap-sources/build/_main.c
@@ -54,7 +54,7 @@ MMC_CATCH_TOP(return rml_execution_failed());
 }
 }
 fflush(NULL);
-EXIT(0);
+exit(0);
 return 0;
 }
 #endif

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica.c
@@ -215,7 +215,7 @@ modelica_integer valueCompare(modelica_metatype lhs, modelica_metatype rhs)
   }
 
   fprintf(stderr, "%s:%d: %ld slots; ctor %lu - FAILED to detect the type\n", __FILE__, __LINE__, (long) numslots, (unsigned long) ctor);
-  EXIT(1);
+  exit(1);
 }
 
 void debug__print(void* prefix, void* any)
@@ -404,7 +404,6 @@ inline static mmc_sint_t anyStringWork(void* any, mmc_sint_t ix, modelica_metaty
   checkAnyStringBufSize(ix,2);
   ix += sprintf(anyStringBuf+ix, ")");
   fprintf(stderr, "\n"); fflush(NULL);
-  /* EXIT(1); */
   return ix;
 }
 
@@ -652,7 +651,7 @@ void printTypeOfAny(void* any) /* for debugging */
   }
 
   fprintf(stderr, "%s:%d: %d slots; ctor %u - FAILED to detect the type\n", __FILE__, __LINE__, numslots, ctor);
-  EXIT(1);
+  exit(1);
 }
 
 inline static int getTypeOfAnyWork(void* any, int ix, int inRecord, modelica_metatype stack)  /* for debugging */

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -526,7 +526,7 @@ modelica_metatype boxptr_listDelete(threadData_t *threadData, modelica_metatype 
   tmpArr = (modelica_metatype *) mmc_alloc_words(ix-1); /* We know the size of the first part of the list */
   if (tmpArr == NULL) {
     fprintf(stderr, "%s:%d: malloc failed", __FILE__, __LINE__);
-    EXIT(1);
+    exit(1);
   }
 
   for (i=0; i<ix-1; i++) {

--- a/OMCompiler/SimulationRuntime/c/openmodelica.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica.h
@@ -78,14 +78,8 @@ extern "C" {
 #endif
 #endif
 
-/* BEFORE: compat.h */
-#if defined(__MINGW32__) || defined(_MSC_VER) || defined(__AVR__)
-#define EXIT(code) exit(code)
-#else
-/* We need to patch exit() on Unix systems
- * It does not change the exit code of simulations for some reason! */
-#include <unistd.h>
-#define EXIT(code) {fflush(NULL); _exit(code);}
+#if defined(__unix__) || defined(__linux__) || defined(__APPLE_CC__)
+  #include <unistd.h>
 #endif
 
 #include "omc_inline.h"

--- a/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
+++ b/OMCompiler/SimulationRuntime/c/optimization/DataManagement/MoveData.c
@@ -284,7 +284,7 @@ static inline void overwriteTimeGridFile(OptDataTime * time, char* filename, lon
   if(time->dt[0] <= 0){
     warningStreamPrint(LOG_STDOUT, 0, "read time grid from file fail!");
     warningStreamPrint(LOG_STDOUT, 0, "line %i: %g <= %g",0, (double)time->t[0][np1], (double)time->t0);
-    EXIT(0);
+    exit(0);
   }
 
 
@@ -307,7 +307,7 @@ static inline void overwriteTimeGridFile(OptDataTime * time, char* filename, lon
       warningStreamPrint(LOG_STDOUT, 0, "read time grid");
       warningStreamPrint(LOG_STDOUT, 0, "line %i/%i: %g <= %g",i, nsi, (double)time->t[i][np1], (double)time->t[i-1][np1]);
       warningStreamPrint(LOG_STDOUT, 0, "failed!");
-      EXIT(0);
+      exit(0);
     }
 
   }
@@ -940,7 +940,7 @@ static inline void pickUpStates(OptData* optData){
       // check if csv file is empty!
       if(n == 0){
         fprintf(stderr, "External input file: %s is empty!\n",cflags); fflush(NULL);
-        EXIT(1);
+        exit(1);
       }else{
         int i, j;
         double start_value;

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_input_xml.c
@@ -608,7 +608,7 @@ void read_input_xml(MODEL_DATA* modelData,
       messageClose(LOG_SIMULATION);
     }
     XML_ParserFree(parser);
-    EXIT(-1);
+    exit(-1);
   }
 
 

--- a/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
+++ b/OMCompiler/SimulationRuntime/c/simulation/simulation_runtime.cpp
@@ -941,7 +941,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
 #ifndef NO_INTERACTIVE_DEPENDENCY
   if (isXMLTCP && !sim_communication_port_open) {
     errorStreamPrint(LOG_STDOUT, 0, "xmltcp log format requires a TCP-port to be passed (and successfully open)");
-    EXIT(1);
+    exit(1);
   }
 #endif
 
@@ -961,7 +961,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
     }
 
     messageClose(LOG_STDOUT);
-    EXIT(1);
+    exit(1);
   }
 
   if(omc_flag[FLAG_HELP])
@@ -1045,13 +1045,13 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
         }
         messageClose(LOG_STDOUT);
 
-        EXIT(0);
+        return 0;
       }
     }
 
     warningStreamPrint(LOG_STDOUT, 0, "invalid command line option: -help=%s", option.c_str());
     warningStreamPrint(LOG_STDOUT, 0, "use %s -help for a list of all command-line flags", argv[0]);
-    EXIT(1);
+    exit(1);
   }
 
   setGlobalVerboseLevel(argc, argv);
@@ -1067,7 +1067,7 @@ int initRuntimeAndSimulation(int argc, char**argv, DATA *data, threadData_t *thr
   if(!data)
   {
     std::cerr << "Error: Could not initialize the global data structure file" << std::endl;
-    EXIT(1);
+    exit(1);
   }
 
   readFlag((int*)&data->simulationInfo->nlsMethod, NLS_MAX, omc_flagValue[FLAG_NLS], "-nls", NLS_NAME, NLS_DESC);

--- a/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
+++ b/OMCompiler/SimulationRuntime/c/simulation/solver/external_input.c
@@ -100,7 +100,7 @@ void externalInputallocate2(DATA* data, const char *filename){
 
   if (NULL == res) {
     fprintf(stderr, "Failed to read CSV-file %s", filename);
-    EXIT(1);
+    exit(1);
   }
 
   data->modelData->nInputVars = nu;

--- a/OMCompiler/SimulationRuntime/c/util/java_interface.c
+++ b/OMCompiler/SimulationRuntime/c/util/java_interface.c
@@ -166,19 +166,19 @@ void loadJNI()
 
     if(libVM == NULL) {
       fprintf(stderr, "Failed to dynamically load JVM\nEnvironment JAVA_HOME = '%s'\nWindows Registry JAVA_HOME = '%s'\n", java_home_env, java_home_registry);
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
 
     OMC_GetCreatedJavaVMs = (GetCreatedJavaVMsFunc) GetProcAddress(libVM, "JNI_GetCreatedJavaVMs");
     if(OMC_GetCreatedJavaVMs == NULL) {
       fprintf(stderr, "GetProcAddress(JNI_GetCreatedJavaVMs) failed\n");
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
 
     OMC_CreateJavaVM = (CreateJavaVMFunc) GetProcAddress(libVM, "JNI_CreateJavaVM");
     if(OMC_CreateJavaVM == NULL) {
       fprintf(stderr, "GetProcAddress(JNI_CreateJavaVM)  failed\n");
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
   }
 }
@@ -226,7 +226,7 @@ void loadJNI()
 
     if(libVM == NULL) {
       fprintf(stderr, "Failed to dynamically load JVM\nEnvironment JAVA_HOME = '%s'\nDefault JAVA_HOME '%s'\n", java_home, default_java_home);
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
 
     /*
@@ -235,17 +235,17 @@ void loadJNI()
      */
     if(libVM == NULL) {
       fprintf(stderr, "dlopen failed: %s\n", dlerror());
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
     *(void **) (&OMC_CreateJavaVM) = dlsym(libVM, "JNI_CreateJavaVM");
     if(OMC_CreateJavaVM == NULL) {
       fprintf(stderr, "dlsym(JNI_CreateJavaVM) failed: %s\n", dlerror());
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
     *(void **) (&OMC_GetCreatedJavaVMs) = dlsym(libVM, "JNI_GetCreatedJavaVMs");
     if(OMC_GetCreatedJavaVMs == NULL) {
       fprintf(stderr, "dlsym(JNI_GetCreatedJavaVMs) failed: %s\n", dlerror());
-      EXIT(EXIT_CODE_JAVA_ERROR);
+      exit(EXIT_CODE_JAVA_ERROR);
     }
   }
 }
@@ -276,7 +276,7 @@ JNIEnv* getJavaEnv()
 
   if(OMC_GetCreatedJavaVMs(&jvm, 1, &nVMs)) {
     fprintf(stderr, "JNI_GetCreatedJavaVMs returned error\n");
-    EXIT(EXIT_CODE_JAVA_ERROR);
+    exit(EXIT_CODE_JAVA_ERROR);
   }
 
   if(nVMs == 1) {
@@ -290,7 +290,7 @@ JNIEnv* getJavaEnv()
   openmodelicahome = getenv("OPENMODELICAHOME");
   if(openmodelicahome == NULL) {
     fprintf(stderr, "getenv(OPENMODELICAHOME) failed - Java subsystem can't find the Java runtime...\n");
-    EXIT(EXIT_CODE_JAVA_ERROR);
+    exit(EXIT_CODE_JAVA_ERROR);
   }
   openmodelicahome = GC_strdup(openmodelicahome);
 
@@ -302,7 +302,7 @@ JNIEnv* getJavaEnv()
   classPath = malloc(classPathLen);
   if(classPath == NULL) {
     fprintf(stderr, "%s:%d malloc failed\n", __FILE__, __LINE__);
-    EXIT(EXIT_CODE_JAVA_ERROR);
+    exit(EXIT_CODE_JAVA_ERROR);
   }
 
   classPathIx = sprintf(classPath, classpathFormatString, openmodelicahome, openmodelicahome, classpathEnv);
@@ -334,7 +334,7 @@ JNIEnv* getJavaEnv()
     env = NULL;
 
     fprintf(stderr, "%s:%d JNI_CreateJavaVM failed\n", __FILE__, __LINE__);
-    EXIT(EXIT_CODE_JAVA_ERROR);
+    exit(EXIT_CODE_JAVA_ERROR);
   }
 
   /* Check that the system works */
@@ -740,7 +740,7 @@ jobject mmc_to_jobject(JNIEnv* env, void* mmc)
 
   fprintf(stderr, "%s:%s: %d slots; ctor %d - FAILED to detect the type\n",
           __FILE__, __FUNCTION__, numslots, ctor);
-  EXIT(EXIT_CODE_JAVA_ERROR);
+  exit(EXIT_CODE_JAVA_ERROR);
 }
 
 const char* jobjectToString(JNIEnv* env, jobject obj)
@@ -763,14 +763,14 @@ const char* copyJstring(JNIEnv* env, jobject jstr)
   const char* str;
   if(jstr == NULL) {
     fprintf(stderr, "%s: Java String was NULL\n", __FUNCTION__);
-    EXIT(EXIT_CODE_JAVA_ERROR);
+    exit(EXIT_CODE_JAVA_ERROR);
   }
   CHECK_FOR_JAVA_EXCEPTION(env);
   str_tmp = (*env)->GetStringUTFChars(env, jstr, NULL);
   CHECK_FOR_JAVA_EXCEPTION(env);
   if(str_tmp == NULL) {
     fprintf(stderr, "%s: GetStringUTFChars failed\n", __FUNCTION__);
-    EXIT(EXIT_CODE_JAVA_ERROR);
+    exit(EXIT_CODE_JAVA_ERROR);
   }
 
   str = GC_strdup(str_tmp);
@@ -966,7 +966,7 @@ void* jobject_to_mmc(JNIEnv* env, jobject o)
 
   fprintf(stderr, "%s:%s: Failed to parse object: %s\n",
           __FILE__, __FUNCTION__, jobjectToString(env, o));
-  EXIT(EXIT_CODE_JAVA_ERROR);
+  exit(EXIT_CODE_JAVA_ERROR);
 }
 
 jint GetJavaInteger(JNIEnv* env, jobject obj) {

--- a/OMCompiler/SimulationRuntime/c/util/java_interface.h
+++ b/OMCompiler/SimulationRuntime/c/util/java_interface.h
@@ -112,7 +112,7 @@ const char* __CheckForJavaException(JNIEnv* env);
   const char* msg = __CheckForJavaException(env); \
   if(msg != NULL) { \
     fprintf(stderr, "Error: External Java Exception Thrown but can't assert in C-mode\nLocation: %s (%s:%d)\nThe exception message was:\n%s\n", __FUNCTION__, __FILE__, __LINE__, msg); \
-    EXIT(EXIT_CODE_JAVA_ERROR); \
+    exit(EXIT_CODE_JAVA_ERROR); \
   } \
 } while(0)
 #endif


### PR DESCRIPTION
### Related Issues

Fixes #12516.

### Purpose

  - Use return instead of `EXIT`
  - This way destructors of loaded libraries are called

### Approach

I don't know why `EXIT` was used in the first place, so merging this could have unwanted side effects. From reading StackOverflow questions I found that there are tiny differences between `return`, `exit` and `_exit`. For sure you never want to call `exit`/`_exit` from a shared library. It will exit the parent process as well.
But why use `exit` when the executable is run from the shell or OMEdit? I tested the provided example with OMEdit on Linux and the destructor is called when `return` is uses.