### PR TITLE
Mark the dependent models dirty and only update them when needed

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -8141,7 +8141,7 @@ void ModelWidget::processPendingModelUpdate()
 void ModelWidget::updateModelIfDependsOn(const QString &modelName)
 {
   if (mDiagramViewLoaded && dependsOnModel(modelName)) {
-    reDrawModelWidget(createModelInfo());
+    setRequiresUpdate(true);
   }
 }
 
@@ -10141,6 +10141,11 @@ void ModelWidgetContainer::currentModelWidgetChanged(QMdiSubWindow *pSubWindow)
     return;
   }
   mpLastActiveSubWindow = pSubWindow;
+  // update the model if its require update flag is set.
+  if (pModelWidget && pModelWidget->requiresUpdate()) {
+    pModelWidget->setRequiresUpdate(false);
+    pModelWidget->reDrawModelWidget(pModelWidget->createModelInfo());
+  }
   /* ticket:4983 Update the documentation browser when a new ModelWidget is selected.
    * Provided that the Documentation Browser is already visible.
    */

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.h
@@ -584,6 +584,8 @@ public:
   void clearDependsOnModels() {mDependsOnModelsList.clear();}
   void setHandleCollidingConnectionsNeeded(bool needed) {mHandleCollidingConnectionsNeeded = needed;}
   bool isHandleCollidingConnectionsNeeded() {return mHandleCollidingConnectionsNeeded;}
+  void setRequiresUpdate(bool requiresUpdate) {mRequiresUpdate = requiresUpdate;}
+  bool requiresUpdate() {return mRequiresUpdate;}
 
   void fetchExtendsModifiers(QString extendsClass);
   void reDrawModelWidgetInheritedClasses();
@@ -678,6 +680,7 @@ private:
   QStringList mDependsOnModelsList;
   bool mHasMissingType = false;
   bool mHandleCollidingConnectionsNeeded = false;
+  bool mRequiresUpdate = false;
 
   void createUndoStack();
   void handleCanUndoRedoChanged();


### PR DESCRIPTION
### Related Issues

#11926

### Purpose

Improve the user response time for simple operations.

### Approach

Avoids calling `getModelInstance` on dependent models. Instead mark them and update when they become active. This is just a workaround. No performance enhancement is done. We just defer the update operation.