### PR TITLE
Optimize List.deleteMemberOnTrue

### DIFF
--- a/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
+++ b/OMCompiler/Compiler/BackEnd/BackendDAEUtil.mo
@@ -4588,7 +4588,7 @@ algorithm
             Integer i;
           case(i,_,_) then i;
         end match for adjacencyElemT in adjacencyRowT);
-      eqns := List.deleteMember(eqns,eqn);
+      eqns := List.deleteMemberOnTrue(eqn,eqns,intEq);
       for e in eqns loop
         adjacencyRow := m[e];
         adjacencyRow := list(

--- a/OMCompiler/Compiler/BackEnd/HpcOmEqSystems.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmEqSystems.mo
@@ -2483,7 +2483,7 @@ algorithm
         vars = listGet(varsIn,idx);
         eq = listGet(eqsIn,idx);
         depEqs = List.flatten(List.map1(vars,Array.getIndexFirst,mt));
-        depEqs = List.deleteMember(depEqs,eq);
+        depEqs = List.deleteMemberOnTrue(eq,depEqs,intEq);
         graph = arrayUpdate(graphIn,eq,depEqs);
         graph = buildMatchedGraphForTornSystem(idx+1,eqsIn,varsIn,m,mt,graph);
     then graph;

--- a/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmScheduler.mo
@@ -1707,7 +1707,7 @@ algorithm
 
         // get the nodes that are necessary to compute the next critical path node, collect unassigned
         levelNodes = List.flatten(List.map1(List.intRange2(levelIdx,critNodeLevel),List.getIndexFirst,levelIn));
-        levelNodes = List.deleteMember(levelNodes,critPathNode);
+        levelNodes = List.deleteMemberOnTrue(critPathNode,levelNodes,intEq);
           //print("levelNodes: \n"+stringDelimitList(List.map(levelNodes,intString)," ; ")+"\n");
         necessaryPredecessors = arrayGet(iGraphT,listHead(restCritNodes));
           //print("necessaryPredecessors: "+stringDelimitList(List.map(necessaryPredecessors,intString)," ; ")+"\n");
@@ -5261,7 +5261,7 @@ algorithm
     case(_,_::_,_)
       equation
         pivotElement = listGet(lstIn,pivotIdx);
-        marked = List.deleteMember(markedLstIn,pivotElement);
+        marked = List.deleteMemberOnTrue(pivotElement,markedLstIn,realEq);
         r1 = listHead(marked);
         r2 = List.last(marked);
         midIdx = intDiv(listLength(marked),2);

--- a/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
+++ b/OMCompiler/Compiler/BackEnd/HpcOmTaskGraph.mo
@@ -4075,7 +4075,7 @@ algorithm
   //print("HpcOmTaskGraph.contractNodesInGraph1 contractNodes: " + stringDelimitList(List.map(contractNodes,intString),",") + "\n");
   //print("HpcOmTaskGraph.contractNodesInGraph1 startNode: " + intString(List.last(contractNodes)) + "\n");
   startNode := List.last(contractNodes);
-  deleteEntries := List.deleteMember(contractNodes,startNode); //all nodes which should be deleted
+  deleteEntries := List.deleteMemberOnTrue(startNode,contractNodes,intEq); //all nodes which should be deleted
   //print("HpcOmTaskGraph.contractNodesInGraph1 deleteEntries: " + stringDelimitList(List.map(deleteEntries,intString),",") + "\n");
   deleteNodesParents := List.flatten(List.map1(deleteEntries, Array.getIndexFirst, graphInT));
   //print("HpcOmTaskGraph.contractNodesInGraph1 deleteNodesParents: " + stringDelimitList(List.map(deleteNodesParents,intString),",") + "\n");
@@ -4394,7 +4394,7 @@ algorithm
         pathLst = listHead(lstIn);
         pathLst = inPath::pathLst;
         lstTmp = List.replaceAt(pathLst, 1, lstIn);
-        rest = List.deleteMember(allNodes,inPath);
+        rest = List.deleteMemberOnTrue(inPath,allNodes,intEq);
         lstTmp = findOneChildParents(rest,graphIn,doNotMerge,lstTmp,child,contrNodes);
       then
         lstTmp;
@@ -4411,7 +4411,7 @@ algorithm
         pathLst = listHead(lstIn);
         pathLst = inPath::pathLst;
         lstTmp = List.replaceAt(pathLst, 1, lstIn);
-        rest = List.deleteMember(allNodes,inPath);
+        rest = List.deleteMemberOnTrue(inPath,allNodes,intEq);
         lstTmp = findOneChildParents(rest,graphIn,doNotMerge,lstTmp,0,contrNodes);
       then
         lstTmp;

--- a/OMCompiler/Compiler/BackEnd/Matching.mo
+++ b/OMCompiler/Compiler/BackEnd/Matching.mo
@@ -5897,7 +5897,7 @@ algorithm
         //update mt
         for varIdx in varIdxs loop
           row := arrayGet(mt,varIdx);
-          row := List.deleteMember(row,e);
+          row := List.deleteMemberOnTrue(e, row, intEq);
           arrayUpdate(mt,varIdx,row);
         end for;
       end for;
@@ -5942,7 +5942,7 @@ algorithm
       //update mt
       for varIdx in varIdxs loop
         row := arrayGet(mt,varIdx);
-        row := List.deleteMember(row,idx);
+        row := List.deleteMemberOnTrue(idx,row,intEq);
         arrayUpdate(mt,varIdx,row);
       end for;
     end if;

--- a/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
+++ b/OMCompiler/Compiler/BackEnd/ResolveLoops.mo
@@ -813,8 +813,8 @@ algorithm
         nextPaths2 = List.filter1OnTrue(allPathsIn, lastInListIsEqual, startNode);
         nextPaths2 = listAppend(nextPaths1,nextPaths2);
         nextPath = listHead(nextPaths2);
-        rest = List.deleteMember(allPathsIn,nextPath);
-        nextPath = List.deleteMember(nextPath,startNode);
+        rest = List.deleteMemberOnTrue(nextPath,allPathsIn, function List.isEqualOnTrue(inCompFunc = intEq));
+        nextPath = List.deleteMemberOnTrue(startNode,nextPath,intEq);
         path = listAppend(nextPath,loopIn);
         path = connectPathsToOneLoop(rest,path);
       then
@@ -826,7 +826,7 @@ algorithm
         nextPaths2 = List.filter1OnTrue(rest, lastInListIsEqual, startNode);
         nextPaths2 = listAppend(nextPaths1,nextPaths2);
         nextPath = listHead(nextPaths2);
-        rest = List.deleteMember(rest,nextPath);
+        rest = List.deleteMemberOnTrue(nextPath,rest, function List.isEqualOnTrue(inCompFunc = intEq));
         path = listAppend(nextPath,restPath);
         path = connectPathsToOneLoop(rest,path);
       then
@@ -886,7 +886,7 @@ algorithm
         pos = -1;
       end if;
 
-      eqs = List.deleteMember(loop1,pos);
+      eqs = List.deleteMemberOnTrue(pos,loop1,intEq);
         //print("contract eqs: "+stringDelimitList(List.map(eqs,intString),",")+" to eq "+intString(pos)+"\n");
 
       // get the corresponding vars
@@ -935,7 +935,7 @@ algorithm
       pos = if not listEmpty(replEqs) then listHead(replEqs) else -1;
       pos = if not listEmpty(eqs) then listHead(eqs) else pos;
 
-      eqs = List.deleteMember(loop1,pos);
+      eqs = List.deleteMemberOnTrue(pos,loop1,intEq);
         //print("contract eqs: "+stringDelimitList(List.map(eqs,intString),",")+" to eq "+intString(pos)+"\n");
 
       // get the corresponding vars
@@ -1128,7 +1128,7 @@ algorithm
       equation
         elemR = listReverse(elem);
         elemR = List.getMember(elemR,elemLst);
-        foldLst = List.deleteMember(foldLstIn,elem);
+        foldLst = List.deleteMemberOnTrue(elem,foldLstIn,function List.isEqualOnTrue(inCompFunc = intEq));
       then
         elemR::foldLst;
     else
@@ -1342,7 +1342,7 @@ algorithm
         else
           next := List.first(eqs);
         end if;
-        rest := List.deleteMember(loopIn,next);
+        rest := List.deleteMemberOnTrue(next,loopIn,intEq);
       then sortLoop(rest,m,mT,next::sortLoopIn);
   end matchcontinue;
 end sortLoop;
@@ -1500,7 +1500,7 @@ algorithm
         // check the next eqNode of the crossEq whether the paths is finished here or the path goes on to another crossEq
         adjVars = arrayGet(mIn,crossEq);
         adjEqs = List.map1(adjVars,Array.getIndexFirst,mTIn);
-        adjEqs = List.map1(adjEqs,List.deleteMember,crossEq);// REMARK: this works only if there are no varCrossNodes
+        adjEqs = list(List.deleteMemberOnTrue(crossEq, eq, intEq) for eq in adjEqs); // REMARK: this works only if there are no varCrossNodes
         adjEqs = List.filterOnFalse(adjEqs,listEmpty);
         nextEqs = List.flatten(adjEqs);
         (endEqs,unfinEqs,_) = List.intersection1OnTrue(nextEqs,allEqCrossNodes,intEq);
@@ -1517,7 +1517,7 @@ algorithm
         prevEq = List.second(pathStart);
         adjVars = arrayGet(mIn,lastEq);
         adjEqs = List.map1(adjVars,Array.getIndexFirst,mTIn);
-        adjEqs = List.map1(adjEqs,List.deleteMember,lastEq);// REMARK: this works only if there are no varCrossNodes
+        adjEqs = list(List.deleteMemberOnTrue(lastEq, eq, intEq) for eq in adjEqs); // REMARK: this works only if there are no varCrossNodes
         adjEqs = List.filterOnFalse(adjEqs,listEmpty);
         nextEqs = List.map(adjEqs,listHead);
         (nextEqs,_) = List.deleteMemberOnTrue(prevEq,nextEqs,intEq); //do not take the path back to the previous node
@@ -2133,7 +2133,7 @@ algorithm
         path = listHead(allPaths);
         endNode = if not listEmpty(allPaths) then List.last(path) else -1;
         endNode = if not listEmpty(paths2) then listHead(path) else -1;
-        rest = List.deleteMember(pathsIn,path);
+        rest = List.deleteMemberOnTrue(path,pathsIn,function List.isEqualOnTrue(inCompFunc = intEq));
         sortedPaths = listAppend(sortedPathsIn,{path});
         sortedPaths = sortPathsAsChain1(rest,firstNode,endNode,sortedPaths);
 
@@ -2149,7 +2149,7 @@ algorithm
         path = listHead(allPaths);
         startNode = if not listEmpty(allPaths) then List.last(path) else -1;
         startNode = if not listEmpty(paths2) then listHead(path) else -1;
-        rest = List.deleteMember(pathsIn,path);
+        rest = List.deleteMemberOnTrue(path,pathsIn,function List.isEqualOnTrue(inCompFunc = intEq));
         sortedPaths = path::sortedPathsIn;
         sortedPaths = sortPathsAsChain1(rest,startNode,lastNode,sortedPaths);
       then

--- a/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
+++ b/OMCompiler/Compiler/BackEnd/SymbolicJacobian.mo
@@ -760,7 +760,7 @@ algorithm
       (pivotIdx,pivot) := getPivotElement(A,rangeIn,indxIn,n);
         //print("pivot: "+intString(pivotIdx)+" has value: "+realString(pivot)+"\n");
       arrayUpdate(permutation,indxIn,pivotIdx);
-      range := List.deleteMember(rangeIn,pivotIdx);
+      range := List.deleteMemberOnTrue(pivotIdx,rangeIn,intEq);
 
       // the pivot row in the A-matrix divided by the pivot element
       for ic in indxIn:n loop

--- a/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
+++ b/OMCompiler/Compiler/BackEnd/SynchronousFeatures.mo
@@ -1219,10 +1219,10 @@ protected
   list<Integer> row;
 algorithm
   row := arrayGet(m,eq);
-  row := List.deleteMember(row,var);
+  row := List.deleteMemberOnTrue(var,row,intEq);
   arrayUpdate(m,eq,row);
   row := arrayGet(mT,var);
-  row := List.deleteMember(row,eq);
+  row := List.deleteMemberOnTrue(eq,row,intEq);
   arrayUpdate(mT,var,row);
 end removeEdge;
 

--- a/OMCompiler/Compiler/BackEnd/Tearing.mo
+++ b/OMCompiler/Compiler/BackEnd/Tearing.mo
@@ -1750,7 +1750,7 @@ try
         if isEntrySolved(entr) then
           (vidx,_,_) := entr;
           algSolvedVars := vidx::algSolvedVars;
-          unsolvedCombined := List.deleteMember(unsolvedCombined,vidx);
+          unsolvedCombined := List.deleteMemberOnTrue(vidx, unsolvedCombined, intEq);
 
           // mark the var to be ignored for later
           // matching.
@@ -3832,7 +3832,7 @@ algorithm
   while not listEmpty(eqns) loop
     eqOut := getMostNonlinearEquation(eqnNonlinPoints, eqns, mapEqnIncRow, mapIncRowEqn);
     (solvable, eqnsOut, varsOut) := eqnSolvableCheck(eqOut, mapEqnIncRow, ass1, m, me);
-    eqns := List.deleteMember(eqns, eqOut);
+    eqns := List.deleteMemberOnTrue(eqOut, eqns, intEq);
     if Flags.isSet(Flags.TEARING_DUMPVERBOSE) then
       print("Most nonlinear equation: " + intString(eqOut) + " - solvable?: " + boolString(solvable) + "\n");
     end if;
@@ -4098,7 +4098,7 @@ algorithm
     rowsIndx := arrayGet(mHelp,entry);
     for rowIndx in rowsIndx loop
       row := arrayGet(mUpdate,rowIndx);
-      row := List.deleteMember(row,entry);
+      row := List.deleteMemberOnTrue(entry, row, intEq);
       Array.replaceAtWithFill(rowIndx,row,row,mUpdate);
     end for;
   end for;

--- a/OMCompiler/Compiler/Script/Refactor.mo
+++ b/OMCompiler/Compiler/Script/Refactor.mo
@@ -1313,7 +1313,8 @@ algorithm
         true = isLayerAnnInList(listAppend(res,rest))/*Fails the case if we have a coordsys without a layer definition*/;
         res = Absyn.MODIFICATION(fi, e, Absyn.IDENT("Coordsys"), SOME(Absyn.CLASSMOD(args, eqMod)),com,mod_info) :: res;
         res = transformClassAnnList(rest,context,res,p);
-      then List.deleteMember(res,Absyn.MODIFICATION(fi, e, Absyn.IDENT("Coordsys"), SOME(Absyn.CLASSMOD(args, eqMod)),com,mod_info));
+        res = List.deleteMemberOnTrue(Absyn.MODIFICATION(fi, e, Absyn.IDENT("Coordsys"), SOME(Absyn.CLASSMOD(args, eqMod)),com,mod_info), res, valueEq);
+      then res;
 
     case(Absyn.MODIFICATION(finalPrefix = fi, eachPrefix = e, path = Absyn.IDENT(name = "Coordsys"), modification = SOME(Absyn.CLASSMOD(elementArgLst = args, eqMod = eqMod)), comment = com, info = mod_info) :: rest,context,res,p)
       equation
@@ -1322,7 +1323,8 @@ algorithm
         res = Absyn.MODIFICATION(false, Absyn.NON_EACH(), Absyn.IDENT("Diagram"), SOME(Absyn.CLASSMOD({coord},Absyn.NOMOD())),NONE(),mod_info)
               :: Absyn.MODIFICATION(false, Absyn.NON_EACH(), Absyn.IDENT("Icon"), SOME(Absyn.CLASSMOD({coord},Absyn.NOMOD())),NONE(),mod_info) :: res;
         res = transformClassAnnList(rest,context,res,p);
-      then List.deleteMember(res,Absyn.MODIFICATION(fi, e, Absyn.IDENT("Coordsys"), SOME(Absyn.CLASSMOD(args, eqMod)),com,mod_info));
+        res = List.deleteMemberOnTrue(Absyn.MODIFICATION(fi, e, Absyn.IDENT("Coordsys"), SOME(Absyn.CLASSMOD(args, eqMod)),com,mod_info), res, valueEq);
+      then res;
 
     case(Absyn.MODIFICATION(finalPrefix = fi, eachPrefix = e, path = Absyn.IDENT(name = "extent"), modification = SOME(Absyn.CLASSMOD(elementArgLst = args, eqMod = Absyn.EQMOD(Absyn.MATRIX(matrix = {{x1,y1},{x2,y2}} ),info))), comment = com, info = mod_info) :: rest,context as ("Coordsys" :: _),res,p)
       equation

--- a/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
+++ b/OMCompiler/Compiler/SimCode/SimCodeUtil.mo
@@ -8049,7 +8049,7 @@ algorithm
 
       //check these equations again
       newEqIdcs := arrayGet(mT,varIdx0);
-      newEqIdcs := List.deleteMember(newEqIdcs,eqIdx);
+      newEqIdcs := List.deleteMemberOnTrue(eqIdx,newEqIdcs,intEq);
       workList := List.append_reverse(newEqIdcs,workList);
       //print("check these equations again: "+stringDelimitList(List.map(newEqIdcs,intString),", ")+"\n");
       // replace the var with the new start value in these equations
@@ -8058,7 +8058,7 @@ algorithm
       eqArr := List.threadFold(newEqIdcs,eqLst,BackendEquation.setAtIndexFirst,eqs);
       // update the adjacencyMatrix m and remove the idcs for the calculated var
       mEntries := List.map1(newEqIdcs,Array.getIndexFirst,m);
-      mEntries := List.map1(mEntries,List.deleteMember,varIdx0);
+      mEntries := list(List.deleteMemberOnTrue(varIdx0, e, intEq) for e in mEntries);
       List.threadMap1_0(newEqIdcs,mEntries,Array.updateIndexFirst,m);
     else
     end try;

--- a/OMCompiler/Compiler/Util/List.mo
+++ b/OMCompiler/Compiler/Util/List.mo
@@ -1662,7 +1662,7 @@ algorithm
   end if;
 
   for e in inList2 loop
-    outDifference := deleteMember(outDifference, e);
+    outDifference := deleteMemberOnTrue(e, outDifference, valueEq);
   end for;
 end setDifference;
 
@@ -4887,39 +4887,6 @@ algorithm
   outElement := inFalseValue;
 end findBoolList;
 
-public function deleteMember<T>
-  "Takes a list and a value, and deletes the first occurence of the value in the
-   list. Example: deleteMember({1, 2, 3, 2}, 2) => {1, 3, 2}"
-  input list<T> inList;
-  input T inElement;
-  output list<T> outList = {};
-protected
-  T e;
-  list<T> rest = inList;
-algorithm
-  while not listEmpty(rest) loop
-    e :: rest := rest;
-
-    if valueEq(e, inElement) then
-      outList := append_reverse(outList, rest);
-      return;
-    end if;
-
-    outList := e :: outList;
-  end while;
-  outList := inList;
-end deleteMember;
-
-public function deleteMemberF<T>
-  "Same as deleteMember, but fails if the element isn't present in the list."
-  input list<T> inList;
-  input T inElement;
-  output list<T> outList;
-algorithm
-  outList := deleteMember(inList, inElement);
-  if referenceEq(outList, inList) then fail(); end if;
-end deleteMemberF;
-
 public function deleteMemberOnTrue<T, VT>
   "Takes a list and a value and a comparison function and deletes the first
   occurence of the value in the list for which the function returns true. It
@@ -4945,7 +4912,7 @@ algorithm
     e :: rest := rest;
 
     if inCompareFunc(inValue, e) then
-      outList := append_reverse(acc, rest);
+      outList := listAppend(listReverseInPlace(acc), rest);
       outDeletedElement := SOME(e);
       return;
     end if;

--- a/testsuite/openmodelica/bootstrapping/UtilTest.mos
+++ b/testsuite/openmodelica/bootstrapping/UtilTest.mos
@@ -53,8 +53,6 @@ UtilTest.listMapMap({1,2,3,4,5});
 getErrorString();
 List.position(1,{1,2,3,4,5});
 getErrorString();
-List.deleteMember({1,2,3,4,5},1);
-getErrorString();
 List.setDifference({1,2,3,4,5},{1});
 getErrorString();
 List.setDifference({1,2,3,4,5},{3});
@@ -111,8 +109,6 @@ getErrorString();
 // {"1.0", "2.0", "3.0", "4.0", "5.0"}
 // ""
 // 1
-// ""
-// {2, 3, 4, 5}
 // ""
 // {2, 3, 4, 5}
 // ""


### PR DESCRIPTION
- Use `listAppend` with `listReverseInPlace` instead of `append_reverse` in `List.deleteMemberOnTrue`, so that as much work as possible is done in the C runtime instead of in MetaModelica.
- Remove `List.deleteMember` and `List.deleteMemberF`, they can be trivially replaced with `List.deleteMemberOnTrue` and `valueEq` is rarely a good equality function.