### PR TITLE
Move addComponent to the typed API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3160,6 +3160,23 @@ and the annotation to set.</p>
 </html>"));
 end addClassAnnotation;
 
+function addComponent
+  input TypeName componentName;
+  input TypeName typeName;
+  input TypeName classPath;
+  input Expression binding = $Expression(());
+  input ExpressionOrModification modification = $Code(());
+  input Expression comment = $Expression(());
+  input Expression annotate = $Expression(());
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Adds a component to the given class.
+</html>"),
+  preferredView="text");
+end addComponent;
+
 function getParameterNames
   input TypeName class_;
   output String[:] parameters;

--- a/OMCompiler/Compiler/FrontEnd/Static.mo
+++ b/OMCompiler/Compiler/FrontEnd/Static.mo
@@ -2155,7 +2155,7 @@ algorithm
       then DAE.T_COMPLEX(ClassInf.UNKNOWN(Absyn.IDENT("Element")),{},NONE(), false);
 
     case Absyn.C_EXPRESSION()
-      then DAE.T_CODE(DAE.C_EXPRESSION_OR_MODIFICATION());
+      then DAE.T_CODE(DAE.C_EXPRESSION());
 
     case Absyn.C_MODIFICATION()
       then DAE.T_CODE(DAE.C_EXPRESSION_OR_MODIFICATION());

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3411,6 +3411,23 @@ and the annotation to set.</p>
 </html>"));
 end addClassAnnotation;
 
+function addComponent
+  input TypeName componentName;
+  input TypeName typeName;
+  input TypeName classPath;
+  input Expression binding = $Expression(());
+  input ExpressionOrModification modification = $Code(());
+  input Expression comment = $Expression(());
+  input Expression annotate = $Expression(());
+  output Boolean success;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  Adds a component to the given class.
+</html>"),
+  preferredView="text");
+end addComponent;
+
 function getParameterNames
   input TypeName class_;
   output String[:] parameters;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1769,7 +1769,7 @@ algorithm
       DAE.Type tp;
       Absyn.Class absynClass;
       Absyn.ClassDef cdef;
-      Absyn.Exp aexp;
+      Absyn.Exp aexp, aexp2, aexp3;
       Option<DAE.DAElist> odae;
       Values.Value v,cvar,cvar2,v1,v2;
       Absyn.ComponentRef cr;
@@ -3160,6 +3160,15 @@ algorithm
       then
         ValuesUtil.makeBoolean(b);
 
+    case ("addComponent", {Values.CODE(Absyn.C_TYPENAME(Absyn.IDENT(name))),
+        Values.CODE(Absyn.C_TYPENAME(path)), Values.CODE(Absyn.C_TYPENAME(classpath)),
+        Values.CODE(Absyn.C_EXPRESSION(aexp)), Values.CODE(Absyn.C_MODIFICATION(modification = mod)),
+        Values.CODE(Absyn.C_EXPRESSION(aexp2)), Values.CODE(Absyn.C_EXPRESSION(aexp3))})
+      algorithm
+        (p, b) := Interactive.addComponent(name, path, classpath, aexp, mod, aexp2, aexp3, SymbolTable.getAbsyn());
+        SymbolTable.setAbsyn(p);
+      then
+        ValuesUtil.makeBoolean(b);
  end matchcontinue;
 end cevalInteractiveFunctions4;
 

--- a/OMCompiler/Parser/BaseModelica_Lexer.g
+++ b/OMCompiler/Parser/BaseModelica_Lexer.g
@@ -326,7 +326,7 @@ NL: '\r\n' | '\n' | '\r';
 /* OpenModelica extensions */
 CODE : '$Code';
 CODE_NAME : '$TypeName';
-CODE_EXP : '$Exp';
+CODE_EXP : '$Expression';
 CODE_ANNOTATION : '$annotation';
 CODE_VAR : '$Var';
 

--- a/OMCompiler/Parser/Modelica.g
+++ b/OMCompiler/Parser/Modelica.g
@@ -2136,6 +2136,7 @@ code_expression returns [void* ast]
       }
   | CODE_NAME LPAR name=name_path RPAR {ast = Absyn__CODE(Absyn__C_5fTYPENAME(name));}
   | CODE_ANNOTATION cmod=class_modification { ast = Absyn__CODE(Absyn__C_5fMODIFICATION(Absyn__CLASSMOD(cmod, Absyn__NOMOD))); }
+  | CODE_EXP LPAR e=expression[metamodelica_enabled()] RPAR { ast = Absyn__CODE(Absyn__C_5fEXPRESSION(e.ast)); }
   | CODE_VAR LPAR cr=component_reference RPAR {ast = Absyn__CODE(Absyn__C_5fVARIABLENAME(cr.ast));}
   )
   ;

--- a/testsuite/openmodelica/interactive-API/addComponent1.mos
+++ b/testsuite/openmodelica/interactive-API/addComponent1.mos
@@ -14,6 +14,7 @@ end InstantiationExample;");
 getErrorString();
 list(InstantiationExample);
 addComponent(myBlock, InstantiationExample.MyBlock,InstantiationExample,annotate=Placement(transformation=transformation(origin={-32,-62},extent={{-10,-10},{10,10}})));
+addComponent(x, Real, InstantiationExample, comment="comment", binding=10, modification = $Code((start = 0.0)));
 getErrorString();
 list(InstantiationExample);
 getErrorString();
@@ -27,6 +28,7 @@ getErrorString();
 //   end MyBlock;
 // end InstantiationExample;"
 // true
+// true
 // ""
 // "model InstantiationExample
 //   block MyBlock
@@ -35,6 +37,7 @@ getErrorString();
 //
 //   MyBlock myBlock annotation(
 //     Placement(transformation(origin = {-32, -62}, extent = {{-10, -10}, {10, 10}})));
+//   Real x(start = 0.0) = 10 \"comment\";
 // end InstantiationExample;"
 // ""
 // endResult


### PR DESCRIPTION
- Move `addComponent` to the typed API.
- Add missing support for `$Expression` code expressions to allow default values on parameters of `Expression` type in `ModelicaBuiltin`.
- Fix `addComponent` to make it possible to add both a binding and a modifier at the same time.