### PR TITLE
Implement options for getAllSubtypeOf

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -2929,7 +2929,7 @@ function getAllSubtypeOf
   "Returns the list of all classes that extend from className given a parentClass where the lookup for className should start"
   input TypeName className;
   input TypeName parentClass = $TypeName(AllLoadedClasses);
-  input Boolean qualified = false;
+  input Boolean qualified = false "Not implemented";
   input Boolean includePartial = false;
   input Boolean sort = false;
   output TypeName classNames[:];

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -3183,7 +3183,7 @@ function getAllSubtypeOf
   "Returns the list of all classes that extend from className given a parentClass where the lookup for className should start"
   input TypeName className;
   input TypeName parentClass = $TypeName(AllLoadedClasses);
-  input Boolean qualified = false;
+  input Boolean qualified = false "Not implemented";
   input Boolean includePartial = false;
   input Boolean sort = false;
   output TypeName classNames[:];

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -1556,7 +1556,7 @@ algorithm
           Values.BOOL(includePartial),
           Values.BOOL(sort)})
       algorithm
-        paths := InteractiveUtil.getAllSubtypeOf(path, parentClass, SymbolTable.getAbsyn(), qualified, includePartial);
+        paths := InteractiveUtil.getAllSubtypeOf(path, parentClass, SymbolTable.getAbsyn(), qualified, includePartial, sort);
         paths := if sort then List.sort(paths, AbsynUtil.pathGe) else paths;
         vals := List.map(paths,ValuesUtil.makeCodeTypeName);
       then

--- a/testsuite/openmodelica/interactive-API/GetAllSubtypeOf3.mos
+++ b/testsuite/openmodelica/interactive-API/GetAllSubtypeOf3.mos
@@ -1,0 +1,37 @@
+// name: GetAllSubtypeOf3
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the getAllSubtypeOf API function.
+//
+
+loadString("
+  partial model A
+  end A;
+
+  partial model B
+    extends A;
+  end B;
+
+  model D
+    extends A;
+  end D;
+
+  model C
+    extends A;
+  end C;
+");
+
+getAllSubtypeOf(A, includePartial = true);
+getAllSubtypeOf(A, includePartial = false);
+getAllSubtypeOf(A, includePartial = true, sort = true);
+getErrorString();
+
+// Result:
+// true
+// {A, B, D, C}
+// {D, C}
+// {A, B, C, D}
+// ""
+// endResult

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -45,6 +45,7 @@ ForStatement7.mos \
 ForStatement8.mos \
 GetAllSubtypeOf1.mos \
 GetAllSubtypeOf2.mos \
+GetAllSubtypeOf3.mos \
 getClassComment.mos \
 getClassNames.mos \
 getCommandLineOptions.mos \


### PR DESCRIPTION
- Implement the `includePartial` and `sort` options for `getAllSubtypeOf`, which were previously present but didn't do anything.
- Document the `qualified` option as not implemented, since it's unclear what it's even supposed to do but removing it might break things.