### PR TITLE
Improve addComponent

### DIFF
--- a/OMCompiler/Compiler/Script/Interactive.mo
+++ b/OMCompiler/Compiler/Script/Interactive.mo
@@ -6675,6 +6675,7 @@ protected
   Option<Absyn.RedeclareKeywords> redecl;
   Absyn.ElementAttributes attr;
   SourceInfo info;
+  Absyn.Path ty_path;
 algorithm
   try
     w := match classPath
@@ -6690,10 +6691,18 @@ algorithm
     modification := InteractiveUtil.makeModifierFromArgs(bindingExp, modifier, info);
     (io, redecl, attr) := getDefaultPrefixes(program, typeName);
 
+    ty_path := AbsynUtil.pathStripSamePrefix(typeName, classPath);
+
+    if AbsynUtil.pathContains(classPath, AbsynUtil.pathFirstIdent(ty_path)) then
+      // Keep the full type name if the first identifier of the stripped name
+      // is part of the class path, to avoid name collisions.
+      ty_path := typeName;
+    end if;
+
     cdef := addToPublic(cdef,
       Absyn.ELEMENTITEM(
         Absyn.ELEMENT(false, redecl, io,
-          Absyn.COMPONENTS(attr, Absyn.TPATH(AbsynUtil.pathStripSamePrefix(typeName, classPath), NONE()),
+          Absyn.COMPONENTS(attr, Absyn.TPATH(ty_path, NONE()),
             {Absyn.COMPONENTITEM(Absyn.COMPONENT(componentName, {}, modification), NONE(), annotation_)}),
           info, NONE())
       )

--- a/testsuite/openmodelica/interactive-API/addComponent1.mos
+++ b/testsuite/openmodelica/interactive-API/addComponent1.mos
@@ -10,11 +10,27 @@ loadString("model InstantiationExample
   block MyBlock
     extends Modelica.Blocks.Icons.Block;
   end MyBlock;
+
+  package P
+    package Example
+      model M
+      end M;
+    end Example;
+
+    model M
+    end M;
+
+    model NotM
+    end NotM;
+  end P;
 end InstantiationExample;");
 getErrorString();
 list(InstantiationExample);
 addComponent(myBlock, InstantiationExample.MyBlock,InstantiationExample,annotate=Placement(transformation=transformation(origin={-32,-62},extent={{-10,-10},{10,10}})));
 addComponent(x, Real, InstantiationExample, comment="comment", binding=10, modification = $Code((start = 0.0)));
+// Check that addComponent doesn't remove the prefix if it would lead to name collisions.
+addComponent(m, InstantiationExample.P.M, InstantiationExample.P.Example.M);
+addComponent(n, InstantiationExample.P.NotM, InstantiationExample.P.Example.M);
 getErrorString();
 list(InstantiationExample);
 getErrorString();
@@ -26,7 +42,22 @@ getErrorString();
 //   block MyBlock
 //     extends Modelica.Blocks.Icons.Block;
 //   end MyBlock;
+//
+//   package P
+//     package Example
+//       model M
+//       end M;
+//     end Example;
+//
+//     model M
+//     end M;
+//
+//     model NotM
+//     end NotM;
+//   end P;
 // end InstantiationExample;"
+// true
+// true
 // true
 // true
 // ""
@@ -34,6 +65,21 @@ getErrorString();
 //   block MyBlock
 //     extends Modelica.Blocks.Icons.Block;
 //   end MyBlock;
+//
+//   package P
+//     package Example
+//       model M
+//         InstantiationExample.P.M m;
+//         NotM n;
+//       end M;
+//     end Example;
+//
+//     model M
+//     end M;
+//
+//     model NotM
+//     end NotM;
+//   end P;
 //
 //   MyBlock myBlock annotation(
 //     Placement(transformation(origin = {-32, -62}, extent = {{-10, -10}, {10, 10}})));


### PR DESCRIPTION
- Keep the full type path if removing the prefix would cause a name collision with the class path.