### PR TITLE
[NB] update for equation inlining

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBInline.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBInline.mo
@@ -121,7 +121,7 @@ public
         Expression range;
         Integer start;
 
-      case Equation.FOR_EQUATION(body = {new_eqn}) guard(Equation.size(Pointer.create(eqn)) == 1) algorithm
+      case Equation.FOR_EQUATION(body = {new_eqn}) guard(Iterator.size(eqn.iter) == 1) algorithm
         replacements := UnorderedMap.new<Expression>(ComponentRef.hash, ComponentRef.isEqual);
         (names, ranges) := Iterator.getFrames(eqn.iter);
         for tpl in List.zip(names, ranges) loop


### PR DESCRIPTION
  - instead of looking if the equation is of size 1, check if the iterator is of size 1. this allows inlining of for-loops with multi dimensional bodies that only iterate over one value