### PR TITLE
Improve mapVector in MetaModelica C++ interface

### DIFF
--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Expression.cpp
@@ -458,8 +458,8 @@ void Array::print(std::ostream &os) const noexcept
 }
 
 Matrix::Matrix(MetaModelica::Record value)
-  : _matrix{value[0].mapVector<Array>([](MetaModelica::Value row) {
-      return row.mapVector<Expression>();
+  : _matrix{value[0].mapVector([](MetaModelica::Value row) {
+      return Array(row.mapVector<Expression>());
      })}
 {
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/FunctionArgsList.cpp
@@ -13,8 +13,8 @@ extern record_description Absyn_NamedArg_NAMEDARG__desc;
 
 FunctionArgsList::FunctionArgsList(MetaModelica::Record value)
   : _args{value[0].mapVector<Expression>()},
-    _namedArgs{value[1].mapVector<NamedArg>([](MetaModelica::Record v) {
-      return std::make_pair(v[0].toString(), v[1]); })
+    _namedArgs{value[1].mapVector([](MetaModelica::Record v) {
+      return NamedArg(v[0].toString(), v[1]); })
     }
 {
 

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Modifier.cpp
@@ -105,7 +105,7 @@ void Modifier::print(std::ostream &os, std::string_view name) const noexcept
 BindingModifier::BindingModifier(MetaModelica::Record value)
   : _final{value[0]},
     _each{value[1]},
-    _subMods{value[2].mapVector<Modifier::SubMod>([](MetaModelica::Record v) {
+    _subMods{value[2].mapVector([](MetaModelica::Record v) {
       return Modifier::SubMod{v[0].toString(), v[1]};
     })},
     _binding{value[3].mapOptional<Expression>()},

--- a/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.cpp
+++ b/OMCompiler/Compiler/FrontEndCpp/Absyn/Statement.cpp
@@ -263,9 +263,9 @@ void WhileStatement::print(std::ostream &os) const noexcept
 
 WhenStatement::WhenStatement(MetaModelica::Record value)
   : Base(Comment{value[1]}, SourceInfo{value[2]}),
-    _branches{value[0].mapVector<Branch>([](MetaModelica::Value v) {
+    _branches{value[0].mapVector([](MetaModelica::Value v) {
       auto t = v.toTuple();
-      return std::pair(t[0], t[1].mapVector<Statement>());
+      return Branch(t[0], t[1].mapVector<Statement>());
     })}
 {
 

--- a/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
+++ b/OMCompiler/Compiler/FrontEndCpp/MetaModelica.h
@@ -7,10 +7,12 @@
 #include <string_view>
 #include <iosfwd>
 #include <optional>
+#include <functional>
 #include <memory>
 #include <initializer_list>
 #include <iterator>
 #include <vector>
+#include <type_traits>
 
 struct record_description;
 
@@ -84,7 +86,8 @@ namespace OpenModelica
         template<typename T> std::vector<T> mapVector() const;
         // Converts an Array or List value to an std::vector<T> using f(value)
         // for each value in the array/list.
-        template<typename T, typename ConvertFunc> std::vector<T> mapVector(ConvertFunc f) const;
+        template<typename ConvertFunc, typename T = typename std::invoke_result<ConvertFunc, Value>::type>
+        std::vector<T> mapVector(ConvertFunc f) const;
 
         // Converts the value using the corresponding Value::toX method for T.
         template<typename T> T to() const;
@@ -267,7 +270,7 @@ namespace OpenModelica
           return v;
         }
 
-        template<typename T, typename ConvertFunc>
+        template<typename ConvertFunc, typename T = typename std::invoke_result<ConvertFunc, Value>::type>
         std::vector<T> mapVector(ConvertFunc f) const
         {
           std::vector<T> v;
@@ -346,7 +349,7 @@ namespace OpenModelica
           return v;
         }
 
-        template<typename T, typename ConvertFunc>
+        template<typename ConvertFunc, typename T = typename std::invoke_result<ConvertFunc, Value>::type>
         std::vector<T> mapVector(ConvertFunc f) const
         {
           std::vector<T> v;
@@ -454,10 +457,10 @@ namespace OpenModelica
       return isList() ? toList().mapVector<T>() : toArray().mapVector<T>();
     }
 
-    template<typename T, typename ConvertFunc>
+    template<typename ConvertFunc, typename T>
     std::vector<T> Value::mapVector(ConvertFunc f) const
     {
-      return isList() ? toList().mapVector<T>(f) : toArray().mapVector<T>(f);
+      return isList() ? toList().mapVector(f) : toArray().mapVector(f);
     }
 
     template<typename T>


### PR DESCRIPTION
- Deduce the type of the returned vector from the return type of the conversion function, to remove the need to manually specify the type when using `mapVector`.