### PR TITLE
OMCompiler: Fix missing fstream include

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp
@@ -39,6 +39,7 @@
 #include "om_pm_model.hpp"
 
 #include <cstring>
+#include <fstream>
 // #include <pugixml.hpp>
 
 #include "json.hpp"


### PR DESCRIPTION
This fixes a missing include in omcompiler when using boost 1.86:

```
$SRC_DIR/OMCompiler/SimulationRuntime/ParModelica/auto/om_pm_model.cpp:272:33: error: variable 'std::ifstream f_s' has initializer but incomplete type
2024-08-17T19:08:00.1183913Z   272 |     std::ifstream  f_s(json_file);
```