### PR TITLE
[SimCode] fix usage of crefApplySubs

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15305,7 +15305,7 @@ algorithm
       else
         sv := BaseHashTable.get(ComponentReference.crefStripSubs(inCref), crefToSimVarHT);
         subs := ComponentReference.crefSubs(inCref);
-        sv.name := ComponentReference.crefApplySubs(sv.name, subs);
+        sv.name := ComponentReference.crefApplySubs(ComponentReference.crefStripSubs(sv.name), subs);
       end if;
 
       sv.variable_index := match sv.variable_index

--- a/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
+++ b/testsuite/simulation/modelica/NBackend/ScalableTestsuite/Makefile
@@ -22,13 +22,13 @@ OneDHeatTransferTT_Modelica.mos \
 CocurrentHeatExchangerEquations.mos \
 CounterCurrentHeatExchangerEquations.mos \
 SimpleAdvection.mos \
+PowerSystemStepLoad.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest
 FAILINGTESTFILES = \
 TransmissionLineEquations.mos \
 CombiTimeTable.mos \ #this actually runs but somehow external functions dont work
-PowerSystemStepLoad.mos \ #ComponentReference.crefApplySubs fails with new check of dimensions
 
 # Dependency files that are not .mo .mos or Makefile
 # Add them here or they will be cleaned.


### PR DESCRIPTION
 - NB leaves some subscripts in place, remove them before applying new subs
 - [testsuite] fixes a previously removed test

### Related Issues

 - fixes removed model of #12951
