### PR TITLE
Improve annotation modifier API:s

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4516,25 +4516,39 @@ annotation(Documentation(info="<html>
 end getSimulationOptions;
 
 function getAnnotationNamedModifiers
-   input TypeName name;
-   input String vendorannotation;
-   output String[:] modifiernamelist;
+   input TypeName className;
+   input String annotationName;
+   output String[:] modifierNames;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Returns the Modifiers name in the vendor annotation example annotation(__OpenModelica_simulationFlags(solver=\"dassl\"))
-calling sequence should be getAnnotationNamedModifiers(className,\"__OpenModelica_simulationFlags\") which returns {solver}.</p>
+<p>Returns the names of the modifiers in the given annotation, for example:
+<pre>
+  model M
+    annotation(experiment(StartTime = 1.0, StopTime = 2.0));
+  end M;
+
+  getAnnotationNamedModifiers(M, \"experiment\") => {\"StartTime\", \"StopTime\"}
+</pre>
+</p>
 </html>"));
 end getAnnotationNamedModifiers;
 
 function getAnnotationModifierValue
-  input TypeName name;
-  input String vendorannotation;
-  input String modifiername;
-  output String modifiernamevalue;
+  input TypeName className;
+  input String annotationName;
+  input String modifierName;
+  output String modifierValue;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Returns the Modifiers value in the vendor annotation example annotation(__OpenModelica_simulationFlags(solver=\"dassl\"))
-calling sequence should be getAnnotationNamedModifiersValue(className,\"__OpenModelica_simulationFlags\",\"modifiername\") which returns \"dassl\".</p>
+<p>Returns the value for a modifier in the given annotation, for example:
+<pre>
+  model M
+    annotation(experiment(StartTime = 1.0, StopTime = 2.0));
+  end M;
+
+  getAnnotationModifierValue(M, \"experiment\", \"StopTime\") => 2.0
+</pre>
+</p>
 </html>"));
 end getAnnotationModifierValue;
 

--- a/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/ValuesUtil.mo
@@ -818,6 +818,23 @@ algorithm
   end match;
 end powElementwiseArrayelt;
 
+public function absynExpValue
+  input Absyn.Exp exp;
+  output Values.Value value;
+algorithm
+  value := match exp
+    case Absyn.Exp.INTEGER() then Values.Value.INTEGER(exp.value);
+    case Absyn.Exp.REAL() then Values.Value.REAL(stringReal(exp.value));
+    case Absyn.Exp.CREF() then Values.Value.CODE(Absyn.CodeNode.C_VARIABLENAME(exp.componentRef));
+    case Absyn.Exp.STRING() then Values.Value.STRING(exp.value);
+    case Absyn.Exp.BOOL() then Values.Value.BOOL(exp.value);
+    case Absyn.Exp.ARRAY() then makeArray(list(absynExpValue(e) for e in exp.arrayExp));
+    case Absyn.Exp.TUPLE() then makeTuple(list(absynExpValue(e) for e in exp.expressions));
+    case Absyn.Exp.CODE() then Values.Value.CODE(exp.code);
+    else Values.Value.CODE(Absyn.CodeNode.C_EXPRESSION(exp));
+  end match;
+end absynExpValue;
+
 public function expValue "Returns the value of constant expressions in DAE.Exp"
   input DAE.Exp inExp;
   output Values.Value outValue;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -4770,25 +4770,39 @@ annotation(Documentation(info="<html>
 end getSimulationOptions;
 
 function getAnnotationNamedModifiers
-   input TypeName name;
-   input String vendorannotation;
-   output String[:] modifiernamelist;
+   input TypeName className;
+   input String annotationName;
+   output String[:] modifierNames;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Returns the Modifiers name in the vendor annotation example annotation(__OpenModelica_simulationFlags(solver=\"dassl\"))
-calling sequence should be getAnnotationNamedModifiers(className,\"__OpenModelica_simulationFlags\") which returns {solver}.</p>
+<p>Returns the names of the modifiers in the given annotation, for example:
+<pre>
+  model M
+    annotation(experiment(StartTime = 1.0, StopTime = 2.0));
+  end M;
+
+  getAnnotationNamedModifiers(M, \"experiment\") => {\"StartTime\", \"StopTime\"}
+</pre>
+</p>
 </html>"));
 end getAnnotationNamedModifiers;
 
 function getAnnotationModifierValue
-  input TypeName name;
-  input String vendorannotation;
-  input String modifiername;
-  output String modifiernamevalue;
+  input TypeName className;
+  input String annotationName;
+  input String modifierName;
+  output String modifierValue;
 external "builtin";
 annotation(Documentation(info="<html>
-<p>Returns the Modifiers value in the vendor annotation example annotation(__OpenModelica_simulationFlags(solver=\"dassl\"))
-calling sequence should be getAnnotationNamedModifiersValue(className,\"__OpenModelica_simulationFlags\",\"modifiername\") which returns \"dassl\".</p>
+<p>Returns the value for a modifier in the given annotation, for example:
+<pre>
+  model M
+    annotation(experiment(StartTime = 1.0, StopTime = 2.0));
+  end M;
+
+  getAnnotationModifierValue(M, \"experiment\", \"StopTime\") => 2.0
+</pre>
+</p>
 </html>"));
 end getAnnotationModifierValue;
 

--- a/testsuite/openmodelica/interactive-API/VendorAnnotation.mo
+++ b/testsuite/openmodelica/interactive-API/VendorAnnotation.mo
@@ -1,3 +1,3 @@
 model M
-    annotation(__OpenModelica_simulationFlags(solver="\n\\ndassl",jacobian="coloredNumerical"),experiment(startTime ="1",stopTime="2"));  
+  annotation(__OpenModelica_simulationFlags(solver="dassl",jacobian="coloredNumerical"),experiment(startTime=1,stopTime=2));
 end M;

--- a/testsuite/openmodelica/interactive-API/VendorAnnotation.mos
+++ b/testsuite/openmodelica/interactive-API/VendorAnnotation.mos
@@ -31,13 +31,12 @@ getErrorString();
 // ""
 // {"solver", "jacobian"}
 // ""
-// "
-// \\ndassl"
+// "dassl"
 // ""
 // "coloredNumerical"
 // ""
-// "1"
+// 1
 // ""
-// "2"
+// 2
 // ""
 // endResult


### PR DESCRIPTION
- Improve `getAnnotationModifierValue` to make it able to return values other than just string literals.
- Rewrite `getAnnotationModifierValue` and `getAnnotationNamedModifiers` to use `AbsynUtil.getNamedAnnotationInClass` instead of their own functions for doing lookup.
- Fix the documentation for these API:s, they work for all annotations and not just vendor annotations.

Fixes #13332