### PR TITLE
Trim empty if-branches

### DIFF
--- a/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFEquation.mo
@@ -95,6 +95,16 @@ public
       end match;
     end mapExp;
 
+    function isEmpty
+      input Branch branch;
+      output Boolean empty;
+    algorithm
+      empty := match branch
+        case Branch.BRANCH() then listEmpty(branch.body);
+        case Branch.INVALID_BRANCH() then isEmpty(branch.branch);
+      end match;
+    end isEmpty;
+
     function sizeOf
       input Branch branch;
       output Integer size;

--- a/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFSimplifyModel.mo
@@ -516,6 +516,7 @@ algorithm
             else
               // Otherwise just discard the rest of the branches.
               accum := Equation.makeBranch(cond, simplifyEquations(body)) :: accum;
+              accum := List.trim(accum, Equation.Branch.isEmpty);
               elements := Equation.makeIf(listReverseInPlace(accum), scope, src) :: elements;
               return;
             end if;
@@ -544,6 +545,8 @@ algorithm
       else branch :: accum;
     end match;
   end for;
+
+  accum := List.trim(accum, Equation.Branch.isEmpty);
 
   if not listEmpty(accum) then
     elements := Equation.makeIf(listReverseInPlace(accum), scope, src) :: elements;


### PR DESCRIPTION
- Remove if-branches that contain no equations from the back of the list of branches.