### PR TITLE
fix fmiFilter when using --exportClocksInModelDescription (#12895)

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8578,9 +8578,10 @@ algorithm
     end if;
   elseif Flags.getConfigEnum(Flags.FMI_FILTER) == Flags.FMI_PROTECTED then
     // All protected model variables will be filtered out in addition
-    // to --fmiFilter=internal.
+    // to --fmiFilter=internal (with minor exceptions. e.g.
+    // for state sets.clocked states and previous vars)
     if not (ComponentReference.isInternalCref(var.varName) and (not BackendVariable.isStateVar(var) and not BackendVariable.isClockedStateVar(var))) then
-      if not (BackendVariable.isProtected(var) and (not BackendVariable.isStateVar(var) and not BackendVariable.isClockedStateVar(var))) then
+      if not (BackendVariable.isProtected(var) and (not BackendVariable.isStateVar(var) and not BackendVariable.isClockedStateVar(var) and not ComponentReference.isPreviousCref(var.varName))) then
         exportVar := SOME(var.varName);
       end if;
     end if;
@@ -15274,6 +15275,12 @@ algorithm
         local Integer index;
         case SOME(index)
         then SOME(index + getScalarElementIndex(subs, List.map(sv.numArrayElement, stringInt)) - 1);
+      end match;
+      // fix fmi_index when using nfScalarize
+      sv.fmi_index := match sv.fmi_index
+        local Integer fmiIndex;
+        case SOME(fmiIndex)
+        then SOME(fmiIndex + getScalarElementIndex(subs, List.map(sv.numArrayElement, stringInt)) - 1);
       end match;
     end if;
     sv := match sv.aliasvar

--- a/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCommon.tpl
@@ -487,7 +487,7 @@ match simVar
   let description = if comment then 'description="<%Util.escapeModelicaStringToXmlString(comment)%>"'
   let variability_ = if getClockIndex(simVar, simCode) then "discrete" else getVariability2(variability)
   let clockIndex = getClockIndex(simVar, simCode)
-  let previous = match varKind case CLOCKED_STATE(__) then '<%getVariableIndex(cref2simvar(previousName, simCode))%>'
+  let previous = match varKind case CLOCKED_STATE(__) then '<%getVariableFMIIndex(cref2simvar(previousName, simCode))%>'
   let caus = getCausality2(causality)
   let initial = getFmiInitialAttributeStr(simVar)
   <<

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -25,6 +25,7 @@ fmi_attributes_21.mos \
 fmi_attributes_22.mos \
 fmi_attributes_23.mos \
 fmi_attributes_24.mos \
+fmiFilterTest.mos \
 FMUResourceTest.mos \
 QuotedIdentifierExport.mos \
 testBug2764.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/fmiFilterTest.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/fmiFilterTest.mos
@@ -1,0 +1,128 @@
+// name: fmiFilterTest.mos
+// keywords: FMI 2.0 export
+// status: correct
+// teardown_command: rm -rf fmiFilterTest.fmu fmiFilterTest.log fmiFilterTest.xml fmiFilterTest_tmp.xml fmiFilterTest_info.json
+
+
+setCommandLineOptions("--exportClocksInModelDescription"); getErrorString();
+
+loadString("
+  model fmiFilterTest
+    input Real u;
+    Integer id(start = 0);
+  protected
+    Real p = 1;
+    Real xc(start = 0);
+    Real xd(start = 0);
+  equation
+    der(xc) = u;
+    when Clock() then
+      xd = previous(xd) + p*u;
+      id = previous(id) + 1;
+    end when;
+  end fmiFilterTest;
+"); getErrorString();
+
+buildModelFMU(fmiFilterTest, fileNamePrefix="fmiFilterTest"); getErrorString();
+
+// unzip to console, quiet, extra quiet
+system("unzip -cqq fmiFilterTest.fmu modelDescription.xml > fmiFilterTest_tmp.xml"); getErrorString();
+
+system("sed -n \"/<ModelVariables>/,/<\\/ModelVariables>/p\" fmiFilterTest_tmp.xml > fmiFilterTest.xml"); getErrorString();
+readFile("fmiFilterTest.xml"); getErrorString();
+
+system("sed -n \"/<ModelStructure>/,/<\\/ModelStructure>/p\" fmiFilterTest_tmp.xml > fmiFilterTest.xml"); getErrorString();
+readFile("fmiFilterTest.xml"); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// ""
+// "fmiFilterTest.fmu"
+// "Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// 0
+// ""
+// 0
+// ""
+// "  <ModelVariables>
+//   <!-- Index of variable = \"1\" -->
+//   <ScalarVariable
+//     name=\"xc\"
+//     valueReference=\"0\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"2\" -->
+//   <ScalarVariable
+//     name=\"der(xc)\"
+//     valueReference=\"1\"
+//     >
+//     <Real derivative=\"1\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"3\" -->
+//   <ScalarVariable
+//     name=\"previous(xd)\"
+//     valueReference=\"2\"
+//     variability=\"discrete\"
+//     clockIndex=\"1\"
+//     >
+//     <Real/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"4\" -->
+//   <ScalarVariable
+//     name=\"u\"
+//     valueReference=\"4\"
+//     causality=\"input\"
+//     >
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"5\" -->
+//   <ScalarVariable
+//     name=\"xd\"
+//     valueReference=\"5\"
+//     variability=\"discrete\"
+//     clockIndex=\"1\"
+//     previous=\"3\"
+//     initial=\"exact\">
+//     <Real start=\"0.0\"/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"6\" -->
+//   <ScalarVariable
+//     name=\"previous(id)\"
+//     valueReference=\"0\"
+//     variability=\"discrete\"
+//     clockIndex=\"1\"
+//     >
+//     <Integer/>
+//   </ScalarVariable>
+//   <!-- Index of variable = \"7\" -->
+//   <ScalarVariable
+//     name=\"id\"
+//     valueReference=\"1\"
+//     variability=\"discrete\"
+//     clockIndex=\"1\"
+//     previous=\"6\"
+//     initial=\"exact\">
+//     <Integer start=\"0\"/>
+//   </ScalarVariable>
+//   </ModelVariables>
+// "
+// ""
+// 0
+// ""
+// "  <ModelStructure>
+//     <Derivatives>
+//       <Unknown index=\"2\" dependencies=\"4\" dependenciesKind=\"dependent\" />
+//     </Derivatives>
+//     <DiscreteStates>
+//       <Unknown index=\"5\" dependencies=\"3 4\" dependenciesKind=\"dependent dependent\" />
+//     </DiscreteStates>
+//     <InitialUnknowns>
+//       <Unknown index=\"2\" dependencies=\"6\" dependenciesKind=\"dependent\" />
+//     </InitialUnknowns>
+//   </ModelStructure>
+// "
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12858

### Purpose

This PR fixes the `previous variable index` when using `fmiFilter` in `modeldescription.xml`
