### PR TITLE
Avoid opening unnecessary new plot window

### DIFF
--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.cpp
@@ -123,6 +123,26 @@ PlotWindow* PlotWindowContainer::getCurrentWindow()
   }
 }
 
+/*!
+ * \brief PlotWindowContainer::getPlotSubWindowFromMdi
+ * Returns the topmost Plot subwindow, if there is any in the PlotWindowContainer
+ * \return
+ */
+QMdiSubWindow* PlotWindowContainer::getPlotSubWindowFromMdi()
+{
+  if (subWindowList(QMdiArea::ActivationHistoryOrder).size() == 0) {
+    return 0;
+  } else {
+    QList<QMdiSubWindow*> subWindowsList = subWindowList(QMdiArea::ActivationHistoryOrder);
+    for (int i = subWindowsList.size() - 1 ; i >= 0 ; i--) {
+      if (isPlotWindow(subWindowsList.at(i)->widget())) {
+        return subWindowsList.at(i);
+      }
+    }
+    return 0;
+  }
+}
+
 PlotWindow* PlotWindowContainer::getInteractiveWindow(QString targetWindow)
 {
   if (subWindowList().size() == 0) {

--- a/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
+++ b/OMEdit/OMEditLIB/Plotting/PlotWindowContainer.h
@@ -54,6 +54,7 @@ public:
   PlotWindowContainer(QWidget *pParent = 0);
   QString getUniqueName(QString name = QString("Plot"), int number = 1);
   OMPlot::PlotWindow* getCurrentWindow();
+  QMdiSubWindow* getPlotSubWindowFromMdi();
   OMPlot::PlotWindow* getInteractiveWindow(QString targetWindow);
 #if !defined(WITHOUT_OSG)
   AnimationWindow* getCurrentAnimationWindow();


### PR DESCRIPTION
### Related Issues

#12911

### Purpose

Do not open a new plot window when its not needed.

### Approach

When a diagram window is active then we plot on the previous plot window, if there is any and make it active. If there is no previous plot window then open a new plot window.