### PR TITLE
Don't allow non-top-level within when loading top-level classes

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1121,6 +1121,7 @@ function loadFile "load file (*.mo) and merge it with the loaded AST."
   input Boolean uses = true;
   input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
   input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
+  input Boolean allowWithin = true "Whether to allow the file to have a within-clause other than 'within;'.";
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
@@ -1140,6 +1141,7 @@ function loadFiles "load files (*.mo) and merges them with the loaded AST."
   input Boolean uses = true;
   input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
   input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
+  input Boolean allowWithin = true "Whether to allow the files to have a within-clause other than 'within;'.";
   output Boolean success;
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1375,6 +1375,7 @@ function loadFile "load file (*.mo) and merge it with the loaded AST."
   input Boolean uses = true;
   input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
   input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
+  input Boolean allowWithin = true "Whether to allow the file to have a within-clause other than 'within;'.";
   output Boolean success;
 external "builtin";
 annotation(Documentation(info="<html>
@@ -1394,6 +1395,7 @@ function loadFiles "load files (*.mo) and merges them with the loaded AST."
   input Boolean uses = true;
   input Boolean notify = true "Give a notification of the libraries and versions that were loaded";
   input Boolean requireExactVersion = false "If the version is required to be exact, if there is a uses Modelica(version=\"3.2\"), Modelica 3.2.1 will not match it.";
+  input Boolean allowWithin = true "Whether to allow the files to have a within-clause other than 'within;'.";
   output Boolean success;
 external "builtin";
 annotation(preferredView="text");

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -1499,20 +1499,11 @@ algorithm
 
     case ("moveClassToBottom", _) then Values.BOOL(false);
 
-    case ("copyClass",{Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(name), Values.CODE(Absyn.C_TYPENAME(Absyn.IDENT("__OpenModelica_TopLevel")))})
-      equation
-        p = SymbolTable.getAbsyn();
-        absynClass = InteractiveUtil.getPathedClassInProgram(classpath, p);
-        p = copyClass(absynClass, name, Absyn.TOP(), classpath, p);
-        SymbolTable.setAbsyn(p);
-      then
-        Values.BOOL(true);
-
     case ("copyClass",{Values.CODE(Absyn.C_TYPENAME(classpath)), Values.STRING(name), Values.CODE(Absyn.C_TYPENAME(path))})
       equation
         p = SymbolTable.getAbsyn();
         absynClass = InteractiveUtil.getPathedClassInProgram(classpath, p);
-        p = copyClass(absynClass, name, Absyn.WITHIN(path), classpath, p);
+        p = copyClass(absynClass, name, InteractiveUtil.parseWithinPath(path), classpath, p);
         SymbolTable.setAbsyn(p);
       then
         Values.BOOL(true);

--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -6233,5 +6233,16 @@ function makeAnnotationArrayValue
 algorithm
   arr := ValuesUtil.makeArray(list(ValuesUtil.makeCodeTypeName(Absyn.Path.IDENT(s)) for s in annotations));
 end makeAnnotationArrayValue;
+
+function parseWithinPath
+  input Absyn.Path path;
+  output Absyn.Within outWithin;
+algorithm
+  outWithin := match path
+    case Absyn.Path.IDENT("__OpenModelica_TopLevel") then Absyn.Within.TOP();
+    else Absyn.Within.WITHIN(path);
+  end match;
+end parseWithinPath;
+
 annotation(__OpenModelica_Interface="backend");
 end InteractiveUtil;

--- a/OMCompiler/SimulationRuntime/OMSICpp/omcWrapper/omcCAPI/src/OMC.cpp
+++ b/OMCompiler/SimulationRuntime/OMSICpp/omcWrapper/omcCAPI/src/OMC.cpp
@@ -180,7 +180,7 @@ int LoadFile(data* omcData, const char* fileName)
     modelica_boolean requireExactVersion = false;
 
     MMC_TRY_TOP_SET(omcData->threadData)
-      result = omc_OpenModelicaScriptingAPI_loadFile(threadData, mmc_mk_scon(fileName), mmc_mk_scon(encoding.c_str()), uses, notify, requireExactVersion);
+      result = omc_OpenModelicaScriptingAPI_loadFile(threadData, mmc_mk_scon(fileName), mmc_mk_scon(encoding.c_str()), uses, notify, requireExactVersion, false);
       CP_TD();
     MMC_CATCH_TOP(return -1)
 

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -1699,12 +1699,12 @@ bool OMCProxy::loadModel(QString className, QString priorityVersion, bool notify
   \param fileName - the file to load.
   \return true on success
   */
-bool OMCProxy::loadFile(QString fileName, QString encoding, bool uses, bool notify, bool requireExactVersion)
+bool OMCProxy::loadFile(QString fileName, QString encoding, bool uses, bool notify, bool requireExactVersion, bool allowWithin)
 {
   mLoadModelError = false;
   bool result = false;
   fileName = fileName.replace('\\', '/');
-  result = mpOMCInterface->loadFile(fileName, encoding, uses, notify, requireExactVersion);
+  result = mpOMCInterface->loadFile(fileName, encoding, uses, notify, requireExactVersion, allowWithin);
   printMessagesStringInternal();
   return result;
 }

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.h
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.h
@@ -165,7 +165,7 @@ public:
   QString getClassComment(QString className);
   QString changeDirectory(QString directory = QString(""));
   bool loadModel(QString className, QString priorityVersion = QString("default"), bool notify = true, QString languageStandard = QString(""), bool requireExactVersion = false);
-  bool loadFile(QString fileName, QString encoding = Helper::utf8, bool uses = true, bool notify = true, bool requireExactVersion = false);
+  bool loadFile(QString fileName, QString encoding = Helper::utf8, bool uses = true, bool notify = true, bool requireExactVersion = false, bool allowWithin = false);
   bool loadString(QString value, QString fileName, QString encoding = Helper::utf8, bool merge = false, bool checkError = true);
   bool loadClassContentString(const QString &data, const QString &className);
   QList<QString> parseFile(QString fileName, QString encoding = Helper::utf8);

--- a/testsuite/openmodelica/interactive-API/interactive_api_loadsave.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_loadsave.mos
@@ -23,7 +23,7 @@ save(A.test);
 save(A);
 clear();
 loadFile("A.mo");
-loadFile("test.mo");
+loadFile("test.mo", allowWithin=true);
 getClassNames();
 getClassNames(A);
 system("rm -rf A.mo test.mo");
@@ -60,7 +60,7 @@ system("rm -rf A.mo test.mo");
 // true
 // Evaluating: loadFile("A.mo")
 // true
-// Evaluating: loadFile("test.mo")
+// Evaluating: loadFile("test.mo", allowWithin = true)
 // true
 // Evaluating: getClassNames()
 // {A}


### PR DESCRIPTION
- Don't allow classes to have non-top-level within clauses when loading with `loadFile` or `loadString`.
- Add flag to `loadFile` and `loadString` to disable this, since it's sometimes useful for testing.

Fixes #13047