### PR TITLE
Ignore noncritical failures in EvalConstants

### DIFF
--- a/testsuite/flattening/modelica/scodeinst/IfEquation10.mo
+++ b/testsuite/flattening/modelica/scodeinst/IfEquation10.mo
@@ -1,0 +1,28 @@
+// name: IfEquation10
+// keywords:
+// status: correct
+//
+
+model IfEquation10
+  parameter Real x[1] = ones(size(x, 1)) annotation(Evaluate=true);
+  Real y;
+equation
+  if time > 1 then
+    y = x[1] + x[2];
+  else
+    y = x[1];
+  end if;
+end IfEquation10;
+
+// Result:
+// class IfEquation10
+//   final parameter Real x[1] = 1.0;
+//   Real y;
+// equation
+//   if time > 1.0 then
+//     y = 1.0 + x[2];
+//   else
+//     y = 1.0;
+//   end if;
+// end IfEquation10;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -731,6 +731,7 @@ IfEquation6.mo \
 IfEquation7.mo \
 IfEquation8.mo \
 IfEquation9.mo \
+IfEquation10.mo \
 IfEquationEval1.mo \
 IfEquationEval2.mo \
 IfEquationEval3.mo \


### PR DESCRIPTION
- Keep crefs as they are if we fail to evaluate them in contexts where they might not be executed, such as inside if-equations.