### PR TITLE
Add type casting of records

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -3502,11 +3502,11 @@ algorithm
 
   (e1, ty1) := typeExp(lhsExp, InstContext.set(context, NFInstContext.LHS), info);
   (e2, ty2) := typeExp(rhsExp, InstContext.set(context, NFInstContext.RHS), info);
-  (e1, e2, ty, mk) := TypeCheck.matchExpressions(e1, ty1, e2, ty2);
+  (e2, e1, ty, mk) := TypeCheck.matchExpressions(e2, ty2, e1, ty1);
 
   if TypeCheck.isIncompatibleMatch(mk) then
     Error.addSourceMessage(Error.EQUATION_TYPE_MISMATCH_ERROR,
-      {Expression.toString(e1) + " = " + Expression.toString(e2),
+      {Expression.toString(lhsExp) + " = " + Expression.toString(rhsExp),
        Type.toString(ty1) + " = " + Type.toString(ty2)}, info);
     fail();
   end if;

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1006,6 +1006,9 @@ RecordConstructor3.mo \
 RecordConstructor4.mo \
 RecordExtends1.mo \
 RecordExtends2.mo \
+RecordOrder1.mo \
+RecordOrder2.mo \
+RecordOrder3.mo \
 RecordUnknownDim1.mo \
 RecursiveConstants1.mo \
 RecursiveExtends1.mo \

--- a/testsuite/flattening/modelica/scodeinst/RecordOrder1.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordOrder1.mo
@@ -1,0 +1,42 @@
+// name: RecordOrder1
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record R1
+  Real x;
+  Real y;
+end R1;
+
+record R2
+  Real y;
+  Real x;
+end R2;
+
+model RecordOrder1
+  R1 r1;
+equation
+  r1 = R2(1.0, 2.0);
+end RecordOrder1;
+
+// Result:
+// function R1 "Automatically generated record constructor for R1"
+//   input Real x;
+//   input Real y;
+//   output R1 res;
+// end R1;
+//
+// function R2 "Automatically generated record constructor for R2"
+//   input Real y;
+//   input Real x;
+//   output R2 res;
+// end R2;
+//
+// class RecordOrder1
+//   Real r1.x;
+//   Real r1.y;
+// equation
+//   r1 = R1(2.0, 1.0);
+// end RecordOrder1;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/RecordOrder2.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordOrder2.mo
@@ -1,0 +1,45 @@
+// name: RecordOrder2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+record R1
+  Real x;
+  Real y;
+end R1;
+
+record R2
+  Real y;
+  Real x;
+end R2;
+
+model RecordOrder2
+  R1 r1;
+  R2 r2 = r1;
+equation
+  r1 = r2;
+end RecordOrder2;
+
+// Result:
+// function R1 "Automatically generated record constructor for R1"
+//   input Real x;
+//   input Real y;
+//   output R1 res;
+// end R1;
+//
+// function R2 "Automatically generated record constructor for R2"
+//   input Real y;
+//   input Real x;
+//   output R2 res;
+// end R2;
+//
+// class RecordOrder2
+//   Real r1.x;
+//   Real r1.y;
+//   Real r2.y = r1.y;
+//   Real r2.x = r1.x;
+// equation
+//   r1 = R1(r2.x, r2.y);
+// end RecordOrder2;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/RecordOrder3.mo
+++ b/testsuite/flattening/modelica/scodeinst/RecordOrder3.mo
@@ -1,0 +1,38 @@
+// name: RecordOrder3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+package Cooling
+  record DXCoil
+    parameter Cooling.Stage sta[1];
+  end DXCoil;
+
+  record Stage
+    parameter Real m_flow_nominal;
+    parameter Real TEvaIn_nominal = 292.55;
+  end Stage;
+end Cooling;
+
+package Heating
+  record DXCoil
+    parameter Heating.Stage sta[1];
+  end DXCoil;
+
+  record Stage
+    parameter Real TEvaIn_nominal = 292.55;
+    parameter Real m_flow_nominal;
+  end Stage;
+end Heating;
+
+model RecordOrder3
+  parameter Cooling.DXCoil datCoi(sta = {Heating.Stage(m_flow_nominal = 2)});
+end RecordOrder3;
+
+// Result:
+// class RecordOrder3
+//   parameter Real datCoi.sta[1].m_flow_nominal = 2.0;
+//   parameter Real datCoi.sta[1].TEvaIn_nominal = 292.55;
+// end RecordOrder3;
+// endResult


### PR DESCRIPTION
- Do type casting of record expressions by creating record constructor calls with the correct order and expressions when necessary, for example when records have the same named components but in different order or contain components that need to be type cast to match the expected type.