### PR TITLE
[NB] Simplify equations structurally

### DIFF
--- a/testsuite/simulation/modelica/NBackend/event_handling/Makefile
+++ b/testsuite/simulation/modelica/NBackend/event_handling/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 compositeEvent.mos \
 eventSystem.mos \
 hybridSys.mos \
+simplifyWhen.mos\
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/event_handling/simplifyWhen.mos
+++ b/testsuite/simulation/modelica/NBackend/event_handling/simplifyWhen.mos
@@ -4,12 +4,10 @@
 
 loadString("
 model SimplifyWhen
-  Real x(start=0, fixed=true);
   Integer n;
 equation
-  der(x) = 1;
-  when {x > 0.5, initial()} then
-    n = integer(x);
+  when {time > 0.5, initial()} then
+    n = integer(time);
   end when;
 end SimplifyWhen;
 "); getErrorString();

--- a/testsuite/simulation/modelica/NBackend/event_handling/simplifyWhen.mos
+++ b/testsuite/simulation/modelica/NBackend/event_handling/simplifyWhen.mos
@@ -1,0 +1,26 @@
+// name: simplifyWhen
+// keywords: NewBackend
+// status: correct
+
+loadString("
+model SimplifyWhen
+  Real x(start=0, fixed=true);
+  Integer n;
+equation
+  der(x) = 1;
+  when {x > 0.5, initial()} then
+    n = integer(x);
+  end when;
+end SimplifyWhen;
+"); getErrorString();
+setCommandLineOptions("--newBackend"); getErrorString();
+buildModel(SimplifyWhen); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// {"SimplifyWhen","SimplifyWhen_init.xml"}
+// ""
+// endResult


### PR DESCRIPTION
### Purpose

`when`-equations need to be simplified structurally if `initial()` is replaced by `false` after the initial system is built.

### Approach

Revert part of #12781 but only simplify equation structure, not expressions since they have been simplified already by `map`.

Also add a test case so we see this before merging.