### PR TITLE
Update the instance JSON after deleting the component

### DIFF
--- a/OMEdit/OMEditLIB/Modeling/Model.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Model.cpp
@@ -1379,6 +1379,22 @@ namespace ModelInstance
   }
 
   /*!
+   * \brief Model::removeElement
+   * Removes the element.
+   * \param name
+   */
+  void Model::removeElement(const QString &name)
+  {
+    foreach (auto pElement, mElements) {
+      if (pElement->getName().compare(name) == 0) {
+        mElements.removeOne(pElement);
+        delete pElement;
+        break;
+      }
+    }
+  }
+
+  /*!
    * \brief Model::getComponents
    * Returns all components of the model, including inherited ones.
    */

--- a/OMEdit/OMEditLIB/Modeling/Model.h
+++ b/OMEdit/OMEditLIB/Modeling/Model.h
@@ -623,6 +623,7 @@ private:
     Annotation *getAnnotation() const;
     void readCoordinateSystemFromExtendsClass(CoordinateSystem *pCoordinateSystem, bool isIcon);
     void addElement(Element *pElement) {mElements.append(pElement);}
+    void removeElement(const QString &name);
     const QList<Element *> &getElements() const {return mElements;}
     QList<Element *> getComponents() const;
     size_t componentCount() const;

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -1154,9 +1154,15 @@ void GraphicsView::deleteElement(Element *pElement)
  */
 void GraphicsView::deleteElementFromClass(Element *pElement)
 {
-  if (mpModelWidget->getLibraryTreeItem()->isModelica()) {
+  if (mpModelWidget && mpModelWidget->getLibraryTreeItem() && mpModelWidget->getLibraryTreeItem()->isModelica()) {
     // delete the component from OMC
     MainWindow::instance()->getOMCProxy()->deleteComponent(pElement->getName(), mpModelWidget->getLibraryTreeItem()->getNameStructure());
+    /* Since we don't call getModelInstance on deleting a component so we need to update instance JSON manually by removing the component from it.
+     * This is needed so the Element Browser shows the correct list of components.
+     */
+    if (mpModelWidget->getModelInstance()) {
+      mpModelWidget->getModelInstance()->removeElement(pElement->getName());
+    }
   }
 }
 


### PR DESCRIPTION
Since we don't call getModelInstance on deleting a component so we need to update instance JSON manually by removing the component from it.