### PR TITLE
Improve ComponentRef.hash

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/MetaModelicaBuiltin.mo
@@ -604,6 +604,14 @@ function stringHashDjb2
 external "builtin";
 end stringHashDjb2;
 
+function stringHashDjb2Continue
+  "Continues computing a hash by adding another string to it."
+  input String str;
+  input Integer hash;
+  output Integer outHash;
+external "builtin";
+end stringHashDjb2Continue;
+
 function stringHashDjb2Mod "Does hashing+modulo without intermediate results."
   input String str;
   input Integer mod;

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.c
@@ -127,6 +127,13 @@ static inline unsigned long djb2_hash(const unsigned char *str)
   return hash;
 }
 
+static inline unsigned long djb2_hash_continue(const unsigned char *str, unsigned long hash)
+{
+  int c;
+  while (0 != (c = *str++)) hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+  return hash;
+}
+
 /*** sdbm hash ***/
 static inline unsigned long sdbm_hash(const unsigned char* str)
 {
@@ -150,6 +157,16 @@ modelica_integer stringHashDjb2(metamodelica_string_const s)
 {
   const char* str = MMC_STRINGDATA(s);
   long res = djb2_hash((const unsigned char*)str);
+  res = labs(res);
+  /* fprintf(stderr, "stringHashDjb2 %s-> %ld %ld %ld\n", str, res, mmc_mk_icon(res), mmc_unbox_integer(mmc_mk_icon(res))); */
+  return res;
+}
+
+/* adrpo: see the comment above about djb2 hash */
+modelica_integer stringHashDjb2Continue(metamodelica_string_const s, modelica_integer hash)
+{
+  const char* str = MMC_STRINGDATA(s);
+  long res = djb2_hash_continue((const unsigned char*)str, (unsigned long)hash);
   res = labs(res);
   /* fprintf(stderr, "stringHashDjb2 %s-> %ld %ld %ld\n", str, res, mmc_mk_icon(res), mmc_unbox_integer(mmc_mk_icon(res))); */
   return res;

--- a/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.h
+++ b/OMCompiler/SimulationRuntime/c/meta/meta_modelica_builtin.h
@@ -82,6 +82,7 @@ extern modelica_integer nobox_stringGet(threadData_t *threadData,metamodelica_st
 extern modelica_metatype boxptr_stringUpdateStringChar(threadData_t *,metamodelica_string str, metamodelica_string c, modelica_metatype ix);
 extern modelica_integer stringHash(metamodelica_string_const);
 extern modelica_integer stringHashDjb2(metamodelica_string_const s);
+extern modelica_integer stringHashDjb2Continue(metamodelica_string_const s, modelica_integer hash);
 extern modelica_integer stringHashDjb2Mod(metamodelica_string_const s,modelica_integer mod);
 extern modelica_integer stringHashSdbm(metamodelica_string_const str);
 #define substring(X,Y,Z) boxptr_substring(threadData,X,mmc_mk_icon(Y),mmc_mk_icon(Z))

--- a/testsuite/simulation/modelica/NBackend/basics/partitioning.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/partitioning.mos
@@ -56,9 +56,9 @@ val(x, 1);
 //
 // Unknown Variables (3/3)
 // *************************
-// (1)       [ALGB] (1) Real y
-// (2)       [ALGB] (1) Real $FUN_2
-// (3)       [DER-] (1) Real $DER.x
+// (1)       [DER-] (1) Real $DER.x
+// (2)       [ALGB] (1) Real y
+// (3)       [ALGB] (1) Real $FUN_2
 //
 //
 // Equations Equations (3/3)

--- a/testsuite/simulation/modelica/NBackend/functions/function_annotation_der.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_annotation_der.mos
@@ -61,6 +61,14 @@ simulate(function_annotation_der); getErrorString();
 // [AFTER ] [SCAL] (1) $pDER_ODE_JAC.a = cos(b) * $SEED_ODE_JAC.b ($RES_$AUX_6)
 //
 // ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $DER.b = f(a, 0, k, k) ($RES_SIM_2)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.b = df(a, 0, k, k, $pDER_ODE_JAC.a, 0.0) ($RES_SIM_2)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $DER.c = f(a, 0, k, b) ($RES_SIM_1)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.c = df(a, 0, k, b, $pDER_ODE_JAC.a, $SEED_ODE_JAC.b) ($RES_SIM_1)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
 // [BEFORE] [SCAL] (1) $DER.d = f(a, 0, b, b) ($RES_SIM_0)
 //
 // [BEFORE] function 'f'
@@ -91,14 +99,6 @@ simulate(function_annotation_der); getErrorString();
 // end '$fDER1.f'
 //
 // [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.d = $fDER1.f(a, 0, b, b, $pDER_ODE_JAC.a, $SEED_ODE_JAC.b, $SEED_ODE_JAC.b) ($RES_SIM_0)
-//
-// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
-// [BEFORE] [SCAL] (1) $DER.c = f(a, 0, k, b) ($RES_SIM_1)
-// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.c = df(a, 0, k, b, $pDER_ODE_JAC.a, $SEED_ODE_JAC.b) ($RES_SIM_1)
-//
-// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
-// [BEFORE] [SCAL] (1) $DER.b = f(a, 0, k, k) ($RES_SIM_2)
-// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.b = df(a, 0, k, k, $pDER_ODE_JAC.a, 0.0) ($RES_SIM_2)
 //
 // record SimulationResult
 //     resultFile = "function_annotation_der_res.mat",

--- a/testsuite/simulation/modelica/NBackend/functions/function_diff.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_diff.mos
@@ -39,7 +39,7 @@ simulate(function_diff); getErrorString();
 // [AFTER ] [SCAL] (1) $pDER_ODE_JAC.y = cos(x) * $SEED_ODE_JAC.x ($RES_$AUX_5)
 //
 // ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
-// [BEFORE] [SCAL] (1) $FUN_3 = f(x) ($RES_$AUX_3)
+// [BEFORE] [SCAL] (1) $FUN_2 = f(y) ($RES_$AUX_4)
 //
 // [BEFORE] function 'f'
 //   input Real 'a';
@@ -69,19 +69,19 @@ simulate(function_diff); getErrorString();
 //   annotation(Inline = false);
 // end '$fDER0.f'
 //
-// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$FUN_3 = $fDER0.f(x, $SEED_ODE_JAC.x) ($RES_$AUX_3)
-//
-// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
-// [BEFORE] [SCAL] (1) $FUN_2 = f(y) ($RES_$AUX_4)
 // [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$FUN_2 = $fDER0.f(y, $pDER_ODE_JAC.y) ($RES_$AUX_4)
-//
-// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
-// [BEFORE] [SCAL] (1) $DER.z = $FUN_3 ($RES_SIM_0)
-// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.z = $pDER_ODE_JAC.$FUN_3 ($RES_SIM_0)
 //
 // ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
 // [BEFORE] [SCAL] (1) $DER.x = $FUN_2 ($RES_SIM_1)
 // [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.x = $pDER_ODE_JAC.$FUN_2 ($RES_SIM_1)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $FUN_3 = f(x) ($RES_$AUX_3)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$FUN_3 = $fDER0.f(x, $SEED_ODE_JAC.x) ($RES_$AUX_3)
+//
+// ### debugDifferentiation | NBJacobian.jacobianSymbolic ###
+// [BEFORE] [SCAL] (1) $DER.z = $FUN_3 ($RES_SIM_0)
+// [AFTER ] [SCAL] (1) $pDER_ODE_JAC.$DER.z = $pDER_ODE_JAC.$FUN_3 ($RES_SIM_0)
 //
 // record SimulationResult
 //     resultFile = "function_diff_res.mat",


### PR DESCRIPTION
- Add builtin function `stringHashDjb2Continue` to allow continuing the computation of a hash.
- Rewrite `ComponentRef.hash` and `ComponentRef.hashStrip` to construct the hash directly without converting the component reference to a string first.