### PR TITLE
Use setFontFamilies in Qt6

### DIFF
--- a/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cell.cpp
@@ -383,7 +383,11 @@ namespace IAEX
       }
       else if( (*current)->attribute() == "FontFamily" )
       {
+#if QT_VERSION >= 0x060000
+        style_.textCharFormat()->setFontFamilies({(*current)->value()});
+#else
         style_.textCharFormat()->setFontFamily( (*current)->value() );
+#endif
       }
       else if( (*current)->attribute() == "InitializationCell" )
       {}

--- a/OMNotebook/OMNotebook/OMNotebookGUI/cellstyle.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/cellstyle.h
@@ -69,7 +69,11 @@ namespace IAEX
   public:
     CellStyle()
     {
+#if QT_VERSION >= 0x060000
+      textFormat_.setFontFamilies({"Times New Roman"});
+#else
       textFormat_.setFontFamily( "Times New Roman" );
+#endif
       textFormat_.setFontItalic( false );
       textFormat_.setFontOverline( false );
       textFormat_.setFontStrikeOut( false );

--- a/OMNotebook/OMNotebook/OMNotebookGUI/stylesheet.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/stylesheet.cpp
@@ -363,7 +363,11 @@ namespace IAEX
         // FAMILY
         if( fontElement.tagName() == "family" )
         {
+#if QT_VERSION >= 0x060000
+          item->textCharFormat()->setFontFamilies({fontElement.text()});
+#else
           item->textCharFormat()->setFontFamily( fontElement.text() );
+#endif
         }
         // SIZE
         else if( fontElement.tagName() == "size" )

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.cpp
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcursorcommands.cpp
@@ -229,7 +229,9 @@ namespace IAEX
     QTextEdit *editor = document()->getCursor()->currentCell()->textEdit();
 
     if( editor )
+    {
       editor->setFontFamily( family_ );
+    }
   }
 
 

--- a/OMShell/OMShell/OMShellGUI/oms.cpp
+++ b/OMShell/OMShell/OMShellGUI/oms.cpp
@@ -280,7 +280,11 @@ OMS::OMS( QWidget* parent )
   }
 
   // command stuff
+#if QT_VERSION >= 0x060000
+  commandSignFormat_.setFontFamilies({"Arial"});
+#else
   commandSignFormat_.setFontFamily( "Arial" );
+#endif
   commandSignFormat_.setFontWeight( QFont::Bold );
   commandSignFormat_.setFontPointSize( fontSize_ );
 
@@ -445,7 +449,11 @@ void OMS::addCommandLine()
 
   // set original text settings
   moshEdit_->document()->setDefaultFont(QFont("Courier New", fontSize_, QFont::Normal));
+#if QT_VERSION >= 0x060000
+  textFormat_.setFontFamilies({"Courier New"});
+#else
   textFormat_.setFontFamily( "Courier New" );
+#endif
   textFormat_.setFontWeight( QFont::Normal );
   textFormat_.setFontPointSize( fontSize_ );
 


### PR DESCRIPTION
setFontFamily is deprecated in Qt6