### PR TITLE
Handle unknown dimensions better in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -953,7 +953,7 @@ protected
       (arg, arg_ty, arg_var, arg_pur) := Typing.typeExp(arg, context, info);
 
       if not (InstContext.inAlgorithm(context) or InstContext.inFunction(context)) then
-        if arg_var > Variability.PARAMETER then
+        if arg_var > Variability.PARAMETER and not InstContext.inInstanceAPI(context) then
           Error.addSourceMessageAndFail(Error.NON_PARAMETER_EXPRESSION_DIMENSION,
             {Expression.toString(arg), String(index),
              List.toString(fillArg :: dimensionArgs, Expression.toString,
@@ -962,7 +962,7 @@ protected
 
         if arg_pur == Purity.PURE and not Structural.isExpressionNotFixed(arg) then
           Structural.markExp(arg);
-          arg := Ceval.evalExp(arg);
+          arg := if InstContext.inInstanceAPI(context) then Ceval.tryEvalExp(arg) else Ceval.evalExp(arg);
           arg_ty := Expression.typeOf(arg);
         end if;
       end if;

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -508,6 +508,7 @@ public
       case COMPONENT(attributes = Attributes.ATTRIBUTES(variability = variability)) then variability;
       case ITERATOR() then component.variability;
       case ENUM_LITERAL() then Variability.CONSTANT;
+      case INVALID_COMPONENT() then variability(component.component);
       else Variability.CONTINUOUS;
     end match;
   end variability;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDim2.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDim2.mos
@@ -1,4 +1,4 @@
-// name: GetModelInstanceDim1
+// name: GetModelInstanceDim2
 // keywords:
 // status: correct
 // cflags: -d=newInst

--- a/testsuite/openmodelica/instance-API/GetModelInstanceDim3.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceDim3.mos
@@ -1,0 +1,174 @@
+// name: GetModelInstanceDim3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  block Table
+    parameter Real offset[:] = {0};
+  end Table;
+
+  model M
+    parameter Real table[:, :];
+    parameter Real offset[:] = fill(0, nout);
+    final parameter Integer nout = size(table, 2) - 1;
+    Table tab(final offset = offset);
+  end M;
+");
+
+getModelInstance(M, prettyPrint = true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"table\",
+//       \"type\": \"Real\",
+//       \"dims\": {
+//         \"absyn\": [
+//           \":\",
+//           \":\"
+//         ],
+//         \"typed\": [
+//           \":\",
+//           \":\"
+//         ]
+//       },
+//       \"prefixes\": {
+//         \"variability\": \"parameter\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"offset\",
+//       \"type\": \"Real\",
+//       \"dims\": {
+//         \"absyn\": [
+//           \":\"
+//         ],
+//         \"typed\": [
+//           \"nout\"
+//         ]
+//       },
+//       \"modifiers\": \"fill(0, nout)\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"call\",
+//           \"name\": \"fill\",
+//           \"arguments\": [
+//             0,
+//             {
+//               \"$kind\": \"cref\",
+//               \"parts\": [
+//                 {
+//                   \"name\": \"nout\"
+//                 }
+//               ]
+//             }
+//           ]
+//         }
+//       },
+//       \"prefixes\": {
+//         \"variability\": \"parameter\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"nout\",
+//       \"type\": \"Integer\",
+//       \"modifiers\": \"size(table, 2) - 1\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"binary_op\",
+//           \"lhs\": {
+//             \"$kind\": \"call\",
+//             \"name\": \"size\",
+//             \"arguments\": [
+//               {
+//                 \"$kind\": \"cref\",
+//                 \"parts\": [
+//                   {
+//                     \"name\": \"table\"
+//                   }
+//                 ]
+//               },
+//               2
+//             ]
+//           },
+//           \"op\": \"-\",
+//           \"rhs\": 1
+//         }
+//       },
+//       \"prefixes\": {
+//         \"final\": true,
+//         \"variability\": \"parameter\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"tab\",
+//       \"type\": {
+//         \"name\": \"Table\",
+//         \"restriction\": \"block\",
+//         \"elements\": [
+//           {
+//             \"$kind\": \"component\",
+//             \"name\": \"offset\",
+//             \"type\": \"Real\",
+//             \"dims\": {
+//               \"absyn\": [
+//                 \":\"
+//               ],
+//               \"typed\": [
+//                 \"nout\"
+//               ]
+//             },
+//             \"modifiers\": \"{0}\",
+//             \"value\": {
+//               \"binding\": {
+//                 \"$kind\": \"cref\",
+//                 \"parts\": [
+//                   {
+//                     \"name\": \"offset\"
+//                   }
+//                 ]
+//               }
+//             },
+//             \"prefixes\": {
+//               \"variability\": \"parameter\"
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 2,
+//           \"columnStart\": 3,
+//           \"lineEnd\": 4,
+//           \"columnEnd\": 12
+//         }
+//       },
+//       \"modifiers\": {
+//         \"offset\": {
+//           \"final\": true,
+//           \"$value\": \"offset\"
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 6,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 11,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -42,6 +42,7 @@ GetModelInstanceDerived2.mos \
 GetModelInstanceDerived3.mos \
 GetModelInstanceDim1.mos \
 GetModelInstanceDim2.mos \
+GetModelInstanceDim3.mos \
 GetModelInstanceDuplicate1.mos \
 GetModelInstanceEnum1.mos \
 GetModelInstanceEnum2.mos \


### PR DESCRIPTION
- Allow `fill` to have unknown dimensions when using the instance API.
- Use the correct variability for invalid components.

Fixes #12662