### PR TITLE
[NB] check alias replacements for validity

### DIFF
--- a/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBEquation.mo
@@ -65,6 +65,7 @@ public
   import OldBackendDAE = BackendDAE;
 
   // New Backend imports
+  import DetectStates = NBDetectStates;
   import Evaluation = NBEvaluation;
   import Inline = NBInline;
   import Replacements = NBReplacements;
@@ -1441,6 +1442,8 @@ public
       input output Equation eq;
       input String name = "";
       input String indent = "";
+      input Pointer<list<Pointer<Variable>>> acc_discrete_states = Pointer.create({});
+      input Pointer<list<Pointer<Variable>>> acc_previous = Pointer.create({});
       input SimplifyFunc simplifyExp = function SimplifyExp.simplifyDump(includeScope = true, name = name, indent = indent);
 
       partial function SimplifyFunc
@@ -1499,7 +1502,9 @@ public
             case SOME(body) algorithm
               eq.body := body;
             then eq;
-            else Equation.DUMMY_EQUATION();
+            else algorithm
+              DetectStates.findDiscreteStatesFromWhenBody(eq.body, acc_discrete_states, acc_previous);
+            then Equation.DUMMY_EQUATION();
           end match;
         then new_eq;
 

--- a/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
+++ b/OMCompiler/Compiler/NBackEnd/Classes/NBVariable.mo
@@ -225,6 +225,17 @@ public
     Pointer.update(par_ptr, par);
   end connectPartners;
 
+  function removePartner
+    "removes the partner for the variable"
+    input Pointer<Variable> var_ptr;
+    input BackendInfo.setPartner func;
+  protected
+    Variable var = Pointer.access(var_ptr);
+  algorithm
+    var.backendinfo := func(var.backendinfo, NONE());
+    Pointer.update(var_ptr, var);
+  end removePartner;
+
   function getVar
     input ComponentRef cref;
     output Variable var;

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -299,7 +299,7 @@ protected
     EqData.mapExp(eqData, function filterPre(acc = exceptionSet));
     for keyValueTpl in UnorderedMap.toList(replacements) loop
       (cref, exp) := keyValueTpl;
-      if isReplaceable(cref, exp, exceptionSet) then
+      if isValidReplacement(cref, exp, exceptionSet) then
         // replacement is valid - add to newReplacements
         UnorderedMap.add(cref, exp, newReplacements);
       else
@@ -311,11 +311,11 @@ protected
     end for;
 
     if Flags.isSet(Flags.DUMP_REPL)  then
-      dumpReplacements(replacements, auxEquations);
+      dumpReplacements(newReplacements, auxEquations);
     end if;
   end checkReplacements;
 
-  function isReplaceable
+  function isValidReplacement
     "Checks if a replacement (cref, exp) is valid"
     input ComponentRef cref;
     input Expression exp;
@@ -326,7 +326,7 @@ protected
     if UnorderedSet.contains(cref, exceptionSet) then
       b := false;
     end if;
-  end isReplaceable;
+  end isValidReplacement;
 
   function filterPre
     "Filter expression for pre call"

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBAlias.mo
@@ -311,7 +311,7 @@ protected
     end for;
 
     if Flags.isSet(Flags.DUMP_REPL)  then
-      dumpReplacements(replacements);
+      dumpReplacements(replacements, auxEquations);
     end if;
   end checkReplacements;
 

--- a/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBDetectStates.mo
+++ b/OMCompiler/Compiler/NBackEnd/Modules/2_Pre/NBDetectStates.mo
@@ -584,6 +584,33 @@ protected
     end if;
   end getPreVar;
 
+  public function findDiscreteStatesFromWhenBody
+    "All variables on the LHS in a when equation are considered discrete, add these to acc lists"
+    input WhenEquationBody body;
+    input Pointer<list<Pointer<Variable>>> acc_discrete_states;
+    input Pointer<list<Pointer<Variable>>> acc_previous;
+  algorithm
+    for body_stmt in body.when_stmts loop
+      () := match body_stmt
+        local
+          ComponentRef state_cref, pre_cref;
+          Pointer<Variable> state_var, pre_var;
+
+        case WhenStatement.ASSIGN(lhs = Expression.CREF(cref = state_cref)) algorithm
+          state_var := BVariable.getVarPointer(state_cref);
+          _ := match BVariable.getVarPre(state_var)
+            case SOME(pre_var) algorithm
+              Pointer.update(acc_previous, pre_var :: Pointer.access(acc_previous));
+            then ();
+            else ();
+          end match;
+          Pointer.update(acc_discrete_states, state_var :: Pointer.access(acc_discrete_states));
+        then ();
+        else ();
+      end match;
+    end for;
+  end findDiscreteStatesFromWhenBody;
+
   annotation(__OpenModelica_Interface="backend");
 end NBDetectStates;
 

--- a/testsuite/simulation/modelica/NBackend/alias/Alias_pre.mos
+++ b/testsuite/simulation/modelica/NBackend/alias/Alias_pre.mos
@@ -1,0 +1,75 @@
+// name: Alias_pre
+// keywords: NewBackend, Alias
+// status: correct
+// tests, if the invalid alias b => -(3.0 - y) is correctly identified
+// otherwise pre(-(3.0 - y)) would result
+
+loadString("
+model Alias_pre
+  Real x, y, b, b_prev;
+initial equation
+  b_prev = 0;
+equation
+  b = x;
+  y = x + 3;
+  y = sin(time);
+  when time > 0.5 then
+    b_prev = pre(b);
+  end when;
+end Alias_pre;
+"); getErrorString();
+
+setCommandLineOptions("--newBackend -d=dumprepl");
+simulate(Alias_pre); getErrorString();
+
+// Result:
+// true
+// ""
+// true
+// =====================================
+//   [dumprepl] Simulation Alias Sets:
+// =====================================
+//
+// Alias Set 1:
+// **************
+// 	<No Constant/Parameter Binding>
+// 	### Set Equations:
+// 	[SCAL] (1) y = $FUN_1 ($RES_SIM_2)
+// 	[SCAL] (1) y = 3.0 + x ($RES_SIM_3)
+// 	[SCAL] (1) b = x ($RES_SIM_4)
+//
+// [dumprepl] Constant Replacements:
+// ***********************************
+// [dumprepl] Trivial Alias Replacements:
+// ****************************************
+// 	$FUN_1	 ==> 	y
+// [dumprepl] Nontrivial Alias Replacements:
+// *******************************************
+// 	x	 ==> 	-(3.0 - y)
+//
+// [dumprepl] Found But Illegal Alias Replacements (added as equations):
+// ***********************************************************************
+// 	[SCAL] (1) b = -(3.0 - y) ($RES_SIM_6)
+//
+// ==================================
+//   [dumprepl] Clocked Alias Sets:
+// ==================================
+//
+// <No Clocked Alias Sets>
+//
+// [dumprepl] Constant Replacements:
+// ***********************************
+// [dumprepl] Trivial Alias Replacements:
+// ****************************************
+// [dumprepl] Nontrivial Alias Replacements:
+// *******************************************
+//
+// record SimulationResult
+//     resultFile = "Alias_pre_res.mat",
+//     simulationOptions = "startTime = 0.0, stopTime = 1.0, numberOfIntervals = 500, tolerance = 1e-6, method = 'dassl', fileNamePrefix = 'Alias_pre', options = '', outputFormat = 'mat', variableFilter = '.*', cflags = '', simflags = ''",
+//     messages = "LOG_SUCCESS       | info    | The initialization finished successfully without homotopy method.
+// LOG_SUCCESS       | info    | The simulation finished successfully.
+// "
+// end SimulationResult;
+// ""
+// endResult

--- a/testsuite/simulation/modelica/NBackend/alias/Makefile
+++ b/testsuite/simulation/modelica/NBackend/alias/Makefile
@@ -9,6 +9,7 @@ Alias_test4.mos \
 Alias_test5.mos \
 ArrayAlias1.mos \
 ArrayAlias2.mos \
+Alias_pre.mos \
 
 # test that currently fail. Move up when fixed.
 # Run make failingtest


### PR DESCRIPTION
- check alias replacements for validity, after aliasCausalize() has been carried out
- invalid alias replacements are added as auxiliary equations
- now discrete variables b, occuring as pre(b), are not replaced
- procedure can be extended for other invalid alias replacements
