### PR TITLE
Fix compilation warnings

### DIFF
--- a/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.cpp
+++ b/OMCompiler/SimulationRuntime/ParModelica/explicit/openclrt/omc_ocl_util.cpp
@@ -157,11 +157,11 @@ void ocl_get_device(){
             clGetDeviceInfo(ocl_device, CL_DEVICE_MAX_CLOCK_FREQUENCY , sizeof(cl_uint), &mem, NULL);
             printf("%d CL_DEVICE_MAX_CLOCK_FREQUENCY :\t%d\n", i,mem);
             clGetDeviceInfo(ocl_device, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(cl_ulong), &mem2, NULL);
-            printf("%d CL_DEVICE_LOCAL_MEM_SIZE :\t%llu KB\n", i, mem2/1024);
+            printf("%d CL_DEVICE_LOCAL_MEM_SIZE :\t%llu KB\n", i, static_cast<unsigned long long>(mem2/1024));
             clGetDeviceInfo(ocl_device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(cl_ulong), &mem2, NULL);
-            printf("%d CL_DEVICE_GLOBAL_MEM_SIZE: %llu MB\n", i, mem2/1024/1024);
+            printf("%d CL_DEVICE_GLOBAL_MEM_SIZE: %llu MB\n", i, static_cast<unsigned long long>(mem2/1024/1024));
             clGetDeviceInfo(ocl_device, CL_DEVICE_MAX_MEM_ALLOC_SIZE, sizeof(cl_ulong), &mem2, NULL);
-            printf("%d CL_DEVICE_MAX_MEM_ALLOC_SIZE: %llu MB\n", i, mem2/1024/1024);
+            printf("%d CL_DEVICE_MAX_MEM_ALLOC_SIZE: %llu MB\n", i, static_cast<unsigned long long>(mem2/1024/1024));
             clGetDeviceInfo(ocl_device, CL_DEVICE_MAX_PARAMETER_SIZE, sizeof(size_t), &arg_nr, NULL);
             printf("%d CL_DEVICE_MAX_PARAMETER_SIZE: %ld MB\n", i, arg_nr);
 

--- a/OMEdit/OMEditLIB/Debugger/Breakpoints/BreakpointMarker.cpp
+++ b/OMEdit/OMEditLIB/Debugger/Breakpoints/BreakpointMarker.cpp
@@ -163,10 +163,11 @@ void DocumentMarker::updateBreakpointsLineNumber()
   QTextBlock block = mpTextDocument->begin();
   int blockNumber = 0;
   while (block.isValid()) {
-    if (const TextBlockUserData *userData = BaseEditorDocumentLayout::testUserData(block))
+    if (const TextBlockUserData *userData = BaseEditorDocumentLayout::testUserData(block)) {
       foreach (ITextMark *mrk, userData->marks()) {
         mrk->updateLineNumber(mLineStartNumber > 0 ? blockNumber + mLineStartNumber : blockNumber + 1);
       }
+    }
     block = block.next();
     ++blockNumber;
   }
@@ -174,8 +175,9 @@ void DocumentMarker::updateBreakpointsLineNumber()
 
 void DocumentMarker::updateBreakpointsBlock(const QTextBlock &block)
 {
-  if (const TextBlockUserData *userData = BaseEditorDocumentLayout::testUserData(block))
+  if (const TextBlockUserData *userData = BaseEditorDocumentLayout::testUserData(block)) {
     foreach (ITextMark *mrk, userData->marks()) {
       mrk->updateBlock(block);
     }
+  }
 }

--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -717,15 +717,13 @@ namespace ModelInstance
   void Dimensions::deserialize(const QJsonObject &jsonObject)
   {
     if (jsonObject.contains("absyn")) {
-      QJsonArray absynDimsArray = jsonObject.value("absyn").toArray();
-      foreach (auto absynDim, absynDimsArray) {
+      for (const QJsonValue &absynDim: jsonObject.value("absyn").toArray()) {
         mAbsynDims.append(absynDim.toString());
       }
     }
 
     if (jsonObject.contains("typed")) {
-      QJsonArray typedDimsArray = jsonObject.value("typed").toArray();
-      foreach (auto typedDim, typedDimsArray) {
+      for (const QJsonValue &typedDim: jsonObject.value("typed").toArray()) {
         mTypedDims.append(typedDim.toString());
       }
     }
@@ -1131,8 +1129,7 @@ namespace ModelInstance
     }
 
     if (mModelJson.contains("connections")) {
-      QJsonArray connections = mModelJson.value("connections").toArray();
-      foreach (QJsonValue connection, connections) {
+      for (const QJsonValue &connection: mModelJson.value("connections").toArray()) {
         QJsonObject connectionObject = connection.toObject();
         if (!connectionObject.isEmpty()) {
           Connection *pConnection = new Connection(this);
@@ -1143,8 +1140,7 @@ namespace ModelInstance
     }
 
     if (mModelJson.contains("transitions")) {
-      QJsonArray transitions = mModelJson.value("transitions").toArray();
-      foreach (QJsonValue transition, transitions) {
+      for (const QJsonValue &transition: mModelJson.value("transitions").toArray()) {
         QJsonObject transitionObject = transition.toObject();
         if (!transitionObject.isEmpty()) {
           Transition *pTransition = new Transition(this);
@@ -1155,8 +1151,7 @@ namespace ModelInstance
     }
 
     if (mModelJson.contains("initialStates")) {
-      QJsonArray initialStates = mModelJson.value("initialStates").toArray();
-      foreach (QJsonValue initialState, initialStates) {
+      for (const QJsonValue &initialState: mModelJson.value("initialStates").toArray()) {
         QJsonObject initialStateObject = initialState.toObject();
         if (!initialStateObject.isEmpty()) {
           InitialState *pInitialState = new InitialState(this);
@@ -1178,7 +1173,7 @@ namespace ModelInstance
    */
   void Model::deserializeElements(const QJsonArray elements)
   {
-    foreach (const QJsonValue &element, elements) {
+    for (const QJsonValue &element: elements) {
       QJsonObject elementObject = element.toObject();
       QString kind = elementObject.value("$kind").toString();
 
@@ -1793,8 +1788,7 @@ namespace ModelInstance
     }
 
     if (jsonObject.contains("choice")) {
-      QJsonArray choices = jsonObject.value("choice").toArray();
-      foreach (auto choice, choices) {
+      for (const auto& choice: jsonObject.value("choice").toArray()) {
         mChoices.append(new Modifier("", choice, mpParentModel));
       }
     }
@@ -2395,8 +2389,7 @@ namespace ModelInstance
     }
 
     if (jsonObject.contains("subscripts")) {
-      QJsonArray subscripts = jsonObject.value("subscripts").toArray();
-      foreach (QJsonValue subscript, subscripts) {
+      for (const QJsonValue &subscript: jsonObject.value("subscripts").toArray()) {
         mSubScripts.append(QString::number(subscript.toInt()));
       }
     }
@@ -2423,7 +2416,7 @@ namespace ModelInstance
 
   void Name::deserialize(const QJsonArray &jsonArray)
   {
-    foreach (QJsonValue part, jsonArray) {
+    for (const QJsonValue &part: jsonArray) {
       Part partObject;
       partObject.deserialize(part.toObject());
       mParts.append(partObject);

--- a/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.cpp
+++ b/OMEdit/OMEditLIB/TransformationalDebugger/OMDumpXML.cpp
@@ -336,7 +336,7 @@ MyHandler::MyHandler(QFile &file, QHash<QString,OMVariable> &vars, QList<OMEquat
         currentEquation->eqs = nestedEquations;
         operations.clear();
         if (currentEquation->index != equations.size()) {
-          printf("failing: %d expect %d\n", currentEquation->index, equations.size()+1);
+          printf("failing: %d expect %zu\n", currentEquation->index, static_cast<size_t>(equations.size())+1);
           break;
         }
         equations.append(currentEquation);

--- a/OMNotebook/OMNotebook/OMNotebookGUI/textcell.h
+++ b/OMNotebook/OMNotebook/OMNotebookGUI/textcell.h
@@ -146,10 +146,10 @@ namespace IAEX
 #endif
 
   protected:
-    void mousePressEvent(QMouseEvent *event);      // Added 2005-11-01 AF
-    void wheelEvent(QWheelEvent * event);        // Added 2005-11-28 AF
-    void insertFromMimeData(const QMimeData *source);  // Added 2006-01-23 AF
-    void keyPressEvent(QKeyEvent *event );        // Added 2006-01-30 AF
+    void mousePressEvent(QMouseEvent *event) override;      // Added 2005-11-01 AF
+    void wheelEvent(QWheelEvent * event) override;        // Added 2005-11-28 AF
+    void insertFromMimeData(const QMimeData *source) override;  // Added 2006-01-23 AF
+    void keyPressEvent(QKeyEvent *event ) override;        // Added 2006-01-30 AF
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     // QTextBrowser interface

--- a/OMShell/OMShell/OMShellGUI/main.cpp
+++ b/OMShell/OMShell/OMShellGUI/main.cpp
@@ -103,8 +103,9 @@ int main(int argc, char *argv[])
   QString locale = QString("OMShell_") + QLocale::system().name();
 
   QTranslator translator;
-  translator.load(locale, dir);
-  app.installTranslator(&translator);
+  if (translator.load(locale, dir)) {
+    app.installTranslator(&translator);
+  }
 
   // Avoid cluttering the whole disk with omc temp-files
   QString tmpDir = env->TmpPath();


### PR DESCRIPTION
- Avoid incorrect format specifiers in ParModelica and OMDumpXML.
- Add braces to avoid dangling else in OMEdit Debugger.
- Use C++ `for` instead of `Qt` foreach when traversing `QJsonArray` to get rid of deprecation warnings.
- Use static `QFontDatabase::families` method with Qt 6.0.
- Add missing `override`.
- Don't ignore return value of `QTranslator::load` in OMShell.