### PR TITLE
Fix OMEdit crash when editing text

### DIFF
--- a/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/BaseEditor.cpp
@@ -1652,7 +1652,7 @@ void PlainTextEdit::keyPressEvent(QKeyEvent *pEvent)
   bool shiftModifier = pEvent->modifiers().testFlag(Qt::ShiftModifier);
   bool controlModifier = pEvent->modifiers().testFlag(Qt::ControlModifier);
   bool isCompleterShortcut = controlModifier && (pEvent->key() == Qt::Key_Space); // CTRL+space
-  bool isCompleterChar = mCompletionCharacters.indexOf(QChar(pEvent->key())) != -1;
+  bool isCompleterChar = !pEvent->text().isEmpty() && mCompletionCharacters.indexOf(pEvent->text().front()) != -1;
   /* Ticket #4404. hide the completer on Esc and enter text based on Tab */
   if (mpCompleter && mpCompleter->popup()->isVisible()) {
     // The following keys are forwarded by the completer to the widget


### PR DESCRIPTION
- Use `QKeyEvent::text()` when checking if the input is a completion character instead of `QKeyEvent::key()`, since the key might not be a valid character.