### PR TITLE
[NB] update event handling with reductions

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
+++ b/OMCompiler/Compiler/FrontEnd/ComponentReference.mo
@@ -835,7 +835,7 @@ protected
 algorithm
   for i in inSubs1 loop
     res::rest := rest;
-    res := if i>res then 1 elseif i<res then -1 else 0;
+    res := if i>res then 1 elseif i < res then -1 else 0;
     if res <> 0 then
       return;
     end if;


### PR DESCRIPTION
 - if events occur inside a reduction, the iterator of the reduction has to be used when creating events
 - fixes backend part of #13328 with the new backend
