### PR TITLE
Handle start attributes with each on parameters without binding

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBinding.mo
@@ -879,5 +879,35 @@ public
     end match;
   end hasTypeOrigin;
 
+  function expandEach
+    "Expands the raw binding with each for a component x into
+     fill(binding, size(x, 1), size(x, 2), ...)"
+    input output Binding binding;
+    input InstNode node;
+  protected
+    list<Absyn.Exp> args;
+    Absyn.Exp node_exp;
+    constant Absyn.ComponentRef size_name = Absyn.ComponentRef.CREF_IDENT("size", {});
+    constant Absyn.ComponentRef fill_name = Absyn.ComponentRef.CREF_IDENT("fill", {});
+  algorithm
+    () := match binding
+      case RAW_BINDING(eachType = EachType.EACH)
+        algorithm
+          node_exp := Absyn.Exp.CREF(Absyn.ComponentRef.CREF_IDENT(InstNode.name(node), {}));
+          args := {};
+
+          for i in InstNode.dimensionCount(node):-1:1 loop
+            args := AbsynUtil.makeCall(size_name, {node_exp, Absyn.Exp.INTEGER(i)}) :: args;
+          end for;
+
+          args := binding.bindingExp :: args;
+          binding.bindingExp := AbsynUtil.makeCall(fill_name, args);
+        then
+          ();
+
+      else ();
+    end match;
+  end expandEach;
+
 annotation(__OpenModelica_Interface="frontend");
 end NFBinding;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -2298,6 +2298,9 @@ function updateParameterBinding
 protected
   Component comp;
   Binding binding;
+  Expression exp;
+  Absyn.Exp aexp;
+  list<Absyn.Exp> args;
 algorithm
   comp := InstNode.component(node);
 
@@ -2315,6 +2318,11 @@ algorithm
     end if;
 
     binding := Binding.unpropagate(binding, node);
+
+    if Binding.isEach(binding) then
+      binding := Binding.expandEach(binding, node);
+    end if;
+
     comp := Component.setBinding(binding, comp);
     InstNode.updateComponent(comp, node);
   end if;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1167,6 +1167,7 @@ UnboundParameter2.mo \
 UnboundParameter3.mo \
 UnboundParameter4.mo \
 UnboundParameter5.mo \
+UnboundParameter6.mo \
 usertype1.mo \
 usertype2.mo \
 usertype3.mo \

--- a/testsuite/flattening/modelica/scodeinst/UnboundParameter6.mo
+++ b/testsuite/flattening/modelica/scodeinst/UnboundParameter6.mo
@@ -1,0 +1,19 @@
+// name: UnboundParameter6
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+model UnboundParameter6
+  parameter Real x[3](each start = 1.0);
+end UnboundParameter6;
+
+// Result:
+// class UnboundParameter6
+//   parameter Real x[1](start = 1.0) = 1.0;
+//   parameter Real x[2](start = 1.0) = 1.0;
+//   parameter Real x[3](start = 1.0) = 1.0;
+// end UnboundParameter6;
+// [flattening/modelica/scodeinst/UnboundParameter6.mo:8:3-8:40:writable] Warning: Parameter x has no value, and is fixed during initialization (fixed=true), using available start value (start=1.0) as default value.
+//
+// endResult


### PR DESCRIPTION
- Expand the binding when using the binding of a start attribute for a parameter without a binding if the binding is `each`, since you can't have an each binding directly on an array component.

Fixes #12838