### PR TITLE
do not change the varkind of the output variable when creating aliases

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1905,8 +1905,10 @@ algorithm
         newVar := BackendVariable.setVarDirection(newVar, DAE.BIDIR());
         newVars := BackendVariable.addVar(newVar, newVars);
 
-        // update output to ordinary variable
-        v := BackendVariable.setVarKind(v, BackendDAE.VARIABLE());
+        /*fix issue https://github.com/OpenModelica/OpenModelica/issues/13342
+         *do not change the varkind of the output variable
+        */
+        //v := BackendVariable.setVarKind(v, BackendDAE.VARIABLE());
         v := BackendVariable.removeFixedAttribute(v);
         v := BackendVariable.removeStartAttribute(v);
         newVars := BackendVariable.addVar(v, newVars);

--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -1906,9 +1906,11 @@ algorithm
         newVars := BackendVariable.addVar(newVar, newVars);
 
         /*fix issue https://github.com/OpenModelica/OpenModelica/issues/13342
-         *do not change the varkind of the output variable
+         *do not change the varkind of the output variable, except if var = BackendDAE.STATE()
         */
-        //v := BackendVariable.setVarKind(v, BackendDAE.VARIABLE());
+        if BackendVariable.isStateVar(v) then
+          v := BackendVariable.setVarKind(v, BackendDAE.VARIABLE());
+        end if;
         v := BackendVariable.removeFixedAttribute(v);
         v := BackendVariable.removeStartAttribute(v);
         newVars := BackendVariable.addVar(v, newVars);

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/Makefile
@@ -29,6 +29,7 @@ fmi_attributes_25.mos \
 fmiFilterTest.mos \
 FMUResourceTest.mos \
 QuotedIdentifierExport.mos \
+RealFFT1.mos \
 testBug2764.mos \
 testBug2765.mos \
 testBug3049.mos \

--- a/testsuite/openmodelica/fmi/ModelExchange/2.0/RealFFT1.mos
+++ b/testsuite/openmodelica/fmi/ModelExchange/2.0/RealFFT1.mos
@@ -1,0 +1,21 @@
+// name:     RealFFT1
+// keywords: fmu export import
+// status: correct
+// teardown_command: rm -rf RealFFT1.fmu RealFFT1.log RealFFT1_info.json
+// https://github.com/OpenModelica/OpenModelica/issues/13342
+
+
+loadModel(Modelica);
+getErrorString();
+
+buildModelFMU(Modelica.Math.FastFourierTransform.Examples.RealFFT1);
+getErrorString();
+
+// Result:
+// true
+// ""
+// "RealFFT1.fmu"
+// "[Modelica 4.0.0+maint.om/Math/FastFourierTransform.mo:538:3-629:25:writable] Warning: Pure function 'Modelica.Math.FastFourierTransform.realFFTwriteToFile' contains a call to impure function 'Modelica.Utilities.Files.removeFile'.
+// Warning: The initial conditions are not fully specified. For more information set -d=initialization. In OMEdit Tools->Options->Simulation->Show additional information from the initialization process, in OMNotebook call setCommandLineOptions(\"-d=initialization\").
+// "
+// endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/13342

### Purpose

This PR fixes the `FMI export issues` when creating output aliases for `OUTPUT` variables.
