### PR TITLE
Properly fix #12065

### DIFF
--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -15895,6 +15895,7 @@ protected
   end addDockerVol;
 algorithm
   (locations, libraries) := getDirectoriesForDLLsFromLinkLibs(libs);
+  locations := listAppend({Settings.getInstallationDirectoryPath() + "/lib/${CMAKE_LIBRARY_ARCHITECTURE}/omc"}, locations); // zlib
   locations := listAppend({Settings.getInstallationDirectoryPath() + "/bin"}, locations);   // pthread located in OpenModelica/bin/ on Windows
   locations := List.map(locations, addDockerVol);
   // Use target_link_directories when CMake 3.13 is available and skip the find_library part
@@ -15907,7 +15908,7 @@ algorithm
   for lib in libraries loop
     cmakecode := cmakecode + "find_library(" + lib + "\n" +
                  "             NAMES " + lib + "\n" +
-                 "             PATHS ${EXTERNAL_LIBDIRECTORIES})\n" +
+                 "             PATHS ${EXTERNAL_LIBDIRECTORIES} NO_DEFAULT_PATH)\n" +
                  "message(STATUS \"Linking ${" + lib + "}\")" + "\n" +
                  "target_link_libraries(${FMU_NAME_HASH} PRIVATE ${" + lib + "})" + "\n" +
                  "list(APPEND RUNTIME_DEPENDS ${" + lib + "})" + "\n";

--- a/OMCompiler/Compiler/runtime/systemimpl.c
+++ b/OMCompiler/Compiler/runtime/systemimpl.c
@@ -702,7 +702,7 @@ int SystemImpl__systemCall(const char* str, const char* outFile)
   if (pID == 0) { // child
     if (*outFile) {
       /* redirect stdout, stderr in the fork'ed process */
-      int fd = open(outFile, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+      int fd = open(outFile, O_RDWR | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
       if (fd < 0) {
         _exit(1);
       }


### PR DESCRIPTION
- add lib/${CMAKE_LIBRARY_ARCHITECTURE}/omc to the EXTERNAL_DIRECTORIES
- add NO_DEFAULT_PATH to disallow cmake to find libraries in other places than what we specify in EXTERNAL_DIRECTORIES

Unrelated changes:
- currently we build an FMU by running 2 commands: configure & build + zip and we lose the log because the zip command will override the previous log
- open the log file for systemCall in append mode (do not override the existing file) for Linux too (already done for Windows)
