### PR TITLE
Remove deprecated connection in DocumentationWidget

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
+++ b/OMEdit/OMEditLIB/Modeling/DocumentationWidget.cpp
@@ -504,7 +504,6 @@ void DocumentationWidget::showDocumentation(LibraryTreeItem *pLibraryTreeItem)
     /* append new url */
     mpDocumentationHistoryList->append(DocumentationHistory(pLibraryTreeItem));
     mDocumentationHistoryPos++;
-    connect(pLibraryTreeItem, SIGNAL(unLoaded()), SLOT(updateDocumentationHistory()));
   }
 
   updatePreviousNextButtons();


### PR DESCRIPTION
- Remove connection to signal `LibraryTreeItem::unLoaded`, since it doesn't exist anymore.