### PR TITLE
Remove ComponentRef.STRING

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFInstNode.mo
@@ -602,6 +602,12 @@ uniontype InstNode
         then
           ();
 
+      case NAME_NODE()
+        algorithm
+          node.name := name;
+        then
+          ();
+
       case VAR_NODE()
         algorithm
           node.name := name;

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -112,7 +112,8 @@ uniontype TypingError
 end TypingError;
 
 // Used by typeDimension for catching cyclic dimension involving :
-constant Expression WHOLEDIM_CREF = Expression.CREF(Type.UNKNOWN(), ComponentRef.STRING(":", ComponentRef.EMPTY()));
+constant Expression WHOLEDIM_CREF = Expression.CREF(Type.UNKNOWN(),
+  ComponentRef.CREF(InstNode.NAME_NODE(":"), {}, Type.UNKNOWN(), NFComponentRef.Origin.CREF, ComponentRef.EMPTY()));
 
 public
 function typeClass

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnit.mo
@@ -41,6 +41,8 @@ public
 import ComponentRef = NFComponentRef;
 import Absyn;
 import AbsynUtil;
+import NFInstNode.InstNode;
+import Type = NFType;
 import UnorderedMap;
 
 protected
@@ -91,7 +93,8 @@ protected uniontype Token
   record T_RPAREN end T_RPAREN;
 end Token;
 
-public constant ComponentRef UPDATECREF = ComponentRef.STRING("jhagemann", ComponentRef.EMPTY());
+public constant ComponentRef UPDATECREF = ComponentRef.CREF(InstNode.NAME_NODE("jhagemann"), {},
+  Type.UNKNOWN(), NFComponentRef.Origin.CREF, ComponentRef.EMPTY());
 
 public constant list<tuple<String, Unit>> LU_COMPLEXUNITS = {
 /*                   fac,mol,cd, m, s, A, K, g*/

--- a/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFUnitCheck.mo
@@ -350,7 +350,8 @@ function makeNewCref
   output Expression outExp;
 algorithm
   outExp := Expression.CREF(Type.UNKNOWN(),
-    ComponentRef.STRING(paramName, ComponentRef.STRING(fnName + "()", ComponentRef.EMPTY())));
+    ComponentRef.prefixCref(InstNode.NAME_NODE(paramName), Type.UNKNOWN(), {},
+      ComponentRef.fromNode(InstNode.NAME_NODE(fnName + "()"), Type.UNKNOWN())));
 end makeNewCref;
 
 function insertUnitInEquation


### PR DESCRIPTION
- Simplify `ComponentRef` by removing the special case `STRING` since it's barely used and has already been mostly replaced by normal component references with name nodes.