### PR TITLE
add separate FMU export output window, which shows FMI export progress in OMEdit

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2524,7 +2524,7 @@ end importFMUModelDescription;
 
 function translateModelFMU
 "Deprecated: Use buildModelFMU instead.
-Translates a modelica model into a Functional Mockup Unit.
+Translates a modelica model to c code without building it
 The only required argument is the className, while all others have some default values.
   Example command:
   translateModelFMU(className, version=\"2.0\");"
@@ -2532,8 +2532,14 @@ The only required argument is the className, while all others have some default 
   input String version = "2.0" "FMU version, 1.0 or 2.0.";
   input String fmuType = "me" "FMU type, me (model exchange), cs (co-simulation), me_cs (both model exchange and co-simulation)";
   input String fileNamePrefix = "<default>" "fileNamePrefix. <default> = \"className\"";
+  input String platforms[:] = {"static"} "The list of platforms to generate code for.
+                                          \"dynamic\"=current platform, dynamically link the runtime.
+                                          \"static\"=current platform, statically link everything.
+                                          \"<cpu>-<vendor>-<os>\", host tripple, e.g. \"x86_64-linux-gnu\" or \"x86_64-w64-mingw32\".
+                                          \"<cpu>-<vendor>-<os> docker run <image>\" host tripple with Docker image, e.g. \"x86_64-linux-gnu docker run --pull=never multiarch/crossbuild\"";
+
   input Boolean includeResources = false "include Modelica based resources via loadResource or not";
-  output String generatedFileName "Returns the full path of the generated FMU.";
+  output Boolean success;
 external "builtin";
 annotation(preferredView="text", version="Deprecated");
 end translateModelFMU;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2776,8 +2776,7 @@ annotation(preferredView="text");
 end importFMUModelDescription;
 
 function translateModelFMU
-"Deprecated: Use buildModelFMU instead.
-Translates a modelica model into a Functional Mockup Unit.
+"Translates a modelica model into c code without building it
 The only required argument is the className, while all others have some default values.
   Example command:
   translateModelFMU(className, version=\"2.0\");"
@@ -2785,8 +2784,13 @@ The only required argument is the className, while all others have some default 
   input String version = "2.0" "FMU version, 1.0 or 2.0.";
   input String fmuType = "me" "FMU type, me (model exchange), cs (co-simulation), me_cs (both model exchange and co-simulation)";
   input String fileNamePrefix = "<default>" "fileNamePrefix. <default> = \"className\"";
+  input String platforms[:] = {"static"} "The list of platforms to generate code for.
+                                          \"dynamic\"=current platform, dynamically link the runtime.
+                                          \"static\"=current platform, statically link everything.
+                                          \"<cpu>-<vendor>-<os>\", host tripple, e.g. \"x86_64-linux-gnu\" or \"x86_64-w64-mingw32\".
+                                          \"<cpu>-<vendor>-<os> docker run <image>\" host tripple with Docker image, e.g. \"x86_64-linux-gnu docker run --pull=never multiarch/crossbuild\"";
   input Boolean includeResources = false "include Modelica based resources via loadResource or not";
-  output String generatedFileName "Returns the full path of the generated FMU.";
+  output Boolean success;
 external "builtin";
 annotation(preferredView="text", version="Deprecated");
 end translateModelFMU;

--- a/OMEdit/OMEditLIB/CMakeLists.txt
+++ b/OMEdit/OMEditLIB/CMakeLists.txt
@@ -87,6 +87,7 @@ set(OMEDITLIB_SOURCES Util/Helper.cpp
                       TLM/TLMCoSimulationThread.cpp
                       FMI/ImportFMUDialog.cpp
                       FMI/ImportFMUModelDescriptionDialog.cpp
+                      FMI/FMUExportOutputWidget.cpp
                       Plotting/VariablesWidget.cpp
                       Plotting/DiagramWindow.cpp
                       Options/NotificationsDialog.cpp
@@ -218,6 +219,7 @@ set(OMEDITLIB_HEADERS Util/Helper.h
                       TLM/TLMCoSimulationThread.h
                       FMI/ImportFMUDialog.h
                       FMI/ImportFMUModelDescriptionDialog.h
+                      FMI/FMUExportOutputWidget.h
                       Plotting/VariablesWidget.h
                       Plotting/DiagramWindow.h
                       Options/NotificationsDialog.h

--- a/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.h
+++ b/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.h
@@ -1,0 +1,92 @@
+#ifndef FMUEXPORTOUTPUTWIDGET_H
+#define FMUEXPORTOUTPUTWIDGET_H
+
+
+#include <QPlainTextEdit>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QWidget>
+#include <QProcess>
+#include <QTabWidget>
+#include "Modeling/LibraryTreeWidget.h"
+
+class Label;
+class OutputPlainTextEdit;
+
+class FmuExportOutputWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  FmuExportOutputWidget(LibraryTreeItem *pLibraryTreeItem, QWidget *pParent = 0);
+  ~FmuExportOutputWidget();
+  QProgressBar* getProgressBar() {return mpProgressBar;}
+  QTabWidget* getGeneratedFilesTabWidget() {return mpGeneratedFilesTabWidget;}
+  QProcess* getCompilationProcess() {return mpCompilationProcess;}
+  void setCompilationProcessKilled(bool killed) {mIsCompilationProcessKilled = killed;}
+  bool isCompilationProcessKilled() {return mIsCompilationProcessKilled;}
+  bool isCompilationProcessRunning() {return mIsCompilationProcessRunning;}
+  QProcess* getPostCompilationProcess() {return mpPostCompilationProcess;}
+  void setPostCompilationProcessKilled(bool killed) {mIsPostCompilationProcessKilled = killed;}
+  bool isPostCompilationProcessKilled() {return mIsPostCompilationProcessKilled;}
+  bool isPostCompilationProcessRunning() {return mIsPostCompilationProcessRunning;}
+  QProcess* getZipCompilationProcess() {return mpZipCompilationProcess;}
+  void setZipCompilationProcessKilled(bool killed) {mIsZipCompilationProcessKilled = killed;}
+  bool isZipCompilationProcessKilled() {return mIsZipCompilationProcessKilled;}
+  bool isZipCompilationProcessRunning() {return mIsZipCompilationProcessRunning;}
+  QString getFMUPath() {return mpFmuLocationPath;}
+  void updateMessageTab(const QString &text);
+  void updateMessageTabProgress();
+  void compileModel();
+private:
+  QString mpFmuTmpPath;
+  QString mpFMUName;
+  QString mpFmuLocationPath;
+  LibraryTreeItem *mpLibraryTreeItem;
+  Label *mpProgressLabel;
+  QProgressBar *mpProgressBar;
+  QPushButton *mpCancelButton;
+  QTabWidget *mpGeneratedFilesTabWidget;
+  OutputPlainTextEdit *mpCompilationOutputTextBox;
+  OutputPlainTextEdit *mpPostCompilationOutputTextBox;
+  QProcess *mpCompilationProcess;
+  bool mIsCompilationProcessKilled;
+  bool mIsCompilationProcessRunning;
+  QProcess *mpPostCompilationProcess;
+  bool mIsPostCompilationProcessKilled;
+  bool mIsPostCompilationProcessRunning;
+  QProcess *mpZipCompilationProcess;
+  bool mIsZipCompilationProcessKilled;
+  bool mIsZipCompilationProcessRunning;
+  void runPostCompilation();
+  void postCompilationProcessFinishedHelper(int exitCode, QProcess::ExitStatus exitStatus);
+  void writeCompilationOutput(QString output, QColor color);
+  void writePostCompilationOutput(QString output, QColor color);
+  void compilationProcessFinishedHelper(int exitCode, QProcess::ExitStatus exitStatus);
+  void zipFMU();
+  void ZipCompilationProcessFinishedHelper(int exitCode, QProcess::ExitStatus exitStatus);
+  void setDefaults();
+private slots:
+  void compilationProcessStarted();
+  void readCompilationStandardOutput();
+  void readCompilationStandardError();
+  void compilationProcessError(QProcess::ProcessError error);
+  void compilationProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+  void postCompilationProcessStarted();
+  void readPostCompilationStandardOutput();
+  void readPostCompilationStandardError();
+  void postCompilationProcessError(QProcess::ProcessError error);
+  void postCompilationProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+  void ZipCompilationProcessStarted();
+  void readZipCompilationStandardOutput();
+  void readZipCompilationStandardError();
+  void ZipCompilationProcessError(QProcess::ProcessError error);
+  void ZipCompilationProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+public slots:
+  void cancelCompilation();
+signals:
+  void updateText(const QString &text);
+  void updateProgressBar(QProgressBar *pProgressBar);
+};
+
+#endif // FMUEXPORTOUTPUTWIDGET_H
+

--- a/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/MessagesWidget.cpp
@@ -41,6 +41,7 @@
 #include "Simulation/SimulationDialog.h"
 #include "Simulation//SimulationOutputWidget.h"
 #include "OMS/OMSSimulationOutputWidget.h"
+#include "FMI/FMUExportOutputWidget.h"
 
 #include <QMenu>
 #include <QMessageBox>
@@ -576,6 +577,15 @@ bool MessagesWidget::closeTab(int index)
   // Close OMSSimulationOutputWidget
   OMSSimulationOutputWidget *pOMSSimulationOutputWidget = qobject_cast<OMSSimulationOutputWidget*>(mpMessagesTabWidget->widget(index));
   if (pOMSSimulationOutputWidget && !pOMSSimulationOutputWidget->isSimulationProcessRunning()) {
+    mpMessagesTabWidget->removeTab(index);
+    emit messageTabClosed(index);
+    return true;
+  }
+  // Close FMUExportOutputWidget
+  FmuExportOutputWidget *pFmuExportOutputWidget = qobject_cast<FmuExportOutputWidget*>(mpMessagesTabWidget->widget(index));
+  if (pFmuExportOutputWidget
+      && !pFmuExportOutputWidget->isCompilationProcessRunning()
+      && !pFmuExportOutputWidget->isPostCompilationProcessRunning()) {
     mpMessagesTabWidget->removeTab(index);
     emit messageTabClosed(index);
     return true;

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -2643,6 +2643,25 @@ QString OMCProxy::buildModelFMU(QString className, QString version, QString type
 }
 
 /*!
+ * \brief OMCProxy::translateModelFMU
+ * Creates the FMU of the model.
+ * \param className - the name of the class.
+ * \param version - the fmu version
+ * \param type - the fmu type
+ * \param fileNamePrefix
+ * \param platforms
+ * \param includeResources
+ * \return
+ */
+bool OMCProxy::translateModelFMU(QString className, QString version, QString type, QString fileNamePrefix, QList<QString> platforms, bool includeResources)
+{
+  fileNamePrefix = fileNamePrefix.isEmpty() ? "<default>" : fileNamePrefix;
+  bool result = mpOMCInterface->translateModelFMU(className, version, type, fileNamePrefix, platforms, includeResources);
+  printMessagesStringInternal();
+  return result;
+}
+
+/*!
  * \brief OMCProxy::translateModelXML
  * Creates the XML of the model.
  * \param className - the name of the class.

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -220,6 +220,7 @@ public:
   bool isExperiment(QString className);
   OMCInterface::getSimulationOptions_res getSimulationOptions(QString className, double defaultTolerance = 1e-6);
   QString buildModelFMU(QString className, QString version, QString type, QString fileNamePrefix, QList<QString> platforms, bool includeResources);
+  bool translateModelFMU(QString className, QString version, QString type, QString fileNamePrefix, QList<QString> platforms, bool includeResources);
   QString translateModelXML(QString className);
   QString importFMU(QString fmuName, QString outputDirectory, int logLevel, bool debugLogging, bool generateInputConnectors, bool generateOutputConnectors, QString modelName);
   QString importFMUModelDescription(QString fmuModelDescriptionName, QString outputDirectory, int logLevel, bool debugLogging, bool generateInputConnectors, bool generateOutputConnectors);

--- a/OMEdit/OMEditLIB/OMEditLIB.pro
+++ b/OMEdit/OMEditLIB/OMEditLIB.pro
@@ -159,6 +159,7 @@ SOURCES += Util/Helper.cpp \
   TLM/TLMCoSimulationThread.cpp \
   FMI/ImportFMUDialog.cpp \
   FMI/ImportFMUModelDescriptionDialog.cpp \
+  FMI/FMUExportOutputWidget.cpp \
   Plotting/VariablesWidget.cpp \
   Plotting/DiagramWindow.cpp \
   Options/NotificationsDialog.cpp \
@@ -274,6 +275,7 @@ HEADERS  += Util/Helper.h \
   TLM/TLMCoSimulationThread.h \
   FMI/ImportFMUDialog.h \
   FMI/ImportFMUModelDescriptionDialog.h \
+  FMI/FMUExportOutputWidget.h \
   Plotting/VariablesWidget.h \
   Plotting/DiagramWindow.h \
   Options/NotificationsDialog.h \


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12828

### Purpose

This PR adds separate output window for FMU export which is interactive to users and shows the progress bar and avoids GUI freezing. 
 
### Approach

- added `TranslateModelFMU`  API which only generates the c code for fmu's and does not build it
- Building the binaries and packing the fmu is done from OMEdit which is run in a separate thread and avoids GUI freezing