### PR TITLE
Improve handling of unqualified imports

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFClass.mo
@@ -162,6 +162,21 @@ constant Prefixes DEFAULT_PREFIXES = Prefixes.PREFIXES(
     cls := PARTIAL_CLASS(tree, Modifier.NOMOD(), Modifier.NOMOD(), prefixes);
   end fromSCode;
 
+  function initImports
+    input output Class cls;
+    input InstNode parent;
+  algorithm
+    () := match cls
+      case PARTIAL_CLASS()
+        algorithm
+          cls.elements := ClassTree.initImports(cls.elements, parent);
+        then
+          ();
+
+      else ();
+    end match;
+  end initImports;
+
   function fromEnumeration
     input list<SCode.Enum> literals;
     input Type enumType;

--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -527,6 +527,8 @@ algorithm
       algorithm
         c := partialInstClass2(InstNode.definition(node), node);
         node := InstNode.updateClass(c, node);
+        c := Class.initImports(c, node);
+        node := InstNode.updateClass(c, node);
       then
         ();
 

--- a/testsuite/flattening/modelica/scodeinst/ImportUnqualified4.mo
+++ b/testsuite/flattening/modelica/scodeinst/ImportUnqualified4.mo
@@ -1,0 +1,26 @@
+// name: ImportUnqualified4.mo
+// status: correct
+// cflags: -d=newInst
+
+package A
+  import A.Units.*;
+
+  model AM
+    parameter Pressure p = 0;
+  end AM;
+
+  package Units
+    type Pressure = Real;
+  end Units;
+end A;
+
+model ImportUnqualified4
+  A.AM am;
+end ImportUnqualified4;
+
+
+// Result:
+// class ImportUnqualified4
+//   parameter Real am.p = 0.0;
+// end ImportUnqualified4;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -783,6 +783,7 @@ ImportSubPackage2.mo \
 ImportUnqualified1.mo \
 ImportUnqualified2.mo \
 ImportUnqualified3.mo \
+ImportUnqualified4.mo \
 ImpureCall1.mo \
 Inline1.mo \
 Inline2.mo \


### PR DESCRIPTION
- Move initialization of unqualified imports out of `ClassTree.fromSCode` into a separate function to allow it to be done after the class tree has been added to its instance node, to avoid dependency issues when a package imports itself.

Fixes #12844