### PR TITLE
Optimize HpcOmTaskGraph.createTaskGraph

### DIFF
--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -186,6 +186,7 @@ algorithm
   //print("createTaskGraph0 varCompMapping created\n");
   compDescs := getEquationStrings(comps,iSyst);  //gets the description i.e. the whole equation, for every component
   ((tmpGraph,inComps,compParamMapping,commCosts,compNames,nodeMark,_)) := List.fold(comps, function createTaskGraph1(iSystInfo=(adjacencyMatrix,iSyst,iShared,listLength(comps)),iVarInfo=(varCompMapping,eqCompMapping,{}),iAnalyzeParameters=iAnalyzeParameters),(tmpGraph,inComps,compParamMapping,commCosts,compNames,nodeMark,1));
+  tmpGraph := Array.mapNoCopy(tmpGraph, function List.sort(inCompFunc = intGt));
   // gather the metadata
   tmpGraphData := TASKGRAPHMETA(inComps, varCompMapping, eqCompMapping, compParamMapping, compNames, compDescs, exeCosts, commCosts, nodeMark, compInformations);
   if(intGt(eqSysIdx,1)) then
@@ -513,7 +514,6 @@ algorithm
   requiredSccs_RefCount := createRequiredSccsRefCount(requiredSccs);
   (commCosts,commCostsOfNode) := updateCommCostBySccRef(requiredSccs_RefCount, componentIndex, commCosts);
   graphTmp := fillAdjacencyList(graphIn,componentIndex,commCostsOfNode,1);
-  graphTmp := Array.map1(graphTmp,List.sort,intGt);
   graphInfoOut := (graphTmp,inComps,compParamMapping,commCosts,compNames,nodeMark,componentIndex+1);
 end createTaskGraph1;
 

--- a/OMCompiler/Compiler/Util/Array.mo
+++ b/OMCompiler/Compiler/Util/Array.mo
@@ -55,7 +55,7 @@ function mapNoCopy<T>
   end FuncType;
 algorithm
   for i in 1:arrayLength(inArray) loop
-    arrayUpdate(inArray, i, inFunc(arrayGetNoBoundsChecking(inArray, i)));
+    arrayUpdateNoBoundsChecking(inArray, i, inFunc(arrayGetNoBoundsChecking(inArray, i)));
   end for;
 end mapNoCopy;
 
@@ -77,7 +77,7 @@ protected
 algorithm
   for i in 1:arrayLength(inArray) loop
     (e, outArg) := inFunc((arrayGetNoBoundsChecking(inArray, i), outArg));
-    arrayUpdate(inArray, i, e);
+    arrayUpdateNoBoundsChecking(inArray, i, e);
   end for;
 end mapNoCopy_1;
 


### PR DESCRIPTION
- Move the sorting of the graph to `createTaskGraph0` once the graph is completed instead of doing it for each component in `createTaskGraph1`, since `createTaskGraph1` only adds nodes.
- Use `Array.mapNoCopy` instead of `Array.map1` when doing the sorting
  since we don't need to copy the array.