### PR TITLE
Improve type checking

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -270,7 +270,7 @@ public
       ty::tys2 := tys2;
       pos := pos-1;
       ty2 := Type.setArrayElementType(ty, resTy);
-      (arg2, ty1, mk) := TypeCheck.matchTypes(ty, ty2, arg, allowUnknown = true);
+      (arg2, ty1, mk) := TypeCheck.matchTypes(ty, ty2, arg, NFTypeCheck.ALLOW_UNKNOWN);
       if TypeCheck.isIncompatibleMatch(mk) then
         Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH, {String(pos), "cat", "arg", Expression.toString(arg), Type.toString(ty), Type.toString(ty2)}, info);
       end if;
@@ -317,7 +317,7 @@ public
     for arg in args2 loop
       ty::tys2 := tys2;
       pos := pos-1;
-      (arg2, ty1, mk) := TypeCheck.matchTypes(ty, resTyToMatch, arg, allowUnknown=true);
+      (arg2, ty1, mk) := TypeCheck.matchTypes(ty, resTyToMatch, arg, NFTypeCheck.ALLOW_UNKNOWN);
       if TypeCheck.isIncompatibleMatch(mk) then
         Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH, {String(pos), "cat", "arg", Expression.toString(arg), Type.toString(ty), Type.toString(resTyToMatch)}, info);
       end if;
@@ -879,7 +879,7 @@ protected
     // Second argument must be Real, array of allowed expressions or record
     // containing only components of allowed expressions.
     // TODO: Also handle records here.
-    (arg2, ty, mk) := TypeCheck.matchTypes(ty2, Type.setArrayElementType(ty2, Type.REAL()), arg2, true);
+    (arg2, ty, mk) := TypeCheck.matchTypes(ty2, Type.setArrayElementType(ty2, Type.REAL()), arg2, NFTypeCheck.ALLOW_UNKNOWN);
 
     if not TypeCheck.isValidArgumentMatch(mk) then
       Error.addSourceMessageAndFail(Error.ARG_TYPE_MISMATCH,

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpandableConnectors.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpandableConnectors.mo
@@ -473,7 +473,7 @@ algorithm
   // Check that the types match now that the connectors have been augmented.
   e1 := Expression.CREF(ty1, Connector.name(c1));
   e2 := Expression.CREF(ty2, Connector.name(c2));
-  (_, _, _, mk) := TypeCheck.matchExpressions(e1, ty1, e2, ty2, allowUnknown = true);
+  (_, _, _, mk) := TypeCheck.matchExpressions(e1, ty1, e2, ty2, NFTypeCheck.ALLOW_UNKNOWN);
 
   if TypeCheck.isIncompatibleMatch(mk) then
     Error.addSourceMessageAndFail(Error.CONNECT_TYPE_MISMATCH,

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -1337,7 +1337,7 @@ uniontype Function
 
       // Check if the type of the argument and the input parameter matches exactly.
       input_ty := Component.getType(comp);
-      (arg_exp, ty, mk) := TypeCheck.matchTypes(arg_ty, input_ty, arg_exp, allowUnknown = true);
+      (arg_exp, ty, mk) := TypeCheck.matchTypes(arg_ty, input_ty, arg_exp, NFTypeCheck.ALLOW_UNKNOWN);
       matched := TypeCheck.isValidArgumentMatch(mk);
 
       if not matched and vectorize then
@@ -1415,7 +1415,7 @@ uniontype Function
     // Check that the argument and the input parameter are type compatible when
     // the dimensions to vectorize over has been removed from the argument's type.
     rest_ty := Type.liftArrayLeftList(Type.arrayElementType(argTy), rest_dims);
-    (argExp, argTy, matchKind) := TypeCheck.matchTypes(rest_ty, inputTy, argExp, allowUnknown = false);
+    (argExp, argTy, matchKind) := TypeCheck.matchTypes(rest_ty, inputTy, argExp);
   end matchArgVectorized;
 
   function fillUnknownVectorizedDims
@@ -1745,7 +1745,7 @@ uniontype Function
         // For each slot that's filled, type check the argument and add it to
         // the arguments of the partial function application.
         SOME(ty_arg) := slot.arg;
-        (arg, _, mk) := TypeCheck.matchTypes(ty_arg.ty, InstNode.getType(slot.node), ty_arg.value, true);
+        (arg, _, mk) := TypeCheck.matchTypes(ty_arg.ty, InstNode.getType(slot.node), ty_arg.value, NFTypeCheck.ALLOW_UNKNOWN);
 
         if TypeCheck.isIncompatibleMatch(mk) then
           Error.addSourceMessage(Error.NAMED_ARG_TYPE_MISMATCH,

--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -1542,12 +1542,6 @@ uniontype InstNode
     else
       same := false;
     end try;
-
-    // TODO: This is wrong, but removing it breakes some expandable connectors
-    //       at the moment.
-    if not same then
-      same := name(node1) == name(node2);
-    end if;
   end isSame;
 
   function checkIdentical


### PR DESCRIPTION
- Change `InstNode.isSame` to not use name equality.
- Replace the `allowUnknown` flag used by the type checking functions with a bit field to allow more options.
- Allow records to contain differently sized arrays when used as array elements.
- Change `Typing.typeArray` to type the first element separately, to avoid having to type match against an unknown type.