### PR TITLE
Move more API calls to the typed API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6681,5 +6681,10 @@ algorithm
   end match;
 end isLiteralExp;
 
+function enumLiteralName
+  input Absyn.EnumLiteral literal;
+  output String name = literal.literal;
+end enumLiteralName;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;

--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -4964,6 +4964,28 @@ annotation(
   preferredView="text");
 end getShortDefinitionBaseClassInformation;
 
+function getExternalFunctionSpecification
+  input TypeName functionName;
+  output Expression result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns information about the given function's external specification: language, output variable, external function name, arguments, annotations on the external declaration, and annotations on the function.</p>
+</html>"),
+  preferredView="text");
+end getExternalFunctionSpecification;
+
+function getEnumerationLiterals
+  input TypeName className;
+  output String[:] result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns the literals for a given enumeration type.</p>
+</html>"),
+  preferredView="text");
+end getEnumerationLiterals;
+
 function getTransitions
   input TypeName cl;
   output String[:,:] transitions;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -5218,6 +5218,28 @@ annotation(
   preferredView="text");
 end getShortDefinitionBaseClassInformation;
 
+function getExternalFunctionSpecification
+  input TypeName functionName;
+  output Expression result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns information about the given function's external specification: language, output variable, external function name, arguments, annotations on the external declaration, and annotations on the function.</p>
+</html>"),
+  preferredView="text");
+end getExternalFunctionSpecification;
+
+function getEnumerationLiterals
+  input TypeName className;
+  output String[:] result;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns the literals for a given enumeration type.</p>
+</html>"),
+  preferredView="text");
+end getEnumerationLiterals;
+
 function getTransitions
   input TypeName cl;
   output String[:,:] transitions;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3277,6 +3277,11 @@ algorithm
     case ("getShortDefinitionBaseClassInformation", {Values.CODE(Absyn.C_TYPENAME(classpath))})
       then Interactive.getShortDefinitionBaseClassInformation(classpath, SymbolTable.getAbsyn());
 
+    case ("getExternalFunctionSpecification", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      then Interactive.getExternalFunctionSpecification(classpath, SymbolTable.getAbsyn());
+
+    case ("getEnumerationLiterals", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      then Interactive.getEnumerationLiterals(classpath, SymbolTable.getAbsyn());
  end matchcontinue;
 end cevalInteractiveFunctions4;
 

--- a/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
+++ b/testsuite/openmodelica/interactive-API/interactive_api_calls.mos
@@ -235,7 +235,7 @@ getMessagesStringInternal(unique = false); // not unique
 // Evaluating: getErrorString()
 // ""
 // Evaluating: getEnumerationLiterals(sizeE)
-// {"Small","Medium","Large"}
+// {"Small", "Medium", "Large"}
 // Evaluating: getErrorString()
 // ""
 // Evaluating: isReplaceable(ReplaceableClass.M1)
@@ -472,7 +472,7 @@ getMessagesStringInternal(unique = false); // not unique
 // Evaluating: getErrorString()
 // ""
 // Evaluating: getExternalFunctionSpecification(TestPack.Ext)
-// {"C","u","externFunc","x, y, z","",""}
+// {"C", "u", "externFunc", "x, y, z", "", ""}
 // Evaluating: getErrorString()
 // ""
 // Evaluating: getExternalFunctionSpecification(TestPack.NoExt)


### PR DESCRIPTION
- Move `getExternalFunctionSpecification` to the typed API.
- Move `getEnumerationLiterals` to the typed API.