### PR TITLE
Include parameter names in function types

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -843,19 +843,26 @@ uniontype Function
 
   function typeString
     "Constructs a string representing the type of the function, on the form
-     function_name<function>(input types) => output type"
+     function_name<function>(inputs) => outputs"
     input Function fn;
     output String str;
-  algorithm
-    str := List.toString(fn.inputs, paramTypeString,
-      AbsynUtil.pathString(name(fn)) + "<function>",
-      "(", ", ", ") => " + Type.toString(fn.returnType), true);
-  end typeString;
+  protected
+    String inputs, outputs;
 
-  function paramTypeString
-    input InstNode param;
-    output String str = Type.toString(InstNode.getType(param));
-  end paramTypeString;
+    function param_str
+      input InstNode p;
+      output String s = Type.toString(InstNode.getType(p)) + " " + InstNode.name(p);
+    end param_str;
+  algorithm
+    inputs := List.toString(fn.inputs, param_str, "", "", ", ", "");
+    outputs := List.toString(fn.outputs, param_str, "", "", ", ", "");
+
+    if listEmpty(fn.outputs) or listLength(fn.outputs) > 1 then
+      outputs := "(" + outputs + ")";
+    end if;
+
+    str := AbsynUtil.pathString(name(fn)) + "<function>(" + inputs + ") => " + outputs;
+  end typeString;
 
   function toFlatStream
     input Function fn;

--- a/testsuite/flattening/modelica/scodeinst/FunctionalArgInvalidType1.mo
+++ b/testsuite/flattening/modelica/scodeinst/FunctionalArgInvalidType1.mo
@@ -28,9 +28,9 @@ end FunctionalArgInvalidType1;
 // Result:
 // Error processing file: FunctionalArgInvalidType1.mo
 // [flattening/modelica/scodeinst/FunctionalArgInvalidType1.mo:25:3-25:21:writable] Error: Type mismatch for positional argument 1 in f1(f=f2). The argument has type:
-//   f2<function>(Integer) => Integer
+//   f2<function>(Integer x) => Integer y
 // expected type:
-//   f<function>(Real) => Real
+//   f<function>(Real x) => Real y
 //
 // # Error encountered! Exiting...
 // # Please check the error message and the flags.


### PR DESCRIPTION
- Include the names of the formal parameters when printing function types, since they matter for function compatibility.

Fixes #13345