### PR TITLE
[NB] update state collection for ALWAYS states

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -722,6 +722,16 @@ public
     end match;
   end getStateCref;
 
+  function hasDerVar
+    input Pointer<Variable> state_var;
+    output Boolean b;
+  algorithm
+    b := match Pointer.access(state_var)
+      case Variable.VARIABLE(backendinfo = BackendExtension.BACKEND_INFO(varKind = BackendExtension.STATE(derivative = SOME(_)))) then true;
+      else false;
+    end match;
+  end hasDerVar;
+
   function getDerVar
     input Pointer<Variable> state_var;
     output Pointer<Variable> der_var;

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBDetectStates.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBDetectStates.mo
@@ -218,7 +218,7 @@ protected
         arguments = {Expression.CREF(cref = state_cref)}))
         algorithm
           state_var := BVariable.getVarPointer(state_cref);
-          if BVariable.isState(state_var) then
+          if BVariable.hasDerVar(state_var) then
             // this derivative was already created -> the variable should already have a pointer to its derivative
             der_cref := BVariable.getDerCref(state_cref);
             if not scalarized then


### PR DESCRIPTION
 - instead of checking if something is a state, check if it has a derivative variable
 - something can be a state without having a designated derivative if it is marked as StateSelect.ALWAYS