### PR TITLE
Implement array traversal with Susan map operator

### DIFF
--- a/OMCompiler/Compiler/susan_codegen/TplCodegen.tpl
+++ b/OMCompiler/Compiler/susan_codegen/TplCodegen.tpl
@@ -48,6 +48,8 @@ template mmDeclaration(MMDeclaration it) ::=
     <%match statements
      case {c as MM_MATCH(__)} then //match function
        mmMatchFunBody(mf.inArgs, mf.outArgs, mf.locals, c.matchCases)
+     case {c as MM_FOR_LOOP(__)} then //for-loop function
+       mmForLoopFunBody(mf.inArgs, mf.outArgs, mf.locals, c.idxName, c.arrName, c.eltName, c.statements)
      case sts then //simple assignment functions
        <<
          <%typedIdentsEx(mf.inArgs, "input", "")%>
@@ -118,6 +120,57 @@ end try;
 %>
 >>
 end mmMatchFunBody;
+
+template mmForLoopFunBody(TypedIdents inArgs, TypedIdents outArgs, TypedIdents locals, Ident idxName, Ident arrName, Ident eltName, list<MMExp> statements) ::=
+<<
+  <%inOutArgs(inArgs, outArgs)%>
+<%if locals then <<
+protected
+  <%typedIdents(locals)%>
+>>%>
+algorithm<% if debugSusan() then
+<<
+
+try
+>>
+%>
+  for <%idxName%> in 1:arrayLength(<%arrName%>) loop
+    <%eltName%> := arrayGet(<%arrName%>, <%idxName%>);
+    <%statements |> it => '<%mmExp(it, ":=")%>;' ;separator="\n"%>
+  end for;<% if debugSusan() then
+<<
+
+else
+  Tpl.fakeStackOverflow();
+end try;
+>>
+%>
+>>
+end mmForLoopFunBody;
+
+template inOutArgs(TypedIdents inArgs, TypedIdents outArgs) ::=
+  match intersectInOutArgs(inArgs, outArgs)
+  case (inOut, in, out) then
+  <<
+  <%if inOut then <<
+  <%typedIdentsEx(inOut, "input output", "")%>
+  <%if in then <<
+
+  >> else if out then <<
+
+  >>%>
+  >>%>
+  <%if in then <<
+  <%typedIdentsEx(in, "input", "")%>
+  <%if out then <<
+
+  >>%>
+  >>%>
+  <%if out then <<
+  <%typedIdentsEx(out, "output", "")%>
+  >>%>
+  >>
+end inOutArgs;
 
 template pathIdent(PathIdent path) ::=
   match path

--- a/OMCompiler/Compiler/susan_codegen/TplCodegenTV.mo
+++ b/OMCompiler/Compiler/susan_codegen/TplCodegenTV.mo
@@ -202,6 +202,13 @@ package TplAbsyn
     record MM_MATCH
       list<MMMatchCase> matchCases;
     end MM_MATCH;
+
+    record MM_FOR_LOOP
+      Ident idxName;
+      Ident arrName;
+      Ident eltName;
+      list<MMExp> statements;
+    end MM_FOR_LOOP;
   end MMExp;
 
   // **** types for dumping purposes ... i.e. Susan input AST
@@ -349,6 +356,12 @@ package TplAbsyn
       Expression exp;
     end TEMPLATE_DEF;
   end TemplateDef;
+
+  function intersectInOutArgs
+    input TypedIdents inList1;
+    input TypedIdents inList2;
+    output tuple<TypedIdents, TypedIdents, TypedIdents> outIntersectionAndRests;
+  end intersectInOutArgs;
 
 end TplAbsyn;
 


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/discussions/12596

### Purpose

Traverse arrays like we can traverse lists with the map operator `|>`, to avoid prior (expensive) conversion with `arrayList()`.

### Approach

Implement an array-map function mostly as an adapted copy of the list-map case above it and the scalar-map case below it. Iterate through the array using a for-loop and avoid `in_` and `out_` prefixes to `input`/`output` arguments (intersect them into `input output` where appropriate), to spare some lines in the generated code, and for clarity.