### PR TITLE
Fix warnings in OMEdit

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -1319,8 +1319,8 @@ void DocumentationViewer::setFocusInternal()
 {
   setFocus(Qt::ActiveWindowFocusReason);
   QPoint center = QPoint(0, 0);
-  QMouseEvent *pMouseEvent1 = new QMouseEvent(QEvent::MouseButtonPress, center, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
-  QMouseEvent *pMouseEvent2 = new QMouseEvent(QEvent::MouseButtonRelease, center, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+  QMouseEvent *pMouseEvent1 = new QMouseEvent(QEvent::MouseButtonPress, center, center, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+  QMouseEvent *pMouseEvent2 = new QMouseEvent(QEvent::MouseButtonRelease, center, center, Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
   QApplication::postEvent(this, pMouseEvent1);
   QApplication::postEvent(this, pMouseEvent2);
 }

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -47,6 +47,17 @@
 
 #include "../../OMCompiler/Compiler/runtime/settingsimpl.h"
 
+QString translationsPath(QString translationsDirectory)
+{
+#ifdef Q_OS_WIN
+  return translationDirectory;
+#elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+  return QLibraryInfo::path(QLibraryInfo::TranslationsPath);
+#else
+  return QLibraryInfo::location(QLibraryInfo::TranslationsPath);
+#endif
+}
+
 /*!
  * \class OMEditApplication
  * \brief It is a subclass for QApplication so that we can handle QFileOpenEvent sent by OSX at startup.
@@ -85,17 +96,13 @@ OMEditApplication::OMEditApplication(int &argc, char **argv, threadData_t* threa
 
   QString translationDirectory = installationDirectoryPath + QString("/share/omedit/nls");
   // install Qt's default translations
-  QTranslator *pQtTranslator = new QTranslator(this);
-#ifdef Q_OS_WIN
-  pQtTranslator->load("qt_" + locale, translationDirectory);
-#else
-  pQtTranslator->load("qt_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
-#endif
-  installTranslator(pQtTranslator);
+  if (mQtTranslator.load("qt_" + locale, translationsPath(translationDirectory))) {
+    installTranslator(&mQtTranslator);
+  }
   // install application translations
-  QTranslator *pTranslator = new QTranslator(this);
-  pTranslator->load("OMEdit_" + locale, translationDirectory);
-  installTranslator(pTranslator);
+  if (mTranslator.load("OMEdit_" + locale, translationDirectory)) {
+    installTranslator(&mTranslator);
+  }
   // Splash Screen
   QPixmap pixmap(":/Resources/icons/omedit_splashscreen.png");
   SplashScreen *pSplashScreen = SplashScreen::instance();

--- a/OMEdit/OMEditLIB/OMEditApplication.h
+++ b/OMEdit/OMEditLIB/OMEditApplication.h
@@ -39,6 +39,7 @@ extern "C" {
 }
 
 #include <QApplication>
+#include <QTranslator>
 #include <QStringList>
 
 class OMEditApplication : public QApplication
@@ -48,6 +49,8 @@ public:
   OMEditApplication(int &argc, char**argv, threadData_t *threadData, bool testsuiteRunning = false);
 private:
   QStringList mFilesToOpenList;
+  QTranslator mQtTranslator;
+  QTranslator mTranslator;
 protected:
   virtual bool event(QEvent *pEvent) override;
 };


### PR DESCRIPTION
- Avoid deprecated `QMouseEvent` constructor.
- Change `QLibraryInfo::location` to `QLibraryInfo::path` for Qt6.
- Don't ignore the `nodiscard` return value of `QTranslator::load`.
- Avoid memory leak by making the translators members of `OMEditApplication` instead of allocating them with `new`, `installTranslator` does not take ownership of them.