### PR TITLE
[NF] add wild to ComponentRef.sizes

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -1838,6 +1838,7 @@ public
         local_lst := sizes_local(cref, withComplex, resize);
         s_lst := listAppend(local_lst, s_lst);
       then sizes(cref.restCref, withComplex, resize, s_lst);
+      case WILD() then {0};
     end match;
   end sizes;
 


### PR DESCRIPTION
fixes some [regressions ](https://libraries.openmodelica.org/branches/history/newInst-newBackend/2025-01-29%2016:32:11..2025-02-11%2009:43:22.html).