### PR TITLE
Move getNthConnector/getConnectorCount to the typed API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6357,6 +6357,26 @@ algorithm
   end match;
 end isBlock;
 
+function isConnector
+  input Absyn.Class cls;
+  output Boolean res;
+algorithm
+  res := match cls
+    case Absyn.Class.CLASS(restriction = Absyn.Restriction.R_CONNECTOR()) then true;
+    else false;
+  end match;
+end isConnector;
+
+function isExpandableConnector
+  input Absyn.Class cls;
+  output Boolean res;
+algorithm
+  res := match cls
+    case Absyn.Class.CLASS(restriction = Absyn.Restriction.R_EXP_CONNECTOR()) then true;
+    else false;
+  end match;
+end isExpandableConnector;
+
 function eachBool
   input Absyn.Each eachPrefix;
   output Boolean res;

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -3652,6 +3652,29 @@ annotation(
   preferredView="text");
 end setComponentDimensions;
 
+function getNthConnector
+  input TypeName className;
+  input Integer n;
+  output Expression result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  <p>Returns the name and type of the n:th public connector in the given class.</p>
+</html>"),
+  preferredView="text");
+end getNthConnector;
+
+function getConnectorCount
+  input TypeName className;
+  output Integer count;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  <p>Returns the number of public connectors in the given class.</p>
+</html>"),
+  preferredView="text");
+end getConnectorCount;
+
 function addConnection
   input VariableName connector1;
   input VariableName connector2;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3906,6 +3906,29 @@ annotation(
   preferredView="text");
 end setComponentDimensions;
 
+function getNthConnector
+  input TypeName className;
+  input Integer n;
+  output Expression result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  <p>Returns the name and type of the n:th public connector in the given class.</p>
+</html>"),
+  preferredView="text");
+end getNthConnector;
+
+function getConnectorCount
+  input TypeName className;
+  output Integer count;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+  <p>Returns the number of public connectors in the given class.</p>
+</html>"),
+  preferredView="text");
+end getConnectorCount;
+
 function addConnection
   input VariableName connector1;
   input VariableName connector2;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3250,6 +3250,11 @@ algorithm
     case ("getNthConnectionAnnotation", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.INTEGER(n)})
       then Interactive.getNthConnectionAnnotation(classpath, n, SymbolTable.getAbsyn());
 
+    case ("getConnectorCount", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      then Interactive.getConnectorCount(classpath, SymbolTable.getAbsyn());
+
+    case ("getNthConnector", {Values.CODE(Absyn.C_TYPENAME(classpath)), Values.INTEGER(n)})
+      then Interactive.getNthConnector(classpath, n, SymbolTable.getAbsyn());
  end matchcontinue;
 end cevalInteractiveFunctions4;
 

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -51,6 +51,7 @@ getCommandLineOptions.mos \
 GetComponents.mos \
 getComponentsTestNF.mos \
 getComponentsTestOF.mos \
+getConnectorCount.mos \
 getDefinitions.mos \
 getDialogAnnotation.mos \
 getElementAnnotation.mos \
@@ -58,6 +59,8 @@ getExtendsModifierNames.mos \
 getIconAnnotation.mos \
 getInheritedClasses1.mos \
 getInheritedClasses2.mos \
+getNthComponentAnnotation.mos \
+getNthConnector.mos \
 getSimulationOptions1.mos \
 getSimulationOptions2.mos \
 getSimulationOptions3.mos \

--- a/testsuite/openmodelica/interactive-API/getConnectorCount.mos
+++ b/testsuite/openmodelica/interactive-API/getConnectorCount.mos
@@ -1,0 +1,33 @@
+// name: getConnectorCount
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  connector C
+    Real e;
+    flow Real f;
+  end C;
+
+  model A
+    C ac1;
+  end A;
+
+  model M
+    extends A;
+    C c1, c2;
+    C c3;
+    Real x;
+  protected
+    C c4;
+  end M;
+");
+
+getConnectorCount(A);
+getConnectorCount(M);
+
+// Result:
+// true
+// 1
+// 4
+// endResult

--- a/testsuite/openmodelica/interactive-API/getNthComponentAnnotation.mos
+++ b/testsuite/openmodelica/interactive-API/getNthComponentAnnotation.mos
@@ -1,0 +1,23 @@
+// name: getNthComponentAnnotation
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  model M
+    Real x annotation(Icon(), Evaluate = true);
+    Real y annotation(Placement(), Evaluate=false), w annotation(Placement());
+    Real z;
+  end M;
+");
+
+getNthComponentAnnotation(M, 1);
+getNthComponentAnnotation(M, 2);
+getNthComponentAnnotation(M, 3);
+
+// Result:
+// true
+// {Icon(-,-,-,-,-,-,-,), Evaluate=true}
+// {{Placement(true,-,-,-,-,-,-,-,-,-,-,-,-,-,)}, {Placement(true,-,-,-,-,-,-,-,-,-,-,-,-,-,), Evaluate=false}}
+// {}
+// endResult

--- a/testsuite/openmodelica/interactive-API/getNthConnector.mos
+++ b/testsuite/openmodelica/interactive-API/getNthConnector.mos
@@ -1,0 +1,41 @@
+// name: getNthConnector
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  connector C
+    Real e;
+    flow Real f;
+  end C;
+
+  model A
+    C ac1;
+  end A;
+
+  model M
+    extends A;
+    C c1, c2;
+    C c3;
+    Real x;
+  protected
+    C c4;
+  end M;
+");
+
+getNthConnector(A, 1);
+getNthConnector(A, 2);
+getNthConnector(M, 1);
+getNthConnector(M, 2);
+getNthConnector(M, 3);
+getNthConnector(M, 4);
+
+// Result:
+// true
+// {ac1, C}
+// false
+// {ac1, C}
+// {c1, C}
+// {c2, C}
+// {c3, C}
+// endResult


### PR DESCRIPTION
- Move `getNthConnector` and `getConnectorCount` to the typed API.
- Add forgotten test case for `getNthComponentAnnotation`.