### PR TITLE
[NB] remove dummy equations after cleanup

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -809,7 +809,7 @@ public
     function hash
       "only hashes the name"
       input Pointer<Equation> eqn;
-      output Integer i = Variable.hash(Pointer.access(getResidualVar(eqn)));
+      output Integer i = if isDummy(Pointer.access(eqn)) then 0 else ComponentRef.hash(getEqnName(eqn));
     end hash;
 
     function equalName

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
@@ -782,6 +782,17 @@ public
     end match;
   end isDiscrete;
 
+  function isDummy
+    input StrongComponent comp;
+    output Boolean b;
+  algorithm
+    b := match comp
+      case SINGLE_COMPONENT() then Equation.isDummy(Pointer.access(comp.eqn));
+      case MULTI_COMPONENT()  then Equation.isDummy(Pointer.access(Slice.getT(comp.eqn)));
+      else false;
+    end match;
+  end isDummy;
+
   function isAlias
     input StrongComponent comp;
     output Boolean b;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -39,6 +39,7 @@ public
   import BEquation = NBEquation;
   import NBEquation.{Equation, EquationPointer, EquationPointers, EqData, EquationAttributes, EquationKind, IfEquationBody, Iterator};
   import NBVariable.{VariablePointer, VariablePointers, VarData};
+  import Evaluation = NBEvaluation;
   import Events = NBEvents;
   import NFFlatten.FunctionTree;
   import Jacobian = NBJacobian;
@@ -277,6 +278,7 @@ public
 
     // (do not change order SOLVE -> JACOBIAN)
     postOptModules := {
+      (Evaluation.removeDummies,    "Remove Dummies"),
       (function Tearing.main(kind = NBPartition.Kind.ODE),    "Tearing"),
       (Partitioning.categorize,                               "Categorize"),
       (Solve.main,                                            "Solve"),
@@ -1510,7 +1512,7 @@ public
     c := Pointer.access(collector_ptr);
     single_sc := intString(c.single_scalar + c.single_array + c.single_record) + " (scalar:" + intString(c.single_scalar) + ", array:" + intString(c.single_array) + ", record:" + intString(c.single_record) + ")";
     multi_sc := intString(c.multi_algorithm + c.multi_when + c.multi_if) + " (algorithm:" + intString(c.multi_algorithm) + ", when:" + intString(c.multi_when) + ", if:" + intString(c.multi_if) + ", tuple:" + intString(c.multi_tpl) + ")";
-    for_sc := intString(c.resizable_for + c.generic_for + c.entwined_for) + " (resizable: " + intString(c.resizable_for) + "generic: " + intString(c.generic_for) + ", entwined:" + intString(c.entwined_for) + ")";
+    for_sc := intString(c.resizable_for + c.generic_for + c.entwined_for) + " (resizable: " + intString(c.resizable_for) + ", generic: " + intString(c.generic_for) + ", entwined:" + intString(c.entwined_for) + ")";
     alg_sc := intString(c.loop_lin + c.loop_nlin) + " (linear: " + intString(c.loop_lin) + ", nonlinear:" + intString(c.loop_nlin) + ")";
 
     Error.addCompilerNotification(

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBInitialization.mo
@@ -578,7 +578,6 @@ public
           bdae.init_0 := SOME(list(Partition.clone(par, false) for par in bdae.init));
           bdae.init_0 := SOME(list(Partition.mapExp(par, function cleanupHomotopy(init = true, hasHom = hasHom)) for par in Util.getOption(bdae.init_0)));
         end if;
-
       then bdae;
 
       else bdae;

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBEvaluation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBEvaluation.mo
@@ -39,6 +39,8 @@ encapsulated package NBEvaluation
 public
   import BackendDAE = NBackendDAE;
   import Module = NBModule;
+  import Partition = NBPartition.Partition;
+  import StrongComponent = NBStrongComponent;
 
 protected
   // Old Backend imports
@@ -66,6 +68,28 @@ public
   end Stages;
 
   constant Stages DEFAULT_STAGES = STAGES(true, true, false, true);
+
+  function removeDummies
+    "removes the dummy components in a partition
+    Note: will be expanded into removeConstantComponents()"
+    input output BackendDAE bdae;
+  algorithm
+    bdae := match bdae
+      case BackendDAE.MAIN() algorithm
+        bdae.ode        := list(removeDummyComponents(p) for p in bdae.ode);
+        bdae.algebraic  := list(removeDummyComponents(p) for p in bdae.algebraic);
+        bdae.ode_event  := list(removeDummyComponents(p) for p in bdae.ode_event);
+        bdae.alg_event  := list(removeDummyComponents(p) for p in bdae.alg_event);
+      then bdae;
+      else bdae;
+    end match;
+  end removeDummies;
+
+  function removeDummyComponents
+    input output Partition part;
+  algorithm
+    part.strongComponents := Util.applyOption(part.strongComponents, function Array.filter(fun = StrongComponent.isDummy));
+  end removeDummyComponents;
 
   annotation(__OpenModelica_Interface="backend");
 end NBEvaluation;

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -484,6 +484,9 @@ public
         end match;
       then (Slice.SLICE(Pointer.create(solved_eqn), eqn_slice.indices), funcTree, status);
 
+      // dummy equation implies removed equation (occurs only in simulation systems)
+      case Equation.DUMMY_EQUATION() then (eqn_slice, funcTree, Status.EXPLICIT);
+
       else algorithm
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed for equation:\n" + Slice.toString(eqn_slice, function Equation.pointerToString(str = ""))});
       then fail();
@@ -524,6 +527,9 @@ public
             + " failed to solve a for-equation with multiple body eqns for a single cref. Please iterate over body elements individually.\n"
             + "cref: " + ComponentRef.toString(cref) + " in equation:\n" + Equation.toString(eqn)});
       then fail();
+
+      // dummy equation implies removed equation (occurs only in simulation systems)
+      case Equation.DUMMY_EQUATION() then (eqn, funcTree, Status.EXPLICIT, false);
 
       else solveBody(eqn, cref, funcTree);
     end match;

--- a/OMCompiler/Compiler/Util/Array.mo
+++ b/OMCompiler/Compiler/Util/Array.mo
@@ -1367,5 +1367,28 @@ algorithm
   end if;
 end generate;
 
+function filter<T>
+  input array<T> arr;
+  input filterFunc fun;
+  output array<T> new_arr;
+  partial function filterFunc
+    input T t;
+    output Boolean b "if b=true then 't' gets removed";
+  end filterFunc;
+protected
+  Integer new_size;
+  T dummy = dummy; // Fool the compiler into thinking dummy is initialized.
+  Integer index = 1;
+algorithm
+  new_size  := arrayLength(arr) - sum(1 for e guard fun(e) in arr);
+  new_arr   := arrayCreateNoInit(new_size, dummy);
+  for e in arr loop
+    if not fun(e) then
+      arrayUpdateNoBoundsChecking(new_arr, index, e);
+      index := index + 1;
+    end if;
+  end for;
+end filter;
+
 annotation(__OpenModelica_Interface="util");
 end Array;


### PR DESCRIPTION
 - Initialization cleanup might create dummy equations for when-equations that are only active during initialization
 - remove corresponding strong components