### PR TITLE
Remove manual alarm from some test cases

### DIFF
--- a/testsuite/simulation/modelica/hpcom/Modelica.Fluid.Examples.BranchingDynamicPipes.mos
+++ b/testsuite/simulation/modelica/hpcom/Modelica.Fluid.Examples.BranchingDynamicPipes.mos
@@ -8,8 +8,6 @@
 // Modelica Standard Library
 //
 
-alarm(800);
-
 loadModel(Modelica,{"3.2.1"});
 
 setMatchingAlgorithm("PFPlusExt"); getErrorString();
@@ -101,7 +99,6 @@ res := OpenModelica.Scripting.compareSimulationResults("Modelica.Fluid.Examples.
    "pipe4.flowModel.m_flows[5]"});
 
 // Result:
-// 900
 // true
 // true
 // ""

--- a/testsuite/simulation/modelica/nonlinear_system/problem2_symjac.mos
+++ b/testsuite/simulation/modelica/nonlinear_system/problem2_symjac.mos
@@ -3,7 +3,6 @@
 // teardown_command: rm -f nonlinear_system.problem2* _nonlinear_system.problem2* output.log
 // cflags: -d=-newInst
 
-alarm(360);
 loadFile("nlsTestPackage.mo"); getErrorString();
 OpenModelica.Scripting.setCommandLineOptions("+tearingMethod=minimalTearing"); getErrorString();
 OpenModelica.Scripting.setCommandLineOptions("+d=NLSanalyticJacobian"); getErrorString();
@@ -22,7 +21,6 @@ val(x[10],{0.0,1.0,2.0});
 val(y,{0.0,1.0,2.0});
 
 // Result:
-// 900
 // true
 // ""
 // true


### PR DESCRIPTION
- Remove manual `alarm` calls from some test cases since the return value is nondeterministic, and manually setting a time limit isn't really necessary anymore.