### PR TITLE
Preserve the prefixes when copying and pasting

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -994,12 +994,22 @@ namespace ModelInstance
   {
     QStringList value;
 
-    if (mRedeclare) {
-      value.append("redeclare");
-    }
     if (mFinal && !skipTopLevel) {
       value.append("final");
     }
+
+    if (mRedeclare) {
+      value.append("redeclare");
+    }
+
+    if (mInner) {
+      value.append("inner");
+    }
+
+    if (mOuter) {
+      value.append("outer");
+    }
+
     if (mpReplaceable) {
       value.append("replaceable");
     }
@@ -2257,6 +2267,10 @@ namespace ModelInstance
 
     value.append(mType);
     value.append(mName);
+    const QString dims = getDimensions().getAbsynDimensionsString();
+    if (!dims.isEmpty()) {
+      value.append("[" % dims % "]");
+    }
     if (mpModifier) {
       value.append(mpModifier->toString());
     }

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -3732,11 +3732,7 @@ void GraphicsView::copyItems(bool cut)
     for (int i = itemsList.size() - 1 ; i >= 0 ; i--) {
       if (itemsList.at(i)->isSelected()) {
         if (Element *pElement = dynamic_cast<Element*>(itemsList.at(i))) {
-          QString modifiers;
-          if (pElement->getModelComponent() && pElement->getModelComponent()->getModifier()) {
-            modifiers = pElement->getModelComponent()->getModifier()->toString();
-          }
-          components << pElement->getClassName() % " " % pElement->getName() % modifiers % " " % "annotation(" % pElement->getPlacementAnnotation(true) % ");";
+          components << pElement->getModelComponent()->toString() % " " % "annotation(" % pElement->getPlacementAnnotation(true) % ");";
           // component JSON
           QJsonObject componentJsonObject;
           componentJsonObject.insert(QLatin1String("classname"), pElement->getClassName());


### PR DESCRIPTION
### Related Issues

Fixes #12899

### Purpose

Do not drop the component prefixes when doing copy and paste

### Approach

Dump the inner and outer prefixes so that they are preserved during copy paste.
