### PR TITLE
Fix s(n)printff buffer size and format errors

### DIFF
--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -995,7 +995,9 @@ function iconv "The iconv() function converts one multibyte characters from one 
 external "C" result=SystemImpl__iconv(string,from,to,true /* Print errors */) annotation(Library = {"omcruntime"});
 end iconv;
 
-function snprintff "sprintf format string that takes one double as argument"
+function snprintff
+  "snprintf format string that takes one double as argument
+   and the maximum length of the formatted string as another argument."
   input String format;
   input Integer maxlen;
   input Real val;
@@ -1004,8 +1006,8 @@ external "C" str=System_snprintff(format,maxlen,val) annotation(Library = {"omcr
 end snprintff;
 
 function sprintff
-  "sprintf format string that takes one double as argument, but unlike snprintff
-   it takes no buffer size as argument.
+  "sprintf format string that takes one double as argument,
+   but unlike snprintff it takes no string length as argument.
 
    NOTE: This function doesn't actually call sprintf, since that would be unsafe.
          It instead calls snprintf with a fixed buffer size that should be enough

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -758,27 +758,38 @@ extern const char* System_snprintff(const char *fmt, int len, double d)
     MMC_THROW();
   }
   buf = ModelicaAllocateString(len);
-  if (snprintf(buf,len,fmt,d) >= len) {
+
+  int str_len = snprintf(buf, len + 1, fmt, d);
+
+  if (str_len < 0) {
+    fprintf(stderr, "System_snprintff: Encoding error.\n");
     MMC_THROW();
   }
+
+  if (str_len > len) {
+    fprintf(stderr, "System_snprintff: The formatted string would have length %d but the buffer only has room for %d characters.\n", str_len, len);
+    MMC_THROW();
+  }
+
   return buf;
 }
 
 extern const char* System_sprintff(const char *fmt, double d)
 {
   char *buf;
-  const int buf_size = 20;
-  buf = ModelicaAllocateString(buf_size);
+  const int len = 20;
+  buf = ModelicaAllocateString(len);
 
-  int len = snprintf(buf, buf_size, fmt, d);
+  int str_len = snprintf(buf, len + 1, fmt, d);
 
-  if (len < 0) {
+  if (str_len < 0) {
+    fprintf(stderr, "System_sprintff: Encoding error.\n");
     MMC_THROW();
   }
 
-  if (len >= buf_size) {
-    buf = ModelicaAllocateString(len + 1);
-    snprintf(buf, len, fmt, d);
+  if (str_len > len) {
+    buf = ModelicaAllocateString(str_len);
+    snprintf(buf, str_len + 1, fmt, d);
   }
 
   return buf;

--- a/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaUtilities.h
+++ b/OMCompiler/SimulationRuntime/ModelicaExternalC/C-Sources/ModelicaUtilities.h
@@ -189,6 +189,7 @@ argument of an external Modelica function. Note, that the storage
 for string arrays (= pointer to string array) is still provided by the
 calling program, as for any other array. If an error occurs, this
 function does not return, but calls "ModelicaError".
+The argument is the length of the string to allocate.
 */
 
 

--- a/OMCompiler/SimulationRuntime/c/ModelicaUtilities.h
+++ b/OMCompiler/SimulationRuntime/c/ModelicaUtilities.h
@@ -189,6 +189,7 @@ argument of an external Modelica function. Note, that the storage
 for string arrays (= pointer to string array) is still provided by the
 calling program, as for any other array. If an error occurs, this
 function does not return, but calls "ModelicaError".
+The argument is the length of the string to allocate.
 */
 
 char* ModelicaDuplicateString(const char *str);


### PR DESCRIPTION
As far as I can tell:
- All implementations of `ModelicaAllocateString()` already allocate one more character to account for the terminating null character (which is automatically set after allocation), so its `len` argument is the string length rather than the buffer size (_but_ `snprintf()` takes the buffer size as argument!).
- `System_snprintff()` should throw an error when the formatting fails (encoding error), like `System_sprintff()` does.
