### PR TITLE
[TPL, C] update index mapping in C

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/DAE.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAE.mo
@@ -1161,7 +1161,6 @@ uniontype Dimension
   end DIM_EXP;
 
   record DIM_UNKNOWN "Dimension with unknown size."
-    //DimensionBinding dimensionBinding "unknown dimension can be bound or unbound";
   end DIM_UNKNOWN;
 end Dimension;
 

--- a/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/DAEUtil.mo
@@ -245,8 +245,27 @@ algorithm
   end match;
 end expTypeArrayDimensions;
 
+public function typeExp
+ "Converts a type to an expression, covering constants and parameters."
+  input DAE.Type tp;
+  output DAE.Exp exp;
+algorithm
+  exp := match tp
+    local
+      DAE.Dimension dim;
+      list<DAE.Dimension> rest;
+    case DAE.T_ARRAY(dims = dim :: rest) algorithm
+      exp := dimExp(dim);
+      for d in rest loop
+        exp := DAE.BINARY(exp, DAE.MUL(DAE.T_INTEGER_DEFAULT), dimExp(d));
+      end for;
+    then exp;
+    else DAE.ICONST(1);
+  end match;
+end typeExp;
+
 public function dimExp
- "Converts a dimension to an expression, covering constants and paramters."
+ "Converts a dimension to an expression, covering constants and parameters."
   input DAE.Dimension dim;
   output DAE.Exp exp;
 algorithm

--- a/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFDimension.mo
@@ -197,13 +197,13 @@ public
       local
         Type ty;
 
-      case INTEGER() then DAE.DIM_INTEGER(dim.size);
-      case BOOLEAN() then DAE.DIM_BOOLEAN();
+      case INTEGER()    then DAE.DIM_INTEGER(dim.size);
+      case BOOLEAN()    then DAE.DIM_BOOLEAN();
       case ENUM(enumType = ty as Type.ENUMERATION())
         then DAE.DIM_ENUM(ty.typePath, ty.literals, listLength(ty.literals));
-      case EXP() then DAE.DIM_EXP(Expression.toDAE(dim.exp));
-      case RESIZABLE() then DAE.DIM_INTEGER(dim.size); //ToDo: have resizable here
-      case UNKNOWN() then DAE.DIM_UNKNOWN();
+      case EXP()        then DAE.DIM_EXP(Expression.toDAE(dim.exp));
+      case RESIZABLE()  then DAE.DIM_EXP(Expression.toDAE(dim.exp));
+      case UNKNOWN()    then DAE.DIM_UNKNOWN();
     end match;
   end toDAE;
 

--- a/OMCompiler/Compiler/Template/CodegenC.tpl
+++ b/OMCompiler/Compiler/Template/CodegenC.tpl
@@ -4821,9 +4821,17 @@ template computeVarIndicesList(list<SimVar> vars)
   (vars |> var => match var
     case SIMVAR(__)
     then
+      let &preExp = buffer ""
+      let &varDecls = buffer ""
+      let &auxFunction = buffer ""
       let ty = crefShortType(name)
       let i = 'i_<%ty%>'
-      '<%ty%>Index[<%i%>+1] = <%ty%>Index[<%i%>] + 1; <%i%>++; <%crefCCommentWithVariability(var)%>'; separator="\n")
+      let size = daeExp(DAEUtil.typeExp(type_), contextOther, &preExp, &varDecls, &auxFunction)
+      <<
+      <%preExp%>
+      <%varDecls%>
+      <%auxFunction%>
+      <%ty%>Index[<%i%>+1] = <%ty%>Index[<%i%>] + <%size%>; <%i%>++; <%crefCCommentWithVariability(var)%>>>; separator="")
 end computeVarIndicesList;
 
 

--- a/OMCompiler/Compiler/Template/SimCodeTV.mo
+++ b/OMCompiler/Compiler/Template/SimCodeTV.mo
@@ -4193,6 +4193,10 @@ package DAEUtil
     output Boolean b;
   end statementsContainTryBlock;
 
+  function typeExp
+    input DAE.Type tp;
+    output DAE.Exp exp;
+  end typeExp;
 end DAEUtil;
 
 package Types


### PR DESCRIPTION
  - compute size of type instead of just using 1 (still defaults to 1 for all scalarized settings)
  - adding proper resizable conversion and size computation