### PR TITLE
[NF] Move some bindings of vectorized components into equations (#12951)

### DIFF
--- a/testsuite/openmodelica/cppruntime/VectorizedPowerSystemTotal.mo
+++ b/testsuite/openmodelica/cppruntime/VectorizedPowerSystemTotal.mo
@@ -325,9 +325,7 @@ package PowerSystems  "Library for electrical power systems"
         package PS = PhaseSystem;
         parameter PS.Voltage[PhaseSystem.n] v_start = ones(PhaseSystem.n) "Start value for voltage drop";
         PowerSystems.Generic.Ports.Terminal_p terminal(redeclare package PhaseSystem = PhaseSystem, v(start = v_start));
-        SI.Power[PhaseSystem.n] p "ToDo: move below equation back to binding; broken since commit 28c5b6f (#9907)";
-      equation
-        p = PhaseSystem.phasePowers_vi(terminal.v, terminal.i);
+        SI.Power[PhaseSystem.n] p = PhaseSystem.phasePowers_vi(terminal.v, terminal.i);
       end PartialLoad;
     end Ports;
   end Generic;

--- a/testsuite/openmodelica/cppruntime/testVectorizedBinding.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedBinding.mos
@@ -1,0 +1,140 @@
+// name:     testVectorizedBinding
+// keywords: vectorized components, array equations, for loops
+// status: correct
+// teardown_command: rm -f *VectorizedBindingTest*
+// cflags: -d=-nfScalarize
+
+setCommandLineOptions("-d=-nfScalarize"); getErrorString();
+setCommandLineOptions("--preOptModules+=dumpDAE"); getErrorString();
+setCommandLineOptions("--postOptModules+=dumpDAE"); getErrorString();
+setCommandLineOptions("--simCodeTarget=Cpp"); getErrorString();
+
+loadString("
+model VectorizedBindingTest
+  function f
+    input Real u, i;
+    output Real p = u * i;
+  end f;
+  model M
+    input Real u = 1;
+    input Real i = 2;
+    output Real p = f(u, i);
+  end M;
+  parameter Integer n = 10;
+  M[n] m(u = 1:1:n);
+end VectorizedBindingTest;
+"); getErrorString();
+
+simulate(VectorizedBindingTest); getErrorString();
+
+val(m.p[1], 1.0);
+val(m.p[4], 1.0);
+val(m.p[7], 1.0);
+val(m.p[10], 1.0);
+
+// Result:
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+// true
+// ""
+//
+// ########################################
+// dumpDAE
+// ########################################
+//
+//
+// unspecified partition
+// ========================================
+//
+// Variables (3)
+// ========================================
+// 1: m.p:VARIABLE()  type: Real[10] [10]
+// 2: m.i:VARIABLE()  type: Real[10] [10]
+// 3: m.u:VARIABLE()  type: Real[10] [10]
+//
+//
+// Equations (3, 3)
+// ========================================
+// 1/1 (10): for $i1 in 1 : 10 loop
+//     m[$i1].p = VectorizedBindingTest.f(m[$i1].u, m[$i1].i); end for;    [dynamic |0|0|0|0|]
+// 2/11 (10): m.u = 1.0:1.0:10.0   [binding |0|0|0|0|]
+// 3/21 (10): m.i = 2.0   [binding |0|0|0|0|]
+//
+//
+// no matching
+//
+//
+//
+// BackendDAEType: simulation
+//
+//
+// Known variables only depending on parameters and constants - globalKnownVars (1)
+// ========================================
+// 1: n:PARAM(final = true )  = 10  type: Integer
+//
+//
+//
+// ########################################
+// dumpDAE
+// ########################################
+//
+//
+// unspecified partition
+// ========================================
+//
+// Variables (3)
+// ========================================
+// 1: m.p:VARIABLE()  type: Real[10] [10]
+// 2: m.i:VARIABLE()  type: Real[10] [10]
+// 3: m.u:VARIABLE()  type: Real[10] [10]
+//
+//
+// Equations (3, 3)
+// ========================================
+// 1/1 (10): for $i1 in 1 : 10 loop
+//     m[$i1].p = VectorizedBindingTest.f(m[$i1].u, m[$i1].i); end for;    [dynamic |0|0|0|0|]
+// 2/11 (10): m.u = 1.0:1.0:10.0   [binding |0|0|0|0|]
+// 3/21 (10): m.i = 2.0   [binding |0|0|0|0|]
+//
+//
+// Matching
+// ========================================
+// 3 variables and equations
+// var 1 is solved in eqn 1
+// var 2 is solved in eqn 3
+// var 3 is solved in eqn 2
+//
+//
+// StrongComponents
+// ========================================
+// Array  {{3:2}}
+// Array  {{2:3}}
+// {1:1}
+//
+//
+//
+// BackendDAEType: simulation
+//
+//
+// Known variables only depending on parameters and constants - globalKnownVars (1)
+// ========================================
+// 1: n:PARAM(final = true )  = 10  type: Integer
+//
+//
+// record SimulationResult
+//     resultFile = "VectorizedBindingTest_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'VectorizedBindingTest', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = ""
+// end SimulationResult;
+// ""
+// 2.0
+// 8.0
+// 14.0
+// 20.0
+// endResult

--- a/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
+++ b/testsuite/openmodelica/cppruntime/testVectorizedPowerSystem.mos
@@ -2,10 +2,10 @@
 // keywords: vectorized components, array equations, for loops
 // status: correct
 // teardown_command: rm -f *VectorizedPowerSystemTest*
-// cflags: -d=-newInst
+// cflags: -d=-nfScalarize
 
 setCommandLineOptions("--std=3.3"); getErrorString();
-setCommandLineOptions("-d=newInst,-nfScalarize"); getErrorString();
+setCommandLineOptions("-d=-nfScalarize"); getErrorString();
 setCommandLineOptions("--preOptModules-=removeSimpleEquations"); getErrorString();
 setCommandLineOptions("--postOptModules-=removeSimpleEquations"); getErrorString();
 setCommandLineOptions("--preOptModules+=dumpDAE"); getErrorString();
@@ -120,7 +120,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 5: busBar1.terminal_n.v:VARIABLE(flow=false unit = fill("V", 1) nominal = fill(1000.0, 1) )  "voltage vector" type: Real[3, 1] [3,1]
 // 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1] [1]
 // 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1] [1]
-// 8: fixedLoad1.p:VARIABLE(unit = fill("W", 1) )  "ToDo: move below equation back to binding; broken since commit 28c5b6f (#9907)" type: Real[3, 1] [3,1]
+// 8: fixedLoad1.p:VARIABLE(unit = fill("W", 1) )  type: Real[3, 1] [3,1]
 // 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = fill("A", 1) nominal = fill(1.0, 1) )  "current vector" type: Real[3, 1] [3,1]
 // 10: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = fill("V", 1) nominal = fill(1000.0, 1) )  "voltage vector" type: Real[3, 1] [3,1]
 // 11: fixedVoltageSource1.p:VARIABLE(unit = "W" )  type: Real[1] [1]
@@ -139,9 +139,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 //     fixedVoltageSource1.terminal.i[$i1] + busBar1.terminal_p.i[$i1] = 0.0; end for;    [dynamic |0|0|0|0|]
 // 5/9 (1): fixedVoltageSource1.terminal.v = {fixedVoltageSource1.V}   [dynamic |0|0|0|0|]
 // 6/10 (3): for $i1 in 1 : 3 loop
-//     fixedLoad1[$i1].terminal.v * fixedLoad1[$i1].terminal.i = fixedLoad1[$i1].P; end for;    [dynamic |0|0|0|0|]
-// 7/13 (3): for $i1 in 1 : 3 loop
 //     fixedLoad1[$i1].p = {fixedLoad1[$i1].terminal.v * fixedLoad1[$i1].terminal.i}; end for;    [dynamic |0|0|0|0|]
+// 7/13 (3): for $i1 in 1 : 3 loop
+//     fixedLoad1[$i1].terminal.v * fixedLoad1[$i1].terminal.i = fixedLoad1[$i1].P; end for;    [dynamic |0|0|0|0|]
 // 8/16 (1): for i in 1 : 1 loop
 //     busBar1.terminal_p.i[i] = -sum(busBar1.terminal_n[:].i[i]); end for;    [dynamic |0|0|0|0|]
 // 9/17 (3): for i in 1 : 3 loop
@@ -465,7 +465,7 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 5: busBar1.terminal_n.v:VARIABLE(flow=false unit = {"V"} nominal = {1000.0} )  "voltage vector" type: Real[3, 1] [3,1]
 // 6: busBar1.terminal_p.i:VARIABLE(flow=true unit = "A" nominal = 1.0 )  "current vector" type: Real[1] [1]
 // 7: busBar1.terminal_p.v:VARIABLE(flow=false unit = "V" nominal = 1000.0 )  "voltage vector" type: Real[1] [1]
-// 8: fixedLoad1.p:VARIABLE(unit = {"W"} )  "ToDo: move below equation back to binding; broken since commit 28c5b6f (#9907)" type: Real[3, 1] [3,1]
+// 8: fixedLoad1.p:VARIABLE(unit = {"W"} )  type: Real[3, 1] [3,1]
 // 9: fixedLoad1.terminal.i:VARIABLE(flow=true unit = {"A"} nominal = {1.0} )  "current vector" type: Real[3, 1] [3,1]
 // 10: fixedLoad1.terminal.v:VARIABLE(flow=false start = fixedLoad1.v_start unit = {"V"} nominal = {1000.0} )  "voltage vector" type: Real[3, 1] [3,1]
 // 11: fixedVoltageSource1.p:VARIABLE(unit = "W" )  type: Real[1] [1]
@@ -484,9 +484,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 //     fixedVoltageSource1.terminal.i[$i1] + busBar1.terminal_p.i[$i1] = 0.0; end for;    [dynamic |0|0|0|0|]
 // 5/9 (1): fixedVoltageSource1.terminal.v = {fixedVoltageSource1.V}   [dynamic |0|0|0|0|]
 // 6/10 (3): for $i1 in 1 : 3 loop
-//     fixedLoad1[$i1].terminal.v * fixedLoad1[$i1].terminal.i = fixedLoad1[$i1].P; end for;    [dynamic |0|0|0|0|]
-// 7/13 (3): for $i1 in 1 : 3 loop
 //     fixedLoad1[$i1].p = {fixedLoad1[$i1].terminal.v * fixedLoad1[$i1].terminal.i}; end for;    [dynamic |0|0|0|0|]
+// 7/13 (3): for $i1 in 1 : 3 loop
+//     fixedLoad1[$i1].terminal.v * fixedLoad1[$i1].terminal.i = fixedLoad1[$i1].P; end for;    [dynamic |0|0|0|0|]
 // 8/16 (1): for i in 1 : 1 loop
 //     busBar1.terminal_p.i[i] = -sum(busBar1.terminal_n[:].i[i]); end for;    [dynamic |0|0|0|0|]
 // 9/17 (3): for i in 1 : 3 loop
@@ -507,8 +507,8 @@ val(fixedVoltageSource1.p[1], 1.0);
 // var 5 is solved in eqn 9
 // var 6 is solved in eqn 8
 // var 7 is solved in eqn 3
-// var 8 is solved in eqn 7
-// var 9 is solved in eqn 6
+// var 8 is solved in eqn 6
+// var 9 is solved in eqn 7
 // var 10 is solved in eqn 1
 // var 11 is solved in eqn 10
 // var 12 is solved in eqn 4
@@ -527,9 +527,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // Array  {{11:3}}
 // Array  {{13:1}}
 // Array  {{1:10}}
-// {6:9}
+// {7:9}
 // {2:4}
-// {7:8}
+// {6:8}
 //
 //
 // unspecified partition


### PR DESCRIPTION
This applies if `-d=-nfScalarize` without `vectorizeBindings` and if the binding contains variables of the vectorized component itself.

See the new `testVectorizedBinding.mos` and `VectorizedPowerSystemTotal.mo` that does not rely on manual conversion to an equation anymore.
