### PR TITLE
disable cmake coloring to disable ANSI escape codes

### DIFF
--- a/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
@@ -182,9 +182,9 @@ void FmuExportOutputWidget::compileModel()
   }
 
 #ifdef Q_OS_WIN
-  arguments << "-G" << "MSYS Makefiles" << CMAKE_BUILD_TYPE << "-DCMAKE_C_COMPILER=clang" << "..";
+  arguments << "-G" << "MSYS Makefiles" << CMAKE_BUILD_TYPE << "-DCMAKE_C_COMPILER=clang" << "-DCMAKE_COLOR_MAKEFILE=OFF" << "..";
 #else
-  arguments << CMAKE_BUILD_TYPE << "-DCMAKE_C_COMPILER=clang" << "..";
+  arguments << CMAKE_BUILD_TYPE << "-DCMAKE_C_COMPILER=clang" << "-DCMAKE_COLOR_MAKEFILE=OFF" << "..";
 #endif
 
   mpCompilationProcess->start(program, arguments);


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/12828

### Purpose

Disable `cmake` coloring in `Makefile`  by setting `DCMAKE_COLOR_MAKEFILE=OFF` to escape ANSI escape codes in `QPlainTexEdit`

