### PR TITLE
Do not load OpenModelica at startup

### DIFF
--- a/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
+++ b/OMEdit/OMEditLIB/Editors/ModelicaEditor.cpp
@@ -258,12 +258,13 @@ void ModelicaEditor::getCompletionSymbols(QString word, QList<CompleterItem> &cl
  */
 LibraryTreeItem *ModelicaEditor::getAnnotationCompletionRoot()
 {
-  LibraryTreeItem *pLibraryRoot = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->getRootLibraryTreeItem();
+  LibraryTreeItem *pLibraryRoot = MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->findLibraryTreeItemOneLevel(Helper::OMEditInternal);
   LibraryTreeItem *pModelicaReference = 0;
 
   for (int i = 0; i < pLibraryRoot->childrenSize(); ++i) {
-    if (pLibraryRoot->childAt(i)->getName() == "OpenModelica")
+    if (pLibraryRoot->childAt(i)->getName() == "OpenModelica") {
       pModelicaReference = pLibraryRoot->childAt(i);
+    }
   }
 
   if (pModelicaReference) {

--- a/OMEdit/OMEditLIB/MainWindow.cpp
+++ b/OMEdit/OMEditLIB/MainWindow.cpp
@@ -1727,7 +1727,6 @@ void MainWindow::addSystemLibraries()
     mpLibrariesMenu->clear();
     // get the available libraries and versions.
     QStringList libraries = MainWindow::instance()->getOMCProxy()->getAvailableLibraries();
-    libraries.sort();
     foreach (QString library, libraries) {
       QStringList versions = MainWindow::instance()->getOMCProxy()->getAvailableLibraryVersions(library);
       if (versions.isEmpty()) {
@@ -2070,8 +2069,7 @@ void MainWindow::unloadAll(bool onlyModelicaClasses)
   for (int i = pLibraryTreeItem->childrenSize(); --i >= 0; ) {
     LibraryTreeItem *pChildLibraryTreeItem = pLibraryTreeItem->child(i);
     if (pChildLibraryTreeItem) {
-      if ((pChildLibraryTreeItem->getNameStructure().compare(QStringLiteral("OpenModelica")) == 0)
-          || (pChildLibraryTreeItem->getNameStructure().compare(QStringLiteral("OMEdit.Search.Feature")) == 0)) {
+      if ((pChildLibraryTreeItem->getNameStructure().compare(Helper::OMEditInternal) == 0)) {
         continue;
       } else if (pChildLibraryTreeItem->isModelica()) {
         MainWindow::instance()->getLibraryWidget()->getLibraryTreeModel()->unloadClass(pChildLibraryTreeItem, false, false);

--- a/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
+++ b/OMEdit/OMEditLIB/Modeling/LibraryTreeWidget.h
@@ -137,6 +137,8 @@ public:
   void setExpanded(bool expanded) {mExpanded = expanded;}
   bool isExpanded() const {return mExpanded;}
   bool isEncryptedClass() const {return mFileName.endsWith(".moc");}
+  bool isInternal() const {return mInternal;}
+  void setInternal(bool internal) {mInternal = internal;}
   bool isAccessAnnotationsEnabled() const {return mAccessAnnotations;}
   void setAccessAnnotations(bool accessAnnotations) {mAccessAnnotations = accessAnnotations;}
   void setOMSElement(oms_element_t *pOMSComponent) {mpOMSElement = pOMSComponent;}
@@ -221,6 +223,7 @@ private:
   QString mClassTextAfter;
   bool mExpanded = false;
   bool mNonExisting = false;
+  bool mInternal = false;
   bool mAccessAnnotations = false;
   oms_element_t *mpOMSElement = 0;
   oms_system_enu_t mSystemType = oms_system_none;

--- a/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditLIB/Options/OptionsDialog.cpp
@@ -4026,13 +4026,15 @@ void AddSystemLibraryDialog::addSystemLibrary()
 {
   // if name text box is empty show error and return
   if (mpNameComboBox->currentText().isEmpty()) {
-    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::ENTER_NAME).arg(tr("a")), QMessageBox::Ok);
+    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::ENTER_NAME).arg(Helper::library), QMessageBox::Ok);
     return;
   }
   // if value text box is empty show error and return
+  QString version;
   if (mpVersionsComboBox->lineEdit()->text().isEmpty()) {
-    QMessageBox::critical(this, QString("%1 - %2").arg(Helper::applicationName, Helper::error), GUIMessages::getMessage(GUIMessages::ENTER_NAME).arg(tr("the value for a")), QMessageBox::Ok);
-    return;
+    version = "default";
+  } else {
+    version = mpVersionsComboBox->lineEdit()->text();
   }
   // if user is adding a new library
   if (!mEditFlag) {
@@ -4041,7 +4043,7 @@ void AddSystemLibraryDialog::addSystemLibrary()
       return;
     }
     QStringList values;
-    values << mpNameComboBox->currentText() << mpVersionsComboBox->lineEdit()->text();
+    values << mpNameComboBox->currentText() << version;
     mpLibrariesPage->getSystemLibrariesTree()->addTopLevelItem(new QTreeWidgetItem(values));
   } else if (mEditFlag) { // if user is editing old library
     QTreeWidgetItem *pItem = mpLibrariesPage->getSystemLibrariesTree()->selectedItems().at(0);
@@ -4050,7 +4052,7 @@ void AddSystemLibraryDialog::addSystemLibrary()
       return;
     }
     pItem->setText(0, mpNameComboBox->currentText());
-    pItem->setText(1, mpVersionsComboBox->lineEdit()->text());
+    pItem->setText(1, version);
   }
   accept();
 }

--- a/OMEdit/OMEditLIB/Util/Helper.cpp
+++ b/OMEdit/OMEditLIB/Util/Helper.cpp
@@ -42,10 +42,11 @@ QString Helper::organization = "openmodelica";  /* case-sensitive string. Don't 
 QString Helper::application = "omedit"; /* case-sensitive string. Don't change it. Used by ini settings file. */
 // Following four variables are set once we are connected to OMC......in OMCProxy::initializeOMC().
 QString Helper::OpenModelicaVersion = "";
-QString Helper::OpenModelicaUsersGuideVersion = "latest";
 QString Helper::OpenModelicaHome = "";
 QString Helper::ModelicaPath = "";
 QString Helper::userHomeDirectory = "";
+QString Helper::OpenModelicaUsersGuideVersion = "latest";
+QString Helper::OMEditInternal = "OMEditInternal";
 QString Helper::OMCServerName = "OMEdit";
 QString Helper::omFileTypes = "All Files (*.mo *.mol *.bmo *.mos *.ssp *.crml);;Modelica Files (*.mo);;Encrypted Modelica Libraries (*.mol);;Base Modelica Files (*.bmo)"
                               ";;Modelica Script Files (*.mos);;System Structure and Parameterization Files (*.ssp);;CRML Files (*.crml)";

--- a/OMEdit/OMEditLIB/Util/Helper.h
+++ b/OMEdit/OMEditLIB/Util/Helper.h
@@ -52,10 +52,11 @@ public:
   static QString organization;
   static QString application;
   static QString OpenModelicaVersion;
-  static QString OpenModelicaUsersGuideVersion;
   static QString OpenModelicaHome;
   static QString ModelicaPath;
   static QString userHomeDirectory;
+  static QString OpenModelicaUsersGuideVersion;
+  static QString OMEditInternal;
   static QString OMCServerName;
   static QString omFileTypes;
   static QString omEncryptedFileTypes;


### PR DESCRIPTION
### Related Issues

Fixes #13331

### Purpose

Allow unloading OpenModelica.

### Approach

Added OpenModelica to the list of system libraries so user can load it if needed. They can even set it up to be loaded at startup. Use internal structure for annotation completion.
