### PR TITLE
Display array notation with component name and tooltip

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/TextAnnotation.cpp
@@ -665,7 +665,15 @@ void TextAnnotation::updateTextString()
       return;
     }
     if (mTextString.toLower().contains("%name")) {
-      mTextString.replace(QRegExp("%name"), mpElement->getName());
+      if (mpElement->getGraphicsView()->getModelWidget()->isNewApi()) {
+        QString name = mpElement->getName();
+        if (mpElement->getModelComponent() && mpElement->getModelComponent()->getDimensions().isArray()) {
+          name.append("[" % mpElement->getModelComponent()->getDimensions().getTypedDimensionsString() % "]");
+        }
+        mTextString.replace(QRegExp("%name"), name);
+      } else {
+        mTextString.replace(QRegExp("%name"), mpElement->getName());
+      }
     }
     if (mTextString.toLower().contains("%class")) {
       mTextString.replace(QRegExp("%class"), mpElement->getClassName());

--- a/OMEdit/OMEditLIB/Element/Element.cpp
+++ b/OMEdit/OMEditLIB/Element/Element.cpp
@@ -3214,12 +3214,16 @@ void Element::updateToolTip()
     comment.replace("src=\"file://", "src=\"");
   #endif
 
+    QString name = mpModelComponent->getName();
+    if (mpModelComponent && mpModelComponent->getDimensions().isArray()) {
+      name.append("[" % mpModelComponent->getDimensions().getTypedDimensionsString() % "]");
+    }
     if ((mIsInheritedElement || isPort()) && mpParentElement && !mpGraphicsView->isVisualizationView()) {
       setToolTip(tr("<b>%1</b> %2<br/>%3<br /><br />Element declared in %4").arg(mpModel->getName())
-                 .arg(mpModelComponent->getName()).arg(comment)
+                 .arg(name).arg(comment)
                  .arg(mpParentElement->getModel()->getName()));
     } else {
-      setToolTip(tr("<b>%1</b> %2<br/>%3").arg(mpModel->getName()).arg(mpModelComponent->getName()).arg(comment));
+      setToolTip(tr("<b>%1</b> %2<br/>%3").arg(mpModel->getName()).arg(name).arg(comment));
     }
   } else {
     if (mpLibraryTreeItem && mpLibraryTreeItem->isSSP()) {


### PR DESCRIPTION
### Related Issues

Fixes #13083