### PR TITLE
fix OMSimulator dll path when building from Makefile

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -112,6 +112,7 @@ omsimulator:
 	cd OMSimulator/build && cmake .. \
 		-G $(CMAKE_TARGET) \
 		-DCMAKE_VERBOSE_MAKEFILE=ON \
+		-DOPENMODELICA_MAKEFILE_BUILD=true \
 		-DCMAKE_INSTALL_PREFIX=../install
 	$(MAKE) -C OMSimulator/build/ install
 	cp -vpPR OMSimulator/install/include/OMSimulator/ $(OMBUILDDIR)/include/omc


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1306

### Purpose

Set `OPENMODELICA_MAKEFILE_BUILD=true` when building `OMSimulator` from `Makefile`

