### PR TITLE
[NB] update array constructor inlining

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -91,7 +91,7 @@ public
 
   // used to process different outcomes of slicing from Util/Slice.mo
   // have to be defined here and not in Util/Slice.mo because it is a uniontype and not a package
-  type Frame                = tuple<ComponentRef, Expression>                       "iterator-like tuple for array handling";
+  type Frame                = tuple<ComponentRef, Expression, Option<Iterator>>     "iterator-like tuple for array handling";
   type FrameLocation        = tuple<array<Integer>, Frame>                          "sliced frame at specific sub locations";
   type SlicingStatus        = enumeration(UNCHANGED, TRIVIAL, NONTRIVIAL, FAILURE)  "final result of slicing";
   type RecollectStatus      = enumeration(SUCCESS, FAILURE)                         "result of sub-routine recollect";
@@ -127,11 +127,13 @@ public
     record SINGLE
       ComponentRef name           "the name of the iterator";
       Expression range            "range as <start, step, stop>";
+      Option<Iterator> map        "maps to a second iterator if derived from a for-expression";
     end SINGLE;
 
     record NESTED
       array<ComponentRef> names   "sorted iterator names";
       array<Expression> ranges    "sorted ranges as <start, step, stop>";
+      array<Option<Iterator>> maps"maps to a second iterator if derived from a for-expression";
     end NESTED;
 
     record EMPTY
@@ -143,16 +145,18 @@ public
     protected
       list<ComponentRef> names;
       list<Expression> ranges;
+      list<Option<Iterator>> maps;
       ComponentRef name;
       Expression range;
+      Option<Iterator> map;
     algorithm
       if listEmpty(frames) then
         iter := EMPTY();
       else
-        (names, ranges) := List.unzip(frames);
-        iter := match (names, ranges)
-          case ({name}, {range})  then SINGLE(name, range);
-                                  else NESTED(listArray(names), listArray(ranges));
+        (names, ranges, maps) := List.unzip3(frames);
+        iter := match (names, ranges, maps)
+          case ({name}, {range}, {map})  then SINGLE(name, range, map);
+                                  else NESTED(listArray(names), listArray(ranges), listArray(maps));
         end match;
       end if;
     end fromFrames;
@@ -163,11 +167,12 @@ public
     protected
       list<ComponentRef> names1, names2;
       list<Expression> ranges1, ranges2;
+      list<Option<Iterator>> maps1, maps2;
     algorithm
       if not listEmpty(frames) then
-        (names1, ranges1) := getFrames(iter);
-        (names2, ranges2) := List.unzip(frames);
-        iter := fromFrames(List.zip(listAppend(names1, names2), listAppend(ranges1, ranges2)));
+        (names1, ranges1, maps1) := getFrames(iter);
+        (names2, ranges2, maps2) := List.unzip3(frames);
+        iter := fromFrames(List.zip3(listAppend(names1, names2), listAppend(ranges1, ranges2), listAppend(maps1, maps2)));
       end if;
     end addFrames;
 
@@ -175,11 +180,12 @@ public
       input Iterator iter;
       output list<ComponentRef> names;
       output list<Expression> ranges;
+      output list<Option<Iterator>> maps;
     algorithm
-      (names, ranges) := match iter
-        case SINGLE() then ({iter.name}, {iter.range});
-        case NESTED() then (arrayList(iter.names), arrayList(iter.ranges));
-        case EMPTY()  then ({}, {});
+      (names, ranges, maps) := match iter
+        case SINGLE() then ({iter.name}, {iter.range}, {iter.map});
+        case NESTED() then (arrayList(iter.names), arrayList(iter.ranges), arrayList(iter.maps));
+        case EMPTY()  then ({}, {}, {});
       end match;
     end getFrames;
 
@@ -190,16 +196,18 @@ public
     protected
       list<ComponentRef> tmp_names, names = {};
       list<Expression> tmp_ranges, ranges = {};
+      list<Option<Iterator>> tmp_maps, maps = {};
     algorithm
       if List.hasOneElement(iterators) then
         result := List.first(iterators);
       else
         for iter in listReverse(iterators) loop
-          (tmp_names, tmp_ranges) := getFrames(iter);
-          names := listAppend(tmp_names, names);
-          ranges := listAppend(tmp_ranges, ranges);
+          (tmp_names, tmp_ranges, tmp_maps) := getFrames(iter);
+          names   := listAppend(tmp_names, names);
+          ranges  := listAppend(tmp_ranges, ranges);
+          maps    := listAppend(tmp_maps, maps);
         end for;
-        result := NESTED(listArray(names), listArray(ranges));
+        result := NESTED(listArray(names), listArray(ranges), listArray(maps));
       end if;
     end merge;
 
@@ -211,9 +219,10 @@ public
     protected
       list<ComponentRef> names;
       list<Expression> ranges;
+      list<Option<Iterator>> maps;
     algorithm
-      (names, ranges) := getFrames(iterator);
-      for tpl in List.zip(names, ranges) loop
+      (names, ranges, maps) := getFrames(iterator);
+      for tpl in List.zip3(names, ranges, maps) loop
         result := Iterator.fromFrames({tpl}) :: result;
       end for;
     end split;
@@ -251,11 +260,15 @@ public
     algorithm
       b := match (iter1, iter2)
         case (EMPTY(), EMPTY()) then true;
-        case (SINGLE(), SINGLE()) then Expression.isEqual(iter1.range, iter2.range);
+        case (SINGLE(), SINGLE()) then Expression.isEqual(iter1.range, iter2.range) and Util.optionEqual(iter1.map, iter2.map, isEqual);
         case (NESTED(), NESTED()) algorithm
-          if arrayLength(iter1.ranges) == arrayLength(iter2.ranges) then
+          if arrayLength(iter1.ranges) == arrayLength(iter2.ranges) and arrayLength(iter1.maps) == arrayLength(iter2.maps) then
             for i in 1:arrayLength(iter1.ranges) loop
               b := Expression.isEqual(iter1.ranges[i], iter2.ranges[i]);
+              if not b then break; end if;
+            end for;
+            for i in 1:arrayLength(iter1.maps) loop
+              b := Util.optionEqual(iter1.maps[i], iter2.maps[i], isEqual);
               if not b then break; end if;
             end for;
           else
@@ -305,14 +318,13 @@ public
                   ty    = Expression.typeOf(iter1.range),
                   start = Expression.INTEGER(start_max),
                   step  = SOME(Expression.INTEGER(step1)),
-                  stop  = Expression.INTEGER(stop_min)
-                )
-              );
+                  stop  = Expression.INTEGER(stop_min)),
+                map  = iter1.map);
             end if;
 
             // create rest
-            rest1 := intersectRest(iter1.name, start1, step1, stop1, start_max-step1, stop_min+step1);
-            rest2 := intersectRest(iter2.name, start2, step2, stop2, start_max-step2, stop_min+step2);
+            rest1 := intersectRest(iter1.name, start1, step1, stop1, start_max-step1, stop_min+step1, iter1.map);
+            rest2 := intersectRest(iter2.name, start2, step2, stop2, start_max-step2, stop_min+step2, iter2.map);
         then (intersection, rest1, rest2);
 
         // cannot intersect
@@ -327,6 +339,7 @@ public
       input Integer stop;
       input Integer start_max;
       input Integer stop_min;
+      input Option<Iterator> map;
       output tuple<Iterator, Iterator> rest;
     protected
       Iterator rest_left, rest_right;
@@ -339,9 +352,8 @@ public
           range = Expression.makeRange(
             start = Expression.INTEGER(start),
             step  = SOME(Expression.INTEGER(step)),
-            stop  = Expression.INTEGER(start_max)
-          )
-        );
+            stop  = Expression.INTEGER(start_max)),
+          map   = map);
       end if;
 
       if stop_min > stop  then
@@ -352,9 +364,8 @@ public
           range = Expression.makeRange(
             start = Expression.INTEGER(stop_min),
             step  = SOME(Expression.INTEGER(step)),
-            stop  = Expression.INTEGER(stop)
-          )
-        );
+            stop  = Expression.INTEGER(stop)),
+          map   = map);
       end if;
       rest := (rest_left, rest_right);
     end intersectRest;
@@ -413,12 +424,14 @@ public
         case SINGLE() guard(arrayLength(location) == 1) algorithm
           (start, step, _) := Expression.getIntegerRange(iter.range);
           UnorderedMap.add(iter.name, Expression.INTEGER(start + location[1]*step), replacements);
+          createMappedLocationReplacement(iter.map, location[1], replacements);
         then ();
 
         case NESTED() guard(arrayLength(location) == arrayLength(iter.ranges)) algorithm
           for i in 1:arrayLength(location) loop
             (start, step, _) := Expression.getIntegerRange(iter.ranges[i]);
             UnorderedMap.add(iter.names[i], Expression.INTEGER(start + location[i]*step), replacements);
+            createMappedLocationReplacement(iter.maps[i], location[i], replacements);
           end for;
         then ();
 
@@ -428,6 +441,27 @@ public
         then fail();
       end match;
     end createLocationReplacements;
+
+    function createMappedLocationReplacement
+      input Option<Iterator> map;
+      input Integer location;
+      input UnorderedMap<ComponentRef, Expression> replacements   "replacement rules";
+    algorithm
+      _ := match map
+        local
+          ComponentRef name;
+          Expression arr;
+          Integer index;
+
+        // only does something if the option is filled with an array
+        // fail if there is something else?
+        case SOME(SINGLE(name = name, range = arr as Expression.ARRAY())) algorithm
+          index := Expression.getInteger(arr.elements[location]);
+          UnorderedMap.add(name, Expression.INTEGER(index), replacements);
+        then ();
+        else ();
+      end match;
+    end createMappedLocationReplacement;
 
     function createReplacement
       "adds a replacement rule for one iterator to another.
@@ -529,7 +563,7 @@ public
         case Expression.CALL(call = call as Call.TYPED_ARRAY_CONSTRUCTOR()) algorithm
           for tpl in listReverse(call.iters) loop
             (node, range) := tpl;
-            frames := (ComponentRef.fromNode(node, Type.INTEGER(), {}, NFComponentRef.Origin.ITERATOR), range) :: frames;
+            frames := (ComponentRef.fromNode(node, Type.INTEGER(), {}, NFComponentRef.Origin.ITERATOR), range, NONE()) :: frames;
           end for;
           tmp := fromFrames(frames);
           if not isEmpty(iter) then
@@ -604,12 +638,20 @@ public
       function singleStr
         input ComponentRef name;
         input Expression range;
+        input Option<Iterator> map;
         output String str = ComponentRef.toString(name) + " in " + Expression.toString(range);
+      protected
+        list<ComponentRef> names;
+      algorithm
+        if Util.isSome(map) then
+          (names, _) := getFrames(Util.getOption(map));
+          str := str + " (" + ComponentRef.toString(List.first(names)) + ")";
+        end if;
       end singleStr;
     algorithm
       str := match iter
-        case SINGLE() then singleStr(iter.name, iter.range);
-        case NESTED() then "{" + stringDelimitList(list(singleStr(iter.names[i], iter.ranges[i]) for i in 1:arrayLength(iter.names)), ", ") + "}";
+        case SINGLE() then singleStr(iter.name, iter.range, iter.map);
+        case NESTED() then "{" + stringDelimitList(list(singleStr(iter.names[i], iter.ranges[i], iter.maps[i]) for i in 1:arrayLength(iter.names)), ", ") + "}";
         case EMPTY()  then "<EMPTY ITERATOR>";
         else algorithm
           Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName() + " failed for an unknown reason."});
@@ -1715,10 +1757,11 @@ public
         local
           list<ComponentRef> names;
           list<Expression> ranges;
+          list<Option<Iterator>> maps;
 
         case FOR_EQUATION() algorithm
-          (names, ranges) := Iterator.getFrames(eqn.iter);
-        then List.zip(names, ranges);
+          (names, ranges, maps) := Iterator.getFrames(eqn.iter);
+        then List.zip3(names, ranges, maps);
 
         else {};
       end match;

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBackendDAE.mo
@@ -895,7 +895,7 @@ protected
             body_elem := Pointer.access(body_elem_ptr);
             body_elem := BEquation.FOR_EQUATION(
               size    = Expression.rangeSize(range) * Equation.size(body_elem_ptr),
-              iter    = Iterator.SINGLE(iterator, range),
+              iter    = Iterator.SINGLE(iterator, range, NONE()),
               body    = {body_elem},
               source  = frontend_equation.source,
               attr    = Equation.getAttributes(body_elem)

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -221,15 +221,16 @@ public
     protected
       list<ComponentRef> iter;
       list<Expression> range;
+      list<Option<Iterator>> maps;
       ComponentRef lhs_cref;
       Pointer<Equation> aux_eqn;
     algorithm
       // if it has a statement index, it already has been created as a statement inside an algorithm (0 implies no index)
       if cond.stmt_index == 0 then
-        (iter, range) := Equation.Iterator.getFrames(cond.iter);
+        (iter, range, maps) := Equation.Iterator.getFrames(cond.iter);
         // lower the subscripts (containing iterators)
         lhs_cref := ComponentRef.mapSubscripts(BVariable.getVarName(aux_var), function Subscript.mapExp(func = function BackendDAE.lowerComponentReferenceExp(variables = variables)));
-        aux_eqn := Equation.makeAssignment(Expression.fromCref(lhs_cref), cond.exp, idx, "EVT", Iterator.fromFrames(List.zip(iter, range)), EquationAttributes.default(EquationKind.DISCRETE, false));
+        aux_eqn := Equation.makeAssignment(Expression.fromCref(lhs_cref), cond.exp, idx, "EVT", Iterator.fromFrames(List.zip3(iter, range, maps)), EquationAttributes.default(EquationKind.DISCRETE, false));
         auxiliary_eqns := aux_eqn :: auxiliary_eqns;
       end if;
       // remove all subscripts from the variable name
@@ -636,7 +637,7 @@ public
         case Statement.FOR(range = SOME(range)) algorithm
           new_stmts := {};
           name := ComponentRef.fromNode(stmt.iterator, Type.INTEGER());
-          new_frames := (name, range) :: frames;
+          new_frames := (name, range, NONE()) :: frames;
           for elem in stmt.body loop
             new_stmt := fromStatement(elem, bucket_ptr, eqn, variables, funcTree, new_frames);
             new_stmts := new_stmt :: new_stmts;

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBFunctionAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBFunctionAlias.mo
@@ -59,7 +59,7 @@ protected
   import Partitioning = NBPartitioning;
   import NBPartitioning.BClock;
   import BVariable = NBVariable;
-  import NBVariable.{VariablePointers, VarData};
+  import NBVariable.{VariablePointer, VariablePointers, VarData};
 
   // Util imports
   import StringUtil;
@@ -221,6 +221,7 @@ protected
   protected
     UnorderedMap<Call_Id, Call_Aux> map = UnorderedMap.new<Call_Aux>(Call_Id.hash, Call_Id.isEqual);
     VariablePointers variables = VarData.getVariables(varData);
+    UnorderedSet<VariablePointer> set = UnorderedSet.new(BVariable.hash, BVariable.equalName) "new iterators";
     UnorderedMap<BClock, ComponentRef> clock_map;
     Pointer<Integer> aux_index = Pointer.create(1);
     list<Pointer<Variable>> new_vars_disc = {}, new_vars_cont = {}, new_vars_init = {}, new_vars_recd = {}, new_vars_clck;
@@ -240,7 +241,7 @@ protected
       case EqData.EQ_DATA_SIM() algorithm
         // first collect all new functions from simulation equations
         eqData.simulation := EquationPointers.map(eqData.simulation,
-          function introduceFunctionAliasEquation(map = map, variables = variables, aux_index = aux_index, eqn_index = eqData.uniqueIndex, init = false));
+          function introduceFunctionAliasEquation(map = map, variables = variables, set = set, aux_index = aux_index, eqn_index = eqData.uniqueIndex, init = false));
 
         // create new simulation variables and corresponding equations for the function alias
         for tpl in listReverse(UnorderedMap.toList(map)) loop
@@ -271,7 +272,7 @@ protected
 
         // afterwards collect all functions from initial equations
         eqData.initials := EquationPointers.map(eqData.initials,
-          function introduceFunctionAliasEquation(map = map, variables = variables, aux_index = aux_index, eqn_index = eqData.uniqueIndex, init = true));
+          function introduceFunctionAliasEquation(map = map, variables = variables, set = set, aux_index = aux_index, eqn_index = eqData.uniqueIndex, init = true));
 
         // create new initialization variables and corresponding equations for the function alias
         for tpl in listReverse(UnorderedMap.toList(map)) loop
@@ -302,6 +303,7 @@ protected
     varData := VarData.addTypedList(varData, new_vars_init, VarData.VarType.PARAMETER);
     varData := VarData.addTypedList(varData, new_vars_recd, VarData.VarType.RECORD);
     varData := VarData.addTypedList(varData, new_vars_clck, VarData.VarType.CLOCK);
+    varData := VarData.addTypedList(varData, UnorderedSet.toList(set), VarData.VarType.ITERATOR);
     eqData  := EqData.addTypedList(eqData, new_eqns_cont, EqData.EqType.CONTINUOUS, false);
     eqData  := EqData.addTypedList(eqData, new_eqns_disc, EqData.EqType.DISCRETE, false);
     eqData  := EqData.addTypedList(eqData, new_eqns_init, EqData.EqType.INITIAL, false);
@@ -334,6 +336,7 @@ protected
     input output Equation eqn;
     input UnorderedMap<Call_Id, Call_Aux> map;
     input VariablePointers variables;
+    input UnorderedSet<VariablePointer> set "new iterators";
     input Pointer<Integer> aux_index;
     input Pointer<Integer> eqn_index;
     input Boolean init;
@@ -342,7 +345,7 @@ protected
     Boolean stop;
   algorithm
     // inline trivial array constructors first
-    eqn := Inline.inlineArrayConstructorSingle(eqn, Iterator.EMPTY(), variables, eqn_index);
+    eqn := Inline.inlineArrayConstructorSingle(eqn, Iterator.EMPTY(), variables, set, eqn_index);
 
     // get iterator and determine if it needs to be checked further
     (iter, stop) := match eqn
@@ -376,6 +379,7 @@ protected
       local
         list<ComponentRef> names;
         list<Expression> ranges;
+        list<Option<Iterator>> maps;
         Iterator new_iter;
         Call_Id id;
         ComponentRef name;
@@ -383,14 +387,13 @@ protected
         Call_Aux aux;
         Option<Call_Aux> aux_opt;
         Expression new_exp, sub_exp;
-        list<ComponentRef> names;
-        list<Expression> tpl_lst;
+       list<Expression> tpl_lst;
 
       case Expression.CALL() guard(checkCallReplacement(exp.call)) algorithm
         // strip nested iterator for the iterators that actually occure in the function call
         if not Iterator.isEmpty(iter) then
-          (names, ranges) := Iterator.getFrames(iter);
-          new_iter := Iterator.fromFrames(filterFrames(exp, names, ranges));
+          (names, ranges, maps) := Iterator.getFrames(iter);
+          new_iter := Iterator.fromFrames(filterFrames(exp, names, ranges, maps));
         else
           new_iter := iter;
         end if;
@@ -486,7 +489,8 @@ protected
     input Expression exp;
     input list<ComponentRef> names;
     input list<Expression> ranges;
-    output list<tuple<ComponentRef, Expression>> frames;
+    input list<Option<Iterator>> maps;
+    output list<tuple<ComponentRef, Expression, Option<Iterator>>> frames;
   protected
     UnorderedMap<ComponentRef, Expression> frame_map = UnorderedMap.fromLists<Expression>(names, ranges, ComponentRef.hash, ComponentRef.isEqual);
     UnorderedMap<ComponentRef, Expression> new_map = UnorderedMap.new<Expression>(ComponentRef.hash, ComponentRef.isEqual);
@@ -510,9 +514,16 @@ protected
         else ();
       end match;
     end collectFrames;
+
+    list<ComponentRef> n;
+    list<Expression> r;
+    list<Option<Iterator>> m;
   algorithm
     _ := Expression.map(exp, function collectFrames(frame_map = frame_map, new_map = new_map));
-    frames := UnorderedMap.toList(new_map);
+    n := UnorderedMap.keyList(new_map);
+    r := UnorderedMap.valueList(new_map);
+    m := List.fill(NONE(), listLength(n));
+    frames := List.zip3(n, r, m);
   end filterFrames;
 
   function addAuxVar

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBTearing.mo
@@ -317,11 +317,12 @@ protected
     Tearing strict;
   protected
     list<list<Slice<EquationPointer>>> acc;
+    UnorderedSet<VariablePointer> dummy_set = UnorderedSet.new(BVariable.hash, BVariable.equalName);
   algorithm
     comp := match comp
       case StrongComponent.ALGEBRAIC_LOOP(strict = strict) algorithm
         // inline potential records
-        acc := list(Inline.inlineRecordSliceEquation(eqn, variables, eq_index, true) for eqn in strict.residual_eqns);
+        acc := list(Inline.inlineRecordSliceEquation(eqn, variables, dummy_set, eq_index, true) for eqn in strict.residual_eqns);
 
         // create residual equations
         strict.residual_eqns := list(Slice.apply(eqn, function Equation.createResidual(new = true)) for eqn in List.flatten(acc));

--- a/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBSlice.mo
@@ -761,7 +761,7 @@ public
           Expression linMap;
 
         // equal inertia, combine the frames
-        case ((inertia1, (loc1, (name1, _))), (inertia2, (loc2, (name2, _)))) guard(inertia1 == inertia2) algorithm
+        case ((inertia1, (loc1, (name1, _, _))), (inertia2, (loc2, (name2, _, _)))) guard(inertia1 == inertia2) algorithm
           addOp := Operator.fromClassification((NFOperator.MathClassification.ADDITION, NFOperator.SizeClassification.SCALAR), Type.INTEGER());
           mulOp := Operator.fromClassification((NFOperator.MathClassification.MULTIPLICATION, NFOperator.SizeClassification.SCALAR), Type.INTEGER());
           if arrayLength(loc1) <> arrayLength(loc2) then
@@ -1568,10 +1568,11 @@ protected
       local
         ComponentRef name;
         Expression exp;
+        Option<Iterator> map;
 
-      case (name, exp as Expression.RANGE()) then (name, Expression.sliceRange(exp, range));
+      case (name, exp as Expression.RANGE(), map) then (name, Expression.sliceRange(exp, range), map);
 
-      case (_, exp) algorithm
+      case (_, exp, _) algorithm
         Error.addMessage(Error.INTERNAL_ERROR,{getInstanceName()
           + " failed because frame expression was not Expression.RANGE(): " + Expression.toString(exp)});
       then fail();

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -1178,21 +1178,6 @@ public
     output Integer start;
     output Integer step;
     output Integer stop;
-  protected
-    function getInteger
-      input Expression exp;
-      output Integer i;
-    protected
-      Expression e;
-    algorithm
-      e := Expression.map(exp, Expression.replaceResizableParameter);
-      i := match SimplifyExp.simplify(e)
-        case INTEGER(i) then i;
-        else algorithm
-          Error.assertion(false, getInstanceName() + " cannot be parsed to an integer: " + toString(exp), sourceInfo());
-        then fail();
-      end match;
-    end getInteger;
   algorithm
     (start, step, stop) := match range
       local
@@ -1217,6 +1202,21 @@ public
       then fail();
     end match;
   end getIntegerRange;
+
+  function getInteger
+    input Expression exp;
+    output Integer i;
+  protected
+    Expression e;
+  algorithm
+    e := Expression.map(exp, Expression.replaceResizableParameter);
+    i := match SimplifyExp.simplify(e)
+      case INTEGER(i) then i;
+      else algorithm
+        Error.assertion(false, getInstanceName() + " cannot be parsed to an integer: " + toString(exp), sourceInfo());
+      then fail();
+    end match;
+  end getInteger;
 
   function makeTuple
     input list<Expression> expl;


### PR DESCRIPTION
 - update iterators to have an optional mapping if derived from an array constructor
 - while inlining array constructors crate the mapping to map arbitrary index lists to a range
 - use the normal iterator and the new mapped iterator while creating indices (adjecency)
 - save the new iterators to variables
 - partially fixes #13031