### PR TITLE
Strip comments for `list(..., interfaceOnly = true)`

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -3758,6 +3758,8 @@ algorithm
       algorithm
         elts as _ :: _ := List.fold(listReverse(def.classParts), getFunctionInterfaceParts, {});
         cl.body := Absyn.PARTS(def.typeVars, def.classAttrs, {Absyn.PUBLIC(elts)}, {}, NONE());
+        cl.commentsBeforeEnd := {};
+        cl.commentsAfterEnd := {};
       then
         ();
   end match;


### PR DESCRIPTION
- Strip before/after end comments in `list()` when generating function interfaces to avoid that internal comments ends up in the documentation.