### PR TITLE
Deactivate Jacobians for SCCs

### DIFF
--- a/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
+++ b/OMCompiler/Compiler/NSimCode/NSimStrongComponent.mo
@@ -682,7 +682,8 @@ public
             end if;
           end for;
 
-          if Util.isSome(strict.jac) then
+          // reactivate this once nonlinear loops actually work
+          if false and Util.isSome(strict.jac) then
             (jacobian, simCodeIndices) := SimJacobian.create(Util.getOption(strict.jac), simCodeIndices, simcode_map);
           else
             jacobian := NONE();

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 ManyEvents.mos \
 ManyEventsManyConditions.mos \
 TransmissionLineModelica.mos \
+DistributionSystemModelicaIndividual.mos \
 Table.mos \
 Verification_Table.mos \
 CascadedFirstOrder.mos \
@@ -29,7 +30,6 @@ FAILINGTESTFILES = \
 CombiTimeTable.mos \
 TransmissionLineEquations.mos \
 CombiTimeTable.mos \
-DistributionSystemModelicaIndividual.mos \
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.

--- a/testsuite/simulation/modelica/NBackend/basics/implicitEquation.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/implicitEquation.mos
@@ -35,71 +35,43 @@ simulate(implicitEquation); getErrorString();
 //
 // Initial Partition
 // -------------------
-//   (4) $FUN_1 := sin(time)
-//   (3) Nonlinear System (size = 1, homotopy = false, mixed = false, torn = true)
+//   (3) $FUN_1 := sin(time)
+//   (2) Nonlinear System (size = 1, homotopy = false, mixed = false, torn = true)
 //   --Iteration Vars:{x}
 //   --(1) 0 = $FUN_1 - ((x + x ^ 3.0) - x ^ 2.0)
 //
 // Algebraic Partition 1
 // -----------------------
-//   (6) Alias of 4
 //   (5) Alias of 3
+//   (4) Alias of 2
 //
 // Event Partition
 // -----------------
-//   (6) Alias of 4
 //   (5) Alias of 3
-//
-// ==========================================================
-//   SimCode Jacobian INI_NLS_JAC_1(idx = 0, partition = 0)
-// ==========================================================
-//
-// ColumnVars (size = 1)
-// ***********************
-//   (0)[JVAR] (1) Real $pDER_INI_NLS_JAC_1.$RES_SIM_0
-//
-// SeedVars (size = 1)
-// *********************
-//   (0)[SEED] (1) Real $SEED_INI_NLS_JAC_1.x
-//
-// Column Equations (size = 1)
-// -----------------------------
-//   (2) $pDER_INI_NLS_JAC_1.$RES_SIM_0 := -(($SEED_INI_NLS_JAC_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_JAC_1.x) - 2.0 * x * $SEED_INI_NLS_JAC_1.x)
-//
-// Sparsity Pattern Cols
-// ***********************
-//   0:	{0}
-//
-// Sparsity Pattern Rows
-// ***********************
-//   0:	{0}
-//
-// Sparsity Coloring Groups
-// **************************
-//   {0}
+//   (4) Alias of 2
 //
 // ======================================================
-//   [EMPTY] SimCode Jacobian A(idx = 1, partition = 0)
+//   [EMPTY] SimCode Jacobian A(idx = 0, partition = 0)
 // ======================================================
 //
 // ======================================================
-//   [EMPTY] SimCode Jacobian B(idx = 2, partition = 0)
+//   [EMPTY] SimCode Jacobian B(idx = 1, partition = 0)
 // ======================================================
 //
 // ======================================================
-//   [EMPTY] SimCode Jacobian C(idx = 3, partition = 0)
+//   [EMPTY] SimCode Jacobian C(idx = 2, partition = 0)
 // ======================================================
 //
 // ======================================================
-//   [EMPTY] SimCode Jacobian D(idx = 4, partition = 0)
+//   [EMPTY] SimCode Jacobian D(idx = 3, partition = 0)
 // ======================================================
 //
 // ======================================================
-//   [EMPTY] SimCode Jacobian F(idx = 5, partition = 0)
+//   [EMPTY] SimCode Jacobian F(idx = 4, partition = 0)
 // ======================================================
 //
 // ======================================================
-//   [EMPTY] SimCode Jacobian H(idx = 6, partition = 0)
+//   [EMPTY] SimCode Jacobian H(idx = 5, partition = 0)
 // ======================================================
 //
 //
@@ -112,8 +84,8 @@ simulate(implicitEquation); getErrorString();
 // allEquations:
 // ========================================
 //
-// 6: alias of 4
 // 5: alias of 3
+// 4: alias of 2
 // ========================================
 //
 //
@@ -126,8 +98,8 @@ simulate(implicitEquation); getErrorString();
 //
 // algebraicEquations (1 systems):
 // ========================================
-// 6: alias of 4
 // 5: alias of 3
+// 4: alias of 2
 // ========================================
 //
 //
@@ -139,16 +111,10 @@ simulate(implicitEquation); getErrorString();
 //
 // initialEquations: (2)
 // ========================================
-// 4: $FUN_1=sin(time) [Real]
-// 3:  (NONLINEAR) index:0 jacobian: true
+// 3: $FUN_1=sin(time) [Real]
+// 2:  (NONLINEAR) index:0 jacobian: false
 // crefs: x
 // 	1: $FUN_1 - (x + x ^ 3.0 - x ^ 2.0) (RESIDUAL)
-// 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_1.$RES_SIM_0=-($SEED_INI_NLS_JAC_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_JAC_1.x - 2.0 * x * $SEED_INI_NLS_JAC_1.x) [Real]
-//
-// columnVars(1)
-// ----------------------
-// index:0: $pDER_INI_NLS_JAC_1.$RES_SIM_0 (no alias)  initial: 	no arrCref index:(1) []
 //
 // ========================================
 //
@@ -193,11 +159,7 @@ simulate(implicitEquation); getErrorString();
 // jacobianMatrices:
 // ========================================
 // 	Jacobian idx: 0
-// 	2: $pDER_INI_NLS_JAC_1.$RES_SIM_0=-($SEED_INI_NLS_JAC_1.x + 3.0 * x ^ 2.0 * $SEED_INI_NLS_JAC_1.x - 2.0 * x * $SEED_INI_NLS_JAC_1.x) [Real]
 //
-// columnVars(1)
-// ----------------------
-// index:0: $pDER_INI_NLS_JAC_1.$RES_SIM_0 (no alias)  initial: 	no arrCref index:(1) []
 // 	Jacobian idx: 1
 //
 // 	Jacobian idx: 2
@@ -207,8 +169,6 @@ simulate(implicitEquation); getErrorString();
 // 	Jacobian idx: 4
 //
 // 	Jacobian idx: 5
-//
-// 	Jacobian idx: 6
 //
 //
 // modelInfo:


### PR DESCRIPTION
Partially reverts #12530 to fix regressions in PowerGrids

### Related Issues

#10034, #12737

### Purpose

Jacobians are still not working properly.