### PR TITLE
OMPlot: Drop AA_UseHighDpiPixmaps for qt6

### DIFF
--- a/OMPlot/OMPlot/OMPlotGUI/PlotApplication.cpp
+++ b/OMPlot/OMPlot/OMPlotGUI/PlotApplication.cpp
@@ -41,7 +41,9 @@ PlotApplication::PlotApplication(int &argc, char *argv[], const QString uniqueKe
     : QApplication(argc, argv)
 {
     setAttribute(Qt::AA_DontShowIconsInMenus, false);
+#if QT_VERSION < 0x060000
     setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
     mSharedMemory.setKey(uniqueKey);
 
     if (mSharedMemory.attach())


### PR DESCRIPTION
This is the default in Qt6:
```
PlotApplication.cpp:44:22: warning: 'Qt::AA_UseHighDpiPixmaps' is deprecated: High-DPI pixmaps are always enabled. This attribute no longer has any effect. [-Wdeprecated-declarations]
```