### PR TITLE
[C] Use common interface for all initialAnalyticJacobian functions

### DIFF
--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -1353,12 +1353,12 @@ template simulationFile(SimCode simCode, String guid, String isModelExchangeFMU)
        <%symbolName(modelNamePrefixStr,"dataReconciliationUnmeasuredVariables")%>,
        <% if isModelExchangeFMU then symbolName(modelNamePrefixStr,"read_simulation_info") else "NULL" %>,
        <% if isModelExchangeFMU then symbolName(modelNamePrefixStr,"read_input_fmu") else "NULL" %>,
-       <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"initialAnalyticJacobianFMIDER") else "NULL" else "NULL" %>,
-       <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"functionJacFMIDER_column") else "NULL" else "NULL" %>,
-       <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"INDEX_JAC_FMIDER") else "-1" else "-1" %>,
-       <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(initialPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"initialAnalyticJacobianFMIDERINIT") else "NULL" else "NULL" %>,
-       <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(initialPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"functionJacFMIDERINIT_column") else "NULL" else "NULL" %>,
-       <% if isSome(modelStructure) then match modelStructure case SOME(FMIMODELSTRUCTURE(initialPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"INDEX_JAC_FMIDERINIT") else "-1" else "-1" %>
+       <% match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"initialAnalyticJacobianFMIDER") else "NULL"%>,
+       <% match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"functionJacFMIDER_column") else "NULL"%>,
+       <% match modelStructure case SOME(FMIMODELSTRUCTURE(continuousPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"INDEX_JAC_FMIDER") else "-1"%>,
+       <% match modelStructure case SOME(FMIMODELSTRUCTURE(initialPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"initialAnalyticJacobianFMIDERINIT") else "NULL"%>,
+       <% match modelStructure case SOME(FMIMODELSTRUCTURE(initialPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"functionJacFMIDERINIT_column") else "NULL"%>,
+       <% match modelStructure case SOME(FMIMODELSTRUCTURE(initialPartialDerivatives=SOME(__))) then symbolName(modelNamePrefixStr,"INDEX_JAC_FMIDERINIT") else "-1"%>
     <%\n%>
     };
 

--- a/OMCompiler/SimulationRuntime/c/openmodelica_func.h
+++ b/OMCompiler/SimulationRuntime/c/openmodelica_func.h
@@ -261,12 +261,12 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   * Return-value 0: jac is present
   * Return-value 1: jac is not present
   */
-  int (*initialAnalyticJacobianA)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianB)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianC)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianD)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianF)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
-  int (*initialAnalyticJacobianH)(DATA* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  initialAnalyticalJacobian_func_ptr initialAnalyticJacobianA;
+  initialAnalyticalJacobian_func_ptr initialAnalyticJacobianB;
+  initialAnalyticalJacobian_func_ptr initialAnalyticJacobianC;
+  initialAnalyticalJacobian_func_ptr initialAnalyticJacobianD;
+  initialAnalyticalJacobian_func_ptr initialAnalyticJacobianF;
+  initialAnalyticalJacobian_func_ptr initialAnalyticJacobianH;
 
   /*
   * These functions calculate specific jacobian column.
@@ -369,14 +369,14 @@ struct OpenModelicaGeneratedFunctionCallbacks {
   /*
   * FMU continuous partial derivative functions
   */
-  int (*initialPartialFMIDER)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  initialAnalyticalJacobian_func_ptr initialPartialFMIDER;
   analyticalJacobianColumn_func_ptr functionJacFMIDER_column;
   const int INDEX_JAC_FMIDER;
 
   /*
   * FMU partial derivative functions for initilization DAE
   */
-  int (*initialPartialFMIDERINIT)(void* data, threadData_t *threadData, ANALYTIC_JACOBIAN* thisJacobian);
+  initialAnalyticalJacobian_func_ptr initialPartialFMIDERINIT;
   analyticalJacobianColumn_func_ptr functionJacFMIDERINIT_column;
   const int INDEX_JAC_FMIDERINIT;
 };

--- a/OMCompiler/SimulationRuntime/c/simulation_data.h
+++ b/OMCompiler/SimulationRuntime/c/simulation_data.h
@@ -286,6 +286,7 @@ typedef struct STATIC_STRING_DATA
 } STATIC_STRING_DATA;
 
 typedef int (*analyticalJacobianColumn_func_ptr)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* thisJacobian, ANALYTIC_JACOBIAN* parentJacobian);
+typedef int (*initialAnalyticalJacobian_func_ptr)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
 
 /**
  * @brief User data provided to residual functions.
@@ -328,7 +329,7 @@ typedef struct NONLINEAR_SYSTEM_DATA
    * if analyticalJacobianColumn == NULL no analyticalJacobian is available
    */
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
+  initialAnalyticalJacobian_func_ptr initialAnalyticalJacobian;
   modelica_integer jacobianIndex;
 
   SPARSE_PATTERN *sparsePattern;       /* sparse pattern if no jacobian is available */
@@ -408,7 +409,7 @@ typedef struct LINEAR_SYSTEM_DATA
   void (*setBElement)(int row, double value, LINEAR_SYSTEM_DATA* linearSystemData, threadData_t* threadData);
 
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
+  initialAnalyticalJacobian_func_ptr initialAnalyticalJacobian;
 
   void (*residualFunc)(RESIDUAL_USERDATA* userData, const double* x, double* res, const int* flag);
   void (*initializeStaticLSData)(DATA* data, threadData_t* threadData, LINEAR_SYSTEM_DATA* linearSystemData, modelica_boolean initSparsePattern);
@@ -499,7 +500,7 @@ typedef struct STATE_SET_DATA
    * if analyticalJacobianColumn == NULL no analyticalJacobian is available
    */
   analyticalJacobianColumn_func_ptr analyticalJacobianColumn;
-  int (*initialAnalyticalJacobian)(DATA* data, threadData_t* threadData, ANALYTIC_JACOBIAN* jacobian);
+  initialAnalyticalJacobian_func_ptr initialAnalyticalJacobian;
   modelica_integer jacobianIndex;
 } STATE_SET_DATA;
 #else


### PR DESCRIPTION
This should fix compilation issues on Windows 11

### Related Issues

#13356