### PR TITLE
Allow merging in root class extends

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInst.mo
@@ -733,6 +733,11 @@ algorithm
         base_nodes as (base_node :: _) := Lookup.lookupBaseClassName(base_path, scope, context, info);
         checkExtendsLoop(base_node, scope, base_path, info);
         checkReplaceableBaseClass(base_nodes, base_path, info);
+
+        if InstNode.isRootClass(scope) and SCodeUtil.isEmptyMod(smod) then
+          base_node := InstUtil.mergeScalars(base_node, base_path);
+        end if;
+
         base_node := expand(base_node, context);
 
         ext := InstNode.setNodeType(InstNodeType.BASE_CLASS(scope, def, InstNode.nodeType(base_node)), base_node);
@@ -1354,7 +1359,8 @@ algorithm
 
           // Finding a different element than before expanding extends
           // (probably an inherited element) is an error.
-          if not referenceEq(InstNode.definition(extendsNode), InstNode.definition(ext_node)) then
+          if not referenceEq(InstNode.definition(extendsNode), InstNode.definition(ext_node)) and
+             not Flags.isSet(Flags.MERGE_COMPONENTS) then
             Error.addMultiSourceMessage(Error.FOUND_OTHER_BASECLASS,
               {AbsynUtil.pathString(elem.baseClassPath)},
               {InstNode.info(extendsNode), InstNode.info(ext_node)});

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -867,6 +867,7 @@ MergeComponents5.mo \
 MergeComponents6.mo \
 MergeComponents7.mo \
 MergeComponents8.mo \
+MergeComponents9.mo \
 MinInvalidArg1.mo \
 MinInvalidArg2.mo \
 MinInvalidArg3.mo \

--- a/testsuite/flattening/modelica/scodeinst/MergeComponents9.mo
+++ b/testsuite/flattening/modelica/scodeinst/MergeComponents9.mo
@@ -1,0 +1,31 @@
+// name: MergeComponents9
+// keywords:
+// status: correct
+// teardown_command: rm MergeComponents9_merged_table.json S1_merged_table.json
+//
+
+model M
+  Real x;
+equation
+  x = 2*time;
+end M;
+
+model S1
+  M m1;
+  M m2;
+end S1;
+
+model MergeComponents9
+  extends S1;
+  annotation(__OpenModelica_commandLineOptions="-d=mergeComponents");
+end MergeComponents9;
+
+// Result:
+// class MergeComponents9
+//   Real $M1[1].x;
+//   Real $M1[2].x;
+// equation
+//   $M1[1].x = 2.0 * time;
+//   $M1[2].x = 2.0 * time;
+// end MergeComponents9;
+// endResult


### PR DESCRIPTION
- Allow merging elements with `-d=mergeComponents` inside inherited classes with no modifiers in the root class.