### PR TITLE
Improve performance of BackendDAEUtil.applyIndexType

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -2376,6 +2376,7 @@ algorithm
   outLst := match(inLst, inIndexType)
     // transform to absolute indexes
     case (_, BackendDAE.ABSOLUTE())
+      guard not AvlSetInt.isEmpty(inLst) and AvlSetInt.smallestKey(inLst) < 0
       algorithm
         outLst := AvlSetInt.EMPTY();
         for key in AvlSetInt.listKeys(inLst) loop

--- a/OMCompiler/Compiler/Util/BaseAvlSet.mo
+++ b/OMCompiler/Compiler/Util/BaseAvlSet.mo
@@ -313,6 +313,17 @@ algorithm
   end if;
 end intersection;
 
+function smallestKey
+  input Tree tree;
+  output Key key;
+algorithm
+  key := match tree
+    case NODE(right = EMPTY()) then tree.key;
+    case NODE() then smallestKey(tree.right);
+    case LEAF() then tree.key;
+  end match;
+end smallestKey;
+
 protected
 
 function referenceEqOrEmpty


### PR DESCRIPTION
- Only apply the tranformation if the set actually contains any negative indices.