### PR TITLE
use Makefile to build FMU's for Cpp runtime in OMEdit

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
+++ b/OMCompiler/Compiler/Template/CodegenFMUCpp.tpl
@@ -772,7 +772,8 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
 
   # simulations use -O0 by default; can be changed to e.g. -O2 or -Ofast
   SIM_OPT_LEVEL=-O0
-
+  # the default is ON by default, override the var from commandLine to skip the zipping of fmu  e.g. make -f ZIP_FMU=OFF
+  ZIP_FMU = ON
   # native build or cross compilation
   ifeq ($(TARGET_TRIPLET),)
     TRIPLET=<%Autoconf.triple%>
@@ -857,11 +858,17 @@ case SIMCODE(modelInfo=MODELINFO(__), makefileParams=MAKEFILE_PARAMS(__), simula
   <%\t%>cp "$(OMHOME)/share/omc/runtime/cpp/licenses/sundials.license" "documentation/"
   endif
   <%\t%>rm -f <%fmuTargetName%>.fmu
+  ifeq ($(ZIP_FMU),ON)
   ifeq ($(USE_FMU_SUNDIALS),ON)
   <%\t%>zip -r "<%fmuTargetName%>.fmu" modelDescription.xml binaries sources documentation
   <%\t%>rm -rf documentation
   else
   <%\t%>zip -r "<%fmuTargetName%>.fmu" modelDescription.xml binaries sources
+  endif
+  endif
+
+  ifeq ($(ZIP_FMU),OFF)
+  <%\t%>rm -f OMCpp<%fileNamePrefix%>* <%fileNamePrefix%>_FMU.* <%fileNamePrefix%>.def <%fileNamePrefix%>.sh <%fileNamePrefix%>.bat <%fileNamePrefix%>.makefile <%fileNamePrefix%>_init.xml
   endif
 
   clean:

--- a/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
+++ b/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.cpp
@@ -53,31 +53,20 @@ FmuExportOutputWidget::FmuExportOutputWidget(LibraryTreeItem* pLibraryTreeItem, 
   mTargetLanguage = OptionsDialog::instance()->getSimulationPage()->getTargetLanguageComboBox()->currentText();
   mpLibraryTreeItem = pLibraryTreeItem;
 
-  // set the FMU Name and the fmuTmpPath
-  if (!OptionsDialog::instance()->getFMIPage()->getFMUNameTextBox()->text().isEmpty()) {
-    /*
-     * fix issue https://github.com/OpenModelica/OpenModelica/issues/12916,
-     * use hashed string for fmu tmp directory
-    */
-    if (mTargetLanguage.compare("C") == 0) {
-      QString hashedString = QString::number(stringHashDjb2(mmc_mk_scon(OptionsDialog::instance()->getFMIPage()->getFMUNameTextBox()->text().toUtf8().constData())));
-      mFmuTmpPath = QDir::currentPath().append("/").append(hashedString.left(3)+".fmutmp");
-    } else {
-      mFmuTmpPath = QDir::currentPath();
-    }
-    mFMUName = OptionsDialog::instance()->getFMIPage()->getFMUNameTextBox()->text();
+  // set the FMU name
+  const QString fmuNameText = OptionsDialog::instance()->getFMIPage()->getFMUNameTextBox()->text();
+  mFMUName = fmuNameText.isEmpty() ? mpLibraryTreeItem->getName() : fmuNameText;
+
+  /*
+   * set the fmuTmpPath
+   * fix issue https://github.com/OpenModelica/OpenModelica/issues/12916,
+   * use hashed string for fmu tmp directory
+  */
+  if (mTargetLanguage.compare("C") == 0) {
+    QString hashedString = QString::number(stringHashDjb2(mmc_mk_scon(mFMUName.toUtf8().constData())));
+    mFmuTmpPath = QDir::currentPath().append("/").append(hashedString.left(3)+".fmutmp");
   } else {
-    /*
-     * fix issue https://github.com/OpenModelica/OpenModelica/issues/12916,
-     * use hashed string for fmu tmp directory
-     */
-     if (mTargetLanguage.compare("C") == 0) {
-       QString hashedString = QString::number(stringHashDjb2(mmc_mk_scon(mpLibraryTreeItem->getName().toUtf8().constData())));
-       mFmuTmpPath = QDir::currentPath().append("/").append(hashedString.left(3)+".fmutmp");
-     } else {
-       mFmuTmpPath = QDir::currentPath();
-     }
-     mFMUName = mpLibraryTreeItem->getName();
+    mFmuTmpPath = QDir::currentPath();
   }
 
   // progress label
@@ -402,7 +391,7 @@ void FmuExportOutputWidget::compileModelCppRuntime()
   connect(mpPostCompilationProcess, SIGNAL(started()), SLOT(postCompilationProcessStarted()));
   connect(mpPostCompilationProcess, SIGNAL(readyReadStandardOutput()), SLOT(readPostCompilationStandardOutput()));
   connect(mpPostCompilationProcess, SIGNAL(readyReadStandardError()), SLOT(readPostCompilationStandardError()));
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
   connect(mpPostCompilationProcess, SIGNAL(errorOccurred(QProcess::ProcessError)), SLOT(postCompilationProcessError(QProcess::ProcessError)));
 #else
   connect(mpPostCompilationProcess, SIGNAL(error(QProcess::ProcessError)), SLOT(postCompilationProcessError(QProcess::ProcessError)));

--- a/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.h
+++ b/OMEdit/OMEditLIB/FMI/FMUExportOutputWidget.h
@@ -65,10 +65,12 @@ public:
   QString getFMUPath() {return mFmuLocationPath;}
   void updateMessageTab(const QString &text);
   void updateMessageTabProgress();
-  void compileModel();
+  void compileModelCRuntime();
+  void compileModelCppRuntime();
 private:
   QString mFmuTmpPath;
   QString mFMUName;
+  QString mTargetLanguage;
   QString mFmuLocationPath;
   LibraryTreeItem *mpLibraryTreeItem;
   Label *mpProgressLabel;

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1170,6 +1170,14 @@ void MainWindow::checkAllModels(LibraryTreeItem *pLibraryTreeItem)
 
 void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
 {
+  // check for supported targetLanguage C or Cpp
+  QString targetLanguage = OptionsDialog::instance()->getSimulationPage()->getTargetLanguageComboBox()->currentText();
+  if (targetLanguage.compare("C") != 0 && targetLanguage.compare("Cpp") != 0) {
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, QString("Target Language <b>%1</b> is not supported for FMU Export. Only <b>C</b> and <b> CPP </b> are supported").arg(targetLanguage),
+                                                                  "FMU_EXPORT Failed", Helper::errorLevel));
+    return;
+  }
+
   /* if Modelica text is changed manually by user then validate it before saving. */
   if (pLibraryTreeItem->getModelWidget()) {
     if (!pLibraryTreeItem->getModelWidget()->validateText(&pLibraryTreeItem)) {
@@ -1186,9 +1194,15 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
    * see https://github.com/OpenModelica/OpenModelica/issues/12171, to have short temp directory path and dump the files in it.
   */
   QString modelDirectoryPath = QString("%1/%2%3").arg(OptionsDialog::instance()->getGeneralSettingsPage()->getWorkingDirectory(), pLibraryTreeItem->getName(), Utilities::generateHash(pLibraryTreeItem->getNameStructure()));
-  if (!QDir().exists(modelDirectoryPath)) {
-    QDir().mkpath(modelDirectoryPath);
+
+  QDir dir(modelDirectoryPath);
+  if (dir.exists()) {
+    dir.removeRecursively();
+    dir.mkpath(modelDirectoryPath);
+  } else {
+    dir.mkpath(modelDirectoryPath);
   }
+
   // set the folder as working directory
   MainWindow::instance()->getOMCProxy()->changeDirectory(modelDirectoryPath);
   // buildModelFMU parameters
@@ -1227,7 +1241,11 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
     // create a FMU compilation window  similar to simulation process
     FmuExportOutputWidget * pFmuExportOutputWidget = new FmuExportOutputWidget(pLibraryTreeItem, this);
     MessagesWidget::instance()->addSimulationOutputTab(pFmuExportOutputWidget, pLibraryTreeItem->getName() + "_fmuExport");
-    pFmuExportOutputWidget->compileModel();
+    if (targetLanguage.compare("C") == 0) {
+      pFmuExportOutputWidget->compileModelCRuntime();
+    } else {
+      pFmuExportOutputWidget->compileModelCppRuntime();
+    }
   } else {
     MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, QString("Translation of FMU: <b>%1</b> Failed").arg(pLibraryTreeItem->getName()),
                                                                   "Translation Error", Helper::errorLevel));

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1173,8 +1173,8 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
   // check for supported targetLanguage C or Cpp
   QString targetLanguage = OptionsDialog::instance()->getSimulationPage()->getTargetLanguageComboBox()->currentText();
   if (targetLanguage.compare("C") != 0 && targetLanguage.compare("Cpp") != 0) {
-    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, QString("Target Language <b>%1</b> is not supported for FMU Export. Only <b>C</b> and <b> CPP </b> are supported").arg(targetLanguage),
-                                                                  "FMU_EXPORT Failed", Helper::errorLevel));
+    MessagesWidget::instance()->addGUIMessage(MessageItem(MessageItem::Modelica, tr("Target Language <b>%1</b> is not supported for FMU Export. Only <b>C</b> and <b>Cpp</b> are supported").arg(targetLanguage),
+                                                                  tr("FMU_EXPORT Failed"), Helper::errorLevel));
     return;
   }
 
@@ -1198,10 +1198,8 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
   QDir dir(modelDirectoryPath);
   if (dir.exists()) {
     dir.removeRecursively();
-    dir.mkpath(modelDirectoryPath);
-  } else {
-    dir.mkpath(modelDirectoryPath);
   }
+  dir.mkpath(modelDirectoryPath);
 
   // set the folder as working directory
   MainWindow::instance()->getOMCProxy()->changeDirectory(modelDirectoryPath);


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/13103

### Purpose

This PR fixes the FMU export for Cpp runtime in OMEdit. Use the generated `Makefile` to build the binaries for cpp runtime.


