### PR TITLE
Keep empty annotations in getModelInstance

### DIFF
--- a/OMCompiler/Compiler/Parsers/JSON.mo
+++ b/OMCompiler/Compiler/Parsers/JSON.mo
@@ -431,13 +431,10 @@ function toStringPP_object
 protected
   String next_indent = indent + "  ";
 algorithm
-  Print.printBuf("{\n");
+  Print.printBuf("{");
 
   for i in 1:UnorderedMap.size(map) loop
-    if i <> 1 then
-      Print.printBuf(",\n");
-    end if;
-
+    Print.printBuf(if i == 1 then "\n" else ",\n");
     Print.printBuf(next_indent);
     Print.printBuf("\"");
     Print.printBuf(UnorderedMap.keyAt(map, i));

--- a/OMCompiler/Compiler/Script/NFApi.mo
+++ b/OMCompiler/Compiler/Script/NFApi.mo
@@ -1288,7 +1288,7 @@ algorithm
         ();
 
     case (Component.COMPONENT(), SCode.Element.COMPONENT())
-algorithm
+      algorithm
         json := JSON.addPair("$kind", JSON.makeString("component"), json);
         json := JSON.addPair("name", JSON.makeString(InstNode.name(node)), json);
         json := JSON.addPair("type", dumpJSONComponentType(cls, node, comp.ty), json);
@@ -1722,6 +1722,12 @@ algorithm
     case (_, SCode.Mod.MOD())
       algorithm
         json := JSON.addPair(name, dumpJSONAnnotationSubMods(mod.subModLst, scope, {}, failOnError), json);
+      then
+        ();
+
+    case (_, SCode.Mod.NOMOD())
+      algorithm
+        json := JSON.addPair(name, JSON.emptyObject(), json);
       then
         ();
 

--- a/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation14.mos
+++ b/testsuite/openmodelica/instance-API/GetModelInstanceAnnotation14.mos
@@ -1,0 +1,42 @@
+// name: GetModelInstanceAnnotation14
+// keywords:
+// status: correct
+// cflags: -d=newInst
+//
+//
+
+loadString("
+  model M
+    Real r annotation(Dialog);
+  end M;
+");
+
+getModelInstance(M, prettyPrint=true);
+getErrorString();
+
+// Result:
+// true
+// "{
+//   \"name\": \"M\",
+//   \"restriction\": \"model\",
+//   \"elements\": [
+//     {
+//       \"$kind\": \"component\",
+//       \"name\": \"r\",
+//       \"type\": \"Real\",
+//       \"annotation\": {
+//         \"Dialog\": {
+//         }
+//       }
+//     }
+//   ],
+//   \"source\": {
+//     \"filename\": \"<interactive>\",
+//     \"lineStart\": 2,
+//     \"columnStart\": 3,
+//     \"lineEnd\": 4,
+//     \"columnEnd\": 8
+//   }
+// }"
+// ""
+// endResult

--- a/testsuite/openmodelica/instance-API/Makefile
+++ b/testsuite/openmodelica/instance-API/Makefile
@@ -15,6 +15,7 @@ GetModelInstanceAnnotation10.mos \
 GetModelInstanceAnnotation11.mos \
 GetModelInstanceAnnotation12.mos \
 GetModelInstanceAnnotation13.mos \
+GetModelInstanceAnnotation14.mos \
 GetModelInstanceAttributes1.mos \
 GetModelInstanceAttributes2.mos \
 GetModelInstanceBinding1.mos \


### PR DESCRIPTION
- Keep empty annotation modifiers when converting Absyn to SCode since they may have meaning, e.g. `annotation(Dialog)`.
- Dump empty modifiers as empty objects in getModelInstance.
- Avoid printing unnecessary empty lines when pretty-printing empty JSON objects.

#13479
