### PR TITLE
Fix name quoting in Base Modelica

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -756,9 +756,8 @@ public
           s := IOStream.append(s, indent);
           s := Attributes.toFlatStream(component.attributes, component.ty, s);
           s := IOStream.append(s, Type.toFlatString(component.ty, format));
-          s := IOStream.append(s, " '");
-          s := IOStream.append(s, name);
-          s := IOStream.append(s, "'");
+          s := IOStream.append(s, " ");
+          s := IOStream.append(s, Util.makeQuotedIdentifier(name));
 
           ty_attrs := list((Modifier.name(a), Modifier.binding(a)) for a in
             Class.getTypeAttributes(InstNode.getClass(component.classInst)));

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1240,7 +1240,7 @@ public
     if format.scalarizeMode == BaseModelica.ScalarizeMode.NOT_SCALARIZED then
       while not listEmpty(crefs) loop
         cr :: crefs := crefs;
-        strl := firstName(cr, baseModelica = true) :: strl;
+        strl := Util.escapeQuotes(firstName(cr, baseModelica = true)) :: strl;
         subs := listAppend(getSubscripts(cr), subs);
 
         if format.recordMode == BaseModelica.RecordMode.WITH_RECORDS and isCref(cr) and
@@ -1262,7 +1262,7 @@ public
     else
       while not listEmpty(crefs) loop
         cr :: crefs := crefs;
-        strl := firstName(cr, baseModelica = true) :: strl;
+        strl := Util.escapeQuotes(firstName(cr, baseModelica = true)) :: strl;
         subs := getSubscripts(cr);
 
         if not listEmpty(subs) and

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -2003,7 +2003,7 @@ public
         then if Type.isBuiltinEnumeration(t) then
             AbsynUtil.pathString(t.typePath) + "." + exp.name
           else
-            "'" + AbsynUtil.pathString(t.typePath) + "'.'" + exp.name + "'";
+            Util.makeQuotedIdentifier(AbsynUtil.pathString(t.typePath)) + "." + Util.makeQuotedIdentifier(exp.name);
 
       case CLKCONST(clk) then ClockKind.toFlatString(clk, format);
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModel.mo
@@ -233,7 +233,7 @@ public
     input output IOStream.IOStream s;
   protected
     FlatModel flat_model = flatModel;
-    String name = className(flatModel);
+    String name = Util.makeQuotedIdentifier(className(flatModel));
     BaseModelica.OutputFormat format;
     Boolean scalarize;
   algorithm
@@ -262,7 +262,7 @@ public
     end if;
 
     s := IOStream.append(s, "//! base 0.1.0\n");
-    s := IOStream.append(s, "package '" + name + "'\n");
+    s := IOStream.append(s, "package " + name + "\n");
 
     for fn in functions loop
       if not (Function.isDefaultRecordConstructor(fn) or Function.isExternalObjectConstructorOrDestructor(fn)) then
@@ -277,7 +277,7 @@ public
       s := IOStream.append(s, ";\n\n");
     end for;
 
-    s := IOStream.append(s, "  model '" + name + "'");
+    s := IOStream.append(s, "  model " + name);
     s := FlatModelicaUtil.appendElementSourceCommentString(flat_model.source, s);
     s := IOStream.append(s, "\n");
 
@@ -312,8 +312,8 @@ public
 
     s := FlatModelicaUtil.appendElementSourceCommentAnnotation(flat_model.source,
       NFFlatModelicaUtil.ElementType.ROOT_CLASS, "    ", ";\n", s);
-    s := IOStream.append(s, "  end '" + name + "';\n");
-    s := IOStream.append(s, "end '" + name + "';\n");
+    s := IOStream.append(s, "  end " + name + ";\n");
+    s := IOStream.append(s, "end " + name + ";\n");
   end appendFlatStream;
 
   function collectFlatTypes

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatModelicaUtil.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatModelicaUtil.mo
@@ -233,7 +233,7 @@ encapsulated package NFFlatModelicaUtil
           str := Dump.printComponentRefStr(exp.componentRef);
 
           if str <> "time" then
-            str := "'" + str + "'";
+            str := Util.makeQuotedIdentifier(str);
             exp.componentRef := Absyn.ComponentRef.CREF_IDENT(str, {});
           end if;
         then

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -1026,35 +1026,22 @@ public
     input BaseModelica.OutputFormat format;
     input String indent;
     input output IOStream.IOStream s;
+  protected
+    Integer index;
+    String name;
+    ComplexType complexTy;
+    Absyn.Path path;
+    InstNode constructor, destructor;
+    Function f;
   algorithm
     s := match ty
-      local
-        Integer index;
-        String name;
-        ComplexType complexTy;
-        Absyn.Path path;
-        InstNode constructor, destructor;
-        Function f;
-
       case ENUMERATION()
         algorithm
           s := IOStream.append(s, indent);
           s := IOStream.append(s, "type ");
           s := IOStream.append(s, Util.makeQuotedIdentifier(AbsynUtil.pathString(ty.typePath)));
           s := IOStream.append(s, " = enumeration(");
-
-          if not listEmpty(ty.literals) then
-            s := IOStream.append(s, "'");
-            s := IOStream.append(s, listHead(ty.literals));
-
-            for l in listRest(ty.literals) loop
-              s := IOStream.append(s, "', '");
-              s := IOStream.append(s, l);
-            end for;
-
-            s := IOStream.append(s, "'");
-          end if;
-
+          s := IOStream.append(s, stringDelimitList(list(Util.makeQuotedIdentifier(l) for l in ty.literals), ", "));
           s := IOStream.append(s, ")");
         then
           s;


### PR DESCRIPTION
- Replace manual quoting in some places with calls to `Util.makeQuotedIdentifier` or `Util.escapeQuotes` to make sure already quoted names are escaped properly.