### PR TITLE
[NB] add retyping for function inlining

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
+++ b/OMCompiler/Compiler/NBackEnd/Util/NBReplacements.mo
@@ -53,12 +53,14 @@ protected
   import ComponentRef = NFComponentRef;
   import Expression = NFExpression;
   import NFInstNode.InstNode;
+  import InstContext = NFInstContext;
   import NFFunction.Function;
   import NFFlatten.FunctionTreeImpl;
   import SimplifyExp = NFSimplifyExp;
   import Statement = NFStatement;
   import Subscript = NFSubscript;
   import Type = NFType;
+  import Typing = NFTyping;
   import Variable = NFVariable;
 
   // Backend imports
@@ -321,6 +323,7 @@ public
         body_exp := getFunctionBody(fn);
         // replace input withs arguments in expression
         body_exp := Expression.map(body_exp, function applySimpleExp(replacements = local_replacements));
+        body_exp := Typing.typeExp(body_exp, NFInstContext.RHS, sourceInfo(), true);
         body_exp := SimplifyExp.combineBinaries(body_exp);
         body_exp := SimplifyExp.simplifyDump(body_exp, true, getInstanceName(), "\n");
 

--- a/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFBuiltinCall.mo
@@ -83,6 +83,13 @@ public
         then
           ();
 
+      // for retyping
+      case Call.TYPED_CALL()
+        algorithm
+          special := Function.isSpecialBuiltin(call.fn);
+        then
+          ();
+
       else
         algorithm
           Error.assertion(false, getInstanceName() + " got unknown call: " +

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -1311,6 +1311,7 @@ function typeExp
   input output Expression exp;
   input InstContext.Type context;
   input SourceInfo info;
+  input Boolean retype = false;
         output Type ty;
         output Variability variability;
         output Purity purity;
@@ -1411,8 +1412,7 @@ algorithm
 
     case Expression.CALL()
       algorithm
-        (e1, ty, var1, pur1) := Call.typeCall(exp, context, info);
-
+        (e1, ty, var1, pur1) := Call.typeCall(exp, context, info, retype);
         // If the call has multiple outputs and isn't alone on either side of an
         // equation/algorithm, select the first output.
         if Type.isTuple(ty) and not InstContext.isSingleExpression(context) then

--- a/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFTyping.mo
@@ -47,6 +47,7 @@ import Class = NFClass;
 import Expression = NFExpression;
 import NFInstNode.InstNode;
 import NFModifier.Modifier;
+import SimplifyExp = NFSimplifyExp;
 import Statement = NFStatement;
 import NFType.Type;
 import Operator = NFOperator;
@@ -1426,7 +1427,7 @@ algorithm
       algorithm
         next_context := InstContext.set(context, NFInstContext.SUBEXPRESSION);
       then
-        typeExp(exp.exp, next_context, info);
+        typeExp(exp.exp, next_context, info, retype);
 
     case Expression.SUBSCRIPTED_EXP()
       then typeSubscriptedExp(exp, context, info);
@@ -1434,7 +1435,7 @@ algorithm
     case Expression.MUTABLE()
       algorithm
         e1 := Mutable.access(exp.exp);
-        (e1, ty, variability, purity) := typeExp(e1, context, info);
+        (e1, ty, variability, purity) := typeExp(e1, context, info, retype);
         exp.exp := Mutable.create(e1);
       then
         (exp, ty, variability, purity);
@@ -1443,6 +1444,8 @@ algorithm
       then Function.typePartialApplication(exp, context, info);
 
     case Expression.FILENAME() then (exp, Type.STRING(),  Variability.CONSTANT, Purity.PURE);
+
+    case Expression.MULTARY() then typeExp(SimplifyExp.splitMultary(exp), context, info, retype);
 
     else
       algorithm

--- a/testsuite/simulation/modelica/NBackend/functions/Makefile
+++ b/testsuite/simulation/modelica/NBackend/functions/Makefile
@@ -5,6 +5,7 @@ builtin_functions.mos\
 function_annotation_der.mos\
 function_diff.mos\
 function_partial_der.mos\
+function_inline_retype.mos\
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest

--- a/testsuite/simulation/modelica/NBackend/functions/function_inline_retype.mos
+++ b/testsuite/simulation/modelica/NBackend/functions/function_inline_retype.mos
@@ -1,0 +1,33 @@
+// name: function_inline_retype
+// keywords: NewBackend
+// status: correct
+// cflags: --newBackend
+
+loadString("
+model function_inline_retype
+  Real[2] x;
+  Real y;
+equation
+  x[1] = time;
+  x[2] = time*2;
+  y = Modelica.Electrical.Polyphase.Functions.quasiRMS(x);
+end function_inline_retype;
+"); getErrorString();
+
+simulate(function_inline_retype); getErrorString();
+
+// Result:
+// true
+// ""
+// record SimulationResult
+//     resultFile = "function_inline_retype_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'function_inline_retype', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// "Notification: Automatically loaded package Complex 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package ModelicaServices 4.0.0 due to uses annotation from Modelica.
+// Notification: Automatically loaded package Modelica 4.0.0 due to usage.
+// "
+// endResult


### PR DESCRIPTION
  - when a function gets inlined, the body has to be retyped if the function had inputs with non determined array sizes. After replacing, the array sizes are now known and can be computed by retyping
  - [NF] provide retyping option
  - [testuite] add minimal model
  - provides solution for #13589