### PR TITLE
Use `map` to simplify equations

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -70,6 +70,7 @@ protected
   import NFFunction.Function;
   import InstNode = NFInstNode.InstNode;
   import Prefixes = NFPrefixes;
+  import SimplifyExp = NFSimplifyExp;
   import Statement = NFStatement;
   import Subscript = NFSubscript;
   import Type = NFType;
@@ -345,7 +346,15 @@ public
       local
         EqData eqData;
       case MAIN(eqData = eqData as BEquation.EQ_DATA_SIM()) algorithm
-        eqData.equations := EquationPointers.map(eqData.equations, function Equation.simplify(name = getInstanceName(), indent = ""));
+        eqData.equations := EquationPointers.map(
+          eqData.equations,
+          function Equation.simplify(
+            name = getInstanceName(),
+            indent = "",
+            simplifyExp = function SimplifyExp.simplifyDump(
+              includeScope = true,
+              name = getInstanceName(),
+              indent = "")));
         bdae.eqData := EqData.compress(eqData);
       then bdae;
       else bdae;

--- a/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
@@ -326,7 +326,6 @@ public
         // inline possible record constructors
         //body_exp := Expression.map(body_exp, function applyFuncTupleExp(variables = variables));
 
-
         if Flags.isSet(Flags.DUMPBACKENDINLINE) then
           print("[" + getInstanceName() + "] Inlining: " + Expression.toString(exp) + "\n");
           print("-- Result: " + Expression.toString(body_exp) + "\n\n");

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -378,7 +378,7 @@ public
         Expression e;
       case BOOLEAN(true) then true;
       case ARRAY() then Array.all(exp.elements, isAllTrue);
-      case CALL(call = Call.TYPED_ARRAY_CONSTRUCTOR(exp = e)) then Expression.isAllTrue(e);
+      case CALL(call = Call.TYPED_ARRAY_CONSTRUCTOR(exp = e)) then isAllTrue(e);
       else false;
     end match;
   end isAllTrue;
@@ -398,9 +398,9 @@ public
     output Boolean b;
   algorithm
     b := match exp
-      case Expression.CREF() then true;
-      case Expression.UNARY(exp = Expression.CREF()) then true;
-      case Expression.LUNARY(exp = Expression.CREF()) then true;
+      case CREF() then true;
+      case UNARY(exp = CREF()) then true;
+      case LUNARY(exp = CREF()) then true;
       else false;
     end match;
   end isTrivialCref;
@@ -4367,6 +4367,11 @@ public
     end match;
   end isZero;
 
+  function isNonZero
+    input Expression exp;
+    output Boolean res = isPositive(exp) or isNegative(exp);
+  end isNonZero;
+
   function isOne
     input Expression exp;
     output Boolean isOne;
@@ -4395,11 +4400,11 @@ public
 
   function isPositive
     input Expression exp;
-    output Boolean positive "true if exp is known to be > 0, otherwise false.";
+    output Boolean positive "true if exp is known to be > 0, otherwise false";
   algorithm
     positive := match exp
       case INTEGER() then exp.value > 0;
-      case REAL() then exp.value > 0;
+      case REAL() then exp.value > 0.0;
       case CAST() then isPositive(exp.exp);
       case UNARY() then isNegative(exp.exp);
       case CREF() then Util.applyOptionOrDefault(ComponentRef.lookupVarAttr(exp.cref, "min"), isPositive, false);
@@ -4409,11 +4414,11 @@ public
 
   function isNegative
     input Expression exp;
-    output Boolean negative "true if exp is known to be < 0, otherwise false.";
+    output Boolean negative "true if exp is known to be < 0, otherwise false";
   algorithm
     negative := match exp
       case INTEGER() then exp.value < 0;
-      case REAL() then exp.value < 0;
+      case REAL() then exp.value < 0.0;
       case CAST() then isNegative(exp.exp);
       case UNARY() then isPositive(exp.exp);
       case CREF() then Util.applyOptionOrDefault(ComponentRef.lookupVarAttr(exp.cref, "max"), isNegative, false);
@@ -4423,11 +4428,11 @@ public
 
   function isNonPositive
     input Expression exp;
-    output Boolean res "true if exp is known to be <= 0, otherwise false.";
+    output Boolean res "true if exp is known to be <= 0, otherwise false";
   algorithm
     res := match exp
       case INTEGER() then exp.value <= 0;
-      case REAL() then exp.value <= 0;
+      case REAL() then exp.value <= 0.0;
       case CAST() then isNonPositive(exp.exp);
       case UNARY() then isNonNegative(exp.exp);
       case CREF() then Util.applyOptionOrDefault(ComponentRef.lookupVarAttr(exp.cref, "max"), isNonPositive, false);
@@ -4437,11 +4442,11 @@ public
 
   function isNonNegative
     input Expression exp;
-    output Boolean res "true if exp is known to be <= 0, otherwise false.";
+    output Boolean res "true if exp is known to be <= 0, otherwise false";
   algorithm
     res := match exp
       case INTEGER() then exp.value >= 0;
-      case REAL() then exp.value >= 0;
+      case REAL() then exp.value >= 0.0;
       case CAST() then isNonNegative(exp.exp);
       case UNARY() then isNonPositive(exp.exp);
       case CREF() then Util.applyOptionOrDefault(ComponentRef.lookupVarAttr(exp.cref, "min"), isNonNegative, false);
@@ -6089,7 +6094,7 @@ public
         algorithm
           json := JSON.emptyObject();
           json := JSON.addPair("$kind", JSON.makeString("enum"), json);
-          json := JSON.addPair("name", JSON.makeString(Expression.toString(exp)), json);
+          json := JSON.addPair("name", JSON.makeString(toString(exp)), json);
           json := JSON.addPair("index", JSON.makeInteger(exp.index), json);
         then
           json;
@@ -6363,7 +6368,7 @@ public
           Pointer.update(idx_ptr, idx + 1);
           UnorderedMap.add(exp, idx, map);
         end if;
-        new_exp := Expression.SHARED_LITERAL(idx, exp);
+        new_exp := SHARED_LITERAL(idx, exp);
       then new_exp;
 
       else exp;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -980,7 +980,7 @@ algorithm
   outExp :=
     if Expression.isOne(exp2) then exp1
     elseif Expression.isMinusOne(exp2) then Expression.negate(exp1)
-    elseif Expression.isZero(exp1) and not Expression.isZero(exp2) then exp1
+    elseif Expression.isZero(exp1) and Expression.isNonZero(exp2) then exp1
     // fix minus signs
     // (-e1)/(-e2) = e1/e2
     // e1/(-e2) = -(e1/e2)

--- a/testsuite/simulation/modelica/NBackend/array_handling/irregular_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/irregular_for.mos
@@ -53,7 +53,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin(($i1 / 2.0) * time) ($RES_$AUX_5)
+// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
 // 	[----] end for;
 // 	 slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
 //
@@ -64,7 +64,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_1)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) x[integer($i1 / 2.0)] = x[integer($i1 / 2.0) + 1] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[integer(0.5 * $i1)] = x[1 + integer(0.5 * $i1)] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {0, 1, 2}
 //
@@ -75,7 +75,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_1)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) x[integer($i1 / 2.0)] = x[integer($i1 / 2.0) + 1] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[integer(0.5 * $i1)] = x[1 + integer(0.5 * $i1)] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {8, 7, 6, 5, 4, 3}
 //
@@ -110,7 +110,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin(($i1 / 2.0) * time) ($RES_$AUX_5)
+// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
 // 	[----] end for;
 // 	 slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
 //
@@ -121,7 +121,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_1)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) x[integer($i1 / 2.0)] = x[integer($i1 / 2.0) + 1] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[integer(0.5 * $i1)] = x[1 + integer(0.5 * $i1)] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {0, 1, 2}
 //
@@ -132,7 +132,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_1)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) x[integer($i1 / 2.0)] = x[integer($i1 / 2.0) + 1] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[integer(0.5 * $i1)] = x[1 + integer(0.5 * $i1)] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {8, 7, 6, 5, 4, 3}
 //
@@ -167,7 +167,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin(($i1 / 2.0) * time) ($RES_$AUX_5)
+// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
 // 	[----] end for;
 // 	 slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
 //
@@ -178,7 +178,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_1)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) x[integer($i1 / 2.0)] = x[integer($i1 / 2.0) + 1] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[integer(0.5 * $i1)] = x[1 + integer(0.5 * $i1)] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {0, 1, 2}
 //
@@ -189,7 +189,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_1)
 // 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) x[integer($i1 / 2.0)] = x[integer($i1 / 2.0) + 1] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[integer(0.5 * $i1)] = x[1 + integer(0.5 * $i1)] + $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {8, 7, 6, 5, 4, 3}
 //

--- a/testsuite/simulation/modelica/NBackend/array_handling/simple_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/simple_for.mos
@@ -503,7 +503,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
 // 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = x[$i1 + 1] + $FUN_1[$i1] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
 //
@@ -549,7 +549,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
 // 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = x[$i1 + 1] + $FUN_1[$i1] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
 //
@@ -595,7 +595,7 @@ val(x[3],1);
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
 // 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = x[$i1 + 1] + $FUN_1[$i1] ($RES_SIM_2)
+// 	[----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
 // 	[----] end for;
 // 	 slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
 //

--- a/testsuite/simulation/modelica/NBackend/array_handling/simple_nested_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/simple_nested_for.mos
@@ -120,7 +120,7 @@ val(x[2,1], 0.5);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
 // 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[$i1 + 1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
 // 	[----] end for;
 // 	 slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
 //
@@ -170,7 +170,7 @@ val(x[2,1], 0.5);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
 // 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[$i1 + 1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
 // 	[----] end for;
 // 	 slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
 //
@@ -220,7 +220,7 @@ val(x[2,1], 0.5);
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
 // 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[$i1 + 1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
 // 	[----] end for;
 // 	 slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
 //


### PR DESCRIPTION
### Purpose

The earlier implementation tried to reimplement `map` but didn't cover all cases.

### Approach

Just use map directly.

Unfortunately `apply` can not be defined as a generic function because the compiler can't resolve the polymorphism for some reason.
