### PR TITLE
[NB] Add variable types int and bool for collecting attributes

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -925,10 +925,10 @@ protected
     if count_fixed == 0 then
       if not List.allEqual(start_lst, Expression.isEqual) then
         if Flags.isSet(Flags.DUMP_REPL) then
-          Error.addCompilerWarning(getInstanceName() + ": No variables are fixed and they have different start values.\n"
+          Error.addCompilerWarning(getInstanceName() + ": Alias set with conflicting unfixed start values detected.\n"
                                   + AliasSet.toString(set) + "\n\tStart map after replacements:\n\t" + UnorderedMap.toString(start_map, ComponentRef.toString, Expression.toString,"\n\t"));
         else
-          Error.addCompilerWarning(getInstanceName() + ": No variables are fixed and they have different start values. Use -d=dumprepl for more information.\n");
+          Error.addCompilerWarning(getInstanceName() + ": Alias set with conflicting unfixed start values detected. Use -d=dumprepl for more information.\n");
         end if;
       end if;
     elseif count_fixed > 1 then
@@ -1228,11 +1228,17 @@ protected
     algorithm
       array_maps := listArray({attrcollector.min_val_map, attrcollector.max_val_map, attrcollector.start_map, attrcollector.fixed_map, attrcollector.nominal_map});
       array_names := listArray({"Min map", "Max map", "Start map", "Fixed map", "Nominal map"});
-      for i in 1:arrayLength(array_names) loop
-        str := str + arrayGet(array_names, i) + ":\n\t"+ UnorderedMap.toString(array_maps[i], ComponentRef.toString, Expression.toString, "\n\t") + "\n";
+      for i in 1:arrayLength(array_maps) loop
+        if UnorderedMap.isEmpty(array_maps[i]) == false then
+          str := str + arrayGet(array_names, i) + ":\n\t"+ UnorderedMap.toString(array_maps[i], ComponentRef.toString, Expression.toString, "\n\t") + "\n";
+        end if;
       end for;
-      str := str + "StateSelect map" + ":\n\t"+ UnorderedMap.toString(attrcollector.stateSelect_map, ComponentRef.toString, BackendExtension.VariableAttributes.stateSelectString, "\n\t") + "\n";
-      str := str + "TearingSelect map" + ":\n\t"+ UnorderedMap.toString(attrcollector.tearingSelect_map, ComponentRef.toString, BackendExtension.VariableAttributes.tearingSelectString, "\n\t") + "\n";
+      if UnorderedMap.isEmpty(attrcollector.stateSelect_map) == false then
+        str := str + "StateSelect map" + ":\n\t"+ UnorderedMap.toString(attrcollector.stateSelect_map, ComponentRef.toString, BackendExtension.VariableAttributes.stateSelectString, "\n\t") + "\n";
+      end if;
+      if UnorderedMap.isEmpty(attrcollector.tearingSelect_map) == false then
+        str := str + "TearingSelect map" + ":\n\t"+ UnorderedMap.toString(attrcollector.tearingSelect_map, ComponentRef.toString, BackendExtension.VariableAttributes.tearingSelectString, "\n\t") + "\n";
+      end if;
     end toString;
 
     function fixValues

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -1176,7 +1176,7 @@ protected
 
       case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_REAL())) algorithm
         attrcollector := optionMinMax(var_ptr, attr.min, attr.max, attrcollector);
-        attrcollector := optionMinMax(var_ptr, attr.start, attr.fixed, attrcollector);
+        attrcollector := optionStartFixed(var_ptr, attr.start, attr.fixed, attrcollector);
         if Util.isSome(attr.nominal) then
           nominal_val := Util.getOption(attr.nominal);
           UnorderedMap.add(BVariable.getVarName(var_ptr), nominal_val, attrcollector.nominal_map);
@@ -1196,11 +1196,11 @@ protected
 
       case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_INT())) algorithm
         attrcollector := optionMinMax(var_ptr, attr.min, attr.max, attrcollector);
-        attrcollector := optionMinMax(var_ptr, attr.start, attr.fixed, attrcollector);
+        attrcollector := optionStartFixed(var_ptr, attr.start, attr.fixed, attrcollector);
       then ();
 
       case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_BOOL())) algorithm
-        attrcollector := optionMinMax(var_ptr, attr.start, attr.fixed, attrcollector);
+        attrcollector := optionStartFixed(var_ptr, attr.start, attr.fixed, attrcollector);
       then ();
 
       else ();

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -1115,6 +1115,42 @@ protected
     print("Mean = "+String(mean_val));
   end mean;
 
+  function optionMinMax
+    "Collects min and max attributes if available."
+    input Pointer<Variable> var_ptr;
+    input Option<Expression> attr_min, attr_max;
+    input output AttributeCollector attrcollector;
+  protected
+    Expression min_val, max_val;
+  algorithm
+    if Util.isSome(attr_min) then
+      min_val := Util.getOption(attr_min);
+      UnorderedMap.add(BVariable.getVarName(var_ptr), min_val, attrcollector.min_val_map);
+    end if;
+    if Util.isSome(attr_max) then
+      max_val := Util.getOption(attr_max);
+      UnorderedMap.add(BVariable.getVarName(var_ptr), max_val, attrcollector.max_val_map);
+    end if;
+  end optionMinMax;
+
+  function optionStartFixed
+    "Collects start and fixed attributes if available."
+    input Pointer<Variable> var_ptr;
+    input Option<Expression> attr_start, attr_fixed;
+    input output AttributeCollector attrcollector;
+  protected
+    Expression start_val, fixed_val;
+  algorithm
+    if Util.isSome(attr_start) then
+      start_val := Util.getOption(attr_start);
+      UnorderedMap.add(BVariable.getVarName(var_ptr), start_val, attrcollector.start_map);
+    end if;
+    if Util.isSome(attr_fixed) then
+      fixed_val := Util.getOption(attr_fixed);
+      UnorderedMap.add(BVariable.getVarName(var_ptr), fixed_val, attrcollector.fixed_map);
+    end if;
+  end optionStartFixed;
+
   function rateVar
     "Rates a variable based on attributes"
     input Pointer<Variable> var_ptr;
@@ -1122,7 +1158,7 @@ protected
     input output AttributeCollector attrcollector;
   protected
     ComponentRef name;
-    Expression min_val, max_val, start_val, fixed_val, nominal_val;
+    Expression nominal_val;
     StateSelect stateSelect_val;
     TearingSelect tearingSelect_val;
   algorithm
@@ -1139,23 +1175,8 @@ protected
           BackendExtension.VariableAttributes attr;
 
       case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_REAL())) algorithm
-
-        if Util.isSome(attr.min) then
-          min_val := Util.getOption(attr.min);
-          UnorderedMap.add(BVariable.getVarName(var_ptr), min_val, attrcollector.min_val_map);
-        end if;
-        if Util.isSome(attr.max) then
-          max_val := Util.getOption(attr.max);
-          UnorderedMap.add(BVariable.getVarName(var_ptr), max_val, attrcollector.max_val_map);
-        end if;
-        if Util.isSome(attr.start) then
-          start_val := Util.getOption(attr.start);
-          UnorderedMap.add(BVariable.getVarName(var_ptr), start_val, attrcollector.start_map);
-        end if;
-        if Util.isSome(attr.fixed) then
-          fixed_val := Util.getOption(attr.fixed);
-          UnorderedMap.add(BVariable.getVarName(var_ptr), fixed_val, attrcollector.fixed_map);
-        end if;
+        attrcollector := optionMinMax(var_ptr, attr.min, attr.max, attrcollector);
+        attrcollector := optionMinMax(var_ptr, attr.start, attr.fixed, attrcollector);
         if Util.isSome(attr.nominal) then
           nominal_val := Util.getOption(attr.nominal);
           UnorderedMap.add(BVariable.getVarName(var_ptr), nominal_val, attrcollector.nominal_map);
@@ -1171,10 +1192,17 @@ protected
           tearingSelect_val := Util.getOption(attr.tearingSelect);
           UnorderedMap.add(BVariable.getVarName(var_ptr), tearingSelect_val, attrcollector.tearingSelect_map);
         end if;
-
       then ();
 
-      case Variable.VARIABLE(backendinfo = BackendExtension.BACKEND_INFO(varKind = BackendExtension.VariableKind.DISCRETE())) then ();
+      case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_INT())) algorithm
+        attrcollector := optionMinMax(var_ptr, attr.min, attr.max, attrcollector);
+        attrcollector := optionMinMax(var_ptr, attr.start, attr.fixed, attrcollector);
+      then ();
+
+      case Variable.VARIABLE(backendinfo=BackendExtension.BACKEND_INFO(attributes=attr as BackendExtension.VariableAttributes.VAR_ATTR_BOOL())) algorithm
+        attrcollector := optionMinMax(var_ptr, attr.start, attr.fixed, attrcollector);
+      then ();
+
       else ();
     end match;
   end rateVar;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -489,7 +489,7 @@ public
           attributes.startOrigin  := Util.applyOption(attributes.startOrigin, function Expression.map(func = func));
         then attributes;
 
-        case VAR_ATTR_INT() algorithm
+        case VAR_ATTR_BOOL() algorithm
           attributes.quantity     := Util.applyOption(attributes.quantity, function Expression.map(func = func));
           attributes.start        := Util.applyOption(attributes.start, function Expression.map(func = func));
           attributes.fixed        := Util.applyOption(attributes.fixed, function Expression.map(func = func));

--- a/testsuite/simulation/modelica/NBackend/basics/Alias_test5.mos
+++ b/testsuite/simulation/modelica/NBackend/basics/Alias_test5.mos
@@ -2,7 +2,7 @@
 // keywords: NewBackend, Alias
 // status: correct
 // Throws two warnings: 1. The quotient of the greatest and lowest nominal values is greater than the nominal threshold.
-//                      2. No variables are fixed and they have different start values.
+//                      2. Alias set with conflicting unfixed start values detected.
 
 loadString("
   model Test5
@@ -77,7 +77,7 @@ simulate(Test5); getErrorString();
 // 	Nominal map after replacements:
 // 	(x, 2.0)
 // 	(z, 1e7)
-// Warning: NBAlias.setStartFixed: No variables are fixed and they have different start values.
+// Warning: NBAlias.setStartFixed: Alias set with conflicting unfixed start values detected.
 // 	<No Constant/Parameter Binding>
 // 	### Set Equations:
 // 	[SCAL] (1) z = $FUN_1 ($RES_SIM_0)

--- a/testsuite/simulation/modelica/NBackend/event_handling/hybridSys.mos
+++ b/testsuite/simulation/modelica/NBackend/event_handling/hybridSys.mos
@@ -26,7 +26,8 @@ val(phase_Start, 1.1);
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
-// ""
+// "Warning: NBAlias.setStartFixed: Alias set with conflicting unfixed start values detected. Use -d=dumprepl for more information.
+// "
 // 10.0
 // 2.353351017981785
 // 1.0


### PR DESCRIPTION
### Purpose

Previously, the attribute collector functioned only for real variables. It now also includes int and bool variables. 

### Approach

Both functions _optionMinMax_ and _optionStartFixed_ operates as auxiliary functions. 
