### PR TITLE
Scalarize partially connected arrays

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFConnections.mo
@@ -264,7 +264,7 @@ public
 
         if count == 0 then
           flows := f :: flows;
-        elseif count > 1 then
+        elseif count > 1 or count == -1 then
           flows := listAppend(Connector.scalarize(f), flows);
         end if;
       end for;
@@ -308,13 +308,16 @@ public
       output Integer outCount;
     algorithm
       outCount := match count
-        case SOME(outCount) then outCount + 1;
+        case SOME(outCount) then if outCount >= 0 then outCount + 1 else -1;
         else 1;
       end match;
     end update;
   algorithm
-    if Connector.isArray(conn) or ComponentRef.hasSubscripts(conn.name) then
+    if Connector.isArray(conn) then
       UnorderedMap.addUpdate(conn, update, connectCounts);
+    elseif ComponentRef.hasSubscripts(conn.name) then
+      // Always scalarize connector arrays that are partially connected.
+      UnorderedMap.add(conn, -1, connectCounts);
     end if;
   end analyseArrayConnector;
 

--- a/testsuite/flattening/modelica/scodeinst/ArrayConnect6.mo
+++ b/testsuite/flattening/modelica/scodeinst/ArrayConnect6.mo
@@ -1,0 +1,33 @@
+// name: ArrayConnect6
+// keywords:
+// status: correct
+//
+
+connector C
+  Real e;
+  flow Real f;
+end C;
+
+model A
+  C c1[2], c2;
+end A;
+
+model ArrayConnect6
+  A a;
+equation
+  connect(a.c1[1], a.c2);
+  annotation(__OpenModelica_commandLineOptions="-d=-nfScalarize");
+end ArrayConnect6;
+
+// Result:
+// class ArrayConnect6
+//   Real[2] a.c1.e;
+//   Real[2] a.c1.f;
+//   Real a.c2.e;
+//   Real a.c2.f;
+// equation
+//   a.c1[1].e = a.c2.e;
+//   a.c2.f + a.c1[1].f = 0.0;
+//   a.c1[2].f = 0.0;
+// end ArrayConnect6;
+// endResult

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -23,6 +23,7 @@ ArrayConnect2.mo \
 ArrayConnect3.mo \
 ArrayConnect4.mo \
 ArrayConnect5.mo \
+ArrayConnect6.mo \
 ArrayConstructorComplex1.mo \
 ArrayConstructorRecord1.mo \
 ArrayConstructorRecord2.mo \


### PR DESCRIPTION
- Disable keeping single connected arrays if one of the connectors have subscripts, since a flow array variable can't currently be partially connected.