### PR TITLE
Move more API calls to the typed API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2687,6 +2687,29 @@ external "builtin";
 annotation(preferredView="text");
 end reduceTerms;
 
+function createModel
+  input TypeName className;
+  output Boolean success;
+external "builtin"
+annotation(
+  Documentation(info="<html>
+  Creates a new empty model.
+</html>"),
+  preferredView="text");
+end createModel;
+
+function newModel
+  input TypeName className;
+  input TypeName withinPath;
+  output Boolean success;
+external "builtin"
+annotation(
+  Documentation(info="<html>
+  Creates a new empty model in the given package.
+</html>"),
+  preferredView="text");
+end newModel;
+
 function moveClass
  "Moves a class up or down depending on the given offset, where a positive
   offset moves the class down and a negative offset up. The offset is truncated
@@ -2728,6 +2751,17 @@ function copyClass
 external "builtin";
 annotation(preferredView="text");
 end copyClass;
+
+function deleteClass
+  input TypeName className;
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Unloads a class.
+</html>"),
+  preferredView="text");
+end deleteClass;
 
 function linearize "creates a model with symbolic linearization matrices"
   input TypeName className "the class that should simulated";
@@ -3404,6 +3438,19 @@ annotation(
 </html>"),
   preferredView="text");
 end removeExtendsModifiers;
+
+function setComponentDimensions
+  input TypeName className;
+  input TypeName componentName;
+  input Expression dimensions;
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Sets the array dimensions of a component.
+</html>"),
+  preferredView="text");
+end setComponentDimensions;
 
 function updateConnection
   input TypeName className;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2938,6 +2938,29 @@ external "builtin";
 annotation(preferredView="text");
 end reduceTerms;
 
+function createModel
+  input TypeName className;
+  output Boolean success;
+external "builtin"
+annotation(
+  Documentation(info="<html>
+  Creates a new empty model.
+</html>"),
+  preferredView="text");
+end createModel;
+
+function newModel
+  input TypeName className;
+  input TypeName withinPath;
+  output Boolean success;
+external "builtin"
+annotation(
+  Documentation(info="<html>
+  Creates a new empty model in the given package.
+</html>"),
+  preferredView="text");
+end newModel;
+
 function moveClass
  "Moves a class up or down depending on the given offset, where a positive
   offset moves the class down and a negative offset up. The offset is truncated
@@ -2979,6 +3002,17 @@ function copyClass
 external "builtin";
 annotation(preferredView="text");
 end copyClass;
+
+function deleteClass
+  input TypeName className;
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Unloads a class.
+</html>"),
+  preferredView="text");
+end deleteClass;
 
 function linearize "creates a model with symbolic linearization matrices"
   input TypeName className "the class that should simulated";
@@ -3655,6 +3689,19 @@ annotation(
 </html>"),
   preferredView="text");
 end removeExtendsModifiers;
+
+function setComponentDimensions
+  input TypeName className;
+  input TypeName componentName;
+  input Expression dimensions;
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Sets the array dimensions of a component.
+</html>"),
+  preferredView="text");
+end setComponentDimensions;
 
 function updateConnection
   input TypeName className;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3130,6 +3130,36 @@ algorithm
 
     case ("isProtected", {Values.CODE(Absyn.C_TYPENAME(path)), Values.CODE(Absyn.C_TYPENAME(classpath))})
       then ValuesUtil.makeBoolean(Interactive.isProtected(path, classpath, SymbolTable.getAbsyn()));
+
+    case ("setComponentDimensions", {Values.CODE(Absyn.C_TYPENAME(classpath)),
+        Values.CODE(Absyn.C_TYPENAME(path)), Values.CODE(Absyn.C_EXPRESSION(aexp as Absyn.Exp.ARRAY()))})
+      algorithm
+        (p, b) := Interactive.setComponentDimensions(classpath, path, aexp.arrayExp, SymbolTable.getAbsyn());
+        SymbolTable.setAbsyn(p);
+      then
+        ValuesUtil.makeBoolean(b);
+
+    case ("createModel", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      algorithm
+        p := Interactive.createModel(classpath, SymbolTable.getAbsyn());
+        SymbolTable.setAbsyn(p);
+      then
+        ValuesUtil.makeBoolean(true);
+
+    case ("newModel", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.CODE(Absyn.C_TYPENAME(path))})
+      algorithm
+        p := Interactive.newModel(classpath, path, SymbolTable.getAbsyn());
+        SymbolTable.setAbsyn(p);
+      then
+        ValuesUtil.makeBoolean(true);
+
+    case ("deleteClass", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      algorithm
+        (b, p) := Interactive.deleteClass(classpath, SymbolTable.getAbsyn());
+        SymbolTable.setAbsyn(p);
+      then
+        ValuesUtil.makeBoolean(b);
+
  end matchcontinue;
 end cevalInteractiveFunctions4;
 

--- a/testsuite/openmodelica/interactive-API/Bug3282.mos
+++ b/testsuite/openmodelica/interactive-API/Bug3282.mos
@@ -18,19 +18,19 @@ list(M); getErrorString();
 //   Real a;
 // end M;"
 // ""
-// Ok
+// true
 // ""
 // "model M
 //   Real a;
 // end M;"
 // ""
-// Ok
+// true
 // ""
 // "model M
 //   Real a[10, 12];
 // end M;"
 // ""
-// Ok
+// true
 // ""
 // "model M
 //   Real a;

--- a/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
@@ -187,7 +187,7 @@ getMessagesStringInternal(unique = false); // not unique
 // Evaluating: getErrorString()
 // ""
 // Evaluating: setComponentDimensions(A, x, {10, 11, 12})
-// Ok
+// true
 // Evaluating: getErrorString()
 // ""
 // Evaluating: list(A)
@@ -197,7 +197,7 @@ getMessagesStringInternal(unique = false); // not unique
 // Evaluating: getErrorString()
 // ""
 // Evaluating: setComponentDimensions(A, x, {1, 2})
-// Ok
+// true
 // Evaluating: getErrorString()
 // ""
 // Evaluating: list(A)


### PR DESCRIPTION
- Move `createModel`, `newModel`, `deleteClass`, and `setComponentDimensions` to the typed API.