### PR TITLE
Fix type checking of connectors

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTypeCheck.mo
@@ -1859,10 +1859,10 @@ algorithm
     opt := setOption(opt, IGNORE_DIMENSIONS);
   end if;
 
-  () := match (cls1, cls2, expression)
+  () := match (cls1, actualType, cls2, expectedType, expression)
 
-    case (Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps1)),
-          Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps2)),
+    case (Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps1)), _,
+          Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps2)), _,
           Expression.RECORD(elements = elements))
       algorithm
         matchKind := MatchKind.PLUG_COMPATIBLE;
@@ -1906,8 +1906,8 @@ algorithm
       then
         ();
 
-    case (Class.INSTANCED_CLASS(ty = Type.COMPLEX(complexTy = cty1 as ComplexType.CONNECTOR())),
-          Class.INSTANCED_CLASS(ty = Type.COMPLEX(complexTy = cty2 as ComplexType.CONNECTOR())), _)
+    case (_, Type.COMPLEX(complexTy = cty1 as ComplexType.CONNECTOR()),
+          _, Type.COMPLEX(complexTy = cty2 as ComplexType.CONNECTOR()), _)
       algorithm
         matchKind := matchComponentList(cty1.potentials, cty2.potentials, options);
         if matchKind <> MatchKind.NOT_COMPATIBLE then
@@ -1923,8 +1923,8 @@ algorithm
       then
         ();
 
-    case (Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps1)),
-          Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps2)), _)
+    case (Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps1)), _,
+          Class.INSTANCED_CLASS(elements = ClassTree.FLAT_TREE(components = comps2)), _, _)
       algorithm
         matchKind := MatchKind.PLUG_COMPATIBLE;
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -3129,7 +3129,8 @@ algorithm
   // Expandable connectors can only be type checked after they've been augmented during
   // the connection handling.
   if not (lhs_deleted or rhs_deleted) and
-     not (Type.isExpandableConnector(lhs_ty) or Type.isExpandableConnector(rhs_ty)) then
+     not (Type.isExpandableConnector(Type.arrayElementType(lhs_ty)) or
+          Type.isExpandableConnector(Type.arrayElementType(rhs_ty))) then
     (lhs, rhs, _, mk) := TypeCheck.matchExpressions(lhs, lhs_ty, rhs, rhs_ty, NFTypeCheck.ALLOW_UNKNOWN);
 
     if TypeCheck.isIncompatibleMatch(mk) then

--- a/testsuite/flattening/modelica/scodeinst/ExpandableConnector14.mo
+++ b/testsuite/flattening/modelica/scodeinst/ExpandableConnector14.mo
@@ -1,0 +1,24 @@
+// name: ExpandableConnector14
+// keywords: expandable connector
+// status: correct
+// cflags: -d=newInst
+//
+
+expandable connector EC
+end EC;
+
+expandable connector EC2
+  Real x;
+end EC2;
+
+model ExpandableConnector14
+  EC ec[3];
+  EC2 ec2[3];
+equation
+  connect(ec, ec2);
+end ExpandableConnector14;
+
+// Result:
+// class ExpandableConnector14
+// end ExpandableConnector14;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -456,6 +456,7 @@ ExpandableConnector10.mo \
 ExpandableConnector11.mo \
 ExpandableConnector12.mo \
 ExpandableConnector13.mo \
+ExpandableConnector14.mo \
 ExpandableConnectorComplex1.mo \
 ExpandableConnectorFlow1.mo \
 ExpandableConnectorFlow2.mo \


### PR DESCRIPTION
- Handle arrays of expandable connectors correctly in `Typing.typeConnect`.
- Use the given types in `TypeCheck.matchComplexTypes` to detect connectors instead of using the types of the class instances, since the class types might not take subscripts into account.