### PR TITLE
Improve performance of Expression.extractUniqueCrefs*

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -58,6 +58,7 @@ protected import Print;
 protected import StringUtil;
 protected import System;
 protected import Types;
+protected import UnorderedSet;
 protected import Util;
 
 
@@ -4077,6 +4078,13 @@ algorithm
     else false;
   end match;
 end isWild;
+
+public function uniqueList
+  input list<DAE.ComponentRef> crefs;
+  output list<DAE.ComponentRef> uniqueCrefs;
+algorithm
+  uniqueCrefs := UnorderedSet.unique_list(crefs, hashComponentRef, crefEqual);
+end uniqueList;
 
 annotation(__OpenModelica_Interface="frontend");
 end ComponentReference;

--- a/OMCompiler/Compiler/FrontEnd/Expression.mo
+++ b/OMCompiler/Compiler/FrontEnd/Expression.mo
@@ -6082,7 +6082,8 @@ public function extractUniqueCrefsFromExp
   input Boolean expand = true;
   output list<DAE.ComponentRef> ocrefs;
 algorithm
-  ocrefs := List.unique(extractCrefsFromExp(inExp));
+  ocrefs := ComponentReference.uniqueList(extractCrefsFromExp(inExp));
+
   if expand then
     ocrefs := List.flatten(List.map1(ocrefs, ComponentReference.expandCref, true));
   end if;
@@ -6125,7 +6126,7 @@ public function extractUniqueCrefsFromExpDerPreStart
   input Boolean expand = true;
   output list<DAE.ComponentRef> ocrefs;
 algorithm
-  ocrefs := List.unique(extractCrefsFromExpDerPreStart(inExp, expand));
+  ocrefs := ComponentReference.uniqueList(extractCrefsFromExpDerPreStart(inExp, expand));
 end extractUniqueCrefsFromExpDerPreStart;
 
 public function extractCrefsFromExpDerPreStart
@@ -6196,8 +6197,8 @@ protected
   list<DAE.ComponentRef> olhscrefs;
 algorithm
   (lhscreflstlst,rhscreflstlst) := List.map_2(inStmts,extractCrefsStatment);
-  orhscrefs := List.unique(List.flatten(rhscreflstlst));
-  olhscrefs := List.unique(List.flatten(lhscreflstlst));
+  orhscrefs := ComponentReference.uniqueList(List.flatten(rhscreflstlst));
+  olhscrefs := ComponentReference.uniqueList(List.flatten(lhscreflstlst));
   ocrefs := (olhscrefs,orhscrefs);
 end extractUniqueCrefsFromStatmentS;
 

--- a/OMCompiler/Compiler/Util/UnorderedSet.mo
+++ b/OMCompiler/Compiler/Util/UnorderedSet.mo
@@ -553,7 +553,7 @@ public
     input list<T> inList;
     input Hash hashFunc;
     input KeyEq keyEqFunc;
-    output list<T> outList = toList(fromList(inList, hashFunc, keyEqFunc));
+    output list<T> outList = if List.hasSeveralElements(inList) then toList(fromList(inList, hashFunc, keyEqFunc)) else inList;
   end unique_list;
 
   function union


### PR DESCRIPTION
- Use `UnorderedSet.unique_list` instead of `List.unique` for the `Expression.extractUniqueCrefs*` functions to improve scaling for large lists.
- Optimize `UnorderedSet.unique_list` to avoid unnecessary work if the list has no more than one element.

Fixes #10252