### PR TITLE
Fix treatment of input records (#13524)

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -130,11 +130,15 @@ public function topLevelInput "author: PA
   input DAE.ConnectorType connectorType;
   input DAE.VarVisibility visibility = DAE.PUBLIC();
   output Boolean isTopLevel;
+protected
+  // the new frontend only keeps top level inputs, obsoleting bogus check for DAE.CREF_IDENT
+  Boolean newInst = Flags.isSet(Flags.SCODE_INST);
 algorithm
-  isTopLevel := match (varDirection, componentRef, visibility)
-    case (          _,                _, DAE.PROTECTED()) then false;
-    case (DAE.INPUT(), DAE.CREF_IDENT(),               _) then true;
-    case (DAE.INPUT(),                _,               _)
+  isTopLevel := match (varDirection, componentRef, visibility, newInst)
+    case (          _,                _, DAE.PROTECTED(),    _) then false;
+    case (DAE.INPUT(),                _,               _, true) then true;
+    case (DAE.INPUT(), DAE.CREF_IDENT(),               _,    _) then true;
+    case (DAE.INPUT(),                _,               _,    _)
       guard(ConnectUtil.faceEqual(ConnectUtil.componentFaceType(componentRef), Connect.OUTSIDE()))
       then topLevelConnectorType(connectorType);
     else false;

--- a/testsuite/simulation/modelica/records/InputRecord.mos
+++ b/testsuite/simulation/modelica/records/InputRecord.mos
@@ -1,0 +1,31 @@
+// name:     InputRecord
+// keywords: record, top-level input, #13524
+// status:   correct
+// cflags:   -d=newInst
+
+loadString("
+model RecordCausality
+  record R
+    Real x;
+  end R;
+  input R u;
+  output R y;
+equation
+  y = u;
+end RecordCausality;
+"); getErrorString();
+
+simulate(RecordCausality); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "RecordCausality_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'RecordCausality', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/records/Makefile
+++ b/testsuite/simulation/modelica/records/Makefile
@@ -6,6 +6,7 @@ constVar1.mos \
 constVar2.mos \
 constVar4.mos \
 InOutRecord.mos \
+InputRecord.mos \
 RecordConstructor1.mos \
 TestComplexSum1.mos \
 TestComplexSum2.mos \


### PR DESCRIPTION
The new frontend only keeps top level inputs.
This obsoletes the bogus check for top level inputs via DAE.CREF_IDENT.
