### PR TITLE
Handle connectorSizing before removing the connection

### DIFF
--- a/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditLIB/Annotations/LineAnnotation.cpp
@@ -1093,7 +1093,7 @@ void LineAnnotation::clearPoints()
 void LineAnnotation::updateStartPoint(QPointF point)
 {
   prepareGeometryChange();
-  manhattanizeShape();
+  manhattanizeShape(false);
   removeRedundantPointsGeometriesAndCornerItems();
   qreal dx = point.x() - mPoints[0].x();
   qreal dy = point.y() - mPoints[0].y();

--- a/OMEdit/OMEditLIB/Modeling/Commands.cpp
+++ b/OMEdit/OMEditLIB/Modeling/Commands.cpp
@@ -406,8 +406,8 @@ void AddConnectionCommand::redoInternal()
  */
 void AddConnectionCommand::undo()
 {
-  mpConnectionLineAnnotation->getGraphicsView()->removeConnectionFromView(mpConnectionLineAnnotation);
   mpConnectionLineAnnotation->getGraphicsView()->deleteConnectionFromClass(mpConnectionLineAnnotation);
+  mpConnectionLineAnnotation->getGraphicsView()->removeConnectionFromView(mpConnectionLineAnnotation);
   mpConnectionLineAnnotation->getGraphicsView()->getModelWidget()->setHandleCollidingConnectionsNeeded(true);
 }
 
@@ -457,8 +457,8 @@ DeleteConnectionCommand::DeleteConnectionCommand(LineAnnotation *pConnectionLine
  */
 void DeleteConnectionCommand::redoInternal()
 {
-  mpConnectionLineAnnotation->getGraphicsView()->removeConnectionFromView(mpConnectionLineAnnotation);
   mpConnectionLineAnnotation->getGraphicsView()->deleteConnectionFromClass(mpConnectionLineAnnotation);
+  mpConnectionLineAnnotation->getGraphicsView()->removeConnectionFromView(mpConnectionLineAnnotation);
 }
 
 /*!

--- a/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditLIB/Modeling/ModelWidgetContainer.cpp
@@ -3375,8 +3375,8 @@ void GraphicsView::deleteConnection(LineAnnotation *pConnectionLineAnnotation)
             for (int i = 0; pStartBus->connectors[i] ; ++i) {
               if (startBusConnectors.contains(pAtomicConnectionLineAnnotation->getStartElement()->getName())
                   && endBusConnectors.contains(pAtomicConnectionLineAnnotation->getEndElement()->getName())) {
-                removeConnectionFromView(pAtomicConnectionLineAnnotation);
                 deleteConnectionFromClass(pAtomicConnectionLineAnnotation);
+                removeConnectionFromView(pAtomicConnectionLineAnnotation);
                 break;
               }
             }
@@ -3384,11 +3384,16 @@ void GraphicsView::deleteConnection(LineAnnotation *pConnectionLineAnnotation)
         }
       }
     }
-    removeConnectionFromView(pConnectionLineAnnotation);
     deleteConnectionFromClass(pConnectionLineAnnotation);
+    removeConnectionFromView(pConnectionLineAnnotation);
   } else {
-    removeConnectionFromView(pConnectionLineAnnotation);
+    /* Issue #12388.
+     * Call deleteConnectionFromClass() before removeConnectionFromView() to makesure connectorSizing is handled properly.
+     * If we remove the connection from view first then the connectorSizing parameter will not be updated because removeConnectionFromView() sets the start and end
+     * connector element to nullptr.
+     */
     deleteConnectionFromClass(pConnectionLineAnnotation);
+    removeConnectionFromView(pConnectionLineAnnotation);
   }
 }
 

--- a/OMEdit/OMEditLIB/OMS/BusDialog.cpp
+++ b/OMEdit/OMEditLIB/OMS/BusDialog.cpp
@@ -1602,8 +1602,8 @@ void BusConnectionDialog::deleteAtomicConnection(QString startConnectorName, QSt
 
     foreach (LineAnnotation *pConnectionLineAnnotation, mpGraphicsView->getConnectionsList()) {
       if ((pConnectionLineAnnotation->getStartElementName().compare(startComponentName) == 0) && (pConnectionLineAnnotation->getEndElementName().compare(endComponentName) == 0)) {
-        mpGraphicsView->removeConnectionFromView(pConnectionLineAnnotation);
         mpGraphicsView->deleteConnectionFromClass(pConnectionLineAnnotation);
+        mpGraphicsView->removeConnectionFromView(pConnectionLineAnnotation);
       }
     }
   }


### PR DESCRIPTION
### Related Issues

Fixes #12388

### Purpose

Update connectorSizing parameter.

### Approach

`GraphicsView::removeConnectionFromView()` sets the start and end connector element to nullptr so update connectorSizing before calling it.

