### PR TITLE
Fix broken detection of Connections operators

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2117,7 +2117,7 @@ public
   algorithm
     isOp := match call
       case TYPED_CALL()
-        then Function.isBuiltin(call.fn) and functionNameFirst(call) == "Connections";
+        then Function.isBuiltin(call.fn) and AbsynUtil.pathFirstIdent(Function.name(call.fn)) == "Connections";
       else false;
     end match;
   end isConnectionsOperator;

--- a/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
@@ -1204,7 +1204,7 @@ public
     res := match eq
       case Equation.CONNECT() then true;
       case Equation.NORETCALL(exp = Expression.CALL(call = call))
-        then Call.functionNameFirst(call) == "Connections";
+        then Call.isConnectionsOperator(call);
       else false;
     end match;
   end isConnection;


### PR DESCRIPTION
- Use `Call.isConnectionsOperator` in `Equation.isConnection` instead of manually checking the name incorrectly.
- Fix `Call.isConnectionsOperator` to use the full name of the function and not the builtin name that's missing the Connections part.