### PR TITLE
Port some parts of #13640

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
+++ b/OMCompiler/Compiler/FrontEnd/AbsynUtil.mo
@@ -6891,5 +6891,13 @@ function enumLiteralName
   output String name = literal.literal;
 end enumLiteralName;
 
+public function elementItemClass
+  input Absyn.ElementItem item;
+  output Absyn.Class cls;
+algorithm
+  Absyn.ElementItem.ELEMENTITEM(element = Absyn.Element.ELEMENT(specification =
+    Absyn.ElementSpec.CLASSDEF(class_ = cls))) := item;
+end elementItemClass;
+
 annotation(__OpenModelica_Interface="frontend");
 end AbsynUtil;


### PR DESCRIPTION
- Clean up loading of ModelicaBuiltin.
- Optimize `getPathedClassInProgram`, do the lookup directly in the class parts instead of creating a list of all classes first.