### PR TITLE
Improve getExtendsModifierNames API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3223,6 +3223,19 @@ annotation(
   preferredView="text");
 end getElementModifierNames;
 
+function getExtendsModifierNames
+  input TypeName className;
+  input TypeName extendsName;
+  input Boolean useQuotes = false;
+  output String modifiers;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Returns the names of the modifiers on an extends clause.
+</html>"),
+  preferredView="text");
+end getExtendsModifierNames;
+
 function setComponentModifierValue = setElementModifierValue;
 
 function setElementModifierValue

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3474,6 +3474,19 @@ annotation(
   preferredView="text");
 end getElementModifierNames;
 
+function getExtendsModifierNames
+  input TypeName className;
+  input TypeName extendsName;
+  input Boolean useQuotes = false;
+  output String modifiers;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Returns the names of the modifiers on an extends clause.
+</html>"),
+  preferredView="text");
+end getExtendsModifierNames;
+
 function setComponentModifierValue = setElementModifierValue;
 
 function setElementModifierValue

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3106,6 +3106,10 @@ algorithm
       then
         Values.BOOL(b);
 
+    case ("getExtendsModifierNames",
+          {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.CODE(Absyn.C_TYPENAME(path)), Values.BOOL(b)})
+      then InteractiveUtil.getExtendsModifierNames(classpath, path, b, SymbolTable.getAbsyn());
+
  end matchcontinue;
 end cevalInteractiveFunctions4;
 

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -53,6 +53,7 @@ getComponentsTestOF.mos \
 getDefinitions.mos \
 getDialogAnnotation.mos \
 getElementAnnotation.mos \
+getExtendsModifierNames.mos \
 getIconAnnotation.mos \
 getInheritedClasses1.mos \
 getInheritedClasses2.mos \

--- a/testsuite/openmodelica/interactive-API/getExtendsModifierNames.mos
+++ b/testsuite/openmodelica/interactive-API/getExtendsModifierNames.mos
@@ -1,0 +1,46 @@
+// name: getExtendsModifierNames
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  record R
+    Real r1;
+    Real r2;
+  end R;
+
+  model A
+    Real x;
+    Real y;
+    Real z;
+    R r;
+    replaceable Real w;
+    replaceable R r2;
+  end A;
+
+  model B
+    extends A(x = 1.0, r(r1 = 2.0), redeclare Real w = 1.0, redeclare R r2(x = 1.0));
+    Real w;
+  end B;
+
+  model C
+    extends A;
+  end C;
+");
+
+getExtendsModifierNames(B, A);
+getErrorString();
+getExtendsModifierNames(B, A, useQuotes = true);
+getErrorString();
+getExtendsModifierNames(C, A);
+getErrorString();
+
+// Result:
+// true
+// {x,r.r1,w,r2}
+// ""
+// {"x","r.r1","w","r2"}
+// ""
+// {}
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
@@ -291,7 +291,7 @@ getMessagesStringInternal(unique = false); // not unique
 // Evaluating: getErrorString()
 // ""
 // Evaluating: getExtendsModifierNames(vector3D, Real)
-// {start, nominal}
+// {start,nominal}
 // Evaluating: getErrorString()
 // ""
 // Evaluating: getExtendsModifierValue(vector3D, Real, start)

--- a/testsuite/openmodelica/interactive-API/interactive_api_param.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_param.mos
@@ -123,7 +123,7 @@ isExtendsModifierFinal(K6,Resistor,x);
 // Evaluating: getComponentModifierValue(C, b1.a2)
 // "33"
 // Evaluating: getExtendsModifierNames(D2, B2)
-// {a.x, f}
+// {a.x,f}
 // Evaluating: getExtendsModifierValue(D2, B2, a.x)
 // 2*y
 // Evaluating: setExtendsModifierValue(D2, B2, a.x, $Code( = 10))
@@ -217,7 +217,7 @@ isExtendsModifierFinal(K6,Resistor,x);
 // Evaluating: getExtendsModifierValue(K3, Resistor, R)
 // 2
 // Evaluating: getExtendsModifierNames(K4, Resistor)
-// {x, x.start, x.fixed}
+// {x,x.start,x.fixed}
 // Evaluating: setExtendsModifierValue(K4, Resistor, x, $Code())
 // true
 // Evaluating: getExtendsModifierValue(K4, Resistor, x)
@@ -231,7 +231,7 @@ isExtendsModifierFinal(K6,Resistor,x);
 // Evaluating: setExtendsModifierValue(K5, Resistor, x, $Code())
 // true
 // Evaluating: getExtendsModifierNames(K5, Resistor)
-// {x.fixed, x.start}
+// {x.fixed,x.start}
 // Evaluating: getExtendsModifierValue(K5, Resistor, x.fixed)
 // true
 // Evaluating: getExtendsModifierValue(K5, Resistor, x.start)


### PR DESCRIPTION
- Move the implementation of `getExtendsModifierNames` to the typed API.
- Include the names of redeclare modifiers too.

Fixes #13012