### PR TITLE
Add implicitParameterStartAttribute flag

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -155,6 +155,7 @@ uniontype FlattenSettings
     Boolean relaxedErrorChecking;
     Boolean newBackend;
     Boolean vectorizeBindings;
+    Boolean implicitStartAttribute;
   end SETTINGS;
 end FlattenSettings;
 
@@ -350,7 +351,8 @@ algorithm
     Flags.isSet(Flags.NF_API),
     Flags.isSet(Flags.NF_API) or Flags.getConfigBool(Flags.CHECK_MODEL),
     Flags.getConfigBool(Flags.NEW_BACKEND),
-    Flags.isSet(Flags.VECTORIZE_BINDINGS)
+    Flags.isSet(Flags.VECTORIZE_BINDINGS),
+    Flags.isConfigFlagSet(Flags.ALLOW_NON_STANDARD_MODELICA, "implicitParameterStartAttribute")
   );
 
   prefix := Prefix.new(classInst, indexed = settings.vectorizeBindings);
@@ -730,7 +732,7 @@ algorithm
   if not settings.relaxedErrorChecking and var < Variability.DISCRETE and
      not unfix and not Type.isComplex(Type.arrayElementType(ty)) then
     // Check that the component has a binding if it's required to have one.
-    verifyBinding(v, var, binding, settings);
+    v := verifyBinding(v, var, binding, settings);
   end if;
 
   vars := v :: vars;
@@ -775,14 +777,27 @@ algorithm
 end isTypeAttributeNamed;
 
 function verifyBinding
-  input Variable var;
+  input output Variable var;
   input Variability variability;
   input Binding binding;
   input FlattenSettings settings;
 protected
   Binding fixed_binding, start_binding;
-  Expression fixed_exp;
+  Option<Expression> fixed_exp_opt;
+  Expression fixed_exp, start_exp;
   Boolean fixed;
+  Option<Expression> min_exp_opt, max_exp_opt;
+
+  function eval_binding
+    input Binding binding;
+    output Option<Expression> result;
+  algorithm
+    if Binding.isBound(binding) then
+      result := SOME(Ceval.tryEvalExp(Binding.getExp(binding)));
+    else
+      result := NONE();
+    end if;
+  end eval_binding;
 algorithm
   if variability > Variability.CONSTANT and Binding.isBound(binding) then
     // Parameter with a binding is ok.
@@ -791,10 +806,10 @@ algorithm
 
   // Check if the variable is fixed or not.
   fixed_binding := Variable.lookupTypeAttribute("fixed", var);
+  fixed_exp_opt := eval_binding(fixed_binding);
 
-  if Binding.isBound(fixed_binding) then
-    fixed_exp := Binding.getExp(fixed_binding);
-    fixed_exp := Ceval.tryEvalExp(fixed_exp);
+  if isSome(fixed_exp_opt) then
+    SOME(fixed_exp) := fixed_exp_opt;
 
     if not Expression.isBoolean(fixed_exp) then
       return;
@@ -828,7 +843,15 @@ algorithm
         Error.addSourceMessage(Error.UNBOUND_PARAMETER_ERROR,
           {ComponentRef.toString(var.name)}, var.info);
 
-        if not settings.relaxedErrorChecking then
+        if settings.implicitStartAttribute then
+          // Create a start attribute if it's missing and
+          // --allowNonStandardModelica=implicitParameterStartAttribute is used
+          min_exp_opt := eval_binding(Variable.lookupTypeAttribute("min", var));
+          max_exp_opt := eval_binding(Variable.lookupTypeAttribute("max", var));
+          start_exp := Expression.makeDefaultValue(var.ty, min_exp_opt, max_exp_opt);
+          var.binding := Binding.makeFlat(start_exp, Expression.variability(start_exp),
+            NFBinding.Source.GENERATED);
+        elseif not settings.relaxedErrorChecking then
           fail();
         end if;
       else

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1382,7 +1382,9 @@ constant ConfigFlag ALLOW_NON_STANDARD_MODELICA = CONFIG_FLAG(143, "allowNonStan
     ("nonStdTopLevelOuter", Gettext.gettext("Allow top level outer.\nSee: https://specification.modelica.org/maint/3.6/scoping-name-lookup-and-flattening.html#S4.p1")),
     ("protectedAccess", Gettext.gettext("Allow access of protected elements")),
     ("reinitInAlgorithms", Gettext.gettext("Allow reinit in algorithm sections")),
-    ("unbalancedModel", Gettext.gettext("Allow models to be locally unbalanced and to have unbalanced connectors"))
+    ("unbalancedModel", Gettext.gettext("Allow models to be locally unbalanced and to have unbalanced connectors")),
+    ("implicitParameterStartAttribute", Gettext.gettext("Allow fixed parameters with no binding or start attribute"))
+
     })),
   Gettext.gettext("Flags to allow non-standard Modelica."));
 

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1164,6 +1164,7 @@ UnboundParameter1.mo \
 UnboundParameter2.mo \
 UnboundParameter3.mo \
 UnboundParameter4.mo \
+UnboundParameter5.mo \
 usertype1.mo \
 usertype2.mo \
 usertype3.mo \

--- a/testsuite/flattening/modelica/scodeinst/UnboundParameter5.mo
+++ b/testsuite/flattening/modelica/scodeinst/UnboundParameter5.mo
@@ -1,0 +1,46 @@
+// name: UnboundParameter5
+// keywords:
+// status: correct
+// cflags: -d=newInst --allowNonStandardModelica=implicitParameterStartAttribute
+//
+
+model UnboundParameter5
+  type E = enumeration(a, b, c, d);
+
+  parameter Real r1;
+  parameter Real r2(min = 1.0, max = 3.0);
+  parameter Real r3(min = -3.0, max = -1.0);
+  parameter Integer i1;
+  parameter Integer i2(min = 1, max = 3);
+  parameter Integer i3(min = -3, max = -1);
+  parameter Boolean b1;
+  parameter String s1;
+  parameter E e1;
+  parameter E e2(min = E.c);
+end UnboundParameter5;
+
+// Result:
+// class UnboundParameter5
+//   parameter Real r1 = 0.0;
+//   parameter Real r2(min = 1.0, max = 3.0) = 1.0;
+//   parameter Real r3(min = -3.0, max = -1.0) = -1.0;
+//   parameter Integer i1 = 0;
+//   parameter Integer i2(min = 1, max = 3) = 1;
+//   parameter Integer i3(min = -3, max = -1) = -1;
+//   parameter Boolean b1 = false;
+//   parameter String s1 = "";
+//   parameter enumeration(a, b, c, d) e1 = E.a;
+//   parameter enumeration(a, b, c, d) e2(min = E.c) = E.c;
+// end UnboundParameter5;
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:10:3-10:20:writable] Error: Parameter r1 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:11:3-11:42:writable] Error: Parameter r2 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:12:3-12:44:writable] Error: Parameter r3 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:13:3-13:23:writable] Error: Parameter i1 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:14:3-14:41:writable] Error: Parameter i2 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:15:3-15:43:writable] Error: Parameter i3 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:16:3-16:23:writable] Error: Parameter b1 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:17:3-17:22:writable] Error: Parameter s1 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:18:3-18:17:writable] Error: Parameter e1 has neither value nor start value, and is fixed during initialization (fixed=true).
+// [flattening/modelica/scodeinst/UnboundParameter5.mo:19:3-19:28:writable] Error: Parameter e2 has neither value nor start value, and is fixed during initialization (fixed=true).
+//
+// endResult


### PR DESCRIPTION
- Add `implicitParameterStartAttribute` option to the `allowNonStandardModelica` flag to allow fixed parameters with no binding or start value and automatically generate start values for them.
- Improve `Expression.makeDefaultValue` to optionally take min/max of the variable into account when generating the default value.