### PR TITLE
Don't check div-by-zero

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -5722,14 +5722,10 @@ case BINARY(__) then
         '(<%e1%>) / <%tvar%>'
       case SIMULATION_CONTEXT() then
         let e2str = Util.escapeModelicaStringToCString(ExpressionDumpTpl.dumpExp(exp2,"\""))
-        if isZero(exp2)
-          then 'ERROR: division by literal zero'
-          else 'DIVISION_SIM(<%e1%>,<%e2%>,"<%e2str%>",equationIndexes)'
+        'DIVISION_SIM(<%e1%>,<%e2%>,"<%e2str%>",equationIndexes)'
       else
         let e2str = Util.escapeModelicaStringToCString(ExpressionDumpTpl.dumpExp(exp2,"\""))
-        if isZero(exp2)
-          then 'ERROR: division by literal zero'
-          else 'DIVISION(<%e1%>,<%e2%>,"<%e2str%>")'
+        'DIVISION(<%e1%>,<%e2%>,"<%e2str%>")'
     )
 
   case POW(__) then

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -3824,11 +3824,6 @@ package Expression
     output Boolean outBoolean;
   end isAtomic;
 
-  function isZero
-    input DAE.Exp inExp;
-    output Boolean outBoolean;
-  end isZero;
-
   function isHalf
     input DAE.Exp inExp;
     output Boolean outBoolean;


### PR DESCRIPTION
Partially reverts #12739

### Purpose

Some models generate `0/0` for `if`-branches that are never reached. omc is not yet smart enough to detect this in all cases.