### PR TITLE
Fix getNthImport

### DIFF
--- a/testsuite/openmodelica/interactive-API/Makefile
+++ b/testsuite/openmodelica/interactive-API/Makefile
@@ -66,6 +66,7 @@ getInheritedClasses2.mos \
 getNthComponentAnnotation.mos \
 getNthConnector.mos \
 getNthConnectorIconAnnotation.mos \
+getNthImport.mos \
 getSimulationOptions1.mos \
 getSimulationOptions2.mos \
 getSimulationOptions3.mos \

--- a/testsuite/openmodelica/interactive-API/getNthImport.mos
+++ b/testsuite/openmodelica/interactive-API/getNthImport.mos
@@ -1,0 +1,28 @@
+// name: getNthImport
+// keywords:
+// status: correct
+// cflags: -d=newInst
+
+loadString("
+  model M
+    import A;
+    import B = C;
+    import D.*;
+    import E.{F, G};
+  end M;
+");
+
+getNthImport(M, 1);
+getNthImport(M, 2);
+getNthImport(M, 3);
+getNthImport(M, 4);
+getNthImport(M, 5);
+
+// Result:
+// true
+// {"A", "", "qualified"}
+// {"C", "B", "named"}
+// {"D.*", "", "unqualified"}
+// {"E.{F,G}", "", "multiple"}
+// {}
+// endResult


### PR DESCRIPTION
- Fix `CevalScript.getImportList` so that the output is in the correct order instead of being reversed.