### PR TITLE
Fix annotation instantiation in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCeval.mo
@@ -346,9 +346,7 @@ protected
   Type cref_ty, exp_ty;
   Integer dim_diff;
 algorithm
-  exp_context := if InstNode.isFunction(InstNode.explicitParent(node))
-    then NFInstContext.FUNCTION else NFInstContext.CLASS;
-
+  exp_context := InstContext.nodeContext(node, target.context);
   Typing.typeComponentBinding(node, exp_context, typeChildren = false);
   comp := InstNode.component(node);
   binding := Component.getBinding(comp);
@@ -696,8 +694,7 @@ protected
 algorithm
   parent_cr := ComponentRef.rest(cref);
   parent := ComponentRef.node(parent_cr);
-  exp_context := if InstNode.isFunction(InstNode.explicitParent(parent))
-    then NFInstContext.FUNCTION else NFInstContext.CLASS;
+  exp_context := InstContext.nodeContext(parent, target.context);
 
   comp := InstNode.component(parent);
   binding := Component.getBinding(comp);

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -2017,7 +2017,7 @@ algorithm
         // The context used when typing a component node depends on where the
         // component was declared, not where it's used. This can be different to
         // the given context, e.g. for package constants used in a function.
-        node_ty := typeComponent(cref.node, crefContext(cref.node, context), typeChildren = firstPart or not InstContext.inDimension(context));
+        node_ty := typeComponent(cref.node, InstContext.nodeContext(cref.node, context), typeChildren = firstPart or not InstContext.inDimension(context));
 
         (subs, subs_var) := typeSubscripts(cref.subscripts, node_ty, Expression.CREF(node_ty, cref), context, info);
         (rest_cr, rest_var) := typeCref2(cref.restCref, context, info, false);
@@ -2043,31 +2043,6 @@ algorithm
     else (cref, Variability.CONSTANT);
   end match;
 end typeCref2;
-
-function crefContext
-  input InstNode crefNode;
-  input InstContext.Type currentContext;
-  output InstContext.Type context;
-protected
-  InstNode parent;
-  Restriction parent_res;
-algorithm
-  parent := InstNode.explicitParent(crefNode);
-
-  context := InstContext.clearScopeFlags(currentContext);
-
-  // Records might actually be record constructors that should count as
-  // functions here, such record constructors are always root classes.
-  if not InstNode.isRootClass(parent) then
-    context := InstContext.set(context, NFInstContext.CLASS);
-    return;
-  end if;
-
-  parent_res := InstNode.restriction(parent);
-  context := if Restriction.isFunction(parent_res) or Restriction.isRecord(parent_res) then
-    InstContext.set(context, NFInstContext.FUNCTION) else
-    InstContext.set(context, NFInstContext.CLASS);
-end crefContext;
 
 function typeSubscripts
   input list<Subscript> subscripts;

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation13.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation13.mos
@@ -1,0 +1,219 @@
+// name: GetModelInstanceAnnotation13
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  package P
+    model C
+      parameter Boolean b = false;
+      parameter E e = E.B;
+      parameter Real x = 0 annotation(Dialog(enable = e == E.A));
+    end C;
+
+    type E = enumeration(A, B, C);
+  end P;
+
+  model M
+    parameter Boolean b = c.b;
+    Real x if b;
+    replaceable model C = P.C;
+    C c;
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"b\",
+//       \"type\": \"Boolean\",
+//       \"modifiers\": \"c.b\",
+//       \"value\": {
+//         \"binding\": {
+//           \"$kind\": \"cref\",
+//           \"parts\": [
+//             {
+//               \"name\": \"c\"
+//             },
+//             {
+//               \"name\": \"b\"
+//             }
+//           ]
+//         },
+//         \"value\": false
+//       },
+//       \"prefixes\": {
+//         \"variability\": \"parameter\"
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"x\",
+//       \"type\": \"Real\",
+//       \"condition\": false
+//     },
+//     {
+//       \"$kind\": \"class\",
+//       \"name\": \"C\",
+//       \"restriction\": \"model\",
+//       \"prefixes\": {
+//         \"replaceable\": true
+//       },
+//       \"baseClass\": \"P.C\",
+//       \"source\": {
+//         \"filename\": \"<interactive>\",
+//         \"lineStart\": 15,
+//         \"columnStart\": 17,
+//         \"lineEnd\": 15,
+//         \"columnEnd\": 30
+//       }
+//     },
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"c\",
+//       \"type\": {
+//         \"name\": \"M.C\",
+//         \"restriction\": \"model\",
+//         \"prefixes\": {
+//           \"replaceable\": true
+//         },
+//         \"elements\": [
+//           {
+//             \"$kind\": \"extends\",
+//             \"baseClass\": {
+//               \"name\": \"P.C\",
+//               \"restriction\": \"model\",
+//               \"elements\": [
+//                 {
+//                   \"$kind\": \"component\",
+//                   \"name\": \"b\",
+//                   \"type\": \"Boolean\",
+//                   \"modifiers\": \"false\",
+//                   \"value\": {
+//                     \"binding\": false
+//                   },
+//                   \"prefixes\": {
+//                     \"variability\": \"parameter\"
+//                   }
+//                 },
+//                 {
+//                   \"$kind\": \"component\",
+//                   \"name\": \"e\",
+//                   \"type\": {
+//                     \"name\": \"P.E\",
+//                     \"restriction\": \"type\",
+//                     \"elements\": [
+//                       {
+//                         \"$kind\": \"extends\",
+//                         \"baseClass\": \"enumeration\"
+//                       },
+//                       {
+//                         \"$kind\": \"component\",
+//                         \"name\": \"A\"
+//                       },
+//                       {
+//                         \"$kind\": \"component\",
+//                         \"name\": \"B\"
+//                       },
+//                       {
+//                         \"$kind\": \"component\",
+//                         \"name\": \"C\"
+//                       }
+//                     ],
+//                     \"source\": {
+//                       \"filename\": \"<interactive>\",
+//                       \"lineStart\": 9,
+//                       \"columnStart\": 5,
+//                       \"lineEnd\": 9,
+//                       \"columnEnd\": 34
+//                     }
+//                   },
+//                   \"modifiers\": \"E.B\",
+//                   \"value\": {
+//                     \"binding\": {
+//                       \"$kind\": \"enum\",
+//                       \"name\": \"P.E.B\",
+//                       \"index\": 2
+//                     }
+//                   },
+//                   \"prefixes\": {
+//                     \"variability\": \"parameter\"
+//                   }
+//                 },
+//                 {
+//                   \"$kind\": \"component\",
+//                   \"name\": \"x\",
+//                   \"type\": \"Real\",
+//                   \"modifiers\": \"0\",
+//                   \"value\": {
+//                     \"binding\": 0
+//                   },
+//                   \"prefixes\": {
+//                     \"variability\": \"parameter\"
+//                   },
+//                   \"annotation\": {
+//                     \"Dialog\": {
+//                       \"enable\": {
+//                         \"$kind\": \"binary_op\",
+//                         \"lhs\": {
+//                           \"$kind\": \"cref\",
+//                           \"parts\": [
+//                             {
+//                               \"name\": \"c\"
+//                             },
+//                             {
+//                               \"name\": \"e\"
+//                             }
+//                           ]
+//                         },
+//                         \"op\": \"==\",
+//                         \"rhs\": {
+//                           \"$kind\": \"enum\",
+//                           \"name\": \"P.E.A\",
+//                           \"index\": 1
+//                         }
+//                       }
+//                     }
+//                   }
+//                 }
+//               ],
+//               \"source\": {
+//                 \"filename\": \"<interactive>\",
+//                 \"lineStart\": 3,
+//                 \"columnStart\": 5,
+//                 \"lineEnd\": 7,
+//                 \"columnEnd\": 10
+//               }
+//             }
+//           }
+//         ],
+//         \"source\": {
+//           \"filename\": \"<interactive>\",
+//           \"lineStart\": 15,
+//           \"columnStart\": 17,
+//           \"lineEnd\": 15,
+//           \"columnEnd\": 30
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 12,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 17,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -14,6 +14,7 @@ GetModelInstanceAnnotation9.mos \
 GetModelInstanceAnnotation10.mos \
 GetModelInstanceAnnotation11.mos \
 GetModelInstanceAnnotation12.mos \
+GetModelInstanceAnnotation13.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \


### PR DESCRIPTION
- Move `Typing.crefContext` to `InstContext.nodeContext` and use it in `Ceval` when typing components to make sure global context flags are taken into account.

Fixes #13418