### PR TITLE
Fix cardinality with NB

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFCall.mo
@@ -2271,6 +2271,17 @@ public
     end match;
   end isStreamOperator;
 
+  function isCardinality
+    input Call call;
+    output Boolean isCardinality;
+  algorithm
+    isCardinality := match call
+      case TYPED_CALL() guard Function.isBuiltin(call.fn)
+        then functionNameFirst(call) == "cardinality";
+      else false;
+    end match;
+  end isCardinality;
+
 protected
   function instNormalCall
     input Absyn.ComponentRef functionName;

--- a/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFFlatten.mo
@@ -2121,7 +2121,9 @@ protected
   algorithm
     res := match exp
       case Expression.CALL()
-        then Call.isConnectionsOperator(exp.call) or Call.isStreamOperator(exp.call);
+        then Call.isConnectionsOperator(exp.call) or
+             Call.isStreamOperator(exp.call) or
+             Call.isCardinality(exp.call);
       else false;
     end match;
   end is_conn_operator;


### PR DESCRIPTION
- Add `cardinality` to the list of functions that should be split out and unrolled in for-loops.

Fixes #13617