### PR TITLE
handle ModelicaError as assert failing with AssertionLevel = error

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -2487,10 +2487,20 @@ case EXTERNAL_FUNCTION(__) then
       '<%extVarName(c)%> = '
     else
       ""
+  /*https://github.com/OpenModelica/OpenModelica/issues/9681
+   * ModelicaError should be handled as assert failing with AssertionLevel = error
+  */
+  let modelicaError = match extName
+    case "ModelicaError" then
+      <<
+      FILE_INFO info = {<%infoArgs(info)%>};
+      omc_assert(threadData, info, <%args%>);
+      >> else ""
+
   <<
   <%match extReturn case SIMEXTARG(__) then extFunCallVardecl(extReturn, &varDecls, &auxFunction, true)%>
   <%dynamicCheck%>
-  <%returnAssign%><%fname%>(<%args%>);
+  <%if modelicaError then '<%modelicaError%>' else '<%returnAssign%><%fname%>(<%args%>);'%>
   <%extArgs |> arg => extFunCallVarcopy(arg, &auxFunction) ;separator="\n"%>
   <%match extReturn case SIMEXTARG(__) then extFunCallVarcopy(extReturn, &auxFunction)%>
   >>

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -86,6 +86,7 @@ matrices.mos \
 Modelica.Media.Examples.getComponents.mos \
 MoveClass2.mos \
 MoveClass.mos \
+ModelicaError.mos \
 Obfuscation1.mos \
 Obfuscation2.mos \
 Obfuscation3.mos \

--- a/testsuite/openmodelica/interactive-API/ModelicaError.mos
+++ b/testsuite/openmodelica/interactive-API/ModelicaError.mos
@@ -1,0 +1,80 @@
+// name: ModelicaError.mos
+// keywords:
+// status: correct
+
+loadString("
+  package ModelicaError
+    function f1
+      input Real x;
+      output Real y;
+    algorithm
+      y := (x - 1)*(x - 10)*(x - 30);
+      if x < 0.8 then
+        Modelica.Utilities.Streams.error(\"x is too small\");
+      end if;
+    end f1;
+
+    function f2
+      input Real x;
+      output Real y;
+    algorithm
+      y := (x - 1)*(x - 10)*(x - 30);
+      assert(x > 0.8, \"x is too small\");
+    end f2;
+
+    model M1
+      Real x(start = 0.7);
+    equation
+      f1(x) = 0;
+    end M1;
+
+    model M2
+      Real x(start = 0.7);
+    equation
+      f2(x) = 0;
+    end M2;
+  end ModelicaError;
+"); getErrorString();
+
+simulate(ModelicaError.M1);getErrorString();
+simulate(ModelicaError.M2);getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "ModelicaError.M1_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelicaError.M1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "
+// LOG_ASSERT        | error   | [Modelica 4.0.0+maint.om/Utilities/Streams.mo:120:3-148:12:writable]
+// |                 | |       | x is too small
+// LOG_STDOUT        | warning | Non-Linear Solver try to handle a problem with a called assert.
+// LOG_STDOUT        | warning | While solving non-linear system an assertion failed during initialization.
+// |                 | |       | | The non-linear solver tries to solve the problem that could take some time.
+// |                 | |       | | It could help to provide better start-values for the iteration variables.
+// |                 | |       | | For more information simulate with -lv LOG_NLS_V
+// lobal homotopy with equidistant step size started.LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica 4.0.0 due to usage.
+// "
+// record SimulationResult
+//     resultFile = "ModelicaError.M2_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelicaError.M2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "
+// LOG_ASSERT        | error   | [<interactive>:18:7-18:40:writable]
+// |                 | |       | x is too small
+// LOG_STDOUT        | warning | Non-Linear Solver try to handle a problem with a called assert.
+// LOG_STDOUT        | warning | While solving non-linear system an assertion failed during initialization.
+// |                 | |       | | The non-linear solver tries to solve the problem that could take some time.
+// |                 | |       | | It could help to provide better start-values for the iteration variables.
+// |                 | |       | | For more information simulate with -lv LOG_NLS_V
+// lobal homotopy with equidistant step size started.LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/ModelicaError.mos
+++ b/testsuite/openmodelica/interactive-API/ModelicaError.mos
@@ -45,15 +45,14 @@ simulate(ModelicaError.M2);getErrorString();
 // record SimulationResult
 //     resultFile = "ModelicaError.M1_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelicaError.M1', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "
-// LOG_ASSERT        | error   | [Modelica 4.0.0+maint.om/Utilities/Streams.mo:120:3-148:12:writable]
+//     messages = "LOG_ASSERT        | error   | [Modelica 4.0.0+maint.om/Utilities/Streams.mo:120:3-148:12:writable]
 // |                 | |       | x is too small
 // LOG_STDOUT        | warning | Non-Linear Solver try to handle a problem with a called assert.
 // LOG_STDOUT        | warning | While solving non-linear system an assertion failed during initialization.
 // |                 | |       | | The non-linear solver tries to solve the problem that could take some time.
 // |                 | |       | | It could help to provide better start-values for the iteration variables.
 // |                 | |       | | For more information simulate with -lv LOG_NLS_V
-// lobal homotopy with equidistant step size started.LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;
@@ -64,15 +63,14 @@ simulate(ModelicaError.M2);getErrorString();
 // record SimulationResult
 //     resultFile = "ModelicaError.M2_res.mat",
 //     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'ModelicaError.M2', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
-//     messages = "
-// LOG_ASSERT        | error   | [<interactive>:18:7-18:40:writable]
+//     messages = "LOG_ASSERT        | error   | [<interactive>:18:7-18:40:writable]
 // |                 | |       | x is too small
 // LOG_STDOUT        | warning | Non-Linear Solver try to handle a problem with a called assert.
 // LOG_STDOUT        | warning | While solving non-linear system an assertion failed during initialization.
 // |                 | |       | | The non-linear solver tries to solve the problem that could take some time.
 // |                 | |       | | It could help to provide better start-values for the iteration variables.
 // |                 | |       | | For more information simulate with -lv LOG_NLS_V
-// lobal homotopy with equidistant step size started.LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
 // LOG_SUCCESS       | info    | The simulation finished successfully.
 // "
 // end SimulationResult;


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/9681

### Purpose
This PR allows `ModelicaError` as assert failing with `AssertionLevel = error` and does not abort the simulation.

