### PR TITLE
Base Modelica improvements

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1800,6 +1800,19 @@ public
       threaded for l in lits, i in 1:listLength(lits));
   end makeEnumLiterals;
 
+  function isIntegerValue
+    "Returns true if the expression is an Integer expression with the given
+     value, otherwise false."
+    input Expression exp;
+    input Integer value;
+    output Boolean result;
+  algorithm
+    result := match exp
+      case INTEGER() then exp.value == value;
+      else false;
+    end match;
+  end isIntegerValue;
+
   function toInteger
     input Expression exp;
     output Integer i;
@@ -1930,7 +1943,10 @@ public
       case BOOLEAN() then boolString(exp.value);
 
       case ENUM_LITERAL(ty = t as Type.ENUMERATION())
-        then "'" + AbsynUtil.pathString(t.typePath) + "'." + exp.name;
+        then if Type.isBuiltinEnumeration(t) then
+            AbsynUtil.pathString(t.typePath) + "." + exp.name
+          else
+            "'" + AbsynUtil.pathString(t.typePath) + "'." + exp.name;
 
       case CLKCONST(clk) then ClockKind.toFlatString(clk, format);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -352,6 +352,7 @@ public
   algorithm
     () := match ty
       case Type.ENUMERATION()
+        guard not Type.isBuiltinEnumeration(ty)
         algorithm
           UnorderedMap.tryAdd(ty.typePath, ty, types);
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -465,6 +465,24 @@ public
     end match;
   end isEnumeration;
 
+  function isBuiltinEnumeration
+    input Type ty;
+    output Boolean isBuiltin;
+  protected
+    String name;
+  algorithm
+    isBuiltin := match ty
+      case ENUMERATION(typePath = Absyn.Path.IDENT(name))
+        then match name
+          case "StateSelect" then true;
+          case "AssertionLevel" then true;
+          else false;
+        end match;
+
+      else false;
+    end match;
+  end isBuiltinEnumeration;
+
   function isUnspecifiedEnumeration
     input Type ty;
     output Boolean res;
@@ -942,7 +960,10 @@ public
       case Type.STRING() then "String";
       case Type.BOOLEAN() then "Boolean";
       case Type.CLOCK() then "Clock";
-      case Type.ENUMERATION() then if listEmpty(ty.literals) then "enumeration(:)" else Util.makeQuotedIdentifier(AbsynUtil.pathString(ty.typePath));
+      case Type.ENUMERATION()
+        then if listEmpty(ty.literals) then "enumeration(:)"
+             elseif Type.isBuiltinEnumeration(ty) then AbsynUtil.pathString(ty.typePath)
+             else Util.makeQuotedIdentifier(AbsynUtil.pathString(ty.typePath));
       case Type.ARRAY() then List.toString(ty.dimensions, function Dimension.toFlatString(format = format), toFlatString(ty.elementType, format), "[", ", ", "]", false);
       case Type.TUPLE() then "(" + stringDelimitList(List.map(ty.types, function toFlatString(format = format)), ", ") + ")";
       case Type.NORETCALL() then "()";

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -35,6 +35,8 @@ TESTFILES = \
 	ScalarizedWithoutRecords1.mo \
 	SD.mo \
 	SimpleCoolingCycle.mo \
+	StateSelect1.mo \
+	String1.mo \
   Tables.mos \
 	Tuple1.mo \
 	Tuple2.mo \

--- a/testsuite/openmodelica/basemodelica/StateSelect1.mo
+++ b/testsuite/openmodelica/basemodelica/StateSelect1.mo
@@ -1,0 +1,20 @@
+// name: StateSelect1
+// status: correct
+
+model StateSelect1
+  Real x(stateSelect = StateSelect.never);
+  parameter StateSelect s = StateSelect.always;
+  Real y(stateSelect = s);
+  annotation(__OpenModelica_commandLineOptions="-f");
+end StateSelect1;
+
+// Result:
+// //! base 0.1.0
+// package 'StateSelect1'
+//   model 'StateSelect1'
+//     Real 'x'(stateSelect = StateSelect.never);
+//     parameter StateSelect 's' = StateSelect.always;
+//     Real 'y'(stateSelect = StateSelect.always);
+//   end 'StateSelect1';
+// end 'StateSelect1';
+// endResult

--- a/testsuite/openmodelica/basemodelica/String1.mo
+++ b/testsuite/openmodelica/basemodelica/String1.mo
@@ -1,0 +1,54 @@
+// name: String1
+// status: correct
+
+model String1
+  Real r;
+  Integer i;
+  Boolean b;
+  type E = enumeration(one, two, three);
+  E e;
+
+  String s_r1 = String(r);
+  String s_r2 = String(r, format = "g");
+  String s_r3 = String(r, minimumLength = 2, leftJustified = false, significantDigits = 4);
+  String s_r4 = String(r, minimumLength = 0, leftJustified = true, significantDigits = 6);
+  String s_r5 = String(r, minimumLength = 2, significantDigits = 6);
+
+  String s_i1 = String(i);
+  String s_i2 = String(i, format = "d");
+  String s_i3 = String(i, minimumLength = 8, leftJustified = false);
+
+  String s_b1 = String(b);
+  String s_b2 = String(b, minimumLength = 4, leftJustified = true);
+
+  String s_e1 = String(e);
+  String s_e2 = String(e, minimumLength = 12, leftJustified = false);
+
+  annotation(__OpenModelica_commandLineOptions="-f");
+end String1;
+
+// Result:
+// //! base 0.1.0
+// package 'String1'
+//   type 'E' = enumeration(one, two, three);
+//
+//   model 'String1'
+//     Real 'r';
+//     Integer 'i';
+//     Boolean 'b';
+//     'E' 'e';
+//     String 's_r1' = String('r');
+//     String 's_r2' = String('r', format = "g");
+//     String 's_r3' = String('r', significantDigits = 4, minimumLength = 2, leftJustified = false);
+//     String 's_r4' = String('r');
+//     String 's_r5' = String('r', minimumLength = 2);
+//     String 's_i1' = String('i');
+//     String 's_i2' = String('i', format = "d");
+//     String 's_i3' = String('i', minimumLength = 8, leftJustified = false);
+//     String 's_b1' = String('b');
+//     String 's_b2' = String('b', minimumLength = 4);
+//     String 's_e1' = String('e');
+//     String 's_e2' = String('e', minimumLength = 12, leftJustified = false);
+//   end 'String1';
+// end 'String1';
+// endResult


### PR DESCRIPTION
- Fix formatting of arguments for the `String` operator.
- Don't quote `StateSelect` and `AssertionLevel`.