### PR TITLE
Convert multiple spaces to no break space

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ItemDelegate.cpp
@@ -62,8 +62,28 @@ QString ItemDelegate::formatDisplayText(QVariant variant) const
     text = variant.toString();
     /* if rich text flag is set */
     if (mDrawRichText) {
+      text = Qt::convertFromPlainText(variant.toString(), Qt::WhiteSpaceNormal);
       text.replace("\n", "<br />");
       text.replace("\t", "&#9;");
+
+      /* Issue #13453.
+       * QTextDocument eats the multiple whitespaces.
+       * This is default behavoir of html. We can use white-space: pre-wrap; css but it causes other issues like word wrap.
+       * So we detect multiple spaces and convert them to no break space.
+       */
+      QString newText;
+      int len = text.length();
+      bool convert = false;
+      for (int i = 0; i < len; i++) {
+        if (text.at(i).isSpace() && (convert || (i + 1 < len && text.at(i + 1).isSpace()))) {
+          convert = true;
+          newText.append("&nbsp;");
+        } else {
+          newText.append(text.at(i));
+          convert = false;
+        }
+      }
+      text = newText;
     }
   }
   return text;

--- a/OMEdit/OMEditLIB/Simulation/SimulationOutputHandler.cpp
+++ b/OMEdit/OMEditLIB/Simulation/SimulationOutputHandler.cpp
@@ -341,11 +341,7 @@ void SimulationOutputHandler::parseSimulationOutput(const QString &output)
           if (attributes.value("text") == QString("The embedded server is initialized.") ){
             mpSimulationOutputWidget->embeddedServerInitialized();
           }
-          if (mpSimulationOutputWidget->isOutputStructured()) {
-            mpSimulationMessage->mText = Qt::convertFromPlainText(attributes.value("text").toString(), Qt::WhiteSpaceNormal);
-          } else {
-            mpSimulationMessage->mText = attributes.value("text").toString();
-          }
+          mpSimulationMessage->mText = attributes.value("text").toString();
           mpSimulationMessage->mLevel = mLevel;
           mSimulationMessagesLevelMap.insert(mLevel, mpSimulationMessage);
           if (mLevel > 0) {


### PR DESCRIPTION
### Related Issues

#13453

### Purpose

Preserve the spaces and the format in the output.

### Approach

Spaces are eaten up by QTextDocument so convert them to no break space to make it html compliant.