### PR TITLE
[NB] add generic solving routine

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -88,6 +88,10 @@ public
     NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFAttributes.DEFAULT_ATTR,
     {}, {}, NONE(), SCodeUtil.dummyInfo, NFBackendExtension.DUMMY_BACKEND_INFO);
 
+  constant Variable SUBST_VARIABLE = Variable.VARIABLE(NFBuiltin.SUBST_CREF, Type.ANY(),
+    NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFAttributes.DEFAULT_ATTR,
+    {}, {}, NONE(), SCodeUtil.dummyInfo, NFBackendExtension.DUMMY_BACKEND_INFO);
+
   constant Variable TIME_VARIABLE = Variable.VARIABLE(NFBuiltin.TIME_CREF, Type.REAL(),
     NFBinding.EMPTY_BINDING, NFPrefixes.Visibility.PUBLIC, NFAttributes.DEFAULT_ATTR,
     {}, {}, NONE(), SCodeUtil.dummyInfo, BackendInfo.BACKEND_INFO(

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -708,7 +708,6 @@ protected
         AttributeCollector collector;
         Pointer<Pointer<Variable>> var_to_keep = Pointer.create(Pointer.create(NBVariable.DUMMY_VARIABLE));
         Status status;
-        Boolean invertRelation;
 
       case SOME(const_eq) algorithm
         // there is a constant binding -> no variable will be kept and all will be replaced by a constant
@@ -739,7 +738,7 @@ protected
         for var in var_lst loop
           rhs := UnorderedMap.getSafe(BVariable.getVarName(var), replacements, sourceInfo());
           eq := Equation.makeAssignment(BVariable.toExpression(var), rhs, Pointer.create(0), NBEquation.TMP_STR, Iterator.EMPTY(), EquationAttributes.default(EquationKind.UNKNOWN, false));
-          (solved_eq,_,status, invertRelation) := Solve.solveBody(Pointer.access(eq), BVariable.getVarName(Pointer.access(var_to_keep)), FunctionTreeImpl.EMPTY());
+          (solved_eq,_,status, _) := Solve.solveBody(Pointer.access(eq), BVariable.getVarName(Pointer.access(var_to_keep)), FunctionTreeImpl.EMPTY());
           collector := AttributeCollector.fixValues(collector, BVariable.getVarName(var), solved_eq);
         end for;
         if Flags.isSet(Flags.DEBUG_ALIAS) then

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBEvents.mo
@@ -412,7 +412,8 @@ public
           local
             Equation tmpEqn;
             Solve.Status status;
-            Boolean invert, can_trigger;
+            Boolean can_trigger;
+            Solve.RelationInversion invert;
             Call call;
             Expression trigger, new_exp;
             TimeEvent timeEvent;
@@ -433,10 +434,10 @@ public
             _ := Equation.map(tmpEqn, function containsTimeTraverseExp(b = containsTime), SOME(function containsTimeTraverseCref(b = containsTime)));
             if Pointer.access(containsTime) then
               (tmpEqn, _, status, invert) := Solve.solveBody(tmpEqn, NFBuiltin.TIME_CREF, funcTree);
-              if status == NBSolve.Status.EXPLICIT then
+              if status == NBSolve.Status.EXPLICIT and invert <> NBSolve.RelationInversion.UNKNOWN then
                 trigger := Equation.getRHS(tmpEqn);
-                exp.operator := if invert then Operator.invert(exp.operator) else exp.operator;
-
+                // only cases for RelationInversion == TRUE or FALSE can be present
+                exp.operator := if invert == NBSolve.RelationInversion.TRUE then Operator.invert(exp.operator) else exp.operator;
                 if Equation.isWhenEquation(eqn) then
                   // if it is a when equation check if it can even trigger
                   can_trigger := match exp.operator.op

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -723,7 +723,7 @@ protected
       // -cref = exp
       case (Expression.UNARY(exp = Expression.CREF(cref = checkCref)), exp)
         guard(ComponentRef.isEqual(cref, checkCref) and not Expression.containsCref(exp, cref))
-      then (Equation.updateLHSandRHS(eqn, Expression.negate(lhs), Expression.negate(rhs)), Status.EXPLICIT, RelationInversion.FALSE);
+      then (Equation.updateLHSandRHS(eqn, Expression.negate(lhs), Expression.negate(rhs)), Status.EXPLICIT, RelationInversion.TRUE);
 
       // 3.2 negate (NOT) lhs and rhs
       // not cref = exp

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -610,7 +610,7 @@ public
         // If eqn is linear in cref:
         (eqn, funcTree) := solveLinear(eqn, residual, derivative, diffArgs, fixed_cref, funcTree);
         // If the derivative is negative, invert possible inequality sign
-        invertRelation := if Expression.isPositive(derivative) then RelationInversion.TRUE else if Expression.isNegative(derivative) then RelationInversion.FALSE else RelationInversion.UNKNOWN;
+        invertRelation := if Expression.isPositive(derivative) then RelationInversion.FALSE else if Expression.isNegative(derivative) then RelationInversion.TRUE else RelationInversion.UNKNOWN;
         status := Status.EXPLICIT;
       else
         // call general solving routine, can solve an equation, if a cref is contained once in the equation

--- a/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/3_Post/NBSolve.mo
@@ -610,7 +610,7 @@ public
         // If eqn is linear in cref:
         (eqn, funcTree) := solveLinear(eqn, residual, derivative, diffArgs, fixed_cref, funcTree);
         // If the derivative is negative, invert possible inequality sign
-        invertRelation := if Expression.isNegative(derivative) then RelationInversion.FALSE else RelationInversion.TRUE;
+        invertRelation := if Expression.isPositive(derivative) then RelationInversion.TRUE else if Expression.isNegative(derivative) then RelationInversion.FALSE else RelationInversion.UNKNOWN;
         status := Status.EXPLICIT;
       else
         // call general solving routine, can solve an equation, if a cref is contained once in the equation

--- a/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBDifferentiate.mo
@@ -1246,6 +1246,29 @@ public
         ret := Expression.MULTARY({Expression.REAL(1.0)}, {ret}, addOp);  // 1-tanh(arg)^2
       then ret;
 
+      // acosh(arg) -> 1/sqrt(arg^2-1)
+      case ("acosh") algorithm
+        ret := Expression.BINARY(arg, powOp, Expression.REAL(2.0));       // arg^2
+        ret := Expression.MULTARY({ret}, {Expression.REAL(1.0)}, addOp);  // arg^2-1
+        ret := Expression.BINARY(ret, powOp, Expression.REAL(0.5));       // sqrt(arg^2-1)
+        ret := Expression.MULTARY({Expression.REAL(1.0)}, {ret}, mulOp);  // 1/sqrt(arg^2-1)
+      then ret;
+
+      // asinh(arg) -> 1/sqrt(arg^2+1)
+      case ("asinh") algorithm
+        ret := Expression.BINARY(arg, powOp, Expression.REAL(2.0));         // arg^2
+        ret := Expression.MULTARY({ret, Expression.REAL(1.0)}, {}, addOp);  // arg^2+1
+        ret := Expression.BINARY(ret, powOp, Expression.REAL(0.5));         // sqrt(arg^2+1)
+        ret := Expression.MULTARY({Expression.REAL(1.0)}, {ret}, mulOp);    // 1/sqrt(arg^2+1)
+      then ret;
+
+      // atanh(arg) -> 1/(1-arg^2)
+      case ("atanh") algorithm
+        ret := Expression.BINARY(arg, powOp, Expression.REAL(2.0));       // arg^2
+        ret := Expression.MULTARY({Expression.REAL(1.0)}, {ret}, addOp);  // 1-arg^2
+        ret := Expression.MULTARY({Expression.REAL(1.0)}, {ret}, mulOp);  // 1/(1-arg^2)
+      then ret;
+
       // exp(arg) -> exp(arg)
       case ("exp") then Expression.CALL(Call.makeTypedCall(
           fn          = NFBuiltinFuncs.EXP_REAL,

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltin.mo
@@ -421,7 +421,25 @@ constant InstNode TIME =
     InstNode.EMPTY_NODE(),
     InstNodeType.NORMAL_COMP());
 
+constant InstNode SUBST_NODE =
+  InstNode.COMPONENT_NODE("$SUBST_CREF",
+    NONE(),
+    Visibility.PUBLIC,
+    Pointer.createImmutable(Component.COMPONENT(
+      REAL_NODE, // TODO: make this generic integer / real
+      Type.ANY(),
+      NFBinding.EMPTY_BINDING,
+      NFBinding.EMPTY_BINDING,
+      NFAttributes.DEFAULT_ATTR,
+      NONE(),
+      ComponentState.TypeChecked,
+      AbsynUtil.dummyInfo)),
+    InstNode.EMPTY_NODE(),
+    InstNodeType.NORMAL_COMP());
+
 constant ComponentRef TIME_CREF = ComponentRef.CREF(TIME, {}, Type.REAL(), Origin.CREF, ComponentRef.EMPTY());
+constant ComponentRef SUBST_CREF = ComponentRef.CREF(SUBST_NODE, {}, Type.ANY(), Origin.CREF, ComponentRef.EMPTY());
+
 
 function makeBuiltinLookupTree
   "This function takes lists of component and class names and prints out a lookup tree.

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinFuncs.mo
@@ -258,6 +258,21 @@ constant Function TAN_REAL = Function.FUNCTION(Path.IDENT("tan"),
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
+constant Function ACOS_REAL = Function.FUNCTION(Path.IDENT("acos"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+
+constant Function ASIN_REAL = Function.FUNCTION(Path.IDENT("asin"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+
+constant Function ATAN_REAL = Function.FUNCTION(Path.IDENT("atan"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+
 constant Function COSH_REAL = Function.FUNCTION(Path.IDENT("cosh"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
@@ -273,6 +288,21 @@ constant Function TANH_REAL = Function.FUNCTION(Path.IDENT("tanh"),
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
     Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
 
+constant Function ACOSH_REAL = Function.FUNCTION(Path.IDENT("acosh"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+
+constant Function ASINH_REAL = Function.FUNCTION(Path.IDENT("asinh"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+
+constant Function ATANH_REAL = Function.FUNCTION(Path.IDENT("atanh"),
+  InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
+    Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),
+    Pointer.createImmutable(FunctionStatus.BUILTIN), Pointer.createImmutable(0));
+    
 constant Function EXP_REAL = Function.FUNCTION(Path.IDENT("exp"),
   InstNode.EMPTY_NODE(), {REAL_PARAM}, {REAL_PARAM}, {}, {},
     Type.REAL(), DAE.FUNCTION_ATTRIBUTES_BUILTIN, {}, {}, listArray({}),

--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -2100,6 +2100,11 @@ public
     output Boolean b = firstName(cref) == "time";
   end isTime;
 
+  function isSubstitute
+    input ComponentRef cref;
+    output Boolean b = firstName(cref) == "$SUBST_CREF";
+  end isSubstitute;
+
   function isTopLevel
     input ComponentRef cref;
     output Boolean b;

--- a/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFExpression.mo
@@ -4491,6 +4491,16 @@ public
     end match;
   end isTime;
 
+  function isSubstitute
+    input Expression exp;
+    output Boolean b;
+  algorithm
+    b := match exp
+      case CREF() then ComponentRef.isSubstitute(exp.cref);
+      else false;
+    end match;
+  end isSubstitute;
+
   function isZero
     input Expression exp;
     output Boolean b;

--- a/OMCompiler/Compiler/Util/Flags.mo
+++ b/OMCompiler/Compiler/Util/Flags.mo
@@ -551,6 +551,8 @@ constant DebugFlag DUMP_EVENTS = DEBUG_FLAG(193, "dumpEvents", false,
   Gettext.gettext("Dumps information about the detected event functions."));
 constant DebugFlag DUMP_RESIZABLE = DEBUG_FLAG(194, "dumpResizable", false,
   Gettext.gettext("Dumps information about resizable paremeter handling."));
+constant DebugFlag DUMP_SOLVE = DEBUG_FLAG(195, "dumpSolve", false,
+  Gettext.gettext("Dumps information about equation solving."));
 
 public
 // CONFIGURATION FLAGS

--- a/OMCompiler/Compiler/Util/FlagsUtil.mo
+++ b/OMCompiler/Compiler/Util/FlagsUtil.mo
@@ -250,7 +250,8 @@ constant list<Flags.DebugFlag> allDebugFlags = {
   Flags.DUMP_SLICE,
   Flags.VECTORIZE_BINDINGS,
   Flags.DUMP_EVENTS,
-  Flags.DUMP_RESIZABLE
+  Flags.DUMP_RESIZABLE,
+  Flags.DUMP_SOLVE
 };
 
 protected

--- a/testsuite/Makefile
+++ b/testsuite/Makefile
@@ -66,6 +66,7 @@ simulationnewbackend-msl.log \
 simulationnewbackend-records.log \
 simulationnewbackend-ScalableTestsuite.log \
 simulationnewbackend-simplification.log \
+simulationnewbackend-solve.log \
 simulationnewbackend-tearing.log \
 simulationnewbackend-tickets.log \
 simulationdeclarations.log \
@@ -369,6 +370,9 @@ simulationnewbackend-ScalableTestsuite.log: omc-diff
 	@echo $@ done
 simulationnewbackend-simplification.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/simplification/ -f Makefile test > $@
+	@echo $@ done
+simulationnewbackend-solve.log: omc-diff
+	$(MAKE) -C simulation/modelica/NBackend/solve/ -f Makefile test > $@
 	@echo $@ done
 simulationnewbackend-tearing.log: omc-diff
 	$(MAKE) -C simulation/modelica/NBackend/tearing/ -f Makefile test > $@

--- a/testsuite/simulation/modelica/NBackend/simplification/splitIf.mos
+++ b/testsuite/simulation/modelica/NBackend/simplification/splitIf.mos
@@ -61,9 +61,9 @@ buildModel(SplitIf); getErrorString();
 // [BEFORE] -3.0 * v2 ^ 2.0 * 1.0
 // [AFTER ] -3.0 * v2 ^ 2.0
 //
-// ### dumpSimplify | NBEquation.Equation.getResidualExp ###
-// [BEFORE] 0.0 - v2 ^ 3.0
-// [AFTER ] -v2 ^ 3.0
+// ### dumpSimplify | NBSolve.solveBody ###
+// [BEFORE] (-0.0) ^ (1/3.0)
+// [AFTER ] 0.0
 //
 // {"SplitIf", "SplitIf_init.xml"}
 // ""

--- a/testsuite/simulation/modelica/NBackend/solve/Makefile
+++ b/testsuite/simulation/modelica/NBackend/solve/Makefile
@@ -1,0 +1,52 @@
+TEST = ../../../../rtest -v
+
+TESTFILES = \
+solveCallExp.mos \
+solveCallTan.mos \
+solveForLoop.mos \
+solveMultaryBinary.mos \
+
+# test that currently fail. Move up when fixed.
+# Run make failingtest
+FAILINGTESTFILES = \
+
+# Dependency files that are not .mo .mos or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.mo \
+*.mos \
+Makefile \
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps failingtest
+
+test:
+	@echo
+	@echo Running tests...
+	@echo
+	@echo OPENMODELICAHOME=" $(OPENMODELICAHOME) "
+	@$(TEST) $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@rm -f $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+# do it after cleaning and updating the folder
+# then you can get a list of file names (which must be dependencies
+# since you got them from repository + your own new files)
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
+
+failingtest:
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/testsuite/simulation/modelica/NBackend/solve/solveCallExp.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveCallExp.mos
@@ -1,4 +1,4 @@
-// name: solveForLoop
+// name: solveCallExp
 // keywords: NewBackend
 // status: correct
 // cflags: --newBackend -d=dumpSolve

--- a/testsuite/simulation/modelica/NBackend/solve/solveCallExp.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveCallExp.mos
@@ -1,0 +1,77 @@
+// name: solveForLoop
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend -d=dumpSolve
+
+loadString("
+  model solveCallExp
+    Real x;
+  equation
+    exp(-(2^x)^2) = sin(2);
+  end solveCallExp;
+"); getErrorString();
+
+setCommandLineOptions("-d=dumpSolve");
+simulate(solveCallExp); getErrorString();
+// Result:
+// true
+// ""
+// true
+//
+// ##########################################
+// START - Solve
+//
+// Solve Input:
+// ### Variable:
+// 	$FUN_1
+// ### Equation:
+// 	[SCAL] (1) $FUN_1 = 0.9092974268256817 ($RES_SIM_0)
+//
+// Solve Output:
+// ### Status:
+// 	Solve.EXPLICIT
+// ### Equation:
+// 	[SCAL] (1) $FUN_1 = 0.9092974268256817 ($RES_SIM_0)
+//
+// END - Solve
+// ##########################################
+//
+//
+// ##########################################
+// START - Solve
+//
+// Solve Input:
+// ### Variable:
+// 	x
+// ### Equation:
+// 	[SCAL] (1) 0.9092974268256817 = exp(-(2.0 ^ x) ^ 2.0) ($RES_AUX_1)
+//
+// SolveUnique Instructions (substitute from top to bottom):
+// 	0 (is initial)
+// 	$SUBST_CREF - (-0.9092974268256817)
+// 	log($SUBST_CREF)
+// 	-$SUBST_CREF
+// 	$SUBST_CREF ^ (1/2.0)
+// 	log($SUBST_CREF)
+// 	$SUBST_CREF / log(2.0)
+// ### Status:
+// 	Solve.EXPLICIT
+//
+// Solve Output:
+// ### Status:
+// 	Solve.EXPLICIT
+// ### Equation:
+// 	[SCAL] (1) x = -1.6973341095413634 ($RES_AUX_1)
+//
+// END - Solve
+// ##########################################
+//
+// record SimulationResult
+//     resultFile = "solveCallExp_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'solveCallExp', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/solve/solveCallTan.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveCallTan.mos
@@ -1,0 +1,73 @@
+// name: solveForLoop
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend -d=dumpSolve
+
+loadString("
+  model solveCallTan
+    Real x;
+  equation
+    tanh(x) = 0.5 + 2 * time;
+  end solveCallTan;
+"); getErrorString();
+
+setCommandLineOptions("-d=dumpSolve");
+simulate(solveCallTan); getErrorString();
+// Result:
+// true
+// ""
+// true
+//
+// ##########################################
+// START - Solve
+//
+// Solve Input:
+// ### Variable:
+// 	$FUN_1
+// ### Equation:
+// 	[SCAL] (1) $FUN_1 = 0.5 + 2.0 * time ($RES_SIM_0)
+//
+// Solve Output:
+// ### Status:
+// 	Solve.EXPLICIT
+// ### Equation:
+// 	[SCAL] (1) $FUN_1 = 0.5 + 2.0 * time ($RES_SIM_0)
+//
+// END - Solve
+// ##########################################
+//
+//
+// ##########################################
+// START - Solve
+//
+// Solve Input:
+// ### Variable:
+// 	x
+// ### Equation:
+// 	[SCAL] (1) 0.5 + 2.0 * time = tanh(x) ($RES_AUX_1)
+//
+// SolveUnique Instructions (substitute from top to bottom):
+// 	0 (is initial)
+// 	$SUBST_CREF + (0.5 + 2.0 * time)
+// 	atanh($SUBST_CREF)
+// ### Status:
+// 	Solve.EXPLICIT
+//
+// Solve Output:
+// ### Status:
+// 	Solve.EXPLICIT
+// ### Equation:
+// 	[SCAL] (1) x = atanh(0.5 + 2.0 * time) ($RES_AUX_1)
+//
+// END - Solve
+// ##########################################
+//
+// record SimulationResult
+//     resultFile = "solveCallTan_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'solveCallTan', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/solve/solveCallTan.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveCallTan.mos
@@ -1,4 +1,4 @@
-// name: solveForLoop
+// name: solveCallTan
 // keywords: NewBackend
 // status: correct
 // cflags: --newBackend -d=dumpSolve

--- a/testsuite/simulation/modelica/NBackend/solve/solveForLoop.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveForLoop.mos
@@ -1,0 +1,50 @@
+// name: solveForLoop
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend -d=dumpSolve
+
+loadString("
+  model solveForLoop
+    parameter Integer n = 2;
+    Real[n] y;
+  equation
+    for i in 1:n loop
+      0 = 2^(time) + (1 + time)^8 * y[i]^5 - 2 * i^n;
+    end for;
+  end solveForLoop;
+"); getErrorString();
+
+setCommandLineOptions("");
+simulate(solveForLoop); getErrorString();
+// Result:
+// true
+// ""
+// true
+//
+// ##########################################
+// START - Solve
+//
+// Solve Input:
+// ### Variable:
+// 	y[$i1]
+// ### Equation:
+// 	[SCAL] (1) 0.0 = ((1.0 + time) ^ 8.0 * y[$i1] ^ 5.0 + 2.0 ^ time) - 2.0 * $i1 ^ 2.0 ($RES_SIM_1)
+//
+// SolveUnique Instructions (substitute from top to bottom):
+// 	0 (is initial)
+// 	($SUBST_CREF + 2.0 * $i1 ^ 2.0) - 2.0 ^ time
+// 	$SUBST_CREF / (1.0 + time) ^ 8.0
+// 	$SUBST_CREF ^ (1/5.0)
+// ### Status:
+// 	Solve.EXPLICIT
+//
+// Solve Output:
+// ### Status:
+// 	Solve.EXPLICIT
+// ### Equation:
+// 	[SCAL] (1) y[$i1] = ((2.0 * $i1 ^ 2.0 - 2.0 ^ time) / (1.0 + time) ^ 8.0) ^ 0.2 ($RES_SIM_1)
+//
+// END - Solve
+// ##########################################
+//
+// endResult

--- a/testsuite/simulation/modelica/NBackend/solve/solveForLoop.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveForLoop.mos
@@ -47,4 +47,12 @@ simulate(solveForLoop); getErrorString();
 // END - Solve
 // ##########################################
 //
+// record SimulationResult
+//     resultFile = "solveForLoop_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'solveForLoop', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
 // endResult

--- a/testsuite/simulation/modelica/NBackend/solve/solveMultaryBinary.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveMultaryBinary.mos
@@ -1,4 +1,4 @@
-// name: solveForLoop
+// name: solveMultaryBinary
 // keywords: NewBackend
 // status: correct
 // cflags: --newBackend -d=dumpSolve

--- a/testsuite/simulation/modelica/NBackend/solve/solveMultaryBinary.mos
+++ b/testsuite/simulation/modelica/NBackend/solve/solveMultaryBinary.mos
@@ -1,0 +1,57 @@
+// name: solveForLoop
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend -d=dumpSolve
+
+loadString("
+  model solveMultaryBinary
+    Real x;
+  equation
+    3 = 2 * (time - 4 + 3 * x^2);
+  end solveMultaryBinary;
+"); getErrorString();
+
+setCommandLineOptions("-d=dumpSolve");
+simulate(solveMultaryBinary); getErrorString();
+// Result:
+// true
+// ""
+// true
+//
+// ##########################################
+// START - Solve
+//
+// Solve Input:
+// ### Variable:
+// 	x
+// ### Equation:
+// 	[SCAL] (1) 3.0 = 2.0 * ((-4.0) + time + 3.0 * x ^ 2.0) ($RES_SIM_0)
+//
+// SolveUnique Instructions (substitute from top to bottom):
+// 	0 (is initial)
+// 	$SUBST_CREF - (-3.0)
+// 	$SUBST_CREF / 2.0
+// 	$SUBST_CREF - (time + (-4.0))
+// 	$SUBST_CREF / 3.0
+// 	$SUBST_CREF ^ (1/2.0)
+// ### Status:
+// 	Solve.EXPLICIT
+//
+// Solve Output:
+// ### Status:
+// 	Solve.EXPLICIT
+// ### Equation:
+// 	[SCAL] (1) x = (0.3333333333333333 * (5.5 - time)) ^ 0.5 ($RES_SIM_0)
+//
+// END - Solve
+// ##########################################
+//
+// record SimulationResult
+//     resultFile = "solveMultaryBinary_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'solveMultaryBinary', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult


### PR DESCRIPTION
### Related Issues
Implement the tearing annotation in the NB: https://github.com/OpenModelica/OpenModelica/issues/13508

### Purpose
- add a generic solving routine to the new backend, which is necessay for tearing
- can solve any (nonlinear) equation that contains a cref once
- fallback to implicit solving, if the equation can't be solved

- add -d=dumpSolve as a debug flag
- add several test cases to test the routine
- add hyperbolic inverse functions and their derivatives