### PR TITLE
Improve functional arguments in Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -377,6 +377,12 @@ public
         then
           ();
 
+      case Type.FUNCTION(fnType = NFType.FunctionType.FUNCTIONAL_PARAMETER)
+        algorithm
+          UnorderedMap.tryAdd(InstNode.scopePath(ty.fn.node), ty, types);
+        then
+          ();
+
       else ();
     end match;
   end collectFlatType;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFunction.mo
@@ -896,6 +896,11 @@ uniontype Function
       fn_name := if stringEmpty(overrideName) then Util.makeQuotedIdentifier(AbsynUtil.pathString(fn.path)) else overrideName;
 
       s := IOStream.append(s, indent);
+
+      if InstNode.isPartial(fn.node) then
+        s := IOStream.append(s, "partial ");
+      end if;
+
       s := IOStream.append(s, "function ");
       s := IOStream.append(s, fn_name);
       s := FlatModelicaUtil.appendCommentString(SOME(cmt), s);

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -992,7 +992,7 @@ public
       case Type.NORETCALL() then "()";
       case Type.UNKNOWN() then "unknown()";
       case Type.COMPLEX() then Util.makeQuotedIdentifier(AbsynUtil.pathString(InstNode.scopePath(ty.cls)));
-      case Type.FUNCTION() then Function.typeString(ty.fn);
+      case Type.FUNCTION() then Util.makeQuotedIdentifier(AbsynUtil.pathString(InstNode.scopePath(ty.fn.node)));
       case Type.METABOXED() then toFlatString(ty.ty, format);
       case Type.POLYMORPHIC() then "<" + ty.name + ">";
       case Type.ANY() then "$ANY$";
@@ -1078,6 +1078,10 @@ public
           s := IOStream.append(s, ";\n\nend ");
           s := IOStream.append(s, name);
         then s;
+
+      case FUNCTION()
+        then Function.toFlatStream(ty.fn, format, indent, s,
+          overrideName = Util.makeQuotedIdentifier(AbsynUtil.pathString(InstNode.scopePath(ty.fn.node))));
 
       else s;
     end match;

--- a/testsuite/openmodelica/basemodelica/Functional1.mo
+++ b/testsuite/openmodelica/basemodelica/Functional1.mo
@@ -1,0 +1,52 @@
+// name: Functional1
+// status: correct
+
+partial function PF
+  input Real x;
+  output Real y;
+end PF;
+
+function f
+  input Real x;
+  input PF pf;
+  output Real y;
+algorithm
+  y := pf(x);
+end f;
+
+function f2
+  input Real x;
+  output Real y = 2*x;
+end f2;
+
+model Functional1
+  Real x = f(time, f2);
+  annotation(__OpenModelica_commandLineOptions="-d=newInst -f");
+end Functional1;
+
+// Result:
+// //! base 0.1.0
+// package 'Functional1'
+//   function 'f'
+//     input Real 'x';
+//     input 'PF' 'pf';
+//     output Real 'y';
+//   algorithm
+//     'y' := 'pf'('x');
+//   end 'f';
+//
+//   function 'f2'
+//     input Real 'x';
+//     output Real 'y' = 2.0 * 'x';
+//   end 'f2';
+//
+//   partial function 'PF'
+//     input Real 'x';
+//     output Real 'y';
+//   end 'PF';
+//
+//   model 'Functional1'
+//     Real 'x' = 'f'(time, 'f2');
+//   end 'Functional1';
+// end 'Functional1';
+// endResult

--- a/testsuite/openmodelica/basemodelica/Makefile
+++ b/testsuite/openmodelica/basemodelica/Makefile
@@ -14,6 +14,7 @@ TESTFILES = \
   DoublePendulum.mos \
 	Enum1.mo \
 	Expression1.mo \
+	Functional1.mo \
 	InStreamNominalThreshold.mo \
 	MoveBindings1.mo \
 	NonScalarizedWithRecords1.mo \


### PR DESCRIPTION
- Print the name of the function instead of the signature as the type of functional input parameters.
- Add partial functions used as types to the package.
- Add partial prefix to partial functions.

Fixes #13388