### PR TITLE
Move getDefaultComponentName/Prefixes to the typed API

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -5066,6 +5066,26 @@ annotation(
 </html>"), preferredView="text");
 end getCrefInfo;
 
+function getDefaultComponentName
+  input TypeName cl;
+  output String name;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns the default component name for a class as defined by the defaultComponentName annotation.</p>
+</html>"), preferredView="text");
+end getDefaultComponentName;
+
+function getDefaultComponentPrefixes
+  input TypeName cl;
+  output String prefixes;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns the default component prefixes for a class as defined by the defaultComponentPrefixes annotation.</p>
+</html>"), preferredView="text");
+end getDefaultComponentPrefixes;
+
 function getShortDefinitionBaseClassInformation
   input TypeName className;
   output Expression result;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -5320,6 +5320,26 @@ annotation(
 </html>"), preferredView="text");
 end getCrefInfo;
 
+function getDefaultComponentName
+  input TypeName cl;
+  output String name;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns the default component name for a class as defined by the defaultComponentName annotation.</p>
+</html>"), preferredView="text");
+end getDefaultComponentName;
+
+function getDefaultComponentPrefixes
+  input TypeName cl;
+  output String prefixes;
+external "builtin";
+annotation(
+  Documentation(info="<html>
+<p>Returns the default component prefixes for a class as defined by the defaultComponentPrefixes annotation.</p>
+</html>"), preferredView="text");
+end getDefaultComponentPrefixes;
+
 function getShortDefinitionBaseClassInformation
   input TypeName className;
   output Expression result;

--- a/OMCompiler/Compiler/Script/CevalScriptBackend.mo
+++ b/OMCompiler/Compiler/Script/CevalScriptBackend.mo
@@ -3316,6 +3316,12 @@ algorithm
     case ("getCrefInfo", {Values.CODE(Absyn.C_TYPENAME(classpath))})
       then Interactive.getCrefInfo(classpath, SymbolTable.getAbsyn());
 
+    case ("getDefaultComponentName", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      then Interactive.getDefaultComponentName(classpath, SymbolTable.getAbsyn());
+
+    case ("getDefaultComponentPrefixes", {Values.CODE(Absyn.C_TYPENAME(classpath))})
+      then Interactive.getDefaultComponentPrefixes(classpath, SymbolTable.getAbsyn());
+
  end matchcontinue;
 end cevalInteractiveFunctions4;
 

--- a/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
+++ b/OMEdit/OMEditLIB/OMC/OMCProxy.cpp
@@ -2064,9 +2064,6 @@ bool OMCProxy::addClassAnnotation(QString className, QString annotation)
 QString OMCProxy::getDefaultComponentName(QString className)
 {
   sendCommand("getDefaultComponentName(" + className + ")");
-  if (getResult().compare("{}") == 0)
-    return "";
-
   return StringHandler::unparse(getResult());
 }
 
@@ -2078,9 +2075,6 @@ QString OMCProxy::getDefaultComponentName(QString className)
 QString OMCProxy::getDefaultComponentPrefixes(QString className)
 {
   sendCommand("getDefaultComponentPrefixes(" + className + ")");
-  if (getResult().compare("{}") == 0)
-    return "";
-
   return StringHandler::unparse(getResult());
 }
 

--- a/testsuite/openmodelica/interactive-API/DefaultComponentName.mos
+++ b/testsuite/openmodelica/interactive-API/DefaultComponentName.mos
@@ -39,6 +39,6 @@ getDefaultComponentPrefixes(A3);
 // end B;"
 // "inner"
 // "inner parameter"
-// {}
+// ""
 // "outer replaceable"
 // endResult


### PR DESCRIPTION
- Move getDefaultComponentName and getDefaultComponentPrefixes to the typed API.
- Change the return value of these APIs to return an empty string when the value is missing instead of `{}` since they should return strings.
- Remove now unnecessary checks for `{}` in OMEdit.