### PR TITLE
Fix InteractiveUtil.recordConstructorToModification

### DIFF
--- a/OMCompiler/Compiler/Script/InteractiveUtil.mo
+++ b/OMCompiler/Compiler/Script/InteractiveUtil.mo
@@ -3654,11 +3654,13 @@ algorithm
       Absyn.Exp e;
       Absyn.Path p;
 
-    /* Covers the case annotate=Diagram(1) */
-    case (Absyn.CALL(function_ = cr,functionArgs = Absyn.FUNCTIONARGS(args = {e}, argNames = {})))
+    /* Covers the case annotate=Diagram(SOMETHING(x=1,y=2)) */
+    case (Absyn.CALL(function_ = cr,functionArgs = Absyn.FUNCTIONARGS(args = {(e as Absyn.CALL())},argNames = nargs)))
       equation
+        eltarglst = List.map(nargs, namedargToModification);
+        emod = recordConstructorToModification(e);
         p = AbsynUtil.crefToPath(cr);
-        res = Absyn.MODIFICATION(false,Absyn.NON_EACH(),p,SOME(Absyn.CLASSMOD({},Absyn.EQMOD(e,AbsynUtil.dummyInfo))),NONE(),AbsynUtil.dummyInfo);
+        res = Absyn.MODIFICATION(false,Absyn.NON_EACH(),p,SOME(Absyn.CLASSMOD((emod :: eltarglst),Absyn.NOMOD())),NONE(),AbsynUtil.dummyInfo);
       then
         res;
     /* Covers the case annotate=Diagram(x=1,y=2) */
@@ -3669,13 +3671,11 @@ algorithm
         res = Absyn.MODIFICATION(false,Absyn.NON_EACH(),p,SOME(Absyn.CLASSMOD(eltarglst,Absyn.NOMOD())),NONE(),AbsynUtil.dummyInfo);
       then
         res;
-    /* Covers the case annotate=Diagram(SOMETHING(x=1,y=2)) */
-    case (Absyn.CALL(function_ = cr,functionArgs = Absyn.FUNCTIONARGS(args = {(e as Absyn.CALL())},argNames = nargs)))
+    /* Covers the case annotate=Diagram(1) */
+    case (Absyn.CALL(function_ = cr,functionArgs = Absyn.FUNCTIONARGS(args = {e}, argNames = {})))
       equation
-        eltarglst = List.map(nargs, namedargToModification);
-        emod = recordConstructorToModification(e);
         p = AbsynUtil.crefToPath(cr);
-        res = Absyn.MODIFICATION(false,Absyn.NON_EACH(),p,SOME(Absyn.CLASSMOD((emod :: eltarglst),Absyn.NOMOD())),NONE(),AbsynUtil.dummyInfo);
+        res = Absyn.MODIFICATION(false,Absyn.NON_EACH(),p,SOME(Absyn.CLASSMOD({},Absyn.EQMOD(e,AbsynUtil.dummyInfo))),NONE(),AbsynUtil.dummyInfo);
       then
         res;
     else

--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -3,6 +3,7 @@ TEST = ../../rtest -v
 TESTFILES = \
 AddClassAnnotation.mos \
 addComponent1.mos \
+addComponent2.mos \
 addConnection1.mos \
 ArraySlicing.mos \
 Bug2871.mos \

--- a/testsuite/openmodelica/interactive-API/addComponent2.mos
+++ b/testsuite/openmodelica/interactive-API/addComponent2.mos
@@ -1,0 +1,37 @@
+// name: addComponent2
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+// Tests the addComponent API.
+//
+
+loadString("
+  model M
+  end M;
+");
+
+// Usual way to define the annotation.
+addComponent(x, Real, M, annotate=Placement(transformation(extent = {{-10, 10}, {-10, 10}})));
+// Unusual way, but still ok probably.
+addComponent(y, Real, M, annotate=Placement(transformation = Transformation(extent = {{-10, 10}, {-10, 10}})));
+// Wrong way, but still allowed for legacy reasons.
+addComponent(z, Real, M, annotate=Placement(transformation = transformation(extent = {{-10, 10}, {-10, 10}})));
+list(M);
+getErrorString();
+
+// Result:
+// true
+// true
+// true
+// true
+// "model M
+//   Real x annotation(
+//     Placement(transformation(extent = {{-10, 10}, {-10, 10}})));
+//   Real y annotation(
+//     Placement(transformation(extent = {{-10, 10}, {-10, 10}})));
+//   Real z annotation(
+//     Placement(transformation(extent = {{-10, 10}, {-10, 10}})));
+// end M;"
+// ""
+// endResult


### PR DESCRIPTION
- Reorder the cases to avoid treating record constructor arguments as equality modifiers.

Fixes #13353