### PR TITLE
Fix InteractiveUtil.getInheritedAnnotation

### DIFF
--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -6058,17 +6058,19 @@ algorithm
         // Check if we have any more inherited annotations.
         extends_path :: extends_paths := extends_paths;
         for a in listRest(extends_oannl) loop
-          SOME(extends_ann2) := a;
-          if not valueEq(extends_ann, extends_ann2) then
-            // Found an inherited annotation that's not equal to the first one, print a warning.
-            Error.addMessage(Error.CONFLICTING_INHERITED_ANNOTATIONS,
-              {annotationName, AbsynUtil.pathString(modelPath),
-               Dump.unparseModificationStr(extends_ann), AbsynUtil.pathString(extends_path),
-               Dump.unparseModificationStr(extends_ann2), AbsynUtil.pathString(listHead(extends_paths))});
-            break;
-          end if;
+          if isSome(a) then
+            SOME(extends_ann2) := a;
+            if not valueEq(extends_ann, extends_ann2) then
+              // Found an inherited annotation that's not equal to the first one, print a warning.
+              Error.addMessage(Error.CONFLICTING_INHERITED_ANNOTATIONS,
+                {annotationName, AbsynUtil.pathString(modelPath),
+                 Dump.unparseModificationStr(extends_ann), AbsynUtil.pathString(extends_path),
+                 Dump.unparseModificationStr(extends_ann2), AbsynUtil.pathString(listHead(extends_paths))});
+              break;
+            end if;
 
-          extends_paths := listRest(extends_paths);
+            extends_paths := listRest(extends_paths);
+          end if;
         end for;
       end if;
 

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -57,6 +57,7 @@ getElementAnnotation.mos \
 getIconAnnotation.mos \
 getSimulationOptions1.mos \
 getSimulationOptions2.mos \
+getSimulationOptions3.mos \
 IfStatementIllegal.mos \
 IfStatement.mos\
 IllegalGraphics.mos\

--- a/testsuite/openmodelica/interactive-API/getSimulationOptions3.mos
+++ b/testsuite/openmodelica/interactive-API/getSimulationOptions3.mos
@@ -1,0 +1,29 @@
+// name: getSimulationOptions3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  model A
+    annotation(experiment(StopTime = 2.0));
+  end A;
+
+  model B
+  end B;
+
+  model M
+    extends A;
+    extends B;
+  end M;
+");
+getErrorString();
+
+getSimulationOptions(M);
+getErrorString();
+
+// Result:
+// true
+// ""
+// (0.0,2.0,1e-6,500,0.004)
+// ""
+// endResult


### PR DESCRIPTION
- Check that the option contains a value before trying to access it.

Fixes #12728