### PR TITLE
Improve Ceval.EvalTarget

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFArrayConnections.mo
@@ -228,7 +228,7 @@ protected
 
         case Equation.FOR(range = SOME(range))
           algorithm
-            range := Ceval.evalExp(range, Ceval.EvalTarget.RANGE(Equation.info(eq)));
+            range := Ceval.evalExp(range, Ceval.EvalTarget.new(Equation.info(eq), NFInstContext.ITERATION_RANGE));
             body := Equation.replaceIteratorList(eq.body, eq.iterator, range);
             addConnectionsToGraph(body, graph, vCount, eCount, nmvTable);
           then

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -821,7 +821,7 @@ protected
          Expression.toString(n_arg), Prefixes.variabilityString(n_var)}, info);
     end if;
 
-    n_arg := Ceval.evalExp(n_arg, Ceval.EvalTarget.GENERIC(info));
+    n_arg := Ceval.evalExp(n_arg, Ceval.EvalTarget.new(info, context));
     n := Expression.integerValue(n_arg);
 
     if n < Type.dimensionCount(exp_ty) then
@@ -1218,7 +1218,7 @@ protected
     if variability > Variability.PARAMETER or purity <> Purity.PURE then
       Error.addSourceMessageAndFail(Error.NF_CAT_FIRST_ARG_EVAL, {Expression.toString(arg), Prefixes.variabilityString(variability)}, info);
     end if;
-    Expression.INTEGER(n) := Ceval.evalExp(arg, Ceval.EvalTarget.GENERIC(info));
+    Expression.INTEGER(n) := Ceval.evalExp(arg, Ceval.EvalTarget.new(info, context));
 
     res := {};
     tys := {};

--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2368,7 +2368,7 @@ protected
               if InstContext.inRelaxed(context) then
                 range := Ceval.tryEvalExp(range);
               else
-                range := Ceval.evalExp(range, Ceval.EvalTarget.RANGE(info));
+                range := Ceval.evalExp(range, Ceval.EvalTarget.new(info, NFInstContext.ITERATION_RANGE));
               end if;
               iter_ty := Expression.typeOf(range);
             end if;
@@ -2842,7 +2842,7 @@ protected
 
           ErrorExt.setCheckpoint(getInstanceName());
           try
-            exp := Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS());
+            exp := Ceval.evalExp(exp);
           else
           end try;
           ErrorExt.rollBack(getInstanceName());

--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -49,7 +49,6 @@ import NFClassTree.ClassTree;
 import ComplexType = NFComplexType;
 import Subscript = NFSubscript;
 import NFTyping.TypingError;
-import DAE;
 import Record = NFRecord;
 import InstContext = NFInstContext;
 
@@ -63,7 +62,6 @@ import MetaModelica.Dangerous.*;
 import Class = NFClass;
 import TypeCheck = NFTypeCheck;
 import ExpandExp = NFExpandExp;
-import ElementSource;
 import Prefixes = NFPrefixes;
 import UnorderedMap;
 import ErrorExt;
@@ -72,98 +70,39 @@ import Vector;
 
 public
 uniontype EvalTarget
-  record DIMENSION
-    InstNode component;
-    Integer index;
-    Expression exp;
+  record EVAL_TARGET
     SourceInfo info;
-  end DIMENSION;
+    InstContext.Type context;
+    Option<EvalTargetData> extra;
+  end EVAL_TARGET;
 
-  record ATTRIBUTE
-    Binding binding;
-  end ATTRIBUTE;
-
-  record RANGE
-    SourceInfo info;
-  end RANGE;
-
-  record CONDITION
-    SourceInfo info;
-  end CONDITION;
-
-  record GENERIC
-    SourceInfo info;
-  end GENERIC;
-
-  record STATEMENT
-    DAE.ElementSource source;
-  end STATEMENT;
-
-  record INSTANCE_API
-  end INSTANCE_API;
-
-  record IGNORE_ERRORS end IGNORE_ERRORS;
-
-  function isRange
-    input EvalTarget target;
-    output Boolean isRange;
-  algorithm
-    isRange := match target
-      case RANGE() then true;
-      else false;
-    end match;
-  end isRange;
-
-  function isDimension
-    input EvalTarget target;
-    output Boolean isDim;
-  algorithm
-    isDim := match target
-      case DIMENSION() then true;
-      else false;
-    end match;
-  end isDimension;
-
-  function isInstanceAPI
-    input EvalTarget target;
-    output Boolean api;
-  algorithm
-    api := match target
-      case INSTANCE_API() then true;
-      else false;
-    end match;
-  end isInstanceAPI;
+  function new
+    input SourceInfo info;
+    input InstContext.Type context = NFInstContext.NO_CONTEXT;
+    input Option<EvalTargetData> extra = NONE();
+    output EvalTarget target = EVAL_TARGET(info, context, extra);
+  end new;
 
   function hasInfo
     input EvalTarget target;
-    output Boolean hasInfo;
-  algorithm
-    hasInfo := match target
-      case DIMENSION() then true;
-      case ATTRIBUTE() then true;
-      case RANGE() then true;
-      case CONDITION() then true;
-      case GENERIC() then true;
-      case STATEMENT() then true;
-      else false;
-    end match;
+    output Boolean res = not stringEmpty(target.info.fileName);
   end hasInfo;
 
   function getInfo
     input EvalTarget target;
-    output SourceInfo info;
-  algorithm
-    info := match target
-      case DIMENSION() then target.info;
-      case ATTRIBUTE() then Binding.getInfo(target.binding);
-      case RANGE() then target.info;
-      case CONDITION() then target.info;
-      case GENERIC() then target.info;
-      case STATEMENT() then ElementSource.getInfo(target.source);
-      else AbsynUtil.dummyInfo;
-    end match;
+    output SourceInfo info = target.info;
   end getInfo;
 end EvalTarget;
+
+constant EvalTarget noTarget = EvalTarget.EVAL_TARGET(AbsynUtil.dummyInfo, NFInstContext.NO_CONTEXT, NONE());
+
+uniontype EvalTargetData
+  record DIMENSION_DATA
+    InstNode component;
+    Integer index;
+    Expression exp;
+  end DIMENSION_DATA;
+end EvalTargetData;
 
 function tryEvalExp
   input output Expression exp;
@@ -180,7 +119,7 @@ end tryEvalExp;
 
 function evalExp
   input output Expression exp;
-  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+  input EvalTarget target = noTarget;
 algorithm
   exp := match exp
     local
@@ -300,7 +239,7 @@ end evalExp;
 
 function evalExpOpt
   input output Option<Expression> oexp;
-  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+  input EvalTarget target = noTarget;
 algorithm
   oexp := match oexp
     local
@@ -325,7 +264,7 @@ function evalExpPartial
    expressions. This can be used to optimize an expression that is expected to
    be evaluated many times, for example the expression in an array constructor."
   input Expression exp;
-  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+  input EvalTarget target = noTarget;
   input Boolean evaluated = true;
   output Expression outExp;
   output Boolean outEvaluated "True if the whole expression is evaluated, otherwise false.";
@@ -823,7 +762,7 @@ function evalTypename
 algorithm
   // Only expand the typename into an array if it's used as a range, and keep
   // them as typenames when used as e.g. dimensions.
-  exp := if EvalTarget.isRange(target) then ExpandExp.expandTypename(ty) else originExp;
+  exp := if InstContext.inIterationRange(target.context) then ExpandExp.expandTypename(ty) else originExp;
 end evalTypename;
 
 function evalRange
@@ -842,7 +781,7 @@ algorithm
   step_exp := evalExpOpt(step_exp, target);
   stop_exp := evalExp(stop_exp, target);
 
-  if EvalTarget.isRange(target) then
+  if InstContext.inIterationRange(target.context) then
     ty := TypeCheck.getRangeType(start_exp, step_exp, stop_exp,
       Type.arrayElementType(ty), EvalTarget.getInfo(target));
     result := Expression.RANGE(ty, start_exp, step_exp, stop_exp);
@@ -963,7 +902,7 @@ function evalBinaryOp
   input Expression exp1;
   input Operator op;
   input Expression exp2;
-  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+  input EvalTarget target = noTarget;
   output Expression exp;
 algorithm
   exp := Expression.mapSplitExpressions(Expression.BINARY(exp1, op, exp2),
@@ -986,7 +925,7 @@ function evalBinaryOp_dispatch
   input Expression exp1;
   input Operator op;
   input Expression exp2;
-  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+  input EvalTarget target = noTarget;
   output Expression exp;
 algorithm
   exp := match op.op
@@ -1464,7 +1403,7 @@ function evalLogicBinaryOp
   input Expression exp1;
   input Operator op;
   input Expression exp2;
-  input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+  input EvalTarget target = noTarget;
   output Expression exp;
 algorithm
   exp := Expression.mapSplitExpressions(Expression.LBINARY(exp1, op, exp2),
@@ -3177,7 +3116,7 @@ protected
   Type ty;
 algorithm
   if listEmpty(ranges) then
-    result := evalExp(exp, EvalTarget.IGNORE_ERRORS());
+    result := evalExp(exp);
   else
     range :: ranges_rest := ranges;
     range := evalExp(range);
@@ -3242,7 +3181,7 @@ algorithm
   end match;
 
   result := Expression.foldReduction(exp, iters, default_exp,
-    function evalExp(target = EvalTarget.IGNORE_ERRORS()), red_fn);
+    function evalExp(target = noTarget), red_fn);
 end evalReduction;
 
 function evalSize
@@ -3341,18 +3280,23 @@ function printUnboundError
   input Component component;
   input EvalTarget target;
   input Expression exp;
+protected
+  EvalTargetData extra;
 algorithm
-  () := match target
-    case EvalTarget.IGNORE_ERRORS() then ();
+  if not EvalTarget.hasInfo(target) then
+    return;
+  end if;
 
-    case EvalTarget.DIMENSION()
+  () := match target.extra
+    case SOME(extra as EvalTargetData.DIMENSION_DATA())
       algorithm
         Error.addSourceMessage(Error.STRUCTURAL_PARAMETER_OR_CONSTANT_WITH_NO_BINDING,
-          {Expression.toString(exp), InstNode.name(target.component)}, target.info);
+          {Expression.toString(extra.exp), InstNode.name(extra.component)}, target.info);
       then
         fail();
 
-    case EvalTarget.CONDITION()
+    case _
+      guard InstContext.inCondition(target.context)
       algorithm
         Error.addSourceMessage(Error.CONDITIONAL_EXP_WITHOUT_VALUE,
           {Expression.toString(exp)}, target.info);

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -585,7 +585,7 @@ public
 
   function eval
     input Dimension dim;
-    input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+    input EvalTarget target = NFCeval.noTarget;
     output Dimension outDim;
   algorithm
     outDim := match dim

--- a/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEvalConstants.mo
@@ -128,7 +128,7 @@ algorithm
         if InstContext.inRelaxed(context) then
           eexp := Ceval.tryEvalExp(eexp);
         else
-          eexp := Ceval.evalExp(eexp, Ceval.EvalTarget.ATTRIBUTE(binding));
+          eexp := Ceval.evalExp(eexp, Ceval.EvalTarget.new(info, context));
         end if;
       end if;
 
@@ -204,7 +204,7 @@ algorithm
         if ComponentRef.nodeVariability(cref) <= Variability.STRUCTURAL_PARAMETER and
            not Type.isExternalObject(ty) then
           // Evaluate all constants and structural parameters.
-          outExp := Ceval.evalCref(cref, outExp, Ceval.EvalTarget.IGNORE_ERRORS(), evalSubscripts = false);
+          outExp := Ceval.evalCref(cref, outExp, NFCeval.noTarget, evalSubscripts = false);
           outExp := Flatten.flattenExp(outExp, Flatten.Prefix.PREFIX(InstNode.EMPTY_NODE(), cref), info);
           outChanged := true;
         elseif outChanged then
@@ -607,7 +607,7 @@ algorithm
         if evaluateAll or not isLocalFunctionVariable(e.cref, fnNode) then
           ErrorExt.setCheckpoint(getInstanceName());
           try
-            outExp := Ceval.evalCref(e.cref, e, Ceval.EvalTarget.IGNORE_ERRORS(), evalSubscripts = false);
+            outExp := Ceval.evalCref(e.cref, e, NFCeval.noTarget, evalSubscripts = false);
           else
             outExp := e;
           end try;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandExp.mo
@@ -343,7 +343,7 @@ public
       // This relies on the fact that Ceval.evalBuiltinCat doesn't actually do any
       // actual constant evaluation, and works on non-constant arrays too as long
       // as they're expanded.
-      exp := Ceval.evalBuiltinCat(listHead(args), expl, Ceval.EvalTarget.IGNORE_ERRORS());
+      exp := Ceval.evalBuiltinCat(listHead(args), expl, NFCeval.noTarget);
     else
       exp := expandGeneric(Expression.CALL(call));
     end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -598,7 +598,7 @@ algorithm
   if Binding.isBound(condition) then
     cond := flattenBinding(condition, prefix);
     exp := Binding.getTypedExp(cond);
-    exp := Ceval.evalExp(exp, Ceval.EvalTarget.CONDITION(Binding.getInfo(cond)));
+    exp := Ceval.evalExp(exp, Ceval.EvalTarget.new(Binding.getInfo(cond), NFInstContext.CONDITION));
     exp := Expression.expandSplitIndices(exp);
 
     // Hack to make arrays work when all elements have the same value.
@@ -1893,9 +1893,7 @@ algorithm
 
   // Print errors for unbound constants/parameters if the if-equation contains
   // connects, since we must select a branch in that case.
-  target := if has_connect then
-    Ceval.EvalTarget.GENERIC(info) else
-    Ceval.EvalTarget.IGNORE_ERRORS();
+  target := if has_connect then Ceval.EvalTarget.new(info) else NFCeval.noTarget;
 
   while not listEmpty(branches) loop
     branch :: branches := branches;
@@ -2009,7 +2007,7 @@ algorithm
 
   // Unroll the loop by replacing the iterator with each of its values in the for loop body.
   range := flattenExp(range, prefix, info);
-  range := Ceval.evalExp(range, Ceval.EvalTarget.RANGE(info));
+  range := Ceval.evalExp(range, Ceval.EvalTarget.new(info, NFInstContext.ITERATION_RANGE));
   range_iter := RangeIterator.fromExp(range);
 
   while RangeIterator.hasNext(range_iter) loop
@@ -2038,7 +2036,7 @@ algorithm
   (connects, non_connects) := splitForLoop2(body);
 
   if not listEmpty(connects) then
-    range := Ceval.evalExpOpt(range, Ceval.EvalTarget.RANGE(Equation.info(forLoop)));
+    range := Ceval.evalExpOpt(range, Ceval.EvalTarget.new(Equation.info(forLoop), NFInstContext.ITERATION_RANGE));
     eq := Equation.FOR(iter, range, connects, scope, src);
 
     if settings.arrayConnect then

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunctionDerivative.mo
@@ -109,7 +109,7 @@ public
       fail();
     end if;
 
-    order := Ceval.evalExp(order, EvalTarget.GENERIC(info));
+    order := Ceval.evalExp(order, EvalTarget.new(info));
   end typeDerivative;
 
   function toDAE

--- a/OMCompiler/Compiler/NFFrontEnd/NFPackage.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFPackage.mo
@@ -293,8 +293,7 @@ public
   algorithm
     exp := match exp
       case Expression.CREF(cref = cref as ComponentRef.CREF())
-        then if ComponentRef.isPackageConstant(cref) then
-          Ceval.evalExp(exp, Ceval.EvalTarget.IGNORE_ERRORS()) else exp;
+        then if ComponentRef.isPackageConstant(cref) then Ceval.evalExp(exp) else exp;
 
       else exp;
     end match;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSBGraphUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSBGraphUtil.mo
@@ -169,7 +169,7 @@ public
       output Expression outExp;
     algorithm
       if Expression.isCref(e) then
-        outExp := Ceval.evalExp(e, Ceval.EvalTarget.RANGE(AbsynUtil.dummyInfo));
+        outExp := Ceval.evalExp(e, Ceval.EvalTarget.new(AbsynUtil.dummyInfo, NFInstContext.ITERATION_RANGE));
       else
         outExp := e;
       end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -188,7 +188,7 @@ algorithm
 
           if is_pure and List.all(args, Expression.isLiteral) and (scalarize or Type.isScalar(call.ty)) then
             try
-              callExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
+              callExp := Ceval.evalCall(call, NFCeval.noTarget);
             else
               callExp := Expression.CALL(call);
             end try;
@@ -223,7 +223,7 @@ algorithm
   ErrorExt.setCheckpoint(getInstanceName());
 
   try
-    outExp := Ceval.evalCall(call, EvalTarget.IGNORE_ERRORS());
+    outExp := Ceval.evalCall(call, NFCeval.noTarget);
     ErrorExt.delCheckpoint(getInstanceName());
   else
     if Flags.isSet(Flags.FAILTRACE) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSubscript.mo
@@ -868,7 +868,7 @@ public
 
   function eval
     input Subscript subscript;
-    input EvalTarget target = EvalTarget.IGNORE_ERRORS();
+    input EvalTarget target = NFCeval.noTarget;
     output Subscript outSubscript;
   algorithm
     outSubscript := match subscript

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1521,7 +1521,7 @@ algorithm
   if evaluate and not Expression.isLiteral(exp) then
     ErrorExt.setCheckpoint(getInstanceName());
     try
-      exp := Ceval.evalExp(exp, NFCeval.EvalTarget.INSTANCE_API());
+      exp := Ceval.evalExp(exp, Ceval.EvalTarget.new(AbsynUtil.dummyInfo, NFInstContext.INSTANCE_API));
       json := JSON.addPair("value", Expression.toJSON(exp), json);
     else
     end try;


### PR DESCRIPTION
- Simplify EvalTarget by changing it from multiple records that indicate the context to a single record with an InstContext field like the rest of the frontend uses, to make it possible to better determine the context of the expression being evaluated.