### PR TITLE
Remove some unused API functions

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1440,32 +1440,6 @@ external "builtin";
 annotation(preferredView="text");
 end setCXXCompiler;
 
-function verifyCompiler
-  output Boolean compilerWorks;
-external "builtin";
-annotation(preferredView="text");
-end verifyCompiler;
-
-function setCompilerPath
-  input String compilerPath;
-  output Boolean success;
-external "builtin";
-annotation(preferredView="text");
-end setCompilerPath;
-
-function getCompileCommand
-  output String compileCommand;
-external "builtin";
-annotation(preferredView="text");
-end getCompileCommand;
-
-function setCompileCommand
-  input String compileCommand;
-  output Boolean success;
-external "builtin";
-annotation(preferredView="text");
-end setCompileCommand;
-
 function setPlotCommand
   input String plotCommand;
   output Boolean success;
@@ -1477,7 +1451,6 @@ function getSettings
   output String settings;
 algorithm
   settings :=
-    "Compile command: " + getCompileCommand() + "\n" +
     "Temp folder path: " + getTempDirectoryPath() + "\n" +
     "Installation folder: " + getInstallationDirectoryPath() + "\n" +
     "Modelica path: " + getModelicaPath() + "\n";

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -1694,32 +1694,6 @@ external "builtin";
 annotation(preferredView="text");
 end setCXXCompiler;
 
-function verifyCompiler
-  output Boolean compilerWorks;
-external "builtin";
-annotation(preferredView="text");
-end verifyCompiler;
-
-function setCompilerPath
-  input String compilerPath;
-  output Boolean success;
-external "builtin";
-annotation(preferredView="text");
-end setCompilerPath;
-
-function getCompileCommand
-  output String compileCommand;
-external "builtin";
-annotation(preferredView="text");
-end getCompileCommand;
-
-function setCompileCommand
-  input String compileCommand;
-  output Boolean success;
-external "builtin";
-annotation(preferredView="text");
-end setCompileCommand;
-
 function setPlotCommand
   input String plotCommand;
   output Boolean success;
@@ -1731,7 +1705,6 @@ function getSettings
   output String settings;
 algorithm
   settings :=
-    "Compile command: " + getCompileCommand() + "\n" +
     "Temp folder path: " + getTempDirectoryPath() + "\n" +
     "Installation folder: " + getInstallationDirectoryPath() + "\n" +
     "Modelica path: " + getModelicaPath() + "\n";

--- a/OMCompiler/Compiler/Script/CevalScript.mo
+++ b/OMCompiler/Compiler/Script/CevalScript.mo
@@ -826,16 +826,6 @@ algorithm
     case ("listVariables",{})
       then ValuesUtil.makeArray(getVariableNames(SymbolTable.getVars(),{}));
 
-    case ("setCompileCommand",{Values.STRING(cmd)})
-      algorithm
-        // cmd = Util.rawStringToInputString(cmd);
-        Settings.setCompileCommand(cmd);
-      then
-        Values.BOOL(true);
-
-    case ("getCompileCommand",{})
-      then Values.STRING(Settings.getCompileCommand());
-
     case ("setTempDirectoryPath",{Values.STRING(cmd)})
       algorithm
         // cmd = Util.rawStringToInputString(cmd);

--- a/OMCompiler/Compiler/Util/Settings.mo
+++ b/OMCompiler/Compiler/Util/Settings.mo
@@ -41,30 +41,6 @@ public function getVersionNr "Returns the version number of this release"
 external "C" outString=Settings_getVersionNr() annotation(Library = "omcruntime");
 end getVersionNr;
 
-public function setCompilePath
-  input String inString;
-  external "C" SettingsImpl__setCompilePath(inString) annotation(Library = "omcruntime");
-end setCompilePath;
-
-/* TODO: Implement an external C function for bootstrapped omc or remove me. DO NOT SIMPLY REMOVE THIS COMMENT
-public function getCompilePath
-  output String outString;
-
-  external "C" outString=Settings_getCompilePath() annotation(Library = "omcruntime");
-end getCompilePath;*/
-
-public function setCompileCommand
-  input String inString;
-
-  external "C" SettingsImpl__setCompileCommand(inString) annotation(Library = "omcruntime");
-end setCompileCommand;
-
-public function getCompileCommand
-  output String outString;
-
-  external "C" outString=Settings_getCompileCommand() annotation(Library = "omcruntime");
-end getCompileCommand;
-
 public function setTempDirectoryPath
   input String inString;
 

--- a/OMCompiler/Compiler/runtime/Settings_omc.cpp
+++ b/OMCompiler/Compiler/runtime/Settings_omc.cpp
@@ -57,11 +57,8 @@ extern const char* Settings_getModelicaPath(int runningTestsuite)
   return path;
 }
 
-extern const char* Settings_getCompileCommand()
-{
-  const char *res = SettingsImpl__getCompileCommand();
-  return strcpy(ModelicaAllocateString(strlen(res)), res);
-}
+// Unused but referenced by the bootstrapping sources.
+extern const char* Settings_getCompileCommand() { return 0; }
 
 extern void Settings_setPlotCommand(const char* _inString);
 

--- a/OMCompiler/Compiler/runtime/settingsimpl.c
+++ b/OMCompiler/Compiler/runtime/settingsimpl.c
@@ -58,8 +58,6 @@
 extern "C" {
 #endif
 
-static char* compileCommand = 0;
-static char* compilePath = 0;
 static char* tempDirectoryPath = 0;
 static int   echo = 1; //true
 
@@ -256,42 +254,9 @@ char* SettingsImpl__getModelicaPath(int runningTestsuite) {
   return omc_modelicaPath;
 }
 
-static const char* SettingsImpl__getCompileCommand(void)
-{
-  if (compileCommand == NULL) {
-    // Get a default command
-    const char *res = getenv("MC_DEFAULT_COMPILE_CMD");
-    if (res == NULL)
-      return DEFAULT_CXX;
-    return res;
-  }
-  return compileCommand;
-}
-
-extern void SettingsImpl__setCompileCommand(const char *command)
-{
-  if(compileCommand)
-    free(compileCommand);
-  compileCommand = strdup(command);
-}
-
-static const char* SettingsImpl__getCompilePath(void)
-{
-  if (compilePath == NULL) {
-    // Get a default command
-    const char *res = getenv("MC_DEFAULT_COMPILE_PATH");
-    if (res == NULL)
-      return "";
-    return res;
-  }
-  return compilePath;
-}
-
-extern void SettingsImpl__setCompilePath(const char *path) {
-  if(compilePath)
-    free(compilePath);
-  compilePath = strdup(path);
-}
+// Unused but referenced by the bootstrapping sources.
+extern void SettingsImpl__setCompileCommand(const char *) { }
+extern void SettingsImpl__setCompilePath(const char*) { }
 
 static void commonSetEnvVar(const char *var, const char *value)
 {


### PR DESCRIPTION
- Remove `set/getCompileCommand` since they haven't been used for ages and have no effect on anything.
- Remove `verifyCompiler` and `setCompilerPath` which aren't even implemented.