### PR TITLE
Fix ExecStat not to measure itself

### DIFF
--- a/OMCompiler/Compiler/Util/ClockIndexes.mo
+++ b/OMCompiler/Compiler/Util/ClockIndexes.mo
@@ -44,7 +44,7 @@ public constant Integer RT_CLOCK_SIMULATE_TOTAL = 8;
 public constant Integer RT_CLOCK_SIMULATE_SIMULATION = 9;
 public constant Integer RT_CLOCK_BUILD_MODEL = 10;
 public constant Integer RT_CLOCK_EXECSTAT = 11;
-public constant Integer RT_CLOCK_EXECSTAT_CUMULATIVE = 12;
+
 public constant Integer RT_CLOCK_FRONTEND = 13;
 public constant Integer RT_CLOCK_BACKEND = 14;
 public constant Integer RT_CLOCK_SIMCODE = 15;
@@ -75,7 +75,6 @@ algorithm
     case RT_CLOCK_SIMULATE_SIMULATION         then "SSI";
     case RT_CLOCK_BUILD_MODEL                 then "BLD";
     case RT_CLOCK_EXECSTAT                    then "EXS";
-    case RT_CLOCK_EXECSTAT_CUMULATIVE         then "EXC";
     case RT_CLOCK_FRONTEND                    then "FRT";
     case RT_CLOCK_BACKEND                     then "BCK";
     case RT_CLOCK_SIMCODE                     then "SCD";

--- a/OMCompiler/Compiler/Util/ExecStat.mo
+++ b/OMCompiler/Compiler/Util/ExecStat.mo
@@ -10,13 +10,18 @@ import Flags;
 import System;
 import StringUtil;
 
+constant String timeFormat = "%.4g"; // Why not "%.9f"?
+constant Integer timeMaxLength = 20; // Why not 21?
+constant Integer memoryMaxSizeInUnit = 500; // Why not 512?
+constant Integer memorySignificantDigits = 4; // Why not 3?
+
 public
 
 function execStatReset
 algorithm
-  System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
-  System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
   setGlobalRoot(Global.gcProfilingIndex, GCExt.getProfStats());
+  System.realtimeClear(ClockIndexes.RT_CLOCK_EXECSTAT);
+  System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
 end execStatReset;
 
 function execStat
@@ -32,34 +37,42 @@ protected
   String timeStr, totalTimeStr, gcStr;
   Integer memory, oldMemory, heapsize_full, free_bytes_full, since, before;
   GCExt.ProfStats stats, oldStats;
+  function snprintff
+    input Real val;
+    output String str = System.snprintff(timeFormat, timeMaxLength, val);
+  end snprintff;
+  function bytesToReadableUnit
+    input Real bytes;
+    output String str = StringUtil.bytesToReadableUnit(bytes, memorySignificantDigits, memoryMaxSizeInUnit);
+  end bytesToReadableUnit;
 algorithm
   if Flags.isSet(Flags.EXEC_STAT) then
     for i in if Flags.isSet(Flags.EXEC_STAT_EXTRA_GC) then {1,2} else {1} loop
       if i==2 then
         GCExt.gcollect();
       end if;
+      t := System.realtimeAccumulate(ClockIndexes.RT_CLOCK_EXECSTAT);
+      total := System.realtimeAccumulated(ClockIndexes.RT_CLOCK_EXECSTAT);
       (stats as GCExt.PROFSTATS(bytes_allocd_since_gc=since, allocd_bytes_before_gc=before, heapsize_full=heapsize_full, free_bytes_full=free_bytes_full)) := GCExt.getProfStats();
       memory := since+before;
       oldStats := getGlobalRoot(Global.gcProfilingIndex);
       GCExt.PROFSTATS(bytes_allocd_since_gc=since, allocd_bytes_before_gc=before) := oldStats;
       oldMemory := since+before;
-      t := System.realtimeTock(ClockIndexes.RT_CLOCK_EXECSTAT);
-      total := System.realtimeTock(ClockIndexes.RT_CLOCK_EXECSTAT_CUMULATIVE);
-      timeStr := System.snprintff("%.4g", 20, t);
-      totalTimeStr := System.snprintff("%.4g", 20, total);
+      timeStr := snprintff(t);
+      totalTimeStr := snprintff(total);
       if Flags.isSet(Flags.GC_PROF) then
         gcStr := GCExt.profStatsStr(stats, head="", delimiter=" / ");
         Error.addMessage(Error.EXEC_STAT_GC, {name + (if i==2 then " GC" else ""), timeStr, totalTimeStr, gcStr});
       else
         Error.addMessage(Error.EXEC_STAT, {name + (if i==2 then " GC" else ""), timeStr, totalTimeStr,
-            StringUtil.bytesToReadableUnit(memory-oldMemory, maxSizeInUnit=500, significantDigits=4),
-            StringUtil.bytesToReadableUnit(memory, maxSizeInUnit=500, significantDigits=4),
-            StringUtil.bytesToReadableUnit(free_bytes_full, maxSizeInUnit=500, significantDigits=4),
-            StringUtil.bytesToReadableUnit(heapsize_full, maxSizeInUnit=500, significantDigits=4)
+            bytesToReadableUnit(memory-oldMemory),
+            bytesToReadableUnit(memory),
+            bytesToReadableUnit(free_bytes_full),
+            bytesToReadableUnit(heapsize_full)
         });
       end if;
-      System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
       setGlobalRoot(Global.gcProfilingIndex, stats);
+      System.realtimeTick(ClockIndexes.RT_CLOCK_EXECSTAT);
     end for;
   end if;
 end execStat;

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -739,6 +739,22 @@ The clock index is 0-31. The function fails if the number is out of range."
   external "C" System_realtimeClear(clockIndex) annotation(Library = "omcruntime");
 end realtimeClear;
 
+public function realtimeAccumulate
+"Accumulates the timer.
+The clock index is 0-31. The function fails if the number is out of range."
+  input Integer clockIndex;
+  output Real outTime;
+  external "C" outTime = System_realtimeAccumulate(clockIndex) annotation(Library = "omcruntime");
+end realtimeAccumulate;
+
+public function realtimeAccumulated
+"Returns the time accumulated from intervals between ticks and tocks.
+The clock index is 0-31. The function fails if the number is out of range."
+  input Integer clockIndex;
+  output Real outTime;
+  external "C" outTime = System_realtimeAccumulated(clockIndex) annotation(Library = "omcruntime");
+end realtimeAccumulated;
+
 public function realtimeNtick
 "Returns the number of ticks since last clear.
 The clock index is 0-31. The function fails if the number is out of range."

--- a/OMCompiler/Compiler/Util/System.mo
+++ b/OMCompiler/Compiler/Util/System.mo
@@ -718,14 +718,14 @@ public function getuid
 end getuid;
 
 public function realtimeTick
-"Tock returns the time since the last tock; undefined if tick was never called.
+"Store current time in timer.
 The clock index is 0-31. The function fails if the number is out of range."
   input Integer clockIndex;
   external "C" System_realtimeTick(clockIndex) annotation(Library = "omcruntime");
 end realtimeTick;
 
 public function realtimeTock
-"Tock returns the time since the last tock, undefined if tick was never called.
+"Tock returns the time since the last tick, undefined if tick was never called.
 The clock index is 0-31. The function fails if the number is out of range."
   input Integer clockIndex;
   output Real outTime;

--- a/OMCompiler/Compiler/runtime/System_omc.c
+++ b/OMCompiler/Compiler/runtime/System_omc.c
@@ -134,6 +134,18 @@ extern void System_realtimeClear(int ix)
   rt_clear(ix);
 }
 
+extern double System_realtimeAccumulate(int ix)
+{
+  if (ix < 0 || ix >= NUM_USER_RT_CLOCKS) MMC_THROW();
+  return rt_accumulate(ix);
+}
+
+extern double System_realtimeAccumulated(int ix)
+{
+  if (ix < 0 || ix >= NUM_USER_RT_CLOCKS) MMC_THROW();
+  return rt_accumulated(ix);
+}
+
 extern int System_realtimeNtick(int ix)
 {
   if (ix < 0 || ix >= NUM_USER_RT_CLOCKS) MMC_THROW();

--- a/OMCompiler/SimulationRuntime/c/util/rtclock.h
+++ b/OMCompiler/SimulationRuntime/c/util/rtclock.h
@@ -121,7 +121,7 @@ double rt_tock(int ix);
 void rt_clear_total(int ix);
 /* clear zeros out the accumulated data, and adds it to the total (we have two levels of accumulation) */
 void rt_clear(int ix);
-void rt_accumulate(int ix); /* Uses integer addition for maximum accuracy and good speed. */
+double rt_accumulate(int ix); /* Uses integer addition for maximum accuracy and good speed. */
 double rt_accumulated(int ix);
 double rt_max_accumulated(int ix);
 double rt_total(int ix);

--- a/OMCompiler/SimulationRuntime/c/util/rtclock.h
+++ b/OMCompiler/SimulationRuntime/c/util/rtclock.h
@@ -63,7 +63,7 @@ typedef int rtclock_t;
 static inline void rt_ext_tp_tick(rtclock_t* tick_tp) {}
 static inline double rt_ext_tp_tock(rtclock_t* tick_tp) {return 0.0;}
 static inline void rt_tick(int ix) {}
-static inline void rt_accumulate(int ix) {}
+static inline double rt_accumulate(int ix) {return 0.0;}
 static inline void rt_clear(int ix) {}
 static inline double rt_tock(int ix) {return 0.0;}
 


### PR DESCRIPTION
When profiling small portions of code for instance in for-loops or traversal functions, then adding or (re)moving an execstat event can make a huge difference in the comparison of the measured time intervals (e.g. as a percentage of the for-loop total duration), because `execStat()` was written in such a way that it actually measured a large part of itself, which it must not.
- Use a single timer for `ExecStat`, accumulate intervals at the very beginning of `execStat()` and tick the timer at the very end.
- Fix the reset of the timer, which should occur after GC stats are initialized otherwise this would be counted in the first event.
- Change the return type of `rt_accumulate()` so that we can retrieve the last interval directly.
- Adapt `rtclock.c` in consequence and refactor it to remove some duplicate code.
- Modify the behavior with `min_time` at some places through the use of the new function `rtclock_compensated_value()` everywhere, so that it is consistent across the different platforms.
- Fix a possible integer overflow when accumulating negative values of nanoseconds in the Linux version of `rt_accumulate()`.
