### PR TITLE
Add option to move Base Modelica bindings

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -36,6 +36,7 @@ encapsulated uniontype NFVariable
   import Component = NFComponent;
   import ComponentRef = NFComponentRef;
   import Dimension = NFDimension;
+  import Equation = NFEquation;
   import Expression = NFExpression;
   import NFInstNode.InstNode;
   import NFPrefixes.Visibility;
@@ -637,6 +638,20 @@ public
       s := IOStream.append(s, ")");
     end if;
   end toFlatStreamModifier;
+
+  function moveBinding
+    "Removes the binding of the variable, if it has one and it has at least
+     discrete variability, and creates an equation from it."
+    input output Variable var;
+    input output list<Equation> equations;
+  algorithm
+    if variability(var) >= Variability.DISCRETE and Binding.isBound(var.binding) then
+      equations := Equation.makeEquality(Expression.fromCref(var.name),
+        Binding.getExp(var.binding), var.ty, InstNode.EMPTY_NODE(),
+        ElementSource.createElementSource(var.info)) :: equations;
+      var.binding := NFBinding.EMPTY_BINDING;
+    end if;
+  end moveBinding;
 
   annotation(__OpenModelica_Interface="frontend");
 end NFVariable;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -1462,6 +1462,12 @@ constant ConfigFlag BASE_MODELICA_FORMAT = CONFIG_FLAG(153, "baseModelicaFormat"
   })),
   Gettext.gettext("Formatting options for Base Modelica"));
 
+constant ConfigFlag BASE_MODELICA_OPTIONS = CONFIG_FLAG(154, "baseModelicaOptions",
+  NONE(), EXTERNAL(), STRING_LIST_FLAG({}), SOME(STRING_DESC_OPTION({
+    ("moveBindings", Gettext.notrans("Moves movable binding equations to normal equations."))
+    })),
+  Gettext.gettext("Enables optional Base Modelica options."));
+
 function getFlags
   "Loads the flags with getGlobalRoot. Assumes flags have been loaded."
   input Boolean initialize = true;

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -411,7 +411,8 @@ constant list<Flags.ConfigFlag> allConfigFlags = {
   Flags.FMU_RUNTIME_DEPENDS,
   Flags.FRONTEND_INLINE,
   Flags.EXPOSE_LOCAL_IOS,
-  Flags.BASE_MODELICA_FORMAT
+  Flags.BASE_MODELICA_FORMAT,
+  Flags.BASE_MODELICA_OPTIONS
 };
 
 public function new

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -14,6 +14,7 @@ TESTFILES = \
   DoublePendulum.mos \
 	Expression1.mo \
 	InStreamNominalThreshold.mo \
+	MoveBindings1.mo \
 	NonScalarizedWithRecords1.mo \
 	NonScalarizedWithoutRecords1.mo \
 	PartiallyScalarizedWithRecords1.mo \

--- a/testsuite/openmodelica/basemodelica/MoveBindings1.mo
+++ b/testsuite/openmodelica/basemodelica/MoveBindings1.mo
@@ -1,0 +1,41 @@
+// name: MoveBindings1
+// status: correct
+// cflags: -d=newInst -f --baseModelicaOptions=moveBindings
+
+model M
+  record R
+    Real x;
+    Real y;
+  end R;
+
+  Real x = 0;
+  Real y[:] = {1, 2, 3};
+  R r = R(1, 2);
+  parameter Integer n = 0;
+  Real z;
+equation
+  z = 1;
+end M;
+
+// Result:
+// //! base 0.1.0
+// package 'M'
+//   record 'R'
+//     Real 'x';
+//     Real 'y';
+//   end 'R';
+//
+//   model 'M'
+//     Real 'x';
+//     Real[3] 'y';
+//     'R' 'r';
+//     parameter Integer 'n' = 0;
+//     Real 'z';
+//   equation
+//     'x' = 0.0;
+//     'r' = 'R'(1.0, 2.0);
+//     'y' = {1.0, 2.0, 3.0};
+//     'z' = 1.0;
+//   end 'M';
+// end 'M';
+// endResult


### PR DESCRIPTION
- Add flag `--baseModelicaOptions=moveBindings` that moves binding equations of variables to the equation section.

Fixes #12496