### PR TITLE
Removing EXIT from simulation main function

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1431,9 +1431,6 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
       <%if Flags.isSet(HPCOM) then "terminateHpcOmThreads();" %>
       <%if Flags.getConfigBool(Flags.PARMODAUTO) then "dump_times(pm_model);" %>
       fflush(NULL);
-    #if !defined(OMC_DLL_MAIN_DEFINE) /* do not exit, return in DLL mode */
-      EXIT(res);
-    #endif
       return res;
     }
 


### PR DESCRIPTION
### Related Issues

Fixes https://github.com/OpenModelica/OpenModelica/issues/12516

### Approach

Remove call to `EXIT(res)` and instead use `return res`.
