### PR TITLE
[NB] Simplify if-equation structure

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -1405,10 +1405,10 @@ public
           Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed for: " + toString(eq)});
         then fail();
       end match;
-      if Flags.isSet(Flags.DUMP_SIMPLIFY) and not isEqual(old_eq, eq)then
+      if Flags.isSet(Flags.DUMP_SIMPLIFY) and not isEqual(old_eq, eq) then
         print(indent + "### dumpSimplify | " + name + " ###\n");
-        print(indent + "[BEFORE] " + toString(old_eq) + "\n");
-        print(indent + "[AFTER ] " + toString(eq) + "\n\n");
+        print(indent + "[BEFORE]\n" + toString(old_eq, indent + "  ") + "\n");
+        print(indent + "[AFTER ]\n" + toString(eq, indent + "  ") + "\n\n");
       end if;
     end simplify;
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -1377,6 +1377,7 @@ public
         case ALGORITHM() algorithm
           eq.alg := SimplifyModel.simplifyAlgorithm(eq.alg);
         then eq;
+
         case WHEN_EQUATION() algorithm
           new_eq := match WhenEquationBody.simplify(SOME(eq.body))
             local
@@ -1387,6 +1388,7 @@ public
             else Equation.DUMMY_EQUATION();
           end match;
         then new_eq;
+
         case IF_EQUATION() algorithm
           new_eq := match IfEquationBody.simplify(SOME(eq.body))
             local
@@ -1406,6 +1408,7 @@ public
           Error.addMessage(Error.INTERNAL_ERROR, {getInstanceName() + " failed for: " + toString(eq)});
         then fail();
       end match;
+
       if Flags.isSet(Flags.DUMP_SIMPLIFY) and not isEqual(old_eq, eq) then
         print(indent + "### dumpSimplify | " + name + " ###\n");
         print(indent + "[BEFORE]\n" + toString(old_eq, indent + "  ") + "\n");

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -1338,7 +1338,7 @@ public
       algorithm
         e := func(e);
       end apply;
-      Equation old_eq = eq;
+      Equation old_eq;
     algorithm
       if Flags.isSet(Flags.DUMP_SIMPLIFY) and not stringEqual(indent, "") then
         print("\n");
@@ -1348,6 +1348,7 @@ public
       eq := map(eq, simplifyExp, mapFunc = apply);
 
       // simplify equation structure
+      old_eq := eq;
       eq := match eq
         local
           Equation new_eq;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -701,7 +701,7 @@ public
           tupl_recd_str := if Type.isTuple(eq.ty) then "[TUPL] " else "[RECD] ";
         then str + tupl_recd_str + s + " " + Expression.toString(eq.lhs) + " = " + Expression.toString(eq.rhs) + EquationAttributes.toString(eq.attr, " ");
         case ALGORITHM()       then str + "[ALGO] " + s + EquationAttributes.toString(eq.attr, " ") + "\n" + Algorithm.toString(eq.alg, str + "[----] ");
-        case IF_EQUATION()     then str + IfEquationBody.toString(eq.body, str + "[----] ", "[-IF-] " + s + EquationAttributes.toString(eq.attr, " "));
+        case IF_EQUATION()     then str + IfEquationBody.toString(eq.body, str + "[----] ", "[-IF-] " + s + EquationAttributes.toString(eq.attr, " ") + "\n");
         case FOR_EQUATION()    then str + forEquationToString(eq.iter, eq.body, "", str + "[----] ", "[FOR-] " + s + EquationAttributes.toString(eq.attr, " "));
         case WHEN_EQUATION()   then str + WhenEquationBody.toString(eq.body, str + "[----] ", "[WHEN] " + s + EquationAttributes.toString(eq.attr, " ") + "\n");
         case AUX_EQUATION()    then str + "[AUX-] " + s + "Auxiliary equation for " + Variable.toString(Pointer.access(eq.auxiliary));
@@ -1350,7 +1350,6 @@ public
       eq := match eq
         local
           Equation new_eq;
-          WhenEquationBody body;
 
         case SCALAR_EQUATION() algorithm
           if Expression.isEqual(eq.lhs, eq.rhs) then
@@ -1378,6 +1377,18 @@ public
         then eq;
         case WHEN_EQUATION() algorithm
           new_eq := match WhenEquationBody.simplify(SOME(eq.body))
+            local
+              WhenEquationBody body;
+            case SOME(body) algorithm
+              eq.body := body;
+            then eq;
+            else Equation.DUMMY_EQUATION();
+          end match;
+        then new_eq;
+        case IF_EQUATION() algorithm
+          new_eq := match IfEquationBody.simplify(SOME(eq.body))
+            local
+              IfEquationBody body;
             case SOME(body) algorithm
               eq.body := body;
             then eq;
@@ -1387,7 +1398,6 @@ public
 
         // ToDo: implement the following correctly:
 
-        case IF_EQUATION()      then eq;
         case FOR_EQUATION()     then eq;
         case AUX_EQUATION()     then eq;
         else algorithm
@@ -2297,20 +2307,21 @@ public
       input String elseStr = "";
       input Boolean selfCall = false;
       output String str;
-    protected
-      IfEquationBody elseIf;
     algorithm
+      str := elseStr;
+      if not selfCall then
+        str := str + indent;
+      end if;
       if not Expression.isEnd(body.condition) then
-        str := elseStr + "if " + Expression.toString(body.condition) + " then\n";
+        str := str + "if " + Expression.toString(body.condition) + " then\n";
       else
-        str := elseStr + "\n";
+        str := str + "\n";
       end if;
       for eqn in body.then_eqns loop
         str := str + Equation.toString(Pointer.access(eqn), indent + "  ") + "\n";
       end for;
       if isSome(body.else_if) then
-        SOME(elseIf) := body.else_if;
-        str := str + toString(elseIf, indent, indent + "else", true);
+        str := str + toString(Util.getOption(body.else_if), indent, indent + "else", true);
       end if;
       if not selfCall then
         str := str + indent + "end if;";
@@ -2507,6 +2518,51 @@ public
       end for;
     end split;
 
+    function simplify
+      input output Option<IfEquationBody> body;
+      input Integer depth = 1;
+    algorithm
+      body := match body
+        local
+          IfEquationBody b;
+          Expression condition;
+          list<Expression> conditions;
+
+        case SOME(b) algorithm
+          // if the condition is True -> cut later unreachable branches
+          // FIXME can't yet handle removing the IF altogether so at least two branches have to remain.
+          if Expression.isTrue(b.condition) and depth >= 2 then
+            b.condition := Expression.END();
+            b.else_if := NONE();
+          else
+            b.else_if := simplify(b.else_if, depth + 1);
+          end if;
+          // if the condition is False -> skip this unreachable branch
+          // FIXME can't yet handle removing the IF altogether so at least two branches have to remain.
+          if Expression.isFalse(b.condition) and depth - 1 + numberOfBranches(b.else_if) >= 2 then
+            body := b.else_if;
+          else
+            body := SOME(b);
+          end if;
+        then body;
+
+        // NONE() stays NONE()
+        else body;
+      end match;
+    end simplify;
+
+    function numberOfBranches
+      input Option<IfEquationBody> body;
+      output Integer numBranches;
+    algorithm
+      numBranches := match body
+        local
+          IfEquationBody b;
+        case SOME(b) then 1 + numberOfBranches(b.else_if);
+        else 0;
+      end match;
+    end numberOfBranches;
+
     function isRecordOrTupleEquation
       "only checks first layer body if it returns multiple variables"
       input IfEquationBody body;
@@ -2585,20 +2641,17 @@ public
       input String elseStr = "";
       input Boolean selfCall = false;
       output String str;
-    protected
-      WhenEquationBody elseWhen;
     algorithm
       str := elseStr;
       if not selfCall then
         str := str + indent;
       end if;
-      str := str + "when " + Expression.toString(body.condition) + " then \n";
+      str := str + "when " + Expression.toString(body.condition) + " then\n";
       for stmt in body.when_stmts loop
         str := str + WhenStatement.toString(stmt, indent + "  ") + "\n";
       end for;
       if isSome(body.else_when) then
-        SOME(elseWhen) := body.else_when;
-        str := str + toString(elseWhen, indent, indent +"else ", true);
+        str := str + toString(Util.getOption(body.else_when), indent, indent + "else", true);
       end if;
       if not selfCall then
         str := str + indent + "end when;";

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -1018,6 +1018,7 @@ protected
         Expression condition;
 
       // logical unarys: e.g. not a
+      // FIXME this is wrong for `not initial()`
       case Expression.LUNARY() algorithm
         (exp, bucket) := collectEventsCondition(exp, Pointer.access(bucket_ptr), iter, eqn, funcTree, createAux);
         Pointer.update(bucket_ptr, bucket);

--- a/testsuite/simulation/modelica/NBackend/simplification/Makefile
+++ b/testsuite/simulation/modelica/NBackend/simplification/Makefile
@@ -1,9 +1,8 @@
 TEST = ../../../../rtest -v
 
 TESTFILES = \
-compositeEvent.mos \
-eventSystem.mos \
-hybridSys.mos \
+simplifyIf.mos\
+simplifyWhen.mos\
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/simplification/simplifyIf.mos
+++ b/testsuite/simulation/modelica/NBackend/simplification/simplifyIf.mos
@@ -27,56 +27,62 @@ buildModel(SimplifyIf); getErrorString();
 // true
 // ""
 // ### dumpSimplify | NBackendDAE.simplify ###
-// [BEFORE] [-IF-] (1) ($RES_SIM_0)
-// [----] if initial() then
-// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
-// [----] elseif time > 0.5 then
-// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
-// [----] elseif true then
-// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
-// [----] else
-// [----]   [SCAL] (1) n = 4 ($RES_SIM_4)
-// [----] end if;
-// [AFTER ] [-IF-] (1) ($RES_SIM_0)
-// [----] if initial() then
-// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
-// [----] elseif time > 0.5 then
-// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
-// [----] else
-// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
-// [----] end if;
+// [BEFORE]
+//   [-IF-] (1) ($RES_SIM_0)
+//   [----] if initial() then
+//   [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+//   [----] elseif time > 0.5 then
+//   [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+//   [----] elseif true then
+//   [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+//   [----] else
+//   [----]   [SCAL] (1) n = 4 ($RES_SIM_4)
+//   [----] end if;
+// [AFTER ]
+//   [-IF-] (1) ($RES_SIM_0)
+//   [----] if initial() then
+//   [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+//   [----] elseif time > 0.5 then
+//   [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+//   [----] else
+//   [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+//   [----] end if;
 //
 // ### dumpSimplify |  ###
-// [BEFORE] [-IF-] (1) ($RES_SIM_0)
-// [----] if false then
-// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
-// [----] elseif $TEV_0 then
-// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
-// [----] else
-// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
-// [----] end if;
-// [AFTER ] [-IF-] (1) ($RES_SIM_0)
-// [----] if $TEV_0 then
-// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
-// [----] else
-// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
-// [----] end if;
+// [BEFORE]
+//   [-IF-] (1) ($RES_SIM_0)
+//   [----] if false then
+//   [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+//   [----] elseif $TEV_0 then
+//   [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+//   [----] else
+//   [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+//   [----] end if;
+// [AFTER ]
+//   [-IF-] (1) ($RES_SIM_0)
+//   [----] if $TEV_0 then
+//   [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+//   [----] else
+//   [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+//   [----] end if;
 //
 // ### dumpSimplify |  ###
-// [BEFORE] [-IF-] (1) ($RES_SIM_0)
-// [----] if true then
-// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
-// [----] elseif $TEV_0 then
-// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
-// [----] else
-// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
-// [----] end if;
-// [AFTER ] [-IF-] (1) ($RES_SIM_0)
-// [----] if true then
-// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
-// [----] else
-// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
-// [----] end if;
+// [BEFORE]
+//   [-IF-] (1) ($RES_SIM_0)
+//   [----] if true then
+//   [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+//   [----] elseif $TEV_0 then
+//   [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+//   [----] else
+//   [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+//   [----] end if;
+// [AFTER ]
+//   [-IF-] (1) ($RES_SIM_0)
+//   [----] if true then
+//   [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+//   [----] else
+//   [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+//   [----] end if;
 //
 // {"SimplifyIf","SimplifyIf_init.xml"}
 // ""

--- a/testsuite/simulation/modelica/NBackend/simplification/simplifyIf.mos
+++ b/testsuite/simulation/modelica/NBackend/simplification/simplifyIf.mos
@@ -1,0 +1,83 @@
+// name: simplifyIf
+// keywords: NewBackend
+// status: correct
+
+loadString("
+model SimplifyIf
+  Integer n;
+  Boolean b = true;
+equation
+  if initial() then
+    n = 1;
+  elseif time > 0.5 then
+    n = 2;
+  elseif b then
+    n = 3;
+  else
+    n = 4;
+  end if;
+end SimplifyIf;
+"); getErrorString();
+setCommandLineOptions("--newBackend -d=dumpSimplify"); getErrorString();
+buildModel(SimplifyIf); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// ### dumpSimplify | NBackendDAE.simplify ###
+// [BEFORE] [-IF-] (1) ($RES_SIM_0)
+// [----] if initial() then
+// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+// [----] elseif time > 0.5 then
+// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+// [----] elseif true then
+// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+// [----] else
+// [----]   [SCAL] (1) n = 4 ($RES_SIM_4)
+// [----] end if;
+// [AFTER ] [-IF-] (1) ($RES_SIM_0)
+// [----] if initial() then
+// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+// [----] elseif time > 0.5 then
+// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+// [----] else
+// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+// [----] end if;
+//
+// ### dumpSimplify |  ###
+// [BEFORE] [-IF-] (1) ($RES_SIM_0)
+// [----] if false then
+// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+// [----] elseif $TEV_0 then
+// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+// [----] else
+// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+// [----] end if;
+// [AFTER ] [-IF-] (1) ($RES_SIM_0)
+// [----] if $TEV_0 then
+// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+// [----] else
+// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+// [----] end if;
+//
+// ### dumpSimplify |  ###
+// [BEFORE] [-IF-] (1) ($RES_SIM_0)
+// [----] if true then
+// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+// [----] elseif $TEV_0 then
+// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+// [----] else
+// [----]   [SCAL] (1) n = 3 ($RES_SIM_3)
+// [----] end if;
+// [AFTER ] [-IF-] (1) ($RES_SIM_0)
+// [----] if true then
+// [----]   [SCAL] (1) n = 1 ($RES_SIM_1)
+// [----] else
+// [----]   [SCAL] (1) n = 2 ($RES_SIM_2)
+// [----] end if;
+//
+// {"SimplifyIf","SimplifyIf_init.xml"}
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/simplification/simplifyWhen.mos
+++ b/testsuite/simulation/modelica/NBackend/simplification/simplifyWhen.mos
@@ -20,14 +20,16 @@ buildModel(SimplifyWhen); getErrorString();
 // true
 // ""
 // ### dumpSimplify |  ###
-// [BEFORE] [WHEN] (1) ($RES_SIM_0)
-// [----] when {$TEV_0, false} then
-// [----]   n := integer(time)
-// [----] end when;
-// [AFTER ] [WHEN] (1) ($RES_SIM_0)
-// [----] when $TEV_0 then
-// [----]   n := integer(time)
-// [----] end when;
+// [BEFORE]
+//   [WHEN] (1) ($RES_SIM_0)
+//   [----] when {$TEV_0, false} then
+//   [----]   n := integer(time)
+//   [----] end when;
+// [AFTER ]
+//   [WHEN] (1) ($RES_SIM_0)
+//   [----] when $TEV_0 then
+//   [----]   n := integer(time)
+//   [----] end when;
 //
 // {"SimplifyWhen","SimplifyWhen_init.xml"}
 // ""

--- a/testsuite/simulation/modelica/NBackend/simplification/simplifyWhen.mos
+++ b/testsuite/simulation/modelica/NBackend/simplification/simplifyWhen.mos
@@ -11,7 +11,7 @@ equation
   end when;
 end SimplifyWhen;
 "); getErrorString();
-setCommandLineOptions("--newBackend"); getErrorString();
+setCommandLineOptions("--newBackend -d=dumpSimplify"); getErrorString();
 buildModel(SimplifyWhen); getErrorString();
 
 // Result:
@@ -19,6 +19,16 @@ buildModel(SimplifyWhen); getErrorString();
 // ""
 // true
 // ""
+// ### dumpSimplify |  ###
+// [BEFORE] [WHEN] (1) ($RES_SIM_0)
+// [----] when {$TEV_0, false} then
+// [----]   n := integer(time)
+// [----] end when;
+// [AFTER ] [WHEN] (1) ($RES_SIM_0)
+// [----] when $TEV_0 then
+// [----]   n := integer(time)
+// [----] end when;
+//
 // {"SimplifyWhen","SimplifyWhen_init.xml"}
 // ""
 // endResult


### PR DESCRIPTION
### Purpose

Remove branches of `if`-equation if there are boolean literals..

### Approach

* When there is a `true` condition, everything after can be removed.
* When there is a `false` condition, that branch can be removed.

The only catch is that at least two branches must remain. Otherwise the `if`-equation becomes a list of equations and that's difficult to handle with the current way we simplify equations.

### TODO
- [x] Add test cases
