### PR TITLE
Update Modelica versions

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -63,6 +63,7 @@ import Attributes = NFAttributes;
 import Builtin = NFBuiltin;
 import BuiltinCall = NFBuiltinCall;
 import Ceval = NFCeval;
+import Config;
 import ComponentRef = NFComponentRef;
 import Origin = NFComponentRef.Origin;
 import ExecStat.execStat;
@@ -2006,6 +2007,7 @@ algorithm
     case ComponentRef.CREF(node = InstNode.COMPONENT_NODE())
       algorithm
         if Component.hasCondition(InstNode.component(cref.node)) and
+           not Config.languageStandardAtLeast(Config.LanguageStandard.experimental) and
            (not InstContext.inConnect(context) or InstContext.inSubscript(context)) and not InstContext.inRelaxed(context) then
           Error.addStrictMessage(Error.CONDITIONAL_COMPONENT_INVALID_CONTEXT,
             {InstNode.name(cref.node)}, info);

--- a/OMCompiler/Compiler/Util/Config.mo
+++ b/OMCompiler/Compiler/Util/Config.mo
@@ -47,7 +47,7 @@ import System;
 
 public
 
-type LanguageStandard = enumeration('1.x', '2.x', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', latest, experimental)
+type LanguageStandard = enumeration('1.x', '2.x', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', latest, experimental)
   "Defines the various modelica language versions that OMC can use.";
 
 public function typeinfo "+t"
@@ -444,7 +444,7 @@ protected function languageStandardInt
   input LanguageStandard inStandard;
   output Integer outValue;
 protected
-  constant Integer lookup[LanguageStandard] = array(10, 20, 30, 31, 32, 33, 34, 1000, 1035, 9999);
+  constant Integer lookup[LanguageStandard] = array(10, 20, 30, 31, 32, 33, 34, 35, 36, 1000, 9999);
 algorithm
   outValue := lookup[inStandard];
 end languageStandardInt;
@@ -462,6 +462,7 @@ algorithm
     case 33 then LanguageStandard.'3.3';
     case 34 then LanguageStandard.'3.4';
     case 35 then LanguageStandard.'3.5';
+    case 36 then LanguageStandard.'3.6';
     case 1000 then LanguageStandard.latest;
     case 9999 then LanguageStandard.experimental;
   end match;
@@ -471,7 +472,7 @@ public function languageStandardString
   input LanguageStandard inStandard;
   output String outString;
 protected
-  constant String lookup[LanguageStandard] = array("1.x","2.x","3.0","3.1","3.2","3.3","3.4","3.5","3.5","experimental" /*Change this to latest version if you add more versions!*/);
+  constant String lookup[LanguageStandard] = array("1.x","2.x","3.0","3.1","3.2","3.3","3.4","3.5","3.6","3.6","experimental" /*Change this to latest version if you add more versions!*/);
 algorithm
   outString := lookup[inStandard];
 end languageStandardString;
@@ -543,6 +544,7 @@ algorithm
     case "3" :: "1" :: _ then LanguageStandard.'3.1';
     case "3" :: _ then LanguageStandard.'3.2';
     case "4" :: "0" :: _ then LanguageStandard.'3.4';
+    case "4" :: "1" :: _ then LanguageStandard.'3.6';
     case _ then LanguageStandard.latest;
   end match;
 end versionStringToStd2;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -596,8 +596,8 @@ constant ConfigFlag ANNOTATION_VERSION = CONFIG_FLAG(7, "annotationVersion",
 constant ConfigFlag LANGUAGE_STANDARD = CONFIG_FLAG(8, "std", NONE(), EXTERNAL(),
   ENUM_FLAG(1000,
     {("1.x", 10), ("2.x", 20), ("3.0", 30), ("3.1", 31), ("3.2", 32), ("3.3", 33),
-     ("3.4", 34), ("3.5", 35), ("latest",1000), ("experimental", 9999)}),
-  SOME(STRING_OPTION({"1.x", "2.x", "3.1", "3.2", "3.3", "3.4", "3.5", "latest", "experimental"})),
+     ("3.4", 34), ("3.5", 35), ("3.6", 36), ("latest",1000), ("experimental", 9999)}),
+  SOME(STRING_OPTION({"1.x", "2.x", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "latest", "experimental"})),
   Gettext.gettext("Sets the language standard that should be used."));
 
 constant ConfigFlag SHOW_ERROR_MESSAGES = CONFIG_FLAG(9, "showErrorMessages",


### PR DESCRIPTION
- Add 3.6 to `--std` flag.
- Assume upcoming MSL 4.1.0 will use Modelica 3.6.
- Disable warning for conditional components in previously invalid context when using `--std=experimental` (upcoming 3.7).