### PR TITLE
Fix evaluation of call type dimensions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -69,6 +69,7 @@ import Prefixes = NFPrefixes;
 import Restriction = NFRestriction;
 import SCodeUtil;
 import SimplifyExp = NFSimplifyExp;
+import Structural = NFStructural;
 import Subscript = NFSubscript;
 import TypeCheck = NFTypeCheck;
 import Typing = NFTyping;
@@ -2842,6 +2843,7 @@ protected
 
           ErrorExt.setCheckpoint(getInstanceName());
           try
+            Structural.markExp(exp);
             exp := Ceval.evalExp(exp);
           else
           end try;

--- a/testsuite/flattening/modelica/scodeinst/DimUnknown16.mo
+++ b/testsuite/flattening/modelica/scodeinst/DimUnknown16.mo
@@ -1,0 +1,41 @@
+// name: DimUnknown16
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+function f
+  input Integer nrow;
+  input Integer ncol;
+  output Real[nrow, ncol] matrix;
+external "C" f(nrow, ncol, matrix);
+end f;
+
+impure function f2
+  input Integer dummy;
+  output Integer dim;
+external "C" dim = strlen("aa");
+end f2;
+
+model DimUnknown16
+  parameter Integer dummy = 0;
+  parameter Integer dim = f2(dummy);
+  parameter Real A[:, :] = f(dim, dim);
+end DimUnknown16;
+
+// Result:
+// impure function f
+//   input Integer nrow;
+//   input Integer ncol;
+//   output Real[nrow, ncol] matrix;
+//
+//   external "C" f(nrow, ncol, matrix);
+// end f;
+//
+// class DimUnknown16
+//   final parameter Integer dummy = 0;
+//   final parameter Integer dim = 2;
+//   parameter Real[2, 2] A = f(2, 2);
+// end DimUnknown16;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/FuncUnknownDim3.mo
+++ b/testsuite/flattening/modelica/scodeinst/FuncUnknownDim3.mo
@@ -8,7 +8,7 @@ function f
   input Real[n] v;
   output Real[n] result = fill(1.0, n);
 protected
-  parameter Integer n = size(v, 1);
+  Integer n = size(v, 1);
 end f;
 
 model FuncUnknownDim3
@@ -19,7 +19,7 @@ end FuncUnknownDim3;
 // function f
 //   input Real[n] v;
 //   output Real[n] result = fill(1.0, n);
-//   protected parameter Integer n = size(v, 1);
+//   protected Integer n = size(v, 1);
 // end f;
 //
 // class FuncUnknownDim3

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -370,6 +370,7 @@ DimUnknown12.mo \
 DimUnknown13.mo \
 DimUnknown14.mo \
 DimUnknown15.mo \
+DimUnknown16.mo \
 dim1.mo \
 dim13.mo \
 dim16.mo \


### PR DESCRIPTION
- Mark dimension expressions as structural when evaluating the type of a function call, to avoid having them be marked as non-structural when they depend on external functions.

Fixes #12605