### PR TITLE
Avoid split indices with getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1538,6 +1538,7 @@ algorithm
     ErrorExt.setCheckpoint(getInstanceName());
     try
       exp := Ceval.evalExp(exp, Ceval.EvalTarget.new(AbsynUtil.dummyInfo, NFInstContext.INSTANCE_API));
+      exp := Expression.map(exp, Expression.expandSplitIndices);
       json := JSON.addPair("value", Expression.toJSON(exp), json);
     else
     end try;


### PR DESCRIPTION
- Remove split indices from the evaluated bindings too, since evaluating an expression can result in split indices.