### PR TITLE
[NB] v1 resizable module

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBStrongComponent.mo
@@ -194,7 +194,7 @@ public
       case RESIZABLE_COMPONENT() algorithm
         str := StringUtil.headline_3("BLOCK" + indexStr + ": Resizable Component (status = " + Solve.statusString(comp.status) + ")");
         str := str + "### Variable:\n\t" + ComponentRef.toString(comp.var_cref) + "\n";
-        str := str + "### Equation:\n" + Slice.toString(comp.eqn, function Equation.pointerToString(str = "\t")) + "\n";
+        str := str + "### Equation:\n\t" + Equation.pointerToString(Slice.getT(comp.eqn)) + "\n";
       then str;
 
       case ENTWINED_COMPONENT() algorithm

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -693,9 +693,9 @@ protected
       case (NFPrefixes.Variability.DISCRETE, _, _)                    then VariableKind.DISCRETE();
       case (NFPrefixes.Variability.IMPLICITLY_DISCRETE, _, _)         then VariableKind.DISCRETE();
 
-      case (NFPrefixes.Variability.PARAMETER, _, _)                   then VariableKind.PARAMETER();
-      case (NFPrefixes.Variability.STRUCTURAL_PARAMETER, _, _)        then VariableKind.PARAMETER(); // CONSTANT ?
-      case (NFPrefixes.Variability.NON_STRUCTURAL_PARAMETER, _, _)    then VariableKind.PARAMETER();
+      case (NFPrefixes.Variability.PARAMETER, _, _)                   then VariableKind.PARAMETER(NONE());
+      case (NFPrefixes.Variability.STRUCTURAL_PARAMETER, _, _)        then VariableKind.PARAMETER(NONE()); // CONSTANT ?
+      case (NFPrefixes.Variability.NON_STRUCTURAL_PARAMETER, _, _)    then VariableKind.PARAMETER(NONE());
       case (NFPrefixes.Variability.CONSTANT, _, _)                    then VariableKind.CONSTANT();
 
       else algorithm
@@ -1225,7 +1225,7 @@ protected
     list<ComponentRef> inputs, outputs;
     EquationAttributes attr;
   algorithm
-    size := sum(ComponentRef.size(out, true) for out in alg.outputs);
+    size := sum(ComponentRef.size(out, false) for out in alg.outputs);
 
     if listEmpty(alg.outputs) then
       attr := EquationAttributes.default(EquationKind.EMPTY, init);

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBMatching.mo
@@ -257,10 +257,10 @@ public
       end for;
 
       // get the slice lists while sorting indices and simplifying whole slices to {}
-      matched_vars    := list(Slice.simplify(slice, BVariable.size) for slice in Slice.fromMap(var_map_matched));
-      unmatched_vars  := list(Slice.simplify(slice, BVariable.size) for slice in Slice.fromMap(var_map_unmatched));
-      matched_eqns    := list(Slice.simplify(slice, Equation.size) for slice in Slice.fromMap(eqn_map_matched));
-      unmatched_eqns  := list(Slice.simplify(slice, Equation.size) for slice in Slice.fromMap(eqn_map_unmatched));
+      matched_vars    := list(Slice.simplify(slice, function BVariable.size(resize = true)) for slice in Slice.fromMap(var_map_matched));
+      unmatched_vars  := list(Slice.simplify(slice, function BVariable.size(resize = true)) for slice in Slice.fromMap(var_map_unmatched));
+      matched_eqns    := list(Slice.simplify(slice, function Equation.size(resize = true)) for slice in Slice.fromMap(eqn_map_matched));
+      unmatched_eqns  := list(Slice.simplify(slice, function Equation.size(resize = true)) for slice in Slice.fromMap(eqn_map_unmatched));
     else
       // check if variables are matched and sort them accordingly
       for var in 1:arrayLength(matching.var_to_eqn) loop

--- a/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBResolveSingularities.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/1_Main/NBResolveSingularities.mo
@@ -146,10 +146,10 @@ public
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName()
           + " failed because there were not enough state candidates to balance out the constraint equations.\n"
           + StringUtil.headline_4("(" + intString(listLength(state_candidates)) + "|"
-          + intString(sum(Slice.size(v, BVariable.size) for v in state_candidates)) + ") State Candidates")
+          + intString(sum(Slice.size(v, function BVariable.size(resize = true)) for v in state_candidates)) + ") State Candidates")
           + List.toString(state_candidates, function Slice.toString(func=BVariable.pointerToString, maxLength=10), "", "\t", "\n\t", "\n", true) + "\n"
           + StringUtil.headline_4("(" + intString(listLength(constraint_eqns)) + "|"
-          + intString(sum(Slice.size(e, Equation.size) for e in constraint_eqns)) + ") Constraint Equations")
+          + intString(sum(Slice.size(e, function Equation.size(resize = true)) for e in constraint_eqns)) + ") Constraint Equations")
           + List.toString(constraint_eqns, function Slice.toString(func=function Equation.pointerToString(str=""), maxLength=10), "", "\t", "\n\t", "\n", true) + "\n"});
         fail();
       end if;
@@ -297,10 +297,10 @@ public
     if not listEmpty(unmatched_vars) then
       err_str := getInstanceName()
         + " failed.\n" + StringUtil.headline_4("(" + intString(listLength(unmatched_vars)) + "|"
-        + intString(sum(Slice.size(v, BVariable.size) for v in unmatched_vars)) + ") Unmatched Variables")
+        + intString(sum(Slice.size(v, function BVariable.size(resize = true)) for v in unmatched_vars)) + ") Unmatched Variables")
         + List.toString(unmatched_vars, function Slice.toString(func=BVariable.pointerToString, maxLength=10), "", "\t", "\n\t", "\n", true) + "\n"
         + StringUtil.headline_4("(" + intString(listLength(unmatched_eqns)) + "|"
-        + intString(sum(Slice.size(e, Equation.size) for e in unmatched_eqns)) + ") Unmatched Equations")
+        + intString(sum(Slice.size(e, function Equation.size(resize = true)) for e in unmatched_eqns)) + ") Unmatched Equations")
         + List.toString(unmatched_eqns, function Slice.toString(func=function Equation.pointerToString(str=""), maxLength=10), "", "\t", "\n\t", "\n", true) + "\n";
       if Flags.isSet(Flags.BLT_DUMP) then
         // get the minimally structurally singular subset

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -259,7 +259,7 @@ protected
           // otherwise they would not show in the result file
           (const_vars, alias_vars) := List.splitOnTrue(alias_vars, BVariable.hasConstOrParamAliasBinding);
           for var in const_vars loop
-            BVariable.setVarKind(var, VariableKind.PARAMETER());
+            BVariable.setVarKind(var, VariableKind.PARAMETER(NONE()));
             BVariable.setBindingAsStartAndFix(var);
           end for;
           varData.parameters := VariablePointers.addList(const_vars, varData.parameters);

--- a/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
@@ -1141,7 +1141,7 @@ protected
       // skip to an array element
       case (Type.ARRAY(), rest) guard List.compareLength(rest, ty.dimensions) >= 0 algorithm
         (rest, tail) := List.split(rest, listLength(ty.dimensions));
-        index := locationToIndex(List.zip(list(Dimension.size(dim) for dim in ty.dimensions), rest), index);
+        index := locationToIndex(List.zip(list(Dimension.size(dim, true) for dim in ty.dimensions), rest), index);
       then resolveSkips(index, ty.elementType, tail, cref, fullmap);
 
       // skip for tuple or array, but the skip is too large
@@ -1242,8 +1242,8 @@ protected
       for tpl in skip_lst loop
         (skip_idx, skip_ty) := tpl;
         // get equation and iterator sizes and frames
-        body_size       := Type.sizeOf(skip_ty);
-        iter_size       := Iterator.size(iter);
+        body_size       := Type.sizeOf(skip_ty, true);
+        iter_size       := Iterator.size(iter, true);
         size            := body_size * iter_size;
         (names, ranges) := Iterator.getFrames(iter);
         frames          := List.zip(names, ranges);
@@ -1377,7 +1377,7 @@ protected
 
       case (dim, false)::rest algorithm
         // reduced dimension, keep key index at 0 and go deeper with next dimension
-        for i in 1:Dimension.size(dim) loop
+        for i in 1:Dimension.size(dim, true) loop
           resolveEquationDimensions(rest, map, key, m, modes, mode, eqn_idx_ptr, index+1);
         end for;
       then ();
@@ -1385,7 +1385,7 @@ protected
       case (dim, true)::rest algorithm
         // regular dimension, update key index to corresponding dimension index
         // and go deeper with next dimension
-        for i in 1:Dimension.size(dim) loop
+        for i in 1:Dimension.size(dim, true) loop
           arrayUpdate(key, index, i);
           resolveEquationDimensions(rest, map, key, m, modes, mode, eqn_idx_ptr, index+1);
         end for;

--- a/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBackendExtension.mo
@@ -199,7 +199,9 @@ public
     record PREVIOUS end PREVIOUS;
     record CLOCK end CLOCK;
     record CLOCKED end CLOCKED;
-    record PARAMETER end PARAMETER;
+    record PARAMETER
+      Option<Integer> resize_value          "if the parameter is resizable, this is the computed optimal size";
+    end PARAMETER;
     record CONSTANT end CONSTANT;
     record ITERATOR end ITERATOR;
     record RECORD
@@ -296,7 +298,7 @@ public
       if Type.isRecord(ty) then
         varKind := RECORD({}, makeParam); // ToDo: children!
       elseif makeParam then
-        varKind := PARAMETER();
+        varKind := PARAMETER(NONE());
       elseif Type.isDiscrete(ty) then
         varKind := DISCRETE();
       else

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponent.mo
@@ -996,7 +996,7 @@ public
       if isRoot then
         comp_size := 1;
       elseif Type.hasKnownSize(ty) then
-        comp_size := Dimension.sizesProduct(Type.arrayDims(ty));
+        comp_size := Dimension.sizesProduct(Type.arrayDims(ty), false);
       else
         comp_size := 0;
         knownSize := false;

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -244,6 +244,7 @@ public
 
   function size
     input Dimension dim;
+    input Boolean resize = false;
     output Integer size;
   algorithm
     size := match dim
@@ -251,7 +252,7 @@ public
         Type ty;
 
       case INTEGER()    then dim.size;
-      case RESIZABLE()  then dim.size;
+      case RESIZABLE()  then if resize then Util.getOptionOrDefault(dim.opt_size, dim.size) else dim.size;
       case BOOLEAN()    then 2;
       case ENUM(enumType = ty as Type.ENUMERATION()) then listLength(ty.literals);
       else algorithm
@@ -265,10 +266,11 @@ public
   function sizesProduct
     "Returns the product of the given dimension sizes."
     input list<Dimension> dims;
+    input Boolean resize = false;
     output Integer outSize = 1;
   algorithm
     for dim in dims loop
-      outSize := outSize * Dimension.size(dim);
+      outSize := outSize * Dimension.size(dim, resize);
     end for;
   end sizesProduct;
 
@@ -670,7 +672,9 @@ public
   algorithm
     outDim := match dim
       case EXP() then fromExp(Ceval.evalExp(dim.exp, target), dim.var);
-      case RESIZABLE() then fromExp(Ceval.evalExp(dim.exp, target), dim.var);
+      case RESIZABLE() algorithm
+        dim.exp := Ceval.evalExp(dim.exp, target);
+      then dim;
       else dim;
     end match;
   end eval;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyExp.mo
@@ -164,8 +164,12 @@ algorithm
      referenceEq(ty, ty2) then
     exp := range;
   else
-    ty := TypeCheck.getRangeType(start_exp2, step_exp2, stop_exp2,
-      Type.arrayElementType(ty), AbsynUtil.dummyInfo);
+    if not Type.isResizable(ty) then
+      ty := TypeCheck.getRangeType(start_exp2, step_exp2, stop_exp2,
+        Type.arrayElementType(ty), AbsynUtil.dummyInfo);
+    else
+      ty := ty2;
+    end if;
     exp := Expression.RANGE(ty, start_exp2, step_exp2, stop_exp2);
   end if;
 end simplifyRange;

--- a/OMCompiler/Compiler/NFFrontEnd/NFType.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFType.mo
@@ -337,6 +337,11 @@ public
     end match;
   end isConditionalArray;
 
+  function isResizable
+    input Type ty;
+    output Boolean b = List.any(arrayDims(ty), Dimension.isResizable);
+  end isResizable;
+
   function setConditionalArrayTypes
     input Type condType;
     input Type trueType;
@@ -1410,6 +1415,7 @@ public
 
   function sizeOf
     input Type ty;
+    input Boolean resize = false;
     output Integer sz;
     function fold_comp_size
       input InstNode comp;
@@ -1424,7 +1430,7 @@ public
       case BOOLEAN() then 1;
       case CLOCK() then 1;
       case ENUMERATION() then 1;
-      case ARRAY() then sizeOf(ty.elementType) * Dimension.sizesProduct(ty.dimensions);
+      case ARRAY() then sizeOf(ty.elementType) * Dimension.sizesProduct(ty.dimensions, resize);
       case TUPLE() then List.fold(list(sizeOf(t) for t in ty.types), intAdd, 0);
       case COMPLEX(complexTy = ComplexType.EXTERNAL_OBJECT()) then 1;
       case COMPLEX(complexTy = ComplexType.RECORD())
@@ -1439,13 +1445,14 @@ public
     Arrays of complex will only return the size of the contained complex type.
     Non-complex types will return NONE()."
     input Type ty;
+    input Boolean resize = false;
     output Option<Integer> sz;
   protected
     Class cls;
   algorithm
     sz := match ty
-      case ARRAY()                                    then complexSize(ty.elementType);
-      case COMPLEX(complexTy = ComplexType.RECORD())  then SOME(sizeOf(ty));
+      case ARRAY()                                    then complexSize(ty.elementType, resize);
+      case COMPLEX(complexTy = ComplexType.RECORD())  then SOME(sizeOf(ty, resize));
                                                       else NONE();
     end match;
   end complexSize;

--- a/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFVariable.mo
@@ -125,7 +125,8 @@ public
 
   function size
     input Variable var;
-    output Integer s = Type.sizeOf(var.ty);
+    input Boolean resize = false;
+    output Integer s = Type.sizeOf(var.ty, resize);
   end size;
 
   function hash
@@ -379,6 +380,17 @@ public
 
     binding := NFBinding.EMPTY_BINDING;
   end lookupTypeAttribute;
+
+  function applyToType
+    input output Variable var;
+    input typeFunc func;
+    partial function typeFunc
+      input output Type ty;
+    end typeFunc;
+  algorithm
+    var.ty := func(var.ty);
+    var.name := ComponentRef.applyToType(var.name, func);
+  end applyToType;
 
   function propagateAnnotation
     input String name;

--- a/testsuite/simulation/modelica/NBackend/array_handling/irregular_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/irregular_for.mos
@@ -52,10 +52,9 @@ val(x[3],1);
 // 	$FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))]
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
-// 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 2:2:18 loop
+// [----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Sliced Component (status = Solve.UNPROCESSED)
 // --------------------------------------------------------
@@ -109,10 +108,9 @@ val(x[3],1);
 // 	$FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))]
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
-// 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 2:2:18 loop
+// [----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Sliced Component (status = Solve.UNPROCESSED)
 // --------------------------------------------------------
@@ -166,10 +164,9 @@ val(x[3],1);
 // 	$FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))]
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
-// 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 2:2:18 loop
+// [----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Sliced Component (status = Solve.UNPROCESSED)
 // --------------------------------------------------------
@@ -226,10 +223,9 @@ val(x[3],1);
 // 	$FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))]
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
-// 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 2:2:18 loop
+// [----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // --- Alias of INI[1 | 4] ---
 // BLOCK 4: Generic Component (status = Solve.EXPLICIT)
@@ -285,10 +281,9 @@ val(x[3],1);
 // 	$FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))]
 // ### Equation:
 // 	[FOR-] (9) ($RES_$AUX_4)
-// 	[----] for $i1 in 2:2:18 loop
-// 	[----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 2:2:18 loop
+// [----]   [SCAL] (1) $FUN_1[integer(1.0 + 0.5 * ((-2.0) + $i1))] = sin((0.5 * $i1) * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Generic Component (status = Solve.EXPLICIT)
 // ------------------------------------------------------

--- a/testsuite/simulation/modelica/NBackend/array_handling/simple_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/simple_for.mos
@@ -63,10 +63,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_2)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
+// [----] end for;
 //
 // BLOCK 2: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -74,10 +73,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_0)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
+// [----] end for;
 //
 // #################################################
 //
@@ -95,10 +93,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_2)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
+// [----] end for;
 //
 // BLOCK 2: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -106,10 +103,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_0)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
+// [----] end for;
 //
 // #########################################
 //
@@ -127,10 +123,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_2)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
+// [----] end for;
 //
 // BLOCK 2: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -138,10 +133,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_0)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
+// [----] end for;
 //
 // ################################
 //
@@ -160,10 +154,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_2)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
+// [----] end for;
 //
 // --- Alias of INI[1 | 2] ---
 // BLOCK 2: Resizable Component (status = Solve.EXPLICIT)
@@ -172,10 +165,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_0)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
+// [----] end for;
 //
 // #####################################
 //
@@ -193,10 +185,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_2)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_3)
+// [----] end for;
 //
 // BLOCK 2: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -204,10 +195,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_0)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_1)
+// [----] end for;
 //
 // record SimulationResult
 //     resultFile = "simple_for1_res.mat",
@@ -248,10 +238,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -259,10 +248,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // #################################################
 //
@@ -294,10 +282,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -305,10 +292,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // #########################################
 //
@@ -340,10 +326,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -351,10 +336,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // ################################
 //
@@ -389,10 +373,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // --- Alias of INI[1 | 4] ---
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
@@ -401,10 +384,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // #####################################
 //
@@ -436,10 +418,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -447,10 +428,9 @@ val(x[3],1);
 // 	x[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // record SimulationResult
 //     resultFile = "simple_for2_res.mat",
@@ -491,10 +471,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -502,10 +481,9 @@ val(x[3],1);
 // 	x[1 + $i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // #################################################
 //
@@ -537,10 +515,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -548,10 +525,9 @@ val(x[3],1);
 // 	x[1 + $i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // #########################################
 //
@@ -583,10 +559,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -594,10 +569,9 @@ val(x[3],1);
 // 	x[1 + $i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[$i1] = x[1 + $i1] + $FUN_1[$i1] ($RES_SIM_2)
+// [----] end for;
 //
 // ################################
 //
@@ -632,10 +606,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // --- Alias of INI[1 | 4] ---
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
@@ -644,10 +617,9 @@ val(x[3],1);
 // 	x[1 + $i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[1 + $i1] = -($FUN_1[$i1] - x[$i1]) ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[1 + $i1] = -($FUN_1[$i1] - x[$i1]) ($RES_SIM_2)
+// [----] end for;
 //
 // #####################################
 //
@@ -679,10 +651,9 @@ val(x[3],1);
 // 	$FUN_1[$i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_$AUX_4)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) $FUN_1[$i1] = sin($i1 * time) ($RES_$AUX_5)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -690,10 +661,9 @@ val(x[3],1);
 // 	x[1 + $i1]
 // ### Equation:
 // 	[FOR-] (10) ($RES_SIM_1)
-// 	[----] for $i1 in 1:10 loop
-// 	[----]   [SCAL] (1) x[1 + $i1] = -($FUN_1[$i1] - x[$i1]) ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
+// [----] for $i1 in 1:10 loop
+// [----]   [SCAL] (1) x[1 + $i1] = -($FUN_1[$i1] - x[$i1]) ($RES_SIM_2)
+// [----] end for;
 //
 // record SimulationResult
 //     resultFile = "simple_for3_res.mat",

--- a/testsuite/simulation/modelica/NBackend/array_handling/simple_nested_for.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/simple_nested_for.mos
@@ -97,10 +97,9 @@ val(x[2,1], 0.5);
 // 	$FUN_1[$i2]
 // ### Equation:
 // 	[FOR-] (3) ($RES_$AUX_5)
-// 	[----] for $i2 in 1:3 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i2 in 1:3 loop
+// [----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -108,10 +107,9 @@ val(x[2,1], 0.5);
 // 	x[4, $i1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -119,10 +117,9 @@ val(x[2,1], 0.5);
 // 	x[$i1, $i2]
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
-// 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
-// 	[----] end for;
-// 	slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
+// [----] for {$i1 in 1:3, $i2 in 1:3} loop
+// [----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// [----] end for;
 //
 // #################################################
 //
@@ -147,10 +144,9 @@ val(x[2,1], 0.5);
 // 	$FUN_1[$i2]
 // ### Equation:
 // 	[FOR-] (3) ($RES_$AUX_5)
-// 	[----] for $i2 in 1:3 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i2 in 1:3 loop
+// [----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -158,10 +154,9 @@ val(x[2,1], 0.5);
 // 	x[4, $i1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -169,10 +164,9 @@ val(x[2,1], 0.5);
 // 	x[$i1, $i2]
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
-// 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
-// 	[----] end for;
-// 	slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
+// [----] for {$i1 in 1:3, $i2 in 1:3} loop
+// [----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// [----] end for;
 //
 // #########################################
 //
@@ -197,10 +191,9 @@ val(x[2,1], 0.5);
 // 	x[4, $i1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -208,10 +201,9 @@ val(x[2,1], 0.5);
 // 	$FUN_1[$i2]
 // ### Equation:
 // 	[FOR-] (3) ($RES_$AUX_5)
-// 	[----] for $i2 in 1:3 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i2 in 1:3 loop
+// [----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -219,10 +211,9 @@ val(x[2,1], 0.5);
 // 	x[$i1, $i2]
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
-// 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
-// 	[----] end for;
-// 	slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
+// [----] for {$i1 in 1:3, $i2 in 1:3} loop
+// [----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// [----] end for;
 //
 // ################################
 //
@@ -249,10 +240,9 @@ val(x[2,1], 0.5);
 // 	$FUN_1[$i2]
 // ### Equation:
 // 	[FOR-] (3) ($RES_$AUX_5)
-// 	[----] for $i2 in 1:3 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i2 in 1:3 loop
+// [----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
+// [----] end for;
 //
 // --- Alias of INI[1 | 2] ---
 // BLOCK 3: Resizable Component (status = Solve.EXPLICIT)
@@ -261,10 +251,9 @@ val(x[2,1], 0.5);
 // 	x[4, $i1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
+// [----] end for;
 //
 // --- Alias of INI[1 | 4] ---
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
@@ -273,10 +262,9 @@ val(x[2,1], 0.5);
 // 	x[$i1, $i2]
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
-// 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
-// 	[----] end for;
-// 	slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
+// [----] for {$i1 in 1:3, $i2 in 1:3} loop
+// [----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// [----] end for;
 //
 // #####################################
 //
@@ -301,10 +289,9 @@ val(x[2,1], 0.5);
 // 	x[4, $i1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) x[4, $i1] = $i1 * $FUN_2 ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -312,10 +299,9 @@ val(x[2,1], 0.5);
 // 	$FUN_1[$i2]
 // ### Equation:
 // 	[FOR-] (3) ($RES_$AUX_5)
-// 	[----] for $i2 in 1:3 loop
-// 	[----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i2 in 1:3 loop
+// [----]   [SCAL] (1) $FUN_1[$i2] = sin($i2 * time) ($RES_$AUX_6)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -323,10 +309,9 @@ val(x[2,1], 0.5);
 // 	x[$i1, $i2]
 // ### Equation:
 // 	[FOR-] (9) ($RES_SIM_2)
-// 	[----] for {$i1 in 1:3, $i2 in 1:3} loop
-// 	[----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
-// 	[----] end for;
-// 	slice: {2, 5, 8, 1, 4, 7, 0, 3, 6}
+// [----] for {$i1 in 1:3, $i2 in 1:3} loop
+// [----]   [SCAL] (1) x[$i1, $i2] = x[1 + $i1, $i2] + $i1 * $FUN_1[$i2] ($RES_SIM_3)
+// [----] end for;
 //
 // record SimulationResult
 //     resultFile = "simple_nested_for5_res.mat",

--- a/testsuite/simulation/modelica/NBackend/array_handling/testVectorizedPowerSystem.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/testVectorizedPowerSystem.mos
@@ -38,10 +38,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].v
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -49,10 +48,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].terminal.i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_33)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P ($RES_SIM_34)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P ($RES_SIM_34)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -60,10 +58,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_16)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] + fixedLoad1[$i1].terminal.i[1] = 0.0 ($RES_SIM_17)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] + fixedLoad1[$i1].terminal.i[1] = 0.0 ($RES_SIM_17)
+// [----] end for;
 //
 // BLOCK 5: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -120,10 +117,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].p[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_36)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
+// [----] end for;
 //
 // ================================
 //   (2) Continuous ODE Partition
@@ -180,10 +176,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].v
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -191,10 +186,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].terminal.i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_33)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P ($RES_SIM_34)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P ($RES_SIM_34)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -202,10 +196,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_16)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] + fixedLoad1[$i1].terminal.i[1] = 0.0 ($RES_SIM_17)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] + fixedLoad1[$i1].terminal.i[1] = 0.0 ($RES_SIM_17)
+// [----] end for;
 //
 // BLOCK 5: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -262,10 +255,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].p[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_36)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
+// [----] end for;
 //
 // ================================
 //   (2) Continuous ODE Partition
@@ -319,10 +311,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].v
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -330,10 +321,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].terminal.i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_33)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P ($RES_SIM_34)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P ($RES_SIM_34)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -341,10 +331,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_16)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] + fixedLoad1[$i1].terminal.i[1] = 0.0 ($RES_SIM_17)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] + fixedLoad1[$i1].terminal.i[1] = 0.0 ($RES_SIM_17)
+// [----] end for;
 //
 // BLOCK 5: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -431,10 +420,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].p[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_36)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
+// [----] end for;
 //
 // ################################
 //
@@ -461,10 +449,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].v
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
+// [----] end for;
 //
 // --- Alias of INI[1 | 3] ---
 // BLOCK 3: Resizable Component (status = Solve.EXPLICIT)
@@ -473,10 +460,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].terminal.i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_33)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P / busBar1.terminal_n[1].v[$i1] ($RES_SIM_34)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P / busBar1.terminal_n[1].v[$i1] ($RES_SIM_34)
+// [----] end for;
 //
 // --- Alias of INI[1 | 4] ---
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
@@ -485,10 +471,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_16)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] = -fixedLoad1[$i1].terminal.i[1] ($RES_SIM_17)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] = -fixedLoad1[$i1].terminal.i[1] ($RES_SIM_17)
+// [----] end for;
 //
 // --- Alias of INI[1 | 5] ---
 // BLOCK 5: Single Strong Component (status = Solve.EXPLICIT)
@@ -553,10 +538,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].p[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_36)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
+// [----] end for;
 //
 // ================================
 //   (2) Continuous ODE Partition
@@ -605,10 +589,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].v
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_0)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [ARRY] (1) busBar1.terminal_n[$i1].v = busBar1.v ($RES_SIM_1)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -616,10 +599,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].terminal.i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_33)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P / busBar1.terminal_n[1].v[$i1] ($RES_SIM_34)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].terminal.i[1] = fixedLoad1[$i1].P / busBar1.terminal_n[1].v[$i1] ($RES_SIM_34)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -627,10 +609,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	busBar1.terminal_n[$i1].i[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_16)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] = -fixedLoad1[$i1].terminal.i[1] ($RES_SIM_17)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) busBar1.terminal_n[$i1].i[1] = -fixedLoad1[$i1].terminal.i[1] ($RES_SIM_17)
+// [----] end for;
 //
 // BLOCK 5: Single Strong Component (status = Solve.EXPLICIT)
 // ------------------------------------------------------------
@@ -717,10 +698,9 @@ val(fixedVoltageSource1.p[1], 1.0);
 // 	fixedLoad1[$i1].p[1]
 // ### Equation:
 // 	[FOR-] (3) ($RES_SIM_36)
-// 	[----] for $i1 in 1:3 loop
-// 	[----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
-// 	[----] end for;
-// 	slice: {2, 1, 0}
+// [----] for $i1 in 1:3 loop
+// [----]   [SCAL] (1) fixedLoad1[$i1].p[1] = busBar1.terminal_n[1].v[$i1] * fixedLoad1[$i1].terminal.i[1] ($RES_SIM_37)
+// [----] end for;
 //
 // record SimulationResult
 //     resultFile = "VectorizedPowerSystemTest_res.mat",

--- a/testsuite/simulation/modelica/NBackend/array_handling/testVectorizedSolarSystem.mos
+++ b/testsuite/simulation/modelica/NBackend/array_handling/testVectorizedSolarSystem.mos
@@ -42,10 +42,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].on
 // ### Equation:
 // 	[FOR-] (1000) ($RES_BND_8)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -53,10 +52,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.v
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_1)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -64,10 +62,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_3)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0 ($RES_SIM_4)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0 ($RES_SIM_4)
+// [----] end for;
 //
 // BLOCK 5: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -75,10 +72,9 @@ val(grid.P_grid, 0.0);
 // 	grid.terms[$i1].i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_5)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.i + grid.terms[$i1].i = 0.0 ($RES_SIM_6)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.i + grid.terms[$i1].i = 0.0 ($RES_SIM_6)
+// [----] end for;
 //
 // BLOCK 6: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -110,10 +106,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].on
 // ### Equation:
 // 	[FOR-] (1000) ($RES_BND_8)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
+// [----] end for;
 //
 // BLOCK 3: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -121,10 +116,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.v
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_1)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -132,10 +126,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_3)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0 ($RES_SIM_4)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0 ($RES_SIM_4)
+// [----] end for;
 //
 // BLOCK 5: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -143,10 +136,9 @@ val(grid.P_grid, 0.0);
 // 	grid.terms[$i1].i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_5)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.i + grid.terms[$i1].i = 0.0 ($RES_SIM_6)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.i + grid.terms[$i1].i = 0.0 ($RES_SIM_6)
+// [----] end for;
 //
 // BLOCK 6: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -171,10 +163,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].on
 // ### Equation:
 // 	[FOR-] (1000) ($RES_BND_8)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
+// [----] end for;
 //
 // BLOCK 2: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -189,10 +180,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.v
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_1)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -200,10 +190,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_3)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0 ($RES_SIM_4)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v * plant[$i1].term.i = if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0 ($RES_SIM_4)
+// [----] end for;
 //
 // BLOCK 5: Resizable Component (status = Solve.UNPROCESSED)
 // -----------------------------------------------------------
@@ -211,10 +200,9 @@ val(grid.P_grid, 0.0);
 // 	grid.terms[$i1].i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_5)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.i + grid.terms[$i1].i = 0.0 ($RES_SIM_6)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.i + grid.terms[$i1].i = 0.0 ($RES_SIM_6)
+// [----] end for;
 //
 // BLOCK 6: Single Strong Component (status = Solve.UNPROCESSED)
 // ---------------------------------------------------------------
@@ -248,10 +236,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].on
 // ### Equation:
 // 	[FOR-] (1000) ($RES_BND_8)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
+// [----] end for;
 //
 // --- Alias of INI[1 | 3] ---
 // BLOCK 3: Resizable Component (status = Solve.EXPLICIT)
@@ -260,10 +247,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.v
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_1)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
+// [----] end for;
 //
 // --- Alias of INI[1 | 4] ---
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
@@ -272,10 +258,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_3)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.i = (if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0) / plant[$i1].term.v ($RES_SIM_4)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.i = (if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0) / plant[$i1].term.v ($RES_SIM_4)
+// [----] end for;
 //
 // --- Alias of INI[1 | 5] ---
 // BLOCK 5: Resizable Component (status = Solve.EXPLICIT)
@@ -284,10 +269,9 @@ val(grid.P_grid, 0.0);
 // 	grid.terms[$i1].i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_5)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) grid.terms[$i1].i = -plant[$i1].term.i ($RES_SIM_6)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) grid.terms[$i1].i = -plant[$i1].term.i ($RES_SIM_6)
+// [----] end for;
 //
 // --- Alias of INI[1 | 6] ---
 // BLOCK 6: Single Strong Component (status = Solve.EXPLICIT)
@@ -313,10 +297,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].on
 // ### Equation:
 // 	[FOR-] (1000) ($RES_BND_8)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].on = true ($RES_BND_9)
+// [----] end for;
 //
 // BLOCK 2: Single Strong Component (status = Solve.EXPLICIT)
 // ------------------------------------------------------------
@@ -331,10 +314,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.v
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_1)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.v = grid.V ($RES_SIM_2)
+// [----] end for;
 //
 // BLOCK 4: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -342,10 +324,9 @@ val(grid.P_grid, 0.0);
 // 	plant[$i1].term.i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_3)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) plant[$i1].term.i = (if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0) / plant[$i1].term.v ($RES_SIM_4)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) plant[$i1].term.i = (if plant[$i1].on then plant[$i1].eta * plant[$i1].P_solar else 0.0) / plant[$i1].term.v ($RES_SIM_4)
+// [----] end for;
 //
 // BLOCK 5: Resizable Component (status = Solve.EXPLICIT)
 // --------------------------------------------------------
@@ -353,10 +334,9 @@ val(grid.P_grid, 0.0);
 // 	grid.terms[$i1].i
 // ### Equation:
 // 	[FOR-] (1000) ($RES_SIM_5)
-// 	[----] for $i1 in 1:1000 loop
-// 	[----]   [SCAL] (1) grid.terms[$i1].i = -plant[$i1].term.i ($RES_SIM_6)
-// 	[----] end for;
-// 	slice: {999, 998, 997, 996, 995, 994, 993, 992, 991, 990, ...}
+// [----] for $i1 in 1:1000 loop
+// [----]   [SCAL] (1) grid.terms[$i1].i = -plant[$i1].term.i ($RES_SIM_6)
+// [----] end for;
 //
 // BLOCK 6: Single Strong Component (status = Solve.EXPLICIT)
 // ------------------------------------------------------------


### PR DESCRIPTION
 - add a resize boolean to most size() functions. if set to true it uses the optimal resized size instead of the original one (if there is one)
 - use resized sizes for all of causalization (+reporting) use normal sizes for everything else
 - compiling a model scales independently of structural parameters marked with resizable=true (current exceptions: jacobian, simcode, they still scalarize)