### PR TITLE
Fix flattening of crefs with no scalarization

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFComponentRef.mo
@@ -907,6 +907,8 @@ public
     input ComponentRef srcCref;
     input ComponentRef dstCref;
     output ComponentRef cref;
+  protected
+    list<Subscript> subs;
   algorithm
     cref := match (srcCref, dstCref)
       case (EMPTY(), _) then dstCref;
@@ -923,8 +925,12 @@ public
       case (CREF(), CREF()) guard InstNode.refEqual(srcCref.node, dstCref.node)
         algorithm
           cref := transferSubscripts(srcCref.restCref, dstCref.restCref);
+          // Don't remove subscripts unless there's something to replace them with.
+          // This avoids loosing subscripts when flattening an already flattened cref with
+          // a prefix without subscripts, which can happen in the non-scalarized path.
+          subs := if listEmpty(srcCref.subscripts) then dstCref.subscripts else srcCref.subscripts;
         then
-          CREF(dstCref.node, srcCref.subscripts, dstCref.ty, dstCref.origin, cref);
+          CREF(dstCref.node, subs, dstCref.ty, dstCref.origin, cref);
 
       case (CREF(), CREF())
         then transferSubscripts(srcCref.restCref, dstCref);

--- a/testsuite/flattening/modelica/scodeinst/Makefile
+++ b/testsuite/flattening/modelica/scodeinst/Makefile
@@ -1190,6 +1190,7 @@ VectorizeBindings1.mo \
 VectorizeBindings2.mo \
 VectorizeBindings3.mo \
 VectorizeBindings4.mo \
+VectorizeBindings5.mo \
 VectorTest.mo \
 Visibility1.mo \
 Visibility2.mo \

--- a/testsuite/flattening/modelica/scodeinst/VectorizeBindings5.mo
+++ b/testsuite/flattening/modelica/scodeinst/VectorizeBindings5.mo
@@ -1,0 +1,45 @@
+// name: VectorizeBindings5
+// keywords:
+// status: correct
+//
+
+model Failing
+  parameter Boolean initialEquation = true;
+  Real pOut(start=0);
+initial equation
+  if initialEquation then
+    pOut = 1;
+  end if;
+equation
+  der(pOut) = sin(time);
+end Failing;
+
+model Module
+  parameter Boolean initialEquation = true;
+  Failing f(initialEquation = initialEquation);
+end Module;
+
+model VectorizeBindings5
+  parameter Integer N = 2;
+  parameter Boolean initialEquation[N] = fill(true,N);
+  Module module[N](initialEquation = initialEquation);
+  annotation(__OpenModelica_commandLineOptions="--newBackend");
+end VectorizeBindings5;
+
+// Result:
+// class VectorizeBindings5
+//   final parameter Integer N = 2;
+//   parameter Boolean[2] initialEquation = array(true for $f1 in 1:2);
+//   parameter Boolean[2] module.initialEquation = array(initialEquation[$module1] for $module1 in 1:2);
+//   final parameter Boolean[2] module.f.initialEquation = array(module[$module1].initialEquation for $module1 in 1:2);
+//   Real[2] module.f.pOut(start = array(0.0 for $f1 in 1:2));
+// initial equation
+//   for $i1 in 1:2 loop
+//     module[$i1].f.pOut = 1.0;
+//   end for;
+// equation
+//   for $i1 in 1:2 loop
+//     der(module[$i1].f.pOut) = sin(time);
+//   end for;
+// end VectorizeBindings5;
+// endResult


### PR DESCRIPTION
- Keep destination subscripts in ComponentRef.transferSubscripts when there are no source ones, to avoid loosing subscripts when reflattening a cref with a prefix without subscripts.

Fixes #13602