### PR TITLE
attempt to fix #12245

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -960,7 +960,7 @@ algorithm
         simVar.name := ComponentReference.crefPrefixPrevious(cr);
         clockedVars := simVar::clockedVars;
         simEq := SimCode.SES_SIMPLE_ASSIGN(ouniqueEqIndex, simVar.name, DAE.CREF(cr, simVar.type_), DAE.emptyElementSource, BackendDAE.EQ_ATTR_DEFAULT_UNKNOWN);
-         equations := simEq::equations;
+        equations := simEq::equations;
         ouniqueEqIndex := ouniqueEqIndex + 1;
       end if;
     end for;
@@ -992,6 +992,7 @@ algorithm
       simSubPartitions := List.map(Array.getRange(off, off + basePartition.nSubClocks - 1, subPartitions), Util.getOption);
       simSubPartitions := listReverse(simSubPartitions);
     else
+      // we should skip it and remove the base clock but that is quite complicated
       simSubPartitions := {};
     end if;
     off := off + basePartition.nSubClocks;

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -538,7 +538,13 @@ template functionSystemsSynchronous(list<ClockedPartition> clockedPartitions, St
     match partition
       case CLOCKED_PARTITION(subPartitions = (sub as _::_)) then
         functionSystemsSynchronousSubClocks(subPartitions, base_idx, modelNamePrefix)
-      else ""
+      else // adrpo: generate a fake call if the subPartitions = {}
+        let name = 'functionEquationsSynchronous_system_<%base_idx%>_0'
+        <<
+        case 0: // this is a fake function call for CLOCKED_PARTITION(subPartitions = {})
+          ret = <%symbolName(modelNamePrefix, name)%>(data, threadData);
+          break;
+        >>
     ; separator = "\n"
 
   let systs = clockedPartitions |> partition hasindex base_idx =>
@@ -553,7 +559,17 @@ template functionSystemsSynchronous(list<ClockedPartition> clockedPartitions, St
         <<
         <%funcCall%>
         >>
-      else ""
+      else // adrpo: generate a fake function for subPartitions = {}
+        <<
+        int <%symbolName(modelNamePrefix, 'functionEquationsSynchronous_system_<%base_idx%>_0')%>(DATA *data, threadData_t *threadData)
+        {
+          TRACE_PUSH
+          int i;
+          // do nothing, this is a fake function for CLOCKED_PARTITION(subPartitions = {})
+          TRACE_POP
+          return 0;
+        }
+        >>
     ; separator = "\n"
 
   <<

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -508,27 +508,27 @@ template functionSystemsSynchronousSubClocks(list<SubPartition> subPartitions, I
 ::=
   let subCases = subPartitions |> subPartition hasindex sub_idx =>
     match subPartition
-      case SUBPARTITION(__) then
-        let name = 'functionEquationsSynchronous_system_<%base_idx%>_<%sub_idx%>'
-        <<
-        case <%sub_idx%>:
-          ret = <%symbolName(modelNamePrefix, name)%>(data, threadData);
-          break;
-        >>
-      else ""
-    ; separator = "\n"
-
-  <<
-  case <%base_idx%>:
-    switch (sub_idx) {
-      <%subCases%>
-      default:
-        throwStreamPrint(NULL, "Internal Error: unknown sub-clock partition %ld", sub_idx);
-        ret = 1;
+    case SUBPARTITION(__) then
+      let name = 'functionEquationsSynchronous_system_<%base_idx%>_<%sub_idx%>'
+      <<
+      case <%sub_idx%>:
+        ret = <%symbolName(modelNamePrefix, name)%>(data, threadData);
         break;
-    }
-    break;
-  >>
+      >>
+    else ""
+  ; separator = "\n"
+
+<<
+case <%base_idx%>:
+  switch (sub_idx) {
+    <%subCases%>
+    default:
+      throwStreamPrint(NULL, "Internal Error: unknown sub-clock partition %ld", sub_idx);
+      ret = 1;
+      break;
+  }
+  break;
+>>
 end functionSystemsSynchronousSubClocks;
 
 
@@ -536,18 +536,18 @@ template functionSystemsSynchronous(list<ClockedPartition> clockedPartitions, St
 ::=
   let baseCases = clockedPartitions |> partition hasindex base_idx =>
     match partition
-      case CLOCKED_PARTITION(__) then
+      case CLOCKED_PARTITION(subPartitions = (sub as _::_)) then
         functionSystemsSynchronousSubClocks(subPartitions, base_idx, modelNamePrefix)
       else ""
     ; separator = "\n"
 
   let systs = clockedPartitions |> partition hasindex base_idx =>
     match partition
-      case CLOCKED_PARTITION(__) then
+      case CLOCKED_PARTITION(subPartitions = (sub as _::_)) then
         let funcCall = subPartitions |> subPart hasindex sub_idx =>
           match subPart
             case SUBPARTITION(__) then
-            functionEquationsSynchronous(base_idx, sub_idx, vars, listAppend(equations, removedEquations), modelNamePrefix)
+              functionEquationsSynchronous(base_idx, sub_idx, vars, listAppend(equations, removedEquations), modelNamePrefix)
             else ""
         ; separator = "\n"
         <<

--- a/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
+++ b/OMCompiler/Compiler/Template/CodegenCFunctions.tpl
@@ -62,7 +62,7 @@ static int rml_execution_failed()
   return 1;
 }
 
-DLLExport int __omc_main(int argc, char **argv)
+DLLDirection int __omc_main(int argc, char **argv)
 {
   MMC_INIT(0);
   {
@@ -366,7 +366,7 @@ template functionHeader(Function fn, Boolean inFunc, Boolean isSimulation, Text 
     case RECORD_CONSTRUCTOR(__) then
       let fname = underscorePath(name)
       let funArgsStr = (funArgs |> var as VARIABLE(__) => ', <%varType(var)%> omc_<%crefStr(name)%>')
-      let vis = (match visibility case PUBLIC() then "DLLExport")
+      let vis = (match visibility case PUBLIC() then "DLLDirection")
       <<
       <% if Flags.isSet(Flags.OMC_RELOCATABLE_FUNCTIONS)
         then
@@ -963,7 +963,7 @@ template functionHeaderImpl(String fname, list<Variable> fargs, list<Variable> o
   let prototype = functionPrototype(fname, fargs, outVars, boxed, visibility, isSimulation, true, dummy)
   let inFnStr = if boolAnd(boxed,inFunc) then
     <<
-    DLLExport
+    DLLDirection
     int in_<%fname%>(threadData_t *threadData, type_description * inArgs, type_description * outVar);
     >>
   match visibility
@@ -976,7 +976,7 @@ template functionHeaderImpl(String fname, list<Variable> fargs, list<Variable> o
     else
       <<
       <%inFnStr%>
-      <%if dynamicLoad then '' else 'DLLExport<%\n%><%prototype%>;'%>
+      <%if dynamicLoad then '' else 'DLLDirection<%\n%><%prototype%>;'%>
       >>
 end functionHeaderImpl;
 
@@ -1482,7 +1482,7 @@ case FUNCTION(__) then
   let prototype = functionPrototype(fname, functionArguments, outVars, false, visibility, isSimulation, false, afterBody)
   <<
   <%auxFunction%>
-  <% match visibility case PUBLIC(__) then "DLLExport" %>
+  <% match visibility case PUBLIC(__) then "DLLDirection" %>
   <%prototype%>
   {
     <%varDecls%>
@@ -1508,7 +1508,7 @@ end functionBodyRegularFunction;
 template generateInFunc(Text fname, list<Variable> functionArguments, list<Variable> outVars)
 ::=
   <<
-  DLLExport
+  DLLDirection
   int in_<%fname%>(threadData_t *threadData, type_description * inArgs, type_description * outVar)
   {
     //if (!mmc_GC_state) mmc_GC_init();

--- a/OMCompiler/Compiler/Template/GenerateAPIFunctionsTpl.tpl
+++ b/OMCompiler/Compiler/Template/GenerateAPIFunctionsTpl.tpl
@@ -141,6 +141,8 @@ template getQtInterfaceHeaders(list<DAE.Type> tys, String className)
 
   #include <QOpenGLContext> // must be first include to fix undefined GLDEBUGPROC
   #include <QtCore>
+  /* import the scripting here */
+  #define IMPORT_INTO
   #include "OpenModelicaScriptingAPI.h"
 
   class <%className%> : public QObject


### PR DESCRIPTION
- Skip CLOCKED_PARTITION with empty subpartitions as otherwise the generation of indexes for BASEIDX and SUBCLOCKIDX are generated badly in the definition/call of: functionEquationsSynchronous_system_BASEIDX_SUBCLOCKIDX
- How should we really handle this? The simulation fails of course as we have a switch for an index that does not exist. Should we remove those switch cases for the CLOCKED_PARTITION with empty subpartitions?

Unrelated changes:
- use DLLDirection instead of DLLExport so we can define it for import/export
