### PR TITLE
Add context to `Inst.expand`

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFLookupState.mo
@@ -166,7 +166,7 @@ uniontype LookupState
     end if;
 
     n := InstNode.resolveInner(node);
-    Inst.expand(n);
+    Inst.expand(n, NFInstContext.NO_CONTEXT);
 
     callable := match InstNode.restriction(n)
       case Restriction.RECORD() then true;

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -205,7 +205,7 @@ algorithm
 
           smod := AbsynToSCode.translateMod(SOME(Absyn.CLASSMOD(stripped_mod, Absyn.NOMOD())), SCode.NOT_FINAL(), SCode.NOT_EACH(), NONE(), info);
           anncls := Lookup.lookupClassName(Absyn.IDENT(annName), inst_cls, ANNOTATION_CONTEXT, AbsynUtil.dummyInfo, checkAccessViolations = false);
-          inst_anncls := NFInst.expand(anncls);
+          inst_anncls := NFInst.expand(anncls, ANNOTATION_CONTEXT);
           inst_anncls := NFInst.instClass(inst_anncls, Modifier.create(smod, annName, ModifierScope.CLASS(annName), inst_cls), NFAttributes.DEFAULT_ATTR, true, 0, inst_cls, ANNOTATION_CONTEXT);
           // Instantiate expressions (i.e. anything that can contains crefs, like
           // bindings, dimensions, etc). This is done as a separate step after
@@ -423,7 +423,7 @@ algorithm
 
           smod := AbsynToSCode.translateMod(SOME(Absyn.CLASSMOD(mod, Absyn.NOMOD())), SCode.NOT_FINAL(), SCode.NOT_EACH(), info);
           anncls := Lookup.lookupClassName(Absyn.IDENT(annName), inst_cls, context, AbsynUtil.dummyInfo, checkAccessViolations = false);
-          inst_anncls := NFInst.expand(anncls);
+          inst_anncls := NFInst.expand(anncls, context);
           inst_anncls := NFInst.instClass(inst_anncls, Modifier.create(smod, annName, ModifierScope.CLASS(annName), inst_cls), NFComponent.DEFAULT_ATTR, true, 0, inst_cls, context);
 
           // Instantiate expressions (i.e. anything that can contains crefs, like
@@ -810,10 +810,10 @@ algorithm
   name := AbsynUtil.pathString(classPath);
 
   (program, top) := mkTop(absynProgram, name);
-  cls := Inst.lookupRootClass(classPath, top, InstContext.set(NFInstContext.RELAXED, NFInstContext.FAST_LOOKUP));
+  cls := Inst.lookupRootClass(classPath, top, FAST_CONTEXT);
 
   // Expand the class.
-  expanded_cls := NFInst.expand(cls);
+  expanded_cls := NFInst.expand(cls, FAST_CONTEXT);
 
   if Flags.isSet(Flags.EXEC_STAT) then
     execStat("NFApi.frontEndLookup_dispatch("+ name +")");
@@ -1157,7 +1157,7 @@ protected
   Boolean annotation_is_literal = true;
   SCode.Element def;
 algorithm
-  Inst.expand(node);
+  Inst.expand(node, ANNOTATION_CONTEXT);
   def := InstNode.definition(node);
   json := JSON.addPair("name", dumpJSONNodePath(node), json);
 
@@ -2404,7 +2404,7 @@ algorithm
   // Make a top node and look up the class in it.
   (_, top) := mkTop(SymbolTable.getAbsyn(), AbsynUtil.pathString(clsPath));
   cls_node := Inst.lookupRootClass(clsPath, top, FAST_CONTEXT);
-  Inst.expand(cls_node);
+  Inst.expand(cls_node, FAST_CONTEXT);
 
   // Get the destination path including the class name.
   dest_path := match destination
@@ -2427,7 +2427,7 @@ algorithm
     // Change the scope in the environment to this class, if the class has its
     // own scope (i.e. is a long class definition).
     cls_node := Lookup.lookupLocalSimpleName(cls.name, env.scope);
-    Inst.expand(cls_node);
+    Inst.expand(cls_node, FAST_CONTEXT);
     cls_env := MoveEnv.MOVE_ENV(cls_node, AbsynUtil.suffixPath(env.destinationPath, cls.name));
   else
     cls_env := env;

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -14,7 +14,6 @@ Bug3520.mos \
 Bug3783.mos \
 Bug3974.mos \
 Bug3979.mos \
-Bug4209.mos \
 Bug4248.mos \
 Buildings.PartialFlowMachine.mos \
 checkAllModelsRecursive1.mos \
@@ -55,6 +54,8 @@ getDefinitions.mos \
 getDialogAnnotation.mos \
 getElementAnnotation.mos \
 getIconAnnotation.mos \
+getInheritedClasses1.mos \
+getInheritedClasses2.mos \
 getSimulationOptions1.mos \
 getSimulationOptions2.mos \
 getSimulationOptions3.mos \

--- a/testsuite/openmodelica/interactive-API/getInheritedClasses1.mos
+++ b/testsuite/openmodelica/interactive-API/getInheritedClasses1.mos
@@ -1,4 +1,4 @@
-// name: Bug4209.mos
+// name: getInheritedClasses1
 // keywords:
 // status: correct
 // cflags: -d=newInst

--- a/testsuite/openmodelica/interactive-API/getInheritedClasses2.mos
+++ b/testsuite/openmodelica/interactive-API/getInheritedClasses2.mos
@@ -1,0 +1,40 @@
+// name: getInheritedClasses2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+
+loadString("
+  package P1
+    package P2
+      package P3
+        extends P1.P2.Icons.Package;
+
+        model M
+          extends P1.P2.P3.Internal.M;
+        end M;
+
+        package Internal
+          model M
+          end M;
+        end Internal;
+      end P3;
+
+      package Icons
+        package Package
+        end Package;
+      end Icons;
+    end P2;
+  end P1;
+");
+getErrorString();
+
+getInheritedClasses(P1.P2.P3.M);
+getErrorString();
+
+// Result:
+// true
+// ""
+// {P1.P2.P3.Internal.M}
+// ""
+// endResult


### PR DESCRIPTION
- Add context argument to `Inst.expand`, since expanding a class can involve instantiating packages during lookup which depends on the context for proper behaviour.

Fixes #12902