### PR TITLE
Remove more unused API calls

### DIFF
--- a/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/FrontEnd/ModelicaBuiltin.mo
@@ -1818,13 +1818,6 @@ annotation(preferredView="text", Documentation(info="<html>
 </html>"));
 end getErrorString;
 
-function getMessagesString
-  "see getErrorString()"
-  output String messagesString;
-external "builtin" messagesString=getErrorString();
-annotation(preferredView="text");
-end getMessagesString;
-
 record SourceInfo
   String fileName;
   Boolean readonly;
@@ -1892,25 +1885,6 @@ function echo "echo(false) disables Interactive output, echo(true) enables it ag
 external "builtin";
 annotation(preferredView="text");
 end echo;
-
-function getClassesInModelicaPath "MathCore-specific or not? Who knows!"
-  output String classesInModelicaPath;
-external "builtin";
-annotation(preferredView="text");
-end getClassesInModelicaPath;
-
-/* These don't influence anything...
-function getClassNamesForSimulation
-  output String classNamesForSimulation;
-external "builtin";
-end getClassNamesForSimulation;
-
-function setClassNamesForSimulation
-  input String classNamesForSimulation;
-  output Boolean success;
-external "builtin";
-end setClassNamesForSimulation;
-*/
 
 function getAnnotationVersion "Returns the current annotation version."
   output String annotationVersion;

--- a/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
+++ b/OMCompiler/Compiler/NFFrontEnd/NFModelicaBuiltin.mo
@@ -2072,13 +2072,6 @@ annotation(preferredView="text", Documentation(info="<html>
 </html>"));
 end getErrorString;
 
-function getMessagesString
-  "see getErrorString()"
-  output String messagesString;
-external "builtin" messagesString=getErrorString();
-annotation(preferredView="text");
-end getMessagesString;
-
 record SourceInfo
   String fileName;
   Boolean readonly;
@@ -2146,25 +2139,6 @@ function echo "echo(false) disables Interactive output, echo(true) enables it ag
 external "builtin";
 annotation(preferredView="text");
 end echo;
-
-function getClassesInModelicaPath "MathCore-specific or not? Who knows!"
-  output String classesInModelicaPath;
-external "builtin";
-annotation(preferredView="text");
-end getClassesInModelicaPath;
-
-/* These don't influence anything...
-function getClassNamesForSimulation
-  output String classNamesForSimulation;
-external "builtin";
-end getClassNamesForSimulation;
-
-function setClassNamesForSimulation
-  input String classNamesForSimulation;
-  output Boolean success;
-external "builtin";
-end setClassNamesForSimulation;
-*/
 
 function getAnnotationVersion "Returns the current annotation version."
   output String annotationVersion;


### PR DESCRIPTION
- Remove `getMessagesString` which is implemented as an alias for `getErrorString` but doesn't actually work.
- Remove `getClassesInModelicaPath` which has no implementation.