### PR TITLE
addressing: #13053

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -306,5 +306,5 @@ clean:
 	test ! -d $(OMBUILDDIR) || rm -rf $(OMBUILDDIR)
 
 gitclean:
-	git submodule foreach --recursive 'git clean -fdx -e /git -e /svn'
+	git submodule foreach --recursive 'git clean -fdx -e /git -e /svn -e .vscode/'
 	git clean -fdx -e OpenModelicaSetup -e OMSetup -e OMEncryption -e .project -e *.launch -e .vscode/

--- a/OMCompiler/Makefile.omdev.mingw
+++ b/OMCompiler/Makefile.omdev.mingw
@@ -37,6 +37,8 @@ ifeq (ucrt64,$(findstring ucrt64,$(MSYSTEM_PREFIX)))
 override CFLAGS += -DUCRT64
 endif
 
+# adrpo: automake 1.17 breaks compilation of libffi on msys2/ucrt
+export WANT_AUTOMAKE=1.16
 
 # makefile for Windows MinGW OMDev
 all : .testvariables settings omc

--- a/OMEdit/OMEditLIB/OMEditApplication.cpp
+++ b/OMEdit/OMEditLIB/OMEditApplication.cpp
@@ -50,7 +50,7 @@
 QString translationsPath(QString translationsDirectory)
 {
 #ifdef Q_OS_WIN
-  return translationDirectory;
+  return translationsDirectory;
 #elif (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
   return QLibraryInfo::path(QLibraryInfo::TranslationsPath);
 #else


### PR DESCRIPTION
OMDev update of automake breaks libffi, force automake to 1.16

